### PR TITLE
feat: formalize U1-U3 method citations and validation

### DIFF
--- a/src/shared/python/injury/spinal_load_analysis.py
+++ b/src/shared/python/injury/spinal_load_analysis.py
@@ -29,6 +29,12 @@ from enum import Enum
 
 import numpy as np
 
+from src.shared.python.analysis.dataclasses import (
+    CITATION_CRUNCH_FACTOR,
+    CITATION_SPINAL_LOAD,
+    CITATION_X_FACTOR,
+    MethodCitation,
+)
 from src.shared.python.constants import GRAVITY_M_S2
 
 
@@ -63,6 +69,7 @@ class XFactorMetrics:
     x_factor_stretch_time: float  # time of maximum stretch (s)
     separation_rate: float  # rate of change at transition (deg/s)
     transition_duration: float  # time from top to impact (s)
+    methodology: MethodCitation = CITATION_X_FACTOR
 
 
 @dataclass
@@ -75,6 +82,7 @@ class CrunchFactorMetrics:
     peak_crunch: float  # maximum crunch factor value
     peak_crunch_time: float  # time of peak crunch (s)
     asymmetry_ratio: float  # left vs right side loading ratio
+    methodology: MethodCitation = CITATION_CRUNCH_FACTOR
 
 
 @dataclass
@@ -108,6 +116,9 @@ class SpinalLoadResult:
     # Cumulative load (for tracking over sessions)
     cumulative_compression_impulse: float = 0.0  # N*s
     cumulative_shear_impulse: float = 0.0  # N*s
+
+    # Methodology citation
+    methodology: MethodCitation = CITATION_SPINAL_LOAD
 
 
 class SpinalLoadAnalyzer:

--- a/src/shared/python/kinematic_sequence.py
+++ b/src/shared/python/kinematic_sequence.py
@@ -17,6 +17,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from src.shared.python.analysis.dataclasses import (
+    CITATION_KINEMATIC_SEQUENCE,
+    MethodCitation,
+)
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -46,6 +51,7 @@ class KinematicSequenceResult:
         default_factory=dict
     )  # Time diff between peaks
     is_valid_sequence: bool = False  # True if order matches expected
+    methodology: MethodCitation | None = None
 
 
 class SegmentTimingAnalyzer:
@@ -219,6 +225,7 @@ class SegmentTimingAnalyzer:
             sequence_consistency=sequence_consistency,
             timing_gaps=timing_gaps,
             is_valid_sequence=is_valid,
