### PR TITLE
fix: Remove unused frontend dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.2",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@tanstack/react-query": "^5.90.20",
@@ -25,13 +24,10 @@
     "postcss": "^8.5.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-hook-form": "^7.71.1",
     "react-router-dom": "^7.13.0",
     "recharts": "^3.7.0",
     "tailwindcss": "^3.4.17",
-    "three": "^0.182.0",
-    "zod": "^4.3.6",
-    "zustand": "^5.0.10"
+    "three": "^0.182.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
Closes #1000

Removes the following unused dependencies from ui/package.json:
- zustand (state management)
- react-hook-form (form library)
- zod (schema validation)
- @hookform/resolvers (hook form integration)

**Verification:**
- Searched codebase for imports of these packages - none found
- These were likely added for planned features that were never implemented

**Benefits:**
- Smaller bundle size
- Reduced security surface area
- Less dependency maintenance burden

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency cleanup only; no runtime logic changes, with low risk aside from potential hidden/indirect usage surfacing at build time.
> 
> **Overview**
> Removes unused UI dependencies from `ui/package.json`: `zustand`, `zod`, `react-hook-form`, and `@hookform/resolvers`, reducing the installed/bundled dependency set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3ba22948285fc81415889b3d6fceb44b5e3a5b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->