### PR TITLE
fix(urdf-generator): enable MuJoCo 3D visualization and fix model loading

### DIFF
--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -60,13 +60,13 @@ models:
     name: "Matlab Simscape 2D"
     description: "2D golf swing Simscape Multibody model"
     type: "matlab_app"
-    path: "engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/GolfSwingZVCF.slx"
+    path: "src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/GolfSwingZVCF.slx"
 
   - id: "simscape_3d"
     name: "Matlab Simscape 3D"
     description: "3D golf swing Simscape Multibody model"
     type: "matlab_app"
-    path: "engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/Model/GolfSwing3D.slx"
+    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/model/GolfSwing3D_Kinetic.slx"
 
   # =============================================================================
   # MUJOCO SPECIFIC MODELS (for engine selector)
@@ -74,18 +74,11 @@ models:
 
 
 
-  - id: "humanoid_7dof"
-    name: "7-DOF Spatial Model"
-    description: "Full spatial whole-body model."
-    type: "engine_managed"
-    path: "engines/physics_engines/mujoco/models/humanoid_7dof.xml"
-    engine_type: "mujoco"
-
   - id: "pendulum_simple"
     name: "Simple Pendulum"
     description: "Basic single link pendulum test."
     type: "engine_managed"
-    path: "engines/physics_engines/mujoco/models/simple_pendulum.xml"
+    path: "src/engines/physics_engines/mujoco/models/simple_pendulum.xml"
     engine_type: "mujoco"
 
   # =============================================================================
@@ -96,24 +89,24 @@ models:
     name: "URDF Generator"
     description: "Interactive URDF model builder"
     type: "special_app"
-    path: "tools/urdf_generator/launch_urdf_generator.py"
+    path: "src/tools/urdf_generator/launch_urdf_generator.py"
 
   - id: "c3d_viewer"
     name: "C3D Motion Viewer"
     description: "C3D motion capture file viewer and analyzer"
     type: "special_app"
-    path: "engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
+    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
 
   - id: "matlab_dataset_gui"
     name: "Dataset Generator GUI"
     description: "MATLAB forward dynamics dataset generator"
     type: "special_app"
-    path: "engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/scripts/dataset_generator/Dataset_GUI.m"
+    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/scripts/dataset_generator/Dataset_GUI.m"
 
   - id: "matlab_golf_gui"
     name: "Golf Swing Analysis GUI"
     description: "MATLAB plotting suite with skeleton visualization"
     type: "special_app"
-    path: "engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/2D GUI/main_scripts/golf_swing_analysis_gui.m"
+    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/2D GUI/main_scripts/golf_swing_analysis_gui.m"
 
 

--- a/src/engines/physics_engines/drake/python/src/drake_gui_app.py
+++ b/src/engines/physics_engines/drake/python/src/drake_gui_app.py
@@ -8,6 +8,12 @@ import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+# Add project root to path for src imports when run as standalone script
+# Path: src/engines/physics_engines/drake/python/src/drake_gui_app.py -> need 7 parents
+_project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import numpy as np
 
 from src.shared.python.engine_availability import (

--- a/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
+++ b/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
@@ -10,6 +10,12 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+# Add project root to path for src imports when run as standalone script
+# Path: src/engines/physics_engines/mujoco/python/humanoid_launcher.py -> need 6 parents
+_project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import numpy as np
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QPalette

--- a/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
+++ b/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
@@ -8,7 +8,15 @@ Refactored to use shared engine availability module (DRY principle).
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Any
+
+# Add project root to path for src imports when run as standalone script
+# Path: src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py -> need 6 parents
+_project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
 
 import numpy as np
 

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
@@ -5,6 +5,12 @@ import types
 from pathlib import Path
 from typing import Any
 
+# Add project root to path for src imports when run as standalone script
+# Path: src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py -> need 7 parents
+_project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import numpy as np
 import pinocchio as pin  # type: ignore
 from PyQt6 import QtCore, QtWidgets

--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -271,6 +271,15 @@ class GolfLauncher(QMainWindow):
         else:
             self.toast_manager = None
 
+    def _get_subprocess_env(self) -> dict[str, str]:
+        """Get environment dict with PYTHONPATH set for subprocess launches."""
+        env = os.environ.copy()
+        pythonpath = str(REPOS_ROOT)
+        if "PYTHONPATH" in env:
+            pythonpath = f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+        env["PYTHONPATH"] = pythonpath
+        return env
+
     def _setup_keyboard_shortcuts(self) -> None:
         """Set up global keyboard shortcuts."""
         # Ctrl+? or F1 for shortcuts overlay
@@ -1295,7 +1304,7 @@ class GolfLauncher(QMainWindow):
 
         try:
             # Determine launch strategy
-            repo_path = getattr(model, "repo_path", None)
+            repo_path = getattr(model, "path", None)
 
             # If path provided, use it
             if repo_path:
@@ -1398,6 +1407,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, "-m", "mujoco_humanoid_golf"],
                 cwd=str(python_dir),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["mujoco_dashboard"] = process
