### PR TITLE
refactor: Remove all sys.path hacks from 48 files (closes #1297)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,12 @@ ignore_errors = true
 [tool.pytest.ini_options]
 # Consolidated pytest configuration (replaces duplicate pytest.ini files)
 testpaths = ["tests"]
+pythonpath = [
+    ".",
+    "src",
+    "src/shared/python",
+    "vendor/ud-tools/src/shared/python",
+]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"

--- a/scripts/create_issues_from_assessment.py
+++ b/scripts/create_issues_from_assessment.py
@@ -14,7 +14,6 @@ from typing import Any
 # Add project root to path for imports
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 # noqa: E402 -- Required for local imports from project root in standalone scripts
 from scripts.script_utils import run_main, setup_script_logging

--- a/scripts/finalize_comprehensive_assessment.py
+++ b/scripts/finalize_comprehensive_assessment.py
@@ -12,7 +12,6 @@ from pathlib import Path
 # Add project root to path for imports
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.script_utils import run_main, setup_script_logging  # noqa: E402
 

--- a/scripts/generate_assessment_summary.py
+++ b/scripts/generate_assessment_summary.py
@@ -18,7 +18,6 @@ from typing import Any
 # Add project root to path for imports
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.script_utils import run_main, setup_script_logging  # noqa: E402
 

--- a/scripts/migrate_api_keys.py
+++ b/scripts/migrate_api_keys.py
@@ -46,7 +46,6 @@ from typing import Any
 from src.shared.python.path_utils import get_src_root
 
 # Add parent directory to path for imports
-sys.path.insert(0, str(get_src_root()))
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url

--- a/scripts/refactor_dry_orthogonality.py
+++ b/scripts/refactor_dry_orthogonality.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 # Add repo root to path
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT))
 
 from src.shared.python.logging_config import get_logger  # noqa: E402
 

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -21,7 +21,6 @@ from typing import Any, TypeVar
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parent
 if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from src.shared.python.logging_config import get_logger, setup_logging  # noqa: E402
 

--- a/scripts/show_physics_parameters.py
+++ b/scripts/show_physics_parameters.py
@@ -6,8 +6,6 @@ from pathlib import Path
 # Add project root to path first (script is in scripts/ directory)
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROJECT_ROOT = _SCRIPT_DIR.parent
-sys.path.insert(0, str(_PROJECT_ROOT))
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from src.shared.python.physics.physics_parameters import get_registry  # noqa: E402
 

--- a/scripts/validate_suite.py
+++ b/scripts/validate_suite.py
@@ -12,14 +12,11 @@ from pathlib import Path
 # Add project root to path first (script is in scripts/ directory)
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROJECT_ROOT = _SCRIPT_DIR.parent
-sys.path.insert(0, str(_PROJECT_ROOT))
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from src.shared.python.path_utils import get_src_root  # noqa: E402
 
 # Add suite root to path
 SUITE_ROOT = get_src_root()
-sys.path.insert(0, str(SUITE_ROOT))
 
 from src.shared.python.common_utils import setup_logging  # noqa: E402
 

--- a/scripts/verify_physics.py
+++ b/scripts/verify_physics.py
@@ -16,14 +16,11 @@ import pytest
 # Add project root to path first (script is in scripts/ directory)
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROJECT_ROOT = _SCRIPT_DIR.parent
-sys.path.insert(0, str(_PROJECT_ROOT))
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from src.shared.python.path_utils import get_src_root  # noqa: E402
 
 # Add root to path
 ROOT_DIR = get_src_root()
-sys.path.append(str(ROOT_DIR))
 
 from src.shared.python.engine_manager import EngineManager  # noqa: E402
 

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/python/tests/test_example.py
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/python/tests/test_example.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 from src import constants, logger_utils
 
 

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/tools/code_quality_check.py
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[5]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
@@ -6,7 +6,6 @@ Test script to verify data loading and GUI functionality
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from golf_gui_application import GolfVisualizerMainWindow
 from PyQt6.QtWidgets import QApplication

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_improved_visualization.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_improved_visualization.py
@@ -16,7 +16,6 @@ import numpy as np
 import pandas as pd
 
 # Add the current directory to Python path
