### PR TITLE
Fix Module Reload Corruption in Tests

### DIFF
--- a/engines/physics_engines/myosuite/python/muscle_analysis.py
+++ b/engines/physics_engines/myosuite/python/muscle_analysis.py
@@ -370,7 +370,7 @@ class MyoSuiteMuscleAnalyzer:
             mujoco.mj_fullM(self.model, M, self.data.qM)
         except (TypeError, AttributeError):
             # Handle mocked objects - return identity matrix as fallback
-            M = np.eye(nv_int)
+            M = np.eye(nv_int)  # type: ignore[assignment]
 
         # Get muscle torques
         muscle_torques = self.compute_muscle_joint_torques()

--- a/shared/python/ai/types.py
+++ b/shared/python/ai/types.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-
-UTC = timezone.utc
 from enum import Enum, auto
 from typing import Any
+
+UTC = timezone.utc  # noqa: UP017
 
 
 class ExpertiseLevel(Enum):

--- a/shared/python/ai/workflow_engine.py
+++ b/shared/python/ai/workflow_engine.py
@@ -19,14 +19,14 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-
-UTC = timezone.utc
 from enum import Enum, auto
 from typing import Any
 
 from shared.python.ai.exceptions import WorkflowError
 from shared.python.ai.tool_registry import ToolRegistry
 from shared.python.ai.types import ConversationContext, ExpertiseLevel, ToolResult
+
+UTC = timezone.utc  # noqa: UP017
 
 logger = logging.getLogger(__name__)
 

--- a/shared/python/impact_model.py
+++ b/shared/python/impact_model.py
@@ -331,8 +331,8 @@ class SpringDamperImpactModel(ImpactModel):
                 break
             else:
                 # Pre-contact: advance positions
-                x_ball = x_ball + v_ball * self.dt
-                x_club = x_club + v_club * self.dt
+                x_ball = x_ball + v_ball * self.dt  # type: ignore[assignment]
+                x_club = x_club + v_club * self.dt  # type: ignore[assignment]
                 # Don't increment contact_time here, it's only for contact duration
 
                 # Check if we've reached the ball

--- a/tests/integration/isolated/test_drake_strict.py
+++ b/tests/integration/isolated/test_drake_strict.py
@@ -1,8 +1,7 @@
-
 import logging
 from unittest.mock import MagicMock, patch
+
 import numpy as np
-import pytest
 
 # --- Global Mocking Setup (Duplicated for Isolation) ---
 mock_pydrake = MagicMock()