@@ -1418,6 +1428,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, "-m", "src.drake_gui_app"],
                 cwd=str(python_dir),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["drake_gui"] = process
@@ -1439,6 +1450,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, str(script)],
                 cwd=str(python_dir),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["pinocchio_gui"] = process
@@ -1461,6 +1473,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, str(script)],
                 cwd=str(script.parent),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["opensim_gui"] = process
@@ -1482,6 +1495,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, str(script)],
                 cwd=str(script.parent),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["myosim_gui"] = process
@@ -1502,6 +1516,7 @@ class GolfLauncher(QMainWindow):
             process = subprocess.Popen(
                 [sys.executable, str(script)],
                 cwd=str(script.parent),
+                env=self._get_subprocess_env(),
                 creationflags=creation_flags,
             )
             self.running_processes["openpose_gui"] = process
@@ -1600,6 +1615,7 @@ class GolfLauncher(QMainWindow):
             process = secure_popen(
                 [sys.executable, str(script_path)],
                 cwd=str(cwd),
+                env=self._get_subprocess_env(),
                 creationflags=CREATE_NEW_CONSOLE if os.name == "nt" else 0,
             )
             self.running_processes[name] = process

--- a/src/shared/python/constants.py
+++ b/src/shared/python/constants.py
@@ -58,9 +58,9 @@ DRAKE_LAUNCHER_SCRIPT: Path = Path(
 PINOCCHIO_LAUNCHER_SCRIPT: Path = Path(
     "engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py"
 )
-URDF_GENERATOR_SCRIPT: Path = Path("tools/urdf_generator/main.py")
+URDF_GENERATOR_SCRIPT: Path = Path("src/tools/urdf_generator/launch_urdf_generator.py")
 C3D_VIEWER_SCRIPT: Path = Path(
-    "engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
+    "src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
 )
 GUI_LAUNCHER_SCRIPT: Path = Path("launchers/golf_launcher.py")
 LOCAL_LAUNCHER_SCRIPT: Path = Path("launchers/golf_suite_launcher.py")

--- a/src/tools/urdf_generator/bundled_assets/__init__.py
+++ b/src/tools/urdf_generator/bundled_assets/__init__.py
@@ -16,10 +16,22 @@ Usage:
 from __future__ import annotations
 
 import json
+import logging
+import sys
 from pathlib import Path
 from typing import Any
 
-from src.shared.python.logging_config import get_logger
+# Add project root to path for src imports when run as part of tool
+_project_root = Path(__file__).resolve().parent.parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+try:
+    from src.shared.python.logging_config import get_logger
+except ImportError:
+    # Fallback if logging module not available
+    def get_logger(name: str) -> logging.Logger:
+        return logging.getLogger(name)
 
 logger = get_logger(__name__)
 

--- a/src/tools/urdf_generator/bundled_assets/human_models/human_subject_with_meshes/model.urdf
+++ b/src/tools/urdf_generator/bundled_assets/human_models/human_subject_with_meshes/model.urdf
@@ -8,7 +8,7 @@
     </inertial>
     <visual name="Pelvis">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Pelvis.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Pelvis.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -17,7 +17,7 @@
     </visual>
     <visual name="Pelvis_RightRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Pelvis_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Pelvis_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -26,7 +26,7 @@
     </visual>
     <visual name="Pelvis_RightErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Pelvis_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Pelvis_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -35,7 +35,7 @@
     </visual>
     <visual name="Pelvis_LeftRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Pelvis_LeftRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Pelvis_LeftRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -44,7 +44,7 @@
     </visual>
     <visual name="Pelvis_LeftErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Pelvis_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Pelvis_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -73,7 +73,7 @@
     </inertial>
     <visual name="LowerTrunk">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LowerTrunk.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LowerTrunk.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -82,7 +82,7 @@
     </visual>
     <visual name="LowerTrunk_RightRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LowerTrunk_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LowerTrunk_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -91,7 +91,7 @@
     </visual>
     <visual name="LowerTrunk_RightErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LowerTrunk_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LowerTrunk_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -100,7 +100,7 @@
     </visual>
     <visual name="LowerTrunk_LefttRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LowerTrunk_LefttRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LowerTrunk_LefttRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -109,7 +109,7 @@
     </visual>
     <visual name="LowerTrunk_LeftErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LowerTrunk_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LowerTrunk_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -145,7 +145,7 @@
     </inertial>
     <visual name="UpperTrunk">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/UpperTrunk.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/UpperTrunk.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -154,7 +154,7 @@
     </visual>
     <visual name="UpperTrunk_RightRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/UpperTrunk_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/UpperTrunk_RightRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -163,7 +163,7 @@
     </visual>
     <visual name="UpperTrunk_RightErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/UpperTrunk_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/UpperTrunk_RightErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -172,7 +172,7 @@
     </visual>
     <visual name="UpperTrunk_LeftRecAbd">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/UpperTrunk_LeftRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/UpperTrunk_LeftRecAbd.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -181,7 +181,7 @@
     </visual>
     <visual name="UpperTrunk_LeftErcSpin">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/UpperTrunk_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
+        <mesh filename="meshes/UpperTrunk_LeftErcSpin.stl" scale="0.58333333 1.03030303 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -203,7 +203,7 @@
     </inertial>
     <visual name="RightShoulder">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightShoulder.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/RightShoulder.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -225,7 +225,7 @@
     </inertial>
     <visual name="LeftShoulder">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftShoulder.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/LeftShoulder.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -261,7 +261,7 @@
     </inertial>
     <visual name="Neck">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Neck.stl" scale="0.73076923 0.73076923 1.03030303"/>
+        <mesh filename="meshes/Neck.stl" scale="0.73076923 0.73076923 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -290,7 +290,7 @@
     </inertial>
     <visual name="Head">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/Head.stl" scale="1.03030303 1.03030303 1.03030303"/>
+        <mesh filename="meshes/Head.stl" scale="1.03030303 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -326,7 +326,7 @@
     </inertial>
     <visual name="RightUpperArm">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightUpperArm.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/RightUpperArm.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -335,7 +335,7 @@
     </visual>
     <visual name="RightTricBrac">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightTricBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/RightTricBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -344,7 +344,7 @@
     </visual>
     <visual name="RightBicBrac">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightBicBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/RightBicBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -373,7 +373,7 @@
     </inertial>
     <visual name="RightForeArm">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightForeArm.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/RightForeArm.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -382,7 +382,7 @@
     </visual>
     <visual name="RightFlexCarp">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightFlexCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/RightFlexCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -391,7 +391,7 @@
     </visual>
     <visual name="RightExtCarp">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightExtCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/RightExtCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -420,7 +420,7 @@
     </inertial>
     <visual name="RightHand">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightHand.stl" scale="0.9        1.03030303 0.55555556"/>
+        <mesh filename="meshes/RightHand.stl" scale="0.9        1.03030303 0.55555556"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -469,7 +469,7 @@
     </inertial>
     <visual name="LeftUpperArm">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftUpperArm.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/LeftUpperArm.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -478,7 +478,7 @@
     </visual>
     <visual name="LeftTricBrac">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftTricBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/LeftTricBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -487,7 +487,7 @@
     </visual>
     <visual name="LeftBicBrac">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftBicBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
+        <mesh filename="meshes/LeftBicBrac.stl" scale="0.64444444 0.64444444 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -516,7 +516,7 @@
     </inertial>
     <visual name="LeftForeArm">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftForeArm.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/LeftForeArm.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -525,7 +525,7 @@
     </visual>
     <visual name="LeftFlexCarp">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftFlexCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/LeftFlexCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -534,7 +534,7 @@
     </visual>
     <visual name="LeftExtCarp">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftExtCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
+        <mesh filename="meshes/LeftExtCarp.stl" scale="0.61111111 0.61111111 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -563,7 +563,7 @@
     </inertial>
     <visual name="LeftHand">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftHand.stl" scale="0.9        1.03030303 0.55555556"/>
+        <mesh filename="meshes/LeftHand.stl" scale="0.9        1.03030303 0.55555556"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -612,7 +612,7 @@
     </inertial>
     <visual name="RightUpperLeg">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightUpperLeg.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/RightUpperLeg.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -621,7 +621,7 @@
     </visual>
     <visual name="RightRecFem">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightRecFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/RightRecFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -630,7 +630,7 @@
     </visual>
     <visual name="RightBicFem">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightBicFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/RightBicFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -659,7 +659,7 @@
     </inertial>
     <visual name="RightLowerLeg">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightLowerLeg.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/RightLowerLeg.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -668,7 +668,7 @@
     </visual>
     <visual name="RightTibAnt">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightTibAnt.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/RightTibAnt.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -677,7 +677,7 @@
     </visual>
     <visual name="RightGasMed">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightGasMed.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/RightGasMed.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -686,7 +686,7 @@
     </visual>
     <visual name="RightGasLat">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightGasLat.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/RightGasLat.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -722,7 +722,7 @@
     </inertial>
     <visual name="RightFoot">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightFoot.stl" scale="1.03030303 1.03030303 1.03030303"/>
+        <mesh filename="meshes/RightFoot.stl" scale="1.03030303 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -744,7 +744,7 @@
     </inertial>
     <visual name="RightToe">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/RightToe.stl" scale="1.03030303 1.03030303 1.03030303"/>
+        <mesh filename="meshes/RightToe.stl" scale="1.03030303 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -793,7 +793,7 @@
     </inertial>
     <visual name="LeftUpperLeg">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftUpperLeg.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/LeftUpperLeg.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -802,7 +802,7 @@
     </visual>
     <visual name="LeftRecFem">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftRecFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/LeftRecFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -811,7 +811,7 @@
     </visual>
     <visual name="LeftBicFem">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftBicFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
+        <mesh filename="meshes/LeftBicFem.stl" scale="0.83333333 0.83333333 1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -840,7 +840,7 @@
     </inertial>
     <visual name="LeftLowerLeg">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftLowerLeg.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/LeftLowerLeg.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -849,7 +849,7 @@
     </visual>
     <visual name="LeftTibAnt">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftTibAnt.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/LeftTibAnt.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -858,7 +858,7 @@
     </visual>
     <visual name="LeftGasMed">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftGasMed.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/LeftGasMed.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -867,7 +867,7 @@
     </visual>
     <visual name="LeftGasLat">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftGasLat.stl" scale="0.7826087  0.7826087  1.03030303"/>
+        <mesh filename="meshes/LeftGasLat.stl" scale="0.7826087  0.7826087  1.03030303"/>
       </geometry>
       <material name="muscle">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -903,7 +903,7 @@
     </inertial>
     <visual name="LeftFoot">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftFoot.stl" scale="1.03030303 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LeftFoot.stl" scale="1.03030303 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -925,7 +925,7 @@
     </inertial>
     <visual name="LeftToe">
       <geometry>
-        <mesh filename="package://human-gazebo/meshes/LeftToe.stl" scale="1.03030303 1.03030303 1.03030303"/>
+        <mesh filename="meshes/LeftToe.stl" scale="1.03030303 1.03030303 1.03030303"/>
       </geometry>
       <material name="Link">
         <color rgba="0.9922 0.8667 0.7922 1.    "/>
@@ -1905,3 +1905,4 @@
     <origin xyz="-0.045 0.0 -0.03315" rpy="0.0 0.0 0.0"/>
   </joint>
 </robot>
+

--- a/src/tools/urdf_generator/launch_urdf_generator.py
+++ b/src/tools/urdf_generator/launch_urdf_generator.py
@@ -2,14 +2,23 @@
 """Launch script for the Interactive URDF Generator."""
 
 import sys
+from pathlib import Path
+
+# Add project root to path for src imports when run as standalone script
+# Path: src/tools/urdf_generator/launch_urdf_generator.py -> need 4 parents
+_project_root = Path(__file__).resolve().parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+# CRITICAL: Import MuJoCo BEFORE any Qt imports to avoid DLL conflicts on Windows.
+# Qt's OpenGL context initialization conflicts with MuJoCo's plugin loading.
+try:
+    import mujoco  # noqa: F401
+except ImportError:
+    pass  # MuJoCo not installed, will fall back to grid view
 
 from src.shared.python.logging_config import configure_gui_logging, get_logger
-from src.shared.python.path_utils import setup_import_paths
-
-# Add the project root to the Python path
-setup_import_paths()
-
-from src.tools.urdf_generator.main_window import main  # noqa: E402
+from src.tools.urdf_generator.main_window import main
 
 if __name__ == "__main__":
     # Set up logging

--- a/src/tools/urdf_generator/main_window.py
+++ b/src/tools/urdf_generator/main_window.py
@@ -318,11 +318,10 @@ class URDFGeneratorWindow(QMainWindow):
                                 f"Loaded golf club: {model_key}"
                             )
                     elif category == "human":
