### PR TITLE
feat: shared physics backend API, engine capabilities, and simulation controls (#1202, #1204, #1209)

### DIFF
--- a/src/api/models/responses.py
+++ b/src/api/models/responses.py
@@ -101,3 +101,185 @@ class TaskStatusResponse(BaseModel):
     progress: float | None = Field(None, description="Progress percentage (0-100)")
     result: dict[str, Any] | None = Field(None, description="Task result if completed")
     error: str | None = Field(None, description="Error message if failed")
+
+
+# ──────────────────────────────────────────────────────────────
+#  Phase 2: Shared Physics Backend API Responses (#1209, #1204, #1202)
+# ──────────────────────────────────────────────────────────────
+
+
+class JointInfoResponse(BaseModel):
+    """Response model for a single joint's info."""
+
+    index: int = Field(..., description="Joint index in state vector")
+    name: str = Field(..., description="Joint name")
+    torque_limit: float = Field(..., description="Maximum absolute torque (N*m)")
+    position_limit_lower: float = Field(..., description="Lower position limit (rad)")
+    position_limit_upper: float = Field(..., description="Upper position limit (rad)")
+    velocity_limit: float = Field(..., description="Max absolute velocity (rad/s)")
+    current_torque: float = Field(..., description="Currently applied torque")
+
+
+class ActuatorStateResponse(BaseModel):
+    """Response model for actuator/control state.
+
+    See issue #1209
+    """
+
+    strategy: str = Field(..., description="Active control strategy")
+    n_joints: int = Field(..., description="Number of actuated joints", ge=0)
+    joint_names: list[str] = Field(..., description="Names of all joints")
+    torques: list[float] = Field(..., description="Current applied torques")
+    target_positions: list[float] | None = Field(
+        None, description="Target positions if set"
+    )
+    target_velocities: list[float] | None = Field(
+        None, description="Target velocities if set"
+    )
+    kp: list[float] = Field(..., description="Proportional gains")
+    kd: list[float] = Field(..., description="Derivative gains")
+    ki: list[float] = Field(..., description="Integral gains")
+    joints: list[JointInfoResponse] = Field(..., description="Per-joint details")
+    available_strategies: list[dict[str, str]] = Field(
+        ..., description="All available control strategies"
+    )
+
+
+class ForceVectorResponse(BaseModel):
+    """Response model for force/torque vector data.
+
+    Postconditions:
+        - vectors list may be empty if no forces computed
+
+    See issue #1209
+    """
+
+    sim_time: float = Field(..., description="Current simulation time")
+    gravity_forces: list[float] | None = Field(
+        None, description="Gravity force vector g(q)"
+    )
+    contact_forces: list[float] | None = Field(
+        None, description="Ground reaction forces"
+    )
+    applied_torques: list[float] = Field(..., description="Currently applied torques")
+    bias_forces: list[float] | None = Field(
+        None, description="Bias forces C(q,v) + g(q)"
+    )
+
+
+class BiomechanicsMetricsResponse(BaseModel):
+    """Response model for biomechanics metrics.
+
+    See issue #1209
+    """
+
+    sim_time: float = Field(..., description="Current simulation time")
+    club_head_speed: float | None = Field(
+        None, description="Club head speed (m/s)"
+    )
+    kinetic_energy: float | None = Field(
+        None, description="Total kinetic energy (J)"
+    )
+    potential_energy: float | None = Field(
+        None, description="Total potential energy (J)"
+    )
+    joint_positions: list[float] = Field(..., description="Current joint positions")
+    joint_velocities: list[float] = Field(..., description="Current joint velocities")
+    peak_torque: float | None = Field(
+        None, description="Peak torque across all joints (N*m)"
+    )
+    total_torque_magnitude: float | None = Field(
+        None, description="Sum of absolute torques (N*m)"
+    )
+
+
+class CapabilityLevelResponse(BaseModel):
+    """Response model for a single capability level."""
+
+    name: str = Field(..., description="Capability name")
+    level: str = Field(..., description="Support level: full, partial, or none")
+    supported: bool = Field(..., description="Whether capability is available")
+
+
+class EngineCapabilitiesResponse(BaseModel):
+    """Response model for engine capabilities.
+
+    See issue #1204
+    """
+
+    engine_name: str = Field(..., description="Engine identifier")
+    engine_type: str = Field(..., description="Engine type enum value")
+    capabilities: list[CapabilityLevelResponse] = Field(
+        ..., description="All capabilities with support levels"
+    )
+    summary: dict[str, int] = Field(
+        ..., description="Counts: full, partial, none"
+    )
+
+
+class ControlFeaturesResponse(BaseModel):
+    """Response model for control features registry data.
+
+    See issue #1209
+    """
+
+    engine: str = Field(..., description="Engine class name")
+    total_features: int = Field(..., description="Total registered features")
+    available_features: int = Field(..., description="Available on this engine")
+    categories: list[dict[str, Any]] = Field(
+        ..., description="Feature categories with counts"
+    )
+    features: list[dict[str, Any]] = Field(..., description="Feature descriptors")
+
+
+class SimulationStatsResponse(BaseModel):
+    """Response model for simulation runtime statistics.
+
+    See issue #1202
+    """
+
+    sim_time: float = Field(..., description="Current simulation time (s)")
+    wall_time: float = Field(..., description="Wall clock time elapsed (s)")
+    fps: float = Field(..., description="Simulation frames per second")
+    real_time_factor: float = Field(
+        ..., description="Sim time / wall time ratio"
+    )
+    speed_factor: float = Field(
+        ..., description="Current speed multiplier"
+    )
+    is_recording: bool = Field(..., description="Whether trajectory is being recorded")
+    frame_count: int = Field(..., description="Total frames simulated")
+
+
+class SpeedControlResponse(BaseModel):
+    """Response model for speed control updates.
+
+    See issue #1202
+    """
+
+    speed_factor: float = Field(..., description="Applied speed multiplier")
+    status: str = Field(..., description="Status message")
+
+
+class CameraPresetResponse(BaseModel):
+    """Response model for camera preset application.
+
+    See issue #1202
+    """
+
+    preset: str = Field(..., description="Applied camera preset")
+    position: list[float] = Field(..., description="Camera position [x, y, z]")
+    target: list[float] = Field(..., description="Camera look-at target [x, y, z]")
+    up: list[float] = Field(..., description="Camera up vector [x, y, z]")
+
+
+class TrajectoryRecordResponse(BaseModel):
+    """Response model for trajectory recording state.
+
+    See issue #1202
+    """
+
+    recording: bool = Field(..., description="Whether recording is active")
+    frame_count: int = Field(..., description="Frames recorded so far")
+    status: str = Field(..., description="Status message")
+    export_path: str | None = Field(None, description="Path to exported file")

--- a/src/api/routes/physics.py
+++ b/src/api/routes/physics.py
@@ -1,0 +1,575 @@
+"""Physics simulation control routes.
+
+Provides endpoints for per-actuator control, force/torque queries,
+biomechanics metrics, control features registry, and simulation
+runtime controls (speed, camera, recording).
+
+See issue #1209, #1202
+
+All dependencies are injected via FastAPI's Depends() mechanism.
+No module-level mutable state.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..dependencies import get_engine_manager, get_logger
+from ..models.requests import (
+    ActuatorUpdateRequest,
+    CameraPresetRequest,
+    SpeedControlRequest,
+    TrajectoryRecordRequest,
+)
+from ..models.responses import (
+    ActuatorStateResponse,
+    BiomechanicsMetricsResponse,
+    CameraPresetResponse,
+    ControlFeaturesResponse,
+    ForceVectorResponse,
+    SimulationStatsResponse,
+    SpeedControlResponse,
+    TrajectoryRecordResponse,
+)
+
+if TYPE_CHECKING:
+    from src.shared.python.engine_manager import EngineManager
+
+router = APIRouter()
+
+# Module-level state is stored in app.state via dependency injection.
+# These defaults are used when no simulation state exists yet.
+_DEFAULT_SPEED_FACTOR = 1.0
+
+# Camera preset definitions (position, target, up vectors)
+CAMERA_PRESETS: dict[str, dict[str, list[float]]] = {
+    "side": {
+        "position": [3.0, 0.0, 1.5],
+        "target": [0.0, 0.0, 1.0],
+        "up": [0.0, 0.0, 1.0],
+    },
+    "front": {
+        "position": [0.0, 3.0, 1.5],
+        "target": [0.0, 0.0, 1.0],
+        "up": [0.0, 0.0, 1.0],
+    },
+    "top": {
+        "position": [0.0, 0.0, 5.0],
+        "target": [0.0, 0.0, 0.0],
+        "up": [0.0, 1.0, 0.0],
+    },
+    "follow_ball": {
+        "position": [2.0, 2.0, 1.0],
+        "target": [0.0, 0.0, 0.0],
+        "up": [0.0, 0.0, 1.0],
+    },
+    "follow_club": {
+        "position": [1.5, -1.0, 2.0],
+        "target": [0.0, 0.0, 1.5],
+        "up": [0.0, 0.0, 1.0],
+    },
+}
+
+
+def _get_control_interface(
+    engine_manager: EngineManager,
+) -> Any:
+    """Get or create a ControlInterface for the active engine.
+
+    Returns:
+        ControlInterface instance, or None if no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        return None
+
+    # Check if we already have a cached control interface
+    if hasattr(engine_manager, "_control_interface"):
+        return engine_manager._control_interface
+
+    try:
+        from src.shared.python.control_interface import ControlInterface
+
+        ctrl = ControlInterface(engine)
+        engine_manager._control_interface = ctrl  # type: ignore[attr-defined]
+        return ctrl
+    except Exception:
+        return None
+
+
+def _get_features_registry(
+    engine_manager: EngineManager,
+) -> Any:
+    """Get or create a ControlFeaturesRegistry for the active engine.
+
+    Returns:
+        ControlFeaturesRegistry instance, or None if no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        return None
+
+    if hasattr(engine_manager, "_features_registry"):
+        return engine_manager._features_registry
+
+    try:
+        from src.shared.python.control_features_registry import (
+            ControlFeaturesRegistry,
+        )
+
+        registry = ControlFeaturesRegistry(engine)
+        engine_manager._features_registry = registry  # type: ignore[attr-defined]
+        return registry
+    except Exception:
+        return None
+
+
+# ──────────────────────────────────────────────────────────────
+#  Actuator Control (See issue #1209)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.post("/simulation/actuators", response_model=ActuatorStateResponse)
+async def update_actuators(
+    request: ActuatorUpdateRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> ActuatorStateResponse:
+    """Update per-actuator control parameters.
+
+    Allows setting control strategy, torques, gains, and target
+    positions/velocities for the active physics engine.
+
+    Args:
+        request: Actuator parameter updates.
+        engine_manager: Injected engine manager.
+        logger: Injected logger.
+
+    Returns:
+        Current actuator/control state after applying updates.
+
+    Raises:
+        HTTPException: If no engine is loaded or parameters are invalid.
+    """
+    ctrl = _get_control_interface(engine_manager)
+    if ctrl is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        if request.strategy is not None:
+            ctrl.set_strategy(request.strategy)
+
+        if request.torques is not None:
+            ctrl.set_torques(request.torques)
+
+        if request.kp is not None or request.kd is not None or request.ki is not None:
+            ctrl.set_gains(kp=request.kp, kd=request.kd, ki=request.ki)
+
+        if request.target_positions is not None:
+            ctrl.set_target_positions(request.target_positions)
+
+        if request.target_velocities is not None:
+            ctrl.set_target_velocities(request.target_velocities)
+
+        state = ctrl.get_state()
+        return ActuatorStateResponse(
+            **state,
+            available_strategies=ctrl.get_available_strategies(),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        if logger:
+            logger.error("Actuator update error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Actuator update failed: {str(exc)}"
+        ) from exc
+
+
+@router.get("/simulation/actuators", response_model=ActuatorStateResponse)
+async def get_actuator_state(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> ActuatorStateResponse:
+    """Get current actuator/control state.
+
+    Returns:
+        Current actuator state including strategy, torques, and gains.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    ctrl = _get_control_interface(engine_manager)
+    if ctrl is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    state = ctrl.get_state()
+    return ActuatorStateResponse(
+        **state,
+        available_strategies=ctrl.get_available_strategies(),
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+#  Force/Torque Vectors (See issue #1209)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/simulation/forces", response_model=ForceVectorResponse)
+async def get_forces(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> ForceVectorResponse:
+    """Get current force and torque vectors from the active engine.
+
+    Returns:
+        Force vectors including gravity, contact forces, applied torques,
+        and bias forces.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        sim_time = getattr(engine, "time", 0.0)
+
+        # Gravity forces
+        gravity = None
+        try:
+            g = engine.compute_gravity_forces()
+            gravity = g.tolist() if hasattr(g, "tolist") else list(g)
+        except Exception:
+            pass
+
+        # Contact forces
+        contact = None
+        try:
+            c = engine.compute_contact_forces()
+            contact = c.tolist() if hasattr(c, "tolist") else list(c)
+        except Exception:
+            pass
+
+        # Applied torques from control interface
+        ctrl = _get_control_interface(engine_manager)
+        applied = []
+        if ctrl is not None:
+            applied = ctrl.current_torques.tolist()
+
+        # Bias forces
+        bias = None
+        try:
+            b = engine.compute_bias_forces()
+            bias = b.tolist() if hasattr(b, "tolist") else list(b)
+        except Exception:
+            pass
+
+        return ForceVectorResponse(
+            sim_time=sim_time,
+            gravity_forces=gravity,
+            contact_forces=contact,
+            applied_torques=applied,
+            bias_forces=bias,
+        )
+    except Exception as exc:
+        if logger:
+            logger.error("Force query error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Force query failed: {str(exc)}"
+        ) from exc
+
+
+# ──────────────────────────────────────────────────────────────
+#  Biomechanics Metrics (See issue #1209)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/simulation/metrics", response_model=BiomechanicsMetricsResponse)
+async def get_metrics(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> BiomechanicsMetricsResponse:
+    """Get current biomechanics metrics from the active simulation.
+
+    Returns:
+        Metrics including club head speed, energy, joint states, and torques.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        sim_time = getattr(engine, "time", 0.0)
+        q, v = engine.get_state()
+
+        # Club head speed: try to get from Jacobian of end-effector
+        club_head_speed = None
+        try:
+            jac = engine.compute_jacobian("club_head")
+            if jac is not None and "linear" in jac:
+                import numpy as np
+
+                linear_vel = jac["linear"] @ v
+                club_head_speed = float(np.linalg.norm(linear_vel))
+        except Exception:
+            pass
+
+        # Energy calculations
+        kinetic_energy = None
+        potential_energy = None
+        try:
+            import numpy as np
+
+            M = engine.compute_mass_matrix()
+            kinetic_energy = float(0.5 * v @ M @ v)
+        except Exception:
+            pass
+
+        # Torque metrics
+        ctrl = _get_control_interface(engine_manager)
+        peak_torque = None
+        total_torque_magnitude = None
+        if ctrl is not None:
+            import numpy as np
+
+            torques = ctrl.current_torques
+            peak_torque = float(np.max(np.abs(torques)))
+            total_torque_magnitude = float(np.sum(np.abs(torques)))
+
+        return BiomechanicsMetricsResponse(
+            sim_time=sim_time,
+            club_head_speed=club_head_speed,
+            kinetic_energy=kinetic_energy,
+            potential_energy=potential_energy,
+            joint_positions=q.tolist(),
+            joint_velocities=v.tolist(),
+            peak_torque=peak_torque,
+            total_torque_magnitude=total_torque_magnitude,
+        )
+    except Exception as exc:
+        if logger:
+            logger.error("Metrics query error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Metrics query failed: {str(exc)}"
+        ) from exc
+
+
+# ──────────────────────────────────────────────────────────────
+#  Control Features Registry (See issue #1209)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/simulation/control-features", response_model=ControlFeaturesResponse)
+async def get_control_features(
+    category: str | None = None,
+    available_only: bool = False,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> ControlFeaturesResponse:
+    """Get control features registry data including ZTCF/ZVCF availability.
+
+    Args:
+        category: Filter by feature category (optional).
+        available_only: If True, only return available features.
+        engine_manager: Injected engine manager.
+
+    Returns:
+        Registry summary with feature descriptors.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    registry = _get_features_registry(engine_manager)
+    if registry is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    summary = registry.get_summary()
+    features = registry.list_features(category=category, available_only=available_only)
+
+    return ControlFeaturesResponse(
+        engine=summary["engine"],
+        total_features=summary["total_features"],
+        available_features=summary["available_features"],
+        categories=summary["categories"],
+        features=features,
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+#  Simulation Controls (See issue #1202)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/simulation/stats", response_model=SimulationStatsResponse)
+async def get_simulation_stats(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> SimulationStatsResponse:
+    """Get simulation runtime statistics.
+
+    Returns:
+        Stats including sim time, FPS, real-time factor, and recording state.
+    """
+    engine = engine_manager.get_active_physics_engine()
+
+    sim_time = 0.0
+    if engine is not None:
+        sim_time = getattr(engine, "time", 0.0)
+
+    # Retrieve simulation tracking state from engine manager
+    start_time = getattr(engine_manager, "_sim_start_time", time.time())
+    wall_time = time.time() - start_time
+    frame_count = getattr(engine_manager, "_sim_frame_count", 0)
+    speed_factor = getattr(engine_manager, "_speed_factor", _DEFAULT_SPEED_FACTOR)
+    is_recording = getattr(engine_manager, "_is_recording", False)
+
+    fps = frame_count / wall_time if wall_time > 0 else 0.0
+    real_time_factor = sim_time / wall_time if wall_time > 0 else 0.0
+
+    return SimulationStatsResponse(
+        sim_time=sim_time,
+        wall_time=wall_time,
+        fps=fps,
+        real_time_factor=real_time_factor,
+        speed_factor=speed_factor,
+        is_recording=is_recording,
+        frame_count=frame_count,
+    )
+
+
+@router.post("/simulation/speed", response_model=SpeedControlResponse)
+async def set_simulation_speed(
+    request: SpeedControlRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+) -> SpeedControlResponse:
+    """Set simulation speed multiplier.
+
+    Args:
+        request: Speed control parameters.
+        engine_manager: Injected engine manager.
+
+    Returns:
+        Applied speed factor and status.
+    """
+    engine_manager._speed_factor = request.speed_factor  # type: ignore[attr-defined]
+
+    return SpeedControlResponse(
+        speed_factor=request.speed_factor,
+        status=f"Speed set to {request.speed_factor}x",
+    )
+
+
+@router.post("/simulation/camera", response_model=CameraPresetResponse)
+async def set_camera_preset(
+    request: CameraPresetRequest,
+) -> CameraPresetResponse:
+    """Apply a camera preset.
+
+    Args:
+        request: Camera preset selection.
+
+    Returns:
+        Applied camera position, target, and up vector.
+
+    Raises:
+        HTTPException: If preset is unknown.
+    """
+    preset_data = CAMERA_PRESETS.get(request.preset)
+    if preset_data is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown camera preset: {request.preset}",
+        )
+
+    return CameraPresetResponse(
+        preset=request.preset,
+        position=preset_data["position"],
+        target=preset_data["target"],
+        up=preset_data["up"],
+    )
+
+
+@router.post("/simulation/recording", response_model=TrajectoryRecordResponse)
+async def control_recording(
+    request: TrajectoryRecordRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> TrajectoryRecordResponse:
+    """Control trajectory recording (start, stop, export).
+
+    Args:
+        request: Recording action and export format.
+        engine_manager: Injected engine manager.
+        logger: Injected logger.
+
+    Returns:
+        Current recording state.
+    """
+    action = request.action
+
+    if action == "start":
+        engine_manager._is_recording = True  # type: ignore[attr-defined]
+        engine_manager._recorded_frames = []  # type: ignore[attr-defined]
+        return TrajectoryRecordResponse(
+            recording=True,
+            frame_count=0,
+            status="Recording started",
+        )
+
+    elif action == "stop":
+        engine_manager._is_recording = False  # type: ignore[attr-defined]
+        frame_count = len(getattr(engine_manager, "_recorded_frames", []))
+        return TrajectoryRecordResponse(
+            recording=False,
+            frame_count=frame_count,
+            status="Recording stopped",
+        )
+
+    elif action == "export":
+        recorded = getattr(engine_manager, "_recorded_frames", [])
+        frame_count = len(recorded)
+        export_path = None
+
+        if frame_count > 0:
+            import json
+            import tempfile
+
+            export_path = tempfile.mktemp(suffix=f".{request.export_format}")
+            with open(export_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {"frames": recorded, "format": request.export_format},
+                    f,
+                    indent=2,
+                )
+            if logger:
+                logger.info("Trajectory exported to %s (%d frames)", export_path, frame_count)
+
+        return TrajectoryRecordResponse(
+            recording=getattr(engine_manager, "_is_recording", False),
+            frame_count=frame_count,
+            status="Trajectory exported" if export_path else "No frames to export",
+            export_path=export_path,
+        )
+
+    # Should not reach here due to validator, but safety fallback
+    raise HTTPException(status_code=400, detail=f"Unknown action: {action}")

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -41,6 +41,7 @@ from .routes import dataset as dataset_routes
 from .routes import engines as engine_routes
 from .routes import export as export_routes
 from .routes import launcher as launcher_routes
+from .routes import physics as physics_routes
 from .routes import simulation as simulation_routes
 from .routes import terrain as terrain_routes
 from .routes import video as video_routes
@@ -282,6 +283,7 @@ app.include_router(export_routes.router)
 app.include_router(launcher_routes.router)
 app.include_router(terrain_routes.router)
 app.include_router(dataset_routes.router)
+app.include_router(physics_routes.router)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_physics_api.py
+++ b/tests/api/test_physics_api.py
@@ -1,0 +1,465 @@
+"""Tests for Phase 2 physics API routes.
+
+Validates the shared physics backend REST API (#1209),
+engine capabilities API (#1204), and simulation controls (#1202).
+
+Tests cover:
+- Pydantic contract validation for all new request/response models
+- Actuator control endpoints
+- Force/torque query endpoints
+- Biomechanics metrics endpoints
+- Control features registry endpoint
+- Engine capabilities endpoint
+- Simulation controls (speed, camera, recording, stats)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models.requests import (
+    VALID_CAMERA_PRESETS,
+    VALID_CONTROL_STRATEGIES,
+    ActuatorUpdateRequest,
+    CameraPresetRequest,
+    SpeedControlRequest,
+    TrajectoryRecordRequest,
+)
+from src.api.models.responses import (
+    ActuatorStateResponse,
+    BiomechanicsMetricsResponse,
+    CameraPresetResponse,
+    CapabilityLevelResponse,
+    ControlFeaturesResponse,
+    EngineCapabilitiesResponse,
+    ForceVectorResponse,
+    SimulationStatsResponse,
+    SpeedControlResponse,
+    TrajectoryRecordResponse,
+)
+
+try:
+    from fastapi.testclient import TestClient
+
+    from src.api.server import app
+
+    HAS_FASTAPI = True
+except ImportError:
+    HAS_FASTAPI = False
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: ActuatorUpdateRequest
+# ──────────────────────────────────────────────────────────────
+class TestActuatorUpdateRequestContract:
+    """Validate ActuatorUpdateRequest preconditions."""
+
+    def test_empty_request_valid(self) -> None:
+        """An empty update (no changes) is valid."""
+        req = ActuatorUpdateRequest()
+        assert req.strategy is None
+        assert req.torques is None
+
+    def test_valid_strategy(self) -> None:
+        """All valid strategies are accepted."""
+        for strategy in VALID_CONTROL_STRATEGIES:
+            req = ActuatorUpdateRequest(strategy=strategy)
+            assert req.strategy == strategy
+
+    def test_invalid_strategy_rejected(self) -> None:
+        """Unknown strategy raises ValidationError."""
+        with pytest.raises(ValidationError, match="Unknown strategy"):
+            ActuatorUpdateRequest(strategy="nonexistent_strategy")
+
+    def test_strategy_normalized(self) -> None:
+        """Strategy is lowercased and stripped."""
+        req = ActuatorUpdateRequest(strategy="  PD  ")
+        assert req.strategy == "pd"
+
+    def test_torques_accepted(self) -> None:
+        """Torque list is accepted."""
+        req = ActuatorUpdateRequest(torques=[1.0, -2.0, 3.5])
+        assert req.torques == [1.0, -2.0, 3.5]
+
+    def test_gains_must_be_positive(self) -> None:
+        """Negative kp/kd gains are rejected."""
+        with pytest.raises(ValidationError):
+            ActuatorUpdateRequest(kp=-1.0)
+        with pytest.raises(ValidationError):
+            ActuatorUpdateRequest(kd=-1.0)
+
+    def test_ki_allows_zero(self) -> None:
+        """ki gain allows zero (ge=0)."""
+        req = ActuatorUpdateRequest(ki=0.0)
+        assert req.ki == 0.0
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: SpeedControlRequest
+# ──────────────────────────────────────────────────────────────
+class TestSpeedControlRequestContract:
+    """Validate SpeedControlRequest preconditions."""
+
+    def test_default_speed(self) -> None:
+        """Default speed factor is 1.0."""
+        req = SpeedControlRequest()
+        assert req.speed_factor == 1.0
+
+    def test_valid_range(self) -> None:
+        """Speed within [0.1, 10.0] is valid."""
+        req = SpeedControlRequest(speed_factor=5.0)
+        assert req.speed_factor == 5.0
+
+    def test_below_minimum_rejected(self) -> None:
+        """Speed below 0.1 is rejected."""
+        with pytest.raises(ValidationError):
+            SpeedControlRequest(speed_factor=0.05)
+
+    def test_above_maximum_rejected(self) -> None:
+        """Speed above 10.0 is rejected."""
+        with pytest.raises(ValidationError):
+            SpeedControlRequest(speed_factor=15.0)
+
+    def test_boundary_values(self) -> None:
+        """Boundary values 0.1 and 10.0 are accepted."""
+        req_min = SpeedControlRequest(speed_factor=0.1)
+        req_max = SpeedControlRequest(speed_factor=10.0)
+        assert req_min.speed_factor == 0.1
+        assert req_max.speed_factor == 10.0
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: CameraPresetRequest
+# ──────────────────────────────────────────────────────────────
+class TestCameraPresetRequestContract:
+    """Validate CameraPresetRequest preconditions."""
+
+    def test_valid_presets(self) -> None:
+        """All valid camera presets are accepted."""
+        for preset in VALID_CAMERA_PRESETS:
+            req = CameraPresetRequest(preset=preset)
+            assert req.preset == preset
+
+    def test_invalid_preset_rejected(self) -> None:
+        """Unknown preset raises ValidationError."""
+        with pytest.raises(ValidationError, match="Unknown preset"):
+            CameraPresetRequest(preset="orbital")
+
+    def test_preset_normalized(self) -> None:
+        """Preset is lowercased and stripped."""
+        req = CameraPresetRequest(preset="  FRONT  ")
+        assert req.preset == "front"
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: TrajectoryRecordRequest
+# ──────────────────────────────────────────────────────────────
+class TestTrajectoryRecordRequestContract:
+    """Validate TrajectoryRecordRequest preconditions."""
+
+    def test_valid_actions(self) -> None:
+        """start, stop, export are valid actions."""
+        for action in ("start", "stop", "export"):
+            req = TrajectoryRecordRequest(action=action)
+            assert req.action == action
+
+    def test_invalid_action_rejected(self) -> None:
+        """Unknown action raises ValidationError."""
+        with pytest.raises(ValidationError, match="Unknown action"):
+            TrajectoryRecordRequest(action="reset")
+
+    def test_default_export_format(self) -> None:
+        """Default export format is json."""
+        req = TrajectoryRecordRequest(action="export")
+        assert req.export_format == "json"
+
+
+# ──────────────────────────────────────────────────────────────
+#  Response Model Tests
+# ──────────────────────────────────────────────────────────────
+class TestResponseModels:
+    """Validate response model construction."""
+
+    def test_actuator_state_response(self) -> None:
+        """ActuatorStateResponse can be constructed with valid data."""
+        resp = ActuatorStateResponse(
+            strategy="pd",
+            n_joints=3,
+            joint_names=["j0", "j1", "j2"],
+            torques=[0.0, 0.0, 0.0],
+            kp=[100.0, 100.0, 100.0],
+            kd=[10.0, 10.0, 10.0],
+            ki=[0.0, 0.0, 0.0],
+            joints=[],
+            available_strategies=[{"name": "pd", "description": "PD control"}],
+        )
+        assert resp.n_joints == 3
+
+    def test_force_vector_response(self) -> None:
+        """ForceVectorResponse can be constructed."""
+        resp = ForceVectorResponse(
+            sim_time=1.5,
+            applied_torques=[0.0, 0.0],
+        )
+        assert resp.sim_time == 1.5
+        assert resp.gravity_forces is None
+
+    def test_biomechanics_metrics_response(self) -> None:
+        """BiomechanicsMetricsResponse can be constructed."""
+        resp = BiomechanicsMetricsResponse(
+            sim_time=2.0,
+            joint_positions=[0.1, 0.2],
+            joint_velocities=[0.0, 0.0],
+        )
+        assert resp.sim_time == 2.0
+        assert resp.club_head_speed is None
+
+    def test_engine_capabilities_response(self) -> None:
+        """EngineCapabilitiesResponse can be constructed."""
+        resp = EngineCapabilitiesResponse(
+            engine_name="MuJoCo",
+            engine_type="mujoco",
+            capabilities=[
+                CapabilityLevelResponse(
+                    name="mass_matrix", level="full", supported=True
+                ),
+            ],
+            summary={"full": 1, "partial": 0, "none": 0},
+        )
+        assert resp.engine_name == "MuJoCo"
+        assert len(resp.capabilities) == 1
+
+    def test_control_features_response(self) -> None:
+        """ControlFeaturesResponse can be constructed."""
+        resp = ControlFeaturesResponse(
+            engine="PendulumPhysicsEngine",
+            total_features=15,
+            available_features=10,
+            categories=[],
+            features=[],
+        )
+        assert resp.total_features == 15
+
+    def test_simulation_stats_response(self) -> None:
+        """SimulationStatsResponse can be constructed."""
+        resp = SimulationStatsResponse(
+            sim_time=5.0,
+            wall_time=5.2,
+            fps=500.0,
+            real_time_factor=0.96,
+            speed_factor=1.0,
+            is_recording=False,
+            frame_count=2500,
+        )
+        assert resp.frame_count == 2500
+
+    def test_speed_control_response(self) -> None:
+        """SpeedControlResponse can be constructed."""
+        resp = SpeedControlResponse(speed_factor=2.0, status="Speed set to 2.0x")
+        assert resp.speed_factor == 2.0
+
+    def test_camera_preset_response(self) -> None:
+        """CameraPresetResponse can be constructed."""
+        resp = CameraPresetResponse(
+            preset="side",
+            position=[3.0, 0.0, 1.5],
+            target=[0.0, 0.0, 1.0],
+            up=[0.0, 0.0, 1.0],
+        )
+        assert resp.preset == "side"
+
+    def test_trajectory_record_response(self) -> None:
+        """TrajectoryRecordResponse can be constructed."""
+        resp = TrajectoryRecordResponse(
+            recording=True,
+            frame_count=100,
+            status="Recording started",
+        )
+        assert resp.recording is True
+
+
+# ──────────────────────────────────────────────────────────────
+#  API Integration Tests (require FastAPI)
+# ──────────────────────────────────────────────────────────────
+@pytest.fixture()
+def client():
+    """Create test client."""
+    if not HAS_FASTAPI:
+        pytest.skip("FastAPI not available")
+    with TestClient(app) as c:
+        yield c
+
+
+class TestCameraPresetAPI:
+    """Test camera preset endpoint."""
+
+    def test_valid_preset_returns_200(self, client) -> None:
+        """POST /simulation/camera with valid preset returns 200."""
+        resp = client.post("/simulation/camera", json={"preset": "side"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preset"] == "side"
+        assert len(data["position"]) == 3
+        assert len(data["target"]) == 3
+        assert len(data["up"]) == 3
+
+    def test_all_presets_return_200(self, client) -> None:
+        """All camera presets return valid responses."""
+        for preset in VALID_CAMERA_PRESETS:
+            resp = client.post("/simulation/camera", json={"preset": preset})
+            assert resp.status_code == 200, f"Preset {preset} failed"
+
+    def test_invalid_preset_returns_422(self, client) -> None:
+        """Invalid preset returns 422 validation error."""
+        resp = client.post("/simulation/camera", json={"preset": "orbital"})
+        assert resp.status_code == 422
+
+
+class TestSpeedControlAPI:
+    """Test simulation speed control endpoint."""
+
+    def test_set_speed_returns_200(self, client) -> None:
+        """POST /simulation/speed with valid factor returns 200."""
+        resp = client.post("/simulation/speed", json={"speed_factor": 2.0})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["speed_factor"] == 2.0
+        assert "status" in data
+
+    def test_default_speed(self, client) -> None:
+        """Default speed factor 1.0 is accepted."""
+        resp = client.post("/simulation/speed", json={"speed_factor": 1.0})
+        assert resp.status_code == 200
+
+    def test_invalid_speed_rejected(self, client) -> None:
+        """Speed out of range returns 422."""
+        resp = client.post("/simulation/speed", json={"speed_factor": 100.0})
+        assert resp.status_code == 422
+
+
+class TestRecordingAPI:
+    """Test trajectory recording endpoint."""
+
+    def test_start_recording(self, client) -> None:
+        """POST /simulation/recording with start action works."""
+        resp = client.post(
+            "/simulation/recording",
+            json={"action": "start", "export_format": "json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recording"] is True
+
+    def test_stop_recording(self, client) -> None:
+        """POST /simulation/recording with stop action works."""
+        # Start then stop
+        client.post(
+            "/simulation/recording",
+            json={"action": "start", "export_format": "json"},
+        )
+        resp = client.post(
+            "/simulation/recording",
+            json={"action": "stop", "export_format": "json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recording"] is False
+
+    def test_export_empty(self, client) -> None:
+        """Export with no recorded frames returns message."""
+        resp = client.post(
+            "/simulation/recording",
+            json={"action": "export", "export_format": "json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "No frames" in data["status"] or data["frame_count"] == 0
+
+
+class TestSimulationStatsAPI:
+    """Test simulation stats endpoint."""
+
+    def test_stats_returns_200(self, client) -> None:
+        """GET /simulation/stats returns 200."""
+        resp = client.get("/simulation/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sim_time" in data
+        assert "fps" in data
+        assert "real_time_factor" in data
+        assert "speed_factor" in data
+        assert "is_recording" in data
+        assert "frame_count" in data
+
+
+class TestEngineCapabilitiesAPI:
+    """Test engine capabilities endpoint. See issue #1204."""
+
+    def test_pendulum_capabilities(self, client) -> None:
+        """GET /engines/pendulum/capabilities returns 200."""
+        resp = client.get("/engines/pendulum/capabilities")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "engine_type" in data
+        assert "capabilities" in data
+        assert "summary" in data
+        assert isinstance(data["capabilities"], list)
+
+    def test_unknown_engine_returns_400(self, client) -> None:
+        """Unknown engine type returns 400."""
+        resp = client.get("/engines/nonexistent/capabilities")
+        assert resp.status_code == 400
+
+    def test_capabilities_have_required_fields(self, client) -> None:
+        """Each capability entry has name, level, supported fields."""
+        resp = client.get("/engines/pendulum/capabilities")
+        if resp.status_code == 200:
+            data = resp.json()
+            for cap in data["capabilities"]:
+                assert "name" in cap
+                assert "level" in cap
+                assert "supported" in cap
+                assert cap["level"] in ("full", "partial", "none")
+
+
+class TestActuatorEndpoints:
+    """Test actuator control endpoints (require loaded engine)."""
+
+    def test_get_actuators_no_engine_returns_400(self, client) -> None:
+        """GET /simulation/actuators returns 400 when no engine loaded."""
+        resp = client.get("/simulation/actuators")
+        # Should be 400 since no engine is loaded
+        assert resp.status_code == 400
+
+    def test_post_actuators_no_engine_returns_400(self, client) -> None:
+        """POST /simulation/actuators returns 400 when no engine loaded."""
+        resp = client.post("/simulation/actuators", json={"strategy": "pd"})
+        assert resp.status_code == 400
+
+
+class TestForceEndpoints:
+    """Test force/torque query endpoints."""
+
+    def test_get_forces_no_engine_returns_400(self, client) -> None:
+        """GET /simulation/forces returns 400 when no engine loaded."""
+        resp = client.get("/simulation/forces")
+        assert resp.status_code == 400
+
+
+class TestMetricsEndpoints:
+    """Test biomechanics metrics endpoints."""
+
+    def test_get_metrics_no_engine_returns_400(self, client) -> None:
+        """GET /simulation/metrics returns 400 when no engine loaded."""
+        resp = client.get("/simulation/metrics")
+        assert resp.status_code == 400
+
+
+class TestControlFeaturesEndpoints:
+    """Test control features registry endpoint."""
+
+    def test_get_features_no_engine_returns_400(self, client) -> None:
+        """GET /simulation/control-features returns 400 when no engine loaded."""
+        resp = client.get("/simulation/control-features")
+        assert resp.status_code == 400

--- a/ui/src/api/useEngineCapabilities.test.ts
+++ b/ui/src/api/useEngineCapabilities.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for useEngineCapabilities hook.
+ *
+ * See issue #1204
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEngineCapabilities } from './useEngineCapabilities';
+import type { EngineCapabilitiesData } from './useEngineCapabilities';
+
+const mockCapabilities: EngineCapabilitiesData = {
+  engine_name: 'MuJoCo',
+  engine_type: 'mujoco',
+  capabilities: [
+    { name: 'mass_matrix', level: 'full', supported: true },
+    { name: 'jacobian', level: 'full', supported: true },
+    { name: 'contact_forces', level: 'partial', supported: true },
+    { name: 'video_export', level: 'none', supported: false },
+  ],
+  summary: { full: 2, partial: 1, none: 1 },
+};
+
+describe('useEngineCapabilities', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts in idle state when no engine type provided', () => {
+    const { result } = renderHook(() => useEngineCapabilities());
+
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.loadState).toBe('idle');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetches capabilities when engine type is provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCapabilities),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useEngineCapabilities('mujoco'));
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('loaded');
+    });
+
+    expect(result.current.capabilities).toEqual(mockCapabilities);
+    expect(fetchMock).toHaveBeenCalledWith('/engines/mujoco/capabilities');
+  });
+
+  it('handles fetch errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ detail: 'Engine not found' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useEngineCapabilities('unknown'));
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('error');
+    });
+
+    expect(result.current.error).toBe('Engine not found');
+  });
+
+  it('isSupported returns true for full and partial capabilities', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCapabilities),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useEngineCapabilities('mujoco'));
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('loaded');
+    });
+
+    expect(result.current.isSupported('mass_matrix')).toBe(true);
+    expect(result.current.isSupported('contact_forces')).toBe(true);
+    expect(result.current.isSupported('video_export')).toBe(false);
+    expect(result.current.isSupported('nonexistent')).toBe(false);
+  });
+
+  it('isFullySupported returns true only for full level', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCapabilities),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useEngineCapabilities('mujoco'));
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('loaded');
+    });
+
+    expect(result.current.isFullySupported('mass_matrix')).toBe(true);
+    expect(result.current.isFullySupported('contact_forces')).toBe(false);
+  });
+
+  it('getLevel returns correct levels', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCapabilities),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useEngineCapabilities('mujoco'));
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('loaded');
+    });
+
+    expect(result.current.getLevel('mass_matrix')).toBe('full');
+    expect(result.current.getLevel('contact_forces')).toBe('partial');
+    expect(result.current.getLevel('video_export')).toBe('none');
+    expect(result.current.getLevel('nonexistent')).toBe('none');
+  });
+
+  it('resets to idle when engine type changes to undefined', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCapabilities),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ engineType }: { engineType?: string }) => useEngineCapabilities(engineType),
+      { initialProps: { engineType: 'mujoco' } as { engineType?: string } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('loaded');
+    });
+
+    rerender({ engineType: undefined });
+
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.loadState).toBe('idle');
+  });
+});

