### PR TITLE
docs(workflows): add CI/CD trigger assessment report

### DIFF
--- a/docs/workflow-trigger-assessment.md
+++ b/docs/workflow-trigger-assessment.md
@@ -1,0 +1,179 @@
+# CI/CD Workflow Trigger Assessment
+
+**Date:** January 26, 2026
+**Status:** Assessment Complete - Fixes Recommended
+
+## Executive Summary
+
+Analysis of overnight workflow runs identified critical gaps in the CI/CD pipeline trigger configuration that cause some PRs to not receive full CI/CD coverage. The primary issue is the use of `GITHUB_TOKEN` in auto-fix workflows, which prevents subsequent workflow triggers due to GitHub's security design.
+
+---
+
+## Workflow Overview
+
+| Workflow | Purpose | Triggers | Status |
+|----------|---------|----------|--------|
+| **CI Standard** | Comprehensive quality gate + tests | push→main, pull_request, dispatch | ⚠️ Gaps |
+| **CI Fast Tests** | Quick feedback on all branches | push→all, pull_request, dispatch | ✅ OK |
+| **Bot CI Trigger** | Ensure bot PRs get CI | PR (bot), schedule, dispatch | ⚠️ Gaps |
+| **Jules-PR-AutoFix** | Auto-fix CI failures | workflow_run (CI failure) | 🔴 Critical |
+
+---
+
+## Critical Issues Found
+
+### 1. GITHUB_TOKEN Limitation in Jules-PR-AutoFix
+
+**Location:** `.github/workflows/Jules-PR-AutoFix.yml`
+
+**Problem:** When `Jules-PR-AutoFix` pushes fixes to a PR branch, it uses `GITHUB_TOKEN`. GitHub's security model prevents actions using `GITHUB_TOKEN` from triggering new workflow runs (to prevent infinite loops).
+
+**Impact:**
+- Fixes are pushed but CI never re-runs to verify them
+- PRs appear "stuck" without updated CI status
+- Manual intervention required to re-trigger CI
+
+**Solution:** Use `BOT_PAT` (Personal Access Token) for checkout and push operations:
+```yaml
+- uses: actions/checkout@v4
+  with:
+    token: ${{ secrets.BOT_PAT }}  # Instead of GITHUB_TOKEN
+```
+
+### 2. Incomplete Bot Detection in Bot-CI-Trigger
+
+**Location:** `.github/workflows/Bot-CI-Trigger.yml:44-50`
+
+**Problem:** Bot detection logic uses `contains()` which may miss some bot patterns:
+```yaml
+contains(github.event.pull_request.user.login, 'bot') ||
+contains(github.event.pull_request.user.login, 'github-actions') ||
+github.event.pull_request.user.type == 'Bot'
+```
+
+**Missing patterns:**
+- Claude Code PRs (branches starting with `claude/`)
+- GitHub Apps that don't include "bot" in username
+- PRs created via API with service accounts
+
+**Solution:** Expand detection to include branch naming patterns:
+```yaml
+contains(github.event.pull_request.user.login, 'claude') ||
+startsWith(github.event.pull_request.head.ref, 'claude/')
+```
+
+### 3. Implicit PR Event Types
+
+**Location:** `.github/workflows/ci-standard.yml`
+
+**Problem:** No explicit `types:` specified for `pull_request` trigger, relying on GitHub defaults (`opened`, `synchronize`, `reopened`).
+
+**Missing events:**
+- `ready_for_review` - Draft PRs marked ready don't trigger CI
+- `converted_to_draft` - May want to skip CI for drafts
+
+**Solution:** Add explicit event types:
+```yaml
+pull_request:
+  types: [opened, synchronize, reopened, ready_for_review]
+```
+
+---
+
+## Workflow Chain Analysis
+
+```
+PR Created/Updated
+       │
+       ▼
+┌─────────────────┐
+│  CI Standard    │
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    │         │
+ success   failure
+    │         │
+    ▼         ▼
+  Done   ┌────────────────┐
+         │ Jules-PR-AutoFix│
+         └────────┬───────┘
+                  │
+                  ▼
+         Push fixes with GITHUB_TOKEN
+                  │
+                  ▼
+         ❌ NO NEW CI TRIGGERED
+                  │
+                  ▼
+         Bot-CI-Trigger (15 min schedule)
+                  │
+                  ▼
+         May or may not detect PR
+```
+
+---
+
+## Recommended Fixes
+
+### Priority 1: Critical (Immediate)
+
+1. **Update Jules-PR-AutoFix to use BOT_PAT**
+   - File: `.github/workflows/Jules-PR-AutoFix.yml`
+   - Change: Use `secrets.BOT_PAT` for checkout token
+   - Impact: Fixes will trigger CI re-runs
+
+2. **Verify BOT_PAT secret is configured**
+   - Must have `repo` and `workflow` scopes
+   - Must not be expired
+
+### Priority 2: High (This Week)
+
+3. **Expand bot detection patterns**
+   - File: `.github/workflows/Bot-CI-Trigger.yml`
+   - Add: Claude branch pattern detection
+   - Add: More bot username patterns
+
+4. **Add explicit PR event types**
+   - File: `.github/workflows/ci-standard.yml`
+   - Add: `ready_for_review` to types
+
+### Priority 3: Medium (Backlog)
+
+5. **Reduce Bot-CI-Trigger schedule frequency**
+   - Current: Every 15 minutes
+   - Recommended: Every 30 minutes (reduces Actions minutes usage)
+
+6. **Add workflow documentation**
+   - Document trigger strategy in CONTRIBUTING.md
+   - Add inline comments explaining trigger choices
+
+---
+
+## Verification Checklist
+
+After implementing fixes, verify:
+
+- [ ] Bot PRs receive CI runs within 5 minutes of creation
+- [ ] Jules-PR-AutoFix pushes trigger new CI runs
+- [ ] Claude Code PRs are detected by Bot-CI-Trigger
+- [ ] Draft PRs marked ready trigger CI
+- [ ] No infinite loops occur (loop prevention still works)
+
+---
+
+## Related Files
+
+- `.github/workflows/ci-standard.yml` - Main CI workflow
+- `.github/workflows/ci-fast-tests.yml` - Fast feedback workflow
+- `.github/workflows/Bot-CI-Trigger.yml` - Bot PR CI trigger
+- `.github/workflows/Jules-PR-AutoFix.yml` - Auto-fix on CI failure
+- `.github/workflows/Jules-Control-Tower.yml` - Workflow orchestration
+
+---
+
+## References
+
+- [GitHub Actions: Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
+- [GitHub Actions: GITHUB_TOKEN permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+- [Triggering workflows from workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)


### PR DESCRIPTION
Document findings from overnight workflow analysis identifying
why some PRs are not triggering full CI/CD pipeline. Key issues:
- GITHUB_TOKEN limitation in Jules-PR-AutoFix
- Incomplete bot detection patterns
- Missing PR event types

Includes recommended fixes and verification checklist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Provides a concise assessment of CI/CD trigger gaps and concrete remediation steps.
> 
> - Highlights `GITHUB_TOKEN` limitation in `Jules-PR-AutoFix` preventing downstream workflow triggers; recommends using `secrets.BOT_PAT`
> - Notes incomplete bot detection in `Bot-CI-Trigger` (add Claude patterns and broader bot/app checks)
> - Recommends explicit `pull_request` event `types` (e.g., `ready_for_review`) in `ci-standard`
> - Includes prioritized fixes, schedule tuning, and a post-fix verification checklist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d323747f501a8a4df0c5db671bab7bb5be5b22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->