### PR TITLE
feat: add Design by Contract decorators to physics engines

### DIFF
--- a/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
+++ b/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
@@ -20,6 +20,11 @@ if str(_project_root) not in sys.path:
 
 import numpy as np  # noqa: E402
 
+from src.shared.python.contracts import (  # noqa: E402
+    check_finite,
+    postcondition,
+    precondition,
+)
 from src.shared.python.engine_availability import MYOSUITE_AVAILABLE  # noqa: E402
 from src.shared.python.interfaces import PhysicsEngine  # noqa: E402
 from src.shared.python.logging_config import get_logger  # noqa: E402
@@ -63,6 +68,11 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             return self.sim.model
         return None
 
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the engine has a loaded environment and simulation."""
+        return self.env is not None and self.sim is not None
+
     def load_from_path(self, path: str) -> None:
         """Load environment by ID (passed as path)."""
         if not MYOSUITE_AVAILABLE:
@@ -105,11 +115,15 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             "MyoSuite does not support loading from string (requires Env ID registration)"
         )
 
+    @precondition(lambda self: self.env is not None, "Environment must be loaded")
     def reset(self) -> None:
         """Reset environment."""
         if self.env:
             self.env.reset()
 
+    @precondition(
+        lambda self, dt=None: self.env is not None, "Environment must be loaded"
+    )
     def step(self, dt: float | None = None) -> None:
         """Step simulation."""
         if not self.env:
@@ -144,6 +158,7 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             zero_action = self.env.action_space.sample() * 0
             self.env.step(zero_action)
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:
         """Compute forward dynamics."""
         if self.sim:
@@ -222,6 +237,8 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             return float(self.sim.data.time)
         return 0.0
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Mass matrix must contain finite values")
     def compute_mass_matrix(self) -> np.ndarray:
         if not self.sim:
             return np.array([])
@@ -253,6 +270,8 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             logger.error("Failed to compute mass matrix: %s", e)
             return np.array([])
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Bias forces must contain finite values")
     def compute_bias_forces(self) -> np.ndarray:
         if self.sim:
             return np.array(self.sim.data.qfrc_bias)
@@ -262,6 +281,10 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
         # Not easily exposed separately in basic bindings without extra calc
         return np.array([])
 
+    @precondition(
+        lambda self, qacc: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Inverse dynamics torques must contain finite values")
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
         # Requires calling mj_inverse
         if not self.sim:
@@ -301,6 +324,8 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
 
     # -------- Section F: Drift-Control Decomposition --------
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Drift acceleration must contain finite values")
     def compute_drift_acceleration(self) -> np.ndarray:
         """Compute passive (drift) acceleration with zero muscle activations.
 
@@ -338,6 +363,10 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             logger.error(f"Failed to compute drift acceleration: {e}")
             return np.array([])
 
+    @precondition(
+        lambda self, tau: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Control acceleration must contain finite values")
     def compute_control_acceleration(self, tau: np.ndarray) -> np.ndarray:
         """Compute control-attributed acceleration from muscle activations.
 

--- a/src/engines/physics_engines/opensim/python/opensim_physics_engine.py
+++ b/src/engines/physics_engines/opensim/python/opensim_physics_engine.py
@@ -10,6 +10,11 @@ from typing import Any
 
 import numpy as np
 
+from src.shared.python.contracts import (
+    check_finite,
+    postcondition,
+    precondition,
+)
 from src.shared.python.engine_availability import OPENSIM_AVAILABLE
 from src.shared.python.interfaces import PhysicsEngine
 from src.shared.python.logging_config import get_logger
@@ -45,6 +50,11 @@ class OpenSimPhysicsEngine(PhysicsEngine):
         if self._model:
             return self._model.getName()
         return "OpenSim_NoModel"
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the engine has a loaded model."""
+        return self._model is not None and self._state is not None
 
     def load_from_path(self, path: str) -> None:
         if opensim is None:
@@ -96,6 +106,7 @@ class OpenSimPhysicsEngine(PhysicsEngine):
                         f"Failed to remove temporary file {tmp_path}: {cleanup_error}"
                     )
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def reset(self) -> None:
         if self._model and self._state:
             # Re-initialize the system to defaults
@@ -104,6 +115,9 @@ class OpenSimPhysicsEngine(PhysicsEngine):
             self._manager.setSessionTime(0.0)
             self._manager.setIntegrator(opensim.RungeKuttaMersonIntegrator(self._model))
 
+    @precondition(
+        lambda self, dt=None: self.is_initialized, "Engine must be initialized"
+    )
     def step(self, dt: float | None = None) -> None:
         if not self._model or not self._state:
             return
@@ -118,6 +132,7 @@ class OpenSimPhysicsEngine(PhysicsEngine):
         # Integrate
         self._manager.integrate(current_time + step_size)
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:
         if self._model and self._state:
             self._model.realizeDynamics(self._state)
@@ -179,6 +194,8 @@ class OpenSimPhysicsEngine(PhysicsEngine):
             return self._state.getTime()
         return 0.0
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Mass matrix must contain finite values")
     def compute_mass_matrix(self) -> np.ndarray:
         if not self._model or not self._state:
             return np.array([])
