### PR TITLE
chore: Add clear comments for disabled MATLAB/Arduino tests

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -195,10 +195,18 @@ jobs:
       - name: Build Check
         run: npm run build
 
+  # =============================================================================
+  # MATLAB TESTS - DISABLED BY DEFAULT
+  # =============================================================================
+  # This job requires a MATLAB license which is NOT available in GitHub CI.
+  # DO NOT enable (remove 'if: false') unless you have configured MATLAB licensing.
+  # To enable: set 'if: true' and configure matlab-actions.
+  # Users with local MATLAB can run: matlab/run_all.m for equivalent tests.
+  # =============================================================================
   matlab-tests:
     needs: quality-gate
     runs-on: ubuntu-latest
-    if: false
+    if: false  # DISABLED - Requires MATLAB license not available in CI
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -209,10 +217,15 @@ jobs:
             addpath('matlab');
             run_all
 
+  # =============================================================================
+  # ARDUINO BUILD - DISABLED BY DEFAULT
+  # =============================================================================
+  # No Arduino components in this project - disabled.
+  # =============================================================================
   arduino-build:
     needs: quality-gate
     runs-on: ubuntu-latest
-    if: false # Disabled - no Arduino components in this project
+    if: false  # DISABLED - No Arduino components in this project
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -221,3 +234,4 @@ jobs:
       - name: Verify Build
         working-directory: ./arduino
         run: pio run -e uno
+


### PR DESCRIPTION
MATLAB tests require a license not available in GitHub Actions CI.

**DO NOT re-enable MATLAB tests unless you have configured MATLAB licensing for CI.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only comment changes; no behavior changes since both jobs remain gated by `if: false`.
> 
> **Overview**
> Adds prominent comment blocks to `ci-standard.yml` explaining that the `matlab-tests` job is disabled due to missing CI licensing and how to enable/run it locally.
> 
> Clarifies that the `arduino-build` job is intentionally disabled because the repo has no Arduino components, and standardizes the inline `if: false` disable comments for both jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74d0cbf4f044e55a46acd2cd8c46b89d2ccf887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->