### PR TITLE
chore: update CI workflows to use main branch

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,7 +1,7 @@
 name: Auto-Update PRs
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -1,7 +1,7 @@
 name: CI Standard
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Update branch references from master to main after branch rename

## Test plan
- CI workflows should trigger on main branch instead of master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflows now target `main`**
> 
> - Updated `push` branch filters in `auto-update-prs.yml` and `ci-standard.yml` to use `main` (removed `master`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e85f73180ccc123bce7402bf88d7946bd7ab1e31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->