### PR TITLE
feat(urdf-editor): Add advanced URDF editor components for component manipulation

### DIFF
--- a/src/tools/model_explorer/__init__.py
+++ b/src/tools/model_explorer/__init__.py
@@ -3,15 +3,50 @@
 This module provides an interactive GUI tool for creating URDF files
 with support for parallel kinematic configurations commonly used in
 golf swing modeling.
+
+New in v2.0.0:
+- Component library with read-only protection and copy-to-edit
+- URDF code editor with syntax highlighting and validation
+- Frankenstein mode for combining URDFs
+- Chain manipulation tools for inserting/editing branches
+- End effector swap system with visual interface
+- Joint auto-loader and manipulation panel
+- Mesh/STL browser with copy functionality
 """
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 __author__ = "Golf Modeling Suite Team"
 
 from .segment_manager import SegmentManager
 from .urdf_builder import Handedness, URDFBuilder
 
-__all__ = ["URDFGeneratorWindow", "URDFBuilder", "SegmentManager", "Handedness"]
+__all__ = [
+    # Main windows
+    "URDFGeneratorWindow",
+    "URDFEditorWindow",
+    # Core classes
+    "URDFBuilder",
+    "SegmentManager",
+    "Handedness",
+    # Component library
+    "ComponentLibrary",
+    "ComponentLibraryWidget",
+    # Code editor
+    "URDFCodeEditor",
+    "URDFCodeEditorWidget",
+    # Frankenstein mode
+    "FrankensteinEditor",
+    # Chain manipulation
+    "ChainManipulationWidget",
+    "KinematicTree",
+    # End effector manager
+    "EndEffectorManagerWidget",
+    "EndEffectorLibrary",
+    # Joint manipulator
+    "JointManipulatorWidget",
+    # Mesh browser
+    "MeshBrowserWidget",
+]
 
 
 def __getattr__(name: str) -> type:
@@ -20,4 +55,52 @@ def __getattr__(name: str) -> type:
         from .main_window import URDFGeneratorWindow
 
         return URDFGeneratorWindow
+    if name == "URDFEditorWindow":
+        from .urdf_editor_window import URDFEditorWindow
+
+        return URDFEditorWindow
+    if name == "ComponentLibrary":
+        from .component_library import ComponentLibrary
+
+        return ComponentLibrary
+    if name == "ComponentLibraryWidget":
+        from .component_library import ComponentLibraryWidget
+
+        return ComponentLibraryWidget
+    if name == "URDFCodeEditor":
+        from .urdf_code_editor import URDFCodeEditor
+
+        return URDFCodeEditor
+    if name == "URDFCodeEditorWidget":
+        from .urdf_code_editor import URDFCodeEditorWidget
+
+        return URDFCodeEditorWidget
+    if name == "FrankensteinEditor":
+        from .frankenstein_editor import FrankensteinEditor
+
+        return FrankensteinEditor
+    if name == "ChainManipulationWidget":
+        from .chain_manipulation import ChainManipulationWidget
+
+        return ChainManipulationWidget
+    if name == "KinematicTree":
+        from .chain_manipulation import KinematicTree
+
+        return KinematicTree
+    if name == "EndEffectorManagerWidget":
+        from .end_effector_manager import EndEffectorManagerWidget
+
+        return EndEffectorManagerWidget
+    if name == "EndEffectorLibrary":
+        from .end_effector_manager import EndEffectorLibrary
+
+        return EndEffectorLibrary
+    if name == "JointManipulatorWidget":
+        from .joint_manipulator import JointManipulatorWidget
+
+        return JointManipulatorWidget
+    if name == "MeshBrowserWidget":
+        from .mesh_browser import MeshBrowserWidget
+
+        return MeshBrowserWidget
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/tools/model_explorer/chain_manipulation.py
+++ b/src/tools/model_explorer/chain_manipulation.py
@@ -1,0 +1,806 @@
+"""Chain Manipulation Tools for URDF kinematic chain editing.
+
+Provides tools for inserting segments into chains, editing branch structures,
+and managing the kinematic hierarchy of URDF models.
+"""
+
+from __future__ import annotations
+
+import copy
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGraphicsEllipseItem,
+    QGraphicsLineItem,
+    QGraphicsScene,
+    QGraphicsTextItem,
+    QGraphicsView,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QSplitter,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ChainNode:
+    """Represents a node in the kinematic chain."""
+
+    name: str
+    link_element: ET.Element | None = None
+    joint_to_parent: ET.Element | None = None
+    parent: "ChainNode | None" = None
+    children: list["ChainNode"] = field(default_factory=list)
+    depth: int = 0
+
+    def get_chain_to_root(self) -> list["ChainNode"]:
+        """Get the chain from this node to the root."""
+        chain = [self]
+        current = self.parent
+        while current:
+            chain.append(current)
+            current = current.parent
+        return list(reversed(chain))
+
+    def get_all_descendants(self) -> list["ChainNode"]:
+        """Get all descendant nodes."""
+        descendants = []
+        for child in self.children:
+            descendants.append(child)
+            descendants.extend(child.get_all_descendants())
+        return descendants
+
+    def is_leaf(self) -> bool:
+        """Check if this is a leaf node (no children)."""
+        return len(self.children) == 0
+
+    def is_end_effector(self) -> bool:
+        """Check if this could be an end effector (leaf with common naming)."""
+        if not self.is_leaf():
+            return False
+        lower_name = self.name.lower()
+        end_effector_hints = [
+            "hand", "gripper", "tool", "effector", "finger",
+            "tip", "end", "head", "foot", "palm"
+        ]
+        return any(hint in lower_name for hint in end_effector_hints)
+
+
+class KinematicTree:
+    """Represents the kinematic tree structure of a URDF."""
+
+    def __init__(self) -> None:
+        """Initialize the kinematic tree."""
+        self.root: ChainNode | None = None
+        self.nodes: dict[str, ChainNode] = {}
+
+    def build_from_urdf(self, urdf_content: str) -> None:
+        """Build the tree from URDF XML content."""
+        try:
+            root_elem = ET.fromstring(urdf_content)
+        except ET.ParseError as e:
+            logger.error(f"Failed to parse URDF: {e}")
+            return
+
+        self.nodes.clear()
+        self.root = None
+
+        # Extract links
+        links = {}
+        for link in root_elem.findall("link"):
+            name = link.get("name", "")
+            links[name] = link
+            self.nodes[name] = ChainNode(name=name, link_element=link)
+
+        # Extract joints and build hierarchy
+        child_links = set()
+        for joint in root_elem.findall("joint"):
+            parent_elem = joint.find("parent")
+            child_elem = joint.find("child")
+
+            if parent_elem is None or child_elem is None:
+                continue
+
+            parent_name = parent_elem.get("link", "")
+            child_name = child_elem.get("link", "")
+
+            if parent_name in self.nodes and child_name in self.nodes:
+                parent_node = self.nodes[parent_name]
+                child_node = self.nodes[child_name]
+
+                child_node.parent = parent_node
+                child_node.joint_to_parent = joint
+                parent_node.children.append(child_node)
+                child_links.add(child_name)
+
+        # Find root (link that is never a child)
+        for name, node in self.nodes.items():
+            if name not in child_links:
+                if self.root is None:
+                    self.root = node
+                else:
+                    # Multiple roots - use first one
+                    logger.warning(f"Multiple root links found. Using '{self.root.name}'")
+
+        # Calculate depths
+        self._calculate_depths()
+
+    def _calculate_depths(self) -> None:
+        """Calculate depth for each node."""
+        if self.root is None:
+            return
+
+        def set_depth(node: ChainNode, depth: int) -> None:
+            node.depth = depth
+            for child in node.children:
+                set_depth(child, depth + 1)
+
+        set_depth(self.root, 0)
+
+    def get_chain(self, from_link: str, to_link: str) -> list[ChainNode]:
+        """Get the chain between two links.
+
+        Args:
+            from_link: Starting link name
+            to_link: Ending link name
+
+        Returns:
+            List of nodes in the chain (may be empty if no path exists)
+        """
+        if from_link not in self.nodes or to_link not in self.nodes:
+            return []
+
+        from_node = self.nodes[from_link]
+        to_node = self.nodes[to_link]
+
+        # Get paths to root
+        from_path = from_node.get_chain_to_root()
+        to_path = to_node.get_chain_to_root()
+
+        # Find common ancestor
+        from_set = set(n.name for n in from_path)
+        common_ancestor = None
+        for node in to_path:
+            if node.name in from_set:
+                common_ancestor = node
+                break
+
+        if common_ancestor is None:
+            return []
+
+        # Build path
+        chain = []
+
+        # From from_link to common ancestor
+        for node in from_path:
+            chain.append(node)
+            if node.name == common_ancestor.name:
+                break
+
+        # From common ancestor to to_link (reversed)
+        to_chain = []
+        for node in to_path:
+            if node.name == common_ancestor.name:
+                break
+            to_chain.append(node)
+
+        chain.extend(reversed(to_chain))
+        return chain
+
+    def get_all_chains(self) -> list[list[ChainNode]]:
+        """Get all chains from root to leaves."""
+        chains = []
+
+        def collect_chains(node: ChainNode, current_chain: list[ChainNode]) -> None:
+            current_chain = current_chain + [node]
+            if node.is_leaf():
+                chains.append(current_chain)
+            else:
+                for child in node.children:
+                    collect_chains(child, current_chain)
+
+        if self.root:
+            collect_chains(self.root, [])
+
+        return chains
+
+    def get_end_effectors(self) -> list[ChainNode]:
+        """Get all potential end effectors."""
+        return [node for node in self.nodes.values() if node.is_leaf()]
+
+    def get_branch_points(self) -> list[ChainNode]:
+        """Get all branch points (nodes with multiple children)."""
+        return [node for node in self.nodes.values() if len(node.children) > 1]
+
+
+class ChainVisualizer(QGraphicsView):
+    """Visual representation of the kinematic chain."""
+
+    node_selected = pyqtSignal(str)  # Link name
+    node_double_clicked = pyqtSignal(str)  # For insertion point
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the visualizer."""
+        super().__init__(parent)
+        self.scene = QGraphicsScene(self)
+        self.setScene(self.scene)
+        self.tree: KinematicTree | None = None
+        self.node_items: dict[str, QGraphicsEllipseItem] = {}
+
+        # Visual settings
+        self.node_radius = 20
+        self.level_height = 80
+        self.sibling_spacing = 60
+
+    def set_tree(self, tree: KinematicTree) -> None:
+        """Set the kinematic tree to visualize."""
+        self.tree = tree
+        self._render_tree()
+
+    def _render_tree(self) -> None:
+        """Render the kinematic tree."""
+        self.scene.clear()
+        self.node_items.clear()
+
+        if self.tree is None or self.tree.root is None:
+            return
+
+        # Calculate positions
+        positions = self._calculate_positions()
+
+        # Draw edges first (so they appear behind nodes)
+        for name, node in self.tree.nodes.items():
+            if node.parent and name in positions and node.parent.name in positions:
+                x1, y1 = positions[node.parent.name]
+                x2, y2 = positions[name]
+                line = QGraphicsLineItem(x1, y1, x2, y2)
+                line.setPen(QColor("#888888"))
+                self.scene.addItem(line)
+
+        # Draw nodes
+        for name, (x, y) in positions.items():
+            node = self.tree.nodes[name]
+            self._draw_node(node, x, y)
+
+        # Fit view
+        self.fitInView(self.scene.sceneRect(), Qt.AspectRatioMode.KeepAspectRatio)
+
+    def _calculate_positions(self) -> dict[str, tuple[float, float]]:
+        """Calculate node positions using a simple tree layout."""
+        positions: dict[str, tuple[float, float]] = {}
+
+        if self.tree is None or self.tree.root is None:
+            return positions
+
+        # Count nodes at each depth
+        depth_counts: dict[int, int] = {}
+        depth_indices: dict[int, int] = {}
+
+        for node in self.tree.nodes.values():
+            if node.depth not in depth_counts:
+                depth_counts[node.depth] = 0
+                depth_indices[node.depth] = 0
+            depth_counts[node.depth] += 1
+
+        # Assign positions
+        def assign_position(node: ChainNode) -> None:
+            depth = node.depth
+            count = depth_counts[depth]
+            index = depth_indices[depth]
+
+            x = (index - (count - 1) / 2) * self.sibling_spacing
+            y = depth * self.level_height
+
+            positions[node.name] = (x, y)
+            depth_indices[depth] += 1
+
+            for child in node.children:
+                assign_position(child)
+
+        assign_position(self.tree.root)
+        return positions
+
+    def _draw_node(self, node: ChainNode, x: float, y: float) -> None:
+        """Draw a single node."""
+        r = self.node_radius
+
+        # Determine color based on node type
+        if node.is_end_effector():
+            color = QColor("#FF6B6B")  # Red for end effectors
+        elif len(node.children) > 1:
+            color = QColor("#4ECDC4")  # Teal for branch points
+        elif node.parent is None:
+            color = QColor("#45B7D1")  # Blue for root
+        else:
+            color = QColor("#96CEB4")  # Green for regular nodes
+
+        # Draw ellipse
+        ellipse = QGraphicsEllipseItem(x - r, y - r, r * 2, r * 2)
+        ellipse.setBrush(color)
+        ellipse.setPen(QColor("#333333"))
+        ellipse.setData(0, node.name)
+        self.scene.addItem(ellipse)
+        self.node_items[node.name] = ellipse
+
+        # Draw label
+        text = QGraphicsTextItem(node.name)
+        text.setPos(x - text.boundingRect().width() / 2, y + r + 2)
+        font = text.font()
+        font.setPointSize(8)
+        text.setFont(font)
+        self.scene.addItem(text)
+
+    def mousePressEvent(self, event: Any) -> None:
+        """Handle mouse press for node selection."""
+        super().mousePressEvent(event)
+
+        item = self.itemAt(event.pos())
+        if isinstance(item, QGraphicsEllipseItem):
+            name = item.data(0)
+            if name:
+                self.node_selected.emit(name)
+
+    def mouseDoubleClickEvent(self, event: Any) -> None:
+        """Handle double-click for insertion point selection."""
+        super().mouseDoubleClickEvent(event)
+
+        item = self.itemAt(event.pos())
+        if isinstance(item, QGraphicsEllipseItem):
+            name = item.data(0)
+            if name:
+                self.node_double_clicked.emit(name)
+
+
+class InsertSegmentDialog(QDialog):
+    """Dialog for inserting a new segment into the chain."""
+
+    def __init__(
+        self,
+        tree: KinematicTree,
+        insert_after: str | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.tree = tree
+        self.setWindowTitle("Insert Segment")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        # Insertion point
+        insertion_group = QGroupBox("Insertion Point")
+        insertion_layout = QFormLayout(insertion_group)
+
+        self.parent_combo = QComboBox()
+        for name in tree.nodes.keys():
+            self.parent_combo.addItem(name)
+        if insert_after:
+            index = self.parent_combo.findText(insert_after)
+            if index >= 0:
+                self.parent_combo.setCurrentIndex(index)
+        insertion_layout.addRow("Insert after link:", self.parent_combo)
+
+        layout.addWidget(insertion_group)
+
+        # New link properties
+        link_group = QGroupBox("New Link")
+        link_layout = QFormLayout(link_group)
+
+        self.link_name_edit = QLineEdit()
+        self.link_name_edit.setPlaceholderText("new_link")
+        link_layout.addRow("Link name:", self.link_name_edit)
+
+        self.geometry_combo = QComboBox()
+        self.geometry_combo.addItems(["box", "cylinder", "sphere", "capsule"])
+        link_layout.addRow("Geometry:", self.geometry_combo)
+
+        self.mass_spin = QDoubleSpinBox()
+        self.mass_spin.setRange(0.001, 1000)
+        self.mass_spin.setValue(1.0)
+        self.mass_spin.setSuffix(" kg")
+        link_layout.addRow("Mass:", self.mass_spin)
+
+        layout.addWidget(link_group)
+
+        # New joint properties
+        joint_group = QGroupBox("New Joint")
+        joint_layout = QFormLayout(joint_group)
+
+        self.joint_name_edit = QLineEdit()
+        self.joint_name_edit.setPlaceholderText("new_joint")
+        joint_layout.addRow("Joint name:", self.joint_name_edit)
+
+        self.joint_type_combo = QComboBox()
+        self.joint_type_combo.addItems(
+            ["fixed", "revolute", "prismatic", "continuous"]
+        )
+        joint_layout.addRow("Joint type:", self.joint_type_combo)
+
+        # Axis
+        axis_layout = QHBoxLayout()
+        self.axis_x = QDoubleSpinBox()
+        self.axis_x.setRange(-1, 1)
+        self.axis_x.setValue(0)
+        self.axis_y = QDoubleSpinBox()
+        self.axis_y.setRange(-1, 1)
+        self.axis_y.setValue(0)
+        self.axis_z = QDoubleSpinBox()
+        self.axis_z.setRange(-1, 1)
+        self.axis_z.setValue(1)
+        axis_layout.addWidget(QLabel("X:"))
+        axis_layout.addWidget(self.axis_x)
+        axis_layout.addWidget(QLabel("Y:"))
+        axis_layout.addWidget(self.axis_y)
+        axis_layout.addWidget(QLabel("Z:"))
+        axis_layout.addWidget(self.axis_z)
+        joint_layout.addRow("Axis:", axis_layout)
+
+        layout.addWidget(joint_group)
+
+        # Re-parenting option
+        reparent_group = QGroupBox("Re-parent Children")
+        reparent_layout = QVBoxLayout(reparent_group)
+
+        parent_name = self.parent_combo.currentText()
+        if parent_name in tree.nodes:
+            node = tree.nodes[parent_name]
+            if node.children:
+                self.reparent_list = QListWidget()
+                self.reparent_list.setSelectionMode(
+                    QListWidget.SelectionMode.MultiSelection
+                )
+                for child in node.children:
+                    item = QListWidgetItem(child.name)
+                    item.setSelected(True)  # Select all by default
+                    self.reparent_list.addItem(item)
+                reparent_layout.addWidget(QLabel("Select children to re-parent to new link:"))
+                reparent_layout.addWidget(self.reparent_list)
+            else:
+                reparent_layout.addWidget(QLabel("No children to re-parent"))
+                self.reparent_list = None
+        else:
+            reparent_layout.addWidget(QLabel("Select a parent link first"))
+            self.reparent_list = None
+
+        layout.addWidget(reparent_group)
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        # Update reparent list when parent changes
+        self.parent_combo.currentTextChanged.connect(self._update_reparent_list)
+
+    def _update_reparent_list(self, parent_name: str) -> None:
+        """Update the reparent list when parent selection changes."""
+        if self.reparent_list is None:
+            return
+
+        self.reparent_list.clear()
+
+        if parent_name in self.tree.nodes:
+            node = self.tree.nodes[parent_name]
+            for child in node.children:
+                item = QListWidgetItem(child.name)
+                item.setSelected(True)
+                self.reparent_list.addItem(item)
+
+    def get_configuration(self) -> dict[str, Any]:
+        """Get the dialog configuration."""
+        children_to_reparent = []
+        if self.reparent_list:
+            for i in range(self.reparent_list.count()):
+                item = self.reparent_list.item(i)
+                if item and item.isSelected():
+                    children_to_reparent.append(item.text())
+
+        return {
+            "parent_link": self.parent_combo.currentText(),
+            "link_name": self.link_name_edit.text() or "new_link",
+            "geometry": self.geometry_combo.currentText(),
+            "mass": self.mass_spin.value(),
+            "joint_name": self.joint_name_edit.text() or "new_joint",
+            "joint_type": self.joint_type_combo.currentText(),
+            "axis": (self.axis_x.value(), self.axis_y.value(), self.axis_z.value()),
+            "reparent_children": children_to_reparent,
+        }
+
+
+class ChainManipulationWidget(QWidget):
+    """Widget for manipulating kinematic chains."""
+
+    chain_modified = pyqtSignal(str)  # Emits new URDF content
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the chain manipulation widget."""
+        super().__init__(parent)
+        self.tree = KinematicTree()
+        self.urdf_content: str = ""
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Main splitter
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left side - chain info and controls
+        left_widget = QWidget()
+        left_layout = QVBoxLayout(left_widget)
+
+        # Chain info
+        info_group = QGroupBox("Chain Information")
+        info_layout = QVBoxLayout(info_group)
+
+        self.links_label = QLabel("Links: 0")
+        self.joints_label = QLabel("Joints: 0")
+        self.branches_label = QLabel("Branches: 0")
+        self.end_effectors_label = QLabel("End effectors: 0")
+
+        info_layout.addWidget(self.links_label)
+        info_layout.addWidget(self.joints_label)
+        info_layout.addWidget(self.branches_label)
+        info_layout.addWidget(self.end_effectors_label)
+
+        left_layout.addWidget(info_group)
+
+        # Chain list
+        chains_group = QGroupBox("Kinematic Chains")
+        chains_layout = QVBoxLayout(chains_group)
+
+        self.chains_list = QListWidget()
+        chains_layout.addWidget(self.chains_list)
+
+        left_layout.addWidget(chains_group)
+
+        # Controls
+        controls_group = QGroupBox("Chain Operations")
+        controls_layout = QVBoxLayout(controls_group)
+
+        self.insert_btn = QPushButton("Insert Segment")
+        self.remove_btn = QPushButton("Remove Segment")
+        self.split_chain_btn = QPushButton("Split Chain")
+        self.merge_chains_btn = QPushButton("Merge Chains")
+
+        controls_layout.addWidget(self.insert_btn)
+        controls_layout.addWidget(self.remove_btn)
+        controls_layout.addWidget(self.split_chain_btn)
+        controls_layout.addWidget(self.merge_chains_btn)
+
+        left_layout.addWidget(controls_group)
+
+        splitter.addWidget(left_widget)
+
+        # Right side - visualization
+        right_widget = QWidget()
+        right_layout = QVBoxLayout(right_widget)
+
+        right_layout.addWidget(QLabel("Chain Visualization (double-click to select insertion point):"))
+
+        self.visualizer = ChainVisualizer()
+        self.visualizer.setMinimumSize(400, 300)
+        right_layout.addWidget(self.visualizer)
+
+        # Selected node info
+        self.selected_label = QLabel("Selected: None")
+        right_layout.addWidget(self.selected_label)
+
+        splitter.addWidget(right_widget)
+
+        layout.addWidget(splitter)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.insert_btn.clicked.connect(self._on_insert_segment)
+        self.remove_btn.clicked.connect(self._on_remove_segment)
+        self.split_chain_btn.clicked.connect(self._on_split_chain)
+        self.merge_chains_btn.clicked.connect(self._on_merge_chains)
+
+        self.visualizer.node_selected.connect(self._on_node_selected)
+        self.visualizer.node_double_clicked.connect(self._on_node_double_clicked)
+
+    def load_urdf(self, content: str) -> None:
+        """Load URDF content and build the kinematic tree."""
+        self.urdf_content = content
+        self.tree.build_from_urdf(content)
+        self._update_info()
+        self._update_chains_list()
+        self.visualizer.set_tree(self.tree)
+
+    def _update_info(self) -> None:
+        """Update the chain information display."""
+        self.links_label.setText(f"Links: {len(self.tree.nodes)}")
+
+        joint_count = sum(
+            1 for n in self.tree.nodes.values() if n.joint_to_parent is not None
+        )
+        self.joints_label.setText(f"Joints: {joint_count}")
+
+        branches = len(self.tree.get_branch_points())
+        self.branches_label.setText(f"Branch points: {branches}")
+
+        end_effectors = len(self.tree.get_end_effectors())
+        self.end_effectors_label.setText(f"End effectors: {end_effectors}")
+
+    def _update_chains_list(self) -> None:
+        """Update the chains list widget."""
+        self.chains_list.clear()
+
+        chains = self.tree.get_all_chains()
+        for i, chain in enumerate(chains):
+            chain_str = " -> ".join(n.name for n in chain)
+            self.chains_list.addItem(f"Chain {i + 1}: {chain_str}")
+
+    def _on_node_selected(self, name: str) -> None:
+        """Handle node selection."""
+        node = self.tree.nodes.get(name)
+        if node:
+            info = f"Selected: {name}"
+            if node.joint_to_parent:
+                joint_type = node.joint_to_parent.get("type", "unknown")
+                info += f" (joint: {joint_type})"
+            if node.is_end_effector():
+                info += " [End Effector]"
+            self.selected_label.setText(info)
+
+    def _on_node_double_clicked(self, name: str) -> None:
+        """Handle node double-click for insertion."""
+        self._show_insert_dialog(name)
+
+    def _on_insert_segment(self) -> None:
+        """Handle insert segment button."""
+        # Get currently selected node, if any
+        selected = None
+        if self.tree.root:
+            selected = self.tree.root.name
+
+        self._show_insert_dialog(selected)
+
+    def _show_insert_dialog(self, insert_after: str | None) -> None:
+        """Show the insert segment dialog."""
+        if not self.tree.nodes:
+            QMessageBox.warning(self, "No Model", "Load a URDF first.")
+            return
+
+        dialog = InsertSegmentDialog(self.tree, insert_after, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            config = dialog.get_configuration()
+            self._insert_segment(config)
+
+    def _insert_segment(self, config: dict[str, Any]) -> None:
+        """Insert a new segment into the URDF."""
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        parent_link = config["parent_link"]
+        link_name = config["link_name"]
+        joint_name = config["joint_name"]
+
+        # Create new link
+        new_link = ET.Element("link", name=link_name)
+
+        # Add inertial
+        inertial = ET.SubElement(new_link, "inertial")
+        ET.SubElement(inertial, "mass", value=str(config["mass"]))
+        ET.SubElement(inertial, "inertia", ixx="0.01", iyy="0.01", izz="0.01",
+                      ixy="0", ixz="0", iyz="0")
+
+        # Add visual
+        visual = ET.SubElement(new_link, "visual")
+        geometry = ET.SubElement(visual, "geometry")
+        if config["geometry"] == "box":
+            ET.SubElement(geometry, "box", size="0.1 0.1 0.1")
+        elif config["geometry"] == "cylinder":
+            ET.SubElement(geometry, "cylinder", radius="0.05", length="0.1")
+        elif config["geometry"] == "sphere":
+            ET.SubElement(geometry, "sphere", radius="0.05")
+        else:
+            ET.SubElement(geometry, "box", size="0.1 0.1 0.1")
+
+        # Add collision (same as visual)
+        collision = ET.SubElement(new_link, "collision")
+        collision_geom = ET.SubElement(collision, "geometry")
+        collision_geom.append(copy.deepcopy(list(geometry)[0]))
+
+        root.append(new_link)
+
+        # Create new joint connecting parent to new link
+        new_joint = ET.Element("joint", name=joint_name, type=config["joint_type"])
+        ET.SubElement(new_joint, "parent", link=parent_link)
+        ET.SubElement(new_joint, "child", link=link_name)
+        ET.SubElement(new_joint, "origin", xyz="0 0 0.1", rpy="0 0 0")
+
+        axis = config["axis"]
+        ET.SubElement(new_joint, "axis", xyz=f"{axis[0]} {axis[1]} {axis[2]}")
+
+        if config["joint_type"] in ["revolute", "prismatic"]:
+            ET.SubElement(new_joint, "limit", lower="-3.14", upper="3.14",
+                          effort="100", velocity="10")
+
+        root.append(new_joint)
+
+        # Re-parent children if specified
+        for child_name in config["reparent_children"]:
+            # Find the joint that connects parent to this child
+            for joint in root.findall("joint"):
+                parent_elem = joint.find("parent")
+                child_elem = joint.find("child")
+                if (parent_elem is not None and child_elem is not None and
+                    parent_elem.get("link") == parent_link and
+                    child_elem.get("link") == child_name):
+                    # Change the parent to the new link
+                    parent_elem.set("link", link_name)
+                    break
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        self.urdf_content = new_content
+        self.load_urdf(new_content)
+        self.chain_modified.emit(new_content)
+
+    def _on_remove_segment(self) -> None:
+        """Handle remove segment button."""
+        # This is a placeholder - full implementation would need
+        # to handle re-parenting children
+        QMessageBox.information(
+            self,
+            "Remove Segment",
+            "Select a segment in the visualizer to remove.\n"
+            "Children will be re-parented to the removed segment's parent."
+        )
+
+    def _on_split_chain(self) -> None:
+        """Handle split chain button."""
+        QMessageBox.information(
+            self,
+            "Split Chain",
+            "Select a link to create a new branch point.\n"
+            "This will duplicate the selected link's children as a new branch."
+        )
+
+    def _on_merge_chains(self) -> None:
+        """Handle merge chains button."""
+        QMessageBox.information(
+            self,
+            "Merge Chains",
+            "Select two leaf nodes to merge into a single chain.\n"
+            "This will connect the end of one chain to the start of another."
+        )
+
+    def get_urdf_content(self) -> str:
+        """Get the current URDF content."""
+        return self.urdf_content

--- a/src/tools/model_explorer/component_library.py
+++ b/src/tools/model_explorer/component_library.py
@@ -1,0 +1,700 @@
+"""Component Library for URDF parts with read-only protection and copy-to-edit.
+
+This module provides a library system where components from existing URDFs
+are read-only but can be copied and edited. This prevents corruption of
+source files while enabling reuse and modification.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QIcon
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ComponentType(Enum):
+    """Types of URDF components."""
+
+    LINK = "link"
+    JOINT = "joint"
+    MATERIAL = "material"
+    TRANSMISSION = "transmission"
+    GAZEBO = "gazebo"
+    SENSOR = "sensor"
+
+
+@dataclass
+class URDFComponent:
+    """Represents a single URDF component (link, joint, etc.)."""
+
+    component_type: ComponentType
+    name: str
+    xml_content: str
+    source_file: Path | None = None
+    is_library: bool = False  # True if from library (read-only)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_read_only(self) -> bool:
+        """Check if component is read-only (library component)."""
+        return self.is_library
+
+    def get_hash(self) -> str:
+        """Get unique hash for this component."""
+        return hashlib.md5(self.xml_content.encode()).hexdigest()[:8]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert component to dictionary."""
+        return {
+            "type": self.component_type.value,
+            "name": self.name,
+            "xml_content": self.xml_content,
+            "source_file": str(self.source_file) if self.source_file else None,
+            "is_library": self.is_library,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_xml_element(
+        cls,
+        element: ET.Element,
+        source_file: Path | None = None,
+        is_library: bool = False,
+    ) -> "URDFComponent":
+        """Create component from XML element."""
+        tag_to_type = {
+            "link": ComponentType.LINK,
+            "joint": ComponentType.JOINT,
+            "material": ComponentType.MATERIAL,
+            "transmission": ComponentType.TRANSMISSION,
+            "gazebo": ComponentType.GAZEBO,
+            "sensor": ComponentType.SENSOR,
+        }
+
+        component_type = tag_to_type.get(element.tag, ComponentType.LINK)
+        name = element.get("name", f"unnamed_{element.tag}")
+
+        # Convert element to string
+        xml_content = ET.tostring(element, encoding="unicode")
+
+        # Extract metadata
+        metadata: dict[str, Any] = {}
+        if component_type == ComponentType.LINK:
+            # Extract geometry info
+            visual = element.find("visual/geometry")
+            if visual is not None:
+                for geom in visual:
+                    metadata["geometry_type"] = geom.tag
+                    break
+            # Extract mass
+            mass_elem = element.find("inertial/mass")
+            if mass_elem is not None:
+                metadata["mass"] = mass_elem.get("value", "unknown")
+
+        elif component_type == ComponentType.JOINT:
+            metadata["joint_type"] = element.get("type", "unknown")
+            parent = element.find("parent")
+            child = element.find("child")
+            if parent is not None:
+                metadata["parent"] = parent.get("link", "")
+            if child is not None:
+                metadata["child"] = child.get("link", "")
+
+        return cls(
+            component_type=component_type,
+            name=name,
+            xml_content=xml_content,
+            source_file=source_file,
+            is_library=is_library,
+            metadata=metadata,
+        )
+
+
+class ComponentLibrary:
+    """Manages a library of URDF components with read-only protection."""
+
+    def __init__(self) -> None:
+        """Initialize the component library."""
+        self._library_components: dict[str, URDFComponent] = {}
+        self._working_components: dict[str, URDFComponent] = {}
+        self._source_files: set[Path] = set()
+
+    def load_urdf_as_library(self, urdf_path: Path) -> list[URDFComponent]:
+        """Load a URDF file as read-only library components.
+
+        Args:
+            urdf_path: Path to URDF file
+
+        Returns:
+            List of loaded components
+        """
+        if not urdf_path.exists():
+            logger.error(f"URDF file not found: {urdf_path}")
+            return []
+
+        try:
+            tree = ET.parse(urdf_path)
+            root = tree.getroot()
+        except ET.ParseError as e:
+            logger.error(f"Failed to parse URDF: {e}")
+            return []
+
+        components = []
+        self._source_files.add(urdf_path)
+
+        # Extract all components
+        for tag in ["link", "joint", "material", "transmission", "gazebo", "sensor"]:
+            for element in root.findall(tag):
+                component = URDFComponent.from_xml_element(
+                    element, source_file=urdf_path, is_library=True
+                )
+                key = f"{urdf_path.stem}:{component.name}"
+                self._library_components[key] = component
+                components.append(component)
+
+        logger.info(f"Loaded {len(components)} components from {urdf_path.name}")
+        return components
+
+    def load_urdf_as_working(self, urdf_path: Path) -> list[URDFComponent]:
+        """Load a URDF file as editable working components.
+
+        Args:
+            urdf_path: Path to URDF file
+
+        Returns:
+            List of loaded components
+        """
+        if not urdf_path.exists():
+            logger.error(f"URDF file not found: {urdf_path}")
+            return []
+
+        try:
+            tree = ET.parse(urdf_path)
+            root = tree.getroot()
+        except ET.ParseError as e:
+            logger.error(f"Failed to parse URDF: {e}")
+            return []
+
+        components = []
+
+        # Extract all components as editable
+        for tag in ["link", "joint", "material", "transmission", "gazebo", "sensor"]:
+            for element in root.findall(tag):
+                component = URDFComponent.from_xml_element(
+                    element, source_file=urdf_path, is_library=False
+                )
+                self._working_components[component.name] = component
+                components.append(component)
+
+        logger.info(f"Loaded {len(components)} working components from {urdf_path.name}")
+        return components
+
+    def copy_to_working(
+        self, library_key: str, new_name: str | None = None
+    ) -> URDFComponent | None:
+        """Copy a library component to working set for editing.
+
+        Args:
+            library_key: Key of library component
+            new_name: Optional new name for the copy
+
+        Returns:
+            The new editable component, or None if not found
+        """
+        if library_key not in self._library_components:
+            logger.error(f"Library component not found: {library_key}")
+            return None
+
+        original = self._library_components[library_key]
+
+        # Create a deep copy
+        new_component = copy.deepcopy(original)
+        new_component.is_library = False
+
+        # Update name if provided
+        if new_name:
+            new_component.name = new_name
+            # Update XML content with new name
+            new_component.xml_content = new_component.xml_content.replace(
+                f'name="{original.name}"', f'name="{new_name}"', 1
+            )
+
+        # Add to working components
+        self._working_components[new_component.name] = new_component
+
+        logger.info(f"Copied library component '{library_key}' as '{new_component.name}'")
+        return new_component
+
+    def get_library_components(
+        self, filter_type: ComponentType | None = None
+    ) -> list[URDFComponent]:
+        """Get all library components, optionally filtered by type.
+
+        Args:
+            filter_type: Optional component type filter
+
+        Returns:
+            List of library components
+        """
+        components = list(self._library_components.values())
+        if filter_type:
+            components = [c for c in components if c.component_type == filter_type]
+        return components
+
+    def get_working_components(
+        self, filter_type: ComponentType | None = None
+    ) -> list[URDFComponent]:
+        """Get all working components, optionally filtered by type.
+
+        Args:
+            filter_type: Optional component type filter
+
+        Returns:
+            List of working components
+        """
+        components = list(self._working_components.values())
+        if filter_type:
+            components = [c for c in components if c.component_type == filter_type]
+        return components
+
+    def get_component(self, name: str, from_library: bool = False) -> URDFComponent | None:
+        """Get a component by name.
+
+        Args:
+            name: Component name
+            from_library: If True, search library; otherwise search working
+
+        Returns:
+            Component if found, None otherwise
+        """
+        if from_library:
+            # Search by name in library (could be multiple files)
+            for key, comp in self._library_components.items():
+                if comp.name == name:
+                    return comp
+            return None
+        return self._working_components.get(name)
+
+    def update_working_component(self, name: str, xml_content: str) -> bool:
+        """Update XML content of a working component.
+
+        Args:
+            name: Component name
+            xml_content: New XML content
+
+        Returns:
+            True if updated successfully
+        """
+        if name not in self._working_components:
+            logger.error(f"Working component not found: {name}")
+            return False
+
+        component = self._working_components[name]
+        if component.is_read_only:
+            logger.error(f"Cannot modify read-only component: {name}")
+            return False
+
+        component.xml_content = xml_content
+        logger.info(f"Updated working component: {name}")
+        return True
+
+    def remove_working_component(self, name: str) -> bool:
+        """Remove a component from working set.
+
+        Args:
+            name: Component name
+
+        Returns:
+            True if removed successfully
+        """
+        if name in self._working_components:
+            del self._working_components[name]
+            logger.info(f"Removed working component: {name}")
+            return True
+        return False
+
+    def export_working_to_urdf(self, robot_name: str = "robot") -> str:
+        """Export working components to URDF XML.
+
+        Args:
+            robot_name: Name for the robot element
+
+        Returns:
+            URDF XML string
+        """
+        root = ET.Element("robot", name=robot_name)
+
+        # Sort components: materials first, then links, then joints
+        order = {
+            ComponentType.MATERIAL: 0,
+            ComponentType.LINK: 1,
+            ComponentType.JOINT: 2,
+            ComponentType.TRANSMISSION: 3,
+            ComponentType.GAZEBO: 4,
+            ComponentType.SENSOR: 5,
+        }
+
+        sorted_components = sorted(
+            self._working_components.values(),
+            key=lambda c: order.get(c.component_type, 99),
+        )
+
+        for component in sorted_components:
+            try:
+                element = ET.fromstring(component.xml_content)
+                root.append(element)
+            except ET.ParseError as e:
+                logger.error(f"Failed to parse component {component.name}: {e}")
+
+        # Pretty print
+        ET.indent(root, space="  ")
+        return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+    def clear_working(self) -> None:
+        """Clear all working components."""
+        self._working_components.clear()
+        logger.info("Cleared working components")
+
+    def clear_library(self) -> None:
+        """Clear all library components."""
+        self._library_components.clear()
+        self._source_files.clear()
+        logger.info("Cleared library components")
+
+    def get_source_files(self) -> list[Path]:
+        """Get list of loaded source files."""
+        return list(self._source_files)
+
+
+class ComponentLibraryWidget(QWidget):
+    """Widget for browsing and managing component library."""
+
+    component_selected = pyqtSignal(object)  # URDFComponent
+    component_copied = pyqtSignal(object)  # URDFComponent (the copy)
+    component_edited = pyqtSignal(object)  # URDFComponent
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the component library widget."""
+        super().__init__(parent)
+        self.library = ComponentLibrary()
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Create splitter for library and working areas
+        splitter = QSplitter(Qt.Orientation.Vertical)
+
+        # Library section (read-only)
+        library_group = QGroupBox("Component Library (Read-Only)")
+        library_layout = QVBoxLayout(library_group)
+
+        # Load button
+        load_layout = QHBoxLayout()
+        self.load_library_btn = QPushButton("Load URDF as Library")
+        load_layout.addWidget(self.load_library_btn)
+        library_layout.addLayout(load_layout)
+
+        # Library tree
+        self.library_tree = QTreeWidget()
+        self.library_tree.setHeaderLabels(["Component", "Type", "Source"])
+        self.library_tree.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        header = self.library_tree.header()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        library_layout.addWidget(self.library_tree)
+
+        # Copy button
+        copy_layout = QHBoxLayout()
+        self.copy_btn = QPushButton("Copy to Working Set")
+        self.copy_btn.setEnabled(False)
+        copy_layout.addWidget(self.copy_btn)
+        library_layout.addLayout(copy_layout)
+
+        splitter.addWidget(library_group)
+
+        # Working section (editable)
+        working_group = QGroupBox("Working Components (Editable)")
+        working_layout = QVBoxLayout(working_group)
+
+        # Working tree
+        self.working_tree = QTreeWidget()
+        self.working_tree.setHeaderLabels(["Component", "Type", "Status"])
+        self.working_tree.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        header = self.working_tree.header()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        working_layout.addWidget(self.working_tree)
+
+        # Edit/Remove buttons
+        btn_layout = QHBoxLayout()
+        self.edit_btn = QPushButton("Edit")
+        self.edit_btn.setEnabled(False)
+        self.remove_btn = QPushButton("Remove")
+        self.remove_btn.setEnabled(False)
+        btn_layout.addWidget(self.edit_btn)
+        btn_layout.addWidget(self.remove_btn)
+        working_layout.addLayout(btn_layout)
+
+        splitter.addWidget(working_group)
+
+        layout.addWidget(splitter)
+
+        # Preview area
+        preview_group = QGroupBox("Component Preview")
+        preview_layout = QVBoxLayout(preview_group)
+        self.preview_text = QTextEdit()
+        self.preview_text.setReadOnly(True)
+        self.preview_text.setMaximumHeight(150)
+        preview_layout.addWidget(self.preview_text)
+        layout.addWidget(preview_group)
+
+    def _connect_signals(self) -> None:
+        """Connect signals to slots."""
+        self.load_library_btn.clicked.connect(self._on_load_library)
+        self.copy_btn.clicked.connect(self._on_copy_to_working)
+        self.edit_btn.clicked.connect(self._on_edit_component)
+        self.remove_btn.clicked.connect(self._on_remove_component)
+
+        self.library_tree.itemSelectionChanged.connect(self._on_library_selection_changed)
+        self.working_tree.itemSelectionChanged.connect(self._on_working_selection_changed)
+
+    def _on_load_library(self) -> None:
+        """Handle load library button click."""
+        from PyQt6.QtWidgets import QFileDialog
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load URDF as Library",
+            "",
+            "URDF Files (*.urdf);;XML Files (*.xml);;All Files (*)",
+        )
+
+        if file_path:
+            path = Path(file_path)
+            components = self.library.load_urdf_as_library(path)
+            self._refresh_library_tree()
+
+            if components:
+                QMessageBox.information(
+                    self,
+                    "Library Loaded",
+                    f"Loaded {len(components)} components from {path.name}.\n"
+                    "These components are read-only. Use 'Copy to Working Set' to edit.",
+                )
+
+    def _on_copy_to_working(self) -> None:
+        """Handle copy to working button click."""
+        current = self.library_tree.currentItem()
+        if not current:
+            return
+
+        library_key = current.data(0, Qt.ItemDataRole.UserRole)
+        if not library_key:
+            return
+
+        # Ask for new name
+        original_name = current.text(0)
+        dialog = CopyComponentDialog(original_name, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            new_name = dialog.get_new_name()
+            component = self.library.copy_to_working(library_key, new_name)
+            if component:
+                self._refresh_working_tree()
+                self.component_copied.emit(component)
+
+    def _on_edit_component(self) -> None:
+        """Handle edit button click."""
+        current = self.working_tree.currentItem()
+        if not current:
+            return
+
+        name = current.text(0)
+        component = self.library.get_component(name, from_library=False)
+        if component:
+            self.component_edited.emit(component)
+
+    def _on_remove_component(self) -> None:
+        """Handle remove button click."""
+        current = self.working_tree.currentItem()
+        if not current:
+            return
+
+        name = current.text(0)
+        reply = QMessageBox.question(
+            self,
+            "Remove Component",
+            f"Remove component '{name}' from working set?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply == QMessageBox.StandardButton.Yes:
+            self.library.remove_working_component(name)
+            self._refresh_working_tree()
+
+    def _on_library_selection_changed(self) -> None:
+        """Handle library tree selection change."""
+        current = self.library_tree.currentItem()
+        self.copy_btn.setEnabled(current is not None and current.data(0, Qt.ItemDataRole.UserRole) is not None)
+
+        if current:
+            library_key = current.data(0, Qt.ItemDataRole.UserRole)
+            if library_key and library_key in self.library._library_components:
+                component = self.library._library_components[library_key]
+                self.preview_text.setPlainText(component.xml_content)
+                self.component_selected.emit(component)
+        else:
+            self.preview_text.clear()
+
+    def _on_working_selection_changed(self) -> None:
+        """Handle working tree selection change."""
+        current = self.working_tree.currentItem()
+        has_selection = current is not None
+        self.edit_btn.setEnabled(has_selection)
+        self.remove_btn.setEnabled(has_selection)
+
+        if current:
+            name = current.text(0)
+            component = self.library.get_component(name, from_library=False)
+            if component:
+                self.preview_text.setPlainText(component.xml_content)
+                self.component_selected.emit(component)
+        else:
+            self.preview_text.clear()
+
+    def _refresh_library_tree(self) -> None:
+        """Refresh the library tree widget."""
+        self.library_tree.clear()
+
+        # Group by source file
+        by_source: dict[str, list[tuple[str, URDFComponent]]] = {}
+        for key, component in self.library._library_components.items():
+            source = component.source_file.name if component.source_file else "Unknown"
+            if source not in by_source:
+                by_source[source] = []
+            by_source[source].append((key, component))
+
+        for source, components in by_source.items():
+            source_item = QTreeWidgetItem([source, "", ""])
+            source_item.setFlags(source_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+            self.library_tree.addTopLevelItem(source_item)
+
+            for key, component in components:
+                item = QTreeWidgetItem([
+                    component.name,
+                    component.component_type.value,
+                    component.get_hash(),
+                ])
+                item.setData(0, Qt.ItemDataRole.UserRole, key)
+                # Visual indication of read-only
+                item.setForeground(0, QColor(100, 100, 100))
+                source_item.addChild(item)
+
+            source_item.setExpanded(True)
+
+    def _refresh_working_tree(self) -> None:
+        """Refresh the working tree widget."""
+        self.working_tree.clear()
+
+        # Group by type
+        by_type: dict[ComponentType, list[URDFComponent]] = {}
+        for component in self.library._working_components.values():
+            if component.component_type not in by_type:
+                by_type[component.component_type] = []
+            by_type[component.component_type].append(component)
+
+        for comp_type, components in by_type.items():
+            type_item = QTreeWidgetItem([comp_type.value.title() + "s", "", ""])
+            type_item.setFlags(type_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+            self.working_tree.addTopLevelItem(type_item)
+
+            for component in components:
+                status = "Modified" if not component.source_file else "Copied"
+                item = QTreeWidgetItem([
+                    component.name,
+                    component.component_type.value,
+                    status,
+                ])
+                type_item.addChild(item)
+
+            type_item.setExpanded(True)
+
+    def load_urdf_to_library(self, urdf_path: Path) -> None:
+        """Load a URDF file into the library."""
+        self.library.load_urdf_as_library(urdf_path)
+        self._refresh_library_tree()
+
+    def load_urdf_to_working(self, urdf_path: Path) -> None:
+        """Load a URDF file into the working set."""
+        self.library.load_urdf_as_working(urdf_path)
+        self._refresh_working_tree()
+
+    def get_library(self) -> ComponentLibrary:
+        """Get the underlying component library."""
+        return self.library
+
+
+class CopyComponentDialog(QDialog):
+    """Dialog for copying a component with a new name."""
+
+    def __init__(self, original_name: str, parent: QWidget | None = None) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.setWindowTitle("Copy Component")
+        self.setMinimumWidth(300)
+
+        layout = QVBoxLayout(self)
+
+        # Name input
+        layout.addWidget(QLabel(f"Original name: {original_name}"))
+        layout.addWidget(QLabel("Enter name for the copy:"))
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setText(f"{original_name}_copy")
+        self.name_edit.selectAll()
+        layout.addWidget(self.name_edit)
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_new_name(self) -> str:
+        """Get the new name entered by the user."""
+        return self.name_edit.text().strip()

--- a/src/tools/model_explorer/end_effector_manager.py
+++ b/src/tools/model_explorer/end_effector_manager.py
@@ -1,0 +1,884 @@
+"""End Effector Manager - Tools for swapping and managing end effectors.
+
+Provides visual interface for easily swapping end effectors between URDFs,
+changing attachment points, and managing end effector configurations.
+"""
+
+from __future__ import annotations
+
+import copy
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class EndEffector:
+    """Represents an end effector configuration."""
+
+    name: str
+    link_element: ET.Element
+    joint_element: ET.Element | None  # Joint connecting to parent
+    child_links: list[ET.Element]  # Links that are part of this end effector
+    child_joints: list[ET.Element]  # Joints within the end effector
+    source_file: Path | None = None
+
+    def get_all_link_names(self) -> list[str]:
+        """Get names of all links in this end effector."""
+        names = [self.link_element.get("name", "")]
+        for link in self.child_links:
+            names.append(link.get("name", ""))
+        return names
+
+    def get_attachment_joint_type(self) -> str:
+        """Get the joint type for attaching to parent."""
+        if self.joint_element is not None:
+            return self.joint_element.get("type", "fixed")
+        return "fixed"
+
+    def to_xml_elements(self) -> tuple[list[ET.Element], list[ET.Element]]:
+        """Convert to XML elements (links, joints)."""
+        links = [copy.deepcopy(self.link_element)]
+        links.extend(copy.deepcopy(link) for link in self.child_links)
+
+        joints = []
+        if self.joint_element is not None:
+            joints.append(copy.deepcopy(self.joint_element))
+        joints.extend(copy.deepcopy(joint) for joint in self.child_joints)
+
+        return links, joints
+
+
+class EndEffectorLibrary:
+    """Library of available end effectors."""
+
+    def __init__(self) -> None:
+        """Initialize the library."""
+        self.end_effectors: dict[str, EndEffector] = {}
+        self._builtin_definitions = self._create_builtin_definitions()
+
+    def _create_builtin_definitions(self) -> dict[str, dict[str, Any]]:
+        """Create built-in end effector definitions."""
+        return {
+            "simple_gripper": {
+                "name": "Simple Gripper",
+                "description": "Basic two-finger parallel gripper",
+                "link_xml": """
+                    <link name="gripper_base">
+                        <inertial>
+                            <mass value="0.5"/>
+                            <inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>
+                        </inertial>
+                        <visual>
+                            <geometry><box size="0.08 0.08 0.02"/></geometry>
+                            <material name="gray"><color rgba="0.5 0.5 0.5 1"/></material>
+                        </visual>
+                        <collision><geometry><box size="0.08 0.08 0.02"/></geometry></collision>
+                    </link>
+                """,
+                "child_links": [
+                    """<link name="left_finger">
+                        <inertial><mass value="0.1"/>
+                        <inertia ixx="0.0001" iyy="0.0001" izz="0.0001" ixy="0" ixz="0" iyz="0"/></inertial>
+                        <visual><origin xyz="0 0 0.025"/><geometry><box size="0.01 0.02 0.05"/></geometry>
+                        <material name="blue"><color rgba="0.2 0.2 0.8 1"/></material></visual>
+                        <collision><origin xyz="0 0 0.025"/><geometry><box size="0.01 0.02 0.05"/></geometry></collision>
+                    </link>""",
+                    """<link name="right_finger">
+                        <inertial><mass value="0.1"/>
+                        <inertia ixx="0.0001" iyy="0.0001" izz="0.0001" ixy="0" ixz="0" iyz="0"/></inertial>
+                        <visual><origin xyz="0 0 0.025"/><geometry><box size="0.01 0.02 0.05"/></geometry>
+                        <material name="blue"><color rgba="0.2 0.2 0.8 1"/></material></visual>
+                        <collision><origin xyz="0 0 0.025"/><geometry><box size="0.01 0.02 0.05"/></geometry></collision>
+                    </link>""",
+                ],
+                "child_joints": [
+                    """<joint name="left_finger_joint" type="prismatic">
+                        <parent link="gripper_base"/><child link="left_finger"/>
+                        <origin xyz="0.02 0 0.01" rpy="0 0 0"/>
+                        <axis xyz="1 0 0"/>
+                        <limit lower="-0.02" upper="0.02" effort="10" velocity="0.5"/>
+                    </joint>""",
+                    """<joint name="right_finger_joint" type="prismatic">
+                        <parent link="gripper_base"/><child link="right_finger"/>
+                        <origin xyz="-0.02 0 0.01" rpy="0 0 0"/>
+                        <axis xyz="1 0 0"/>
+                        <limit lower="-0.02" upper="0.02" effort="10" velocity="0.5"/>
+                    </joint>""",
+                ],
+            },
+            "tool_flange": {
+                "name": "Tool Flange",
+                "description": "Simple tool attachment flange",
+                "link_xml": """
+                    <link name="tool_flange">
+                        <inertial>
+                            <mass value="0.2"/>
+                            <inertia ixx="0.0005" iyy="0.0005" izz="0.0005" ixy="0" ixz="0" iyz="0"/>
+                        </inertial>
+                        <visual>
+                            <geometry><cylinder radius="0.04" length="0.02"/></geometry>
+                            <material name="metal"><color rgba="0.7 0.7 0.7 1"/></material>
+                        </visual>
+                        <collision><geometry><cylinder radius="0.04" length="0.02"/></geometry></collision>
+                    </link>
+                """,
+                "child_links": [],
+                "child_joints": [],
+            },
+            "golf_club_attachment": {
+                "name": "Golf Club Attachment",
+                "description": "Attachment point for golf club grip",
+                "link_xml": """
+                    <link name="club_mount">
+                        <inertial>
+                            <mass value="0.1"/>
+                            <inertia ixx="0.0001" iyy="0.0001" izz="0.0001" ixy="0" ixz="0" iyz="0"/>
+                        </inertial>
+                        <visual>
+                            <geometry><cylinder radius="0.015" length="0.05"/></geometry>
+                            <material name="rubber"><color rgba="0.1 0.1 0.1 1"/></material>
+                        </visual>
+                        <collision><geometry><cylinder radius="0.015" length="0.05"/></geometry></collision>
+                    </link>
+                """,
+                "child_links": [],
+                "child_joints": [],
+            },
+        }
+
+    def get_builtin(self, key: str) -> EndEffector | None:
+        """Get a built-in end effector definition."""
+        if key not in self._builtin_definitions:
+            return None
+
+        definition = self._builtin_definitions[key]
+
+        # Parse link XML
+        link_elem = ET.fromstring(definition["link_xml"].strip())
+
+        # Parse child links
+        child_links = []
+        for link_xml in definition["child_links"]:
+            child_links.append(ET.fromstring(link_xml.strip()))
+
+        # Parse child joints
+        child_joints = []
+        for joint_xml in definition["child_joints"]:
+            child_joints.append(ET.fromstring(joint_xml.strip()))
+
+        return EndEffector(
+            name=definition["name"],
+            link_element=link_elem,
+            joint_element=None,  # Will be created on attachment
+            child_links=child_links,
+            child_joints=child_joints,
+        )
+
+    def get_builtin_names(self) -> list[str]:
+        """Get list of built-in end effector names."""
+        return list(self._builtin_definitions.keys())
+
+    def get_builtin_info(self, key: str) -> dict[str, str] | None:
+        """Get info about a built-in end effector."""
+        if key in self._builtin_definitions:
+            return {
+                "name": self._builtin_definitions[key]["name"],
+                "description": self._builtin_definitions[key]["description"],
+            }
+        return None
+
+    def extract_from_urdf(
+        self,
+        urdf_content: str,
+        end_effector_link: str,
+        source_file: Path | None = None,
+    ) -> EndEffector | None:
+        """Extract an end effector and its subtree from a URDF.
+
+        Args:
+            urdf_content: URDF XML content
+            end_effector_link: Name of the root link of the end effector
+            source_file: Source file path for reference
+
+        Returns:
+            Extracted end effector, or None if not found
+        """
+        try:
+            root = ET.fromstring(urdf_content)
+        except ET.ParseError:
+            return None
+
+        # Find the end effector link
+        ee_link = None
+        for link in root.findall("link"):
+            if link.get("name") == end_effector_link:
+                ee_link = link
+                break
+
+        if ee_link is None:
+            return None
+
+        # Find the joint connecting to this link (as child)
+        ee_joint = None
+        for joint in root.findall("joint"):
+            child = joint.find("child")
+            if child is not None and child.get("link") == end_effector_link:
+                ee_joint = joint
+                break
+
+        # Recursively find all child links and joints
+        child_links = []
+        child_joints = []
+
+        def collect_children(parent_name: str) -> None:
+            for joint in root.findall("joint"):
+                parent = joint.find("parent")
+                child = joint.find("child")
+                if parent is not None and parent.get("link") == parent_name:
+                    child_name = child.get("link") if child is not None else None
+                    if child_name:
+                        # Find the child link
+                        for link in root.findall("link"):
+                            if link.get("name") == child_name:
+                                child_links.append(link)
+                                child_joints.append(joint)
+                                collect_children(child_name)
+                                break
+
+        collect_children(end_effector_link)
+
+        return EndEffector(
+            name=end_effector_link,
+            link_element=ee_link,
+            joint_element=ee_joint,
+            child_links=child_links,
+            child_joints=child_joints,
+            source_file=source_file,
+        )
+
+    def add_to_library(self, key: str, end_effector: EndEffector) -> None:
+        """Add an end effector to the library."""
+        self.end_effectors[key] = end_effector
+
+    def remove_from_library(self, key: str) -> bool:
+        """Remove an end effector from the library."""
+        if key in self.end_effectors:
+            del self.end_effectors[key]
+            return True
+        return False
+
+
+class AttachmentPointSelector(QDialog):
+    """Dialog for selecting and configuring attachment point."""
+
+    def __init__(
+        self,
+        available_links: list[str],
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.setWindowTitle("Select Attachment Point")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        # Attachment link selection
+        attach_group = QGroupBox("Attachment Configuration")
+        attach_layout = QFormLayout(attach_group)
+
+        self.link_combo = QComboBox()
+        self.link_combo.addItems(available_links)
+        attach_layout.addRow("Attach to link:", self.link_combo)
+
+        self.joint_type_combo = QComboBox()
+        self.joint_type_combo.addItems(
+            ["fixed", "revolute", "prismatic", "continuous"]
+        )
+        attach_layout.addRow("Joint type:", self.joint_type_combo)
+
+        layout.addWidget(attach_group)
+
+        # Position offset
+        offset_group = QGroupBox("Position Offset")
+        offset_layout = QFormLayout(offset_group)
+
+        self.offset_x = QDoubleSpinBox()
+        self.offset_x.setRange(-10, 10)
+        self.offset_x.setValue(0)
+        self.offset_x.setSuffix(" m")
+        offset_layout.addRow("X:", self.offset_x)
+
+        self.offset_y = QDoubleSpinBox()
+        self.offset_y.setRange(-10, 10)
+        self.offset_y.setValue(0)
+        self.offset_y.setSuffix(" m")
+        offset_layout.addRow("Y:", self.offset_y)
+
+        self.offset_z = QDoubleSpinBox()
+        self.offset_z.setRange(-10, 10)
+        self.offset_z.setValue(0.1)
+        self.offset_z.setSuffix(" m")
+        offset_layout.addRow("Z:", self.offset_z)
+
+        layout.addWidget(offset_group)
+
+        # Orientation
+        orient_group = QGroupBox("Orientation (RPY)")
+        orient_layout = QFormLayout(orient_group)
+
+        self.roll = QDoubleSpinBox()
+        self.roll.setRange(-3.15, 3.15)
+        self.roll.setValue(0)
+        self.roll.setSuffix(" rad")
+        orient_layout.addRow("Roll:", self.roll)
+
+        self.pitch = QDoubleSpinBox()
+        self.pitch.setRange(-3.15, 3.15)
+        self.pitch.setValue(0)
+        self.pitch.setSuffix(" rad")
+        orient_layout.addRow("Pitch:", self.pitch)
+
+        self.yaw = QDoubleSpinBox()
+        self.yaw.setRange(-3.15, 3.15)
+        self.yaw.setValue(0)
+        self.yaw.setSuffix(" rad")
+        orient_layout.addRow("Yaw:", self.yaw)
+
+        layout.addWidget(orient_group)
+
+        # Name prefix
+        prefix_group = QGroupBox("Naming")
+        prefix_layout = QFormLayout(prefix_group)
+
+        self.prefix_edit = QLineEdit()
+        self.prefix_edit.setPlaceholderText("optional prefix for link/joint names")
+        prefix_layout.addRow("Name prefix:", self.prefix_edit)
+
+        layout.addWidget(prefix_group)
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_configuration(self) -> dict[str, Any]:
+        """Get the attachment configuration."""
+        return {
+            "parent_link": self.link_combo.currentText(),
+            "joint_type": self.joint_type_combo.currentText(),
+            "offset": (self.offset_x.value(), self.offset_y.value(), self.offset_z.value()),
+            "orientation": (self.roll.value(), self.pitch.value(), self.yaw.value()),
+            "name_prefix": self.prefix_edit.text(),
+        }
+
+
+class EndEffectorManagerWidget(QWidget):
+    """Widget for managing and swapping end effectors."""
+
+    urdf_modified = pyqtSignal(str)  # Emits new URDF content
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the end effector manager."""
+        super().__init__(parent)
+        self.library = EndEffectorLibrary()
+        self.urdf_content: str = ""
+        self.current_end_effectors: list[str] = []  # Links identified as EEs
+        self._setup_ui()
+        self._connect_signals()
+        self._populate_builtin_list()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Main splitter
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left side - current model end effectors
+        current_widget = QWidget()
+        current_layout = QVBoxLayout(current_widget)
+
+        current_group = QGroupBox("Current End Effectors")
+        current_inner = QVBoxLayout(current_group)
+
+        self.current_list = QListWidget()
+        current_inner.addWidget(self.current_list)
+
+        btn_layout = QHBoxLayout()
+        self.identify_btn = QPushButton("Identify EEs")
+        self.remove_ee_btn = QPushButton("Remove Selected")
+        self.extract_btn = QPushButton("Extract to Library")
+        btn_layout.addWidget(self.identify_btn)
+        btn_layout.addWidget(self.remove_ee_btn)
+        btn_layout.addWidget(self.extract_btn)
+        current_inner.addLayout(btn_layout)
+
+        current_layout.addWidget(current_group)
+
+        # Selected EE info
+        info_group = QGroupBox("Selected End Effector")
+        info_layout = QVBoxLayout(info_group)
+        self.ee_info_text = QTextEdit()
+        self.ee_info_text.setReadOnly(True)
+        self.ee_info_text.setMaximumHeight(100)
+        info_layout.addWidget(self.ee_info_text)
+        current_layout.addWidget(info_group)
+
+        splitter.addWidget(current_widget)
+
+        # Right side - library
+        library_widget = QWidget()
+        library_layout = QVBoxLayout(library_widget)
+
+        # Built-in end effectors
+        builtin_group = QGroupBox("Built-in End Effectors")
+        builtin_layout = QVBoxLayout(builtin_group)
+
+        self.builtin_list = QListWidget()
+        builtin_layout.addWidget(self.builtin_list)
+
+        library_layout.addWidget(builtin_group)
+
+        # Custom library
+        custom_group = QGroupBox("Custom Library")
+        custom_layout = QVBoxLayout(custom_group)
+
+        self.custom_list = QListWidget()
+        custom_layout.addWidget(self.custom_list)
+
+        import_btn_layout = QHBoxLayout()
+        self.import_from_file_btn = QPushButton("Import from URDF")
+        import_btn_layout.addWidget(self.import_from_file_btn)
+        custom_layout.addLayout(import_btn_layout)
+
+        library_layout.addWidget(custom_group)
+
+        # Attach button
+        self.attach_btn = QPushButton("Attach Selected to Model")
+        self.attach_btn.setStyleSheet("font-weight: bold; padding: 10px;")
+        library_layout.addWidget(self.attach_btn)
+
+        splitter.addWidget(library_widget)
+
+        layout.addWidget(splitter)
+
+        # Status
+        self.status_label = QLabel("Load a URDF to manage end effectors")
+        self.status_label.setStyleSheet("color: #888;")
+        layout.addWidget(self.status_label)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.identify_btn.clicked.connect(self._on_identify_end_effectors)
+        self.remove_ee_btn.clicked.connect(self._on_remove_end_effector)
+        self.extract_btn.clicked.connect(self._on_extract_to_library)
+        self.import_from_file_btn.clicked.connect(self._on_import_from_file)
+        self.attach_btn.clicked.connect(self._on_attach_end_effector)
+
+        self.current_list.itemSelectionChanged.connect(self._on_current_selection_changed)
+        self.builtin_list.itemSelectionChanged.connect(self._on_library_selection_changed)
+        self.custom_list.itemSelectionChanged.connect(self._on_library_selection_changed)
+
+    def _populate_builtin_list(self) -> None:
+        """Populate the built-in end effectors list."""
+        self.builtin_list.clear()
+        for key in self.library.get_builtin_names():
+            info = self.library.get_builtin_info(key)
+            if info:
+                item = QListWidgetItem(f"{info['name']}")
+                item.setData(Qt.ItemDataRole.UserRole, key)
+                item.setToolTip(info["description"])
+                self.builtin_list.addItem(item)
+
+    def load_urdf(self, content: str) -> None:
+        """Load URDF content."""
+        self.urdf_content = content
+        self._on_identify_end_effectors()
+
+    def _on_identify_end_effectors(self) -> None:
+        """Identify end effectors in the current URDF."""
+        if not self.urdf_content:
+            return
+
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        # Find all links
+        links = {link.get("name"): link for link in root.findall("link")}
+
+        # Find links that are children but not parents (leaf nodes)
+        parent_links = set()
+        child_links = set()
+
+        for joint in root.findall("joint"):
+            parent = joint.find("parent")
+            child = joint.find("child")
+            if parent is not None:
+                parent_links.add(parent.get("link"))
+            if child is not None:
+                child_links.add(child.get("link"))
+
+        # End effectors are leaves (in child_links but not in parent_links)
+        end_effector_names = child_links - parent_links
+
+        # Also check for naming hints
+        ee_hints = ["hand", "gripper", "tool", "effector", "finger", "tip", "end"]
+
+        self.current_list.clear()
+        self.current_end_effectors = []
+
+        for name in links.keys():
+            is_leaf = name in end_effector_names
+            has_hint = any(hint in name.lower() for hint in ee_hints)
+
+            if is_leaf or has_hint:
+                self.current_end_effectors.append(name)
+                item = QListWidgetItem(name)
+                if is_leaf:
+                    item.setForeground(QColor("#006400"))  # Green for leaves
+                    item.setToolTip("Leaf link (no children)")
+                else:
+                    item.setForeground(QColor("#0000FF"))  # Blue for name hints
+                    item.setToolTip("Identified by naming convention")
+                self.current_list.addItem(item)
+
+        self.status_label.setText(
+            f"Found {len(self.current_end_effectors)} potential end effector(s)"
+        )
+
+    def _on_current_selection_changed(self) -> None:
+        """Handle current EE list selection change."""
+        current = self.current_list.currentItem()
+        if not current:
+            self.ee_info_text.clear()
+            return
+
+        link_name = current.text()
+
+        # Extract info about this end effector
+        ee = self.library.extract_from_urdf(self.urdf_content, link_name)
+        if ee:
+            info = f"Link: {ee.name}\n"
+            info += f"Child links: {len(ee.child_links)}\n"
+            info += f"Child joints: {len(ee.child_joints)}\n"
+            if ee.joint_element is not None:
+                info += f"Attachment joint: {ee.joint_element.get('name', 'unknown')}\n"
+                info += f"Joint type: {ee.get_attachment_joint_type()}"
+            self.ee_info_text.setPlainText(info)
+        else:
+            self.ee_info_text.setPlainText(f"Link: {link_name}")
+
+    def _on_library_selection_changed(self) -> None:
+        """Handle library selection change."""
+        # Deselect in the other list
+        sender = self.sender()
+        if sender == self.builtin_list:
+            self.custom_list.clearSelection()
+        else:
+            self.builtin_list.clearSelection()
+
+    def _on_remove_end_effector(self) -> None:
+        """Remove the selected end effector from the model."""
+        current = self.current_list.currentItem()
+        if not current:
+            self.status_label.setText("Select an end effector to remove")
+            return
+
+        link_name = current.text()
+
+        reply = QMessageBox.question(
+            self,
+            "Remove End Effector",
+            f"Remove end effector '{link_name}' and all its children?\n"
+            "This cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        # Extract the EE first to get all links to remove
+        ee = self.library.extract_from_urdf(self.urdf_content, link_name)
+        if not ee:
+            return
+
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        # Get all link names to remove
+        links_to_remove = ee.get_all_link_names()
+
+        # Remove links
+        for link in list(root.findall("link")):
+            if link.get("name") in links_to_remove:
+                root.remove(link)
+
+        # Remove joints connected to these links
+        for joint in list(root.findall("joint")):
+            parent = joint.find("parent")
+            child = joint.find("child")
+            parent_link = parent.get("link") if parent is not None else None
+            child_link = child.get("link") if child is not None else None
+
+            if parent_link in links_to_remove or child_link in links_to_remove:
+                root.remove(joint)
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        self.urdf_content = new_content
+        self._on_identify_end_effectors()
+        self.urdf_modified.emit(new_content)
+        self.status_label.setText(f"Removed end effector '{link_name}'")
+
+    def _on_extract_to_library(self) -> None:
+        """Extract selected EE to custom library."""
+        current = self.current_list.currentItem()
+        if not current:
+            self.status_label.setText("Select an end effector to extract")
+            return
+
+        link_name = current.text()
+        ee = self.library.extract_from_urdf(self.urdf_content, link_name)
+
+        if ee:
+            key = link_name.lower().replace(" ", "_")
+            self.library.add_to_library(key, ee)
+
+            item = QListWidgetItem(ee.name)
+            item.setData(Qt.ItemDataRole.UserRole, key)
+            self.custom_list.addItem(item)
+
+            self.status_label.setText(f"Extracted '{link_name}' to library")
+
+    def _on_import_from_file(self) -> None:
+        """Import an end effector from another URDF file."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select URDF with End Effector",
+            "",
+            "URDF Files (*.urdf);;XML Files (*.xml)",
+        )
+
+        if not file_path:
+            return
+
+        try:
+            content = Path(file_path).read_text(encoding="utf-8")
+            root = ET.fromstring(content)
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to load file: {e}")
+            return
+
+        # Get list of links
+        links = [link.get("name", "") for link in root.findall("link")]
+
+        if not links:
+            QMessageBox.warning(self, "No Links", "No links found in the file.")
+            return
+
+        # Let user select which link to import as EE
+        link_name, ok = self._select_from_list(
+            "Select End Effector Link",
+            "Select the root link of the end effector:",
+            links,
+        )
+
+        if ok and link_name:
+            ee = self.library.extract_from_urdf(content, link_name, Path(file_path))
+            if ee:
+                key = f"imported_{link_name}".lower().replace(" ", "_")
+                self.library.add_to_library(key, ee)
+
+                item = QListWidgetItem(f"{ee.name} (imported)")
+                item.setData(Qt.ItemDataRole.UserRole, key)
+                self.custom_list.addItem(item)
+
+                self.status_label.setText(f"Imported '{link_name}' from {Path(file_path).name}")
+
+    def _select_from_list(
+        self, title: str, label: str, items: list[str]
+    ) -> tuple[str, bool]:
+        """Show a simple selection dialog."""
+        from PyQt6.QtWidgets import QInputDialog
+
+        item, ok = QInputDialog.getItem(
+            self, title, label, items, 0, False
+        )
+        return item, ok
+
+    def _on_attach_end_effector(self) -> None:
+        """Attach selected library EE to the model."""
+        # Check which list has selection
+        builtin_item = self.builtin_list.currentItem()
+        custom_item = self.custom_list.currentItem()
+
+        ee: EndEffector | None = None
+        source = ""
+
+        if builtin_item:
+            key = builtin_item.data(Qt.ItemDataRole.UserRole)
+            ee = self.library.get_builtin(key)
+            source = "built-in"
+        elif custom_item:
+            key = custom_item.data(Qt.ItemDataRole.UserRole)
+            ee = self.library.end_effectors.get(key)
+            source = "library"
+
+        if not ee:
+            self.status_label.setText("Select an end effector from the library")
+            return
+
+        if not self.urdf_content:
+            self.status_label.setText("Load a URDF first")
+            return
+
+        # Get available links for attachment
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        available_links = [link.get("name", "") for link in root.findall("link")]
+
+        if not available_links:
+            self.status_label.setText("No links available for attachment")
+            return
+
+        # Show attachment dialog
+        dialog = AttachmentPointSelector(available_links, self)
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        config = dialog.get_configuration()
+        self._attach_end_effector(ee, config)
+
+    def _attach_end_effector(self, ee: EndEffector, config: dict[str, Any]) -> None:
+        """Attach an end effector to the model."""
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        prefix = config["name_prefix"]
+        parent_link = config["parent_link"]
+
+        # Get link and joint elements
+        links, joints = ee.to_xml_elements()
+
+        # Rename if prefix is specified
+        name_mapping: dict[str, str] = {}
+        if prefix:
+            for link in links:
+                old_name = link.get("name", "")
+                new_name = prefix + old_name
+                link.set("name", new_name)
+                name_mapping[old_name] = new_name
+
+            for joint in joints:
+                old_name = joint.get("name", "")
+                joint.set("name", prefix + old_name)
+
+                # Update parent/child references
+                parent = joint.find("parent")
+                child = joint.find("child")
+                if parent is not None:
+                    old_link = parent.get("link", "")
+                    if old_link in name_mapping:
+                        parent.set("link", name_mapping[old_link])
+                if child is not None:
+                    old_link = child.get("link", "")
+                    if old_link in name_mapping:
+                        child.set("link", name_mapping[old_link])
+
+        # Add links to model
+        for link in links:
+            root.append(link)
+
+        # Add joints to model
+        for joint in joints:
+            root.append(joint)
+
+        # Create attachment joint
+        ee_root_name = links[0].get("name", "end_effector")
+        attachment_joint = ET.Element(
+            "joint",
+            name=f"{prefix}attachment_joint" if prefix else "attachment_joint",
+            type=config["joint_type"],
+        )
+
+        ET.SubElement(attachment_joint, "parent", link=parent_link)
+        ET.SubElement(attachment_joint, "child", link=ee_root_name)
+
+        offset = config["offset"]
+        orient = config["orientation"]
+        ET.SubElement(
+            attachment_joint,
+            "origin",
+            xyz=f"{offset[0]} {offset[1]} {offset[2]}",
+            rpy=f"{orient[0]} {orient[1]} {orient[2]}",
+        )
+
+        if config["joint_type"] in ["revolute", "prismatic"]:
+            ET.SubElement(attachment_joint, "axis", xyz="0 0 1")
+            ET.SubElement(
+                attachment_joint,
+                "limit",
+                lower="-3.14",
+                upper="3.14",
+                effort="100",
+                velocity="10",
+            )
+
+        root.append(attachment_joint)
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        self.urdf_content = new_content
+        self._on_identify_end_effectors()
+        self.urdf_modified.emit(new_content)
+        self.status_label.setText(f"Attached end effector '{ee.name}' to '{parent_link}'")
+
+    def get_urdf_content(self) -> str:
+        """Get the current URDF content."""
+        return self.urdf_content

--- a/src/tools/model_explorer/frankenstein_editor.py
+++ b/src/tools/model_explorer/frankenstein_editor.py
@@ -1,0 +1,825 @@
+"""Frankenstein Editor - Side-by-side URDF editor for component stealing.
+
+Enables combining components from multiple URDF files by displaying
+two models side-by-side and allowing drag-and-drop or copy-paste
+of components between them.
+"""
+
+from __future__ import annotations
+
+import copy
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QAction, QColor, QDragEnterEvent, QDropEvent
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+from .component_library import ComponentLibrary, ComponentType, URDFComponent
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class URDFModel:
+    """Represents a loaded URDF model."""
+
+    file_path: Path | None
+    robot_name: str
+    links: dict[str, ET.Element]
+    joints: dict[str, ET.Element]
+    materials: dict[str, ET.Element]
+    other_elements: list[ET.Element]
+    is_modified: bool = False
+
+    @classmethod
+    def from_file(cls, file_path: Path) -> "URDFModel":
+        """Load a URDF model from file."""
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+        return cls.from_element(root, file_path)
+
+    @classmethod
+    def from_element(
+        cls, root: ET.Element, file_path: Path | None = None
+    ) -> "URDFModel":
+        """Create model from XML element."""
+        robot_name = root.get("name", "unnamed_robot")
+
+        links = {}
+        joints = {}
+        materials = {}
+        other_elements = []
+
+        for child in root:
+            name = child.get("name", "")
+            if child.tag == "link":
+                links[name] = child
+            elif child.tag == "joint":
+                joints[name] = child
+            elif child.tag == "material":
+                materials[name] = child
+            else:
+                other_elements.append(child)
+
+        return cls(
+            file_path=file_path,
+            robot_name=robot_name,
+            links=links,
+            joints=joints,
+            materials=materials,
+            other_elements=other_elements,
+        )
+
+    @classmethod
+    def create_empty(cls, name: str = "new_robot") -> "URDFModel":
+        """Create an empty URDF model."""
+        return cls(
+            file_path=None,
+            robot_name=name,
+            links={},
+            joints={},
+            materials={},
+            other_elements=[],
+        )
+
+    def to_xml(self) -> str:
+        """Convert model to XML string."""
+        root = ET.Element("robot", name=self.robot_name)
+
+        # Add materials first
+        for material in self.materials.values():
+            root.append(copy.deepcopy(material))
+
+        # Add links
+        for link in self.links.values():
+            root.append(copy.deepcopy(link))
+
+        # Add joints
+        for joint in self.joints.values():
+            root.append(copy.deepcopy(joint))
+
+        # Add other elements
+        for elem in self.other_elements:
+            root.append(copy.deepcopy(elem))
+
+        ET.indent(root, space="  ")
+        return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+    def add_link(self, link: ET.Element, new_name: str | None = None) -> str:
+        """Add a link to the model.
+
+        Args:
+            link: Link element to add
+            new_name: Optional new name for the link
+
+        Returns:
+            The name used for the link
+        """
+        link_copy = copy.deepcopy(link)
+        name = new_name or link_copy.get("name", "unnamed_link")
+
+        # Ensure unique name
+        original_name = name
+        counter = 1
+        while name in self.links:
+            name = f"{original_name}_{counter}"
+            counter += 1
+
+        link_copy.set("name", name)
+        self.links[name] = link_copy
+        self.is_modified = True
+        return name
+
+    def add_joint(
+        self,
+        joint: ET.Element,
+        new_name: str | None = None,
+        parent_mapping: dict[str, str] | None = None,
+    ) -> str:
+        """Add a joint to the model.
+
+        Args:
+            joint: Joint element to add
+            new_name: Optional new name for the joint
+            parent_mapping: Optional mapping from old link names to new ones
+
+        Returns:
+            The name used for the joint
+        """
+        joint_copy = copy.deepcopy(joint)
+        name = new_name or joint_copy.get("name", "unnamed_joint")
+
+        # Ensure unique name
+        original_name = name
+        counter = 1
+        while name in self.joints:
+            name = f"{original_name}_{counter}"
+            counter += 1
+
+        joint_copy.set("name", name)
+
+        # Update parent/child references if mapping provided
+        if parent_mapping:
+            parent = joint_copy.find("parent")
+            if parent is not None:
+                old_link = parent.get("link", "")
+                if old_link in parent_mapping:
+                    parent.set("link", parent_mapping[old_link])
+
+            child = joint_copy.find("child")
+            if child is not None:
+                old_link = child.get("link", "")
+                if old_link in parent_mapping:
+                    child.set("link", parent_mapping[old_link])
+
+        self.joints[name] = joint_copy
+        self.is_modified = True
+        return name
+
+    def add_material(self, material: ET.Element) -> str:
+        """Add a material to the model."""
+        material_copy = copy.deepcopy(material)
+        name = material_copy.get("name", "unnamed_material")
+
+        if name not in self.materials:
+            self.materials[name] = material_copy
+            self.is_modified = True
+
+        return name
+
+    def remove_link(self, name: str) -> bool:
+        """Remove a link and its connected joints."""
+        if name not in self.links:
+            return False
+
+        del self.links[name]
+
+        # Remove joints connected to this link
+        joints_to_remove = []
+        for joint_name, joint in self.joints.items():
+            parent = joint.find("parent")
+            child = joint.find("child")
+            if (parent is not None and parent.get("link") == name) or \
+               (child is not None and child.get("link") == name):
+                joints_to_remove.append(joint_name)
+
+        for joint_name in joints_to_remove:
+            del self.joints[joint_name]
+
+        self.is_modified = True
+        return True
+
+    def remove_joint(self, name: str) -> bool:
+        """Remove a joint."""
+        if name not in self.joints:
+            return False
+
+        del self.joints[name]
+        self.is_modified = True
+        return True
+
+    def get_link_names(self) -> list[str]:
+        """Get list of link names."""
+        return list(self.links.keys())
+
+    def get_joint_names(self) -> list[str]:
+        """Get list of joint names."""
+        return list(self.joints.keys())
+
+
+class ModelPanel(QWidget):
+    """Panel displaying a single URDF model with component tree."""
+
+    component_selected = pyqtSignal(str, str, object)  # type, name, element
+    component_double_clicked = pyqtSignal(str, str, object)  # For stealing
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        """Initialize the model panel."""
+        super().__init__(parent)
+        self.title = title
+        self.model: URDFModel | None = None
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Header
+        header = QHBoxLayout()
+        self.title_label = QLabel(self.title)
+        self.title_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        header.addWidget(self.title_label)
+
+        self.load_btn = QPushButton("Load URDF")
+        self.new_btn = QPushButton("New")
+        self.save_btn = QPushButton("Save")
+        self.save_btn.setEnabled(False)
+
+        header.addWidget(self.load_btn)
+        header.addWidget(self.new_btn)
+        header.addWidget(self.save_btn)
+        layout.addLayout(header)
+
+        # File info
+        self.file_label = QLabel("No file loaded")
+        self.file_label.setStyleSheet("color: gray;")
+        layout.addWidget(self.file_label)
+
+        # Component tree
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Component", "Type", "Details"])
+        self.tree.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.tree.setDragEnabled(True)
+        self.tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        header = self.tree.header()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        layout.addWidget(self.tree)
+
+        # Preview
+        preview_group = QGroupBox("Preview")
+        preview_layout = QVBoxLayout(preview_group)
+        self.preview_text = QTextEdit()
+        self.preview_text.setReadOnly(True)
+        self.preview_text.setMaximumHeight(120)
+        preview_layout.addWidget(self.preview_text)
+        layout.addWidget(preview_group)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.load_btn.clicked.connect(self._on_load)
+        self.new_btn.clicked.connect(self._on_new)
+        self.save_btn.clicked.connect(self._on_save)
+        self.tree.itemSelectionChanged.connect(self._on_selection_changed)
+        self.tree.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.tree.customContextMenuRequested.connect(self._on_context_menu)
+
+    def _on_load(self) -> None:
+        """Handle load button click."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load URDF File",
+            "",
+            "URDF Files (*.urdf);;XML Files (*.xml);;All Files (*)",
+        )
+
+        if file_path:
+            self.load_file(Path(file_path))
+
+    def load_file(self, file_path: Path) -> bool:
+        """Load a URDF file."""
+        try:
+            self.model = URDFModel.from_file(file_path)
+            self.file_label.setText(f"File: {file_path.name}")
+            self.save_btn.setEnabled(True)
+            self._refresh_tree()
+            logger.info(f"Loaded URDF: {file_path}")
+            return True
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to load URDF: {e}")
+            logger.error(f"Failed to load URDF: {e}")
+            return False
+
+    def _on_new(self) -> None:
+        """Handle new button click."""
+        self.model = URDFModel.create_empty()
+        self.file_label.setText("New model (unsaved)")
+        self.save_btn.setEnabled(True)
+        self._refresh_tree()
+
+    def _on_save(self) -> None:
+        """Handle save button click."""
+        if not self.model:
+            return
+
+        if self.model.file_path:
+            file_path = self.model.file_path
+        else:
+            file_path_str, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save URDF File",
+                "robot.urdf",
+                "URDF Files (*.urdf);;XML Files (*.xml)",
+            )
+            if not file_path_str:
+                return
+            file_path = Path(file_path_str)
+
+        try:
+            content = self.model.to_xml()
+            file_path.write_text(content, encoding="utf-8")
+            self.model.file_path = file_path
+            self.model.is_modified = False
+            self.file_label.setText(f"File: {file_path.name}")
+            logger.info(f"Saved URDF: {file_path}")
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save URDF: {e}")
+
+    def _on_selection_changed(self) -> None:
+        """Handle tree selection change."""
+        current = self.tree.currentItem()
+        if not current:
+            self.preview_text.clear()
+            return
+
+        element = current.data(0, Qt.ItemDataRole.UserRole)
+        if element is not None:
+            xml_str = ET.tostring(element, encoding="unicode")
+            self.preview_text.setPlainText(xml_str)
+
+            comp_type = current.data(1, Qt.ItemDataRole.UserRole) or ""
+            name = current.text(0)
+            self.component_selected.emit(comp_type, name, element)
+
+    def _on_item_double_clicked(self, item: QTreeWidgetItem, column: int) -> None:
+        """Handle double-click for stealing component."""
+        element = item.data(0, Qt.ItemDataRole.UserRole)
+        if element is not None:
+            comp_type = item.data(1, Qt.ItemDataRole.UserRole) or ""
+            name = item.text(0)
+            self.component_double_clicked.emit(comp_type, name, element)
+
+    def _on_context_menu(self, pos: Any) -> None:
+        """Show context menu for components."""
+        item = self.tree.itemAt(pos)
+        if not item:
+            return
+
+        element = item.data(0, Qt.ItemDataRole.UserRole)
+        if element is None:
+            return
+
+        menu = QMenu(self)
+
+        copy_action = QAction("Copy to Other Model", self)
+        copy_action.triggered.connect(lambda: self._emit_copy(item))
+        menu.addAction(copy_action)
+
+        if self.model:
+            remove_action = QAction("Remove", self)
+            remove_action.triggered.connect(lambda: self._remove_component(item))
+            menu.addAction(remove_action)
+
+        menu.exec(self.tree.mapToGlobal(pos))
+
+    def _emit_copy(self, item: QTreeWidgetItem) -> None:
+        """Emit signal to copy component."""
+        element = item.data(0, Qt.ItemDataRole.UserRole)
+        if element is not None:
+            comp_type = item.data(1, Qt.ItemDataRole.UserRole) or ""
+            name = item.text(0)
+            self.component_double_clicked.emit(comp_type, name, element)
+
+    def _remove_component(self, item: QTreeWidgetItem) -> None:
+        """Remove a component from the model."""
+        if not self.model:
+            return
+
+        name = item.text(0)
+        comp_type = item.data(1, Qt.ItemDataRole.UserRole)
+
+        reply = QMessageBox.question(
+            self,
+            "Remove Component",
+            f"Remove {comp_type} '{name}'?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply == QMessageBox.StandardButton.Yes:
+            if comp_type == "link":
+                self.model.remove_link(name)
+            elif comp_type == "joint":
+                self.model.remove_joint(name)
+
+            self._refresh_tree()
+
+    def _refresh_tree(self) -> None:
+        """Refresh the component tree."""
+        self.tree.clear()
+        if not self.model:
+            return
+
+        # Links
+        links_item = QTreeWidgetItem(["Links", "", f"({len(self.model.links)})"])
+        links_item.setFlags(links_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+        self.tree.addTopLevelItem(links_item)
+
+        for name, link in self.model.links.items():
+            # Get geometry info
+            geom_info = "unknown"
+            visual = link.find("visual/geometry")
+            if visual is not None:
+                for child in visual:
+                    geom_info = child.tag
+                    break
+
+            item = QTreeWidgetItem([name, "link", geom_info])
+            item.setData(0, Qt.ItemDataRole.UserRole, link)
+            item.setData(1, Qt.ItemDataRole.UserRole, "link")
+            links_item.addChild(item)
+
+        links_item.setExpanded(True)
+
+        # Joints
+        joints_item = QTreeWidgetItem(["Joints", "", f"({len(self.model.joints)})"])
+        joints_item.setFlags(joints_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+        self.tree.addTopLevelItem(joints_item)
+
+        for name, joint in self.model.joints.items():
+            joint_type = joint.get("type", "unknown")
+            item = QTreeWidgetItem([name, "joint", joint_type])
+            item.setData(0, Qt.ItemDataRole.UserRole, joint)
+            item.setData(1, Qt.ItemDataRole.UserRole, "joint")
+            joints_item.addChild(item)
+
+        joints_item.setExpanded(True)
+
+        # Materials
+        if self.model.materials:
+            materials_item = QTreeWidgetItem(
+                ["Materials", "", f"({len(self.model.materials)})"]
+            )
+            materials_item.setFlags(materials_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+            self.tree.addTopLevelItem(materials_item)
+
+            for name, material in self.model.materials.items():
+                item = QTreeWidgetItem([name, "material", ""])
+                item.setData(0, Qt.ItemDataRole.UserRole, material)
+                item.setData(1, Qt.ItemDataRole.UserRole, "material")
+                materials_item.addChild(item)
+
+            materials_item.setExpanded(True)
+
+    def add_component(
+        self,
+        comp_type: str,
+        element: ET.Element,
+        name_prefix: str = "",
+    ) -> str | None:
+        """Add a component to this model.
+
+        Args:
+            comp_type: Component type (link, joint, material)
+            element: XML element to add
+            name_prefix: Prefix for the new name
+
+        Returns:
+            The name used, or None if failed
+        """
+        if not self.model:
+            self.model = URDFModel.create_empty()
+
+        try:
+            if comp_type == "link":
+                new_name = name_prefix + element.get("name", "link") if name_prefix else None
+                result = self.model.add_link(element, new_name)
+            elif comp_type == "joint":
+                new_name = name_prefix + element.get("name", "joint") if name_prefix else None
+                result = self.model.add_joint(element, new_name)
+            elif comp_type == "material":
+                result = self.model.add_material(element)
+            else:
+                return None
+
+            self._refresh_tree()
+            self.save_btn.setEnabled(True)
+            return result
+
+        except Exception as e:
+            logger.error(f"Failed to add component: {e}")
+            return None
+
+    def get_model(self) -> URDFModel | None:
+        """Get the current model."""
+        return self.model
+
+
+class FrankensteinEditor(QWidget):
+    """Side-by-side URDF editor for combining components from multiple files."""
+
+    model_updated = pyqtSignal(str, object)  # panel_id, model
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the Frankenstein editor."""
+        super().__init__(parent)
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Instructions
+        instructions = QLabel(
+            "Double-click or right-click on a component to copy it to the other model. "
+            "Components are copied - source files are never modified."
+        )
+        instructions.setWordWrap(True)
+        instructions.setStyleSheet("color: #666; font-style: italic; padding: 5px;")
+        layout.addWidget(instructions)
+
+        # Main splitter with two model panels
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        self.left_panel = ModelPanel("Source Model (Read-Only)")
+        self.right_panel = ModelPanel("Working Model (Editable)")
+
+        splitter.addWidget(self.left_panel)
+        splitter.addWidget(self.right_panel)
+
+        layout.addWidget(splitter)
+
+        # Transfer buttons
+        transfer_layout = QHBoxLayout()
+        transfer_layout.addStretch()
+
+        self.copy_selected_btn = QPushButton("Copy Selected Component -->")
+        self.copy_chain_btn = QPushButton("Copy Link Chain -->")
+        self.merge_all_btn = QPushButton("Merge All Components -->")
+
+        transfer_layout.addWidget(self.copy_selected_btn)
+        transfer_layout.addWidget(self.copy_chain_btn)
+        transfer_layout.addWidget(self.merge_all_btn)
+        transfer_layout.addStretch()
+
+        layout.addLayout(transfer_layout)
+
+        # Status
+        self.status_label = QLabel("Ready - Load URDFs to begin")
+        self.status_label.setStyleSheet("color: #888;")
+        layout.addWidget(self.status_label)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        # Left panel signals (source)
+        self.left_panel.component_double_clicked.connect(self._on_copy_to_right)
+
+        # Button signals
+        self.copy_selected_btn.clicked.connect(self._on_copy_selected)
+        self.copy_chain_btn.clicked.connect(self._on_copy_chain)
+        self.merge_all_btn.clicked.connect(self._on_merge_all)
+
+    def _on_copy_to_right(self, comp_type: str, name: str, element: ET.Element) -> None:
+        """Copy component from left to right panel."""
+        result = self.right_panel.add_component(comp_type, element)
+        if result:
+            self.status_label.setText(f"Copied {comp_type} '{name}' as '{result}'")
+        else:
+            self.status_label.setText(f"Failed to copy {comp_type} '{name}'")
+
+    def _on_copy_selected(self) -> None:
+        """Copy currently selected component."""
+        current = self.left_panel.tree.currentItem()
+        if not current:
+            self.status_label.setText("No component selected in source model")
+            return
+
+        element = current.data(0, Qt.ItemDataRole.UserRole)
+        if element is None:
+            return
+
+        comp_type = current.data(1, Qt.ItemDataRole.UserRole) or ""
+        name = current.text(0)
+        self._on_copy_to_right(comp_type, name, element)
+
+    def _on_copy_chain(self) -> None:
+        """Copy a link and all its connected joints/child links."""
+        current = self.left_panel.tree.currentItem()
+        if not current:
+            self.status_label.setText("Select a link in the source model")
+            return
+
+        comp_type = current.data(1, Qt.ItemDataRole.UserRole)
+        if comp_type != "link":
+            self.status_label.setText("Please select a link (not a joint)")
+            return
+
+        source_model = self.left_panel.get_model()
+        if not source_model:
+            return
+
+        # Get the selected link
+        link_name = current.text(0)
+        copied_count = self._copy_link_chain(source_model, link_name)
+        self.status_label.setText(f"Copied chain starting from '{link_name}': {copied_count} components")
+
+    def _copy_link_chain(
+        self,
+        source_model: URDFModel,
+        link_name: str,
+        name_mapping: dict[str, str] | None = None,
+    ) -> int:
+        """Recursively copy a link and its child chain.
+
+        Args:
+            source_model: Source model
+            link_name: Name of link to copy
+            name_mapping: Mapping of old names to new names
+
+        Returns:
+            Number of components copied
+        """
+        if name_mapping is None:
+            name_mapping = {}
+
+        count = 0
+
+        # Copy the link
+        if link_name in source_model.links:
+            link = source_model.links[link_name]
+            new_name = self.right_panel.add_component("link", link)
+            if new_name:
+                name_mapping[link_name] = new_name
+                count += 1
+
+        # Find joints where this link is the parent
+        for joint_name, joint in source_model.joints.items():
+            parent = joint.find("parent")
+            if parent is not None and parent.get("link") == link_name:
+                # Copy the joint
+                new_joint_name = self.right_panel.add_component("joint", joint)
+                if new_joint_name:
+                    count += 1
+
+                # Recursively copy the child link
+                child = joint.find("child")
+                if child is not None:
+                    child_link = child.get("link")
+                    if child_link and child_link in source_model.links:
+                        count += self._copy_link_chain(source_model, child_link, name_mapping)
+
+        return count
+
+    def _on_merge_all(self) -> None:
+        """Merge all components from source to working model."""
+        source_model = self.left_panel.get_model()
+        if not source_model:
+            self.status_label.setText("No source model loaded")
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Merge All",
+            "This will copy all links, joints, and materials from the source model. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        count = 0
+
+        # Copy all materials first
+        for name, material in source_model.materials.items():
+            if self.right_panel.add_component("material", material):
+                count += 1
+
+        # Copy all links
+        for name, link in source_model.links.items():
+            if self.right_panel.add_component("link", link):
+                count += 1
+
+        # Copy all joints
+        for name, joint in source_model.joints.items():
+            if self.right_panel.add_component("joint", joint):
+                count += 1
+
+        self.status_label.setText(f"Merged {count} components from source model")
+
+    def load_source(self, file_path: Path) -> bool:
+        """Load a file into the source (left) panel."""
+        return self.left_panel.load_file(file_path)
+
+    def load_working(self, file_path: Path) -> bool:
+        """Load a file into the working (right) panel."""
+        return self.right_panel.load_file(file_path)
+
+    def get_working_model(self) -> URDFModel | None:
+        """Get the working model."""
+        return self.right_panel.get_model()
+
+    def get_working_xml(self) -> str | None:
+        """Get the working model as XML string."""
+        model = self.right_panel.get_model()
+        if model:
+            return model.to_xml()
+        return None
+
+
+class StealComponentDialog(QDialog):
+    """Dialog for configuring component stealing with renaming."""
+
+    def __init__(
+        self,
+        comp_type: str,
+        original_name: str,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.setWindowTitle("Copy Component")
+        self.setMinimumWidth(350)
+
+        layout = QVBoxLayout(self)
+
+        # Info
+        layout.addWidget(QLabel(f"Copying {comp_type}: {original_name}"))
+
+        # Name input
+        form = QFormLayout()
+        self.name_edit = QLineEdit(original_name)
+        form.addRow("New name:", self.name_edit)
+
+        # Prefix option
+        self.prefix_edit = QLineEdit()
+        self.prefix_edit.setPlaceholderText("e.g., 'imported_'")
+        form.addRow("Add prefix:", self.prefix_edit)
+
+        layout.addLayout(form)
+
+        # Include related checkbox (for links)
+        if comp_type == "link":
+            self.include_materials = QLabel("Note: Referenced materials will also be copied")
+            layout.addWidget(self.include_materials)
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_new_name(self) -> str:
+        """Get the new name with prefix."""
+        prefix = self.prefix_edit.text()
+        name = self.name_edit.text()
+        return prefix + name

--- a/src/tools/model_explorer/joint_manipulator.py
+++ b/src/tools/model_explorer/joint_manipulator.py
@@ -1,0 +1,744 @@
+"""Joint Manipulator - Auto-load and manipulate URDF joints.
+
+Provides tools for automatically loading joints from URDFs,
+visualizing joint configurations, and interactively manipulating
+joint parameters.
+"""
+
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSlider,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class JointInfo:
+    """Information about a URDF joint."""
+
+    name: str
+    joint_type: str
+    parent_link: str
+    child_link: str
+    origin_xyz: tuple[float, float, float]
+    origin_rpy: tuple[float, float, float]
+    axis: tuple[float, float, float]
+    lower_limit: float | None
+    upper_limit: float | None
+    effort_limit: float | None
+    velocity_limit: float | None
+    damping: float
+    friction: float
+    current_position: float = 0.0
+
+    @classmethod
+    def from_element(cls, element: ET.Element) -> "JointInfo":
+        """Create JointInfo from XML element."""
+        name = element.get("name", "unnamed")
+        joint_type = element.get("type", "fixed")
+
+        # Parent and child
+        parent = element.find("parent")
+        child = element.find("child")
+        parent_link = parent.get("link", "") if parent is not None else ""
+        child_link = child.get("link", "") if child is not None else ""
+
+        # Origin
+        origin = element.find("origin")
+        if origin is not None:
+            xyz_str = origin.get("xyz", "0 0 0")
+            rpy_str = origin.get("rpy", "0 0 0")
+            xyz = tuple(float(x) for x in xyz_str.split())
+            rpy = tuple(float(x) for x in rpy_str.split())
+        else:
+            xyz = (0.0, 0.0, 0.0)
+            rpy = (0.0, 0.0, 0.0)
+
+        # Axis
+        axis_elem = element.find("axis")
+        if axis_elem is not None:
+            axis_str = axis_elem.get("xyz", "0 0 1")
+            axis = tuple(float(x) for x in axis_str.split())
+        else:
+            axis = (0.0, 0.0, 1.0)
+
+        # Limits
+        limit = element.find("limit")
+        if limit is not None:
+            lower = float(limit.get("lower", "0"))
+            upper = float(limit.get("upper", "0"))
+            effort = float(limit.get("effort", "0"))
+            velocity = float(limit.get("velocity", "0"))
+        else:
+            lower = None
+            upper = None
+            effort = None
+            velocity = None
+
+        # Dynamics
+        dynamics = element.find("dynamics")
+        if dynamics is not None:
+            damping = float(dynamics.get("damping", "0"))
+            friction = float(dynamics.get("friction", "0"))
+        else:
+            damping = 0.0
+            friction = 0.0
+
+        return cls(
+            name=name,
+            joint_type=joint_type,
+            parent_link=parent_link,
+            child_link=child_link,
+            origin_xyz=xyz,  # type: ignore
+            origin_rpy=rpy,  # type: ignore
+            axis=axis,  # type: ignore
+            lower_limit=lower,
+            upper_limit=upper,
+            effort_limit=effort,
+            velocity_limit=velocity,
+            damping=damping,
+            friction=friction,
+        )
+
+    def is_movable(self) -> bool:
+        """Check if this joint type allows movement."""
+        return self.joint_type in ["revolute", "prismatic", "continuous"]
+
+    def get_position_range(self) -> tuple[float, float]:
+        """Get the valid position range for this joint."""
+        if self.joint_type == "continuous":
+            return (-math.pi * 2, math.pi * 2)
+        elif self.lower_limit is not None and self.upper_limit is not None:
+            return (self.lower_limit, self.upper_limit)
+        else:
+            return (-math.pi, math.pi)
+
+    def get_position_unit(self) -> str:
+        """Get the unit for joint position."""
+        if self.joint_type == "prismatic":
+            return "m"
+        else:
+            return "rad"
+
+
+class JointSliderWidget(QWidget):
+    """Widget for controlling a single joint with a slider."""
+
+    value_changed = pyqtSignal(str, float)  # joint_name, value
+
+    def __init__(self, joint: JointInfo, parent: QWidget | None = None) -> None:
+        """Initialize the joint slider widget."""
+        super().__init__(parent)
+        self.joint = joint
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(5, 2, 5, 2)
+
+        # Joint name
+        name_label = QLabel(self.joint.name)
+        name_label.setMinimumWidth(120)
+        name_label.setToolTip(
+            f"Type: {self.joint.joint_type}\n"
+            f"Parent: {self.joint.parent_link}\n"
+            f"Child: {self.joint.child_link}"
+        )
+        layout.addWidget(name_label)
+
+        # Type indicator
+        type_label = QLabel(f"[{self.joint.joint_type[0].upper()}]")
+        type_label.setStyleSheet("color: #888; font-size: 10px;")
+        layout.addWidget(type_label)
+
+        # Slider
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        self.slider.setMinimumWidth(150)
+
+        min_val, max_val = self.joint.get_position_range()
+        # Scale to integer for slider (100 steps per unit)
+        self.scale = 100
+        self.slider.setMinimum(int(min_val * self.scale))
+        self.slider.setMaximum(int(max_val * self.scale))
+        self.slider.setValue(int(self.joint.current_position * self.scale))
+
+        layout.addWidget(self.slider)
+
+        # Value spinbox
+        self.spinbox = QDoubleSpinBox()
+        self.spinbox.setRange(min_val, max_val)
+        self.spinbox.setValue(self.joint.current_position)
+        self.spinbox.setSingleStep(0.01)
+        self.spinbox.setDecimals(3)
+        self.spinbox.setSuffix(f" {self.joint.get_position_unit()}")
+        self.spinbox.setMinimumWidth(100)
+        layout.addWidget(self.spinbox)
+
+        # Reset button
+        self.reset_btn = QPushButton("0")
+        self.reset_btn.setFixedWidth(30)
+        self.reset_btn.setToolTip("Reset to zero")
+        layout.addWidget(self.reset_btn)
+
+        # Disable if not movable
+        if not self.joint.is_movable():
+            self.slider.setEnabled(False)
+            self.spinbox.setEnabled(False)
+            self.reset_btn.setEnabled(False)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.slider.valueChanged.connect(self._on_slider_changed)
+        self.spinbox.valueChanged.connect(self._on_spinbox_changed)
+        self.reset_btn.clicked.connect(self._on_reset)
+
+    def _on_slider_changed(self, value: int) -> None:
+        """Handle slider value change."""
+        float_value = value / self.scale
+        self.spinbox.blockSignals(True)
+        self.spinbox.setValue(float_value)
+        self.spinbox.blockSignals(False)
+        self.joint.current_position = float_value
+        self.value_changed.emit(self.joint.name, float_value)
+
+    def _on_spinbox_changed(self, value: float) -> None:
+        """Handle spinbox value change."""
+        self.slider.blockSignals(True)
+        self.slider.setValue(int(value * self.scale))
+        self.slider.blockSignals(False)
+        self.joint.current_position = value
+        self.value_changed.emit(self.joint.name, value)
+
+    def _on_reset(self) -> None:
+        """Reset joint to zero."""
+        self.spinbox.setValue(0.0)
+
+    def set_value(self, value: float) -> None:
+        """Set the joint value programmatically."""
+        self.spinbox.setValue(value)
+
+    def get_value(self) -> float:
+        """Get the current joint value."""
+        return self.spinbox.value()
+
+
+class JointTableWidget(QWidget):
+    """Table view of all joints with editing capabilities."""
+
+    joint_modified = pyqtSignal(str, dict)  # joint_name, new_properties
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the joint table widget."""
+        super().__init__(parent)
+        self.joints: dict[str, JointInfo] = {}
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Table
+        self.table = QTableWidget()
+        self.table.setColumnCount(8)
+        self.table.setHorizontalHeaderLabels([
+            "Name", "Type", "Parent", "Child", "Lower", "Upper", "Axis", "Movable"
+        ])
+
+        header = self.table.horizontalHeader()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+            for i in range(1, 8):
+                header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
+
+        layout.addWidget(self.table)
+
+        # Summary
+        self.summary_label = QLabel("No joints loaded")
+        layout.addWidget(self.summary_label)
+
+    def load_joints(self, joints: dict[str, JointInfo]) -> None:
+        """Load joints into the table."""
+        self.joints = joints
+        self.table.setRowCount(len(joints))
+
+        movable_count = 0
+        for row, (name, joint) in enumerate(joints.items()):
+            self.table.setItem(row, 0, QTableWidgetItem(name))
+            self.table.setItem(row, 1, QTableWidgetItem(joint.joint_type))
+            self.table.setItem(row, 2, QTableWidgetItem(joint.parent_link))
+            self.table.setItem(row, 3, QTableWidgetItem(joint.child_link))
+
+            lower = f"{joint.lower_limit:.3f}" if joint.lower_limit is not None else "-"
+            upper = f"{joint.upper_limit:.3f}" if joint.upper_limit is not None else "-"
+            self.table.setItem(row, 4, QTableWidgetItem(lower))
+            self.table.setItem(row, 5, QTableWidgetItem(upper))
+
+            axis_str = f"({joint.axis[0]:.1f}, {joint.axis[1]:.1f}, {joint.axis[2]:.1f})"
+            self.table.setItem(row, 6, QTableWidgetItem(axis_str))
+
+            movable = "Yes" if joint.is_movable() else "No"
+            item = QTableWidgetItem(movable)
+            if joint.is_movable():
+                item.setForeground(QColor("#006400"))
+                movable_count += 1
+            else:
+                item.setForeground(QColor("#888888"))
+            self.table.setItem(row, 7, item)
+
+        self.summary_label.setText(
+            f"Total joints: {len(joints)} | Movable: {movable_count} | "
+            f"Fixed: {len(joints) - movable_count}"
+        )
+
+
+class JointEditorPanel(QWidget):
+    """Panel for editing individual joint properties."""
+
+    joint_updated = pyqtSignal(str, ET.Element)  # joint_name, new_element
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the joint editor panel."""
+        super().__init__(parent)
+        self.current_joint: JointInfo | None = None
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Joint selection
+        select_layout = QHBoxLayout()
+        select_layout.addWidget(QLabel("Edit Joint:"))
+        self.joint_combo = QComboBox()
+        select_layout.addWidget(self.joint_combo)
+        layout.addLayout(select_layout)
+
+        # Basic properties
+        basic_group = QGroupBox("Basic Properties")
+        basic_layout = QFormLayout(basic_group)
+
+        self.name_edit = QLineEdit()
+        basic_layout.addRow("Name:", self.name_edit)
+
+        self.type_combo = QComboBox()
+        self.type_combo.addItems([
+            "fixed", "revolute", "prismatic", "continuous", "floating", "planar"
+        ])
+        basic_layout.addRow("Type:", self.type_combo)
+
+        layout.addWidget(basic_group)
+
+        # Axis
+        axis_group = QGroupBox("Joint Axis")
+        axis_layout = QHBoxLayout(axis_group)
+
+        self.axis_x = QDoubleSpinBox()
+        self.axis_x.setRange(-1, 1)
+        self.axis_x.setSingleStep(0.1)
+        axis_layout.addWidget(QLabel("X:"))
+        axis_layout.addWidget(self.axis_x)
+
+        self.axis_y = QDoubleSpinBox()
+        self.axis_y.setRange(-1, 1)
+        self.axis_y.setSingleStep(0.1)
+        axis_layout.addWidget(QLabel("Y:"))
+        axis_layout.addWidget(self.axis_y)
+
+        self.axis_z = QDoubleSpinBox()
+        self.axis_z.setRange(-1, 1)
+        self.axis_z.setSingleStep(0.1)
+        axis_layout.addWidget(QLabel("Z:"))
+        axis_layout.addWidget(self.axis_z)
+
+        layout.addWidget(axis_group)
+
+        # Limits
+        limits_group = QGroupBox("Joint Limits")
+        limits_layout = QFormLayout(limits_group)
+
+        self.lower_spin = QDoubleSpinBox()
+        self.lower_spin.setRange(-100, 100)
+        self.lower_spin.setDecimals(4)
+        limits_layout.addRow("Lower:", self.lower_spin)
+
+        self.upper_spin = QDoubleSpinBox()
+        self.upper_spin.setRange(-100, 100)
+        self.upper_spin.setDecimals(4)
+        limits_layout.addRow("Upper:", self.upper_spin)
+
+        self.effort_spin = QDoubleSpinBox()
+        self.effort_spin.setRange(0, 10000)
+        limits_layout.addRow("Effort:", self.effort_spin)
+
+        self.velocity_spin = QDoubleSpinBox()
+        self.velocity_spin.setRange(0, 1000)
+        limits_layout.addRow("Velocity:", self.velocity_spin)
+
+        layout.addWidget(limits_group)
+
+        # Dynamics
+        dynamics_group = QGroupBox("Dynamics")
+        dynamics_layout = QFormLayout(dynamics_group)
+
+        self.damping_spin = QDoubleSpinBox()
+        self.damping_spin.setRange(0, 1000)
+        self.damping_spin.setDecimals(4)
+        dynamics_layout.addRow("Damping:", self.damping_spin)
+
+        self.friction_spin = QDoubleSpinBox()
+        self.friction_spin.setRange(0, 1000)
+        self.friction_spin.setDecimals(4)
+        dynamics_layout.addRow("Friction:", self.friction_spin)
+
+        layout.addWidget(dynamics_group)
+
+        # Apply button
+        self.apply_btn = QPushButton("Apply Changes")
+        self.apply_btn.setEnabled(False)
+        layout.addWidget(self.apply_btn)
+
+        layout.addStretch()
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.joint_combo.currentTextChanged.connect(self._on_joint_selected)
+        self.apply_btn.clicked.connect(self._on_apply)
+
+    def load_joints(self, joints: dict[str, JointInfo]) -> None:
+        """Load joints into the combo box."""
+        self.joint_combo.clear()
+        self.joint_combo.addItems(joints.keys())
+
+    def _on_joint_selected(self, name: str) -> None:
+        """Handle joint selection."""
+        # This would load the joint's current values into the editor
+        self.apply_btn.setEnabled(bool(name))
+
+    def set_joint(self, joint: JointInfo) -> None:
+        """Set the joint to edit."""
+        self.current_joint = joint
+
+        self.name_edit.setText(joint.name)
+        index = self.type_combo.findText(joint.joint_type)
+        if index >= 0:
+            self.type_combo.setCurrentIndex(index)
+
+        self.axis_x.setValue(joint.axis[0])
+        self.axis_y.setValue(joint.axis[1])
+        self.axis_z.setValue(joint.axis[2])
+
+        if joint.lower_limit is not None:
+            self.lower_spin.setValue(joint.lower_limit)
+        if joint.upper_limit is not None:
+            self.upper_spin.setValue(joint.upper_limit)
+        if joint.effort_limit is not None:
+            self.effort_spin.setValue(joint.effort_limit)
+        if joint.velocity_limit is not None:
+            self.velocity_spin.setValue(joint.velocity_limit)
+
+        self.damping_spin.setValue(joint.damping)
+        self.friction_spin.setValue(joint.friction)
+
+        self.apply_btn.setEnabled(True)
+
+    def _on_apply(self) -> None:
+        """Apply changes to the joint."""
+        if self.current_joint is None:
+            return
+
+        # Build new joint element
+        joint_elem = ET.Element(
+            "joint",
+            name=self.name_edit.text(),
+            type=self.type_combo.currentText(),
+        )
+
+        ET.SubElement(joint_elem, "parent", link=self.current_joint.parent_link)
+        ET.SubElement(joint_elem, "child", link=self.current_joint.child_link)
+
+        xyz = self.current_joint.origin_xyz
+        rpy = self.current_joint.origin_rpy
+        ET.SubElement(
+            joint_elem,
+            "origin",
+            xyz=f"{xyz[0]} {xyz[1]} {xyz[2]}",
+            rpy=f"{rpy[0]} {rpy[1]} {rpy[2]}",
+        )
+
+        axis = f"{self.axis_x.value()} {self.axis_y.value()} {self.axis_z.value()}"
+        ET.SubElement(joint_elem, "axis", xyz=axis)
+
+        if self.type_combo.currentText() in ["revolute", "prismatic"]:
+            ET.SubElement(
+                joint_elem,
+                "limit",
+                lower=str(self.lower_spin.value()),
+                upper=str(self.upper_spin.value()),
+                effort=str(self.effort_spin.value()),
+                velocity=str(self.velocity_spin.value()),
+            )
+
+        if self.damping_spin.value() > 0 or self.friction_spin.value() > 0:
+            ET.SubElement(
+                joint_elem,
+                "dynamics",
+                damping=str(self.damping_spin.value()),
+                friction=str(self.friction_spin.value()),
+            )
+
+        self.joint_updated.emit(self.current_joint.name, joint_elem)
+
+
+class JointManipulatorWidget(QWidget):
+    """Main widget for joint manipulation with auto-loading."""
+
+    joints_updated = pyqtSignal(dict)  # dict[str, float] joint positions
+    urdf_modified = pyqtSignal(str)  # new URDF content
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the joint manipulator widget."""
+        super().__init__(parent)
+        self.joints: dict[str, JointInfo] = {}
+        self.urdf_content: str = ""
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Header with controls
+        header = QHBoxLayout()
+
+        self.auto_load_btn = QPushButton("Auto-Load Joints")
+        header.addWidget(self.auto_load_btn)
+
+        self.reset_all_btn = QPushButton("Reset All")
+        header.addWidget(self.reset_all_btn)
+
+        self.random_btn = QPushButton("Random Pose")
+        header.addWidget(self.random_btn)
+
+        header.addStretch()
+
+        # Filter
+        header.addWidget(QLabel("Filter:"))
+        self.filter_combo = QComboBox()
+        self.filter_combo.addItems(["All", "Movable Only", "Fixed Only"])
+        header.addWidget(self.filter_combo)
+
+        layout.addLayout(header)
+
+        # Main splitter
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left side - sliders
+        sliders_widget = QWidget()
+        sliders_layout = QVBoxLayout(sliders_widget)
+
+        sliders_layout.addWidget(QLabel("Joint Sliders (interactive control):"))
+
+        # Scroll area for sliders
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        self.sliders_container = QWidget()
+        self.sliders_layout = QVBoxLayout(self.sliders_container)
+        self.sliders_layout.addStretch()
+        scroll.setWidget(self.sliders_container)
+
+        sliders_layout.addWidget(scroll)
+
+        splitter.addWidget(sliders_widget)
+
+        # Right side - table and editor
+        right_widget = QWidget()
+        right_layout = QVBoxLayout(right_widget)
+
+        # Table
+        self.table_widget = JointTableWidget()
+        right_layout.addWidget(self.table_widget)
+
+        # Editor
+        self.editor_panel = JointEditorPanel()
+        right_layout.addWidget(self.editor_panel)
+
+        splitter.addWidget(right_widget)
+
+        layout.addWidget(splitter)
+
+        # Status
+        self.status_label = QLabel("Load a URDF to auto-detect joints")
+        layout.addWidget(self.status_label)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.auto_load_btn.clicked.connect(self._on_auto_load)
+        self.reset_all_btn.clicked.connect(self._on_reset_all)
+        self.random_btn.clicked.connect(self._on_random_pose)
+        self.filter_combo.currentTextChanged.connect(self._on_filter_changed)
+        self.editor_panel.joint_updated.connect(self._on_joint_updated)
+
+    def load_urdf(self, content: str) -> None:
+        """Load URDF content and auto-detect joints."""
+        self.urdf_content = content
+        self._on_auto_load()
+
+    def _on_auto_load(self) -> None:
+        """Auto-load joints from the URDF."""
+        if not self.urdf_content:
+            self.status_label.setText("No URDF loaded")
+            return
+
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError as e:
+            self.status_label.setText(f"Parse error: {e}")
+            return
+
+        self.joints.clear()
+
+        # Extract all joints
+        for joint_elem in root.findall("joint"):
+            joint_info = JointInfo.from_element(joint_elem)
+            self.joints[joint_info.name] = joint_info
+
+        # Update UI
+        self._populate_sliders()
+        self.table_widget.load_joints(self.joints)
+        self.editor_panel.load_joints(self.joints)
+
+        movable = sum(1 for j in self.joints.values() if j.is_movable())
+        self.status_label.setText(
+            f"Loaded {len(self.joints)} joints ({movable} movable)"
+        )
+
+    def _populate_sliders(self) -> None:
+        """Populate the sliders container."""
+        # Clear existing sliders
+        while self.sliders_layout.count() > 1:  # Keep the stretch
+            item = self.sliders_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+        # Add sliders for movable joints
+        filter_mode = self.filter_combo.currentText()
+
+        for name, joint in self.joints.items():
+            if filter_mode == "Movable Only" and not joint.is_movable():
+                continue
+            if filter_mode == "Fixed Only" and joint.is_movable():
+                continue
+
+            slider_widget = JointSliderWidget(joint)
+            slider_widget.value_changed.connect(self._on_joint_value_changed)
+            self.sliders_layout.insertWidget(self.sliders_layout.count() - 1, slider_widget)
+
+    def _on_filter_changed(self, filter_text: str) -> None:
+        """Handle filter change."""
+        self._populate_sliders()
+
+    def _on_joint_value_changed(self, name: str, value: float) -> None:
+        """Handle joint value change from slider."""
+        if name in self.joints:
+            self.joints[name].current_position = value
+
+        # Emit all current positions
+        positions = {name: j.current_position for name, j in self.joints.items()}
+        self.joints_updated.emit(positions)
+
+    def _on_reset_all(self) -> None:
+        """Reset all joints to zero."""
+        for i in range(self.sliders_layout.count() - 1):
+            item = self.sliders_layout.itemAt(i)
+            if item and item.widget():
+                widget = item.widget()
+                if isinstance(widget, JointSliderWidget):
+                    widget.set_value(0.0)
+
+    def _on_random_pose(self) -> None:
+        """Set random poses for all movable joints."""
+        import random
+
+        for i in range(self.sliders_layout.count() - 1):
+            item = self.sliders_layout.itemAt(i)
+            if item and item.widget():
+                widget = item.widget()
+                if isinstance(widget, JointSliderWidget) and widget.joint.is_movable():
+                    min_val, max_val = widget.joint.get_position_range()
+                    random_val = random.uniform(min_val, max_val)
+                    widget.set_value(random_val)
+
+    def _on_joint_updated(self, name: str, new_element: ET.Element) -> None:
+        """Handle joint update from editor."""
+        if not self.urdf_content:
+            return
+
+        try:
+            root = ET.fromstring(self.urdf_content)
+        except ET.ParseError:
+            return
+
+        # Find and replace the joint
+        for joint in root.findall("joint"):
+            if joint.get("name") == name:
+                root.remove(joint)
+                root.append(new_element)
+                break
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        self.urdf_content = new_content
+        self._on_auto_load()  # Reload joints
+        self.urdf_modified.emit(new_content)
+        self.status_label.setText(f"Updated joint '{name}'")
+
+    def get_joint_positions(self) -> dict[str, float]:
+        """Get current positions of all joints."""
+        return {name: j.current_position for name, j in self.joints.items()}
+
+    def set_joint_positions(self, positions: dict[str, float]) -> None:
+        """Set joint positions."""
+        for i in range(self.sliders_layout.count() - 1):
+            item = self.sliders_layout.itemAt(i)
+            if item and item.widget():
+                widget = item.widget()
+                if isinstance(widget, JointSliderWidget):
+                    if widget.joint.name in positions:
+                        widget.set_value(positions[widget.joint.name])
+
+    def get_urdf_content(self) -> str:
+        """Get the current URDF content."""
+        return self.urdf_content

--- a/src/tools/model_explorer/mesh_browser.py
+++ b/src/tools/model_explorer/mesh_browser.py
@@ -1,0 +1,769 @@
+"""Mesh Browser - Browse and copy mesh/STL components between URDFs.
+
+Provides a side-by-side interface for browsing mesh files referenced
+in URDFs and copying mesh references between models.
+"""
+
+from __future__ import annotations
+
+import copy
+import shutil
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QPixmap
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class MeshReference:
+    """Information about a mesh reference in a URDF."""
+
+    filename: str
+    absolute_path: Path | None
+    link_name: str
+    context: str  # 'visual' or 'collision'
+    scale: tuple[float, float, float]
+    origin_xyz: tuple[float, float, float]
+    origin_rpy: tuple[float, float, float]
+    exists: bool = False
+    file_size: int = 0
+
+    @classmethod
+    def from_element(
+        cls,
+        mesh_elem: ET.Element,
+        link_name: str,
+        context: str,
+        urdf_dir: Path | None,
+    ) -> "MeshReference":
+        """Create MeshReference from a mesh XML element.
+
+        Args:
+            mesh_elem: The <mesh> XML element
+            link_name: Name of the parent link
+            context: 'visual' or 'collision'
+            urdf_dir: Directory containing the URDF file
+        """
+        filename = mesh_elem.get("filename", "")
+
+        # Parse scale
+        scale_str = mesh_elem.get("scale", "1 1 1")
+        try:
+            scale = tuple(float(x) for x in scale_str.split())
+            if len(scale) != 3:
+                scale = (1.0, 1.0, 1.0)
+        except ValueError:
+            scale = (1.0, 1.0, 1.0)
+
+        # Get origin from parent geometry element's sibling
+        origin_xyz = (0.0, 0.0, 0.0)
+        origin_rpy = (0.0, 0.0, 0.0)
+
+        # Resolve absolute path
+        absolute_path = None
+        exists = False
+        file_size = 0
+
+        if urdf_dir and filename:
+            # Handle package:// URIs
+            if filename.startswith("package://"):
+                # Strip package:// prefix, path is relative to package
+                rel_path = filename.replace("package://", "").split("/", 1)
+                if len(rel_path) > 1:
+                    filename = rel_path[1]
+
+            # Handle file:// URIs
+            elif filename.startswith("file://"):
+                filename = filename.replace("file://", "")
+
+            # Resolve relative paths
+            if not Path(filename).is_absolute():
+                absolute_path = urdf_dir / filename
+            else:
+                absolute_path = Path(filename)
+
+            if absolute_path.exists():
+                exists = True
+                file_size = absolute_path.stat().st_size
+
+        return cls(
+            filename=filename,
+            absolute_path=absolute_path,
+            link_name=link_name,
+            context=context,
+            scale=scale,  # type: ignore
+            origin_xyz=origin_xyz,  # type: ignore
+            origin_rpy=origin_rpy,  # type: ignore
+            exists=exists,
+            file_size=file_size,
+        )
+
+    def get_file_extension(self) -> str:
+        """Get the file extension."""
+        return Path(self.filename).suffix.lower()
+
+    def get_display_name(self) -> str:
+        """Get a display name for the mesh."""
+        return Path(self.filename).name
+
+    def format_size(self) -> str:
+        """Format file size for display."""
+        if self.file_size < 1024:
+            return f"{self.file_size} B"
+        elif self.file_size < 1024 * 1024:
+            return f"{self.file_size / 1024:.1f} KB"
+        else:
+            return f"{self.file_size / (1024 * 1024):.1f} MB"
+
+
+class MeshExtractor:
+    """Extracts mesh information from URDF files."""
+
+    @staticmethod
+    def extract_meshes(
+        urdf_content: str, urdf_path: Path | None = None
+    ) -> list[MeshReference]:
+        """Extract all mesh references from a URDF.
+
+        Args:
+            urdf_content: URDF XML content
+            urdf_path: Path to URDF file for resolving relative paths
+
+        Returns:
+            List of MeshReference objects
+        """
+        try:
+            root = ET.fromstring(urdf_content)
+        except ET.ParseError:
+            return []
+
+        urdf_dir = urdf_path.parent if urdf_path else None
+        meshes = []
+
+        for link in root.findall("link"):
+            link_name = link.get("name", "unnamed")
+
+            # Visual meshes
+            for visual in link.findall("visual"):
+                geometry = visual.find("geometry")
+                if geometry is not None:
+                    mesh = geometry.find("mesh")
+                    if mesh is not None:
+                        ref = MeshReference.from_element(
+                            mesh, link_name, "visual", urdf_dir
+                        )
+                        meshes.append(ref)
+
+            # Collision meshes
+            for collision in link.findall("collision"):
+                geometry = collision.find("geometry")
+                if geometry is not None:
+                    mesh = geometry.find("mesh")
+                    if mesh is not None:
+                        ref = MeshReference.from_element(
+                            mesh, link_name, "collision", urdf_dir
+                        )
+                        meshes.append(ref)
+
+        return meshes
+
+    @staticmethod
+    def get_unique_mesh_files(meshes: list[MeshReference]) -> list[MeshReference]:
+        """Get unique mesh files (deduplicated by filename)."""
+        seen = set()
+        unique = []
+        for mesh in meshes:
+            if mesh.filename not in seen:
+                seen.add(mesh.filename)
+                unique.append(mesh)
+        return unique
+
+
+class MeshBrowserPanel(QWidget):
+    """Panel for browsing meshes in a single URDF."""
+
+    mesh_selected = pyqtSignal(object)  # MeshReference
+    mesh_double_clicked = pyqtSignal(object)  # For copying
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        """Initialize the mesh browser panel."""
+        super().__init__(parent)
+        self.title = title
+        self.meshes: list[MeshReference] = []
+        self.urdf_path: Path | None = None
+        self.urdf_content: str = ""
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Header
+        header = QHBoxLayout()
+        self.title_label = QLabel(self.title)
+        self.title_label.setStyleSheet("font-weight: bold;")
+        header.addWidget(self.title_label)
+
+        self.load_btn = QPushButton("Load URDF")
+        header.addWidget(self.load_btn)
+        layout.addLayout(header)
+
+        # File info
+        self.file_label = QLabel("No file loaded")
+        self.file_label.setStyleSheet("color: gray;")
+        layout.addWidget(self.file_label)
+
+        # Mesh table
+        self.table = QTableWidget()
+        self.table.setColumnCount(5)
+        self.table.setHorizontalHeaderLabels([
+            "Mesh File", "Link", "Type", "Size", "Status"
+        ])
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+
+        header = self.table.horizontalHeader()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+            for i in range(1, 5):
+                header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
+
+        layout.addWidget(self.table)
+
+        # Summary
+        summary_layout = QHBoxLayout()
+        self.summary_label = QLabel("No meshes")
+        summary_layout.addWidget(self.summary_label)
+
+        self.missing_label = QLabel("")
+        self.missing_label.setStyleSheet("color: red;")
+        summary_layout.addWidget(self.missing_label)
+
+        layout.addLayout(summary_layout)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.load_btn.clicked.connect(self._on_load)
+        self.table.itemSelectionChanged.connect(self._on_selection_changed)
+        self.table.cellDoubleClicked.connect(self._on_double_click)
+
+    def _on_load(self) -> None:
+        """Handle load button click."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load URDF",
+            "",
+            "URDF Files (*.urdf);;XML Files (*.xml)",
+        )
+
+        if file_path:
+            self.load_file(Path(file_path))
+
+    def load_file(self, file_path: Path) -> bool:
+        """Load a URDF file."""
+        try:
+            self.urdf_content = file_path.read_text(encoding="utf-8")
+            self.urdf_path = file_path
+            self.meshes = MeshExtractor.extract_meshes(self.urdf_content, file_path)
+            self._populate_table()
+            self.file_label.setText(f"File: {file_path.name}")
+            logger.info(f"Loaded {len(self.meshes)} meshes from {file_path}")
+            return True
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to load file: {e}")
+            return False
+
+    def load_content(self, content: str, file_path: Path | None = None) -> None:
+        """Load URDF content directly."""
+        self.urdf_content = content
+        self.urdf_path = file_path
+        self.meshes = MeshExtractor.extract_meshes(content, file_path)
+        self._populate_table()
+        if file_path:
+            self.file_label.setText(f"File: {file_path.name}")
+        else:
+            self.file_label.setText("Content loaded (no file)")
+
+    def _populate_table(self) -> None:
+        """Populate the mesh table."""
+        self.table.setRowCount(len(self.meshes))
+
+        missing_count = 0
+        for row, mesh in enumerate(self.meshes):
+            # Filename
+            self.table.setItem(row, 0, QTableWidgetItem(mesh.get_display_name()))
+
+            # Link
+            self.table.setItem(row, 1, QTableWidgetItem(mesh.link_name))
+
+            # Type (visual/collision)
+            type_item = QTableWidgetItem(mesh.context)
+            if mesh.context == "visual":
+                type_item.setForeground(QColor("#006400"))
+            else:
+                type_item.setForeground(QColor("#0000CD"))
+            self.table.setItem(row, 2, type_item)
+
+            # Size
+            size_text = mesh.format_size() if mesh.exists else "-"
+            self.table.setItem(row, 3, QTableWidgetItem(size_text))
+
+            # Status
+            if mesh.exists:
+                status_item = QTableWidgetItem("Found")
+                status_item.setForeground(QColor("#006400"))
+            else:
+                status_item = QTableWidgetItem("Missing")
+                status_item.setForeground(QColor("#FF0000"))
+                missing_count += 1
+            self.table.setItem(row, 4, status_item)
+
+        # Update summary
+        unique = len(MeshExtractor.get_unique_mesh_files(self.meshes))
+        self.summary_label.setText(
+            f"Total references: {len(self.meshes)} | Unique files: {unique}"
+        )
+
+        if missing_count > 0:
+            self.missing_label.setText(f"Missing: {missing_count}")
+        else:
+            self.missing_label.setText("")
+
+    def _on_selection_changed(self) -> None:
+        """Handle table selection change."""
+        row = self.table.currentRow()
+        if 0 <= row < len(self.meshes):
+            self.mesh_selected.emit(self.meshes[row])
+
+    def _on_double_click(self, row: int, column: int) -> None:
+        """Handle double-click for copying."""
+        if 0 <= row < len(self.meshes):
+            self.mesh_double_clicked.emit(self.meshes[row])
+
+    def get_selected_mesh(self) -> MeshReference | None:
+        """Get the currently selected mesh."""
+        row = self.table.currentRow()
+        if 0 <= row < len(self.meshes):
+            return self.meshes[row]
+        return None
+
+    def get_meshes(self) -> list[MeshReference]:
+        """Get all meshes."""
+        return self.meshes
+
+    def get_urdf_content(self) -> str:
+        """Get the URDF content."""
+        return self.urdf_content
+
+    def get_urdf_path(self) -> Path | None:
+        """Get the URDF file path."""
+        return self.urdf_path
+
+
+class CopyMeshDialog(QDialog):
+    """Dialog for configuring mesh copy operation."""
+
+    def __init__(
+        self,
+        mesh: MeshReference,
+        target_links: list[str],
+        target_urdf_dir: Path | None,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.mesh = mesh
+        self.target_urdf_dir = target_urdf_dir
+        self.setWindowTitle("Copy Mesh Reference")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        # Source info
+        source_group = QGroupBox("Source Mesh")
+        source_layout = QFormLayout(source_group)
+        source_layout.addRow("File:", QLabel(mesh.get_display_name()))
+        source_layout.addRow("From link:", QLabel(mesh.link_name))
+        source_layout.addRow("Type:", QLabel(mesh.context))
+
+        status = "Found" if mesh.exists else "Missing (file will need to be copied)"
+        status_label = QLabel(status)
+        status_label.setStyleSheet(
+            "color: green;" if mesh.exists else "color: orange;"
+        )
+        source_layout.addRow("Status:", status_label)
+
+        layout.addWidget(source_group)
+
+        # Target configuration
+        target_group = QGroupBox("Target Configuration")
+        target_layout = QFormLayout(target_group)
+
+        self.link_combo = QComboBox()
+        self.link_combo.addItems(target_links)
+        target_layout.addRow("Add to link:", self.link_combo)
+
+        self.context_combo = QComboBox()
+        self.context_combo.addItems(["visual", "collision", "both"])
+        self.context_combo.setCurrentText(mesh.context)
+        target_layout.addRow("As:", self.context_combo)
+
+        layout.addWidget(target_group)
+
+        # File handling
+        if mesh.exists and target_urdf_dir:
+            file_group = QGroupBox("File Handling")
+            file_layout = QVBoxLayout(file_group)
+
+            self.copy_file_check = QCheckBox("Copy mesh file to target directory")
+            self.copy_file_check.setChecked(True)
+            file_layout.addWidget(self.copy_file_check)
+
+            self.mesh_subdir_edit = QLineEdit("meshes")
+            form = QFormLayout()
+            form.addRow("Mesh subdirectory:", self.mesh_subdir_edit)
+            file_layout.addLayout(form)
+
+            layout.addWidget(file_group)
+        else:
+            self.copy_file_check = None
+            self.mesh_subdir_edit = None
+
+        # Buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_configuration(self) -> dict[str, Any]:
+        """Get the copy configuration."""
+        return {
+            "target_link": self.link_combo.currentText(),
+            "context": self.context_combo.currentText(),
+            "copy_file": self.copy_file_check.isChecked() if self.copy_file_check else False,
+            "mesh_subdir": self.mesh_subdir_edit.text() if self.mesh_subdir_edit else "meshes",
+        }
+
+
+class MeshBrowserWidget(QWidget):
+    """Side-by-side mesh browser for copying between URDFs."""
+
+    urdf_modified = pyqtSignal(str)  # New URDF content
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the mesh browser widget."""
+        super().__init__(parent)
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+
+        # Instructions
+        instructions = QLabel(
+            "Browse meshes in two URDFs side-by-side. "
+            "Double-click or use the Copy button to copy mesh references."
+        )
+        instructions.setWordWrap(True)
+        instructions.setStyleSheet("color: #666; font-style: italic;")
+        layout.addWidget(instructions)
+
+        # Main splitter
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        self.left_panel = MeshBrowserPanel("Source URDF")
+        self.right_panel = MeshBrowserPanel("Target URDF")
+
+        splitter.addWidget(self.left_panel)
+        splitter.addWidget(self.right_panel)
+
+        layout.addWidget(splitter)
+
+        # Controls
+        controls = QHBoxLayout()
+        controls.addStretch()
+
+        self.copy_btn = QPushButton("Copy Selected Mesh -->")
+        self.copy_all_btn = QPushButton("Copy All Meshes -->")
+        self.swap_btn = QPushButton("Swap Models")
+
+        controls.addWidget(self.copy_btn)
+        controls.addWidget(self.copy_all_btn)
+        controls.addWidget(self.swap_btn)
+        controls.addStretch()
+
+        layout.addLayout(controls)
+
+        # Preview
+        preview_group = QGroupBox("Selected Mesh Details")
+        preview_layout = QVBoxLayout(preview_group)
+        self.preview_text = QTextEdit()
+        self.preview_text.setReadOnly(True)
+        self.preview_text.setMaximumHeight(100)
+        preview_layout.addWidget(self.preview_text)
+        layout.addWidget(preview_group)
+
+        # Status
+        self.status_label = QLabel("Load URDFs to browse meshes")
+        self.status_label.setStyleSheet("color: #888;")
+        layout.addWidget(self.status_label)
+
+    def _connect_signals(self) -> None:
+        """Connect signals."""
+        self.copy_btn.clicked.connect(self._on_copy_selected)
+        self.copy_all_btn.clicked.connect(self._on_copy_all)
+        self.swap_btn.clicked.connect(self._on_swap)
+
+        self.left_panel.mesh_selected.connect(self._on_mesh_selected)
+        self.left_panel.mesh_double_clicked.connect(self._on_copy_mesh)
+        self.right_panel.mesh_selected.connect(self._on_mesh_selected)
+
+    def _on_mesh_selected(self, mesh: MeshReference) -> None:
+        """Handle mesh selection."""
+        details = f"File: {mesh.filename}\n"
+        details += f"Link: {mesh.link_name}\n"
+        details += f"Type: {mesh.context}\n"
+        details += f"Scale: ({mesh.scale[0]:.2f}, {mesh.scale[1]:.2f}, {mesh.scale[2]:.2f})\n"
+        details += f"Exists: {'Yes' if mesh.exists else 'No'}\n"
+        if mesh.exists:
+            details += f"Size: {mesh.format_size()}\n"
+            details += f"Path: {mesh.absolute_path}"
+        self.preview_text.setPlainText(details)
+
+    def _on_copy_selected(self) -> None:
+        """Copy the selected mesh from left to right."""
+        mesh = self.left_panel.get_selected_mesh()
+        if mesh:
+            self._on_copy_mesh(mesh)
+        else:
+            self.status_label.setText("Select a mesh in the source panel")
+
+    def _on_copy_mesh(self, mesh: MeshReference) -> None:
+        """Copy a mesh reference to the target URDF."""
+        target_content = self.right_panel.get_urdf_content()
+        if not target_content:
+            self.status_label.setText("Load a target URDF first")
+            return
+
+        try:
+            target_root = ET.fromstring(target_content)
+        except ET.ParseError:
+            self.status_label.setText("Invalid target URDF")
+            return
+
+        # Get target links
+        target_links = [link.get("name", "") for link in target_root.findall("link")]
+        if not target_links:
+            self.status_label.setText("No links in target URDF")
+            return
+
+        # Show configuration dialog
+        dialog = CopyMeshDialog(
+            mesh, target_links, self.right_panel.get_urdf_path(), self
+        )
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        config = dialog.get_configuration()
+        self._apply_mesh_copy(mesh, config)
+
+    def _apply_mesh_copy(self, mesh: MeshReference, config: dict[str, Any]) -> None:
+        """Apply the mesh copy to the target URDF."""
+        target_content = self.right_panel.get_urdf_content()
+        target_path = self.right_panel.get_urdf_path()
+
+        try:
+            root = ET.fromstring(target_content)
+        except ET.ParseError:
+            return
+
+        # Find target link
+        target_link = None
+        for link in root.findall("link"):
+            if link.get("name") == config["target_link"]:
+                target_link = link
+                break
+
+        if target_link is None:
+            self.status_label.setText(f"Link '{config['target_link']}' not found")
+            return
+
+        # Copy mesh file if requested
+        new_filename = mesh.filename
+        if config["copy_file"] and mesh.exists and mesh.absolute_path and target_path:
+            mesh_subdir = config["mesh_subdir"]
+            target_mesh_dir = target_path.parent / mesh_subdir
+            target_mesh_dir.mkdir(parents=True, exist_ok=True)
+
+            target_mesh_path = target_mesh_dir / mesh.absolute_path.name
+            try:
+                shutil.copy2(mesh.absolute_path, target_mesh_path)
+                new_filename = f"{mesh_subdir}/{mesh.absolute_path.name}"
+                logger.info(f"Copied mesh file to {target_mesh_path}")
+            except Exception as e:
+                logger.error(f"Failed to copy mesh file: {e}")
+
+        # Create mesh element(s)
+        contexts = []
+        if config["context"] == "both":
+            contexts = ["visual", "collision"]
+        else:
+            contexts = [config["context"]]
+
+        for context in contexts:
+            # Create or find the context element (visual/collision)
+            context_elem = ET.SubElement(target_link, context)
+
+            # Add origin
+            origin = ET.SubElement(context_elem, "origin")
+            origin.set("xyz", f"{mesh.origin_xyz[0]} {mesh.origin_xyz[1]} {mesh.origin_xyz[2]}")
+            origin.set("rpy", f"{mesh.origin_rpy[0]} {mesh.origin_rpy[1]} {mesh.origin_rpy[2]}")
+
+            # Add geometry with mesh
+            geometry = ET.SubElement(context_elem, "geometry")
+            mesh_elem = ET.SubElement(geometry, "mesh")
+            mesh_elem.set("filename", new_filename)
+
+            if mesh.scale != (1.0, 1.0, 1.0):
+                mesh_elem.set("scale", f"{mesh.scale[0]} {mesh.scale[1]} {mesh.scale[2]}")
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        # Reload right panel
+        self.right_panel.load_content(new_content, target_path)
+        self.urdf_modified.emit(new_content)
+        self.status_label.setText(
+            f"Added mesh '{mesh.get_display_name()}' to link '{config['target_link']}'"
+        )
+
+    def _on_copy_all(self) -> None:
+        """Copy all meshes from source to target."""
+        meshes = self.left_panel.get_meshes()
+        if not meshes:
+            self.status_label.setText("No meshes in source URDF")
+            return
+
+        target_content = self.right_panel.get_urdf_content()
+        if not target_content:
+            self.status_label.setText("Load a target URDF first")
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Copy All Meshes",
+            f"Copy {len(meshes)} mesh reference(s) to target?\n"
+            "Each mesh will be added to a link with the same name if it exists.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        # Get unique meshes
+        unique_meshes = MeshExtractor.get_unique_mesh_files(meshes)
+
+        try:
+            root = ET.fromstring(target_content)
+        except ET.ParseError:
+            return
+
+        target_links = {link.get("name"): link for link in root.findall("link")}
+        copied_count = 0
+
+        for mesh in unique_meshes:
+            # Try to find matching link in target
+            if mesh.link_name in target_links:
+                target_link = target_links[mesh.link_name]
+
+                # Create visual/collision element
+                context_elem = ET.SubElement(target_link, mesh.context)
+                geometry = ET.SubElement(context_elem, "geometry")
+                mesh_elem = ET.SubElement(geometry, "mesh")
+                mesh_elem.set("filename", mesh.filename)
+
+                if mesh.scale != (1.0, 1.0, 1.0):
+                    mesh_elem.set("scale", f"{mesh.scale[0]} {mesh.scale[1]} {mesh.scale[2]}")
+
+                copied_count += 1
+
+        # Generate new URDF
+        ET.indent(root, space="  ")
+        new_content = ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+        self.right_panel.load_content(new_content, self.right_panel.get_urdf_path())
+        self.urdf_modified.emit(new_content)
+        self.status_label.setText(f"Copied {copied_count} of {len(unique_meshes)} meshes")
+
+    def _on_swap(self) -> None:
+        """Swap the source and target models."""
+        left_content = self.left_panel.get_urdf_content()
+        left_path = self.left_panel.get_urdf_path()
+        right_content = self.right_panel.get_urdf_content()
+        right_path = self.right_panel.get_urdf_path()
+
+        if right_content:
+            self.left_panel.load_content(right_content, right_path)
+        if left_content:
+            self.right_panel.load_content(left_content, left_path)
+
+        self.status_label.setText("Swapped source and target models")
+
+    def load_source(self, file_path: Path) -> bool:
+        """Load a source URDF."""
+        return self.left_panel.load_file(file_path)
+
+    def load_target(self, file_path: Path) -> bool:
+        """Load a target URDF."""
+        return self.right_panel.load_file(file_path)
+
+    def load_source_content(self, content: str, file_path: Path | None = None) -> None:
+        """Load source URDF from content."""
+        self.left_panel.load_content(content, file_path)
+
+    def load_target_content(self, content: str, file_path: Path | None = None) -> None:
+        """Load target URDF from content."""
+        self.right_panel.load_content(content, file_path)
+
+    def get_target_content(self) -> str:
+        """Get the modified target URDF content."""
+        return self.right_panel.get_urdf_content()

--- a/src/tools/model_explorer/urdf_code_editor.py
+++ b/src/tools/model_explorer/urdf_code_editor.py
@@ -1,0 +1,706 @@
+"""URDF Code Editor with XML syntax highlighting and validation.
+
+Provides a code editor experience for viewing and editing URDF/XML files
+with syntax highlighting, line numbers, validation, and auto-completion.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+
+from PyQt6.QtCore import QRect, QRegularExpression, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import (
+    QColor,
+    QFont,
+    QFontMetrics,
+    QPainter,
+    QSyntaxHighlighter,
+    QTextCharFormat,
+    QTextDocument,
+)
+from PyQt6.QtWidgets import (
+    QCompleter,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QPlainTextEdit,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class XMLHighlighter(QSyntaxHighlighter):
+    """Syntax highlighter for XML/URDF content."""
+
+    def __init__(self, parent: QTextDocument | None = None) -> None:
+        """Initialize the highlighter."""
+        super().__init__(parent)
+        self._setup_highlighting_rules()
+
+    def _setup_highlighting_rules(self) -> None:
+        """Set up highlighting rules for XML."""
+        self.highlighting_rules: list[tuple[QRegularExpression, QTextCharFormat]] = []
+
+        # Tag names (blue)
+        tag_format = QTextCharFormat()
+        tag_format.setForeground(QColor("#0000FF"))
+        tag_format.setFontWeight(QFont.Weight.Bold)
+        self.highlighting_rules.append(
+            (QRegularExpression(r"</?[\w:-]+"), tag_format)
+        )
+
+        # Attribute names (dark cyan)
+        attr_format = QTextCharFormat()
+        attr_format.setForeground(QColor("#008B8B"))
+        self.highlighting_rules.append(
+            (QRegularExpression(r'\b[\w:-]+(?==")'), attr_format)
+        )
+
+        # Attribute values (dark red/maroon)
+        value_format = QTextCharFormat()
+        value_format.setForeground(QColor("#8B0000"))
+        self.highlighting_rules.append(
+            (QRegularExpression(r'"[^"]*"'), value_format)
+        )
+
+        # Comments (gray)
+        comment_format = QTextCharFormat()
+        comment_format.setForeground(QColor("#808080"))
+        comment_format.setFontItalic(True)
+        self.highlighting_rules.append(
+            (QRegularExpression(r"<!--.*?-->"), comment_format)
+        )
+
+        # XML declaration (purple)
+        decl_format = QTextCharFormat()
+        decl_format.setForeground(QColor("#800080"))
+        self.highlighting_rules.append(
+            (QRegularExpression(r"<\?xml.*?\?>"), decl_format)
+        )
+
+        # URDF-specific keywords (green)
+        urdf_format = QTextCharFormat()
+        urdf_format.setForeground(QColor("#006400"))
+        urdf_format.setFontWeight(QFont.Weight.Bold)
+        urdf_keywords = [
+            "robot", "link", "joint", "visual", "collision", "inertial",
+            "geometry", "origin", "mass", "inertia", "material", "color",
+            "parent", "child", "axis", "limit", "dynamics", "transmission",
+            "box", "cylinder", "sphere", "mesh", "capsule",
+        ]
+        for keyword in urdf_keywords:
+            self.highlighting_rules.append(
+                (QRegularExpression(rf"</?{keyword}\b"), urdf_format)
+            )
+
+        # Numbers (orange)
+        number_format = QTextCharFormat()
+        number_format.setForeground(QColor("#FF8C00"))
+        self.highlighting_rules.append(
+            (QRegularExpression(r'"[\d\s\.\-e+]+(?=")|[\d\.]+'), number_format)
+        )
+
+    def highlightBlock(self, text: str) -> None:
+        """Apply highlighting rules to a block of text."""
+        for pattern, fmt in self.highlighting_rules:
+            match_iterator = pattern.globalMatch(text)
+            while match_iterator.hasNext():
+                match = match_iterator.next()
+                self.setFormat(match.capturedStart(), match.capturedLength(), fmt)
+
+
+class LineNumberArea(QWidget):
+    """Widget displaying line numbers for the code editor."""
+
+    def __init__(self, editor: "URDFCodeEditor") -> None:
+        """Initialize the line number area."""
+        super().__init__(editor)
+        self.editor = editor
+
+    def sizeHint(self) -> QSize:
+        """Return the recommended size."""
+        return QSize(self.editor.line_number_area_width(), 0)
+
+    def paintEvent(self, event: Any) -> None:
+        """Paint the line numbers."""
+        self.editor.line_number_area_paint_event(event)
+
+
+class URDFCodeEditor(QPlainTextEdit):
+    """Code editor for URDF/XML with syntax highlighting and line numbers."""
+
+    content_changed = pyqtSignal(str)  # Emitted when content changes
+    validation_result = pyqtSignal(bool, list)  # (is_valid, errors)
+    cursor_position_changed = pyqtSignal(int, int)  # (line, column)
+
+    # URDF tag completions
+    URDF_COMPLETIONS = [
+        "robot", "link", "joint", "visual", "collision", "inertial",
+        "geometry", "origin", "mass", "inertia", "material", "color",
+        "parent", "child", "axis", "limit", "dynamics", "transmission",
+        "box", "cylinder", "sphere", "mesh", "capsule", "name", "type",
+        "xyz", "rpy", "value", "filename", "scale", "rgba", "ixx", "iyy",
+        "izz", "ixy", "ixz", "iyz", "lower", "upper", "effort", "velocity",
+        "fixed", "revolute", "prismatic", "continuous", "floating", "planar",
+    ]
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the code editor."""
+        super().__init__(parent)
+        self._setup_editor()
+        self._setup_highlighter()
+        self._setup_line_numbers()
+        self._setup_completer()
+        self._connect_signals()
+
+    def _setup_editor(self) -> None:
+        """Set up editor appearance."""
+        # Set monospace font
+        font = QFont("Consolas", 10)
+        font.setStyleHint(QFont.StyleHint.Monospace)
+        self.setFont(font)
+
+        # Set tab width to 4 spaces
+        metrics = QFontMetrics(font)
+        self.setTabStopDistance(4 * metrics.horizontalAdvance(" "))
+
+        # Enable word wrap
+        self.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+
+        # Set placeholder
+        self.setPlaceholderText("Enter URDF/XML content here...")
+
+    def _setup_highlighter(self) -> None:
+        """Set up syntax highlighter."""
+        self.highlighter = XMLHighlighter(self.document())
+
+    def _setup_line_numbers(self) -> None:
+        """Set up line number area."""
+        self.line_number_area = LineNumberArea(self)
+        self.blockCountChanged.connect(self.update_line_number_area_width)
+        self.updateRequest.connect(self.update_line_number_area)
+        self.update_line_number_area_width(0)
+
+    def _setup_completer(self) -> None:
+        """Set up auto-completion."""
+        self.completer = QCompleter(self.URDF_COMPLETIONS, self)
+        self.completer.setWidget(self)
+        self.completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self.completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.completer.activated.connect(self.insert_completion)
+
+    def _connect_signals(self) -> None:
+        """Connect internal signals."""
+        self.textChanged.connect(self._on_text_changed)
+        self.cursorPositionChanged.connect(self._on_cursor_position_changed)
+
+    def _on_text_changed(self) -> None:
+        """Handle text changes."""
+        content = self.toPlainText()
+        self.content_changed.emit(content)
+
+    def _on_cursor_position_changed(self) -> None:
+        """Handle cursor position changes."""
+        cursor = self.textCursor()
+        line = cursor.blockNumber() + 1
+        column = cursor.columnNumber() + 1
+        self.cursor_position_changed.emit(line, column)
+
+    def line_number_area_width(self) -> int:
+        """Calculate the width needed for line numbers."""
+        digits = 1
+        max_num = max(1, self.blockCount())
+        while max_num >= 10:
+            max_num //= 10
+            digits += 1
+
+        space = 10 + self.fontMetrics().horizontalAdvance("9") * digits
+        return space
+
+    def update_line_number_area_width(self, _: int) -> None:
+        """Update the margins to account for line number area."""
+        self.setViewportMargins(self.line_number_area_width(), 0, 0, 0)
+
+    def update_line_number_area(self, rect: QRect, dy: int) -> None:
+        """Update the line number area when scrolling."""
+        if dy:
+            self.line_number_area.scroll(0, dy)
+        else:
+            self.line_number_area.update(
+                0, rect.y(), self.line_number_area.width(), rect.height()
+            )
+
+        if rect.contains(self.viewport().rect()):
+            self.update_line_number_area_width(0)
+
+    def resizeEvent(self, event: Any) -> None:
+        """Handle resize events."""
+        super().resizeEvent(event)
+        cr = self.contentsRect()
+        self.line_number_area.setGeometry(
+            QRect(cr.left(), cr.top(), self.line_number_area_width(), cr.height())
+        )
+
+    def line_number_area_paint_event(self, event: Any) -> None:
+        """Paint line numbers."""
+        painter = QPainter(self.line_number_area)
+        painter.fillRect(event.rect(), QColor("#F0F0F0"))
+
+        block = self.firstVisibleBlock()
+        block_number = block.blockNumber()
+        top = round(self.blockBoundingGeometry(block).translated(self.contentOffset()).top())
+        bottom = top + round(self.blockBoundingRect(block).height())
+
+        while block.isValid() and top <= event.rect().bottom():
+            if block.isVisible() and bottom >= event.rect().top():
+                number = str(block_number + 1)
+                painter.setPen(QColor("#808080"))
+                painter.drawText(
+                    0,
+                    top,
+                    self.line_number_area.width() - 5,
+                    self.fontMetrics().height(),
+                    Qt.AlignmentFlag.AlignRight,
+                    number,
+                )
+
+            block = block.next()
+            top = bottom
+            bottom = top + round(self.blockBoundingRect(block).height())
+            block_number += 1
+
+    def keyPressEvent(self, event: Any) -> None:
+        """Handle key press events for auto-completion."""
+        if self.completer.popup().isVisible():
+            if event.key() in (
+                Qt.Key.Key_Enter,
+                Qt.Key.Key_Return,
+                Qt.Key.Key_Escape,
+                Qt.Key.Key_Tab,
+                Qt.Key.Key_Backtab,
+            ):
+                event.ignore()
+                return
+
+        super().keyPressEvent(event)
+
+        # Trigger completion on typing
+        completion_prefix = self._get_completion_prefix()
+        if len(completion_prefix) >= 2:
+            if completion_prefix != self.completer.completionPrefix():
+                self.completer.setCompletionPrefix(completion_prefix)
+                popup = self.completer.popup()
+                popup.setCurrentIndex(self.completer.completionModel().index(0, 0))
+
+            cr = self.cursorRect()
+            cr.setWidth(
+                self.completer.popup().sizeHintForColumn(0)
+                + self.completer.popup().verticalScrollBar().sizeHint().width()
+            )
+            self.completer.complete(cr)
+        else:
+            self.completer.popup().hide()
+
+    def _get_completion_prefix(self) -> str:
+        """Get the current word being typed for completion."""
+        cursor = self.textCursor()
+        cursor.select(cursor.SelectionType.WordUnderCursor)
+        return cursor.selectedText()
+
+    def insert_completion(self, completion: str) -> None:
+        """Insert the selected completion."""
+        cursor = self.textCursor()
+        extra = len(completion) - len(self.completer.completionPrefix())
+        cursor.movePosition(cursor.MoveOperation.Left)
+        cursor.movePosition(cursor.MoveOperation.EndOfWord)
+        cursor.insertText(completion[-extra:])
+        self.setTextCursor(cursor)
+
+    def validate_xml(self) -> tuple[bool, list[str]]:
+        """Validate the XML content.
+
+        Returns:
+            Tuple of (is_valid, list of error messages)
+        """
+        content = self.toPlainText()
+        if not content.strip():
+            return True, []
+
+        errors = []
+        try:
+            ET.fromstring(content)
+            self.validation_result.emit(True, [])
+            return True, []
+        except ET.ParseError as e:
+            error_msg = str(e)
+            # Extract line and column info
+            match = re.search(r"line (\d+), column (\d+)", error_msg)
+            if match:
+                line, col = match.groups()
+                errors.append(f"XML Error at line {line}, column {col}: {error_msg}")
+            else:
+                errors.append(f"XML Error: {error_msg}")
+
+            self.validation_result.emit(False, errors)
+            return False, errors
+
+    def validate_urdf(self) -> tuple[bool, list[str]]:
+        """Validate URDF-specific structure.
+
+        Returns:
+            Tuple of (is_valid, list of error/warning messages)
+        """
+        content = self.toPlainText()
+        if not content.strip():
+            return True, []
+
+        errors: list[str] = []
+
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError:
+            # XML parsing errors handled by validate_xml
+            return False, ["Invalid XML - cannot validate URDF structure"]
+
+        # Check for robot root element
+        if root.tag != "robot":
+            errors.append("Root element must be 'robot'")
+
+        # Check for robot name
+        if not root.get("name"):
+            errors.append("Robot element should have a 'name' attribute")
+
+        # Collect links and joints
+        links = {link.get("name") for link in root.findall("link")}
+        joints = root.findall("joint")
+
+        # Check for at least one link
+        if not links:
+            errors.append("URDF must have at least one link")
+
+        # Validate joints
+        for joint in joints:
+            joint_name = joint.get("name", "unnamed")
+            joint_type = joint.get("type")
+
+            # Check joint type
+            valid_types = ["fixed", "revolute", "prismatic", "continuous", "floating", "planar"]
+            if joint_type not in valid_types:
+                errors.append(
+                    f"Joint '{joint_name}' has invalid type '{joint_type}'. "
+                    f"Must be one of: {', '.join(valid_types)}"
+                )
+
+            # Check parent/child links exist
+            parent = joint.find("parent")
+            child = joint.find("child")
+
+            if parent is not None:
+                parent_link = parent.get("link")
+                if parent_link and parent_link not in links:
+                    errors.append(
+                        f"Joint '{joint_name}' references non-existent parent link '{parent_link}'"
+                    )
+
+            if child is not None:
+                child_link = child.get("link")
+                if child_link and child_link not in links:
+                    errors.append(
+                        f"Joint '{joint_name}' references non-existent child link '{child_link}'"
+                    )
+
+            # Check limits for revolute/prismatic
+            if joint_type in ["revolute", "prismatic"]:
+                limit = joint.find("limit")
+                if limit is None:
+                    errors.append(f"Joint '{joint_name}' ({joint_type}) must have limits")
+
+        is_valid = len(errors) == 0
+        self.validation_result.emit(is_valid, errors)
+        return is_valid, errors
+
+    def set_content(self, content: str) -> None:
+        """Set the editor content."""
+        self.setPlainText(content)
+
+    def get_content(self) -> str:
+        """Get the editor content."""
+        return self.toPlainText()
+
+    def go_to_line(self, line: int) -> None:
+        """Move cursor to a specific line."""
+        block = self.document().findBlockByLineNumber(line - 1)
+        cursor = self.textCursor()
+        cursor.setPosition(block.position())
+        self.setTextCursor(cursor)
+        self.centerCursor()
+
+    def find_text(self, text: str, case_sensitive: bool = False) -> bool:
+        """Find text in the editor.
+
+        Args:
+            text: Text to find
+            case_sensitive: Whether to match case
+
+        Returns:
+            True if found
+        """
+        flags = QTextDocument.FindFlag(0)
+        if case_sensitive:
+            flags |= QTextDocument.FindFlag.FindCaseSensitively
+
+        return self.find(text, flags)
+
+    def replace_text(self, find: str, replace: str, all_occurrences: bool = False) -> int:
+        """Replace text in the editor.
+
+        Args:
+            find: Text to find
+            replace: Replacement text
+            all_occurrences: Replace all if True
+
+        Returns:
+            Number of replacements made
+        """
+        count = 0
+        content = self.toPlainText()
+
+        if all_occurrences:
+            new_content = content.replace(find, replace)
+            count = content.count(find)
+            if count > 0:
+                self.setPlainText(new_content)
+        else:
+            cursor = self.textCursor()
+            if cursor.hasSelection() and cursor.selectedText() == find:
+                cursor.insertText(replace)
+                count = 1
+            else:
+                if self.find_text(find):
+                    cursor = self.textCursor()
+                    cursor.insertText(replace)
+                    count = 1
+
+        return count
+
+
+class URDFCodeEditorWidget(QWidget):
+    """Complete code editor widget with toolbar and status."""
+
+    content_saved = pyqtSignal(str)  # Emitted when content is saved
+    validation_changed = pyqtSignal(bool, list)  # Validation status
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the code editor widget."""
+        super().__init__(parent)
+        self._setup_ui()
+        self._connect_signals()
+        self._current_file: str | None = None
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Toolbar
+        toolbar = QHBoxLayout()
+
+        self.validate_btn = QPushButton("Validate")
+        self.format_btn = QPushButton("Format")
+        self.find_btn = QPushButton("Find/Replace")
+
+        toolbar.addWidget(self.validate_btn)
+        toolbar.addWidget(self.format_btn)
+        toolbar.addWidget(self.find_btn)
+        toolbar.addStretch()
+
+        layout.addLayout(toolbar)
+
+        # Main splitter
+        splitter = QSplitter(Qt.Orientation.Vertical)
+
+        # Code editor
+        self.editor = URDFCodeEditor()
+        splitter.addWidget(self.editor)
+
+        # Error/output panel
+        self.output_panel = QTextEdit()
+        self.output_panel.setReadOnly(True)
+        self.output_panel.setMaximumHeight(100)
+        self.output_panel.setPlaceholderText("Validation messages will appear here...")
+        splitter.addWidget(self.output_panel)
+
+        splitter.setStretchFactor(0, 4)
+        splitter.setStretchFactor(1, 1)
+
+        layout.addWidget(splitter)
+
+        # Status bar
+        status_layout = QHBoxLayout()
+        self.position_label = QLabel("Line 1, Col 1")
+        self.status_label = QLabel("Ready")
+        status_layout.addWidget(self.position_label)
+        status_layout.addStretch()
+        status_layout.addWidget(self.status_label)
+        layout.addLayout(status_layout)
+
+    def _connect_signals(self) -> None:
+        """Connect signals to slots."""
+        self.validate_btn.clicked.connect(self._on_validate)
+        self.format_btn.clicked.connect(self._on_format)
+        self.find_btn.clicked.connect(self._on_find_replace)
+
+        self.editor.cursor_position_changed.connect(self._on_cursor_position_changed)
+        self.editor.validation_result.connect(self._on_validation_result)
+
+    def _on_validate(self) -> None:
+        """Handle validate button click."""
+        # First validate XML
+        xml_valid, xml_errors = self.editor.validate_xml()
+        if not xml_valid:
+            self._show_errors(xml_errors)
+            return
+
+        # Then validate URDF structure
+        urdf_valid, urdf_errors = self.editor.validate_urdf()
+        if urdf_valid:
+            self.output_panel.setHtml(
+                '<span style="color: green;">Validation successful - URDF is valid!</span>'
+            )
+            self.status_label.setText("Valid URDF")
+        else:
+            self._show_errors(urdf_errors)
+
+    def _show_errors(self, errors: list[str]) -> None:
+        """Display validation errors."""
+        html = '<span style="color: red;">Validation errors:</span><br>'
+        for error in errors:
+            html += f'<span style="color: red;">- {error}</span><br>'
+        self.output_panel.setHtml(html)
+        self.status_label.setText(f"{len(errors)} error(s)")
+
+    def _on_format(self) -> None:
+        """Handle format button click."""
+        content = self.editor.get_content()
+        if not content.strip():
+            return
+
+        try:
+            # Parse and re-format XML
+            root = ET.fromstring(content)
+            ET.indent(root, space="  ")
+            formatted = ET.tostring(root, encoding="unicode", xml_declaration=True)
+            self.editor.set_content(formatted)
+            self.status_label.setText("Formatted")
+        except ET.ParseError as e:
+            self.output_panel.setHtml(
+                f'<span style="color: red;">Cannot format - invalid XML: {e}</span>'
+            )
+
+    def _on_find_replace(self) -> None:
+        """Handle find/replace button click."""
+        dialog = FindReplaceDialog(self.editor, self)
+        dialog.exec()
+
+    def _on_cursor_position_changed(self, line: int, col: int) -> None:
+        """Handle cursor position changes."""
+        self.position_label.setText(f"Line {line}, Col {col}")
+
+    def _on_validation_result(self, is_valid: bool, errors: list[str]) -> None:
+        """Handle validation results."""
+        self.validation_changed.emit(is_valid, errors)
+
+    def set_content(self, content: str, file_path: str | None = None) -> None:
+        """Set editor content."""
+        self.editor.set_content(content)
+        self._current_file = file_path
+        if file_path:
+            self.status_label.setText(f"Loaded: {file_path}")
+
+    def get_content(self) -> str:
+        """Get editor content."""
+        return self.editor.get_content()
+
+
+class FindReplaceDialog(QDialog):
+    """Dialog for find and replace functionality."""
+
+    def __init__(self, editor: URDFCodeEditor, parent: QWidget | None = None) -> None:
+        """Initialize the dialog."""
+        super().__init__(parent)
+        self.editor = editor
+        self.setWindowTitle("Find and Replace")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        # Find row
+        find_layout = QHBoxLayout()
+        find_layout.addWidget(QLabel("Find:"))
+        self.find_edit = QLineEdit()
+        find_layout.addWidget(self.find_edit)
+        self.find_btn = QPushButton("Find Next")
+        find_layout.addWidget(self.find_btn)
+        layout.addLayout(find_layout)
+
+        # Replace row
+        replace_layout = QHBoxLayout()
+        replace_layout.addWidget(QLabel("Replace:"))
+        self.replace_edit = QLineEdit()
+        replace_layout.addWidget(self.replace_edit)
+        self.replace_btn = QPushButton("Replace")
+        self.replace_all_btn = QPushButton("Replace All")
+        replace_layout.addWidget(self.replace_btn)
+        replace_layout.addWidget(self.replace_all_btn)
+        layout.addLayout(replace_layout)
+
+        # Status
+        self.status_label = QLabel("")
+        layout.addWidget(self.status_label)
+
+        # Close button
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        layout.addWidget(close_btn)
+
+        # Connect signals
+        self.find_btn.clicked.connect(self._on_find)
+        self.replace_btn.clicked.connect(self._on_replace)
+        self.replace_all_btn.clicked.connect(self._on_replace_all)
+
+    def _on_find(self) -> None:
+        """Handle find button click."""
+        text = self.find_edit.text()
+        if text:
+            found = self.editor.find_text(text)
+            if found:
+                self.status_label.setText("Found")
+            else:
+                self.status_label.setText("Not found")
+
+    def _on_replace(self) -> None:
+        """Handle replace button click."""
+        find = self.find_edit.text()
+        replace = self.replace_edit.text()
+        if find:
+            count = self.editor.replace_text(find, replace)
+            self.status_label.setText(f"Replaced {count} occurrence(s)")
+
+    def _on_replace_all(self) -> None:
+        """Handle replace all button click."""
+        find = self.find_edit.text()
+        replace = self.replace_edit.text()
+        if find:
+            count = self.editor.replace_text(find, replace, all_occurrences=True)
+            self.status_label.setText(f"Replaced {count} occurrence(s)")

--- a/src/tools/model_explorer/urdf_editor_window.py
+++ b/src/tools/model_explorer/urdf_editor_window.py
@@ -1,0 +1,560 @@
+"""URDF Editor Window - Integrated editor with all component manipulation features.
+
+This module provides a comprehensive URDF editor that integrates:
+- Component library with read-only protection
+- Code editor with syntax highlighting
+- Frankenstein mode for combining URDFs
+- Chain manipulation tools
+- End effector swap system
+- Joint auto-loader and manipulation
+- Mesh/STL browser and copy functionality
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QAction, QKeySequence
+from PyQt6.QtWidgets import (
+    QDockWidget,
+    QFileDialog,
+    QMainWindow,
+    QMessageBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.logging_config import get_logger
+
+from .chain_manipulation import ChainManipulationWidget
+from .component_library import ComponentLibraryWidget
+from .end_effector_manager import EndEffectorManagerWidget
+from .frankenstein_editor import FrankensteinEditor
+from .joint_manipulator import JointManipulatorWidget
+from .mesh_browser import MeshBrowserWidget
+from .urdf_code_editor import URDFCodeEditorWidget
+from .visualization_widget import VisualizationWidget
+
+logger = get_logger(__name__)
+
+
+class URDFEditorWindow(QMainWindow):
+    """Comprehensive URDF editor window with all editing features."""
+
+    urdf_changed = pyqtSignal(str)  # Emitted when URDF content changes
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the URDF editor window."""
+        super().__init__(parent)
+        self.current_file: Path | None = None
+        self.urdf_content: str = ""
+        self._is_modified: bool = False
+
+        self._setup_ui()
+        self._setup_menu_bar()
+        self._setup_dock_widgets()
+        self._connect_signals()
+
+        self.setWindowTitle("URDF Editor - Golf Modeling Suite")
+        self.setMinimumSize(1400, 900)
+
+        logger.info("URDF Editor window initialized")
+
+    def _setup_ui(self) -> None:
+        """Set up the main user interface."""
+        # Main tab widget as central widget
+        self.central_tabs = QTabWidget()
+        self.central_tabs.setTabPosition(QTabWidget.TabPosition.South)
+        self.setCentralWidget(self.central_tabs)
+
+        # Tab 1: Code Editor
+        self.code_editor = URDFCodeEditorWidget()
+        self.central_tabs.addTab(self.code_editor, "Code Editor")
+
+        # Tab 2: Frankenstein Mode
+        self.frankenstein = FrankensteinEditor()
+        self.central_tabs.addTab(self.frankenstein, "Frankenstein Mode")
+
+        # Tab 3: Chain Manipulation
+        self.chain_tools = ChainManipulationWidget()
+        self.central_tabs.addTab(self.chain_tools, "Chain Tools")
+
+        # Tab 4: End Effector Manager
+        self.ee_manager = EndEffectorManagerWidget()
+        self.central_tabs.addTab(self.ee_manager, "End Effectors")
+
+        # Tab 5: Joint Manipulator
+        self.joint_tools = JointManipulatorWidget()
+        self.central_tabs.addTab(self.joint_tools, "Joints")
+
+        # Tab 6: Mesh Browser
+        self.mesh_browser = MeshBrowserWidget()
+        self.central_tabs.addTab(self.mesh_browser, "Meshes")
+
+    def _setup_menu_bar(self) -> None:
+        """Set up the menu bar."""
+        menubar = self.menuBar()
+        if menubar is None:
+            return
+
+        # File menu
+        file_menu = menubar.addMenu("&File")
+        if file_menu is None:
+            return
+
+        new_action = QAction("&New", self)
+        new_action.setShortcut(QKeySequence.StandardKey.New)
+        new_action.triggered.connect(self.new_urdf)
+        file_menu.addAction(new_action)
+
+        open_action = QAction("&Open...", self)
+        open_action.setShortcut(QKeySequence.StandardKey.Open)
+        open_action.triggered.connect(self.open_urdf)
+        file_menu.addAction(open_action)
+
+        file_menu.addSeparator()
+
+        save_action = QAction("&Save", self)
+        save_action.setShortcut(QKeySequence.StandardKey.Save)
+        save_action.triggered.connect(self.save_urdf)
+        file_menu.addAction(save_action)
+
+        save_as_action = QAction("Save &As...", self)
+        save_as_action.setShortcut(QKeySequence.StandardKey.SaveAs)
+        save_as_action.triggered.connect(self.save_urdf_as)
+        file_menu.addAction(save_as_action)
+
+        file_menu.addSeparator()
+
+        close_action = QAction("&Close", self)
+        close_action.setShortcut(QKeySequence.StandardKey.Close)
+        close_action.triggered.connect(self.close)
+        file_menu.addAction(close_action)
+
+        # Edit menu
+        edit_menu = menubar.addMenu("&Edit")
+        if edit_menu is None:
+            return
+
+        validate_action = QAction("&Validate URDF", self)
+        validate_action.setShortcut("Ctrl+Shift+V")
+        validate_action.triggered.connect(self._validate_current)
+        edit_menu.addAction(validate_action)
+
+        format_action = QAction("&Format XML", self)
+        format_action.setShortcut("Ctrl+Shift+F")
+        format_action.triggered.connect(self._format_current)
+        edit_menu.addAction(format_action)
+
+        # View menu
+        view_menu = menubar.addMenu("&View")
+        if view_menu is None:
+            return
+
+        self.show_preview_action = QAction("Show &3D Preview", self)
+        self.show_preview_action.setCheckable(True)
+        self.show_preview_action.setChecked(True)
+        self.show_preview_action.triggered.connect(self._toggle_preview)
+        view_menu.addAction(self.show_preview_action)
+
+        self.show_library_action = QAction("Show Component &Library", self)
+        self.show_library_action.setCheckable(True)
+        self.show_library_action.setChecked(True)
+        self.show_library_action.triggered.connect(self._toggle_library)
+        view_menu.addAction(self.show_library_action)
+
+        # Tools menu
+        tools_menu = menubar.addMenu("&Tools")
+        if tools_menu is None:
+            return
+
+        frankenstein_action = QAction("&Frankenstein Mode", self)
+        frankenstein_action.triggered.connect(
+            lambda: self.central_tabs.setCurrentWidget(self.frankenstein)
+        )
+        tools_menu.addAction(frankenstein_action)
+
+        chain_action = QAction("&Chain Tools", self)
+        chain_action.triggered.connect(
+            lambda: self.central_tabs.setCurrentWidget(self.chain_tools)
+        )
+        tools_menu.addAction(chain_action)
+
+        ee_action = QAction("&End Effector Manager", self)
+        ee_action.triggered.connect(
+            lambda: self.central_tabs.setCurrentWidget(self.ee_manager)
+        )
+        tools_menu.addAction(ee_action)
+
+        joint_action = QAction("&Joint Manipulator", self)
+        joint_action.triggered.connect(
+            lambda: self.central_tabs.setCurrentWidget(self.joint_tools)
+        )
+        tools_menu.addAction(joint_action)
+
+        mesh_action = QAction("&Mesh Browser", self)
+        mesh_action.triggered.connect(
+            lambda: self.central_tabs.setCurrentWidget(self.mesh_browser)
+        )
+        tools_menu.addAction(mesh_action)
+
+        # Help menu
+        help_menu = menubar.addMenu("&Help")
+        if help_menu is None:
+            return
+
+        about_action = QAction("&About", self)
+        about_action.triggered.connect(self._show_about)
+        help_menu.addAction(about_action)
+
+    def _setup_dock_widgets(self) -> None:
+        """Set up dock widgets for preview and library."""
+        # 3D Preview dock
+        self.preview_dock = QDockWidget("3D Preview", self)
+        self.preview_dock.setObjectName("PreviewDock")
+        self.visualization = VisualizationWidget()
+        self.preview_dock.setWidget(self.visualization)
+        self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.preview_dock)
+
+        # Component Library dock
+        self.library_dock = QDockWidget("Component Library", self)
+        self.library_dock.setObjectName("LibraryDock")
+        self.component_library = ComponentLibraryWidget()
+        self.library_dock.setWidget(self.component_library)
+        self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.library_dock)
+
+    def _connect_signals(self) -> None:
+        """Connect all signals."""
+        # Code editor signals
+        self.code_editor.editor.content_changed.connect(self._on_content_changed)
+        self.code_editor.validation_changed.connect(self._on_validation_changed)
+
+        # Frankenstein signals
+        self.frankenstein.right_panel.tree.itemSelectionChanged.connect(
+            self._on_frankenstein_update
+        )
+
+        # Chain manipulation signals
+        self.chain_tools.chain_modified.connect(self._on_urdf_modified)
+
+        # End effector signals
+        self.ee_manager.urdf_modified.connect(self._on_urdf_modified)
+
+        # Joint manipulator signals
+        self.joint_tools.urdf_modified.connect(self._on_urdf_modified)
+        self.joint_tools.joints_updated.connect(self._on_joints_updated)
+
+        # Mesh browser signals
+        self.mesh_browser.urdf_modified.connect(self._on_urdf_modified)
+
+        # Component library signals
+        self.component_library.component_edited.connect(self._on_component_edit_requested)
+
+        # Tab change
+        self.central_tabs.currentChanged.connect(self._on_tab_changed)
+
+    def _on_content_changed(self, content: str) -> None:
+        """Handle code editor content change."""
+        self.urdf_content = content
+        self._is_modified = True
+        self._update_title()
+        self._update_preview()
+
+    def _on_urdf_modified(self, content: str) -> None:
+        """Handle URDF modification from any tool."""
+        self.urdf_content = content
+        self._is_modified = True
+        self._update_title()
+
+        # Update code editor
+        self.code_editor.set_content(content)
+
+        # Update preview
+        self._update_preview()
+
+        # Update other tools with new content
+        self._sync_tools_with_content()
+
+    def _on_validation_changed(self, is_valid: bool, errors: list[str]) -> None:
+        """Handle validation status change."""
+        if is_valid:
+            self.statusBar().showMessage("URDF is valid")
+        else:
+            self.statusBar().showMessage(f"Validation errors: {len(errors)}")
+
+    def _on_frankenstein_update(self) -> None:
+        """Handle Frankenstein editor update."""
+        model = self.frankenstein.get_working_model()
+        if model:
+            content = model.to_xml()
+            self._on_urdf_modified(content)
+
+    def _on_joints_updated(self, positions: dict[str, float]) -> None:
+        """Handle joint position updates for preview."""
+        # This could update the 3D preview with new joint positions
+        pass
+
+    def _on_component_edit_requested(self, component: Any) -> None:
+        """Handle request to edit a component."""
+        # Switch to code editor and highlight the component
+        self.central_tabs.setCurrentWidget(self.code_editor)
+        # Could search for and highlight the component in the code
+
+    def _on_tab_changed(self, index: int) -> None:
+        """Handle tab change."""
+        current_widget = self.central_tabs.currentWidget()
+
+        # Sync content to the new tab
+        if current_widget == self.chain_tools and self.urdf_content:
+            self.chain_tools.load_urdf(self.urdf_content)
+        elif current_widget == self.ee_manager and self.urdf_content:
+            self.ee_manager.load_urdf(self.urdf_content)
+        elif current_widget == self.joint_tools and self.urdf_content:
+            self.joint_tools.load_urdf(self.urdf_content)
+        elif current_widget == self.mesh_browser and self.urdf_content:
+            self.mesh_browser.load_target_content(self.urdf_content, self.current_file)
+
+    def _sync_tools_with_content(self) -> None:
+        """Synchronize all tools with current URDF content."""
+        # Only sync the currently visible tool to avoid overhead
+        current_widget = self.central_tabs.currentWidget()
+
+        if current_widget == self.chain_tools:
+            self.chain_tools.load_urdf(self.urdf_content)
+        elif current_widget == self.ee_manager:
+            self.ee_manager.load_urdf(self.urdf_content)
+        elif current_widget == self.joint_tools:
+            self.joint_tools.load_urdf(self.urdf_content)
+
+    def _update_preview(self) -> None:
+        """Update the 3D preview."""
+        if self.urdf_content:
+            file_path = str(self.current_file) if self.current_file else None
+            self.visualization.update_visualization(self.urdf_content, file_path)
+
+    def _update_title(self) -> None:
+        """Update the window title."""
+        title = "URDF Editor - Golf Modeling Suite"
+        if self.current_file:
+            title = f"{self.current_file.name} - {title}"
+        if self._is_modified:
+            title = f"*{title}"
+        self.setWindowTitle(title)
+
+    def _validate_current(self) -> None:
+        """Validate the current URDF."""
+        if self.central_tabs.currentWidget() == self.code_editor:
+            self.code_editor.editor.validate_urdf()
+
+    def _format_current(self) -> None:
+        """Format the current URDF."""
+        if self.central_tabs.currentWidget() == self.code_editor:
+            self.code_editor._on_format()
+
+    def _toggle_preview(self) -> None:
+        """Toggle 3D preview visibility."""
+        self.preview_dock.setVisible(self.show_preview_action.isChecked())
+
+    def _toggle_library(self) -> None:
+        """Toggle component library visibility."""
+        self.library_dock.setVisible(self.show_library_action.isChecked())
+
+    def _show_about(self) -> None:
+        """Show about dialog."""
+        QMessageBox.about(
+            self,
+            "About URDF Editor",
+            "URDF Editor - Golf Modeling Suite\n\n"
+            "Features:\n"
+            "- Code editor with syntax highlighting\n"
+            "- Frankenstein mode for combining URDFs\n"
+            "- Chain manipulation tools\n"
+            "- End effector swap system\n"
+            "- Joint auto-loader and manipulation\n"
+            "- Mesh/STL browser\n\n"
+            "Components from library URDFs are read-only.\n"
+            "Use 'Copy to Working Set' to edit them.",
+        )
+
+    def new_urdf(self) -> None:
+        """Create a new URDF."""
+        if self._is_modified:
+            reply = QMessageBox.question(
+                self,
+                "Unsaved Changes",
+                "Save changes before creating new file?",
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel,
+            )
+
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_urdf()
+            elif reply == QMessageBox.StandardButton.Cancel:
+                return
+
+        # Create minimal URDF
+        self.urdf_content = """<?xml version="1.0"?>
+<robot name="new_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" iyy="0.01" izz="0.01" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+</robot>
+"""
+
+        self.current_file = None
+        self._is_modified = False
+        self.code_editor.set_content(self.urdf_content)
+        self._update_title()
+        self._update_preview()
+        self.statusBar().showMessage("New URDF created")
+
+    def open_urdf(self) -> None:
+        """Open a URDF file."""
+        if self._is_modified:
+            reply = QMessageBox.question(
+                self,
+                "Unsaved Changes",
+                "Save changes before opening another file?",
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel,
+            )
+
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_urdf()
+            elif reply == QMessageBox.StandardButton.Cancel:
+                return
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open URDF",
+            "",
+            "URDF Files (*.urdf);;XML Files (*.xml);;All Files (*)",
+        )
+
+        if file_path:
+            self.load_file(Path(file_path))
+
+    def load_file(self, file_path: Path) -> bool:
+        """Load a URDF file."""
+        try:
+            self.urdf_content = file_path.read_text(encoding="utf-8")
+            self.current_file = file_path
+            self._is_modified = False
+
+            self.code_editor.set_content(self.urdf_content, str(file_path))
+            self._update_title()
+            self._update_preview()
+
+            # Add to library for reference
+            self.component_library.load_urdf_to_library(file_path)
+
+            self.statusBar().showMessage(f"Loaded: {file_path.name}")
+            logger.info(f"Loaded URDF: {file_path}")
+            return True
+
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to load file: {e}")
+            logger.error(f"Failed to load URDF: {e}")
+            return False
+
+    def save_urdf(self) -> None:
+        """Save the current URDF."""
+        if self.current_file:
+            self._save_to_file(self.current_file)
+        else:
+            self.save_urdf_as()
+
+    def save_urdf_as(self) -> None:
+        """Save the current URDF with a new filename."""
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save URDF",
+            "robot.urdf",
+            "URDF Files (*.urdf);;XML Files (*.xml)",
+        )
+
+        if file_path:
+            self._save_to_file(Path(file_path))
+
+    def _save_to_file(self, file_path: Path) -> None:
+        """Save URDF to file."""
+        try:
+            # Get content from code editor (most up-to-date)
+            content = self.code_editor.get_content()
+
+            file_path.write_text(content, encoding="utf-8")
+            self.current_file = file_path
+            self.urdf_content = content
+            self._is_modified = False
+
+            self._update_title()
+            self.statusBar().showMessage(f"Saved: {file_path.name}")
+            logger.info(f"Saved URDF: {file_path}")
+
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save file: {e}")
+            logger.error(f"Failed to save URDF: {e}")
+
+    def closeEvent(self, event: Any) -> None:
+        """Handle window close event."""
+        if self._is_modified:
+            reply = QMessageBox.question(
+                self,
+                "Unsaved Changes",
+                "Save changes before closing?",
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel,
+            )
+
+            if reply == QMessageBox.StandardButton.Save:
+                self.save_urdf()
+                if self._is_modified:  # Save was cancelled
+                    event.ignore()
+                    return
+            elif reply == QMessageBox.StandardButton.Cancel:
+                event.ignore()
+                return
+
+        event.accept()
+        logger.info("URDF Editor window closed")
+
+
+def launch_urdf_editor() -> None:
+    """Launch the URDF editor as a standalone application."""
+    import sys
+
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+    app.setApplicationName("URDF Editor")
+
+    window = URDFEditorWindow()
+    window.show()
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    launch_urdf_editor()


### PR DESCRIPTION
This major update adds comprehensive URDF editing capabilities:

**Component Library (component_library.py)**
- Read-only library components with copy-to-edit protection
- Source files never corrupted - work with copies only
- Visual tree view of library vs working components

**Code Editor (urdf_code_editor.py)**
- XML syntax highlighting for URDF files
- Line numbers and auto-completion
- Real-time XML and URDF validation
- Find/replace functionality

**Frankenstein Mode (frankenstein_editor.py)**
- Side-by-side URDF editor for combining models
- Double-click or drag to copy components between models
- Copy individual links, full chains, or merge entire models

**Chain Manipulation (chain_manipulation.py)**
- Visual kinematic tree representation
- Insert segments into existing chains
- Edit branch structures and re-parent children
- Split and merge kinematic chains

**End Effector Manager (end_effector_manager.py)**
- Auto-detect end effectors in URDFs
- Built-in library of grippers and tool flanges
- Visual attachment point configuration
- Easy swap between end effector types

**Joint Manipulator (joint_manipulator.py)**
- Auto-load all joints from URDF
- Interactive sliders for movable joints
- Table view with detailed joint properties
- Edit joint limits, axes, and dynamics

**Mesh Browser (mesh_browser.py)**
- Browse mesh references in URDFs
- Side-by-side comparison between models
- Copy mesh references with file handling
- Detect missing mesh files

**Integration (urdf_editor_window.py)**
- Unified editor window with all tools
- Tabbed interface for different editing modes
- 3D preview dock and component library dock
- Tools menu in main window for quick access

https://claude.ai/code/session_018zktVZMNp2UfkNao1vUeMW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large addition of new PyQt6 editor/tooling that mutates URDF XML (insertion, joint edits, end-effector/mesh ops); risk is mainly correctness of URDF rewriting and UX regressions, not security-critical behavior.
> 
> **Overview**
> Introduces a **v2.0 “advanced URDF editor” feature set** under `model_explorer`, adding new PyQt6 widgets for component reuse and editing: a read-only `ComponentLibrary` with copy-to-working behavior, a `URDFCodeEditor` with syntax highlighting, find/replace and XML/URDF validation, and a side-by-side `FrankensteinEditor` for copying/merging components between URDFs.
> 
> Adds interactive URDF-structure manipulation tools: `ChainManipulationWidget` (visual kinematic tree + segment insertion with optional child reparenting), `EndEffectorManagerWidget` (detect/remove/extract/attach end effectors with built-ins), `JointManipulatorWidget` (auto-load joints, sliders, and joint property editing that rewrites URDF XML), and `MeshBrowserWidget` (inspect/copy mesh references and optionally copy mesh files).
> 
> Integrates these capabilities by bumping `model_explorer` to `2.0.0`, expanding lazy exports in `__init__.py`, and adding a new `Tools` menu in `main_window.py` to launch the advanced editor, Frankenstein mode, and the standalone code editor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880f55a38d49f1cd1034e7b6781ea698116c4682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->