### PR TITLE
feat: terrain/environment API routes + presets (#1145, #1142)

### DIFF
--- a/src/api/routes/terrain.py
+++ b/src/api/routes/terrain.py
@@ -1,0 +1,433 @@
+"""Terrain and environment API routes for Golf Modeling Suite.
+
+Provides engine-agnostic terrain queries, preset environment loading,
+and surface property inspection.
+
+Fixes #1145
+Fixes #1142
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from src.shared.python.terrain import (
+    MATERIALS,
+    TERRAIN_MATERIAL_MAP,
+    ElevationMap,
+    Terrain,
+    TerrainPatch,
+    TerrainRegion,
+    TerrainType,
+    create_flat_terrain,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/terrain", tags=["terrain"])
+
+
+# ──────────────────────────────────────────────────────────────
+#  Pydantic Models
+# ──────────────────────────────────────────────────────────────
+
+
+class TerrainQueryRequest(BaseModel):
+    """Request for querying terrain properties at a point."""
+
+    x: float = Field(..., description="X coordinate in meters")
+    y: float = Field(..., description="Y coordinate in meters")
+
+
+class TerrainQueryResponse(BaseModel):
+    """Response with terrain properties at a point."""
+
+    x: float
+    y: float
+    elevation: float
+    slope_angle_deg: float
+    terrain_type: str
+    friction: float
+    restitution: float
+    rolling_resistance: float
+
+
+class EnvironmentPreset(BaseModel):
+    """An available environment preset."""
+
+    name: str = Field(..., description="Preset identifier")
+    description: str = Field(..., description="Human-readable description")
+    terrain_types: list[str] = Field(
+        ..., description="Terrain types in this environment"
+    )
+    width_m: float = Field(..., description="Width in meters")
+    length_m: float = Field(..., description="Length in meters")
+
+
+class CreateEnvironmentRequest(BaseModel):
+    """Request to create a terrain environment."""
+
+    preset: str = Field(
+        ..., description="Preset name (putting_green, fairway, driving_range, etc.)"
+    )
+    width: float | None = Field(None, description="Override width (meters)")
+    length: float | None = Field(None, description="Override length (meters)")
+    slope_angle_deg: float = Field(0.0, description="Slope angle (degrees)")
+    slope_direction_deg: float = Field(0.0, description="Slope direction (degrees)")
+
+
+class SurfaceMaterialResponse(BaseModel):
+    """Surface material properties."""
+
+    name: str
+    friction_coefficient: float
+    rolling_resistance: float
+    restitution: float
+    hardness: float
+    grass_height_m: float
+    compressibility: float
+
+
+# ──────────────────────────────────────────────────────────────
+#  In-memory terrain state
+# ──────────────────────────────────────────────────────────────
+
+_active_terrain: Terrain | None = None
+
+
+def _get_active_terrain() -> Terrain:
+    """Get the active terrain, creating a default if none exists."""
+    global _active_terrain  # noqa: PLW0603
+    if _active_terrain is None:
+        _active_terrain = create_flat_terrain(
+            name="default_fairway",
+            width=100.0,
+            length=200.0,
+            terrain_type=TerrainType.FAIRWAY,
+        )
+    return _active_terrain
+
+
+# ──────────────────────────────────────────────────────────────
+#  Environment Presets
+# ──────────────────────────────────────────────────────────────
+
+ENVIRONMENT_PRESETS: dict[str, dict[str, Any]] = {
+    "putting_green": {
+        "description": "Close-range putting green with detailed surface (1–30 ft)",
+        "width": 10.0,
+        "length": 15.0,
+        "terrain_types": ["green", "fringe"],
+        "builder": "_build_putting_green",
+    },
+    "fairway": {
+        "description": "Medium-range fairway with gentle slopes (50–200 yards)",
+        "width": 50.0,
+        "length": 200.0,
+        "terrain_types": ["fairway", "rough", "bunker"],
+        "builder": "_build_fairway",
+    },
+    "driving_range": {
+        "description": "Long-range practice environment (100–300+ yards)",
+        "width": 80.0,
+        "length": 300.0,
+        "terrain_types": ["tee", "fairway", "rough"],
+        "builder": "_build_driving_range",
+    },
+    "bunker": {
+        "description": "Sand bunker practice area with varied lip heights",
+        "width": 20.0,
+        "length": 20.0,
+        "terrain_types": ["bunker", "green", "fringe"],
+        "builder": "_build_bunker",
+    },
+    "rough": {
+        "description": "Thick rough practice area with high grass",
+        "width": 30.0,
+        "length": 40.0,
+        "terrain_types": ["rough", "fairway"],
+        "builder": "_build_rough",
+    },
+    "full_hole": {
+        "description": "Complete golf hole from tee to green (par 4, ~370 yards)",
+        "width": 60.0,
+        "length": 340.0,
+        "terrain_types": ["tee", "fairway", "rough", "bunker", "fringe", "green"],
+        "builder": "_build_full_hole",
+    },
+}
+
+
+def _build_putting_green(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a putting green environment."""
+    elevation = ElevationMap.sloped(
+        width=width,
+        length=length,
+        resolution=0.1,
+        slope_angle_deg=slope if slope != 0 else 1.5,
+        slope_direction_deg=direction,
+    )
+    patches = [
+        TerrainPatch(TerrainType.GREEN, 0, width, 0, length),
+        TerrainPatch(TerrainType.FRINGE, 0, width, 0, 1.0),
+        TerrainPatch(TerrainType.FRINGE, 0, width, length - 1.0, length),
+    ]
+    return Terrain(name="putting_green", elevation=elevation, patches=patches)
+
+
+def _build_fairway(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a fairway environment."""
+    elevation = ElevationMap.sloped(
+        width=width,
+        length=length,
+        resolution=1.0,
+        slope_angle_deg=slope if slope != 0 else 0.5,
+        slope_direction_deg=direction,
+    )
+    patches = [
+        TerrainPatch(TerrainType.FAIRWAY, 5, width - 5, 0, length),
+        TerrainPatch(TerrainType.ROUGH, 0, 5, 0, length),
+        TerrainPatch(TerrainType.ROUGH, width - 5, width, 0, length),
+    ]
+    regions = [
+        TerrainRegion.circle(TerrainType.BUNKER, width / 2 + 8, length * 0.6, 5.0),
+        TerrainRegion.circle(TerrainType.BUNKER, width / 2 - 10, length * 0.75, 4.0),
+    ]
+    return Terrain(
+        name="fairway",
+        elevation=elevation,
+        patches=patches,
+        regions=regions,
+    )
+
+
+def _build_driving_range(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a driving range environment."""
+    elevation = ElevationMap.flat(width=width, length=length, resolution=2.0)
+    patches = [
+        TerrainPatch(TerrainType.TEE, 0, width, 0, 5.0),
+        TerrainPatch(TerrainType.FAIRWAY, 0, width, 5, length),
+        TerrainPatch(TerrainType.ROUGH, 0, 5, 5, length),
+        TerrainPatch(TerrainType.ROUGH, width - 5, width, 5, length),
+    ]
+    return Terrain(name="driving_range", elevation=elevation, patches=patches)
+
+
+def _build_bunker(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a bunker practice environment."""
+    elevation = ElevationMap.flat(width=width, length=length, resolution=0.5)
+    patches = [
+        TerrainPatch(TerrainType.GREEN, 0, width, length / 2, length),
+        TerrainPatch(TerrainType.FRINGE, 0, width, length / 2 - 2, length / 2),
+    ]
+    regions = [
+        TerrainRegion.circle(TerrainType.BUNKER, width / 2, length / 4, 6.0),
+    ]
+    return Terrain(
+        name="bunker",
+        elevation=elevation,
+        patches=patches,
+        regions=regions,
+        default_type=TerrainType.ROUGH,
+    )
+
+
+def _build_rough(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a rough practice environment."""
+    elevation = ElevationMap.sloped(
+        width=width,
+        length=length,
+        resolution=0.5,
+        slope_angle_deg=slope if slope != 0 else 2.0,
+        slope_direction_deg=direction,
+    )
+    patches = [
+        TerrainPatch(TerrainType.ROUGH, 0, width, 0, length * 0.7),
+        TerrainPatch(TerrainType.FAIRWAY, 5, width - 5, length * 0.7, length),
+    ]
+    return Terrain(
+        name="rough",
+        elevation=elevation,
+        patches=patches,
+        default_type=TerrainType.ROUGH,
+    )
+
+
+def _build_full_hole(
+    width: float, length: float, slope: float, direction: float
+) -> Terrain:
+    """Build a complete golf hole (par 4)."""
+    elevation = ElevationMap.sloped(
+        width=width,
+        length=length,
+        resolution=2.0,
+        slope_angle_deg=slope if slope != 0 else 0.3,
+        slope_direction_deg=direction,
+    )
+    patches = [
+        TerrainPatch(TerrainType.TEE, 20, 40, 0, 10),
+        TerrainPatch(TerrainType.FAIRWAY, 10, 50, 10, length - 20),
+        TerrainPatch(TerrainType.ROUGH, 0, 10, 10, length - 20),
+        TerrainPatch(TerrainType.ROUGH, 50, width, 10, length - 20),
+    ]
+    regions = [
+        TerrainRegion.circle(TerrainType.GREEN, width / 2, length - 12, 8.0),
+        TerrainRegion.circle(TerrainType.FRINGE, width / 2, length - 12, 10.0),
+        TerrainRegion.circle(TerrainType.BUNKER, width / 2 + 12, length - 15, 4.0),
+        TerrainRegion.circle(TerrainType.BUNKER, width / 2 - 8, length - 8, 3.0),
+    ]
+    return Terrain(
+        name="full_hole",
+        elevation=elevation,
+        patches=patches,
+        regions=regions,
+        default_type=TerrainType.ROUGH,
+    )
+
+
+_BUILDERS = {
+    "putting_green": _build_putting_green,
+    "fairway": _build_fairway,
+    "driving_range": _build_driving_range,
+    "bunker": _build_bunker,
+    "rough": _build_rough,
+    "full_hole": _build_full_hole,
+}
+
+
+# ──────────────────────────────────────────────────────────────
+#  Routes
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/presets", response_model=list[EnvironmentPreset])
+async def list_presets() -> list[EnvironmentPreset]:
+    """List available environment presets."""
+    return [
+        EnvironmentPreset(
+            name=name,
+            description=info["description"],
+            terrain_types=info["terrain_types"],
+            width_m=info["width"],
+            length_m=info["length"],
+        )
+        for name, info in ENVIRONMENT_PRESETS.items()
+    ]
+
+
+@router.post("/load", response_model=dict[str, Any])
+async def load_environment(request: CreateEnvironmentRequest) -> dict[str, Any]:
+    """Load an environment preset as the active terrain."""
+    global _active_terrain  # noqa: PLW0603
+
+    preset_name = request.preset.lower().strip()
+    if preset_name not in _BUILDERS:
+        return {
+            "success": False,
+            "error": f"Unknown preset '{request.preset}'. "
+            f"Available: {sorted(_BUILDERS.keys())}",
+        }
+
+    preset_info = ENVIRONMENT_PRESETS[preset_name]
+    width = request.width or preset_info["width"]
+    length = request.length or preset_info["length"]
+
+    builder = _BUILDERS[preset_name]
+    _active_terrain = builder(
+        width, length, request.slope_angle_deg, request.slope_direction_deg
+    )
+
+    logger.info("Loaded environment preset: %s (%gx%g m)", preset_name, width, length)
+
+    return {
+        "success": True,
+        "name": _active_terrain.name,
+        "width_m": width,
+        "length_m": length,
+        "terrain_types": preset_info["terrain_types"],
+    }
+
+
+@router.post("/query", response_model=TerrainQueryResponse)
+async def query_terrain(request: TerrainQueryRequest) -> TerrainQueryResponse:
+    """Query terrain properties at a specific point."""
+    terrain = _get_active_terrain()
+
+    try:
+        elevation = terrain.elevation.get_elevation(request.x, request.y)
+        slope_angle = terrain.elevation.get_slope_angle(request.x, request.y)
+        terrain_type = terrain.get_terrain_type(request.x, request.y)
+        material = terrain.get_material(request.x, request.y)
+    except ValueError as exc:
+        # Coordinates out of bounds — clamp to edge
+        logger.warning("Terrain query out of bounds: %s", exc)
+        elevation = 0.0
+        slope_angle = 0.0
+        terrain_type = terrain.default_type
+        material_name = TERRAIN_MATERIAL_MAP.get(terrain_type, "rough")
+        material = MATERIALS[material_name]
+
+    return TerrainQueryResponse(
+        x=request.x,
+        y=request.y,
+        elevation=elevation,
+        slope_angle_deg=slope_angle,
+        terrain_type=terrain_type.name.lower(),
+        friction=material.friction_coefficient,
+        restitution=material.restitution,
+        rolling_resistance=material.rolling_resistance,
+    )
+
+
+@router.get("/materials", response_model=list[SurfaceMaterialResponse])
+async def list_materials() -> list[SurfaceMaterialResponse]:
+    """List all available surface materials and their properties."""
+    return [
+        SurfaceMaterialResponse(
+            name=mat.name,
+            friction_coefficient=mat.friction_coefficient,
+            rolling_resistance=mat.rolling_resistance,
+            restitution=mat.restitution,
+            hardness=mat.hardness,
+            grass_height_m=mat.grass_height_m,
+            compressibility=mat.compressibility,
+        )
+        for mat in MATERIALS.values()
+    ]
+
+
+@router.get("/types", response_model=list[str])
+async def list_terrain_types() -> list[str]:
+    """List all available terrain types."""
+    return [t.name.lower() for t in TerrainType]
+
+
+@router.get("/active", response_model=dict[str, Any])
+async def get_active_terrain() -> dict[str, Any]:
+    """Get information about the currently active terrain."""
+    terrain = _get_active_terrain()
+    patch_count = len(terrain.patches)
+    region_count = len(terrain.regions)
+    return {
+        "name": terrain.name,
+        "width_m": terrain.elevation.width,
+        "length_m": terrain.elevation.length,
+        "resolution_m": terrain.elevation.resolution,
+        "default_type": terrain.default_type.name.lower(),
+        "patch_count": patch_count,
+        "region_count": region_count,
+    }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -44,6 +44,7 @@ from .routes import core as core_routes
 from .routes import engines as engine_routes
 from .routes import export as export_routes
 from .routes import simulation as simulation_routes
+from .routes import terrain as terrain_routes
 from .routes import video as video_routes
 from .services.analysis_service import AnalysisService
 from .services.simulation_service import SimulationService
@@ -276,6 +277,7 @@ app.include_router(simulation_routes.router)
 app.include_router(video_routes.router)
 app.include_router(analysis_routes.router)
 app.include_router(export_routes.router)
+app.include_router(terrain_routes.router)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_terrain_api.py
+++ b/tests/api/test_terrain_api.py
@@ -1,0 +1,244 @@
+"""Tests for terrain/environment API routes.
+
+Validates environment presets, terrain queries, material listing,
+and environment loading via the REST API.
+
+Fixes #1145 (engine-agnostic environment system)
+Fixes #1142 (expandable environment system beyond putting green)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.server import app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    """Create test client."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ──────────────────────────────────────────────────────────────
+#  Preset Listing
+# ──────────────────────────────────────────────────────────────
+class TestPresetListing:
+    """Verify environment preset discovery."""
+
+    def test_list_presets_returns_200(self, client: TestClient) -> None:
+        """GET /api/terrain/presets returns 200."""
+        resp = client.get("/api/terrain/presets")
+        assert resp.status_code == 200
+
+    def test_list_presets_returns_list(self, client: TestClient) -> None:
+        """Presets response is a list."""
+        data = client.get("/api/terrain/presets").json()
+        assert isinstance(data, list)
+        assert len(data) >= 6  # at least 6 presets
+
+    def test_preset_has_required_fields(self, client: TestClient) -> None:
+        """Each preset has name, description, terrain_types, width, length."""
+        data = client.get("/api/terrain/presets").json()
+        for preset in data:
+            assert "name" in preset
+            assert "description" in preset
+            assert "terrain_types" in preset
+            assert "width_m" in preset
+            assert "length_m" in preset
+
+    def test_putting_green_in_presets(self, client: TestClient) -> None:
+        """Putting green preset exists."""
+        data = client.get("/api/terrain/presets").json()
+        names = [p["name"] for p in data]
+        assert "putting_green" in names
+
+    def test_driving_range_in_presets(self, client: TestClient) -> None:
+        """Driving range preset exists."""
+        data = client.get("/api/terrain/presets").json()
+        names = [p["name"] for p in data]
+        assert "driving_range" in names
+
+    def test_full_hole_in_presets(self, client: TestClient) -> None:
+        """Full hole preset exists."""
+        data = client.get("/api/terrain/presets").json()
+        names = [p["name"] for p in data]
+        assert "full_hole" in names
+
+
+# ──────────────────────────────────────────────────────────────
+#  Environment Loading
+# ──────────────────────────────────────────────────────────────
+class TestEnvironmentLoading:
+    """Verify environment loading via API."""
+
+    VALID_PRESETS = [
+        "putting_green",
+        "fairway",
+        "driving_range",
+        "bunker",
+        "rough",
+        "full_hole",
+    ]
+
+    @pytest.mark.parametrize("preset", VALID_PRESETS)
+    def test_load_preset_succeeds(self, client: TestClient, preset: str) -> None:
+        """Each valid preset loads successfully."""
+        resp = client.post("/api/terrain/load", json={"preset": preset})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "name" in data
+
+    def test_load_invalid_preset_returns_error(self, client: TestClient) -> None:
+        """Invalid preset returns success=False."""
+        resp = client.post("/api/terrain/load", json={"preset": "moon_surface"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is False
+        assert "error" in data
+
+    def test_load_with_custom_dimensions(self, client: TestClient) -> None:
+        """Custom width/length override preset defaults."""
+        resp = client.post(
+            "/api/terrain/load",
+            json={"preset": "fairway", "width": 100.0, "length": 400.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["width_m"] == 100.0
+        assert data["length_m"] == 400.0
+
+    def test_load_with_slope(self, client: TestClient) -> None:
+        """Environment loads with slope parameters."""
+        resp = client.post(
+            "/api/terrain/load",
+            json={
+                "preset": "putting_green",
+                "slope_angle_deg": 3.0,
+                "slope_direction_deg": 45.0,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+
+# ──────────────────────────────────────────────────────────────
+#  Terrain Queries
+# ──────────────────────────────────────────────────────────────
+class TestTerrainQueries:
+    """Verify terrain property queries."""
+
+    def test_query_returns_200(self, client: TestClient) -> None:
+        """POST /api/terrain/query returns 200."""
+        # Load an environment first
+        client.post("/api/terrain/load", json={"preset": "fairway"})
+        resp = client.post("/api/terrain/query", json={"x": 25.0, "y": 100.0})
+        assert resp.status_code == 200
+
+    def test_query_response_fields(self, client: TestClient) -> None:
+        """Query response has all required fields."""
+        client.post("/api/terrain/load", json={"preset": "fairway"})
+        data = client.post(
+            "/api/terrain/query", json={"x": 25.0, "y": 100.0}
+        ).json()
+        assert "elevation" in data
+        assert "slope_angle_deg" in data
+        assert "terrain_type" in data
+        assert "friction" in data
+        assert "restitution" in data
+        assert "rolling_resistance" in data
+
+    def test_query_returns_numeric_values(self, client: TestClient) -> None:
+        """Query results are numeric."""
+        client.post("/api/terrain/load", json={"preset": "fairway"})
+        data = client.post(
+            "/api/terrain/query", json={"x": 25.0, "y": 100.0}
+        ).json()
+        assert isinstance(data["elevation"], (int, float))
+        assert isinstance(data["friction"], (int, float))
+        assert data["friction"] > 0
+
+    def test_query_different_terrain_types(self, client: TestClient) -> None:
+        """Querying different positions returns different terrain types."""
+        # Load full hole which has multiple terrain types
+        client.post("/api/terrain/load", json={"preset": "full_hole"})
+        # Center should be fairway
+        center = client.post(
+            "/api/terrain/query", json={"x": 30.0, "y": 100.0}
+        ).json()
+        assert center["terrain_type"] in [
+            "fairway",
+            "rough",
+            "tee",
+            "green",
+            "bunker",
+            "fringe",
+        ]
+
+    def test_query_out_of_bounds_handled(self, client: TestClient) -> None:
+        """Out-of-bounds query gracefully handled."""
+        client.post("/api/terrain/load", json={"preset": "putting_green"})
+        resp = client.post("/api/terrain/query", json={"x": 9999.0, "y": 9999.0})
+        assert resp.status_code == 200
+
+
+# ──────────────────────────────────────────────────────────────
+#  Material & Type Listing
+# ──────────────────────────────────────────────────────────────
+class TestMaterialListing:
+    """Verify material and terrain type listing."""
+
+    def test_list_materials_returns_200(self, client: TestClient) -> None:
+        """GET /api/terrain/materials returns 200."""
+        resp = client.get("/api/terrain/materials")
+        assert resp.status_code == 200
+
+    def test_materials_include_all_terrain_types(self, client: TestClient) -> None:
+        """Materials include fairway, rough, green, bunker."""
+        data = client.get("/api/terrain/materials").json()
+        names = [m["name"] for m in data]
+        for expected in ["fairway", "rough", "green", "bunker"]:
+            assert expected in names
+
+    def test_material_has_physics_properties(self, client: TestClient) -> None:
+        """Each material has friction, restitution, etc."""
+        data = client.get("/api/terrain/materials").json()
+        for mat in data:
+            assert "friction_coefficient" in mat
+            assert "restitution" in mat
+            assert "hardness" in mat
+            assert mat["friction_coefficient"] >= 0
+            assert 0 <= mat["restitution"] <= 1
+
+    def test_list_terrain_types_returns_all(self, client: TestClient) -> None:
+        """GET /api/terrain/types returns all terrain type names."""
+        data = client.get("/api/terrain/types").json()
+        assert isinstance(data, list)
+        for expected in ["fairway", "rough", "green", "bunker", "tee", "fringe"]:
+            assert expected in data
+
+
+# ──────────────────────────────────────────────────────────────
+#  Active Terrain
+# ──────────────────────────────────────────────────────────────
+class TestActiveTerrain:
+    """Verify active terrain info endpoint."""
+
+    def test_active_terrain_default(self, client: TestClient) -> None:
+        """Default active terrain exists."""
+        resp = client.get("/api/terrain/active")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "name" in data
+        assert "width_m" in data
+        assert "resolution_m" in data
+
+    def test_active_terrain_after_load(self, client: TestClient) -> None:
+        """Active terrain updates after loading a preset."""
+        client.post("/api/terrain/load", json={"preset": "driving_range"})
+        data = client.get("/api/terrain/active").json()
+        assert data["name"] == "driving_range"


### PR DESCRIPTION
Fixes #1145
Fixes #1142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new stateful API endpoints backed by a process-global in-memory `_active_terrain`, which could behave unexpectedly under concurrency or multi-worker deployments. Core auth/security paths aren’t modified, but new physics/terrain query logic could affect downstream simulation correctness.
> 
> **Overview**
> Adds a new `terrain` API surface (`/api/terrain`) that can load predefined golf environments (putting green, fairway, driving range, bunker, rough, full hole) into an in-memory active terrain and expose its metadata.
> 
> Introduces endpoints to query elevation/slope/terrain type and derived surface physics at a point, and to list available terrain `materials` and `types`; out-of-bounds queries are handled gracefully.
> 
> Wires the new router into `src/api/server.py` and adds comprehensive API tests covering preset discovery/loading, querying, materials/types listing, and active-terrain behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff3a5a5379fd36db0fbf10407e082bfc361c193f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->