### PR TITLE
refactor: Extract repeated Tailwind button classes

### DIFF
--- a/ui/src/components/simulation/SimulationControls.tsx
+++ b/ui/src/components/simulation/SimulationControls.tsx
@@ -9,6 +9,14 @@ interface Props {
   onResume: () => void;
 }
 
+// Extracted button styles to reduce duplication and ensure consistency
+const buttonStyles = {
+  base: 'flex items-center justify-center gap-2 font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900',
+  primary: 'flex-1 bg-green-600 hover:bg-green-700 text-white focus:ring-green-400',
+  warning: 'flex-1 bg-yellow-600 hover:bg-yellow-700 text-white focus:ring-yellow-400',
+  danger: 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-400',
+};
+
 export function SimulationControls({ isRunning, isPaused, onStart, onStop, onPause, onResume }: Props) {
   return (
     <div
@@ -20,37 +28,37 @@ export function SimulationControls({ isRunning, isPaused, onStart, onStop, onPau
         <button
           onClick={onStart}
           aria-label="Start simulation"
-          className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+          className={`${buttonStyles.base} ${buttonStyles.primary}`}
         >
           <Play size={20} aria-hidden="true" />
           Start
         </button>
       ) : (
         <>
-            {isPaused ? (
-                 <button
-                    onClick={onResume}
-                    aria-label="Resume simulation"
-                    className="flex-1 flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900"
-                >
-                    <Play size={20} aria-hidden="true" />
-                    Resume
-                </button>
-            ) : (
-                 <button
-                    onClick={onPause}
-                    aria-label="Pause simulation"
-                    className="flex-1 flex items-center justify-center gap-2 bg-yellow-600 hover:bg-yellow-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-gray-900"
-                >
-                    <Pause size={20} aria-hidden="true" />
-                    Pause
-                </button>
-            )}
+          {isPaused ? (
+            <button
+              onClick={onResume}
+              aria-label="Resume simulation"
+              className={`${buttonStyles.base} ${buttonStyles.primary}`}
+            >
+              <Play size={20} aria-hidden="true" />
+              Resume
+            </button>
+          ) : (
+            <button
+              onClick={onPause}
+              aria-label="Pause simulation"
+              className={`${buttonStyles.base} ${buttonStyles.warning}`}
+            >
+              <Pause size={20} aria-hidden="true" />
+              Pause
+            </button>
+          )}
 
           <button
             onClick={onStop}
             aria-label="Stop simulation"
-            className="flex items-center justify-center gap-2 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+            className={`${buttonStyles.base} ${buttonStyles.danger}`}
           >
             <Square size={20} aria-hidden="true" />
             Stop


### PR DESCRIPTION
Closes #1004

## Changes
Extracts duplicated Tailwind button classes to a `buttonStyles` object with semantic variants.

## Before
Each button had 80+ characters of inline classes repeated 4 times.

## After


## Benefits
- Single source of truth for button styles
- Easy to update colors/padding globally
- More readable component code
- Semantic naming (primary, warning, danger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of CSS class composition in a single UI component; minimal risk aside from potential minor styling regressions.
> 
> **Overview**
> Refactors `SimulationControls` to centralize repeated Tailwind class strings into a shared `buttonStyles` object (`base` + `primary`/`warning`/`danger`) and uses template composition on each button.
> 
> No behavior changes to start/pause/resume/stop logic; this is a UI styling/maintainability cleanup to keep button styling consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dd76dfeabea7df20b4f111e49c8f50e63c22419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->