### PR TITLE
refactor: Consolidate engine availability checks (Phase 2)

### DIFF
--- a/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
@@ -12,15 +12,16 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from src.shared.python.engine_availability import PINOCCHIO_AVAILABLE
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-try:
+if PINOCCHIO_AVAILABLE:
     import pinocchio as pin
+else:
+    pin = None  # type: ignore[assignment]
 
-    PINOCCHIO_AVAILABLE = True
-except ImportError:
-    PINOCCHIO_AVAILABLE = False
 
 try:
     import pink

--- a/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
@@ -14,16 +14,18 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from src.shared.python.engine_availability import PINOCCHIO_AVAILABLE
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-try:
+if PINOCCHIO_AVAILABLE:
     import pinocchio as pin
     from pinocchio.visualize import MeshcatVisualizer
+else:
+    pin = None  # type: ignore[assignment]
+    MeshcatVisualizer = None  # type: ignore[misc, assignment]
 
-    PINOCCHIO_AVAILABLE = True
-except ImportError:
-    PINOCCHIO_AVAILABLE = False
 
 try:
     import meshcat

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
@@ -23,6 +23,10 @@ _project_root = (
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+from src.shared.python.engine_availability import (  # noqa: E402
+    PINOCCHIO_AVAILABLE,
+    PYQT6_AVAILABLE,
+)
 from src.shared.python.logging_config import get_logger  # noqa: E402
 from src.shared.python.pose_editor.core import (  # noqa: E402
     BasePoseEditor,
@@ -40,23 +44,17 @@ from src.shared.python.pose_editor.widgets import (  # noqa: E402
 logger = get_logger(__name__)
 
 # PyQt6 imports
-try:
+if PYQT6_AVAILABLE:
     from PyQt6 import QtCore, QtGui, QtWidgets
-
-    PYQT6_AVAILABLE = True
-except ImportError:
-    PYQT6_AVAILABLE = False
+else:
     QtCore = None  # type: ignore[misc, assignment]
     QtGui = None  # type: ignore[misc, assignment]
     QtWidgets = None  # type: ignore[misc, assignment]
 
 # Pinocchio imports
-try:
+if PINOCCHIO_AVAILABLE:
     import pinocchio as pin
-
-    PINOCCHIO_AVAILABLE = True
-except ImportError:
-    PINOCCHIO_AVAILABLE = False
+else:
     pin = None  # type: ignore[misc, assignment]
 
 

--- a/src/tools/model_explorer/visualization_widget.py
+++ b/src/tools/model_explorer/visualization_widget.py
@@ -15,21 +15,23 @@ _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+from src.shared.python.engine_availability import MUJOCO_AVAILABLE  # noqa: E402
 from src.shared.python.logging_config import get_logger  # noqa: E402
 
 logger = get_logger(__name__)
 
-# Check MuJoCo availability
-MUJOCO_AVAILABLE = False
-try:
-    pass
+# Import MuJoCo viewer if available
+if MUJOCO_AVAILABLE:
+    try:
+        from .mujoco_viewer import MuJoCoViewerWidget
 
-    from .mujoco_viewer import MuJoCoViewerWidget
-
-    MUJOCO_AVAILABLE = True
-    logger.info("MuJoCo 3D viewer available")
-except ImportError as e:
-    logger.info(f"MuJoCo not available, using fallback grid view: {e}")
+        logger.info("MuJoCo 3D viewer available")
+    except ImportError as e:
+        logger.info(f"MuJoCo viewer widget not available: {e}")
+        MuJoCoViewerWidget = None  # type: ignore[misc, assignment]
+else:
+    logger.info("MuJoCo not available, using fallback grid view")
+    MuJoCoViewerWidget = None  # type: ignore[misc, assignment]
 
 
 class VisualizationWidget(QWidget):


### PR DESCRIPTION
## Summary
Continued consolidation of engine availability checks to use the centralized  module.

## Changes
| File | Flags Consolidated |
|------|-------------------|
|  |  |
|  |  |
|  | ,  |
|  |  |

## Combined Progress (Phase 1 + 2)
- **8 files** now use centralized availability flags
- Engine detection pattern is now consistent across:
  - Drake (2 files)
  - Pinocchio (4 files)
  - MuJoCo (2 files)

## Testing
- All linting passes (ruff check, ruff format)
- No behavioral changes - same import semantics maintained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor of optional-import plumbing and logging; runtime behavior should be unchanged aside from clearer fallback paths when optional deps are missing.
> 
> **Overview**
> Refactors optional dependency handling to rely on centralized flags from `src.shared.python.engine_availability` instead of per-file `try/except ImportError` checks.
> 
> Pinocchio-related modules now conditionally import `pinocchio` (and `MeshcatVisualizer`) based on `PINOCCHIO_AVAILABLE`, and the Pinocchio pose editor similarly gates PyQt6/Pinocchio imports on `PYQT6_AVAILABLE`/`PINOCCHIO_AVAILABLE`. The model explorer’s visualization widget now uses `MUJOCO_AVAILABLE` to decide whether to load the MuJoCo viewer, with clearer fallback logging and a `None` placeholder when the viewer widget can’t be imported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f1dd9edcf9582277187eef5c33167f155b67e56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->