### PR TITLE
feat: add scientific assessment framework and initial audit

### DIFF
--- a/docs/assessments/Assessment_C_Results.md
+++ b/docs/assessments/Assessment_C_Results.md
@@ -1,0 +1,96 @@
+# Ultra-Critical Scientific Python Project Review: Golf Modeling Suite
+
+**Reviewer Identity:** Automated Principal Agent
+**Date:** 2026-01-04
+**Scope:** Physics Engines (MuJoCo, Inverse Dynamics), State Management
+
+## 1. Executive Summary
+
+The `Golf_Modeling_Suite` is a high-complexity robotics simulation leveraging advanced physics engines (MuJoCo, Drake). While the mathematical implementation of inverse dynamics is sophisticated, the state management practices introduce dangerous side effects that threaten scientific reproducibility.
+
+*   **Overall Assessment**:
+    *   **Architecture**: heavily relies on shared mutable state (`mujoco.MjData`). Several analysis methods mutate this state as a side effect of calculation.
+    *   **Scientific Correctness**: The equations of motion (RNE, Inverse Dynamics) are implemented correctly using MuJoCo's primitives.
+    *   **Safety**: "Observer Effect" bugs are highly likely. Calling a validation function moves the simulation forward in time.
+    *   **Reliability**: The code handles API version differences (Jacobian signature) gracefully, showing good defensive engineering.
+
+*   **Top Risks**:
+    1.  **Observer Effect in Validation**: The `validate_solution` method calls `mj_step`, which advances the simulation time and state. Using this method to "check" a result will silently change the result of subsequent calculations.
+    2.  **Implicit State Mutation**: `compute_required_torques` and `compute_induced_accelerations` overwrite `data.qpos`, `data.qvel`, and `data.ctrl` in place. If the `MjData` object is shared across visualization and analysis threads, this causes race conditions and visual artifacts (robot "teleporting").
+    3.  **Jacobian Flattening**: The fallback for flat Jacobians suggests potential version mismatch issues that could lead to dimension alignment errors if not rigorously tested.
+
+*   **Scientific Credibility Verdict**:
+    *   *Would I trust results?* **Yes, but only in isolation.** The individual math is correct, but I would not trust a long-running analysis pipeline that intertwines validation and simulation due to the state mutation risks.
+    *   *What breaks first?* **Parallel Analysis**. If two analyzers verify different time steps using the same `MjData` structure, they will corrupt each other's state instantly.
+
+## 2. Scorecard
+
+| Category | Score (0-10) | Notes |
+| :--- | :--- | :--- |
+| **A. Problem Definition** | 9 | Physics are well-defined via URDF/MJCF and standard rigid body algorithms. |
+| **B. Model Formulation** | 8 | Uses robust RNE and Cholesky decompositions. |
+| **C. Architecture** | 5 | **Major Issue**: Heavy reliance on shared mutable state (`MjData`) violates functional purity needed for safe scientific analysis. |
+| **D. API Safety** | 4 | "Validate" methods cause side effects (time advancement). This is a trap for users. |
+| **E. Code Quality** | 8 | Clean, typed, and well-structured code. |
+| **F. Type System** | 8 | Good use of numpy typing and dataclasses. |
+| **G. Testing** | 7 | Existence of "Validation" methods is good, but they are architecturally dangerous. |
+| **H. Validation** | 6 | Relies on internal self-consistency (F=Ma) rather than external ground truth. |
+| **I. Reliability** | 7 | Defensive coding against API changes is noted. |
+| **J. Observability** | 6 | Debugging state mutations is difficult without deep tracing. |
+| **K. Performance** | 8 | Optimizations like `_use_flat_jacobian` and skipping `mj_fullM` when possible are evident. |
+| **L. Data Integrity** | 7 | CSV exports are structured. |
+| **M. Reproducibility** | 5 | Sensitive to the sequence of calls due to state mutation. |
+| **N. Documentation** | 8 | Docstrings are excellent and explain the physics clearly. |
+
+**Weighted Score: 6.8/10** (Strong engine, Dangerous integration)
+
+## 3. Findings Table
+
+| ID | Severity | Category | Location | Symptom | Root Cause | Impact |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **F-001** | **Critical** | Architecture | `inverse_dynamics.py`:500 | Side Effects | `validate_solution` calls `mj_step`. | Checking specific results alters the global simulation state (t -> t+dt). |
+| **F-002** | **Major** | Concurrency | `inverse_dynamics.py`:148 | Race Condition | In-place modification of `data.qpos`. | Shared `MjData` usage prevents parallel analysis or async visualization. |
+| **F-003** | **Minor** | Maintainability | `inverse_dynamics.py`:111 | Technical Debt | Try-except block for Jacobian signature. | Hides dependency version requirements; should be enforced in `requirements.txt`. |
+
+## 4. Refactor / Remediation Plan
+
+### Phase 1: Stop the Bleeding (48 Hours)
+1.  **Fix Validation Side Effects**: Change `validate_solution` to use `mj_forward` (static calculation) instead of `mj_step` (integration), or clone the `MjData` structure before stepping.
+
+### Phase 2: Structural Fixes (2 Weeks)
+1.  **State Isolation**: Modify `InverseDynamicsSolver` to take a *copy* of `MjData` or creating a dedicated `MjData` for analysis that is separate from the visualization/simulation loop.
+2.  **Context Managers**: Implement a context manager that saves/restores `MjData` state when performing invasive analysis.
+
+### Phase 3: Architectural Hardening (6 Weeks)
+1.  **Functional Physics Interface**: Create a wrapper that treats `MjData` as an immutable input and returns a new state or derived values, enforcing functional patterns.
+
+## 5. Diff-Style Change Proposals
+
+### Fix F-001: Remove Logic Side Effect (Pseudo-diff)
+```python
+# inverse_dynamics.py
+
+    def validate_solution(self, ...):
++       # Save state to prevent side effects
++       qpos_backup = self.data.qpos.copy()
++       qvel_backup = self.data.qvel.copy()
++       time_backup = self.data.time
+        
+        # ... logic ...
+        
+-       mujoco.mj_step(self.model, self.data)
++       # Use forward dynamics instead of stepping if possible, 
++       # OR restore state after stepping
++       mujoco.mj_forward(self.model, self.data) # Computes acc from forces
+        
++       # Restore state
++       self.data.qpos[:] = qpos_backup
++       self.data.qvel[:] = qvel_backup
++       self.data.time = time_backup
+```
+
+## 6. Non-Obvious Improvements
+
+1.  **Analytical derivative checks**: Instead of just checking f=ma, implement finite-difference checks on the Jacobians `mj_jacBody` vs numerical differentiation of positions to verify the kinematic chain definition.
+2.  **Energy Auditing**: Add a method to compute Total Energy (K + P) before and after the inverse dynamics solve to ensure the computed torques are consistent with the work-energy theorem.
+3.  **Null-Space Projection**: For redundant systems (golfers have many DOFs), expose the null-space posture control explicitly in the Inverse Dynamics solver to allow "secondary tasks" (e.g., keep head still while swinging).

