### PR TITLE
fix(workflow): improve error logging for Jules API session creation

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -112,16 +112,26 @@ jobs:
           )
 
           echo "Creating Jules session..."
-          SESSION_RESPONSE=$(curl -sf -X POST \
+          # Use -s to suppress progress but capture both stdout and stderr
+          # Use -w to get HTTP status code
+          HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
             -H "X-Goog-Api-Key: $JULES_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{\"source\": \"$SOURCE_ID\", \"prompt\": $(echo "$PROMPT" | jq -Rs .)}" \
             "$API_BASE/sessions")
 
+          SESSION_RESPONSE=$(cat /tmp/session_response.json)
+          echo "HTTP Status: $HTTP_CODE"
+          echo "Response: $SESSION_RESPONSE"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Jules API returned HTTP $HTTP_CODE"
+            exit 1
+          fi
+
           SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
           if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
-            echo "::error::Failed to create Jules session"
-            echo "$SESSION_RESPONSE"
+            echo "::error::Failed to create Jules session - no session ID in response"
             exit 1
           fi
 


### PR DESCRIPTION
Improves error logging for Jules API session creation to show HTTP status codes and response messages when failures occur.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances visibility and failure handling during Jules session creation in the workflow.
> 
> - Capture HTTP status via `curl -w` and write response to `/tmp/session_response.json`; echo both status and body
> - Add explicit check to exit on non-`200` responses
> - Improve error message when no `session ID` is present in the response
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 199c70197f75e4a768591d404feaff6b553d885a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->