### PR TITLE
fix: Correct path to code_quality_check.py in CI workflow

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -70,7 +70,7 @@ jobs:
       # Code Quality Check (Issue #781) - checks for placeholders, magic numbers, etc.
       - name: Code Quality Check
         run: |
-          python tools/code_quality_check.py || echo "::warning::Code quality issues found - see output above"
+          python src/tools/code_quality_check.py || echo "::warning::Code quality issues found - see output above"
 
       - name: MATLAB Quality Check
         continue-on-error: true


### PR DESCRIPTION
The code_quality_check.py script was being called from the wrong path.
The CI was trying to run `python tools/code_quality_check.py` but the
tools/ directory does not exist at the repository root.

The correct path is `src/tools/code_quality_check.py`.

https://claude.ai/code/session_01Y9duHmBhTcaffbr4UuUHYZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that fixes an incorrect script path; low risk aside from potentially surfacing previously skipped quality warnings.
> 
> **Overview**
> Updates the `CI Standard` GitHub Actions workflow to run the code quality check via `python src/tools/code_quality_check.py` instead of the non-existent `tools/code_quality_check.py`, ensuring the step actually executes during CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0520188891a3c5422282135b109d0f8a556c2db6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->