### PR TITLE
feat: URDF/MJCF rendering, analysis tools, and simulation controls (#1179, #1201, #1203)

### DIFF
--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -1,0 +1,539 @@
+"""Analysis tools and simulation control routes.
+
+Provides endpoints for:
+- Real-time analysis metrics and statistics (#1203)
+- Dataset export to CSV/JSON (#1203)
+- Body positioning and measurement tools (#1179)
+
+See issue #1203, #1179
+
+All dependencies are injected via FastAPI's Depends() mechanism.
+No module-level mutable state.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import math
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+
+from ..dependencies import get_engine_manager, get_logger
+from ..models.requests import (
+    BodyPositionUpdateRequest,
+    DataExportRequest,
+    MeasurementRequest,
+)
+from ..models.responses import (
+    AnalysisMetricsSummary,
+    AnalysisStatisticsResponse,
+    BodyPositionResponse,
+    JointAngleDisplay,
+    MeasurementResult,
+    MeasurementToolsResponse,
+)
+
+if TYPE_CHECKING:
+    from src.shared.python.engine_manager import EngineManager
+
+router = APIRouter()
+
+
+def _collect_metrics(engine_manager: EngineManager) -> dict[str, Any]:
+    """Collect current metrics from the active engine.
+
+    Args:
+        engine_manager: Engine manager instance.
+
+    Returns:
+        Dictionary of metric name to current value.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        return {}
+
+    metrics: dict[str, Any] = {}
+
+    sim_time = getattr(engine, "time", 0.0)
+    metrics["sim_time"] = sim_time
+
+    try:
+        q, v = engine.get_state()
+        metrics["joint_positions"] = q.tolist() if hasattr(q, "tolist") else list(q)
+        metrics["joint_velocities"] = v.tolist() if hasattr(v, "tolist") else list(v)
+
+        # Derived metrics
+        if len(v) > 0:
+            import numpy as np
+
+            metrics["max_velocity"] = float(np.max(np.abs(v)))
+            metrics["rms_velocity"] = float(np.sqrt(np.mean(v**2)))
+    except Exception:
+        pass
+
+    # Energy
+    try:
+        M = engine.compute_mass_matrix()
+        if M is not None:
+            import numpy as np
+
+            q, v = engine.get_state()
+            metrics["kinetic_energy"] = float(0.5 * v @ M @ v)
+    except Exception:
+        pass
+
+    # Club head speed
+    try:
+        jac = engine.compute_jacobian("club_head")
+        if jac is not None and "linear" in jac:
+            import numpy as np
+
+            _, v = engine.get_state()
+            linear_vel = jac["linear"] @ v
+            metrics["club_head_speed"] = float(np.linalg.norm(linear_vel))
+    except Exception:
+        pass
+
+    return metrics
+
+
+def _get_metric_history(engine_manager: EngineManager) -> list[dict[str, Any]]:
+    """Get stored metric history from engine manager.
+
+    Returns:
+        List of metric snapshots over time.
+    """
+    return getattr(engine_manager, "_metric_history", [])
+
+
+def _store_metric_snapshot(
+    engine_manager: EngineManager, metrics: dict[str, Any]
+) -> None:
+    """Store a metric snapshot in the engine manager history.
+
+    Keeps a bounded buffer of metrics for statistics computation.
+
+    Args:
+        engine_manager: Engine manager instance.
+        metrics: Current metrics snapshot.
+    """
+    max_history = 500
+    if not hasattr(engine_manager, "_metric_history"):
+        engine_manager._metric_history = []  # type: ignore[attr-defined]
+
+    engine_manager._metric_history.append(metrics)  # type: ignore[attr-defined]
+    if len(engine_manager._metric_history) > max_history:  # type: ignore[attr-defined]
+        engine_manager._metric_history = engine_manager._metric_history[-max_history:]  # type: ignore[attr-defined]
+
+
+# ──────────────────────────────────────────────────────────────
+#  Analysis Metrics (See issue #1203)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.get("/analysis/metrics")
+async def get_analysis_metrics(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> dict[str, Any]:
+    """Get current real-time analysis metrics.
+
+    Collects current biomechanics metrics from the active engine
+    and stores a snapshot for historical statistics.
+
+    Returns:
+        Current metrics dictionary.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        metrics = _collect_metrics(engine_manager)
+        _store_metric_snapshot(engine_manager, metrics)
+        return {"status": "ok", "metrics": metrics}
+    except Exception as exc:
+        if logger:
+            logger.error("Metrics collection error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Metrics collection failed: {str(exc)}"
+        ) from exc
+
+
+@router.get(
+    "/analysis/statistics", response_model=AnalysisStatisticsResponse
+)
+async def get_analysis_statistics(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> AnalysisStatisticsResponse:
+    """Get statistical summary of analysis metrics over time.
+
+    Computes min, max, mean, and std_dev for each scalar metric
+    from the stored metric history.
+
+    Returns:
+        Statistical summaries.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        history = _get_metric_history(engine_manager)
+        sim_time = getattr(engine, "time", 0.0)
+
+        # Compute statistics for scalar metrics
+        metric_summaries: list[AnalysisMetricsSummary] = []
+        time_series: dict[str, list[float]] = {}
+
+        # Identify scalar metric keys
+        scalar_keys: set[str] = set()
+        for snapshot in history:
+            for key, value in snapshot.items():
+                if isinstance(value, (int, float)) and not math.isnan(value):
+                    scalar_keys.add(key)
+
+        for key in sorted(scalar_keys):
+            values = []
+            for snapshot in history:
+                val = snapshot.get(key)
+                if isinstance(val, (int, float)) and not math.isnan(val):
+                    values.append(float(val))
+
+            if not values:
+                continue
+
+            import numpy as np
+
+            arr = np.array(values)
+            metric_summaries.append(AnalysisMetricsSummary(
+                metric_name=key,
+                current=values[-1],
+                minimum=float(np.min(arr)),
+                maximum=float(np.max(arr)),
+                mean=float(np.mean(arr)),
+                std_dev=float(np.std(arr)),
+            ))
+
+            time_series[key] = values
+
+        return AnalysisStatisticsResponse(
+            sim_time=sim_time,
+            sample_count=len(history),
+            metrics=metric_summaries,
+            time_series=time_series,
+        )
+    except Exception as exc:
+        if logger:
+            logger.error("Statistics computation error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Statistics computation failed: {str(exc)}"
+        ) from exc
+
+
+# ──────────────────────────────────────────────────────────────
+#  Data Export (See issue #1203)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.post("/analysis/export")
+async def export_analysis_data(
+    request: DataExportRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> StreamingResponse:
+    """Export analysis data as CSV or JSON download.
+
+    Exports the stored metric history and current statistics
+    as a downloadable file.
+
+    Args:
+        request: Export parameters (format, filters).
+        engine_manager: Injected engine manager.
+        logger: Injected logger.
+
+    Returns:
+        Streaming file response.
+    """
+    history = _get_metric_history(engine_manager)
+
+    if not history:
+        raise HTTPException(
+            status_code=400,
+            detail="No data to export. Run a simulation first.",
+        )
+
+    # Apply time range filter
+    filtered = history
+    if request.time_range and len(request.time_range) == 2:
+        t_start, t_end = request.time_range
+        filtered = [
+            s for s in history
+            if t_start <= s.get("sim_time", 0) <= t_end
+        ]
+
+    try:
+        if request.format == "csv":
+            # Build CSV
+            output = io.StringIO()
+            if filtered:
+                # Get all keys from all snapshots
+                all_keys: set[str] = set()
+                for snapshot in filtered:
+                    for key, value in snapshot.items():
+                        if isinstance(value, (int, float)):
+                            all_keys.add(key)
+
+                fieldnames = sorted(all_keys)
+                writer = csv.DictWriter(output, fieldnames=fieldnames)
+                writer.writeheader()
+                for snapshot in filtered:
+                    row = {}
+                    for key in fieldnames:
+                        val = snapshot.get(key)
+                        if isinstance(val, (int, float)):
+                            row[key] = val
+                    writer.writerow(row)
+
+            content = output.getvalue()
+            return StreamingResponse(
+                io.BytesIO(content.encode("utf-8")),
+                media_type="text/csv",
+                headers={
+                    "Content-Disposition": "attachment; filename=analysis_export.csv"
+                },
+            )
+        else:
+            # JSON export
+            export_data = {
+                "format": "json",
+                "record_count": len(filtered),
+                "data": filtered,
+            }
+            content = json.dumps(export_data, indent=2, default=str)
+            return StreamingResponse(
+                io.BytesIO(content.encode("utf-8")),
+                media_type="application/json",
+                headers={
+                    "Content-Disposition": "attachment; filename=analysis_export.json"
+                },
+            )
+    except Exception as exc:
+        if logger:
+            logger.error("Export error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Export failed: {str(exc)}"
+        ) from exc
+
+
+# ──────────────────────────────────────────────────────────────
+#  Body Positioning (See issue #1179)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.post("/simulation/position", response_model=BodyPositionResponse)
+async def set_body_position(
+    request: BodyPositionUpdateRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> BodyPositionResponse:
+    """Set the position and/or rotation of a body in the simulation.
+
+    Allows interactive repositioning of bodies for setup and analysis.
+
+    Args:
+        request: Body name, position, and rotation.
+        engine_manager: Injected engine manager.
+        logger: Injected logger.
+
+    Returns:
+        Applied position and rotation.
+
+    Raises:
+        HTTPException: If no engine is loaded or body not found.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    position = request.position or [0.0, 0.0, 0.0]
+    rotation = request.rotation or [0.0, 0.0, 0.0]
+
+    try:
+        # Try to set body position via engine API
+        if hasattr(engine, "set_body_position"):
+            engine.set_body_position(request.body_name, position)
+        if hasattr(engine, "set_body_rotation"):
+            engine.set_body_rotation(request.body_name, rotation)
+
+        return BodyPositionResponse(
+            body_name=request.body_name,
+            position=position,
+            rotation=rotation,
+            status=f"Position set for {request.body_name}",
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"Body not found: {str(exc)}"
+        ) from exc
+    except Exception as exc:
+        if logger:
+            logger.error("Body positioning error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Positioning failed: {str(exc)}"
+        ) from exc
+
+
+# ──────────────────────────────────────────────────────────────
+#  Measurement Tools (See issue #1179)
+# ──────────────────────────────────────────────────────────────
+
+
+@router.post("/simulation/measure", response_model=MeasurementResult)
+async def measure_distance(
+    request: MeasurementRequest,
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> MeasurementResult:
+    """Measure the distance between two bodies.
+
+    Args:
+        request: Body names to measure between.
+        engine_manager: Injected engine manager.
+        logger: Injected logger.
+
+    Returns:
+        Distance measurement and body positions.
+
+    Raises:
+        HTTPException: If no engine loaded or bodies not found.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        # Get body positions
+        pos_a = [0.0, 0.0, 0.0]
+        pos_b = [0.0, 0.0, 0.0]
+
+        if hasattr(engine, "get_body_position"):
+            pa = engine.get_body_position(request.body_a)
+            if pa is not None:
+                pos_a = pa.tolist() if hasattr(pa, "tolist") else list(pa)
+
+            pb = engine.get_body_position(request.body_b)
+            if pb is not None:
+                pos_b = pb.tolist() if hasattr(pb, "tolist") else list(pb)
+
+        # Compute distance
+        delta = [b - a for a, b in zip(pos_a, pos_b, strict=True)]
+        distance = math.sqrt(sum(d * d for d in delta))
+
+        return MeasurementResult(
+            body_a=request.body_a,
+            body_b=request.body_b,
+            distance=distance,
+            position_a=pos_a,
+            position_b=pos_b,
+            delta=delta,
+        )
+    except Exception as exc:
+        if logger:
+            logger.error("Measurement error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Measurement failed: {str(exc)}"
+        ) from exc
+
+
+@router.get(
+    "/simulation/measurements", response_model=MeasurementToolsResponse
+)
+async def get_measurement_tools(
+    engine_manager: EngineManager = Depends(get_engine_manager),
+    logger: Any = Depends(get_logger),
+) -> MeasurementToolsResponse:
+    """Get all joint angles and active measurements.
+
+    Provides a unified view of joint angle displays and any
+    active distance measurements for the simulation toolbar.
+
+    Returns:
+        Joint angles and measurements data.
+
+    Raises:
+        HTTPException: If no engine is loaded.
+    """
+    engine = engine_manager.get_active_physics_engine()
+    if engine is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No physics engine loaded. Load an engine first.",
+        )
+
+    try:
+        joint_angles: list[JointAngleDisplay] = []
+
+        # Get state
+        q, v = engine.get_state()
+        q_list = q.tolist() if hasattr(q, "tolist") else list(q)
+        v_list = v.tolist() if hasattr(v, "tolist") else list(v)
+
+        # Get joint names if available
+        joint_names: list[str] = []
+        if hasattr(engine, "get_joint_names"):
+            joint_names = engine.get_joint_names()
+
+        # Get torques if available
+        torques: list[float] = []
+        if hasattr(engine, "get_applied_torques"):
+            t = engine.get_applied_torques()
+            torques = t.tolist() if hasattr(t, "tolist") else list(t)
+
+        for i in range(len(q_list)):
+            name = joint_names[i] if i < len(joint_names) else f"joint_{i}"
+            angle_rad = q_list[i]
+            vel = v_list[i] if i < len(v_list) else 0.0
+            torque = torques[i] if i < len(torques) else 0.0
+
+            joint_angles.append(JointAngleDisplay(
+                joint_name=name,
+                angle_rad=angle_rad,
+                angle_deg=math.degrees(angle_rad),
+                velocity=vel,
+                torque=torque,
+            ))
+
+        return MeasurementToolsResponse(
+            joint_angles=joint_angles,
+            measurements=[],
+        )
+    except Exception as exc:
+        if logger:
+            logger.error("Measurement tools error: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Measurement tools failed: {str(exc)}"
+        ) from exc

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -1,0 +1,351 @@
+"""URDF/MJCF model serving routes.
+
+Provides endpoints for listing and retrieving parsed URDF/MJCF models
+for 3D rendering in the frontend.
+
+See issue #1201
+
+All dependencies are injected via FastAPI's Depends() mechanism.
+No module-level mutable state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..dependencies import get_logger
+from ..models.responses import (
+    ModelListResponse,
+    URDFJointDescriptor,
+    URDFLinkGeometry,
+    URDFModelResponse,
+)
+
+router = APIRouter()
+
+# Base directories for model discovery
+_MODEL_DIRS = [
+    Path("src/shared/urdf"),
+    Path("src/engines/physics_engines/pinocchio/models/generated"),
+    Path("tests/fixtures/models"),
+]
+
+
+def _find_project_root() -> Path:
+    """Find the project root directory by looking for known markers."""
+    # Walk up from this file's location
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / "src" / "shared" / "urdf").exists():
+            return parent
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return Path.cwd()
+
+
+def _discover_models() -> list[dict[str, str]]:
+    """Discover available URDF/MJCF model files.
+
+    Returns:
+        List of dicts with name, format, and path keys.
+    """
+    root = _find_project_root()
+    models: list[dict[str, str]] = []
+    seen_names: set[str] = set()
+
+    for model_dir in _MODEL_DIRS:
+        full_dir = root / model_dir
+        if not full_dir.exists():
+            continue
+
+        for ext in ("*.urdf", "*.xml"):
+            for filepath in full_dir.rglob(ext):
+                name = filepath.stem
+                if name in seen_names:
+                    # Disambiguate with parent directory
+                    name = f"{filepath.parent.name}/{name}"
+                seen_names.add(name)
+
+                fmt = "urdf" if filepath.suffix == ".urdf" else "mjcf"
+                models.append({
+                    "name": name,
+                    "format": fmt,
+                    "path": str(filepath.relative_to(root)),
+                })
+
+    return models
+
+
+def _parse_urdf_geometry(visual_elem: Any, materials: dict[str, list[float]]) -> dict:
+    """Parse a single <visual> element into geometry data.
+
+    Args:
+        visual_elem: XML element for <visual>.
+        materials: Dictionary mapping material names to RGBA color lists.
+
+    Returns:
+        Dictionary with geometry_type, dimensions, origin, rotation, and color.
+    """
+    result: dict[str, Any] = {
+        "geometry_type": "box",
+        "dimensions": {},
+        "origin": [0.0, 0.0, 0.0],
+        "rotation": [0.0, 0.0, 0.0],
+        "color": [0.5, 0.5, 0.5, 1.0],
+        "mesh_path": None,
+    }
+
+    # Parse origin
+    origin_elem = visual_elem.find("origin")
+    if origin_elem is not None:
+        xyz = origin_elem.get("xyz", "0 0 0")
+        rpy = origin_elem.get("rpy", "0 0 0")
+        result["origin"] = [float(x) for x in xyz.split()]
+        result["rotation"] = [float(x) for x in rpy.split()]
+
+    # Parse geometry
+    geom_elem = visual_elem.find("geometry")
+    if geom_elem is not None:
+        box = geom_elem.find("box")
+        cylinder = geom_elem.find("cylinder")
+        sphere = geom_elem.find("sphere")
+        mesh = geom_elem.find("mesh")
+
+        if box is not None:
+            result["geometry_type"] = "box"
+            size = box.get("size", "0.1 0.1 0.1")
+            dims = [float(x) for x in size.split()]
+            result["dimensions"] = {
+                "width": dims[0] if len(dims) > 0 else 0.1,
+                "height": dims[1] if len(dims) > 1 else 0.1,
+                "depth": dims[2] if len(dims) > 2 else 0.1,
+            }
+        elif cylinder is not None:
+            result["geometry_type"] = "cylinder"
+            result["dimensions"] = {
+                "radius": float(cylinder.get("radius", "0.05")),
+                "length": float(cylinder.get("length", "0.3")),
+            }
+        elif sphere is not None:
+            result["geometry_type"] = "sphere"
+            result["dimensions"] = {
+                "radius": float(sphere.get("radius", "0.1")),
+            }
+        elif mesh is not None:
+            result["geometry_type"] = "mesh"
+            result["mesh_path"] = mesh.get("filename", "")
+            scale = mesh.get("scale", "1 1 1")
+            scale_vals = [float(x) for x in scale.split()]
+            result["dimensions"] = {
+                "scale_x": scale_vals[0] if len(scale_vals) > 0 else 1.0,
+                "scale_y": scale_vals[1] if len(scale_vals) > 1 else 1.0,
+                "scale_z": scale_vals[2] if len(scale_vals) > 2 else 1.0,
+            }
+
+    # Parse material/color
+    mat_elem = visual_elem.find("material")
+    if mat_elem is not None:
+        mat_name = mat_elem.get("name", "")
+        color_elem = mat_elem.find("color")
+        if color_elem is not None:
+            rgba = color_elem.get("rgba", "0.5 0.5 0.5 1.0")
+            result["color"] = [float(x) for x in rgba.split()]
+        elif mat_name in materials:
+            result["color"] = materials[mat_name]
+
+    return result
+
+
+def _parse_urdf(urdf_content: str) -> URDFModelResponse:
+    """Parse a URDF XML string into a URDFModelResponse.
+
+    Args:
+        urdf_content: Raw URDF XML string.
+
+    Returns:
+        Parsed model data.
+
+    Raises:
+        ValueError: If the URDF cannot be parsed.
+    """
+    try:
+        root = ElementTree.fromstring(urdf_content)  # noqa: S314
+    except ElementTree.ParseError as e:
+        raise ValueError(f"Invalid URDF XML: {e}") from e
+
+    model_name = root.get("name", "unknown")
+
+    # Parse top-level materials
+    materials: dict[str, list[float]] = {}
+    for mat_elem in root.findall("material"):
+        mat_name = mat_elem.get("name", "")
+        color_elem = mat_elem.find("color")
+        if color_elem is not None:
+            rgba = color_elem.get("rgba", "0.5 0.5 0.5 1.0")
+            materials[mat_name] = [float(x) for x in rgba.split()]
+
+    # Parse links
+    links: list[URDFLinkGeometry] = []
+    for link_elem in root.findall("link"):
+        link_name = link_elem.get("name", "unnamed")
+        visual_elem = link_elem.find("visual")
+        if visual_elem is not None:
+            geom_data = _parse_urdf_geometry(visual_elem, materials)
+            links.append(URDFLinkGeometry(
+                link_name=link_name,
+                **geom_data,
+            ))
+
+    # Parse joints
+    joints: list[URDFJointDescriptor] = []
+    child_links: set[str] = set()
+    for joint_elem in root.findall("joint"):
+        joint_name = joint_elem.get("name", "unnamed")
+        joint_type = joint_elem.get("type", "fixed")
+
+        parent_elem = joint_elem.find("parent")
+        child_elem = joint_elem.find("child")
+        parent_link = parent_elem.get("link", "") if parent_elem is not None else ""
+        child_link = child_elem.get("link", "") if child_elem is not None else ""
+        child_links.add(child_link)
+
+        origin = [0.0, 0.0, 0.0]
+        rotation = [0.0, 0.0, 0.0]
+        origin_elem = joint_elem.find("origin")
+        if origin_elem is not None:
+            xyz = origin_elem.get("xyz", "0 0 0")
+            rpy = origin_elem.get("rpy", "0 0 0")
+            origin = [float(x) for x in xyz.split()]
+            rotation = [float(x) for x in rpy.split()]
+
+        axis = [0.0, 0.0, 1.0]
+        axis_elem = joint_elem.find("axis")
+        if axis_elem is not None:
+            axis_str = axis_elem.get("xyz", "0 0 1")
+            axis = [float(x) for x in axis_str.split()]
+
+        lower_limit = None
+        upper_limit = None
+        limit_elem = joint_elem.find("limit")
+        if limit_elem is not None:
+            lower_limit = float(limit_elem.get("lower", "0"))
+            upper_limit = float(limit_elem.get("upper", "0"))
+
+        joints.append(URDFJointDescriptor(
+            name=joint_name,
+            joint_type=joint_type,
+            parent_link=parent_link,
+            child_link=child_link,
+            origin=origin,
+            rotation=rotation,
+            axis=axis,
+            lower_limit=lower_limit,
+            upper_limit=upper_limit,
+        ))
+
+    # Find root link (not a child of any joint)
+    all_link_names = {link.link_name for link in links}
+    root_candidates = all_link_names - child_links
+    root_link = next(iter(root_candidates)) if root_candidates else (
+        links[0].link_name if links else "base"
+    )
+
+    return URDFModelResponse(
+        model_name=model_name,
+        links=links,
+        joints=joints,
+        root_link=root_link,
+        urdf_raw=urdf_content,
+    )
+
+
+@router.get("/models", response_model=ModelListResponse)
+async def list_models(
+    logger: Any = Depends(get_logger),
+) -> ModelListResponse:
+    """List available URDF/MJCF models.
+
+    Returns:
+        List of available model files.
+    """
+    try:
+        models = _discover_models()
+        return ModelListResponse(models=models)
+    except Exception as exc:
+        if logger:
+            logger.error("Error listing models: %s", exc)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list models: {str(exc)}"
+        ) from exc
+
+
+@router.get("/models/{model_name}/urdf", response_model=URDFModelResponse)
+async def get_model_urdf(
+    model_name: str,
+    logger: Any = Depends(get_logger),
+) -> URDFModelResponse:
+    """Get parsed URDF model data for 3D rendering.
+
+    Parses the URDF XML and returns structured geometry, joint,
+    and kinematic chain data that can be directly consumed by
+    the frontend URDFViewer component.
+
+    Args:
+        model_name: Model identifier (from /models list).
+        logger: Injected logger.
+
+    Returns:
+        Parsed URDF model data.
+
+    Raises:
+        HTTPException: If model not found or parse fails.
+    """
+    # Find the model file
+    root = _find_project_root()
+    models = _discover_models()
+    model_entry = None
+
+    for m in models:
+        if m["name"] == model_name:
+            model_entry = m
+            break
+
+    if model_entry is None:
+        # Try partial match
+        for m in models:
+            if model_name in m["name"] or m["name"].endswith(model_name):
+                model_entry = m
+                break
+
+    if model_entry is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{model_name}' not found. "
+            f"Available: {[m['name'] for m in models[:10]]}",
+        )
+
+    filepath = root / model_entry["path"]
+    if not filepath.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model file not found: {model_entry['path']}",
+        )
+
+    try:
+        urdf_content = filepath.read_text(encoding="utf-8")
+        result = _parse_urdf(urdf_content)
+        return result
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422, detail=f"Failed to parse URDF: {str(exc)}"
+        ) from exc
+    except Exception as exc:
+        if logger:
+            logger.error("Error loading model %s: %s", model_name, exc)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to load model: {str(exc)}"
+        ) from exc

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -35,12 +35,14 @@ from .database import init_db
 from .middleware.security_headers import add_security_headers
 from .middleware.upload_limits import validate_upload_size
 from .routes import analysis as analysis_routes
+from .routes import analysis_tools as analysis_tools_routes
 from .routes import auth as auth_routes
 from .routes import core as core_routes
 from .routes import dataset as dataset_routes
 from .routes import engines as engine_routes
 from .routes import export as export_routes
 from .routes import launcher as launcher_routes
+from .routes import models as model_routes
 from .routes import physics as physics_routes
 from .routes import simulation as simulation_routes
 from .routes import terrain as terrain_routes
@@ -284,6 +286,8 @@ app.include_router(launcher_routes.router)
 app.include_router(terrain_routes.router)
 app.include_router(dataset_routes.router)
 app.include_router(physics_routes.router)
+app.include_router(model_routes.router)
+app.include_router(analysis_tools_routes.router)
 
 
 if __name__ == "__main__":

--- a/tests/api/test_phase3_api.py
+++ b/tests/api/test_phase3_api.py
@@ -1,0 +1,677 @@
+"""Tests for Phase 3 API: URDF/MJCF rendering, analysis tools, simulation controls.
+
+Validates Pydantic contract models and route logic for:
+- URDF model parsing and serving (#1201)
+- Analysis metrics, statistics, and export (#1203)
+- Body positioning, measurement tools (#1179)
+
+See issue #1201, #1203, #1179
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models.requests import (
+    BodyPositionUpdateRequest,
+    DataExportRequest,
+    MeasurementRequest,
+)
+from src.api.models.responses import (
+    AnalysisMetricsSummary,
+    AnalysisStatisticsResponse,
+    BodyPositionResponse,
+    DataExportResponse,
+    JointAngleDisplay,
+    MeasurementResult,
+    MeasurementToolsResponse,
+    ModelListResponse,
+    URDFJointDescriptor,
+    URDFLinkGeometry,
+    URDFModelResponse,
+)
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: URDF Model Responses (#1201)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestURDFLinkGeometryContract:
+    """Validate URDFLinkGeometry response model."""
+
+    def test_box_geometry(self) -> None:
+        """Box geometry with all fields."""
+        link = URDFLinkGeometry(
+            link_name="torso",
+            geometry_type="box",
+            dimensions={"width": 0.2, "height": 0.4, "depth": 0.6},
+            origin=[0.0, 0.0, 0.3],
+            rotation=[0.0, 0.0, 0.0],
+            color=[0.0, 0.0, 0.8, 1.0],
+        )
+        assert link.link_name == "torso"
+        assert link.geometry_type == "box"
+        assert link.dimensions["width"] == 0.2
+
+    def test_cylinder_geometry(self) -> None:
+        """Cylinder geometry."""
+        link = URDFLinkGeometry(
+            link_name="arm",
+            geometry_type="cylinder",
+            dimensions={"radius": 0.05, "length": 0.3},
+        )
+        assert link.geometry_type == "cylinder"
+        assert link.dimensions["radius"] == 0.05
+
+    def test_sphere_geometry(self) -> None:
+        """Sphere geometry."""
+        link = URDFLinkGeometry(
+            link_name="head",
+            geometry_type="sphere",
+            dimensions={"radius": 0.12},
+        )
+        assert link.geometry_type == "sphere"
+
+    def test_mesh_geometry(self) -> None:
+        """Mesh geometry with path."""
+        link = URDFLinkGeometry(
+            link_name="hand",
+            geometry_type="mesh",
+            dimensions={"scale_x": 1.0, "scale_y": 1.0, "scale_z": 1.0},
+            mesh_path="meshes/hand.stl",
+        )
+        assert link.geometry_type == "mesh"
+        assert link.mesh_path == "meshes/hand.stl"
+
+    def test_defaults(self) -> None:
+        """Defaults are applied when not specified."""
+        link = URDFLinkGeometry(
+            link_name="test",
+            geometry_type="box",
+        )
+        assert link.origin == [0.0, 0.0, 0.0]
+        assert link.rotation == [0.0, 0.0, 0.0]
+        assert link.color == [0.5, 0.5, 0.5, 1.0]
+        assert link.mesh_path is None
+
+
+class TestURDFJointDescriptorContract:
+    """Validate URDFJointDescriptor response model."""
+
+    def test_revolute_joint(self) -> None:
+        """Revolute joint with limits."""
+        joint = URDFJointDescriptor(
+            name="shoulder",
+            joint_type="revolute",
+            parent_link="torso",
+            child_link="upper_arm",
+            origin=[0.1, 0.0, 0.5],
+            rotation=[0.0, 0.0, 0.0],
+            axis=[0.0, 1.0, 0.0],
+            lower_limit=-3.14,
+            upper_limit=3.14,
+        )
+        assert joint.name == "shoulder"
+        assert joint.joint_type == "revolute"
+        assert joint.parent_link == "torso"
+        assert joint.child_link == "upper_arm"
+        assert joint.lower_limit == -3.14
+
+    def test_fixed_joint(self) -> None:
+        """Fixed joint (no limits needed)."""
+        joint = URDFJointDescriptor(
+            name="base_fixed",
+            joint_type="fixed",
+            parent_link="world",
+            child_link="base",
+        )
+        assert joint.joint_type == "fixed"
+        assert joint.lower_limit is None
+
+    def test_defaults(self) -> None:
+        """Defaults are applied."""
+        joint = URDFJointDescriptor(
+            name="test",
+            joint_type="revolute",
+            parent_link="a",
+            child_link="b",
+        )
+        assert joint.origin == [0.0, 0.0, 0.0]
+        assert joint.axis == [0.0, 0.0, 1.0]
+
+
+class TestURDFModelResponseContract:
+    """Validate URDFModelResponse contract."""
+
+    def test_full_model(self) -> None:
+        """Complete model with links and joints."""
+        model = URDFModelResponse(
+            model_name="simple_humanoid",
+            links=[
+                URDFLinkGeometry(
+                    link_name="torso",
+                    geometry_type="box",
+                    dimensions={"width": 0.2, "height": 0.4, "depth": 0.6},
+                ),
+                URDFLinkGeometry(
+                    link_name="head",
+                    geometry_type="sphere",
+                    dimensions={"radius": 0.12},
+                ),
+            ],
+            joints=[
+                URDFJointDescriptor(
+                    name="neck",
+                    joint_type="revolute",
+                    parent_link="torso",
+                    child_link="head",
+                    origin=[0.0, 0.0, 0.6],
+                ),
+            ],
+            root_link="torso",
+        )
+        assert model.model_name == "simple_humanoid"
+        assert len(model.links) == 2
+        assert len(model.joints) == 1
+        assert model.root_link == "torso"
+
+    def test_empty_model(self) -> None:
+        """Model with no links or joints."""
+        model = URDFModelResponse(
+            model_name="empty",
+            links=[],
+            joints=[],
+            root_link="base",
+        )
+        assert model.model_name == "empty"
+
+    def test_with_raw_urdf(self) -> None:
+        """Model includes raw URDF XML."""
+        model = URDFModelResponse(
+            model_name="test",
+            links=[],
+            joints=[],
+            root_link="base",
+            urdf_raw="<robot name='test'></robot>",
+        )
+        assert model.urdf_raw is not None
+
+
+class TestModelListResponseContract:
+    """Validate ModelListResponse contract."""
+
+    def test_list_with_models(self) -> None:
+        """List with multiple model entries."""
+        resp = ModelListResponse(
+            models=[
+                {"name": "humanoid", "format": "urdf", "path": "models/humanoid.urdf"},
+                {"name": "golfer", "format": "urdf", "path": "models/golfer.urdf"},
+            ]
+        )
+        assert len(resp.models) == 2
+
+    def test_empty_list(self) -> None:
+        """Empty model list."""
+        resp = ModelListResponse(models=[])
+        assert len(resp.models) == 0
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: Analysis Tools (#1203)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestDataExportRequestContract:
+    """Validate DataExportRequest preconditions."""
+
+    def test_csv_format(self) -> None:
+        """CSV format is valid."""
+        req = DataExportRequest(format="csv")
+        assert req.format == "csv"
+
+    def test_json_format(self) -> None:
+        """JSON format is valid."""
+        req = DataExportRequest(format="json")
+        assert req.format == "json"
+
+    def test_invalid_format_rejected(self) -> None:
+        """Invalid format raises ValidationError."""
+        with pytest.raises(ValidationError):
+            DataExportRequest(format="hdf5")
+
+    def test_case_insensitive(self) -> None:
+        """Format is normalized to lowercase."""
+        req = DataExportRequest(format="CSV")
+        assert req.format == "csv"
+
+    def test_time_range(self) -> None:
+        """Optional time range is accepted."""
+        req = DataExportRequest(format="csv", time_range=[0.0, 1.5])
+        assert req.time_range == [0.0, 1.5]
+
+    def test_defaults(self) -> None:
+        """Default values are applied."""
+        req = DataExportRequest(format="csv")
+        assert req.include_metrics is True
+        assert req.include_time_series is True
+        assert req.time_range is None
+
+
+class TestAnalysisMetricsSummaryContract:
+    """Validate AnalysisMetricsSummary response model."""
+
+    def test_full_summary(self) -> None:
+        """Complete metric summary."""
+        summary = AnalysisMetricsSummary(
+            metric_name="club_head_speed",
+            current=45.2,
+            minimum=0.0,
+            maximum=52.1,
+            mean=30.5,
+            std_dev=12.3,
+        )
+        assert summary.metric_name == "club_head_speed"
+        assert summary.current == 45.2
+
+    def test_default_std_dev(self) -> None:
+        """std_dev defaults to 0."""
+        summary = AnalysisMetricsSummary(
+            metric_name="test",
+            current=1.0,
+            minimum=0.0,
+            maximum=2.0,
+            mean=1.0,
+        )
+        assert summary.std_dev == 0.0
+
+
+class TestAnalysisStatisticsResponseContract:
+    """Validate AnalysisStatisticsResponse contract."""
+
+    def test_full_response(self) -> None:
+        """Response with metrics and time series."""
+        resp = AnalysisStatisticsResponse(
+            sim_time=2.5,
+            sample_count=100,
+            metrics=[
+                AnalysisMetricsSummary(
+                    metric_name="ke",
+                    current=10.0,
+                    minimum=0.0,
+                    maximum=15.0,
+                    mean=8.0,
+                    std_dev=3.0,
+                ),
+            ],
+            time_series={"ke": [1.0, 2.0, 5.0, 10.0]},
+        )
+        assert resp.sim_time == 2.5
+        assert resp.sample_count == 100
+        assert len(resp.metrics) == 1
+
+    def test_no_time_series(self) -> None:
+        """Response without time series."""
+        resp = AnalysisStatisticsResponse(
+            sim_time=0.0,
+            sample_count=0,
+            metrics=[],
+        )
+        assert resp.time_series is None
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: Body Positioning & Measurements (#1179)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestBodyPositionUpdateRequestContract:
+    """Validate BodyPositionUpdateRequest preconditions."""
+
+    def test_valid_position(self) -> None:
+        """Position with 3 elements is valid."""
+        req = BodyPositionUpdateRequest(
+            body_name="torso",
+            position=[1.0, 2.0, 3.0],
+        )
+        assert req.body_name == "torso"
+        assert req.position == [1.0, 2.0, 3.0]
+
+    def test_valid_rotation(self) -> None:
+        """Rotation with 3 elements is valid."""
+        req = BodyPositionUpdateRequest(
+            body_name="head",
+            rotation=[0.1, 0.2, 0.3],
+        )
+        assert req.rotation == [0.1, 0.2, 0.3]
+
+    def test_invalid_position_length(self) -> None:
+        """Position with wrong length raises error."""
+        with pytest.raises(ValidationError):
+            BodyPositionUpdateRequest(
+                body_name="torso",
+                position=[1.0, 2.0],  # Only 2 elements
+            )
+
+    def test_invalid_rotation_length(self) -> None:
+        """Rotation with wrong length raises error."""
+        with pytest.raises(ValidationError):
+            BodyPositionUpdateRequest(
+                body_name="torso",
+                rotation=[1.0],  # Only 1 element
+            )
+
+    def test_both_none(self) -> None:
+        """Both position and rotation can be None."""
+        req = BodyPositionUpdateRequest(body_name="arm")
+        assert req.position is None
+        assert req.rotation is None
+
+
+class TestMeasurementRequestContract:
+    """Validate MeasurementRequest model."""
+
+    def test_valid_request(self) -> None:
+        """Valid measurement request."""
+        req = MeasurementRequest(body_a="torso", body_b="head")
+        assert req.body_a == "torso"
+        assert req.body_b == "head"
+
+
+class TestBodyPositionResponseContract:
+    """Validate BodyPositionResponse model."""
+
+    def test_full_response(self) -> None:
+        """Complete position response."""
+        resp = BodyPositionResponse(
+            body_name="torso",
+            position=[1.0, 2.0, 3.0],
+            rotation=[0.0, 0.0, 0.0],
+            status="Position set for torso",
+        )
+        assert resp.body_name == "torso"
+
+
+class TestMeasurementResultContract:
+    """Validate MeasurementResult model."""
+
+    def test_full_measurement(self) -> None:
+        """Complete measurement result."""
+        result = MeasurementResult(
+            body_a="torso",
+            body_b="head",
+            distance=0.6,
+            position_a=[0.0, 0.0, 0.0],
+            position_b=[0.0, 0.0, 0.6],
+            delta=[0.0, 0.0, 0.6],
+        )
+        assert result.distance == 0.6
+        assert result.delta == [0.0, 0.0, 0.6]
+
+
+class TestJointAngleDisplayContract:
+    """Validate JointAngleDisplay model."""
+
+    def test_full_display(self) -> None:
+        """Complete joint angle display."""
+        display = JointAngleDisplay(
+            joint_name="shoulder",
+            angle_rad=1.57,
+            angle_deg=90.0,
+            velocity=0.5,
+            torque=10.0,
+        )
+        assert display.joint_name == "shoulder"
+        assert display.angle_deg == 90.0
+
+    def test_defaults(self) -> None:
+        """Defaults for velocity and torque."""
+        display = JointAngleDisplay(
+            joint_name="elbow",
+            angle_rad=0.0,
+            angle_deg=0.0,
+        )
+        assert display.velocity == 0.0
+        assert display.torque == 0.0
+
+
+class TestMeasurementToolsResponseContract:
+    """Validate MeasurementToolsResponse model."""
+
+    def test_with_data(self) -> None:
+        """Response with joint angles and measurements."""
+        resp = MeasurementToolsResponse(
+            joint_angles=[
+                JointAngleDisplay(
+                    joint_name="hip",
+                    angle_rad=0.5,
+                    angle_deg=28.6,
+                ),
+            ],
+            measurements=[
+                MeasurementResult(
+                    body_a="a",
+                    body_b="b",
+                    distance=1.0,
+                    position_a=[0, 0, 0],
+                    position_b=[1, 0, 0],
+                    delta=[1, 0, 0],
+                ),
+            ],
+        )
+        assert len(resp.joint_angles) == 1
+        assert len(resp.measurements) == 1
+
+    def test_empty(self) -> None:
+        """Empty response."""
+        resp = MeasurementToolsResponse(
+            joint_angles=[],
+        )
+        assert len(resp.measurements) == 0
+
+
+# ──────────────────────────────────────────────────────────────
+#  URDF Parser Tests (#1201)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestURDFParser:
+    """Test the URDF XML parser in the models route."""
+
+    def test_parse_simple_humanoid(self) -> None:
+        """Parse the simple_humanoid.urdf from test fixtures."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<?xml version="1.0"?>
+        <robot name="test_robot">
+          <material name="blue">
+            <color rgba="0 0 0.8 1"/>
+          </material>
+          <link name="base">
+            <visual>
+              <geometry>
+                <box size="0.2 0.3 0.4"/>
+              </geometry>
+              <material name="blue"/>
+              <origin xyz="0 0 0.2" rpy="0 0 0"/>
+            </visual>
+          </link>
+          <link name="arm">
+            <visual>
+              <geometry>
+                <cylinder radius="0.05" length="0.3"/>
+              </geometry>
+              <origin xyz="0.15 0 0" rpy="0 1.57 0"/>
+            </visual>
+          </link>
+          <joint name="shoulder" type="revolute">
+            <parent link="base"/>
+            <child link="arm"/>
+            <origin xyz="0.1 0 0.4" rpy="0 0 0"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-3.14" upper="3.14" effort="30" velocity="1"/>
+          </joint>
+        </robot>
+        """
+        result = _parse_urdf(urdf)
+
+        assert result.model_name == "test_robot"
+        assert len(result.links) == 2
+        assert len(result.joints) == 1
+        assert result.root_link == "base"
+
+        # Check link parsing
+        base_link = next(l for l in result.links if l.link_name == "base")
+        assert base_link.geometry_type == "box"
+        assert base_link.dimensions["width"] == 0.2
+        assert base_link.color == [0.0, 0.0, 0.8, 1.0]  # From material
+
+        arm_link = next(l for l in result.links if l.link_name == "arm")
+        assert arm_link.geometry_type == "cylinder"
+        assert arm_link.dimensions["radius"] == 0.05
+
+        # Check joint parsing
+        shoulder = result.joints[0]
+        assert shoulder.name == "shoulder"
+        assert shoulder.joint_type == "revolute"
+        assert shoulder.parent_link == "base"
+        assert shoulder.child_link == "arm"
+        assert shoulder.axis == [0.0, 1.0, 0.0]
+        assert shoulder.lower_limit == -3.14
+
+    def test_parse_sphere_geometry(self) -> None:
+        """Parse sphere geometry."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="sphere_test">
+          <link name="ball">
+            <visual>
+              <geometry>
+                <sphere radius="0.1"/>
+              </geometry>
+            </visual>
+          </link>
+        </robot>"""
+        result = _parse_urdf(urdf)
+        assert result.links[0].geometry_type == "sphere"
+        assert result.links[0].dimensions["radius"] == 0.1
+
+    def test_parse_mesh_geometry(self) -> None:
+        """Parse mesh geometry with scale."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="mesh_test">
+          <link name="body">
+            <visual>
+              <geometry>
+                <mesh filename="body.stl" scale="0.001 0.001 0.001"/>
+              </geometry>
+            </visual>
+          </link>
+        </robot>"""
+        result = _parse_urdf(urdf)
+        assert result.links[0].geometry_type == "mesh"
+        assert result.links[0].mesh_path == "body.stl"
+        assert result.links[0].dimensions["scale_x"] == 0.001
+
+    def test_parse_fixed_joint(self) -> None:
+        """Parse fixed joint type."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="fixed_test">
+          <link name="world"/>
+          <link name="base">
+            <visual>
+              <geometry><box size="1 1 1"/></geometry>
+            </visual>
+          </link>
+          <joint name="world_joint" type="fixed">
+            <parent link="world"/>
+            <child link="base"/>
+          </joint>
+        </robot>"""
+        result = _parse_urdf(urdf)
+        assert result.joints[0].joint_type == "fixed"
+
+    def test_parse_invalid_xml(self) -> None:
+        """Invalid XML raises ValueError."""
+        from src.api.routes.models import _parse_urdf
+
+        with pytest.raises(ValueError, match="Invalid URDF XML"):
+            _parse_urdf("not valid xml <><><>")
+
+    def test_parse_inline_material_color(self) -> None:
+        """Parse material color defined inline in the visual."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="color_test">
+          <link name="colored">
+            <visual>
+              <geometry><sphere radius="0.1"/></geometry>
+              <material name="red">
+                <color rgba="1 0 0 1"/>
+              </material>
+            </visual>
+          </link>
+        </robot>"""
+        result = _parse_urdf(urdf)
+        assert result.links[0].color == [1.0, 0.0, 0.0, 1.0]
+
+    def test_parse_multiple_joints_kinematic_chain(self) -> None:
+        """Parse a chain of multiple joints."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="chain_test">
+          <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+          <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+          <link name="c"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+          <joint name="j1" type="revolute">
+            <parent link="a"/><child link="b"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-1" upper="1" effort="10" velocity="1"/>
+          </joint>
+          <joint name="j2" type="revolute">
+            <parent link="b"/><child link="c"/>
+            <axis xyz="0 1 0"/>
+            <limit lower="-1" upper="1" effort="10" velocity="1"/>
+          </joint>
+        </robot>"""
+        result = _parse_urdf(urdf)
+        assert result.root_link == "a"
+        assert len(result.joints) == 2
+        assert result.joints[0].parent_link == "a"
+        assert result.joints[1].parent_link == "b"
+
+
+# ──────────────────────────────────────────────────────────────
+#  Model Discovery Tests (#1201)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestModelDiscovery:
+    """Test model file discovery."""
+
+    def test_discover_models_returns_list(self) -> None:
+        """Model discovery returns a list of dicts."""
+        from src.api.routes.models import _discover_models
+
+        models = _discover_models()
+        assert isinstance(models, list)
+
+        # Should find at least some URDF files in the project
+        if models:
+            assert "name" in models[0]
+            assert "format" in models[0]
+            assert "path" in models[0]
+
+    def test_discover_models_finds_urdf(self) -> None:
+        """Model discovery finds URDF files."""
+        from src.api.routes.models import _discover_models
+
+        models = _discover_models()
+        urdf_models = [m for m in models if m["format"] == "urdf"]
+        # There are URDF files in the test fixtures
+        assert len(urdf_models) > 0

--- a/ui/src/api/simulationTools.ts
+++ b/ui/src/api/simulationTools.ts
@@ -1,0 +1,59 @@
+/**
+ * API utilities for simulation tools: body positioning and measurement.
+ *
+ * These are standalone functions that can be called from any component
+ * that needs to interact with the simulation tools endpoints.
+ *
+ * See issue #1179
+ */
+
+import type { MeasurementResult } from '@/components/simulation/SimulationToolbar';
+
+/**
+ * Set the position of a body in the active simulation.
+ *
+ * @param bodyName - Name of the body to position
+ * @param position - Target position [x, y, z]
+ * @returns Applied position response or throws on error
+ */
+export async function positionBody(
+  bodyName: string,
+  position: [number, number, number],
+): Promise<{ body_name: string; position: number[]; rotation: number[]; status: string }> {
+  const response = await fetch('/api/simulation/position', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      body_name: bodyName,
+      position,
+    }),
+  });
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}));
+    throw new Error(errData.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Measure distance between two bodies in the active simulation.
+ *
+ * @param bodyA - First body name
+ * @param bodyB - Second body name
+ * @returns Measurement result with distance and positions
+ */
+export async function measureDistance(
+  bodyA: string,
+  bodyB: string,
+): Promise<MeasurementResult> {
+  const response = await fetch('/api/simulation/measure', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body_a: bodyA, body_b: bodyB }),
+  });
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}));
+    throw new Error(errData.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}

