### PR TITLE
[CI] Fix PR comment workflow cascade with queue system

### DIFF
--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -1,0 +1,351 @@
+name: Jules Comment Processor
+
+# Processes queued PR comments in bulk
+# Runs on schedule to prevent workflow cascades
+# Called by Control Tower or can run manually
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run - show what would be processed without acting'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  schedule:
+    - cron: "0 3 * * *"  # Daily at 3 AM UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: jules-comment-processor-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  process-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check Queue
+        id: queue
+        run: |
+          QUEUE_FILE=".jules/pending/pr_comments.json"
+
+          if [ ! -f "$QUEUE_FILE" ]; then
+            echo "No queue file found. Nothing to process."
+            echo "has_comments=false" >> $GITHUB_OUTPUT
+            echo "count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Count pending comments
+          COUNT=$(python3 -c "import json; q=json.load(open('$QUEUE_FILE')); print(len(q.get('comments', [])))")
+
+          echo "Found $COUNT pending comments"
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "has_comments=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_comments=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if Empty
+        if: steps.queue.outputs.has_comments != 'true'
+        run: |
+          echo "No pending comments to process."
+          echo "Queue is empty - exiting gracefully."
+
+      - name: Analyze and Deduplicate Queue
+        id: analyze
+        if: steps.queue.outputs.has_comments == 'true'
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          from collections import defaultdict
+
+          QUEUE_FILE = ".jules/pending/pr_comments.json"
+
+          with open(QUEUE_FILE, 'r') as f:
+              queue = json.load(f)
+
+          comments = queue.get('comments', [])
+
+          # Group by PR number
+          by_pr = defaultdict(list)
+          for c in comments:
+              pr_num = c.get('pr_number')
+              if pr_num:
+                  by_pr[pr_num].append(c)
+
+          # Deduplicate (same author + similar body within same PR)
+          deduplicated = []
+          seen_keys = set()
+
+          for pr_num, pr_comments in by_pr.items():
+              for c in pr_comments:
+                  # Create a key based on PR, author, and first 100 chars of body
+                  body_snippet = c.get('body', '')[:100]
+                  key = f"{pr_num}:{c.get('author')}:{body_snippet}"
+
+                  if key not in seen_keys:
+                      seen_keys.add(key)
+                      deduplicated.append(c)
+
+          print(f"Original: {len(comments)} comments")
+          print(f"After deduplication: {len(deduplicated)} comments")
+          print(f"Across {len(by_pr)} PRs")
+
+          # Save deduplicated list for processing
+          with open('.jules/pending/to_process.json', 'w') as f:
+              json.dump({
+                  "comments": deduplicated,
+                  "by_pr": {str(k): v for k, v in by_pr.items()},
+                  "pr_count": len(by_pr),
+                  "comment_count": len(deduplicated)
+              }, f, indent=2)
+
+          # Write outputs
+          with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
+              f.write(f"original_count={len(comments)}\n")
+              f.write(f"dedup_count={len(deduplicated)}\n")
+              f.write(f"pr_count={len(by_pr)}\n")
+              f.write(f"prs={','.join(str(p) for p in by_pr.keys())}\n")
+          PYEOF
+
+      - name: Dry Run Summary
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run == 'true'
+        run: |
+          echo "## Dry Run Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Original comments**: ${{ steps.analyze.outputs.original_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "**After deduplication**: ${{ steps.analyze.outputs.dedup_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Unique PRs**: ${{ steps.analyze.outputs.pr_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "**PR numbers**: ${{ steps.analyze.outputs.prs }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Comments to Process" >> $GITHUB_STEP_SUMMARY
+          cat .jules/pending/to_process.json >> $GITHUB_STEP_SUMMARY
+
+          echo "Dry run complete - no actions taken"
+
+      - name: Create Processing Branch
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
+        run: |
+          BRANCH_NAME="jules/comment-fixes-$(date +%Y%m%d-%H%M)"
+          git checkout -b "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Process Comments with Jules
+        id: jules
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
+        env:
+          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+        run: |
+          set -e
+          REPO="${{ github.repository }}"
+          API_BASE="https://jules.googleapis.com/v1alpha"
+
+          if [ -z "$JULES_API_KEY" ]; then
+            echo "::warning::JULES_API_KEY not configured. Skipping Jules processing."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get source ID
+          SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
+          OWNER=$(echo "$REPO" | cut -d'/' -f1)
+          REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
+
+          if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
+            echo "::warning::Repository $REPO not found in Jules sources."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found source: $SOURCE_ID"
+
+          # Build comprehensive prompt with all comments
+          COMMENTS_JSON=$(cat .jules/pending/to_process.json)
+
+          PROMPT=$(cat << PROMPT_EOF
+          You are processing a batch of PR review comments that have been collected over time.
+          Your task is to address each comment by making appropriate code changes.
+
+          ## Comments to Address
+
+          $COMMENTS_JSON
+
+          ## Instructions
+
+          1. For each comment, understand what change is being requested
+          2. Make the appropriate code changes
+          3. Group changes by file when possible
+          4. Keep changes minimal and focused on what was requested
+          5. Do NOT respond to comments that are:
+             - Just acknowledgments or thank-yous
+             - Questions that don't require code changes
+             - Already addressed in earlier comments
+
+          ## Important
+
+          - Make changes directly to the files
+          - Do NOT create new PRs - changes will be committed to the branch: $BRANCH_NAME
+          - Focus on code quality and addressing the reviewer's concerns
+          PROMPT_EOF
+          )
+
+          echo "Creating Jules session for batch processing..."
+          REQUEST_JSON=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg source "$SOURCE_ID" \
+            --arg branch "$BRANCH_NAME" \
+            '{
+              prompt: $prompt,
+              sourceContext: {
+                source: $source,
+                githubRepoContext: {
+                  startingBranch: $branch
+                }
+              }
+            }')
+
+          HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
+            -H "X-Goog-Api-Key: $JULES_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$REQUEST_JSON" \
+            "$API_BASE/sessions")
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::warning::Jules API returned HTTP $HTTP_CODE"
+            cat /tmp/session_response.json
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SESSION_ID=$(cat /tmp/session_response.json | jq -r '.name')
+          echo "Created session: $SESSION_ID"
+
+          # Poll for completion
+          MAX_WAIT=1800
+          POLL_INTERVAL=30
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
+            STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
+            echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
+
+            case "$STATE" in
+              "COMPLETED"|"SUBMITTED")
+                echo "Session completed successfully!"
+                echo "ran=true" >> "$GITHUB_OUTPUT"
+                break
+                ;;
+              "FAILED"|"CANCELLED")
+                echo "::warning::Session $STATE"
+                echo "ran=false" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+      - name: Clear Processed Queue
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
+        run: |
+          # Archive processed comments
+          mkdir -p .jules/processed
+          ARCHIVE_FILE=".jules/processed/comments_$(date +%Y%m%d_%H%M%S).json"
+          cp .jules/pending/pr_comments.json "$ARCHIVE_FILE"
+
+          # Clear the queue
+          echo '{"comments": [], "last_cleared": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'"}' > .jules/pending/pr_comments.json
+
+          echo "Archived processed comments to $ARCHIVE_FILE"
+          echo "Queue cleared"
+
+      - name: Commit and Create PR
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clean up temp files
+          rm -f .jules/pending/to_process.json
+
+          git add -A
+
+          if ! git diff --staged --quiet; then
+            git commit -m "$(cat <<EOF
+          fix: address batch PR review comments
+
+          Processed ${{ steps.analyze.outputs.dedup_count }} comments across ${{ steps.analyze.outputs.pr_count }} PRs.
+
+          PRs addressed: #${{ steps.analyze.outputs.prs }}
+
+          Co-Authored-By: Jules <jules-bot@users.noreply.github.com>
+          EOF
+          )"
+
+            git push -u origin "$BRANCH_NAME"
+
+            # Create single PR for all changes
+            gh pr create \
+              --title "[Jules/Comment-Processor] Address batch PR review comments" \
+              --body "$(cat <<EOF
+          ## Summary
+
+          This PR addresses **${{ steps.analyze.outputs.dedup_count }}** review comments collected from **${{ steps.analyze.outputs.pr_count }}** PRs.
+
+          ### PRs with comments addressed
+          $(echo "${{ steps.analyze.outputs.prs }}" | tr ',' '\n' | while read pr; do echo "- #$pr"; done)
+
+          ### Processing Details
+          - Original comments collected: ${{ steps.analyze.outputs.original_count }}
+          - After deduplication: ${{ steps.analyze.outputs.dedup_count }}
+          - Processed by: Jules Comment Processor (batch)
+
+          ## Review Checklist
+          - [ ] Changes address the original comments
+          - [ ] No unintended side effects
+          - [ ] Code quality maintained
+
+          ---
+          Processed by [Jules Comment Processor](https://github.com/${{ github.repository }}/actions/workflows/Jules-Comment-Processor.yml)
+          EOF
+          )"
+
+            echo "PR created for batch comment fixes"
+          else
+            echo "No changes made by Jules - queue cleared anyway"
+          fi
+
+      - name: Summary
+        if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
+        run: |
+          echo "## Comment Processing Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Comments processed**: ${{ steps.analyze.outputs.dedup_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **PRs addressed**: ${{ steps.analyze.outputs.pr_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR numbers**: ${{ steps.analyze.outputs.prs }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Queue has been cleared. Processed comments archived." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -1,47 +1,59 @@
-name: PR Comment Responder
+name: PR Comment Collector
 
