### PR TITLE
fix(ci): Handle existing assessment branch in Assessment Generator

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -95,6 +95,9 @@ jobs:
             exit 0
           fi
 
+          # Delete remote branch if it exists (from previous run today)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
           # Create a new branch for the assessment
           git checkout -b "$BRANCH"
 


### PR DESCRIPTION
Deletes remote branch if it exists before creating new one to prevent non-fast-forward errors when workflow runs multiple times per day.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow robustness**
> 
> - Updates `Jules-Assessment-Generator.yml` to delete the remote `jules/assessment-$DATE` branch (if it exists) before creating a new branch
> - Prevents non-fast-forward push errors when the workflow runs multiple times in a day
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef862da73f95167e015c2777c435b538d3dcbc1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->