--- a/docs/assessments/Assessment_Prompt_A.md
+++ b/docs/assessments/Assessment_Prompt_A.md
@@ -1,0 +1,231 @@
+r1) Here’s a “drop-in” prompt you can give to any AI reviewer (or a human) to evaluate a large Python project like a top-tier staff/principal engineer doing a brutal architecture + code review. It forces concrete evidence, scoring, prioritization, and actionable fixes—not vibes.
+
+---
+
+## Ultra-Critical Python Project Review Prompt (copy/paste)
+
+You are a **principal/staff-level Python engineer and software architect** doing an **adversarial, evidence-based** review of a large Python project. Your job is to **find weaknesses, risks, and quality gaps** the way a top company’s internal review board would. Assume this project may go into production and be maintained for years by multiple engineers.
+
+### Inputs I will provide
+
+* Repository contents (code, config, tests, docs)
+* Optional: requirements/feature goals, target users, deployment environment, performance/SLA needs
+
+### Your output must be ruthless, structured, and specific
+
+Do **not** be polite. Do **not** generalize. Do **not** say “looks good overall.”
+Every claim must cite **exact files/paths, modules, functions**, or **config keys**. Prefer “proof”: callouts, examples, failure modes, and how to reproduce. Provide fixes with suggested code patterns.
+
+---
+
+# 0) Deliverables and format requirements
+
+Produce the review with these sections:
+
+1. **Executive Summary (1 page max)**
+
+* Overall assessment in 5 bullets
+* Top 10 risks (ranked)
+* “If we shipped today, what breaks first?” (realistic scenario)
+
+2. **Scorecard**
+   Give a score **0–10** for each category below, plus a weighted overall score.
+   For every score ≤8, list *why*, *evidence*, and *what it would take to reach 9–10*.
+3. **Findings Table (the core output)**
+   A table of findings with:
+
+* ID, Severity (Blocker/Critical/Major/Minor/Nit)
+* Category, Location (path + symbol), Symptom, Root cause
+* Impact, Likelihood, How to reproduce (if applicable)
+* Fix (specific), Effort estimate (S/M/L), Owner type (backend/devops/data/etc.)
+
+4. **Refactor / Remediation Plan**
+
+* A phased plan: **48 hours**, **2 weeks**, **6 weeks**
+* Include “stop-the-bleeding” items vs. long-term architecture
+
+5. **Diff-style suggestions**
+   Provide at least 5 concrete change proposals (pseudo-diffs are fine), each tied to a finding.
+6. **Non-obvious improvements**
+   List 10+ improvements that aren’t typical lint/test suggestions (e.g., dependency hygiene, build reproducibility, observability, API ergonomics, failure isolation, etc.)
+
+---
+
+# 1) Review categories and criteria (be exhaustive)
+
+## A. Product requirements & correctness
+
+* Does the project clearly encode requirements? Where are they documented?
+* Trace “major feature X” to code: entry points, flow, invariants.
+* Identify ambiguous behavior, undefined edge cases, and mismatches between docs and implementation.
+* Look for silent failures, swallowed exceptions, implicit defaults, and “works on my machine” assumptions.
+* Are there explicit correctness properties? Any property tests? Invariants? Assertions?
+
+## B. Architecture & modularity (the big one)
+
+* High-level architecture: boundaries, layers, dependency direction, coupling.
+* Evaluate whether modules have a single responsibility.
+* Identify circular dependencies, leaky abstractions, shared mutable state, “god modules,” and tight coupling to frameworks.
+* Are interfaces clean? Are adapters used for external systems?
+* Extensibility: how hard is it to add a new feature without editing 15 files?
+
+## C. API/UX design (library or service)
+
+* Public API clarity: naming, consistency, discoverability.
+* Backwards compatibility story, deprecation patterns.
+* Error reporting: are exceptions meaningful? Are error types stable and documented?
+* For CLIs: help text quality, exit codes, flags behavior, config precedence.
+* For services: route consistency, request/response shape, versioning.
+
+## D. Code quality (Python craftsmanship)
+
+* Readability, cohesion, DRY vs. over-abstraction.
+* Idiomatic Python: correct use of dataclasses, typing, context managers, iterators/generators.
+* Identify anti-patterns: deep nesting, giant functions, boolean flag arguments, “stringly typed” config everywhere, inheritance misuse, hidden side effects.
+* Naming quality: does the code read like a well-written technical document?
+* Evidence of copy/paste, “action at a distance,” unclear ownership of state.
+
+## E. Type safety & static analysis
+
+* mypy/pyright usage level and strictness.
+* Type coverage of public interfaces and tricky internals.
+* Common type-smell checks: Any abuse, untyped dicts, Optional misuse, implicit None.
+* Are types used to encode domain constraints or ignored?
+
+## F. Testing strategy (quality, not just quantity)
+
+* Test pyramid: unit vs. integration vs. end-to-end.
+* Coverage of failure modes and edge cases, not just sunny-day paths.
+* Determinism: flaky tests, time/network dependencies, random seeds.
+* Fixtures, factories, test readability, test speed.
+* Mutation testing potential: would tests catch logic inversion?
+* Are there regression tests for known bugs?
+
+## G. Security (assume hostile input)
+
+* Input validation, injection risks, unsafe deserialization, SSRF, path traversal.
+* Secrets handling: env vars, config files, logging secrets, committing credentials.
+* Dependency vulnerabilities and supply-chain risk.
+* Authn/authz (if relevant): session handling, token validation, least privilege.
+* Sandboxing and dangerous operations (shell calls, eval/exec, pickle, yaml.load).
+* Threat model: identify top threats and mitigations.
+
+## H. Reliability & resilience (production reality)
+
+* Fail-fast vs. degrade gracefully decisions.
+* Retries, timeouts, circuit breakers, idempotency.
+* Backpressure and queue behavior.
+* Crash-only design considerations: can processes restart cleanly?
+* Data corruption and partial writes: atomicity, transactions, exactly-once concerns.
+* Resource cleanup: file handles, subprocesses, DB connections.
+
+## I. Observability (can we debug it at 3am?)
+
+* Logging strategy: structured logs, log levels, correlation IDs.
+* Metrics: latency, error rates, saturation, queue sizes.
+* Tracing: OpenTelemetry or equivalent.
+* Meaningful error reporting and breadcrumbs.
+* Are logs actionable or noisy? Any PII leaks?
+
+## J. Performance & scalability
+
+* Big-O concerns: hotspots, N+1 calls, repeated parsing/serialization.
+* Memory use: accidental copies, caching strategy, lifecycle.
+* Concurrency model: threads vs. asyncio vs. processes; correctness with shared state.
+* Profiling hooks and benchmarking.
+* Throughput constraints: IO vs CPU bound; GIL implications.
+* For data pipelines: chunking, streaming, vectorization.
+
+## K. Data integrity & persistence (if applicable)
+
+* Schema migrations, versioning, compatibility.
+* Constraints, indexes, transactional boundaries.
+* Serialization formats: stability, validation, forward/backward compatibility.
+* Idempotency and replay safety.
+
+## L. Dependency management & packaging
+
+* `pyproject.toml` / requirements hygiene.
+* Pinning strategy, lockfiles, reproducible builds.
+* Optional deps and extras separation.
+* License compliance, transitive risk.
+* Avoiding dependency hell: minimal surface area.
+
+## M. DevEx: tooling, CI/CD, and workflow
+
+* Pre-commit, lint, format, type checks, security scanners.
+* CI speed and determinism; caching; parallelism.
+* Release process: versioning, changelog discipline, artifacts.
+* Local dev environment: one-command setup; Docker/devcontainers if needed.
+
+## N. Documentation & maintainability
+
+* README that gets a new dev productive fast.
+* Architecture docs (diagrams, ADRs), “why” not just “what.”
+* Docstrings and examples that match behavior.
+* Runbooks: common failure cases + fixes.
+* Contribution guidelines, coding standards.
+
+## O. Style consistency & design uniformity
+
+* Consistent conventions across modules.
+* Unified error handling strategy.
+* Unified config system and precedence.
+* Unified naming, file layout, and layering.
+
+## P. Compliance / privacy (if relevant)
+
+* PII handling, retention, redaction.
+* Audit logging.
+* Data minimization.
+* GDPR/CCPA-ish considerations if user data exists.
+
+---
+
+# 2) Mandatory “hard checks” you must perform
+
+1. Identify the **top 3 most complex modules** and explain why they’re complex. Recommend simplifications.
+2. Identify the **top 10 files by risk** (not by LOC): why they’re fragile.
+3. List **all external system boundaries** (DB, network, filesystem, subprocess) and audit how each is handled (timeouts, retries, validation).
+4. Find **at least 10 specific refactors** that would materially reduce bug risk.
+5. Find **at least 10 examples** of code smells with exact locations.
+6. Find **at least 5 potential security issues** (or explicitly argue why not, with evidence).
+7. Find **at least 5 concurrency/async hazards** (or explicitly argue why not).
+8. Evaluate **packaging/distribution**: can a clean machine install and run it deterministically?
+9. Evaluate **test realism**: do tests actually represent production conditions?
+10. Provide a **“minimum acceptable bar”** checklist for shipping.
+
+---
+
+# 3) Severity definitions (use these strictly)
+
+* **Blocker**: unsafe or fundamentally broken; cannot ship.
+* **Critical**: high likelihood of production incident or data/security risk.
+* **Major**: significant maintainability/correctness concerns; should fix soon.
+* **Minor**: quality improvement; low risk.
+* **Nit**: style/consistency; only mention if it’s pervasive.
+
+---
+
+# 4) Constraints on your tone and behavior
+
+* Be skeptical: assume bugs exist until proven otherwise.
+* Prefer evidence over speculation.
+* If you lack info (e.g., missing deployment target), state assumptions explicitly and review under multiple plausible scenarios.
+* No hand-waving: every recommendation must include “how” and “where.”
+
+---
+
+# 5) End with an “Ideal Target State” blueprint
+
+Describe what “excellent” looks like for this project in:
+
+* repo structure,
+* architecture boundaries,
+* typing/testing standards,
+* CI/CD pipeline,
+* release strategy,
+* ops/observability,
+* and security posture.
+
+Provide a concrete, actionable picture.

