### PR TITLE
fix: use unique timestamp in branch names to avoid conflicts

### DIFF
--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -70,7 +70,8 @@ jobs:
           TARGET: ${{ steps.target.outputs.file }}
         run: |
           BASENAME=$(basename "$TARGET" .py)
-          BRANCH_NAME="refactor/auto-$(date +%Y%m%d)-${BASENAME}"
+          # Use timestamp for unique branch name
+          BRANCH_NAME="refactor/auto-$(date +%Y%m%d%H%M%S)-${BASENAME}"
           git checkout -b "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Uses timestamp with seconds to ensure unique branch names for Auto-Refactor workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix CI branch naming to avoid collisions**
> 
> - In `.github/workflows/Jules-Auto-Refactor.yml`, updates the `Create Refactor Branch` step to include seconds in the timestamp (`%Y%m%d%H%M%S`) when generating `BRANCH_NAME` for auto-refactor branches, ensuring uniqueness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db532dde6b710aafd051ac5a280c48df67d6746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->