### PR TITLE
fix: Redesign video_analyzer icon to avoid YouTube similarity

### DIFF
--- a/assets/logos/video_analyzer.svg
+++ b/assets/logos/video_analyzer.svg
@@ -1,10 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
   <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
-  <rect x="14" y="18" width="36" height="24" rx="3" stroke="#e53935" stroke-width="2" fill="none"/>
-  <polygon points="28,24 28,38 40,31" fill="#e53935" opacity="0.8"/>
-  <rect x="14" y="44" width="36" height="4" rx="2" fill="#ef9a9a" opacity="0.4"/>
-  <rect x="14" y="44" width="18" height="4" rx="2" fill="#e53935" opacity="0.6"/>
-  <circle cx="18" cy="15" r="2" fill="#ef5350" opacity="0.6"/>
-  <circle cx="24" cy="15" r="2" fill="#ff8a65" opacity="0.6"/>
-  <circle cx="30" cy="15" r="2" fill="#66bb6a" opacity="0.6"/>
+  <!-- Film strip sprocket holes -->
+  <rect x="12" y="14" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="12" y="24" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="12" y="34" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="12" y="44" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <!-- Frame border -->
+  <rect x="18" y="14" width="28" height="36" rx="2" stroke="#5c6bc0" stroke-width="1.5" fill="none"/>
+  <line x1="18" y1="26" x2="46" y2="26" stroke="#5c6bc0" stroke-width="0.75" opacity="0.4"/>
+  <line x1="18" y1="38" x2="46" y2="38" stroke="#5c6bc0" stroke-width="0.75" opacity="0.4"/>
+  <!-- Pose skeleton figure (center frame) -->
+  <circle cx="32" cy="30" r="2.5" fill="#7986cb"/>
+  <line x1="32" y1="32.5" x2="32" y2="39" stroke="#7986cb" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="32" y1="34" x2="27" y2="37" stroke="#7986cb" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="32" y1="34" x2="37" y2="37" stroke="#7986cb" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="32" y1="39" x2="28" y2="45" stroke="#7986cb" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="32" y1="39" x2="36" y2="45" stroke="#7986cb" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Joint markers -->
+  <circle cx="27" cy="37" r="1.2" fill="#9fa8da"/>
+  <circle cx="37" cy="37" r="1.2" fill="#9fa8da"/>
+  <circle cx="28" cy="45" r="1.2" fill="#9fa8da"/>
+  <circle cx="36" cy="45" r="1.2" fill="#9fa8da"/>
+  <!-- Motion trail dots (top frame) -->
+  <circle cx="26" cy="18" r="1" fill="#9fa8da" opacity="0.3"/>
+  <circle cx="30" cy="19" r="1" fill="#9fa8da" opacity="0.5"/>
+  <circle cx="34" cy="18" r="1" fill="#9fa8da" opacity="0.7"/>
+  <circle cx="38" cy="20" r="1.2" fill="#9fa8da" opacity="0.9"/>
+  <!-- Waveform hint (right side) -->
+  <rect x="48" y="14" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="48" y="24" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="48" y="34" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
+  <rect x="48" y="44" width="4" height="4" rx="1" fill="#5c6bc0" opacity="0.5"/>
 </svg>


### PR DESCRIPTION
Replace play-button-in-rectangle with film-strip + pose skeleton motif.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Asset-only SVG change with no runtime behavior impact; main risk is visual/regression in branding or layout if dimensions differ.
> 
> **Overview**
> Updates the `assets/logos/video_analyzer.svg` artwork, replacing the prior play-button/seekbar style graphic with a new film-strip frame that includes sprocket holes, a pose-skeleton motif, and subtle motion/waveform accents to reduce similarity to common video-player icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ced7159074ae1bad373c780ad1aa02631338252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->