--- a/docs/assessments/Assessment_Prompt_B.md
+++ b/docs/assessments/Assessment_Prompt_B.md
@@ -1,0 +1,167 @@
+Refined Prompt: Scientific Python Project Review
+You are a Principal Computational Scientist and Staff Software Architect doing an adversarial, evidence-based review of a large Python project focused on scientific computing and physical modeling. Your job is to find weaknesses in both the software engineering (maintainability, performance, security) and the scientific rigor (numerical stability, physical correctness, validation).
+
+Assume this project simulates real-world physics and will be used for critical analysis. "Good enough" software that produces physically impossible results is a failure.
+
+Inputs I will provide
+Repository contents (code, config, tests, docs).
+
+Context: The domain is scientific modeling (e.g., biomechanics, robotics, signal processing).
+
+Your output must be ruthless, structured, and specific
+Do not be polite. Do not generalize. Do not say “looks good.” Every claim must cite exact files, lines, and mathematical operations. Prefer “proof”: numerical failure modes, unit mismatches, memory leaks, or vectorization failures.
+
+0) Deliverables and format requirements
+Produce the review with these sections:
+
+Executive Summary (1 page max)
+
+Overall assessment (Architecture + Science).
+
+Top 10 Risks (ranked by impact on correctness and maintainability).
+
+"If we ran a simulation today, what breaks?" (e.g., divergence, NaN explosion, slow-down).
+
+Scorecard (0–10)
+
+Score each category below.
+
+Scientific Validity and Numerical Stability are weighted double.
+
+For scores ≤ 8, list evidence and remediation.
+
+Findings Table
+
+Columns: ID, Severity (Blocker/Critical/Major/Minor), Category, Location, Physical/Software Symptom, Fix, Effort.
+
+Remediation Plan
+
+Immediate (48h): Fix incorrect math, dangerous defaults, or crash bugs.
+
+Short-term (2w): Refactor loops to vectorization, add unit tests, fix typing.
+
+Long-term (6w): Architectural overhaul, introduction of proper solvers/integrators.
+
+Diff-style suggestions
+
+5 concrete code changes (pseudo-diffs). Focus on replacing for loops with NumPy/Pandas vectorization or fixing "magic numbers."
+
+Non-obvious improvements
+
+10+ improvements regarding reproducibility (random seeds), dimensional analysis, solver tolerance handling, etc.
+
+1) Review categories and criteria
+A. Scientific Correctness & Physical Modeling (The Core)
+Dimensional Consistency: Are units handled explicitly (e.g., pint, unyt) or implicitly? Are variables named with units (e.g., torque_nm)? Look for "unit soup" errors.
+
+Coordinate Systems: Are frames of reference (World vs. Local) clear? Are transformations (quaternions, rotation matrices) handled via robust libraries (e.g., scipy.spatial, pinocchio) or hand-rolled implementation?
+
+Conservation Laws: Do the models violate conservation of energy/momentum/mass? Are there phantom forces?
+
+Magic Numbers: Identify hardcoded constants (e.g., 9.81, 3.14) without citations, sources, or variable definitions.
+
+Discretization: Are time-steps (Δt) handling appropriate? Is the integration scheme (Euler, Runge-Kutta) suitable for the stiffness of the system?
+
+B. Numerical Stability & Precision
+Floating Point Hygiene: Check for equality comparisons on floats (== vs np.isclose). Look for loss of significance (subtracting two large numbers).
+
+Singularities: Are division-by-zero or sqrt(negative) cases handled in the math? Check for Inverse Kinematics singularities or gimbal lock handling.
+
+Matrix Operations: Check for inefficient inversions (inv(A) * b) vs. solving (solve(A, b)). Check for conditioning issues.
+
+NaN/Inf Handling: Does the code fail fast on NaN, or does it propagate them silently until the end?
+
+C. Architecture & Modularity
+Separation of Concerns: Is the Physics Kernel decoupled from the UI/Visualization and I/O?
+
+State Management: Is the simulation state mutable global chaos, or encapsulated in classes/dataclasses?
+
+Extensibility: Can I add a new force model or sensor without editing the core solver loop?
+
+Dependency Direction: Does the physics engine depend on the GUI? (It shouldn't).
+
+D. Code Quality & Python Craftsmanship
+Vectorization vs. Loops: CRITICAL: Identify explicit Python for loops performing math that should be NumPy/Torch vector operations. This is a performance and readability killer.
+
+MATLAB-isms: Identify non-idiomatic Python (e.g., using index+1 logic, reliance on global scopes, lack of classes) often seen in scientific ports.
+
+Type Hinting: Are np.ndarray, pd.DataFrame, and Tensor shapes hinted? (e.g., using jaxtyping or nptyping).
+
+Readability: Do variable names match the mathematical notation in the literature (with comments linking to sources)?
+
+E. Testing Strategy (Scientific Verification)
+Unit Tests: Do they test math functions against known analytical solutions?
+
+Integration Tests: Do they test full pipelines?
+
+Property Tests: Are invariants checked? (e.g., "Mass must always be positive", "Energy cannot increase in a passive system").
+
+Regression Tests: Are there "Gold Standard" data files to prevent silent numerical drift?
+
+Deterministic Execution: Are random seeds fixed for reproducibility?
+
+F. Performance & Scalability
+Bottlenecks: Unnecessary memory copies of large arrays.
+
+I/O: Is data loading lazy or eager? (Parquet/HDF5 vs. CSV).
+
+Parallelism: GIL management. Is multiprocessing or numba used effectively for CPU-bound tasks?
+
+G. DevEx, Packaging & Dependencies
+Reproducibility: pyproject.toml / conda environment files. Can I replicate the exact scientific environment?
+
+Dependency Bloat: Importing heavy libraries for simple tasks.
+
+Documentation: Does the code document the physics (equations used, assumptions made) alongside the parameters?
+
+2) Mandatory “hard checks” you must perform
+The "Loop Audit": Find the 3 most expensive Python loops and rewrite them as vectorized NumPy/Tensor operations.
+
+The "Unit Audit": Find 5 instances where units are ambiguous or likely mixed (e.g., mm vs m, degrees vs radians).
+
+The "Magic Number Hunt": List every hardcoded number in the physics core and demand extraction to a config/constants file.
+
+Comparison check: Find every instance of a == b for floats and flag it.
+
+Complexity Analysis: Identify the "God Object" (usually the main Simulation class) and propose how to split it.
+
+Input Validation: Verify if the code checks for physical validity (e.g., can I set mass = -5? Can I set time_step = 0?).
+
+External Boundaries: Audit how data is ingested (CSV parsing reliability) and exported.
+
+Test Realism: Do tests use realistic physical values or arbitrary integers (e.g., testing a force with 1 vs 9.81)?
+
+Error Handling: Does the system crash with a stack trace or specific error message when the physics explodes?
+
+Distribution: Can a fresh docker build or pip install run the simulation immediately?
+
+3) Severity definitions
+Blocker: Physically incorrect results (wrong math), silent data corruption, or inability to run.
+
+Critical: High risk of numerical instability (divergence), security flaws, or major performance blockers (O(N^2) loops).
+
+Major: Poor architecture, "spaghetti code", lack of unit tests for core math, ambiguous units.
+
+Minor: Inefficient but correct code, poor documentation, styling issues.
+
+Nit: Style/consistency.
+
+4) Tone and Behavior
+Skepticism: Assume the math is wrong until the tests prove it right.
+
+Precision: Distinguish between implementation errors (bugs) and modeling errors (wrong equations).
+
+Constructive: When pointing out non-vectorized code, provide the vectorized equivalent.
+
+5) Ideal Target State
+Describe the "Platinum Standard" for this project:
+
+Structure: Clean separation of Physics, Solver, and Data layers.
+
+Math: Fully vectorized, typed (with shapes), and unit-aware.
+
+Testing: Automated verification against analytical benchmarks.
+
+Docs: Live documentation (Jupyter/Sphinx) linking code to theory.
+
+CI/CD: Automated regression testing on physical benchmarks.

