### PR TITLE
Address PR comments in workflow files

### DIFF
--- a/.github/workflows/ci-fast-tests.yml
+++ b/.github/workflows/ci-fast-tests.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -83,7 +83,6 @@ jobs:
           # - Parallel execution (-n auto uses all CPU cores)
           # - 30 second timeout per test
           # - Skip slow tests
-          # - Fail fast on first error (-x) for quicker feedback
           # - Short traceback for faster output
           xvfb-run --auto-servernum pytest \
             -n auto \
@@ -134,7 +133,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -212,7 +211,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
Addressed comments from PR #748 found in `pr_748_comments_api.json` (as `.actionable_comments.json` was missing). 
Specifically:
- Fixed `actions/cache@v5` -> `v4` in `ci-fast-tests.yml`.
- Fixed `actions/download-artifact@v7` -> `v4` in `ci-fast-tests.yml`.
- Removed stale comment about `-x` flag in `ci-fast-tests.yml`.
- Verified other files (`close_jules_prs.sh`, `Comment-to-Issue-Converter.yml`, `Jules-Ideas-Generator.yml`, `api/server.py`) match the expected state or have addressed the comments.

---
*PR created automatically by Jules for task [2966015678984488891](https://jules.google.com/task/2966015678984488891) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **ci-fast-tests workflow maintenance**
> 
> - Standardizes `actions/cache` to `v4` in both fast and integration test jobs
> - Standardizes `actions/download-artifact` to `v4` in the test summary job
> - Removes a stale comment about the `-x` pytest flag
> 
> These are configuration-only updates to the CI workflow; no code or test logic changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdbf4b982e8559c65e31c80a5873398b59260bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->