### PR TITLE
fix(workflow): Fix PR-Comment-Responder

### DIFF
--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -50,7 +50,7 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
           # Get PR details
-          gh pr view $PR_NUMBER --json headRefName,headRepository,headRepositoryOwner,isCrossRepository,title,body,comments,reviewComments \
+          gh pr view $PR_NUMBER --json headRefName,headRepository,headRepositoryOwner,isCrossRepository,title,body,comments,reviews \
             > .pr_details.json
 
           # Get the branch
@@ -76,7 +76,7 @@ jobs:
           actionable_comments = []
 
           # Check review comments (inline code comments)
-          for comment in pr.get('reviewComments', []):
+          for comment in pr.get('reviews', []):
               body = comment.get('body', '').lower()
               # Look for actionable patterns
               if any(word in body for word in ['please', 'should', 'could you', 'can you', 'fix', 'change', 'update', 'add', 'remove', '?']):


### PR DESCRIPTION
Fixes invalid JSON field 'reviewComments' -> 'reviews' in gh pr view command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the GitHub CLI JSON field used to fetch review feedback in the PR comment responder workflow.
> 
> - Switches `gh pr view` field from `reviewComments` to `reviews`
> - Updates Python parsing loop to iterate over `reviews` when collecting actionable comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca0e04eac4aa310ed0199e5e957434ebeda6e397. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->