-                        # Load human model URDF
-                        model_dir = library.human_models_path / model_key
-                        urdf_path = model_dir / "model.urdf"
+                        # Load human model URDF (prefers bundled assets)
+                        urdf_path = library.get_human_model(model_key)
 
-                        if urdf_path.exists():
+                        if urdf_path and urdf_path.exists():
                             self._load_urdf_file(urdf_path)
                             self.status_bar.showMessage(
                                 f"Loaded human model: {model_key}"
@@ -330,10 +329,9 @@ class URDFGeneratorWindow(QMainWindow):
                         else:
                             QMessageBox.information(
                                 self,
-                                "Model Not Downloaded",
-                                "This model has not been downloaded yet.\n"
-                                "Please use the 'Download from human-gazebo' button "
-                                "in the model loader dialog.",
+                                "Model Not Available",
+                                "This model is not bundled or downloaded.\n"
+                                "Check bundled_assets/ for available models.",
                             )
 
         except Exception as e:
@@ -359,7 +357,10 @@ class URDFGeneratorWindow(QMainWindow):
             urdf_content = file_path.read_text(encoding="utf-8")
             # URDF parsing for segment panel population is a future enhancement
             # Currently loading for visualization only
-            self.visualization_widget.update_visualization(urdf_content)
+            # Pass file path for mesh resolution in MuJoCo
+            self.visualization_widget.update_visualization(
+                urdf_content, str(file_path)
+            )
             self.current_file_path = file_path
             self.setWindowTitle(f"Interactive URDF Generator - {file_path.name}")
             logger.info(f"URDF loaded: {file_path}")

--- a/src/tools/urdf_generator/model_library.py
+++ b/src/tools/urdf_generator/model_library.py
@@ -17,18 +17,29 @@ Use BundledAssets from bundled_assets/ for local models.
 from __future__ import annotations
 
 import json
+import logging
 import math
+import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
 
-from src.shared.python.logging_config import get_logger
+# Add project root to path for src imports when run as standalone script
+_project_root = Path(__file__).resolve().parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+try:
+    from src.shared.python.logging_config import get_logger
+except ImportError:
+    def get_logger(name: str) -> logging.Logger:
+        return logging.getLogger(name)
 
 logger = get_logger(__name__)
 
 # Try to import bundled assets for local model access
 try:
-    from tools.urdf_generator.bundled_assets import (
+    from src.tools.urdf_generator.bundled_assets import (
         BundledAssetNotFoundError,
         BundledAssets,
     )

--- a/src/tools/urdf_generator/model_loader_dialog.py
+++ b/src/tools/urdf_generator/model_loader_dialog.py
@@ -6,7 +6,15 @@ including human models and golf clubs.
 
 from __future__ import annotations
 
+import logging
+import sys
+from pathlib import Path
 from typing import Any
+
+# Add project root to path for src imports
+_project_root = Path(__file__).resolve().parent.parent.parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
 
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
@@ -23,7 +31,11 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from src.shared.python.logging_config import get_logger
+try:
+    from src.shared.python.logging_config import get_logger
+except ImportError:
+    def get_logger(name: str) -> logging.Logger:
+        return logging.getLogger(name)
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- Fix multiple path and import issues preventing Golf Modeling Suite models from launching
- Enable MuJoCo 3D visualization in the URDF Generator
- Fix bundled assets loading to use local mesh files instead of failed downloads

## Changes

### Path and Import Fixes
- Fix model paths in `models.yaml` (add missing `src/` prefix)
- Fix `URDF_GENERATOR_SCRIPT` and `C3D_VIEWER_SCRIPT` paths in `constants.py`
- Fix `model.repo_path` -> `model.path` attribute access in `golf_launcher.py`
- Add `PYTHONPATH` to subprocess environment for module resolution
- Add `sys.path` setup in launcher scripts for standalone execution

### MuJoCo Integration Fixes
- Import MuJoCo BEFORE Qt to avoid DLL conflicts on Windows
- Fix `Renderer` parameter order: `(model, height, width)` not `(model, width, height)`
- Fix `GRAVITY_M_S2` PhysicalConstant to float conversion for MJCF XML
- Add preprocessing to fix zero/small mass and inertia values that MuJoCo rejects
- Use model's offscreen dimensions for framebuffer compatibility

### Bundled Assets
- Fix URDF mesh paths from `package://human-gazebo/meshes/` URLs to relative `meshes/` paths
- Update `bundled_assets` module with proper path setup
- Load models from bundled assets instead of attempting network downloads

## Test plan
- [ ] Launch Golf Modeling Suite from desktop shortcut
- [ ] Open URDF Generator
- [ ] Load human model from File → Load from Library → human/human_with_meshes
- [ ] Verify 3D model renders in MuJoCo viewer
- [ ] Test mouse rotation/zoom controls on the 3D view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables stable MuJoCo-based 3D visualization in the URDF Generator and fixes multiple launch/path issues across engines and tools.
> 
> - Updates paths in `models.yaml` and `constants.py` (add `src/` prefixes; correct `URDF_GENERATOR_SCRIPT`, `C3D_VIEWER_SCRIPT`)
> - Launcher robustness: add project-root `sys.path` bootstrapping to Drake/MuJoCo/Pinocchio/Myosuite scripts; in `golf_launcher.py` use `model.path` (not `repo_path`) and pass a `PYTHONPATH`-augmented env to all subprocess launches
> - URDF Generator: new `launch_urdf_generator.py` (imports MuJoCo before Qt), `main_window.py` passes file path to visualization; `VisualizationWidget` prefers MuJoCo viewer with graceful fallback
> - MuJoCo viewer fixes: correct `Renderer` arg order, ensure float gravity in MJCF, larger offscreen buffers, and a file-loader that pre-processes URDF inertials/mass (temp file) for mesh resolution and Mujoco compatibility
> - Bundled assets: switch URDF mesh URIs from `package://...` to relative `meshes/`; add bundled human model; harden imports/path setup in `bundled_assets`, `model_library`, and dialog
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cfd739287359daefe50f85730080c9aee1a3aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->