-# This workflow triggers when comments are added to PRs
-# It can be configured to use Claude API or other AI services
+# Collects PR comments into a queue for batch processing
+# Does NOT act immediately - prevents workflow cascades
+# Comments are processed by Jules-Comment-Processor on a schedule
 
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to review comments on'
-        required: true
-        type: string
 
 permissions:
   contents: write
-  pull-requests: write
+  pull-requests: read
   issues: read
 
+# Prevent concurrent runs from corrupting the queue file
+concurrency:
+  group: pr-comment-collector-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
-  respond-to-comments:
-    # Run on PR comments (from issue_comment), review comments (from pull_request_review_comment), or manual dispatch
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request != null
+  collect-comment:
+    # Only run on PR comments (not issue comments)
+    if: |
+      (github.event_name == 'pull_request_review_comment') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Filter Bot Comments
+        id: filter
+        run: |
+          ACTOR="${{ github.actor }}"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+          # List of bot actors to ignore
+          BOTS="copilot-pull-request-reviewer[bot] cursor[bot] dependabot[bot] github-actions[bot] renovate[bot] codecov[bot] sonarcloud[bot]"
 
-      - name: Get PR Details
-        id: pr
+          for bot in $BOTS; do
+            if [ "$ACTOR" = "$bot" ]; then
+              echo "::notice::Ignoring comment from bot: $ACTOR"
+              echo "is_bot=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+
+          echo "is_bot=false" >> $GITHUB_OUTPUT
+
+      - name: Get PR State
+        id: pr_state
+        if: steps.filter.outputs.is_bot != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
           else
             PR_NUMBER="${{ github.event.issue.number }}"
