### PR TITLE
feat: Tauri launcher parity — tile-grid dashboard (Phase 2)

### DIFF
--- a/tests/api/test_launcher_api.py
+++ b/tests/api/test_launcher_api.py
@@ -1,0 +1,182 @@
+"""TDD Tests for Launcher API Parity.
+
+Tests that the /api/launcher/* endpoints serve the manifest correctly,
+ensuring the Tauri/React frontend can consume the same tile definitions
+as the PyQt launcher.
+
+Tests:
+    1. GET /api/launcher/manifest returns full manifest
+    2. GET /api/launcher/tiles returns all tiles in order
+    3. GET /api/launcher/engines returns only physics_engine tiles
+    4. GET /api/launcher/tools returns only tool tiles
+    5. GET /api/launcher/tiles/{id} returns specific tile
+    6. GET /api/launcher/tiles/{id} returns 404 for unknown tile
+    7. Response format matches what React frontend expects
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.server import app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Create test client with proper application lifespan."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+class TestLauncherManifestEndpoints:
+    """Test /api/launcher/* endpoints for launcher parity."""
+
+    def test_get_manifest(self, client: TestClient) -> None:
+        """GET /api/launcher/manifest returns full manifest."""
+        response = client.get("/api/launcher/manifest")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "version" in data
+        assert "tiles" in data
+        assert isinstance(data["tiles"], list)
+        assert len(data["tiles"]) > 0
+
+    def test_manifest_tiles_have_required_fields(self, client: TestClient) -> None:
+        """All tiles in the manifest have required fields."""
+        response = client.get("/api/launcher/manifest")
+        data = response.json()
+
+        for tile in data["tiles"]:
+            assert "id" in tile, f"Tile missing id: {tile}"
+            assert "name" in tile, f"Tile missing name: {tile.get('id')}"
+            assert "description" in tile, f"Tile missing description: {tile.get('id')}"
+            assert "category" in tile, f"Tile missing category: {tile.get('id')}"
+            assert "type" in tile, f"Tile missing type: {tile.get('id')}"
+            assert "logo" in tile, f"Tile missing logo: {tile.get('id')}"
+            assert "status" in tile, f"Tile missing status: {tile.get('id')}"
+            assert "capabilities" in tile, (
+                f"Tile missing capabilities: {tile.get('id')}"
+            )
+            assert "order" in tile, f"Tile missing order: {tile.get('id')}"
+
+    def test_manifest_tiles_sorted_by_order(self, client: TestClient) -> None:
+        """Tiles are sorted by their order field."""
+        response = client.get("/api/launcher/manifest")
+        tiles = response.json()["tiles"]
+        orders = [t["order"] for t in tiles]
+        assert orders == sorted(orders)
+
+    def test_model_explorer_is_first(self, client: TestClient) -> None:
+        """Model Explorer must be the first tile."""
+        response = client.get("/api/launcher/manifest")
+        tiles = response.json()["tiles"]
+        assert tiles[0]["id"] == "model_explorer"
+
+    def test_get_tiles(self, client: TestClient) -> None:
+        """GET /api/launcher/tiles returns all tiles."""
+        response = client.get("/api/launcher/tiles")
+        assert response.status_code == 200
+
+        tiles = response.json()
+        assert isinstance(tiles, list)
+        assert len(tiles) > 0
+
+    def test_get_tile_by_id(self, client: TestClient) -> None:
+        """GET /api/launcher/tiles/{id} returns specific tile."""
+        response = client.get("/api/launcher/tiles/mujoco_unified")
+        assert response.status_code == 200
+
+        tile = response.json()
+        assert tile["id"] == "mujoco_unified"
+        assert tile["name"] == "MuJoCo"
+        assert tile["category"] == "physics_engine"
+
+    def test_get_tile_not_found(self, client: TestClient) -> None:
+        """GET /api/launcher/tiles/{id} returns 404 for unknown tile."""
+        response = client.get("/api/launcher/tiles/nonexistent")
+        assert response.status_code == 404
+
+    def test_get_engines(self, client: TestClient) -> None:
+        """GET /api/launcher/engines returns only physics engine tiles."""
+        response = client.get("/api/launcher/engines")
+        assert response.status_code == 200
+
+        engines = response.json()
+        assert isinstance(engines, list)
+        assert len(engines) > 0
+        for eng in engines:
+            assert eng["category"] == "physics_engine"
+            assert "engine_type" in eng
+
+    def test_get_tools(self, client: TestClient) -> None:
+        """GET /api/launcher/tools returns only tool tiles."""
+        response = client.get("/api/launcher/tools")
+        assert response.status_code == 200
+
+        tools = response.json()
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+        for tool in tools:
+            assert tool["category"] == "tool"
+
+
+class TestLauncherParityRequirements:
+    """Test that the API serves data matching PyQt launcher expectations.
+
+    These tests ensure the Tauri frontend can reproduce the PyQt launcher's
+    tile grid layout using only data from the API.
+    """
+
+    REQUIRED_TILE_IDS = {
+        "mujoco_unified",
+        "drake_golf",
+        "pinocchio_golf",
+        "opensim_golf",
+        "myosim_suite",
+        "putting_green",
+        "matlab_unified",
+        "motion_capture",
+        "model_explorer",
+    }
+
+    def test_all_required_tiles_present(self, client: TestClient) -> None:
+        """All tiles from the PyQt launcher must be available."""
+        response = client.get("/api/launcher/tiles")
+        tile_ids = {t["id"] for t in response.json()}
+        missing = self.REQUIRED_TILE_IDS - tile_ids
+        assert not missing, f"Missing required tiles: {missing}"
+
+    def test_status_chips_not_unknown(self, client: TestClient) -> None:
+        """No tile should have 'unknown' status (fixes #1168)."""
+        response = client.get("/api/launcher/tiles")
+        for tile in response.json():
+            assert tile["status"] != "unknown", (
+                f"Tile '{tile['id']}' has unknown status"
+            )
+
+    def test_putting_green_has_valid_status(self, client: TestClient) -> None:
+        """Putting Green tile has a valid (non-unknown) status chip."""
+        response = client.get("/api/launcher/tiles/putting_green")
+        assert response.status_code == 200
+        tile = response.json()
+        assert tile["status"] == "simulator"
+
+    def test_special_app_tiles_have_valid_status(self, client: TestClient) -> None:
+        """All special_app tiles have valid (non-unknown) status chips."""
+        response = client.get("/api/launcher/tiles")
+        special_apps = [t for t in response.json() if t["type"] == "special_app"]
+        for tile in special_apps:
+            assert tile["status"] in {"utility", "external"}, (
+                f"special_app tile '{tile['id']}' has status '{tile['status']}'"
+            )
+
+    def test_motion_capture_has_all_capabilities(self, client: TestClient) -> None:
+        """Motion Capture tile declares C3D, OpenPose, and MediaPipe capabilities."""
+        response = client.get("/api/launcher/tiles/motion_capture")
+        assert response.status_code == 200
+        caps = response.json()["capabilities"]
+        assert "c3d_viewer" in caps
+        assert "openpose" in caps
+        assert "mediapipe" in caps

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,11 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-// Mock the SimulationPage to isolate App component testing
+// Mock the pages to isolate App component testing
 vi.mock('@/pages/Simulation', () => ({
   SimulationPage: () => <div data-testid="simulation-page-mock">SimulationPage Mock</div>,
+}));
+
+vi.mock('@/pages/Dashboard', () => ({
+  DashboardPage: () => <div data-testid="dashboard-page-mock">DashboardPage Mock</div>,
 }));
 
 import App from './App';
@@ -27,16 +31,20 @@ describe('App', () => {
     vi.clearAllMocks();
   });
 
-  it('renders without crashing', () => {
-    render(<App />, { wrapper: createWrapper() });
-
-    expect(screen.getByTestId('simulation-page-mock')).toBeInTheDocument();
+  afterEach(() => {
+    // Reset the URL after each test
+    window.history.pushState({}, '', '/');
   });
 
-  it('renders SimulationPage component', () => {
+  it('renders without crashing', () => {
     render(<App />, { wrapper: createWrapper() });
+    // At "/" the Dashboard should render
+    expect(screen.getByTestId('dashboard-page-mock')).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('SimulationPage Mock')).toBeInTheDocument();
+  it('renders DashboardPage at root route', () => {
+    render(<App />, { wrapper: createWrapper() });
+    expect(screen.getByText('DashboardPage Mock')).toBeInTheDocument();
   });
 
   it('exports default App component', () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,13 +1,20 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { SimulationPage } from './pages/Simulation';
+import { DashboardPage } from './pages/Dashboard';
 import { ToastProvider } from './components/ui/Toast';
 import { DiagnosticsPanel } from './components/ui/DiagnosticsPanel';
 
 function App() {
   return (
-    <ToastProvider>
-      <SimulationPage />
-      <DiagnosticsPanel />
-    </ToastProvider>
+    <BrowserRouter>
+      <ToastProvider>
+        <Routes>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/simulation" element={<SimulationPage />} />
+        </Routes>
+        <DiagnosticsPanel />
+      </ToastProvider>
+    </BrowserRouter>
   );
 }
 

--- a/ui/src/api/useLauncherManifest.test.ts
+++ b/ui/src/api/useLauncherManifest.test.ts
@@ -1,0 +1,198 @@
+/**
+ * TDD Tests for useLauncherManifest hook.
+ *
+ * Tests the manifest fetching, parsing, and category filtering.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLauncherManifest } from './useLauncherManifest';
+import type { LauncherManifest } from './useLauncherManifest';
+
+const MOCK_MANIFEST: LauncherManifest = {
+    version: '1.0.0',
+    description: 'Test manifest',
+    tiles: [
+        {
+            id: 'model_explorer',
+            name: 'Model Explorer',
+            description: 'Browse models',
+            category: 'tool',
+            type: 'special_app',
+            path: 'src/tools/urdf_generator/launch_urdf_generator.py',
+            logo: 'urdf_icon.png',
+            status: 'utility',
+            capabilities: ['model_browsing'],
+            order: 1,
+        },
+        {
+            id: 'mujoco_unified',
+            name: 'MuJoCo',
+            description: 'MuJoCo simulation',
+            category: 'physics_engine',
+            type: 'custom_humanoid',
+            path: 'src/launchers/mujoco_unified_launcher.py',
+            logo: 'mujoco_humanoid.png',
+            status: 'gui_ready',
+            capabilities: ['rigid_body'],
+            order: 2,
+            engine_type: 'mujoco',
+        },
+        {
+            id: 'drake_golf',
+            name: 'Drake',
+            description: 'Drake dynamics',
+            category: 'physics_engine',
+            type: 'drake',
+            path: 'src/engines/drake.py',
+            logo: 'drake.png',
+            status: 'gui_ready',
+            capabilities: ['rigid_body'],
+            order: 3,
+            engine_type: 'drake',
+        },
+        {
+            id: 'matlab_unified',
+            name: 'Matlab Models',
+            description: 'Matlab stuff',
+            category: 'external',
+            type: 'special_app',
+            path: 'src/launchers/matlab.py',
+            logo: 'matlab_logo.png',
+            status: 'external',
+            capabilities: ['simscape'],
+            order: 8,
+        },
+    ],
+};
+
+// Save original fetch
+const originalFetch = global.fetch;
+
+describe('useLauncherManifest', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('starts in idle state and transitions to loaded', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(MOCK_MANIFEST),
+        });
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        // Initially loading
+        expect(result.current.loadState).toBe('loading');
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('loaded');
+        });
+
+        expect(result.current.manifest).not.toBeNull();
+        expect(result.current.tiles).toHaveLength(4);
+    });
+
+    it('returns tiles sorted by order', async () => {
+        // Shuffle tiles to test sorting
+        const shuffled = {
+            ...MOCK_MANIFEST,
+            tiles: [...MOCK_MANIFEST.tiles].reverse(),
+        };
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(shuffled),
+        });
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('loaded');
+        });
+
+        expect(result.current.tiles[0].id).toBe('model_explorer');
+        expect(result.current.tiles[0].order).toBe(1);
+    });
+
+    it('correctly filters engines', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(MOCK_MANIFEST),
+        });
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('loaded');
+        });
+
+        expect(result.current.engines).toHaveLength(2);
+        expect(result.current.engines.every((e) => e.category === 'physics_engine')).toBe(true);
+    });
+
+    it('correctly filters tools and external tiles', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(MOCK_MANIFEST),
+        });
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('loaded');
+        });
+
+        expect(result.current.tools).toHaveLength(2);
+        expect(result.current.tools.some((t) => t.id === 'model_explorer')).toBe(true);
+        expect(result.current.tools.some((t) => t.id === 'matlab_unified')).toBe(true);
+    });
+
+    it('transitions to error state on fetch failure', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+        });
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('error');
+        });
+
+        expect(result.current.error).toContain('500');
+        expect(result.current.tiles).toHaveLength(0);
+    });
+
+    it('transitions to error state on network failure', async () => {
+        global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('error');
+        });
+
+        expect(result.current.error).toContain('Network error');
+    });
+
+    it('fetches from /api/launcher/manifest', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(MOCK_MANIFEST),
+        });
+        global.fetch = mockFetch;
+
+        const { result } = renderHook(() => useLauncherManifest());
+
+        await waitFor(() => {
+            expect(result.current.loadState).toBe('loaded');
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/launcher/manifest');
+    });
+});

--- a/ui/src/api/useLauncherManifest.ts
+++ b/ui/src/api/useLauncherManifest.ts
@@ -1,0 +1,92 @@
+/**
+ * Launcher Manifest Hook — Fetches tile definitions from the shared manifest API.
+ *
+ * This hook reads from `/api/launcher/manifest` which is served by the Python
+ * backend and derived from `launcher_manifest.json` — the single source of truth
+ * for both PyQt and Tauri launchers.
+ *
+ * Design by Contract:
+ *   Postcondition: returned tiles are always sorted by `order` field
+ *   Invariant: tile IDs are unique
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+export interface LauncherTile {
+    id: string;
+    name: string;
+    description: string;
+    category: 'physics_engine' | 'tool' | 'external';
+    type: string;
+    path: string;
+    logo: string;
+    status: string;
+    capabilities: string[];
+    order: number;
+    engine_type?: string;
+}
+
+export interface LauncherManifest {
+    version: string;
+    description: string;
+    tiles: LauncherTile[];
+}
+
+export type ManifestLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+interface UseLauncherManifestResult {
+    manifest: LauncherManifest | null;
+    tiles: LauncherTile[];
+    engines: LauncherTile[];
+    tools: LauncherTile[];
+    loadState: ManifestLoadState;
+    error: string | null;
+    refetch: () => Promise<void>;
+}
+
+export function useLauncherManifest(): UseLauncherManifestResult {
+    const [manifest, setManifest] = useState<LauncherManifest | null>(null);
+    const [loadState, setLoadState] = useState<ManifestLoadState>('idle');
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchManifest = useCallback(async () => {
+        setLoadState('loading');
+        setError(null);
+
+        try {
+            const response = await fetch('/api/launcher/manifest');
+            if (!response.ok) {
+                throw new Error(`Failed to fetch manifest: ${response.status}`);
+            }
+            const data: LauncherManifest = await response.json();
+
+            // DBC Postcondition: sort tiles by order
+            data.tiles.sort((a, b) => a.order - b.order);
+
+            setManifest(data);
+            setLoadState('loaded');
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to load launcher manifest';
+            setError(message);
+            setLoadState('error');
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchManifest();
+    }, [fetchManifest]);
+
+    const tiles = manifest?.tiles ?? [];
+    const engines = tiles.filter((t) => t.category === 'physics_engine');
+    const tools = tiles.filter((t) => t.category === 'tool' || t.category === 'external');
+
+    return {
+        manifest,
+        tiles,
+        engines,
+        tools,
+        loadState,
+        error,
+        refetch: fetchManifest,
+    };
+}

--- a/ui/src/components/simulation/LauncherDashboard.test.tsx
+++ b/ui/src/components/simulation/LauncherDashboard.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * TDD Tests for LauncherDashboard component.
+ *
+ * Tests:
+ *   - Tile grid rendering (all tiles appear)
+ *   - Category sections (engines vs tools)
+ *   - Status chips for all tile types (#1168)
+ *   - Model Explorer is first tile
+ *   - Launch button always visible (#1165)
+ *   - Help button prominently displayed (#1170)
+ *   - Tile selection and launch
+ *   - Loading and error states
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { screen, fireEvent, within } from '@testing-library/dom';
+import { LauncherDashboard } from './LauncherDashboard';
+import type { LauncherTile } from '@/api/useLauncherManifest';
+
+const MOCK_TILES: LauncherTile[] = [
+    {
+        id: 'model_explorer',
+        name: 'Model Explorer',
+        description: 'Browse models',
+        category: 'tool',
+        type: 'special_app',
+        path: 'src/tools/urdf_generator/launch_urdf_generator.py',
+        logo: 'urdf_icon.png',
+        status: 'utility',
+        capabilities: ['model_browsing', 'urdf_generation'],
+        order: 1,
+    },
+    {
+        id: 'mujoco_unified',
+        name: 'MuJoCo',
+        description: 'MuJoCo simulation',
+        category: 'physics_engine',
+        type: 'custom_humanoid',
+        path: 'src/launchers/mujoco.py',
+        logo: 'mujoco_humanoid.png',
+        status: 'gui_ready',
+        capabilities: ['rigid_body', 'contact'],
+        order: 2,
+        engine_type: 'mujoco',
+    },
+    {
+        id: 'drake_golf',
+        name: 'Drake',
+        description: 'Drake dynamics',
+        category: 'physics_engine',
+        type: 'drake',
+        path: 'src/engines/drake.py',
+        logo: 'drake.png',
+        status: 'gui_ready',
+        capabilities: ['rigid_body', 'optimization'],
+        order: 3,
+        engine_type: 'drake',
+    },
+    {
+        id: 'putting_green',
+        name: 'Putting Green',
+        description: 'putting simulation',
+        category: 'physics_engine',
+        type: 'putting_green',
+        path: 'src/putting_green.py',
+        logo: 'putting_green.png',
+        status: 'simulator',
+        capabilities: ['ball_physics'],
+        order: 7,
+        engine_type: 'putting_green',
+    },
+    {
+        id: 'motion_capture',
+        name: 'Motion Capture',
+        description: 'C3D Viewer, OpenPose, MediaPipe',
+        category: 'tool',
+        type: 'special_app',
+        path: 'src/launchers/motion_capture.py',
+        logo: 'c3d_icon.png',
+        status: 'utility',
+        capabilities: ['c3d_viewer', 'openpose', 'mediapipe'],
+        order: 9,
+    },
+    {
+        id: 'matlab_unified',
+        name: 'Matlab Models',
+        description: 'Simscape models',
+        category: 'external',
+        type: 'special_app',
+        path: 'src/launchers/matlab.py',
+        logo: 'matlab_logo.png',
+        status: 'external',
+        capabilities: ['simscape_2d', 'simscape_3d'],
+        order: 8,
+    },
+];
+
+describe('LauncherDashboard', () => {
+    const defaultProps = {
+        tiles: MOCK_TILES,
+        loadState: 'loaded' as const,
+        error: null,
+        selectedTileId: null,
+        onSelectTile: vi.fn(),
+        onLaunchTile: vi.fn(),
+        onShowHelp: vi.fn(),
+        onRefetch: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Tile Grid Rendering (#1171)
+    // ────────────────────────────────────────────────────────────
+    describe('tile grid rendering (#1171)', () => {
+        it('renders all tiles from the manifest', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+
+            expect(screen.getByText('MuJoCo')).toBeInTheDocument();
+            expect(screen.getByText('Drake')).toBeInTheDocument();
+            expect(screen.getByText('Putting Green')).toBeInTheDocument();
+            expect(screen.getByText('Model Explorer')).toBeInTheDocument();
+            expect(screen.getByText('Motion Capture')).toBeInTheDocument();
+            expect(screen.getByText('Matlab Models')).toBeInTheDocument();
+        });
+
+        it('renders category sections', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+
+            expect(screen.getByRole('region', { name: /physics engines/i })).toBeInTheDocument();
+            expect(screen.getByRole('region', { name: /tools and utilities/i })).toBeInTheDocument();
+        });
+
+        it('groups engines separately from tools', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+
+            const engineGrid = screen.getByRole('group', { name: /physics engine tiles/i });
+            const toolGrid = screen.getByRole('group', { name: /tool tiles/i });
+
+            // MuJoCo should be in engine grid
+            expect(within(engineGrid).getByText('MuJoCo')).toBeInTheDocument();
+            // Model Explorer should be in tool grid
+            expect(within(toolGrid).getByText('Model Explorer')).toBeInTheDocument();
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Status Chips (#1168)
+    // ────────────────────────────────────────────────────────────
+    describe('status chips (#1168)', () => {
+        it('shows GUI Ready for gui_ready engines', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getAllByText('GUI Ready').length).toBeGreaterThan(0);
+        });
+
+        it('shows Utility for special_app tools', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getAllByText('Utility').length).toBeGreaterThan(0);
+        });
+
+        it('shows Simulator for putting_green', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Simulator')).toBeInTheDocument();
+        });
+
+        it('shows External for matlab', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('External')).toBeInTheDocument();
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Launch Button Accessibility (#1165)
+    // ────────────────────────────────────────────────────────────
+    describe('launch button always visible (#1165)', () => {
+        it('renders the launch button', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByRole('button', { name: /launch simulation/i })).toBeInTheDocument();
+        });
+
+        it('launch button is in a sticky footer', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            const footer = document.getElementById('launch-footer');
+            expect(footer).not.toBeNull();
+            expect(footer?.classList.contains('flex-shrink-0')).toBe(true);
+        });
+
+        it('launch button is disabled when no tile selected', () => {
+            render(<LauncherDashboard {...defaultProps} selectedTileId={null} />);
+            expect(screen.getByRole('button', { name: /launch simulation/i })).toBeDisabled();
+        });
+
+        it('launch button is enabled when tile selected', () => {
+            render(<LauncherDashboard {...defaultProps} selectedTileId="mujoco_unified" />);
+            expect(screen.getByRole('button', { name: /launch mujoco/i })).not.toBeDisabled();
+        });
+
+        it('clicking launch button calls onLaunchTile', () => {
+            const onLaunchTile = vi.fn();
+            render(
+                <LauncherDashboard
+                    {...defaultProps}
+                    selectedTileId="mujoco_unified"
+                    onLaunchTile={onLaunchTile}
+                />
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: /launch mujoco/i }));
+            expect(onLaunchTile).toHaveBeenCalledWith('mujoco_unified');
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Help Button (#1170)
+    // ────────────────────────────────────────────────────────────
+    describe('help button (#1170)', () => {
+        it('renders a prominent help button', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument();
+        });
+
+        it('help button has visible text (not icon-only)', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            const helpBtn = screen.getByRole('button', { name: /help/i });
+            expect(helpBtn.textContent).toContain('Help');
+        });
+
+        it('clicking help button calls onShowHelp', () => {
+            const onShowHelp = vi.fn();
+            render(<LauncherDashboard {...defaultProps} onShowHelp={onShowHelp} />);
+
+            fireEvent.click(screen.getByRole('button', { name: /help/i }));
+            expect(onShowHelp).toHaveBeenCalled();
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Tile Selection
+    // ────────────────────────────────────────────────────────────
+    describe('tile selection', () => {
+        it('clicking a tile calls onSelectTile', () => {
+            const onSelectTile = vi.fn();
+            render(<LauncherDashboard {...defaultProps} onSelectTile={onSelectTile} />);
+
+            const tile = document.getElementById('tile-mujoco_unified')!;
+            fireEvent.click(tile);
+            expect(onSelectTile).toHaveBeenCalledWith('mujoco_unified');
+        });
+
+        it('selected tile has aria-pressed=true', () => {
+            render(<LauncherDashboard {...defaultProps} selectedTileId="drake_golf" />);
+            const tile = document.getElementById('tile-drake_golf')!;
+            expect(tile).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        it('double-clicking a tile calls onLaunchTile', () => {
+            const onLaunchTile = vi.fn();
+            render(<LauncherDashboard {...defaultProps} onLaunchTile={onLaunchTile} />);
+
+            const tile = document.getElementById('tile-mujoco_unified')!;
+            fireEvent.doubleClick(tile);
+            expect(onLaunchTile).toHaveBeenCalledWith('mujoco_unified');
+        });
+
+        it('shows selected tile name in footer', () => {
+            render(<LauncherDashboard {...defaultProps} selectedTileId="mujoco_unified" />);
+            const footer = document.getElementById('launch-footer');
+            expect(footer?.textContent).toContain('MuJoCo');
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Loading & Error States
+    // ────────────────────────────────────────────────────────────
+    describe('loading and error states', () => {
+        it('shows loading spinner', () => {
+            render(<LauncherDashboard {...defaultProps} loadState="loading" tiles={[]} />);
+            expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+        });
+
+        it('shows error with retry button', () => {
+            render(
+                <LauncherDashboard
+                    {...defaultProps}
+                    loadState="error"
+                    error="Connection refused"
+                    tiles={[]}
+                />
+            );
+            expect(screen.getByRole('alert')).toBeInTheDocument();
+            expect(screen.getByText('Connection refused')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+        });
+
+        it('clicking Retry calls onRefetch', () => {
+            const onRefetch = vi.fn();
+            render(
+                <LauncherDashboard
+                    {...defaultProps}
+                    loadState="error"
+                    error="fail"
+                    tiles={[]}
+                    onRefetch={onRefetch}
+                />
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+            expect(onRefetch).toHaveBeenCalled();
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Missing Tiles Parity (#1162)
+    // ────────────────────────────────────────────────────────────
+    describe('all required tiles present (#1162)', () => {
+        it('renders Motion Capture tile', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Motion Capture')).toBeInTheDocument();
+        });
+
+        it('renders Matlab Models tile', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Matlab Models')).toBeInTheDocument();
+        });
+
+        it('renders Model Explorer tile', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Model Explorer')).toBeInTheDocument();
+        });
+
+        it('renders Putting Green tile', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Putting Green')).toBeInTheDocument();
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────
+    // Header
+    // ────────────────────────────────────────────────────────────
+    describe('header', () => {
+        it('shows application title', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText('Golf Modeling Suite')).toBeInTheDocument();
+        });
+
+        it('shows tile counts', () => {
+            render(<LauncherDashboard {...defaultProps} />);
+            expect(screen.getByText(/6 tiles/)).toBeInTheDocument();
+            expect(screen.getByText(/3 engines/)).toBeInTheDocument();
+        });
+    });
+});

--- a/ui/src/components/simulation/LauncherDashboard.tsx
+++ b/ui/src/components/simulation/LauncherDashboard.tsx
@@ -1,0 +1,306 @@
+/**
+ * LauncherDashboard — Tile-based grid dashboard for the Tauri launcher.
+ *
+ * This is the primary entry point for the application, displaying all
+ * available tiles in a responsive grid layout matching the PyQt launcher.
+ *
+ * Features:
+ *   - Tiles loaded from shared manifest API (DRY — single source of truth)
+ *   - Model Explorer is first tile (simulation setup entry point)
+ *   - Category sections: Physics Engines, Tools & Utilities
+ *   - Status chips showing tile readiness
+ *   - Logo/icon display for each tile
+ *   - Help button prominently displayed
+ *   - "Launch Simulation" button always visible (sticky bottom)
+ */
+
+import { HelpCircle, Loader2, AlertTriangle, Zap, Wrench, ExternalLink, RefreshCw } from 'lucide-react';
+import type { LauncherTile } from '@/api/useLauncherManifest';
+import type { ManifestLoadState } from '@/api/useLauncherManifest';
+
+interface Props {
+    tiles: LauncherTile[];
+    loadState: ManifestLoadState;
+    error: string | null;
+    selectedTileId: string | null;
+    onSelectTile: (tileId: string) => void;
+    onLaunchTile: (tileId: string) => void;
+    onShowHelp: () => void;
+    onRefetch: () => void;
+}
+
+/** Map status values to display colors and labels */
+function getStatusChip(status: string): { label: string; color: string } {
+    switch (status) {
+        case 'gui_ready':
+            return { label: 'GUI Ready', color: 'bg-emerald-500/20 text-emerald-300 border-emerald-600/50' };
+        case 'engine_ready':
+            return { label: 'Ready', color: 'bg-blue-500/20 text-blue-300 border-blue-600/50' };
+        case 'utility':
+            return { label: 'Utility', color: 'bg-purple-500/20 text-purple-300 border-purple-600/50' };
+        case 'external':
+            return { label: 'External', color: 'bg-amber-500/20 text-amber-300 border-amber-600/50' };
+        case 'simulator':
+            return { label: 'Simulator', color: 'bg-cyan-500/20 text-cyan-300 border-cyan-600/50' };
+        default:
+            return { label: status || 'Unknown', color: 'bg-gray-500/20 text-gray-300 border-gray-600/50' };
+    }
+}
+
+/** Map category to an icon */
+function CategoryIcon({ category }: { category: string }) {
+    switch (category) {
+        case 'physics_engine':
+            return <Zap className="w-3.5 h-3.5" aria-hidden="true" />;
+        case 'tool':
+            return <Wrench className="w-3.5 h-3.5" aria-hidden="true" />;
+        case 'external':
+            return <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />;
+        default:
+            return null;
+    }
+}
+
+function TileCard({
+    tile,
+    isSelected,
+    onSelect,
+    onLaunch,
+}: {
+    tile: LauncherTile;
+    isSelected: boolean;
+    onSelect: () => void;
+    onLaunch: () => void;
+}) {
+    const status = getStatusChip(tile.status);
+
+    return (
+        <button
+            id={`tile-${tile.id}`}
+            onClick={onSelect}
+            onDoubleClick={onLaunch}
+            aria-label={`${tile.name} — ${tile.description}`}
+            aria-pressed={isSelected}
+            className={`
+        group relative flex flex-col items-center p-4 rounded-xl border-2 transition-all duration-200
+        hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5
+        focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900
+        ${isSelected
+                    ? 'border-blue-500 bg-blue-500/15 ring-1 ring-blue-500/40 shadow-md shadow-blue-500/20'
+                    : 'border-gray-700 bg-gray-800/80 hover:border-gray-500'
+                }
+      `}
+        >
+            {/* Logo area */}
+            <div className="w-16 h-16 rounded-lg bg-gray-700/50 flex items-center justify-center mb-3 group-hover:bg-gray-600/50 transition-colors">
+                <img
+                    src={`/api/launcher/logos/${tile.logo}`}
+                    alt={`${tile.name} logo`}
+                    className="w-12 h-12 object-contain"
+                    onError={(e) => {
+                        // Fallback to category icon if logo not found
+                        (e.target as HTMLImageElement).style.display = 'none';
+                        const parent = (e.target as HTMLImageElement).parentElement;
+                        if (parent) {
+                            parent.classList.add('text-gray-400');
+                        }
+                    }}
+                />
+                {/* Fallback icon rendered behind the img; visible if img fails */}
+                <span className="absolute text-gray-400 opacity-0 group-[img-error]:opacity-100" aria-hidden="true">
+                    <CategoryIcon category={tile.category} />
+                </span>
+            </div>
+
+            {/* Name */}
+            <h3 className="text-sm font-semibold text-white text-center mb-1 leading-tight">
+                {tile.name}
+            </h3>
+
+            {/* Description */}
+            <p className="text-xs text-gray-400 text-center mb-2 leading-relaxed line-clamp-2">
+                {tile.description}
+            </p>
+
+            {/* Status chip */}
+            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border ${status.color}`}>
+                <CategoryIcon category={tile.category} />
+                {status.label}
+            </span>
+
+            {/* Capabilities badges — show on hover */}
+            <div className="mt-2 flex flex-wrap gap-1 justify-center opacity-0 group-hover:opacity-100 transition-opacity max-h-0 group-hover:max-h-20 overflow-hidden">
+                {tile.capabilities.slice(0, 3).map((cap) => (
+                    <span
+                        key={cap}
+                        className="px-1.5 py-0.5 bg-gray-700/80 text-gray-400 text-[9px] rounded"
+                    >
+                        {cap.replace(/_/g, ' ')}
+                    </span>
+                ))}
+                {tile.capabilities.length > 3 && (
+                    <span className="px-1.5 py-0.5 text-gray-500 text-[9px]">
+                        +{tile.capabilities.length - 3}
+                    </span>
+                )}
+            </div>
+        </button>
+    );
+}
+
+export function LauncherDashboard({
+    tiles,
+    loadState,
+    error,
+    selectedTileId,
+    onSelectTile,
+    onLaunchTile,
+    onShowHelp,
+    onRefetch,
+}: Props) {
+    const engines = tiles.filter((t) => t.category === 'physics_engine');
+    const toolsAndExternal = tiles.filter((t) => t.category === 'tool' || t.category === 'external');
+    const selectedTile = tiles.find((t) => t.id === selectedTileId);
+
+    if (loadState === 'loading') {
+        return (
+            <div className="flex items-center justify-center h-screen bg-gray-900" role="status" aria-label="Loading launcher">
+                <div className="text-center">
+                    <Loader2 className="w-10 h-10 animate-spin text-blue-400 mx-auto mb-4" aria-hidden="true" />
+                    <p className="text-gray-400 text-sm">Loading launcher tiles...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (loadState === 'error') {
+        return (
+            <div className="flex items-center justify-center h-screen bg-gray-900" role="alert">
+                <div className="text-center max-w-md">
+                    <AlertTriangle className="w-10 h-10 text-red-400 mx-auto mb-4" aria-hidden="true" />
+                    <h2 className="text-lg font-semibold text-white mb-2">Failed to Load</h2>
+                    <p className="text-sm text-gray-400 mb-4">{error || 'Could not connect to the launcher API.'}</p>
+                    <button
+                        onClick={onRefetch}
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                        <RefreshCw className="w-4 h-4" aria-hidden="true" />
+                        Retry
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-screen bg-gray-900">
+            {/* Header */}
+            <header className="flex items-center justify-between px-6 py-4 bg-gray-800/80 border-b border-gray-700 flex-shrink-0">
+                <div>
+                    <h1 className="text-xl font-bold text-white">Golf Modeling Suite</h1>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                        {tiles.length} tiles · {engines.length} engines · {toolsAndExternal.length} tools
+                    </p>
+                </div>
+                <button
+                    id="help-button"
+                    onClick={onShowHelp}
+                    aria-label="Help"
+                    className="flex items-center gap-2 px-3 py-2 bg-blue-600/20 hover:bg-blue-600/30 text-blue-300 rounded-lg border border-blue-600/40 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                    <HelpCircle className="w-5 h-5" aria-hidden="true" />
+                    <span className="text-sm font-medium">Help</span>
+                </button>
+            </header>
+
+            {/* Scrollable tile grid */}
+            <main className="flex-1 overflow-y-auto px-6 py-6" id="tile-grid-container">
+                {/* Physics Engines */}
+                {engines.length > 0 && (
+                    <section aria-label="Physics Engines" className="mb-8">
+                        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4 flex items-center gap-2">
+                            <Zap className="w-4 h-4" aria-hidden="true" />
+                            Physics Engines
+                        </h2>
+                        <div
+                            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"
+                            role="group"
+                            aria-label="Physics engine tiles"
+                            id="engine-tiles-grid"
+                        >
+                            {engines.map((tile) => (
+                                <TileCard
+                                    key={tile.id}
+                                    tile={tile}
+                                    isSelected={selectedTileId === tile.id}
+                                    onSelect={() => onSelectTile(tile.id)}
+                                    onLaunch={() => onLaunchTile(tile.id)}
+                                />
+                            ))}
+                        </div>
+                    </section>
+                )}
+
+                {/* Tools & Utilities */}
+                {toolsAndExternal.length > 0 && (
+                    <section aria-label="Tools and Utilities" className="mb-8">
+                        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4 flex items-center gap-2">
+                            <Wrench className="w-4 h-4" aria-hidden="true" />
+                            Tools & Utilities
+                        </h2>
+                        <div
+                            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"
+                            role="group"
+                            aria-label="Tool tiles"
+                            id="tool-tiles-grid"
+                        >
+                            {toolsAndExternal.map((tile) => (
+                                <TileCard
+                                    key={tile.id}
+                                    tile={tile}
+                                    isSelected={selectedTileId === tile.id}
+                                    onSelect={() => onSelectTile(tile.id)}
+                                    onLaunch={() => onLaunchTile(tile.id)}
+                                />
+                            ))}
+                        </div>
+                    </section>
+                )}
+            </main>
+
+            {/* Sticky bottom bar — Launch button always visible (fixes #1165) */}
+            <footer
+                className="flex items-center justify-between px-6 py-3 bg-gray-800/95 border-t border-gray-700 flex-shrink-0 backdrop-blur-sm"
+                id="launch-footer"
+            >
+                <div className="text-sm text-gray-400">
+                    {selectedTile ? (
+                        <span>
+                            Selected: <strong className="text-white">{selectedTile.name}</strong>
+                            <span className="ml-2 text-xs text-gray-500">{selectedTile.description}</span>
+                        </span>
+                    ) : (
+                        <span className="text-gray-500">Select a tile to launch</span>
+                    )}
+                </div>
+                <button
+                    id="launch-simulation-button"
+                    onClick={() => selectedTile && onLaunchTile(selectedTile.id)}
+                    disabled={!selectedTile}
+                    aria-label={selectedTile ? `Launch ${selectedTile.name}` : 'Launch Simulation'}
+                    className={`
+            inline-flex items-center gap-2 px-6 py-2.5 rounded-lg font-semibold text-sm transition-all
+            focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900
+            ${selectedTile
+                            ? 'bg-green-600 hover:bg-green-500 text-white shadow-lg shadow-green-600/30 hover:shadow-green-500/40'
+                            : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                        }
+          `}
+                >
+                    <Zap className="w-4 h-4" aria-hidden="true" />
+                    Launch Simulation
+                </button>
+            </footer>
+        </div>
+    );
+}

--- a/ui/src/pages/Dashboard.test.tsx
+++ b/ui/src/pages/Dashboard.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * TDD Tests for Dashboard page.
+ *
+ * Tests:
+ *   - Page renders the LauncherDashboard
+ *   - Navigation to simulation page works
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '@/components/ui/Toast';
+
+// Mock the manifest hook
+const mockManifest = {
+    tiles: [
+        {
+            id: 'mujoco_unified',
+            name: 'MuJoCo',
+            description: 'MuJoCo simulation',
+            category: 'physics_engine' as const,
+            type: 'custom_humanoid',
+            path: 'src/mujoco.py',
+            logo: 'mujoco.png',
+            status: 'gui_ready',
+            capabilities: ['rigid_body'],
+            order: 2,
+            engine_type: 'mujoco',
+        },
+        {
+            id: 'model_explorer',
+            name: 'Model Explorer',
+            description: 'Browse models',
+            category: 'tool' as const,
+            type: 'special_app',
+            path: 'src/tools/urdf.py',
+            logo: 'urdf_icon.png',
+            status: 'utility',
+            capabilities: ['model_browsing'],
+            order: 1,
+        },
+    ],
+    engines: [],
+    tools: [],
+    loadState: 'loaded' as const,
+    error: null,
+    manifest: null,
+    refetch: vi.fn(),
+};
+
+vi.mock('@/api/useLauncherManifest', () => ({
+    useLauncherManifest: vi.fn(() => mockManifest),
+}));
+
+// Now import after mocking
+import { DashboardPage } from './Dashboard';
+
+const renderWithRouter = (ui: React.ReactElement) =>
+    render(
+        <MemoryRouter>
+            <ToastProvider>{ui}</ToastProvider>
+        </MemoryRouter>
+    );
+
+describe('DashboardPage', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('renders the dashboard with tiles', () => {
+        renderWithRouter(<DashboardPage />);
+
+        expect(screen.getByText('Golf Modeling Suite')).toBeInTheDocument();
+        expect(screen.getByText('MuJoCo')).toBeInTheDocument();
+        expect(screen.getByText('Model Explorer')).toBeInTheDocument();
+    });
+
+    it('renders help button', () => {
+        renderWithRouter(<DashboardPage />);
+        expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument();
+    });
+
+    it('renders launch button', () => {
+        renderWithRouter(<DashboardPage />);
+        expect(screen.getByRole('button', { name: /launch simulation/i })).toBeInTheDocument();
+    });
+});

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,0 +1,61 @@
+/**
+ * Dashboard Page — Main entry point for the Tauri launcher.
+ *
+ * Wraps the LauncherDashboard component with the manifest hook
+ * and navigation logic.
+ */
+
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLauncherManifest } from '@/api/useLauncherManifest';
+import { LauncherDashboard } from '@/components/simulation/LauncherDashboard';
+import { useToast } from '@/components/ui/Toast';
+
+export function DashboardPage() {
+    const navigate = useNavigate();
+    const { tiles, loadState, error, refetch } = useLauncherManifest();
+    const [selectedTileId, setSelectedTileId] = useState<string | null>(null);
+    const { showInfo, showError } = useToast();
+
+    const handleLaunchTile = useCallback(
+        (tileId: string) => {
+            const tile = tiles.find((t) => t.id === tileId);
+            if (!tile) {
+                showError('Tile not found');
+                return;
+            }
+
+            // Physics engines navigate to the simulation page with the engine preselected
+            if (tile.category === 'physics_engine' && tile.engine_type) {
+                showInfo(`Opening ${tile.name} simulation...`);
+                navigate(`/simulation?engine=${tile.engine_type}`);
+                return;
+            }
+
+            // Tools and external apps are launched via the backend API
+            showInfo(`Launching ${tile.name}...`);
+            fetch(`/api/launcher/launch/${tile.id}`, { method: 'POST' }).catch(() => {
+                showError(`Failed to launch ${tile.name}`);
+            });
+        },
+        [tiles, navigate, showInfo, showError]
+    );
+
+    const handleShowHelp = useCallback(() => {
+        showInfo('Help system opening...');
+        // Future: open HelpDialog component
+    }, [showInfo]);
+
+    return (
+        <LauncherDashboard
+            tiles={tiles}
+            loadState={loadState}
+            error={error}
+            selectedTileId={selectedTileId}
+            onSelectTile={setSelectedTileId}
+            onLaunchTile={handleLaunchTile}
+            onShowHelp={handleShowHelp}
+            onRefetch={refetch}
+        />
+    );
+}


### PR DESCRIPTION
Phase 2: tile-grid dashboard, manifest hook, status chips, sticky launch button, 52 new TDD tests. Fixes #1162, #1165, #1168, #1169, #1170, #1171

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new navigation and launch behavior (including backend POST launch calls) plus a large new UI surface area; while mostly additive, routing changes can impact app entrypoint behavior.
> 
> **Overview**
> Adds a new Tauri-first launcher UI flow: `App` is now router-based, with a new `DashboardPage` at `/` and the existing simulation view moved to `/simulation`.
> 
> Introduces a manifest-driven launcher dashboard: `useLauncherManifest` fetches `/api/launcher/manifest`, sorts tiles by `order`, and exposes engine/tool filtering; `LauncherDashboard` renders a tile grid grouped by category with status chips, selection + double-click launch, a prominent Help button, loading/error+retry states, and a sticky “Launch Simulation” footer. `DashboardPage` wires selection/launch behavior, navigating engines to `/simulation?engine=...` and POSTing tool launches to `/api/launcher/launch/{id}`.
> 
> Adds extensive TDD coverage: new FastAPI API parity tests for `/api/launcher/*` responses/ordering/status requirements, plus new unit tests for the manifest hook, dashboard component, and updated `App` routing expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94c775e7a7af4ecef3e800fcbc300e6d4c60d5c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->