### PR TITLE
fix: diagnostics endpoint for browser mode (#1143)

### DIFF
--- a/src/api/routes/core.py
+++ b/src/api/routes/core.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 from fastapi import APIRouter
 
 from src.api.utils.datetime_compat import iso_format, utc_now
@@ -38,4 +41,23 @@ async def health_check() -> dict[str, str | int]:
             len(_engine_manager.get_available_engines()) if _engine_manager else 0
         ),
         "timestamp": iso_format(utc_now()),
+    }
+
+
+@router.get("/api/diagnostics", response_model=None)
+async def get_diagnostics() -> dict:  # type: ignore[type-arg]
+    """Get comprehensive diagnostic information for browser mode."""
+    repo_root = Path(__file__).parent.parent.parent.parent
+    
+    return {
+        "backend": {
+            "running": True,
+            "pid": None,  # Not available in browser mode
+            "port": 8001,  # Docker backend port
+            "error": None,
+        },
+        "python_found": True,
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "repo_root": str(repo_root),
+        "local_server_found": True,  # If this endpoint is hit, server is found
     }

--- a/ui/src/api/backend.ts
+++ b/ui/src/api/backend.ts
@@ -59,13 +59,28 @@ export async function getBackendStatus(): Promise<BackendStatus> {
 /** Get comprehensive diagnostic info (Tauri only). */
 export async function getDiagnostics(): Promise<DiagnosticInfo> {
   if (!isTauri()) {
-    return {
-      backend: { running: false, pid: null, port: 8080, error: null },
-      python_found: false,
-      python_version: null,
-      repo_root: null,
-      local_server_found: false,
-    };
+    // In browser mode, call the backend API endpoint
+    try {
+      const response = await fetch('/api/diagnostics');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      // Fallback if backend is not available
+      return {
+        backend: {
+          running: false,
+          pid: null,
+          port: 8001,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        python_found: false,
+        python_version: null,
+        repo_root: null,
+        local_server_found: false,
+      };
+    }
   }
   return invoke<DiagnosticInfo>('get_diagnostics');
 }


### PR DESCRIPTION
Fixes #1143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public diagnostics endpoint and changes runtime behavior in browser mode; risk is mainly around incorrect environment assumptions (e.g., fixed port/repo path) and potential information disclosure.
> 
> **Overview**
> Adds a new FastAPI route `GET /api/diagnostics` that returns browser-mode diagnostic data (Python version, inferred repo root, and a Docker backend port assumption).
> 
> Updates `ui/src/api/backend.ts` so `getDiagnostics()` calls `/api/diagnostics` in non-Tauri (browser) mode instead of returning a static placeholder, and falls back to an error-filled `DiagnosticInfo` when the fetch fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5fd313aa0697a051d5e1dfec990c492e65aa8f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->