@@ -49,281 +61,162 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-          # Get PR details
-          gh pr view $PR_NUMBER --json headRefName,headRepository,headRepositoryOwner,isCrossRepository,title,body,comments,reviews \
-            > .pr_details.json
+          # Check if PR is already merged or closed
+          PR_STATE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json state --jq '.state')
+          echo "pr_state=$PR_STATE" >> $GITHUB_OUTPUT
 
-          # Get the branch
-          BRANCH=$(cat .pr_details.json | jq -r '.headRefName')
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-
-          IS_FORK=$(cat .pr_details.json | jq -r '.isCrossRepository // false')
-          HEAD_REPO=$(cat .pr_details.json | jq -r '.headRepository.nameWithOwner // ""')
-          echo "is_fork=$IS_FORK" >> $GITHUB_OUTPUT
-          echo "head_repo=$HEAD_REPO" >> $GITHUB_OUTPUT
-
-      - name: Analyze Comments
-        id: analyze
-        run: |
-          python3 << 'PYEOF'
-          import json
-          import os
-
-          with open('.pr_details.json', 'r') as f:
-              pr = json.load(f)
-
-          # Collect all comments that might need response
-          actionable_comments = []
-
-          # Check review comments (inline code comments)
-          for comment in pr.get('reviews', []):
-              body = comment.get('body', '').lower()
-              # Look for actionable patterns
-              if any(word in body for word in ['please', 'should', 'could you', 'can you', 'fix', 'change', 'update', 'add', 'remove', '?']):
-                  actionable_comments.append({
-            'type': 'review',
-            'path': comment.get('path', ''),
-            'line': comment.get('line', 0),
-            'body': comment.get('body', '')
-                  })
-
-          # Check PR comments
-          for comment in pr.get('comments', []):
-              body = comment.get('body', '').lower()
-              if any(word in body for word in ['please', 'should', 'could you', 'can you', 'fix', 'change', 'update', 'add', 'remove', '?']):
-                  actionable_comments.append({
-            'type': 'pr',
-            'body': comment.get('body', '')
-                  })
-
-          with open('.actionable_comments.json', 'w') as f:
-              json.dump(actionable_comments, f, indent=2)
-
-          count = len(actionable_comments)
-          print(f"Found {count} actionable comments")
-
-          with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
-              f.write(f"count={count}\n")
-              f.write(f"has_comments={'true' if count > 0 else 'false'}\n")
-          PYEOF
-
-      - name: Skip if No Actionable Comments
-        if: steps.analyze.outputs.has_comments != 'true'
-        run: |
-          echo "No actionable comments found. Exiting."
-
-      - name: Skip Forked PRs
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork == 'true'
-        run: |
-          echo "PR is from a fork. Skipping branch checkout and push-based automation."
-
-      - name: Checkout PR Branch
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
-        run: |
-          git fetch origin ${{ steps.pr.outputs.branch }}
-          git checkout ${{ steps.pr.outputs.branch }}
-
-      # Option 1: Use Jules if available
-      - name: Address Comments with Jules
-        id: jules
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
-        env:
-          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
-        run: |
-          set -e
-          DATE=$(date +%Y-%m-%d)
-          REPO="${{ github.repository }}"
-          API_BASE="https://jules.googleapis.com/v1alpha"
-          
-          # Check if API key is configured
-          if [ -z "$JULES_API_KEY" ]; then
-            echo "::warning::JULES_API_KEY not configured. Skipping Jules task."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          echo "Looking up repository source..."
-          SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          
-          OWNER=$(echo "$REPO" | cut -d'/' -f1)
-          REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
-          
-          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
-          
-          if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
-            echo "::warning::Repository $REPO not found in Jules sources."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          echo "Found source: $SOURCE_ID"
-          
-          # Create session prompt
-          PROMPT=$(cat << 'PROMPT_EOF'
-          Review and address the PR comments in .actionable_comments.json
-          
-          For each comment:
-          1. Understand what change is being requested
-          2. Make the appropriate code change
-          3. Keep changes minimal and focused
-          
-          Do NOT respond to comments that are just acknowledgments or thank-yous.
-          PROMPT_EOF
-          )
-          
-          echo "Creating Jules session..."
-          REQUEST_JSON=$(jq -n \
-            --arg prompt "$PROMPT" \
-            --arg source "$SOURCE_ID" \
-            '{
-              prompt: $prompt,
-              sourceContext: {
-                source: $source,
-                githubRepoContext: {
-                  startingBranch: "main"
-                }
-              },
-              automationMode: "AUTO_CREATE_PR"
-            }')
-          
-          echo "Request: $REQUEST_JSON"
-          
-          HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
-            -H "X-Goog-Api-Key: $JULES_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$REQUEST_JSON" \
-            "$API_BASE/sessions")
-          
-          SESSION_RESPONSE=$(cat /tmp/session_response.json)
-          echo "HTTP Status: $HTTP_CODE"
-          
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Jules API returned HTTP $HTTP_CODE"
-            exit 1
-          fi
-          
-          SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
-          echo "Created session: $SESSION_ID"
-          
-          # Poll for completion
-          MAX_WAIT=1800
-          POLL_INTERVAL=30
-          ELAPSED=0
-          JULES_DONE=false
-          
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
-            STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
-            echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
-          
-            case "$STATE" in
-              "COMPLETED"|"SUBMITTED")
-                JULES_DONE=true
-                echo "Session completed successfully!"
-                break
-                ;;
-              "FAILED"|"CANCELLED")
-                echo "::error::Session $STATE"
-                exit 1
-                ;;
-            esac
-            sleep $POLL_INTERVAL
-            ELAPSED=$((ELAPSED + POLL_INTERVAL))
-          done
-          
-          if [ "$JULES_DONE" = "true" ]; then
-            echo "ran=true" >> "$GITHUB_OUTPUT"
+          if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+            echo "::notice::PR #$PR_NUMBER is $PR_STATE, skipping comment collection"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
           else
