### PR TITLE
fix(ci): repair yaml indentation in control tower script

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -125,23 +125,23 @@ jobs:
               if (schedule) {
                 switch (schedule) {
                   case "0 8 * * *":
-          target = "assessment-generator";
-          break;
+                    target = "assessment-generator";
+                    break;
                   case "30 8 * * *":
-          target = "code-quality-reviewer";
-          break;
+                    target = "code-quality-reviewer";
+                    break;
                   case "0 9 * * *":
-          target = "completist";
-          break;
+                    target = "completist";
+                    break;
                   case "30 9 * * *":
-          target = "laymans-terms-writer";
-          break;
+                    target = "laymans-terms-writer";
+                    break;
                   case "0 10 * * *":
-          target = "critics-comments-writer";
-          break;
+                    target = "critics-comments-writer";
+                    break;
                   case "30 10 * * *":
-          target = "sentinel";
-          break;
+                    target = "sentinel";
+                    break;
                   case "0 11 * * *":
           target = day === 4 ? "thesis-defender" : "tech-custodian";
           break;


### PR DESCRIPTION
Fixes syntax error where script indentation broke the YAML block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes YAML/script syntax in `Jules-Control-Tower.yml` by correcting indentation in the scheduled routing `switch` cases.
> 
> - Properly indents `target` and `break` lines for cron-based cases to align with other cases
> - No behavioral changes to routing logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e71c13d1b7ef8f31afc28a5fbc6ec38a042c11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->