--- a/ui/src/api/useURDFModel.ts
+++ b/ui/src/api/useURDFModel.ts
@@ -1,0 +1,45 @@
+/**
+ * Hook to fetch a URDF model from the backend API.
+ *
+ * Returns the model data and loading/error states.
+ *
+ * See issue #1201
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import type { URDFModel } from '@/components/visualization/URDFViewer';
+
+export function useURDFModel(modelName: string | null) {
+  const [model, setModel] = useState<URDFModel | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchModel = useCallback(async (name: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/models/${encodeURIComponent(name)}/urdf`);
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `Failed to load model: ${response.status}`);
+      }
+      const data = await response.json();
+      setModel(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      setModel(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (modelName) {
+      fetchModel(modelName);
+    } else {
+      setModel(null);
+    }
+  }, [modelName, fetchModel]);
+
+  return { model, loading, error, refetch: fetchModel };
+}

--- a/ui/src/components/analysis/AnalysisPanel.test.tsx
+++ b/ui/src/components/analysis/AnalysisPanel.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for AnalysisPanel component.
+ *
+ * See issue #1203
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mock recharts to avoid canvas rendering in tests
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart-mock">{children}</div>
+  ),
+  Line: () => <div data-testid="line-mock" />,
+  XAxis: () => <div data-testid="xaxis-mock" />,
+  YAxis: () => <div data-testid="yaxis-mock" />,
+  CartesianGrid: () => <div data-testid="grid-mock" />,
+  Tooltip: () => <div data-testid="tooltip-mock" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container-mock">{children}</div>
+  ),
+  Legend: () => <div data-testid="legend-mock" />,
+}));
+
+import { AnalysisPanel } from './AnalysisPanel';
+
+describe('AnalysisPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('renders tab headers', () => {
+      render(<AnalysisPanel isRunning={false} />);
+
+      expect(screen.getByLabelText('View metrics')).toBeInTheDocument();
+      expect(screen.getByLabelText('View plots')).toBeInTheDocument();
+      expect(screen.getByLabelText('Export data')).toBeInTheDocument();
+    });
+
+    it('shows waiting message when not running', () => {
+      render(<AnalysisPanel isRunning={false} />);
+
+      expect(
+        screen.getByText('Start a simulation to see metrics.'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows collecting message when running but no data', () => {
+      // Mock fetch to return error (no engine)
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ detail: 'No engine loaded' }),
+      });
+
+      render(<AnalysisPanel isRunning={true} />);
+
+      // Initially shows collecting message before fetch completes
+      expect(
+        screen.getByText('Collecting metrics...'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('tab switching', () => {
+    it('switches to plots tab', () => {
+      render(<AnalysisPanel isRunning={false} />);
+
+      fireEvent.click(screen.getByLabelText('View plots'));
+
+      expect(
+        screen.getByText('Start a simulation to see time-series plots.'),
+      ).toBeInTheDocument();
+    });
+
+    it('switches to export tab', () => {
+      render(<AnalysisPanel isRunning={false} />);
+
+      fireEvent.click(screen.getByLabelText('Export data'));
+
+      expect(
+        screen.getByText('Export simulation analysis data for offline processing.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('export', () => {
+    it('disables export buttons when no data', () => {
+      render(<AnalysisPanel isRunning={false} />);
+
+      fireEvent.click(screen.getByLabelText('Export data'));
+
+      const csvButton = screen.getByLabelText('Export as CSV');
+      const jsonButton = screen.getByLabelText('Export as JSON');
+
+      expect(csvButton).toBeDisabled();
+      expect(jsonButton).toBeDisabled();
+    });
+  });
+});

--- a/ui/src/components/analysis/AnalysisPanel.tsx
+++ b/ui/src/components/analysis/AnalysisPanel.tsx
@@ -1,0 +1,480 @@
+/**
+ * AnalysisPanel - Real-time biomechanics metrics and multi-plot display.
+ *
+ * Displays current metrics from the simulation, statistical summaries,
+ * and multiple time-series plots. Supports CSV/JSON data export.
+ *
+ * See issue #1203
+ */
+
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { Download, BarChart2, Activity, TrendingUp } from 'lucide-react';
+
+/** Analysis metric from the backend. */
+interface AnalysisMetric {
+  metric_name: string;
+  current: number;
+  minimum: number;
+  maximum: number;
+  mean: number;
+  std_dev: number;
+}
+
+/** Statistics response from the backend. */
+interface AnalysisStatistics {
+  sim_time: number;
+  sample_count: number;
+  metrics: AnalysisMetric[];
+  time_series: Record<string, number[]> | null;
+}
+
+interface Props {
+  /** Whether the simulation is running */
+  isRunning: boolean;
+  /** Polling interval in ms (default 500) */
+  pollInterval?: number;
+  /** Maximum data points for time series plots */
+  maxDataPoints?: number;
+}
+
+// Color palette for metric plots
+const METRIC_COLORS = [
+  '#60a5fa', // blue
+  '#34d399', // green
+  '#fbbf24', // yellow
+  '#f87171', // red
+  '#a78bfa', // purple
+  '#2dd4bf', // teal
+  '#fb923c', // orange
+  '#f472b6', // pink
+];
+
+// Metrics to highlight in the dashboard
+const HIGHLIGHT_METRICS = [
+  'club_head_speed',
+  'kinetic_energy',
+  'max_velocity',
+  'rms_velocity',
+  'sim_time',
+];
+
+export function AnalysisPanel({
+  isRunning,
+  pollInterval = 500,
+  maxDataPoints = 200,
+}: Props) {
+  const [statistics, setStatistics] = useState<AnalysisStatistics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'metrics' | 'plots' | 'export'>(
+    'metrics',
+  );
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+  const [timeSeriesData, setTimeSeriesData] = useState<
+    Record<string, number>[]
+  >([]);
+
+  // Fetch metrics and statistics from the backend
+  const fetchStatistics = useCallback(async () => {
+    try {
+      // First collect a new metric snapshot
+      await fetch('/api/analysis/metrics');
+
+      // Then get statistics
+      const response = await fetch('/api/analysis/statistics');
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+      const data: AnalysisStatistics = await response.json();
+      setStatistics(data);
+      setError(null);
+
+      // Build time series chart data
+      if (data.time_series) {
+        const timeSeries = data.time_series;
+        const maxLen = Math.max(
+          ...Object.values(timeSeries).map((v) => v.length),
+          0,
+        );
+        const chartData: Record<string, number>[] = [];
+        for (let i = Math.max(0, maxLen - maxDataPoints); i < maxLen; i++) {
+          const point: Record<string, number> = { index: i };
+          for (const [key, values] of Object.entries(timeSeries)) {
+            if (i < values.length) {
+              point[key] = values[i];
+            }
+          }
+          chartData.push(point);
+        }
+        setTimeSeriesData(chartData);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch');
+    }
+  }, [maxDataPoints]);
+
+  // Start/stop polling when simulation runs
+  useEffect(() => {
+    if (isRunning) {
+      fetchStatistics();
+      pollRef.current = setInterval(fetchStatistics, pollInterval);
+    } else {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [isRunning, pollInterval, fetchStatistics]);
+
+  // Export handler
+  const handleExport = useCallback(async (format: 'csv' | 'json') => {
+    try {
+      const response = await fetch('/api/analysis/export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format, include_metrics: true, include_time_series: true }),
+      });
+      if (!response.ok) {
+        throw new Error(`Export failed: ${response.status}`);
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `analysis_export.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed');
+    }
+  }, []);
+
+  // Get highlighted metrics for the dashboard
+  const highlightedMetrics = useMemo(() => {
+    if (!statistics) return [];
+    return statistics.metrics.filter((m) =>
+      HIGHLIGHT_METRICS.includes(m.metric_name),
+    );
+  }, [statistics]);
+
+  // Get plottable metric keys (exclude sim_time since it is the x-axis)
+  const plottableKeys = useMemo(() => {
+    if (!statistics?.time_series) return [];
+    return Object.keys(statistics.time_series).filter(
+      (k) => k !== 'sim_time' && k !== 'index',
+    );
+  }, [statistics]);
+
+  return (
+    <div className="bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
+      {/* Tab header */}
+      <div className="flex border-b border-gray-700">
+        <button
+          onClick={() => setActiveTab('metrics')}
+          className={`flex items-center gap-1 px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'metrics'
+              ? 'bg-gray-800 text-white border-b-2 border-blue-500'
+              : 'text-gray-400 hover:text-white'
+          }`}
+          aria-label="View metrics"
+        >
+          <Activity size={14} aria-hidden="true" />
+          Metrics
+        </button>
+        <button
+          onClick={() => setActiveTab('plots')}
+          className={`flex items-center gap-1 px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'plots'
+              ? 'bg-gray-800 text-white border-b-2 border-blue-500'
+              : 'text-gray-400 hover:text-white'
+          }`}
+          aria-label="View plots"
+        >
+          <BarChart2 size={14} aria-hidden="true" />
+          Plots
+        </button>
+        <button
+          onClick={() => setActiveTab('export')}
+          className={`flex items-center gap-1 px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'export'
+              ? 'bg-gray-800 text-white border-b-2 border-blue-500'
+              : 'text-gray-400 hover:text-white'
+          }`}
+          aria-label="Export data"
+        >
+          <Download size={14} aria-hidden="true" />
+          Export
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-4 py-2 bg-red-900/50 text-red-300 text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* Tab content */}
+      <div className="p-4">
+        {activeTab === 'metrics' && (
+          <div>
+            {!statistics ? (
+              <p className="text-gray-500 text-sm italic">
+                {isRunning
+                  ? 'Collecting metrics...'
+                  : 'Start a simulation to see metrics.'}
+              </p>
+            ) : (
+              <>
+                {/* Sim time header */}
+                <div className="flex items-center justify-between mb-3">
+                  <span className="text-xs text-gray-400">
+                    Sim Time: {statistics.sim_time.toFixed(3)}s
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    Samples: {statistics.sample_count}
+                  </span>
+                </div>
+
+                {/* Highlighted metric cards */}
+                <div
+                  className="grid grid-cols-2 gap-2 mb-4"
+                  role="group"
+                  aria-label="Key metrics"
+                >
+                  {highlightedMetrics.map((metric) => (
+                    <div
+                      key={metric.metric_name}
+                      className="bg-gray-800 rounded p-2"
+                    >
+                      <div className="text-xs text-gray-400 truncate">
+                        {metric.metric_name.replace(/_/g, ' ')}
+                      </div>
+                      <div className="text-lg font-mono text-white">
+                        {metric.current.toFixed(3)}
+                      </div>
+                      <div className="text-xs text-gray-500 flex justify-between">
+                        <span>min: {metric.minimum.toFixed(2)}</span>
+                        <span>max: {metric.maximum.toFixed(2)}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Full metrics table */}
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs" role="table">
+                    <thead>
+                      <tr className="text-gray-400 border-b border-gray-700">
+                        <th className="text-left py-1 px-2">Metric</th>
+                        <th className="text-right py-1 px-2">Current</th>
+                        <th className="text-right py-1 px-2">Mean</th>
+                        <th className="text-right py-1 px-2">Std Dev</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {statistics.metrics.map((metric) => (
+                        <tr
+                          key={metric.metric_name}
+                          className="text-gray-300 border-b border-gray-800"
+                        >
+                          <td className="py-1 px-2 font-mono">
+                            {metric.metric_name}
+                          </td>
+                          <td className="text-right py-1 px-2 font-mono">
+                            {metric.current.toFixed(4)}
+                          </td>
+                          <td className="text-right py-1 px-2 font-mono">
+                            {metric.mean.toFixed(4)}
+                          </td>
+                          <td className="text-right py-1 px-2 font-mono">
+                            {metric.std_dev.toFixed(4)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'plots' && (
+          <div>
+            {timeSeriesData.length < 2 ? (
+              <p className="text-gray-500 text-sm italic">
+                {isRunning
+                  ? 'Collecting data for plots...'
+                  : 'Start a simulation to see time-series plots.'}
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {/* Multi-series plot */}
+                <div>
+                  <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                    <TrendingUp
+                      size={12}
+                      className="inline mr-1"
+                      aria-hidden="true"
+                    />
+                    Time Series
+                  </h4>
+                  <div className="h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart
+                        data={timeSeriesData}
+                        margin={{
+                          top: 5,
+                          right: 20,
+                          left: 0,
+                          bottom: 5,
+                        }}
+                      >
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="#374151"
+                        />
+                        <XAxis
+                          dataKey="index"
+                          stroke="#9ca3af"
+                          tick={{ fontSize: 10 }}
+                        />
+                        <YAxis
+                          stroke="#9ca3af"
+                          tick={{ fontSize: 10 }}
+                          tickFormatter={(value: number) => value.toFixed(2)}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: '#1f2937',
+                            border: '1px solid #374151',
+                            borderRadius: '6px',
+                          }}
+                          labelStyle={{ color: '#9ca3af' }}
+                          itemStyle={{ color: '#e5e7eb' }}
+                        />
+                        <Legend wrapperStyle={{ fontSize: '10px' }} />
+                        {plottableKeys.map((key, idx) => (
+                          <Line
+                            key={key}
+                            type="monotone"
+                            dataKey={key}
+                            name={key.replace(/_/g, ' ')}
+                            stroke={METRIC_COLORS[idx % METRIC_COLORS.length]}
+                            strokeWidth={1.5}
+                            dot={false}
+                            isAnimationActive={false}
+                          />
+                        ))}
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+
+                {/* Individual metric sparklines */}
+                {plottableKeys.slice(0, 4).map((key, idx) => (
+                  <div key={key}>
+                    <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+                      {key.replace(/_/g, ' ')}
+                    </h4>
+                    <div className="h-24">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart
+                          data={timeSeriesData}
+                          margin={{
+                            top: 2,
+                            right: 10,
+                            left: 0,
+                            bottom: 2,
+                          }}
+                        >
+                          <Line
+                            type="monotone"
+                            dataKey={key}
+                            stroke={
+                              METRIC_COLORS[idx % METRIC_COLORS.length]
+                            }
+                            strokeWidth={1.5}
+                            dot={false}
+                            isAnimationActive={false}
+                          />
+                          <YAxis
+                            hide
+                            domain={['auto', 'auto']}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'export' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-400">
+              Export simulation analysis data for offline processing.
+            </p>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => handleExport('csv')}
+                disabled={!statistics || statistics.sample_count === 0}
+                className={`flex items-center gap-2 px-4 py-2 rounded font-medium text-sm transition-colors ${
+                  statistics && statistics.sample_count > 0
+                    ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                    : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                }`}
+                aria-label="Export as CSV"
+              >
+                <Download size={16} aria-hidden="true" />
+                Export CSV
+              </button>
+              <button
+                onClick={() => handleExport('json')}
+                disabled={!statistics || statistics.sample_count === 0}
+                className={`flex items-center gap-2 px-4 py-2 rounded font-medium text-sm transition-colors ${
+                  statistics && statistics.sample_count > 0
+                    ? 'bg-green-600 hover:bg-green-700 text-white'
+                    : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                }`}
+                aria-label="Export as JSON"
+              >
+                <Download size={16} aria-hidden="true" />
+                Export JSON
+              </button>
+            </div>
+
+            {statistics && (
+              <div className="text-xs text-gray-500">
+                {statistics.sample_count} samples available ({statistics.metrics.length}{' '}
+                metrics tracked)
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/simulation/SimulationToolbar.test.tsx
+++ b/ui/src/components/simulation/SimulationToolbar.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for SimulationToolbar component.
+ *
+ * See issue #1179
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { SimulationToolbar } from './SimulationToolbar';
+
+describe('SimulationToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders tool mode buttons', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      expect(screen.getByLabelText('Select mode')).toBeInTheDocument();
+      expect(screen.getByLabelText('Position mode')).toBeInTheDocument();
+      expect(screen.getByLabelText('Rotate mode')).toBeInTheDocument();
+      expect(screen.getByLabelText('Measure mode')).toBeInTheDocument();
+    });
+
+    it('renders toggle buttons', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      expect(
+        screen.getByLabelText('Show force overlays'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('Show joint angles'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders toolbar with proper ARIA role', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      expect(
+        screen.getByRole('toolbar', { name: 'Simulation tools' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('tool mode switching', () => {
+    it('calls onToolModeChange when mode changes', () => {
+      const onToolModeChange = vi.fn();
+      render(
+        <SimulationToolbar
+          isRunning={false}
+          onToolModeChange={onToolModeChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText('Position mode'));
+      expect(onToolModeChange).toHaveBeenCalledWith('position');
+
+      fireEvent.click(screen.getByLabelText('Measure mode'));
+      expect(onToolModeChange).toHaveBeenCalledWith('measure');
+    });
+
+    it('highlights active mode button', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      const selectButton = screen.getByLabelText('Select mode');
+      expect(selectButton).toHaveAttribute('aria-pressed', 'true');
+
+      fireEvent.click(screen.getByLabelText('Position mode'));
+      expect(screen.getByLabelText('Position mode')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getByLabelText('Select mode')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+  });
+
+  describe('force overlay toggle', () => {
+    it('calls onForceOverlayToggle when toggled', () => {
+      const onForceOverlayToggle = vi.fn();
+      render(
+        <SimulationToolbar
+          isRunning={false}
+          onForceOverlayToggle={onForceOverlayToggle}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText('Show force overlays'));
+      expect(onForceOverlayToggle).toHaveBeenCalledWith(true);
+    });
+
+    it('updates aria-pressed state on toggle', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      const forcesButton = screen.getByLabelText('Show force overlays');
+      expect(forcesButton).toHaveAttribute('aria-pressed', 'false');
+
+      fireEvent.click(forcesButton);
+      // After click, button should now say "Hide force overlays"
+      expect(
+        screen.getByLabelText('Hide force overlays'),
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  describe('joint angles display', () => {
+    it('does not show joint angles by default', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      expect(screen.queryByText('Joint Angles')).not.toBeInTheDocument();
+    });
+
+    it('toggles joint angles display', () => {
+      render(<SimulationToolbar isRunning={false} />);
+
+      fireEvent.click(screen.getByLabelText('Show joint angles'));
+      // Even though there is no data yet, the toggle state changes
+      expect(
+        screen.getByLabelText('Hide joint angles'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/simulation/SimulationToolbar.tsx
+++ b/ui/src/components/simulation/SimulationToolbar.tsx
@@ -1,0 +1,290 @@
+/**
+ * SimulationToolbar - Interactive tools for model positioning,
+ * measurement, and force/torque visualization.
+ *
+ * Provides buttons and displays for:
+ * - Body positioning (translate/rotate)
+ * - Distance measurement between bodies
+ * - Joint angle display
+ * - Force/torque overlay toggle
+ *
+ * See issue #1179
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  Move,
+  Ruler,
+  RotateCw,
+  Eye,
+  EyeOff,
+  Crosshair,
+  ArrowUpDown,
+} from 'lucide-react';
+
+/** Joint angle data from the measurement tools endpoint. */
+export interface JointAngleDisplay {
+  joint_name: string;
+  angle_rad: number;
+  angle_deg: number;
+  velocity: number;
+  torque: number;
+}
+
+/** Measurement between two bodies. */
+export interface MeasurementResult {
+  body_a: string;
+  body_b: string;
+  distance: number;
+  position_a: [number, number, number];
+  position_b: [number, number, number];
+  delta: [number, number, number];
+}
+
+/** Active tool mode. */
+export type ToolMode = 'select' | 'position' | 'measure' | 'rotate';
+
+interface Props {
+  /** Whether the simulation is running */
+  isRunning: boolean;
+  /** Callback when force overlay visibility changes */
+  onForceOverlayToggle?: (visible: boolean) => void;
+  /** Callback when tool mode changes */
+  onToolModeChange?: (mode: ToolMode) => void;
+  /** Polling interval for joint angle display (ms) */
+  pollInterval?: number;
+}
+
+const buttonBase =
+  'flex items-center justify-center gap-1 py-1.5 px-3 rounded text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-gray-900';
+
+export function SimulationToolbar({
+  isRunning,
+  onForceOverlayToggle,
+  onToolModeChange,
+  pollInterval = 1000,
+}: Props) {
+  const [activeMode, setActiveMode] = useState<ToolMode>('select');
+  const [showForces, setShowForces] = useState(false);
+  const [jointAngles, setJointAngles] = useState<JointAngleDisplay[]>([]);
+  const [measurements, setMeasurements] = useState<MeasurementResult[]>([]);
+  const [showJoints, setShowJoints] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Handle tool mode change
+  const handleModeChange = useCallback(
+    (mode: ToolMode) => {
+      setActiveMode(mode);
+      onToolModeChange?.(mode);
+    },
+    [onToolModeChange],
+  );
+
+  // Toggle force overlays
+  const handleForceToggle = useCallback(() => {
+    const newState = !showForces;
+    setShowForces(newState);
+    onForceOverlayToggle?.(newState);
+  }, [showForces, onForceOverlayToggle]);
+
+  // Fetch joint angles from the measurement tools endpoint
+  const fetchMeasurements = useCallback(async () => {
+    try {
+      const response = await fetch('/api/simulation/measurements');
+      if (!response.ok) {
+        if (response.status === 400) {
+          // No engine loaded -- not an error
+          return;
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      setJointAngles(data.joint_angles ?? []);
+      setMeasurements(data.measurements ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fetch failed');
+    }
+  }, []);
+
+  // Poll for joint angles when showing and simulation is running
+  useEffect(() => {
+    if (showJoints && isRunning) {
+      fetchMeasurements();
+      pollRef.current = setInterval(fetchMeasurements, pollInterval);
+    } else {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [showJoints, isRunning, pollInterval, fetchMeasurements]);
+
+  return (
+    <div className="space-y-2">
+      {/* Tool mode buttons */}
+      <div
+        className="flex gap-1"
+        role="toolbar"
+        aria-label="Simulation tools"
+      >
+        <button
+          onClick={() => handleModeChange('select')}
+          aria-label="Select mode"
+          aria-pressed={activeMode === 'select'}
+          className={`${buttonBase} ${
+            activeMode === 'select'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          <Crosshair size={14} aria-hidden="true" />
+          Select
+        </button>
+        <button
+          onClick={() => handleModeChange('position')}
+          aria-label="Position mode"
+          aria-pressed={activeMode === 'position'}
+          className={`${buttonBase} ${
+            activeMode === 'position'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          <Move size={14} aria-hidden="true" />
+          Move
+        </button>
+        <button
+          onClick={() => handleModeChange('rotate')}
+          aria-label="Rotate mode"
+          aria-pressed={activeMode === 'rotate'}
+          className={`${buttonBase} ${
+            activeMode === 'rotate'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          <RotateCw size={14} aria-hidden="true" />
+          Rotate
+        </button>
+        <button
+          onClick={() => handleModeChange('measure')}
+          aria-label="Measure mode"
+          aria-pressed={activeMode === 'measure'}
+          className={`${buttonBase} ${
+            activeMode === 'measure'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          <Ruler size={14} aria-hidden="true" />
+          Measure
+        </button>
+      </div>
+
+      {/* Toggle buttons */}
+      <div className="flex gap-1">
+        <button
+          onClick={handleForceToggle}
+          aria-label={showForces ? 'Hide force overlays' : 'Show force overlays'}
+          aria-pressed={showForces}
+          className={`${buttonBase} flex-1 ${
+            showForces
+              ? 'bg-yellow-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          <ArrowUpDown size={14} aria-hidden="true" />
+          Forces
+        </button>
+        <button
+          onClick={() => setShowJoints(!showJoints)}
+          aria-label={showJoints ? 'Hide joint angles' : 'Show joint angles'}
+          aria-pressed={showJoints}
+          className={`${buttonBase} flex-1 ${
+            showJoints
+              ? 'bg-green-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          {showJoints ? (
+            <Eye size={14} aria-hidden="true" />
+          ) : (
+            <EyeOff size={14} aria-hidden="true" />
+          )}
+          Joints
+        </button>
+      </div>
+
+      {/* Error display */}
+      {error && (
+        <div className="text-xs text-red-400 px-2 py-1 bg-red-900/30 rounded">
+          {error}
+        </div>
+      )}
+
+      {/* Joint angles display */}
+      {showJoints && jointAngles.length > 0 && (
+        <div
+          className="bg-gray-800 rounded p-2 max-h-48 overflow-y-auto"
+          role="table"
+          aria-label="Joint angles"
+        >
+          <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+            Joint Angles
+          </div>
+          <div className="space-y-0.5">
+            {jointAngles.map((joint) => (
+              <div
+                key={joint.joint_name}
+                className="flex justify-between text-xs"
+              >
+                <span className="text-gray-400 font-mono truncate max-w-[40%]">
+                  {joint.joint_name}
+                </span>
+                <span className="text-white font-mono">
+                  {joint.angle_deg.toFixed(1)}&deg;
+                </span>
+                <span className="text-gray-500 font-mono">
+                  {joint.velocity.toFixed(2)} rad/s
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Active measurements */}
+      {measurements.length > 0 && (
+        <div
+          className="bg-gray-800 rounded p-2"
+          role="table"
+          aria-label="Distance measurements"
+        >
+          <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+            Measurements
+          </div>
+          <div className="space-y-0.5">
+            {measurements.map((m, idx) => (
+              <div key={idx} className="flex justify-between text-xs">
+                <span className="text-gray-400 font-mono">
+                  {m.body_a} &harr; {m.body_b}
+                </span>
+                <span className="text-white font-mono">
+                  {m.distance.toFixed(4)} m
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/visualization/URDFViewer.test.tsx
+++ b/ui/src/components/visualization/URDFViewer.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * Tests for URDFViewer component.
+ *
+ * See issue #1201
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Mock react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => (
+    <div data-testid="canvas-mock" {...props}>{children}</div>
+  ),
+  useFrame: vi.fn((callback) => {
+    if (typeof callback === 'function') {
+      callback({ clock: { getElapsedTime: () => 0 } }, 0);
+    }
+  }),
+}));
+
+// Mock three.js
+vi.mock('three', () => ({
+  Color: class Color {
+    constructor(public r: number, public g: number, public b: number) {}
+  },
+  Vector3: class Vector3 {
+    constructor(public x = 0, public y = 0, public z = 0) {}
+    normalize() { return this; }
+    clone() { return new (this.constructor as typeof Vector3)(this.x, this.y, this.z); }
+    multiplyScalar(s: number) {
+      this.x *= s; this.y *= s; this.z *= s;
+      return this;
+    }
+    toArray() { return [this.x, this.y, this.z]; }
+    add(v: { x: number; y: number; z: number }) {
+      this.x += v.x; this.y += v.y; this.z += v.z;
+      return this;
+    }
+    copy(v: { x: number; y: number; z: number }) {
+      this.x = v.x; this.y = v.y; this.z = v.z;
+      return this;
+    }
+  },
+  Euler: class Euler {
+    constructor(public x = 0, public y = 0, public z = 0, public order = 'XYZ') {}
+  },
+  Quaternion: class Quaternion {
+    x = 0; y = 0; z = 0; w = 1;
+    setFromAxisAngle() { return this; }
+    setFromEuler() { return this; }
+    setFromUnitVectors() { return this; }
+    copy() { return this; }
+    multiply() { return this; }
+  },
+  Group: class Group {
+    position = { x: 0, y: 0, z: 0, copy() { return this; }, add() { return this; } };
+    rotation = { x: 0, y: 0, z: 0 };
+    quaternion = {
+      x: 0, y: 0, z: 0, w: 1,
+      copy() { return this; },
+      multiply() { return this; },
+    };
+  },
+  Mesh: class Mesh {
+    position = { x: 0, y: 0, z: 0 };
+    rotation = { x: 0, y: 0, z: 0 };
+  },
+}));
+
+import { URDFViewer } from './URDFViewer';
+import type { URDFModel } from './URDFViewer';
+
+describe('URDFViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createTestModel = (): URDFModel => ({
+    model_name: 'test_robot',
+    links: [
+      {
+        link_name: 'torso',
+        geometry_type: 'box',
+        dimensions: { width: 0.2, height: 0.4, depth: 0.6 },
+        origin: [0, 0, 0.3] as [number, number, number],
+        rotation: [0, 0, 0] as [number, number, number],
+        color: [0, 0, 0.8, 1] as [number, number, number, number],
+      },
+      {
+        link_name: 'head',
+        geometry_type: 'sphere',
+        dimensions: { radius: 0.12 },
+        origin: [0, 0, 0.12] as [number, number, number],
+        rotation: [0, 0, 0] as [number, number, number],
+        color: [1, 1, 1, 1] as [number, number, number, number],
+      },
+      {
+        link_name: 'arm',
+        geometry_type: 'cylinder',
+        dimensions: { radius: 0.05, length: 0.3 },
+        origin: [0.15, 0, 0] as [number, number, number],
+        rotation: [0, 1.57, 0] as [number, number, number],
+        color: [1, 1, 1, 1] as [number, number, number, number],
+      },
+    ],
+    joints: [
+      {
+        name: 'neck',
+        joint_type: 'revolute',
+        parent_link: 'torso',
+        child_link: 'head',
+        origin: [0, 0, 0.6] as [number, number, number],
+        rotation: [0, 0, 0] as [number, number, number],
+        axis: [0, 0, 1] as [number, number, number],
+        lower_limit: -1.57,
+        upper_limit: 1.57,
+      },
+      {
+        name: 'shoulder',
+        joint_type: 'revolute',
+        parent_link: 'torso',
+        child_link: 'arm',
+        origin: [0.1, 0, 0.5] as [number, number, number],
+        rotation: [0, 0, 0] as [number, number, number],
+        axis: [0, 1, 0] as [number, number, number],
+        lower_limit: -3.14,
+        upper_limit: 3.14,
+      },
+    ],
+    root_link: 'torso',
+  });
+
+  describe('rendering', () => {
+    it('renders null when model is null', () => {
+      const { container } = render(
+        <URDFViewer model={null} />,
+      );
+      // Should render nothing
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders with a valid model', () => {
+      const model = createTestModel();
+      const { container } = render(
+        <URDFViewer model={model} />,
+      );
+      // Should render something (group elements)
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('renders all link geometries', () => {
+      const model = createTestModel();
+      const { container } = render(
+        <URDFViewer model={model} />,
+      );
+      // The component renders Three.js elements which become divs in test DOM
+      expect(container.innerHTML).not.toBe('');
+    });
+  });
+
+  describe('joint angles', () => {
+    it('accepts joint angles as array', () => {
+      const model = createTestModel();
+      const angles = [0.5, -0.3];
+      const { container } = render(
+        <URDFViewer model={model} jointAngles={angles} />,
+      );
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('accepts joint angles as object', () => {
+      const model = createTestModel();
+      const angles = { neck: 0.5, shoulder: -0.3 };
+      const { container } = render(
+        <URDFViewer model={model} jointAngles={angles} />,
+      );
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('handles empty joint angles', () => {
+      const model = createTestModel();
+      const { container } = render(
+        <URDFViewer model={model} jointAngles={[]} />,
+      );
+      expect(container.innerHTML).not.toBe('');
+    });
+  });
+
+  describe('options', () => {
+    it('renders with showAxes enabled', () => {
+      const model = createTestModel();
+      const { container } = render(
+        <URDFViewer model={model} showAxes={true} />,
+      );
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('renders with custom opacity', () => {
+      const model = createTestModel();
+      const { container } = render(
+        <URDFViewer model={model} opacity={0.5} />,
+      );
+      expect(container.innerHTML).not.toBe('');
+    });
+  });
+
+  describe('model types', () => {
+    it('handles model with only boxes', () => {
+      const model: URDFModel = {
+        model_name: 'boxes',
+        links: [
+          {
+            link_name: 'box1',
+            geometry_type: 'box',
+            dimensions: { width: 1, height: 1, depth: 1 },
+            origin: [0, 0, 0] as [number, number, number],
+            rotation: [0, 0, 0] as [number, number, number],
+            color: [1, 0, 0, 1] as [number, number, number, number],
+          },
+        ],
+        joints: [],
+        root_link: 'box1',
+      };
+      const { container } = render(<URDFViewer model={model} />);
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('handles model with mesh type (fallback)', () => {
+      const model: URDFModel = {
+        model_name: 'mesh_model',
+        links: [
+          {
+            link_name: 'mesh_link',
+            geometry_type: 'mesh',
+            dimensions: { scale_x: 1, scale_y: 1, scale_z: 1 },
+            origin: [0, 0, 0] as [number, number, number],
+            rotation: [0, 0, 0] as [number, number, number],
+            color: [0.5, 0.5, 0.5, 1] as [number, number, number, number],
+            mesh_path: 'test.stl',
+          },
+        ],
+        joints: [],
+        root_link: 'mesh_link',
+      };
+      const { container } = render(<URDFViewer model={model} />);
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('handles model with no visual links (empty)', () => {
+      const model: URDFModel = {
+        model_name: 'empty',
+        links: [],
+        joints: [],
+        root_link: 'base',
+      };
+      // Should render but with no visible geometry
+      const { container } = render(<URDFViewer model={model} />);
+      expect(container.innerHTML).not.toBe('');
+    });
+  });
+});

--- a/ui/src/components/visualization/URDFViewer.tsx
+++ b/ui/src/components/visualization/URDFViewer.tsx
@@ -1,0 +1,275 @@
+/**
+ * URDFViewer - Renders a URDF model using Three.js primitives.
+ *
+ * Parses URDF model data from the backend API and builds a kinematic
+ * chain using Three.js groups and primitive geometries (box, cylinder,
+ * sphere). Supports joint angle updates for real-time animation.
+ *
+ * See issue #1201
+ */
+
+import { useRef, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+/** Geometry descriptor from the backend URDF parser. */
+export interface URDFLinkGeometry {
+  link_name: string;
+  geometry_type: 'box' | 'cylinder' | 'sphere' | 'mesh';
+  dimensions: Record<string, number>;
+  origin: [number, number, number];
+  rotation: [number, number, number];
+  color: [number, number, number, number];
+  mesh_path?: string | null;
+}
+
+/** Joint descriptor from the backend URDF parser. */
+export interface URDFJointDescriptor {
+  name: string;
+  joint_type: 'revolute' | 'prismatic' | 'fixed' | 'continuous' | 'floating';
+  parent_link: string;
+  child_link: string;
+  origin: [number, number, number];
+  rotation: [number, number, number];
+  axis: [number, number, number];
+  lower_limit?: number | null;
+  upper_limit?: number | null;
+}
+
+/** Parsed URDF model from the backend. */
+export interface URDFModel {
+  model_name: string;
+  links: URDFLinkGeometry[];
+  joints: URDFJointDescriptor[];
+  root_link: string;
+  urdf_raw?: string | null;
+}
+
+interface URDFViewerProps {
+  /** URDF model data from the API */
+  model: URDFModel | null;
+  /** Current joint angles keyed by joint name or index */
+  jointAngles?: Record<string, number> | number[];
+  /** Opacity for the model (0-1) */
+  opacity?: number;
+  /** Whether to show joint axes */
+  showAxes?: boolean;
+}
+
+/** Helper to create a Three.js Euler from RPY angles. */
+function rpyToEuler(rpy: [number, number, number]): THREE.Euler {
+  return new THREE.Euler(rpy[0], rpy[1], rpy[2], 'XYZ');
+}
+
+/**
+ * Renders a single URDF link geometry as a Three.js mesh.
+ */
+function LinkMesh({ link }: { link: URDFLinkGeometry }) {
+  const color = useMemo(
+    () => new THREE.Color(link.color[0], link.color[1], link.color[2]),
+    [link.color],
+  );
+  const opacity = link.color[3] ?? 1.0;
+  const position = useMemo(
+    () => new THREE.Vector3(...link.origin),
+    [link.origin],
+  );
+  const rotation = useMemo(
+    () => rpyToEuler(link.rotation),
+    [link.rotation],
+  );
+
+  const geometry = useMemo(() => {
+    const dims = link.dimensions;
+    switch (link.geometry_type) {
+      case 'box':
+        return (
+          <boxGeometry
+            args={[
+              dims.width ?? 0.1,
+              dims.height ?? 0.1,
+              dims.depth ?? 0.1,
+            ]}
+          />
+        );
+      case 'cylinder':
+        return (
+          <cylinderGeometry
+            args={[
+              dims.radius ?? 0.05,
+              dims.radius ?? 0.05,
+              dims.length ?? 0.3,
+              16,
+            ]}
+          />
+        );
+      case 'sphere':
+        return <sphereGeometry args={[dims.radius ?? 0.1, 16, 16]} />;
+      default:
+        // Fallback to a small sphere for unsupported geometry types (mesh, etc.)
+        return <sphereGeometry args={[0.02, 8, 8]} />;
+    }
+  }, [link.geometry_type, link.dimensions]);
+
+  return (
+    <mesh position={position} rotation={rotation}>
+      {geometry}
+      <meshStandardMaterial
+        color={color}
+        opacity={opacity}
+        transparent={opacity < 1.0}
+      />
+    </mesh>
+  );
+}
+
+/**
+ * Recursively builds the kinematic chain from URDF data.
+ *
+ * Each joint creates a nested Three.js group with the joint's
+ * origin transform, and the child link geometry is placed inside.
+ */
+function KinematicChain({
+  linkName,
+  links,
+  joints,
+  jointAngles,
+  showAxes,
+}: {
+  linkName: string;
+  links: Map<string, URDFLinkGeometry>;
+  joints: URDFJointDescriptor[];
+  jointAngles: Map<string, number>;
+  showAxes: boolean;
+}) {
+  const link = links.get(linkName);
+
+  // Find child joints (where this link is the parent)
+  const childJoints = useMemo(
+    () => joints.filter((j) => j.parent_link === linkName),
+    [joints, linkName],
+  );
+
+  // Create refs for animated joints
+  const jointRefs = useRef<Map<string, THREE.Group>>(new Map());
+
+  // Update joint angles on each frame
+  useFrame(() => {
+    for (const joint of childJoints) {
+      const ref = jointRefs.current.get(joint.name);
+      if (!ref) continue;
+
+      const angle = jointAngles.get(joint.name) ?? 0;
+
+      if (joint.joint_type === 'revolute' || joint.joint_type === 'continuous') {
+        // Apply rotation around the joint axis
+        const axis = new THREE.Vector3(...joint.axis).normalize();
+        const quat = new THREE.Quaternion().setFromAxisAngle(axis, angle);
+        // Combine with the joint's base rotation
+        const baseEuler = rpyToEuler(joint.rotation);
+        const baseQuat = new THREE.Quaternion().setFromEuler(baseEuler);
+        ref.quaternion.copy(baseQuat).multiply(quat);
+      } else if (joint.joint_type === 'prismatic') {
+        // Apply translation along the joint axis
+        const axis = new THREE.Vector3(...joint.axis).normalize();
+        const basePos = new THREE.Vector3(...joint.origin);
+        ref.position.copy(basePos.add(axis.multiplyScalar(angle)));
+      }
+    }
+  });
+
+  return (
+    <group>
+      {/* Render this link's geometry */}
+      {link && <LinkMesh link={link} />}
+
+      {/* Render child joints and their subtrees */}
+      {childJoints.map((joint) => (
+        <group
+          key={joint.name}
+          ref={(ref: THREE.Group | null) => {
+            if (ref) {
+              jointRefs.current.set(joint.name, ref);
+            }
+          }}
+          position={joint.origin}
+          rotation={rpyToEuler(joint.rotation)}
+        >
+          {showAxes && <axesHelper args={[0.1]} />}
+          <KinematicChain
+            linkName={joint.child_link}
+            links={links}
+            joints={joints}
+            jointAngles={jointAngles}
+            showAxes={showAxes}
+          />
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * URDFViewer component renders a URDF robot model in Three.js.
+ *
+ * Accepts parsed URDF data from the backend and builds a kinematic
+ * chain with proper joint transforms. Joint angles can be updated
+ * in real-time for simulation animation.
+ */
+export function URDFViewer({
+  model,
+  jointAngles,
+  // opacity reserved for future group-level transparency. See issue #1201
+  opacity: _opacity = 1.0, // eslint-disable-line @typescript-eslint/no-unused-vars
+  showAxes = false,
+}: URDFViewerProps) {
+  // Build lookup maps
+  const linkMap = useMemo(() => {
+    const map = new Map<string, URDFLinkGeometry>();
+    if (model) {
+      for (const link of model.links) {
+        map.set(link.link_name, link);
+      }
+    }
+    return map;
+  }, [model]);
+
+  const jointAngleMap = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!jointAngles || !model) return map;
+
+    if (Array.isArray(jointAngles)) {
+      // Map by joint index
+      model.joints.forEach((joint, idx) => {
+        if (idx < jointAngles.length) {
+          map.set(joint.name, jointAngles[idx]);
+        }
+      });
+    } else {
+      // Map by joint name
+      for (const [name, angle] of Object.entries(jointAngles)) {
+        map.set(name, angle);
+      }
+    }
+    return map;
+  }, [jointAngles, model]);
+
+  if (!model) {
+    return null;
+  }
+
+  return (
+    <group>
+      <KinematicChain
+        linkName={model.root_link}
+        links={linkMap}
+        joints={model.joints}
+        jointAngles={jointAngleMap}
+        showAxes={showAxes}
+      />
+    </group>
+  );
+}
+
+// useURDFModel hook is exported from @/api/useURDFModel.ts
+// to comply with react-refresh (components-only files).


### PR DESCRIPTION
## Summary

Phase 3 implementation covering three issues:

- **#1201 URDF/MJCF Model Rendering**: Backend URDF parser + API endpoints (`GET /models`, `GET /models/{name}/urdf`), `URDFViewer.tsx` component with kinematic chain rendering using Three.js primitives, `Scene3D.tsx` updated with URDF/fallback rendering and force overlays, `useURDFModel` hook
- **#1203 Analysis Tools**: Real-time metrics collection (`GET /analysis/metrics`), statistical summaries (`GET /analysis/statistics`), CSV/JSON export (`POST /analysis/export`), `AnalysisPanel.tsx` with tabbed metrics/plots/export UI using Recharts
- **#1179 Simulation Controls**: Body positioning (`POST /simulation/position`), distance measurement (`POST /simulation/measure`), joint angle display (`GET /simulation/measurements`), `SimulationToolbar.tsx` with tool modes and force overlay toggle

## Details

### Backend (Python/FastAPI)
- 2 new route modules: `routes/models.py` (URDF serving), `routes/analysis_tools.py` (analysis + controls)
- 16 new Pydantic contract models (requests + responses) following contract-first pattern
- URDF XML parser supporting box/cylinder/sphere/mesh geometries, materials, and kinematic chains
- Model discovery scanning `src/shared/urdf/`, `src/engines/`, and `tests/fixtures/models/`

### Frontend (React/TypeScript)
- `URDFViewer.tsx`: Renders parsed URDF models as Three.js kinematic chains with real-time joint animation
- `AnalysisPanel.tsx`: Tabbed panel with metrics dashboard, multi-series time-series plots, and data export
- `SimulationToolbar.tsx`: Tool mode buttons (select/position/rotate/measure), force overlay toggle, joint angle display
- `useURDFModel.ts`: API hook for fetching model data
- `simulationTools.ts`: Standalone positioning/measurement API utilities

### Tests
- 44 Python tests: Pydantic contract validation + URDF parser unit tests
- Frontend component tests for URDFViewer, AnalysisPanel, SimulationToolbar

## Test plan
- [x] 44 Python contract + parser tests pass
- [x] 106 total API/parity tests pass (Phase 2 + 3)
- [x] 253 frontend tests pass (17 test files)
- [x] `ruff check src/` passes clean
- [x] `tsc --noEmit` type check passes
- [x] ESLint passes clean
- [x] Vite production build succeeds

Closes #1179, closes #1201, closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new API endpoints and UI polling/export paths, including in-memory metric history stored on `EngineManager`, which could impact runtime behavior and performance if misused or if engine implementations lack expected methods.
> 
> **Overview**
> Implements **Phase 3** functionality across backend and UI: a new URDF/MJCF model-serving API (model discovery plus URDF parsing) and a Three.js `URDFViewer` path in `Scene3D` to render the parsed model (with joint-angle animation) while retaining the existing fallback geometry.
> 
> Adds analysis tooling endpoints for **real-time metric snapshots**, computed statistics over a bounded history, and **CSV/JSON export** downloads, plus a new `AnalysisPanel` UI to view metrics, plots, and trigger exports.
> 
> Introduces simulation control/measurement endpoints for **body positioning**, **distance measurement**, and **joint-angle display**, along with a new `SimulationToolbar` UI, force-vector overlay rendering, small API utilities/hooks (`simulationTools.ts`, `useURDFModel.ts`), and comprehensive contract/component tests to lock down the new API/UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e79351dd4334280d392078967dde448c6f78744e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->