-sys.path.append(str(Path(__file__).parent))
 
 from golf_gui_application import GolfVisualizerMainWindow
 from PyQt6.QtWidgets import QApplication

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
@@ -13,7 +13,6 @@ import numpy as np
 import scipy.io
 
 # Add the current directory to the path so we can import the golf modules
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from golf_data_core import MatlabDataLoader
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
@@ -20,7 +20,6 @@ except (ImportError, ValueError):
     # target: src/
     src_path = Path(__file__).resolve().parent.parent.parent
     if str(src_path) not in sys.path:
-        sys.path.insert(0, str(src_path))
     try:
         from c3d_reader import C3DDataReader  # type: ignore[no-redef]
         from logger_utils import log_execution_time

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_constants_file.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_constants_file.py
@@ -8,7 +8,6 @@ import pytest
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(project_root))
 
 # Import constants after adding to path
 # Use try/except to handle different path configurations

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_quality_check.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_quality_check.py
@@ -7,9 +7,7 @@ from pathlib import Path
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(project_root))
 scripts_path = project_root / "scripts"
-sys.path.insert(0, str(scripts_path))
 
 # Import the quality check module
 # Use importlib to import from scripts directory

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/tools/code_quality_check.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[5]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/engines/pendulum_models/tools/code_quality_check.py
+++ b/src/engines/pendulum_models/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/engines/physics_engines/drake/python/__main__.py
+++ b/src/engines/physics_engines/drake/python/__main__.py
@@ -13,7 +13,6 @@ try:
             break
 
     if suite_root and str(suite_root) not in sys.path:
-        sys.path.insert(0, str(suite_root))
 except (FileNotFoundError, OSError):
     pass
 

--- a/src/engines/physics_engines/drake/python/src/drake_gui_app.py
+++ b/src/engines/physics_engines/drake/python/src/drake_gui_app.py
@@ -14,7 +14,6 @@ _project_root = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
 )
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 import numpy as np  # noqa: E402
 

--- a/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
+++ b/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
@@ -21,7 +21,6 @@ _project_root = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
 )
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from src.shared.python.engine_availability import (  # noqa: E402
     DRAKE_AVAILABLE,

--- a/src/engines/physics_engines/drake/tools/code_quality_check.py
+++ b/src/engines/physics_engines/drake/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[5]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/engines/physics_engines/mujoco/docker_test_dependencies.py
+++ b/src/engines/physics_engines/mujoco/docker_test_dependencies.py
@@ -81,7 +81,6 @@ def test_specific_imports() -> bool:
         # Add the python directory to path
         python_dir = "/workspace/python"
         if python_dir not in sys.path:
-            sys.path.insert(0, python_dir)
             logger.info("  Added %s to Python path", python_dir)
 
         if importlib.util.find_spec("mujoco_humanoid_golf.urdf_io"):

--- a/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
+++ b/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
@@ -20,7 +20,6 @@ from typing import Any
 # Path: src/engines/physics_engines/mujoco/python/humanoid_launcher.py -> need 6 parents
 _project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 import numpy as np  # noqa: E402
 from PyQt6.QtCore import Qt  # noqa: E402

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/__main__.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/__main__.py
@@ -14,7 +14,6 @@ try:
             break
 
     if suite_root and str(suite_root) not in sys.path:
-        sys.path.insert(0, str(suite_root))
 except (FileNotFoundError, OSError):
     pass
 

--- a/src/engines/physics_engines/mujoco/rebuild_docker.py
+++ b/src/engines/physics_engines/mujoco/rebuild_docker.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 # Add repo root to path for imports
 _repo_root = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_repo_root))
 
 from scripts.script_utils import run_command, setup_script_logging  # noqa: E402
 

--- a/src/engines/physics_engines/mujoco/tools/code_quality_check.py
+++ b/src/engines/physics_engines/mujoco/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[5]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
+++ b/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
@@ -16,7 +16,6 @@ from typing import Any
 # Path: src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py -> need 6 parents
 _project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 import numpy as np  # noqa: E402
 

