### PR TITLE
fix: simplify Auto-Rebase conflict comment to avoid YAML parsing issues

### DIFF
--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -107,15 +107,7 @@ jobs:
               # Comment if not already commented about this conflict
               LAST_COMMENT=$(gh pr view $PR_NUM --json comments --jq '.comments[-1].body // ""')
               if [[ ! "$LAST_COMMENT" =~ "merge conflicts" ]]; then
-                gh pr comment $PR_NUM --body "This PR has merge conflicts that could not be automatically resolved. Please rebase manually:
-
-\`\`\`bash
-git checkout $BRANCH
-git fetch origin main
-git rebase origin/main
-# Resolve conflicts, then:
-git push --force-with-lease
-\`\`\`"
+                gh pr comment $PR_NUM --body "This PR has merge conflicts that could not be automatically resolved. Please rebase manually onto main and force-push."
               fi
 
               CONFLICTING=$((CONFLICTING + 1))


### PR DESCRIPTION
Fixes YAML syntax error in Jules-Auto-Rebase.yml caused by multi-line string with backticks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the conflict notification in `Jules-Auto-Rebase.yml` to a single-line `gh pr comment` string, replacing the prior multi-line bash guidance to prevent YAML parsing issues.
> 
> - Update only affects the comment posted when a rebase fails due to merge conflicts; no workflow logic or control flow changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1b41ebbfa1d389ff00ad1ce1c790438dd8cfafb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->