### PR TITLE
a11y: add accessibility attributes to React components

### DIFF
--- a/ui/src/components/simulation/EngineSelector.tsx
+++ b/ui/src/components/simulation/EngineSelector.tsx
@@ -14,7 +14,15 @@ export function EngineSelector({ value, onChange, disabled }: Props) {
   });
 
   if (isLoading) {
-    return <div className="animate-pulse h-10 bg-gray-700 rounded" />;
+    return (
+      <div
+        className="animate-pulse h-10 bg-gray-700 rounded"
+        role="status"
+        aria-label="Loading physics engines"
+      >
+        <span className="sr-only">Loading engines...</span>
+      </div>
+    );
   }
 
   if (error) {
@@ -23,14 +31,19 @@ export function EngineSelector({ value, onChange, disabled }: Props) {
         <label className="block text-sm font-medium text-gray-300 mb-2">
           Physics Engine
         </label>
-        <div className="p-4 rounded-lg border border-red-500 bg-red-500/10 text-red-400">
+        <div
+          className="p-4 rounded-lg border border-red-500 bg-red-500/10 text-red-400"
+          role="alert"
+          aria-live="polite"
+        >
           <div className="font-medium mb-2">Failed to load engines</div>
           <div className="text-xs mb-3">
             {error instanceof Error ? error.message : 'Unknown error occurred'}
           </div>
           <button
             onClick={() => refetch()}
-            className="px-3 py-1 text-xs bg-red-500/20 border border-red-500 rounded hover:bg-red-500/30 transition-colors"
+            aria-label="Retry loading physics engines"
+            className="px-3 py-1 text-xs bg-red-500/20 border border-red-500 rounded hover:bg-red-500/30 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-gray-900"
           >
             Retry
           </button>
@@ -41,15 +54,25 @@ export function EngineSelector({ value, onChange, disabled }: Props) {
 
   return (
     <div className="mb-6">
-      <label className="block text-sm font-medium text-gray-300 mb-2">
+      <label
+        id="engine-selector-label"
+        className="block text-sm font-medium text-gray-300 mb-2"
+      >
         Physics Engine
       </label>
-      <div className="grid grid-cols-1 gap-2">
+      <div
+        className="grid grid-cols-1 gap-2"
+        role="radiogroup"
+        aria-labelledby="engine-selector-label"
+      >
         {engines?.map((engine, index) => (
           <button
             key={`${engine.name}-${index}`}
             onClick={() => onChange(engine.name)}
             disabled={disabled || !engine.available}
+            role="radio"
+            aria-checked={value === engine.name}
+            aria-label={`${engine.name} physics engine${!engine.available ? ' (not installed)' : ''}`}
             className={`
               p-3 rounded-lg border text-left transition-all
               ${value === engine.name
@@ -58,6 +81,7 @@ export function EngineSelector({ value, onChange, disabled }: Props) {
               }
               ${!engine.available && 'opacity-50 cursor-not-allowed'}
               ${disabled && 'cursor-not-allowed'}
+              focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900
             `}
           >
             <div className="font-medium">{engine.name}</div>

--- a/ui/src/components/simulation/SimulationControls.tsx
+++ b/ui/src/components/simulation/SimulationControls.tsx
@@ -11,13 +11,18 @@ interface Props {
 
 export function SimulationControls({ isRunning, isPaused, onStart, onStop, onPause, onResume }: Props) {
   return (
-    <div className="flex gap-2 mt-4">
+    <div
+      className="flex gap-2 mt-4"
+      role="toolbar"
+      aria-label="Simulation controls"
+    >
       {!isRunning ? (
         <button
           onClick={onStart}
-          className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+          aria-label="Start simulation"
+          className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900"
         >
-          <Play size={20} />
+          <Play size={20} aria-hidden="true" />
           Start
         </button>
       ) : (
@@ -25,26 +30,29 @@ export function SimulationControls({ isRunning, isPaused, onStart, onStop, onPau
             {isPaused ? (
                  <button
                     onClick={onResume}
-                    className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+                    aria-label="Resume simulation"
+                    className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900"
                 >
-                    <Play size={20} />
+                    <Play size={20} aria-hidden="true" />
                     Resume
                 </button>
             ) : (
                  <button
                     onClick={onPause}
-                    className="flex-1 flex items-center justify-center gap-2 bg-yellow-600 hover:bg-yellow-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+                    aria-label="Pause simulation"
+                    className="flex-1 flex items-center justify-center gap-2 bg-yellow-600 hover:bg-yellow-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-gray-900"
                 >
-                    <Pause size={20} />
+                    <Pause size={20} aria-hidden="true" />
                     Pause
                 </button>
             )}
-            
+
           <button
             onClick={onStop}
-            className="flex items-center justify-center gap-2 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+            aria-label="Stop simulation"
+            className="flex items-center justify-center gap-2 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-gray-900"
           >
-            <Square size={20} />
+            <Square size={20} aria-hidden="true" />
             Stop
           </button>
         </>

--- a/ui/src/components/visualization/Scene3D.tsx
+++ b/ui/src/components/visualization/Scene3D.tsx
@@ -158,6 +158,12 @@ export function Scene3D({ engine: _engine, frame, frames }: Props) {
   // If a full reset is needed when switching engines, consider resetting frame/frames state
   // in the parent component instead of remounting the entire Canvas.
   return (
+    <div
+      role="img"
+      aria-label="3D golf swing simulation visualization. Use mouse to rotate view, scroll to zoom."
+      tabIndex={0}
+      className="w-full h-full focus:outline-none focus:ring-2 focus:ring-blue-400"
+    >
     <Canvas
       camera={{ position: [3, 2, 3], fov: 50 }}
       className="bg-gray-900 w-full h-full"
@@ -189,5 +195,6 @@ export function Scene3D({ engine: _engine, frame, frames }: Props) {
 
       <Environment preset="studio" />
     </Canvas>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds ARIA accessibility attributes to React UI components for improved screen reader support.

## Components Updated

### SimulationControls
- Added `role="toolbar"` for button group
- Added `aria-label` to each button
- Added `aria-hidden="true"` to decorative icons
- Added visible focus ring styles

### EngineSelector
- Added `role="radiogroup"` for engine selection
- Added `role="radio"` and `aria-checked` for each option
- Added `role="status"` for loading state
- Added `role="alert"` for error states
- Added retry button with descriptive aria-label

### Scene3D
- Added `role="img"` with descriptive aria-label
- Added tabIndex for keyboard accessibility

## Test plan
- [x] Manual review of accessibility attributes
- [x] Components render correctly

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds ARIA metadata and focus-ring styling; behavior changes are minimal aside from semantics (roles/labels) and keyboard focus on the 3D container.
> 
> **Overview**
> **Improves accessibility semantics and keyboard affordances** across simulation UI components.
> 
> `EngineSelector` now exposes loading/error states to assistive tech (`role="status"`/`role="alert"`), treats engine choices as a labeled `radiogroup` with per-option `role="radio"` + `aria-checked`, and adds clearer labels plus focus-ring styles (including on the retry button).
> 
> `SimulationControls` is marked as a `toolbar`, adds descriptive `aria-label`s for start/pause/resume/stop, hides decorative icons from screen readers, and adds consistent focus-ring styling. `Scene3D` is wrapped in a focusable container with `role="img"` and a descriptive `aria-label` to make the visualization discoverable to screen readers/keyboard users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f6818f5514e0601b2de763a97cbcbc4b9be7a7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->