### PR TITLE
feat(theme): read semantic colors from shared themes.json

### DIFF
--- a/src/shared/python/theme/fleet_adapter.py
+++ b/src/shared/python/theme/fleet_adapter.py
@@ -178,18 +178,10 @@ def fleet_to_theme_colors(theme_name: str) -> ThemeColors:
 
     # Semantic colors - read from theme dict (populated from themes.json),
     # falling back to reasonable defaults based on dark/light
-    success = ft.get(
-        "success", "#30D158" if is_dark else "#28A745"
-    )
-    warning = ft.get(
-        "warning", "#FF9F0A" if is_dark else "#E67E00"
-    )
-    error = ft.get(
-        "error", "#FF375F" if is_dark else "#DC3545"
-    )
-    info = ft.get(
-        "info", "#64D2FF" if is_dark else "#17A2B8"
-    )
+    success = ft.get("success", "#30D158" if is_dark else "#28A745")
+    warning = ft.get("warning", "#FF9F0A" if is_dark else "#E67E00")
+    error = ft.get("error", "#FF375F" if is_dark else "#DC3545")
+    info = ft.get("info", "#64D2FF" if is_dark else "#17A2B8")
 
     return ThemeColors(
         name=theme_name,


### PR DESCRIPTION
## Summary
- Update `fleet_adapter.py` to read semantic colors (success, warning, error, info, link) from the shared `themes.json` source of truth instead of hardcoding them
- Map `info` semantic key to `chart_cyan` and `link` to `text_link` for richer theme-aware colors
- Part of the cross-platform shared theme system (Phase 5 of fleet theme unification)

## Test plan
- [ ] Verify `fleet_to_theme_colors()` returns correct semantic colors for all 14 themes
- [ ] Launch UpstreamDrift UI and confirm theme switching still works
- [ ] Confirm chart colors use theme-specific success/warning/error/info values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to theme color mapping logic; main risk is minor visual regressions if `themes.json` is missing keys or has unexpected values.
> 
> **Overview**
> Updates `fleet_to_theme_colors()` to source semantic colors from the fleet `themes.json` data (via `FLEET_THEMES`) instead of hardcoded dark/light defaults.
> 
> Adds support for the `info` and `link` theme keys, mapping `info` to `chart_cyan` and `link` to `text_link`, and updates docs/comments to reflect 14 available fleet themes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f779faaca6a0f48c9a007f0db4d7f4536d5487f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->