### PR TITLE
feat: add free local code quality hooks (Semgrep + Radon)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -221,6 +221,30 @@ repos:
         pass_filenames: false
         types: [python]
 
+
+  # Semgrep - Free local security + code quality scanning (pre-push)
+  - repo: https://github.com/semgrep/semgrep
+    rev: v1.102.0
+    hooks:
+      - id: semgrep
+        name: "semgrep (security + quality)"
+        stages: [pre-push]
+        args: ["--config", "auto", "--error", "--quiet"]
+        types: [python]
+        exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
+
+  # Radon - Cyclomatic complexity check (pre-push)
+  - repo: https://github.com/rubik/radon
+    rev: v6.0.1
+    hooks:
+      - id: radon
+        name: "radon (complexity check)"
+        stages: [pre-push]
+        args: ["cc", "--min", "C", "--show-complexity", "--total-average"]
+        types: [python]
+        files: ^src/
+        exclude: ^(tests/|archive/|legacy/|experimental/)
+
 # =============================================================================
 # Global Settings
 # =============================================================================
@@ -260,4 +284,4 @@ ci:
   autofix_prs: true
   autoupdate_branch: "main"
   autoupdate_commit_msg: "chore: update pre-commit hooks"
-  skip: [pytest-unit, bandit, mypy]  # Skip slow hooks in CI
+  skip: [pytest-unit, bandit, mypy, semgrep, radon]  # Skip slow hooks in CI


### PR DESCRIPTION
## Summary

- Add Semgrep pre-push hook for free local security + code quality scanning
- Add Radon pre-push hook for cyclomatic complexity analysis

## Details

These tools run locally on pre-push only, so they don't slow down the development workflow. No servers, no CI costs.

**Semgrep** catches:
- Security vulnerabilities (OWASP rules)
- Code quality issues
- Best practice violations

**Radon** reports:
- Cyclomatic complexity per function
- Flags functions with complexity grade C or worse

## Test plan

- [ ] Verify pre-commit install --hook-type pre-push works
- [ ] Verify hooks run on git push

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change affecting developer pre-push workflow; no production code or runtime behavior is modified.
> 
> **Overview**
> Adds two new *pre-push-only* pre-commit hooks: `semgrep` (auto ruleset) for local security/quality scanning and `radon cc` for cyclomatic complexity reporting (grade C+), with exclusions for tests/legacy/etc.
> 
> Updates pre-commit CI settings to also skip these new hooks (`semgrep`, `radon`) alongside existing slow checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 917ea38928de71082c900669c85f3d52ccd19eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>917ea38</u></sup><!-- /BUGBOT_STATUS -->