### PR TITLE
feat(plot_theme): integrate shared plot theming system

### DIFF
--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -2005,6 +2005,14 @@ def main() -> None:
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
 
+    # Apply plot theme for matplotlib visualizations
+    try:
+        from shared.python.plot_theme import apply_plot_theme
+
+        apply_plot_theme(settings_app="GolfModelingSuite")
+    except ImportError:
+        logger.debug("Plot theme module not available")
+
     # Show splash
     splash = GolfSplashScreen()
     splash.show()


### PR DESCRIPTION
## Summary
- Integrated shared plot theming system for matplotlib visualizations
- Added plot theme initialization on application startup
- Themes are persisted via QSettings per application
- Graceful fallback when plot_theme module not available

## Dependencies
Requires Tools PR #557 to be merged first (shared plot theme module)

## Test plan
- [ ] CI pipeline passes
- [ ] Plot theme is applied on startup
- [ ] Theme persists across application restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup-time change that only affects optional matplotlib theming and falls back cleanly on `ImportError`; minimal impact beyond visualization styling.
> 
> **Overview**
> Applies the shared matplotlib plot theme at Golf Modeling Suite startup by importing and calling `shared.python.plot_theme.apply_plot_theme` in `golf_launcher.py` before the splash/async startup begins.
> 
> If the shared theme module is unavailable, startup continues unchanged and only logs a debug message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6857e6e14784d68bf841faa212b881afe46fa46b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->