### PR TITLE
Fix: Disable CodeQL Assessments (Issue #938)

### DIFF
--- a/src/engines/physics_engines/drake/python/tests/test_drake_model.py
+++ b/src/engines/physics_engines/drake/python/tests/test_drake_model.py
@@ -12,7 +12,6 @@ import pytest
 # Note: pythonpath is configured in pytest.ini to include the parent directory
 try:
     from pydrake.multibody.tree import SpatialInertia
-
     from python.src.drake_golf_model import (
         GolfModelParams,
         SegmentParams,

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/advanced_export.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/advanced_export.py
@@ -16,9 +16,11 @@ import numpy as np
 from src.shared.python.engine_availability import (
     C3D_AVAILABLE,
     EZC3D_AVAILABLE,
-    SCIPY_AVAILABLE,
 )
 from src.shared.python.engine_availability import HDF5_AVAILABLE as H5PY_AVAILABLE
+from src.shared.python.engine_availability import (
+    SCIPY_AVAILABLE,
+)
 
 # Conditional imports for optional dependencies
 if SCIPY_AVAILABLE:

--- a/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
@@ -23,6 +23,7 @@ def mock_pinocchio_env():
 def test_create_joint_coupling_task(mock_pinocchio_env):
     """Verify that create_joint_coupling_task works as expected."""
     import pinocchio as pin  # This is the mocked pinocchio
+
     from engines.physics_engines.pinocchio.python.dtack.ik.tasks import (
         create_joint_coupling_task,
     )

--- a/src/shared/python/export.py
+++ b/src/shared/python/export.py
@@ -17,9 +17,11 @@ import numpy as np
 from src.shared.python.engine_availability import (
     C3D_AVAILABLE,
     EZC3D_AVAILABLE,
-    SCIPY_AVAILABLE,
 )
 from src.shared.python.engine_availability import HDF5_AVAILABLE as H5PY_AVAILABLE
+from src.shared.python.engine_availability import (
+    SCIPY_AVAILABLE,
+)
 from src.shared.python.logging_config import get_logger
 
 logger = get_logger(__name__)

--- a/src/shared/python/logger_utils.py
+++ b/src/shared/python/logger_utils.py
@@ -33,8 +33,10 @@ try:
     from src.shared.python.logging_config import get_logger as _get_logger
     from src.shared.python.logging_config import setup_logging as _setup_logging
     from src.shared.python.reproducibility import (
-        DEFAULT_SEED,
         log_execution_time,  # Context manager - re-export directly
+    )
+    from src.shared.python.reproducibility import (
+        DEFAULT_SEED,
     )
     from src.shared.python.reproducibility import set_seeds as _set_seeds
 


### PR DESCRIPTION
This PR addresses Issue #938 to disable CodeQL assessments for cost reduction.

Changes:
1.  **Workflow Modification**: Removed `permissions: security-events: write` from `.github/workflows/Jules-Sentinel.yml`. This prevents the workflow from uploading security results (Semgrep/Bandit) to the GitHub Code Scanning dashboard, which is where "CodeQL Assessments" are reported and billed.
2.  **Documentation Updates**:
    *   Removed "Code scanning (CodeQL for public repos)" from `src/engines/Simscape_Multibody_Models/2D_Golf_Model/UNIFIED_CI_APPROACH.md`.
    *   Updated `docs/development/CURRENT_STATE_SUMMARY.md` to state that CodeQL is DISABLED.
    *   Updated `docs/development/PR_CONSOLIDATION_SUMMARY.md` to remove misleading "CodeQL in progress" status.
3.  **Linting**: Ran `ruff check --fix .` and `black .`. This fixed an import order issue in `src/shared/python/error_utils.py` and formatted python files.
4.  **Verification**: Verified that no other workflow files contain "CodeQL" steps or references using `grep` and `find`.
5.  **Cleanup**: Reverted accidental submodule changes caused by `ruff`/`black`.

**Note:** If CodeQL is still running, it is likely enabled via "Default Setup" in GitHub Settings > Code Security > Code Scanning. This cannot be disabled via code changes if no workflow file exists. I have confirmed no `codeql-analysis.yml` exists in the repository.

---
*PR created automatically by Jules for task [7595968282042328141](https://jules.google.com/task/7595968282042328141) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI security reporting is reduced by preventing uploads to GitHub Code Scanning, which could hide findings in the GitHub UI if not replaced by other monitoring. Code changes outside CI are formatting-only and low risk.
> 
> **Overview**
> **Disables GitHub Code Scanning uploads** by removing `security-events: write` permission from `.github/workflows/Jules-Sentinel.yml`, preventing Bandit/Semgrep results from being published to the Code Scanning (CodeQL assessments) dashboard.
> 
> Updates developer docs to reflect **CodeQL being disabled** and removes references to “CodeQL in progress”/CodeQL-required scanning in CI guidance.
> 
> Includes small lint/format-only tweaks in a few Python modules/tests (import reordering/whitespace) with no functional logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 385f0012a0e6fbc723ae136b4da479d7531803a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->