### PR TITLE
fix(workflow): Fix Control Tower YAML indentation

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -119,28 +119,28 @@ jobs:
               if (schedule) {
                 switch (schedule) {
                   case "0 8 * * *":
-          target = "assessment-generator";
-          break;
+                    target = "assessment-generator";
+                    break;
                   case "30 8 * * *":
-          target = "code-quality-reviewer";
-          break;
+                    target = "code-quality-reviewer";
+                    break;
                   case "0 9 * * *":
-          target = "completist";
-          break;
+                    target = "completist";
+                    break;
                   case "30 10 * * *":
-          target = "sentinel";
-          break;
+                    target = "sentinel";
+                    break;
                   case "0 11 * * *":
-          target = "tech-custodian";
-          break;
+                    target = "tech-custodian";
+                    break;
                   case "30 11 * * *":
-          target = "issue-resolver";
-          break;
+                    target = "issue-resolver";
+                    break;
                   case "0 12 * * *":
-          target = "pr-compiler";
-          break;
+                    target = "pr-compiler";
+                    break;
                   default:
-          target = "none";
+                    target = "none";
                 }
               }
 


### PR DESCRIPTION
## Summary
- Fixed corrupted indentation in Control Tower switch/case block that caused YAML parsing failure
- The case body lines had 10 spaces instead of 20, causing "workflow file issue" error

## Test plan
- [x] YAML validation passes
- [ ] Workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes Control Tower workflow formatting**
> 
> - Corrects indentation of `switch (schedule)` case bodies in `Jules-Control-Tower.yml` so each `target` and `break` is properly aligned
> - No logic changes; cron cases still map to the same worker targets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca11804fde5e15988d06f40e4a0411f5da143faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->