### PR TITLE
refactor: Narrow 25 broad except Exception handlers (closes #1294)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
@@ -34,7 +34,7 @@ def test_data_loading():
 
         return {"baseq": baseq_data, "ztcfq": ztcfq_data, "deltaq": deltaq_data}
 
-    except Exception as e:
+    except (FileNotFoundError, ValueError, KeyError, OSError):
         logger.info(f"❌ Data loading failed: {e}")
         return None
 
@@ -69,7 +69,7 @@ def test_gui_launch():
             logger.info("❌ No data available for GUI test")
             return False
 
-    except Exception as e:
+    except (FileNotFoundError, ValueError, KeyError, OSError):
         logger.info(f"❌ GUI launch failed: {e}")
         return False
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_new_data_format.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_new_data_format.py
@@ -42,7 +42,7 @@ def test_new_data_files():
 
                         return True
 
-        except Exception as e:
+        except (FileNotFoundError, ValueError, KeyError, OSError):
             logger.info(f"❌ Error testing {filename}: {e}")
 
     return False

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
@@ -55,7 +55,7 @@ def test_matlab_data_structure():
                     else:
                         logger.info(f"  {key}: {type(value).__name__}")
 
-        except Exception as e:
+        except (FileNotFoundError, ValueError, KeyError, OSError):
             logger.info(f"❌ Error loading {filename}: {e}")
             return False
 
@@ -95,7 +95,7 @@ def test_data_loader():
 
         return True
 
-    except Exception as e:
+    except (FileNotFoundError, ValueError, KeyError, OSError):
         logger.info(f"❌ Error in data loader: {e}")
         import traceback
 
@@ -134,7 +134,7 @@ def test_frame_processor():
 
         return True
 
-    except Exception as e:
+    except (FileNotFoundError, ValueError, KeyError, OSError):
         logger.info(f"❌ Error in frame processor: {e}")
         import traceback
 import logging
@@ -185,7 +185,7 @@ def analyze_signal_bus_structure():
 
         return True
 
-    except Exception as e:
+    except (FileNotFoundError, ValueError, KeyError, OSError):
         logger.info(f"❌ Error analyzing signal bus structure: {e}")
         return False
 
@@ -212,7 +212,7 @@ def main():
         logger.info(f"\n{'=' * 20} {test_name} {'=' * 20}")
         try:
             results[test_name] = test_func()
-        except Exception as e:
+        except (FileNotFoundError, ValueError, KeyError, OSError):
             logger.info(f"❌ {test_name} failed with exception: {e}")
             results[test_name] = False
 

--- a/src/engines/pendulum_models/python/double_pendulum_model/tests/test_ui_smoke.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/tests/test_ui_smoke.py
@@ -11,5 +11,5 @@ def test_smoke() -> None:
     try:
         window = PendulumController()
         assert window is not None
-    except Exception as e:  # noqa: BLE001
+    except (ImportError, RuntimeError):  # noqa: BLE001
         pytest.fail(f"Could not instantiate PendulumController: {e}")

--- a/src/engines/physics_engines/mujoco/test_dependencies.py
+++ b/src/engines/physics_engines/mujoco/test_dependencies.py
@@ -40,7 +40,7 @@ def test_numpy_compatibility() -> None:
     try:
         qpos = data.qpos
         assert isinstance(qpos, np.ndarray | object)  # Depending on binding version
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         logger.warning(f"Direct numpy access check warning: {e}")
 
 
@@ -52,7 +52,7 @@ def test_rendering_backend() -> None:
         from mujoco import MjRenderContextOffscreen  # noqa: F401
     except ImportError:
         logger.warning("MjRenderContextOffscreen not available (might be old version)")
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         # It's okay if it fails to initialize in this test,
         # we just want to know if the symbol exists
         pass

--- a/src/engines/physics_engines/mujoco/test_docker_venv.py
+++ b/src/engines/physics_engines/mujoco/test_docker_venv.py
@@ -35,7 +35,7 @@ def test_docker_venv() -> bool:
             logger.info("❌ robotics_env Docker image not found")
             logger.info("   Run: docker build -t robotics_env . (from docker/ directory)")
             return False
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         logger.info(f"❌ Failed to check Docker images: {e}")
         return False
 
@@ -51,7 +51,7 @@ def test_docker_venv() -> bool:
             logger.info("✓ Container uses virtual environment Python")
         else:
             logger.info("⚠️  Container may not be using virtual environment")
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         logger.info(f"❌ Failed to check Python path: {e}")
 
     # Test 3: Check if defusedxml is available in container
@@ -74,7 +74,7 @@ def test_docker_venv() -> bool:
     except subprocess.CalledProcessError as e:
         logger.info(f"❌ defusedxml not available: {e.stderr}")
         return False
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         logger.info(f"❌ Failed to test defusedxml: {e}")
         return False
 
@@ -98,7 +98,7 @@ def test_docker_venv() -> bool:
     except subprocess.CalledProcessError as e:
         logger.info(f"❌ defusedxml.ElementTree import failed: {e.stderr}")
         return False
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         logger.info(f"❌ Failed to test defusedxml.ElementTree: {e}")
         return False
 
@@ -133,7 +133,7 @@ def test_docker_venv() -> bool:
         except subprocess.CalledProcessError as e:
             logger.info(f"❌ mujoco_golf_pendulum.urdf_io import failed: {e.stderr}")
             return False
-        except Exception as e:
+        except (ImportError, ModuleNotFoundError, OSError):
             logger.info(f"❌ Failed to test module import: {e}")
             return False
 

--- a/src/engines/physics_engines/mujoco/test_mechanisms.py
+++ b/src/engines/physics_engines/mujoco/test_mechanisms.py
@@ -23,7 +23,7 @@ def inclined_plane_model() -> mujoco.MjModel:
     try:
         model = mujoco.MjModel.from_xml_string(TWO_LINK_INCLINED_PLANE_UNIVERSAL_XML)
         return model
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError):
         pytest.fail(f"Failed to load inclined plane model: {e}")
 
 

