### PR TITLE
style(ai): Dark Theme for Settings Dialog

### DIFF
--- a/src/shared/python/ai/gui/settings_dialog.py
+++ b/src/shared/python/ai/gui/settings_dialog.py
@@ -416,6 +416,77 @@ class AISettingsDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("AI Assistant Settings")
         self.setMinimumSize(500, 400)
+        
+        # Apply Dark Theme styling
+        self.setStyleSheet("""
+            QDialog, QWidget {
+                background-color: #1e1e1e;
+                color: #e0e0e0;
+            }
+            QTabWidget::pane {
+                border: 1px solid #3c3c3c;
+                background-color: #1e1e1e;
+            }
+            QTabBar::tab {
+                background-color: #2d2d2d;
+                color: #e0e0e0;
+                padding: 8px 16px;
+                border: 1px solid #3c3c3c;
+                border-bottom: none;
+                border-top-left-radius: 4px;
+                border-top-right-radius: 4px;
+            }
+            QTabBar::tab:selected {
+                background-color: #1e1e1e;
+                border-bottom: 2px solid #FF8800; /* Gitpod Orange Accent */
+                font-weight: bold;
+            }
+            QGroupBox {
+                border: 1px solid #3c3c3c;
+                border-radius: 6px;
+                margin-top: 12px;
+                padding-top: 10px;
+                font-weight: bold;
+                color: #FF8800; /* Orange Title */
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                subcontrol-position: top left;
+                padding: 0 4px;
+                left: 8px;
+            }
+            QLabel {
+                color: #e0e0e0;
+            }
+            QLineEdit, QComboBox {
+                background-color: #252526;
+                color: #e0e0e0;
+                border: 1px solid #3c3c3c;
+                border-radius: 4px;
+                padding: 4px;
+            }
+            QLineEdit:focus, QComboBox:focus {
+                border: 1px solid #FF8800;
+            }
+            QPushButton {
+                background-color: #0e639c; /* Blue default for buttons */
+                color: white;
+                border: none;
+                border-radius: 4px;
+                padding: 6px 12px;
+            }
+            QPushButton:hover {
+                background-color: #1177bb;
+            }
+            QCheckBox {
+                color: #e0e0e0;
+            }
+            /* Specific fix for QDialogButtonBox to look standard */
+            QDialogButtonBox QPushButton {
+                min-width: 60px;
+            }
+        """)
+
         self._settings = AISettings.load()
         self._setup_ui()
         self._load_settings()


### PR DESCRIPTION
Applies the comprehensive dark theme style sheet to the AI Settings Dialog, ensuring text visibility and consistent UI/UX with the main assistant panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies a dark theme to the AI Settings dialog via a QSS stylesheet.
> 
> - Injects comprehensive stylesheet in `AISettingsDialog.__init__` covering `QDialog/QWidget` backgrounds, text colors, `QTabWidget`/`QTabBar`, `QGroupBox` (with orange accents), `QLabel`, `QLineEdit`/`QComboBox` (focus states), `QPushButton` (hover), `QCheckBox`, and `QDialogButtonBox` button sizing
> - No logic or behavior changes; UI styling only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e999daab8cf5a0a2985a09f90433e6b688f0972. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->