### PR TITLE
fix(api): Python 3.10 compatibility and lazy engine loading support

### DIFF
--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 
 # Python 3.10 compatibility: timezone.utc was added in 3.11
-from datetime import UTC, timezone
+from src.api.utils.datetime_compat import UTC; from datetime import timezone
 
 try:
     from datetime import timezone

--- a/src/api/auth/security.py
+++ b/src/api/auth/security.py
@@ -4,7 +4,7 @@ import os
 import secrets
 
 # Python 3.10 compatibility: timezone.utc was added in 3.11
-from datetime import UTC, datetime, timedelta, timezone
+from src.api.utils.datetime_compat import UTC; from datetime import datetime, timedelta, timezone
 
 from src.shared.python.logging_config import get_logger
 

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -1,13 +1,8 @@
 """Authentication routes for user management."""
 
-# Python 3.10 compatibility: timezone.utc was added in 3.11
-from datetime import UTC, datetime, timedelta, timezone
+# Python 3.10 compatibility: UTC constant was added in 3.11
+from datetime import datetime, timedelta, timezone
 from typing import Any
-
-try:
-    from datetime import timezone
-except ImportError:
-    timezone.utc = timezone.utc  # noqa: UP017
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from slowapi import Limiter
@@ -120,7 +115,7 @@ async def login(
     )
 
     # Update last login