--- a/src/engines/physics_engines/pinocchio/docs/api/conf.py
+++ b/src/engines/physics_engines/pinocchio/docs/api/conf.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 # Add python directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 
 project = "DTACK Golf Biomechanics Platform"
 copyright = "2024, Dieter Olson"

--- a/src/engines/physics_engines/pinocchio/python/__main__.py
+++ b/src/engines/physics_engines/pinocchio/python/__main__.py
@@ -13,7 +13,6 @@ try:
             break
 
     if suite_root and str(suite_root) not in sys.path:
-        sys.path.insert(0, str(suite_root))
 except (FileNotFoundError, OSError):
     pass
 

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
@@ -12,7 +12,6 @@ _project_root = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
 )
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 import numpy as np  # noqa: E402
 import pinocchio as pin  # type: ignore  # noqa: E402

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
@@ -21,7 +21,6 @@ _project_root = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent
 )
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from src.shared.python.engine_availability import (  # noqa: E402
     PINOCCHIO_AVAILABLE,

--- a/src/engines/physics_engines/pinocchio/python/tests/test_imports.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_imports.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 
 # Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 
 def test_import_pinocchio_golf() -> None:

--- a/src/engines/physics_engines/pinocchio/python/tests/validation/test_model_validation.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/validation/test_model_validation.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(REPO_ROOT / "python"))
 
 from dtack.utils.urdf_exporter import URDFExporter  # isort: skip # noqa: E402
 

--- a/src/engines/physics_engines/pinocchio/scripts/verify_pipeline.py
+++ b/src/engines/physics_engines/pinocchio/scripts/verify_pipeline.py
@@ -8,7 +8,6 @@ import numpy as np
 from src.shared.python.logging_config import get_logger, setup_logging
 
 # Add project root to path
-sys.path.append(str(Path(__file__).parent.parent))
 
 try:
     import pinocchio as pin

--- a/src/engines/physics_engines/pinocchio/tools/code_quality_check.py
+++ b/src/engines/physics_engines/pinocchio/tools/code_quality_check.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # Add the repo root to path to enable importing the authoritative module
 repo_root = Path(__file__).resolve().parents[5]
-sys.path.insert(0, str(repo_root))
 
 # Import and run the authoritative quality check
 from src.tools.code_quality_check import main  # noqa: E402

--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any
 
 # Add current directory to path so we can import ui_components if needed locally
-sys.path.append(str(Path(__file__).parent))
 
 from PyQt6.QtCore import QEventLoop, QTimer
 from PyQt6.QtGui import QCloseEvent, QIcon

