### PR TITLE
feat: add Tauri desktop application support

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,14 +4,16 @@
   "version": "2.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5180",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.7",
@@ -30,6 +32,7 @@
     "three": "^0.182.0"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
     "@eslint/js": "^9.39.1",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.0",

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "golf-modeling-suite"
+version = "2.1.0"
+description = "Golf Modeling Suite - Biomechanical Golf Simulation"
+authors = ["D-sorganization"]
+license = "MIT"
+repository = "https://github.com/D-sorganization/UpstreamDrift"
+edition = "2021"
+rust-version = "1.77.2"
+
+[lib]
+name = "golf_modeling_suite_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+log = "0.4"
+tauri = { version = "2", features = [] }
+tauri-plugin-log = "2"

--- a/ui/src-tauri/build.rs
+++ b/ui/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -1,0 +1,16 @@
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .setup(|app| {
+            if cfg!(debug_assertions) {
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
+            }
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running Golf Modeling Suite");
+}

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+// Prevents additional console window on Windows in release, DO NOT REMOVE!!
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    golf_modeling_suite_lib::run();
+}

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "productName": "Golf Modeling Suite",
+  "version": "2.1.0",
+  "identifier": "com.dsorganization.golf-modeling-suite",
+  "build": {
+    "frontendDist": "../dist",
+    "devUrl": "http://localhost:5180",
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Golf Modeling Suite",
+        "width": 1600,
+        "height": 1000,
+        "minWidth": 1200,
+        "minHeight": 800,
+        "resizable": true,
+        "fullscreen": false,
+        "center": true
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ]
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   },
 
   server: {
-    port: 3000,
+    port: 5180,
+    strictPort: true,
+    open: false,
     proxy: {
       // Proxy API requests to local backend during development
       '/api': {


### PR DESCRIPTION
## Summary

- Add Tauri 2 configuration for native desktop app wrapper
- Enable running Golf Modeling Suite as a desktop application (not a web page)
- Same technology used in Tools repo for Function Generator and Data Processor

## Changes

- `ui/src-tauri/` - Tauri Rust backend configuration
  - `Cargo.toml` - Rust dependencies (Tauri 2, logging)
  - `tauri.conf.json` - Window settings (1600x1000, resizable)
  - `src/main.rs` and `src/lib.rs` - Rust entry points
- `ui/package.json` - Added `tauri:dev` and `tauri:build` scripts
- `ui/vite.config.ts` - Changed port to 5180 for Tauri compatibility

## Usage

```bash
cd ui
npm install
npm run tauri:dev    # Development with hot reload
npm run tauri:build  # Build production executable
```

## Prerequisites

- Rust toolchain (rustup)
- Node.js 20+
- Windows: WebView2 (usually pre-installed on Windows 10/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Rust/Tauri build and packaging path and changes the dev server port, which can affect local workflows and release/build pipelines.
> 
> **Overview**
> Adds **Tauri v2 desktop wrapper support** for the `ui`, introducing a new `src-tauri` Rust project with app/bundle configuration (`tauri.conf.json`) and a minimal entrypoint that enables logging in debug builds.
> 
> Updates the frontend dev setup for Tauri by pinning Vite to port `5180` (with `strictPort`) and adding `tauri:dev`/`tauri:build` scripts plus `@tauri-apps/cli` to `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc72b3e1c3a76654318dc2655f288b6bf45040c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->