### PR TITLE
fix: Prevent Jules auto-assign from triggering on manual issues

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -1,11 +1,12 @@
 name: Jules Auto-Assign Issues
 
 # Automatically comments @jules on new issues to trigger the fix workflow
-# This enables fully automated issue resolution
+# IMPORTANT: Only triggers for AUTOMATED issues, NOT manually created ones
+# To manually request Jules help, add the 'jules-triage' label to an issue
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   issues: write
@@ -13,8 +14,13 @@ permissions:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
-    # Skip if issue was created by a bot to prevent loops
-    if: "!contains(github.event.issue.user.login, '[bot]') && !contains(github.event.issue.user.login, 'github-actions')"
+    # CHANGED: Only trigger for automated issues or explicit jules-triage label
+    # - Issues created by github-actions (from automated assessments)
+    # - Issues with 'jules-triage' or 'auto-generated' labels
+    # This prevents unwanted cascade of PRs when manually creating issues
+    if: |
+      (github.event.action == 'opened' && github.event.issue.user.login == 'github-actions[bot]') ||
+      (github.event.action == 'labeled' && (github.event.label.name == 'jules-triage' || github.event.label.name == 'auto-generated'))
     steps:
       - name: Check Issue Labels
         id: check
@@ -25,7 +31,7 @@ jobs:
           # LABELS is passed via env to prevent shell injection
 
           # Skip if labeled with 'no-jules', 'question', 'documentation', or 'wontfix'
-          SKIP_LABELS="no-jules question documentation wontfix duplicate invalid"
+          SKIP_LABELS="no-jules question documentation wontfix duplicate invalid jules-assigned"
 
           for label in $SKIP_LABELS; do
             if echo "$LABELS" | jq -e ".[] | select(.name == \"$label\")" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Prevent unwanted cascades of PRs when manually creating issues
- Jules Auto-Assign now only triggers for automated issues or explicit opt-in

## Changes
- Issues created by github-actions[bot] (automated assessments) still trigger
- Issues with 'jules-triage' or 'auto-generated' labels trigger
- Manual issues no longer auto-assign Jules

## How to request Jules help manually
Add the `jules-triage` label to any issue you want Jules to analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-condition and label-filter changes only; risk is limited to missed or extra auto-assignments if conditions/labels are misconfigured.
> 
> **Overview**
> Tightens the `Jules-Auto-Assign-Issues.yml` GitHub Action so it **no longer triggers on manually created issues**, only on issues opened by `github-actions[bot]` or when an issue is labeled `jules-triage`/`auto-generated` (explicit opt-in).
> 
> Adds `labeled` as an event trigger and updates skip logic to ignore issues already marked `jules-assigned`, reducing repeated/looping assignments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00762b33eeeb0d42a4332fd43dd597bbc523c135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->