-            echo "::warning::Jules session timed out after ${MAX_WAIT}s."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
 
+      - uses: actions/checkout@v4
+        if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
+        with:
+          fetch-depth: 1
 
-
-      # Option 2: Use Claude API directly (requires ANTHROPIC_API_KEY secret)
-      # Only runs if Jules was skipped (no JULES_API_KEY) and ANTHROPIC_API_KEY is set
-      - name: Address Comments with Claude API
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true' && steps.jules.outputs.ran != 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+      - name: Analyze Comment
+        id: analyze
+        if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
         run: |
-          # Skip if no Anthropic key
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "ANTHROPIC_API_KEY not configured, skipping"
-            exit 0
+          # Get comment body
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            COMMENT_BODY="${{ github.event.comment.body }}"
+            COMMENT_PATH="${{ github.event.comment.path }}"
+            COMMENT_LINE="${{ github.event.comment.line }}"
+            COMMENT_TYPE="review"
+          else
+            COMMENT_BODY="${{ github.event.comment.body }}"
+            COMMENT_PATH=""
+            COMMENT_LINE=""
+            COMMENT_TYPE="pr"
           fi
-          pip install anthropic
 
-          python3 << 'PYEOF'
-          import anthropic
-          import json
-          import subprocess
-          import os
+          # Check if comment is actionable (contains request-like words)
+          BODY_LOWER=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')
 
