### PR TITLE
fix(ci): Fix assessment generator archive step failure

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -37,13 +37,18 @@ jobs:
           mkdir -p docs/assessments/archive
           DATE=$(date +%Y-%m-%d)
 
+          # Archive individual assessments if they exist
           for file in docs/assessments/Assessment_*.md; do
-            [ -f "$file" ] && mv "$file" "docs/assessments/archive/$(basename "$file" .md)_archived_$DATE.md"
+            [ -f "$file" ] && mv "$file" "docs/assessments/archive/$(basename "$file" .md)_archived_$DATE.md" || true
           done
 
-          [ -f "docs/assessments/Comprehensive_Assessment.md" ] && \
+          # Archive comprehensive assessment if it exists
+          if [ -f "docs/assessments/Comprehensive_Assessment.md" ]; then
             mv "docs/assessments/Comprehensive_Assessment.md" \
                "docs/assessments/archive/Comprehensive_Assessment_archived_$DATE.md"
+          fi
+
+          echo "Archive step completed successfully"
 
       - name: Jules Assessment Generation
         env:


### PR DESCRIPTION
## Summary
- Fixed the Jules Assessment Generator workflow archive step that was failing when no existing assessment files were found
- Added proper error handling with `|| true` and if-then blocks to prevent the step from failing on empty globs

## Test plan
- [x] Workflow syntax is valid
- [ ] Trigger assessment generator workflow after merge to verify fix

## Impact
This fix will allow the A-O assessment workflow to run successfully tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of the `Jules-Assessment-Generator` workflow’s archive step.
> 
> - Guard moves for individual assessments with `|| true` to avoid failures on empty globs
> - Replace short-circuit move of `Comprehensive_Assessment.md` with an explicit `if` check
> - Add a completion log message for the archive step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1181e23f65d04cfa995aec2d8ceef3737fde6a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->