### PR TITLE
fix: correct workflow_call syntax in Jules workflows

### DIFF
--- a/.github/workflows/Jules-Scientific-Auditor.yml
+++ b/.github/workflows/Jules-Scientific-Auditor.yml
@@ -1,5 +1,7 @@
 name: Scientific Auditor (Worker)
-on: workflow_call
+
+on:
+  workflow_call:
 
 jobs:
   audit:

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -1,5 +1,7 @@
 name: Jules Test Generator (Worker)
-on: workflow_call
+
+on:
+  workflow_call:
 
 jobs:
   generate-tests:


### PR DESCRIPTION
## Summary
Fixed inline syntax issues in 2 worker workflows that prevented proper execution when called by Jules Control Tower.

## Changes
- Jules-Test-Generator.yml
- Jules-Scientific-Auditor.yml

Changed from `on: workflow_call` (inline) to proper nested format:
```yaml
on:
  workflow_call:
```

## Reason
GitHub Actions requires nested syntax for workflow triggers. The inline syntax causes validation errors when Control Tower attempts to call these workflows, resulting in startup failures.

## Testing
- YAML syntax validated
- Matches fixes applied to Gasification_Model (PR #633) and AffineDrift (PRs #434-436)

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates two Jules worker workflows and fixes their triggers.
> 
> - Switches both workflows to nested `on: workflow_call:` syntax to be callable by Control Tower
> - Scientific Auditor: installs deps, conditionally runs `tools/scientific_auditor.py` with safe fallback to empty `report.json`, and runs Jules analysis with explicit read-only instruction
> - Test Generator: robustly detects changed non-test Python files via `git diff` with path filters, passes file list via output, and launches parallel Jules sessions only when relevant files are found
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f255a41aabdebd004a04188e382a1172eb1e10f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->