### PR TITLE
fix(workflows): downgrade github-script v8 to v7

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Analyze Event Context
         id: decide
         if: steps.check-limits.outcome == 'skipped' || steps.check-limits.outputs.exceeded != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const event = context.eventName;


### PR DESCRIPTION
Node.js 24 not yet supported on GitHub runners, causing startup_failure.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the Control Tower workflow to restore runner compatibility.
> 
> - Downgrades `actions/github-script` from `v8` to `v7` in `Jules-Control-Tower.yml` (`Analyze Event Context` step) to address runner startup failures due to Node.js version support
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 171281082bb80b54ce6a321005275c8b2158e2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->