--- a/src/launchers/launcher_simulation.py
+++ b/src/launchers/launcher_simulation.py
@@ -76,7 +76,6 @@ class LauncherSimulationMixin:
         import_check_code = f"""
 import sys
 import os
-sys.path.insert(0, os.getcwd())
 try:
     import {module_name}
     print("OK")

--- a/src/shared/python/validation_pkg/kaggle_validation.py
+++ b/src/shared/python/validation_pkg/kaggle_validation.py
@@ -268,7 +268,6 @@ def compare_all_models_to_dataset(
     from pathlib import Path
 
     # Import flight models
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared" / "python"))
 
     from flight_models import (
         BallFlightModel,

--- a/src/tools/humanoid_character_builder/tests/conftest.py
+++ b/src/tools/humanoid_character_builder/tests/conftest.py
@@ -10,4 +10,3 @@ from pathlib import Path
 
 _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
-    sys.path.insert(0, _tools_dir)

--- a/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
+++ b/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
@@ -18,7 +18,6 @@ from pathlib import Path as _Path
 
 _tools_dir = str(_Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
-    sys.path.insert(0, _tools_dir)
 # Evict cached modules that resolve to the wrong location, but preserve
 # anything pytest is currently loading (i.e. anything containing "src." or
 # ".tests").

--- a/src/tools/model_explorer/bundled_assets/__init__.py
+++ b/src/tools/model_explorer/bundled_assets/__init__.py
@@ -23,7 +23,6 @@ from typing import Any
 # Add project root to path for src imports when run as part of tool
 _project_root = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from src.shared.python.logger_utils import get_logger  # noqa: E402
 

--- a/src/tools/model_explorer/launch_model_explorer.py
+++ b/src/tools/model_explorer/launch_model_explorer.py
@@ -8,7 +8,6 @@ from pathlib import Path
 # Path: src/tools/model_explorer/launch_model_explorer.py -> need 4 parents
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 # CRITICAL: Import MuJoCo BEFORE any Qt imports to avoid DLL conflicts on Windows.
 # Qt's OpenGL context initialization conflicts with MuJoCo's plugin loading.

--- a/src/tools/model_explorer/model_library.py
+++ b/src/tools/model_explorer/model_library.py
@@ -30,7 +30,6 @@ from src.shared.python.security_utils import validate_url_scheme
 # Add project root to path for src imports when run as standalone script
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from src.shared.python.logger_utils import get_logger  # noqa: E402
 

--- a/src/tools/model_explorer/model_loader_dialog.py
+++ b/src/tools/model_explorer/model_loader_dialog.py
@@ -13,7 +13,6 @@ from typing import Any
 # Add project root to path for src imports
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from PyQt6.QtCore import Qt, pyqtSignal  # noqa: E402
 from PyQt6.QtWidgets import (  # noqa: E402

--- a/src/tools/model_explorer/visualization_widget.py
+++ b/src/tools/model_explorer/visualization_widget.py
@@ -13,7 +13,6 @@ from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
 # Add project root to path
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
 
 from src.shared.python.engine_availability import MUJOCO_AVAILABLE  # noqa: E402
 from src.shared.python.logging_config import get_logger  # noqa: E402

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -57,7 +57,6 @@ class TestLauncherIntegration:
     def test_unified_launcher_show_status(self):
         """Test UnifiedLauncher.show_status() method."""
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root))
 
         from unittest.mock import patch
 
@@ -79,7 +78,6 @@ class TestEngineProbes:
     def test_engine_manager_probes_available(self):
         """Verify EngineManager has probe functionality."""
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root))
 
         from src.shared.python.engine_manager import EngineManager
 
@@ -92,7 +90,6 @@ class TestEngineProbes:
     def test_probe_all_engines(self):
         """Test probing all engines."""
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root))
 
         from unittest.mock import MagicMock, patch
 
@@ -116,7 +113,6 @@ class TestEngineProbes:
     def test_diagnostic_report_generation(self):
         """Test generating diagnostic report."""
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root))
 
         from unittest.mock import MagicMock, patch
 
@@ -137,7 +133,6 @@ class TestEngineProbes:
     def test_at_least_one_engine_available(self):
         """Verify at least one engine is available or properly diagnosed."""
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root))
 
         from unittest.mock import MagicMock, patch
 
@@ -294,7 +289,6 @@ class TestOutputManager:
         import tempfile
 
         suite_root = get_repo_root()
-        sys.path.insert(0, str(suite_root / "shared" / "python"))
 
         from src.shared.python.output_manager import OutputFormat, OutputManager
 


### PR DESCRIPTION
Phase 1 Emergency Triage: Removes sys.path.insert/append from 48 files across src/, tests/, and scripts/. Adds pythonpath config to pyproject.toml. Preserves import_utils.py centralized path management utility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor of import/path resolution across many entrypoints and tests; main risk is runtime/import regressions in non-pytest execution contexts (standalone scripts, engine launchers) if the environment doesn’t set `PYTHONPATH` similarly.
> 
> **Overview**
> Removes widespread `sys.path.insert`/`append` “path hacks” across scripts, tools wrappers, engine entrypoints, and tests, relying on normal package imports instead.
> 
> Updates `pyproject.toml` pytest config to set `pythonpath` (repo root, `src`, shared python, and vendored shared python) so tests and utilities can resolve imports without per-file path mutation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92579953516421005cf6a6b20c7719ba934058d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->