+            methodology=CITATION_KINEMATIC_SEQUENCE,
         )
 
     def extract_velocities_from_recorder(

--- a/tests/unit/test_method_citations.py
+++ b/tests/unit/test_method_citations.py
@@ -1,0 +1,150 @@
+"""Tests for method citation metadata and cross-engine validation (Issue #777)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.shared.python.analysis.dataclasses import (
+    CITATION_CRUNCH_FACTOR,
+    CITATION_KINEMATIC_SEQUENCE,
+    CITATION_SPINAL_LOAD,
+    CITATION_X_FACTOR,
+    MethodCitation,
+    validate_angle_cross_engine,
+    validate_timing_cross_engine,
+)
+
+
+class TestMethodCitation:
+    """MethodCitation dataclass tests."""
+
+    def test_frozen(self) -> None:
+        """Citations should be immutable."""
+        c = MethodCitation(name="test", authors="A", year=2000, title="T")
+        try:
+            c.name = "modified"  # type: ignore[misc]
+            raise AssertionError("Should have raised FrozenInstanceError")
+        except AttributeError:
+            pass  # Expected — frozen dataclass
+
+    def test_predefined_citations_exist(self) -> None:
+        """All four predefined citations should be populated."""
+        for c in [
+            CITATION_KINEMATIC_SEQUENCE,
+            CITATION_X_FACTOR,
+            CITATION_CRUNCH_FACTOR,
+            CITATION_SPINAL_LOAD,
+        ]:
+            assert c.name
+            assert c.authors
+            assert c.year > 0
+            assert c.title
+
+    def test_optional_fields(self) -> None:
+        """DOI and notes should be optional."""
+        c = MethodCitation(name="N", authors="A", year=2000, title="T")
+        assert c.doi is None
+        assert c.notes is None
+
+
+class TestKinematicSequenceCitation:
+    """Kinematic sequence result carries methodology citation."""
+
+    def test_result_has_methodology(self) -> None:
+        from src.shared.python.kinematic_sequence import SegmentTimingAnalyzer
+
+        times = np.linspace(0, 1.0, 100)
+        data = {
+            "A": np.exp(-((times - 0.2) ** 2) / 0.01) * 10,
+            "B": np.exp(-((times - 0.4) ** 2) / 0.01) * 20,
+        }
+        analyzer = SegmentTimingAnalyzer(expected_order=["A", "B"])
+        result = analyzer.analyze(data, times)
+
+        assert result.methodology is not None
+        assert result.methodology.name == "Proximal-to-Distal Sequencing"
+        assert result.methodology.authors == "Putnam"
+
+
+class TestSpinalLoadCitation:
+    """Spinal load dataclasses carry methodology citations."""
+
+    def test_spinal_load_result_default_citation(self) -> None:
+        from src.shared.python.injury.spinal_load_analysis import SpinalLoadResult
+
+        result = SpinalLoadResult(time=np.array([0.0]))
+        assert result.methodology is not None
+        assert result.methodology.authors == "Hosea et al."
+
+    def test_x_factor_metrics_default_citation(self) -> None:
+        from src.shared.python.injury.spinal_load_analysis import XFactorMetrics
+
+        m = XFactorMetrics(
+            x_factor_angle=np.array([0.0]),
+            x_factor_stretch=30.0,
+            x_factor_stretch_time=0.5,
+            separation_rate=100.0,
+            transition_duration=0.3,
+        )
+        assert m.methodology.name == "X-Factor"
+
+    def test_crunch_factor_metrics_default_citation(self) -> None:
+        from src.shared.python.injury.spinal_load_analysis import CrunchFactorMetrics
+
+        m = CrunchFactorMetrics(
+            lateral_bend_angle=np.array([0.0]),
+            rotation_angle=np.array([0.0]),
+            crunch_factor=np.array([0.0]),
+            peak_crunch=10.0,
+            peak_crunch_time=0.4,
+            asymmetry_ratio=1.0,
+        )
+        assert m.methodology.name == "Crunch Factor"
+
+
+class TestTimingValidation:
+    """Cross-engine timing validation tests."""
+
+    def test_identical_timings_pass(self) -> None:
+        t = np.array([0.1, 0.2, 0.3, 0.4])
+        result = validate_timing_cross_engine(t, t)
+        assert result["passed"] is True
+        assert result["max_diff_s"] == 0.0
+
+    def test_within_tolerance_passes(self) -> None:
+        a = np.array([0.100, 0.200, 0.300])
+        b = np.array([0.102, 0.198, 0.304])
+        result = validate_timing_cross_engine(a, b, tolerance_s=0.005)
+        assert result["passed"] is True
+
+    def test_exceeds_tolerance_fails(self) -> None:
+        a = np.array([0.1, 0.2])
+        b = np.array([0.1, 0.3])  # 100 ms off
+        result = validate_timing_cross_engine(a, b, tolerance_s=0.005)
+        assert result["passed"] is False
+
+    def test_mismatched_lengths_fails(self) -> None:
+        result = validate_timing_cross_engine(np.array([0.1]), np.array([0.1, 0.2]))
+        assert result["passed"] is False
+
+
+class TestAngleValidation:
+    """Cross-engine angle validation tests."""
+
+    def test_identical_angles_pass(self) -> None:
+        a = np.array([30.0, 45.0, 50.0])
+        result = validate_angle_cross_engine(a, a)
+        assert result["passed"] is True
+        assert result["max_diff_deg"] == 0.0
+
+    def test_within_tolerance_passes(self) -> None:
+        a = np.array([30.0, 45.0])
+        b = np.array([31.5, 43.5])
+        result = validate_angle_cross_engine(a, b, tolerance_deg=2.0)
+        assert result["passed"] is True
+
+    def test_exceeds_tolerance_fails(self) -> None:
+        a = np.array([30.0])
+        b = np.array([35.0])
+        result = validate_angle_cross_engine(a, b, tolerance_deg=2.0)
+        assert result["passed"] is False


### PR DESCRIPTION
## Summary
- Add `MethodCitation` frozen dataclass with structured citation metadata
- Predefined citations: kinematic sequence (Putnam 1993), X-Factor (Cheetham 2001), crunch factor (McHardy & Pollard 2005), spinal load (Hosea 1990)
- Wire citations into `KinematicSequenceResult`, `XFactorMetrics`, `CrunchFactorMetrics`, `SpinalLoadResult`
- Add cross-engine validation: `validate_timing_cross_engine` (5ms) and `validate_angle_cross_engine` (2 deg)
- 14 new tests

## Test plan
- [x] All 26 tests pass (12 kinematic + 14 new)
- [x] ruff + black clean
- [ ] CI green

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds metadata fields and standalone validation helpers with unit tests; low risk aside from minor downstream impact if callers construct these dataclasses positionally rather than by keyword.
> 
> **Overview**
> Formalizes *methodology provenance* by introducing a frozen `MethodCitation` plus four reusable citation constants, and wiring these citations into kinematic-sequence outputs (`KinematicSequenceResult`) and spinal-load/X-factor/crunch-factor result dataclasses.
> 
> Adds simple cross-engine comparison helpers (`validate_timing_cross_engine`, `validate_angle_cross_engine`) with default tolerances (5ms, 2°) and exports them publicly, along with new unit tests covering citation defaults/immutability and validation pass/fail cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b789d3e63d4a109ef43e9fd77b1b0fb014900928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->