@@ -23,32 +22,34 @@ module_patches = {
 mock_pydrake.DiagramBuilder = MagicMock()
 mock_pydrake.systems.framework.DiagramBuilder = mock_pydrake.DiagramBuilder
 
+
 class TestDrakeStrict:
     def setup_method(self):
         """Inject mock pydrake into the module namespace."""
         # Use patch.dict context for the import to apply patches
         with patch.dict("sys.modules", module_patches):
             # We must import inside the patch context to ensure the module picks up the mocks
-            # Note: In an isolated process, we don't strictly need reload(), 
+            # Note: In an isolated process, we don't strictly need reload(),
             # but we do need to ensure duplicate imports don't mess things up if run repeatedly.
             import engines.physics_engines.drake.python.drake_physics_engine as mod
-            
+
             # Since we are in a fresh process (ideally), just importing might be enough.
             # But the 'mod' variable scope is what we need.
             pass
 
         # Re-import to capture reference (it will use the sys.modules cache we just populated/patched?)
-        # Actually, simpler: define the class execution *inside* the patch if possible, 
+        # Actually, simpler: define the class execution *inside* the patch if possible,
         # or just rely on sys.modules remaining patched if we don't exit context?
         # The correct way for this test harness:
-        
+
         self.patcher = patch.dict("sys.modules", module_patches)
         self.patcher.start()
-        
+
         import engines.physics_engines.drake.python.drake_physics_engine as mod
+
         self.mod = mod
         self.DrakePhysicsEngine = mod.DrakePhysicsEngine
-        
+
         # Test Constants
         self.TEST_LINEAR_VAL = 1.0
         self.TEST_ANGULAR_VAL = 2.0

--- a/tests/integration/isolated/test_pinocchio_strict.py
+++ b/tests/integration/isolated/test_pinocchio_strict.py
@@ -1,8 +1,6 @@
-
-import logging
 from unittest.mock import MagicMock, patch
+
 import numpy as np
-import pytest
 
 # --- Global Mocking Setup (Duplicated for Isolation) ---
 mock_pinocchio = MagicMock()
@@ -12,16 +10,18 @@ module_patches = {
     "pinocchio": mock_pinocchio,
 }
 
+
 class TestPinocchioStrict:
     def setup_method(self):
         """Inject mock pinocchio into the module namespace."""
         self.patcher = patch.dict("sys.modules", module_patches)
         self.patcher.start()
-        
+
         import engines.physics_engines.pinocchio.python.pinocchio_physics_engine as mod
+
         self.mod = mod
         self.PinocchioPhysicsEngine = mod.PinocchioPhysicsEngine
-        
+
         # Test Constants
         self.TEST_LINEAR_VAL = 1.0
         self.TEST_ANGULAR_VAL = 2.0

--- a/tests/integration/test_energy_conservation.py
+++ b/tests/integration/test_energy_conservation.py
@@ -137,7 +137,7 @@ class TestEnergyConservation:
         # Verify energy conservation
         energies: np.ndarray[tuple[int], np.dtype[np.floating]] = np.array(
             energies_list
-        )
+        )  # type: ignore[assignment]
         energy_variation = np.std(energies) / np.abs(np.mean(energies))
 
         assert energy_variation < TOLERANCE_ENERGY_CONSERVATION, (
@@ -291,7 +291,7 @@ class TestEnergyConservation:
         # Compute dE/dt numerically (central difference)
         energies: np.ndarray[tuple[int], np.dtype[np.floating]] = np.array(
             energies_list
-        )
+        )  # type: ignore[assignment]
         de_dt_numeric = np.gradient(energies, dt)
 
         # Compare with actuator power
