### PR TITLE
feat: implement 4 tool pages - Putting Green, Video Analyzer, Data Explorer, Motion Capture (#1206)

### DIFF
--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -1,0 +1,421 @@
+"""Data Explorer tool API routes.
+
+Provides REST endpoints for browsing, filtering, and visualizing
+simulation datasets in the React Data Explorer tool page.
+
+See issue #1206
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/tools/data-explorer", tags=["data-explorer"])
+
+
+# ── Request / Response Models ──
+
+
+class DatasetInfo(BaseModel):
+    """Information about a discovered dataset file."""
+
+    name: str
+    path: str
+    format: str
+    size_bytes: int
+    columns: list[str] = Field(default_factory=list)
+
+
+class DatasetListResponse(BaseModel):
+    """Response listing available datasets."""
+
+    datasets: list[DatasetInfo]
+    total: int
+    search_dir: str
+
+
+class DatasetPreviewResponse(BaseModel):
+    """Response with a preview of dataset contents."""
+
+    name: str
+    columns: list[str]
+    rows: list[dict[str, Any]]
+    total_rows: int
+    format: str
+
+
+class DatasetStatsResponse(BaseModel):
+    """Response with summary statistics for a dataset."""
+
+    name: str
+    columns: list[str]
+    row_count: int
+    stats: dict[str, dict[str, float | None]]
+
+
+class DatasetFilterRequest(BaseModel):
+    """Request to filter dataset rows."""
+
+    column: str = Field(..., description="Column name to filter on")
+    operator: str = Field(
+        "eq",
+        description="Filter operator: eq, ne, gt, lt, gte, lte, contains",
+    )
+    value: str = Field(..., description="Filter value (string-encoded)")
+    limit: int = Field(100, ge=1, le=10000)
+
+
+class ImportResponse(BaseModel):
+    """Response after importing a dataset."""
+
+    name: str
+    format: str
+    columns: list[str]
+    row_count: int
+
+
+# ── In-memory dataset cache ──
+
+_loaded_datasets: dict[str, dict[str, Any]] = {}
+
+
+def _get_output_dir() -> Path:
+    """Get the project output directory."""
+    return Path(__file__).parent.parent.parent.parent / "output"
+
+
+def _parse_csv_content(content: str) -> tuple[list[str], list[dict[str, Any]]]:
+    """Parse CSV content into columns and rows."""
+    reader = csv.DictReader(io.StringIO(content))
+    columns = reader.fieldnames or []
+    rows = list(reader)
+    return list(columns), rows
+
+
+def _parse_json_content(content: str) -> tuple[list[str], list[dict[str, Any]]]:
+    """Parse JSON content into columns and rows."""
+    data = json.loads(content)
+    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+        columns = list(data[0].keys())
+        return columns, data
+    if isinstance(data, dict):
+        columns = list(data.keys())
+        return columns, [data]
+    return [], []
+
+
+# ── Endpoints ──
+
+
+@router.get("/datasets", response_model=DatasetListResponse)
+async def list_datasets() -> DatasetListResponse:
+    """List available datasets in the output directory.
+
+    See issue #1206
+    """
+    output_dir = _get_output_dir()
+    datasets: list[DatasetInfo] = []
+
+    if output_dir.exists():
+        supported = {".csv", ".json", ".hdf5", ".h5", ".c3d"}
+        for filepath in sorted(output_dir.rglob("*")):
+            if filepath.suffix.lower() in supported and filepath.is_file():
+                columns: list[str] = []
+                try:
+                    if filepath.suffix.lower() == ".csv":
+                        with open(filepath, encoding="utf-8") as f:
+                            header = f.readline().strip()
+                        columns = [
+                            c.strip().strip('"') for c in header.split(",")
+                        ]
+                    elif filepath.suffix.lower() == ".json":
+                        with open(filepath, encoding="utf-8") as f:
+                            data = json.load(f)
+                        if isinstance(data, dict):
+                            columns = list(data.keys())
+                except Exception:
+                    pass
+
+                datasets.append(
+                    DatasetInfo(
+                        name=filepath.name,
+                        path=str(filepath),
+                        format=filepath.suffix.lstrip("."),
+                        size_bytes=filepath.stat().st_size,
+                        columns=columns,
+                    )
+                )
+
+    # Also include any loaded (imported) datasets
+    for name, ds in _loaded_datasets.items():
+        if not any(d.name == name for d in datasets):
+            datasets.append(
+                DatasetInfo(
+                    name=name,
+                    path="(imported)",
+                    format=ds.get("format", "unknown"),
+                    size_bytes=0,
+                    columns=ds.get("columns", []),
+                )
+            )
+
+    return DatasetListResponse(
+        datasets=datasets,
+        total=len(datasets),
+        search_dir=str(output_dir),
+    )
+
+
+@router.get("/datasets/{name}/preview", response_model=DatasetPreviewResponse)
+async def preview_dataset(name: str, limit: int = 50) -> DatasetPreviewResponse:
+    """Get a preview of dataset contents.
+
+    See issue #1206
+    """
+    # Check in-memory cache first
+    if name in _loaded_datasets:
+        ds = _loaded_datasets[name]
+        rows = ds["rows"][:limit]
+        return DatasetPreviewResponse(
+            name=name,
+            columns=ds["columns"],
+            rows=rows,
+            total_rows=len(ds["rows"]),
+            format=ds["format"],
+        )
+
+    # Try to load from disk
+    output_dir = _get_output_dir()
+    matches = list(output_dir.rglob(name))
+    if not matches:
+        raise HTTPException(status_code=404, detail=f"Dataset '{name}' not found")
+
+    filepath = matches[0]
+    try:
+        content = filepath.read_text(encoding="utf-8")
+        if filepath.suffix.lower() == ".csv":
+            columns, rows = _parse_csv_content(content)
+        elif filepath.suffix.lower() == ".json":
+            columns, rows = _parse_json_content(content)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Preview not supported for {filepath.suffix} format",
+            )
+
+        return DatasetPreviewResponse(
+            name=name,
+            columns=columns,
+            rows=rows[:limit],
+            total_rows=len(rows),
+            format=filepath.suffix.lstrip("."),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/datasets/{name}/stats", response_model=DatasetStatsResponse)
+async def dataset_stats(name: str) -> DatasetStatsResponse:
+    """Get summary statistics for a dataset.
+
+    See issue #1206
+    """
+    # Get dataset rows
+    if name in _loaded_datasets:
+        ds = _loaded_datasets[name]
+        columns = ds["columns"]
+        rows = ds["rows"]
+    else:
+        output_dir = _get_output_dir()
+        matches = list(output_dir.rglob(name))
+        if not matches:
+            raise HTTPException(
+                status_code=404, detail=f"Dataset '{name}' not found"
+            )
+        filepath = matches[0]
+        try:
+            content = filepath.read_text(encoding="utf-8")
+            if filepath.suffix.lower() == ".csv":
+                columns, rows = _parse_csv_content(content)
+            elif filepath.suffix.lower() == ".json":
+                columns, rows = _parse_json_content(content)
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Stats not supported for {filepath.suffix}",
+                )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    # Compute statistics per column
+    stats: dict[str, dict[str, float | None]] = {}
+    for col in columns:
+        values: list[float] = []
+        for row in rows:
+            val = row.get(col)
+            if val is not None:
+                try:
+                    values.append(float(val))
+                except (ValueError, TypeError):
+                    pass
+
+        if values:
+            stats[col] = {
+                "min": min(values),
+                "max": max(values),
+                "mean": sum(values) / len(values),
+                "count": float(len(values)),
+            }
+        else:
+            stats[col] = {"min": None, "max": None, "mean": None, "count": 0.0}
+
+    return DatasetStatsResponse(
+        name=name,
+        columns=columns,
+        row_count=len(rows),
+        stats=stats,
+    )
+
+
+@router.post("/import", response_model=ImportResponse)
+async def import_dataset(file: UploadFile) -> ImportResponse:
+    """Import a CSV or JSON dataset.
+
+    See issue #1206
+    """
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Filename is required")
+
+    suffix = Path(file.filename).suffix.lower()
+    if suffix not in {".csv", ".json"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported format: {suffix}. Use .csv or .json",
+        )
+
+    try:
+        content = (await file.read()).decode("utf-8")
+
+        if suffix == ".csv":
+            columns, rows = _parse_csv_content(content)
+        else:
+            columns, rows = _parse_json_content(content)
+
+        _loaded_datasets[file.filename] = {
+            "columns": columns,
+            "rows": rows,
+            "format": suffix.lstrip("."),
+        }
+
+        return ImportResponse(
+            name=file.filename,
+            format=suffix.lstrip("."),
+            columns=columns,
+            row_count=len(rows),
+        )
+
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/datasets/{name}/filter")
+async def filter_dataset(
+    name: str, request: DatasetFilterRequest
+) -> DatasetPreviewResponse:
+    """Filter a dataset by column value.
+
+    See issue #1206
+    """
+    # First get the dataset
+    if name in _loaded_datasets:
+        ds = _loaded_datasets[name]
+        columns = ds["columns"]
+        rows = ds["rows"]
+        fmt = ds["format"]
+    else:
+        output_dir = _get_output_dir()
+        matches = list(output_dir.rglob(name))
+        if not matches:
+            raise HTTPException(
+                status_code=404, detail=f"Dataset '{name}' not found"
+            )
+        filepath = matches[0]
+        content = filepath.read_text(encoding="utf-8")
+        if filepath.suffix.lower() == ".csv":
+            columns, rows = _parse_csv_content(content)
+        elif filepath.suffix.lower() == ".json":
+            columns, rows = _parse_json_content(content)
+        else:
+            raise HTTPException(
+                status_code=400, detail="Filter not supported for this format"
+            )
+        fmt = filepath.suffix.lstrip(".")
+
+    if request.column not in columns:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Column '{request.column}' not found. Available: {columns}",
+        )
+
+    # Apply filter
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        val = str(row.get(request.column, ""))
+        match = False
+        if request.operator == "eq":
+            match = val == request.value
+        elif request.operator == "ne":
+            match = val != request.value
+        elif request.operator == "contains":
+            match = request.value.lower() in val.lower()
+        elif request.operator in ("gt", "lt", "gte", "lte"):
+            try:
+                num_val = float(val)
+                num_filter = float(request.value)
+                if request.operator == "gt":
+                    match = num_val > num_filter
+                elif request.operator == "lt":
+                    match = num_val < num_filter
+                elif request.operator == "gte":
+                    match = num_val >= num_filter
+                elif request.operator == "lte":
+                    match = num_val <= num_filter
+            except (ValueError, TypeError):
+                pass
+
+        if match:
+            filtered.append(row)
+            if len(filtered) >= request.limit:
+                break
+
+    return DatasetPreviewResponse(
+        name=name,
+        columns=columns,
+        rows=filtered,
+        total_rows=len(filtered),
+        format=fmt,
+    )
+
+
+@router.get("/export-formats")
+async def get_export_formats() -> list[dict[str, str]]:
+    """List supported export formats.
+
+    See issue #1206
+    """
+    return [
+        {"format": "csv", "description": "Comma-separated values"},
+        {"format": "json", "description": "JSON array of objects"},
+    ]

--- a/src/api/routes/motion_capture.py
+++ b/src/api/routes/motion_capture.py
@@ -1,0 +1,410 @@
+"""Motion Capture tool API routes.
+
+Provides REST endpoints for the Motion Capture tool page:
+- Capture source enumeration (C3D, OpenPose, MediaPipe)
+- Skeleton data retrieval
+- Recording/playback control
+- Frame-by-frame joint data
+
+See issue #1206
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/tools/motion-capture", tags=["motion-capture"])
+
+
+# ── Request / Response Models ──
+
+
+class CaptureSource(BaseModel):
+    """Available motion capture source."""
+
+    id: str
+    name: str
+    type: str = Field(description="c3d, openpose, or mediapipe")
+    available: bool
+    description: str
+
+
+class JointData(BaseModel):
+    """Single joint position and metadata."""
+
+    name: str
+    position: list[float] = Field(description="[x, y, z] position")
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    parent: str | None = None
+
+
+class SkeletonFrame(BaseModel):
+    """One frame of skeleton data."""
+
+    frame_index: int
+    timestamp: float
+    joints: list[JointData]
+
+
+class RecordingInfo(BaseModel):
+    """Metadata about a motion capture recording."""
+
+    name: str
+    source_type: str
+    total_frames: int
+    duration_seconds: float
+    frame_rate: float
+    joint_names: list[str]
+
+
+class CaptureSessionRequest(BaseModel):
+    """Request to start a capture session."""
+
+    source_type: str = Field(
+        "mediapipe", description="Capture source: c3d, openpose, mediapipe"
+    )
+    frame_rate: float = Field(30.0, description="Target frame rate", gt=0)
+
+
+class CaptureSessionResponse(BaseModel):
+    """Response after starting/stopping a capture session."""
+
+    session_id: str
+    status: str
+    source_type: str
+    message: str
+
+
+class PlaybackRequest(BaseModel):
+    """Request for recording playback control."""
+
+    recording_name: str
+    action: str = Field(description="play, pause, stop, seek")
+    seek_frame: int | None = Field(None, description="Frame to seek to")
+
+
+class PlaybackResponse(BaseModel):
+    """Response with current playback state."""
+
+    recording_name: str
+    status: str
+    current_frame: int
+    total_frames: int
+
+
+# ── Skeleton definitions ──
+
+_MEDIAPIPE_SKELETON: list[dict[str, Any]] = [
+    {"name": "nose", "parent": None},
+    {"name": "left_eye", "parent": "nose"},
+    {"name": "right_eye", "parent": "nose"},
+    {"name": "left_ear", "parent": "left_eye"},
+    {"name": "right_ear", "parent": "right_eye"},
+    {"name": "left_shoulder", "parent": "nose"},
+    {"name": "right_shoulder", "parent": "nose"},
+    {"name": "left_elbow", "parent": "left_shoulder"},
+    {"name": "right_elbow", "parent": "right_shoulder"},
+    {"name": "left_wrist", "parent": "left_elbow"},
+    {"name": "right_wrist", "parent": "right_elbow"},
+    {"name": "left_hip", "parent": "left_shoulder"},
+    {"name": "right_hip", "parent": "right_shoulder"},
+    {"name": "left_knee", "parent": "left_hip"},
+    {"name": "right_knee", "parent": "right_hip"},
+    {"name": "left_ankle", "parent": "left_knee"},
+    {"name": "right_ankle", "parent": "right_knee"},
+]
+
+_OPENPOSE_SKELETON: list[dict[str, Any]] = [
+    {"name": "head", "parent": None},
+    {"name": "neck", "parent": "head"},
+    {"name": "right_shoulder", "parent": "neck"},
+    {"name": "right_elbow", "parent": "right_shoulder"},
+    {"name": "right_wrist", "parent": "right_elbow"},
+    {"name": "left_shoulder", "parent": "neck"},
+    {"name": "left_elbow", "parent": "left_shoulder"},
+    {"name": "left_wrist", "parent": "left_elbow"},
+    {"name": "mid_hip", "parent": "neck"},
+    {"name": "right_hip", "parent": "mid_hip"},
+    {"name": "right_knee", "parent": "right_hip"},
+    {"name": "right_ankle", "parent": "right_knee"},
+    {"name": "left_hip", "parent": "mid_hip"},
+    {"name": "left_knee", "parent": "left_hip"},
+    {"name": "left_ankle", "parent": "left_knee"},
+]
+
+# ── In-memory session state ──
+
+_sessions: dict[str, dict[str, Any]] = {}
+_recordings: dict[str, dict[str, Any]] = {}
+_session_counter = 0
+
+
+# ── Endpoints ──
+
+
+@router.get("/sources", response_model=list[CaptureSource])
+async def list_capture_sources() -> list[CaptureSource]:
+    """List available motion capture sources.
+
+    See issue #1206
+    """
+    sources = [
+        CaptureSource(
+            id="mediapipe",
+            name="MediaPipe Pose",
+            type="mediapipe",
+            available=_check_mediapipe_available(),
+            description="Real-time pose estimation using Google MediaPipe",
+        ),
+        CaptureSource(
+            id="openpose",
+            name="OpenPose",
+            type="openpose",
+            available=_check_openpose_available(),
+            description="Multi-person pose estimation using OpenPose",
+        ),
+        CaptureSource(
+            id="c3d",
+            name="C3D File Import",
+            type="c3d",
+            available=True,
+            description="Import motion capture data from C3D files",
+        ),
+    ]
+    return sources
+
+
+@router.get("/skeleton/{source_type}", response_model=list[JointData])
+async def get_skeleton_template(source_type: str) -> list[JointData]:
+    """Get the skeleton joint template for a given source type.
+
+    See issue #1206
+    """
+    if source_type == "mediapipe":
+        skeleton = _MEDIAPIPE_SKELETON
+    elif source_type == "openpose":
+        skeleton = _OPENPOSE_SKELETON
+    elif source_type == "c3d":
+        skeleton = _MEDIAPIPE_SKELETON  # Default to mediapipe layout for c3d
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown source type: {source_type}. Use mediapipe, openpose, or c3d",
+        )
+
+    return [
+        JointData(
+            name=joint["name"],
+            position=[0.0, 0.0, 0.0],
+            confidence=1.0,
+            parent=joint.get("parent"),
+        )
+        for joint in skeleton
+    ]
+
+
+@router.post("/session/start", response_model=CaptureSessionResponse)
+async def start_capture_session(
+    request: CaptureSessionRequest,
+) -> CaptureSessionResponse:
+    """Start a new motion capture session.
+
+    See issue #1206
+    """
+    global _session_counter  # noqa: PLW0603
+
+    valid_sources = {"mediapipe", "openpose", "c3d"}
+    if request.source_type not in valid_sources:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid source type. Must be one of: {sorted(valid_sources)}",
+        )
+
+    _session_counter += 1
+    session_id = f"session_{_session_counter}"
+
+    _sessions[session_id] = {
+        "source_type": request.source_type,
+        "frame_rate": request.frame_rate,
+        "status": "recording",
+        "frames": [],
+    }
+
+    return CaptureSessionResponse(
+        session_id=session_id,
+        status="recording",
+        source_type=request.source_type,
+        message=f"Capture session started with {request.source_type} at {request.frame_rate} fps",
+    )
+
+
+@router.post("/session/{session_id}/stop", response_model=CaptureSessionResponse)
+async def stop_capture_session(session_id: str) -> CaptureSessionResponse:
+    """Stop an active capture session and save the recording.
+
+    See issue #1206
+    """
+    if session_id not in _sessions:
+        raise HTTPException(
+            status_code=404, detail=f"Session '{session_id}' not found"
+        )
+
+    session = _sessions[session_id]
+    session["status"] = "stopped"
+
+    # Save as a recording
+    recording_name = f"recording_{session_id}"
+    _recordings[recording_name] = {
+        "source_type": session["source_type"],
+        "frame_rate": session["frame_rate"],
+        "frames": session["frames"],
+    }
+
+    return CaptureSessionResponse(
+        session_id=session_id,
+        status="stopped",
+        source_type=session["source_type"],
+        message=f"Session stopped. Recording saved as '{recording_name}'",
+    )
+
+
+@router.get("/recordings", response_model=list[RecordingInfo])
+async def list_recordings() -> list[RecordingInfo]:
+    """List available recordings.
+
+    See issue #1206
+    """
+    result = []
+    for name, rec in _recordings.items():
+        frames = rec.get("frames", [])
+        frame_rate = rec.get("frame_rate", 30.0)
+        total_frames = len(frames)
+        duration = total_frames / frame_rate if frame_rate > 0 else 0.0
+
+        # Get joint names from skeleton
+        if rec["source_type"] == "openpose":
+            skeleton = _OPENPOSE_SKELETON
+        else:
+            skeleton = _MEDIAPIPE_SKELETON
+        joint_names = [j["name"] for j in skeleton]
+
+        result.append(
+            RecordingInfo(
+                name=name,
+                source_type=rec["source_type"],
+                total_frames=total_frames,
+                duration_seconds=duration,
+                frame_rate=frame_rate,
+                joint_names=joint_names,
+            )
+        )
+
+    return result
+
+
+@router.post("/playback", response_model=PlaybackResponse)
+async def control_playback(request: PlaybackRequest) -> PlaybackResponse:
+    """Control recording playback (play, pause, stop, seek).
+
+    See issue #1206
+    """
+    if request.recording_name not in _recordings:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Recording '{request.recording_name}' not found",
+        )
+
+    recording = _recordings[request.recording_name]
+    total_frames = len(recording.get("frames", []))
+
+    valid_actions = {"play", "pause", "stop", "seek"}
+    if request.action not in valid_actions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid action. Must be one of: {sorted(valid_actions)}",
+        )
+
+    current_frame = 0
+    if request.action == "seek" and request.seek_frame is not None:
+        current_frame = max(0, min(request.seek_frame, total_frames - 1))
+
+    status_map = {
+        "play": "playing",
+        "pause": "paused",
+        "stop": "stopped",
+        "seek": "playing",
+    }
+
+    return PlaybackResponse(
+        recording_name=request.recording_name,
+        status=status_map[request.action],
+        current_frame=current_frame,
+        total_frames=total_frames,
+    )
+
+
+@router.get("/frame/{recording_name}/{frame_index}", response_model=SkeletonFrame)
+async def get_frame(recording_name: str, frame_index: int) -> SkeletonFrame:
+    """Get skeleton data for a specific frame.
+
+    See issue #1206
+    """
+    if recording_name not in _recordings:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Recording '{recording_name}' not found",
+        )
+
+    recording = _recordings[recording_name]
+    frames = recording.get("frames", [])
+
+    if frame_index < 0 or frame_index >= len(frames):
+        # Return a default skeleton frame with rest pose
+        if recording["source_type"] == "openpose":
+            skeleton = _OPENPOSE_SKELETON
+        else:
+            skeleton = _MEDIAPIPE_SKELETON
+
+        joints = [
+            JointData(
+                name=j["name"],
+                position=[0.0, 0.0, 0.0],
+                confidence=0.0,
+                parent=j.get("parent"),
+            )
+            for j in skeleton
+        ]
+
+        return SkeletonFrame(
+            frame_index=frame_index,
+            timestamp=frame_index / recording.get("frame_rate", 30.0),
+            joints=joints,
+        )
+
+    return SkeletonFrame(**frames[frame_index])
+
+
+# ── Helpers ──
+
+
+def _check_mediapipe_available() -> bool:
+    """Check if MediaPipe is installed."""
+    try:
+        import mediapipe  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _check_openpose_available() -> bool:
+    """Check if OpenPose Python bindings are available."""
+    try:
+        import openpose  # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/src/api/routes/putting_green.py
+++ b/src/api/routes/putting_green.py
@@ -1,0 +1,339 @@
+"""Putting Green Simulator API routes.
+
+Provides REST endpoints for the putting green simulation tool page:
+- Simulate putts with configurable parameters
+- Read green contours and slope data
+- Get aim-line assist calculations
+- Scatter analysis for practice mode
+
+See issue #1206
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/api/tools/putting-green", tags=["putting-green"])
+
+
+# ── Request / Response Models ──
+
+
+class PuttSimulationRequest(BaseModel):
+    """Request to simulate a single putt."""
+
+    ball_x: float = Field(5.0, description="Ball X position on green [m]")
+    ball_y: float = Field(10.0, description="Ball Y position on green [m]")
+    speed: float = Field(2.0, description="Stroke speed [m/s]", gt=0, le=10)
+    direction_x: float = Field(0.0, description="Aim direction X component")
+    direction_y: float = Field(1.0, description="Aim direction Y component")
+    stimp_rating: float = Field(
+        10.0, description="Green speed (Stimpmeter) [ft]", ge=6.0, le=15.0
+    )
+    green_width: float = Field(20.0, description="Green width [m]", gt=0)
+    green_height: float = Field(20.0, description="Green height [m]", gt=0)
+    hole_x: float = Field(10.0, description="Hole X position [m]")
+    hole_y: float = Field(15.0, description="Hole Y position [m]")
+    wind_speed: float = Field(0.0, description="Wind speed [m/s]", ge=0)
+    wind_direction_x: float = Field(1.0, description="Wind direction X")
+    wind_direction_y: float = Field(0.0, description="Wind direction Y")
+
+
+class PuttSimulationResponse(BaseModel):
+    """Response containing putt simulation results."""
+
+    positions: list[list[float]]
+    velocities: list[list[float]]
+    times: list[float]
+    holed: bool
+    final_position: list[float]
+    total_distance: float
+    duration: float
+
+
+class GreenReadingRequest(BaseModel):
+    """Request for green reading between ball and target."""
+
+    ball_x: float = Field(5.0, description="Ball X position [m]")
+    ball_y: float = Field(5.0, description="Ball Y position [m]")
+    target_x: float = Field(10.0, description="Target X position [m]")
+    target_y: float = Field(15.0, description="Target Y position [m]")
+    green_width: float = Field(20.0, description="Green width [m]", gt=0)
+    green_height: float = Field(20.0, description="Green height [m]", gt=0)
+    stimp_rating: float = Field(10.0, ge=6.0, le=15.0)
+
+
+class GreenReadingResponse(BaseModel):
+    """Response with green reading data."""
+
+    distance: float
+    total_break: float
+    recommended_speed: float
+    aim_point: list[float]
+    elevations: list[float]
+    slopes: list[list[float]]
+
+
+class ScatterAnalysisRequest(BaseModel):
+    """Request for scatter analysis (multiple putts with variance)."""
+
+    ball_x: float = Field(5.0)
+    ball_y: float = Field(10.0)
+    speed: float = Field(2.0, gt=0, le=10)
+    direction_x: float = Field(0.0)
+    direction_y: float = Field(1.0)
+    n_simulations: int = Field(10, ge=1, le=100)
+    speed_variance: float = Field(0.1, ge=0)
+    direction_variance_deg: float = Field(2.0, ge=0)
+    green_width: float = Field(20.0, gt=0)
+    green_height: float = Field(20.0, gt=0)
+    stimp_rating: float = Field(10.0, ge=6.0, le=15.0)
+
+
+class ScatterAnalysisResponse(BaseModel):
+    """Response with scatter analysis results."""
+
+    final_positions: list[list[float]]
+    holed_count: int
+    total_simulations: int
+    average_distance_from_hole: float
+    make_percentage: float
+
+
+class GreenContourResponse(BaseModel):
+    """Response with slope contour data for visualization."""
+
+    width: float
+    height: float
+    grid_x: list[list[float]]
+    grid_y: list[list[float]]
+    elevations: list[list[float]]
+    hole_position: list[float]
+
+
+# ── Endpoints ──
+
+
+@router.post("/simulate", response_model=PuttSimulationResponse)
+async def simulate_putt(request: PuttSimulationRequest) -> PuttSimulationResponse:
+    """Simulate a single putt with given parameters.
+
+    See issue #1206
+    """
+    try:
+        from src.engines.physics_engines.putting_green.python.green_surface import (
+            GreenSurface,
+        )
+        from src.engines.physics_engines.putting_green.python.putter_stroke import (
+            StrokeParameters,
+        )
+        from src.engines.physics_engines.putting_green.python.simulator import (
+            PuttingGreenSimulator,
+            SimulationConfig,
+        )
+        from src.engines.physics_engines.putting_green.python.turf_properties import (
+            TurfProperties,
+        )
+
+        turf = TurfProperties(stimp_rating=request.stimp_rating)
+        green = GreenSurface(
+            width=request.green_width,
+            height=request.green_height,
+            turf=turf,
+        )
+        green.set_hole_position(np.array([request.hole_x, request.hole_y]))
+
+        config = SimulationConfig(record_trajectory=True)
+        sim = PuttingGreenSimulator(green=green, config=config)
+
+        if request.wind_speed > 0:
+            sim.set_wind(
+                request.wind_speed,
+                np.array([request.wind_direction_x, request.wind_direction_y]),
+            )
+
+        direction = np.array([request.direction_x, request.direction_y])
+        norm = np.linalg.norm(direction)
+        if norm > 0:
+            direction = direction / norm
+
+        stroke = StrokeParameters(speed=request.speed, direction=direction)
+        result = sim.simulate_putt(
+            stroke, ball_position=np.array([request.ball_x, request.ball_y])
+        )
+
+        return PuttSimulationResponse(
+            positions=result.positions.tolist(),
+            velocities=result.velocities.tolist(),
+            times=result.times.tolist(),
+            holed=result.holed,
+            final_position=result.final_position.tolist(),
+            total_distance=result.total_distance,
+            duration=result.duration,
+        )
+
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/read-green", response_model=GreenReadingResponse)
+async def read_green(request: GreenReadingRequest) -> GreenReadingResponse:
+    """Read green between ball and target positions.
+
+    See issue #1206
+    """
+    try:
+        from src.engines.physics_engines.putting_green.python.green_surface import (
+            GreenSurface,
+        )
+        from src.engines.physics_engines.putting_green.python.simulator import (
+            PuttingGreenSimulator,
+        )
+        from src.engines.physics_engines.putting_green.python.turf_properties import (
+            TurfProperties,
+        )
+
+        turf = TurfProperties(stimp_rating=request.stimp_rating)
+        green = GreenSurface(
+            width=request.green_width,
+            height=request.green_height,
+            turf=turf,
+        )
+        green.set_hole_position(
+            np.array([request.target_x, request.target_y])
+        )
+
+        sim = PuttingGreenSimulator(green=green)
+        reading = sim.read_green(
+            np.array([request.ball_x, request.ball_y]),
+            np.array([request.target_x, request.target_y]),
+        )
+
+        return GreenReadingResponse(
+            distance=float(reading["distance"]),
+            total_break=float(reading["total_break"]),
+            recommended_speed=float(reading["recommended_speed"]),
+            aim_point=reading["aim_point"].tolist(),
+            elevations=[float(e) for e in reading["elevations"]],
+            slopes=[s.tolist() for s in reading["slopes"]],
+        )
+
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/scatter", response_model=ScatterAnalysisResponse)
+async def scatter_analysis(
+    request: ScatterAnalysisRequest,
+) -> ScatterAnalysisResponse:
+    """Run scatter analysis with multiple putts.
+
+    See issue #1206
+    """
+    try:
+        from src.engines.physics_engines.putting_green.python.green_surface import (
+            GreenSurface,
+        )
+        from src.engines.physics_engines.putting_green.python.putter_stroke import (
+            StrokeParameters,
+        )
+        from src.engines.physics_engines.putting_green.python.simulator import (
+            PuttingGreenSimulator,
+        )
+        from src.engines.physics_engines.putting_green.python.turf_properties import (
+            TurfProperties,
+        )
+
+        turf = TurfProperties(stimp_rating=request.stimp_rating)
+        green = GreenSurface(
+            width=request.green_width,
+            height=request.green_height,
+            turf=turf,
+        )
+
+        sim = PuttingGreenSimulator(green=green)
+
+        direction = np.array([request.direction_x, request.direction_y])
+        norm = np.linalg.norm(direction)
+        if norm > 0:
+            direction = direction / norm
+
+        stroke = StrokeParameters(speed=request.speed, direction=direction)
+        results = sim.simulate_scatter(
+            start_position=np.array([request.ball_x, request.ball_y]),
+            stroke_params=stroke,
+            n_simulations=request.n_simulations,
+            speed_variance=request.speed_variance,
+            direction_variance_deg=request.direction_variance_deg,
+        )
+
+        final_positions = [r.final_position.tolist() for r in results]
+        holed_count = sum(1 for r in results if r.holed)
+        hole_pos = green.hole_position
+        avg_dist = float(
+            np.mean(
+                [
+                    np.linalg.norm(r.final_position - hole_pos)
+                    for r in results
+                ]
+            )
+        )
+
+        return ScatterAnalysisResponse(
+            final_positions=final_positions,
+            holed_count=holed_count,
+            total_simulations=len(results),
+            average_distance_from_hole=avg_dist,
+            make_percentage=(
+                holed_count / len(results) * 100 if results else 0
+            ),
+        )
+
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/contours", response_model=GreenContourResponse)
+async def get_green_contours(
+    width: float = 20.0,
+    height: float = 20.0,
+    resolution: int = 20,
+    stimp_rating: float = 10.0,
+) -> GreenContourResponse:
+    """Get green elevation contour data for 2D visualization.
+
+    See issue #1206
+    """
+    try:
+        from src.engines.physics_engines.putting_green.python.green_surface import (
+            GreenSurface,
+        )
+        from src.engines.physics_engines.putting_green.python.turf_properties import (
+            TurfProperties,
+        )
+
+        turf = TurfProperties(stimp_rating=stimp_rating)
+        green = GreenSurface(width=width, height=height, turf=turf)
+
+        xs = np.linspace(0, width, resolution)
+        ys = np.linspace(0, height, resolution)
+        grid_x, grid_y = np.meshgrid(xs, ys)
+        elevations = np.zeros_like(grid_x)
+
+        for i in range(resolution):
+            for j in range(resolution):
+                elevations[i, j] = green.get_elevation(grid_x[i, j], grid_y[i, j])
+
+        return GreenContourResponse(
+            width=width,
+            height=height,
+            grid_x=grid_x.tolist(),
+            grid_y=grid_y.tolist(),
+            elevations=elevations.tolist(),
+            hole_position=green.hole_position.tolist(),
+        )
+
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -40,6 +40,7 @@ from .routes import analysis as analysis_routes
 from .routes import analysis_tools as analysis_tools_routes
 from .routes import auth as auth_routes
 from .routes import core as core_routes
+from .routes import data_explorer as data_explorer_routes
 from .routes import dataset as dataset_routes
 from .routes import engines as engine_routes
 from .routes import export as export_routes
@@ -47,7 +48,9 @@ from .routes import force_overlays as force_overlay_routes
 from .routes import launcher as launcher_routes
 from .routes import model_explorer as model_explorer_routes
 from .routes import models as model_routes
+from .routes import motion_capture as motion_capture_routes
 from .routes import physics as physics_routes
+from .routes import putting_green as putting_green_routes
 from .routes import simulation as simulation_routes
 from .routes import terrain as terrain_routes
 from .routes import video as video_routes
@@ -297,6 +300,10 @@ app.include_router(force_overlay_routes.router)
 app.include_router(actuator_controls_routes.router)
 app.include_router(model_explorer_routes.router)
 app.include_router(aip_routes.router)
+# Phase 5: Tool pages - Putting Green, Data Explorer, Motion Capture (#1206)
+app.include_router(putting_green_routes.router)
+app.include_router(data_explorer_routes.router)
+app.include_router(motion_capture_routes.router)
 
 
 if __name__ == "__main__":

--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -130,6 +130,7 @@
             "engine_type": "putting_green",
             "logo": "putting_green.svg",
             "status": "simulator",
+            "web_route": "/tools/putting-green",
             "capabilities": [
                 "surface_modeling",
                 "ball_physics",
@@ -162,6 +163,7 @@
             "path": "src/launchers/motion_capture_launcher.py",
             "logo": "c3d_icon.svg",
             "status": "utility",
+            "web_route": "/tools/motion-capture",
             "capabilities": [
                 "c3d_viewer",
                 "openpose",
@@ -179,6 +181,7 @@
             "path": "src/tools/video_analyzer/launch_video_analyzer.py",
             "logo": "video_analyzer.svg",
             "status": "utility",
+            "web_route": "/tools/video-analyzer",
             "capabilities": [
                 "video_processing",
                 "pose_estimation",
@@ -196,6 +199,7 @@
             "path": "src/tools/data_explorer/data_explorer_app.py",
             "logo": "data_explorer.svg",
             "status": "utility",
+            "web_route": "/tools/data-explorer",
             "capabilities": [
                 "data_import",
                 "filtering",

--- a/tests/api/test_phase5_api.py
+++ b/tests/api/test_phase5_api.py
@@ -1,0 +1,461 @@
+"""Tests for Phase 5 API: Tool pages - Putting Green, Data Explorer, Motion Capture.
+
+Validates Pydantic contract models and route logic for:
+- Putting Green simulation endpoints (#1206)
+- Data Explorer dataset browsing endpoints (#1206)
+- Motion Capture skeleton/session endpoints (#1206)
+
+See issue #1206
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.routes.data_explorer import (
+    DatasetFilterRequest,
+    DatasetInfo,
+    DatasetListResponse,
+    DatasetPreviewResponse,
+    DatasetStatsResponse,
+    ImportResponse,
+)
+from src.api.routes.motion_capture import (
+    CaptureSessionRequest,
+    CaptureSessionResponse,
+    CaptureSource,
+    JointData,
+    PlaybackRequest,
+    PlaybackResponse,
+    RecordingInfo,
+    SkeletonFrame,
+)
+from src.api.routes.putting_green import (
+    GreenContourResponse,
+    GreenReadingRequest,
+    GreenReadingResponse,
+    PuttSimulationRequest,
+    PuttSimulationResponse,
+    ScatterAnalysisRequest,
+    ScatterAnalysisResponse,
+)
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: Putting Green (#1206)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestPuttSimulationRequestContract:
+    """Validate PuttSimulationRequest model."""
+
+    def test_default_values(self) -> None:
+        """Defaults should be sensible."""
+        req = PuttSimulationRequest()
+        assert req.ball_x == 5.0
+        assert req.ball_y == 10.0
+        assert req.speed == 2.0
+        assert req.stimp_rating == 10.0
+        assert req.green_width == 20.0
+        assert req.green_height == 20.0
+
+    def test_valid_speed_range(self) -> None:
+        """Speed within range accepted."""
+        req = PuttSimulationRequest(speed=0.5)
+        assert req.speed == 0.5
+        req2 = PuttSimulationRequest(speed=10.0)
+        assert req2.speed == 10.0
+
+    def test_invalid_speed_zero(self) -> None:
+        """Speed at zero rejected."""
+        with pytest.raises(ValidationError):
+            PuttSimulationRequest(speed=0)
+
+    def test_invalid_speed_too_high(self) -> None:
+        """Speed over max rejected."""
+        with pytest.raises(ValidationError):
+            PuttSimulationRequest(speed=15.0)
+
+    def test_invalid_stimp_too_low(self) -> None:
+        """Stimp below minimum rejected."""
+        with pytest.raises(ValidationError):
+            PuttSimulationRequest(stimp_rating=3.0)
+
+    def test_invalid_stimp_too_high(self) -> None:
+        """Stimp above maximum rejected."""
+        with pytest.raises(ValidationError):
+            PuttSimulationRequest(stimp_rating=20.0)
+
+
+class TestPuttSimulationResponseContract:
+    """Validate PuttSimulationResponse model."""
+
+    def test_valid_response(self) -> None:
+        """Valid response parses correctly."""
+        resp = PuttSimulationResponse(
+            positions=[[5.0, 10.0], [5.0, 12.0], [5.0, 14.5]],
+            velocities=[[0.0, 2.0], [0.0, 1.5], [0.0, 0.2]],
+            times=[0.0, 0.5, 1.5],
+            holed=False,
+            final_position=[5.0, 14.5],
+            total_distance=4.5,
+            duration=1.5,
+        )
+        assert len(resp.positions) == 3
+        assert resp.holed is False
+        assert resp.total_distance == 4.5
+
+    def test_holed_response(self) -> None:
+        """Holed putt response."""
+        resp = PuttSimulationResponse(
+            positions=[[10.0, 5.0], [10.0, 15.0]],
+            velocities=[[0.0, 2.0], [0.0, 0.0]],
+            times=[0.0, 2.5],
+            holed=True,
+            final_position=[10.0, 15.0],
+            total_distance=10.0,
+            duration=2.5,
+        )
+        assert resp.holed is True
+
+
+class TestGreenReadingContract:
+    """Validate GreenReading request/response."""
+
+    def test_reading_request_defaults(self) -> None:
+        """Defaults populate correctly."""
+        req = GreenReadingRequest()
+        assert req.ball_x == 5.0
+        assert req.target_x == 10.0
+
+    def test_reading_response(self) -> None:
+        """Valid reading response."""
+        resp = GreenReadingResponse(
+            distance=11.0,
+            total_break=0.05,
+            recommended_speed=2.1,
+            aim_point=[10.02, 14.95],
+            elevations=[0.0, 0.01],
+            slopes=[[0.001, 0.002]],
+        )
+        assert resp.distance == 11.0
+        assert resp.recommended_speed > 0
+
+
+class TestScatterAnalysisContract:
+    """Validate ScatterAnalysis request/response."""
+
+    def test_scatter_request_defaults(self) -> None:
+        """Defaults populate correctly."""
+        req = ScatterAnalysisRequest()
+        assert req.n_simulations == 10
+        assert req.speed_variance == 0.1
+
+    def test_invalid_n_simulations(self) -> None:
+        """Zero simulations rejected."""
+        with pytest.raises(ValidationError):
+            ScatterAnalysisRequest(n_simulations=0)
+
+    def test_scatter_response(self) -> None:
+        """Valid scatter response."""
+        resp = ScatterAnalysisResponse(
+            final_positions=[[10.0, 14.9], [10.1, 15.0]],
+            holed_count=1,
+            total_simulations=2,
+            average_distance_from_hole=0.08,
+            make_percentage=50.0,
+        )
+        assert resp.holed_count == 1
+        assert resp.make_percentage == 50.0
+
+
+class TestGreenContourContract:
+    """Validate GreenContourResponse."""
+
+    def test_contour_response(self) -> None:
+        """Valid contour response."""
+        resp = GreenContourResponse(
+            width=20.0,
+            height=20.0,
+            grid_x=[[0.0, 10.0], [0.0, 10.0]],
+            grid_y=[[0.0, 0.0], [10.0, 10.0]],
+            elevations=[[0.0, 0.01], [0.02, 0.03]],
+            hole_position=[10.0, 10.0],
+        )
+        assert resp.width == 20.0
+        assert len(resp.elevations) == 2
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: Data Explorer (#1206)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestDatasetInfoContract:
+    """Validate DatasetInfo model."""
+
+    def test_basic_dataset_info(self) -> None:
+        """Basic info parses correctly."""
+        info = DatasetInfo(
+            name="results.csv",
+            path="/output/results.csv",
+            format="csv",
+            size_bytes=45200,
+            columns=["time", "x", "y"],
+        )
+        assert info.name == "results.csv"
+        assert len(info.columns) == 3
+
+
+class TestDatasetListResponseContract:
+    """Validate DatasetListResponse."""
+
+    def test_list_response(self) -> None:
+        """Valid list response."""
+        resp = DatasetListResponse(
+            datasets=[
+                DatasetInfo(
+                    name="a.csv", path="/a.csv", format="csv",
+                    size_bytes=100, columns=["x"],
+                ),
+            ],
+            total=1,
+            search_dir="/output",
+        )
+        assert resp.total == 1
+        assert len(resp.datasets) == 1
+
+
+class TestDatasetPreviewResponseContract:
+    """Validate DatasetPreviewResponse."""
+
+    def test_preview_response(self) -> None:
+        """Valid preview response."""
+        resp = DatasetPreviewResponse(
+            name="test.csv",
+            columns=["a", "b"],
+            rows=[{"a": "1", "b": "2"}, {"a": "3", "b": "4"}],
+            total_rows=2,
+            format="csv",
+        )
+        assert len(resp.rows) == 2
+        assert resp.total_rows == 2
+
+
+class TestDatasetFilterRequestContract:
+    """Validate DatasetFilterRequest."""
+
+    def test_filter_request(self) -> None:
+        """Valid filter request."""
+        req = DatasetFilterRequest(
+            column="force",
+            operator="gt",
+            value="50.0",
+        )
+        assert req.column == "force"
+        assert req.operator == "gt"
+
+    def test_filter_default_limit(self) -> None:
+        """Default limit is 100."""
+        req = DatasetFilterRequest(column="x", value="1")
+        assert req.limit == 100
+
+
+class TestDatasetStatsResponseContract:
+    """Validate DatasetStatsResponse."""
+
+    def test_stats_response(self) -> None:
+        """Valid stats response."""
+        resp = DatasetStatsResponse(
+            name="test.csv",
+            columns=["time", "force"],
+            row_count=100,
+            stats={
+                "time": {"min": 0.0, "max": 10.0, "mean": 5.0, "count": 100.0},
+                "force": {"min": -50.0, "max": 150.0, "mean": 42.5, "count": 100.0},
+            },
+        )
+        assert resp.row_count == 100
+        assert resp.stats["time"]["mean"] == 5.0
+
+
+class TestImportResponseContract:
+    """Validate ImportResponse."""
+
+    def test_import_response(self) -> None:
+        """Valid import response."""
+        resp = ImportResponse(
+            name="uploaded.csv",
+            format="csv",
+            columns=["a", "b", "c"],
+            row_count=50,
+        )
+        assert resp.row_count == 50
+        assert len(resp.columns) == 3
+
+
+# ──────────────────────────────────────────────────────────────
+#  Contract Tests: Motion Capture (#1206)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestCaptureSourceContract:
+    """Validate CaptureSource model."""
+
+    def test_mediapipe_source(self) -> None:
+        """MediaPipe source info."""
+        source = CaptureSource(
+            id="mediapipe",
+            name="MediaPipe Pose",
+            type="mediapipe",
+            available=True,
+            description="Real-time pose estimation",
+        )
+        assert source.available is True
+        assert source.type == "mediapipe"
+
+    def test_unavailable_source(self) -> None:
+        """Unavailable source."""
+        source = CaptureSource(
+            id="openpose",
+            name="OpenPose",
+            type="openpose",
+            available=False,
+            description="OpenPose library not installed",
+        )
+        assert source.available is False
+
+
+class TestJointDataContract:
+    """Validate JointData model."""
+
+    def test_root_joint(self) -> None:
+        """Root joint has no parent."""
+        joint = JointData(
+            name="nose",
+            position=[0.0, 0.8, 0.0],
+            confidence=0.95,
+            parent=None,
+        )
+        assert joint.parent is None
+        assert joint.confidence == 0.95
+
+    def test_child_joint(self) -> None:
+        """Child joint references parent."""
+        joint = JointData(
+            name="left_elbow",
+            position=[-0.25, 0.4, 0.0],
+            confidence=0.88,
+            parent="left_shoulder",
+        )
+        assert joint.parent == "left_shoulder"
+
+    def test_confidence_bounds(self) -> None:
+        """Confidence must be in [0, 1]."""
+        with pytest.raises(ValidationError):
+            JointData(
+                name="test",
+                position=[0, 0, 0],
+                confidence=1.5,
+            )
+        with pytest.raises(ValidationError):
+            JointData(
+                name="test",
+                position=[0, 0, 0],
+                confidence=-0.1,
+            )
+
+
+class TestCaptureSessionContract:
+    """Validate CaptureSession request/response."""
+
+    def test_session_request_default(self) -> None:
+        """Default source type is mediapipe."""
+        req = CaptureSessionRequest()
+        assert req.source_type == "mediapipe"
+        assert req.frame_rate == 30.0
+
+    def test_session_response(self) -> None:
+        """Valid session response."""
+        resp = CaptureSessionResponse(
+            session_id="session_1",
+            status="recording",
+            source_type="mediapipe",
+            message="Started",
+        )
+        assert resp.status == "recording"
+
+
+class TestRecordingInfoContract:
+    """Validate RecordingInfo model."""
+
+    def test_recording_info(self) -> None:
+        """Valid recording info."""
+        info = RecordingInfo(
+            name="rec_1",
+            source_type="mediapipe",
+            total_frames=300,
+            duration_seconds=10.0,
+            frame_rate=30.0,
+            joint_names=["nose", "left_shoulder"],
+        )
+        assert info.total_frames == 300
+        assert info.frame_rate == 30.0
+
+
+class TestPlaybackContract:
+    """Validate Playback request/response."""
+
+    def test_playback_request(self) -> None:
+        """Valid playback request."""
+        req = PlaybackRequest(
+            recording_name="rec_1",
+            action="play",
+        )
+        assert req.action == "play"
+        assert req.seek_frame is None
+
+    def test_playback_seek(self) -> None:
+        """Seek request with frame."""
+        req = PlaybackRequest(
+            recording_name="rec_1",
+            action="seek",
+            seek_frame=150,
+        )
+        assert req.seek_frame == 150
+
+    def test_playback_response(self) -> None:
+        """Valid playback response."""
+        resp = PlaybackResponse(
+            recording_name="rec_1",
+            status="playing",
+            current_frame=0,
+            total_frames=300,
+        )
+        assert resp.status == "playing"
+
+
+class TestSkeletonFrameContract:
+    """Validate SkeletonFrame model."""
+
+    def test_skeleton_frame(self) -> None:
+        """Valid skeleton frame."""
+        frame = SkeletonFrame(
+            frame_index=42,
+            timestamp=1.4,
+            joints=[
+                JointData(
+                    name="nose",
+                    position=[0.0, 0.8, 0.0],
+                    confidence=0.95,
+                ),
+                JointData(
+                    name="left_shoulder",
+                    position=[-0.15, 0.6, 0.0],
+                    confidence=0.92,
+                    parent="nose",
+                ),
+            ],
+        )
+        assert frame.frame_index == 42
+        assert len(frame.joints) == 2

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,10 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { SimulationPage } from './pages/Simulation';
 import { DashboardPage } from './pages/Dashboard';
 import { ModelExplorerPage } from './pages/ModelExplorer';
+import { PuttingGreenPage } from './pages/PuttingGreen';
+import { VideoAnalyzerPage } from './pages/VideoAnalyzer';
+import { DataExplorerPage } from './pages/DataExplorer';
+import { MotionCapturePage } from './pages/MotionCapture';
 import { ToastProvider } from './components/ui/Toast';
 import { DiagnosticsPanel } from './components/ui/DiagnosticsPanel';
 import { HelpPanel } from './components/ui/HelpPanel';
@@ -18,6 +22,11 @@ function App() {
           <Route path="/" element={<DashboardPage />} />
           <Route path="/simulation" element={<SimulationPage />} />
           <Route path="/tools/model-explorer" element={<ModelExplorerPage />} />
+          {/* Phase 5: Tool pages (#1206) */}
+          <Route path="/tools/putting-green" element={<PuttingGreenPage />} />
+          <Route path="/tools/video-analyzer" element={<VideoAnalyzerPage />} />
+          <Route path="/tools/data-explorer" element={<DataExplorerPage />} />
+          <Route path="/tools/motion-capture" element={<MotionCapturePage />} />
         </Routes>
         <DiagnosticsPanel />
         <HelpPanel isOpen={helpOpen} onClose={handleCloseHelp} />

--- a/ui/src/pages/DataExplorer.test.tsx
+++ b/ui/src/pages/DataExplorer.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for DataExplorer page.
+ *
+ * See issue #1206
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type {
+  DatasetInfo,
+  DatasetPreview,
+  DatasetStats,
+  ColumnStats,
+} from './DataExplorer';
+
+describe('DataExplorer data structures', () => {
+  it('should parse dataset info listing', () => {
+    const datasets: DatasetInfo[] = [
+      {
+        name: 'simulation_results.csv',
+        path: '/output/simulation_results.csv',
+        format: 'csv',
+        size_bytes: 45200,
+        columns: ['time', 'position_x', 'velocity_y', 'force'],
+      },
+      {
+        name: 'swing_data.json',
+        path: '/output/swing_data.json',
+        format: 'json',
+        size_bytes: 12800,
+        columns: ['timestamp', 'hip_angle', 'shoulder_angle'],
+      },
+    ];
+
+    expect(datasets).toHaveLength(2);
+    expect(datasets[0].columns).toContain('time');
+    expect(datasets[1].format).toBe('json');
+  });
+
+  it('should parse dataset preview with rows', () => {
+    const preview: DatasetPreview = {
+      name: 'results.csv',
+      columns: ['time', 'x', 'y'],
+      rows: [
+        { time: '0.0', x: '1.0', y: '2.0' },
+        { time: '0.1', x: '1.5', y: '2.3' },
+        { time: '0.2', x: '2.0', y: '2.8' },
+      ],
+      total_rows: 100,
+      format: 'csv',
+    };
+
+    expect(preview.columns).toHaveLength(3);
+    expect(preview.rows).toHaveLength(3);
+    expect(preview.total_rows).toBe(100);
+    expect(preview.rows[0].time).toBe('0.0');
+  });
+
+  it('should parse column statistics', () => {
+    const colStats: ColumnStats = {
+      min: 0.0,
+      max: 10.0,
+      mean: 5.2,
+      count: 50,
+    };
+
+    expect(colStats.min).toBe(0.0);
+    expect(colStats.max).toBe(10.0);
+    expect(colStats.mean).toBeCloseTo(5.2, 1);
+    expect(colStats.count).toBe(50);
+  });
+
+  it('should handle non-numeric column stats', () => {
+    const colStats: ColumnStats = {
+      min: null,
+      max: null,
+      mean: null,
+      count: 0,
+    };
+
+    expect(colStats.min).toBeNull();
+    expect(colStats.mean).toBeNull();
+    expect(colStats.count).toBe(0);
+  });
+
+  it('should parse full dataset stats', () => {
+    const stats: DatasetStats = {
+      name: 'results.csv',
+      columns: ['time', 'force', 'label'],
+      row_count: 200,
+      stats: {
+        time: { min: 0.0, max: 10.0, mean: 5.0, count: 200 },
+        force: { min: -50.0, max: 150.0, mean: 42.5, count: 200 },
+        label: { min: null, max: null, mean: null, count: 0 },
+      },
+    };
+
+    expect(stats.row_count).toBe(200);
+    expect(stats.stats.time.mean).toBe(5.0);
+    expect(stats.stats.force.max).toBe(150.0);
+    expect(stats.stats.label.mean).toBeNull();
+  });
+
+  it('should sort rows by column value numerically', () => {
+    const rows = [
+      { time: '2.0', x: '3.0' },
+      { time: '0.5', x: '1.0' },
+      { time: '1.0', x: '2.0' },
+    ];
+
+    const sorted = [...rows].sort((a, b) => {
+      const aVal = Number(a.time);
+      const bVal = Number(b.time);
+      return aVal - bVal;
+    });
+
+    expect(sorted[0].time).toBe('0.5');
+    expect(sorted[1].time).toBe('1.0');
+    expect(sorted[2].time).toBe('2.0');
+  });
+
+  it('should filter rows by column value', () => {
+    const rows = [
+      { time: '0.0', category: 'backswing' },
+      { time: '1.0', category: 'downswing' },
+      { time: '2.0', category: 'impact' },
+      { time: '3.0', category: 'follow_through' },
+    ];
+
+    const filtered = rows.filter((r) => r.category === 'impact');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].time).toBe('2.0');
+  });
+
+  it('should filter rows with numeric comparison', () => {
+    const rows = [
+      { time: '0.0', force: '10.0' },
+      { time: '1.0', force: '50.0' },
+      { time: '2.0', force: '30.0' },
+      { time: '3.0', force: '80.0' },
+    ];
+
+    const filtered = rows.filter((r) => Number(r.force) > 40);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('should validate supported file formats', () => {
+    const supported = new Set(['.csv', '.json', '.hdf5', '.h5', '.c3d']);
+
+    expect(supported.has('.csv')).toBe(true);
+    expect(supported.has('.json')).toBe(true);
+    expect(supported.has('.xlsx')).toBe(false);
+    expect(supported.has('.txt')).toBe(false);
+  });
+});

--- a/ui/src/pages/DataExplorer.tsx
+++ b/ui/src/pages/DataExplorer.tsx
@@ -1,0 +1,591 @@
+/**
+ * DataExplorer - Dataset browser with filtering, sorting, and chart views.
+ *
+ * Supports CSV/JSON import, tabular data grid view, summary statistics,
+ * and column filtering. Connects to the data-explorer REST API.
+ *
+ * See issue #1206
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+
+/** Dataset info from the API. See issue #1206 */
+export interface DatasetInfo {
+  name: string;
+  path: string;
+  format: string;
+  size_bytes: number;
+  columns: string[];
+}
+
+/** Dataset preview response. See issue #1206 */
+export interface DatasetPreview {
+  name: string;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  total_rows: number;
+  format: string;
+}
+
+/** Column statistics. See issue #1206 */
+export interface ColumnStats {
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  count: number;
+}
+
+/** Dataset statistics response. See issue #1206 */
+export interface DatasetStats {
+  name: string;
+  columns: string[];
+  row_count: number;
+  stats: Record<string, ColumnStats>;
+}
+
+/**
+ * DataTable - Tabular display of dataset rows.
+ */
+function DataTable({
+  columns,
+  rows,
+  sortColumn,
+  sortAscending,
+  onSort,
+}: {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  sortColumn: string | null;
+  sortAscending: boolean;
+  onSort: (column: string) => void;
+}) {
+  if (columns.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 italic text-center py-8">
+        No data to display
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-auto max-h-[calc(100vh-200px)]" data-testid="data-table">
+      <table className="w-full text-xs text-left">
+        <thead className="sticky top-0 bg-gray-800 z-10">
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col}
+                className="px-3 py-2 text-gray-400 font-medium border-b border-gray-700 cursor-pointer hover:text-gray-200 select-none"
+                onClick={() => onSort(col)}
+              >
+                <span className="flex items-center gap-1">
+                  {col}
+                  {sortColumn === col && (
+                    <span className="text-blue-400">
+                      {sortAscending ? ' ^' : ' v'}
+                    </span>
+                  )}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr
+              key={idx}
+              className="hover:bg-gray-700/30 border-b border-gray-800"
+            >
+              {columns.map((col) => (
+                <td
+                  key={col}
+                  className="px-3 py-1.5 text-gray-300 font-mono truncate max-w-[200px]"
+                >
+                  {row[col] != null ? String(row[col]) : ''}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * StatsPanel - Column summary statistics display.
+ */
+function StatsPanel({ stats }: { stats: DatasetStats | null }) {
+  if (!stats) {
+    return (
+      <div className="text-xs text-gray-500 italic text-center py-4">
+        Load a dataset to view statistics
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-testid="stats-panel">
+      <div className="text-xs text-gray-400 mb-2">
+        {stats.row_count} rows, {stats.columns.length} columns
+      </div>
+      {Object.entries(stats.stats).map(([col, colStats]) => (
+        <div
+          key={col}
+          className="bg-gray-700/30 p-2 rounded"
+        >
+          <div className="text-xs font-medium text-gray-300 mb-1">{col}</div>
+          {colStats.mean != null ? (
+            <div className="grid grid-cols-3 gap-1 text-xs">
+              <div>
+                <span className="text-gray-500">min</span>
+                <span className="text-gray-300 font-mono ml-1">
+                  {colStats.min?.toFixed(2)}
+                </span>
+              </div>
+              <div>
+                <span className="text-gray-500">avg</span>
+                <span className="text-gray-300 font-mono ml-1">
+                  {colStats.mean?.toFixed(2)}
+                </span>
+              </div>
+              <div>
+                <span className="text-gray-500">max</span>
+                <span className="text-gray-300 font-mono ml-1">
+                  {colStats.max?.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500">Non-numeric</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * DataExplorerPage - Full data explorer tool page.
+ *
+ * See issue #1206
+ */
+export function DataExplorerPage() {
+  const [datasets, setDatasets] = useState<DatasetInfo[]>([]);
+  const [selectedDataset, setSelectedDataset] = useState<string | null>(null);
+  const [preview, setPreview] = useState<DatasetPreview | null>(null);
+  const [stats, setStats] = useState<DatasetStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<'table' | 'stats'>('table');
+
+  // Sorting state
+  const [sortColumn, setSortColumn] = useState<string | null>(null);
+  const [sortAscending, setSortAscending] = useState(true);
+
+  // Filter state
+  const [filterColumn, setFilterColumn] = useState('');
+  const [filterOperator, setFilterOperator] = useState('eq');
+  const [filterValue, setFilterValue] = useState('');
+
+  // Fetch available datasets
+  useEffect(() => {
+    async function fetchDatasets() {
+      try {
+        const response = await fetch('/api/tools/data-explorer/datasets');
+        if (!response.ok) return;
+        const data = await response.json();
+        setDatasets(data.datasets || []);
+      } catch {
+        // API may not be available
+      }
+    }
+    fetchDatasets();
+  }, []);
+
+  // Load dataset preview
+  const loadDataset = useCallback(async (name: string) => {
+    setLoading(true);
+    setError(null);
+    setSelectedDataset(name);
+    setSortColumn(null);
+    setFilterColumn('');
+    setFilterValue('');
+
+    try {
+      const response = await fetch(
+        `/api/tools/data-explorer/datasets/${encodeURIComponent(name)}/preview?limit=100`,
+      );
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+      const data: DatasetPreview = await response.json();
+      setPreview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dataset');
+      setPreview(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Load statistics
+  const loadStats = useCallback(async () => {
+    if (!selectedDataset) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/tools/data-explorer/datasets/${encodeURIComponent(selectedDataset)}/stats`,
+      );
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+      const data: DatasetStats = await response.json();
+      setStats(data);
+      setViewMode('stats');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load stats');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedDataset]);
+
+  // Apply filter
+  const applyFilter = useCallback(async () => {
+    if (!selectedDataset || !filterColumn || !filterValue) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/tools/data-explorer/datasets/${encodeURIComponent(selectedDataset)}/filter`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            column: filterColumn,
+            operator: filterOperator,
+            value: filterValue,
+            limit: 100,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: DatasetPreview = await response.json();
+      setPreview(data);
+      setViewMode('table');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Filter failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedDataset, filterColumn, filterOperator, filterValue]);
+
+  // Handle file import
+  const handleImport = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const response = await fetch('/api/tools/data-explorer/import', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      // Add to dataset list and select it
+      setDatasets((prev) => [
+        ...prev,
+        {
+          name: data.name,
+          path: '(imported)',
+          format: data.format,
+          size_bytes: 0,
+          columns: data.columns,
+        },
+      ]);
+
+      // Load the imported dataset
+      await loadDataset(data.name);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [loadDataset]);
+
+  // Handle sort
+  const handleSort = useCallback(
+    (column: string) => {
+      if (sortColumn === column) {
+        setSortAscending(!sortAscending);
+      } else {
+        setSortColumn(column);
+        setSortAscending(true);
+      }
+    },
+    [sortColumn, sortAscending],
+  );
+
+  // Sort rows
+  const sortedRows = preview?.rows
+    ? sortColumn
+      ? [...preview.rows].sort((a, b) => {
+          const aVal = a[sortColumn];
+          const bVal = b[sortColumn];
+          if (aVal == null && bVal == null) return 0;
+          if (aVal == null) return 1;
+          if (bVal == null) return -1;
+
+          const aNum = Number(aVal);
+          const bNum = Number(bVal);
+          if (!isNaN(aNum) && !isNaN(bNum)) {
+            return sortAscending ? aNum - bNum : bNum - aNum;
+          }
+
+          const cmp = String(aVal).localeCompare(String(bVal));
+          return sortAscending ? cmp : -cmp;
+        })
+      : preview.rows
+    : [];
+
+  return (
+    <div className="flex h-screen bg-gray-900 overflow-hidden">
+      {/* Left Panel: Dataset List + Controls */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-lg font-bold text-white mb-1">Data Explorer</h2>
+          <p className="text-xs text-gray-500">
+            Browse and analyze simulation datasets
+          </p>
+        </div>
+
+        {/* Import */}
+        <div className="p-4 border-b border-gray-700">
+          <label className="w-full py-2 px-4 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded border border-gray-600 transition-colors cursor-pointer block text-center">
+            Import CSV/JSON
+            <input
+              type="file"
+              accept=".csv,.json"
+              onChange={handleImport}
+              className="hidden"
+              data-testid="import-file-input"
+            />
+          </label>
+        </div>
+
+        {/* Dataset List */}
+        <div className="flex-1 overflow-y-auto p-2">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-2">
+            Datasets ({datasets.length})
+          </h3>
+
+          {datasets.length === 0 && (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              No datasets found. Import a CSV or JSON file.
+            </div>
+          )}
+
+          {datasets.map((ds) => (
+            <button
+              key={ds.name}
+              onClick={() => loadDataset(ds.name)}
+              className={`w-full text-left p-2 rounded mb-1 transition-colors ${
+                selectedDataset === ds.name
+                  ? 'bg-blue-900/40 ring-1 ring-blue-500/50'
+                  : 'hover:bg-gray-700/50'
+              }`}
+            >
+              <div className="text-xs text-gray-200 truncate">{ds.name}</div>
+              <div className="text-xs text-gray-500 flex gap-2">
+                <span>{ds.format}</span>
+                {ds.size_bytes > 0 && (
+                  <span>{(ds.size_bytes / 1024).toFixed(1)} KB</span>
+                )}
+                {ds.columns.length > 0 && (
+                  <span>{ds.columns.length} cols</span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* Filter Controls */}
+        {preview && (
+          <div className="p-4 border-t border-gray-700 space-y-2">
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              Filter
+            </h3>
+            <select
+              value={filterColumn}
+              onChange={(e) => setFilterColumn(e.target.value)}
+              className="w-full bg-gray-700 text-gray-200 rounded px-2 py-1 text-xs border-none"
+            >
+              <option value="">Select column...</option>
+              {preview.columns.map((col) => (
+                <option key={col} value={col}>
+                  {col}
+                </option>
+              ))}
+            </select>
+            <div className="flex gap-1">
+              <select
+                value={filterOperator}
+                onChange={(e) => setFilterOperator(e.target.value)}
+                className="bg-gray-700 text-gray-200 rounded px-2 py-1 text-xs border-none"
+              >
+                <option value="eq">=</option>
+                <option value="ne">!=</option>
+                <option value="gt">&gt;</option>
+                <option value="lt">&lt;</option>
+                <option value="gte">&gt;=</option>
+                <option value="lte">&lt;=</option>
+                <option value="contains">contains</option>
+              </select>
+              <input
+                type="text"
+                value={filterValue}
+                onChange={(e) => setFilterValue(e.target.value)}
+                placeholder="Value..."
+                className="flex-1 bg-gray-700 text-gray-200 rounded px-2 py-1 text-xs border-none"
+              />
+            </div>
+            <button
+              onClick={applyFilter}
+              disabled={!filterColumn || !filterValue || loading}
+              className="w-full py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 text-white text-xs rounded transition-colors"
+            >
+              Apply Filter
+            </button>
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="mx-4 mb-4 text-xs text-red-400 bg-red-900/20 p-2 rounded">
+            {error}
+          </div>
+        )}
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col min-w-0">
+        {/* Toolbar */}
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 flex items-center gap-4">
+          <div className="flex gap-1">
+            <button
+              onClick={() => setViewMode('table')}
+              className={`px-3 py-1 text-xs rounded ${
+                viewMode === 'table'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              Table View
+            </button>
+            <button
+              onClick={() => {
+                setViewMode('stats');
+                if (!stats && selectedDataset) loadStats();
+              }}
+              className={`px-3 py-1 text-xs rounded ${
+                viewMode === 'stats'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              Statistics
+            </button>
+          </div>
+
+          {preview && (
+            <div className="text-xs text-gray-400 ml-auto">
+              {preview.total_rows} rows, {preview.columns.length} columns
+              {sortColumn && (
+                <span className="ml-2 text-blue-400">
+                  sorted by {sortColumn} {sortAscending ? 'asc' : 'desc'}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Content Area */}
+        <div className="flex-1 overflow-auto">
+          {loading && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-sm text-gray-400">Loading...</div>
+            </div>
+          )}
+
+          {!loading && !preview && !stats && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center">
+                <div className="text-4xl mb-4 text-gray-600">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-16 h-16 mx-auto text-gray-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1}
+                      d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+                    />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-gray-400 mb-2">
+                  Select a Dataset
+                </h3>
+                <p className="text-sm text-gray-500 max-w-xs">
+                  Choose a dataset from the sidebar or import a CSV/JSON file
+                  to browse and analyze data.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {!loading && viewMode === 'table' && preview && (
+            <DataTable
+              columns={preview.columns}
+              rows={sortedRows}
+              sortColumn={sortColumn}
+              sortAscending={sortAscending}
+              onSort={handleSort}
+            />
+          )}
+
+          {!loading && viewMode === 'stats' && (
+            <div className="p-4 max-w-xl mx-auto">
+              <StatsPanel stats={stats} />
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/MotionCapture.test.tsx
+++ b/ui/src/pages/MotionCapture.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests for MotionCapture page.
+ *
+ * See issue #1206
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type {
+  CaptureSource,
+  JointData,
+  RecordingInfo,
+  CaptureSession,
+  PlaybackState,
+} from './MotionCapture';
+
+describe('MotionCapture data structures', () => {
+  it('should parse capture sources', () => {
+    const sources: CaptureSource[] = [
+      {
+        id: 'mediapipe',
+        name: 'MediaPipe Pose',
+        type: 'mediapipe',
+        available: true,
+        description: 'Real-time pose estimation using Google MediaPipe',
+      },
+      {
+        id: 'openpose',
+        name: 'OpenPose',
+        type: 'openpose',
+        available: false,
+        description: 'Multi-person pose estimation using OpenPose',
+      },
+      {
+        id: 'c3d',
+        name: 'C3D File Import',
+        type: 'c3d',
+        available: true,
+        description: 'Import motion capture data from C3D files',
+      },
+    ];
+
+    expect(sources).toHaveLength(3);
+    expect(sources[0].available).toBe(true);
+    expect(sources[1].available).toBe(false);
+    expect(sources[2].type).toBe('c3d');
+  });
+
+  it('should parse joint data with parent hierarchy', () => {
+    const joints: JointData[] = [
+      { name: 'nose', position: [0.0, 0.8, 0.0], confidence: 0.95, parent: null },
+      {
+        name: 'left_shoulder',
+        position: [-0.15, 0.6, 0.0],
+        confidence: 0.92,
+        parent: 'nose',
+      },
+      {
+        name: 'left_elbow',
+        position: [-0.25, 0.4, 0.0],
+        confidence: 0.88,
+        parent: 'left_shoulder',
+      },
+      {
+        name: 'left_wrist',
+        position: [-0.3, 0.2, 0.0],
+        confidence: 0.85,
+        parent: 'left_elbow',
+      },
+    ];
+
+    expect(joints).toHaveLength(4);
+    expect(joints[0].parent).toBeNull(); // root
+    expect(joints[1].parent).toBe('nose');
+    expect(joints[3].confidence).toBeCloseTo(0.85, 2);
+  });
+
+  it('should build joint hierarchy map', () => {
+    const joints: JointData[] = [
+      { name: 'nose', position: [0, 0, 0], confidence: 1.0, parent: null },
+      { name: 'left_shoulder', position: [0, 0, 0], confidence: 1.0, parent: 'nose' },
+      { name: 'right_shoulder', position: [0, 0, 0], confidence: 1.0, parent: 'nose' },
+      {
+        name: 'left_elbow',
+        position: [0, 0, 0],
+        confidence: 1.0,
+        parent: 'left_shoulder',
+      },
+    ];
+
+    const map = new Map(joints.map((j) => [j.name, j]));
+    expect(map.size).toBe(4);
+    expect(map.get('nose')?.parent).toBeNull();
+    expect(map.get('left_elbow')?.parent).toBe('left_shoulder');
+
+    // Trace chain: left_elbow -> left_shoulder -> nose
+    const chain: string[] = [];
+    let current = map.get('left_elbow');
+    while (current) {
+      chain.push(current.name);
+      current = current.parent ? map.get(current.parent) : undefined;
+    }
+    expect(chain).toEqual(['left_elbow', 'left_shoulder', 'nose']);
+  });
+
+  it('should parse recording info', () => {
+    const recording: RecordingInfo = {
+      name: 'recording_session_1',
+      source_type: 'mediapipe',
+      total_frames: 300,
+      duration_seconds: 10.0,
+      frame_rate: 30.0,
+      joint_names: [
+        'nose',
+        'left_shoulder',
+        'right_shoulder',
+        'left_elbow',
+        'right_elbow',
+      ],
+    };
+
+    expect(recording.total_frames).toBe(300);
+    expect(recording.duration_seconds).toBe(10.0);
+    expect(recording.frame_rate).toBe(30.0);
+    expect(recording.joint_names).toContain('left_shoulder');
+  });
+
+  it('should handle capture session lifecycle', () => {
+    const started: CaptureSession = {
+      session_id: 'session_1',
+      status: 'recording',
+      source_type: 'mediapipe',
+      message: 'Capture session started with mediapipe at 30 fps',
+    };
+
+    const stopped: CaptureSession = {
+      session_id: 'session_1',
+      status: 'stopped',
+      source_type: 'mediapipe',
+      message: "Session stopped. Recording saved as 'recording_session_1'",
+    };
+
+    expect(started.status).toBe('recording');
+    expect(stopped.status).toBe('stopped');
+    expect(stopped.message).toContain('saved');
+  });
+
+  it('should track playback state', () => {
+    const states: PlaybackState[] = [
+      {
+        recording_name: 'rec_1',
+        status: 'playing',
+        current_frame: 0,
+        total_frames: 300,
+      },
+      {
+        recording_name: 'rec_1',
+        status: 'paused',
+        current_frame: 150,
+        total_frames: 300,
+      },
+      {
+        recording_name: 'rec_1',
+        status: 'stopped',
+        current_frame: 0,
+        total_frames: 300,
+      },
+    ];
+
+    expect(states[0].status).toBe('playing');
+    expect(states[1].current_frame).toBe(150);
+    expect(states[2].status).toBe('stopped');
+  });
+
+  it('should compute distance between two joints', () => {
+    const shoulder: JointData = {
+      name: 'shoulder',
+      position: [0.0, 0.6, 0.0],
+      confidence: 0.95,
+      parent: null,
+    };
+    const elbow: JointData = {
+      name: 'elbow',
+      position: [0.25, 0.4, 0.05],
+      confidence: 0.9,
+      parent: 'shoulder',
+    };
+
+    const dx = elbow.position[0] - shoulder.position[0];
+    const dy = elbow.position[1] - shoulder.position[1];
+    const dz = elbow.position[2] - shoulder.position[2];
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    expect(distance).toBeGreaterThan(0);
+    expect(distance).toBeCloseTo(0.323, 2);
+  });
+
+  it('should validate source types', () => {
+    const validTypes = new Set(['mediapipe', 'openpose', 'c3d']);
+
+    expect(validTypes.has('mediapipe')).toBe(true);
+    expect(validTypes.has('openpose')).toBe(true);
+    expect(validTypes.has('c3d')).toBe(true);
+    expect(validTypes.has('kinect')).toBe(false);
+  });
+
+  it('should filter joints by confidence threshold', () => {
+    const joints: JointData[] = [
+      { name: 'nose', position: [0, 0, 0], confidence: 0.95, parent: null },
+      { name: 'left_hip', position: [0, 0, 0], confidence: 0.3, parent: null },
+      { name: 'right_hip', position: [0, 0, 0], confidence: 0.85, parent: null },
+      { name: 'left_foot', position: [0, 0, 0], confidence: 0.1, parent: null },
+    ];
+
+    const highConfidence = joints.filter((j) => j.confidence > 0.5);
+    expect(highConfidence).toHaveLength(2);
+    expect(highConfidence.map((j) => j.name)).toContain('nose');
+    expect(highConfidence.map((j) => j.name)).toContain('right_hip');
+  });
+});

--- a/ui/src/pages/MotionCapture.tsx
+++ b/ui/src/pages/MotionCapture.tsx
@@ -1,0 +1,619 @@
+/**
+ * MotionCapture - Motion capture tool page with skeleton visualization.
+ *
+ * Provides capture source selection (C3D, OpenPose, MediaPipe),
+ * 2D/3D skeleton visualization, and recording/playback controls.
+ * Connects to the motion-capture REST API.
+ *
+ * See issue #1206
+ */
+
+import { useState, useCallback, useEffect, useMemo } from 'react';
+
+/** Capture source from the API. See issue #1206 */
+export interface CaptureSource {
+  id: string;
+  name: string;
+  type: string;
+  available: boolean;
+  description: string;
+}
+
+/** Joint data for skeleton rendering. See issue #1206 */
+export interface JointData {
+  name: string;
+  position: number[];
+  confidence: number;
+  parent: string | null;
+}
+
+/** Recording metadata. See issue #1206 */
+export interface RecordingInfo {
+  name: string;
+  source_type: string;
+  total_frames: number;
+  duration_seconds: number;
+  frame_rate: number;
+  joint_names: string[];
+}
+
+/** Capture session state. See issue #1206 */
+export interface CaptureSession {
+  session_id: string;
+  status: string;
+  source_type: string;
+  message: string;
+}
+
+/** Playback state. See issue #1206 */
+export interface PlaybackState {
+  recording_name: string;
+  status: string;
+  current_frame: number;
+  total_frames: number;
+}
+
+/**
+ * SkeletonRenderer - 2D SVG skeleton visualization.
+ */
+function SkeletonRenderer({
+  joints,
+  width,
+  height,
+}: {
+  joints: JointData[];
+  width: number;
+  height: number;
+}) {
+  // Build a lookup from name to joint
+  const jointMap = useMemo(() => {
+    const map = new Map<string, JointData>();
+    for (const j of joints) {
+      map.set(j.name, j);
+    }
+    return map;
+  }, [joints]);
+
+  // Scale positions to SVG coordinates
+  const scale = (pos: number[], idx: number) => {
+    if (idx === 0) return (pos[0] + 1) * (width / 2); // X: [-1,1] -> [0,width]
+    return (1 - pos[1]) * (height / 2); // Y: [-1,1] -> [height,0] (flip)
+  };
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-full"
+      data-testid="skeleton-renderer"
+    >
+      {/* Background */}
+      <rect x={0} y={0} width={width} height={height} fill="#111827" rx={4} />
+
+      {/* Grid */}
+      {Array.from({ length: 5 }, (_, i) => {
+        const x = (i / 4) * width;
+        const y = (i / 4) * height;
+        return (
+          <g key={i}>
+            <line
+              x1={x}
+              y1={0}
+              x2={x}
+              y2={height}
+              stroke="rgba(255,255,255,0.05)"
+            />
+            <line
+              x1={0}
+              y1={y}
+              x2={width}
+              y2={y}
+              stroke="rgba(255,255,255,0.05)"
+            />
+          </g>
+        );
+      })}
+
+      {/* Bones (lines between parent-child joints) */}
+      {joints.map((joint) => {
+        if (!joint.parent) return null;
+        const parent = jointMap.get(joint.parent);
+        if (!parent) return null;
+
+        const confidence = Math.min(joint.confidence, parent.confidence);
+        const opacity = 0.3 + confidence * 0.7;
+
+        return (
+          <line
+            key={`bone-${joint.name}`}
+            x1={scale(parent.position, 0)}
+            y1={scale(parent.position, 1)}
+            x2={scale(joint.position, 0)}
+            y2={scale(joint.position, 1)}
+            stroke={`rgba(59, 130, 246, ${opacity})`}
+            strokeWidth={2}
+            strokeLinecap="round"
+          />
+        );
+      })}
+
+      {/* Joints (circles) */}
+      {joints.map((joint) => {
+        const x = scale(joint.position, 0);
+        const y = scale(joint.position, 1);
+        const opacity = 0.4 + joint.confidence * 0.6;
+        const r = 3 + joint.confidence * 3;
+
+        return (
+          <g key={`joint-${joint.name}`}>
+            <circle
+              cx={x}
+              cy={y}
+              r={r}
+              fill={`rgba(96, 165, 250, ${opacity})`}
+              stroke="white"
+              strokeWidth={0.5}
+            />
+            {/* Label (only for key joints) */}
+            {joint.confidence > 0.8 && (
+              <text
+                x={x + r + 2}
+                y={y + 3}
+                fill="rgba(156, 163, 175, 0.7)"
+                fontSize={8}
+              >
+                {joint.name.replace('_', ' ')}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/**
+ * MotionCapturePage - Full motion capture tool page.
+ *
+ * See issue #1206
+ */
+export function MotionCapturePage() {
+  const [sources, setSources] = useState<CaptureSource[]>([]);
+  const [selectedSource, setSelectedSource] = useState<string>('mediapipe');
+  const [joints, setJoints] = useState<JointData[]>([]);
+  const [recordings, setRecordings] = useState<RecordingInfo[]>([]);
+  const [activeSession, setActiveSession] = useState<CaptureSession | null>(null);
+  const [selectedRecording, setSelectedRecording] = useState<string | null>(null);
+  const [playback, setPlayback] = useState<PlaybackState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch available sources
+  useEffect(() => {
+    async function fetchSources() {
+      try {
+        const response = await fetch('/api/tools/motion-capture/sources');
+        if (!response.ok) return;
+        const data = await response.json();
+        setSources(data);
+      } catch {
+        // API may not be available
+      }
+    }
+    fetchSources();
+  }, []);
+
+  // Fetch skeleton template when source changes
+  useEffect(() => {
+    async function fetchSkeleton() {
+      try {
+        const response = await fetch(
+          `/api/tools/motion-capture/skeleton/${selectedSource}`,
+        );
+        if (!response.ok) return;
+        const data: JointData[] = await response.json();
+        setJoints(data);
+      } catch {
+        // API may not be available
+      }
+    }
+    fetchSkeleton();
+  }, [selectedSource]);
+
+  // Fetch recordings
+  const fetchRecordings = useCallback(async () => {
+    try {
+      const response = await fetch('/api/tools/motion-capture/recordings');
+      if (!response.ok) return;
+      const data = await response.json();
+      setRecordings(data);
+    } catch {
+      // API may not be available
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRecordings();
+  }, [fetchRecordings]);
+
+  // Start capture session
+  const handleStartCapture = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        '/api/tools/motion-capture/session/start',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            source_type: selectedSource,
+            frame_rate: 30.0,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: CaptureSession = await response.json();
+      setActiveSession(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to start capture',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedSource]);
+
+  // Stop capture session
+  const handleStopCapture = useCallback(async () => {
+    if (!activeSession) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/tools/motion-capture/session/${activeSession.session_id}/stop`,
+        { method: 'POST' },
+      );
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      setActiveSession(null);
+      await fetchRecordings();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to stop capture',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [activeSession, fetchRecordings]);
+
+  // Playback control
+  const handlePlayback = useCallback(
+    async (action: string, seekFrame?: number) => {
+      if (!selectedRecording) return;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          '/api/tools/motion-capture/playback',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              recording_name: selectedRecording,
+              action,
+              seek_frame: seekFrame ?? null,
+            }),
+          },
+        );
+
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          throw new Error(errData.detail || `HTTP ${response.status}`);
+        }
+
+        const data: PlaybackState = await response.json();
+        setPlayback(data);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Playback control failed',
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [selectedRecording],
+  );
+
+  return (
+    <div className="flex h-screen bg-gray-900 overflow-hidden">
+      {/* Left Panel: Source Selection + Controls */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-lg font-bold text-white mb-1">Motion Capture</h2>
+          <p className="text-xs text-gray-500">
+            C3D, OpenPose, and MediaPipe analysis
+          </p>
+        </div>
+
+        {/* Capture Source Selector */}
+        <div className="p-4 border-b border-gray-700 space-y-3">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Capture Source
+          </h3>
+
+          {sources.map((source) => (
+            <button
+              key={source.id}
+              onClick={() => setSelectedSource(source.type)}
+              disabled={!source.available}
+              className={`w-full text-left p-2.5 rounded transition-colors ${
+                selectedSource === source.type
+                  ? 'bg-blue-900/40 ring-1 ring-blue-500/50'
+                  : source.available
+                    ? 'hover:bg-gray-700/50'
+                    : 'opacity-40 cursor-not-allowed'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <div
+                  className={`w-2 h-2 rounded-full ${
+                    source.available ? 'bg-green-500' : 'bg-gray-500'
+                  }`}
+                />
+                <span className="text-xs text-gray-200 font-medium">
+                  {source.name}
+                </span>
+              </div>
+              <div className="text-xs text-gray-500 mt-0.5 ml-4">
+                {source.description}
+              </div>
+            </button>
+          ))}
+
+          {sources.length === 0 && (
+            <div className="text-xs text-gray-500 italic text-center py-2">
+              Loading sources...
+            </div>
+          )}
+        </div>
+
+        {/* Session Controls */}
+        <div className="p-4 border-b border-gray-700 space-y-2">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Capture Session
+          </h3>
+
+          {activeSession ? (
+            <>
+              <div className="flex items-center gap-2 text-xs">
+                <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                <span className="text-red-400">Recording...</span>
+                <span className="text-gray-500 ml-auto">
+                  {activeSession.session_id}
+                </span>
+              </div>
+              <button
+                onClick={handleStopCapture}
+                disabled={loading}
+                className="w-full py-2 px-4 bg-red-600 hover:bg-red-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+                data-testid="stop-capture-btn"
+              >
+                Stop Recording
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={handleStartCapture}
+              disabled={loading}
+              className="w-full py-2 px-4 bg-green-600 hover:bg-green-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+              data-testid="start-capture-btn"
+            >
+              Start Capture
+            </button>
+          )}
+        </div>
+
+        {/* Recordings */}
+        <div className="p-4 border-b border-gray-700">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            Recordings ({recordings.length})
+          </h3>
+
+          {recordings.length === 0 && (
+            <div className="text-xs text-gray-500 italic text-center py-2">
+              No recordings yet
+            </div>
+          )}
+
+          {recordings.map((rec) => (
+            <button
+              key={rec.name}
+              onClick={() => {
+                setSelectedRecording(rec.name);
+                setPlayback(null);
+              }}
+              className={`w-full text-left p-2 rounded mb-1 transition-colors ${
+                selectedRecording === rec.name
+                  ? 'bg-blue-900/40 ring-1 ring-blue-500/50'
+                  : 'hover:bg-gray-700/50'
+              }`}
+            >
+              <div className="text-xs text-gray-200 truncate">{rec.name}</div>
+              <div className="text-xs text-gray-500 flex gap-2">
+                <span>{rec.source_type}</span>
+                <span>{rec.total_frames} frames</span>
+                <span>{rec.duration_seconds.toFixed(1)}s</span>
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* Playback Controls */}
+        {selectedRecording && (
+          <div className="p-4 space-y-2">
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              Playback
+            </h3>
+
+            <div className="flex gap-1">
+              <button
+                onClick={() => handlePlayback('play')}
+                className="flex-1 py-1.5 bg-green-600 hover:bg-green-500 text-white text-xs rounded"
+              >
+                Play
+              </button>
+              <button
+                onClick={() => handlePlayback('pause')}
+                className="flex-1 py-1.5 bg-yellow-600 hover:bg-yellow-500 text-white text-xs rounded"
+              >
+                Pause
+              </button>
+              <button
+                onClick={() => handlePlayback('stop')}
+                className="flex-1 py-1.5 bg-red-600 hover:bg-red-500 text-white text-xs rounded"
+              >
+                Stop
+              </button>
+            </div>
+
+            {playback && (
+              <div className="text-xs text-gray-400 text-center">
+                Frame {playback.current_frame}/{playback.total_frames} |{' '}
+                {playback.status}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="mx-4 mb-4 text-xs text-red-400 bg-red-900/20 p-2 rounded">
+            {error}
+          </div>
+        )}
+      </aside>
+
+      {/* Center: Skeleton Visualization */}
+      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
+        <div className="w-full max-w-2xl aspect-square p-4">
+          <SkeletonRenderer joints={joints} width={500} height={500} />
+        </div>
+
+        {/* Source type overlay */}
+        <div className="absolute top-4 left-4 bg-black/70 backdrop-blur-sm px-3 py-1.5 rounded-lg border border-white/10">
+          <span className="text-sm text-gray-200 font-mono">
+            {selectedSource}
+          </span>
+        </div>
+
+        {/* No data overlay */}
+        {joints.length === 0 && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="text-center">
+              <h3 className="text-lg font-semibold text-gray-400 mb-2">
+                No Skeleton Data
+              </h3>
+              <p className="text-sm text-gray-500 max-w-xs">
+                Select a capture source and start recording, or load a
+                recording to visualize skeleton data.
+              </p>
+            </div>
+          </div>
+        )}
+      </main>
+
+      {/* Right Panel: Joint Data */}
+      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Joint Data
+          </h3>
+
+          <div className="text-xs text-gray-400 mb-2">
+            {joints.length} joints detected
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-1">
+          {joints.map((joint) => (
+            <div
+              key={joint.name}
+              className="bg-gray-700/30 p-1.5 rounded flex items-center gap-2"
+            >
+              <div
+                className={`w-1.5 h-1.5 rounded-full ${
+                  joint.confidence > 0.8
+                    ? 'bg-green-500'
+                    : joint.confidence > 0.5
+                      ? 'bg-yellow-500'
+                      : 'bg-red-500'
+                }`}
+              />
+              <span className="text-xs text-gray-300 truncate flex-1">
+                {joint.name}
+              </span>
+              <span className="text-xs text-gray-500 font-mono">
+                {(joint.confidence * 100).toFixed(0)}%
+              </span>
+            </div>
+          ))}
+
+          {joints.length === 0 && (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              No joints loaded
+            </div>
+          )}
+        </div>
+
+        {/* Selected Recording Info */}
+        {selectedRecording && (
+          <div className="p-4 border-t border-gray-700">
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+              Recording Info
+            </h3>
+            {recordings
+              .filter((r) => r.name === selectedRecording)
+              .map((rec) => (
+                <div key={rec.name} className="space-y-1 text-xs">
+                  <div className="flex justify-between">
+                    <span className="text-gray-400">Source</span>
+                    <span className="text-gray-200">{rec.source_type}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-400">Frames</span>
+                    <span className="text-gray-200 font-mono">
+                      {rec.total_frames}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-400">Duration</span>
+                    <span className="text-gray-200 font-mono">
+                      {rec.duration_seconds.toFixed(1)}s
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-400">Frame Rate</span>
+                    <span className="text-gray-200 font-mono">
+                      {rec.frame_rate} fps
+                    </span>
+                  </div>
+                </div>
+              ))}
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/ui/src/pages/PuttingGreen.test.tsx
+++ b/ui/src/pages/PuttingGreen.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for PuttingGreen page.
+ *
+ * See issue #1206
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { PuttResult, GreenReading, ScatterResult } from './PuttingGreen';
+
+describe('PuttingGreen data structures', () => {
+  it('should parse a putt simulation result', () => {
+    const result: PuttResult = {
+      positions: [
+        [10.0, 5.0],
+        [10.0, 7.0],
+        [10.0, 10.0],
+        [10.0, 14.8],
+      ],
+      velocities: [
+        [0.0, 2.0],
+        [0.0, 1.8],
+        [0.0, 1.2],
+        [0.0, 0.1],
+      ],
+      times: [0.0, 0.5, 1.0, 2.0],
+      holed: false,
+      final_position: [10.0, 14.8],
+      total_distance: 9.8,
+      duration: 2.0,
+    };
+
+    expect(result.positions).toHaveLength(4);
+    expect(result.holed).toBe(false);
+    expect(result.total_distance).toBeCloseTo(9.8, 1);
+    expect(result.final_position).toEqual([10.0, 14.8]);
+  });
+
+  it('should identify a holed putt', () => {
+    const result: PuttResult = {
+      positions: [
+        [10.0, 5.0],
+        [10.0, 15.0],
+      ],
+      velocities: [
+        [0.0, 2.0],
+        [0.0, 0.0],
+      ],
+      times: [0.0, 2.5],
+      holed: true,
+      final_position: [10.0, 15.0],
+      total_distance: 10.0,
+      duration: 2.5,
+    };
+
+    expect(result.holed).toBe(true);
+    expect(result.duration).toBe(2.5);
+  });
+
+  it('should parse a green reading', () => {
+    const reading: GreenReading = {
+      distance: 11.18,
+      total_break: 0.05,
+      recommended_speed: 2.1,
+      aim_point: [10.02, 14.95],
+      elevations: [0.0, 0.01, 0.02, 0.03],
+      slopes: [
+        [0.001, 0.002],
+        [0.001, 0.003],
+      ],
+    };
+
+    expect(reading.distance).toBeGreaterThan(0);
+    expect(reading.recommended_speed).toBeGreaterThan(0);
+    expect(reading.aim_point).toHaveLength(2);
+    expect(reading.elevations.length).toBeGreaterThan(0);
+  });
+
+  it('should parse scatter analysis results', () => {
+    const scatter: ScatterResult = {
+      final_positions: [
+        [10.1, 14.9],
+        [9.8, 15.2],
+        [10.0, 15.0],
+        [10.3, 14.7],
+        [10.0, 15.0],
+      ],
+      holed_count: 2,
+      total_simulations: 5,
+      average_distance_from_hole: 0.15,
+      make_percentage: 40.0,
+    };
+
+    expect(scatter.total_simulations).toBe(5);
+    expect(scatter.holed_count).toBe(2);
+    expect(scatter.make_percentage).toBe(40.0);
+    expect(scatter.final_positions).toHaveLength(5);
+  });
+
+  it('should compute distance between ball and hole', () => {
+    const ballX = 10.0;
+    const ballY = 5.0;
+    const holeX = 10.0;
+    const holeY = 15.0;
+
+    const distance = Math.sqrt(
+      (holeX - ballX) ** 2 + (holeY - ballY) ** 2,
+    );
+    expect(distance).toBeCloseTo(10.0, 5);
+  });
+
+  it('should normalize direction vector', () => {
+    const dirX = 3.0;
+    const dirY = 4.0;
+    const norm = Math.sqrt(dirX * dirX + dirY * dirY);
+    const normalizedX = dirX / norm;
+    const normalizedY = dirY / norm;
+
+    expect(normalizedX).toBeCloseTo(0.6, 5);
+    expect(normalizedY).toBeCloseTo(0.8, 5);
+    expect(
+      Math.sqrt(normalizedX ** 2 + normalizedY ** 2),
+    ).toBeCloseTo(1.0, 10);
+  });
+
+  it('should validate stimp rating range', () => {
+    const validRatings = [6.0, 8.5, 10.0, 12.5, 15.0];
+    const invalidRatings = [5.0, 16.0, -1.0];
+
+    for (const rating of validRatings) {
+      expect(rating).toBeGreaterThanOrEqual(6.0);
+      expect(rating).toBeLessThanOrEqual(15.0);
+    }
+
+    for (const rating of invalidRatings) {
+      const isValid = rating >= 6.0 && rating <= 15.0;
+      expect(isValid).toBe(false);
+    }
+  });
+});

--- a/ui/src/pages/PuttingGreen.tsx
+++ b/ui/src/pages/PuttingGreen.tsx
@@ -1,0 +1,714 @@
+/**
+ * PuttingGreen - Interactive putting green simulator page.
+ *
+ * Provides 2D green visualization with putt trajectory rendering,
+ * slope contours, and speed/slope/distance controls. Connects to
+ * the FastAPI putting green simulation engine.
+ *
+ * See issue #1206
+ */
+
+import { useState, useCallback } from 'react';
+
+/** Putt simulation result from the API. See issue #1206 */
+export interface PuttResult {
+  positions: number[][];
+  velocities: number[][];
+  times: number[];
+  holed: boolean;
+  final_position: number[];
+  total_distance: number;
+  duration: number;
+}
+
+/** Green reading from the API. See issue #1206 */
+export interface GreenReading {
+  distance: number;
+  total_break: number;
+  recommended_speed: number;
+  aim_point: number[];
+  elevations: number[];
+  slopes: number[][];
+}
+
+/** Scatter analysis result. See issue #1206 */
+export interface ScatterResult {
+  final_positions: number[][];
+  holed_count: number;
+  total_simulations: number;
+  average_distance_from_hole: number;
+  make_percentage: number;
+}
+
+/** Green contour data. See issue #1206 */
+export interface GreenContour {
+  width: number;
+  height: number;
+  grid_x: number[][];
+  grid_y: number[][];
+  elevations: number[][];
+  hole_position: number[];
+}
+
+/**
+ * GreenCanvas - 2D putting green visualization with SVG.
+ */
+function GreenCanvas({
+  width,
+  height,
+  holeX,
+  holeY,
+  ballX,
+  ballY,
+  trajectory,
+  scatterPoints,
+  aimPoint,
+}: {
+  width: number;
+  height: number;
+  holeX: number;
+  holeY: number;
+  ballX: number;
+  ballY: number;
+  trajectory: number[][] | null;
+  scatterPoints: number[][] | null;
+  aimPoint: number[] | null;
+}) {
+  // SVG viewbox maps green coords to pixels
+  const svgWidth = 500;
+  const svgHeight = 500;
+  const scaleX = svgWidth / width;
+  const scaleY = svgHeight / height;
+
+  const toSvgX = (x: number) => x * scaleX;
+  const toSvgY = (y: number) => svgHeight - y * scaleY; // Flip Y for SVG
+
+  // Compute trajectory path inline (no useMemo needed; parent re-renders on prop changes)
+  let trajectoryPath: string | null = null;
+  if (trajectory && trajectory.length >= 2) {
+    const points = trajectory.map(
+      ([x, y]) => `${toSvgX(x).toFixed(1)},${toSvgY(y).toFixed(1)}`,
+    );
+    trajectoryPath = `M ${points.join(' L ')}`;
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+      className="w-full h-full"
+      data-testid="green-canvas"
+    >
+      {/* Green surface */}
+      <rect
+        x={0}
+        y={0}
+        width={svgWidth}
+        height={svgHeight}
+        fill="#2d5a27"
+        rx={8}
+      />
+
+      {/* Grid lines */}
+      {Array.from({ length: Math.floor(width) + 1 }, (_, i) => (
+        <line
+          key={`vl-${i}`}
+          x1={toSvgX(i)}
+          y1={0}
+          x2={toSvgX(i)}
+          y2={svgHeight}
+          stroke="rgba(255,255,255,0.08)"
+          strokeWidth={0.5}
+        />
+      ))}
+      {Array.from({ length: Math.floor(height) + 1 }, (_, i) => (
+        <line
+          key={`hl-${i}`}
+          x1={0}
+          y1={toSvgY(i)}
+          x2={svgWidth}
+          y2={toSvgY(i)}
+          stroke="rgba(255,255,255,0.08)"
+          strokeWidth={0.5}
+        />
+      ))}
+
+      {/* Aim point */}
+      {aimPoint && (
+        <>
+          <line
+            x1={toSvgX(ballX)}
+            y1={toSvgY(ballY)}
+            x2={toSvgX(aimPoint[0])}
+            y2={toSvgY(aimPoint[1])}
+            stroke="rgba(255,200,50,0.5)"
+            strokeWidth={1}
+            strokeDasharray="4,4"
+          />
+          <circle
+            cx={toSvgX(aimPoint[0])}
+            cy={toSvgY(aimPoint[1])}
+            r={4}
+            fill="rgba(255,200,50,0.7)"
+          />
+        </>
+      )}
+
+      {/* Scatter points */}
+      {scatterPoints?.map((pt, i) => (
+        <circle
+          key={`scatter-${i}`}
+          cx={toSvgX(pt[0])}
+          cy={toSvgY(pt[1])}
+          r={3}
+          fill="rgba(200,100,100,0.6)"
+          stroke="rgba(255,150,150,0.4)"
+          strokeWidth={0.5}
+        />
+      ))}
+
+      {/* Trajectory */}
+      {trajectoryPath && (
+        <path
+          d={trajectoryPath}
+          fill="none"
+          stroke="white"
+          strokeWidth={2}
+          strokeLinecap="round"
+          opacity={0.9}
+        />
+      )}
+
+      {/* Hole */}
+      <circle
+        cx={toSvgX(holeX)}
+        cy={toSvgY(holeY)}
+        r={8}
+        fill="#1a1a1a"
+        stroke="white"
+        strokeWidth={1}
+      />
+      <circle
+        cx={toSvgX(holeX)}
+        cy={toSvgY(holeY)}
+        r={3}
+        fill="#333"
+      />
+
+      {/* Ball */}
+      <circle
+        cx={toSvgX(ballX)}
+        cy={toSvgY(ballY)}
+        r={6}
+        fill="white"
+        stroke="rgba(0,0,0,0.3)"
+        strokeWidth={1}
+        data-testid="ball"
+      />
+
+      {/* Final ball position if trajectory exists */}
+      {trajectory && trajectory.length > 1 && (
+        <circle
+          cx={toSvgX(trajectory[trajectory.length - 1][0])}
+          cy={toSvgY(trajectory[trajectory.length - 1][1])}
+          r={5}
+          fill="rgba(255,255,255,0.5)"
+          stroke="rgba(255,255,255,0.8)"
+          strokeWidth={1}
+          strokeDasharray="2,2"
+        />
+      )}
+    </svg>
+  );
+}
+
+/**
+ * PuttingGreenPage - Full putting green simulator tool page.
+ *
+ * See issue #1206
+ */
+export function PuttingGreenPage() {
+  // Putt parameters
+  const [ballX, setBallX] = useState(10.0);
+  const [ballY, setBallY] = useState(5.0);
+  const [speed, setSpeed] = useState(2.0);
+  const [dirX, setDirX] = useState(0.0);
+  const [dirY, setDirY] = useState(1.0);
+  const [stimpRating, setStimpRating] = useState(10.0);
+  const [windSpeed, setWindSpeed] = useState(0.0);
+
+  // Green params
+  const [greenWidth] = useState(20.0);
+  const [greenHeight] = useState(20.0);
+  const [holeX, setHoleX] = useState(10.0);
+  const [holeY, setHoleY] = useState(15.0);
+
+  // Results
+  const [result, setResult] = useState<PuttResult | null>(null);
+  const [reading, setReading] = useState<GreenReading | null>(null);
+  const [scatterResult, setScatterResult] = useState<ScatterResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Simulate a putt
+  const handleSimulate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setScatterResult(null);
+
+    try {
+      const response = await fetch('/api/tools/putting-green/simulate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ball_x: ballX,
+          ball_y: ballY,
+          speed,
+          direction_x: dirX,
+          direction_y: dirY,
+          stimp_rating: stimpRating,
+          green_width: greenWidth,
+          green_height: greenHeight,
+          hole_x: holeX,
+          hole_y: holeY,
+          wind_speed: windSpeed,
+          wind_direction_x: 1.0,
+          wind_direction_y: 0.0,
+        }),
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: PuttResult = await response.json();
+      setResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Simulation failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [ballX, ballY, speed, dirX, dirY, stimpRating, greenWidth, greenHeight, holeX, holeY, windSpeed]);
+
+  // Read the green
+  const handleReadGreen = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/tools/putting-green/read-green', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ball_x: ballX,
+          ball_y: ballY,
+          target_x: holeX,
+          target_y: holeY,
+          green_width: greenWidth,
+          green_height: greenHeight,
+          stimp_rating: stimpRating,
+        }),
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: GreenReading = await response.json();
+      setReading(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Green reading failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [ballX, ballY, holeX, holeY, greenWidth, greenHeight, stimpRating]);
+
+  // Scatter analysis
+  const handleScatter = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch('/api/tools/putting-green/scatter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ball_x: ballX,
+          ball_y: ballY,
+          speed,
+          direction_x: dirX,
+          direction_y: dirY,
+          n_simulations: 20,
+          speed_variance: 0.15,
+          direction_variance_deg: 3.0,
+          green_width: greenWidth,
+          green_height: greenHeight,
+          stimp_rating: stimpRating,
+        }),
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: ScatterResult = await response.json();
+      setScatterResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Scatter analysis failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [ballX, ballY, speed, dirX, dirY, greenWidth, greenHeight, stimpRating]);
+
+  const trajectory = result?.positions ?? null;
+  const aimPoint = reading?.aim_point ?? null;
+  const scatterPoints = scatterResult?.final_positions ?? null;
+
+  return (
+    <div className="flex h-screen bg-gray-900 overflow-hidden">
+      {/* Left Panel: Controls */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-lg font-bold text-white mb-1">Putting Green Simulator</h2>
+          <p className="text-xs text-gray-500">Physics-based putting simulation</p>
+        </div>
+
+        {/* Stroke Controls */}
+        <div className="p-4 border-b border-gray-700 space-y-3">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Stroke Parameters
+          </h3>
+
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">
+              Speed: {speed.toFixed(1)} m/s
+            </label>
+            <input
+              type="range"
+              min={0.5}
+              max={8.0}
+              step={0.1}
+              value={speed}
+              onChange={(e) => setSpeed(parseFloat(e.target.value))}
+              className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+              aria-label="Stroke speed"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Dir X: {dirX.toFixed(2)}
+              </label>
+              <input
+                type="range"
+                min={-1}
+                max={1}
+                step={0.01}
+                value={dirX}
+                onChange={(e) => setDirX(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Direction X"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Dir Y: {dirY.toFixed(2)}
+              </label>
+              <input
+                type="range"
+                min={-1}
+                max={1}
+                step={0.01}
+                value={dirY}
+                onChange={(e) => setDirY(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Direction Y"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">
+              Stimp Rating: {stimpRating.toFixed(1)} ft
+            </label>
+            <input
+              type="range"
+              min={6.0}
+              max={15.0}
+              step={0.5}
+              value={stimpRating}
+              onChange={(e) => setStimpRating(parseFloat(e.target.value))}
+              className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+              aria-label="Stimp rating"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">
+              Wind: {windSpeed.toFixed(1)} m/s
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={5}
+              step={0.1}
+              value={windSpeed}
+              onChange={(e) => setWindSpeed(parseFloat(e.target.value))}
+              className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+              aria-label="Wind speed"
+            />
+          </div>
+        </div>
+
+        {/* Position Controls */}
+        <div className="p-4 border-b border-gray-700 space-y-3">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Positions
+          </h3>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Ball X: {ballX.toFixed(1)}
+              </label>
+              <input
+                type="range"
+                min={0.5}
+                max={greenWidth - 0.5}
+                step={0.5}
+                value={ballX}
+                onChange={(e) => setBallX(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Ball X position"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Ball Y: {ballY.toFixed(1)}
+              </label>
+              <input
+                type="range"
+                min={0.5}
+                max={greenHeight - 0.5}
+                step={0.5}
+                value={ballY}
+                onChange={(e) => setBallY(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Ball Y position"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Hole X: {holeX.toFixed(1)}
+              </label>
+              <input
+                type="range"
+                min={0.5}
+                max={greenWidth - 0.5}
+                step={0.5}
+                value={holeX}
+                onChange={(e) => setHoleX(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Hole X position"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Hole Y: {holeY.toFixed(1)}
+              </label>
+              <input
+                type="range"
+                min={0.5}
+                max={greenHeight - 0.5}
+                step={0.5}
+                value={holeY}
+                onChange={(e) => setHoleY(parseFloat(e.target.value))}
+                className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+                aria-label="Hole Y position"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="p-4 space-y-2">
+          <button
+            onClick={handleSimulate}
+            disabled={loading}
+            className="w-full py-2 px-4 bg-green-600 hover:bg-green-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+            data-testid="simulate-btn"
+          >
+            {loading ? 'Simulating...' : 'Simulate Putt'}
+          </button>
+          <button
+            onClick={handleReadGreen}
+            disabled={loading}
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+          >
+            Read Green
+          </button>
+          <button
+            onClick={handleScatter}
+            disabled={loading}
+            className="w-full py-2 px-4 bg-purple-600 hover:bg-purple-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+          >
+            Scatter Analysis
+          </button>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mx-4 mb-4 text-xs text-red-400 bg-red-900/20 p-2 rounded">
+            {error}
+          </div>
+        )}
+      </aside>
+
+      {/* Center: Green Visualization */}
+      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
+        <div className="w-full max-w-[600px] aspect-square p-4">
+          <GreenCanvas
+            width={greenWidth}
+            height={greenHeight}
+            holeX={holeX}
+            holeY={holeY}
+            ballX={ballX}
+            ballY={ballY}
+            trajectory={trajectory}
+            scatterPoints={scatterPoints}
+            aimPoint={aimPoint}
+          />
+        </div>
+
+        {/* Result overlay */}
+        {result && (
+          <div className="absolute top-4 left-4 bg-black/70 backdrop-blur-sm px-3 py-2 rounded-lg border border-white/10">
+            <div className="text-sm text-gray-200 space-y-1">
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full ${result.holed ? 'bg-green-500' : 'bg-red-500'}`} />
+                <span className="font-medium">{result.holed ? 'Holed!' : 'Missed'}</span>
+              </div>
+              <div className="text-xs text-gray-400">
+                Distance: {result.total_distance.toFixed(2)} m
+              </div>
+              <div className="text-xs text-gray-400">
+                Duration: {result.duration.toFixed(2)} s
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Scatter overlay */}
+        {scatterResult && (
+          <div className="absolute top-4 left-4 bg-black/70 backdrop-blur-sm px-3 py-2 rounded-lg border border-white/10">
+            <div className="text-sm text-gray-200 space-y-1">
+              <div className="font-medium">Scatter Analysis</div>
+              <div className="text-xs text-gray-400">
+                Make rate: {scatterResult.make_percentage.toFixed(1)}%
+                ({scatterResult.holed_count}/{scatterResult.total_simulations})
+              </div>
+              <div className="text-xs text-gray-400">
+                Avg miss: {scatterResult.average_distance_from_hole.toFixed(2)} m
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+
+      {/* Right Panel: Green Reading */}
+      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Green Reading
+          </h3>
+
+          {reading ? (
+            <div className="space-y-2">
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Distance</span>
+                <span className="text-gray-200 font-mono">
+                  {reading.distance.toFixed(2)} m
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Total Break</span>
+                <span className="text-gray-200 font-mono">
+                  {reading.total_break.toFixed(3)} m
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Recommended Speed</span>
+                <span className="text-blue-400 font-mono">
+                  {reading.recommended_speed.toFixed(2)} m/s
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Aim Point</span>
+                <span className="text-yellow-400 font-mono">
+                  ({reading.aim_point[0].toFixed(1)}, {reading.aim_point[1].toFixed(1)})
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              Click &quot;Read Green&quot; to analyze the putt line
+            </div>
+          )}
+        </div>
+
+        {/* Putt Result Details */}
+        <div className="p-4 flex-1">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Last Putt
+          </h3>
+
+          {result ? (
+            <div className="space-y-2">
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Result</span>
+                <span className={result.holed ? 'text-green-400' : 'text-red-400'}>
+                  {result.holed ? 'HOLED' : 'MISSED'}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Final Position</span>
+                <span className="text-gray-200 font-mono">
+                  ({result.final_position[0].toFixed(1)}, {result.final_position[1].toFixed(1)})
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Total Distance</span>
+                <span className="text-gray-200 font-mono">
+                  {result.total_distance.toFixed(2)} m
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Duration</span>
+                <span className="text-gray-200 font-mono">
+                  {result.duration.toFixed(2)} s
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Trajectory Points</span>
+                <span className="text-gray-200 font-mono">
+                  {result.positions.length}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              Simulate a putt to see results
+            </div>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/ui/src/pages/VideoAnalyzer.test.tsx
+++ b/ui/src/pages/VideoAnalyzer.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for VideoAnalyzer page.
+ *
+ * See issue #1206
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { VideoAnalysisResult, PoseFrame, TaskStatus } from './VideoAnalyzer';
+
+describe('VideoAnalyzer data structures', () => {
+  it('should parse video analysis result', () => {
+    const result: VideoAnalysisResult = {
+      filename: 'swing_front.mp4',
+      total_frames: 120,
+      valid_frames: 115,
+      average_confidence: 0.87,
+      quality_metrics: {
+        stability: 0.92,
+        coverage: 0.88,
+        smoothness: 0.95,
+      },
+      pose_data: [
+        {
+          timestamp: 0.0,
+          confidence: 0.91,
+          joint_angles: { hip: 45.0, shoulder: 90.0, elbow: 120.0 },
+          keypoints: { nose: [320, 100], left_shoulder: [280, 180] },
+        },
+        {
+          timestamp: 0.033,
+          confidence: 0.89,
+          joint_angles: { hip: 46.0, shoulder: 89.5, elbow: 118.0 },
+          keypoints: { nose: [321, 100], left_shoulder: [281, 181] },
+        },
+      ],
+    };
+
+    expect(result.filename).toBe('swing_front.mp4');
+    expect(result.total_frames).toBe(120);
+    expect(result.valid_frames).toBe(115);
+    expect(result.average_confidence).toBeCloseTo(0.87, 2);
+    expect(result.pose_data).toHaveLength(2);
+    expect(result.quality_metrics.stability).toBe(0.92);
+  });
+
+  it('should access pose frame data', () => {
+    const frame: PoseFrame = {
+      timestamp: 1.5,
+      confidence: 0.93,
+      joint_angles: {
+        hip_flexion: 85.2,
+        shoulder_rotation: 110.5,
+        spine_tilt: 12.3,
+        elbow_angle: 145.0,
+        wrist_cock: 32.1,
+      },
+      keypoints: {
+        left_shoulder: [280, 180, 0],
+        right_shoulder: [360, 180, 0],
+        left_hip: [290, 350, 0],
+        right_hip: [350, 350, 0],
+      },
+    };
+
+    expect(frame.timestamp).toBe(1.5);
+    expect(frame.confidence).toBeGreaterThan(0.9);
+    expect(Object.keys(frame.joint_angles)).toHaveLength(5);
+    expect(frame.keypoints.left_shoulder).toHaveLength(3);
+  });
+
+  it('should handle task status lifecycle', () => {
+    const statuses: TaskStatus[] = [
+      { task_id: 'abc-123', status: 'started' },
+      { task_id: 'abc-123', status: 'processing', progress: 50 },
+      {
+        task_id: 'abc-123',
+        status: 'completed',
+        result: { filename: 'test.mp4', total_frames: 60 },
+      },
+    ];
+
+    expect(statuses[0].status).toBe('started');
+    expect(statuses[1].progress).toBe(50);
+    expect(statuses[2].status).toBe('completed');
+    expect(statuses[2].result).toBeDefined();
+  });
+
+  it('should handle failed task status', () => {
+    const status: TaskStatus = {
+      task_id: 'def-456',
+      status: 'failed',
+      error: 'Video format not supported',
+    };
+
+    expect(status.status).toBe('failed');
+    expect(status.error).toContain('not supported');
+  });
+
+  it('should validate estimator types', () => {
+    const validTypes = ['mediapipe', 'openpose', 'blazepose'];
+    const invalidType = 'unknown_estimator';
+
+    for (const t of validTypes) {
+      expect(validTypes).toContain(t);
+    }
+    expect(validTypes).not.toContain(invalidType);
+  });
+
+  it('should compute frame-to-frame joint angle change', () => {
+    const frame1: PoseFrame = {
+      timestamp: 0.0,
+      confidence: 0.9,
+      joint_angles: { hip: 45.0, shoulder: 90.0 },
+      keypoints: {},
+    };
+    const frame2: PoseFrame = {
+      timestamp: 0.033,
+      confidence: 0.88,
+      joint_angles: { hip: 47.5, shoulder: 88.0 },
+      keypoints: {},
+    };
+
+    const hipDelta = frame2.joint_angles.hip - frame1.joint_angles.hip;
+    const shoulderDelta =
+      frame2.joint_angles.shoulder - frame1.joint_angles.shoulder;
+    const dt = frame2.timestamp - frame1.timestamp;
+    const hipVelocity = hipDelta / dt;
+
+    expect(hipDelta).toBeCloseTo(2.5, 5);
+    expect(shoulderDelta).toBeCloseTo(-2.0, 5);
+    expect(hipVelocity).toBeCloseTo(75.76, 0);
+  });
+});

--- a/ui/src/pages/VideoAnalyzer.tsx
+++ b/ui/src/pages/VideoAnalyzer.tsx
@@ -1,0 +1,490 @@
+/**
+ * VideoAnalyzer - Video-based swing analysis tool page.
+ *
+ * Provides video upload/playback, frame-by-frame analysis with overlay
+ * controls, and integration with existing REST video endpoints.
+ *
+ * See issue #1206
+ */
+
+import { useState, useCallback, useRef } from 'react';
+
+/** Video analysis result from the API. See issue #1206 */
+export interface VideoAnalysisResult {
+  filename: string;
+  total_frames: number;
+  valid_frames: number;
+  average_confidence: number;
+  quality_metrics: Record<string, number>;
+  pose_data: PoseFrame[];
+}
+
+/** A single pose frame. See issue #1206 */
+export interface PoseFrame {
+  timestamp: number;
+  confidence: number;
+  joint_angles: Record<string, number>;
+  keypoints: Record<string, number[]>;
+}
+
+/** Async task status. See issue #1206 */
+export interface TaskStatus {
+  task_id: string;
+  status: 'started' | 'processing' | 'completed' | 'failed';
+  progress?: number;
+  result?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * PoseOverlay - Renders joint keypoints over the video frame.
+ */
+function PoseOverlay({
+  frame,
+  width,
+  height,
+}: {
+  frame: PoseFrame | null;
+  width: number;
+  height: number;
+}) {
+  if (!frame || !frame.keypoints) return null;
+
+  const entries = Object.entries(frame.keypoints);
+  if (entries.length === 0) return null;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="absolute inset-0 w-full h-full pointer-events-none"
+      data-testid="pose-overlay"
+    >
+      {entries.map(([name, coords]) => {
+        if (!coords || coords.length < 2) return null;
+        return (
+          <circle
+            key={name}
+            cx={coords[0]}
+            cy={coords[1]}
+            r={4}
+            fill="rgba(0, 255, 100, 0.8)"
+            stroke="white"
+            strokeWidth={1}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+/**
+ * JointAngleChart - Simple bar chart of joint angles.
+ */
+function JointAngleChart({
+  angles,
+}: {
+  angles: Record<string, number>;
+}) {
+  const entries = Object.entries(angles);
+  if (entries.length === 0) {
+    return (
+      <div className="text-xs text-gray-500 italic text-center py-2">
+        No joint angle data
+      </div>
+    );
+  }
+
+  const maxAngle = Math.max(...entries.map(([, v]) => Math.abs(v)), 1);
+
+  return (
+    <div className="space-y-1" data-testid="joint-angle-chart">
+      {entries.slice(0, 12).map(([name, value]) => (
+        <div key={name} className="flex items-center gap-2">
+          <span className="text-xs text-gray-400 w-24 truncate">{name}</span>
+          <div className="flex-1 h-2 bg-gray-700 rounded overflow-hidden">
+            <div
+              className="h-full bg-blue-500 rounded"
+              style={{ width: `${(Math.abs(value) / maxAngle) * 100}%` }}
+            />
+          </div>
+          <span className="text-xs text-gray-300 font-mono w-12 text-right">
+            {value.toFixed(1)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * VideoAnalyzerPage - Full video analysis tool page.
+ *
+ * See issue #1206
+ */
+export function VideoAnalyzerPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [analysis, setAnalysis] = useState<VideoAnalysisResult | null>(null);
+  const [currentFrameIdx, setCurrentFrameIdx] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [estimatorType, setEstimatorType] = useState('mediapipe');
+  const [minConfidence, setMinConfidence] = useState(0.5);
+  const [showOverlay, setShowOverlay] = useState(true);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Handle file selection
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = e.target.files?.[0];
+      if (selected) {
+        setFile(selected);
+        setVideoUrl(URL.createObjectURL(selected));
+        setAnalysis(null);
+        setCurrentFrameIdx(0);
+        setError(null);
+      }
+    },
+    [],
+  );
+
+  // Upload and analyze
+  const handleAnalyze = useCallback(async () => {
+    if (!file) {
+      setError('Please select a video file first');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const params = new URLSearchParams({
+        estimator_type: estimatorType,
+        min_confidence: minConfidence.toString(),
+        enable_smoothing: 'true',
+      });
+
+      const response = await fetch(
+        `/api/analyze/video?${params.toString()}`,
+        {
+          method: 'POST',
+          body: formData,
+        },
+      );
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || `HTTP ${response.status}`);
+      }
+
+      const data: VideoAnalysisResult = await response.json();
+      setAnalysis(data);
+      setCurrentFrameIdx(0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Analysis failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [file, estimatorType, minConfidence]);
+
+  // Frame navigation
+  const totalFrames = analysis?.pose_data.length ?? 0;
+  const currentFrame =
+    analysis && totalFrames > 0
+      ? analysis.pose_data[Math.min(currentFrameIdx, totalFrames - 1)]
+      : null;
+
+  const handlePrevFrame = useCallback(() => {
+    setCurrentFrameIdx((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleNextFrame = useCallback(() => {
+    setCurrentFrameIdx((prev) => Math.min(totalFrames - 1, prev + 1));
+  }, [totalFrames]);
+
+  return (
+    <div className="flex h-screen bg-gray-900 overflow-hidden">
+      {/* Left Panel: Controls */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-lg font-bold text-white mb-1">Video Analyzer</h2>
+          <p className="text-xs text-gray-500">
+            Upload and analyze golf swing videos
+          </p>
+        </div>
+
+        {/* Upload */}
+        <div className="p-4 border-b border-gray-700 space-y-3">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Video Upload
+          </h3>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="video/*"
+            onChange={handleFileSelect}
+            className="hidden"
+            data-testid="video-file-input"
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full py-2 px-4 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded border border-gray-600 transition-colors"
+          >
+            {file ? file.name : 'Choose Video File...'}
+          </button>
+          {file && (
+            <div className="text-xs text-gray-400">
+              Size: {(file.size / 1024 / 1024).toFixed(1)} MB
+            </div>
+          )}
+        </div>
+
+        {/* Analysis Settings */}
+        <div className="p-4 border-b border-gray-700 space-y-3">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Settings
+          </h3>
+
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">
+              Pose Estimator
+            </label>
+            <select
+              value={estimatorType}
+              onChange={(e) => setEstimatorType(e.target.value)}
+              className="w-full bg-gray-700 text-gray-200 rounded px-2 py-1.5 text-sm border-none focus:ring-1 focus:ring-blue-400"
+            >
+              <option value="mediapipe">MediaPipe</option>
+              <option value="openpose">OpenPose</option>
+              <option value="blazepose">BlazePose</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">
+              Min Confidence: {minConfidence.toFixed(2)}
+            </label>
+            <input
+              type="range"
+              min={0.1}
+              max={0.95}
+              step={0.05}
+              value={minConfidence}
+              onChange={(e) =>
+                setMinConfidence(parseFloat(e.target.value))
+              }
+              className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+              aria-label="Minimum confidence threshold"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showOverlay}
+              onChange={(e) => setShowOverlay(e.target.checked)}
+              className="rounded border-gray-600 bg-gray-700"
+            />
+            <span className="text-xs text-gray-300">Show Pose Overlay</span>
+          </label>
+        </div>
+
+        {/* Analyze Button */}
+        <div className="p-4 border-b border-gray-700">
+          <button
+            onClick={handleAnalyze}
+            disabled={loading || !file}
+            className="w-full py-2 px-4 bg-green-600 hover:bg-green-500 disabled:bg-gray-600 text-white text-sm font-medium rounded transition-colors"
+            data-testid="analyze-btn"
+          >
+            {loading ? 'Analyzing...' : 'Analyze Video'}
+          </button>
+        </div>
+
+        {/* Frame Navigation */}
+        {analysis && (
+          <div className="p-4 border-b border-gray-700 space-y-3">
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              Frame Navigation
+            </h3>
+
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handlePrevFrame}
+                disabled={currentFrameIdx <= 0}
+                className="px-3 py-1 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-700/50 text-gray-200 text-xs rounded"
+              >
+                Prev
+              </button>
+              <span className="text-xs text-gray-300 font-mono flex-1 text-center">
+                {currentFrameIdx + 1} / {totalFrames}
+              </span>
+              <button
+                onClick={handleNextFrame}
+                disabled={currentFrameIdx >= totalFrames - 1}
+                className="px-3 py-1 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-700/50 text-gray-200 text-xs rounded"
+              >
+                Next
+              </button>
+            </div>
+
+            <input
+              type="range"
+              min={0}
+              max={Math.max(0, totalFrames - 1)}
+              value={currentFrameIdx}
+              onChange={(e) =>
+                setCurrentFrameIdx(parseInt(e.target.value, 10))
+              }
+              className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+              aria-label="Frame scrubber"
+            />
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="mx-4 mb-4 text-xs text-red-400 bg-red-900/20 p-2 rounded">
+            {error}
+          </div>
+        )}
+      </aside>
+
+      {/* Center: Video Player */}
+      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
+        {videoUrl ? (
+          <div className="relative w-full max-w-3xl aspect-video">
+            <video
+              ref={videoRef}
+              src={videoUrl}
+              controls
+              className="w-full h-full rounded-lg"
+              data-testid="video-player"
+            />
+            {showOverlay && currentFrame && (
+              <PoseOverlay
+                frame={currentFrame}
+                width={640}
+                height={480}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="text-center">
+            <div className="text-4xl mb-4 text-gray-600">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-16 h-16 mx-auto text-gray-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1}
+                  d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-400 mb-2">
+              Upload a Video
+            </h3>
+            <p className="text-sm text-gray-500 max-w-xs">
+              Select a golf swing video to analyze pose estimation,
+              joint angles, and swing metrics.
+            </p>
+          </div>
+        )}
+      </main>
+
+      {/* Right Panel: Analysis Results */}
+      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+        {/* Summary */}
+        <div className="p-4 border-b border-gray-700">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Analysis Summary
+          </h3>
+
+          {analysis ? (
+            <div className="space-y-2">
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Filename</span>
+                <span className="text-gray-200 truncate max-w-[120px]">
+                  {analysis.filename}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Total Frames</span>
+                <span className="text-gray-200 font-mono">
+                  {analysis.total_frames}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Valid Frames</span>
+                <span className="text-gray-200 font-mono">
+                  {analysis.valid_frames}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Avg Confidence</span>
+                <span className="text-blue-400 font-mono">
+                  {(analysis.average_confidence * 100).toFixed(1)}%
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              No analysis yet
+            </div>
+          )}
+        </div>
+
+        {/* Quality Metrics */}
+        {analysis && Object.keys(analysis.quality_metrics).length > 0 && (
+          <div className="p-4 border-b border-gray-700">
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+              Quality Metrics
+            </h3>
+            <div className="space-y-1">
+              {Object.entries(analysis.quality_metrics).map(([key, val]) => (
+                <div key={key} className="flex justify-between text-xs">
+                  <span className="text-gray-400">{key}</span>
+                  <span className="text-gray-200 font-mono">
+                    {typeof val === 'number' ? val.toFixed(3) : String(val)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Current Frame Data */}
+        <div className="p-4 flex-1">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Frame Joint Angles
+          </h3>
+
+          {currentFrame ? (
+            <>
+              <div className="text-xs text-gray-500 mb-2">
+                t={currentFrame.timestamp.toFixed(3)}s | conf={' '}
+                {(currentFrame.confidence * 100).toFixed(1)}%
+              </div>
+              <JointAngleChart angles={currentFrame.joint_angles} />
+            </>
+          ) : (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              Analyze a video to view joint data
+            </div>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Putting Green Simulator**: React page with 2D SVG green visualization, putt trajectory rendering, speed/slope/distance controls, scatter analysis, and green reading assist. FastAPI endpoints wrap the 804-line Python putting simulator engine.
- **Video Analyzer**: React page with video upload/playback, frame-by-frame pose overlay, joint angle charts, and integration with existing `/api/analyze/video` REST endpoint.
- **Data Explorer**: React page with dataset browser, tabular data grid with sorting/filtering, summary statistics panel, and CSV/JSON import. FastAPI endpoints for dataset discovery, preview, stats, and filtering.
- **Motion Capture**: React page with capture source selector (C3D, OpenPose, MediaPipe), 2D skeleton visualization with bone rendering, recording/playback controls. FastAPI endpoints for sources, sessions, and playback.

## Changes
- 3 new FastAPI route modules: `putting_green.py`, `data_explorer.py`, `motion_capture.py`
- 4 new React page components with full TypeScript typing
- 4 new frontend test files (data structure + logic validation)
- 33 Python Pydantic contract tests in `test_phase5_api.py`
- 4 new routes in `App.tsx` at `/tools/{tool-name}`
- `web_route` fields added to `launcher_manifest.json` for navigation
- All routers registered in `server.py`

## Test plan
- [x] 33 Python API contract tests pass (`test_phase5_api.py`)
- [x] 85 total API tests pass (Phase 4 + Phase 5)
- [x] 300 frontend vitest tests pass (including 4 new test files)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] ESLint passes clean
- [x] Vite build succeeds

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new API surface areas (file import + dataset filtering, in-memory caches, and physics-engine invocation) and new UI routes, which could impact resource usage and error handling despite being largely additive.
> 
> **Overview**
> Adds **Phase 5 tool-page support** end-to-end: new React routes/pages for `PuttingGreen`, `VideoAnalyzer`, `DataExplorer`, and `MotionCapture`, plus launcher manifest `web_route` entries so these tools can be navigated to from the UI.
> 
> Introduces new FastAPI routers for `putting_green`, `data_explorer`, and `motion_capture` and registers them in `server.py`, enabling endpoints for putting simulation/green reading/scatter, dataset listing/preview/stats/filter/import, and motion-capture source listing/skeleton templates/session + playback APIs. Adds Python contract tests (`test_phase5_api.py`) and page-level Vitest type/logic tests for the new UI pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf1d3786b21234588a85e62cb40d35494aab100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->