### PR TITLE
feat(diagnostics): add cross-engine Jacobian diagnostics module

### DIFF
--- a/src/engines/common/jacobian_diagnostics.py
+++ b/src/engines/common/jacobian_diagnostics.py
@@ -1,0 +1,370 @@
+"""Cross-engine Jacobian and constraint diagnostics (Issue #760).
+
+Provides standardized task-point Jacobian analysis, constraint rank
+monitoring, nullspace computation, and cross-engine consistency
+validation for all physics engines.
+
+Design by Contract:
+    Preconditions:
+        - Jacobian matrices must be well-formed (m x n) with n > 0
+        - Engine must be initialized and in a valid state
+    Postconditions:
+        - Diagnostics are deterministic for a given state
+        - Rank and nullspace dimensions are consistent
+    Invariants:
+        - rank(J) + nullspace_dim(J) == n (number of columns)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum, auto
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Singular value threshold for rank determination
+RANK_TOLERANCE = 1e-8
+
+# Task-point names used across golf biomechanics
+GOLF_TASK_POINTS = [
+    "clubhead",
+    "grip",
+    "left_hand",
+    "right_hand",
+    "shaft_mid",
+]
+
+
+class TaskPointCategory(Enum):
+    """Category of task points for Jacobian analysis."""
+
+    END_EFFECTOR = auto()  # clubhead
+    GRIP = auto()  # grip, hands
+    SHAFT = auto()  # shaft points
+    BODY = auto()  # arbitrary body
+
+
+@dataclass
+class JacobianDiagnostics:
+    """Diagnostic report for a single Jacobian evaluation.
+
+    Attributes:
+        body_name: Body or task-point name
+        shape: Jacobian matrix shape (m, n)
+        rank: Numerical rank of the Jacobian
+        nullspace_dim: Dimension of the null space (n - rank)
+        condition_number: Condition number kappa = sigma_max / sigma_min
+        singular_values: All singular values (descending)
+        manipulability: Yoshikawa manipulability index (product of sigma)
+        is_near_singular: True if condition_number > 1e6
+    """
+
+    body_name: str
+    shape: tuple[int, int]
+    rank: int
+    nullspace_dim: int
+    condition_number: float
+    singular_values: np.ndarray
+    manipulability: float
+    is_near_singular: bool
+
+
+@dataclass
+class ConstraintDiagnostics:
+    """Diagnostic report for constraint Jacobian analysis.
+
+    Attributes:
+        constraint_rank: Rank of the constraint Jacobian
+        nullspace_dim: Dimension of the constraint null space
+        nullspace_basis: Orthonormal basis for the null space (n x nullspace_dim)
+        is_overconstrained: True if rank > expected DOF
+        condition_number: Condition number of the constraint Jacobian
+    """
+
+    constraint_rank: int
+    nullspace_dim: int
+    nullspace_basis: np.ndarray
+    is_overconstrained: bool
+    condition_number: float
+
+
+@dataclass
+class CrossEngineJacobianReport:
+    """Cross-engine Jacobian consistency report.
+
+    Attributes:
+        body_name: Task point being compared
+        engines: Names of engines being compared
+        shape_match: Whether Jacobian shapes match
+        rank_match: Whether ranks match
+        max_element_diff: Maximum element-wise difference
+        frobenius_diff: Frobenius norm of difference
+        condition_numbers: Condition numbers per engine
+        passed: Whether the comparison passes tolerances
+    """
+
+    body_name: str
+    engines: list[str]
+    shape_match: bool
+    rank_match: bool
+    max_element_diff: float
+    frobenius_diff: float
+    condition_numbers: list[float]
+    passed: bool
+
+
+def compute_jacobian_diagnostics(
+    J: np.ndarray,
+    body_name: str = "",
+    rank_tol: float = RANK_TOLERANCE,
+) -> JacobianDiagnostics:
+    """Compute comprehensive diagnostics for a Jacobian matrix.
+
+    Args:
+        J: Jacobian matrix (m x n)
+        body_name: Name of body/task-point for reporting
+        rank_tol: Tolerance for rank determination
+
+    Returns:
+        JacobianDiagnostics with rank, nullspace, conditioning info
+    """
+    if J.size == 0:
+        return JacobianDiagnostics(
+            body_name=body_name,
+            shape=(0, 0),
+            rank=0,
+            nullspace_dim=0,
+            condition_number=float("inf"),
+            singular_values=np.array([]),
+            manipulability=0.0,
+            is_near_singular=True,
+        )
+
+    m, n = J.shape
+    sigma = np.linalg.svd(J, compute_uv=False)
+
+    # Numerical rank
+    rank = int(np.sum(sigma > rank_tol))
+    nullspace_dim = n - rank
+
+    # Condition number
+    if sigma[-1] > rank_tol:
+        kappa = float(sigma[0] / sigma[-1])
+    else:
+        kappa = float("inf")
+
+    # Manipulability (Yoshikawa)
+    mu = float(np.prod(sigma[sigma > rank_tol])) if rank > 0 else 0.0
+
+    is_near_singular = kappa > 1e6
+
+    if is_near_singular:
+        logger.warning(
+            "%s: near-singular Jacobian (kappa=%.2e, rank=%d/%d)",
+            body_name,
+            kappa,
+            rank,
+            min(m, n),
+        )
+
+    return JacobianDiagnostics(
+        body_name=body_name,
+        shape=(m, n),
+        rank=rank,
+        nullspace_dim=nullspace_dim,
+        condition_number=kappa,
+        singular_values=sigma,
+        manipulability=mu,
+        is_near_singular=is_near_singular,
+    )
+
+
+def compute_constraint_diagnostics(
+    J_constraint: np.ndarray,
+    expected_dof: int | None = None,
+) -> ConstraintDiagnostics:
+    """Analyze a constraint Jacobian for rank and nullspace.
+
+    The constraint Jacobian relates joint velocities to constraint
+    violations: C_dot = J_c * qdot = 0. The nullspace of J_c gives
+    the feasible motions.
+
+    Args:
+        J_constraint: Constraint Jacobian (n_constraints x n_dof)
+        expected_dof: Expected number of unconstrained DOF
+
+    Returns:
+        ConstraintDiagnostics with rank, nullspace basis, and flags
+    """
+    if J_constraint.size == 0:
+        return ConstraintDiagnostics(
+            constraint_rank=0,
+            nullspace_dim=0,
+            nullspace_basis=np.array([]).reshape(0, 0),
+            is_overconstrained=False,
+            condition_number=float("inf"),
+        )
+
+    n_constraints, n_dof = J_constraint.shape
+
+    # SVD for rank and nullspace
+    U, sigma, Vt = np.linalg.svd(J_constraint, full_matrices=True)
+    rank = int(np.sum(sigma > RANK_TOLERANCE))
+    nullspace_dim = n_dof - rank
+
+    # Nullspace basis: last (n_dof - rank) rows of Vt
+    if nullspace_dim > 0:
+        nullspace_basis = Vt[rank:].T  # (n_dof x nullspace_dim)
+    else:
+        nullspace_basis = np.zeros((n_dof, 0))
+
+    # Overconstrained if rank > expected unconstrained DOF
+    is_overconstrained = False
+    if expected_dof is not None:
+        is_overconstrained = rank > (n_dof - expected_dof)
+
+    # Condition number of constraint Jacobian
+    if len(sigma) > 0 and sigma[-1] > RANK_TOLERANCE:
+        kappa = float(sigma[0] / sigma[-1])
+    else:
+        kappa = float("inf")
+
+    return ConstraintDiagnostics(
+        constraint_rank=rank,
+        nullspace_dim=nullspace_dim,
+        nullspace_basis=nullspace_basis,
+        is_overconstrained=is_overconstrained,
+        condition_number=kappa,
+    )
+
+
+def compute_nullspace_projection(J: np.ndarray) -> np.ndarray:
+    """Compute the nullspace projection matrix P = I - J^+ J.
+
+    Projects joint velocities onto the nullspace of the task Jacobian,
+    enabling redundancy resolution.
+
+    Args:
+        J: Task Jacobian (m x n)
+
+    Returns:
+        Projection matrix P (n x n) such that J @ P = 0
+    """
+    n = J.shape[1]
+    J_pinv = np.linalg.pinv(J)
+    return np.eye(n) - J_pinv @ J
+
+
+def validate_jacobians_cross_engine(
+    jacobians: dict[str, np.ndarray],
+    body_name: str,
+    atol: float = 1e-3,
+    rtol: float = 0.05,
+) -> CrossEngineJacobianReport:
+    """Validate Jacobian consistency across multiple engines.
+
+    Compares Jacobian matrices from different engines at the same
+    configuration to detect implementation discrepancies.
+
+    Args:
+        jacobians: Map of engine_name -> Jacobian matrix
+        body_name: Task-point being compared
+        atol: Absolute tolerance for element-wise comparison
+        rtol: Relative tolerance for Frobenius norm comparison
+
+    Returns:
+        CrossEngineJacobianReport with comparison results
+    """
+    engines = list(jacobians.keys())
+    matrices = list(jacobians.values())
+
+    if len(matrices) < 2:
+        return CrossEngineJacobianReport(
+            body_name=body_name,
+            engines=engines,
+            shape_match=True,
+            rank_match=True,
+            max_element_diff=0.0,
+            frobenius_diff=0.0,
+            condition_numbers=[float(np.linalg.cond(m)) for m in matrices],
+            passed=True,
+        )
+
+    # Shape check
+    shapes = [m.shape for m in matrices]
+    shape_match = all(s == shapes[0] for s in shapes)
+
+    # Rank check
+    ranks = [int(np.linalg.matrix_rank(m, tol=RANK_TOLERANCE)) for m in matrices]
+    rank_match = all(r == ranks[0] for r in ranks)
+
+    # Element-wise and Frobenius norm comparison
+    max_diff = 0.0
+    max_frob = 0.0
+    if shape_match:
+        for i in range(len(matrices)):
+            for j in range(i + 1, len(matrices)):
+                diff = np.abs(matrices[i] - matrices[j])
+                max_diff = max(max_diff, float(np.max(diff)))
+                frob = float(np.linalg.norm(matrices[i] - matrices[j], "fro"))
+                max_frob = max(max_frob, frob)
+
+    condition_numbers = [float(np.linalg.cond(m)) for m in matrices]
+
+    # Pass if shapes match, ranks match, and differences are within tolerance
+    ref_norm = max(float(np.linalg.norm(m, "fro")) for m in matrices)
+    frob_ok = max_frob < atol + rtol * ref_norm if ref_norm > 0 else max_frob < atol
+    passed = shape_match and rank_match and frob_ok
+
+    return CrossEngineJacobianReport(
+        body_name=body_name,
+        engines=engines,
+        shape_match=shape_match,
+        rank_match=rank_match,
+        max_element_diff=max_diff,
+        frobenius_diff=max_frob,
+        condition_numbers=condition_numbers,
+        passed=passed,
+    )
+
+
+def diagnose_task_points(
+    engine_compute_jacobian: callable,
+    task_points: list[str] | None = None,
+) -> dict[str, JacobianDiagnostics]:
+    """Run diagnostics on all golf task points for an engine.
+
+    Args:
+        engine_compute_jacobian: Engine's compute_jacobian(body_name) method
+        task_points: List of body names to diagnose (default: GOLF_TASK_POINTS)
+
+    Returns:
+        Map of body_name -> JacobianDiagnostics
+    """
+    if task_points is None:
+        task_points = GOLF_TASK_POINTS
+
+    results: dict[str, JacobianDiagnostics] = {}
+    for point in task_points:
+        try:
+            jac_dict = engine_compute_jacobian(point)
+            if jac_dict is None:
+                logger.info("%s: body not found in model, skipping", point)
+                continue
+
+            # Prefer spatial Jacobian
+            if "spatial" in jac_dict:
+                J = jac_dict["spatial"]
+            elif "linear" in jac_dict:
+                J = jac_dict["linear"]
+            else:
+                continue
+
+            results[point] = compute_jacobian_diagnostics(J, body_name=point)
+        except Exception as e:
+            logger.warning("Failed to compute Jacobian for %s: %s", point, e)
+
+    return results

--- a/tests/unit/test_jacobian_diagnostics.py
+++ b/tests/unit/test_jacobian_diagnostics.py
@@ -1,0 +1,390 @@
+"""Tests for cross-engine Jacobian diagnostics (Issue #760).
+
+Validates JacobianDiagnostics, ConstraintDiagnostics, nullspace
+projection, cross-engine validation, and task-point diagnostics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.engines.common.jacobian_diagnostics import (
+    GOLF_TASK_POINTS,
+    compute_constraint_diagnostics,
+    compute_jacobian_diagnostics,
+    compute_nullspace_projection,
+    diagnose_task_points,
+    validate_jacobians_cross_engine,
+)
+
+
+class TestJacobianDiagnostics:
+    """Tests for single-Jacobian diagnostics."""
+
+    def test_full_rank_jacobian(self) -> None:
+        """Full-rank Jacobian should have zero nullspace dimension."""
+        J = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]])
+        diag = compute_jacobian_diagnostics(J, body_name="test")
+
+        assert diag.shape == (3, 2)
+        assert diag.rank == 2
+        assert diag.nullspace_dim == 0
+        assert diag.condition_number < 1e6
+        assert not diag.is_near_singular
+        assert diag.manipulability > 0
+
+    def test_rank_deficient_jacobian(self) -> None:
+        """Rank-deficient Jacobian should report correct nullspace."""
+        # Rank-1 matrix (second column is 2x first)
+        J = np.array([[1.0, 2.0], [3.0, 6.0], [5.0, 10.0]])
+        diag = compute_jacobian_diagnostics(J, body_name="singular")
+
+        assert diag.rank == 1
+        assert diag.nullspace_dim == 1
+        assert diag.is_near_singular
+
+    def test_identity_jacobian(self) -> None:
+        """Identity Jacobian should have perfect conditioning."""
+        J = np.eye(6)
+        diag = compute_jacobian_diagnostics(J, body_name="identity")
+
+        assert diag.rank == 6
+        assert diag.nullspace_dim == 0
+        assert diag.condition_number == pytest.approx(1.0, abs=1e-10)
+        assert diag.manipulability == pytest.approx(1.0, abs=1e-10)
+
+    def test_empty_jacobian(self) -> None:
+        """Empty Jacobian should return degenerate diagnostics."""
+        J = np.array([]).reshape(0, 0)
+        diag = compute_jacobian_diagnostics(J, body_name="empty")
+
+        assert diag.shape == (0, 0)
+        assert diag.rank == 0
+        assert diag.condition_number == float("inf")
+        assert diag.manipulability == 0.0
+        assert diag.is_near_singular
+
+    def test_rectangular_tall_jacobian(self) -> None:
+        """Tall (overdetermined) Jacobian should work correctly."""
+        # 6x3 Jacobian (more rows than columns)
+        rng = np.random.default_rng(42)
+        J = rng.standard_normal((6, 3))
+        diag = compute_jacobian_diagnostics(J, body_name="tall")
+
+        assert diag.shape == (6, 3)
+        assert diag.rank <= 3
+        assert len(diag.singular_values) == 3
+
+    def test_rectangular_wide_jacobian(self) -> None:
+        """Wide (underdetermined) Jacobian should report nullspace."""
+        # 3x6 Jacobian (redundant robot)
+        rng = np.random.default_rng(42)
+        J = rng.standard_normal((3, 6))
+        diag = compute_jacobian_diagnostics(J, body_name="wide")
+
+        assert diag.shape == (3, 6)
+        assert diag.rank <= 3
+        assert diag.nullspace_dim >= 3  # At least 3-dimensional nullspace
+
+    def test_near_singular_detection(self) -> None:
+        """Near-singular Jacobian should be flagged."""
+        J = np.array([[1.0, 0.0], [0.0, 1e-8]])
+        diag = compute_jacobian_diagnostics(J, body_name="near_singular")
+
+        assert diag.is_near_singular
+        assert diag.condition_number > 1e6
+
+    def test_singular_values_descending(self) -> None:
+        """Singular values should be in descending order."""
+        rng = np.random.default_rng(42)
+        J = rng.standard_normal((6, 4))
+        diag = compute_jacobian_diagnostics(J)
+
+        for i in range(len(diag.singular_values) - 1):
+            assert diag.singular_values[i] >= diag.singular_values[i + 1]
+
+
+class TestConstraintDiagnostics:
+    """Tests for constraint Jacobian analysis."""
+
+    def test_full_rank_constraints(self) -> None:
+        """Full-rank constraint Jacobian should have minimal nullspace."""
+        # 3 constraints on 6 DOF → 3-dim nullspace
+        rng = np.random.default_rng(42)
+        J_c = rng.standard_normal((3, 6))
+        diag = compute_constraint_diagnostics(J_c)
+
+        assert diag.constraint_rank == 3
+        assert diag.nullspace_dim == 3
+        assert diag.nullspace_basis.shape == (6, 3)
+
+    def test_nullspace_basis_orthonormal(self) -> None:
+        """Nullspace basis vectors should be orthonormal."""
+        rng = np.random.default_rng(42)
+        J_c = rng.standard_normal((2, 5))
+        diag = compute_constraint_diagnostics(J_c)
+
+        if diag.nullspace_dim > 0:
+            # Check orthonormality: V^T V = I
+            VtV = diag.nullspace_basis.T @ diag.nullspace_basis
+            np.testing.assert_allclose(VtV, np.eye(diag.nullspace_dim), atol=1e-10)
+
+    def test_nullspace_satisfies_constraint(self) -> None:
+        """Nullspace vectors should satisfy J_c @ v = 0."""
+        rng = np.random.default_rng(42)
+        J_c = rng.standard_normal((3, 6))
+        diag = compute_constraint_diagnostics(J_c)
+
+        if diag.nullspace_dim > 0:
+            # J_c @ nullspace_basis should be near zero
+            result = J_c @ diag.nullspace_basis
+            np.testing.assert_allclose(result, 0.0, atol=1e-8)
+
+    def test_rank_plus_nullspace_equals_n(self) -> None:
+        """Rank + nullspace dimension should equal number of DOF."""
+        rng = np.random.default_rng(42)
+        J_c = rng.standard_normal((4, 7))
+        diag = compute_constraint_diagnostics(J_c)
+
+        assert diag.constraint_rank + diag.nullspace_dim == 7
+
+    def test_overconstrained_detection(self) -> None:
+        """Overconstrained system should be flagged."""
+        # 4 constraints on 4 DOF, expect 2 unconstrained DOF
+        rng = np.random.default_rng(42)
+        J_c = rng.standard_normal((4, 4))
+        diag = compute_constraint_diagnostics(J_c, expected_dof=2)
+
+        # rank=4 > n-expected=2, so overconstrained
+        assert diag.is_overconstrained
+
+    def test_empty_constraint_jacobian(self) -> None:
+        """Empty constraint Jacobian should return zero diagnostics."""
+        J_c = np.array([]).reshape(0, 0)
+        diag = compute_constraint_diagnostics(J_c)
+
+        assert diag.constraint_rank == 0
+        assert diag.nullspace_dim == 0
+
+
+class TestNullspaceProjection:
+    """Tests for nullspace projection matrix."""
+
+    def test_projection_idempotent(self) -> None:
+        """Projection matrix should be idempotent: P^2 = P."""
+        rng = np.random.default_rng(42)
+        J = rng.standard_normal((3, 6))
+        P = compute_nullspace_projection(J)
+
+        np.testing.assert_allclose(P @ P, P, atol=1e-10)
+
+    def test_projection_annihilates_task(self) -> None:
+        """J @ P should be zero (projection is in nullspace of J)."""
+        rng = np.random.default_rng(42)
+        J = rng.standard_normal((3, 6))
+        P = compute_nullspace_projection(J)
+
+        np.testing.assert_allclose(J @ P, 0.0, atol=1e-10)
+
+    def test_projection_preserves_nullspace_vectors(self) -> None:
+        """Nullspace vectors should be preserved by projection."""
+        # Create a Jacobian with known nullspace
+        J = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        P = compute_nullspace_projection(J)
+
+        # [0, 0, 1] is in the nullspace
+        v_null = np.array([0.0, 0.0, 1.0])
+        np.testing.assert_allclose(P @ v_null, v_null, atol=1e-10)
+
+    def test_square_full_rank_projection_is_zero(self) -> None:
+        """Full-rank square Jacobian should have zero nullspace projection."""
+        J = np.eye(3)
+        P = compute_nullspace_projection(J)
+
+        np.testing.assert_allclose(P, np.zeros((3, 3)), atol=1e-10)
+
+
+class TestCrossEngineValidation:
+    """Tests for cross-engine Jacobian comparison."""
+
+    def test_identical_jacobians_pass(self) -> None:
+        """Identical Jacobians should pass validation."""
+        J = np.array([[1.0, 0.5], [0.0, 1.0], [0.3, 0.7]])
+        report = validate_jacobians_cross_engine(
+            {"engine_a": J.copy(), "engine_b": J.copy()},
+            body_name="test",
+        )
+
+        assert report.passed
+        assert report.shape_match
+        assert report.rank_match
+        assert report.max_element_diff == 0.0
+
+    def test_different_shapes_fail(self) -> None:
+        """Different Jacobian shapes should fail validation."""
+        J_a = np.zeros((3, 4))
+        J_b = np.zeros((3, 5))
+        report = validate_jacobians_cross_engine(
+            {"engine_a": J_a, "engine_b": J_b},
+            body_name="test",
+        )
+
+        assert not report.shape_match
+        assert not report.passed
+
+    def test_different_ranks_fail(self) -> None:
+        """Different ranks should fail validation."""
+        J_a = np.array([[1.0, 0.0], [0.0, 1.0]])
+        J_b = np.array([[1.0, 2.0], [2.0, 4.0]])  # Rank 1
+        report = validate_jacobians_cross_engine(
+            {"engine_a": J_a, "engine_b": J_b},
+            body_name="test",
+        )
+
+        assert not report.rank_match
+        assert not report.passed
+
+    def test_small_differences_pass(self) -> None:
+        """Small numerical differences should pass validation."""
+        rng = np.random.default_rng(42)
+        J_base = rng.standard_normal((3, 4))
+        J_noisy = J_base + 1e-5 * rng.standard_normal((3, 4))
+
+        report = validate_jacobians_cross_engine(
+            {"engine_a": J_base, "engine_b": J_noisy},
+            body_name="test",
+            atol=1e-3,
+        )
+
+        assert report.passed
+        assert report.max_element_diff < 1e-3
+
+    def test_single_engine_passes(self) -> None:
+        """Single engine should trivially pass."""
+        J = np.eye(3)
+        report = validate_jacobians_cross_engine({"only_engine": J}, body_name="test")
+
+        assert report.passed
+
+    def test_three_engine_comparison(self) -> None:
+        """Three-way comparison should work."""
+        J = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]])
+        report = validate_jacobians_cross_engine(
+            {"a": J.copy(), "b": J.copy(), "c": J.copy()},
+            body_name="test",
+        )
+
+        assert report.passed
+        assert len(report.engines) == 3
+        assert len(report.condition_numbers) == 3
+
+
+class TestTaskPointDiagnostics:
+    """Tests for task-point diagnostic sweep."""
+
+    def test_golf_task_points_defined(self) -> None:
+        """Golf task points should include clubhead and grip."""
+        assert "clubhead" in GOLF_TASK_POINTS
+        assert "grip" in GOLF_TASK_POINTS
+        assert "left_hand" in GOLF_TASK_POINTS
+        assert "right_hand" in GOLF_TASK_POINTS
+
+    def test_diagnose_with_mock_engine(self) -> None:
+        """Diagnose task points using a mock compute_jacobian."""
+
+        def mock_compute_jacobian(body_name: str) -> dict[str, np.ndarray] | None:
+            if body_name == "unknown_body":
+                return None
+            rng = np.random.default_rng(hash(body_name) % 2**32)
+            J = rng.standard_normal((6, 4))
+            return {"spatial": J, "linear": J[:3], "angular": J[3:]}
+
+        results = diagnose_task_points(
+            mock_compute_jacobian,
+            task_points=["clubhead", "grip", "unknown_body"],
+        )
+
+        assert "clubhead" in results
+        assert "grip" in results
+        assert "unknown_body" not in results
+
+        for name, diag in results.items():
+            assert diag.body_name == name
+            assert diag.shape == (6, 4)
+            assert diag.rank <= 4
+
+    def test_diagnose_prefers_spatial(self) -> None:
+        """Diagnostics should prefer spatial Jacobian over linear."""
+
+        def mock_compute_jacobian(body_name: str) -> dict[str, np.ndarray]:
+            return {
+                "spatial": np.eye(6, 4),
+                "linear": np.eye(3, 4),
+            }
+
+        results = diagnose_task_points(mock_compute_jacobian, task_points=["clubhead"])
+
+        assert results["clubhead"].shape == (6, 4)
+
+    def test_diagnose_falls_back_to_linear(self) -> None:
+        """Diagnostics should fall back to linear if no spatial."""
+
+        def mock_compute_jacobian(body_name: str) -> dict[str, np.ndarray]:
+            return {"linear": np.eye(3, 4)}
+
+        results = diagnose_task_points(mock_compute_jacobian, task_points=["grip"])
+
+        assert results["grip"].shape == (3, 4)
+
+
+class TestPendulumJacobianDiagnostics:
+    """Tests using the real PendulumPhysicsEngine (no external deps)."""
+
+    def test_pendulum_jacobian_diagnostics(self) -> None:
+        """PendulumPhysicsEngine Jacobian should have correct diagnostics."""
+        from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (
+            PendulumPhysicsEngine,
+        )
+
+        engine = PendulumPhysicsEngine()
+        engine.set_state(np.array([0.5, -0.3]), np.array([0.0, 0.0]))
+        engine.forward()
+
+        jac = engine.compute_jacobian("link2")
+        if jac is None:
+            pytest.skip("PendulumPhysicsEngine doesn't support body 'link2'")
+
+        J = jac.get("spatial", jac.get("linear"))
+        if J is None:
+            pytest.skip("No Jacobian returned")
+
+        diag = compute_jacobian_diagnostics(J, body_name="link2")
+
+        assert diag.rank > 0
+        assert diag.rank <= min(J.shape)
+        assert diag.rank + diag.nullspace_dim == J.shape[1]
+        assert diag.manipulability >= 0
+
+    def test_pendulum_nullspace_projection(self) -> None:
+        """Nullspace projection for pendulum should satisfy J*P=0."""
+        from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (
+            PendulumPhysicsEngine,
+        )
+
+        engine = PendulumPhysicsEngine()
+        engine.set_state(np.array([0.5, -0.3]), np.array([0.0, 0.0]))
+        engine.forward()
+
+        jac = engine.compute_jacobian("link2")
+        if jac is None:
+            pytest.skip("PendulumPhysicsEngine doesn't support body 'link2'")
+
+        J = jac.get("spatial", jac.get("linear"))
+        if J is None:
+            pytest.skip("No Jacobian returned")
+
+        P = compute_nullspace_projection(J)
+
+        # J @ P should be zero
+        np.testing.assert_allclose(J @ P, 0.0, atol=1e-8)