--- a/src/engines/physics_engines/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/tests/test_induced_acceleration.py
@@ -117,7 +117,7 @@ def test_mujoco_iaa_logic():
 
     try:
         phys = MockPhysics()
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         pytest.skip("Failed to initialize MuJoCo model")
 
     res = iaa_helper.compute_induced_accelerations(phys)

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -534,7 +534,7 @@ class LauncherUISetupMixin:
                 logger.info("Synced chat session: %s", session_id)
         except (ImportError, OSError) as e:
             logger.debug("Chat server sync skipped (server may not be running): %s", e)
-        except Exception as e:
+        except (ImportError, RuntimeError, OSError):
             # Catch any other unexpected errors (e.g. urllib.error.HTTPError)
             # to prevent crashing the launcher during initialization
             logger.debug("Chat session sync failed: %s", e)

--- a/src/shared/models/myosuite/examples/train_elbow_policy.py
+++ b/src/shared/models/myosuite/examples/train_elbow_policy.py
@@ -132,7 +132,7 @@ def evaluate_policy(model: SAC, env: gym.Env, n_episodes: int = 5) -> None:
             # Visualize (if display available)
             try:
                 env.mj_render()
-            except Exception:
+            except (ValueError, RuntimeError):
                 pass  # Headless mode
 
         logger.info(f"Episode {episode + 1}: Steps={step}, Reward={total_reward:.2f}")

--- a/src/shared/models/opensim/opensim-models/test_models.py
+++ b/src/shared/models/opensim/opensim-models/test_models.py
@@ -35,7 +35,7 @@ for i in range(len(osimpaths)):
     try:
         model = opensim.Model(filename)
         s = model.initSystem()
-    except Exception as e:
+    except (ImportError, OSError):
         logger.info(f"Oops, Model '{modelname}' failed:\n{e.message}")
         sys.exit(1)
 
@@ -48,7 +48,7 @@ for i in range(len(osimpaths)):
     try:
         reloadedModel = opensim.Model(filename_new)
         s2 = reloadedModel.initSystem()
-    except Exception as e:
+    except (ImportError, OSError):
         logger.info(f"Oops, 4.0 written Model '{modelname_new}' failed:\n{e.message}")
         sys.exit(1)
 

--- a/src/shared/models/opensim/opensim-models/update_models.py
+++ b/src/shared/models/opensim/opensim-models/update_models.py
@@ -34,7 +34,7 @@ for i in range(len(osimpaths)):
     try:
         model = opensim.Model(filename)
         s = model.initSystem()
-    except Exception:
+    except (ImportError, OSError):
         sys.exit(1)
 
     # Print the latest model to file
@@ -43,5 +43,5 @@ for i in range(len(osimpaths)):
     try:
         reloadedModel = opensim.Model(filename)
         s2 = reloadedModel.initSystem()
-    except Exception:
+    except (ImportError, OSError):
         sys.exit(1)

--- a/src/shared/python/tests/test_launcher_integration.py
+++ b/src/shared/python/tests/test_launcher_integration.py
@@ -74,5 +74,5 @@ def test_mujoco_availability_logic():
     try:
         available = engine_availability.is_engine_available("mujoco")
         assert isinstance(available, bool)
-    except Exception as e:
+    except (ImportError, RuntimeError):
         pytest.fail(f"Checking MuJoCo availability raised exception: {e}")


### PR DESCRIPTION
Replaces 25 broad except Exception handlers with specific exception types (ImportError, OSError, ValueError, etc). 11 remaining are intentionally broad (noqa: BLE001). Prioritized physics engine and data loading code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical changes, but narrowing exception handling can surface previously-hidden failures and alter test/launcher behavior; some updated handlers appear error-prone (e.g., missing `as e` / stray characters) and could introduce new runtime or syntax errors.
> 
> **Overview**
> This PR refactors various scripts/tests (Simscape golf GUI loaders, MuJoCo/pendulum/launcher integration tests, OpenSim utilities, and a MyoSuite example) to **replace broad `except Exception` handlers with specific exception types** such as `ImportError`, `ModuleNotFoundError`, `OSError`, `ValueError`, `KeyError`, and `RuntimeError`.
> 
> Net effect is tighter error handling and more intentional test skipping/failure behavior around optional dependencies (e.g., MuJoCo/GL, Docker tooling, OpenSim, PyQt instantiation) rather than swallowing unrelated runtime errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ff76e9d69e3e63b4b0b11ebed80501acb41b5ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->