### PR TITLE
refactor(launcher): Address DRY violations from Pragmatic Programmer review

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package for Golf Modeling Suite automation and utilities."""

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,0 +1,155 @@
+"""Shared utilities for Golf Modeling Suite scripts.
+
+This module consolidates common patterns used across scripts to address
+DRY violations identified by Pragmatic Programmer reviews.
+
+Common Patterns Consolidated:
+- Logging setup
+- Repository root detection
+- PYTHONPATH environment setup
+- Subprocess execution with consistent error handling
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory.
+
+    Works from any script location within the repository.
+
+    Returns:
+        Path to the repository root.
+    """
+    # Scripts are in {repo_root}/scripts/
+    return Path(__file__).resolve().parent.parent
+
+
+def setup_script_logging(
+    name: str,
+    level: int = logging.INFO,
+    format_string: str = "%(asctime)s - %(levelname)s - %(message)s",
+) -> logging.Logger:
+    """Configure logging for a script with consistent formatting.
+
+    Args:
+        name: Logger name (typically __name__).
+        level: Logging level.
+        format_string: Log message format.
+
+    Returns:
+        Configured logger instance.
+    """
+    logging.basicConfig(
+        level=level,
+        format=format_string,
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+    return logging.getLogger(name)
+
+
+def get_pythonpath_env(additional_paths: Sequence[Path] | None = None) -> dict:
+    """Get environment dict with PYTHONPATH set correctly.
+
+    Args:
+        additional_paths: Additional paths to include in PYTHONPATH.
+
+    Returns:
+        Environment dict with PYTHONPATH configured.
+    """
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH", "")
+
+    paths = [str(get_repo_root())]
+    if additional_paths:
+        paths.extend(str(p) for p in additional_paths)
+
+    env["PYTHONPATH"] = os.pathsep.join(paths) + (
+        os.pathsep + pythonpath if pythonpath else ""
+    )
+    return env
+
+
+def run_command(
+    cmd: Sequence[str],
+    cwd: Path | None = None,
+    env: dict | None = None,
+    capture_output: bool = False,
+    check: bool = False,
+    logger: logging.Logger | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess command with consistent error handling.
+
+    Args:
+        cmd: Command and arguments to run.
+        cwd: Working directory (defaults to repo root).
+        env: Environment variables (defaults to PYTHONPATH-enhanced env).
+        capture_output: Whether to capture stdout/stderr.
+        check: Whether to raise on non-zero exit.
+        logger: Optional logger for command logging.
+
+    Returns:
+        CompletedProcess instance.
+    """
+    if cwd is None:
+        cwd = get_repo_root()
+    if env is None:
+        env = get_pythonpath_env()
+
+    if logger:
+        logger.info(f"Executing: {' '.join(str(c) for c in cmd)}")
+
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        capture_output=capture_output,
+        check=check,
+    )
+
+
+def run_pytest(
+    test_paths: Sequence[str | Path],
+    verbose: bool = True,
+    markers: str | None = None,
+    extra_args: Sequence[str] | None = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Run pytest with consistent configuration.
+
+    Args:
+        test_paths: Paths to test files or directories.
+        verbose: Enable verbose output.
+        markers: Pytest marker expression.
+        extra_args: Additional pytest arguments.
+        logger: Optional logger for status messages.
+
+    Returns:
+        True if tests passed, False otherwise.
+    """
+    cmd = [sys.executable, "-m", "pytest"]
+    cmd.extend(str(p) for p in test_paths)
+
+    if verbose:
+        cmd.append("-v")
+    if markers:
+        cmd.extend(["-m", markers])
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = run_command(cmd, logger=logger)
+
+    if logger:
+        if result.returncode == 0:
+            logger.info("Tests PASSED")
+        else:
+            logger.error(f"Tests FAILED (Exit Code: {result.returncode})")
+
+    return result.returncode == 0


### PR DESCRIPTION
## Summary

This PR addresses DRY (Don't Repeat Yourself) violations identified by the Pragmatic Programmer automated review, improving code quality and maintainability.

### Key Changes

**launch_golf_suite.py Refactoring:**
- Created `EngineConfig` dataclass to encapsulate engine-specific launch parameters
- Introduced `ENGINE_CONFIGS` registry for centralized engine configuration
- Implemented `_launch_physics_engine()` as a single generic launcher function
- Added helper functions: `_run_subprocess()`, `_validate_engine()`
- Reduced `launch_mujoco()`, `launch_drake()`, `launch_pinocchio()` to thin wrappers
- Consolidated `_show_basic_status()` using nested dictionary structure

**New Shared Utilities (scripts/script_utils.py):**
- `get_repo_root()`: Consistent repository root detection
- `setup_script_logging()`: Standardized logging configuration
- `get_pythonpath_env()`: PYTHONPATH environment setup helper
- `run_command()`: Subprocess execution with consistent error handling
- `run_pytest()`: Standardized test runner configuration

**validate_physics.py Refactoring:**
- Refactored to use the new shared utilities module
- Extracted test file configuration into data structure
- Simplified main logic using helper functions

### Pragmatic Programmer Principles Addressed

| Principle | Improvement |
|-----------|-------------|
| **DRY** | Eliminated duplicate engine launching code, extracted shared patterns |
| **Orthogonality** | Separated configuration from execution logic |
| **Reversibility** | Configuration-driven design allows easy engine additions |

## Test plan

- [x] Verify Python syntax with `py_compile`
- [x] Pass `ruff` linting checks
- [x] Verify module imports work correctly
- [ ] CI/CD pipeline passes all checks
- [ ] Existing functionality preserved (no behavioral changes)

## Related Issues

Addresses findings from Pragmatic Programmer Review (2026-01-23):
- DRY principle score: 0.0 -> Expected improvement
- Multiple duplicate code blocks in launch_golf_suite.py
- Repeated patterns across script files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves maintainability by centralizing engine launch logic and consolidating common script patterns.
> 
> - Introduces `EngineConfig` and `ENGINE_CONFIGS` with `_launch_physics_engine()` to replace duplicated `mujoco/drake/pinocchio` launch code
> - Adds helpers `_run_subprocess()`, `_validate_engine()`, and generalized `_validate_and_get_workdir()`; CLI `--engine` choices now derived from `ENGINE_CONFIGS`
> - Simplifies `launch_mujoco/drake/pinocchio()` to thin wrappers; refactors `_show_basic_status()` into sectioned checks
> - Adds `scripts/script_utils.py` (`get_repo_root()`, `setup_script_logging()`, `get_pythonpath_env()`, `run_command()`, `run_pytest()`) and `scripts/__init__.py`
> - Refactors `scripts/validate_physics.py` to use shared utilities and a test file map, simplifying test selection and execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85ac16d8fc09bc0929577734c5b5116d5947aab9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->