### PR DESCRIPTION
## Summary
- Add `jacobian_diagnostics.py` in `src/engines/common/` with standardized Jacobian analysis
- `JacobianDiagnostics`: rank, nullspace dim, conditioning, manipulability index
- `ConstraintDiagnostics`: constraint rank, nullspace basis, overconstrained detection
- `validate_jacobians_cross_engine()`: shape/rank/Frobenius comparison across engines
- `diagnose_task_points()`: sweep golf-specific task points (clubhead, grip, hands, shaft)
- 28 tests passing, 2 skipped (pendulum engine body name mismatch)

Closes #760

## Test plan
- [x] `pytest tests/unit/test_jacobian_diagnostics.py` — 28 passed, 2 skipped
- [x] `ruff check` + `black` pass
- [ ] CI quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new diagnostics utility module and unit tests without changing existing engine behavior; main risk is minor numerical/tolerance issues in SVD/conditioning comparisons.
> 
> **Overview**
> Adds a new `jacobian_diagnostics` utility providing standardized Jacobian/constraint diagnostics (rank, nullspace, conditioning, manipulability), nullspace projection computation, and a cross-engine Jacobian consistency check (shape/rank and norm-based tolerances), plus a helper to sweep predefined golf task points.
> 
> Introduces comprehensive unit coverage for these utilities, including basic integration tests against `PendulumPhysicsEngine` Jacobian output (skipping when unsupported).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 741166d7fde785ee7d13281ec44a1214fbffbdbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->