### PR TITLE
Address PR comments: Fix CI workflow configuration

### DIFF
--- a/.github/workflows/ci-fast-tests.yml
+++ b/.github/workflows/ci-fast-tests.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -83,7 +83,6 @@ jobs:
           # - Parallel execution (-n auto uses all CPU cores)
           # - 30 second timeout per test
           # - Skip slow tests
-          # - Fail fast on first error (-x) for quicker feedback
           # - Short traceback for faster output
           xvfb-run --auto-servernum pytest \
             -n auto \
@@ -134,7 +133,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -212,7 +211,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
Addresses actionable comments from PR #748 review. Specifically, fixes invalid GitHub Action versions (v5/v7 -> v4) and removes a misleading comment about the `-x` flag which was already removed from the command. Confirmed that other issues raised in the review (hardcoded paths, Python version downgrades, heredoc quotes) were already resolved in the current codebase.

---
*PR created automatically by Jules for task [3590031546030642133](https://jules.google.com/task/3590031546030642133) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI workflow to ensure compatibility and clarity.
> 
> - Switches `actions/cache` to `v4` in fast and integration test jobs
> - Switches `actions/download-artifact` to `v4` in the test summary job
> - Removes an outdated comment about `-x` fail-fast (command already omitted)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fdf9acea6326cb2766d337cad7abeceb6051217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->