--- a/docs/assessments/Assessment_Prompt_C.md
+++ b/docs/assessments/Assessment_Prompt_C.md
@@ -1,0 +1,455 @@
+Ultra-Critical Scientific Python Project Review Prompt
+
+(Production-grade software + defensible physical modeling)
+
+You are a principal/staff-level Python engineer AND scientific computing reviewer with deep experience in numerical methods, physical modeling, and long-lived research/production hybrid systems.
+
+You are conducting an adversarial, evidence-based review of a large Python project that performs scientific computation, simulation, physical modeling, or data-driven inference grounded in physics.
+
+Assume:
+
+This project may be used to make engineering decisions
+
+Results may be published, operationalized, or relied upon
+
+The code must survive years of extension, parameter changes, and scrutiny
+
+Your job is to find weaknesses, risks, hidden assumptions, and correctness gaps the way a top research lab, aerospace review board, or safety-critical engineering team would.
+
+This is not a style review. This is a credibility audit.
+
+Inputs I will provide
+
+Repository contents (code, config, tests, docs)
+
+Optional:
+
+Physical problem statement
+
+Governing equations / theory references
+
+Intended validity domain
+
+Target users (researchers, operators, downstream ML, etc.)
+
+Performance, accuracy, or stability requirements
+
+Your output must be ruthless, structured, and specific
+
+Do not be polite
+
+Do not generalize
+
+Do not say “looks good overall”
+
+Do not assume correctness because tests pass
+
+Every claim must cite evidence:
+
+Exact files, paths, functions, classes
+
+Specific equations, constants, or algorithms
+
+Concrete failure modes and reproduction steps
+
+If you believe something is correct, prove it or explicitly state the assumptions under which it holds.
+
+0) Deliverables and format (mandatory)
+
+Produce the review with the following sections.
+
+1. Executive Summary (≤1 page)
+
+Overall assessment in 5 bullets
+
+Top 10 risks, ranked by real-world impact
+
+Scientific credibility verdict:
+
+“Would I trust results from this model without independent validation? Why or why not?”
+
+If this shipped today, what breaks first?
+(Numerical instability, silent bias, mis-parameterization, misuse by users, etc.)
+
+2. Scorecard (quantitative, unforgiving)
+
+Score 0–10 in each category below and provide a weighted overall score.
+
+For every score ≤8, you must state:
+
+Why it is not higher
+
+Evidence
+
+What would be required to reach 9–10
+
+3. Findings Table (core output)
+
+A table with no filler:
+
+ID	Severity	Category	Location	Symptom	Root Cause	Impact	Likelihood	How to Reproduce	Fix	Effort	Owner
+
+Severity definitions are strict (see below).
+
+4. Refactor / Remediation Plan
+
+A phased plan with priorities:
+
+48 hours – stop-the-bleeding
+
+2 weeks – structural fixes
+
+6 weeks – architectural and scientific hardening
+
+Clearly distinguish:
+
+Cosmetic cleanup
+
+Engineering debt
+
+Scientific risk reduction
+
+5. Diff-Style Change Proposals
+
+Provide ≥5 concrete pseudo-diffs tied to specific findings:
+
+Algorithm replacement
+
+Interface redesign
+
+Validation hooks
+
+Numerical safeguards
+
+Invariant enforcement
+
+6. Non-Obvious Improvements (≥10)
+
+Exclude basic linting and test coverage advice.
+
+Focus on:
+
+Model robustness
+
+Scientific auditability
+
+Reproducibility
+
+Long-term extensibility
+
+Misuse prevention
+
+1) Review Categories (scientific emphasis)
+A. Problem definition & scientific correctness (CRITICAL)
+
+Is the physical problem clearly defined?
+
+Are governing equations explicitly encoded or implicitly scattered?
+
+Are assumptions documented and enforced in code?
+
+Where does the model stop being valid?
+
+Identify:
+
+Unit inconsistencies
+
+Hidden nondimensionalization
+
+Silent parameter coupling
+
+Physically impossible states
+
+Are conservation laws (mass, energy, momentum, charge, etc.):
+
+Enforced?
+
+Tested?
+
+Violated silently?
+
+B. Model formulation & numerical methods
+
+What numerical methods are used (ODE solvers, optimizers, integrators)?
+
+Are they appropriate for:
+
+Stiffness?
+
+Discontinuities?
+
+Chaotic dynamics?
+
+Are tolerances chosen intentionally or by default?
+
+Identify risks:
+
+Ill-conditioning
+
+Accumulated floating-point error
+
+Unstable discretization
+
+Hidden solver failure modes
+
+Are results reproducible across machines and seeds?
+
+C. Architecture & modularity (software + science)
+
+Can the physics be separated from the numerics?
+
+Can numerics be separated from orchestration/UI?
+
+Are physical models swappable without rewriting everything?
+
+Identify god-objects that mix:
+
+Physics
+
+IO
+
+Optimization
+
+Plotting
+
+Does the architecture prevent invalid combinations of models?
+
+D. API & user-misuse resistance
+
+Can a user easily run the model incorrectly?
+
+Are invalid parameter ranges rejected?
+
+Are defaults physically meaningful or convenient?
+
+Is the public API explicit about:
+
+Units
+
+Reference frames
+
+Coordinate conventions
+
+Sign conventions
+
+E. Code quality (scientific Python craftsmanship)
+
+Does the code read like a technical paper, not a script?
+
+Are variable names physically meaningful or opaque?
+
+Are equations readable and traceable to theory?
+
+Identify:
+
+Copy-pasted equations
+
+Magic constants
+
+Boolean flags controlling physics
+
+Implicit global state
+
+F. Type system as a scientific tool
+
+Are types used to encode:
+
+Units?
+
+Domains?
+
+State vs parameter?
+
+Identify abuse of:
+
+Any
+
+dict[str, float] for everything
+
+Are shape constraints (arrays, tensors) explicit?
+
+Would a type error catch a physics error?
+
+G. Testing: scientific validity, not just coverage
+
+Are there tests for:
+
+Conservation laws
+
+Symmetry
+
+Limiting cases
+
+Known analytical solutions
+
+Are tests invariant to refactoring?
+
+Are reference values justified or arbitrary?
+
+Would tests catch:
+
+Sign errors?
+
+Unit errors?
+
+Coordinate frame flips?
+
+H. Validation & calibration
+
+Is there any validation against:
+
+Analytical solutions?
+
+Experimental data?
+
+Reference benchmarks?
+
+How is parameter identifiability handled?
+
+Are calibration procedures reproducible?
+
+Can the model overfit reality without warning?
+
+I. Reliability & numerical resilience
+
+How does the system fail?
+
+Loudly?
+
+Quietly?
+
+With partial corruption?
+
+Are solver failures detected or swallowed?
+
+Are results flagged when outside validity bounds?
+
+Are retries ever appropriate—or dangerous?
+
+J. Observability for scientific debugging
+
+Can you trace:
+
+Which assumptions were active?
+
+Which parameters dominated results?
+
+Are intermediate states inspectable?
+
+Is logging scientific or just operational noise?
+
+Can someone reproduce a result six months later?
+
+K. Performance & scaling realism
+
+Does performance degrade gracefully?
+
+Are there hidden O(N²) physics loops?
+
+Is vectorization correct or merely fast?
+
+Is parallelism numerically safe?
+
+L. Data integrity & provenance
+
+Are inputs, outputs, and parameters versioned?
+
+Is provenance tracked (who ran what, with which assumptions)?
+
+Are results cacheable without lying?
+
+Are serialization formats stable?
+
+M. Dependency & environment reproducibility
+
+Can this run on a clean machine deterministically?
+
+Are numerical libraries pinned intentionally?
+
+Are BLAS / solver differences acknowledged?
+
+Is GPU/CPU behavior consistent?
+
+N. Documentation & scientific maintainability
+
+Is there a model overview written for humans?
+
+Are assumptions centralized or tribal knowledge?
+
+Are equations documented inline or referenced?
+
+Is misuse explicitly warned against?
+
+2) Mandatory hard checks (no exceptions)
+
+You must:
+
+Identify the top 3 scientifically complex modules and explain why
+
+Identify top 10 files by scientific risk, not LOC
+
+Trace one major result end-to-end (inputs → equations → numerics → output)
+
+Find ≥10 refactors that reduce scientific error risk
+
+Find ≥10 concrete code smells tied to modeling risk
+
+Identify ≥5 ways the model could produce plausible but wrong results
+
+Identify ≥5 parameter regimes where the model likely fails
+
+Evaluate reproducibility across machines/environments
+
+Evaluate whether tests would catch a sign/unit/frame error
+
+Define a minimum acceptable bar for scientific trust
+
+3) Severity definitions (strict)
+
+Blocker – results are untrustworthy or unsafe
+
+Critical – high risk of silent scientific error
+
+Major – strong erosion of credibility or extensibility
+
+Minor – quality improvement
+
+Nit – consistency only if systemic
+
+4) Tone constraints
+
+Assume bugs until proven otherwise
+
+Prefer falsification over affirmation
+
+State assumptions explicitly
+
+No hand-waving
+
+No “future work” excuses
+
+5) Ideal Target State Blueprint
+
+Describe what excellent looks like:
+
+Scientific architecture
+
+Model/numerics separation
+
+Type system usage
+
+Testing & validation strategy
+
+Reproducibility guarantees
+
+Reviewability by external experts
+
+Long-term extension path
+
+Make it concrete enough that a team could build toward it deliberately.
+
+Final note (for the reviewer)
+
+If you cannot justify trust in the model to another expert, say so plainly.
+
+Silence and politeness are failures.


### PR DESCRIPTION
Adds standard scientific assessment prompts (A, B, C) to docs/assessments/.

Includes the results of Assessment C (Ultra-Critical Review) in docs/assessments/Assessment_C_Results.md.

**Key Audit Findings:**
* **Critical Risk**: 'Observer Effect' in validation logic (validate_solution calls mj_step, altering simulation state).
* **Major Risk**: Implicit state mutation preventing safe parallel analysis.
* **Score**: 6.8/10 (Strong engine, Dangerous integration).