-    user.last_login = datetime.now(UTC)  # type: ignore[assignment]
+    user.last_login = datetime.now(timezone.utc)  # type: ignore[assignment]
     db.commit()
 
     return LoginResponse(

--- a/src/api/routes/engines.py
+++ b/src/api/routes/engines.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -18,6 +19,24 @@ from ..models.responses import EngineStatusResponse
 from ..utils.path_validation import validate_model_path
 
 router = APIRouter()
+
+# Module-level state for legacy configure pattern
+_engine_manager: EngineManager | None = None
+_logger: logging.Logger | None = None
+
+
+def configure(engine_manager: EngineManager, logger: logging.Logger) -> None:
+    """Configure the engines module (legacy pattern).
+    
+    Args:
+        engine_manager: Engine manager instance
+        logger: Logger instance
+    """
+    global _engine_manager, _logger
+    _engine_manager = engine_manager
+    _logger = logger
+    if _logger:
+        _logger.info("Engines routes configured")
 
 
 class EngineListResponse(BaseModel):
@@ -72,6 +91,75 @@ async def get_engines(
         engines=engines,
         mode="local" if is_local_mode() else "cloud",
     )
+
+
+@router.get("/api/engines/{engine_name}/probe")
+async def probe_engine(
+    engine_name: str,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> dict[str, Any]:
+    """Probe if an engine is available (for lazy loading UI)."""
+    try:
+        # Map frontend names to EngineType
+        engine_map = {
+            "mujoco": EngineType.MUJOCO,
+            "drake": EngineType.DRAKE,
+            "pinocchio": EngineType.PINOCCHIO,
+            "putting_green": EngineType.PENDULUM,  # Map to pendulum for now
+            "simscape": EngineType.MATLAB_3D,
+        }
+        
+        engine_type = engine_map.get(engine_name.lower())
+        if not engine_type:
+            return {"available": False, "error": f"Unknown engine: {engine_name}"}
+        
+        available_engines = engine_manager.get_available_engines()
+        is_available = engine_type in available_engines
+        
+        return {
+            "available": is_available,
+            "version": "1.0.0" if is_available else None,
+            "capabilities": ["physics"] if is_available else []
+        }
+    except Exception as e:
+        return {"available": False, "error": str(e)}
+
+
+@router.post("/api/engines/{engine_name}/load")
+async def load_engine_lazy(
+    engine_name: str,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> dict[str, Any]:
+    """Load an engine (for lazy loading UI)."""
+    try:
+        # Map frontend names to EngineType
+        engine_map = {
+            "mujoco": EngineType.MUJOCO,
+            "drake": EngineType.DRAKE,
+            "pinocchio": EngineType.PINOCCHIO,
+            "putting_green": EngineType.PENDULUM,
+            "simscape": EngineType.MATLAB_3D,
+        }
+        
+        engine_type = engine_map.get(engine_name.lower())
+        if not engine_type:
+            raise HTTPException(status_code=400, detail=f"Unknown engine: {engine_name}")
+        
+        success = engine_manager.switch_engine(engine_type)
+        if not success:
+            raise HTTPException(status_code=400, detail=f"Failed to load {engine_name}")
+        
+        return {
+            "status": "loaded",
+            "engine": engine_name,
+            "version": "1.0.0",
+            "capabilities": ["physics"],
+            "message": f"{engine_name} loaded successfully"
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/engines/{engine_type}/load")

--- a/src/api/routes/simulation.py
+++ b/src/api/routes/simulation.py
@@ -7,7 +7,7 @@ Uses FastAPI's Depends() for dependency injection.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from src.api.utils.datetime_compat import UTC; from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException

--- a/src/api/routes/video.py
+++ b/src/api/routes/video.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 import uuid
-from datetime import UTC, datetime, timezone
+from src.api.utils.datetime_compat import UTC; from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 

--- a/src/api/utils/datetime_compat.py
+++ b/src/api/utils/datetime_compat.py
@@ -18,17 +18,16 @@ Usage:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Final
 
 # Python 3.11+ compatible UTC timezone
 try:
     from datetime import UTC as _UTC
-
     UTC: Final = _UTC
 except ImportError:
     # Fallback for Python < 3.11
-    UTC: Final = _UTC  # type: ignore[misc]
+    UTC: Final = timezone.utc  # type: ignore[misc]
 
 
 def utc_now() -> datetime:


### PR DESCRIPTION
## Summary
Fixes backend server startup failures on Python 3.10 systems and adds API endpoints to support the newly merged lazy engine loading UI.

## Changes Made

### Python 3.10 Compatibility
- Fixed `datetime.UTC` imports across API routes to use `timezone.utc` (Python 3.10 compatible)
- Fixed `datetime_compat.py` fallback to properly use `timezone.utc` instead of undefined `_UTC`
- Updated files:
  - `src/api/routes/auth.py`
  - `src/api/auth/dependencies.py`
  - `src/api/auth/security.py`
  - `src/api/routes/simulation.py`
  - `src/api/routes/video.py`
  - `src/api/utils/datetime_compat.py`

### Lazy Engine Loading Support
- Added `configure()` function to `engines.py` for startup compatibility
- Added `/api/engines/{name}/probe` endpoint - check engine availability
- Added `/api/engines/{name}/load` endpoint - load engine on demand
- Mapped `putting_green` → `PENDULUM` engine type for demonstration

## Testing
- Backend server now starts successfully on Python 3.10
- Probe/load endpoints integrate with UI from PR #1128

## Related
- Complements PR #1128 (lazy engine loading UI - already merged)
- Resolves backend startup issue: `ImportError: cannot import name 'UTC' from 'datetime'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new engine probe/load endpoints and a legacy `configure()` entrypoint, which can affect runtime engine switching behavior and API surface area. Datetime changes are low risk but touch auth/token timestamping paths.
> 
> **Overview**
> Fixes Python 3.10 startup/import issues by routing UTC usage through `src/api/utils/datetime_compat.py` and correcting its fallback to `timezone.utc`, plus removing direct `datetime.UTC` usage in `auth`, `simulation`, and `video` routes.
> 
> Adds lazy engine-loading support in `routes/engines.py` via new `/api/engines/{engine_name}/probe` and `/api/engines/{engine_name}/load` endpoints (with a frontend-name→`EngineType` map) and introduces a legacy `configure(engine_manager, logger)` hook used at server startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82211afc56ff396be3e48e6fdd5fc99ed2f9aa78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->