### PR TITLE
chore: ignore jules artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ temp-worktree/engines/physics_engines/mujoco/vendor/mujoco_menagerie/
 # MyPy and coverage output
 mypy_errors.txt
 ruff_errors.json
+
+# Jules generated files
+.jules/bolt*
+.jules/palette*
+.jules/pallette*
+.jules/sentinel*


### PR DESCRIPTION
Excludes bolt, palette, and sentinel files generated by .jules from version control.