### PR TITLE
refactor: Consolidate engine availability checks to single source of truth

### DIFF
--- a/src/engines/physics_engines/drake/python/src/manipulability.py
+++ b/src/engines/physics_engines/drake/python/src/manipulability.py
@@ -7,20 +7,19 @@ from dataclasses import dataclass
 
 import numpy as np
 
+# Import from centralized availability module (DRY compliance)
+from src.shared.python.engine_availability import DRAKE_AVAILABLE
 from src.shared.python.logging_config import get_logger
 
-# Try to import Drake. If failing, we define dummies or rely on user env.
-try:
+# Try to import Drake types for actual usage
+if DRAKE_AVAILABLE:
     from pydrake.all import (
         BodyIndex,
         Context,
         JacobianWrtVariable,
         MultibodyPlant,
     )
-
-    DRAKE_AVAILABLE = True
-except ImportError:
-    DRAKE_AVAILABLE = False
+else:
     # Dummies for type checking
     MultibodyPlant = object
     Context = object

--- a/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
+++ b/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
@@ -23,6 +23,10 @@ _project_root = (
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+from src.shared.python.engine_availability import (  # noqa: E402
+    DRAKE_AVAILABLE,
+    PYQT6_AVAILABLE,
+)
 from src.shared.python.logging_config import get_logger  # noqa: E402
 from src.shared.python.pose_editor.core import (  # noqa: E402
     BasePoseEditor,
@@ -39,19 +43,17 @@ from src.shared.python.pose_editor.widgets import (  # noqa: E402
 
 logger = get_logger(__name__)
 
-# PyQt6 imports
-try:
-    from PyQt6 import QtCore, QtGui, QtWidgets
 
-    PYQT6_AVAILABLE = True
-except ImportError:
-    PYQT6_AVAILABLE = False
+# PyQt6 imports
+if PYQT6_AVAILABLE:
+    from PyQt6 import QtCore, QtGui, QtWidgets
+else:
     QtCore = None  # type: ignore[misc, assignment]
     QtGui = None  # type: ignore[misc, assignment]
     QtWidgets = None  # type: ignore[misc, assignment]
 
 # Drake imports
-try:
+if DRAKE_AVAILABLE:
     from pydrake.all import (
         Context,
         JointIndex,
@@ -60,10 +62,7 @@ try:
         RevoluteJoint,
         RigidTransform,
     )
-
-    DRAKE_AVAILABLE = True
-except ImportError:
-    DRAKE_AVAILABLE = False
+else:
     MultibodyPlant = None  # type: ignore[misc, assignment]
     JointIndex = None  # type: ignore[misc, assignment]
     PrismaticJoint = None  # type: ignore[misc, assignment]

--- a/src/engines/physics_engines/myosuite/python/muscle_analysis.py
+++ b/src/engines/physics_engines/myosuite/python/muscle_analysis.py
@@ -11,17 +11,17 @@ from typing import Any
 
 import numpy as np
 
+from src.shared.python.engine_availability import MUJOCO_AVAILABLE
 from src.shared.python.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-try:
+if MUJOCO_AVAILABLE:
     import mujoco
-
-    MUJOCO_AVAILABLE = True
-except ImportError:
-    MUJOCO_AVAILABLE = False
+else:
+    mujoco = None  # type: ignore[assignment]
     logger.warning("MuJoCo not available - muscle analysis limited")
+
 
 # Constants for muscle analysis
 MJDYN_MUSCLE = 2  # MuJoCo dyntype constant for muscle actuators

--- a/src/engines/physics_engines/pinocchio/python/dtack/backends/pinocchio_backend.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/backends/pinocchio_backend.py
@@ -8,16 +8,12 @@ from pathlib import Path
 import numpy as np  # noqa: TID253
 import numpy.typing as npt  # noqa: TID253
 
+from src.shared.python.engine_availability import PINOCCHIO_AVAILABLE
 from src.shared.python.logging_config import get_logger
 
-try:
+if PINOCCHIO_AVAILABLE:
     import pinocchio as pin
-
-    PINOCCHIO_AVAILABLE = True
-except ImportError:
-    PINOCCHIO_AVAILABLE = False
-
-    # Define dummy pin module to allow import without pinocchio
+else:
     # Define dummy pin module to allow import without pinocchio
     class DummyPin:
         """Dummy class to prevent NameError when Pinocchio is missing.
@@ -58,7 +54,8 @@ except ImportError:
                 )
                 raise ImportError(msg)
 
-    pin = DummyPin()
+    pin = DummyPin()  # type: ignore[assignment]
+
 logger = get_logger(__name__)
 
 


### PR DESCRIPTION
## Summary
Replaced scattered engine availability check patterns with imports from the centralized  module.

## Changes
- : Now imports  instead of local try/except
- : Now imports  and 
- : Now imports 
- : Now imports 

## DRY Compliance
This PR addresses **4 of the 7 identified engine detection DRY violations**, reducing scattered availability checks across the codebase.

## Testing
- All linting passes (ruff check, ruff format)
- No behavioral changes - same import semantics maintained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of import-gating logic; runtime behavior should be unchanged aside from relying on `engine_availability`’s import-time detection semantics.
> 
> **Overview**
> **Consolidates optional dependency detection** by replacing per-file `try/except ImportError` availability checks with centralized flags from `src.shared.python.engine_availability`.
> 
> Updates Drake manipulability + pose editor code to gate `pydrake`/`PyQt6` imports via `DRAKE_AVAILABLE`/`PYQT6_AVAILABLE`, and updates MyoSuite and Pinocchio integrations to rely on `MUJOCO_AVAILABLE`/`PINOCCHIO_AVAILABLE` while keeping the existing fallback dummy/stub behavior for type checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28db6f302c488a9a3608349d0362e5204698d35b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->