### PR TITLE
fix(mypy): remove signal_toolkit/ from exclusion list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ exclude = [
     "src/engines/Simscape_Multibody_Models/3D_Golf_Model",
     "src/shared/models/opensim/opensim-models",
     # Pending type annotation cleanup (consolidated PR 2026-01-31)
-    "src/shared/python/signal_toolkit/",
     "src/shared/python/plotting/",
     "src/shared/python/tests/",
     "src/shared/python/ui/qt/widgets/",
@@ -186,7 +185,6 @@ exclude = [
 # Mypy overrides for modules with pre-existing type issues
 [[tool.mypy.overrides]]
 module = [
-    "src.shared.python.signal_toolkit.*",
     "src.shared.python.plotting.*",
     "src.shared.python.ui.*",
     "src.shared.python.spatial_algebra.*",

--- a/src/shared/python/signal_toolkit/core.py
+++ b/src/shared/python/signal_toolkit/core.py
@@ -62,14 +62,14 @@ class Signal:
         """Sampling frequency in Hz."""
         if len(self.time) < 2:
             return 1.0
-        return 1.0 / np.mean(np.diff(self.time))
+        return float(1.0 / np.mean(np.diff(self.time)))
 
     @property
     def dt(self) -> float:
         """Time step in seconds."""
         if len(self.time) < 2:
             return 1.0
-        return np.mean(np.diff(self.time))
+        return float(np.mean(np.diff(self.time)))
 
     @property
     def duration(self) -> float:

--- a/src/shared/python/signal_toolkit/filters.py
+++ b/src/shared/python/signal_toolkit/filters.py
@@ -131,6 +131,7 @@ class FilterDesigner:
         nyquist = fs / 2
         btype = filter_type.value
 
+        wn: float | tuple[float, float]
         if filter_type in (FilterType.BANDPASS, FilterType.BANDSTOP):
             if not isinstance(cutoff, tuple):
                 msg = "Bandpass/bandstop filters require (low, high) cutoff tuple"
@@ -184,6 +185,7 @@ class FilterDesigner:
         nyquist = fs / 2
         btype = filter_type.value
 
+        wn: float | tuple[float, float]
         if filter_type in (FilterType.BANDPASS, FilterType.BANDSTOP, FilterType.NOTCH):
             if not isinstance(cutoff, tuple):
                 msg = "Bandpass/bandstop/notch filters require (low, high) cutoff tuple"
@@ -233,6 +235,7 @@ class FilterDesigner:
         nyquist = fs / 2
         btype = filter_type.value
 
+        wn: float | tuple[float, float]
         if filter_type in (FilterType.BANDPASS, FilterType.BANDSTOP, FilterType.NOTCH):
             if not isinstance(cutoff, tuple):
                 msg = "Bandpass/bandstop/notch filters require (low, high) cutoff tuple"
@@ -284,6 +287,7 @@ class FilterDesigner:
         nyquist = fs / 2
         btype = filter_type.value
 
+        wn: float | tuple[float, float]
         if filter_type in (FilterType.BANDPASS, FilterType.BANDSTOP, FilterType.NOTCH):
             if not isinstance(cutoff, tuple):
                 msg = "Bandpass/bandstop/notch filters require (low, high) cutoff tuple"
@@ -331,6 +335,7 @@ class FilterDesigner:
         nyquist = fs / 2
         btype = filter_type.value
 
+        wn: float | tuple[float, float]
         if filter_type in (FilterType.BANDPASS, FilterType.BANDSTOP, FilterType.NOTCH):
             if not isinstance(cutoff, tuple):
                 msg = "Bandpass/bandstop/notch filters require (low, high) cutoff tuple"

--- a/src/shared/python/signal_toolkit/fitting.py
+++ b/src/shared/python/signal_toolkit/fitting.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 from scipy import optimize
@@ -672,7 +673,7 @@ class CustomFunctionFitter:
 
         def custom_func(t: np.ndarray, *args: float) -> np.ndarray:
             # Build evaluation context with parameters
-            names = dict(safe_names)
+            names: dict[str, Any] = dict(safe_names)
             names["t"] = t
             for name, val in zip(param_names, args, strict=False):
                 names[name] = val

--- a/src/shared/python/signal_toolkit/noise.py
+++ b/src/shared/python/signal_toolkit/noise.py
@@ -86,7 +86,7 @@ class NoiseGenerator:
 
         elif noise_type == NoiseType.PERIODIC:
             frequency = kwargs.get("frequency", 60.0)  # Default 60 Hz (line noise)
-            fs = 1.0 / np.mean(np.diff(t)) if len(t) > 1 else 1000.0
+            fs = float(1.0 / np.mean(np.diff(t))) if len(t) > 1 else 1000.0
             values = self._generate_periodic_noise(n, amplitude, frequency, fs)
 
         else:
@@ -244,9 +244,9 @@ def add_noise_to_signal(
         # Calculate amplitude from SNR
         signal_power = np.mean(signal.values**2)
         noise_power = signal_power / (10 ** (snr_db / 10))
-        amplitude = np.sqrt(noise_power)
+        amplitude = float(np.sqrt(noise_power))
     elif amplitude is None:
-        amplitude = 0.1 * np.std(signal.values)
+        amplitude = float(0.1 * np.std(signal.values))
 
     noise = generator.generate(
         signal.time,


### PR DESCRIPTION
## Summary
- Fixed 17 mypy type errors across 5 files in `src/shared/python/signal_toolkit/`
- Removed `signal_toolkit/` from mypy exclusion list and overrides in `pyproject.toml`

## Changes
- **core.py**: Cast `np.mean()` returns to `float` for `fs`/`dt` properties
- **filters.py**: Add `wn: float | tuple[float, float]` annotations in all 5 filter design methods
- **fitting.py**: Annotate `names` dict as `dict[str, Any]` for mixed-type values
- **noise.py**: Cast `np.sqrt`/`np.std` returns to `float`, fix `floating[Any]` arg-type
- **io.py**: Annotate `value_data` dict, fix `process_all` return type, suppress numpy `savez` arg-type

## Test plan
- [x] `mypy` passes cleanly on all signal_toolkit files (0 errors)
- [x] 42/45 signal_toolkit tests pass (3 pre-existing tanh saturation failures)
- [x] `ruff check` and `black` pass

Closes #998 (partial - signal_toolkit directory complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily typing/annotation-only changes with minimal runtime impact; small risk limited to places where numpy scalar results are now explicitly cast to `float` and where `process_all`’s signature affects downstream type expectations.
> 
> **Overview**
> Removes `src/shared/python/signal_toolkit/` from mypy `exclude`/override lists so it is type-checked.
> 
> Fixes the resulting mypy errors by tightening types and adding explicit `float` casts/annotations across `core.py`, `filters.py`, `io.py`, `fitting.py`, and `noise.py` (including `process_all`’s return type, mixed-type expression eval context, and a couple `numpy.savez*` arg-type suppressions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eabc8752a5e4627dfbe2f3d84b812c577d0531d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->