### PR TITLE
fix: correct invalid GitHub Action versions in CI workflow

### DIFF
--- a/.github/workflows/ci-fast-tests.yml
+++ b/.github/workflows/ci-fast-tests.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -134,7 +134,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
This PR fixes invalid GitHub Action versions in `.github/workflows/ci-fast-tests.yml`. Specifically, it updates `actions/cache` from `v5` (non-existent) to `v4` and `actions/download-artifact` from `v7` (non-existent) to `v4`. These changes ensure the CI workflow can execute successfully.

---
*PR created automatically by Jules for task [2543179261562098242](https://jules.google.com/task/2543179261562098242) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the CI workflow uses valid GitHub Action versions.
> 
> - Updates `actions/cache` from `v5` to `v4` in fast-tests and integration-tests jobs
> - Updates `actions/download-artifact` from `v7` to `v4` in the test-summary job
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f3b04f10d956ea1302a00409c2b12ec02e95997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->