### PR TITLE
Debug failing tests in pull request

### DIFF
--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -11,6 +11,17 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 
+def _is_docker_available() -> bool:
+    """Check if Docker is available."""
+    try:
+        result = subprocess.run(
+            ["docker", "--version"], capture_output=True, timeout=5
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
 class TestDockerBuild(unittest.TestCase):
     """Test Docker image building and configuration."""
 
@@ -40,10 +51,7 @@ class TestDockerBuild(unittest.TestCase):
         self.assertIn("/workspace/shared/python", pythonpath_line)
         self.assertIn("/workspace/engines", pythonpath_line)
 
-    @unittest.skipUnless(
-        subprocess.run(["docker", "--version"], capture_output=True).returncode == 0,
-        "Docker not available",
-    )
+    @unittest.skipUnless(_is_docker_available(), "Docker not available")
     def test_docker_available(self):
         """Test that Docker is available for building."""
         result = subprocess.run(["docker", "--version"], capture_output=True, text=True)


### PR DESCRIPTION
The test_docker_integration.py file was causing test collection to fail when docker is not installed. The @unittest.skipUnless decorator was evaluating subprocess.run(["docker", "--version"]) at module import time, which raised FileNotFoundError during test collection.

Changes:
- Added _is_docker_available() helper function that catches FileNotFoundError
- Updated @unittest.skipUnless decorator to use the helper function
- Tests now collect successfully even when docker is not installed
- The docker availability test is properly skipped when docker is unavailable

This fixes the persistent test failures in CI where docker is not available during test collection.

## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added
