### PR TITLE
fix: Optimize workflow schedule to 2x weekly (Mon/Thu)

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -9,16 +9,9 @@ on:
     workflows: ["CI Standard"]
     types: [completed]
   schedule:
-    # OVERNIGHT SCHEDULE - All work done before morning (midnight-6 AM PST / 8 AM-2 PM UTC)
-    - cron: "0 8 */3 * *"   # Midnight PST (Mondays) - Assessment Generator
-    - cron: "0 8 */3 * *"
-    - cron: "0 8 */3 * *"   # 1 AM PST (Mondays) - Completist (incomplete impl)
-    - cron: "0 8 */3 * *"
-    - cron: "0 8 */3 * *"
-    - cron: "0 8 */3 * *"  # 3 AM PST (Mondays) - Auto-Refactor
-    - cron: "0 8 */3 * *"
-    - cron: "0 8 */3 * *"  # 5 AM PST (Mondays) - Auto-Rebase
-    - cron: "0 8 */3 * *"  # 4 AM PST (Mondays) - PR Compiler (consolidate PRs)
+    # COST OPTIMIZED: Runs Mon/Thu (2x weekly for active repos)
+    # Time-based routing in triage step handles worker selection
+    - cron: "0 8 * * 1,4"  # Monday and Thursday at midnight PST
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
## Problem
- Multiple identical cron expressions caused 9x workflow runs per trigger
- The `*/3` pattern caused consecutive-day runs at month boundaries (Jan 31 + Feb 1)

## Solution
- Single optimized cron schedule (2x weekly (Mon/Thu))
- Time-based routing handles worker selection
- Reduces GitHub Actions costs significantly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger timing/frequency changes only; primary risk is reduced automation cadence or unexpected worker routing based on the new cron string.
> 
> **Overview**
> Updates `Jules-Control-Tower.yml` to **replace multiple redundant `*/3` cron entries** with a single cost-optimized schedule that runs **twice weekly (Mon/Thu at 08:00 UTC / midnight PST)**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d2dde69666aeb37af9a8e795a6284951af068fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->