### PR TITLE
Fix mypy type error for pytestmark reassignment

### DIFF
--- a/tests/integration/test_c3d_workflow.py
+++ b/tests/integration/test_c3d_workflow.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 
 # Mark all tests in this file as integration tests
-pytestmark = pytest.mark.integration
+pytestmark: list[pytest.MarkDecorator] = [pytest.mark.integration]
 
 # Add source path for imports
 # Adjust based on repository root


### PR DESCRIPTION
Change pytestmark from a single MarkDecorator to a list from the start, preventing "Incompatible types in assignment" error when conditionally reassigning to a list in the PYQT6_AVAILABLE check.

## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added
