### PR TITLE
fix(workflow): Remove --label flags from Jules-Assessment-AutoFix

### DIFF
--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -195,8 +195,7 @@ jobs:
           EOF
           )" \
               --base main \
-              --head "$ASSESSMENT_BRANCH" \
-              --label "automation,assessments"
+              --head "$ASSESSMENT_BRANCH"
           else
             echo "Existing PR #$PR_NUMBER updated."
           fi
@@ -385,8 +384,7 @@ jobs:
           EOF
           )" \
             --base main \
-            --head "$BRANCH_NAME" \
-            --label "auto-generated,quality-control,${{ matrix.fix_type }}"
+            --head "$BRANCH_NAME"
 
   create-github-issues:
     name: Create GitHub Issues for Untracked Problems
@@ -433,8 +431,7 @@ jobs:
             echo "Creating new assessment summary issue"
             gh issue create \
               --title "📊 Weekly Assessment Summary" \
-              --body "$(cat docs/assessments/COMPREHENSIVE_ASSESSMENT_SUMMARY_*.md)" \
-              --label "assessment-summary,report"
+              --body "$(cat docs/assessments/COMPREHENSIVE_ASSESSMENT_SUMMARY_*.md)"
           fi
 
   # Close source PR if specified (prevents PR proliferation)


### PR DESCRIPTION
Removes --label flags that fail when labels don't exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines PR/issue creation in `Jules-Assessment-AutoFix.yml` by removing label assignment that could fail when labels are missing.
> 
> - Removes `--label` flags from `gh pr create` for assessment report PRs and auto-fix PRs
> - Removes `--label` flag from `gh issue create` for weekly assessment summary issues
> - No other workflow logic changed; creation now omits labels to avoid errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef4f009bfb6addda6f626665977050cdf5e94b19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->