--- a/ui/src/api/useEngineCapabilities.ts
+++ b/ui/src/api/useEngineCapabilities.ts
@@ -1,0 +1,152 @@
+/**
+ * Engine Capabilities Hook - Dynamic UI Adaptation
+ *
+ * Fetches and caches engine capability data from the backend,
+ * enabling the UI to dynamically show/hide features based on
+ * what the active physics engine supports.
+ *
+ * See issue #1204
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+/** Support level for a single engine capability. */
+export type CapabilityLevel = 'full' | 'partial' | 'none';
+
+/** A single capability entry from the backend. */
+export interface CapabilityEntry {
+  name: string;
+  level: CapabilityLevel;
+  supported: boolean;
+}
+
+/** Full capabilities response from the backend. */
+export interface EngineCapabilitiesData {
+  engine_name: string;
+  engine_type: string;
+  capabilities: CapabilityEntry[];
+  summary: {
+    full: number;
+    partial: number;
+    none: number;
+  };
+}
+
+export type CapabilitiesLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+export interface UseEngineCapabilitiesResult {
+  /** Current capabilities data, null if not loaded. */
+  capabilities: EngineCapabilitiesData | null;
+  /** Loading state. */
+  loadState: CapabilitiesLoadState;
+  /** Error message if loading failed. */
+  error: string | null;
+  /** Fetch capabilities for a specific engine. */
+  fetchCapabilities: (engineType: string) => Promise<void>;
+  /** Check if a specific capability is supported (full or partial). */
+  isSupported: (capabilityName: string) => boolean;
+  /** Check if a capability has full support. */
+  isFullySupported: (capabilityName: string) => boolean;
+  /** Get the level of a specific capability. */
+  getLevel: (capabilityName: string) => CapabilityLevel;
+}
+
+/**
+ * Hook to fetch and query engine capabilities.
+ *
+ * Automatically fetches capabilities when engineType changes.
+ * Provides helper methods for checking feature support levels.
+ *
+ * @param engineType - Engine type to fetch capabilities for.
+ *                     If undefined, capabilities are not fetched.
+ */
+export function useEngineCapabilities(
+  engineType?: string,
+): UseEngineCapabilitiesResult {
+  const [capabilities, setCapabilities] = useState<EngineCapabilitiesData | null>(null);
+  const [loadState, setLoadState] = useState<CapabilitiesLoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  const fetchCapabilities = useCallback(async (engine: string) => {
+    setLoadState('loading');
+    setError(null);
+
+    try {
+      const response = await fetch(`/engines/${engine}/capabilities`);
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `Failed to fetch capabilities for ${engine}`);
+      }
+
+      const data: EngineCapabilitiesData = await response.json();
+
+      if (isMountedRef.current) {
+        setCapabilities(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        setError(message);
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  // Auto-fetch when engineType changes
+  useEffect(() => {
+    if (engineType) {
+      fetchCapabilities(engineType);
+    } else {
+      setCapabilities(null);
+      setLoadState('idle');
+      setError(null);
+    }
+  }, [engineType, fetchCapabilities]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const isSupported = useCallback(
+    (capabilityName: string): boolean => {
+      if (!capabilities) return false;
+      const cap = capabilities.capabilities.find((c) => c.name === capabilityName);
+      return cap?.supported ?? false;
+    },
+    [capabilities],
+  );
+
+  const isFullySupported = useCallback(
+    (capabilityName: string): boolean => {
+      if (!capabilities) return false;
+      const cap = capabilities.capabilities.find((c) => c.name === capabilityName);
+      return cap?.level === 'full';
+    },
+    [capabilities],
+  );
+
+  const getLevel = useCallback(
+    (capabilityName: string): CapabilityLevel => {
+      if (!capabilities) return 'none';
+      const cap = capabilities.capabilities.find((c) => c.name === capabilityName);
+      return cap?.level ?? 'none';
+    },
+    [capabilities],
+  );
+
+  return {
+    capabilities,
+    loadState,
+    error,
+    fetchCapabilities,
+    isSupported,
+    isFullySupported,
+    getLevel,
+  };
+}

--- a/ui/src/components/simulation/SimulationControls.test.tsx
+++ b/ui/src/components/simulation/SimulationControls.test.tsx
@@ -133,4 +133,300 @@ describe('SimulationControls', () => {
       expect(button.className).toContain('focus:ring');
     });
   });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Speed Control Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('speed control', () => {
+    it('renders speed slider when onSpeedChange is provided', () => {
+      const onSpeedChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onSpeedChange={onSpeedChange}
+        />
+      );
+
+      expect(screen.getByLabelText(/simulation speed/i)).toBeInTheDocument();
+    });
+
+    it('does not render speed slider when onSpeedChange is not provided', () => {
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+        />
+      );
+
+      expect(screen.queryByLabelText(/simulation speed/i)).not.toBeInTheDocument();
+    });
+
+    it('displays speed value', () => {
+      const onSpeedChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onSpeedChange={onSpeedChange}
+          initialSpeed={2.0}
+        />
+      );
+
+      expect(screen.getByText('2.0x')).toBeInTheDocument();
+    });
+
+    it('renders speed preset buttons', () => {
+      const onSpeedChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onSpeedChange={onSpeedChange}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /set speed to 1x/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /set speed to 2x/i })).toBeInTheDocument();
+    });
+
+    it('calls onSpeedChange when preset button is clicked', () => {
+      const onSpeedChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onSpeedChange={onSpeedChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /set speed to 2x/i }));
+      expect(onSpeedChange).toHaveBeenCalledWith(2.0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Single-Step Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('single step', () => {
+    it('renders step button when onStep is provided and running', () => {
+      const onStep = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={true}
+          {...mockHandlers}
+          onStep={onStep}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /single step/i })).toBeInTheDocument();
+    });
+
+    it('step button is disabled when not paused', () => {
+      const onStep = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={false}
+          {...mockHandlers}
+          onStep={onStep}
+        />
+      );
+
+      const stepBtn = screen.getByRole('button', { name: /single step/i });
+      expect(stepBtn).toBeDisabled();
+    });
+
+    it('calls onStep when step button is clicked while paused', () => {
+      const onStep = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={true}
+          {...mockHandlers}
+          onStep={onStep}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /single step/i }));
+      expect(onStep).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Camera Preset Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('camera presets', () => {
+    it('renders camera preset buttons when onCameraChange is provided', () => {
+      const onCameraChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onCameraChange={onCameraChange}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /side camera view/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /front camera view/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /top camera view/i })).toBeInTheDocument();
+    });
+
+    it('calls onCameraChange when preset is clicked', () => {
+      const onCameraChange = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onCameraChange={onCameraChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /front camera view/i }));
+      expect(onCameraChange).toHaveBeenCalledWith('front');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Recording Controls Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('recording controls', () => {
+    it('renders record button when onRecordingToggle is provided', () => {
+      const onRecordingToggle = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onRecordingToggle={onRecordingToggle}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /start recording/i })).toBeInTheDocument();
+    });
+
+    it('toggles recording state when clicked', () => {
+      const onRecordingToggle = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onRecordingToggle={onRecordingToggle}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+      expect(onRecordingToggle).toHaveBeenCalledWith(true);
+    });
+
+    it('renders export button when onExportTrajectory is provided', () => {
+      const onRecordingToggle = vi.fn();
+      const onExportTrajectory = vi.fn();
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+          onRecordingToggle={onRecordingToggle}
+          onExportTrajectory={onExportTrajectory}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /export trajectory/i })).toBeInTheDocument();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Stats Display Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('stats display', () => {
+    const mockStats = {
+      simTime: 2.345,
+      fps: 500,
+      realTimeFactor: 0.96,
+      frameCount: 1172,
+    };
+
+    it('renders stats when provided', () => {
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={false}
+          {...mockHandlers}
+          stats={mockStats}
+        />
+      );
+
+      expect(screen.getByText('2.345s')).toBeInTheDocument();
+      expect(screen.getByText('500')).toBeInTheDocument();
+      expect(screen.getByText('0.96x')).toBeInTheDocument();
+      expect(screen.getByText('1172')).toBeInTheDocument();
+    });
+
+    it('has accessible status role', () => {
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={false}
+          {...mockHandlers}
+          stats={mockStats}
+        />
+      );
+
+      expect(screen.getByRole('status', { name: /simulation statistics/i })).toBeInTheDocument();
+    });
+
+    it('does not render stats when not provided', () => {
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+        />
+      );
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  //  Phase 2: Keyboard Shortcuts Tests (See issue #1202)
+  // ──────────────────────────────────────────────────────────────
+  describe('keyboard shortcuts', () => {
+    it('Space starts simulation when not running', () => {
+      render(
+        <SimulationControls
+          isRunning={false}
+          {...mockHandlers}
+        />
+      );
+
+      fireEvent.keyDown(window, { code: 'Space' });
+      expect(mockHandlers.onStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('Space resumes when paused', () => {
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={true}
+          {...mockHandlers}
+        />
+      );
+
+      fireEvent.keyDown(window, { code: 'Space' });
+      expect(mockHandlers.onResume).toHaveBeenCalledTimes(1);
+    });
+
+    it('Escape stops simulation', () => {
+      render(
+        <SimulationControls
+          isRunning={true}
+          isPaused={false}
+          {...mockHandlers}
+        />
+      );
+
+      fireEvent.keyDown(window, { code: 'Escape' });
+      expect(mockHandlers.onStop).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/ui/src/components/simulation/SimulationControls.tsx
+++ b/ui/src/components/simulation/SimulationControls.tsx
@@ -1,4 +1,25 @@
-import { Play, Pause, Square } from 'lucide-react';
+/**
+ * SimulationControls - Comprehensive simulation control panel.
+ *
+ * Provides play/pause/stop, speed slider, single-step, camera presets,
+ * trajectory recording, and real-time stats display.
+ *
+ * See issue #1202
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Play, Pause, Square, SkipForward, Camera, Circle, Download, Gauge } from 'lucide-react';
+
+/** Camera preset identifiers matching the backend. */
+export type CameraPreset = 'side' | 'front' | 'top' | 'follow_ball' | 'follow_club';
+
+/** Simulation runtime statistics from the backend. */
+export interface SimulationStats {
+  simTime: number;
+  fps: number;
+  realTimeFactor: number;
+  frameCount: number;
+}
 
 interface Props {
   isRunning: boolean;
@@ -8,6 +29,20 @@ interface Props {
   onPause: () => void;
   onResume: () => void;
   disabled?: boolean;
+  /** Callback for single-step advance (optional). */
+  onStep?: () => void;
+  /** Callback when speed changes (optional). */
+  onSpeedChange?: (speed: number) => void;
+  /** Callback when camera preset changes (optional). */
+  onCameraChange?: (preset: CameraPreset) => void;
+  /** Callback for recording toggle (optional). */
+  onRecordingToggle?: (recording: boolean) => void;
+  /** Callback for trajectory export (optional). */
+  onExportTrajectory?: () => void;
+  /** Current simulation stats (optional). */
+  stats?: SimulationStats;
+  /** Initial speed factor (default 1.0). */
+  initialSpeed?: number;
 }
 
 // Extracted button styles to reduce duplication and ensure consistency
@@ -17,56 +52,318 @@ const buttonStyles = {
   warning: 'flex-1 bg-yellow-600 hover:bg-yellow-700 text-white focus:ring-yellow-400',
   danger: 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-400',
   disabled: 'flex-1 bg-gray-600 text-gray-400 cursor-not-allowed',
+  secondary: 'bg-gray-700 hover:bg-gray-600 text-white focus:ring-gray-400',
+  accent: 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-400',
+  recording: 'bg-red-500 hover:bg-red-600 text-white focus:ring-red-400 animate-pulse',
+  small: 'py-1 px-2 text-sm',
 };
 
-export function SimulationControls({ isRunning, isPaused, onStart, onStop, onPause, onResume, disabled }: Props) {
+const CAMERA_PRESETS: { id: CameraPreset; label: string }[] = [
+  { id: 'side', label: 'Side' },
+  { id: 'front', label: 'Front' },
+  { id: 'top', label: 'Top' },
+  { id: 'follow_ball', label: 'Ball' },
+  { id: 'follow_club', label: 'Club' },
+];
+
+const SPEED_PRESETS = [0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0];
+
+export function SimulationControls({
+  isRunning,
+  isPaused,
+  onStart,
+  onStop,
+  onPause,
+  onResume,
+  disabled,
+  onStep,
+  onSpeedChange,
+  onCameraChange,
+  onRecordingToggle,
+  onExportTrajectory,
+  stats,
+  initialSpeed = 1.0,
+}: Props) {
+  const [speedFactor, setSpeedFactor] = useState(initialSpeed);
+  const [isRecording, setIsRecording] = useState(false);
+  const [activeCamera, setActiveCamera] = useState<CameraPreset>('side');
+
+  // Handle speed change
+  const handleSpeedChange = useCallback(
+    (value: number) => {
+      setSpeedFactor(value);
+      onSpeedChange?.(value);
+    },
+    [onSpeedChange],
+  );
+
+  // Handle camera preset change
+  const handleCameraChange = useCallback(
+    (preset: CameraPreset) => {
+      setActiveCamera(preset);
+      onCameraChange?.(preset);
+    },
+    [onCameraChange],
+  );
+
+  // Handle recording toggle
+  const handleRecordingToggle = useCallback(() => {
+    const newState = !isRecording;
+    setIsRecording(newState);
+    onRecordingToggle?.(newState);
+  }, [isRecording, onRecordingToggle]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Only handle shortcuts when not typing in an input
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+
+      switch (e.code) {
+        case 'Space':
+          e.preventDefault();
+          if (!isRunning) {
+            onStart();
+          } else if (isPaused) {
+            onResume();
+          } else {
+            // When running and not paused: single-step if available, else pause
+            if (onStep) {
+              onStep();
+            } else {
+              onPause();
+            }
+          }
+          break;
+        case 'Escape':
+          if (isRunning) {
+            onStop();
+          }
+          break;
+        case 'Period':
+          // Single step with '.' key
+          if (isRunning && isPaused && onStep) {
+            onStep();
+          }
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isRunning, isPaused, onStart, onStop, onPause, onResume, onStep]);
+
   return (
-    <div
-      className="flex gap-2 mt-4"
-      role="toolbar"
-      aria-label="Simulation controls"
-    >
-      {!isRunning ? (
-        <button
-          onClick={onStart}
-          disabled={disabled}
-          aria-label="Start simulation"
-          className={`${buttonStyles.base} ${disabled ? buttonStyles.disabled : buttonStyles.primary}`}
-        >
-          <Play size={20} aria-hidden="true" />
-          Start
-        </button>
-      ) : (
-        <>
-          {isPaused ? (
+    <div className="space-y-3">
+      {/* Primary controls */}
+      <div
+        className="flex gap-2"
+        role="toolbar"
+        aria-label="Simulation controls"
+      >
+        {!isRunning ? (
+          <button
+            onClick={onStart}
+            disabled={disabled}
+            aria-label="Start simulation"
+            className={`${buttonStyles.base} ${disabled ? buttonStyles.disabled : buttonStyles.primary}`}
+          >
+            <Play size={20} aria-hidden="true" />
+            Start
+          </button>
+        ) : (
+          <>
+            {isPaused ? (
+              <button
+                onClick={onResume}
+                aria-label="Resume simulation"
+                className={`${buttonStyles.base} ${buttonStyles.primary}`}
+              >
+                <Play size={20} aria-hidden="true" />
+                Resume
+              </button>
+            ) : (
+              <button
+                onClick={onPause}
+                aria-label="Pause simulation"
+                className={`${buttonStyles.base} ${buttonStyles.warning}`}
+              >
+                <Pause size={20} aria-hidden="true" />
+                Pause
+              </button>
+            )}
+
+            {onStep && (
+              <button
+                onClick={onStep}
+                disabled={!isPaused}
+                aria-label="Single step"
+                title="Single step (. key)"
+                className={`${buttonStyles.base} ${buttonStyles.small} ${
+                  isPaused ? buttonStyles.secondary : buttonStyles.disabled
+                }`}
+              >
+                <SkipForward size={16} aria-hidden="true" />
+              </button>
+            )}
+
             <button
-              onClick={onResume}
-              aria-label="Resume simulation"
-              className={`${buttonStyles.base} ${buttonStyles.primary}`}
+              onClick={onStop}
+              aria-label="Stop simulation"
+              className={`${buttonStyles.base} ${buttonStyles.danger}`}
             >
-              <Play size={20} aria-hidden="true" />
-              Resume
+              <Square size={20} aria-hidden="true" />
+              Stop
             </button>
-          ) : (
-            <button
-              onClick={onPause}
-              aria-label="Pause simulation"
-              className={`${buttonStyles.base} ${buttonStyles.warning}`}
+          </>
+        )}
+      </div>
+
+      {/* Speed control */}
+      {onSpeedChange && (
+        <div className="bg-gray-800 rounded p-3" role="group" aria-label="Speed control">
+          <div className="flex items-center justify-between mb-1">
+            <label
+              htmlFor="speed-slider"
+              className="text-xs text-gray-400 flex items-center gap-1"
             >
-              <Pause size={20} aria-hidden="true" />
-              Pause
+              <Gauge size={14} aria-hidden="true" />
+              Speed
+            </label>
+            <span className="text-xs text-green-400 font-mono">
+              {speedFactor.toFixed(1)}x
+            </span>
+          </div>
+          <input
+            id="speed-slider"
+            type="range"
+            min={0.1}
+            max={10.0}
+            step={0.1}
+            value={speedFactor}
+            onChange={(e) => handleSpeedChange(parseFloat(e.target.value))}
+            className="w-full h-1 bg-gray-600 rounded-lg appearance-none cursor-pointer accent-green-500"
+            aria-label="Simulation speed"
+            aria-valuemin={0.1}
+            aria-valuemax={10.0}
+            aria-valuenow={speedFactor}
+            aria-valuetext={`${speedFactor.toFixed(1)}x speed`}
+          />
+          <div className="flex justify-between mt-1 gap-1">
+            {SPEED_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                onClick={() => handleSpeedChange(preset)}
+                className={`text-xs px-1 py-0.5 rounded ${
+                  Math.abs(speedFactor - preset) < 0.05
+                    ? 'bg-green-600 text-white'
+                    : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
+                }`}
+                aria-label={`Set speed to ${preset}x`}
+              >
+                {preset}x
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Camera presets */}
+      {onCameraChange && (
+        <div className="bg-gray-800 rounded p-3" role="group" aria-label="Camera presets">
+          <div className="flex items-center gap-1 mb-2">
+            <Camera size={14} className="text-gray-400" aria-hidden="true" />
+            <span className="text-xs text-gray-400">Camera</span>
+          </div>
+          <div className="flex gap-1">
+            {CAMERA_PRESETS.map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => handleCameraChange(id)}
+                aria-label={`${label} camera view`}
+                aria-pressed={activeCamera === id}
+                className={`${buttonStyles.base} ${buttonStyles.small} ${
+                  activeCamera === id ? buttonStyles.accent : buttonStyles.secondary
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Recording controls */}
+      {onRecordingToggle && (
+        <div className="flex gap-2" role="group" aria-label="Recording controls">
+          <button
+            onClick={handleRecordingToggle}
+            aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+            aria-pressed={isRecording}
+            className={`${buttonStyles.base} ${buttonStyles.small} flex-1 ${
+              isRecording ? buttonStyles.recording : buttonStyles.secondary
+            }`}
+          >
+            <Circle
+              size={14}
+              fill={isRecording ? 'currentColor' : 'none'}
+              aria-hidden="true"
+            />
+            {isRecording ? 'Recording...' : 'Record'}
+          </button>
+          {onExportTrajectory && (
+            <button
+              onClick={onExportTrajectory}
+              disabled={isRecording}
+              aria-label="Export trajectory"
+              className={`${buttonStyles.base} ${buttonStyles.small} ${
+                isRecording ? buttonStyles.disabled : buttonStyles.secondary
+              }`}
+            >
+              <Download size={14} aria-hidden="true" />
+              Export
             </button>
           )}
+        </div>
+      )}
 
-          <button
-            onClick={onStop}
-            aria-label="Stop simulation"
-            className={`${buttonStyles.base} ${buttonStyles.danger}`}
-          >
-            <Square size={20} aria-hidden="true" />
-            Stop
-          </button>
-        </>
+      {/* Real-time stats display */}
+      {stats && (
+        <div
+          className="bg-gray-800 rounded p-3 grid grid-cols-2 gap-2 text-xs"
+          role="status"
+          aria-label="Simulation statistics"
+        >
+          <div>
+            <span className="text-gray-400">Sim Time</span>
+            <span className="block text-white font-mono">
+              {stats.simTime.toFixed(3)}s
+            </span>
+          </div>
+          <div>
+            <span className="text-gray-400">FPS</span>
+            <span className="block text-white font-mono">
+              {stats.fps.toFixed(0)}
+            </span>
+          </div>
+          <div>
+            <span className="text-gray-400">RT Factor</span>
+            <span className="block text-white font-mono">
+              {stats.realTimeFactor.toFixed(2)}x
+            </span>
+          </div>
+          <div>
+            <span className="text-gray-400">Frames</span>
+            <span className="block text-white font-mono">
+              {stats.frameCount}
+            </span>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Shared Physics Backend REST API (#1209)**: 9 new FastAPI endpoints for actuator control, force/torque queries, biomechanics metrics, control features registry, simulation speed/camera/recording controls, and runtime stats
- **Engine Capabilities API (#1204)**: `GET /engines/{type}/capabilities` endpoint exposing `EngineCapabilities` dataclass + `useEngineCapabilities()` React hook with `isSupported`/`isFullySupported`/`getLevel` helpers for dynamic UI adaptation
- **Simulation Controls (#1202)**: Enhanced `SimulationControls.tsx` with speed slider (0.1x-10x), single-step button, camera presets (side/front/top/follow-ball/follow-club), trajectory recording toggle, real-time stats display, and keyboard shortcuts (Space/Escape/.)

## Details
All backend endpoints follow contract-first design with Pydantic request/response models including precondition validators. The existing `ControlInterface` (7 strategies), `ControlFeaturesRegistry` (ZTCF/ZVCF), and `EngineCapabilities` dataclass are exposed through clean REST endpoints.

## Test plan
- [x] 45 Python tests pass (contract validation + API integration)
- [x] Frontend component tests for all new SimulationControls features
- [x] `useEngineCapabilities` hook tests with mock fetch
- [x] `ruff check src/` passes
- [x] `npm run type-check && npm run lint && npm run build` pass
- [x] Pre-existing test failures unchanged (engine loading, benchmarks)

Closes #1202, #1204, #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces multiple new public API endpoints and overlaps an existing `/engines/{...}/capabilities` route, so routing/behavior regressions are possible despite added contract and integration tests.
> 
> **Overview**
> Adds a new **Phase 2 physics REST API** under `/simulation/*`, including actuator control (`GET/POST /simulation/actuators`), force/torque vector queries (`/simulation/forces`), biomechanics metrics (`/simulation/metrics`), control-feature registry introspection (`/simulation/control-features`), and runtime controls for speed/camera/recording plus stats (`/simulation/speed`, `/simulation/camera`, `/simulation/recording`, `/simulation/stats`). This introduces new Pydantic request/response contracts with validation/normalization for control strategies, speed range, camera presets, and recording actions.
> 
> Adds an **engine capabilities** endpoint `GET /engines/{engine_type}/capabilities` returning per-capability support levels and a summary, and wires the new `physics` router into the server.
> 
> On the frontend, adds `useEngineCapabilities()` (with tests) to fetch/query capability levels for dynamic UI behavior, and significantly expands `SimulationControls` to support speed presets/slider, single-step, camera presets, recording/export controls, stats display, and keyboard shortcuts (with comprehensive component tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1082ea94e75e6f0350a1cb888bc0a1c8d4e9cc7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->