@@ -359,7 +359,7 @@ class TestConservationLaws:
         # Verify angular momentum magnitude is conserved
         angular_momenta: np.ndarray[tuple[int], np.dtype[np.floating]] = np.array(
             angular_momenta_list
-        )
+        )  # type: ignore[assignment]
         momentum_variation = np.std(angular_momenta) / np.mean(angular_momenta)
 
         assert momentum_variation < 1e-3, (

--- a/tests/integration/test_physics_engines_strict.py
+++ b/tests/integration/test_physics_engines_strict.py
@@ -8,11 +8,9 @@ to ensure it can run in any CI environment to verify LOGIC and PROTOCOL complian
 needing heavy binary dependencies.
 """
 
-import logging
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
 
 # --- Global Mocking Setup ---
 # We must mock these libs BEFORE importing the engines, because some engines
@@ -147,9 +145,6 @@ class TestMuJoCoStrict:
 
         sensors = engine.get_sensors()
         assert sensors["sensor_0"] == 0.123
-
-
-
 
 
 class TestOpenSimStrict:

--- a/tests/integration/test_process_isolation_strict.py
+++ b/tests/integration/test_process_isolation_strict.py
@@ -1,4 +1,3 @@
-
 """Process Isolation Tests for Strict Physics Engine Protocols.
 
 This module executes strict unit tests for aggressive engines (Drake, Pinocchio)
@@ -8,13 +7,15 @@ C-extension mocking/reloading within a single pytest session (Issue #496).
 
 import subprocess
 import sys
-import pytest
 from pathlib import Path
+
+import pytest
 
 # Paths to the isolated test files
 ISOLATED_TESTS_DIR = Path(__file__).parent / "isolated"
 TEST_DRAKE_STRICT = ISOLATED_TESTS_DIR / "test_drake_strict.py"
 TEST_PINOCCHIO_STRICT = ISOLATED_TESTS_DIR / "test_pinocchio_strict.py"
+
 
 class TestProcessIsolationStrict:
     """Run specific strict tests in isolated subprocesses."""
@@ -22,15 +23,15 @@ class TestProcessIsolationStrict:
     def run_isolated_test(self, test_file: Path):
         """Helper to run pytest on a single file in a subprocess."""
         cmd = [sys.executable, "-m", "pytest", str(test_file), "-v", "--no-cov"]
-        
+
         # Capture output to help debugging if it fails
         result = subprocess.run(
-            cmd, 
-            capture_output=True, 
-            text=True, 
-            check=False # We check returncode manually for better error reporting
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,  # We check returncode manually for better error reporting
         )
-        
+
         if result.returncode != 0:
             pytest.fail(
                 f"Isolated test {test_file.name} failed with exit code {result.returncode}.\n"

--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -1,29 +1,38 @@
+import sys
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from unittest.mock import MagicMock, patch, Mock
-import sys
-from shared.python.ai.types import ConversationContext, ExpertiseLevel, ToolCall, AgentResponse
-from shared.python.ai.exceptions import AIProviderError
+
+from shared.python.ai.types import (
+    ConversationContext,
+    ExpertiseLevel,
+)
 
 # Mock modules
 mock_openai_module = MagicMock()
 mock_anthropic_module = MagicMock()
 
+
 @pytest.fixture
 def mock_openai_adapter():
     with patch.dict(sys.modules, {"openai": mock_openai_module}):
         from shared.python.ai.adapters.openai_adapter import OpenAIAdapter
+
         yield OpenAIAdapter(api_key="test-key")
+
 
 @pytest.fixture
 def mock_anthropic_adapter():
     with patch.dict(sys.modules, {"anthropic": mock_anthropic_module}):
         from shared.python.ai.adapters.anthropic_adapter import AnthropicAdapter
+
         yield AnthropicAdapter(api_key="test-key")
+
 
 @pytest.fixture
 def context():
     return ConversationContext(user_expertise=ExpertiseLevel.BEGINNER)
+
 
 class TestOpenAIAdapter:
     def test_initialization(self, mock_openai_adapter):
@@ -34,14 +43,14 @@ class TestOpenAIAdapter:
         client = mock_openai_adapter._get_client()
         assert client is not None
         mock_openai_module.OpenAI.assert_called_once()
-        
+
     def test_validate_connection_success(self, mock_openai_adapter):
         client_mock = mock_openai_adapter._get_client()
         # Mock models list
         model_mock = Mock()
         model_mock.id = "gpt-4-turbo-preview"
         client_mock.models.list.return_value.data = [model_mock]
-        
+
         success, msg = mock_openai_adapter.validate_connection()
         assert success is True
         assert "Connected" in msg
@@ -51,14 +60,15 @@ class TestOpenAIAdapter:
         mock_response = Mock()
         mock_response.choices = [Mock(message=Mock(content="Hello", tool_calls=None))]
         client_mock.chat.completions.create.return_value = mock_response
-        
+
         response = mock_openai_adapter.send_message("Hi", context, [])
         assert response.content == "Hello"
-        
+
         # Verify call args
         call_kwargs = client_mock.chat.completions.create.call_args.kwargs
         assert call_kwargs["model"] == "gpt-4-turbo-preview"
-        assert len(call_kwargs["messages"]) >= 2 # System + User
+        assert len(call_kwargs["messages"]) >= 2  # System + User
+
 
 class TestAnthropicAdapter:
     def test_initialization(self, mock_anthropic_adapter):
@@ -70,7 +80,7 @@ class TestAnthropicAdapter:
         mock_response = Mock()
         mock_response.content = "Response"
         client_mock.messages.create.return_value = mock_response
-        
+
         success, msg = mock_anthropic_adapter.validate_connection()
         assert success is True
 
@@ -78,15 +88,15 @@ class TestAnthropicAdapter:
         # Add messages that are sequential same role
         context.add_user_message("msg1")
         # format_messages adds the current message "msg2" at the end
-        
+
         msgs = mock_anthropic_adapter._format_messages(context, "msg2")
-        
+
         # Should merge msg1 and msg2 into one user block or ensure proper structure
         # Implementation details: _format_messages processes history then adds current.
         # History: [User(msg1)]
         # Total: [User(msg1), User(msg2)]
         # _ensure_alternating_roles should merge them.
-        
+
         assert len(msgs) == 1
         assert "msg1" in msgs[0]["content"]
         assert "msg2" in msgs[0]["content"]

--- a/tests/test_injury_risk.py
+++ b/tests/test_injury_risk.py
@@ -1,13 +1,15 @@
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock, MagicMock
+
 from shared.python.injury.injury_risk import (
-    InjuryRiskScorer,
-    RiskLevel,
-    InjuryType,
     InjuryRiskReport,
-    RiskFactor
+    InjuryRiskScorer,
+    InjuryType,
+    RiskFactor,
+    RiskLevel,
 )
+
 
 class TestInjuryRiskScorer:
     @pytest.fixture
@@ -19,11 +21,11 @@ class TestInjuryRiskScorer:
         result = Mock()
         result.peak_compression_bw = 5.0  # Caution range (4-6)
         result.peak_lateral_shear_bw = 0.8  # Caution range (0.5-1.0)
-        
+
         x_factor = Mock()
         x_factor.x_factor_stretch = 48.0  # Caution range (45-55)
         result.x_factor = x_factor
-        
+
         return result
 
     @pytest.fixture
@@ -49,27 +51,27 @@ class TestInjuryRiskScorer:
     def mock_swing_metrics(self):
         return {
             "sequence_timing_error": 0.10,  # Middle of range
-            "tempo_ratio": 3.5,            # Error of 0.5
-            "early_extension": 10.0,       # Middle of range
+            "tempo_ratio": 3.5,  # Error of 0.5
+            "early_extension": 10.0,  # Middle of range
         }
 
     @pytest.fixture
     def mock_training_load(self):
         return {
-            "acwr": 1.4,          # High (>1.3)
-            "weekly_swings": 800, # High (500-1000)
+            "acwr": 1.4,  # High (>1.3)
+            "weekly_swings": 800,  # High (500-1000)
         }
 
     def test_score_spinal_risks(self, scorer, mock_spinal_result):
         report = InjuryRiskReport()
         scorer._score_spinal_risks(mock_spinal_result, report)
-        
+
         # Verify specific risk factors were added
         factor_names = [f.name for f in scorer.risk_factors]
         assert "spinal_compression" in factor_names
         assert "spinal_shear" in factor_names
         assert "x_factor_stretch" in factor_names
-        
+
         # Verify region score calculation
         assert InjuryType.LOW_BACK in report.region_scores
         score = report.region_scores[InjuryType.LOW_BACK]
@@ -79,13 +81,13 @@ class TestInjuryRiskScorer:
     def test_score_joint_risks(self, scorer, mock_joint_results):
         report = InjuryRiskReport()
         scorer._score_joint_risks(mock_joint_results, report)
-        
+
         # Verify region scores are populated
         assert InjuryType.HIP in report.region_scores
         assert InjuryType.SHOULDER in report.region_scores
         assert InjuryType.ELBOW in report.region_scores
         assert InjuryType.WRIST in report.region_scores
-        
+
         # Verify scores match averages
         # Hip: (45 + 30) / 2 = 37.5
         assert report.region_scores[InjuryType.HIP] == 37.5
@@ -93,9 +95,9 @@ class TestInjuryRiskScorer:
     def test_score_technique_risks(self, scorer, mock_swing_metrics):
         report = InjuryRiskReport()
         scorer._score_technique_risks(mock_swing_metrics, report)
-        
+
         assert report.technique_risk_score > 0
-        
+
         factor_names = [f.name for f in scorer.risk_factors]
         assert "kinematic_sequence" in factor_names
         assert "swing_tempo" in factor_names
@@ -104,9 +106,9 @@ class TestInjuryRiskScorer:
     def test_score_training_load_risks(self, scorer, mock_training_load):
         report = InjuryRiskReport()
         scorer._score_training_load_risks(mock_training_load, report)
-        
+
         assert report.chronic_risk_score > 0
-        
+
         factor_names = [f.name for f in scorer.risk_factors]
         assert "acwr" in factor_names
         assert "weekly_swings" in factor_names
@@ -116,15 +118,15 @@ class TestInjuryRiskScorer:
         report.acute_risk_score = 60.0
         report.chronic_risk_score = 40.0
         report.technique_risk_score = 50.0
-        
+
         # Add a dummy risk factor to sort
         scorer.risk_factors = [
             RiskFactor("high_risk", 10.0, 5.0, 8.0),
-            RiskFactor("low_risk", 2.0, 5.0, 8.0)
+            RiskFactor("low_risk", 2.0, 5.0, 8.0),
         ]
-        
+
         scorer._compute_overall_scores(report)
-        
+
         # Expected: 0.5*60 + 0.3*40 + 0.2*50 = 30 + 12 + 10 = 52
         assert report.overall_risk_score == pytest.approx(52.0)
         assert report.overall_risk_level == RiskLevel.HIGH  # 50-75 range
@@ -132,32 +134,44 @@ class TestInjuryRiskScorer:
 
     def test_generate_recommendations(self, scorer):
         report = InjuryRiskReport()
-        
+
         # Add high risk factors
         scorer.risk_factors = [
-            RiskFactor("spinal_compression", 8.0, 4.0, 6.0, modifiable=True),  # High score
-            RiskFactor("elbow_stress", 60.0, 25.0, 50.0, modifiable=True)      # High score
+            RiskFactor(
+                "spinal_compression", 8.0, 4.0, 6.0, modifiable=True
+            ),  # High score
+            RiskFactor("elbow_stress", 60.0, 25.0, 50.0, modifiable=True),  # High score
         ]
         report.overall_risk_level = RiskLevel.HIGH
-        
+
         scorer._generate_recommendations(report)
-        
+
         print(f"Recommendations: {report.recommendations}")
-        
+
         assert len(report.recommendations) > 0
         # Should have specific recommendations + general advice
         assert any("spinal compression" in r.lower() for r in report.recommendations)
         assert any("elbow" in r.lower() for r in report.recommendations)
-        assert any("consult" in r.lower() and "professional" in r.lower() for r in report.recommendations)
+        assert any(
+            "consult" in r.lower() and "professional" in r.lower()
+            for r in report.recommendations
+        )
 
-    def test_full_scoring_pipeline(self, scorer, mock_spinal_result, mock_joint_results, mock_swing_metrics, mock_training_load):
+    def test_full_scoring_pipeline(
+        self,
+        scorer,
+        mock_spinal_result,
+        mock_joint_results,
+        mock_swing_metrics,
+        mock_training_load,
+    ):
         report = scorer.score(
             spinal_result=mock_spinal_result,
             joint_results=mock_joint_results,
             swing_metrics=mock_swing_metrics,
-            training_load=mock_training_load
+            training_load=mock_training_load,
         )
-        
+
         assert isinstance(report, InjuryRiskReport)
         assert report.overall_risk_score > 0
         assert len(report.recommendations) > 0

--- a/tests/test_spinal_load_analysis.py
+++ b/tests/test_spinal_load_analysis.py
@@ -1,11 +1,12 @@
-
-import pytest
 import numpy as np
+import pytest
+
 from shared.python.injury.spinal_load_analysis import (
     SpinalLoadAnalyzer,
     SpinalLoadResult,
-    SpinalRiskLevel
+    SpinalRiskLevel,
 )
+
 
 class TestSpinalLoadAnalyzer:
     @pytest.fixture
@@ -18,7 +19,7 @@ class TestSpinalLoadAnalyzer:
         time = np.linspace(0, 1.0, 100)
         zeros = np.zeros_like(time)
         ones = np.ones_like(time)
-        
+
         return {
             "time": time,
             "joint_angles": {
@@ -29,15 +30,17 @@ class TestSpinalLoadAnalyzer:
             "joint_velocities": {
                 "lumbar_flexion": zeros,
                 "lumbar_lateral": zeros,
-                "lumbar_rotation": ones * 5.0, # High velocity
+                "lumbar_rotation": ones * 5.0,  # High velocity
             },
             "joint_torques": {
-                "lumbar_flexion": ones * 100.0, # 100 Nm flexion torque
+                "lumbar_flexion": ones * 100.0,  # 100 Nm flexion torque
                 "lumbar_lateral": ones * 50.0,
                 "lumbar_rotation": ones * 80.0,
             },
             "pelvis_angles": np.zeros((100, 3)),
-            "thorax_angles": np.column_stack([zeros, zeros, ones * 0.5]), # 0.5 rad rotation diff
+            "thorax_angles": np.column_stack(
+                [zeros, zeros, ones * 0.5]
+            ),  # 0.5 rad rotation diff
         }
 
     def test_compute_segment_loads(self, analyzer, sample_data):
@@ -47,15 +50,15 @@ class TestSpinalLoadAnalyzer:
             sample_data["joint_angles"],
             sample_data["joint_velocities"],
             sample_data["joint_torques"],
-            sample_data["time"]
+            sample_data["time"],
         )
-        
+
         # Verify non-zero loads
         assert np.any(segment.compression > 0)
         assert np.any(segment.ap_shear > 0)
         assert np.any(segment.lateral_shear > 0)
         assert np.any(segment.torsion > 0)
-        
+
         # Check specific physics: Compression = Gravity + Torque/Arm
         # Muscle compression = 100 / 0.05 = 2000 N
         # Gravity > 0
@@ -65,9 +68,9 @@ class TestSpinalLoadAnalyzer:
         metrics = analyzer._compute_x_factor(
             sample_data["pelvis_angles"],
             sample_data["thorax_angles"],
-            sample_data["time"]
+            sample_data["time"],
         )
-        
+
         # rotation diff is 0.5 rad = approx 28.6 degrees
         assert metrics.x_factor_stretch == pytest.approx(np.degrees(0.5))
         assert metrics.separation_rate >= 0
@@ -76,9 +79,9 @@ class TestSpinalLoadAnalyzer:
         metrics = analyzer._compute_crunch_factor(
             sample_data["joint_angles"]["lumbar_lateral"],
             sample_data["joint_angles"]["lumbar_rotation"],
-            sample_data["time"]
+            sample_data["time"],
         )
-        
+
         # deg(0.05) * deg(0.2) / 100
         # 2.86 * 11.46 / 100 = ~0.33
         assert metrics.peak_crunch > 0
@@ -91,28 +94,28 @@ class TestSpinalLoadAnalyzer:
             sample_data["joint_torques"],
             sample_data["time"],
             sample_data["pelvis_angles"],
-            sample_data["thorax_angles"]
+            sample_data["thorax_angles"],
         )
-        
+
         assert isinstance(result, SpinalLoadResult)
         assert "L5-S1" in result.segments
         assert result.x_factor is not None
         assert result.crunch_factor is not None
-        
+
         # Risk assessment should run
         assert isinstance(result.overall_risk, SpinalRiskLevel)
-        
+
         # Cumulative loads should be computed
         assert result.cumulative_compression_impulse > 0
 
     def test_risk_assessment_thresholds(self, analyzer):
         result = SpinalLoadResult(time=np.array([0]))
-        
+
         # Case 1: Safe
         result.peak_compression_bw = 3.0
         result = analyzer._assess_risk(result)
         assert result.compression_risk == SpinalRiskLevel.SAFE
-        
+
         # Case 2: Critical
         result.peak_compression_bw = 9.0
         result = analyzer._assess_risk(result)
@@ -123,7 +126,7 @@ class TestSpinalLoadAnalyzer:
         result.overall_risk = SpinalRiskLevel.HIGH_RISK
         result.compression_risk = SpinalRiskLevel.HIGH_RISK
         result.peak_compression_bw = 7.0
-        
+
         recs = analyzer.get_recommendations(result)
         assert len(recs) > 0
         assert "compression" in recs[0].lower()

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -1,19 +1,21 @@
+from collections import namedtuple
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock, MagicMock
-from collections import namedtuple
-from shared.python.ai.workflow_engine import (
-    WorkflowEngine,
-    Workflow,
-    WorkflowStep,
-    StepStatus,
-    RecoveryStrategy,
-    ExpertiseLevel
-)
+
 from shared.python.ai.tool_registry import ToolRegistry, ToolResult
+from shared.python.ai.workflow_engine import (
+    ExpertiseLevel,
+    RecoveryStrategy,
+    StepStatus,
+    Workflow,
+    WorkflowEngine,
+    WorkflowStep,
+)
 
 # Minimal Context Mock
 Context = namedtuple("Context", ["user_id"])
+
 
 class TestWorkflowEngine:
     @pytest.fixture
@@ -32,7 +34,7 @@ class TestWorkflowEngine:
             id="test_wf",
             name="Test Workflow",
             description="Testing",
-            expertise_level=ExpertiseLevel.BEGINNER
+            expertise_level=ExpertiseLevel.BEGINNER,
         )
         wf.add_step(WorkflowStep("step1", "Step 1", "Do something"))
         wf.add_step(WorkflowStep("step2", "Step 2", "Do else"))
@@ -46,9 +48,9 @@ class TestWorkflowEngine:
     def test_start_workflow(self, engine, simple_workflow):
         engine.register_workflow(simple_workflow)
         ctx = Context(user_id="user1")
-        
+
         execution = engine.start_workflow("test_wf", ctx, initial_state={"key": "val"})
-        
+
         assert execution.workflow_id == "test_wf"
         assert execution.status == StepStatus.RUNNING
         assert execution.state["key"] == "val"
@@ -59,13 +61,13 @@ class TestWorkflowEngine:
         engine.register_workflow(simple_workflow)
         ctx = Context("user1")
         exe = engine.start_workflow("test_wf", ctx)
-        
+
         # Step 1
         res1 = engine.execute_next_step(exe)
         assert res1.step_id == "step1"
         assert res1.status == StepStatus.COMPLETED
         assert exe.current_step_index == 1
-        
+
         # Step 2
         res2 = engine.execute_next_step(exe)
         assert res2.step_id == "step2"
@@ -75,70 +77,91 @@ class TestWorkflowEngine:
 
     def test_tool_execution(self, engine, mock_registry):
         wf = Workflow("tool_wf", "Tool WF", "Desc")
-        wf.add_step(WorkflowStep(
-            id="tool_step",
-            name="Tool Step",
-            description="Run tool",
-            tool_name="my_tool",
-            tool_arguments={"arg": 1}
-        ))
+        wf.add_step(
+            WorkflowStep(
+                id="tool_step",
+                name="Tool Step",
+                description="Run tool",
+                tool_name="my_tool",
+                tool_arguments={"arg": 1},
+            )
+        )
         engine.register_workflow(wf)
-        
+
         exe = engine.start_workflow("tool_wf", Context("u1"))
         res = engine.execute_next_step(exe)
-        
+
         mock_registry.execute.assert_called_with("my_tool", {"arg": 1})
         assert res.status == StepStatus.COMPLETED
         assert res.result == "success"
 
     def test_step_failure_abort(self, engine):
         wf = Workflow("fail_wf", "Fail WF", "Desc")
-        wf.add_step(WorkflowStep(
-            id="fail_step",
-            name="Fail Step",
-            description="Will fail",
-            tool_name="bad_tool",
-            on_failure=RecoveryStrategy.ABORT
-        ))
+        wf.add_step(
+            WorkflowStep(
+                id="fail_step",
+                name="Fail Step",
+                description="Will fail",
+                tool_name="bad_tool",
+                on_failure=RecoveryStrategy.ABORT,
+            )
+        )
         engine.register_workflow(wf)
-        
+
         # Mock registry failure
         engine._tool_registry.execute.side_effect = Exception("Tool explosion")
-        
+
         exe = engine.start_workflow("fail_wf", Context("u1"))
         res = engine.execute_next_step(exe)
-        
+
         assert res.status == StepStatus.FAILED
         assert "Tool explosion" in res.error
         assert exe.status == StepStatus.FAILED
 
     def test_step_condition_skip(self, engine):
         wf = Workflow("cond_wf", "Cond WF", "Desc")
-        wf.add_step(WorkflowStep(
-            id="cond_step",
-            name="Conditional",
-            description="Maybe run",
-            condition=lambda state: state.get("run_me", False)
-        ))
+        wf.add_step(
+            WorkflowStep(
+                id="cond_step",
+                name="Conditional",
+                description="Maybe run",
+                condition=lambda state: state.get("run_me", False),
+            )
+        )
         engine.register_workflow(wf)
-        
+
         # Case 1: Skip
-        exe = engine.start_workflow("cond_wf", Context("u1"), initial_state={"run_me": False})
+        exe = engine.start_workflow(
+            "cond_wf", Context("u1"), initial_state={"run_me": False}
+        )
         res = engine.execute_next_step(exe)
         assert res.status == StepStatus.SKIPPED
-        
+
         # Case 2: Run
-        exe2 = engine.start_workflow("cond_wf", Context("u1"), initial_state={"run_me": True})
+        exe2 = engine.start_workflow(
+            "cond_wf", Context("u1"), initial_state={"run_me": True}
+        )
         res2 = engine.execute_next_step(exe2)
         assert res2.status == StepStatus.COMPLETED
 
     def test_educational_content(self, engine):
         step = WorkflowStep(
-            "edu", "Edu", "Desc",
-            educational_content={"beginner": "Learn X", "expert": "Review Y"}
+            "edu",
+            "Edu",
+            "Desc",
+            educational_content={"beginner": "Learn X", "expert": "Review Y"},
         )
-        
-        assert engine.get_step_educational_content(step, ExpertiseLevel.BEGINNER) == "Learn X"
-        assert engine.get_step_educational_content(step, ExpertiseLevel.EXPERT) == "Review Y"
+
+        assert (
+            engine.get_step_educational_content(step, ExpertiseLevel.BEGINNER)
+            == "Learn X"
+        )
+        assert (
+            engine.get_step_educational_content(step, ExpertiseLevel.EXPERT)
+            == "Review Y"
+        )
         # Fallback
-        assert engine.get_step_educational_content(step, ExpertiseLevel.INTERMEDIATE) == "Learn X"
+        assert (
+            engine.get_step_educational_content(step, ExpertiseLevel.INTERMEDIATE)
+            == "Learn X"
+        )


### PR DESCRIPTION
Isolated Drake and Pinocchio strict tests into separate processes to avoid numpy corruption caused by 'sys.modules' patching and reloading. This resolves the skipped tests in 'test_physics_engines_strict.py'.

Fixes #496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Process isolation for strict engine tests**
> 
> - Runs Drake/Pinocchio strict suites in separate processes via `tests/integration/test_process_isolation_strict.py` and new isolated tests under `tests/integration/isolated/`, avoiding NumPy/C-extension corruption
> - Simplifies `test_physics_engines_strict.py` to keep non-Drake/Pinocchio checks
> 
> **Expanded test coverage**
> 
> - Adds unit tests for AI adapters (`tests/test_ai_adapters.py`), tool registry (`tests/test_tool_registry.py`), workflow engine (`tests/test_workflow_engine.py`)
> - Introduces biomechanics tests: spinal load, joint stress, and injury risk scoring (`tests/test_spinal_load_analysis.py`, `tests/test_joint_stress.py`, `tests/test_injury_risk.py`)
> 
> **Minor code cleanups**
> 
> - Standardizes UTC to `timezone.utc` with `UTC` alias in `shared/python/ai/types.py` and `shared/python/ai/workflow_engine.py`
> - Adds type hint suppressions (`# type: ignore[assignment]`) and safe fallbacks in `muscle_analysis.py`, `impact_model.py`, and energy tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43ccd0292fd1fd0d0d51385b6b094a6ee7cd916f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->