-          client = anthropic.Anthropic()
+          IS_ACTIONABLE=false
+          for word in "please" "should" "could you" "can you" "fix" "change" "update" "add" "remove" "consider" "suggest" "recommend"; do
+            if echo "$BODY_LOWER" | grep -q "$word"; then
+              IS_ACTIONABLE=true
+              break
+            fi
+          done
 
-          with open('.actionable_comments.json', 'r') as f:
-              comments = json.load(f)
+          # Also check for question marks (requests for clarification/changes)
+          if echo "$COMMENT_BODY" | grep -q "?"; then
+            IS_ACTIONABLE=true
+          fi
 
-          # Read relevant files mentioned in comments
-          files_to_read = set()
-          for c in comments:
-              if c.get('path'):
-                  files_to_read.add(c['path'])
+          echo "is_actionable=$IS_ACTIONABLE" >> $GITHUB_OUTPUT
 
-          file_contents = {}
-          for path in files_to_read:
-              try:
-                  with open(path, 'r') as f:
-            file_contents[path] = f.read()
-              except:
-                  pass
+          if [ "$IS_ACTIONABLE" = "false" ]; then
+            echo "::notice::Comment does not appear actionable, skipping"
+          fi
 
-          prompt = f"""You are a code reviewer assistant. Address these PR comments by suggesting specific code changes.
-
-          Comments to address:
-          {json.dumps(comments, indent=2)}
-
-          Relevant file contents:
-          {json.dumps(file_contents, indent=2)}
-
-          For each comment, provide:
-          1. The file path
-          2. The exact change needed (as a diff or replacement)
-          3. Brief explanation
-
-          Format your response as JSON with structure:
-          {{"changes": [{{"file": "path", "old": "old code", "new": "new code", "explanation": "why"}}]}}
-          """
-
-          message = client.messages.create(
-              model="claude-sonnet-4-20250514",
-              max_tokens=4096,
-              messages=[{"role": "user", "content": prompt}]
-          )
-
-          print(message.content[0].text)
-          # Note: In a full implementation, you would parse the response
-          # and apply the changes automatically
-          PYEOF
-
-      - name: Commit Changes
-        if: steps.analyze.outputs.has_comments == 'true' && steps.pr.outputs.is_fork != 'true'
+      - name: Queue Comment for Processing
+        if: |
+          steps.filter.outputs.is_bot != 'true' &&
+          steps.pr_state.outputs.should_skip != 'true' &&
+          steps.analyze.outputs.is_actionable == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git add -A
-          if ! git diff --staged --quiet; then
-            git commit -m "Address PR review comments
+          mkdir -p .jules/pending
+          QUEUE_FILE=".jules/pending/pr_comments.json"
 
