### PR TITLE
fix(workflow): use correct sourceContext format for Jules API

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -112,12 +112,29 @@ jobs:
           )
 
           echo "Creating Jules session..."
+          # Build the request JSON with sourceContext (per Jules API docs)
+          REQUEST_JSON=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg source "$SOURCE_ID" \
+            '{
+              prompt: $prompt,
+              sourceContext: {
+                source: $source,
+                githubRepoContext: {
+                  startingBranch: "main"
+                }
+              },
+              automationMode: "AUTO_CREATE_PR"
+            }')
+
+          echo "Request: $REQUEST_JSON"
+
           # Use -s to suppress progress but capture both stdout and stderr
           # Use -w to get HTTP status code
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
             -H "X-Goog-Api-Key: $JULES_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"source\": \"$SOURCE_ID\", \"prompt\": $(echo "$PROMPT" | jq -Rs .)}" \
+            -d "$REQUEST_JSON" \
             "$API_BASE/sessions")
 
           SESSION_RESPONSE=$(cat /tmp/session_response.json)


### PR DESCRIPTION
Fixes the session creation request body to use the correct sourceContext format per Jules API docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Jules Assessment workflow to comply with the Jules API request format.
> 
> - Builds `REQUEST_JSON` via `jq` including `prompt`, `sourceContext.source`, `sourceContext.githubRepoContext.startingBranch` ("main"), and `automationMode: "AUTO_CREATE_PR"`
> - Replaces inline `curl -d` body with the constructed `REQUEST_JSON` and logs the request for visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e4599140f32f959960e675c6d053dc32a35a950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->