### PR TITLE
fix(ui): clean up launcher top bar and fix window icon

### DIFF
--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -44,7 +44,6 @@ from src.launchers.ui_components import HelpDialog as LegacyHelpDialog
 # Import new help system (graceful degradation if not available)
 try:
     from src.shared.python.help_system import (
-        HelpButton,
         HelpDialog,
         TooltipManager,
     )
@@ -198,14 +197,14 @@ class GolfLauncher(QMainWindow):
             startup_results.startup_time_ms if startup_results else 0
         )
 
-        # Set Icon - Use Windows-optimized icon for maximum clarity on Windows
+        # Set Icon - Prefer .ico on Windows for proper taskbar/title bar display
         icon_candidates = [
-            ASSETS_DIR
-            / "golf_robot_windows_optimized.png",  # Windows-optimized (best for Windows)
-            ASSETS_DIR / "golf_robot_ultra_sharp.png",  # Ultra-sharp version
-            ASSETS_DIR / "golf_robot_cropped_icon.png",  # Cropped version
-            ASSETS_DIR / "golf_robot_icon.png",  # High-quality standard
-            ASSETS_DIR / "golf_icon.png",  # Original fallback
+            ASSETS_DIR / "golf_suite_unified.ico",  # Multi-size .ico (best for Windows)
+            ASSETS_DIR / "golf_robot_windows_optimized.ico",
+            ASSETS_DIR / "golf_icon.ico",
+            ASSETS_DIR / "golf_robot_windows_optimized.png",
+            ASSETS_DIR / "golf_robot_icon.png",
+            ASSETS_DIR / "golf_icon.png",
         ]
 
         icon_loaded = False
@@ -1067,13 +1066,6 @@ except Exception as e:
         """)
         top_bar.addWidget(btn_help)
 
-        # Add help button for engine selection (next to grid)
-        if HELP_SYSTEM_AVAILABLE:
-            btn_engine_help = HelpButton(
-                "engine_selection", "Help with engine selection", self
-            )
-            top_bar.addWidget(btn_engine_help)
-
         btn_diagnostics = QPushButton("Diagnostics")
         btn_diagnostics.setToolTip("Run diagnostics to troubleshoot launcher issues")
         btn_diagnostics.setStyleSheet("""
@@ -1091,22 +1083,7 @@ except Exception as e:
         btn_diagnostics.clicked.connect(self.open_diagnostics)
         top_bar.addWidget(btn_diagnostics)
 
-        btn_bug = QPushButton("Report Bug")
-        btn_bug.setStyleSheet("""
-            QPushButton {
-                background-color: #d32f2f;
-                color: white;
-                padding: 8px 16px;
-                border: none;
-                border-radius: 4px;
-            }
-            QPushButton:hover {
-                background-color: #b71c1c;
-            }
-        """)
-        btn_bug.setToolTip("Report a bug via email")
-        btn_bug.clicked.connect(self._report_bug)
-        top_bar.addWidget(btn_bug)
+        # Report Bug moved to Help dialog bottom bar
 
         # AI Assistant Button (if available)
         if AI_AVAILABLE:

--- a/src/shared/python/help_system.py
+++ b/src/shared/python/help_system.py
@@ -22,8 +22,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from PyQt6.QtCore import QSize, Qt
-from PyQt6.QtGui import QFont, QKeySequence, QShortcut
+from PyQt6.QtCore import QSize, Qt, QUrl
+from PyQt6.QtGui import QDesktopServices, QFont, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -307,6 +307,16 @@ class HelpDialog(QDialog):
         lbl_links.setOpenExternalLinks(True)
         layout.addWidget(lbl_links)
 
+        # Report a Bug button
+        btn_bug = QPushButton("Report a Bug")
+        btn_bug.setStyleSheet(
+            "background-color: #d32f2f; color: white; padding: 6px 14px;"
+            " border: none; border-radius: 4px;"
+        )
+        btn_bug.setToolTip("Report a bug via email")
+        btn_bug.clicked.connect(self._report_bug)
+        layout.addWidget(btn_bug)
+
         layout.addStretch()
 
         # Close button
@@ -329,6 +339,16 @@ class HelpDialog(QDialog):
         """Focus the search input."""
         self.search_input.setFocus()
         self.search_input.selectAll()
+
+    def _report_bug(self) -> None:
+        """Open default mail client to report a bug."""
+        from urllib.parse import quote
+
+        subject = "Bug Report: Golf Modeling Suite"
+        body = "Please describe the issue you encountered:\n\n"
+        email = "support@golfmodelingsuite.com"
+        mailto_url = f"mailto:{email}?subject={quote(subject)}&body={quote(body)}"
+        QDesktopServices.openUrl(QUrl(mailto_url))
 
     def _apply_styles(self) -> None:
         """Apply CSS styles to the dialog."""


### PR DESCRIPTION
## Summary
- Remove redundant HelpButton (? question mark icon) from top bar — the "Help" text button already opens the same dialog
- Move "Report a Bug" button from main GUI toolbar into the HelpDialog bottom bar to reduce toolbar clutter
- Fix window icon to prefer `.ico` format on Windows for proper taskbar/title bar display

## Test plan
- [ ] Launch GUI and verify only one Help button appears in top bar
- [ ] Click Help → verify "Report a Bug" button is in the Help dialog bottom bar
- [ ] Verify window icon appears correctly in taskbar on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes with minimal logic impact; main risk is small regressions in icon selection order or help-dialog bug-report action wiring.
> 
> **Overview**
> Cleans up the launcher top bar by removing the redundant context `HelpButton` and moving the **Report Bug** action out of the main toolbar.
> 
> Improves Windows icon handling by preferring `.ico` assets (including a new unified multi-size candidate) before falling back to `.png`. Adds a **Report a Bug** button to the `HelpDialog` bottom bar that opens a prefilled `mailto:` link via `QDesktopServices`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 138af3c976ea846327c97ad96adb0fe8aa3d94c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->