-          Automated response to reviewer feedback.
+          # Initialize queue file if it doesn't exist
+          if [ ! -f "$QUEUE_FILE" ]; then
+            echo '{"comments": []}' > "$QUEUE_FILE"
+          fi
 
-          Co-Authored-By: Claude <noreply@anthropic.com>"
+          # Create comment entry
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          PR_NUMBER="${{ steps.pr_state.outputs.pr_number }}"
 
-            git push origin ${{ steps.pr.outputs.branch }}
-
-            gh pr comment ${{ steps.pr.outputs.pr_number }} --body "I've addressed the review comments. Please take another look!"
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            COMMENT_ID="${{ github.event.comment.id }}"
+            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
+            COMMENT_PATH="${{ github.event.comment.path }}"
+            COMMENT_LINE="${{ github.event.comment.line }}"
+            COMMENT_TYPE="review"
+            COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
           else
-            echo "No changes made"
+            COMMENT_ID="${{ github.event.comment.id }}"
+            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
+            COMMENT_PATH=""
+            COMMENT_LINE=""
+            COMMENT_TYPE="pr"
+            COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
+          fi
+
+          # Use Python for safe JSON manipulation
+          python3 << PYEOF
+          import json
+          import os
+
+          queue_file = "$QUEUE_FILE"
+
+          # Load existing queue
+          try:
+              with open(queue_file, 'r') as f:
+                  queue = json.load(f)
+          except:
+              queue = {"comments": []}
+
+          # Check for duplicate (same comment ID)
+          comment_id = "$COMMENT_ID"
+          existing_ids = [c.get('comment_id') for c in queue.get('comments', [])]
+
+          if comment_id in existing_ids:
+              print(f"Comment {comment_id} already in queue, skipping")
+          else:
+              # Add new comment
+              new_comment = {
+                  "comment_id": comment_id,
+                  "pr_number": int("$PR_NUMBER"),
+                  "type": "$COMMENT_TYPE",
+                  "author": "$COMMENT_AUTHOR",
+                  "body": $COMMENT_BODY,
+                  "path": "$COMMENT_PATH" if "$COMMENT_PATH" else None,
+                  "line": int("$COMMENT_LINE") if "$COMMENT_LINE" else None,
+                  "queued_at": "$TIMESTAMP",
+                  "repository": "${{ github.repository }}"
+              }
+
+              queue["comments"].append(new_comment)
+              queue["last_updated"] = "$TIMESTAMP"
+
+              with open(queue_file, 'w') as f:
+                  json.dump(queue, f, indent=2)
+
+              print(f"Queued comment {comment_id} from PR #{new_comment['pr_number']}")
+              print(f"Queue now has {len(queue['comments'])} pending comments")
+          PYEOF
+
+      - name: Commit Queue Update
+        if: |
+          steps.filter.outputs.is_bot != 'true' &&
+          steps.pr_state.outputs.should_skip != 'true' &&
+          steps.analyze.outputs.is_actionable == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .jules/pending/pr_comments.json
+
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: queue PR comment for batch processing
+
+          PR: #${{ steps.pr_state.outputs.pr_number }}
+          Comment ID: ${{ github.event.comment.id }}
+
+          This comment will be processed by Jules-Comment-Processor on the next scheduled run."
+
+            git push
+            echo "::notice::Comment queued for batch processing"
+          else
+            echo "No changes to commit"
           fi


### PR DESCRIPTION
Fix PR-Comment-Responder cascade issue. See AffineDrift PR #807 for details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a two-stage system to prevent workflow cascades and batch-handle review feedback.
> 
> - **Add** `PR-Comment-Responder.yml` → `PR Comment Collector` that filters bot comments, skips closed/merged PRs, detects actionable comments, and appends them to `.jules/pending/pr_comments.json` with concurrency protection
> - **Add** `Jules-Comment-Processor.yml` scheduled/manual workflow to deduplicate comments by PR/author/body, create a working branch, invoke Jules API to apply fixes, clear/archive the queue, and open a single PR summarizing processed items (supports `dry_run`)
> - **Set** appropriate permissions and concurrency groups; commits queue updates and batch-fix branches using `github-actions[bot]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f509bbc91d2e00068e0bcfc785eec3331ccd8f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->