### PR TITLE
refactor: Replace generic exception catches with specific handlers

### DIFF
--- a/src/api/routes/simulation.py
+++ b/src/api/routes/simulation.py
@@ -45,9 +45,7 @@ async def run_simulation(request: SimulationRequest) -> SimulationResponse:
     except TimeoutError as exc:
         if _logger:
             _logger.warning("Simulation timeout: %s", exc)
-        raise HTTPException(
-            status_code=504, detail="Simulation timed out"
-        ) from exc
+        raise HTTPException(status_code=504, detail="Simulation timed out") from exc
     except ValueError as exc:
         if _logger:
             _logger.warning("Invalid simulation parameters: %s", exc)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -229,9 +229,7 @@ async def startup_event() -> None:
             )
             video_pipeline = VideoPosePipeline(video_config)
         except ImportError as e:
-            logger.info(
-                "MediaPipe not installed, video features disabled: %s", e
-            )
+            logger.info("MediaPipe not installed, video features disabled: %s", e)
             video_pipeline = None
         except OSError as e:
             logger.warning(
@@ -239,9 +237,7 @@ async def startup_event() -> None:
             )
             video_pipeline = None
         except RuntimeError as e:
-            logger.warning(
-                "Video pipeline runtime initialization failed: %s", e
-            )
+            logger.warning("Video pipeline runtime initialization failed: %s", e)
             video_pipeline = None
 
         core_routes.configure(engine_manager)


### PR DESCRIPTION
Closes #999

## Summary
Replaces generic  catches with specific exception handlers for better debugging and error handling.

## Changes

### src/api/routes/simulation.py
- Added  handler (504 status)
- Added  handler (400 status)  
- Added  handler (500 status)
- Keep generic Exception as fallback with  for full traceback

### src/api/server.py
- Added  handler for missing dependencies
- Added  handler for database/filesystem issues
- Added  handler for engine initialization
- Use  for unexpected errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refines exception-to-HTTP/status mapping and logging; behavior changes are limited to error responses and startup diagnostics.
> 
> **Overview**
> Improves API error handling by replacing broad `except Exception` blocks with **typed exception handlers** that return more appropriate HTTP status codes and clearer logs.
> 
> `POST /simulate` now maps `TimeoutError` to 504, `ValueError` to 400, and `RuntimeError` to 500, while reserving a final catch-all that uses `_logger.exception` and returns a generic 500. Server startup now distinguishes `ImportError`/`OSError`/`RuntimeError` during video pipeline init and overall initialization, and logs unexpected startup failures with full tracebacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d3e8568f7525e1ed04b9826483d1729f8a79c04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->