### PR TITLE
refactor: remove engines/common from mypy exclusion list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ exclude = [
     "src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/",
     "src/api/",
     "src/launchers/",
-    "src/engines/common/",
     # Additional directories with complex typing issues (pre-existing)
     "src/shared/python/pose_editor/",
     "src/shared/python/ai/gui/",

--- a/src/engines/common/physics.py
+++ b/src/engines/common/physics.py
@@ -170,7 +170,7 @@ class AerodynamicsCalculator:
         Returns:
             Drag force vector [N] (opposes velocity)
         """
-        speed = np.linalg.norm(velocity)
+        speed = float(np.linalg.norm(velocity))
         if speed < 1e-6:
             return np.zeros(3)
 
@@ -196,7 +196,7 @@ class AerodynamicsCalculator:
         Returns:
             Lift force vector [N]
         """
-        speed = np.linalg.norm(velocity)
+        speed = float(np.linalg.norm(velocity))
         if speed < 1e-6:
             return np.zeros(3)
 
@@ -235,8 +235,8 @@ class AerodynamicsCalculator:
         Returns:
             Magnus force vector [N]
         """
-        speed = np.linalg.norm(velocity)
-        spin_mag = np.linalg.norm(spin)
+        speed = float(np.linalg.norm(velocity))
+        spin_mag = float(np.linalg.norm(spin))
 
         if speed < 1e-6 or spin_mag < 1e-6:
             return np.zeros(3)


### PR DESCRIPTION
## Summary
- Fix 3 `arg-type` mypy errors in `src/engines/common/physics.py` by casting `np.linalg.norm()` results to `float`
- Remove `src/engines/common/` from the mypy exclusion list in `pyproject.toml`
- All 6 files in the directory now pass mypy cleanly

## Test plan
- [x] `mypy src/engines/common/` reports 0 errors
- [x] ruff + black clean
- [ ] CI green

Partial progress on #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-checking configuration plus small numeric type casts; runtime behavior should be unchanged aside from ensuring scalar floats are passed where required.
> 
> **Overview**
> Removes `src/engines/common/` from the `tool.mypy.exclude` list so this engine-shared code is type-checked by mypy.
> 
> Fixes mypy `arg-type` issues in `src/engines/common/physics.py` by explicitly casting `np.linalg.norm(...)` results to `float` in the drag, lift, and Magnus force calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8798cacaabf1a2aa6a3cccd96854e50deaf41559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->