@@ -197,6 +214,8 @@ class OpenSimPhysicsEngine(PhysicsEngine):
                 res[r, c] = m_mat.get(r, c)
         return res
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Bias forces must contain finite values")
     def compute_bias_forces(self) -> np.ndarray:
         """Compute C(q,u) + G(q).
 
@@ -215,6 +234,8 @@ class OpenSimPhysicsEngine(PhysicsEngine):
             logger.error(f"Failed to compute bias forces: {e}")
             return np.array([])
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Gravity forces must contain finite values")
     def compute_gravity_forces(self) -> np.ndarray:
         """Compute gravity forces g(q).
 
@@ -244,6 +265,10 @@ class OpenSimPhysicsEngine(PhysicsEngine):
             logger.error(f"Failed to compute gravity forces: {e}")
             return np.array([])
 
+    @precondition(
+        lambda self, qacc: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Inverse dynamics torques must contain finite values")
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
         if not self._model or not self._state:
             return np.array([])
@@ -438,6 +463,8 @@ class OpenSimPhysicsEngine(PhysicsEngine):
 
     # -------- Section F: Drift-Control Decomposition --------
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Drift acceleration must contain finite values")
     def compute_drift_acceleration(self) -> np.ndarray:
         """Compute passive (drift) acceleration with zero control inputs.
 
@@ -461,6 +488,10 @@ class OpenSimPhysicsEngine(PhysicsEngine):
 
         return a_drift
 
+    @precondition(
+        lambda self, tau: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Control acceleration must contain finite values")
     def compute_control_acceleration(self, tau: np.ndarray) -> np.ndarray:
         """Compute control-attributed acceleration from applied torques/muscles.
 

--- a/src/engines/physics_engines/pendulum/python/pendulum_physics_engine.py
+++ b/src/engines/physics_engines/pendulum/python/pendulum_physics_engine.py
@@ -11,6 +11,11 @@ from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pen
     DoublePendulumDynamics,
     DoublePendulumState,
 )
+from src.shared.python.contracts import (
+    check_finite,
+    postcondition,
+    precondition,
+)
 from src.shared.python.interfaces import PhysicsEngine
 from src.shared.python.logging_config import get_logger
 
@@ -52,6 +57,11 @@ class PendulumPhysicsEngine(PhysicsEngine):
     def model_name(self) -> str:
         """Return the name of the currently loaded model."""
         return "DoublePendulum"
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the engine is initialized (always True for pendulum)."""
+        return self.dynamics is not None
 
     def load_from_path(self, path: str) -> None:
         """Load model from file path."""
@@ -119,12 +129,16 @@ class PendulumPhysicsEngine(PhysicsEngine):
         """Get the current simulation time."""
         return self.time
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Mass matrix must contain finite values")
     def compute_mass_matrix(self) -> np.ndarray:
         """Compute the dense inertia matrix M(q)."""
         # returns ((m11, m12), (m12, m22))
         m_tuple = self.dynamics.mass_matrix(self.state.theta2)
         return np.array(m_tuple)
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Bias forces must contain finite values")
     def compute_bias_forces(self) -> np.ndarray:
         """Compute bias forces C(q,v) + g(q) + d(q,v)."""
         # We can use joint_torque_breakdown with zero control to get the rest?
@@ -148,11 +162,17 @@ class PendulumPhysicsEngine(PhysicsEngine):
 
         return np.array([c1 + g1 + d1, c2 + g2 + d2])
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Gravity forces must contain finite values")
     def compute_gravity_forces(self) -> np.ndarray:
         """Compute gravity forces g(q)."""
         g1, g2 = self.dynamics.gravity_vector(self.state.theta1, self.state.theta2)
         return np.array([g1, g2])
 
+    @precondition(
+        lambda self, qacc: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Inverse dynamics torques must contain finite values")
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
         """Compute inverse dynamics tau = ID(q, v, a)."""
         if len(qacc) < 2:
@@ -163,6 +183,8 @@ class PendulumPhysicsEngine(PhysicsEngine):
         )
         return np.array([tau1, tau2])
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Drift acceleration must contain finite values")
     def compute_drift_acceleration(self) -> np.ndarray:
         """Compute passive (drift) acceleration with zero control inputs.
 
@@ -177,6 +199,10 @@ class PendulumPhysicsEngine(PhysicsEngine):
         a_drift = np.linalg.solve(M, -bias)
         return a_drift
 
