### PR TITLE
feat: Logo audit — 10 SVG logos + serving API (Phase 3, closes #1164)

### DIFF
--- a/assets/logos/c3d_icon.svg
+++ b/assets/logos/c3d_icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <circle cx="24" cy="24" r="4" stroke="#26c6da" stroke-width="2" fill="none"/>
+  <circle cx="40" cy="24" r="4" stroke="#26c6da" stroke-width="2" fill="none"/>
+  <circle cx="32" cy="40" r="4" stroke="#26c6da" stroke-width="2" fill="none"/>
+  <line x1="27" y1="26" x2="30" y2="37" stroke="#26c6da" stroke-width="1.5"/>
+  <line x1="37" y1="26" x2="34" y2="37" stroke="#26c6da" stroke-width="1.5"/>
+  <line x1="28" y1="24" x2="36" y2="24" stroke="#26c6da" stroke-width="1.5"/>
+  <circle cx="24" cy="24" r="1.5" fill="#26c6da"/>
+  <circle cx="40" cy="24" r="1.5" fill="#26c6da"/>
+  <circle cx="32" cy="40" r="1.5" fill="#26c6da"/>
+  <path d="M16 50 L22 44 L28 48 L34 42 L40 46 L48 40" stroke="#80deea" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.6"/>
+</svg>

--- a/assets/logos/data_explorer.svg
+++ b/assets/logos/data_explorer.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <rect x="14" y="28" width="36" height="20" rx="2" stroke="#42a5f5" stroke-width="2" fill="none"/>
+  <line x1="14" y1="34" x2="50" y2="34" stroke="#42a5f5" stroke-width="1"/>
+  <rect x="18" y="36" width="12" height="8" rx="1" fill="#42a5f5" opacity="0.3"/>
+  <path d="M34 40 L38 36 L42 40 L46 38" stroke="#64b5f6" stroke-width="1.5" stroke-linecap="round" fill="none"/>
+  <circle cx="22" cy="22" r="4" stroke="#42a5f5" stroke-width="1.5" fill="none"/>
+  <path d="M22 20 L22 24 M20 22 L24 22" stroke="#42a5f5" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M26 22 L34 22 L34 28" stroke="#42a5f5" stroke-width="1" stroke-dasharray="2 2"/>
+</svg>

--- a/assets/logos/drake.svg
+++ b/assets/logos/drake.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <path d="M16 48 L32 16 L48 48" stroke="#66bb6a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="22" y1="38" x2="42" y2="38" stroke="#66bb6a" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="32" cy="16" r="3" fill="#66bb6a"/>
+  <circle cx="22" cy="38" r="2" fill="#a5d6a7" opacity="0.7"/>
+  <circle cx="42" cy="38" r="2" fill="#a5d6a7" opacity="0.7"/>
+</svg>

--- a/assets/logos/matlab_logo.svg
+++ b/assets/logos/matlab_logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <rect x="16" y="16" width="32" height="32" rx="4" stroke="#f57c00" stroke-width="2" fill="#f57c00" fill-opacity="0.1"/>
+  <line x1="16" y1="26" x2="48" y2="26" stroke="#f57c00" stroke-width="1" opacity="0.5"/>
+  <line x1="16" y1="38" x2="48" y2="38" stroke="#f57c00" stroke-width="1" opacity="0.5"/>
+  <line x1="28" y1="16" x2="28" y2="48" stroke="#f57c00" stroke-width="1" opacity="0.5"/>
+  <line x1="38" y1="16" x2="38" y2="48" stroke="#f57c00" stroke-width="1" opacity="0.5"/>
+  <text x="32" y="35" text-anchor="middle" font-family="monospace" font-size="10" font-weight="bold" fill="#f57c00">M</text>
+</svg>

--- a/assets/logos/mujoco_humanoid.svg
+++ b/assets/logos/mujoco_humanoid.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <circle cx="32" cy="24" r="8" stroke="#4fc3f7" stroke-width="2"/>
+  <path d="M20 44 L32 32 L44 44" stroke="#4fc3f7" stroke-width="2" stroke-linecap="round"/>
+  <rect x="18" y="46" width="28" height="4" rx="2" fill="#4fc3f7" opacity="0.5"/>
+  <circle cx="32" cy="24" r="3" fill="#4fc3f7"/>
+  <line x1="28" y1="38" x2="24" y2="42" stroke="#81d4fa" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="36" y1="38" x2="40" y2="42" stroke="#81d4fa" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/assets/logos/myosim.svg
+++ b/assets/logos/myosim.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <path d="M20 44 C20 30, 28 20, 32 20 C36 20, 44 30, 44 44" stroke="#ab47bc" stroke-width="2.5" fill="none"/>
+  <line x1="24" y1="36" x2="24" y2="44" stroke="#ce93d8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="28" y1="30" x2="28" y2="44" stroke="#ce93d8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="32" y1="26" x2="32" y2="44" stroke="#ce93d8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="36" y1="30" x2="36" y2="44" stroke="#ce93d8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="40" y1="36" x2="40" y2="44" stroke="#ce93d8" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="18" y="44" width="28" height="3" rx="1.5" fill="#ab47bc" opacity="0.5"/>
+  <circle cx="32" cy="18" r="2" fill="#ab47bc"/>
+</svg>

--- a/assets/logos/opensim.svg
+++ b/assets/logos/opensim.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <ellipse cx="32" cy="28" rx="12" ry="16" stroke="#ff7043" stroke-width="2"/>
+  <line x1="22" y1="24" x2="18" y2="18" stroke="#ff7043" stroke-width="2" stroke-linecap="round"/>
+  <line x1="42" y1="24" x2="46" y2="18" stroke="#ff7043" stroke-width="2" stroke-linecap="round"/>
+  <line x1="26" y1="42" x2="22" y2="52" stroke="#ff7043" stroke-width="2" stroke-linecap="round"/>
+  <line x1="38" y1="42" x2="42" y2="52" stroke="#ff7043" stroke-width="2" stroke-linecap="round"/>
+  <path d="M26 30 Q32 26 38 30" stroke="#ffab91" stroke-width="1.5" fill="none"/>
+  <circle cx="28" cy="24" r="1.5" fill="#ffab91"/>
+  <circle cx="36" cy="24" r="1.5" fill="#ffab91"/>
+</svg>

--- a/assets/logos/pinocchio.svg
+++ b/assets/logos/pinocchio.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <circle cx="32" cy="20" r="4" fill="#ef5350"/>
+  <line x1="32" y1="24" x2="32" y2="36" stroke="#ef5350" stroke-width="2.5"/>
+  <line x1="32" y1="28" x2="22" y2="32" stroke="#ef5350" stroke-width="2" stroke-linecap="round"/>
+  <line x1="32" y1="28" x2="42" y2="32" stroke="#ef5350" stroke-width="2" stroke-linecap="round"/>
+  <line x1="32" y1="36" x2="24" y2="48" stroke="#ef5350" stroke-width="2" stroke-linecap="round"/>
+  <line x1="32" y1="36" x2="40" y2="48" stroke="#ef5350" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="22" cy="32" r="2" fill="#ef9a9a" opacity="0.6"/>
+  <circle cx="42" cy="32" r="2" fill="#ef9a9a" opacity="0.6"/>
+</svg>

--- a/assets/logos/putting_green.svg
+++ b/assets/logos/putting_green.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <ellipse cx="32" cy="40" rx="18" ry="6" fill="#4caf50" opacity="0.3"/>
+  <ellipse cx="32" cy="40" rx="18" ry="6" stroke="#4caf50" stroke-width="1.5" fill="none"/>
+  <circle cx="32" cy="30" r="4" fill="#fff" opacity="0.9"/>
+  <path d="M32 34 Q34 38 32 40" stroke="#e0e0e0" stroke-width="1" stroke-dasharray="2 1"/>
+  <line x1="14" y1="46" x2="50" y2="46" stroke="#388e3c" stroke-width="1"/>
+  <rect x="28" y="44" width="2" height="4" fill="#fff" opacity="0.3" rx="0.5"/>
+  <rect x="34" y="44" width="2" height="4" fill="#fff" opacity="0.3" rx="0.5"/>
+</svg>

--- a/assets/logos/urdf_icon.svg
+++ b/assets/logos/urdf_icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+  <rect x="16" y="20" width="32" height="24" rx="3" stroke="#7e57c2" stroke-width="2" fill="none"/>
+  <circle cx="26" cy="32" r="6" stroke="#7e57c2" stroke-width="1.5" fill="none"/>
+  <line x1="30" y1="36" x2="34" y2="40" stroke="#7e57c2" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="36" y="26" width="8" height="2" rx="1" fill="#b39ddb" opacity="0.7"/>
+  <rect x="36" y="30" width="6" height="2" rx="1" fill="#b39ddb" opacity="0.5"/>
+  <rect x="36" y="34" width="7" height="2" rx="1" fill="#b39ddb" opacity="0.5"/>
+  <path d="M20 16 L20 20 M28 16 L28 20" stroke="#7e57c2" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/api/routes/launcher.py
+++ b/src/api/routes/launcher.py
@@ -7,8 +7,9 @@ enabling both launchers to derive their tile lists from a single source.
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
 
-from src.config.launcher_manifest_loader import LauncherManifest
+from src.config.launcher_manifest_loader import ASSETS_DIR, LauncherManifest
 from src.shared.python.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -102,3 +103,62 @@ async def get_tools() -> list[dict]:  # type: ignore[type-arg]
     """
     manifest = _get_manifest()
     return [t.to_dict() for t in manifest.tools]
+
+
+@router.get("/logos/validate")
+async def validate_logos() -> dict:  # type: ignore[type-arg]
+    """Validate that all tile logos exist on disk.
+
+    Returns:
+        Validation report with missing and present logo lists.
+    """
+    manifest = _get_manifest()
+    missing = manifest.validate_logos()
+    total = len(manifest.tiles)
+    present = total - len(missing)
+
+    return {
+        "total": total,
+        "present": present,
+        "missing_count": len(missing),
+        "missing_tiles": missing,
+        "all_valid": len(missing) == 0,
+    }
+
+
+@router.get("/logos/{filename}")
+async def get_logo(filename: str) -> FileResponse:
+    """Serve a tile logo file.
+
+    Args:
+        filename: Logo filename (e.g., 'mujoco_humanoid.svg').
+
+    Returns:
+        The logo file as an image response.
+
+    Raises:
+        HTTPException: If logo not found or invalid filename.
+    """
+    # DBC Precondition: prevent path traversal
+    if ".." in filename or "/" in filename or "\\" in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    logo_path = ASSETS_DIR / filename
+    if not logo_path.exists():
+        raise HTTPException(status_code=404, detail=f"Logo not found: {filename}")
+
+    # Determine media type
+    suffix = logo_path.suffix.lower()
+    media_types = {
+        ".svg": "image/svg+xml",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+    }
+    media_type = media_types.get(suffix, "application/octet-stream")
+
+    return FileResponse(
+        path=str(logo_path),
+        media_type=media_type,
+        filename=filename,
+    )

--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -9,9 +9,13 @@
       "category": "tool",
       "type": "special_app",
       "path": "src/tools/urdf_generator/launch_urdf_generator.py",
-      "logo": "urdf_icon.png",
+      "logo": "urdf_icon.svg",
       "status": "utility",
-      "capabilities": ["model_browsing", "urdf_generation", "open_in_engine"],
+      "capabilities": [
+        "model_browsing",
+        "urdf_generation",
+        "open_in_engine"
+      ],
       "order": 1
     },
     {
@@ -22,7 +26,7 @@
       "type": "custom_humanoid",
       "path": "src/launchers/mujoco_unified_launcher.py",
       "engine_type": "mujoco",
-      "logo": "mujoco_humanoid.png",
+      "logo": "mujoco_humanoid.svg",
       "status": "gui_ready",
       "capabilities": [
         "rigid_body",
@@ -49,7 +53,7 @@
       "type": "drake",
       "path": "src/engines/physics_engines/drake/python/src/drake_gui_app.py",
       "engine_type": "drake",
-      "logo": "drake.png",
+      "logo": "drake.svg",
       "status": "gui_ready",
       "capabilities": [
         "rigid_body",
@@ -68,7 +72,7 @@
       "type": "pinocchio",
       "path": "src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py",
       "engine_type": "pinocchio",
-      "logo": "pinocchio.png",
+      "logo": "pinocchio.svg",
       "status": "gui_ready",
       "capabilities": [
         "rigid_body",
@@ -86,7 +90,7 @@
       "type": "opensim",
       "path": "src/engines/physics_engines/opensim/python/opensim_gui.py",
       "engine_type": "opensim",
-      "logo": "opensim.png",
+      "logo": "opensim.svg",
       "status": "engine_ready",
       "capabilities": [
         "musculoskeletal",
@@ -105,7 +109,7 @@
       "type": "myosim",
       "path": "src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py",
       "engine_type": "myosuite",
-      "logo": "myosim.png",
+      "logo": "myosim.svg",
       "status": "engine_ready",
       "capabilities": [
         "musculoskeletal",
@@ -124,9 +128,13 @@
       "type": "putting_green",
       "path": "src/engines/physics_engines/putting_green/python/simulator.py",
       "engine_type": "putting_green",
-      "logo": "putting_green.png",
+      "logo": "putting_green.svg",
       "status": "simulator",
-      "capabilities": ["surface_modeling", "ball_physics", "terrain"],
+      "capabilities": [
+        "surface_modeling",
+        "ball_physics",
+        "terrain"
+      ],
       "order": 7
     },
     {
@@ -136,9 +144,13 @@
       "category": "external",
       "type": "special_app",
       "path": "src/launchers/matlab_launcher_unified.py",
-      "logo": "matlab_logo.png",
+      "logo": "matlab_logo.svg",
       "status": "external",
-      "capabilities": ["simscape_2d", "simscape_3d", "analysis_tools"],
+      "capabilities": [
+        "simscape_2d",
+        "simscape_3d",
+        "analysis_tools"
+      ],
       "order": 8
     },
     {
@@ -148,7 +160,7 @@
       "category": "tool",
       "type": "special_app",
       "path": "src/launchers/motion_capture_launcher.py",
-      "logo": "c3d_icon.png",
+      "logo": "c3d_icon.svg",
       "status": "utility",
       "capabilities": [
         "c3d_viewer",
@@ -165,9 +177,14 @@
       "category": "tool",
       "type": "special_app",
       "path": "src/tools/data_explorer/data_explorer_app.py",
-      "logo": "data_explorer.png",
+      "logo": "data_explorer.svg",
       "status": "utility",
-      "capabilities": ["data_import", "filtering", "visualization", "export"],
+      "capabilities": [
+        "data_import",
+        "filtering",
+        "visualization",
+        "export"
+      ],
       "order": 10
     }
   ]

--- a/src/config/launcher_manifest_loader.py
+++ b/src/config/launcher_manifest_loader.py
@@ -30,7 +30,7 @@ logger = get_logger(__name__)
 # Paths
 CONFIG_DIR = Path(__file__).parent
 MANIFEST_PATH = CONFIG_DIR / "launcher_manifest.json"
-ASSETS_DIR = Path(__file__).parent.parent / "launchers" / "assets"
+ASSETS_DIR = Path(__file__).parent.parent.parent / "assets" / "logos"
 
 
 @dataclass(frozen=True)

--- a/tests/config/test_launcher_manifest.py
+++ b/tests/config/test_launcher_manifest.py
@@ -79,9 +79,9 @@ class TestManifestLoading:
     def test_manifest_has_no_duplicate_ids(self, manifest: LauncherManifest) -> None:
         """DBC Postcondition: all tile IDs must be unique."""
         ids = [t.id for t in manifest.tiles]
-        assert len(ids) == len(
-            set(ids)
-        ), f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+        assert len(ids) == len(set(ids)), (
+            f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+        )
 
     def test_manifest_file_not_found_raises(self) -> None:
         """DBC Precondition: missing file raises FileNotFoundError."""
@@ -135,9 +135,9 @@ class TestTileProperties:
         """Category must be one of the allowed values."""
         valid_categories = {"physics_engine", "tool", "external"}
         for tile in manifest.tiles:
-            assert (
-                tile.category in valid_categories
-            ), f"Tile '{tile.id}' has invalid category: '{tile.category}'"
+            assert tile.category in valid_categories, (
+                f"Tile '{tile.id}' has invalid category: '{tile.category}'"
+            )
 
     def test_physics_engines_have_engine_type(self, manifest: LauncherManifest) -> None:
         """All physics_engine tiles must have an engine_type."""
@@ -176,10 +176,14 @@ class TestLogoValidation:
         assert ASSETS_DIR.exists(), f"Assets dir missing: {ASSETS_DIR}"
 
     def test_all_tiles_have_logo_files(self, manifest: LauncherManifest) -> None:
-        """Every tile's logo file must exist in the assets directory."""
+        """Every tile's logo file must exist in the assets directory.
+
+        All SVG logos were created in Phase 3 (closes #1164).
+        """
         missing = manifest.validate_logos()
-        if missing:
-            pytest.skip(f"Known missing logos (tracked in issue #1164): {missing}")
+        assert not missing, (
+            f"Missing logo files for tiles: {missing}. Expected in: {ASSETS_DIR}"
+        )
 
     def test_logo_path_property(self, sample_tile_dict: dict) -> None:
         """Tile logo_path property returns absolute path."""
@@ -204,9 +208,9 @@ class TestOrdering:
     def test_model_explorer_is_first(self, manifest: LauncherManifest) -> None:
         """Model Explorer must be the first tile (order=1)."""
         first = manifest.tiles[0]
-        assert (
-            first.id == "model_explorer"
-        ), f"First tile should be model_explorer, got: {first.id}"
+        assert first.id == "model_explorer", (
+            f"First tile should be model_explorer, got: {first.id}"
+        )
 
     def test_ordered_ids_returns_deterministic_list(
         self, manifest: LauncherManifest


### PR DESCRIPTION
Phase 3: Created all 10 tile logos as SVG, added logo-serving API endpoint with path traversal protection, logo validation endpoint, converted skip test to assertion. 67 Python + 177 React tests all pass.

Closes #1164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new file-serving endpoints; while guarded against traversal, mistakes in path validation or asset directory configuration could expose unintended files or break logo loading.
> 
> **Overview**
> Adds 10 new SVG tile logo assets and updates the launcher manifest to reference `.svg` logos instead of `.png`.
> 
> Extends the launcher API with `/api/launcher/logos/{filename}` to serve logo files (with basic path-traversal protection and correct image `Content-Type`) and `/api/launcher/logos/validate` to report missing logos.
> 
> Moves `ASSETS_DIR` to `assets/logos` and tightens tests to assert all manifest logos exist and are servable via the new endpoints (including traversal and 404 cases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18226b0ad2a9aea55adf118d5bad2106fb259f13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->