### PR TITLE
chore: update branding to UpstreamDrift and fix code issues

### DIFF
--- a/src/api/routes/simulation.py
+++ b/src/api/routes/simulation.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
-
-try:
-    from datetime import timezone
-except ImportError:
-    timezone.utc = timezone.utc  # noqa: UP017
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1,4 +1,4 @@
-"""FastAPI server for Golf Modeling Suite.
+"""FastAPI server for UpstreamDrift.
 
 Provides REST API endpoints for:
 - Physics engine management and simulation
@@ -52,9 +52,9 @@ limiter = Limiter(key_func=get_remote_address)
 
 # Initialize FastAPI app
 app = FastAPI(
-    title="Golf Modeling Suite API",
+    title="UpstreamDrift API",
     description="Professional biomechanical analysis and physics simulation API",
-    version="1.0.0",
+    version="2.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
 )

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ui",
+  "name": "upstream-drift-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
- Rename API title from "Golf Modeling Suite" to "UpstreamDrift"
- Update API version to 2.1.0 to match pyproject.toml
- Remove redundant timezone import in simulation routes
- Update UI package name and version to match project

https://claude.ai/code/session_01QD4Cz9TsMdXLzFYAmGtC6G

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly metadata/branding updates plus a small cleanup of `timezone` imports; no behavior changes beyond API/UI identifiers and reported version strings.
> 
> **Overview**
> Updates public-facing branding/version metadata: the FastAPI app is renamed to **UpstreamDrift** and its reported version is bumped to `2.1.0`, and the UI `package.json` is renamed to `upstream-drift-ui` with version `2.1.0`.
> 
> Cleans up `simulation.py` by removing redundant/legacy `timezone` import/compatibility handling, relying on `datetime.now(UTC)` for task timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5350f13910ebee284a9ab6a75c1ddc773f4ba3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->