+    @precondition(
+        lambda self, tau: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Control acceleration must contain finite values")
     def compute_control_acceleration(self, tau: np.ndarray) -> np.ndarray:
         """Compute control-attributed acceleration from applied torques only.
 

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
@@ -11,6 +11,11 @@ from typing import Any, cast
 
 import numpy as np
 
+from src.shared.python.contracts import (
+    check_finite,
+    postcondition,
+    precondition,
+)
 from src.shared.python.engine_availability import PINOCCHIO_AVAILABLE
 from src.shared.python.logging_config import get_logger
 
@@ -52,6 +57,11 @@ class PinocchioPhysicsEngine(PhysicsEngine):
         if self.model:
             return cast(str, self.model.name)
         return self.model_name_str
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the engine has a loaded model."""
+        return self.model is not None and self.data is not None
 
     def load_from_path(self, path: str) -> None:
         """Load model from file path (URDF)."""
@@ -96,6 +106,7 @@ class PinocchioPhysicsEngine(PhysicsEngine):
             logger.error("Failed to load Pinocchio model from string: %s", e)
             raise
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def reset(self) -> None:
         """Reset the simulation to its initial state."""
         if self.model:
@@ -107,6 +118,9 @@ class PinocchioPhysicsEngine(PhysicsEngine):
             # Refresh data
             self.forward()
 
+    @precondition(
+        lambda self, dt=None: self.is_initialized, "Engine must be initialized"
+    )
     def step(self, dt: float | None = None) -> None:
         """Advance the simulation by one time step."""
         if self.model is None or self.data is None:
@@ -128,6 +142,7 @@ class PinocchioPhysicsEngine(PhysicsEngine):
 
         self.time += time_step
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:
         """Compute forward kinematics/dynamics without advancing time."""
         if self.model is None or self.data is None:
@@ -208,6 +223,8 @@ class PinocchioPhysicsEngine(PhysicsEngine):
 
     # -------- Dynamics Interface --------
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Mass matrix must contain finite values")
     def compute_mass_matrix(self) -> np.ndarray:
         """Compute the dense inertia matrix M(q)."""
         if self.model is None or self.data is None:
@@ -222,6 +239,8 @@ class PinocchioPhysicsEngine(PhysicsEngine):
         M = np.triu(M) + np.triu(M, 1).T
         return cast(np.ndarray, M)
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Bias forces must contain finite values")
     def compute_bias_forces(self) -> np.ndarray:
         """Compute bias forces C(q,v) + g(q)."""
         if self.model is None or self.data is None:
@@ -236,6 +255,8 @@ class PinocchioPhysicsEngine(PhysicsEngine):
             pin.rnea(self.model, self.data, self.q, self.v, a_zero),
         )
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Gravity forces must contain finite values")
     def compute_gravity_forces(self) -> np.ndarray:
         """Compute gravity forces g(q)."""
         if self.model is None or self.data is None:
@@ -246,6 +267,10 @@ class PinocchioPhysicsEngine(PhysicsEngine):
             np.ndarray, pin.computeGeneralizedGravity(self.model, self.data, self.q)
         )
 
+    @precondition(
+        lambda self, qacc: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Inverse dynamics torques must contain finite values")
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
         """Compute inverse dynamics tau = ID(q, v, a)."""
         if self.model is None or self.data is None:
@@ -324,6 +349,8 @@ class PinocchioPhysicsEngine(PhysicsEngine):
 
     # -------- Section F: Drift-Control Decomposition --------
 
+    @precondition(lambda self: self.is_initialized, "Engine must be initialized")
+    @postcondition(check_finite, "Drift acceleration must contain finite values")
     def compute_drift_acceleration(self) -> np.ndarray:
         """Compute passive (drift) acceleration with zero control inputs.
 
@@ -343,6 +370,10 @@ class PinocchioPhysicsEngine(PhysicsEngine):
 
         return cast(np.ndarray, a_drift)
 
+    @precondition(
+        lambda self, tau: self.is_initialized, "Engine must be initialized"
+    )
+    @postcondition(check_finite, "Control acceleration must contain finite values")
     def compute_control_acceleration(self, tau: np.ndarray) -> np.ndarray:
         """Compute control-attributed acceleration from applied torques only.
 


### PR DESCRIPTION
## Summary
- Add `is_initialized` property to all physics engines to check engine state
- Add `@precondition` decorators for initialization checks on `step`, `forward`, `reset`, and compute methods
- Add `@postcondition(check_finite)` decorators to ensure compute methods return finite values

Engines updated:
- MuJoCo
- Drake
- Pinocchio
- OpenSim
- MyoSuite
- Pendulum

## Test plan
- [x] All physics engine files import correctly
- [x] Unit tests pass with proper mocking
- [x] Linting passes (no F401 unused import errors)

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds runtime contract enforcement to core simulation APIs, which can introduce new exceptions/behavior changes during initialization and numerical failures across multiple engines.
> 
> **Overview**
> Adds Design-by-Contract enforcement across Drake, MuJoCo, MyoSuite, OpenSim, Pendulum, and Pinocchio physics engines by introducing an `is_initialized` property and applying `@precondition` guards to `step`/`forward`/`reset` and key `compute_*` methods.
> 
> Adds `@postcondition(check_finite)` checks to dynamics computations (e.g., mass matrix, bias/gravity forces, inverse dynamics, drift/control accelerations) to fail fast on NaN/Inf outputs, and tightens MuJoCo inverse dynamics argument validation by raising `PreconditionError` on `qacc` dimension mismatch instead of logging/returning empty arrays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 573ee6530952887ad3c5ab21820c9d921544fd97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->