### PR TITLE
chore: Add return type hints to 1086 functions across 160 files

### DIFF
--- a/src/api/auth/middleware.py
+++ b/src/api/auth/middleware.py
@@ -32,7 +32,7 @@ class LocalUser:
 class OptionalAuth(HTTPBearer):
     """Bearer auth that's optional in local mode."""
 
-    def __init__(self, auto_error: bool = True):
+    def __init__(self, auto_error: bool = True) -> None:
         super().__init__(auto_error=auto_error)
 
     async def __call__(

--- a/src/api/auth/security.py
+++ b/src/api/auth/security.py
@@ -84,7 +84,7 @@ def compute_prefix_hash(prefix: str) -> str:
 class SecurityManager:
     """Handles authentication and authorization security."""
 
-    def __init__(self, secret_key: str = SECRET_KEY):
+    def __init__(self, secret_key: str = SECRET_KEY) -> None:
         """Initialize security manager.
 
         Args:
@@ -247,7 +247,7 @@ class SecurityManager:
 class RoleChecker:
     """Role-based access control checker."""
 
-    def __init__(self, required_role: UserRole):
+    def __init__(self, required_role: UserRole) -> None:
         """Initialize role checker.
 
         Args:

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -149,7 +149,7 @@ def create_local_app() -> FastAPI:
 
     # Launcher logos endpoint - serves tile logo images for React frontend
     @app.get("/api/launcher/logos/{logo_name:path}")
-    async def get_launcher_logo(logo_name: str):
+    async def get_launcher_logo(logo_name: str) -> Any:
         """Serve logo images from assets/logos directory."""
         from fastapi.responses import FileResponse
 
@@ -385,7 +385,7 @@ def create_local_app() -> FastAPI:
             from fastapi.responses import FileResponse
 
             @app.get("/{full_path:path}")
-            async def serve_spa(request: Request, full_path: str):
+            async def serve_spa(request: Request, full_path: str) -> Any:
                 """Serve the SPA index.html for all non-API routes."""
                 if full_path.startswith("api/"):
                     return JSONResponse(
@@ -499,7 +499,7 @@ def create_local_app() -> FastAPI:
     return app
 
 
-def print_logo_animated():
+def print_logo_animated() -> None:
     """Print the Upstream Drift logo with scroll animation."""
     import sys
     import time
@@ -535,14 +535,14 @@ def print_logo_animated():
     logger.info("")
 
 
-def print_matrix_status(message: str, indent: int = 4):
+def print_matrix_status(message: str, indent: int = 4) -> None:
     """Print status message in matrix green style."""
     GREEN = "\033[38;5;46m"  # Bright matrix green
     RESET = "\033[0m"
     logger.info("%s%s>%s %s%s%s", " " * indent, GREEN, RESET, GREEN, message, RESET)
 
 
-def print_server_info(host: str, port: int):
+def print_server_info(host: str, port: int) -> None:
     """Print server info box."""
     CYAN = "\033[38;5;51m"
     RESET = "\033[0m"
@@ -567,7 +567,7 @@ def print_server_info(host: str, port: int):
         logger.info("    Press Ctrl+C to stop.\n")
 
 
-def main():
+def main() -> None:
     """Launch local server with auto-open browser."""
     import time
     import webbrowser
@@ -596,7 +596,7 @@ def main():
     logger.info("")
 
     # Open browser after server starts
-    def open_browser():
+    def open_browser() -> None:
         if os.environ.get("GOLF_NO_BROWSER") != "true":
             webbrowser.open(f"http://{host}:{port}")
 

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -22,7 +22,7 @@ class SimulationFrame(BaseModel):
 async def simulation_stream(
     websocket: WebSocket,
     engine_type: str,
-):
+) -> None:
     """
     Stream simulation in real-time over WebSocket.
 

--- a/src/api/services/analysis_service.py
+++ b/src/api/services/analysis_service.py
@@ -29,7 +29,7 @@ class AnalysisService:
     by interfacing with the active physics engine.
     """
 
-    def __init__(self, engine_manager: EngineManager):
+    def __init__(self, engine_manager: EngineManager) -> None:
         """Initialize analysis service.
 
         Args:

--- a/src/api/services/simulation_service.py
+++ b/src/api/services/simulation_service.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 class SimulationService:
     """Service for managing physics simulations."""
 
-    def __init__(self, engine_manager: EngineManager):
+    def __init__(self, engine_manager: EngineManager) -> None:
         """Initialize simulation service.
 
         Args:

--- a/src/api/utils/error_codes.py
+++ b/src/api/utils/error_codes.py
@@ -411,7 +411,7 @@ class APIException(HTTPException):
         code: ErrorCode,
         message: str | None = None,
         details: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """Initialize APIException.
 
         Args:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
@@ -6,7 +6,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def analyze_coordinate_system():
+def analyze_coordinate_system() -> None:
     """Analyze the coordinate system and golfer orientation in the data"""
 
     # Load the Excel file

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_simscape_data.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_simscape_data.py
@@ -11,7 +11,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def analyze_simscape_data(csv_file):
+def analyze_simscape_data(csv_file) -> tuple | None:
     """Analyze the Simscape CSV file and identify key joint positions."""
 
     logger.info("Analyzing Simscape data file: %s", csv_file)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_camera_system.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_camera_system.py
@@ -187,7 +187,7 @@ class CameraController(QObject):
     animationFinished = pyqtSignal()
     modeChanged = pyqtSignal(str)
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # Core state
@@ -230,7 +230,7 @@ class CameraController(QObject):
 
         logger.info("📷 Advanced camera controller initialized")
 
-    def _setup_presets(self):
+    def _setup_presets(self) -> None:
         """Setup predefined camera presets"""
         self.presets = {
             CameraPreset.DEFAULT: CameraState(
@@ -363,7 +363,7 @@ class CameraController(QObject):
     # INTERACTION HANDLING
     # ========================================================================
 
-    def handle_mouse_orbit(self, dx: float, dy: float):
+    def handle_mouse_orbit(self, dx: float, dy: float) -> None:
         """Handle mouse orbital movement"""
         if self.mode != CameraMode.ORBIT:
             return
@@ -387,7 +387,7 @@ class CameraController(QObject):
         self._apply_constraints()
         self.cameraChanged.emit()
 
-    def handle_mouse_pan(self, dx: float, dy: float):
+    def handle_mouse_pan(self, dx: float, dy: float) -> None:
         """Handle mouse panning movement"""
         if self.mode not in [CameraMode.ORBIT, CameraMode.FLY]:
             return
@@ -414,7 +414,7 @@ class CameraController(QObject):
 
         self.cameraChanged.emit()
 
-    def handle_mouse_zoom(self, delta: float):
+    def handle_mouse_zoom(self, delta: float) -> None:
         """Handle mouse wheel zoom"""
         zoom_factor = 1.0 + (delta * self.zoom_sensitivity)
         new_distance = self.current_state.distance / zoom_factor
@@ -429,7 +429,7 @@ class CameraController(QObject):
 
         self.cameraChanged.emit()
 
-    def update_inertia(self):
+    def update_inertia(self) -> None:
         """Update camera movement with inertia"""
         if not self.inertia_enabled:
             return
@@ -489,7 +489,7 @@ class CameraController(QObject):
 
     def set_preset(
         self, preset: CameraPreset, animate: bool = True, duration: float = 1.0
-    ):
+    ) -> None:
         """Set camera to predefined preset"""
         if preset not in self.presets:
             logger.warning("Warning: Preset %s not found", preset)
@@ -511,7 +511,7 @@ class CameraController(QObject):
         target_state: CameraState,
         duration: float = 1.0,
         easing: Callable | None = None,
-    ):
+    ) -> None:
         """Animate camera to target state"""
         # Stop any current animation
         self.stop_animation()
@@ -529,7 +529,7 @@ class CameraController(QObject):
 
         logger.info("📷 Animating camera over %ss", duration)
 
-    def _update_animation(self):
+    def _update_animation(self) -> None:
         """Update ongoing camera animation"""
         if not self.current_state.is_animating:
             return
@@ -586,12 +586,12 @@ class CameraController(QObject):
         if progress >= 1.0:
             self.animationFinished.emit()
 
-    def stop_animation(self):
+    def stop_animation(self) -> None:
         """Stop any ongoing animation"""
         self.animation_timer.stop()
         self.current_state.is_animating = False
 
-    def _copy_state(self, source: CameraState, destination: CameraState):
+    def _copy_state(self, source: CameraState, destination: CameraState) -> None:
         """Copy camera state"""
         destination.position = source.position.copy()
         destination.target = source.target.copy()
@@ -610,7 +610,7 @@ class CameraController(QObject):
         time: float,
         state: CameraState | None = None,
         easing: QEasingCurve.Type = QEasingCurve.Type.InOutCubic,
-    ):
+    ) -> None:
         """Add a keyframe for cinematic animation"""
         if state is None:
             state = CameraState()
@@ -631,14 +631,14 @@ class CameraController(QObject):
 
         logger.info("📷 Added keyframe at %ss", time)
 
-    def clear_keyframes(self):
+    def clear_keyframes(self) -> None:
         """Clear all cinematic keyframes"""
         self.keyframes.clear()
         logger.info("📷 Cleared all keyframes")
 
     def start_cinematic_playback(
         self, duration: float | None = None, loop: bool = False
-    ):
+    ) -> None:
         """Start cinematic camera playback"""
         if not self.keyframes:
             logger.warning("Warning: No keyframes defined for cinematic playback")
@@ -658,7 +658,7 @@ class CameraController(QObject):
 
         logger.info("📷 Started cinematic playback: %ss", self.cinematic_duration)
 
-    def update_cinematic_camera(self, time_delta: float):
+    def update_cinematic_camera(self, time_delta: float) -> None:
         """Update camera position during cinematic playback"""
         if self.mode != CameraMode.CINEMATIC:
             return
@@ -710,7 +710,7 @@ class CameraController(QObject):
 
         self.cameraChanged.emit()
 
-    def stop_cinematic_playback(self):
+    def stop_cinematic_playback(self) -> None:
         """Stop cinematic camera playback"""
         self.mode = CameraMode.ORBIT
         self.animation_timer.stop()
@@ -719,7 +719,7 @@ class CameraController(QObject):
 
     def _interpolate_between_states(
         self, state1: CameraState, state2: CameraState, t: float
-    ):
+    ) -> None:
         """Interpolate between two camera states"""
         # Spherical interpolation
         spherical1 = (state1.distance, state1.azimuth, state1.elevation)
@@ -746,7 +746,7 @@ class CameraController(QObject):
     # AUTO-FRAMING AND SMART FEATURES
     # ========================================================================
 
-    def frame_data(self, data_points: list[np.ndarray], margin: float = 1.5):
+    def frame_data(self, data_points: list[np.ndarray], margin: float = 1.5) -> None:
         """Automatically frame camera to view all data points"""
         if not data_points:
             return
@@ -781,7 +781,7 @@ class CameraController(QObject):
             f"distance={self.current_state.distance:.2f}"
         )
 
-    def follow_point(self, point: np.ndarray, smooth_factor: float = 0.1):
+    def follow_point(self, point: np.ndarray, smooth_factor: float = 0.1) -> None:
         """Smoothly follow a moving point"""
         if self.mode != CameraMode.FOLLOW:
             return
@@ -798,7 +798,7 @@ class CameraController(QObject):
 
     def look_at_point(
         self, point: np.ndarray, animate: bool = True, duration: float = 0.5
-    ):
+    ) -> None:
         """Look at a specific point"""
         if not np.isfinite(point).all():
             return
@@ -818,7 +818,7 @@ class CameraController(QObject):
     # UTILITY METHODS
     # ========================================================================
 
-    def _apply_constraints(self):
+    def _apply_constraints(self) -> None:
         """Apply camera constraints"""
         # Distance constraints
         self.current_state.distance = np.clip(
@@ -846,14 +846,14 @@ class CameraController(QObject):
                 self.current_state.target, min_bounds, max_bounds
             )
 
-    def set_mode(self, mode: CameraMode):
+    def set_mode(self, mode: CameraMode) -> None:
         """Set camera operation mode"""
         if mode != self.mode:
             self.mode = mode
             self.modeChanged.emit(mode.value)
             logger.info("📷 Camera mode: %s", mode.value)
 
-    def reset_to_default(self, animate: bool = True):
+    def reset_to_default(self, animate: bool = True) -> None:
         """Reset camera to default position"""
         self.set_preset(CameraPreset.DEFAULT, animate)
 
@@ -869,7 +869,7 @@ class CameraController(QObject):
             "mode": self.mode.value,
         }
 
-    def load_state_dict(self, state_dict: dict, animate: bool = True):
+    def load_state_dict(self, state_dict: dict, animate: bool = True) -> None:
         """Load camera state from dictionary"""
         target_state = CameraState()
         target_state.position = np.array(

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
@@ -49,7 +49,7 @@ except ImportError as e:
 class EnhancedGolfVisualizerApp(QApplication):
     """Enhanced main application with advanced features"""
 
-    def __init__(self, argv):
+    def __init__(self, argv) -> None:
         super().__init__(argv)
 
         # Application metadata
@@ -73,7 +73,7 @@ class EnhancedGolfVisualizerApp(QApplication):
 
         logger.info("Enhanced Golf Visualizer App initialized")
 
-    def _setup_application_style(self):
+    def _setup_application_style(self) -> None:
         """Setup application-wide styling and fonts"""
         # Set default font
         font = QFont("Segoe UI", 9)
@@ -148,7 +148,7 @@ class EnhancedGolfVisualizerApp(QApplication):
 
         return splash
 
-    def _auto_load_data(self):
+    def _auto_load_data(self) -> None:
         """Attempt to auto-load data files if they exist"""
         data_files = ["BASEQ.mat", "ZTCFQ.mat", "DELTAQ.mat"]
 
@@ -165,7 +165,7 @@ class PerformanceMonitor(QThread):
 
     performanceUpdate = pyqtSignal(dict)
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.monitoring = False
         self.stats = {
@@ -175,19 +175,19 @@ class PerformanceMonitor(QThread):
             "frame_rate": 0.0,
         }
 
-    def start_monitoring(self):
+    def start_monitoring(self) -> None:
         """Start performance monitoring"""
         self.monitoring = True
         self.start()
         logger.info("Performance monitoring started")
 
-    def stop_monitoring(self):
+    def stop_monitoring(self) -> None:
         """Stop performance monitoring"""
         self.monitoring = False
         self.wait()
         logger.info("Performance monitoring stopped")
 
-    def run(self):
+    def run(self) -> None:
         """Performance monitoring loop"""
         while self.monitoring:
             try:
@@ -211,7 +211,7 @@ class PerformanceMonitor(QThread):
 class EnhancedMainWindow(GolfVisualizerMainWindow):
     """Enhanced main window with additional features"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # Enhanced camera system
@@ -231,7 +231,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
 
         logger.info("Enhanced main window initialized")
 
-    def _integrate_camera_system(self):
+    def _integrate_camera_system(self) -> None:
         """Integrate advanced camera system"""
         if hasattr(self.gl_widget, "camera_controller"):
             # Replace the basic camera with our advanced system
@@ -247,7 +247,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
         # Add camera preset menu
         self._add_camera_preset_menu()
 
-    def _add_camera_preset_menu(self):
+    def _add_camera_preset_menu(self) -> None:
         """Add camera preset menu to menubar"""
         menubar = self.menuBar()
         camera_menu = menubar.addMenu("Camera")
@@ -283,7 +283,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
             self._demo_cinematic_tour
         )
 
-    def _setup_enhanced_features(self):
+    def _setup_enhanced_features(self) -> None:
         """Setup enhanced application features"""
         # Add toolbar extensions
         self._add_enhanced_toolbar()
@@ -294,7 +294,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
         # Setup status monitoring
         self._setup_status_monitoring()
 
-    def _add_enhanced_toolbar(self):
+    def _add_enhanced_toolbar(self) -> None:
         """Add enhanced toolbar with additional controls"""
         toolbar = self.findChild(object, "MainToolBar")  # Find existing toolbar
         if toolbar:
@@ -315,7 +315,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
             export_action.setToolTip("Export Data/Video")
             export_action.triggered.connect(self._show_export_dialog)
 
-    def _setup_enhanced_shortcuts(self):
+    def _setup_enhanced_shortcuts(self) -> None:
         """Setup enhanced keyboard shortcuts"""
         from PyQt6.QtGui import QKeySequence, QShortcut
 
@@ -350,7 +350,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
             self._toggle_measurement_mode
         )
 
-    def _setup_status_monitoring(self):
+    def _setup_status_monitoring(self) -> None:
         """Setup enhanced status monitoring"""
         # Create timer for regular status updates
         self.status_timer = QTimer()
@@ -428,16 +428,16 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
     # ENHANCED FEATURE IMPLEMENTATIONS
     # ========================================================================
 
-    def _on_camera_mode_changed(self, mode: str):
+    def _on_camera_mode_changed(self, mode: str) -> None:
         """Handle camera mode changes"""
         self.statusBar().showMessage(f"Camera mode: {mode}")
         logger.info(f"Camera mode changed to: {mode}")
 
-    def _on_camera_animation_finished(self):
+    def _on_camera_animation_finished(self) -> None:
         """Handle camera animation completion"""
         self.statusBar().showMessage("Camera animation complete")
 
-    def _demo_orbit_animation(self):
+    def _demo_orbit_animation(self) -> None:
         """Demonstrate smooth orbit animation"""
         if not self.gl_widget.frame_processor:
             QMessageBox.information(self, "Info", "Please load data first")
@@ -458,7 +458,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
         self.camera_controller.animate_to_state(target_state, duration=4.0)
         self.statusBar().showMessage("Demonstrating orbit animation...")
 
-    def _demo_cinematic_tour(self):
+    def _demo_cinematic_tour(self) -> None:
         """Demonstrate cinematic camera tour"""
         if not self.gl_widget.frame_processor:
             QMessageBox.information(self, "Info", "Please load data first")
@@ -485,25 +485,25 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
         self.camera_controller.start_cinematic_playback(duration=10.0, loop=False)
         self.statusBar().showMessage("Playing cinematic tour...")
 
-    def _jump_frames(self, delta: int):
+    def _jump_frames(self, delta: int) -> None:
         """Jump multiple frames at once"""
         if self.gl_widget.frame_processor:
             new_frame = self.gl_widget.current_frame + delta
             new_frame = max(0, min(new_frame, self.gl_widget.num_frames - 1))
             self.gl_widget.set_frame(new_frame)
 
-    def _toggle_realtime_analysis(self):
+    def _toggle_realtime_analysis(self) -> None:
         """Toggle real-time analysis display"""
         # This would toggle additional analysis overlays
         self.statusBar().showMessage("Real-time analysis toggled")
         logger.info("Real-time analysis toggled")
 
-    def _toggle_measurement_mode(self):
+    def _toggle_measurement_mode(self) -> None:
         """Toggle measurement/annotation mode"""
         self.statusBar().showMessage("Measurement mode toggled")
         logger.info("Measurement mode toggled")
 
-    def _start_recording(self):
+    def _start_recording(self) -> None:
         """Start recording animation"""
         try:
             filename = f"golf_swing_recording_{int(time.time())}.mp4"
@@ -515,7 +515,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
                 self, "Recording Error", f"Failed to start recording:\n{e}"
             )
 
-    def _show_export_dialog(self):
+    def _show_export_dialog(self) -> None:
         """Show export options dialog"""
         from PyQt6.QtWidgets import (
             QCheckBox,
@@ -588,7 +588,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
             self.statusBar().showMessage("Export started...")
             logger.info("Export dialog accepted")
 
-    def _update_enhanced_status(self):
+    def _update_enhanced_status(self) -> None:
         """Update enhanced status information"""
         if self.gl_widget.frame_processor:
             # Update performance panel with additional info
@@ -605,7 +605,7 @@ class EnhancedMainWindow(GolfVisualizerMainWindow):
 class SessionManager:
     """Manage analysis sessions and data persistence"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.sessions: dict[str, dict] = {}
         self.current_session: str | None = None
 
@@ -628,7 +628,7 @@ class SessionManager:
         logger.info(f"Created session: {session_id}")
         return session_id
 
-    def save_session(self, session_id: str, filepath: str):
+    def save_session(self, session_id: str, filepath: str) -> None:
         """Save session to file"""
         if session_id in self.sessions:
             import json
@@ -657,16 +657,16 @@ class SessionManager:
 class ExportManager:
     """Manage various export functionalities"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.export_queue: list[dict] = []
         self.is_exporting = False
 
-    def export_video(self, frames: list, output_path: str, fps: int = 30):
+    def export_video(self, frames: list, output_path: str, fps: int = 30) -> None:
         """Export frames as video"""
         # This would use OpenCV or similar to create video
         logger.info(f"Exporting video: {output_path}")
 
-    def export_data(self, data: dict, output_path: str, format: str = "csv"):
+    def export_data(self, data: dict, output_path: str, format: str = "csv") -> None:
         """Export analysis data"""
         if format.lower() == "csv":
             import pandas as pd
@@ -675,7 +675,7 @@ class ExportManager:
             df.to_csv(output_path, index=False)
         logger.info(f"Exported data: {output_path}")
 
-    def export_images(self, frames: list, output_dir: str, format: str = "png"):
+    def export_images(self, frames: list, output_dir: str, format: str = "png") -> None:
         """Export frame sequence as images"""
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # Export logic here
@@ -685,17 +685,17 @@ class ExportManager:
 class PluginManager:
     """Manage plugins and extensions"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.plugins: dict[str, object] = {}
         self.plugin_dir = Path("plugins")
 
-    def load_plugins(self):
+    def load_plugins(self) -> None:
         """Load available plugins"""
         if self.plugin_dir.exists():
             logger.info("Loading plugins...")
             # Plugin loading logic here
 
-    def register_plugin(self, name: str, plugin: object):
+    def register_plugin(self, name: str, plugin: object) -> None:
         """Register a plugin"""
         self.plugins[name] = plugin
         logger.info(f"Plugin registered: {name}")
@@ -706,11 +706,11 @@ class PluginManager:
 # ============================================================================
 
 
-def main():
+def main() -> Any:
     """Enhanced main entry point with comprehensive error handling"""
 
     # Setup exception handling
-    def handle_exception(exc_type, exc_value, exc_traceback):
+    def handle_exception(exc_type, exc_value, exc_traceback) -> None:
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
             return

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/final_robustness_test.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/final_robustness_test.py
@@ -12,7 +12,7 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-def test_data_loading_accuracy():
+def test_data_loading_accuracy() -> bool:
     """Test the accuracy of data loading"""
     logger.info("🔍 TESTING DATA LOADING ACCURACY")
     logger.info("%s", "=" * 60)
@@ -87,7 +87,7 @@ def test_data_loading_accuracy():
         return False
 
 
-def test_data_consistency():
+def test_data_consistency() -> bool:
     """Test consistency between datasets"""
     logger.info("\n🔄 TESTING DATA CONSISTENCY")
     logger.info("%s", "=" * 60)
@@ -148,7 +148,7 @@ def test_data_consistency():
         return False
 
 
-def test_error_handling():
+def test_error_handling() -> bool:
     """Test error handling capabilities"""
     logger.error("\n🛡️ TESTING ERROR HANDLING")
     logger.info("%s", "=" * 60)
@@ -191,7 +191,7 @@ def test_error_handling():
         return False
 
 
-def test_performance():
+def test_performance() -> bool:
     """Test performance characteristics"""
     logger.info("\n⚡ TESTING PERFORMANCE")
     logger.info("%s", "=" * 60)
@@ -238,7 +238,7 @@ def test_performance():
         return False
 
 
-def generate_final_report():
+def generate_final_report() -> Any:
     """Generate the final robustness report"""
     logger.info("📋 FINAL ROBUSTNESS AND ACCURACY ANALYSIS REPORT")
     logger.info("%s", "=" * 80)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
@@ -72,12 +72,12 @@ class FrameData:
         default_factory=lambda: np.array([1, 0, 0], dtype=np.float32)
     )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Calculate derived properties after initialization"""
         self._calculate_shaft_properties()
         self._ensure_data_types()
 
-    def _calculate_shaft_properties(self):
+    def _calculate_shaft_properties(self) -> None:
         """Calculate shaft vector, length and ensure proper types"""
         if np.isfinite([self.butt, self.clubhead]).all():
             self.shaft_vector = self.clubhead - self.butt
@@ -86,7 +86,7 @@ class FrameData:
             self.shaft_vector = np.array([0, 0, 1], dtype=np.float32)
             self.shaft_length = 1.0
 
-    def _ensure_data_types(self):
+    def _ensure_data_types(self) -> None:
         """Ensure all arrays are float32 for OpenGL compatibility"""
         for attr_name in [
             "butt",
@@ -188,7 +188,7 @@ class PerformanceStats:
     memory_usage_mb: float = 0.0
     frame_times: list[float] = field(default_factory=list)
 
-    def update_frame_time(self, frame_time: float):
+    def update_frame_time(self, frame_time: float) -> None:
         """Update frame timing statistics"""
         self.frame_times.append(frame_time)
         if len(self.frame_times) > 120:  # Keep last 2 seconds at 60fps
@@ -208,7 +208,7 @@ class PerformanceStats:
 class MatlabDataLoader:
     """High-performance MATLAB data loader with caching and validation"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.cache = {}
         self.load_stats = {}
 
@@ -406,7 +406,7 @@ class MatlabDataLoader:
             )
             return np.zeros(num_rows, dtype=np.float32)
 
-    def _validate_dataframe(self, df: pd.DataFrame, dataset_name: str):
+    def _validate_dataframe(self, df: pd.DataFrame, dataset_name: str) -> None:
         """Validate DataFrame has required columns and data"""
         required_columns = [
             "Butt",
@@ -436,7 +436,7 @@ class MatlabDataLoader:
         if len(df) == 0:
             raise ValueError(f"No data rows in {dataset_name}")
 
-    def _validate_dataset_consistency(self, datasets: dict[str, pd.DataFrame]):
+    def _validate_dataset_consistency(self, datasets: dict[str, pd.DataFrame]) -> None:
         """Validate that all datasets have consistent frame counts"""
         frame_counts = {name: len(df) for name, df in datasets.items()}
 
@@ -460,7 +460,7 @@ class FrameProcessor:
         self,
         datasets: tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame],
         config: RenderConfig,
-    ):
+    ) -> None:
         self.baseq_df, self.ztcfq_df, self.deltaq_df = datasets
         self.config = config
         self.num_frames = len(self.baseq_df)
@@ -482,13 +482,13 @@ class FrameProcessor:
         # Track current frame for UI coordination
         self.current_frame = 0
 
-    def set_filter(self, filter_type: str):
+    def set_filter(self, filter_type: str) -> None:
         """Set the data filter and invalidate dynamics cache."""
         if filter_type != self.current_filter:
             self.current_filter = filter_type
             self.invalidate_cache()
 
-    def invalidate_cache(self):
+    def invalidate_cache(self) -> None:
         """Invalidate cached dynamics data."""
         with self._dynamics_cache_lock:
             self.dynamics_cache = {}
@@ -517,7 +517,7 @@ class FrameProcessor:
 
         return frame_data
 
-    def _calculate_dynamics_for_filter(self):
+    def _calculate_dynamics_for_filter(self) -> None:
         """Calculate inverse dynamics for the entire dataset with the current filter.
 
         Note: Must be called while holding self._dynamics_cache_lock.
@@ -670,18 +670,18 @@ class FrameProcessor:
         """Get time vector."""
         return self.time_vector
 
-    def set_filter_type(self, filter_type: str):
+    def set_filter_type(self, filter_type: str) -> None:
         """Set the current filter type and invalidate cached filtered data"""
         self.set_filter(filter_type)  # Use existing method
 
-    def set_filter_param(self, param_name: str, value):
+    def set_filter_param(self, param_name: str, value) -> None:
         """Set a filter parameter and invalidate cached filtered data"""
         if not hasattr(self, "filter_params"):
             self.filter_params = {}
         self.filter_params[param_name] = value
         self.invalidate_cache()
 
-    def set_vector_visibility(self, vector_type: str, visible: bool):
+    def set_vector_visibility(self, vector_type: str, visible: bool) -> None:
         """Set visibility for calculated vector types"""
         if vector_type == "force":
             self.config.show_calculated_force = visible
@@ -689,7 +689,7 @@ class FrameProcessor:
             self.config.show_calculated_torque = visible
         # Update any other vector types as needed
 
-    def set_vector_scale(self, vector_type: str, scale: float):
+    def set_vector_scale(self, vector_type: str, scale: float) -> None:
         """Set scale for vector rendering"""
         if vector_type == "all":
             self.config.calculated_vector_scale = scale

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
@@ -71,7 +71,7 @@ class SmoothPlaybackController(QObject):
     frameUpdated = pyqtSignal(FrameData)  # Emits interpolated frame data
     positionChanged = pyqtSignal(float)  # Emits current position (0.0 to total_frames)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
 
         # Frame data
@@ -89,7 +89,7 @@ class SmoothPlaybackController(QObject):
         self.is_playing = False
         self.loop_playback = True  # Default to looping
 
-    def load_frame_processor(self, frame_processor: FrameProcessor):
+    def load_frame_processor(self, frame_processor: FrameProcessor) -> None:
         """Load frame processor with motion data"""
         self.frame_processor = frame_processor
         self.stop()
@@ -105,7 +105,7 @@ class SmoothPlaybackController(QObject):
         return self._current_position
 
     @position.setter
-    def position(self, value: float):
+    def position(self, value: float) -> None:
         """Set playback position with interpolation"""
         if self.frame_processor is None:
             return
@@ -122,7 +122,7 @@ class SmoothPlaybackController(QObject):
     # Playback Control
     # ========================================================================
 
-    def play(self):
+    def play(self) -> None:
         """Start smooth playback"""
         if self.frame_processor is None:
             return
@@ -152,7 +152,7 @@ class SmoothPlaybackController(QObject):
 
         self.is_playing = True
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause playback"""
         if not self.is_playing:
             return
@@ -160,20 +160,20 @@ class SmoothPlaybackController(QObject):
         self.animation.pause()
         self.is_playing = False
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop playback and reset to beginning"""
         self.animation.stop()
         self.is_playing = False
         self.seek(0.0)
 
-    def toggle_playback(self):
+    def toggle_playback(self) -> None:
         """Toggle between play and pause"""
         if self.is_playing:
             self.pause()
         else:
             self.play()
 
-    def seek(self, position: float):
+    def seek(self, position: float) -> None:
         """Seek to specific frame position"""
         if self.frame_processor is None:
             return
@@ -188,7 +188,7 @@ class SmoothPlaybackController(QObject):
         if was_playing:
             self.play()
 
-    def set_playback_speed(self, speed: float):
+    def set_playback_speed(self, speed: float) -> None:
         """Set playback speed multiplier (0.5 = half speed, 2.0 = double speed)"""
         self._playback_speed = np.clip(speed, 0.1, 10.0)
 
@@ -307,11 +307,11 @@ class SmoothPlaybackController(QObject):
     # Internal Callbacks
     # ========================================================================
 
-    def _on_position_changed(self, value: float):
+    def _on_position_changed(self, value: float) -> None:
         """Called by QPropertyAnimation on every frame update"""
         # Position property setter handles the interpolation
 
-    def _on_animation_finished(self):
+    def _on_animation_finished(self) -> None:
         """Called when animation completes"""
         self.is_playing = False
 
@@ -328,7 +328,7 @@ class SmoothPlaybackController(QObject):
 class MotionCaptureTab(QWidget):
     """Tab for motion capture data visualization with smooth playback"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.parent = parent
         self.frame_processor = None
@@ -341,7 +341,7 @@ class MotionCaptureTab(QWidget):
         self._setup_ui()
         self._setup_connections()
 
-    def _setup_ui(self):
+    def _setup_ui(self) -> None:
         """Setup the motion capture tab UI"""
         layout = QVBoxLayout()
 
@@ -359,7 +359,7 @@ class MotionCaptureTab(QWidget):
 
         self.setLayout(layout)
 
-    def _create_control_panel(self):
+    def _create_control_panel(self) -> Any:
         """Create the control panel for motion capture data"""
         panel = QGroupBox("Motion Capture Controls")
         layout = QGridLayout()
@@ -407,7 +407,7 @@ class MotionCaptureTab(QWidget):
         panel.setLayout(layout)
         return panel
 
-    def _setup_connections(self):
+    def _setup_connections(self) -> None:
         """Setup signal connections"""
         self.load_button.clicked.connect(self._load_motion_capture_data)
         self.play_button.clicked.connect(self._toggle_playback)
@@ -417,7 +417,7 @@ class MotionCaptureTab(QWidget):
         # Visualization checkboxes don't need connections anymore
         # (handled by smooth frame updates)
 
-    def _load_motion_capture_data(self):
+    def _load_motion_capture_data(self) -> None:
         """Load motion capture data"""
         try:
             swing_type = self.swing_combo.currentText()
@@ -457,12 +457,12 @@ class MotionCaptureTab(QWidget):
             self.status_label.setText(f"Error loading data: {str(e)}")
             traceback.print_exc()
 
-    def _on_swing_changed(self, swing_type: str):
+    def _on_swing_changed(self, swing_type: str) -> None:
         """Handle swing type change"""
         if self.frame_processor is not None:
             self._load_motion_capture_data()
 
-    def _toggle_playback(self):
+    def _toggle_playback(self) -> None:
         """Toggle smooth playback"""
         if not self.frame_processor:
             return
@@ -474,12 +474,12 @@ class MotionCaptureTab(QWidget):
         else:
             self.play_button.setText("Play")
 
-    def _on_slider_moved(self, value: int):
+    def _on_slider_moved(self, value: int) -> None:
         """Handle manual slider movement (scrubbing)"""
         # Seek to slider position for smooth scrubbing
         self.playback_controller.seek(float(value))
 
-    def _on_position_changed(self, position: float):
+    def _on_position_changed(self, position: float) -> None:
         """Update UI when playback position changes"""
         total_frames = (
             len(self.frame_processor.time_vector) if self.frame_processor else 0
@@ -493,7 +493,7 @@ class MotionCaptureTab(QWidget):
         self.frame_slider.setValue(int(position))
         self.frame_slider.blockSignals(False)
 
-    def _on_smooth_frame_updated(self, frame_data: FrameData):
+    def _on_smooth_frame_updated(self, frame_data: FrameData) -> None:
         """Called on every interpolated frame update (60+ FPS!)"""
         if not self.opengl_widget.renderer:
             return
@@ -522,12 +522,12 @@ class MotionCaptureTab(QWidget):
 class SimulinkModelTab(QWidget):
     """Tab for Simulink model data visualization (future)"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.parent = parent
         self._setup_ui()
 
-    def _setup_ui(self):
+    def _setup_ui(self) -> None:
         """Setup the Simulink model tab UI"""
         layout = QVBoxLayout()
 
@@ -558,12 +558,12 @@ class SimulinkModelTab(QWidget):
 class ComparisonTab(QWidget):
     """Tab for comparing motion capture vs Simulink model data"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.parent = parent
         self._setup_ui()
 
-    def _setup_ui(self):
+    def _setup_ui(self) -> None:
         """Setup the comparison tab UI"""
         layout = QVBoxLayout()
 
@@ -599,7 +599,7 @@ class ComparisonTab(QWidget):
 class GolfVisualizerWidget(QOpenGLWidget):
     """OpenGL widget for 3D golf swing visualization"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.renderer = None
         self.frame_processor = None
@@ -622,7 +622,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
         # Set focus policy for keyboard events
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
-    def initializeGL(self):
+    def initializeGL(self) -> None:
         """Initialize OpenGL context"""
         try:
             # Create moderngl context
@@ -644,12 +644,12 @@ class GolfVisualizerWidget(QOpenGLWidget):
             logger.error("❌ OpenGL initialization failed: %s", e)
             traceback.print_exc()
 
-    def resizeGL(self, w: int, h: int):
+    def resizeGL(self, w: int, h: int) -> None:
         """Handle OpenGL widget resize"""
         if self.renderer:
             self.renderer.set_viewport(w, h)
 
-    def paintGL(self):
+    def paintGL(self) -> None:
         """Render the OpenGL scene"""
         if not self.renderer or not self.current_frame_data:
             return
@@ -760,7 +760,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
 
     def load_data_from_dataframes(
         self, dataframes: tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
-    ):
+    ) -> None:
         """Load data from pandas DataFrames"""
         try:
             baseq_df, ztcfq_df, deltaq_df = dataframes
@@ -790,13 +790,13 @@ class GolfVisualizerWidget(QOpenGLWidget):
             logger.error("❌ Data loading failed: %s", e)
             traceback.print_exc()
 
-    def update_frame(self, frame_data: FrameData, render_config: RenderConfig):
+    def update_frame(self, frame_data: FrameData, render_config: RenderConfig) -> None:
         """Update the current frame data and render config"""
         self.current_frame_data = frame_data
         self.current_render_config = render_config
         self.update()
 
-    def _frame_camera_to_data(self):
+    def _frame_camera_to_data(self) -> None:
         """Frame camera to show all data and set proper ground level"""
         if not self.current_frame_data:
             return
@@ -838,44 +838,44 @@ class GolfVisualizerWidget(QOpenGLWidget):
             f"distance={self.camera_distance:.2f}"
         )
 
-    def set_face_on_view(self):
+    def set_face_on_view(self) -> None:
         """Set camera to face-on view (looking at golfer from front)"""
         self.camera_azimuth = 0.0
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Face-on view")
 
-    def set_down_the_line_view(self):
+    def set_down_the_line_view(self) -> None:
         """Set camera to down-the-line view (90° from face-on)"""
         self.camera_azimuth = 90.0  # 90° from face-on, not 180°
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Down-the-line view")
 
-    def set_behind_view(self):
+    def set_behind_view(self) -> None:
         """Set camera to behind view (180° from face-on)"""
         self.camera_azimuth = 180.0
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Behind view")
 
-    def set_above_view(self):
+    def set_above_view(self) -> None:
         """Set camera to overhead view"""
         self.camera_azimuth = 0.0
         self.camera_elevation = 80.0
         self.update()
         logger.info("📷 Camera: Overhead view")
 
-    def mousePressEvent(self, event):
+    def mousePressEvent(self, event) -> None:
         """Handle mouse press events"""
         self.last_mouse_pos = event.pos()
         self.mouse_pressed = True
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent(self, event) -> None:
         """Handle mouse release events"""
         self.mouse_pressed = False
 
-    def mouseMoveEvent(self, event):
+    def mouseMoveEvent(self, event) -> None:
         """Handle mouse move events"""
         if not self.mouse_pressed or not self.last_mouse_pos:
             return
@@ -906,14 +906,14 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.last_mouse_pos = event.pos()
         self.update()
 
-    def wheelEvent(self, event):
+    def wheelEvent(self, event) -> None:
         """Handle mouse wheel events"""
         zoom_factor = 1.1 if event.angleDelta().y() > 0 else 0.9
         self.camera_distance *= zoom_factor
         self.camera_distance = np.clip(self.camera_distance, 0.1, 50.0)
         self.update()
 
-    def keyPressEvent(self, event):
+    def keyPressEvent(self, event) -> None:
         """Handle keyboard shortcuts"""
         key = event.key()
 
@@ -945,7 +945,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
 class GolfVisualizerMainWindow(QMainWindow):
     """Main window for the Golf Swing Visualizer with tabular interface"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Golf Swing Visualizer - Multi-Data Analysis Platform")
         self.setGeometry(100, 100, 1200, 800)  # More reasonable window size
@@ -960,7 +960,7 @@ class GolfVisualizerMainWindow(QMainWindow):
 
         logger.info("[*] Golf Visualizer main window created")
 
-    def _setup_ui(self):
+    def _setup_ui(self) -> None:
         """Setup the main UI with tabular structure"""
         # Create central widget with tab widget
         self.central_widget = QWidget()
@@ -988,7 +988,7 @@ class GolfVisualizerMainWindow(QMainWindow):
         global_controls = self._create_global_controls()
         main_layout.addWidget(global_controls)
 
-    def _create_global_controls(self):
+    def _create_global_controls(self) -> Any:
         """Create global control panel"""
         panel = QGroupBox("Global Controls")
         layout = QGridLayout()
@@ -1038,7 +1038,7 @@ class GolfVisualizerMainWindow(QMainWindow):
         panel.setLayout(layout)
         return panel
 
-    def _setup_menu(self):
+    def _setup_menu(self) -> None:
         """Setup the menu bar"""
         menubar = self.menuBar()
 
@@ -1080,13 +1080,13 @@ class GolfVisualizerMainWindow(QMainWindow):
         about_action.triggered.connect(self._show_about)
         help_menu.addAction(about_action)
 
-    def _setup_status_bar(self):
+    def _setup_status_bar(self) -> None:
         """Setup the status bar"""
         self.status_bar = QStatusBar()
         self.setStatusBar(self.status_bar)
         self.status_bar.showMessage("Ready - Select a tab to begin analysis")
 
-    def _apply_modern_style(self):
+    def _apply_modern_style(self) -> None:
         """Apply modern white theme"""
         self.setStyleSheet("""
             QMainWindow {
@@ -1224,13 +1224,13 @@ class GolfVisualizerMainWindow(QMainWindow):
             }
         """)
 
-    def _load_motion_capture_data(self):
+    def _load_motion_capture_data(self) -> None:
         """Load motion capture data"""
         # This will be handled by the motion capture tab
         self.tab_widget.setCurrentIndex(0)
         self.motion_capture_tab._load_motion_capture_data()
 
-    def _export_video(self):
+    def _export_video(self) -> None:
         """Export current animation to high-quality video"""
         # Check if we have data loaded
         tab = self.motion_capture_tab
@@ -1250,33 +1250,33 @@ class GolfVisualizerMainWindow(QMainWindow):
         )
         dialog.exec()
 
-    def _reset_camera(self):
+    def _reset_camera(self) -> None:
         """Reset camera to default position"""
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget._frame_camera_to_data()
             self.gl_widget.update()
 
-    def _set_face_on_view(self):
+    def _set_face_on_view(self) -> None:
         """Set face-on camera view"""
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget.set_face_on_view()
 
-    def _set_down_line_view(self):
+    def _set_down_line_view(self) -> None:
         """Set down-the-line camera view"""
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget.set_down_the_line_view()
 
-    def _set_behind_view(self):
+    def _set_behind_view(self) -> None:
         """Set behind camera view"""
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget.set_behind_view()
 
-    def _set_above_view(self):
+    def _set_above_view(self) -> None:
         """Set overhead camera view"""
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget.set_above_view()
 
-    def _toggle_face_normal(self, state):
+    def _toggle_face_normal(self, state) -> None:
         """Toggle face normal visibility"""
         if (
             hasattr(self, "gl_widget")
@@ -1286,7 +1286,7 @@ class GolfVisualizerMainWindow(QMainWindow):
             self.gl_widget.current_render_config.show_face_normal = bool(state)
             self.gl_widget.update()
 
-    def _toggle_ball(self, state):
+    def _toggle_ball(self, state) -> None:
         """Toggle ball visibility"""
         if (
             hasattr(self, "gl_widget")
@@ -1296,7 +1296,7 @@ class GolfVisualizerMainWindow(QMainWindow):
             self.gl_widget.current_render_config.show_ball = bool(state)
             self.gl_widget.update()
 
-    def _show_about(self):
+    def _show_about(self) -> None:
         """Show about dialog"""
         QMessageBox.about(
             self,
@@ -1317,7 +1317,7 @@ class GolfVisualizerMainWindow(QMainWindow):
 # ============================================================================
 
 
-def main():
+def main() -> None:
     """Main application entry point"""
     app = QApplication(sys.argv)
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
@@ -3,7 +3,7 @@ from scipy import signal
 from scipy.interpolate import UnivariateSpline
 
 
-def butter_lowpass_filter(data, cutoff, fs, order=4):
+def butter_lowpass_filter(data, cutoff, fs, order=4) -> Any:
     """Apply a Butterworth low-pass filter."""
     nyq = 0.5 * fs
     normal_cutoff = cutoff / nyq
@@ -12,19 +12,19 @@ def butter_lowpass_filter(data, cutoff, fs, order=4):
     return y
 
 
-def savitzky_golay_filter(data, window_length=9, polyorder=3):
+def savitzky_golay_filter(data, window_length=9, polyorder=3) -> Any:
     """Apply a Savitzky-Golay filter."""
     if window_length % 2 == 0:
         window_length += 1  # Must be odd
     return signal.savgol_filter(data, window_length, polyorder)
 
 
-def moving_average_filter(data, window_size=5):
+def moving_average_filter(data, window_size=5) -> Any:
     """Apply a moving average filter."""
     return np.convolve(data, np.ones(window_size) / window_size, mode="valid")
 
 
-def calculate_derivatives(data, time):
+def calculate_derivatives(data, time) -> tuple:
     """Calculate velocity and acceleration using splines for accuracy."""
     spline = UnivariateSpline(time, data, s=0)
     velocity = spline.derivative(n=1)(time)
@@ -34,7 +34,7 @@ def calculate_derivatives(data, time):
 
 def calculate_inverse_dynamics(
     position_data, orientation_data, time_vector, club_mass=0.2, eval_offset=0.0
-):
+) -> dict:
     """
     Calculate inverse dynamics (forces and torques).
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_opengl_renderer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_opengl_renderer.py
@@ -150,7 +150,7 @@ class GeometryObject:
     rotation: np.ndarray | None = None
     scale: np.ndarray | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.position is None:
             self.position = np.zeros(3, dtype=np.float32)
         if self.rotation is None:
@@ -162,7 +162,7 @@ class GeometryObject:
 class GeometryManager:
     """Fixed geometry management"""
 
-    def __init__(self, ctx: mgl.Context):
+    def __init__(self, ctx: mgl.Context) -> None:
         self.ctx = ctx
         self.geometry_objects: dict[str, GeometryObject] = {}
         self.mesh_library: dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
@@ -172,7 +172,7 @@ class GeometryManager:
         self._create_standard_meshes()
         self._compile_shaders()
 
-    def _create_standard_meshes(self):
+    def _create_standard_meshes(self) -> None:
         """Create simple mesh library"""
         try:
             logger.info("🔧 Creating standard meshes...")
@@ -207,7 +207,7 @@ class GeometryManager:
             traceback.print_exc()
             raise
 
-    def _create_ground_mesh(self):
+    def _create_ground_mesh(self) -> None:
         """Create simple ground plane mesh"""
         size = 10.0
         vertices = [
@@ -241,7 +241,7 @@ class GeometryManager:
             np.array(indices, dtype=np.uint32),
         )
 
-    def _compile_shaders(self):
+    def _compile_shaders(self) -> None:
         """Compile fixed shader programs"""
         try:
             logger.info("🔧 Compiling shader programs...")
@@ -322,7 +322,7 @@ class GeometryManager:
         position: np.ndarray,
         rotation: np.ndarray,
         scale: float | np.ndarray,
-    ):
+    ) -> None:
         """Update object transformation efficiently"""
         if name not in self.geometry_objects:
             return
@@ -336,7 +336,7 @@ class GeometryManager:
         else:
             obj.scale = np.array(scale, dtype=np.float32)
 
-    def set_object_visibility(self, name: str, visible: bool):
+    def set_object_visibility(self, name: str, visible: bool) -> None:
         """Set object visibility"""
         if name in self.geometry_objects:
             self.geometry_objects[name].visible = visible
@@ -362,7 +362,7 @@ class GeometryManager:
 
         return T @ R @ S
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up OpenGL resources"""
         for obj in self.geometry_objects.values():
             obj.vao.release()
@@ -381,7 +381,7 @@ class GeometryManager:
 class OpenGLRenderer:
     """High-performance OpenGL renderer with modern shaders"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.ctx = None
         self.geometry_manager = None
         self.programs = {}
@@ -399,7 +399,7 @@ class OpenGLRenderer:
             "render_time_ms": 0.0,
         }
 
-    def initialize(self, ctx: mgl.Context):
+    def initialize(self, ctx: mgl.Context) -> None:
         """Initialize OpenGL context and resources"""
         self.ctx = ctx
 
@@ -420,7 +420,7 @@ class OpenGLRenderer:
         logger.info("   OpenGL Version: %s", self.ctx.info["GL_VERSION"])
         logger.info("   Renderer: %s", self.ctx.info["GL_RENDERER"])
 
-    def _create_standard_objects(self):
+    def _create_standard_objects(self) -> None:
         """Create standard geometry objects for rendering"""
         if not self.geometry_manager:
             return
@@ -452,7 +452,7 @@ class OpenGLRenderer:
             f"geometry objects"
         )
 
-    def set_viewport(self, width: int, height: int):
+    def set_viewport(self, width: int, height: int) -> None:
         """Set viewport size"""
         self.viewport_size = (width, height)
         if self.ctx:
@@ -466,7 +466,7 @@ class OpenGLRenderer:
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
-    ):
+    ) -> None:
         """Render complete frame with all elements"""
         if not self.ctx or not self.geometry_manager:
             return
@@ -502,7 +502,7 @@ class OpenGLRenderer:
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
-    ):
+    ) -> None:
         """Render ground plane at proper level with golf grid"""
         if not self.geometry_manager:
             return
@@ -559,7 +559,7 @@ class OpenGLRenderer:
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
-    ):
+    ) -> None:
         """Render all body segments"""
         if not self.geometry_manager:
             return
@@ -687,7 +687,7 @@ class OpenGLRenderer:
         color: list[float],
         opacity: float,
         program: mgl.Program,
-    ):
+    ) -> None:
         """Render cylinder between two 3D points"""
         if not self.geometry_manager:
             return
@@ -755,7 +755,7 @@ class OpenGLRenderer:
         color: list[float],
         opacity: float,
         program: mgl.Program,
-    ):
+    ) -> None:
         """Render sphere at specific point"""
         if not self.geometry_manager:
             return
@@ -794,7 +794,7 @@ class OpenGLRenderer:
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
-    ):
+    ) -> None:
         """Render golf club with improved geometry and face normal"""
         if not self.geometry_manager:
             return
@@ -900,7 +900,7 @@ class OpenGLRenderer:
                 "ball", ball_position, ball_radius, ball_color, 1.0, program
             )
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up OpenGL resources"""
         if self.geometry_manager:
             self.geometry_manager.cleanup()

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
@@ -46,12 +46,12 @@ class DataLoadingThread(QThread):
     loadingProgress = pyqtSignal(str)
     loadingError = pyqtSignal(str)
 
-    def __init__(self, excel_file_path: str, config: WiffleDataConfig):
+    def __init__(self, excel_file_path: str, config: WiffleDataConfig) -> None:
         super().__init__()
         self.excel_file_path = excel_file_path
         self.config = config
 
-    def run(self):
+    def run(self) -> None:
         """Load data in background thread"""
         try:
             self.loadingProgress.emit("Initializing Wiffle data loader...")
@@ -80,7 +80,7 @@ class DataLoadingThread(QThread):
 class WiffleGolfMainWindow(QMainWindow):
     """Enhanced main window with Wiffle_ProV1 data support"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # Window setup
@@ -108,7 +108,7 @@ class WiffleGolfMainWindow(QMainWindow):
 
         logger.info("🎯 Wiffle Golf Main Window initialized")
 
-    def _create_ui(self):
+    def _create_ui(self) -> None:
         """Create the main user interface"""
         # Central widget
         central_widget = QWidget()
@@ -129,7 +129,7 @@ class WiffleGolfMainWindow(QMainWindow):
         # Connect signals
         self._connect_signals()
 
-    def _create_control_panels(self):
+    def _create_control_panels(self) -> None:
         """Create dockable control panels"""
         # Data loading panel
         self.data_panel = self._create_data_panel()
@@ -310,7 +310,7 @@ class WiffleGolfMainWindow(QMainWindow):
         layout.addStretch()
         return panel
 
-    def _create_menu_bar(self):
+    def _create_menu_bar(self) -> None:
         """Create menu bar"""
         menubar = self.menuBar()
 
@@ -343,7 +343,7 @@ class WiffleGolfMainWindow(QMainWindow):
         about_action.triggered.connect(self._show_about)
         help_menu.addAction(about_action)
 
-    def _create_toolbar(self):
+    def _create_toolbar(self) -> None:
         """Create toolbar"""
         toolbar = self.addToolBar("Main Toolbar")
 
@@ -370,11 +370,11 @@ class WiffleGolfMainWindow(QMainWindow):
         reset_camera_action.triggered.connect(self.visualizer_widget.reset_camera)
         toolbar.addAction(reset_camera_action)
 
-    def _create_status_bar(self):
+    def _create_status_bar(self) -> None:
         """Create status bar"""
         self.statusBar().showMessage("Ready to load Wiffle_ProV1 data")
 
-    def _connect_signals(self):
+    def _connect_signals(self) -> None:
         """Connect widget signals"""
         # Visualizer signals
         self.visualizer_widget.frameChanged.connect(self._on_frame_changed)
@@ -385,13 +385,13 @@ class WiffleGolfMainWindow(QMainWindow):
         self.show_wiffle_cb.toggled.connect(self._on_visibility_changed)
         self.show_difference_cb.toggled.connect(self._on_visibility_changed)
 
-    def _try_auto_load_data(self):
+    def _try_auto_load_data(self) -> None:
         """Try to automatically load the default Excel file"""
         default_file = Path("Matlab Inverse Dynamics/Wiffle_ProV1_club_3D_data.xlsx")
         if default_file.exists():
             self._load_excel_file(str(default_file))
 
-    def _load_excel_file(self, file_path: str = None):
+    def _load_excel_file(self, file_path: str = None) -> None:
         """Load Excel file with Wiffle_ProV1 data"""
         if file_path is None:
             file_path, _ = QFileDialog.getOpenFileName(
@@ -425,12 +425,12 @@ class WiffleGolfMainWindow(QMainWindow):
         self.loading_thread.loadingError.connect(self._on_loading_error)
         self.loading_thread.start()
 
-    def _on_loading_progress(self, message: str):
+    def _on_loading_progress(self, message: str) -> None:
         """Handle loading progress updates"""
         self.progress_text.append(message)
         self.statusBar().showMessage(message)
 
-    def _on_data_loaded(self, baseq, ztcfq, deltaq):
+    def _on_data_loaded(self, baseq, ztcfq, deltaq) -> None:
         """Handle successful data loading"""
         self.baseq_data = baseq
         self.ztcfq_data = ztcfq
@@ -460,14 +460,14 @@ class WiffleGolfMainWindow(QMainWindow):
 
         self.statusBar().showMessage("Data loaded successfully!")
 
-    def _on_loading_error(self, error_message: str):
+    def _on_loading_error(self, error_message: str) -> None:
         """Handle loading errors"""
         self.progress_bar.setVisible(False)
         self.progress_text.setVisible(False)
         QMessageBox.critical(self, "Loading Error", error_message)
         self.statusBar().showMessage("Data loading failed")
 
-    def _on_ball_type_changed(self, ball_type: str):
+    def _on_ball_type_changed(self, ball_type: str) -> None:
         """Handle ball type selection change"""
         if not self.data_loaded:
             return
@@ -488,7 +488,7 @@ class WiffleGolfMainWindow(QMainWindow):
                 self.deltaq_data, self.baseq_data, self.ztcfq_data
             )
 
-    def _on_visibility_changed(self):
+    def _on_visibility_changed(self) -> None:
         """Handle visibility checkbox changes"""
         if not self.data_loaded:
             return
@@ -510,13 +510,13 @@ class WiffleGolfMainWindow(QMainWindow):
         # Trigger visualizer update
         self.visualizer_widget.update()
 
-    def _on_frame_changed(self, frame_idx: int):
+    def _on_frame_changed(self, frame_idx: int) -> None:
         """Handle frame change events"""
         if self.data_loaded:
             # Update metrics for current frame
             self._update_frame_metrics(frame_idx)
 
-    def _reload_data(self):
+    def _reload_data(self) -> None:
         """Reload data with current settings"""
         if hasattr(self, "loading_thread") and self.loading_thread:
             self.loading_thread.quit()
@@ -532,7 +532,7 @@ class WiffleGolfMainWindow(QMainWindow):
                 # This is a simplified approach - in practice you'd store the path
                 self._load_excel_file()
 
-    def _calculate_metrics(self):
+    def _calculate_metrics(self) -> None:
         """Calculate comparison metrics between ProV1 and Wiffle"""
         if not self.data_loaded:
             return
@@ -585,7 +585,7 @@ class WiffleGolfMainWindow(QMainWindow):
         except (KeyError, ValueError, IndexError):
             return 0.0
 
-    def _update_frame_metrics(self, frame_idx: int):
+    def _update_frame_metrics(self, frame_idx: int) -> None:
         """Update metrics for current frame"""
         if not self.data_loaded or frame_idx >= len(self.baseq_data):
             return
@@ -620,7 +620,7 @@ class WiffleGolfMainWindow(QMainWindow):
         except (ValueError, TypeError, RuntimeError):
             pass
 
-    def _export_comparison(self):
+    def _export_comparison(self) -> None:
         """Export comparison data"""
         if not self.data_loaded:
             QMessageBox.warning(self, "No Data", "No data loaded to export")
@@ -664,7 +664,7 @@ class WiffleGolfMainWindow(QMainWindow):
                     self, "Export Error", f"Error exporting data: {str(e)}"
                 )
 
-    def _show_about(self):
+    def _show_about(self) -> None:
         """Show about dialog"""
         QMessageBox.about(
             self,
@@ -681,7 +681,7 @@ class WiffleGolfMainWindow(QMainWindow):
             "Version: 1.0",
         )
 
-    def _apply_modern_style(self):
+    def _apply_modern_style(self) -> None:
         """Apply modern styling to the application"""
         self.setStyleSheet("""
             QMainWindow {
@@ -734,7 +734,7 @@ class WiffleGolfMainWindow(QMainWindow):
         """)
 
 
-def main():
+def main() -> None:
     """Main application entry point"""
     app = QApplication(sys.argv)
     app.setApplicationName("Golf Swing Visualizer - Wiffle_ProV1")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class PerformanceOptionsDialog:
     """Dialog for configuring simulation performance options"""
 
-    def __init__(self, parent):
+    def __init__(self, parent) -> None:
         self.parent = parent
         self.result = None
 
@@ -27,7 +27,7 @@ class PerformanceOptionsDialog:
 
         self.create_dialog()
 
-    def create_dialog(self):
+    def create_dialog(self) -> None:
         """Create the performance options dialog"""
         self.dialog = tk.Toplevel(self.parent)
         self.dialog.title("Simulation Performance Options")
@@ -120,7 +120,7 @@ class PerformanceOptionsDialog:
         # Initialize info display
         self.update_simscape_info()
 
-    def update_simscape_info(self):
+    def update_simscape_info(self) -> None:
         """Update the Simscape option info display"""
         if self.simscape_var.get():
             self.simscape_info.config(
@@ -135,7 +135,7 @@ class PerformanceOptionsDialog:
                 foreground="orange",
             )
 
-    def ok_clicked(self):
+    def ok_clicked(self) -> None:
         """Handle OK button click"""
         self.settings = {
             "disable_simscape_results": self.simscape_var.get(),
@@ -145,24 +145,24 @@ class PerformanceOptionsDialog:
         self.result = self.settings
         self.dialog.destroy()
 
-    def cancel_clicked(self):
+    def cancel_clicked(self) -> None:
         """Handle Cancel button click"""
         self.result = None
         self.dialog.destroy()
 
-    def show(self):
+    def show(self) -> Any:
         """Show the dialog and return the result"""
         self.dialog.wait_window()
         return self.result
 
 
-def get_performance_options(parent):
+def get_performance_options(parent) -> Any:
     """Show performance options dialog and return settings"""
     dialog = PerformanceOptionsDialog(parent)
     return dialog.show()
 
 
-def generate_matlab_performance_script(settings):
+def generate_matlab_performance_script(settings) -> Any:
     """Generate MATLAB script with performance settings"""
     script_lines = []
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
@@ -14,7 +14,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def analyze_matlab_files():
+def analyze_matlab_files() -> bool:
     """Analyze the MATLAB data files to understand the current structure"""
     logger.info("=== Analyzing MATLAB Data Files ===")
 
@@ -58,7 +58,7 @@ def analyze_matlab_files():
     return True
 
 
-def check_signal_bus_structure():
+def check_signal_bus_structure() -> bool:
     """Check if the data structure suggests signal bus logging"""
     logger.info("\n=== Checking Signal Bus Structure ===")
 
@@ -100,7 +100,7 @@ def check_signal_bus_structure():
         return False
 
 
-def check_required_signals():
+def check_required_signals() -> bool:
     """Check if required signals for GUI are present"""
     logger.info("\n=== Checking Required Signals ===")
 
@@ -145,7 +145,7 @@ def check_required_signals():
         return False
 
 
-def main():
+def main() -> Any:
     """Main analysis function"""
     logger.info("🚀 Starting Signal Bus Analysis")
     logger.info("=" * 50)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_improved_visualization.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_improved_visualization.py
@@ -24,7 +24,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def create_sample_data():
+def create_sample_data() -> tuple:
     """Create sample golf swing data for testing"""
     num_frames = 100
 
@@ -94,7 +94,7 @@ def create_sample_data():
     return baseq_df, ztcfq_df, deltaq_df
 
 
-def main():
+def main() -> None:
     """Main test function"""
     logger.info("🎯 Testing Improved Golf Visualization")
     logger.info("=" * 50)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
@@ -45,7 +45,7 @@ class MotionDataConfig:
     filter_noise: bool = True
     interpolate_missing: bool = True
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Set default column mappings if not provided"""
         if self.prov1_columns is None:
             self.prov1_columns = {
@@ -121,7 +121,7 @@ class MotionDataConfig:
 class MotionDataLoader:
     """Loader for motion capture Excel data"""
 
-    def __init__(self, config: MotionDataConfig | None = None):
+    def __init__(self, config: MotionDataConfig | None = None) -> None:
         self.config = config or MotionDataConfig()
         self.data_cache: dict[str, Any] = {}
 
@@ -600,7 +600,7 @@ class MotionDataLoader:
         return deltaq_data
 
 
-def main():
+def main() -> None:
     """Test the Wiffle data loader"""
     logger.info("[TEST] Testing Wiffle Data Loader")
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_headless_gui.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_headless_gui.py
@@ -13,20 +13,20 @@ from apps.core.models import C3DDataModel  # noqa: E402
 
 
 @pytest.fixture
-def app(qtbot):
+def app(qtbot) -> Any:
     """Fixture to provide the main window."""
     window = C3DViewerMainWindow()
     qtbot.addWidget(window)
     return window
 
 
-def test_viewer_startup(app):
+def test_viewer_startup(app) -> None:
     """Smoke test: Verify the application starts up without crashing."""
     assert app.windowTitle() == "C3D Motion Analysis Viewer"
     assert app.tabs.count() == 5  # Ensure all 5 tabs are created
 
 
-def test_load_model_ui_update(app, qtbot):
+def test_load_model_ui_update(app, qtbot) -> None:
     """Verify UI updates when a model is loaded."""
     # Mock data model
     model = C3DDataModel(
@@ -48,7 +48,7 @@ def test_load_model_ui_update(app, qtbot):
 
 
 @patch("apps.c3d_viewer.C3DLoaderThread")
-def test_open_file_dialog_cancel(mock_loader, app, monkeypatch):
+def test_open_file_dialog_cancel(mock_loader, app, monkeypatch) -> None:
     """Test that cancelling the file dialog does nothing."""
     # Mock file dialog to return empty
     monkeypatch.setattr(

--- a/src/engines/physics_engines/drake/python/src/manipulability.py
+++ b/src/engines/physics_engines/drake/python/src/manipulability.py
@@ -55,7 +55,7 @@ class ManipulabilityResult:
 class DrakeManipulabilityAnalyzer:
     """Computes manipulability metrics using Drake."""
 
-    def __init__(self, plant: MultibodyPlant):
+    def __init__(self, plant: MultibodyPlant) -> None:
         """Initialize with a Drake MultibodyPlant."""
         self.plant = plant
         if DRAKE_AVAILABLE:

--- a/src/engines/physics_engines/drake/python/tests/test_drake_visualizer.py
+++ b/src/engines/physics_engines/drake/python/tests/test_drake_visualizer.py
@@ -16,18 +16,18 @@ sys.modules["pydrake.all"] = mock_pydrake
 # RotationMatrix needs to be a class with MakeYRotation classmethod
 class MockRotationMatrix:
     @staticmethod
-    def MakeXRotation(angle):
+    def MakeXRotation(angle) -> Any:
         return MagicMock()
 
     @staticmethod
-    def MakeYRotation(angle):
+    def MakeYRotation(angle) -> Any:
         return MagicMock()
 
     @staticmethod
-    def MakeZRotation(angle):
+    def MakeZRotation(angle) -> Any:
         return MagicMock()
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         pass
 
 
@@ -38,7 +38,7 @@ mock_pydrake.RotationMatrix = MockRotationMatrix
 # coroutines (which causes ValueError on .T).
 # So we make it a simple class or function that returns a mock.
 class MockRigidTransform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
 
@@ -57,21 +57,21 @@ class TestDrakeVisualizer:
     """Test suite for DrakeVisualizer."""
 
     @pytest.fixture
-    def mock_meshcat(self):
+    def mock_meshcat(self) -> Any:
         """Mock Meshcat."""
         return MagicMock()
 
     @pytest.fixture
-    def mock_plant(self):
+    def mock_plant(self) -> Any:
         """Mock MultibodyPlant."""
         return MagicMock()
 
     @pytest.fixture
-    def visualizer(self, mock_meshcat, mock_plant):
+    def visualizer(self, mock_meshcat, mock_plant) -> Any:
         """Create visualizer instance."""
         return DrakeVisualizer(mock_meshcat, mock_plant)
 
-    def test_initialization(self, visualizer, mock_meshcat, mock_plant):
+    def test_initialization(self, visualizer, mock_meshcat, mock_plant) -> None:
         """Test initialization."""
         assert visualizer.meshcat == mock_meshcat
         assert visualizer.plant == mock_plant
@@ -80,7 +80,7 @@ class TestDrakeVisualizer:
         assert len(visualizer.visible_coms) == 0
         assert len(visualizer.visible_ellipsoids) == 0
 
-    def test_toggle_frame_visible(self, visualizer, mock_meshcat):
+    def test_toggle_frame_visible(self, visualizer, mock_meshcat) -> None:
         """Test enabling frame visualization."""
         body_name = "test_body"
 
@@ -96,7 +96,7 @@ class TestDrakeVisualizer:
         # Verify Transforms were set
         assert mock_meshcat.SetTransform.call_count == 3
 
-    def test_toggle_frame_hidden(self, visualizer, mock_meshcat):
+    def test_toggle_frame_hidden(self, visualizer, mock_meshcat) -> None:
         """Test disabling frame visualization."""
         body_name = "test_body"
         visualizer.visible_frames.add(body_name)
@@ -106,7 +106,7 @@ class TestDrakeVisualizer:
         assert body_name not in visualizer.visible_frames
         mock_meshcat.Delete.assert_called_with(f"visual_overlays/frames/{body_name}")
 
-    def test_update_frame_transforms(self, visualizer, mock_meshcat, mock_plant):
+    def test_update_frame_transforms(self, visualizer, mock_meshcat, mock_plant) -> None:
         """Test updating frame transforms."""
         body_name = "test_body"
         visualizer.visible_frames.add(body_name)
@@ -128,7 +128,7 @@ class TestDrakeVisualizer:
             f"visual_overlays/frames/{body_name}", X_WB
         )
 
-    def test_toggle_com_visible(self, visualizer, mock_meshcat):
+    def test_toggle_com_visible(self, visualizer, mock_meshcat) -> None:
         """Test enabling COM visualization."""
         body_name = "test_body"
 
@@ -139,7 +139,7 @@ class TestDrakeVisualizer:
         args, _ = mock_meshcat.SetObject.call_args
         assert args[0] == f"visual_overlays/coms/{body_name}"
 
-    def test_toggle_com_hidden(self, visualizer, mock_meshcat):
+    def test_toggle_com_hidden(self, visualizer, mock_meshcat) -> None:
         """Test disabling COM visualization."""
         body_name = "test_body"
         visualizer.visible_coms.add(body_name)
@@ -149,7 +149,7 @@ class TestDrakeVisualizer:
         assert body_name not in visualizer.visible_coms
         mock_meshcat.Delete.assert_called_with(f"visual_overlays/coms/{body_name}")
 
-    def test_update_com_transforms(self, visualizer, mock_meshcat, mock_plant):
+    def test_update_com_transforms(self, visualizer, mock_meshcat, mock_plant) -> None:
         """Test updating COM transforms."""
         body_name = "test_body"
         visualizer.visible_coms.add(body_name)
@@ -183,7 +183,7 @@ class TestDrakeVisualizer:
         # MockRigidTransform eats them, but no crash is good)
         mock_meshcat.SetTransform.assert_called()
 
-    def test_draw_ellipsoid(self, visualizer, mock_meshcat):
+    def test_draw_ellipsoid(self, visualizer, mock_meshcat) -> None:
         """Test drawing ellipsoid."""
         name = "test_ellipsoid"
         rotation_matrix = np.eye(3)
@@ -204,7 +204,7 @@ class TestDrakeVisualizer:
         assert T_arg.shape == (4, 4)
         np.testing.assert_allclose(T_arg[:3, 3], position)
 
-    def test_clear_ellipsoids(self, visualizer, mock_meshcat):
+    def test_clear_ellipsoids(self, visualizer, mock_meshcat) -> None:
         """Test clearing ellipsoids."""
         visualizer.visible_ellipsoids.add("e1")
         visualizer.clear_ellipsoids()
@@ -212,7 +212,7 @@ class TestDrakeVisualizer:
         assert len(visualizer.visible_ellipsoids) == 0
         mock_meshcat.Delete.assert_called_with("visual_overlays/ellipsoids")
 
-    def test_clear_all(self, visualizer, mock_meshcat):
+    def test_clear_all(self, visualizer, mock_meshcat) -> None:
         """Test clearing all overlays."""
         visualizer.visible_frames.add("f1")
         visualizer.visible_coms.add("c1")

--- a/src/engines/physics_engines/drake/python/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/drake/python/tests/test_induced_acceleration.py
@@ -22,7 +22,7 @@ class TestDrakeInducedAcceleration:
     """Test suite for DrakeInducedAccelerationAnalyzer."""
 
     @pytest.fixture
-    def mock_plant(self):
+    def mock_plant(self) -> Any:
         """Mock MultibodyPlant."""
         plant = MagicMock()
         # Setup basic mock behavior
@@ -30,15 +30,15 @@ class TestDrakeInducedAcceleration:
         return plant
 
     @pytest.fixture
-    def analyzer(self, mock_plant):
+    def analyzer(self, mock_plant) -> Any:
         """Create analyzer instance."""
         return DrakeInducedAccelerationAnalyzer(mock_plant)
 
-    def test_initialization(self, analyzer, mock_plant):
+    def test_initialization(self, analyzer, mock_plant) -> None:
         """Test initialization."""
         assert analyzer.plant == mock_plant
 
-    def test_compute_components_basic(self, analyzer, mock_plant):
+    def test_compute_components_basic(self, analyzer, mock_plant) -> None:
         """Test compute_components with simple inputs."""
         context = MagicMock()
 
@@ -78,7 +78,7 @@ class TestDrakeInducedAcceleration:
         mock_plant.CalcGravityGeneralizedForces.assert_called_with(context)
         mock_plant.CalcBiasTerm.assert_called_with(context)
 
-    def test_compute_components_with_non_identity_mass(self, analyzer, mock_plant):
+    def test_compute_components_with_non_identity_mass(self, analyzer, mock_plant) -> None:
         """Test compute_components with non-identity mass matrix."""
         context = MagicMock()
 
@@ -106,7 +106,7 @@ class TestDrakeInducedAcceleration:
         # total = 0
         np.testing.assert_allclose(results["total"], [0.0, 0.0], atol=1e-10)
 
-    def test_compute_components_structure(self, analyzer, mock_plant):
+    def test_compute_components_structure(self, analyzer, mock_plant) -> None:
         """Verify the result dictionary structure."""
         mock_plant.CalcMassMatrix.return_value = np.eye(2)
         mock_plant.CalcGravityGeneralizedForces.return_value = np.zeros(2)

--- a/src/engines/physics_engines/mujoco/docker/gui/deepmind_control_suite_MuJoCo_GUI.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/deepmind_control_suite_MuJoCo_GUI.py
@@ -968,7 +968,7 @@ class GolfSimulationGUI:
         self.log("Updating robotics_env with missing dependencies...")
         self.btn_rebuild.config(state=tk.DISABLED)
 
-        def run_update():
+        def run_update() -> None:
             try:
                 # Create a minimal Dockerfile to add defusedxml
                 dockerfile_content = (

--- a/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
+++ b/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
@@ -45,7 +45,7 @@ TARGET_POSE = {
 }
 
 
-def np_encoder(object):
+def np_encoder(object) -> Any:
     """JSON encoder for NumPy types."""
     if isinstance(object, np.generic):
         return object.item()
@@ -236,7 +236,7 @@ class TimeStep:
     def last(self) -> bool:
         return bool(self.step_type == 2)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> Any:
         return getattr(self, key)
 
 
@@ -383,7 +383,7 @@ def run_simulation(
     actuators = utils.get_actuator_indices(physics)
 
     # 3. Setup Initialization Logic
-    def initialize_episode(phys):
+    def initialize_episode(phys) -> None:
         """Initialize episode state from file or default pose."""
         if load_path:
             load_state(phys, load_path)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/controls_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/controls_tab.py
@@ -770,7 +770,7 @@ class ActuatorDetailDialog(QtWidgets.QDialog):
         actuator_name: str,
         slider_sync: Callable[[float], None] | None,
         parent: QtWidgets.QWidget | None = None,
-    ):
+    ) -> None:
         """Build the detail dialog for a single actuator."""
         super().__init__(parent)
         self.control_system = control_system

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/meshcat_adapter.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/meshcat_adapter.py
@@ -23,7 +23,7 @@ class MuJoCoMeshcatAdapter:
     Adapts MuJoCo model/data to Meshcat for web-based visualization.
     """
 
-    def __init__(self, model: mujoco.MjModel | None = None):
+    def __init__(self, model: mujoco.MjModel | None = None) -> None:
         if meshcat is None:
             logger.warning("Meshcat not installed. Visualization disabled.")
             self.vis = None

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
@@ -36,7 +36,7 @@ class ConnectionPool:
     while ensuring thread safety.
     """
 
-    def __init__(self, db_path: str):
+    def __init__(self, db_path: str) -> None:
         self.db_path = db_path
         self._local = threading.local()
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/sim_widget.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/sim_widget.py
@@ -51,7 +51,7 @@ class ModelLoaderThread(QtCore.QThread):
     # Signal returns (model, data) on success, or (None, error_msg) on failure
     finished_loading = QtCore.pyqtSignal(object, object, str)
 
-    def __init__(self, xml_content: str, is_file: bool = False):
+    def __init__(self, xml_content: str, is_file: bool = False) -> None:
         super().__init__()
         self.xml_content = xml_content
         self.is_file = is_file

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/tests/unit/test_verification.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/tests/unit/test_verification.py
@@ -5,7 +5,7 @@ from mujoco_humanoid_golf.verification import EnergyMonitor, JacobianTester
 
 
 # Helper to create a simple pendulum model if none exists
-def create_pendulum_model():
+def create_pendulum_model() -> Any:
     xml = """
     <mujoco>
       <worldbody>
@@ -23,12 +23,12 @@ class TestVerificationEngine:
     """Test suite for Phase 2 Verification Tools."""
 
     @pytest.fixture
-    def model_and_data(self):
+    def model_and_data(self) -> tuple:
         model = create_pendulum_model()
         data = mujoco.MjData(model)
         return model, data
 
-    def test_energy_monitor_conservation(self, model_and_data):
+    def test_energy_monitor_conservation(self, model_and_data) -> None:
         """Test EnergyMonitor correctly tracks conservation on a passive pendulum."""
         model, data = model_and_data
         monitor = EnergyMonitor(model, data)
@@ -52,7 +52,7 @@ class TestVerificationEngine:
         assert passed, f"Energy drift too high: {drift}"
         assert len(monitor.history) > 100
 
-    def test_energy_monitor_work_tracking(self, model_and_data):
+    def test_energy_monitor_work_tracking(self, model_and_data) -> None:
         """Test that work input is correctly tracked."""
         model, data = model_and_data
         monitor = EnergyMonitor(model, data)
@@ -74,7 +74,7 @@ class TestVerificationEngine:
         # Work should be positive as we are adding energy
         assert monitor.cumulative_work > 0
 
-    def test_jacobian_tester(self, model_and_data):
+    def test_jacobian_tester(self, model_and_data) -> None:
         """Test that JacobianTester confirms analytical vs FD match."""
         model, _ = model_and_data
         tester = JacobianTester(model)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/verification.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/verification.py
@@ -45,7 +45,7 @@ class EnergyMonitor:
     - User code modifying state (teleportation)
     """
 
-    def __init__(self, model: mujoco.MjModel, data: mujoco.MjData):
+    def __init__(self, model: mujoco.MjModel, data: mujoco.MjData) -> None:
         self.model = model
         self.data = data
         self.history: list[EnergyState] = []
@@ -144,7 +144,7 @@ class JacobianTester:
     3. 'Observer Effect' where reading data modifies it.
     """
 
-    def __init__(self, model: mujoco.MjModel):
+    def __init__(self, model: mujoco.MjModel) -> None:
         self.model = model
         # Use a private MjData to avoid side effects (Phase 1 Fix)
         self.data = mujoco.MjData(model)

--- a/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
@@ -9,7 +9,7 @@ from mujoco_humanoid_golf.counterfactuals import (
 
 
 @pytest.fixture
-def simple_pendulum_model():
+def simple_pendulum_model() -> Any:
     """Create simple pendulum for testing."""
     xml = """
     <mujoco>
@@ -31,7 +31,7 @@ def simple_pendulum_model():
 class TestZTCF:
     """Test Zero-Torque Counterfactual (Guideline G1)."""
 
-    def test_ztcf_with_zero_control_gives_zero_delta(self, simple_pendulum_model):
+    def test_ztcf_with_zero_control_gives_zero_delta(self, simple_pendulum_model) -> None:
         """Test ZTCF: zero control means observed = counterfactual."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -50,7 +50,7 @@ class TestZTCF:
         assert np.allclose(result.delta_acceleration, 0, atol=1e-6)
         assert result.type == "ztcf"
 
-    def test_ztcf_positive_torque_gives_positive_delta(self, simple_pendulum_model):
+    def test_ztcf_positive_torque_gives_positive_delta(self, simple_pendulum_model) -> None:
         """Test ZTCF: upward torque creates positive acceleration delta."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -69,7 +69,7 @@ class TestZTCF:
         # Observed > counterfactual
         assert result.observed_acceleration[0] > result.counterfactual_acceleration[0]
 
-    def test_ztcf_negative_torque_opposes_gravity(self, simple_pendulum_model):
+    def test_ztcf_negative_torque_opposes_gravity(self, simple_pendulum_model) -> None:
         """Test ZTCF: downward torque opposes upward swing."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -85,7 +85,7 @@ class TestZTCF:
             result.delta_acceleration[0] < 0
         ), "Opposing torque should create negative acceleration delta"
 
-    def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model):
+    def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test ZTCF: delta scales linearly with applied torque."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -104,7 +104,7 @@ class TestZTCF:
         ratio = result_large.delta_acceleration[0] / result_small.delta_acceleration[0]
         assert 1.8 < ratio < 2.2, f"Expected ~2x scaling, got {ratio:.2f}x"
 
-    def test_ztcf_trajectory_integration(self, simple_pendulum_model):
+    def test_ztcf_trajectory_integration(self, simple_pendulum_model) -> None:
         """Test ZTCF with trajectory prediction."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -128,7 +128,7 @@ class TestZTCF:
 class TestZVCF:
     """Test Zero-Velocity Counterfactual (Guideline G2)."""
 
-    def test_zvcf_with_zero_velocity_gives_zero_delta(self, simple_pendulum_model):
+    def test_zvcf_with_zero_velocity_gives_zero_delta(self, simple_pendulum_model) -> None:
         """Test ZVCF: zero velocity means observed = counterfactual."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -146,7 +146,7 @@ class TestZVCF:
         assert np.allclose(result.delta_acceleration, 0, atol=1e-6)
         assert result.type == "zvcf"
 
-    def test_zvcf_nonzero_velocity_creates_delta(self, simple_pendulum_model):
+    def test_zvcf_nonzero_velocity_creates_delta(self, simple_pendulum_model) -> None:
         """Test ZVCF: non-zero velocity creates acceleration delta."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -162,7 +162,7 @@ class TestZVCF:
             abs(result.delta_acceleration[0]) > 1e-3
         ), "Non-zero velocity should create acceleration delta"
 
-    def test_zvcf_delta_scales_with_velocity(self, simple_pendulum_model):
+    def test_zvcf_delta_scales_with_velocity(self, simple_pendulum_model) -> None:
         """Test ZVCF: delta scales with velocity."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -182,7 +182,7 @@ class TestZVCF:
             result_low.delta_acceleration[0]
         ), "Higher velocity should create larger Coriolis effect"
 
-    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model):
+    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model) -> None:
         """Test ZVCF: counterfactual has only gravity, observed has
         gravity + Coriolis.
         """
@@ -208,7 +208,7 @@ class TestZVCF:
 class TestCounterfactualTrajectoryAnalysis:
     """Test trajectory-level counterfactual analysis."""
 
-    def test_ztcf_trajectory_analysis(self, simple_pendulum_model):
+    def test_ztcf_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test ZTCF analysis on full trajectory."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -227,7 +227,7 @@ class TestCounterfactualTrajectoryAnalysis:
         for r in results:
             assert abs(r.delta_acceleration[0]) > 1e-6
 
-    def test_zvcf_trajectory_analysis(self, simple_pendulum_model):
+    def test_zvcf_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test ZVCF analysis on full trajectory."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -252,7 +252,7 @@ class TestCounterfactualTrajectoryAnalysis:
 class TestCounterfactualPhysics:
     """Integration tests for counterfactual physics validation."""
 
-    def test_ztcf_plus_counterfactual_equals_observed(self, simple_pendulum_model):
+    def test_ztcf_plus_counterfactual_equals_observed(self, simple_pendulum_model) -> None:
         """Test physics: counterfactual + delta = observed."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -269,7 +269,7 @@ class TestCounterfactualPhysics:
             result.observed_acceleration, reconstructed, atol=1e-6
         ), "Physics violation: observed != counterfactual + delta"
 
-    def test_zvcf_plus_counterfactual_equals_observed(self, simple_pendulum_model):
+    def test_zvcf_plus_counterfactual_equals_observed(self, simple_pendulum_model) -> None:
         """Test physics: counterfactual + delta = observed."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -285,7 +285,7 @@ class TestCounterfactualPhysics:
             result.observed_acceleration, reconstructed, atol=1e-6
         ), "Physics violation: observed != counterfactual + delta"
 
-    def test_ztcf_reveals_control_authority(self, simple_pendulum_model):
+    def test_ztcf_reveals_control_authority(self, simple_pendulum_model) -> None:
         """Test that ZTCF correctly identifies control authority."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_csv_export_validation.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_csv_export_validation.py
@@ -11,7 +11,7 @@ from mujoco_humanoid_golf.inverse_dynamics import (
 class TestCSVExportValidation:
     """Test comprehensive input validation for CSV export (Finding A-007)."""
 
-    def test_export_validates_times_is_numpy_array(self, tmp_path):
+    def test_export_validates_times_is_numpy_array(self, tmp_path) -> None:
         """Test that times must be a numpy array."""
         results = [
             InverseDynamicsResult(joint_torques=np.array([1.0, 2.0]), success=True)
@@ -22,7 +22,7 @@ class TestCSVExportValidation:
         with pytest.raises(TypeError, match="times must be numpy array"):
             export_inverse_dynamics_to_csv([0.0], results, str(filepath))
 
-    def test_export_validates_results_is_list(self, tmp_path):
+    def test_export_validates_results_is_list(self, tmp_path) -> None:
         """Test that results must be a list."""
         times = np.array([0.0])
         result = InverseDynamicsResult(joint_torques=np.array([1.0, 2.0]), success=True)
@@ -32,7 +32,7 @@ class TestCSVExportValidation:
         with pytest.raises(TypeError, match="results must be list"):
             export_inverse_dynamics_to_csv(times, result, str(filepath))
 
-    def test_export_validates_non_empty_results(self, tmp_path):
+    def test_export_validates_non_empty_results(self, tmp_path) -> None:
         """Test that results list cannot be empty."""
         times = np.array([])
         results: list[InverseDynamicsResult] = []
@@ -41,7 +41,7 @@ class TestCSVExportValidation:
         with pytest.raises(ValueError, match="Cannot export empty results list"):
             export_inverse_dynamics_to_csv(times, results, str(filepath))
 
-    def test_export_validates_length_match(self, tmp_path):
+    def test_export_validates_length_match(self, tmp_path) -> None:
         """Test that times and results must have same length."""
         times = np.array([0.0, 1.0, 2.0])
         results = [
@@ -55,7 +55,7 @@ class TestCSVExportValidation:
         ):
             export_inverse_dynamics_to_csv(times, results, str(filepath))
 
-    def test_export_validates_result_types(self, tmp_path):
+    def test_export_validates_result_types(self, tmp_path) -> None:
         """Test that all results must be InverseDynamicsResult instances."""
         times = np.array([0.0, 1.0])
         results = [
@@ -67,7 +67,7 @@ class TestCSVExportValidation:
         with pytest.raises(TypeError, match=r"results\[1\] is dict, expected"):
             export_inverse_dynamics_to_csv(times, results, str(filepath))
 
-    def test_export_validates_consistent_joint_counts(self, tmp_path):
+    def test_export_validates_consistent_joint_counts(self, tmp_path) -> None:
         """Test that all results must have same number of joints."""
         times = np.array([0.0, 1.0])
         results = [
@@ -85,7 +85,7 @@ class TestCSVExportValidation:
         ):
             export_inverse_dynamics_to_csv(times, results, str(filepath))
 
-    def test_export_succeeds_with_valid_input(self, tmp_path):
+    def test_export_succeeds_with_valid_input(self, tmp_path) -> None:
         """Test that export succeeds with valid input."""
         times = np.array([0.0, 1.0, 2.0])
         results = [
@@ -129,7 +129,7 @@ class TestCSVExportValidation:
         assert "1.0,3.0" in content
         assert "2.0,5.0" in content
 
-    def test_export_handles_none_optional_fields(self, tmp_path):
+    def test_export_handles_none_optional_fields(self, tmp_path) -> None:
         """Test export with None values for optional fields."""
         times = np.array([0.0])
         results = [

--- a/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
@@ -10,7 +10,7 @@ from mujoco_humanoid_golf.drift_control import (
 
 
 @pytest.fixture
-def simple_pendulum_model():
+def simple_pendulum_model() -> Any:
     """Create simple pendulum for testing."""
     xml = """
     <mujoco>
@@ -32,7 +32,7 @@ def simple_pendulum_model():
 class TestDriftControlDecomposer:
     """Test drift-control decomposition implementation."""
 
-    def test_decomposer_initialization(self, simple_pendulum_model):
+    def test_decomposer_initialization(self, simple_pendulum_model) -> None:
         """Test decomposer creates private data structures."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -44,7 +44,7 @@ class TestDriftControlDecomposer:
         assert id(decomposer._data_drift) != id(decomposer._data_control)
         assert id(decomposer._data_drift) != id(decomposer._data_full)
 
-    def test_superposition_principle(self, simple_pendulum_model):
+    def test_superposition_principle(self, simple_pendulum_model) -> None:
         """Test that drift + control = full (Guideline F requirement)."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -68,7 +68,7 @@ class TestDriftControlDecomposer:
             result.residual < 1e-5
         ), f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
 
-    def test_zero_control_gives_drift_only(self, simple_pendulum_model):
+    def test_zero_control_gives_drift_only(self, simple_pendulum_model) -> None:
         """Test that zero control gives drift-only acceleration."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -88,7 +88,7 @@ class TestDriftControlDecomposer:
             result.full_acceleration, result.drift_acceleration, atol=1e-6
         )
 
-    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model):
+    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model) -> None:
         """Test ZVCF: counterfactual has only gravity, observed has
         gravity + Coriolis.
         """
@@ -111,7 +111,7 @@ class TestDriftControlDecomposer:
             result.drift_acceleration, result.drift_gravity_component, atol=1e-6
         )
 
-    def test_gravity_acceleration_matches_mgL_sin_theta(self, simple_pendulum_model):
+    def test_gravity_acceleration_matches_mgL_sin_theta(self, simple_pendulum_model) -> None:
         """Test gravity acceleration matches analytical solution."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -134,7 +134,7 @@ class TestDriftControlDecomposer:
             abs(result.drift_gravity_component[0]) > 1.0
         ), "Expected significant gravity acceleration at 30 degrees"
 
-    def test_control_scales_with_torque(self, simple_pendulum_model):
+    def test_control_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test that control acceleration scales linearly with applied torque."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -155,7 +155,7 @@ class TestDriftControlDecomposer:
         )
         assert 1.8 < ratio < 2.2, f"Expected ~2x scaling, got {ratio:.2f}x"
 
-    def test_trajectory_analysis(self, simple_pendulum_model):
+    def test_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test analyzing full trajectory."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -176,7 +176,7 @@ class TestDriftControlDecomposer:
                 r.residual < 1e-5
             ), f"Trajectory point failed superposition: residual={r.residual:.2e}"
 
-    def test_decomposition_is_reproducible(self, simple_pendulum_model):
+    def test_decomposition_is_reproducible(self, simple_pendulum_model) -> None:
         """Test that decomposition gives same results with same inputs."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -199,13 +199,13 @@ class TestDriftControlPhysics:
 
     def test_passive_pendulum_drift_matches_energy_conservation(
         self, simple_pendulum_model
-    ):
+    ) -> None:
         """Test drift component matches energy-conserving motion."""
         pytest.skip("Requires energy calculation utilities - implement in follow-up")
 
         # (modulo damping losses if present)
 
-    def test_control_enables_upward_swing(self, simple_pendulum_model):
+    def test_control_enables_upward_swing(self, simple_pendulum_model) -> None:
         """Test that control can drive pendulum upward against gravity."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_plotting_analysis.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_plotting_analysis.py
@@ -26,7 +26,7 @@ GolfSwingPlotter = plotting.GolfSwingPlotter
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> Any:
     recorder = MagicMock()
 
     # Mock data
@@ -39,7 +39,7 @@ def mock_recorder():
     return recorder
 
 
-def test_plot_frequency_analysis(mock_recorder):
+def test_plot_frequency_analysis(mock_recorder) -> None:
     plotter = GolfSwingPlotter(mock_recorder)
     fig = MagicMock()
 
@@ -51,7 +51,7 @@ def test_plot_frequency_analysis(mock_recorder):
     assert ax.semilogy.called
 
 
-def test_plot_spectrogram(mock_recorder):
+def test_plot_spectrogram(mock_recorder) -> None:
     plotter = GolfSwingPlotter(mock_recorder)
     fig = MagicMock()
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_statistical_analysis.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_statistical_analysis.py
@@ -24,7 +24,7 @@ StatisticalAnalyzer = statistical_analysis.StatisticalAnalyzer
 SummaryStatistics = statistical_analysis.SummaryStatistics
 
 
-def test_compute_summary_stats():
+def test_compute_summary_stats() -> None:
     data = np.array([0, 1, 2, 3, 4, 5, 100], dtype=float)
     times = np.arange(len(data), dtype=float)
     # Mock analyzer with just times
@@ -47,7 +47,7 @@ def test_compute_summary_stats():
     assert stats.std == np.std(data)
 
 
-def test_generate_comprehensive_report_consistency():
+def test_generate_comprehensive_report_consistency() -> None:
     N = 100
     nq = 2
     times = np.linspace(0, 1.0, N)
@@ -78,7 +78,7 @@ def test_generate_comprehensive_report_consistency():
     assert np.isclose(pos["max"], 180.0, atol=1e-5)
 
 
-def test_frequency_analysis_and_smoothness():
+def test_frequency_analysis_and_smoothness() -> None:
     N = 1000
     fs = 1000.0
     times = np.arange(N) / fs

--- a/src/engines/physics_engines/mujoco/python/tests/test_telemetry.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_telemetry.py
@@ -12,7 +12,7 @@ from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.telemetry im
 
 
 @pytest.fixture
-def mock_mujoco_model_data():
+def mock_mujoco_model_data() -> tuple:
     """Create mock MuJoCo model and data."""
     model = MagicMock(spec=mujoco.MjModel)
     model.nbody = 2
@@ -40,7 +40,7 @@ def mock_mujoco_model_data():
     return model, data
 
 
-def test_telemetry_recorder_init(mock_mujoco_model_data):
+def test_telemetry_recorder_init(mock_mujoco_model_data) -> None:
     model, _ = mock_mujoco_model_data
 
     with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
@@ -51,7 +51,7 @@ def test_telemetry_recorder_init(mock_mujoco_model_data):
     assert len(recorder._actuator_dof_map) == 2
 
 
-def test_telemetry_recorder_record_step(mock_mujoco_model_data):
+def test_telemetry_recorder_record_step(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
     with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
@@ -73,7 +73,7 @@ def test_telemetry_recorder_record_step(mock_mujoco_model_data):
     assert sample.custom_metrics["test_metric"] == 123.45
 
 
-def test_telemetry_report_generation(mock_mujoco_model_data):
+def test_telemetry_report_generation(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
     with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
@@ -98,7 +98,7 @@ def test_telemetry_report_generation(mock_mujoco_model_data):
     assert report_dict["sample_count"] == 2
 
 
-def test_telemetry_reset(mock_mujoco_model_data):
+def test_telemetry_reset(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
     with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
@@ -110,7 +110,7 @@ def test_telemetry_reset(mock_mujoco_model_data):
         assert len(recorder.samples) == 0
 
 
-def test_export_telemetry_json():
+def test_export_telemetry_json() -> None:
     data = {"scalar": 1.0, "array": np.array([1, 2, 3])}
 
     with patch("builtins.open", mock_open()) as mock_file:
@@ -121,7 +121,7 @@ def test_export_telemetry_json():
     # Verify json dump called? (Implicit by success returning True)
 
 
-def test_export_telemetry_csv():
+def test_export_telemetry_csv() -> None:
     data = {"time": np.array([0.0, 0.1]), "vec3": np.array([[1, 2, 3], [4, 5, 6]])}
 
     with patch("builtins.open", mock_open()) as mock_file:
@@ -138,7 +138,7 @@ def test_export_telemetry_csv():
         assert success
 
 
-def test_export_fail_handling():
+def test_export_fail_handling() -> None:
     # Test exceptions
     with patch("builtins.open", side_effect=PermissionError):
         assert not export_telemetry_json("fail.json", {})

--- a/src/engines/physics_engines/mujoco/python/tests/test_urdf_io.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_urdf_io.py
@@ -14,7 +14,7 @@ from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.urdf_io impo
 
 
 @pytest.fixture
-def mock_mujoco_model():
+def mock_mujoco_model() -> Any:
     """Create a mock MuJoCo model."""
     model = MagicMock(spec=mujoco.MjModel)
 
@@ -60,7 +60,7 @@ def mock_mujoco_model():
 
 
 @pytest.fixture
-def sample_urdf_xml():
+def sample_urdf_xml() -> str:
     return """
     <robot name="test_robot">
         <link name="base_link">
@@ -96,19 +96,19 @@ def sample_urdf_xml():
     """
 
 
-def test_urdf_exporter_init(mock_mujoco_model):
+def test_urdf_exporter_init(mock_mujoco_model) -> None:
     with patch("mujoco.MjData", autospec=True) as mock_data_cls:
         exporter = URDFExporter(mock_mujoco_model)
         assert exporter.model == mock_mujoco_model
         assert exporter.data == mock_data_cls.return_value
 
 
-def test_export_to_urdf(mock_mujoco_model):
+def test_export_to_urdf(mock_mujoco_model) -> Any:
     with patch("mujoco.MjData", autospec=True):
         exporter = URDFExporter(mock_mujoco_model)
 
         # Mock mj_id2name to return names
-        def id2name(m, obj_type, obj_id):
+        def id2name(m, obj_type, obj_id) -> Any:
             if obj_type == mujoco.mjtObj.mjOBJ_BODY:
                 return ["world", "link1", "link2"][obj_id]
             if obj_type == mujoco.mjtObj.mjOBJ_JOINT:
@@ -161,7 +161,7 @@ def test_export_to_urdf(mock_mujoco_model):
             assert 'type="prismatic"' in urdf_str
 
 
-def test_export_model_to_urdf_function(mock_mujoco_model):
+def test_export_model_to_urdf_function(mock_mujoco_model) -> None:
     # Test convenience function
     with (
         patch("mujoco.mj_id2name", return_value="test_name"),
@@ -172,7 +172,7 @@ def test_export_model_to_urdf_function(mock_mujoco_model):
         assert len(urdf_str) > 0
 
 
-def test_urdf_importer_import(sample_urdf_xml):
+def test_urdf_importer_import(sample_urdf_xml) -> None:
     importer = URDFImporter()
 
     with (
@@ -192,7 +192,7 @@ def test_urdf_importer_import(sample_urdf_xml):
         assert 'pos="1 0 0"' in mjcf_str  # From joint origin
 
 
-def test_import_urdf_to_mujoco_function(sample_urdf_xml):
+def test_import_urdf_to_mujoco_function(sample_urdf_xml) -> None:
     with (
         patch("defusedxml.ElementTree.parse") as mock_parse,
         patch("pathlib.Path.exists", return_value=True),
@@ -205,13 +205,13 @@ def test_import_urdf_to_mujoco_function(sample_urdf_xml):
         assert len(mjcf_str) > 0
 
 
-def test_importer_file_not_found():
+def test_importer_file_not_found() -> None:
     importer = URDFImporter()
     with pytest.raises(FileNotFoundError):
         importer.import_from_urdf("nonexistent.urdf")
 
 
-def test_exporter_no_root_body(mock_mujoco_model):
+def test_exporter_no_root_body(mock_mujoco_model) -> None:
     # Setup model so find_root_body returns None
     mock_mujoco_model.nbody = 1  # Only world
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_video_export.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_video_export.py
@@ -23,7 +23,7 @@ FPS = 30
 
 
 @pytest.fixture
-def mock_mujoco():
+def mock_mujoco() -> tuple:
     """Create mock MuJoCo model and data."""
     model = MagicMock(spec=mujoco.MjModel)
     model.nq = 2
@@ -49,7 +49,7 @@ def mock_renderer():
 
 
 @pytest.fixture
-def mock_cv2():
+def mock_cv2() -> Any:
     """Mock cv2 module."""
     # Since we mocked it in sys.modules, we can just grab it
     mock = sys.modules["cv2"]
@@ -73,7 +73,7 @@ def mock_cv2():
 
 
 @pytest.fixture
-def mock_imageio():
+def mock_imageio() -> Any:
     """Mock imageio module."""
     mock = sys.modules["imageio"]
     mock.reset_mock()
@@ -81,7 +81,7 @@ def mock_imageio():
 
 
 class TestVideoExporter:
-    def test_init(self, mock_mujoco, mock_renderer):
+    def test_init(self, mock_mujoco, mock_renderer) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS)
 
@@ -91,7 +91,7 @@ class TestVideoExporter:
         assert exporter.format == VideoFormat.MP4
         mock_renderer.assert_called_once_with(model, width=WIDTH, height=HEIGHT)
 
-    def test_start_recording_mp4(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_start_recording_mp4(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -109,7 +109,7 @@ class TestVideoExporter:
         assert args[3] == (WIDTH, HEIGHT)
         assert exporter.writer is not None
 
-    def test_start_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_start_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -123,7 +123,7 @@ class TestVideoExporter:
         assert exporter.frames == []
         assert exporter.writer is None
 
-    def test_add_frame_video(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_add_frame_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -140,7 +140,7 @@ class TestVideoExporter:
         exporter.writer.write.assert_called_once()
         assert exporter.frame_count == 1
 
-    def test_add_frame_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_add_frame_gif(self, mock_mujoco, mock_renderer, mock_imageio) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -154,7 +154,7 @@ class TestVideoExporter:
         assert len(exporter.frames) == 1
         assert exporter.frame_count == 1
 
-    def test_finish_recording_video(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_finish_recording_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -169,7 +169,7 @@ class TestVideoExporter:
         writer.release.assert_called_once()
         assert exporter.writer is None
 
-    def test_finish_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_finish_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio) -> None:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -184,16 +184,16 @@ class TestVideoExporter:
         mock_imageio.mimsave.assert_called_once()
         assert exporter.frames == []
 
-    def test_export_recording(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_export_recording(self, mock_mujoco, mock_renderer, mock_cv2) -> Any:
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
         initial_state = np.zeros(4)  # nq=2 + nv=2
 
-        def control_func(t):
+        def control_func(t) -> Any:
             return np.array([0.0])
 
-        def progress_cb(current, total):
+        def progress_cb(current, total) -> None:
             pass
 
         with (
@@ -221,7 +221,7 @@ class TestVideoExporter:
         assert exporter.frame_count > 0
         mock_cv2.VideoWriter.return_value.release.assert_called_once()
 
-    def test_metrics_overlay(self, mock_mujoco, mock_cv2):
+    def test_metrics_overlay(self, mock_mujoco, mock_cv2) -> None:
         model, data = mock_mujoco
         frame = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
 
@@ -239,7 +239,7 @@ class TestVideoExporter:
 
     def test_export_simulation_video_function(
         self, mock_mujoco, mock_renderer, mock_cv2
-    ):
+    ) -> None:
         model, data = mock_mujoco
 
         N = 10

--- a/src/engines/physics_engines/myosuite/python/muscle_analysis.py
+++ b/src/engines/physics_engines/myosuite/python/muscle_analysis.py
@@ -83,7 +83,7 @@ class MyoSuiteMuscleAnalyzer:
     - Activation-driven grip force modeling
     """
 
-    def __init__(self, sim: Any, model: Any = None):
+    def __init__(self, sim: Any, model: Any = None) -> None:
         """Initialize muscle analyzer.
 
         Args:
@@ -463,7 +463,7 @@ class MyoSuiteGripModel:
     - Activation-driven grip force control
     """
 
-    def __init__(self, sim: Any, analyzer: MyoSuiteMuscleAnalyzer):
+    def __init__(self, sim: Any, analyzer: MyoSuiteMuscleAnalyzer) -> None:
         """Initialize grip model.
 
         Args:

--- a/src/engines/physics_engines/opensim/python/muscle_analysis.py
+++ b/src/engines/physics_engines/opensim/python/muscle_analysis.py
@@ -54,7 +54,7 @@ class OpenSimMuscleAnalyzer:
     - Muscle contribution to joint accelerations
     """
 
-    def __init__(self, model: opensim.Model, state: opensim.State):
+    def __init__(self, model: opensim.Model, state: opensim.State) -> None:
         """Initialize muscle analyzer.
 
         Args:
@@ -291,7 +291,7 @@ class OpenSimGripModel:
     - Muscle routing through contact points
     """
 
-    def __init__(self, model: opensim.Model):
+    def __init__(self, model: opensim.Model) -> None:
         """Initialize grip model.
 
         Args:

--- a/src/engines/physics_engines/opensim/python/tests/test_opensim_core.py
+++ b/src/engines/physics_engines/opensim/python/tests/test_opensim_core.py
@@ -81,7 +81,7 @@ def mock_opensim_missing_env():
 
 
 @pytest.fixture
-def temp_model_file(tmp_path):
+def temp_model_file(tmp_path) -> Any:
     """Create a temporary .osim file for testing."""
     model_file = tmp_path / "test_model.osim"
     model_file.write_text("<OpenSimModel/>")
@@ -91,24 +91,24 @@ def temp_model_file(tmp_path):
 class TestGolfSwingModel:
     """Test suite for GolfSwingModel without fallback behavior."""
 
-    def test_model_path_required(self):
+    def test_model_path_required(self) -> None:
         """Test that model_path is required - no silent fallback."""
         with pytest.raises(ValueError, match="model_path is required"):
             GolfSwingModel(model_path=None)
 
-    def test_model_file_not_found(self):
+    def test_model_file_not_found(self) -> None:
         """Test that missing model file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="OpenSim model file not found"):
             GolfSwingModel(model_path="/nonexistent/path/model.osim")
 
     def test_opensim_not_installed_error(
         self, mock_opensim_missing_env, temp_model_file
-    ):
+    ) -> None:
         """Test that missing OpenSim raises OpenSimNotInstalledError."""
         with pytest.raises(OpenSimNotInstalledError, match="OpenSim is not installed"):
             GolfSwingModel(model_path=temp_model_file)
 
-    def test_opensim_model_load_error(self, mock_opensim_env, temp_model_file):
+    def test_opensim_model_load_error(self, mock_opensim_env, temp_model_file) -> None:
         """Test that OpenSim Model load failure raises OpenSimModelLoadError."""
         # Make the mock Model constructor raise an exception
         mock_opensim_env.Model.side_effect = RuntimeError("Model load failed")
@@ -116,7 +116,7 @@ class TestGolfSwingModel:
         with pytest.raises(OpenSimModelLoadError, match="Failed to load OpenSim model"):
             GolfSwingModel(model_path=temp_model_file)
 
-    def test_opensim_model_loads_successfully(self, mock_opensim_env, temp_model_file):
+    def test_opensim_model_loads_successfully(self, mock_opensim_env, temp_model_file) -> None:
         """Test successful model loading with mocked OpenSim."""
         model = GolfSwingModel(model_path=temp_model_file)
 
@@ -124,7 +124,7 @@ class TestGolfSwingModel:
         assert model.use_opensim is True
         assert model._opensim_model is not None
 
-    def test_simulation_runs(self, mock_opensim_env, temp_model_file):
+    def test_simulation_runs(self, mock_opensim_env, temp_model_file) -> None:
         """Test that simulation runs without error."""
         model = GolfSwingModel(model_path=temp_model_file)
         model.duration = 0.01  # Short duration for test
@@ -136,7 +136,7 @@ class TestGolfSwingModel:
         assert result.states.shape[1] == 4  # 2Q + 2U
         assert result.marker_positions["TestMarker"].shape[1] == 3
 
-    def test_use_opensim_always_true(self, mock_opensim_env, temp_model_file):
+    def test_use_opensim_always_true(self, mock_opensim_env, temp_model_file) -> None:
         """Test that use_opensim is always True (no fallback mode)."""
         model = GolfSwingModel(model_path=temp_model_file)
         assert model.use_opensim is True
@@ -145,14 +145,14 @@ class TestGolfSwingModel:
 class TestNoFallbackBehavior:
     """Tests to verify there is NO fallback/demo behavior."""
 
-    def test_no_demo_simulation_method(self):
+    def test_no_demo_simulation_method(self) -> None:
         """Verify _run_demo_simulation method does not exist."""
         # This test ensures we don't accidentally re-add the demo mode
         assert not hasattr(GolfSwingModel, "_run_demo_simulation")
 
     def test_error_messages_are_helpful(
         self, mock_opensim_missing_env, temp_model_file
-    ):
+    ) -> None:
         """Test that error messages include installation guidance."""
         try:
             GolfSwingModel(model_path=temp_model_file)

--- a/src/engines/physics_engines/pinocchio/python/dtack/gui/main_window.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/gui/main_window.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 class GuiRecorder(RecorderInterface):
     """Recorder adapter for the GUI data."""
 
-    def __init__(self, data_store: list[BiomechanicalData]):
+    def __init__(self, data_store: list[BiomechanicalData]) -> None:
         self.data_store = data_store
 
     def get_time_series(self, field_name: str) -> tuple[np.ndarray, np.ndarray | list]:

--- a/src/engines/physics_engines/pinocchio/python/motion_training/__init__.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/__init__.py
@@ -53,7 +53,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazy import for module components."""
     if name in (
         "ClubTrajectory",

--- a/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
@@ -279,12 +279,12 @@ class ClubTrajectoryParser:
         # Access by index (works for both pandas Series and list)
         if hasattr(row, "iloc"):
 
-            def get(i):
+            def get(i) -> Any:
                 return row.iloc[i] if i < len(row) else None
 
         else:
 
-            def get(i):
+            def get(i) -> Any:
                 return row[i] if i < len(row) else None
 
         # Skip header rows or invalid data

--- a/src/engines/physics_engines/pinocchio/python/motion_training/tests/test_motion_training.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/tests/test_motion_training.py
@@ -18,7 +18,7 @@ from motion_training.club_trajectory_parser import (
 class TestClubFrame:
     """Tests for ClubFrame dataclass."""
 
-    def test_create_frame(self):
+    def test_create_frame(self) -> None:
         """Test creating a club frame."""
         frame = ClubFrame(
             time=0.0,
@@ -37,7 +37,7 @@ class TestClubTrajectory:
     """Tests for ClubTrajectory."""
 
     @pytest.fixture
-    def sample_trajectory(self):
+    def sample_trajectory(self) -> Any:
         """Create a sample trajectory for testing."""
         frames = []
         for i in range(10):
@@ -57,33 +57,33 @@ class TestClubTrajectory:
             events=SwingEventMarkers(address=0, top=3, impact=6, finish=9),
         )
 
-    def test_num_frames(self, sample_trajectory):
+    def test_num_frames(self, sample_trajectory) -> None:
         """Test frame count."""
         assert sample_trajectory.num_frames == 10
 
-    def test_duration(self, sample_trajectory):
+    def test_duration(self, sample_trajectory) -> None:
         """Test duration calculation."""
         assert sample_trajectory.duration == pytest.approx(0.09)
 
-    def test_times_property(self, sample_trajectory):
+    def test_times_property(self, sample_trajectory) -> None:
         """Test times array."""
         times = sample_trajectory.times
         assert len(times) == 10
         assert times[0] == 0.0
         assert times[-1] == pytest.approx(0.09)
 
-    def test_grip_positions_property(self, sample_trajectory):
+    def test_grip_positions_property(self, sample_trajectory) -> None:
         """Test grip positions array."""
         positions = sample_trajectory.grip_positions
         assert positions.shape == (10, 3)
 
-    def test_get_event_frame(self, sample_trajectory):
+    def test_get_event_frame(self, sample_trajectory) -> None:
         """Test getting event frames."""
         impact = sample_trajectory.get_event_frame("impact")
         assert impact is not None
         assert impact.sample_index == 6
 
-    def test_get_frame_at_time(self, sample_trajectory):
+    def test_get_frame_at_time(self, sample_trajectory) -> None:
         """Test interpolation."""
         # Get frame at middle time
         frame = sample_trajectory.get_frame_at_time(0.045)
@@ -101,7 +101,7 @@ class TestClubTrajectory:
 class TestComputeHandPositions:
     """Tests for hand position computation."""
 
-    def test_default_offsets(self):
+    def test_default_offsets(self) -> None:
         """Test hand positions with default offsets."""
         frame = ClubFrame(
             time=0.0,
@@ -119,7 +119,7 @@ class TestComputeHandPositions:
         np.testing.assert_array_almost_equal(left, [0.0, 0.0, 1.04])
         np.testing.assert_array_almost_equal(right, [0.0, 0.0, 0.96])
 
-    def test_custom_offsets(self):
+    def test_custom_offsets(self) -> None:
         """Test hand positions with custom offsets."""
         frame = ClubFrame(
             time=0.0,
@@ -139,13 +139,13 @@ class TestComputeHandPositions:
 class TestClubTrajectoryParser:
     """Tests for trajectory parser."""
 
-    def test_init_with_invalid_path(self):
+    def test_init_with_invalid_path(self) -> None:
         """Test initialization with non-existent file."""
         with pytest.raises(FileNotFoundError):
             ClubTrajectoryParser("/nonexistent/path.xlsx")
 
     @pytest.fixture
-    def mock_excel_data(self):
+    def mock_excel_data(self) -> Any:
         """Create mock Excel data for testing."""
         return np.array(
             [
@@ -268,7 +268,7 @@ class TestClubTrajectoryParser:
 class TestSwingEventMarkers:
     """Tests for SwingEventMarkers."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         """Test default marker values."""
         markers = SwingEventMarkers()
         assert markers.address == 0
@@ -277,7 +277,7 @@ class TestSwingEventMarkers:
         assert markers.finish == 0
         assert markers.club_head_speed == 0.0
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         """Test custom marker values."""
         markers = SwingEventMarkers(
             address=10,
@@ -298,7 +298,7 @@ class TestDualHandIKSolver:
     """Tests for dual-hand IK solver."""
 
     @pytest.fixture
-    def mock_model(self):
+    def mock_model(self) -> Any:
         """Create mock Pinocchio model."""
         pin = pytest.importorskip("pinocchio")
 
@@ -306,14 +306,14 @@ class TestDualHandIKSolver:
         model = pin.buildSampleModelManipulator()
         return model
 
-    def test_ik_solver_import(self):
+    def test_ik_solver_import(self) -> None:
         """Test that IK solver can be imported."""
         try:
             pass
         except ImportError as e:
             pytest.skip(f"IK solver dependencies not available: {e}")
 
-    def test_ik_settings_defaults(self):
+    def test_ik_settings_defaults(self) -> None:
         """Test IK settings have reasonable defaults."""
         from motion_training.dual_hand_ik_solver import IKSolverSettings
 
@@ -330,7 +330,7 @@ class TestTrajectoryExporter:
     """Tests for trajectory exporter."""
 
     @pytest.fixture
-    def sample_ik_result(self):
+    def sample_ik_result(self) -> Any:
         """Create sample IK result for testing."""
         from motion_training.dual_hand_ik_solver import TrajectoryIKResult
 
@@ -343,7 +343,7 @@ class TestTrajectoryExporter:
         result.convergence_rate = 0.9
         return result
 
-    def test_exporter_init(self, sample_ik_result):
+    def test_exporter_init(self, sample_ik_result) -> None:
         """Test exporter initialization."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -351,7 +351,7 @@ class TestTrajectoryExporter:
         assert exporter.num_frames == 10
         assert exporter.num_dof == 12
 
-    def test_export_csv(self, sample_ik_result, tmp_path):
+    def test_export_csv(self, sample_ik_result, tmp_path) -> None:
         """Test CSV export."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -361,7 +361,7 @@ class TestTrajectoryExporter:
         assert output_path.exists()
         assert output_path.suffix == ".csv"
 
-    def test_export_npz(self, sample_ik_result, tmp_path):
+    def test_export_npz(self, sample_ik_result, tmp_path) -> None:
         """Test NPZ export."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -376,7 +376,7 @@ class TestTrajectoryExporter:
         assert "q" in data
         assert "times" in data
 
-    def test_export_json(self, sample_ik_result, tmp_path):
+    def test_export_json(self, sample_ik_result, tmp_path) -> None:
         """Test JSON export."""
         import json
 
@@ -394,7 +394,7 @@ class TestTrajectoryExporter:
         assert "metadata" in data
         assert "trajectory" in data
 
-    def test_export_unsupported_format(self, sample_ik_result, tmp_path):
+    def test_export_unsupported_format(self, sample_ik_result, tmp_path) -> None:
         """Test that unsupported format raises error."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/induced_acceleration.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/induced_acceleration.py
@@ -18,7 +18,7 @@ class InducedAccelerationAnalyzer:
     - Total: q_ddot = q_ddot_g + q_ddot_v + q_ddot_t
     """
 
-    def __init__(self, model: pin.Model, data: pin.Data):
+    def __init__(self, model: pin.Model, data: pin.Data) -> None:
         self.model = model
         self.data = data
         self.nq = model.nq

--- a/src/engines/physics_engines/pinocchio/python/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_induced_acceleration.py
@@ -27,7 +27,7 @@ class TestPinocchioInducedAcceleration:
         yield
 
     @pytest.fixture
-    def mock_model(self):
+    def mock_model(self) -> Any:
         """Mock Pinocchio Model."""
         model = MagicMock()
         model.nq = 2
@@ -36,23 +36,23 @@ class TestPinocchioInducedAcceleration:
         return model
 
     @pytest.fixture
-    def mock_data(self):
+    def mock_data(self) -> Any:
         """Mock Pinocchio Data."""
         return MagicMock()
 
     @pytest.fixture
-    def analyzer(self, mock_model, mock_data):
+    def analyzer(self, mock_model, mock_data) -> Any:
         """Create analyzer instance."""
         return InducedAccelerationAnalyzer(mock_model, mock_data)
 
-    def test_initialization(self, analyzer, mock_model, mock_data):
+    def test_initialization(self, analyzer, mock_model, mock_data) -> None:
         """Test initialization."""
         assert analyzer.model == mock_model
         assert analyzer.data == mock_data
         assert analyzer._temp_data is not None
         assert analyzer._temp_data != mock_data  # Should be a new instance
 
-    def test_compute_components_logic(self, analyzer, mock_model):
+    def test_compute_components_logic(self, analyzer, mock_model) -> Any:
         """Test compute_components logical flow."""
         q = np.array([0.0, 0.0])
         v = np.array([0.1, 0.2])
@@ -60,7 +60,7 @@ class TestPinocchioInducedAcceleration:
 
         # We need to control return values of pin.aba to verify the subtraction logic
 
-        def aba_side_effect(model, data, q_arg, v_arg, tau_arg):
+        def aba_side_effect(model, data, q_arg, v_arg, tau_arg) -> Any:
             # Check inputs to return corresponding acceleration
             if np.array_equal(v_arg, np.zeros(2)) and np.array_equal(
                 tau_arg, np.zeros(2)
@@ -91,12 +91,12 @@ class TestPinocchioInducedAcceleration:
         # Verify calls were made
         assert mock_pin.aba.call_count == 3
 
-    def test_compute_specific_control(self, analyzer, mock_model):
+    def test_compute_specific_control(self, analyzer, mock_model) -> Any:
         """Test compute_specific_control."""
         q = np.zeros(2)
         specific_tau = np.array([5.0, 5.0])
 
-        def aba_side_effect(model, data, q_arg, v_arg, tau_arg):
+        def aba_side_effect(model, data, q_arg, v_arg, tau_arg) -> Any:
             if np.array_equal(tau_arg, np.zeros(2)):
                 return np.array([-9.8, 0])  # Gravity accel
             else:
@@ -112,7 +112,7 @@ class TestPinocchioInducedAcceleration:
         np.testing.assert_allclose(result, [5.0, 5.0])
         assert mock_pin.aba.call_count == 2
 
-    def test_compute_counterfactuals(self, analyzer, mock_model):
+    def test_compute_counterfactuals(self, analyzer, mock_model) -> None:
         """Test compute_counterfactuals."""
         q = np.zeros(2)
         v = np.zeros(2)

--- a/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
@@ -20,7 +20,7 @@ def mock_pinocchio_env():
         yield
 
 
-def test_create_joint_coupling_task(mock_pinocchio_env):
+def test_create_joint_coupling_task(mock_pinocchio_env) -> None:
     """Verify that create_joint_coupling_task works as expected."""
     # This is the mocked pinocchio
     import pinocchio as pin  # noqa: I001

--- a/src/engines/physics_engines/pinocchio/python/tests/test_torque_fitting.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_torque_fitting.py
@@ -16,7 +16,7 @@ from src.engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting 
 class TestTorqueFitting:
     """Test suite for torque fitting utilities."""
 
-    def test_fit_torque_poly_exact(self):
+    def test_fit_torque_poly_exact(self) -> None:
         """Test fitting a polynomial to exact data."""
         # y = 2x^2 + 3x + 1
         t = np.linspace(0, 10, 20)
@@ -27,7 +27,7 @@ class TestTorqueFitting:
         # Coefficients should be [2, 3, 1] (highest power first)
         np.testing.assert_allclose(coeffs, [2, 3, 1], atol=1e-10)
 
-    def test_evaluate_torque_poly(self):
+    def test_evaluate_torque_poly(self) -> None:
         """Test evaluating a polynomial."""
         coeffs = np.array([2.0, 3.0, 1.0])  # 2x^2 + 3x + 1
         t = np.array([0, 1, 2])
@@ -37,7 +37,7 @@ class TestTorqueFitting:
 
         np.testing.assert_allclose(result, expected)
 
-    def test_fit_shape_mismatch(self):
+    def test_fit_shape_mismatch(self) -> None:
         """Test error on shape mismatch."""
         t = np.array([1, 2, 3])
         tau = np.array([1, 2])  # Mismatch
@@ -45,7 +45,7 @@ class TestTorqueFitting:
         with pytest.raises(ValueError, match="t and tau must have same shape"):
             fit_torque_poly(t, tau)
 
-    def test_main(self):
+    def test_main(self) -> None:
         """Test main function via mocking."""
         # Create a dummy CSV file content
         # csv_content = "t,tau\n0,1\n1,6\n2,15\n"  # y = 2x^2 + 3x + 1

--- a/src/launchers/_archive/golf_launcher_pre_refactor_ce85e6ec.py
+++ b/src/launchers/_archive/golf_launcher_pre_refactor_ce85e6ec.py
@@ -383,7 +383,7 @@ class AsyncStartupWorker(QThread):
     finished_signal = pyqtSignal(object)  # StartupResults
     error_signal = pyqtSignal(str)  # Error message
 
-    def __init__(self, repos_root: Path):
+    def __init__(self, repos_root: Path) -> None:
         super().__init__()
         self.repos_root = repos_root
         self.results = StartupResults()
@@ -497,7 +497,7 @@ class StartupResults:
 class DraggableModelCard(QFrame):
     """Draggable model card widget with reordering support."""
 
-    def __init__(self, model: Any, parent: Any = None):
+    def __init__(self, model: Any, parent: Any = None) -> None:
         # Check if parent is actually a QWidget by checking its type
         from unittest.mock import Mock
 

--- a/src/launchers/assets/generate_tile_images.py
+++ b/src/launchers/assets/generate_tile_images.py
@@ -143,7 +143,7 @@ def draw_rounded_rect_with_text(
     return pixels
 
 
-def draw_letter(pixels: list, width: int, x: int, y: int, size: int, char: str):
+def draw_letter(pixels: list, width: int, x: int, y: int, size: int, char: str) -> None:
     """Draw a simple blocky letter representation."""
     white = (255, 255, 255, 255)
     thickness = max(3, size // 6)
@@ -242,7 +242,7 @@ def draw_letter(pixels: list, width: int, x: int, y: int, size: int, char: str):
                         pixels[idx] = white
 
 
-def generate_all_tiles():
+def generate_all_tiles() -> None:
     """Generate all tile images."""
     size = 200  # 200x200 pixels
 

--- a/src/launchers/model_registry.py
+++ b/src/launchers/model_registry.py
@@ -25,7 +25,7 @@ class ModelSpec:
 class ModelRegistry:
     """Registry for managing available models."""
 
-    def __init__(self, config_path: str = "config/models.yaml"):
+    def __init__(self, config_path: str = "config/models.yaml") -> None:
         self.config_path = Path(config_path)
         self.models: list[ModelSpec] = []
         self._loaded = False

--- a/src/launchers/tests/test_environment_dialog_ux.py
+++ b/src/launchers/tests/test_environment_dialog_ux.py
@@ -13,7 +13,7 @@ sys.modules["shared.python.secure_subprocess"] = MagicMock()
 
 
 @pytest.fixture
-def app():
+def app() -> Any:
     """Create a Qt application instance."""
     app = QApplication.instance()
     if not app:
@@ -30,7 +30,7 @@ def dialog(app):
         dlg.close()
 
 
-def test_build_button_feedback(dialog):
+def test_build_button_feedback(dialog) -> None:
     """Test that the build button text changes during build process."""
 
     # Initial state
@@ -57,7 +57,7 @@ def test_build_button_feedback(dialog):
         assert dialog.btn_build.isEnabled() is True
 
 
-def test_build_button_feedback_failure(dialog):
+def test_build_button_feedback_failure(dialog) -> None:
     """Test that the build button text restores even on failure."""
 
     # Start build

--- a/src/launchers/tests/test_unified_launcher.py
+++ b/src/launchers/tests/test_unified_launcher.py
@@ -19,7 +19,7 @@ def mock_qapp():
 
 
 @pytest.fixture
-def mock_golf_launcher():
+def mock_golf_launcher() -> Any:
     # unified_launcher imports GolfLauncher from .golf_launcher locally
     # We need to patch the class where it is used.
     # Since it's imported inside __init__, we patch it there?
@@ -31,18 +31,18 @@ def mock_golf_launcher():
     return mock_instance
 
 
-def test_init(mock_qapp, mock_golf_launcher):
+def test_init(mock_qapp, mock_golf_launcher) -> None:
     launcher = UnifiedLauncher()
     assert launcher is not None
 
 
-def test_init_no_pyqt():
+def test_init_no_pyqt() -> None:
     with patch("launchers.unified_launcher.PYQT6_AVAILABLE", False):
         with pytest.raises(ImportError, match="PyQt6 is required"):
             UnifiedLauncher()
 
 
-def test_mainloop(mock_qapp, mock_golf_launcher):
+def test_mainloop(mock_qapp, mock_golf_launcher) -> None:
     launcher = UnifiedLauncher()
     mock_qapp.exec.return_value = 0
 
@@ -54,13 +54,13 @@ def test_mainloop(mock_qapp, mock_golf_launcher):
     sys.modules["launchers.golf_launcher"].main.assert_called_once()
 
 
-def test_launch_function():
+def test_launch_function() -> None:
     with patch("src.launchers.golf_launcher.main") as mock_main:
         launch()
         mock_main.assert_called_once()
 
 
-def test_show_status():
+def test_show_status() -> None:
     with (
         patch("shared.python.engine_manager.EngineManager") as mock_mgr_cls,
         patch("builtins.print") as mock_print,
@@ -116,7 +116,7 @@ def test_show_status():
             assert found
 
 
-def test_get_version():
+def test_get_version() -> None:
     with (
         patch("launchers.unified_launcher.QApplication"),
         patch("launchers.golf_launcher.GolfLauncher"),

--- a/src/launchers/ui_components.py
+++ b/src/launchers/ui_components.py
@@ -306,7 +306,7 @@ class AsyncStartupWorker(QThread):
     finished_signal = pyqtSignal(object)
     error_signal = pyqtSignal(str)
 
-    def __init__(self, repos_root: Path):
+    def __init__(self, repos_root: Path) -> None:
         super().__init__()
         self.repos_root = repos_root
         self.results = StartupResults()
@@ -349,7 +349,7 @@ class AsyncStartupWorker(QThread):
 class DraggableModelCard(QFrame):
     """Draggable model card widget with reordering support."""
 
-    def __init__(self, model: Any, parent_launcher: Any):
+    def __init__(self, model: Any, parent_launcher: Any) -> None:
         super().__init__(None)
         self.model = model
         self.parent_launcher = parent_launcher

--- a/src/learning/imitation/dataset.py
+++ b/src/learning/imitation/dataset.py
@@ -199,7 +199,7 @@ class DemonstrationDataset:
         """Get demonstration by index."""
         return self.demonstrations[idx]
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         """Iterate over demonstrations."""
         return iter(self.demonstrations)
 

--- a/src/learning/rl/manipulation_envs.py
+++ b/src/learning/rl/manipulation_envs.py
@@ -178,7 +178,7 @@ class ManipulationPickPlaceEnv(RoboticsGymEnv):
 
         return np.concatenate(obs_parts).astype(np.float32)
 
-    def _build_observation_space(self):
+    def _build_observation_space(self) -> Any:
         """Build observation space including object state."""
         from gymnasium import spaces
 
@@ -325,7 +325,7 @@ class DualArmManipulationEnv(RoboticsGymEnv):
         """Dual arm has two end-effectors."""
         return 2
 
-    def _build_action_space(self):
+    def _build_action_space(self) -> Any:
         """Build action space for both arms."""
         from gymnasium import spaces
 

--- a/src/shared/models/myosuite/myo_sim/test_sims.py
+++ b/src/shared/models/myosuite/myo_sim/test_sims.py
@@ -47,7 +47,7 @@ model_paths = [
 
 
 class TestSims(unittest.TestCase):
-    def get_sim(self, model_path: str | None = None, model_xmlstr: str | None = None):
+    def get_sim(self, model_path: str | None = None, model_xmlstr: str | None = None) -> Any:
         """
         Get sim using model_path or model_xmlstr.
         """
@@ -76,7 +76,7 @@ class TestSims(unittest.TestCase):
 
         return model
 
-    def test_sims(self):
+    def test_sims(self) -> None:
         for model_path in model_paths:
             logger.info(f"Testing: {model_path}")
             self.get_sim(model_path)

--- a/src/shared/models/opensim/opensim-models/Geometry/remove_vtp_normals.py
+++ b/src/shared/models/opensim/opensim-models/Geometry/remove_vtp_normals.py
@@ -8,11 +8,11 @@ _normals_pattern = re.compile(
 )
 
 
-def remove_normals_node(vtp_content):
+def remove_normals_node(vtp_content) -> Any:
     return re.sub(_normals_pattern, "", vtp_content)
 
 
-def remove_normals_from_vtp(vtp_path):
+def remove_normals_from_vtp(vtp_path) -> None:
     with open(vtp_path, newline="") as fd:
         vtp_content = fd.read()
 
@@ -23,7 +23,7 @@ def remove_normals_from_vtp(vtp_path):
             fd.write(modified_vtp_content)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description='removes <PointData Normals="Normals">...</PointData> in each given VTP file'
     )

--- a/src/shared/python/ai/adapters/gemini_adapter.py
+++ b/src/shared/python/ai/adapters/gemini_adapter.py
@@ -34,7 +34,7 @@ except ImportError:
 class GeminiAdapter(BaseAgentAdapter):
     """Adapter for Google Gemini API."""
 
-    def __init__(self, api_key: str, model: str = "gemini-pro"):
+    def __init__(self, api_key: str, model: str = "gemini-pro") -> None:
         """Initialize Gemini adapter.
 
         Args:

--- a/src/shared/python/biomechanics/activation_dynamics.py
+++ b/src/shared/python/biomechanics/activation_dynamics.py
@@ -53,7 +53,7 @@ class ActivationDynamics:
         tau_act: float = 0.010,
         tau_deact: float = 0.040,
         min_activation: float = 0.001,
-    ):
+    ) -> None:
         """Initialize activation dynamics.
 
         Args:

--- a/src/shared/python/biomechanics/hill_muscle.py
+++ b/src/shared/python/biomechanics/hill_muscle.py
@@ -75,7 +75,7 @@ class HillMuscleModel:
     F_total = (F_CE + F_PEE) * cos(alpha)
     """
 
-    def __init__(self, params: MuscleParameters):
+    def __init__(self, params: MuscleParameters) -> None:
         """Initialize muscle model.
 
         Args:

--- a/src/shared/python/config/config_utils.py
+++ b/src/shared/python/config/config_utils.py
@@ -182,7 +182,7 @@ class ConfigLoader:
         loader.save(config)
     """
 
-    def __init__(self, path: str | Path, format: str = "json"):
+    def __init__(self, path: str | Path, format: str = "json") -> None:
         """Initialize configuration loader.
 
         Args:

--- a/src/shared/python/config/environment.py
+++ b/src/shared/python/config/environment.py
@@ -46,7 +46,7 @@ class EnvironmentError(ConfigurationError):
         reason: str | None = None,
         expected: str | None = None,
         actual: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             config_key=var_name,
             reason=reason or "Environment variable not set or invalid",

--- a/src/shared/python/config/model_registry.py
+++ b/src/shared/python/config/model_registry.py
@@ -23,7 +23,7 @@ class ModelConfig:
 class ModelRegistry:
     """Registry for loading and accessing model configurations."""
 
-    def __init__(self, config_path: str | Path = "config/models.yaml"):
+    def __init__(self, config_path: str | Path = "config/models.yaml") -> None:
         """Initialize registry.
 
         Args:

--- a/src/shared/python/config/standard_models.py
+++ b/src/shared/python/config/standard_models.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 class StandardModelManager:
     """Manages standardized models for consistent cross-engine simulation."""
 
-    def __init__(self, suite_root: Path | None = None):
+    def __init__(self, suite_root: Path | None = None) -> None:
         """Initialize standard model manager.
 
         Args:

--- a/src/shared/python/core/contracts.py
+++ b/src/shared/python/core/contracts.py
@@ -53,7 +53,7 @@ class ContractViolationError(Exception):
         message: str,
         function_name: str | None = None,
         details: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         self.contract_type = contract_type
         self.function_name = function_name
         self.details = details or {}
@@ -78,7 +78,7 @@ class PreconditionError(ContractViolationError):
         function_name: str | None = None,
         parameter: str | None = None,
         value: Any = None,
-    ):
+    ) -> None:
         details = {}
         if parameter:
             details["parameter"] = parameter
@@ -103,7 +103,7 @@ class PostconditionError(ContractViolationError):
         message: str,
         function_name: str | None = None,
         result: Any = None,
-    ):
+    ) -> None:
         details = {}
         if result is not None:
             # Avoid storing large arrays
@@ -130,7 +130,7 @@ class InvariantError(ContractViolationError):
         message: str,
         class_name: str | None = None,
         method_name: str | None = None,
-    ):
+    ) -> None:
         details = {}
         if class_name:
             details["class"] = class_name
@@ -156,7 +156,7 @@ class StateError(ContractViolationError):
         current_state: str | None = None,
         required_state: str | None = None,
         operation: str | None = None,
-    ):
+    ) -> None:
         details = {}
         if current_state:
             details["current_state"] = current_state

--- a/src/shared/python/core/error_decorators.py
+++ b/src/shared/python/core/error_decorators.py
@@ -167,7 +167,7 @@ class ErrorContext:
         operation: str,
         reraise: bool = True,
         log_success: bool = False,
-    ):
+    ) -> None:
         """Initialize error context.
 
         Args:

--- a/src/shared/python/core/error_utils.py
+++ b/src/shared/python/core/error_utils.py
@@ -50,7 +50,7 @@ class EngineNotAvailableError(GolfSuiteError):
         engine_name: str,
         operation: str | None = None,
         install_hint: str | None = None,
-    ):
+    ) -> None:
         self.engine_name = engine_name
         self.operation = operation
 
@@ -85,7 +85,7 @@ class ConfigurationError(GolfSuiteError):
         reason: str | None = None,
         expected: Any = None,
         actual: Any = None,
-    ):
+    ) -> None:
         self.config_key = config_key
         self.reason = reason
         self.expected = expected
@@ -112,7 +112,7 @@ class ValidationError(GolfSuiteError):
         reason: str | None = None,
         valid_values: list[Any] | None = None,
         message: str | None = None,
-    ):
+    ) -> None:
         self.field = field
         self.value = value
         self.reason = reason
@@ -141,7 +141,7 @@ class ModelError(GolfSuiteError):
         model_name: str,
         operation: str,
         details: str | None = None,
-    ):
+    ) -> None:
         self.model_name = model_name
         self.operation = operation
         self.details = details
@@ -161,7 +161,7 @@ class SimulationError(GolfSuiteError):
         message: str,
         time_step: float | None = None,
         state: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         self.time_step = time_step
         self.state = state
 
@@ -180,7 +180,7 @@ class FileOperationError(GolfSuiteError):
         path: Path | str,
         operation: str,
         reason: str | None = None,
-    ):
+    ) -> None:
         self.path = Path(path)
         self.operation = operation
         self.reason = reason
@@ -382,7 +382,7 @@ class EnvironmentError(ConfigurationError):
         reason: str | None = None,
         expected: str | None = None,
         actual: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             config_key=var_name,
             reason=reason or "Environment variable not set or invalid",
@@ -398,7 +398,7 @@ class IOError(GolfSuiteError):
     Consolidated from io_utils.py.
     """
 
-    def __init__(self, message: str, path: Path | str | None = None):
+    def __init__(self, message: str, path: Path | str | None = None) -> None:
         self.path = Path(path) if path else None
         if self.path:
             message = f"{message}: {self.path}"
@@ -411,7 +411,7 @@ class FileNotFoundIOError(IOError):
     Consolidated from io_utils.py.
     """
 
-    def __init__(self, path: Path | str, context: str | None = None):
+    def __init__(self, path: Path | str, context: str | None = None) -> None:
         self.context = context
         message = "File not found"
         if context:
@@ -430,7 +430,7 @@ class FileParseError(IOError):
         path: Path | str,
         format_type: str,
         details: str | None = None,
-    ):
+    ) -> None:
         self.format_type = format_type
         self.details = details
         message = f"Failed to parse {format_type} file"
@@ -450,7 +450,7 @@ class PhysicalValidationError(ValidationError):
         field: str,
         value: Any = None,
         physical_constraint: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             field=field,
             value=value,
@@ -470,7 +470,7 @@ class DataFormatError(GolfSuiteError):
         message: str,
         expected_format: str | None = None,
         actual_format: str | None = None,
-    ):
+    ) -> None:
         self.expected_format = expected_format
         self.actual_format = actual_format
 
@@ -493,7 +493,7 @@ class TimeoutError(GolfSuiteError):
         operation: str,
         timeout_seconds: float,
         details: str | None = None,
-    ):
+    ) -> None:
         self.operation = operation
         self.timeout_seconds = timeout_seconds
         self.details = details
@@ -515,7 +515,7 @@ class ResourceError(GolfSuiteError):
         self,
         resource_type: str,
         reason: str | None = None,
-    ):
+    ) -> None:
         self.resource_type = resource_type
         self.reason = reason
 

--- a/src/shared/python/core/exceptions.py
+++ b/src/shared/python/core/exceptions.py
@@ -41,7 +41,7 @@ class ArrayDimensionError(GolfSuiteError):
         expected_shape: tuple[int, ...] | None = None,
         actual_shape: tuple[int, ...] | None = None,
         message: str | None = None,
-    ):
+    ) -> None:
         self.expected_shape = expected_shape
         self.actual_shape = actual_shape
 

--- a/src/shared/python/dashboard/advanced_analysis.py
+++ b/src/shared/python/dashboard/advanced_analysis.py
@@ -58,7 +58,7 @@ class SpectrogramTab(QtWidgets.QWidget):
 
     def __init__(
         self, recorder: RecorderInterface, initial_key: str = "joint_positions"
-    ):
+    ) -> None:
         super().__init__()
         self.recorder = recorder
         self.current_key = initial_key
@@ -161,7 +161,7 @@ class WaveletTab(QtWidgets.QWidget):
 
     def __init__(
         self, recorder: RecorderInterface, initial_key: str = "joint_velocities"
-    ):
+    ) -> None:
         super().__init__()
         self.recorder = recorder
         self.current_key = initial_key
@@ -263,7 +263,7 @@ class WaveletTab(QtWidgets.QWidget):
 class SwingPlaneTab(QtWidgets.QWidget):
     """Tab for Swing Plane Analysis (3D)."""
 
-    def __init__(self, recorder: RecorderInterface):
+    def __init__(self, recorder: RecorderInterface) -> None:
         super().__init__()
         self.recorder = recorder
         self.analyzer = SwingPlaneAnalyzer()
@@ -364,7 +364,7 @@ class SwingPlaneTab(QtWidgets.QWidget):
 class CorrelationTab(QtWidgets.QWidget):
     """Tab for Correlation Heatmap of scalar metrics."""
 
-    def __init__(self, recorder: RecorderInterface):
+    def __init__(self, recorder: RecorderInterface) -> None:
         super().__init__()
         self.recorder = recorder
 
@@ -469,7 +469,7 @@ class CorrelationTab(QtWidgets.QWidget):
 class PhasePlaneTab(QtWidgets.QWidget):
     """Tab for Phase Plane Analysis (Position vs Velocity)."""
 
-    def __init__(self, recorder: RecorderInterface):
+    def __init__(self, recorder: RecorderInterface) -> None:
         super().__init__()
         self.recorder = recorder
 
@@ -560,7 +560,7 @@ class CoherenceTab(QtWidgets.QWidget):
         recorder: RecorderInterface,
         key1: str = "joint_positions",
         key2: str = "joint_torques",
-    ):
+    ) -> None:
         super().__init__()
         self.recorder = recorder
 
@@ -681,7 +681,7 @@ class AdvancedAnalysisDialog(QtWidgets.QDialog):
         recorder: RecorderInterface,
         current_key: str = "joint_positions",
         comparison_key: str | None = None,
-    ):
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Advanced Analysis Tools")
         self.resize(1000, 800)  # Increased size for more tabs

--- a/src/shared/python/dashboard/tests/test_widgets.py
+++ b/src/shared/python/dashboard/tests/test_widgets.py
@@ -12,7 +12,7 @@ from src.shared.python.interfaces import RecorderInterface
 
 
 class MockRecorder(RecorderInterface):
-    def __init__(self):
+    def __init__(self) -> None:
         self.engine = None
         self.data = {
             "joint_positions": (np.arange(100) * 0.1, np.random.rand(100, 3)),
@@ -20,55 +20,55 @@ class MockRecorder(RecorderInterface):
         }
         self.config = {}
 
-    def get_time_series(self, key):
+    def get_time_series(self, key) -> Any:
         return self.data.get(key, (np.array([]), None))
 
-    def get_induced_acceleration_series(self, src_idx):
+    def get_induced_acceleration_series(self, src_idx) -> tuple:
         return np.array([]), None
 
-    def set_analysis_config(self, config):
+    def set_analysis_config(self, config) -> None:
         self.config = config
 
-    def start(self):
+    def start(self) -> None:
         pass
 
-    def stop(self):
+    def stop(self) -> None:
         pass
 
-    def reset(self):
+    def reset(self) -> None:
         pass
 
-    def record_step(self):
+    def record_step(self) -> None:
         pass
 
-    def compute_analysis_post_hoc(self):
+    def compute_analysis_post_hoc(self) -> None:
         pass
 
-    def get_counterfactual_series(self, key):
+    def get_counterfactual_series(self, key) -> tuple:
         return np.array([]), None
 
-    def get_data_dict(self):
+    def get_data_dict(self) -> Any:
         # Fix: return the data dict so widget can initialize metrics if it uses this (it doesn't actually use this for init, it uses hardcoded keys, but good practice)
         return self.data
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> Any:
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> Any:
     return MockRecorder()
 
 
-def test_live_plot_widget_init(app, recorder):
+def test_live_plot_widget_init(app, recorder) -> None:
     widget = LivePlotWidget(recorder)
     assert widget.current_key == "joint_positions"
     assert widget.lbl_stats.text().startswith("Mean:")
 
 
-def test_live_plot_widget_stats_update(app, recorder):
+def test_live_plot_widget_stats_update(app, recorder) -> None:
     widget = LivePlotWidget(recorder)
     widget.update_plot()
 
@@ -80,7 +80,7 @@ def test_live_plot_widget_stats_update(app, recorder):
     assert text != "Mean: 0.00 | Std: 0.00 | Min: 0.00 | Max: 0.00"
 
 
-def test_live_plot_widget_xy_mode(app, recorder):
+def test_live_plot_widget_xy_mode(app, recorder) -> None:
     widget = LivePlotWidget(recorder)
 
     # Enable X-Y mode
@@ -104,7 +104,7 @@ def test_live_plot_widget_xy_mode(app, recorder):
     assert widget.ax2 is None
 
 
-def test_live_plot_widget_freq_analysis(app, recorder):
+def test_live_plot_widget_freq_analysis(app, recorder) -> None:
     widget = LivePlotWidget(recorder)
 
     # Mock QDialog.exec to prevent blocking
@@ -120,7 +120,7 @@ def test_live_plot_widget_freq_analysis(app, recorder):
             # widget.show_freq_analysis instantiates FrequencyAnalysisDialog which calls compute_psd
 
 
-def test_frequency_analysis_dialog(app):
+def test_frequency_analysis_dialog(app) -> None:
     data = np.random.rand(100, 2)
     fs = 10.0
 
@@ -139,12 +139,12 @@ def test_frequency_analysis_dialog(app):
 
 
 @pytest.fixture
-def control_panel(qapp):
+def control_panel(qapp) -> Any:
     """Fixture for ControlPanel widget."""
     return ControlPanel()
 
 
-def test_control_panel_init(control_panel):
+def test_control_panel_init(control_panel) -> None:
     """Test ControlPanel initializes with all buttons."""
     assert control_panel.btn_start is not None
     assert control_panel.btn_pause is not None
@@ -152,31 +152,31 @@ def test_control_panel_init(control_panel):
     assert control_panel.btn_reset is not None
 
 
-def test_control_panel_start_signal(control_panel, qtbot):
+def test_control_panel_start_signal(control_panel, qtbot) -> None:
     """Test start button emits start_requested signal."""
     with qtbot.waitSignal(control_panel.start_requested, timeout=1000):
         control_panel.btn_start.click()
 
 
-def test_control_panel_pause_signal(control_panel, qtbot):
+def test_control_panel_pause_signal(control_panel, qtbot) -> None:
     """Test pause button emits pause_requested signal."""
     with qtbot.waitSignal(control_panel.pause_requested, timeout=1000):
         control_panel.btn_pause.click()
 
 
-def test_control_panel_stop_signal(control_panel, qtbot):
+def test_control_panel_stop_signal(control_panel, qtbot) -> None:
     """Test stop button emits stop_requested signal."""
     with qtbot.waitSignal(control_panel.stop_requested, timeout=1000):
         control_panel.btn_stop.click()
 
 
-def test_control_panel_reset_signal(control_panel, qtbot):
+def test_control_panel_reset_signal(control_panel, qtbot) -> None:
     """Test reset button emits reset_requested signal."""
     with qtbot.waitSignal(control_panel.reset_requested, timeout=1000):
         control_panel.btn_reset.click()
 
 
-def test_control_panel_pause_checkable(control_panel):
+def test_control_panel_pause_checkable(control_panel) -> None:
     """Test pause button is checkable (toggle state)."""
     assert control_panel.btn_pause.isCheckable()
     control_panel.btn_pause.click()
@@ -185,7 +185,7 @@ def test_control_panel_pause_checkable(control_panel):
     assert not control_panel.btn_pause.isChecked()
 
 
-def test_control_panel_tooltips(control_panel):
+def test_control_panel_tooltips(control_panel) -> None:
     """Test buttons have appropriate tooltips with shortcuts."""
     assert "Ctrl+R" in control_panel.btn_start.toolTip()
     assert "Space" in control_panel.btn_pause.toolTip()
@@ -193,7 +193,7 @@ def test_control_panel_tooltips(control_panel):
     assert "R" in control_panel.btn_reset.toolTip()
 
 
-def test_control_panel_accessibility(control_panel):
+def test_control_panel_accessibility(control_panel) -> None:
     """Test ControlPanel has accessibility attributes."""
     assert control_panel.accessibleName() == "Simulation Control Panel"
     assert "Controls for starting" in control_panel.accessibleDescription()
@@ -204,7 +204,7 @@ def test_control_panel_accessibility(control_panel):
 # =============================================================================
 
 
-def test_live_plot_widget_metric_switching(app, recorder):
+def test_live_plot_widget_metric_switching(app, recorder) -> None:
     """Test switching between different metrics."""
     widget = LivePlotWidget(recorder)
 
@@ -217,7 +217,7 @@ def test_live_plot_widget_metric_switching(app, recorder):
     assert widget.current_key == "joint_positions"
 
 
-def test_live_plot_widget_plot_mode_norm(app, recorder):
+def test_live_plot_widget_plot_mode_norm(app, recorder) -> None:
     """Test 'Norm' plot mode (magnitude of vector)."""
     widget = LivePlotWidget(recorder)
     widget.combo_plot_mode.setCurrentText("Norm")
@@ -227,11 +227,11 @@ def test_live_plot_widget_plot_mode_norm(app, recorder):
     assert len(lines) == 1
 
 
-def test_live_plot_widget_empty_data(app):
+def test_live_plot_widget_empty_data(app) -> tuple:
     """Test widget handles empty data gracefully."""
 
     class EmptyRecorder(MockRecorder):
-        def get_time_series(self, key):
+        def get_time_series(self, key) -> tuple:
             return np.array([]), None
 
     empty_recorder = EmptyRecorder()
@@ -243,7 +243,7 @@ def test_live_plot_widget_empty_data(app):
     assert "Mean:" in text
 
 
-def test_live_plot_widget_single_dimension(app, recorder):
+def test_live_plot_widget_single_dimension(app, recorder) -> None:
     """Test 'Single Dimension' plot mode with dimension selector."""
     widget = LivePlotWidget(recorder)
     widget.combo_plot_mode.setCurrentText("Single Dimension")
@@ -257,7 +257,7 @@ def test_live_plot_widget_single_dimension(app, recorder):
     assert len(lines) == 1
 
 
-def test_live_plot_widget_snapshot(app, recorder, tmp_path, monkeypatch):
+def test_live_plot_widget_snapshot(app, recorder, tmp_path, monkeypatch) -> None:
     """Test snapshot capture functionality."""
     from PyQt6 import QtWidgets
 

--- a/src/shared/python/data_io/data_utils.py
+++ b/src/shared/python/data_io/data_utils.py
@@ -219,7 +219,7 @@ class DataLoader:
         data = loader.load(use_cache=False)
     """
 
-    def __init__(self, path: str | Path):
+    def __init__(self, path: str | Path) -> None:
         """Initialize data loader.
 
         Args:

--- a/src/shared/python/data_io/import_utils.py
+++ b/src/shared/python/data_io/import_utils.py
@@ -251,7 +251,7 @@ class ImportContext:
             from src.shared.python import utils
     """
 
-    def __init__(self, *paths: str | Path):
+    def __init__(self, *paths: str | Path) -> None:
         """Initialize import context.
 
         Args:

--- a/src/shared/python/data_io/output_manager.py
+++ b/src/shared/python/data_io/output_manager.py
@@ -78,7 +78,7 @@ class OutputManager:
             cls._io_executor.shutdown(wait=True)
             cls._io_executor = None
 
-    def __init__(self, base_path: str | Path | None = None):
+    def __init__(self, base_path: str | Path | None = None) -> None:
         """
         Initialize OutputManager.
 

--- a/src/shared/python/engine_core/base_physics_engine.py
+++ b/src/shared/python/engine_core/base_physics_engine.py
@@ -49,7 +49,7 @@ logger = get_logger(__name__)
 class EngineState:
     """Common state representation for physics engines."""
 
-    def __init__(self, nq: int = 0, nv: int = 0):
+    def __init__(self, nq: int = 0, nv: int = 0) -> None:
         """Initialize engine state.
 
         Args:
@@ -103,7 +103,7 @@ class BasePhysicsEngine(ContractChecker, PhysicsEngine):
     - reset()
     """
 
-    def __init__(self, allowed_dirs: list[Path] | None = None):
+    def __init__(self, allowed_dirs: list[Path] | None = None) -> None:
         """Initialize base physics engine.
 
         Args:

--- a/src/shared/python/engine_core/engine_manager.py
+++ b/src/shared/python/engine_core/engine_manager.py
@@ -36,7 +36,7 @@ class EngineManager:
     Refactored to use EngineRegistry (Decoupling Phase).
     """
 
-    def __init__(self, suite_root: Path | None = None):
+    def __init__(self, suite_root: Path | None = None) -> None:
         """Initialize the engine manager.
 
         Args:

--- a/src/shared/python/engine_core/unified_engine_interface.py
+++ b/src/shared/python/engine_core/unified_engine_interface.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 class UnifiedEngineInterface:
     """Unified interface for all physics engines with standardized model loading."""
 
-    def __init__(self, suite_root: Path | None = None):
+    def __init__(self, suite_root: Path | None = None) -> None:
         """Initialize unified engine interface.
 
         Args:

--- a/src/shared/python/gui_pkg/gui_utils.py
+++ b/src/shared/python/gui_pkg/gui_utils.py
@@ -136,7 +136,7 @@ class BaseApplicationWindow(QMainWindow):
         title: str,
         size: tuple[int, int] = (1400, 900),
         icon_path: Path | None = None,
-    ):
+    ) -> None:
         """Initialize base application window.
 
         Args:
@@ -358,7 +358,7 @@ class LayoutBuilder:
                   .build())
     """
 
-    def __init__(self, layout: Any):
+    def __init__(self, layout: Any) -> None:
         """Initialize layout builder.
 
         Args:

--- a/src/shared/python/injury/joint_stress.py
+++ b/src/shared/python/injury/joint_stress.py
@@ -171,7 +171,7 @@ class JointStressAnalyzer:
         body_weight: float,
         handedness: str = "right",
         height: float | None = None,
-    ):
+    ) -> None:
         """
         Initialize the joint stress analyzer.
 

--- a/src/shared/python/injury/spinal_load_analysis.py
+++ b/src/shared/python/injury/spinal_load_analysis.py
@@ -162,7 +162,7 @@ class SpinalLoadAnalyzer:
         height: float | None = None,
         trunk_length: float | None = None,
         lumbar_segments: list[str] | None = None,
-    ):
+    ) -> None:
         """
         Initialize the spinal load analyzer.
 

--- a/src/shared/python/optimization/tests/test_swing_optimizer.py
+++ b/src/shared/python/optimization/tests/test_swing_optimizer.py
@@ -28,13 +28,13 @@ from src.shared.python.optimization.swing_optimizer import (
 
 
 @pytest.fixture
-def default_golfer():
+def default_golfer() -> Any:
     """Default golfer model with average parameters."""
     return GolferModel()
 
 
 @pytest.fixture
-def custom_golfer():
+def custom_golfer() -> Any:
     """Custom golfer with specific parameters."""
     return GolferModel(
         height=1.85,
@@ -46,13 +46,13 @@ def custom_golfer():
 
 
 @pytest.fixture
-def default_club():
+def default_club() -> Any:
     """Default driver club model."""
     return ClubModel()
 
 
 @pytest.fixture
-def iron_club():
+def iron_club() -> Any:
     """7-iron club model."""
     return ClubModel(
         total_length=0.95,
@@ -63,7 +63,7 @@ def iron_club():
 
 
 @pytest.fixture
-def basic_config():
+def basic_config() -> Any:
     """Basic optimization config for fast testing."""
     return OptimizationConfig(
         objectives={OptimizationObjective.CLUBHEAD_VELOCITY: 1.0},
@@ -78,7 +78,7 @@ def basic_config():
 # =============================================================================
 
 
-def test_golfer_model_defaults():
+def test_golfer_model_defaults() -> None:
     """Test GolferModel has reasonable defaults."""
     golfer = GolferModel()
     assert golfer.height == 1.75
@@ -87,14 +87,14 @@ def test_golfer_model_defaults():
     assert golfer.flexibility_factor == 1.0
 
 
-def test_golfer_model_custom():
+def test_golfer_model_custom() -> None:
     """Test GolferModel accepts custom parameters."""
     golfer = GolferModel(height=1.90, mass=90.0)
     assert golfer.height == 1.90
     assert golfer.mass == 90.0
 
 
-def test_golfer_model_joint_limits():
+def test_golfer_model_joint_limits() -> None:
     """Test GolferModel joint limits are tuples."""
     golfer = GolferModel()
     assert isinstance(golfer.shoulder_rom, tuple)
@@ -102,7 +102,7 @@ def test_golfer_model_joint_limits():
     assert golfer.shoulder_rom[0] < golfer.shoulder_rom[1]
 
 
-def test_golfer_model_torque_limits_positive():
+def test_golfer_model_torque_limits_positive() -> None:
     """Test GolferModel torque limits are positive."""
     golfer = GolferModel()
     assert golfer.max_shoulder_torque > 0
@@ -117,7 +117,7 @@ def test_golfer_model_torque_limits_positive():
 # =============================================================================
 
 
-def test_club_model_defaults():
+def test_club_model_defaults() -> None:
     """Test ClubModel has reasonable defaults for a driver."""
     club = ClubModel()
     assert club.total_length == 1.15
@@ -125,14 +125,14 @@ def test_club_model_defaults():
     assert club.shaft_flex == "regular"
 
 
-def test_club_model_total_mass():
+def test_club_model_total_mass() -> None:
     """Test ClubModel calculates total mass correctly."""
     club = ClubModel()
     expected_mass = club.head_mass + club.shaft_mass + club.grip_mass
     assert club.total_mass == expected_mass
 
 
-def test_club_model_moment_of_inertia():
+def test_club_model_moment_of_inertia() -> None:
     """Test ClubModel MOI is positive and reasonable."""
     club = ClubModel()
     assert club.club_moi > 0
@@ -145,7 +145,7 @@ def test_club_model_moment_of_inertia():
 # =============================================================================
 
 
-def test_optimization_config_defaults():
+def test_optimization_config_defaults() -> None:
     """Test OptimizationConfig has valid defaults."""
     config = OptimizationConfig()
     assert config.n_nodes >= 10
@@ -153,7 +153,7 @@ def test_optimization_config_defaults():
     assert len(config.objectives) > 0
 
 
-def test_optimization_config_custom_objectives():
+def test_optimization_config_custom_objectives() -> None:
     """Test OptimizationConfig accepts custom objectives."""
     config = OptimizationConfig(
         objectives={
@@ -165,7 +165,7 @@ def test_optimization_config_custom_objectives():
     assert OptimizationObjective.INJURY_RISK in config.objectives
 
 
-def test_optimization_config_constraints():
+def test_optimization_config_constraints() -> None:
     """Test OptimizationConfig accepts constraints."""
     config = OptimizationConfig(
         constraints=[
@@ -182,7 +182,7 @@ def test_optimization_config_constraints():
 # =============================================================================
 
 
-def test_optimizer_init(default_golfer, default_club, basic_config):
+def test_optimizer_init(default_golfer, default_club, basic_config) -> None:
     """Test SwingOptimizer initializes correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert optimizer.golfer == default_golfer
@@ -190,14 +190,14 @@ def test_optimizer_init(default_golfer, default_club, basic_config):
     assert optimizer.config == basic_config
 
 
-def test_optimizer_init_default_config(default_golfer, default_club):
+def test_optimizer_init_default_config(default_golfer, default_club) -> None:
     """Test SwingOptimizer uses default config when not provided."""
     optimizer = SwingOptimizer(default_golfer, default_club)
     assert optimizer.config is not None
     assert isinstance(optimizer.config, OptimizationConfig)
 
 
-def test_optimizer_joint_limits_setup(default_golfer, default_club, basic_config):
+def test_optimizer_joint_limits_setup(default_golfer, default_club, basic_config) -> None:
     """Test SwingOptimizer sets up joint limits correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert "hip_rotation" in optimizer.joint_limits
@@ -205,14 +205,14 @@ def test_optimizer_joint_limits_setup(default_golfer, default_club, basic_config
     assert len(optimizer.joint_limits) == len(SwingOptimizer.JOINTS)
 
 
-def test_optimizer_torque_limits_setup(default_golfer, default_club, basic_config):
+def test_optimizer_torque_limits_setup(default_golfer, default_club, basic_config) -> None:
     """Test SwingOptimizer sets up torque limits correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert "hip_rotation" in optimizer.torque_limits
     assert all(t > 0 for t in optimizer.torque_limits.values())
 
 
-def test_optimizer_lever_length(default_golfer, default_club, basic_config):
+def test_optimizer_lever_length(default_golfer, default_club, basic_config) -> None:
     """Test total lever (arm + club) is calculated correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     expected = default_golfer.arm_length + default_club.total_length
@@ -224,7 +224,7 @@ def test_optimizer_lever_length(default_golfer, default_club, basic_config):
 # =============================================================================
 
 
-def test_swing_trajectory_creation():
+def test_swing_trajectory_creation() -> None:
     """Test SwingTrajectory can be created with valid data."""
     n_nodes = 20
     trajectory = SwingTrajectory(
@@ -245,7 +245,7 @@ def test_swing_trajectory_creation():
 
 
 @pytest.mark.slow
-def test_optimizer_optimize_runs(default_golfer, default_club, basic_config):
+def test_optimizer_optimize_runs(default_golfer, default_club, basic_config) -> None:
     """Test optimize() runs without error (smoke test)."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -253,7 +253,7 @@ def test_optimizer_optimize_runs(default_golfer, default_club, basic_config):
 
 
 @pytest.mark.slow
-def test_optimizer_result_has_trajectory(default_golfer, default_club, basic_config):
+def test_optimizer_result_has_trajectory(default_golfer, default_club, basic_config) -> None:
     """Test optimization result contains a trajectory."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -262,7 +262,7 @@ def test_optimizer_result_has_trajectory(default_golfer, default_club, basic_con
 
 
 @pytest.mark.slow
-def test_optimizer_result_has_metrics(default_golfer, default_club, basic_config):
+def test_optimizer_result_has_metrics(default_golfer, default_club, basic_config) -> None:
     """Test optimization result contains performance metrics."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -270,7 +270,7 @@ def test_optimizer_result_has_metrics(default_golfer, default_club, basic_config
 
 
 @pytest.mark.slow
-def test_optimizer_respects_joint_limits(default_golfer, default_club, basic_config):
+def test_optimizer_respects_joint_limits(default_golfer, default_club, basic_config) -> None:
     """Test optimized trajectory respects joint limits."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -285,12 +285,12 @@ def test_optimizer_respects_joint_limits(default_golfer, default_club, basic_con
 
 
 @pytest.mark.slow
-def test_optimizer_callback(default_golfer, default_club, basic_config):
+def test_optimizer_callback(default_golfer, default_club, basic_config) -> None:
     """Test optimizer calls callback function."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     callback_calls = []
 
-    def my_callback(iteration, value):
+    def my_callback(iteration, value) -> None:
         callback_calls.append((iteration, value))
 
     optimizer.optimize(callback=my_callback)
@@ -302,7 +302,7 @@ def test_optimizer_callback(default_golfer, default_club, basic_config):
 # =============================================================================
 
 
-def test_optimizer_with_zero_flexibility(default_club, basic_config):
+def test_optimizer_with_zero_flexibility(default_club, basic_config) -> None:
     """Test optimizer handles golfer with minimal flexibility."""
     stiff_golfer = GolferModel(flexibility_factor=0.5)
     optimizer = SwingOptimizer(stiff_golfer, default_club, basic_config)
@@ -310,7 +310,7 @@ def test_optimizer_with_zero_flexibility(default_club, basic_config):
     assert optimizer.golfer.flexibility_factor == 0.5
 
 
-def test_optimizer_with_heavy_club(default_golfer, basic_config):
+def test_optimizer_with_heavy_club(default_golfer, basic_config) -> None:
     """Test optimizer handles heavy club."""
     heavy_club = ClubModel(head_mass=0.35, shaft_mass=0.12)
     optimizer = SwingOptimizer(default_golfer, heavy_club, basic_config)
@@ -318,13 +318,13 @@ def test_optimizer_with_heavy_club(default_golfer, basic_config):
     assert optimizer.club.head_mass == 0.35
 
 
-def test_optimizer_objectives_enum():
+def test_optimizer_objectives_enum() -> None:
     """Test all optimization objectives are defined."""
     assert len(OptimizationObjective) >= 5
     assert OptimizationObjective.CLUBHEAD_VELOCITY.value == "clubhead_velocity"
 
 
-def test_optimizer_constraints_enum():
+def test_optimizer_constraints_enum() -> None:
     """Test all optimization constraints are defined."""
     assert len(OptimizationConstraint) >= 4
     assert OptimizationConstraint.JOINT_LIMITS.value == "joint_limits"

--- a/src/shared/python/physics/ball_flight_physics.py
+++ b/src/shared/python/physics/ball_flight_physics.py
@@ -329,7 +329,7 @@ class BallFlightSimulator:
         ball: BallProperties | None = None,
         env: EnvironmentalConditions | None = None,
         environment: EnvironmentalConditions | None = None,
-    ):
+    ) -> None:
         self.ball = ball or BallProperties()
         self.environment = env or environment or EnvironmentalConditions()
 

--- a/src/shared/python/security/subprocess_utils.py
+++ b/src/shared/python/security/subprocess_utils.py
@@ -273,7 +273,7 @@ class CommandRunner:
 
     def __init__(
         self, cwd: str | Path | None = None, env: dict[str, str] | None = None
-    ):
+    ) -> None:
         """Initialize command runner.
 
         Args:

--- a/src/shared/python/signal_toolkit/signal_processing.py
+++ b/src/shared/python/signal_toolkit/signal_processing.py
@@ -808,7 +808,7 @@ class KalmanFilter:
         R: np.ndarray | None = None,
         P: np.ndarray | None = None,
         x: np.ndarray | None = None,
-    ):
+    ) -> None:
         """Initialize Kalman Filter.
 
         Args:

--- a/src/shared/python/test_utils.py
+++ b/src/shared/python/test_utils.py
@@ -334,7 +334,7 @@ class PerformanceTimer:
             engine.load_from_path("model.xml")
     """
 
-    def __init__(self, name: str, log_result: bool = True):
+    def __init__(self, name: str, log_result: bool = True) -> None:
         """Initialize timer.
 
         Args:

--- a/src/shared/python/tests/mock_physics_engine.py
+++ b/src/shared/python/tests/mock_physics_engine.py
@@ -12,7 +12,7 @@ from src.shared.python.interfaces import PhysicsEngine
 class MockPhysicsEngine:
     """Mock physics engine for testing purposes."""
 
-    def __init__(self, n_dof: int = 2):
+    def __init__(self, n_dof: int = 2) -> None:
         """Initialize mock engine.
 
         Args:

--- a/src/shared/python/tests/test_advanced_analysis.py
+++ b/src/shared/python/tests/test_advanced_analysis.py
@@ -23,7 +23,7 @@ except ImportError:
 class MockRecorder:
     """Mock recorder for testing."""
 
-    def __init__(self, length: int = 100):
+    def __init__(self, length: int = 100) -> None:
         self.times = np.linspace(0, 1, length)
         # Create a simple sine wave
         self.position = np.sin(2 * np.pi * self.times)
@@ -62,7 +62,7 @@ class MockRecorder:
         return self.times, np.zeros_like(self.times)
 
 
-def test_poincare_map_3d():
+def test_poincare_map_3d() -> None:
     """Test Poincaré Map plotting."""
     recorder = MockRecorder()
     plotter = GolfSwingPlotter(recorder, joint_names=["J0", "J1", "J2"])  # type: ignore
@@ -87,7 +87,7 @@ def test_poincare_map_3d():
     assert len(fig.axes) > 0
 
 
-def test_phase_space_reconstruction():
+def test_phase_space_reconstruction() -> None:
     """Test Phase Space Reconstruction plotting."""
     recorder = MockRecorder()
     plotter = GolfSwingPlotter(recorder)  # type: ignore
@@ -102,7 +102,7 @@ def test_phase_space_reconstruction():
     assert len(fig.axes) > 0
 
 
-def test_lyapunov_exponent():
+def test_lyapunov_exponent() -> None:
     """Test Lyapunov Exponent estimation."""
     # Generate chaotic data (Lorenz system) or just random walk
     # Use simple sine wave -> LLE should be near 0
@@ -136,7 +136,7 @@ def test_lyapunov_exponent():
     assert isinstance(lle_exp, float)
 
 
-def test_dtw_analysis():
+def test_dtw_analysis() -> None:
     """Test Dynamic Time Warping analysis."""
     rec_a = MockRecorder(100)
     rec_b = MockRecorder(100)
@@ -163,7 +163,7 @@ def test_dtw_analysis():
 
 
 @pytest.mark.skipif(not SKLEARN_AVAILABLE, reason="sklearn not installed")
-def test_muscle_synergies():
+def test_muscle_synergies() -> None:
     """Test Muscle Synergy Analysis."""
     # Create synthetic synergy data
     # 2 Synergies, 4 Muscles

--- a/src/shared/python/tests/test_advanced_analysis_features.py
+++ b/src/shared/python/tests/test_advanced_analysis_features.py
@@ -12,7 +12,7 @@ from src.shared.python.dashboard.advanced_analysis import (
 
 
 class MockRecorder:
-    def get_time_series(self, key: str):
+    def get_time_series(self, key: str) -> tuple:
         t = np.linspace(0, 1, 100)
 
         # Base signal
@@ -51,16 +51,16 @@ class MockRecorder:
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> Any:
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> Any:
     return MockRecorder()
 
 
-def test_wavelet_tab(recorder, qtbot):
+def test_wavelet_tab(recorder, qtbot) -> None:
     tab = WaveletTab(recorder)
     qtbot.addWidget(tab)
 
@@ -73,7 +73,7 @@ def test_wavelet_tab(recorder, qtbot):
     assert len(tab.ax.collections) > 0
 
 
-def test_swing_plane_tab(recorder, qtbot):
+def test_swing_plane_tab(recorder, qtbot) -> None:
     tab = SwingPlaneTab(recorder)
     qtbot.addWidget(tab)
 
@@ -87,7 +87,7 @@ def test_swing_plane_tab(recorder, qtbot):
     assert len(ax3d.collections) > 0 or len(ax3d.patches) > 0
 
 
-def test_correlation_tab(recorder, qtbot):
+def test_correlation_tab(recorder, qtbot) -> None:
     tab = CorrelationTab(recorder)
     qtbot.addWidget(tab)
 
@@ -105,7 +105,7 @@ def test_correlation_tab(recorder, qtbot):
     assert len(tab.ax.images) > 0
 
 
-def test_advanced_analysis_dialog_features(recorder, qtbot):
+def test_advanced_analysis_dialog_features(recorder, qtbot) -> None:
     dlg = AdvancedAnalysisDialog(None, recorder)
     qtbot.addWidget(dlg)
 

--- a/src/shared/python/tests/test_advanced_features.py
+++ b/src/shared/python/tests/test_advanced_features.py
@@ -12,7 +12,7 @@ from src.shared.python.statistical_analysis import StatisticalAnalyzer
 
 
 class MockRecorder(RecorderInterface):
-    def __init__(self, data_dict):
+    def __init__(self, data_dict) -> None:
         self.data = data_dict
         # Compatibility with new tests which might pass more args?
         # New tests MockRecorder takes (times, positions, velocities, accelerations, torques)
@@ -20,18 +20,18 @@ class MockRecorder(RecorderInterface):
         # I need to unify or rename the class in appended code.
         # I'll rename the new MockRecorder to MockRecorderNew in appended code.
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> Any:
         return self.data.get(field_name, ([], []))
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
         return np.array([]), np.array([])
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
         return np.array([]), np.array([])
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> tuple:
     t = np.linspace(0, 1, 100)
     # Simple sine wave
     pos = np.column_stack([np.sin(2 * np.pi * t), np.cos(2 * np.pi * t)])
@@ -45,7 +45,7 @@ def sample_data():
 
 
 @pytest.fixture
-def analyzer(sample_data):
+def analyzer(sample_data) -> Any:
     t, pos, vel, torque = sample_data
     return StatisticalAnalyzer(
         times=t,
@@ -55,7 +55,7 @@ def analyzer(sample_data):
     )
 
 
-def test_joint_stiffness_metrics(analyzer):
+def test_joint_stiffness_metrics(analyzer) -> None:
     """Test computation of joint stiffness."""
     metrics = analyzer.compute_joint_stiffness(0)
     assert metrics is not None
@@ -70,7 +70,7 @@ def test_joint_stiffness_metrics(analyzer):
     assert analyzer.compute_joint_stiffness(99) is None
 
 
-def test_dynamic_stiffness(analyzer):
+def test_dynamic_stiffness(analyzer) -> None:
     """Test computation of rolling stiffness."""
     t, k, r2 = analyzer.compute_dynamic_stiffness(0, window_size=20)
     assert len(t) > 0
@@ -81,7 +81,7 @@ def test_dynamic_stiffness(analyzer):
     assert np.all(r2 > 0.9)
 
 
-def test_fractal_dimension(analyzer):
+def test_fractal_dimension(analyzer) -> None:
     """Test Higuchi Fractal Dimension."""
     # Sine wave is smooth, FD should be close to 1
     # Re-generate clean sine
@@ -98,7 +98,7 @@ def test_fractal_dimension(analyzer):
     assert fd_noise > 1.5
 
 
-def test_sample_entropy(analyzer):
+def test_sample_entropy(analyzer) -> None:
     """Test Sample Entropy."""
     # Sine wave is regular -> low entropy
     t = np.linspace(0, 1, 200)
@@ -113,7 +113,7 @@ def test_sample_entropy(analyzer):
     assert samp_en_noise > 1.0
 
 
-def test_permutation_entropy(analyzer):
+def test_permutation_entropy(analyzer) -> None:
     """Test Permutation Entropy."""
     # Sine wave is regular -> low entropy
     t = np.linspace(0, 1, 200)
@@ -133,7 +133,7 @@ def test_permutation_entropy(analyzer):
     assert pe_noise > 2.0
 
 
-def test_plot_joint_stiffness(sample_data):
+def test_plot_joint_stiffness(sample_data) -> None:
     """Test plotting of joint stiffness."""
     t, pos, vel, torque = sample_data
     recorder = MockRecorder(
@@ -158,7 +158,7 @@ def test_plot_joint_stiffness(sample_data):
     )  # scatter points (collection) + regression line + maybe trajectory line
 
 
-def test_plot_dynamic_stiffness(sample_data):
+def test_plot_dynamic_stiffness(sample_data) -> None:
     """Test plotting of dynamic stiffness."""
     t, pos, vel, torque = sample_data
     recorder = MockRecorder(
@@ -177,7 +177,7 @@ def test_plot_dynamic_stiffness(sample_data):
     assert len(fig.axes) == 2
 
 
-def test_plot_bland_altman(sample_data):
+def test_plot_bland_altman(sample_data) -> None:
     """Test Bland-Altman plot."""
     t, pos, _, _ = sample_data
     # Create two slightly different signals
@@ -205,14 +205,14 @@ def test_plot_bland_altman(sample_data):
 
 
 class MockRecorderNew(RecorderInterface):
-    def __init__(self, times, positions, velocities, accelerations, torques):
+    def __init__(self, times, positions, velocities, accelerations, torques) -> None:
         self.times = times
         self.positions = positions
         self.velocities = velocities
         self.accelerations = accelerations
         self.torques = torques
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple:
         if field_name == "joint_positions":
             return self.times, self.positions
         elif field_name == "joint_velocities":
@@ -223,15 +223,15 @@ class MockRecorderNew(RecorderInterface):
             return self.times, self.torques
         return [], []
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
         return [], []
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
         return [], []
 
 
 class TestAdvancedSignalProcessing:
-    def test_compute_jerk(self):
+    def test_compute_jerk(self) -> None:
         """Test jerk computation using cubic polynomial."""
         t = np.linspace(0, 1, 100)
         # Position x(t) = t^3
@@ -248,7 +248,7 @@ class TestAdvancedSignalProcessing:
         valid_jerk = jerk[10:-10]
         np.testing.assert_allclose(valid_jerk, 6.0, rtol=0.05)
 
-    def test_compute_time_shift(self):
+    def test_compute_time_shift(self) -> None:
         """Test time shift detection."""
         fs = 100.0
         t = np.linspace(0, 2, 200)
@@ -270,7 +270,7 @@ class TestAdvancedSignalProcessing:
 
 
 class TestAdvancedStatisticalAnalysis:
-    def test_compute_jerk_metrics(self):
+    def test_compute_jerk_metrics(self) -> None:
         """Test jerk metrics computation."""
         t = np.linspace(0, 1, 100)
         accel = 6 * t
@@ -295,7 +295,7 @@ class TestAdvancedStatisticalAnalysis:
         assert metrics.peak_jerk == pytest.approx(6.0, rel=0.1)
         assert metrics.rms_jerk == pytest.approx(6.0, rel=0.1)
 
-    def test_compute_lag_matrix(self):
+    def test_compute_lag_matrix(self) -> None:
         """Test lag matrix computation."""
         t = np.linspace(0, 2, 200)
 
@@ -322,7 +322,7 @@ class TestAdvancedStatisticalAnalysis:
         # matrix[0, 2] = lag(x, z) = 0.2
         assert matrix[0, 2] == pytest.approx(0.2, abs=0.01)
 
-    def test_compute_multiscale_entropy(self):
+    def test_compute_multiscale_entropy(self) -> None:
         """Test MSE computation."""
         # Random noise should have high entropy at scale 1, decay or stay high?
         # White noise: entropy decreases with scale.
@@ -347,7 +347,7 @@ class TestAdvancedStatisticalAnalysis:
 
 
 class TestAdvancedPlotting:
-    def test_plots(self):
+    def test_plots(self) -> None:
         """Test that new plots run without error."""
         t = np.linspace(0, 2, 200)
         x = np.sin(2 * np.pi * 2 * t)

--- a/src/shared/python/tests/test_advanced_features_new.py
+++ b/src/shared/python/tests/test_advanced_features_new.py
@@ -10,14 +10,14 @@ from src.shared.python.statistical_analysis import StatisticalAnalyzer
 
 
 class MockRecorder(RecorderInterface):
-    def __init__(self, times, positions, velocities, accelerations, torques):
+    def __init__(self, times, positions, velocities, accelerations, torques) -> None:
         self.times = times
         self.positions = positions
         self.velocities = velocities
         self.accelerations = accelerations
         self.torques = torques
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple:
         if field_name == "joint_positions":
             return self.times, self.positions
         elif field_name == "joint_velocities":
@@ -28,15 +28,15 @@ class MockRecorder(RecorderInterface):
             return self.times, self.torques
         return [], []
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
         return [], []
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
         return [], []
 
 
 class TestAdvancedSignalProcessing:
-    def test_compute_jerk(self):
+    def test_compute_jerk(self) -> None:
         """Test jerk computation using cubic polynomial."""
         t = np.linspace(0, 1, 100)
         # Position x(t) = t^3
@@ -53,7 +53,7 @@ class TestAdvancedSignalProcessing:
         valid_jerk = jerk[10:-10]
         np.testing.assert_allclose(valid_jerk, 6.0, rtol=0.05)
 
-    def test_compute_time_shift(self):
+    def test_compute_time_shift(self) -> None:
         """Test time shift detection."""
         fs = 100.0
         t = np.linspace(0, 2, 200)
@@ -75,7 +75,7 @@ class TestAdvancedSignalProcessing:
 
 
 class TestAdvancedStatisticalAnalysis:
-    def test_compute_jerk_metrics(self):
+    def test_compute_jerk_metrics(self) -> None:
         """Test jerk metrics computation."""
         t = np.linspace(0, 1, 100)
         accel = 6 * t
@@ -99,7 +99,7 @@ class TestAdvancedStatisticalAnalysis:
         assert metrics.peak_jerk == pytest.approx(6.0, rel=0.1)
         assert metrics.rms_jerk == pytest.approx(6.0, rel=0.1)
 
-    def test_compute_lag_matrix(self):
+    def test_compute_lag_matrix(self) -> None:
         """Test lag matrix computation."""
         t = np.linspace(0, 2, 200)
 
@@ -126,7 +126,7 @@ class TestAdvancedStatisticalAnalysis:
         # matrix[0, 2] = lag(x, z) = 0.2
         assert matrix[0, 2] == pytest.approx(0.2, abs=0.01)
 
-    def test_compute_multiscale_entropy(self):
+    def test_compute_multiscale_entropy(self) -> None:
         """Test MSE computation."""
         # Random noise should have high entropy at scale 1, decay or stay high?
         # White noise: entropy decreases with scale.
@@ -151,7 +151,7 @@ class TestAdvancedStatisticalAnalysis:
 
 
 class TestAdvancedPlotting:
-    def test_plots(self):
+    def test_plots(self) -> None:
         """Test that new plots run without error."""
         t = np.linspace(0, 2, 200)
         x = np.sin(2 * np.pi * 2 * t)

--- a/src/shared/python/tests/test_ball_flight_physics.py
+++ b/src/shared/python/tests/test_ball_flight_physics.py
@@ -9,7 +9,7 @@ from src.shared.python.ball_flight_physics import (
 
 
 class TestBallFlightPhysics:
-    def test_trajectory_simulation(self):
+    def test_trajectory_simulation(self) -> None:
         """Test basic trajectory simulation."""
         simulator = BallFlightSimulator()
         launch = LaunchConditions(
@@ -33,7 +33,7 @@ class TestBallFlightPhysics:
         assert metrics["carry_distance"] > 100.0
         assert metrics["max_height"] > 10.0
 
-    def test_no_spin_trajectory(self):
+    def test_no_spin_trajectory(self) -> None:
         """Test trajectory without spin."""
         simulator = BallFlightSimulator()
         launch = LaunchConditions(
@@ -43,7 +43,7 @@ class TestBallFlightPhysics:
         trajectory = simulator.simulate_trajectory(launch)
         assert len(trajectory) > 0
 
-    def test_spin_axis_effect(self):
+    def test_spin_axis_effect(self) -> None:
         """Test that spin axis causes lateral movement."""
         simulator = BallFlightSimulator()
 
@@ -60,7 +60,7 @@ class TestBallFlightPhysics:
         # Should have significant Y deviation
         assert abs(final_pos[1]) > 0.1
 
-    def test_stop_condition(self):
+    def test_stop_condition(self) -> None:
         """Test that simulation stops at ground."""
         simulator = BallFlightSimulator()
         launch = LaunchConditions(velocity=10.0, launch_angle=np.radians(45.0))
@@ -69,7 +69,7 @@ class TestBallFlightPhysics:
         # Z should be close to 0 at end
         assert trajectory[-1].position[2] <= 0.1
 
-    def test_wind_effect(self):
+    def test_wind_effect(self) -> None:
         """Test that wind affects trajectory."""
         ball = BallProperties()
 
@@ -94,7 +94,7 @@ class TestBallFlightPhysics:
         # Headwind should reduce distance
         assert dist_wind < dist_calm
 
-    def test_physics_model_consistency(self):
+    def test_physics_model_consistency(self) -> None:
         """Verify that the reported forces match the simulated acceleration.
 
         This test ensures that the physics logic in `ode_func` (optimized closure)

--- a/src/shared/python/tests/test_checkpoint.py
+++ b/src/shared/python/tests/test_checkpoint.py
@@ -12,7 +12,7 @@ from src.shared.python.checkpoint import (
 
 
 class TestStateCheckpoint(unittest.TestCase):
-    def test_creation(self):
+    def test_creation(self) -> None:
         cp = StateCheckpoint(timestamp=1.0)
         self.assertEqual(cp.timestamp, 1.0)
         self.assertIsNone(cp.engine_state)
@@ -32,7 +32,7 @@ class TestStateCheckpoint(unittest.TestCase):
 
 
 class MockCheckpointable(Checkpointable):
-    def __init__(self):
+    def __init__(self) -> None:
         self.current_state = 0
         self.time = 0.0
 
@@ -48,11 +48,11 @@ class MockCheckpointable(Checkpointable):
 
 
 class TestCheckpointManager(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.target = MockCheckpointable()
         self.manager = CheckpointManager(self.target, max_history=5)
 
-    def test_save_and_restore(self):
+    def test_save_and_restore(self) -> None:
         # Initial state
         self.target.current_state = 10
         self.target.time = 1.0
@@ -77,7 +77,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual(self.target.current_state, 10)
         self.assertEqual(self.target.time, 1.0)
 
-    def test_circular_buffer(self):
+    def test_circular_buffer(self) -> None:
         for i in range(10):
             self.target.current_state = i
             self.target.time = float(i)
@@ -89,7 +89,7 @@ class TestCheckpointManager(unittest.TestCase):
         # Newest should be i=9
         self.assertEqual(self.manager._history[-1].engine_state["val"], 9)
 
-    def test_restore_by_timestamp(self):
+    def test_restore_by_timestamp(self) -> None:
         self.target.time = 1.0
         self.manager.save_checkpoint()
         self.target.time = 2.0
@@ -103,7 +103,7 @@ class TestCheckpointManager(unittest.TestCase):
 
 
 class TestBasePhysicsEngineCheckpoint(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # Patch abstract methods so we can instantiate BasePhysicsEngine
         # We need to list all abstract methods
         patcher = patch.multiple(BasePhysicsEngine, __abstractmethods__=set())
@@ -118,7 +118,7 @@ class TestBasePhysicsEngineCheckpoint(unittest.TestCase):
         self.engine.state.v = np.array([0.1, 0.2])
         self.engine.state.time = 1.5
 
-    def test_save_checkpoint(self):
+    def test_save_checkpoint(self) -> None:
         cp = self.engine.save_checkpoint()
         self.assertEqual(cp.timestamp, 1.5)
         self.assertIsNotNone(cp.engine_state)
@@ -126,7 +126,7 @@ class TestBasePhysicsEngineCheckpoint(unittest.TestCase):
         np.testing.assert_array_equal(cp.engine_state["v"], np.array([0.1, 0.2]))
         self.assertEqual(cp.engine_state["t"], 1.5)
 
-    def test_restore_checkpoint(self):
+    def test_restore_checkpoint(self) -> None:
         cp = StateCheckpoint(
             timestamp=2.0,
             engine_state={
@@ -141,7 +141,7 @@ class TestBasePhysicsEngineCheckpoint(unittest.TestCase):
         np.testing.assert_array_equal(self.engine.state.q, np.array([3.0, 4.0]))
         np.testing.assert_array_equal(self.engine.state.v, np.array([0.3, 0.4]))
 
-    def test_restore_checkpoint_partial(self):
+    def test_restore_checkpoint_partial(self) -> None:
         # Should handle missing engine_state gracefully
         original_time = self.engine.state.time
         cp = StateCheckpoint(timestamp=3.0, engine_state=None)

--- a/src/shared/python/tests/test_comparative_analysis.py
+++ b/src/shared/python/tests/test_comparative_analysis.py
@@ -11,15 +11,15 @@ from src.shared.python.comparative_analysis import (
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self, data_dict):
+    def __init__(self, data_dict) -> None:
         self.data = data_dict
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> Any:
         return self.data.get(field_name, (np.array([]), np.array([])))
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> tuple:
     t = np.linspace(0, 1, 10)
 
     # Swing A: linear
@@ -43,7 +43,7 @@ def sample_data():
     return data_a, data_b
 
 
-def test_align_signals(sample_data):
+def test_align_signals(sample_data) -> None:
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)
@@ -73,7 +73,7 @@ def test_align_signals(sample_data):
     assert aligned_oob is None
 
 
-def test_compare_scalars():
+def test_compare_scalars() -> None:
     rec = MockRecorder({})
     analyzer = ComparativeSwingAnalyzer(rec, rec)
 
@@ -84,7 +84,7 @@ def test_compare_scalars():
     assert np.isclose(metric.percent_diff, (2.0 / 9.0) * 100)
 
 
-def test_generate_comparison_report(sample_data):
+def test_generate_comparison_report(sample_data) -> None:
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)
@@ -105,7 +105,7 @@ def test_generate_comparison_report(sample_data):
     assert "CoP Path Length" in metric_names
 
 
-def test_missing_data_report():
+def test_missing_data_report() -> None:
     rec_empty = MockRecorder({})
     analyzer = ComparativeSwingAnalyzer(rec_empty, rec_empty)
 
@@ -113,7 +113,7 @@ def test_missing_data_report():
     assert len(report["metrics"]) == 0
 
 
-def test_compute_dtw_distance(sample_data):
+def test_compute_dtw_distance(sample_data) -> None:
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)

--- a/src/shared/python/tests/test_comparative_plotting.py
+++ b/src/shared/python/tests/test_comparative_plotting.py
@@ -15,7 +15,7 @@ from src.shared.python.plotting import RecorderInterface
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self, prefix=""):
+    def __init__(self, prefix="") -> None:
         self.prefix = prefix
         self.data = {
             "joint_positions": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
@@ -25,20 +25,20 @@ class MockRecorder(RecorderInterface):
             "kinetic_energy": (np.linspace(0, 1, 10), np.random.rand(10)),
         }
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> Any:
         return self.data.get(field_name, (np.array([]), np.array([])))
 
-    def get_counterfactual_series(self, field_name: str):
+    def get_counterfactual_series(self, field_name: str) -> tuple:
         """Return counterfactual data series."""
         return np.array([]), np.array([])
 
-    def get_induced_acceleration_series(self, field_name: str | int):
+    def get_induced_acceleration_series(self, field_name: str | int) -> tuple:
         """Return induced acceleration data series."""
         return np.array([]), np.array([])
 
 
 @pytest.fixture
-def mock_analyzer():
+def mock_analyzer() -> Any:
     rec_a = MockRecorder("A")
     rec_b = MockRecorder("B")
     analyzer = MagicMock(spec=ComparativeSwingAnalyzer)
@@ -48,7 +48,7 @@ def mock_analyzer():
     analyzer.name_b = "Swing B"
 
     # Mock align_signals
-    def mock_align(field_name, joint_idx=None):
+    def mock_align(field_name, joint_idx=None) -> Any:
         if field_name not in rec_a.data:
             return None
 
@@ -88,20 +88,20 @@ def mock_analyzer():
 
 
 @pytest.fixture
-def plotter(mock_analyzer):
+def plotter(mock_analyzer) -> Any:
     return ComparativePlotter(mock_analyzer)
 
 
 @pytest.fixture
-def fig():
+def fig() -> Any:
     return Figure()
 
 
-def test_init(plotter, mock_analyzer):
+def test_init(plotter, mock_analyzer) -> None:
     assert plotter.analyzer == mock_analyzer
 
 
-def test_plot_comparison(plotter, fig):
+def test_plot_comparison(plotter, fig) -> None:
     plotter.plot_comparison(fig, "club_head_speed")
     assert len(fig.axes) > 0  # GridSpec creates axes on fig
 
@@ -112,7 +112,7 @@ def test_plot_comparison(plotter, fig):
     assert len(fig.axes) > 0  # Should show "Data not available"
 
 
-def test_plot_phase_comparison(plotter, fig):
+def test_plot_phase_comparison(plotter, fig) -> None:
     plotter.plot_phase_comparison(fig, joint_idx=0)
     assert len(fig.axes) > 0
 
@@ -123,7 +123,7 @@ def test_plot_phase_comparison(plotter, fig):
     assert len(fig.axes) == 1
 
 
-def test_plot_3d_trajectory_comparison(plotter, fig):
+def test_plot_3d_trajectory_comparison(plotter, fig) -> None:
     plotter.plot_3d_trajectory_comparison(fig)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
@@ -135,7 +135,7 @@ def test_plot_3d_trajectory_comparison(plotter, fig):
     assert len(fig.axes) > 0  # Text axis
 
 
-def test_plot_dashboard(plotter, fig):
+def test_plot_dashboard(plotter, fig) -> None:
     # This calls plot_comparison with subfigures
     # Note: Figure.add_subfigure is new in Matplotlib 3.4+
 
@@ -148,12 +148,12 @@ def test_plot_dashboard(plotter, fig):
     assert len(fig.subfigs) >= 2 or len(fig.axes) > 0
 
 
-def test_plot_comparison_with_joint_idx(plotter, fig):
+def test_plot_comparison_with_joint_idx(plotter, fig) -> None:
     plotter.plot_comparison(fig, "joint_positions", joint_idx=0)
     assert len(fig.axes) > 0
 
 
-def test_plot_comparison_no_metrics(plotter, fig):
+def test_plot_comparison_no_metrics(plotter, fig) -> None:
     plotter.analyzer.generate_comparison_report.return_value = {"metrics": []}
     plotter.plot_dashboard(fig)
     # Check that it didn't crash

--- a/src/shared/python/tests/test_dashboard_advanced_analysis.py
+++ b/src/shared/python/tests/test_dashboard_advanced_analysis.py
@@ -12,7 +12,7 @@ from src.shared.python.dashboard.advanced_analysis import (
 
 
 class MockRecorder:
-    def get_time_series(self, key: str):
+    def get_time_series(self, key: str) -> tuple:
         t = np.linspace(0, 1, 100)
         data = np.sin(2 * np.pi * 10 * t)
         if key == "joint_positions":
@@ -25,16 +25,16 @@ class MockRecorder:
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> Any:
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> Any:
     return MockRecorder()
 
 
-def test_spectrogram_tab(recorder, qtbot):
+def test_spectrogram_tab(recorder, qtbot) -> None:
     tab = SpectrogramTab(recorder)
     qtbot.addWidget(tab)
 
@@ -48,7 +48,7 @@ def test_spectrogram_tab(recorder, qtbot):
     assert len(tab.ax.collections) > 0
 
 
-def test_phase_plane_tab(recorder, qtbot):
+def test_phase_plane_tab(recorder, qtbot) -> None:
     tab = PhasePlaneTab(recorder)
     qtbot.addWidget(tab)
 
@@ -61,7 +61,7 @@ def test_phase_plane_tab(recorder, qtbot):
     assert len(tab.ax.lines) >= 1
 
 
-def test_coherence_tab(recorder, qtbot):
+def test_coherence_tab(recorder, qtbot) -> None:
     tab = CoherenceTab(recorder)
     qtbot.addWidget(tab)
 
@@ -73,7 +73,7 @@ def test_coherence_tab(recorder, qtbot):
     assert len(tab.ax.lines) > 0
 
 
-def test_advanced_analysis_dialog(recorder, qtbot):
+def test_advanced_analysis_dialog(recorder, qtbot) -> None:
     dlg = AdvancedAnalysisDialog(None, recorder)
     qtbot.addWidget(dlg)
 

--- a/src/shared/python/tests/test_dashboard_recorder.py
+++ b/src/shared/python/tests/test_dashboard_recorder.py
@@ -6,7 +6,7 @@ from src.shared.python.interfaces import PhysicsEngine
 
 
 class MockPhysicsEngine(PhysicsEngine):
-    def __init__(self):
+    def __init__(self) -> None:
         # self.model_name = "MockEngine" # Handled by property
         self._time = 0.0
         self._q = np.array([0.0, 0.0])
@@ -18,126 +18,126 @@ class MockPhysicsEngine(PhysicsEngine):
     def get_state(self) -> tuple[np.ndarray, np.ndarray]:
         return self._q, self._v
 
-    def set_state(self, q, v):
+    def set_state(self, q, v) -> None:
         self._q = q
         self._v = v
 
-    def forward(self):
+    def forward(self) -> None:
         pass
 
-    def set_control(self, u):
+    def set_control(self, u) -> None:
         pass
 
-    def compute_mass_matrix(self):
+    def compute_mass_matrix(self) -> Any:
         return np.eye(2)
 
-    def compute_ztcf(self, q, v):
+    def compute_ztcf(self, q, v) -> Any:
         return np.array([0.1, 0.2])
 
-    def compute_zvcf(self, q):
+    def compute_zvcf(self, q) -> Any:
         return np.array([0.3, 0.4])
 
-    def compute_drift_acceleration(self):
+    def compute_drift_acceleration(self) -> Any:
         return np.array([0.01, 0.02])
 
-    def compute_control_acceleration(self, tau):
+    def compute_control_acceleration(self, tau) -> Any:
         return tau  # Identity for simplicity
 
     # Implement other required abstract methods with dummy implementations
-    def compute_gravity_forces(self):
+    def compute_gravity_forces(self) -> Any:
         return np.zeros(2)
 
-    def compute_jacobian(self, body_name):
+    def compute_jacobian(self, body_name) -> dict:
         return {}
 
-    def compute_coriolis_centrifugal_forces(self):
+    def compute_coriolis_centrifugal_forces(self) -> Any:
         return np.zeros(2)
 
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
         return np.zeros(2)
 
-    def compute_forward_dynamics(self, q, v, tau):
+    def compute_forward_dynamics(self, q, v, tau) -> Any:
         return np.zeros(2)
 
-    def compute_bias_forces(self):
+    def compute_bias_forces(self) -> Any:
         return np.zeros(2)
 
-    def load_from_path(self, path):
+    def load_from_path(self, path) -> None:
         pass
 
     def load_from_string(self, content: str, extension: str | None = None) -> None:
         pass
 
     @property
-    def model_name(self):
+    def model_name(self) -> str:
         return "MockEngine"
 
     def step(self, dt: float | None = None) -> None:
         if dt is not None:
             self._time += dt
 
-    def reset(self):
+    def reset(self) -> None:
         self._time = 0.0
 
-    def get_joint_names(self):
+    def get_joint_names(self) -> list:
         return ["j1", "j2"]
 
-    def get_actuator_names(self):
+    def get_actuator_names(self) -> list:
         return ["a1", "a2"]
 
-    def get_body_names(self):
+    def get_body_names(self) -> list:
         return ["b1"]
 
-    def get_body_mass(self, body_name):
+    def get_body_mass(self, body_name) -> float:
         return 1.0
 
-    def get_body_inertia(self, body_name):
+    def get_body_inertia(self, body_name) -> Any:
         return np.eye(3)
 
-    def get_body_position(self, body_name):
+    def get_body_position(self, body_name) -> Any:
         return np.zeros(3)
 
-    def get_body_rotation(self, body_name):
+    def get_body_rotation(self, body_name) -> Any:
         return np.eye(3)
 
-    def get_body_velocity(self, body_name):
+    def get_body_velocity(self, body_name) -> Any:
         return np.zeros(6)
 
-    def get_contact_forces(self):
+    def get_contact_forces(self) -> list:
         return []
 
-    def get_joint_limits(self):
+    def get_joint_limits(self) -> Any:
         return np.zeros((2, 2))
 
-    def get_actuator_limits(self):
+    def get_actuator_limits(self) -> Any:
         return np.zeros((2, 2))
 
-    def get_dof(self):
+    def get_dof(self) -> int:
         return 2
 
-    def get_num_actuators(self):
+    def get_num_actuators(self) -> int:
         return 2
 
-    def get_num_bodies(self):
+    def get_num_bodies(self) -> int:
         return 1
 
 
 class TestGenericPhysicsRecorder:
     @pytest.fixture
-    def engine(self):
+    def engine(self) -> Any:
         return MockPhysicsEngine()
 
     @pytest.fixture
-    def recorder(self, engine):
+    def recorder(self, engine) -> Any:
         return GenericPhysicsRecorder(engine, max_samples=100)
 
-    def test_initialization(self, recorder):
+    def test_initialization(self, recorder) -> None:
         assert recorder.current_idx == 0
         assert not recorder.is_recording
         assert not recorder._buffers_initialized
         assert "times" in recorder.data
 
-    def test_recording_cycle(self, recorder, engine):
+    def test_recording_cycle(self, recorder, engine) -> None:
         recorder.start()
         assert recorder.is_recording
 
@@ -159,7 +159,7 @@ class TestGenericPhysicsRecorder:
         assert len(pos) == 10
         assert pos[9, 0] == 9.0
 
-    def test_buffer_allocation_on_first_step(self, recorder, engine):
+    def test_buffer_allocation_on_first_step(self, recorder, engine) -> None:
         recorder.start()
         recorder.record_step()
 
@@ -167,7 +167,7 @@ class TestGenericPhysicsRecorder:
         # Dynamic buffer sizing: starts at 1000 (or max_samples if smaller)
         assert recorder.data["joint_positions"].shape == (1000, 2)
 
-    def test_buffer_full(self, engine):
+    def test_buffer_full(self, engine) -> None:
         # Test with initial_capacity=5 to match max_samples
         recorder = GenericPhysicsRecorder(engine, max_samples=5, initial_capacity=5)
         recorder.start()
@@ -181,7 +181,7 @@ class TestGenericPhysicsRecorder:
         assert recorder.current_idx == 5
         assert not recorder.is_recording  # Auto-stopped when buffer full
 
-    def test_analysis_config_allocation(self, recorder, engine):
+    def test_analysis_config_allocation(self, recorder, engine) -> None:
         recorder.start()
         recorder.record_step()  # Initialize buffers
 
@@ -194,7 +194,7 @@ class TestGenericPhysicsRecorder:
         recorder.record_step()
         assert recorder.data["ztcf_accel"][1, 0] == 0.1  # Mock value
 
-    def test_post_hoc_analysis(self, recorder, engine):
+    def test_post_hoc_analysis(self, recorder, engine) -> None:
         recorder.start()
         for _i in range(5):
             recorder.record_step(control_input=np.array([1.0, 1.0]))
@@ -207,7 +207,7 @@ class TestGenericPhysicsRecorder:
         assert len(times) == 5
         assert len(vals) == 5
 
-    def test_get_data_dict(self, recorder, engine):
+    def test_get_data_dict(self, recorder, engine) -> None:
         recorder.start()
         recorder.record_step()
 

--- a/src/shared/python/tests/test_engine_loaders_coverage.py
+++ b/src/shared/python/tests/test_engine_loaders_coverage.py
@@ -68,7 +68,7 @@ def test_load_drake_missing(tmp_path: object) -> None:
             else __import__
         )
 
-        def side_effect(name, *args, **kwargs):
+        def side_effect(name, *args, **kwargs) -> Any:
             if name == "pydrake" or name.startswith("pydrake."):
                 raise ImportError(f"No module named {name}")
             return original_import(name, *args, **kwargs)

--- a/src/shared/python/tests/test_engine_manager_extended.py
+++ b/src/shared/python/tests/test_engine_manager_extended.py
@@ -15,7 +15,7 @@ from src.shared.python.engine_manager import (
 
 
 @pytest.fixture
-def mock_suite_root(tmp_path):
+def mock_suite_root(tmp_path) -> Any:
     """Create a mock suite root directory structure."""
     root = tmp_path / "golf_suite"
     root.mkdir()
@@ -75,19 +75,19 @@ def engine_manager(mock_suite_root):
 # --- Tests ---
 
 
-def test_initialization(engine_manager, mock_suite_root):
+def test_initialization(engine_manager, mock_suite_root) -> None:
     assert engine_manager.suite_root == mock_suite_root
     assert engine_manager.current_engine is None
     assert len(engine_manager.engine_status) > 0
 
 
-def test_discover_engines(engine_manager):
+def test_discover_engines(engine_manager) -> None:
     # All directories were created in fixture, so all should be available
     for status in engine_manager.engine_status.values():
         assert status == EngineStatus.AVAILABLE
 
 
-def test_discover_engines_missing(mock_suite_root):
+def test_discover_engines_missing(mock_suite_root) -> None:
     # Remove a directory
     shutil.rmtree(mock_suite_root / "engines" / "physics_engines" / "mujoco")
 
@@ -105,16 +105,16 @@ def test_discover_engines_missing(mock_suite_root):
     assert manager.get_engine_status(EngineType.MUJOCO) == EngineStatus.UNAVAILABLE
 
 
-def test_switch_engine_unknown(engine_manager):
+def test_switch_engine_unknown(engine_manager) -> None:
     assert engine_manager.switch_engine("unknown_engine") is False
 
 
-def test_switch_engine_unavailable(engine_manager):
+def test_switch_engine_unavailable(engine_manager) -> None:
     engine_manager.engine_status[EngineType.MUJOCO] = EngineStatus.UNAVAILABLE
     assert engine_manager.switch_engine(EngineType.MUJOCO) is False
 
 
-def test_switch_engine_success(engine_manager):
+def test_switch_engine_success(engine_manager) -> None:
     with patch.object(engine_manager, "_load_engine") as mock_load:
         result = engine_manager.switch_engine(EngineType.MUJOCO)
         assert result is True
@@ -122,7 +122,7 @@ def test_switch_engine_success(engine_manager):
         assert engine_manager.current_engine == EngineType.MUJOCO
 
 
-def test_switch_engine_failure(engine_manager):
+def test_switch_engine_failure(engine_manager) -> None:
     with patch.object(
         engine_manager, "_load_engine", side_effect=GolfModelingError("Load failed")
     ):
@@ -131,7 +131,7 @@ def test_switch_engine_failure(engine_manager):
         assert engine_manager.engine_status[EngineType.MUJOCO] == EngineStatus.ERROR
 
 
-def test_load_engine_no_loader(engine_manager):
+def test_load_engine_no_loader(engine_manager) -> None:
     # Mock the registry to return None (no registration)
     from shared.python.engine_registry import get_registry
 
@@ -142,7 +142,7 @@ def test_load_engine_no_loader(engine_manager):
             engine_manager._load_engine(EngineType.MUJOCO)
 
 
-def test_load_mujoco_engine_success(engine_manager):
+def test_load_mujoco_engine_success(engine_manager) -> None:
     # Test using the current registry-based approach
     engine_manager.engine_status[EngineType.MUJOCO] = EngineStatus.AVAILABLE
 
@@ -164,7 +164,7 @@ def test_load_mujoco_engine_success(engine_manager):
             )
 
 
-def test_load_mujoco_engine_probe_fail(engine_manager):
+def test_load_mujoco_engine_probe_fail(engine_manager) -> None:
     # Test probe failure through switch_engine
     engine_manager.engine_status[EngineType.MUJOCO] = EngineStatus.AVAILABLE
 
@@ -183,7 +183,7 @@ def test_load_mujoco_engine_probe_fail(engine_manager):
             assert engine_manager.engine_status[EngineType.MUJOCO] == EngineStatus.ERROR
 
 
-def test_load_drake_engine_success(engine_manager):
+def test_load_drake_engine_success(engine_manager) -> None:
     # Test using the current registry-based approach
     engine_manager.engine_status[EngineType.DRAKE] = EngineStatus.AVAILABLE
 
@@ -203,7 +203,7 @@ def test_load_drake_engine_success(engine_manager):
             assert engine_manager.engine_status[EngineType.DRAKE] == EngineStatus.LOADED
 
 
-def test_load_pinocchio_engine_success(engine_manager):
+def test_load_pinocchio_engine_success(engine_manager) -> None:
     # Test using the current registry-based approach
     engine_manager.engine_status[EngineType.PINOCCHIO] = EngineStatus.AVAILABLE
 
@@ -226,7 +226,7 @@ def test_load_pinocchio_engine_success(engine_manager):
             )
 
 
-def test_load_matlab_engine_success(engine_manager):
+def test_load_matlab_engine_success(engine_manager) -> None:
     mock_matlab = MagicMock()
     mock_matlab_engine = MagicMock()
     mock_matlab.engine = mock_matlab_engine
@@ -239,35 +239,35 @@ def test_load_matlab_engine_success(engine_manager):
             assert engine_manager._matlab_engine is not None
 
 
-def test_load_pendulum_engine(engine_manager):
+def test_load_pendulum_engine(engine_manager) -> None:
     engine_manager._load_pendulum_engine()
 
 
-def test_cleanup(engine_manager):
+def test_cleanup(engine_manager) -> None:
     engine_manager._matlab_engine = MagicMock()
     engine_manager.cleanup()
     assert engine_manager._matlab_engine is None
     assert engine_manager.current_engine is None
 
 
-def test_get_engine_info(engine_manager):
+def test_get_engine_info(engine_manager) -> None:
     info = engine_manager.get_engine_info()
     assert "available_engines" in info
     assert "engine_status" in info
 
 
-def test_validate_engine_configuration(engine_manager):
+def test_validate_engine_configuration(engine_manager) -> None:
     assert engine_manager.validate_engine_configuration(EngineType.MUJOCO) is False
     (engine_manager.engine_paths[EngineType.MUJOCO] / "python").mkdir()
     assert engine_manager.validate_engine_configuration(EngineType.MUJOCO) is True
 
 
-def test_probe_all_engines(engine_manager):
+def test_probe_all_engines(engine_manager) -> None:
     engine_manager.probe_all_engines()
     assert len(engine_manager.probe_results) == len(EngineType)
 
 
-def test_get_diagnostic_report(engine_manager):
+def test_get_diagnostic_report(engine_manager) -> None:
     # Mock probes to have deterministic output
     for mock_cls in engine_manager._mocks.values():  # type: ignore[attr-defined]
         mock_instance = mock_cls.return_value

--- a/src/shared/python/tests/test_equipment_coverage.py
+++ b/src/shared/python/tests/test_equipment_coverage.py
@@ -3,7 +3,7 @@ import pytest
 from shared.python.equipment import CLUB_CONFIGS, get_club_config
 
 
-def test_get_club_config_success():
+def test_get_club_config_success() -> None:
     for club_type in CLUB_CONFIGS:
         config = get_club_config(club_type)
         assert isinstance(config, dict)
@@ -11,13 +11,13 @@ def test_get_club_config_success():
         assert "shaft_length" in config
 
 
-def test_get_club_config_invalid():
+def test_get_club_config_invalid() -> None:
     with pytest.raises(ValueError) as exc:
         get_club_config("invalid_club")
     assert "Invalid club_type" in str(exc.value)
 
 
-def test_config_integrity():
+def test_config_integrity() -> None:
     # Ensure all configs have standard fields
     required_fields = ["grip_length", "head_mass", "total_length"]
     for config in CLUB_CONFIGS.values():

--- a/src/shared/python/tests/test_hill_muscle.py
+++ b/src/shared/python/tests/test_hill_muscle.py
@@ -11,7 +11,7 @@ from src.shared.python.hill_muscle import (
 
 
 @pytest.fixture
-def muscle_params():
+def muscle_params() -> Any:
     """Default muscle parameters for testing."""
     return MuscleParameters(
         F_max=1000.0, l_opt=0.10, l_slack=0.20, v_max=1.0, pennation_angle=0.0
@@ -19,18 +19,18 @@ def muscle_params():
 
 
 @pytest.fixture
-def muscle_model(muscle_params):
+def muscle_model(muscle_params) -> Any:
     """Hill muscle model instance."""
     return HillMuscleModel(muscle_params)
 
 
-def test_force_length_active_at_optimal(muscle_model):
+def test_force_length_active_at_optimal(muscle_model) -> None:
     """Test active force at optimal length."""
     # At optimal length (norm = 1.0), force multiplier should be 1.0
     assert np.isclose(muscle_model.force_length_active(1.0), 1.0)
 
 
-def test_force_length_active_bell_curve(muscle_model):
+def test_force_length_active_bell_curve(muscle_model) -> None:
     """Test bell curve shape of active force-length relationship."""
     # Force should be lower at shorter and longer lengths
     l_short = 0.5
@@ -45,7 +45,7 @@ def test_force_length_active_bell_curve(muscle_model):
     assert f_long > 0
 
 
-def test_force_length_passive(muscle_model):
+def test_force_length_passive(muscle_model) -> None:
     """Test passive force-length relationship."""
     # No passive force below optimal length
     assert muscle_model.force_length_passive(0.9) == 0.0
@@ -59,7 +59,7 @@ def test_force_length_passive(muscle_model):
     assert f_1_5 > f_1_2
 
 
-def test_force_velocity_isometric(muscle_model):
+def test_force_velocity_isometric(muscle_model) -> None:
     """Test force-velocity at isometric conditions."""
     # At v=0, force multiplier is not 1.0 in this implementation?
     # Wait, the formula says:
@@ -68,7 +68,7 @@ def test_force_velocity_isometric(muscle_model):
     assert np.isclose(muscle_model.force_velocity(0.0), 1.0)
 
 
-def test_force_velocity_shortening(muscle_model):
+def test_force_velocity_shortening(muscle_model) -> None:
     """Test force-velocity during shortening (concentric).
 
     Standard Hill model: Force decreases as shortening velocity increases.
@@ -84,7 +84,7 @@ def test_force_velocity_shortening(muscle_model):
     assert f_v > 0.0  # Force should still be positive
 
 
-def test_tendon_force(muscle_model):
+def test_tendon_force(muscle_model) -> None:
     """Test tendon force-strain relationship."""
     # Slack length strain <= 0 -> Force 0
     assert muscle_model.tendon_force(1.0) == 0.0  # At slack length
@@ -95,7 +95,7 @@ def test_tendon_force(muscle_model):
     assert f_stretch > 0
 
 
-def test_compute_muscle_force_isometric_max(muscle_model, muscle_params):
+def test_compute_muscle_force_isometric_max(muscle_model, muscle_params) -> None:
     """Test max isometric force computation."""
     # At optimal length with full activation and zero velocity
     state = MuscleState(
@@ -110,7 +110,7 @@ def test_compute_muscle_force_isometric_max(muscle_model, muscle_params):
     assert np.isclose(force, muscle_params.F_max, rtol=0.1)
 
 
-def test_compute_muscle_force_pennation(muscle_params):
+def test_compute_muscle_force_pennation(muscle_params) -> None:
     """Test effect of pennation angle."""
     angle = np.pi / 3  # 60 degrees, cos = 0.5
     muscle_params.pennation_angle = angle

--- a/src/shared/python/tests/test_impact_model.py
+++ b/src/shared/python/tests/test_impact_model.py
@@ -18,12 +18,12 @@ from src.shared.python.impact_model import (
 
 
 @pytest.fixture
-def default_impact_params():
+def default_impact_params() -> Any:
     return ImpactParameters(cor=0.8, friction_coefficient=0.4)
 
 
 @pytest.fixture
-def basic_pre_state():
+def basic_pre_state() -> Any:
     return PreImpactState(
         clubhead_velocity=np.array([45.0, 0.0, 0.0]),  # 45 m/s (~100 mph)
         clubhead_angular_velocity=np.zeros(3),
@@ -37,7 +37,7 @@ def basic_pre_state():
     )
 
 
-def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params):
+def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params) -> None:
     """Test momentum conservation in rigid body impact."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -56,7 +56,7 @@ def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params):
     np.testing.assert_allclose(p_initial, p_final, atol=1e-5)
 
 
-def test_rigid_body_impact_cor(basic_pre_state, default_impact_params):
+def test_rigid_body_impact_cor(basic_pre_state, default_impact_params) -> None:
     """Test coefficient of restitution logic."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -79,7 +79,7 @@ def test_rigid_body_impact_cor(basic_pre_state, default_impact_params):
     assert np.isclose(v_sep, expected_v_sep)
 
 
-def test_rigid_body_friction_spin(basic_pre_state, default_impact_params):
+def test_rigid_body_friction_spin(basic_pre_state, default_impact_params) -> None:
     """Test spin generation from glancing impact."""
     # Modify pre-state to have tangential velocity component
     # Club moving slightly up (launch angle)
@@ -180,7 +180,7 @@ def test_rigid_body_friction_spin(basic_pre_state, default_impact_params):
     assert post_state.ball_angular_velocity[1] == 0
 
 
-def test_finite_time_model(basic_pre_state, default_impact_params):
+def test_finite_time_model(basic_pre_state, default_impact_params) -> None:
     """Test finite time model delegates to rigid body but sets duration."""
     model = FiniteTimeImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -192,7 +192,7 @@ def test_finite_time_model(basic_pre_state, default_impact_params):
     np.testing.assert_array_equal(post_state.ball_velocity, rigid_post.ball_velocity)
 
 
-def test_spring_damper_model(basic_pre_state, default_impact_params):
+def test_spring_damper_model(basic_pre_state, default_impact_params) -> None:
     """Test spring damper model produces physical results."""
     # Use softer params for stability in test to avoid numerical blow-up
     # Stiff springs (1e7) require very small dt (<< 1e-6) for stability with simple integrators.
@@ -226,7 +226,7 @@ def test_spring_damper_model(basic_pre_state, default_impact_params):
     assert post_state.contact_duration > 0
 
 
-def test_gear_effect_spin():
+def test_gear_effect_spin() -> None:
     """Test gear effect spin calculation."""
     v_club = np.array([45.0, 0.0, 0.0])
     normal = np.array([1.0, 0.0, 0.0])
@@ -249,7 +249,7 @@ def test_gear_effect_spin():
     assert spin_heel[2] > 0
 
 
-def test_validate_energy_balance(basic_pre_state, default_impact_params):
+def test_validate_energy_balance(basic_pre_state, default_impact_params) -> None:
     """Test energy balance validation function."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -263,7 +263,7 @@ def test_validate_energy_balance(basic_pre_state, default_impact_params):
     assert analysis["energy_lost"] > 0  # Inelastic collision (COR < 1)
 
 
-def test_create_impact_model():
+def test_create_impact_model() -> None:
     """Test factory function."""
     assert isinstance(
         create_impact_model(ImpactModelType.RIGID_BODY), RigidBodyImpactModel

--- a/src/shared/python/tests/test_openpose_gui_coverage.py
+++ b/src/shared/python/tests/test_openpose_gui_coverage.py
@@ -32,26 +32,26 @@ def qapp():
 
 
 @pytest.fixture
-def gui(qapp, qtbot):
+def gui(qapp, qtbot) -> Any:
     window = OpenPoseGUI()
     qtbot.addWidget(window)
     return window
 
 
-def test_initial_state(gui):
+def test_initial_state(gui) -> None:
     assert gui.lbl_file.text() == "No file selected."
     assert not gui.btn_run.isEnabled()
     assert gui.progress.value() == 0
 
 
-def test_load_video_cancel(gui):
+def test_load_video_cancel(gui) -> None:
     with patch.object(QFileDialog, "getOpenFileName", return_value=("", "")):
         gui.load_video()
         assert gui.lbl_file.text() == "No file selected."
         assert not gui.btn_run.isEnabled()
 
 
-def test_load_video_success(gui):
+def test_load_video_success(gui) -> None:
     test_file = "/path/to/video.mp4"
     with patch.object(
         QFileDialog,
@@ -64,7 +64,7 @@ def test_load_video_success(gui):
         assert "Loaded video" in gui.log_area.toPlainText()
 
 
-def test_run_analysis(gui, qtbot):
+def test_run_analysis(gui, qtbot) -> None:
     # Setup state
     gui.lbl_file.setText("/path/to/video.mp4")
     gui.btn_run.setEnabled(True)
@@ -91,6 +91,6 @@ def test_run_analysis(gui, qtbot):
         mock_msg.assert_called_once()
 
 
-def test_log(gui):
+def test_log(gui) -> None:
     gui.log("Test message")
     assert "Test message" in gui.log_area.toPlainText()

--- a/src/shared/python/tests/test_output_manager.py
+++ b/src/shared/python/tests/test_output_manager.py
@@ -14,14 +14,14 @@ from src.shared.python.output_manager import (
 
 
 @pytest.fixture
-def temp_output_dir(tmp_path):
+def temp_output_dir(tmp_path) -> Any:
     """Create a temporary output manager."""
     manager = OutputManager(base_path=tmp_path)
     manager.create_output_structure()
     return manager
 
 
-def test_initialization(tmp_path):
+def test_initialization(tmp_path) -> None:
     """Test directory creation."""
     manager = OutputManager(base_path=tmp_path)
     manager.create_output_structure()
@@ -32,7 +32,7 @@ def test_initialization(tmp_path):
     assert (tmp_path / "simulations" / "mujoco").exists()
 
 
-def test_save_load_csv(temp_output_dir):
+def test_save_load_csv(temp_output_dir) -> None:
     """Test saving and loading CSV."""
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     path = temp_output_dir.save_simulation_results(
@@ -48,7 +48,7 @@ def test_save_load_csv(temp_output_dir):
     pd.testing.assert_frame_equal(df, loaded)
 
 
-def test_save_load_json(temp_output_dir):
+def test_save_load_json(temp_output_dir) -> None:
     """Test saving and loading JSON."""
     # When saving raw list, it wraps it in {results: [...]}
     data = [1, 2, 3]
@@ -80,7 +80,7 @@ def test_save_load_json(temp_output_dir):
     assert loaded2 == data_struct
 
 
-def test_save_load_parquet(temp_output_dir):
+def test_save_load_parquet(temp_output_dir) -> None:
     """Test saving and loading Parquet."""
     try:
         import pyarrow  # noqa: F401
@@ -104,14 +104,14 @@ def test_save_load_parquet(temp_output_dir):
     pd.testing.assert_frame_equal(df, loaded)
 
 
-def test_save_pickle_disabled(temp_output_dir):
+def test_save_pickle_disabled(temp_output_dir) -> None:
     """Test that pickle is disabled for security."""
     data = [1, 2, 3]
     with pytest.raises(ValueError, match="Security: Pickle format is disabled"):
         temp_output_dir.save_simulation_results(data, "test", OutputFormat.PICKLE)
 
 
-def test_export_report_html(temp_output_dir):
+def test_export_report_html(temp_output_dir) -> None:
     """Test HTML report generation."""
     data = {"accuracy": 0.95, "speed": 100}
     path = temp_output_dir.export_analysis_report(data, "test_report", "html")
@@ -123,7 +123,7 @@ def test_export_report_html(temp_output_dir):
     assert "0.95" in content
 
 
-def test_cleanup_old_files(temp_output_dir):
+def test_cleanup_old_files(temp_output_dir) -> None:
     """Test file cleanup logic."""
     # Create an old file
     old_file = temp_output_dir.directories["simulations"] / "old.csv"
@@ -147,7 +147,7 @@ def test_cleanup_old_files(temp_output_dir):
     assert new_file.exists()
 
 
-def test_convenience_functions(tmp_path, monkeypatch):
+def test_convenience_functions(tmp_path, monkeypatch) -> None:
     """Test the top-level save_results and load_results functions."""
     # The convenience functions create a new OutputManager internally.
     # We can test them by using unittest.mock.patch as a context manager.

--- a/src/shared/python/tests/test_physics_parameters.py
+++ b/src/shared/python/tests/test_physics_parameters.py
@@ -12,11 +12,11 @@ from src.shared.python.physics_parameters import (
 
 class TestPhysicsParameters:
     @pytest.fixture
-    def registry(self):
+    def registry(self) -> Any:
         """Create a new registry for each test."""
         return PhysicsParameterRegistry()
 
-    def test_parameter_validation(self):
+    def test_parameter_validation(self) -> None:
         """Test parameter validation logic."""
         param = PhysicsParameter(
             name="TEST_PARAM",
@@ -56,7 +56,7 @@ class TestPhysicsParameters:
         assert not valid
         assert "constant" in msg
 
-    def test_registry_initialization(self, registry):
+    def test_registry_initialization(self, registry) -> None:
         """Test that default parameters are loaded."""
         assert len(registry.parameters) > 0
 
@@ -65,7 +65,7 @@ class TestPhysicsParameters:
         assert registry.get("BALL_MASS") is not None
         assert registry.get("CLUB_LENGTH") is not None
 
-    def test_get_set_parameter(self, registry):
+    def test_get_set_parameter(self, registry) -> None:
         """Test getting and setting parameters."""
         # Get
         param = registry.get("CLUB_LENGTH")
@@ -88,7 +88,7 @@ class TestPhysicsParameters:
         assert not success
         assert "not found" in msg
 
-    def test_get_by_category(self, registry):
+    def test_get_by_category(self, registry) -> None:
         """Test filtering by category."""
         ball_params = registry.get_by_category(ParameterCategory.BALL)
         assert len(ball_params) > 0
@@ -98,7 +98,7 @@ class TestPhysicsParameters:
         env_params = registry.get_by_category(ParameterCategory.ENVIRONMENT)
         assert len(env_params) > 0
 
-    def test_export_import_json(self, registry, tmp_path):
+    def test_export_import_json(self, registry, tmp_path) -> None:
         """Test JSON export and import."""
         # Export
         json_path = tmp_path / "params.json"
@@ -120,14 +120,14 @@ class TestPhysicsParameters:
         assert count > 0
         assert registry.get("CLUB_LENGTH").value == 1.0
 
-    def test_get_summary(self, registry):
+    def test_get_summary(self, registry) -> None:
         """Test summary string generation."""
         summary = registry.get_summary()
         assert "Physics Parameter Registry" in summary
         assert "GRAVITY" in summary
         assert "BALL_MASS" in summary
 
-    def test_global_registry(self):
+    def test_global_registry(self) -> None:
         """Test singleton accessor."""
         reg1 = get_registry()
         reg2 = get_registry()

--- a/src/shared/python/tests/test_plotting.py
+++ b/src/shared/python/tests/test_plotting.py
@@ -10,7 +10,7 @@ from src.shared.python.plotting import GolfSwingPlotter, RecorderInterface
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.data = {
             "joint_positions": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
             "joint_velocities": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
@@ -28,34 +28,34 @@ class MockRecorder(RecorderInterface):
         self.induced_acc = {"gravity": (np.linspace(0, 1, 10), np.random.rand(10, 3))}
         self.counterfactuals = {"ztcf": (np.linspace(0, 1, 10), np.random.rand(10, 3))}
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> Any:
         return self.data.get(field_name, (np.array([]), np.array([])))
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> Any:
         if not isinstance(source_name, str):
             return np.array([]), np.array([])
         return self.induced_acc.get(source_name, (np.array([]), np.array([])))
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> Any:
         return self.counterfactuals.get(cf_name, (np.array([]), np.array([])))
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> Any:
     return MockRecorder()
 
 
 @pytest.fixture
-def plotter(mock_recorder):
+def plotter(mock_recorder) -> Any:
     return GolfSwingPlotter(mock_recorder, joint_names=["Joint1", "Joint2", "Joint3"])
 
 
 @pytest.fixture
-def fig():
+def fig() -> Any:
     return Figure()
 
 
-def test_init(mock_recorder):
+def test_init(mock_recorder) -> None:
     plotter = GolfSwingPlotter(mock_recorder)
     assert plotter.recorder == mock_recorder
     assert plotter.joint_names == []
@@ -64,13 +64,13 @@ def test_init(mock_recorder):
     assert plotter_named.joint_names == ["J1"]
 
 
-def test_get_joint_name(plotter):
+def test_get_joint_name(plotter) -> None:
     assert plotter.get_joint_name(0) == "Joint1"
     assert plotter.get_joint_name(1) == "Joint2"
     assert plotter.get_joint_name(99) == "Joint 99"
 
 
-def test_get_aligned_label(plotter):
+def test_get_aligned_label(plotter) -> None:
     # Perfect match
     assert plotter._get_aligned_label(0, 3) == "Joint1"
 
@@ -82,7 +82,7 @@ def test_get_aligned_label(plotter):
     assert plotter._get_aligned_label(0, 7) == "DoF 0"
 
 
-def test_plot_joint_angles(plotter, fig):
+def test_plot_joint_angles(plotter, fig) -> None:
     plotter.plot_joint_angles(fig)
     assert len(fig.axes) > 0
 
@@ -93,54 +93,54 @@ def test_plot_joint_angles(plotter, fig):
     assert len(fig.axes) > 0  # Should still create axes to show "No data" text
 
 
-def test_plot_joint_velocities(plotter, fig):
+def test_plot_joint_velocities(plotter, fig) -> None:
     plotter.plot_joint_velocities(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_joint_torques(plotter, fig):
+def test_plot_joint_torques(plotter, fig) -> None:
     plotter.plot_joint_torques(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_actuator_powers(plotter, fig):
+def test_plot_actuator_powers(plotter, fig) -> None:
     plotter.plot_actuator_powers(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_energy_analysis(plotter, fig):
+def test_plot_energy_analysis(plotter, fig) -> None:
     plotter.plot_energy_analysis(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_club_head_speed(plotter, fig):
+def test_plot_club_head_speed(plotter, fig) -> None:
     plotter.plot_club_head_speed(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_club_head_trajectory(plotter, fig):
+def test_plot_club_head_trajectory(plotter, fig) -> None:
     plotter.plot_club_head_trajectory(fig)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_phase_diagram(plotter, fig):
+def test_plot_phase_diagram(plotter, fig) -> None:
     plotter.plot_phase_diagram(fig, joint_idx=0)
     assert len(fig.axes) > 0
 
 
-def test_plot_torque_comparison(plotter, fig):
+def test_plot_torque_comparison(plotter, fig) -> None:
     plotter.plot_torque_comparison(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_frequency_analysis(plotter, fig):
+def test_plot_frequency_analysis(plotter, fig) -> None:
     with patch("scipy.signal.welch", return_value=(np.array([1, 2]), np.array([1, 2]))):
         plotter.plot_frequency_analysis(fig, joint_idx=0)
         assert len(fig.axes) > 0
 
 
-def test_plot_spectrogram(plotter, fig):
+def test_plot_spectrogram(plotter, fig) -> None:
     with patch(
         "scipy.signal.spectrogram",
         return_value=(np.array([1]), np.array([1]), np.array([[1]])),
@@ -149,30 +149,30 @@ def test_plot_spectrogram(plotter, fig):
         assert len(fig.axes) > 0
 
 
-def test_plot_summary_dashboard(plotter, fig):
+def test_plot_summary_dashboard(plotter, fig) -> None:
     plotter.plot_summary_dashboard(fig)
     # Should have multiple axes
     assert len(fig.axes) >= 6
 
 
-def test_plot_kinematic_sequence(plotter, fig):
+def test_plot_kinematic_sequence(plotter, fig) -> None:
     segments = {"Seg1": 0, "Seg2": 1}
     plotter.plot_kinematic_sequence(fig, segments)
     assert len(fig.axes) > 0
 
 
-def test_plot_3d_phase_space(plotter, fig):
+def test_plot_3d_phase_space(plotter, fig) -> None:
     plotter.plot_3d_phase_space(fig, joint_idx=0)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_correlation_matrix(plotter, fig):
+def test_plot_correlation_matrix(plotter, fig) -> None:
     plotter.plot_correlation_matrix(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_swing_plane(plotter, fig):
+def test_plot_swing_plane(plotter, fig) -> None:
     # Need enough points for fit
     N = 10
     positions = np.random.rand(N, 3)
@@ -185,38 +185,38 @@ def test_plot_swing_plane(plotter, fig):
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_angular_momentum(plotter, fig):
+def test_plot_angular_momentum(plotter, fig) -> None:
     plotter.plot_angular_momentum(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_cop_trajectory(plotter, fig):
+def test_plot_cop_trajectory(plotter, fig) -> None:
     plotter.plot_cop_trajectory(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_cop_vector_field(plotter, fig):
+def test_plot_cop_vector_field(plotter, fig) -> None:
     plotter.plot_cop_vector_field(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_radar_chart(plotter, fig):
+def test_plot_radar_chart(plotter, fig) -> None:
     metrics = {"A": 0.5, "B": 0.8, "C": 0.2}
     plotter.plot_radar_chart(fig, metrics)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "polar"
 
 
-def test_plot_power_flow(plotter, fig):
+def test_plot_power_flow(plotter, fig) -> None:
     plotter.plot_power_flow(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_induced_acceleration(plotter, fig):
+def test_plot_induced_acceleration(plotter, fig) -> None:
     plotter.plot_induced_acceleration(fig, "gravity")
     assert len(fig.axes) > 0
 
 
-def test_plot_counterfactual_comparison(plotter, fig):
+def test_plot_counterfactual_comparison(plotter, fig) -> None:
     plotter.plot_counterfactual_comparison(fig, "ztcf")
     assert len(fig.axes) > 0

--- a/src/shared/python/tests/test_plotting_extended.py
+++ b/src/shared/python/tests/test_plotting_extended.py
@@ -9,7 +9,7 @@ from src.shared.python.tests.test_plotting import MockRecorder
 
 
 @pytest.fixture
-def extended_plotter():
+def extended_plotter() -> Any:
     # Seed for reproducible test data generation
     np.random.seed(42)
     recorder = MockRecorder()
@@ -19,11 +19,11 @@ def extended_plotter():
 
 
 @pytest.fixture
-def fig():
+def fig() -> Any:
     return Figure()
 
 
-def test_plot_dynamic_correlation(extended_plotter, fig):
+def test_plot_dynamic_correlation(extended_plotter, fig) -> None:
     extended_plotter.plot_dynamic_correlation(
         fig, joint_idx_1=0, joint_idx_2=1, window_size=5
     )
@@ -33,7 +33,7 @@ def test_plot_dynamic_correlation(extended_plotter, fig):
     assert ax.get_title().startswith("Dynamic Correlation")
 
 
-def test_plot_synergy_trajectory(extended_plotter, fig):
+def test_plot_synergy_trajectory(extended_plotter, fig) -> None:
     # Mock synergy result
     synergy_result = MagicMock()
     synergy_result.activations = np.random.rand(2, 10)
@@ -44,7 +44,7 @@ def test_plot_synergy_trajectory(extended_plotter, fig):
     assert ax.get_title() == "Synergy Space Trajectory"
 
 
-def test_plot_3d_vector_field(extended_plotter, fig):
+def test_plot_3d_vector_field(extended_plotter, fig) -> None:
     # Setup recorder with necessary data
     # Angular momentum and CoM position
     extended_plotter.recorder.data["angular_momentum"] = (
@@ -63,7 +63,7 @@ def test_plot_3d_vector_field(extended_plotter, fig):
     assert ax.get_title().startswith("3D Vector Field")
 
 
-def test_plot_local_stability(extended_plotter, fig):
+def test_plot_local_stability(extended_plotter, fig) -> None:
     # Setup data
     extended_plotter.recorder.data["joint_velocities"] = (
         np.linspace(0, 1, 50),
@@ -80,7 +80,7 @@ def test_plot_local_stability(extended_plotter, fig):
     assert ax.get_title().startswith("Local Stability")
 
 
-def test_plot_dynamic_correlation_insufficient_data(extended_plotter, fig):
+def test_plot_dynamic_correlation_insufficient_data(extended_plotter, fig) -> None:
     extended_plotter.recorder.data["joint_velocities"] = (np.array([]), np.array([]))
     extended_plotter.plot_dynamic_correlation(fig, 0, 1)
     assert len(fig.axes) > 0

--- a/src/shared/python/tests/test_signal_processing.py
+++ b/src/shared/python/tests/test_signal_processing.py
@@ -18,7 +18,7 @@ from src.shared.python.signal_processing import (
 
 class TestSignalProcessing:
     @pytest.fixture
-    def sample_data(self):
+    def sample_data(self) -> tuple:
         # Generate a synthetic signal: 10 Hz sine wave + noise
         fs = 100.0
         t = np.arange(0, 5.0, 1 / fs)
@@ -26,7 +26,7 @@ class TestSignalProcessing:
         signal_clean = np.sin(2 * np.pi * freq * t)
         return t, signal_clean, fs
 
-    def test_compute_psd(self, sample_data):
+    def test_compute_psd(self, sample_data) -> None:
         t, data, fs = sample_data
         freqs, psd = compute_psd(data, fs=fs, nperseg=128)
 
@@ -38,7 +38,7 @@ class TestSignalProcessing:
         peak_freq = freqs[np.argmax(psd)]
         assert np.isclose(peak_freq, 10.0, atol=1.0)
 
-    def test_compute_spectrogram(self, sample_data):
+    def test_compute_spectrogram(self, sample_data) -> None:
         t, data, fs = sample_data
         f, t_spec, Sxx = compute_spectrogram(data, fs=fs, nperseg=64, noverlap=32)
 
@@ -47,7 +47,7 @@ class TestSignalProcessing:
         assert Sxx.shape[0] == len(f)
         assert Sxx.shape[1] == len(t_spec)
 
-    def test_compute_spectral_arc_length_smoothness(self):
+    def test_compute_spectral_arc_length_smoothness(self) -> None:
         # Smooth movement (Gaussian) vs Jerky movement
         fs = 100.0
         t = np.linspace(0, 1, 100)
@@ -68,13 +68,13 @@ class TestSignalProcessing:
         assert sal_smooth < 0
         assert sal_jerky < 0
 
-    def test_compute_spectral_arc_length_empty(self):
+    def test_compute_spectral_arc_length_empty(self) -> None:
         assert compute_spectral_arc_length(np.array([]), 100.0) == 0.0
 
-    def test_compute_spectral_arc_length_zeros(self):
+    def test_compute_spectral_arc_length_zeros(self) -> None:
         assert compute_spectral_arc_length(np.zeros(100), 100.0) == 0.0
 
-    def test_morlet2_impl(self):
+    def test_morlet2_impl(self) -> None:
         # Compare custom implementation with scipy if available, or just check properties
         M = 100
         s = 10.0
@@ -89,7 +89,7 @@ class TestSignalProcessing:
             or np.argmax(np.abs(wavelet)) == M // 2 - 1
         )
 
-    def test_compute_cwt(self, sample_data):
+    def test_compute_cwt(self, sample_data) -> None:
         t, data, fs = sample_data
         freq_range = (5.0, 20.0)
         num_freqs = 15
@@ -108,7 +108,7 @@ class TestSignalProcessing:
         avg_power = np.mean(np.abs(cwt), axis=1)
         assert avg_power[idx_10hz] > np.mean(avg_power)
 
-    def test_compute_xwt(self, sample_data):
+    def test_compute_xwt(self, sample_data) -> None:
         t, data1, fs = sample_data
         # data2 is data1 shifted + noise
         data2 = np.roll(data1, 10)
@@ -127,7 +127,7 @@ class TestSignalProcessing:
         # Just check it runs and produces output for now
         assert not np.all(phases == 0)
 
-    def test_compute_coherence(self, sample_data):
+    def test_compute_coherence(self, sample_data) -> None:
         t, data1, fs = sample_data
         # data2 is data1 + noise
         data2 = data1 + 0.1 * np.random.randn(len(data1))
@@ -142,7 +142,7 @@ class TestSignalProcessing:
 
     # --- New Tests ---
 
-    def test_compute_jerk(self):
+    def test_compute_jerk(self) -> None:
         """Test jerk computation."""
         fs = 100.0
         t = np.linspace(0, 2, 200)
@@ -162,7 +162,7 @@ class TestSignalProcessing:
         error = np.abs(jerk[10:-10] - expected[10:-10])
         assert np.mean(error) < 1.0  # Loose tolerance for discrete derivative
 
-    def test_compute_time_shift(self):
+    def test_compute_time_shift(self) -> None:
         """Test time shift calculation."""
         fs = 100.0
         t = np.linspace(0, 2, 200)
@@ -181,7 +181,7 @@ class TestSignalProcessing:
         expected_lag = shift_samples / fs
         assert np.isclose(tau, expected_lag, atol=0.02)
 
-    def test_compute_dtw_distance(self):
+    def test_compute_dtw_distance(self) -> None:
         """Test DTW distance."""
         s1 = np.array([0, 1, 2, 3, 2, 1, 0])
         s2 = np.array([0, 0, 1, 2, 3, 2, 1, 0])  # s1 stretched/shifted
@@ -194,7 +194,7 @@ class TestSignalProcessing:
         assert dist < euclidean
         assert dist >= 0
 
-    def test_compute_dtw_path(self):
+    def test_compute_dtw_path(self) -> None:
         """Test DTW path."""
         s1 = np.array([0, 1, 0])
         s2 = np.array([0, 0, 1, 0])

--- a/src/shared/python/tests/test_simulation_gui_base.py
+++ b/src/shared/python/tests/test_simulation_gui_base.py
@@ -79,7 +79,7 @@ class ConcreteSimGUI(SimulationGUIBase):
 
 
 @pytest.fixture(scope="module")
-def qapp():
+def qapp() -> Any:
     """Ensure a QApplication exists for the whole test module."""
     app = QtWidgets.QApplication.instance()
     if app is None:

--- a/src/shared/python/tests/test_statistical_analysis.py
+++ b/src/shared/python/tests/test_statistical_analysis.py
@@ -17,7 +17,7 @@ from src.shared.python.statistical_analysis import (
 
 class TestStatisticalAnalyzer:
     @pytest.fixture
-    def sample_data(self):
+    def sample_data(self) -> dict:
         # Create synthetic data
         fs = 100.0
         duration = 2.0
@@ -66,13 +66,13 @@ class TestStatisticalAnalyzer:
             "cop_position": cop_position,
         }
 
-    def test_initialization(self, sample_data):
+    def test_initialization(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         assert len(analyzer.times) == 200
         assert analyzer.dt == 0.01
         assert analyzer.duration == 1.99
 
-    def test_compute_summary_stats(self, sample_data):
+    def test_compute_summary_stats(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         data = sample_data["joint_positions"][:, 0]
         stats = analyzer.compute_summary_stats(data)
@@ -81,7 +81,7 @@ class TestStatisticalAnalyzer:
         assert np.isclose(stats.max, 1.0, atol=0.01)
         assert np.isclose(stats.min, -1.0, atol=0.01)
 
-    def test_find_peaks_in_data(self, sample_data):
+    def test_find_peaks_in_data(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         data = sample_data["joint_positions"][:, 0]  # Sine wave
         peaks = analyzer.find_peaks_in_data(data, height=0.5)
@@ -90,7 +90,7 @@ class TestStatisticalAnalyzer:
         assert isinstance(peaks[0], PeakInfo)
         assert peaks[0].value > 0.5
 
-    def test_find_club_head_speed_peak(self, sample_data):
+    def test_find_club_head_speed_peak(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         peak = analyzer.find_club_head_speed_peak()
 
@@ -98,14 +98,14 @@ class TestStatisticalAnalyzer:
         assert np.isclose(peak.time, 1.0, atol=0.02)
         assert np.isclose(peak.value, 50.0, atol=0.1)
 
-    def test_compute_range_of_motion(self, sample_data):
+    def test_compute_range_of_motion(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         # Joint 0 is sin(t), range [-1, 1] rad -> [-57.3, 57.3] deg
         # ROM ~ 114.6 deg
         min_deg, max_deg, rom = analyzer.compute_range_of_motion(0)
         assert np.isclose(rom, 2 * np.rad2deg(1.0), atol=1.0)
 
-    def test_compute_tempo(self, sample_data):
+    def test_compute_tempo(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         # With Gaussian speed peak at 1.0s
         # Start search 5 (0.05s).
@@ -119,7 +119,7 @@ class TestStatisticalAnalyzer:
             assert bs > 0
             assert ds > 0
 
-    def test_detect_swing_phases(self, sample_data):
+    def test_detect_swing_phases(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         phases = analyzer.detect_swing_phases()
 
@@ -131,7 +131,7 @@ class TestStatisticalAnalyzer:
         if impact_phases:
             assert np.isclose(impact_phases[0].start_time, 1.0, atol=0.2)
 
-    def test_compute_grf_metrics(self, sample_data):
+    def test_compute_grf_metrics(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         metrics = analyzer.compute_grf_metrics()
 
@@ -140,7 +140,7 @@ class TestStatisticalAnalyzer:
         assert metrics.peak_vertical_force is not None
         assert metrics.peak_vertical_force > 0
 
-    def test_compute_stability_metrics(self, sample_data):
+    def test_compute_stability_metrics(self, sample_data) -> None:
         # Needs COM
         data = sample_data.copy()
         data["com_position"] = np.zeros((200, 3))  # COM at origin
@@ -151,14 +151,14 @@ class TestStatisticalAnalyzer:
         assert isinstance(metrics, StabilityMetrics)
         assert metrics.mean_com_cop_distance > 0
 
-    def test_compute_coordination_metrics(self, sample_data):
+    def test_compute_coordination_metrics(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         metrics = analyzer.compute_coordination_metrics(0, 1)
 
         assert isinstance(metrics, CoordinationMetrics)
         assert 0 <= metrics.in_phase_pct <= 100
 
-    def test_compute_work_metrics(self, sample_data):
+    def test_compute_work_metrics(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         work = analyzer.compute_work_metrics(0)
 
@@ -169,7 +169,7 @@ class TestStatisticalAnalyzer:
             work["net_work"], 0.0, atol=50.0
         )  # Loose tolerance for discrete integration
 
-    def test_compute_recurrence_matrix_and_rqa(self, sample_data):
+    def test_compute_recurrence_matrix_and_rqa(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         # Using small subset to speed up
         analyzer.joint_positions = analyzer.joint_positions[:50]
@@ -184,7 +184,7 @@ class TestStatisticalAnalyzer:
             assert isinstance(rqa, RQAMetrics)
             assert 0 <= rqa.recurrence_rate <= 1.0
 
-    def test_estimate_lyapunov_exponent(self, sample_data):
+    def test_estimate_lyapunov_exponent(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         # Sine wave is predictable, LLE should be low or 0?
         # Ideally chaos detection requires more data.
@@ -192,7 +192,7 @@ class TestStatisticalAnalyzer:
         lle = analyzer.estimate_lyapunov_exponent(data, dim=2, tau=10, window=10)
         assert isinstance(lle, float)
 
-    def test_compute_pca(self, sample_data):
+    def test_compute_pca(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         pca = analyzer.compute_principal_component_analysis(n_components=2)
 
@@ -200,26 +200,26 @@ class TestStatisticalAnalyzer:
         assert pca.components.shape == (2, 3)  # 2 components, 3 joints
         assert pca.projected_data.shape == (200, 2)
 
-    def test_compute_permutation_entropy(self, sample_data):
+    def test_compute_permutation_entropy(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         data = sample_data["joint_positions"][:, 0]
         pe = analyzer.compute_permutation_entropy(data, order=3)
         assert pe >= 0
 
-    def test_compute_fractal_dimension(self, sample_data):
+    def test_compute_fractal_dimension(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         data = sample_data["joint_positions"][:, 0]
         # Sine wave dimension is 1.0
         fd = analyzer.compute_fractal_dimension(data)
         assert np.isclose(fd, 1.0, atol=0.2)  # Higuchi approx
 
-    def test_compute_sample_entropy(self, sample_data):
+    def test_compute_sample_entropy(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         data = sample_data["joint_positions"][:, 0]
         sampen = analyzer.compute_sample_entropy(data, m=2, r=0.2)
         assert sampen >= 0
 
-    def test_compute_joint_stiffness(self, sample_data):
+    def test_compute_joint_stiffness(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         # Joint 0: Pos ~ sin, Torque ~ -sin.  T = -k * theta approx.
         # Plotting T vs Theta should be linear-ish with negative slope.
@@ -228,24 +228,24 @@ class TestStatisticalAnalyzer:
         # Slope should be negative (Torque opposes motion/displacement)
         assert stiff.stiffness < 0
 
-    def test_compute_dynamic_stiffness(self, sample_data):
+    def test_compute_dynamic_stiffness(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         times, k, r2 = analyzer.compute_dynamic_stiffness(0, window_size=20)
         assert len(times) == len(k)
         assert len(k) > 0
 
-    def test_compute_rolling_correlation(self, sample_data):
+    def test_compute_rolling_correlation(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         times, corr = analyzer.compute_rolling_correlation(0, 0, window_size=20)
         # Auto-correlation should be 1.0
         assert np.allclose(corr, 1.0)
 
-    def test_compute_local_divergence_rate(self, sample_data):
+    def test_compute_local_divergence_rate(self, sample_data) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         times, ldr = analyzer.compute_local_divergence_rate(0, window=10)
         assert len(times) == len(ldr)
 
-    def test_export_statistics_csv(self, sample_data, tmp_path):
+    def test_export_statistics_csv(self, sample_data, tmp_path) -> None:
         analyzer = StatisticalAnalyzer(**sample_data)
         csv_path = tmp_path / "stats.csv"
         analyzer.export_statistics_csv(str(csv_path))

--- a/src/shared/python/tests/test_swing_plane_analysis.py
+++ b/src/shared/python/tests/test_swing_plane_analysis.py
@@ -5,7 +5,7 @@ from src.shared.python.swing_plane_analysis import SwingPlaneAnalyzer
 
 
 class TestSwingPlaneAnalysis:
-    def test_fit_plane_perfect(self):
+    def test_fit_plane_perfect(self) -> None:
         """Test fitting a plane to points that lie perfectly on it."""
         # Plane z = 0 (XY plane)
         points = np.array(
@@ -23,7 +23,7 @@ class TestSwingPlaneAnalysis:
         assert abs(normal[1]) < 1e-10
         assert abs(abs(normal[2]) - 1.0) < 1e-10
 
-    def test_fit_plane_inclined(self):
+    def test_fit_plane_inclined(self) -> None:
         """Test fitting to an inclined plane."""
         # Points: x=i, y=i, z=-x.
         # Vector on plane 1: (1, 1, -1) [from i=0 to i=1]
@@ -66,7 +66,7 @@ class TestSwingPlaneAnalysis:
         dot = np.abs(np.dot(normal, expected))
         np.testing.assert_allclose(dot, 1.0, atol=1e-10)
 
-    def test_calculate_deviation(self):
+    def test_calculate_deviation(self) -> None:
         """Test deviation calculation."""
         points = np.array(
             [
@@ -84,7 +84,7 @@ class TestSwingPlaneAnalysis:
         expected = np.array([1.0, -1.0, 0.0])
         np.testing.assert_allclose(devs, expected, atol=1e-10)
 
-    def test_full_analysis(self):
+    def test_full_analysis(self) -> None:
         """Test full analysis flow."""
         points = np.random.rand(10, 3)
         # Flatten to Z=0 to ensure perfect fit
@@ -100,7 +100,7 @@ class TestSwingPlaneAnalysis:
         # Wait, analyze ensures normal Z > 0.
         # If normal is [0, 0, 1], angle with [0, 0, 1] is 0.
 
-    def test_insufficient_points(self):
+    def test_insufficient_points(self) -> None:
         """Test error handling for too few points."""
         points = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
         analyzer = SwingPlaneAnalyzer()

--- a/src/shared/python/tests/test_validation.py
+++ b/src/shared/python/tests/test_validation.py
@@ -17,7 +17,7 @@ from src.shared.python.validation import (
 class TestValidation:
     """Tests for physical validation functions."""
 
-    def test_validate_mass(self):
+    def test_validate_mass(self) -> None:
         """Test validate_mass."""
         validate_mass(1.0)
         validate_mass(1e-6)
@@ -28,7 +28,7 @@ class TestValidation:
         with pytest.raises(PhysicalValidationError, match="mass > 0"):
             validate_mass(-1.0)
 
-    def test_validate_timestep(self):
+    def test_validate_timestep(self) -> None:
         """Test validate_timestep."""
         validate_timestep(0.01)
         validate_timestep(1e-4)
@@ -43,7 +43,7 @@ class TestValidation:
         # Assuming logger warning doesn't raise, checking logic passes
         validate_timestep(1.1)
 
-    def test_validate_inertia_matrix(self):
+    def test_validate_inertia_matrix(self) -> None:
         """Test validate_inertia_matrix."""
         # Valid: Identity
         validate_inertia_matrix(np.eye(3))
@@ -70,7 +70,7 @@ class TestValidation:
         with pytest.raises(PhysicalValidationError, match="positive definite"):
             validate_inertia_matrix(zero_eig)
 
-    def test_validate_joint_limits(self):
+    def test_validate_joint_limits(self) -> None:
         """Test validate_joint_limits."""
         q_min = np.array([-1.0, -1.0])
         q_max = np.array([1.0, 1.0])
@@ -86,7 +86,7 @@ class TestValidation:
         with pytest.raises(PhysicalValidationError, match="shape mismatch"):
             validate_joint_limits(np.zeros(3), q_max)
 
-    def test_validate_friction_coefficient(self):
+    def test_validate_friction_coefficient(self) -> None:
         """Test validate_friction_coefficient."""
         validate_friction_coefficient(0.0)
         validate_friction_coefficient(0.5)
@@ -107,37 +107,37 @@ class TestValidatePhysicalBoundsDecorator:
         friction: float = 0.5,
         q_min: np.ndarray | None = None,
         q_max: np.ndarray | None = None,
-    ):
+    ) -> bool:
         return True
 
-    def test_decorator_pass(self):
+    def test_decorator_pass(self) -> None:
         """Test valid inputs pass through."""
         assert self.dummy_func()
         assert self.dummy_func(mass=2.0)
         assert self.dummy_func(friction=0.0)
         assert self.dummy_func(inertia=np.eye(3))
 
-    def test_decorator_mass_validation(self):
+    def test_decorator_mass_validation(self) -> None:
         """Test mass validation via decorator."""
         with pytest.raises(PhysicalValidationError, match="mass > 0"):
             self.dummy_func(mass=-1.0)
 
-    def test_decorator_timestep_validation(self):
+    def test_decorator_timestep_validation(self) -> None:
         """Test timestep validation via decorator."""
         with pytest.raises(PhysicalValidationError, match="dt > 0"):
             self.dummy_func(dt=0.0)
 
-    def test_decorator_friction_validation(self):
+    def test_decorator_friction_validation(self) -> None:
         """Test friction validation via decorator."""
         with pytest.raises(PhysicalValidationError, match="friction coefficient >= 0"):
             self.dummy_func(friction=-0.5)
 
-    def test_decorator_inertia_validation(self):
+    def test_decorator_inertia_validation(self) -> None:
         """Test inertia validation via decorator."""
         with pytest.raises(PhysicalValidationError, match="positive definite"):
             self.dummy_func(inertia=np.diag([1.0, -1.0, 1.0]))
 
-    def test_decorator_joint_limits_validation(self):
+    def test_decorator_joint_limits_validation(self) -> None:
         """Test joint limits validation via decorator."""
         q_min = np.array([0.0])
         q_max = np.array([-1.0])

--- a/src/shared/python/theme/dialogs/custom_theme_editor.py
+++ b/src/shared/python/theme/dialogs/custom_theme_editor.py
@@ -40,7 +40,7 @@ class ColorPickerButton(QPushButton):
 
     color_changed = pyqtSignal(str)  # Emits hex color string
 
-    def __init__(self, initial_color: str = "#ffffff", parent: QWidget | None = None):
+    def __init__(self, initial_color: str = "#ffffff", parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._color = initial_color
         self.setFixedSize(60, 30)
@@ -88,7 +88,7 @@ class ColorPickerButton(QPushButton):
 class ThemePreviewWidget(QWidget):
     """Widget that shows a preview of how the theme will look."""
 
-    def __init__(self, parent: QWidget | None = None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._setup_ui()
 
@@ -158,7 +158,7 @@ class CustomThemeEditor(QDialog):
         theme_manager: ThemeManager,
         parent: QWidget | None = None,
         edit_theme: str | None = None,
-    ):
+    ) -> None:
         super().__init__(parent)
         self.theme_manager = theme_manager
         self.edit_theme = edit_theme

--- a/src/shared/python/theme/dialogs/theme_manager_dialog.py
+++ b/src/shared/python/theme/dialogs/theme_manager_dialog.py
@@ -40,7 +40,7 @@ class ThemeListItem(QListWidgetItem):
 
     def __init__(
         self, theme_name: str, is_builtin: bool = False, is_current: bool = False
-    ):
+    ) -> None:
         super().__init__()
         self.theme_name = theme_name
         self.is_builtin = is_builtin
@@ -71,7 +71,7 @@ class ThemeManagerDialog(QDialog):
 
     theme_changed = pyqtSignal(str)
 
-    def __init__(self, theme_manager: ThemeManager, parent: QWidget | None = None):
+    def __init__(self, theme_manager: ThemeManager, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.theme_manager = theme_manager
         self.theme_items: dict[str, ThemeListItem] = {}

--- a/src/shared/python/ui/qt/utils.py
+++ b/src/shared/python/ui/qt/utils.py
@@ -136,7 +136,7 @@ class BaseApplicationWindow(QMainWindow):
         title: str,
         size: tuple[int, int] = (1400, 900),
         icon_path: Path | None = None,
-    ):
+    ) -> None:
         """Initialize base application window.
 
         Args:
@@ -358,7 +358,7 @@ class LayoutBuilder:
                   .build())
     """
 
-    def __init__(self, layout: Any):
+    def __init__(self, layout: Any) -> None:
         """Initialize layout builder.
 
         Args:

--- a/src/shared/python/validation_pkg/validation.py
+++ b/src/shared/python/validation_pkg/validation.py
@@ -44,7 +44,7 @@ class PhysicalValidationError(ValidationError):
         message_or_field: str,
         value: Any = None,
         physical_constraint: str | None = None,
-    ):
+    ) -> None:
         # Support both old-style (single message) and new-style (field, value, constraint)
         if value is None and physical_constraint is None:
             # Old-style: message_or_field is the full error message

--- a/src/tools/humanoid_character_builder/core/body_parameters.py
+++ b/src/tools/humanoid_character_builder/core/body_parameters.py
@@ -42,7 +42,7 @@ class Vector3:
         """Return as tuple."""
         return (self.x, self.y, self.z)
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         """Allow unpacking."""
         return iter([self.x, self.y, self.z])
 

--- a/src/tools/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/tools/humanoid_character_builder/generators/urdf_generator.py
@@ -122,7 +122,7 @@ class HumanoidURDFGenerator:
     - Outputting valid URDF XML
     """
 
-    def __init__(self, config: URDFGeneratorConfig | None = None):
+    def __init__(self, config: URDFGeneratorConfig | None = None) -> None:
         """
         Initialize the generator.
 

--- a/src/tools/humanoid_character_builder/interfaces/api.py
+++ b/src/tools/humanoid_character_builder/interfaces/api.py
@@ -250,7 +250,7 @@ class CharacterBuilder:
         self,
         urdf_config: URDFGeneratorConfig | None = None,
         mesh_backend: MeshGeneratorBackend = MeshGeneratorBackend.PRIMITIVE,
-    ):
+    ) -> None:
         """
         Initialize the character builder.
 

--- a/src/tools/humanoid_character_builder/mesh/inertia_calculator.py
+++ b/src/tools/humanoid_character_builder/mesh/inertia_calculator.py
@@ -166,7 +166,7 @@ class MeshInertiaCalculator:
     # Default tissue density (kg/m^3) - approximately human tissue
     DEFAULT_DENSITY = 1050.0
 
-    def __init__(self, default_density: float = DEFAULT_DENSITY):
+    def __init__(self, default_density: float = DEFAULT_DENSITY) -> None:
         """
         Initialize the inertia calculator.
 

--- a/src/tools/humanoid_character_builder/mesh/mesh_processor.py
+++ b/src/tools/humanoid_character_builder/mesh/mesh_processor.py
@@ -75,7 +75,7 @@ class MeshProcessor:
 
     SUPPORTED_FORMATS = {"stl", "obj", "ply", "dae", "glb", "gltf", "off"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the mesh processor."""
         self._trimesh_available = self._check_trimesh()
 
@@ -531,7 +531,7 @@ class LODGenerator:
     # Default LOD ratios (fraction of original faces to keep)
     DEFAULT_RATIOS = [1.0, 0.5, 0.25, 0.1, 0.05]
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the LOD generator."""
         self._processor = MeshProcessor()
 

--- a/src/tools/humanoid_character_builder/tests/test_api.py
+++ b/src/tools/humanoid_character_builder/tests/test_api.py
@@ -24,11 +24,11 @@ from humanoid_character_builder.presets.loader import (
 class TestCharacterBuilder:
     """Tests for CharacterBuilder class."""
 
-    def test_init_default(self):
+    def test_init_default(self) -> None:
         builder = CharacterBuilder()
         assert builder.urdf_config is not None
 
-    def test_build_default_params(self):
+    def test_build_default_params(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
 
@@ -38,7 +38,7 @@ class TestCharacterBuilder:
         assert result.urdf_xml is not None
         assert len(result.segments) > 0
 
-    def test_build_custom_params(self):
+    def test_build_custom_params(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters(
             height_m=1.85,
@@ -51,7 +51,7 @@ class TestCharacterBuilder:
         assert result.success
         assert result.params.height_m == 1.85
 
-    def test_generate_urdf(self):
+    def test_generate_urdf(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
 
@@ -60,7 +60,7 @@ class TestCharacterBuilder:
         assert urdf is not None
         assert "<robot" in urdf
 
-    def test_generate_urdf_to_file(self):
+    def test_generate_urdf_to_file(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
 
@@ -70,7 +70,7 @@ class TestCharacterBuilder:
 
             assert output_path.exists()
 
-    def test_compute_segment_inertia(self):
+    def test_compute_segment_inertia(self) -> None:
         builder = CharacterBuilder()
 
         inertia = builder.compute_segment_inertia("left_thigh", mass=10.0)
@@ -80,7 +80,7 @@ class TestCharacterBuilder:
         assert inertia.iyy > 0
         assert inertia.izz > 0
 
-    def test_compute_segment_inertia_with_dimensions(self):
+    def test_compute_segment_inertia_with_dimensions(self) -> None:
         builder = CharacterBuilder()
 
         inertia = builder.compute_segment_inertia(
@@ -92,7 +92,7 @@ class TestCharacterBuilder:
         assert inertia.mass == 10.0
         assert inertia.is_valid()
 
-    def test_compute_all_inertias(self):
+    def test_compute_all_inertias(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
 
@@ -107,13 +107,13 @@ class TestCharacterBuilder:
         for name, inertia in inertias.items():
             assert inertia.ixx > 0, f"{name} has invalid ixx"
 
-    def test_create_from_preset(self):
+    def test_create_from_preset(self) -> None:
         params = CharacterBuilder.create_from_preset("athletic")
 
         assert params.muscularity > 0.5
         assert params.body_fat_factor < 0.2
 
-    def test_create_from_preset_with_overrides(self):
+    def test_create_from_preset_with_overrides(self) -> None:
         params = CharacterBuilder.create_from_preset(
             "athletic", height_m=1.90, mass_kg=90.0
         )
@@ -121,14 +121,14 @@ class TestCharacterBuilder:
         assert params.height_m == 1.90
         assert params.mass_kg == 90.0
 
-    def test_list_presets(self):
+    def test_list_presets(self) -> None:
         presets = CharacterBuilder.list_presets()
 
         assert len(presets) > 0
         assert "athletic" in presets
         assert "average" in presets
 
-    def test_list_segments(self):
+    def test_list_segments(self) -> None:
         segments = CharacterBuilder.list_segments()
 
         assert len(segments) > 0
@@ -136,7 +136,7 @@ class TestCharacterBuilder:
         assert "head" in segments
         assert "left_hand" in segments
 
-    def test_get_segment_definition(self):
+    def test_get_segment_definition(self) -> None:
         definition = CharacterBuilder.get_segment_definition("pelvis")
 
         assert definition is not None
@@ -147,7 +147,7 @@ class TestCharacterBuilder:
 class TestCharacterBuildResult:
     """Tests for CharacterBuildResult class."""
 
-    def test_export_urdf(self):
+    def test_export_urdf(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
         result = builder.build(params, generate_meshes=False)
@@ -158,7 +158,7 @@ class TestCharacterBuildResult:
             assert urdf_path.exists()
             assert (Path(tmpdir) / "config").exists()
 
-    def test_export_urdf_custom_options(self):
+    def test_export_urdf_custom_options(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
         result = builder.build(params, generate_meshes=False)
@@ -175,7 +175,7 @@ class TestCharacterBuildResult:
             assert urdf_path.name == "custom.urdf"
             assert (Path(tmpdir) / "config" / "body_params.json").exists()
 
-    def test_get_segment(self):
+    def test_get_segment(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
         result = builder.build(params, generate_meshes=False)
@@ -186,7 +186,7 @@ class TestCharacterBuildResult:
         assert segment.segment_name == "pelvis"
         assert segment.mass_kg > 0
 
-    def test_get_total_mass(self):
+    def test_get_total_mass(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters(mass_kg=75.0)
         result = builder.build(params, generate_meshes=False)
@@ -196,7 +196,7 @@ class TestCharacterBuildResult:
         # Should be approximately the specified mass
         assert abs(total_mass - 75.0) < 5.0  # Allow some variance
 
-    def test_to_dict(self):
+    def test_to_dict(self) -> None:
         builder = CharacterBuilder()
         params = BodyParameters()
         result = builder.build(params, generate_meshes=False)
@@ -212,45 +212,45 @@ class TestCharacterBuildResult:
 class TestQuickFunctions:
     """Tests for quick convenience functions."""
 
-    def test_quick_build_default(self):
+    def test_quick_build_default(self) -> None:
         result = quick_build()
 
         assert result.success
         assert result.params.height_m == 1.75
         assert result.params.mass_kg == 75.0
 
-    def test_quick_build_custom(self):
+    def test_quick_build_custom(self) -> None:
         result = quick_build(height_m=1.85, mass_kg=85.0)
 
         assert result.success
         assert result.params.height_m == 1.85
 
-    def test_quick_build_with_preset(self):
+    def test_quick_build_with_preset(self) -> None:
         result = quick_build(preset="athletic")
 
         assert result.success
         assert result.params.muscularity > 0.5
 
-    def test_quick_build_with_output(self):
+    def test_quick_build_with_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             result = quick_build(output_dir=tmpdir)
 
             assert result.success
             assert (Path(tmpdir) / "humanoid.urdf").exists()
 
-    def test_quick_urdf_default(self):
+    def test_quick_urdf_default(self) -> None:
         urdf = quick_urdf()
 
         assert urdf is not None
         assert "<robot" in urdf
 
-    def test_quick_urdf_custom(self):
+    def test_quick_urdf_custom(self) -> None:
         urdf = quick_urdf(height_m=1.90)
 
         assert urdf is not None
         assert "<robot" in urdf
 
-    def test_quick_urdf_with_preset(self):
+    def test_quick_urdf_with_preset(self) -> None:
         urdf = quick_urdf(preset="heavy")
 
         assert urdf is not None
@@ -260,7 +260,7 @@ class TestQuickFunctions:
 class TestPresets:
     """Tests for preset loading."""
 
-    def test_list_available_presets(self):
+    def test_list_available_presets(self) -> None:
         presets = list_available_presets()
 
         assert len(presets) > 0
@@ -268,18 +268,18 @@ class TestPresets:
         assert "average" in presets
         assert "heavy" in presets
 
-    def test_load_body_preset_athletic(self):
+    def test_load_body_preset_athletic(self) -> None:
         params = load_body_preset("athletic")
 
         assert params.muscularity > 0.5
         assert params.body_fat_factor < 0.2
 
-    def test_load_body_preset_average(self):
+    def test_load_body_preset_average(self) -> None:
         params = load_body_preset("average")
 
         assert params.muscularity == 0.5
 
-    def test_load_body_preset_with_overrides(self):
+    def test_load_body_preset_with_overrides(self) -> None:
         params = load_body_preset("athletic", height_m=2.0, mass_kg=100.0)
 
         assert params.height_m == 2.0
@@ -287,11 +287,11 @@ class TestPresets:
         # Should still have athletic properties
         assert params.muscularity > 0.5
 
-    def test_load_body_preset_invalid(self):
+    def test_load_body_preset_invalid(self) -> None:
         with pytest.raises(ValueError):
             load_body_preset("nonexistent_preset")
 
-    def test_get_preset_info(self):
+    def test_get_preset_info(self) -> None:
         info = get_preset_info("athletic")
 
         assert info["name"] == "athletic"
@@ -299,7 +299,7 @@ class TestPresets:
         assert "mass_kg" in info
         assert "description" in info
 
-    def test_preset_names_constant(self):
+    def test_preset_names_constant(self) -> None:
         assert len(PRESET_NAMES) > 0
         assert "athletic" in PRESET_NAMES
 
@@ -307,7 +307,7 @@ class TestPresets:
 class TestExportOptions:
     """Tests for ExportOptions."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         options = ExportOptions()
 
         assert options.urdf_filename == "humanoid.urdf"
@@ -315,7 +315,7 @@ class TestExportOptions:
         assert options.generate_meshes is True
         assert options.mesh_format == "stl"
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         options = ExportOptions(
             urdf_filename="robot.urdf",
             mesh_format="obj",

--- a/src/tools/humanoid_character_builder/tests/test_body_parameters.py
+++ b/src/tools/humanoid_character_builder/tests/test_body_parameters.py
@@ -18,23 +18,23 @@ from humanoid_character_builder.core.body_parameters import (
 class TestVector3:
     """Tests for Vector3 class."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         v = Vector3()
         assert v.x == 1.0
         assert v.y == 1.0
         assert v.z == 1.0
 
-    def test_as_tuple(self):
+    def test_as_tuple(self) -> None:
         v = Vector3(1.0, 2.0, 3.0)
         assert v.as_tuple() == (1.0, 2.0, 3.0)
 
-    def test_uniform(self):
+    def test_uniform(self) -> None:
         v = Vector3.uniform(0.5)
         assert v.x == 0.5
         assert v.y == 0.5
         assert v.z == 0.5
 
-    def test_from_tuple(self):
+    def test_from_tuple(self) -> None:
         v = Vector3.from_tuple((1.0, 2.0, 3.0))
         assert v.x == 1.0
         assert v.y == 2.0
@@ -44,16 +44,16 @@ class TestVector3:
 class TestRGBA:
     """Tests for RGBA class."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         c = RGBA()
         assert c.r == 0.8
         assert c.a == 1.0
 
-    def test_as_tuple(self):
+    def test_as_tuple(self) -> None:
         c = RGBA(1.0, 0.5, 0.25, 0.75)
         assert c.as_tuple() == (1.0, 0.5, 0.25, 0.75)
 
-    def test_as_hex(self):
+    def test_as_hex(self) -> None:
         c = RGBA(1.0, 0.5, 0.0, 1.0)
         assert c.as_hex() == "#ff7f00"
 
@@ -61,13 +61,13 @@ class TestRGBA:
 class TestBodyParameters:
     """Tests for BodyParameters class."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         params = BodyParameters()
         assert params.height_m == 1.75
         assert params.mass_kg == 75.0
         assert params.build_type == BuildType.AVERAGE
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         params = BodyParameters(
             height_m=1.80,
             mass_kg=80.0,
@@ -78,7 +78,7 @@ class TestBodyParameters:
         assert params.mass_kg == 80.0
         assert params.muscularity == 0.7
 
-    def test_gender_factor(self):
+    def test_gender_factor(self) -> None:
         male = BodyParameters(gender_model=GenderModel.MALE)
         female = BodyParameters(gender_model=GenderModel.FEMALE)
         neutral = BodyParameters(gender_model=GenderModel.NEUTRAL)
@@ -87,22 +87,22 @@ class TestBodyParameters:
         assert female.get_effective_gender_factor() == 0.0
         assert neutral.get_effective_gender_factor() == 0.5
 
-    def test_validate_valid_params(self):
+    def test_validate_valid_params(self) -> None:
         params = BodyParameters(height_m=1.75, mass_kg=75.0)
         errors = params.validate()
         assert len(errors) == 0
 
-    def test_validate_invalid_height(self):
+    def test_validate_invalid_height(self) -> None:
         params = BodyParameters(height_m=-1.0)
         errors = params.validate()
         assert any("height_m" in e for e in errors)
 
-    def test_validate_invalid_mass(self):
+    def test_validate_invalid_mass(self) -> None:
         params = BodyParameters(mass_kg=-10.0)
         errors = params.validate()
         assert any("mass_kg" in e for e in errors)
 
-    def test_segment_override(self):
+    def test_segment_override(self) -> None:
         params = BodyParameters()
         seg_params = SegmentParameters(mass_kg=5.0)
         params.set_segment_override("left_thigh", seg_params)
@@ -111,7 +111,7 @@ class TestBodyParameters:
         assert retrieved.mass_kg == 5.0
         assert retrieved.has_mass_override()
 
-    def test_to_dict(self):
+    def test_to_dict(self) -> None:
         params = BodyParameters(height_m=1.80, name="test_model")
         data = params.to_dict()
 
@@ -119,7 +119,7 @@ class TestBodyParameters:
         assert data["name"] == "test_model"
         assert "build_type" in data
 
-    def test_from_dict(self):
+    def test_from_dict(self) -> None:
         data = {
             "height_m": 1.85,
             "mass_kg": 85.0,
@@ -137,23 +137,23 @@ class TestBodyParameters:
 class TestFactoryFunctions:
     """Tests for convenience factory functions."""
 
-    def test_create_athletic_body(self):
+    def test_create_athletic_body(self) -> None:
         params = create_athletic_body()
         assert params.build_type == BuildType.MESOMORPH
         assert params.muscularity > 0.5
         assert params.body_fat_factor < 0.2
 
-    def test_create_athletic_body_with_overrides(self):
+    def test_create_athletic_body_with_overrides(self) -> None:
         params = create_athletic_body(height_m=1.90, mass_kg=90.0)
         assert params.height_m == 1.90
         assert params.mass_kg == 90.0
 
-    def test_create_average_body(self):
+    def test_create_average_body(self) -> None:
         params = create_average_body()
         assert params.build_type == BuildType.AVERAGE
         assert params.muscularity == 0.5
 
-    def test_create_heavy_body(self):
+    def test_create_heavy_body(self) -> None:
         params = create_heavy_body()
         assert params.build_type == BuildType.ENDOMORPH
         assert params.body_fat_factor > 0.3
@@ -162,12 +162,12 @@ class TestFactoryFunctions:
 class TestSegmentParameters:
     """Tests for SegmentParameters class."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         seg = SegmentParameters()
         assert seg.mass_kg is None
         assert seg.inertia_override is None
 
-    def test_has_overrides(self):
+    def test_has_overrides(self) -> None:
         seg = SegmentParameters()
         assert not seg.has_mass_override()
         assert not seg.has_inertia_override()
@@ -178,7 +178,7 @@ class TestSegmentParameters:
         seg.inertia_override = {"ixx": 0.1, "iyy": 0.1, "izz": 0.1}
         assert seg.has_inertia_override()
 
-    def test_scale(self):
+    def test_scale(self) -> None:
         seg = SegmentParameters(scale=Vector3(1.2, 1.0, 0.8))
         assert seg.scale.x == 1.2
         assert seg.scale.z == 0.8

--- a/src/tools/humanoid_character_builder/tests/test_inertia_calculator.py
+++ b/src/tools/humanoid_character_builder/tests/test_inertia_calculator.py
@@ -21,14 +21,14 @@ from humanoid_character_builder.mesh.primitive_inertia import (
 class TestInertiaResult:
     """Tests for InertiaResult class."""
 
-    def test_default_creation(self):
+    def test_default_creation(self) -> None:
         result = InertiaResult.create_default(mass=1.0)
         assert result.mass == 1.0
         assert result.ixx > 0
         assert result.iyy > 0
         assert result.izz > 0
 
-    def test_as_matrix(self):
+    def test_as_matrix(self) -> None:
         result = InertiaResult(
             ixx=1.0, iyy=2.0, izz=3.0, ixy=0.1, ixz=0.2, iyz=0.3, mass=1.0
         )
@@ -42,7 +42,7 @@ class TestInertiaResult:
         assert matrix[0, 2] == 0.2
         assert matrix[1, 2] == 0.3
 
-    def test_as_urdf_dict(self):
+    def test_as_urdf_dict(self) -> None:
         result = InertiaResult(
             ixx=1.0, iyy=2.0, izz=3.0, ixy=0.1, ixz=0.2, iyz=0.3, mass=1.0
         )
@@ -54,21 +54,21 @@ class TestInertiaResult:
         assert "ixy" in urdf_dict
         assert urdf_dict["ixx"] == 1.0
 
-    def test_is_valid_positive(self):
+    def test_is_valid_positive(self) -> None:
         # Valid inertia for a symmetric shape
         result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, mass=1.0)
         assert result.is_valid()
 
-    def test_is_valid_negative_diagonal(self):
+    def test_is_valid_negative_diagonal(self) -> None:
         result = InertiaResult(ixx=-1.0, iyy=1.0, izz=1.0, mass=1.0)
         assert not result.is_valid()
 
-    def test_validate_positive_definite(self):
+    def test_validate_positive_definite(self) -> None:
         # Sphere-like inertia is positive definite
         result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, mass=1.0)
         assert result.validate_positive_definite()
 
-    def test_as_dict(self):
+    def test_as_dict(self) -> None:
         result = InertiaResult(
             ixx=1.0,
             iyy=2.0,
@@ -88,7 +88,7 @@ class TestInertiaResult:
 class TestPrimitiveInertiaCalculator:
     """Tests for PrimitiveInertiaCalculator."""
 
-    def test_box_inertia(self):
+    def test_box_inertia(self) -> None:
         calc = PrimitiveInertiaCalculator()
         result = calc.compute_box(mass=1.0, size_x=1.0, size_y=1.0, size_z=1.0)
 
@@ -99,7 +99,7 @@ class TestPrimitiveInertiaCalculator:
         assert abs(result.izz - expected_i) < 1e-10
         assert result.volume == 1.0
 
-    def test_cylinder_inertia(self):
+    def test_cylinder_inertia(self) -> None:
         calc = PrimitiveInertiaCalculator()
         mass = 1.0
         radius = 0.5
@@ -116,7 +116,7 @@ class TestPrimitiveInertiaCalculator:
         assert abs(result.ixx - expected_ixx) < 1e-10
         assert abs(result.iyy - expected_ixx) < 1e-10
 
-    def test_sphere_inertia(self):
+    def test_sphere_inertia(self) -> None:
         calc = PrimitiveInertiaCalculator()
         mass = 1.0
         radius = 1.0
@@ -133,7 +133,7 @@ class TestPrimitiveInertiaCalculator:
         expected_volume = (4.0 / 3.0) * math.pi * radius**3
         assert abs(result.volume - expected_volume) < 1e-10
 
-    def test_capsule_inertia(self):
+    def test_capsule_inertia(self) -> None:
         calc = PrimitiveInertiaCalculator()
         mass = 1.0
         radius = 0.1
@@ -147,7 +147,7 @@ class TestPrimitiveInertiaCalculator:
         assert result.izz > 0
         assert result.validate_positive_definite()
 
-    def test_ellipsoid_inertia(self):
+    def test_ellipsoid_inertia(self) -> None:
         calc = PrimitiveInertiaCalculator()
         mass = 1.0
         a, b, c = 1.0, 0.5, 0.25
@@ -158,7 +158,7 @@ class TestPrimitiveInertiaCalculator:
         expected_ixx = 0.2 * mass * (b**2 + c**2)
         assert abs(result.ixx - expected_ixx) < 1e-10
 
-    def test_compute_generic(self):
+    def test_compute_generic(self) -> None:
         calc = PrimitiveInertiaCalculator()
 
         # Test with string shape
@@ -173,18 +173,18 @@ class TestPrimitiveInertiaCalculator:
 class TestEstimateSegmentPrimitive:
     """Tests for segment primitive estimation."""
 
-    def test_head_is_sphere(self):
+    def test_head_is_sphere(self) -> None:
         shape, dims = estimate_segment_primitive("head", 0.2)
         assert shape == PrimitiveShape.SPHERE
         assert "radius" in dims
 
-    def test_thigh_is_capsule(self):
+    def test_thigh_is_capsule(self) -> None:
         shape, dims = estimate_segment_primitive("thigh", 0.4, 0.1)
         assert shape == PrimitiveShape.CAPSULE
         assert "radius" in dims
         assert "length" in dims
 
-    def test_torso_is_box(self):
+    def test_torso_is_box(self) -> None:
         shape, dims = estimate_segment_primitive("thorax", 0.3, 0.25, 0.15)
         assert shape == PrimitiveShape.BOX
         assert "x" in dims
@@ -195,23 +195,23 @@ class TestEstimateSegmentPrimitive:
 class TestValidateInertiaTensor:
     """Tests for inertia tensor validation."""
 
-    def test_valid_tensor(self):
+    def test_valid_tensor(self) -> None:
         # Valid diagonal tensor
         inertia = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         errors = validate_inertia_tensor(inertia)
         assert len(errors) == 0
 
-    def test_non_symmetric(self):
+    def test_non_symmetric(self) -> None:
         inertia = np.array([[1.0, 0.5, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         errors = validate_inertia_tensor(inertia)
         assert any("symmetric" in e for e in errors)
 
-    def test_negative_diagonal(self):
+    def test_negative_diagonal(self) -> None:
         inertia = np.array([[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         errors = validate_inertia_tensor(inertia)
         assert any("positive" in e.lower() for e in errors)
 
-    def test_wrong_shape(self):
+    def test_wrong_shape(self) -> None:
         inertia = np.array([[1.0, 0.0], [0.0, 1.0]])
         errors = validate_inertia_tensor(inertia)
         assert any("3x3" in e for e in errors)
@@ -220,7 +220,7 @@ class TestValidateInertiaTensor:
 class TestMeshInertiaCalculator:
     """Tests for MeshInertiaCalculator."""
 
-    def test_create_manual_inertia(self):
+    def test_create_manual_inertia(self) -> None:
         result = MeshInertiaCalculator.create_manual_inertia(
             ixx=1.0, iyy=2.0, izz=3.0, mass=5.0, com=(0.1, 0.2, 0.3)
         )
@@ -232,7 +232,7 @@ class TestMeshInertiaCalculator:
         assert result.center_of_mass == (0.1, 0.2, 0.3)
         assert result.mode == InertiaMode.MANUAL
 
-    def test_transform_inertia_rotation(self):
+    def test_transform_inertia_rotation(self) -> None:
         calc = MeshInertiaCalculator()
 
         # Create inertia
@@ -248,7 +248,7 @@ class TestMeshInertiaCalculator:
         assert abs(transformed.iyy - original.iyy) < 1e-10
         assert abs(transformed.izz - original.izz) < 1e-10
 
-    def test_check_trimesh_availability(self):
+    def test_check_trimesh_availability(self) -> None:
         calc = MeshInertiaCalculator()
         # Just verify it doesn't crash
         _ = calc._trimesh_available

--- a/src/tools/humanoid_character_builder/tests/test_urdf_generator.py
+++ b/src/tools/humanoid_character_builder/tests/test_urdf_generator.py
@@ -18,13 +18,13 @@ from humanoid_character_builder.mesh.inertia_calculator import InertiaMode
 class TestURDFGeneratorConfig:
     """Tests for URDFGeneratorConfig."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         config = URDFGeneratorConfig()
         assert config.inertia_mode == InertiaMode.PRIMITIVE_APPROXIMATION
         assert config.generate_collision is True
         assert config.expand_composite_joints is True
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         config = URDFGeneratorConfig(
             inertia_mode=InertiaMode.MESH_UNIFORM_DENSITY,
             default_density=1100.0,
@@ -38,7 +38,7 @@ class TestURDFGeneratorConfig:
 class TestHumanoidURDFGenerator:
     """Tests for HumanoidURDFGenerator."""
 
-    def test_generate_default_params(self):
+    def test_generate_default_params(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -49,7 +49,7 @@ class TestHumanoidURDFGenerator:
         assert "<?xml" in urdf_xml
         assert "<robot" in urdf_xml
 
-    def test_generate_custom_params(self):
+    def test_generate_custom_params(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters(
             height_m=1.90,
@@ -61,7 +61,7 @@ class TestHumanoidURDFGenerator:
 
         assert 'name="tall_humanoid"' in urdf_xml
 
-    def test_generate_valid_xml(self):
+    def test_generate_valid_xml(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -76,7 +76,7 @@ class TestHumanoidURDFGenerator:
         root = ET.fromstring(xml_content)
         assert root.tag == "robot"
 
-    def test_generate_has_links(self):
+    def test_generate_has_links(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -99,7 +99,7 @@ class TestHumanoidURDFGenerator:
         assert "head" in link_names
         assert "left_thigh" in link_names
 
-    def test_generate_has_joints(self):
+    def test_generate_has_joints(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -115,7 +115,7 @@ class TestHumanoidURDFGenerator:
         # Should have multiple joints
         assert len(joints) > 10
 
-    def test_generate_inertial_properties(self):
+    def test_generate_inertial_properties(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -143,7 +143,7 @@ class TestHumanoidURDFGenerator:
             assert "iyy" in inertia.attrib
             assert "izz" in inertia.attrib
 
-    def test_generate_visual_geometry(self):
+    def test_generate_visual_geometry(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -166,7 +166,7 @@ class TestHumanoidURDFGenerator:
 
         assert visual_count > 10
 
-    def test_generate_collision_geometry(self):
+    def test_generate_collision_geometry(self) -> None:
         config = URDFGeneratorConfig(generate_collision=True)
         generator = HumanoidURDFGenerator(config)
         params = BodyParameters()
@@ -188,7 +188,7 @@ class TestHumanoidURDFGenerator:
 
         assert collision_count > 10
 
-    def test_generate_no_collision(self):
+    def test_generate_no_collision(self) -> None:
         config = URDFGeneratorConfig(generate_collision=False)
         generator = HumanoidURDFGenerator(config)
         params = BodyParameters()
@@ -198,7 +198,7 @@ class TestHumanoidURDFGenerator:
         # Should still be valid but without collision
         assert "<collision>" not in urdf_xml
 
-    def test_generate_write_to_file(self):
+    def test_generate_write_to_file(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -210,7 +210,7 @@ class TestHumanoidURDFGenerator:
             content = output_path.read_text()
             assert content == urdf_xml
 
-    def test_generate_joint_limits(self):
+    def test_generate_joint_limits(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -230,7 +230,7 @@ class TestHumanoidURDFGenerator:
                 assert "lower" in limit.attrib
                 assert "upper" in limit.attrib
 
-    def test_generate_joint_dynamics(self):
+    def test_generate_joint_dynamics(self) -> None:
         generator = HumanoidURDFGenerator()
         params = BodyParameters()
 
@@ -256,14 +256,14 @@ class TestHumanoidURDFGenerator:
 class TestGenerateHumanoidURDF:
     """Tests for convenience function."""
 
-    def test_basic_call(self):
+    def test_basic_call(self) -> None:
         params = BodyParameters()
         urdf = generate_humanoid_urdf(params)
 
         assert urdf is not None
         assert "<robot" in urdf
 
-    def test_with_config(self):
+    def test_with_config(self) -> None:
         params = BodyParameters()
         config = URDFGeneratorConfig(generate_collision=False)
 
@@ -271,7 +271,7 @@ class TestGenerateHumanoidURDF:
 
         assert "<collision>" not in urdf
 
-    def test_with_output_path(self):
+    def test_with_output_path(self) -> None:
         params = BodyParameters()
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -284,7 +284,7 @@ class TestGenerateHumanoidURDF:
 class TestCompositeJointExpansion:
     """Tests for composite joint expansion."""
 
-    def test_gimbal_joint_expansion(self):
+    def test_gimbal_joint_expansion(self) -> None:
         config = URDFGeneratorConfig(expand_composite_joints=True)
         generator = HumanoidURDFGenerator(config)
         params = BodyParameters()
@@ -295,7 +295,7 @@ class TestCompositeJointExpansion:
         # Check for intermediate links and joints
         assert "_z" in urdf_xml or "_y" in urdf_xml or "_x" in urdf_xml
 
-    def test_no_expansion(self):
+    def test_no_expansion(self) -> None:
         config = URDFGeneratorConfig(expand_composite_joints=False)
         generator = HumanoidURDFGenerator(config)
         params = BodyParameters()
@@ -309,7 +309,7 @@ class TestCompositeJointExpansion:
 class TestProportionFactors:
     """Tests for body proportion factors."""
 
-    def test_tall_character(self):
+    def test_tall_character(self) -> None:
         generator = HumanoidURDFGenerator()
 
         # Normal height
@@ -324,7 +324,7 @@ class TestProportionFactors:
         assert "<robot" in normal_urdf
         assert "<robot" in tall_urdf
 
-    def test_wide_shoulders(self):
+    def test_wide_shoulders(self) -> None:
         generator = HumanoidURDFGenerator()
 
         params = BodyParameters(shoulder_width_factor=1.2)
@@ -332,7 +332,7 @@ class TestProportionFactors:
 
         assert "<robot" in urdf
 
-    def test_muscular_build(self):
+    def test_muscular_build(self) -> None:
         generator = HumanoidURDFGenerator()
 
         params = BodyParameters(muscularity=0.8, body_fat_factor=0.1)

--- a/src/tools/model_explorer/segment_panel.py
+++ b/src/tools/model_explorer/segment_panel.py
@@ -29,7 +29,7 @@ class SegmentPanel(QWidget):
     segment_removed = pyqtSignal(str)
     segment_modified = pyqtSignal(dict)
 
-    def __init__(self, parent: QWidget | None = None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         """Initialize the segment panel.
 
         Args:

--- a/src/tools/model_generation/api/rest_api.py
+++ b/src/tools/model_generation/api/rest_api.py
@@ -121,7 +121,7 @@ class ModelGenerationAPI:
         FastAPIAdapter(api).register(app)
     """
 
-    def __init__(self, prefix: str = "/api/v1"):
+    def __init__(self, prefix: str = "/api/v1") -> None:
         """
         Initialize API.
 
@@ -1022,7 +1022,7 @@ class ModelGenerationAPI:
 class FlaskAdapter:
     """Adapter for Flask framework."""
 
-    def __init__(self, api: ModelGenerationAPI):
+    def __init__(self, api: ModelGenerationAPI) -> None:
         self.api = api
 
     def register(self, app: Any) -> None:
@@ -1033,8 +1033,8 @@ class FlaskAdapter:
         for route in self.api.get_routes():
             endpoint = route.path.replace("/", "_").replace("{", "").replace("}", "")
 
-            def make_handler(r: Route):
-                def handler(**kwargs):
+            def make_handler(r: Route) -> Any:
+                def handler(**kwargs) -> Any:
                     # Build APIRequest
                     api_request = APIRequest(
                         method=HTTPMethod(flask_request.method),
@@ -1077,7 +1077,7 @@ class FlaskAdapter:
 class FastAPIAdapter:
     """Adapter for FastAPI framework."""
 
-    def __init__(self, api: ModelGenerationAPI):
+    def __init__(self, api: ModelGenerationAPI) -> None:
         self.api = api
 
     def register(self, app: Any) -> None:
@@ -1087,8 +1087,8 @@ class FastAPIAdapter:
 
         for route in self.api.get_routes():
 
-            async def make_handler(r: Route):
-                async def handler(request: Request, **kwargs):
+            async def make_handler(r: Route) -> Any:
+                async def handler(request: Request, **kwargs) -> Any:
                     body = None
                     try:
                         body = await request.json()

--- a/src/tools/model_generation/builders/base_builder.py
+++ b/src/tools/model_generation/builders/base_builder.py
@@ -98,7 +98,7 @@ class BaseURDFBuilder(ABC):
     All builders (manual, parametric, composite) implement this interface.
     """
 
-    def __init__(self, robot_name: str = "robot"):
+    def __init__(self, robot_name: str = "robot") -> None:
         """
         Initialize builder.
 

--- a/src/tools/model_generation/builders/manual_builder.py
+++ b/src/tools/model_generation/builders/manual_builder.py
@@ -65,7 +65,7 @@ class ManualBuilder(BaseURDFBuilder):
         robot_name: str = "robot",
         handedness: Handedness = Handedness.RIGHT,
         validate_on_add: bool = True,
-    ):
+    ) -> None:
         """
         Initialize manual builder.
 

--- a/src/tools/model_generation/builders/parametric_builder.py
+++ b/src/tools/model_generation/builders/parametric_builder.py
@@ -78,7 +78,7 @@ class ParametricBuilder(BaseURDFBuilder):
         self,
         robot_name: str = "humanoid",
         config: ParametricConfig | None = None,
-    ):
+    ) -> None:
         """
         Initialize parametric builder.
 

--- a/src/tools/model_generation/converters/mjcf_converter.py
+++ b/src/tools/model_generation/converters/mjcf_converter.py
@@ -78,7 +78,7 @@ class MJCFConverter:
     URDF uses a flat structure with explicit parent-child relationships.
     """
 
-    def __init__(self, config: MJCFConfig | None = None):
+    def __init__(self, config: MJCFConfig | None = None) -> None:
         """
         Initialize converter.
 

--- a/src/tools/model_generation/converters/simscape/mdl_parser.py
+++ b/src/tools/model_generation/converters/simscape/mdl_parser.py
@@ -255,7 +255,7 @@ class MDLParser:
         "simulink/Ports & Subsystems/Subsystem": SimscapeBlockType.SUBSYSTEM,
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize parser."""
         self._current_path: list[str] = []
 

--- a/src/tools/model_generation/converters/simscape/simscape_converter.py
+++ b/src/tools/model_generation/converters/simscape/simscape_converter.py
@@ -138,7 +138,7 @@ class SimscapeToURDFConverter:
         SimscapeBlockType.SIX_DOF_JOINT: JointType.FLOATING,
     }
 
-    def __init__(self, config: ConversionConfig | None = None):
+    def __init__(self, config: ConversionConfig | None = None) -> None:
         """
         Initialize converter.
 

--- a/src/tools/model_generation/converters/urdf_parser.py
+++ b/src/tools/model_generation/converters/urdf_parser.py
@@ -136,7 +136,7 @@ class URDFParser:
     - Preserves original XML for text editing
     """
 
-    def __init__(self, resolve_meshes: bool = True):
+    def __init__(self, resolve_meshes: bool = True) -> None:
         """
         Initialize parser.
 

--- a/src/tools/model_generation/core/types.py
+++ b/src/tools/model_generation/core/types.py
@@ -602,7 +602,7 @@ class Joint:
     composite_axes: list[tuple[float, float, float]] | None = None
     composite_limits: list[JointLimits] | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Ensure limits are set for limited joint types."""
         if self.joint_type == JointType.REVOLUTE and self.limits is None:
             self.limits = JointLimits()

--- a/src/tools/model_generation/editor/frankenstein_editor.py
+++ b/src/tools/model_generation/editor/frankenstein_editor.py
@@ -103,7 +103,7 @@ class FrankensteinEditor:
         urdf_string = editor.export_model("cyborg")
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the Frankenstein editor."""
         self._models: dict[str, ParsedModel] = {}
         self._parser = URDFParser()

--- a/src/tools/model_generation/editor/text_editor.py
+++ b/src/tools/model_generation/editor/text_editor.py
@@ -128,7 +128,7 @@ class URDFTextEditor:
         editor.save_file()
     """
 
-    def __init__(self, max_history: int = 100):
+    def __init__(self, max_history: int = 100) -> None:
         """
         Initialize the editor.
 

--- a/src/tools/model_generation/humanoid/__init__.py
+++ b/src/tools/model_generation/humanoid/__init__.py
@@ -47,7 +47,7 @@ except ImportError:
     # humanoid_character_builder not available
     __all__ = []
 
-    def _not_available(*args, **kwargs):
+    def _not_available(*args, **kwargs) -> None:
         raise ImportError(
             "humanoid_character_builder not available. Ensure it is in the Python path."
         )

--- a/src/tools/model_generation/library/cache.py
+++ b/src/tools/model_generation/library/cache.py
@@ -94,7 +94,7 @@ class ModelCache:
 
     INDEX_FILE = "cache_index.json"
 
-    def __init__(self, config: CacheConfig | None = None):
+    def __init__(self, config: CacheConfig | None = None) -> None:
         """
         Initialize cache.
 

--- a/src/tools/model_generation/library/model_library.py
+++ b/src/tools/model_generation/library/model_library.py
@@ -205,7 +205,7 @@ class ModelLibrary:
         },
     }
 
-    def __init__(self, config: LibraryConfig | None = None):
+    def __init__(self, config: LibraryConfig | None = None) -> None:
         """
         Initialize model library.
 

--- a/src/tools/model_generation/library/repository.py
+++ b/src/tools/model_generation/library/repository.py
@@ -90,7 +90,7 @@ class LocalRepository(Repository):
         path: Path | str,
         name: str | None = None,
         description: str = "",
-    ):
+    ) -> None:
         """
         Initialize local repository.
 
@@ -170,7 +170,7 @@ class GitHubRepository(Repository):
         path: str = "",
         name: str | None = None,
         description: str = "",
-    ):
+    ) -> None:
         """
         Initialize GitHub repository.
 
@@ -337,7 +337,7 @@ class CompositeRepository(Repository):
         repositories: list[Repository],
         name: str = "Combined",
         description: str = "Combined repository",
-    ):
+    ) -> None:
         """
         Initialize composite repository.
 

--- a/src/tools/model_generation/models/pendulum_putter.py
+++ b/src/tools/model_generation/models/pendulum_putter.py
@@ -438,7 +438,7 @@ class PendulumPutterModelBuilder(BaseURDFBuilder):
         include_club: bool = True,
         club_config: ClubConfig | None = None,
         stand_config: StandConfig | None = None,
-    ):
+    ) -> None:
         """
         Initialize the pendulum putter builder.
 

--- a/src/tools/model_generation/tests/test_api.py
+++ b/src/tools/model_generation/tests/test_api.py
@@ -28,7 +28,7 @@ def _body(response: Any) -> dict[str, Any]:
 class TestAPIClasses:
     """Tests for API data classes."""
 
-    def test_api_request_creation(self):
+    def test_api_request_creation(self) -> None:
         """Test APIRequest creation."""
         from model_generation.api import APIRequest, HTTPMethod
 
@@ -42,7 +42,7 @@ class TestAPIClasses:
         assert request.path == "/api/v1/health"
         assert request.query_params["key"] == "value"
 
-    def test_api_response_ok(self):
+    def test_api_response_ok(self) -> None:
         """Test APIResponse.ok factory."""
         from model_generation.api import APIResponse
 
@@ -51,7 +51,7 @@ class TestAPIClasses:
         assert response.status_code == 200
         assert _body(response)["status"] == "healthy"
 
-    def test_api_response_error(self):
+    def test_api_response_error(self) -> None:
         """Test APIResponse.error factory."""
         from model_generation.api import APIResponse
 
@@ -60,7 +60,7 @@ class TestAPIClasses:
         assert response.status_code == 400
         assert "error" in _body(response)
 
-    def test_api_response_not_found(self):
+    def test_api_response_not_found(self) -> None:
         """Test APIResponse.not_found factory."""
         from model_generation.api import APIResponse
 
@@ -68,7 +68,7 @@ class TestAPIClasses:
 
         assert response.status_code == 404
 
-    def test_api_response_file(self):
+    def test_api_response_file(self) -> None:
         """Test APIResponse.file factory."""
         from model_generation.api import APIResponse
 
@@ -82,14 +82,14 @@ class TestAPIClasses:
 class TestModelGenerationAPI:
     """Tests for ModelGenerationAPI class."""
 
-    def test_api_creation(self):
+    def test_api_creation(self) -> None:
         """Test API instantiation."""
         from model_generation.api import ModelGenerationAPI
 
         api = ModelGenerationAPI()
         assert api is not None
 
-    def test_api_routes_registered(self):
+    def test_api_routes_registered(self) -> None:
         """Test routes are registered."""
         from model_generation.api import ModelGenerationAPI
 
@@ -102,7 +102,7 @@ class TestModelGenerationAPI:
         assert any("/generate" in p for p in paths)
         assert any("/validate" in p for p in paths)
 
-    def test_health_endpoint(self):
+    def test_health_endpoint(self) -> None:
         """Test health check endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -117,7 +117,7 @@ class TestModelGenerationAPI:
         assert response.status_code == 200
         assert _body(response)["status"] == "healthy"
 
-    def test_info_endpoint(self):
+    def test_info_endpoint(self) -> None:
         """Test API info endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -133,7 +133,7 @@ class TestModelGenerationAPI:
         assert "name" in _body(response)
         assert "endpoints" in _body(response)
 
-    def test_generate_humanoid_endpoint(self):
+    def test_generate_humanoid_endpoint(self) -> None:
         """Test humanoid generation endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -155,7 +155,7 @@ class TestModelGenerationAPI:
         assert "links" in _body(response)
         assert _body(response)["robot_name"] == "test_humanoid"
 
-    def test_validate_endpoint_valid_urdf(self):
+    def test_validate_endpoint_valid_urdf(self) -> None:
         """Test validation endpoint with valid URDF."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -171,7 +171,7 @@ class TestModelGenerationAPI:
         assert response.status_code == 200
         assert _body(response)["valid"] is True
 
-    def test_validate_endpoint_invalid_urdf(self):
+    def test_validate_endpoint_invalid_urdf(self) -> None:
         """Test validation endpoint with invalid URDF."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -188,7 +188,7 @@ class TestModelGenerationAPI:
         assert _body(response)["valid"] is False
         assert _body(response)["error_count"] > 0
 
-    def test_parse_endpoint(self):
+    def test_parse_endpoint(self) -> None:
         """Test URDF parsing endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -206,7 +206,7 @@ class TestModelGenerationAPI:
         assert "links" in _body(response)
         assert "joints" in _body(response)
 
-    def test_inertia_calculation_endpoint(self):
+    def test_inertia_calculation_endpoint(self) -> None:
         """Test inertia calculation endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -228,7 +228,7 @@ class TestModelGenerationAPI:
         assert "ixx" in _body(response)["inertia"]
         assert _body(response)["is_positive_definite"] is True
 
-    def test_inertia_sphere(self):
+    def test_inertia_sphere(self) -> None:
         """Test inertia calculation for sphere."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -251,7 +251,7 @@ class TestModelGenerationAPI:
         assert abs(inertia["ixx"] - inertia["iyy"]) < 1e-10
         assert abs(inertia["iyy"] - inertia["izz"]) < 1e-10
 
-    def test_inertia_missing_shape(self):
+    def test_inertia_missing_shape(self) -> None:
         """Test inertia calculation with missing shape."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -267,7 +267,7 @@ class TestModelGenerationAPI:
         assert response.status_code == 400
         assert "error" in _body(response)
 
-    def test_library_list_endpoint(self):
+    def test_library_list_endpoint(self) -> None:
         """Test library listing endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -283,7 +283,7 @@ class TestModelGenerationAPI:
         assert "models" in _body(response)
         assert "count" in _body(response)
 
-    def test_diff_endpoint(self):
+    def test_diff_endpoint(self) -> None:
         """Test diff endpoint."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -307,7 +307,7 @@ class TestModelGenerationAPI:
         assert _body(response)["has_changes"] is True
         assert "unified_diff" in _body(response)
 
-    def test_not_found_route(self):
+    def test_not_found_route(self) -> None:
         """Test handling of non-existent route."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -321,7 +321,7 @@ class TestModelGenerationAPI:
 
         assert response.status_code == 404
 
-    def test_generate_from_params_endpoint(self):
+    def test_generate_from_params_endpoint(self) -> None:
         """Test generation from detailed parameters."""
         from model_generation.api import APIRequest, HTTPMethod, ModelGenerationAPI
 
@@ -374,11 +374,11 @@ class TestModelGenerationAPI:
 class TestRoute:
     """Tests for Route class."""
 
-    def test_route_creation(self):
+    def test_route_creation(self) -> None:
         """Test Route creation."""
         from model_generation.api import HTTPMethod, Route
 
-        def dummy_handler(request):
+        def dummy_handler(request) -> None:
             return None
 
         route = Route(
@@ -398,7 +398,7 @@ class TestRoute:
 class TestHTTPMethod:
     """Tests for HTTPMethod enum."""
 
-    def test_http_methods(self):
+    def test_http_methods(self) -> None:
         """Test HTTP method values."""
         from model_generation.api import HTTPMethod
 

--- a/src/tools/model_generation/tests/test_cli.py
+++ b/src/tools/model_generation/tests/test_cli.py
@@ -22,14 +22,14 @@ SIMPLE_URDF = """<?xml version="1.0"?>
 class TestCLIParser:
     """Tests for CLI argument parsing."""
 
-    def test_create_parser(self):
+    def test_create_parser(self) -> None:
         """Test parser creation."""
         from model_generation.cli import create_parser
 
         parser = create_parser()
         assert parser is not None
 
-    def test_parse_generate_command(self):
+    def test_parse_generate_command(self) -> None:
         """Test parsing generate command."""
         from model_generation.cli import create_parser
 
@@ -40,7 +40,7 @@ class TestCLIParser:
         assert args.name == "my_robot"
         assert args.humanoid is True
 
-    def test_parse_convert_command(self):
+    def test_parse_convert_command(self) -> None:
         """Test parsing convert command."""
         from model_generation.cli import create_parser
 
@@ -54,7 +54,7 @@ class TestCLIParser:
         assert args.output == "output.urdf"
         assert args.from_format == "simscape"
 
-    def test_parse_validate_command(self):
+    def test_parse_validate_command(self) -> None:
         """Test parsing validate command."""
         from model_generation.cli import create_parser
 
@@ -65,7 +65,7 @@ class TestCLIParser:
         assert args.input == "robot.urdf"
         assert args.json is True
 
-    def test_parse_diff_command(self):
+    def test_parse_diff_command(self) -> None:
         """Test parsing diff command."""
         from model_generation.cli import create_parser
 
@@ -77,7 +77,7 @@ class TestCLIParser:
         assert args.file_b == "file2.urdf"
         assert args.side_by_side is True
 
-    def test_parse_info_command(self):
+    def test_parse_info_command(self) -> None:
         """Test parsing info command."""
         from model_generation.cli import create_parser
 
@@ -88,7 +88,7 @@ class TestCLIParser:
         assert args.input == "robot.urdf"
         assert args.json is True
 
-    def test_parse_inertia_command(self):
+    def test_parse_inertia_command(self) -> None:
         """Test parsing inertia command."""
         from model_generation.cli import create_parser
 
@@ -103,7 +103,7 @@ class TestCLIParser:
         assert args.dimensions == [0.1, 0.2, 0.3]
         assert args.json is True
 
-    def test_parse_library_list(self):
+    def test_parse_library_list(self) -> None:
         """Test parsing library list command."""
         from model_generation.cli import create_parser
 
@@ -114,7 +114,7 @@ class TestCLIParser:
         assert args.lib_command == "list"
         assert args.category == "humanoid"
 
-    def test_parse_compose_command(self):
+    def test_parse_compose_command(self) -> None:
         """Test parsing compose command."""
         from model_generation.cli import create_parser
 
@@ -142,7 +142,7 @@ class TestCLIParser:
 class TestCLICommands:
     """Tests for CLI command execution."""
 
-    def test_cmd_validate_valid_urdf(self):
+    def test_cmd_validate_valid_urdf(self) -> None:
         """Test validate command with valid URDF."""
         import argparse
 
@@ -166,7 +166,7 @@ class TestCLICommands:
         finally:
             temp_path.unlink()
 
-    def test_cmd_validate_invalid_urdf(self):
+    def test_cmd_validate_invalid_urdf(self) -> None:
         """Test validate command with invalid URDF."""
         import argparse
 
@@ -192,7 +192,7 @@ class TestCLICommands:
         finally:
             temp_path.unlink()
 
-    def test_cmd_info(self):
+    def test_cmd_info(self) -> None:
         """Test info command."""
         import argparse
 
@@ -214,7 +214,7 @@ class TestCLICommands:
         finally:
             temp_path.unlink()
 
-    def test_cmd_inertia_box(self):
+    def test_cmd_inertia_box(self) -> None:
         """Test inertia calculation for box."""
         import argparse
 
@@ -230,7 +230,7 @@ class TestCLICommands:
         result = cmd_inertia(args)
         assert result == 0
 
-    def test_cmd_inertia_cylinder(self):
+    def test_cmd_inertia_cylinder(self) -> None:
         """Test inertia calculation for cylinder."""
         import argparse
 
@@ -246,7 +246,7 @@ class TestCLICommands:
         result = cmd_inertia(args)
         assert result == 0
 
-    def test_cmd_inertia_sphere(self):
+    def test_cmd_inertia_sphere(self) -> None:
         """Test inertia calculation for sphere."""
         import argparse
 
@@ -262,7 +262,7 @@ class TestCLICommands:
         result = cmd_inertia(args)
         assert result == 0
 
-    def test_cmd_diff(self):
+    def test_cmd_diff(self) -> None:
         """Test diff command."""
         import argparse
 
@@ -299,7 +299,7 @@ class TestCLICommands:
 class TestCLIMain:
     """Tests for main entry point."""
 
-    def test_main_no_args(self):
+    def test_main_no_args(self) -> None:
         """Test main with no arguments shows help."""
         from model_generation.cli import main
 
@@ -307,7 +307,7 @@ class TestCLIMain:
         result = main([])
         assert result == 0
 
-    def test_main_help(self):
+    def test_main_help(self) -> None:
         """Test main with --help."""
         from model_generation.cli import main
 
@@ -315,7 +315,7 @@ class TestCLIMain:
             main(["--help"])
         assert exc_info.value.code == 0
 
-    def test_main_version(self):
+    def test_main_version(self) -> None:
         """Test main with --version."""
         from model_generation.cli import main
 

--- a/src/tools/model_generation/tests/test_editor.py
+++ b/src/tools/model_generation/tests/test_editor.py
@@ -71,7 +71,7 @@ TWO_ARM_URDF = """<?xml version="1.0"?>
 class TestFrankensteinEditor:
     """Tests for FrankensteinEditor class."""
 
-    def test_editor_creation(self):
+    def test_editor_creation(self) -> None:
         """Test editor instantiation."""
         from model_generation.editor import FrankensteinEditor
 
@@ -79,7 +79,7 @@ class TestFrankensteinEditor:
         assert editor is not None
         assert editor.list_models() == []
 
-    def test_load_model_from_string(self):
+    def test_load_model_from_string(self) -> None:
         """Test loading a model from URDF string."""
         from model_generation.editor import FrankensteinEditor
 
@@ -92,7 +92,7 @@ class TestFrankensteinEditor:
         assert len(model.joints) == 1
         assert "test" in editor.list_models()
 
-    def test_create_model(self):
+    def test_create_model(self) -> None:
         """Test creating a new empty model."""
         from model_generation.editor import FrankensteinEditor
 
@@ -104,7 +104,7 @@ class TestFrankensteinEditor:
         assert len(model.links) == 1  # Base link
         assert "new_model" in editor.list_models()
 
-    def test_duplicate_model(self):
+    def test_duplicate_model(self) -> None:
         """Test duplicating a model."""
         from model_generation.editor import FrankensteinEditor
 
@@ -120,7 +120,7 @@ class TestFrankensteinEditor:
         assert original is not None
         assert len(original.links) == len(copy.links)
 
-    def test_copy_link(self):
+    def test_copy_link(self) -> None:
         """Test copying a single link to clipboard."""
         from model_generation.editor import FrankensteinEditor
 
@@ -135,7 +135,7 @@ class TestFrankensteinEditor:
         assert info["link_count"] == 1
         assert "arm_link" in info["link_names"]
 
-    def test_copy_subtree(self):
+    def test_copy_subtree(self) -> None:
         """Test copying a subtree to clipboard."""
         from model_generation.editor import FrankensteinEditor
 
@@ -149,7 +149,7 @@ class TestFrankensteinEditor:
         assert not info["empty"]
         assert info["link_count"] >= 1
 
-    def test_paste_to_model(self):
+    def test_paste_to_model(self) -> None:
         """Test pasting clipboard contents to a model."""
         from model_generation.editor import FrankensteinEditor
 
@@ -169,7 +169,7 @@ class TestFrankensteinEditor:
         link_names = [link.name for link in target.links]
         assert "arm_link" in link_names or any("arm" in n for n in link_names)
 
-    def test_delete_link(self):
+    def test_delete_link(self) -> None:
         """Test deleting a link."""
         from model_generation.editor import FrankensteinEditor
 
@@ -187,7 +187,7 @@ class TestFrankensteinEditor:
         link_names = [link.name for link in model.links]
         assert "arm_link" not in link_names
 
-    def test_rename_link(self):
+    def test_rename_link(self) -> None:
         """Test renaming a link."""
         from model_generation.editor import FrankensteinEditor
 
@@ -208,7 +208,7 @@ class TestFrankensteinEditor:
         joint = model.joints[0]
         assert joint.child == "new_arm_name"
 
-    def test_undo_redo(self):
+    def test_undo_redo(self) -> None:
         """Test undo/redo functionality."""
         from model_generation.editor import FrankensteinEditor
 
@@ -240,7 +240,7 @@ class TestFrankensteinEditor:
         assert model is not None
         assert len(model.links) < original_count
 
-    def test_export_model(self):
+    def test_export_model(self) -> None:
         """Test exporting a model to URDF string."""
         from model_generation.editor import FrankensteinEditor
 
@@ -252,7 +252,7 @@ class TestFrankensteinEditor:
         assert "<robot" in urdf_string
         assert "simple_robot" in urdf_string
 
-    def test_compare_models(self):
+    def test_compare_models(self) -> None:
         """Test comparing two models."""
         from model_generation.editor import FrankensteinEditor
 
@@ -265,7 +265,7 @@ class TestFrankensteinEditor:
         assert "joints" in comparison
         assert "stats" in comparison
 
-    def test_get_model_statistics(self):
+    def test_get_model_statistics(self) -> None:
         """Test getting model statistics."""
         from model_generation.editor import FrankensteinEditor
 
@@ -281,14 +281,14 @@ class TestFrankensteinEditor:
 class TestURDFTextEditor:
     """Tests for URDFTextEditor class."""
 
-    def test_editor_creation(self):
+    def test_editor_creation(self) -> None:
         """Test editor instantiation."""
         from model_generation.editor import URDFTextEditor
 
         editor = URDFTextEditor()
         assert editor is not None
 
-    def test_load_string(self):
+    def test_load_string(self) -> None:
         """Test loading URDF from string."""
         from model_generation.editor import URDFTextEditor
 
@@ -298,7 +298,7 @@ class TestURDFTextEditor:
         content = editor.get_content()
         assert content == SIMPLE_URDF
 
-    def test_load_file(self):
+    def test_load_file(self) -> None:
         """Test loading URDF from file."""
         from model_generation.editor import URDFTextEditor
 
@@ -313,7 +313,7 @@ class TestURDFTextEditor:
         finally:
             temp_path.unlink()
 
-    def test_validate_valid_urdf(self):
+    def test_validate_valid_urdf(self) -> None:
         """Test validation of valid URDF."""
         from model_generation.editor import URDFTextEditor, ValidationSeverity
 
@@ -324,7 +324,7 @@ class TestURDFTextEditor:
         errors = [m for m in messages if m.severity == ValidationSeverity.ERROR]
         assert len(errors) == 0
 
-    def test_validate_invalid_xml(self):
+    def test_validate_invalid_xml(self) -> None:
         """Test validation catches invalid XML."""
         from model_generation.editor import URDFTextEditor, ValidationSeverity
 
@@ -337,7 +337,7 @@ class TestURDFTextEditor:
         errors = [m for m in messages if m.severity == ValidationSeverity.ERROR]
         assert len(errors) > 0
 
-    def test_validate_missing_link_reference(self):
+    def test_validate_missing_link_reference(self) -> None:
         """Test validation catches missing link references."""
         from model_generation.editor import URDFTextEditor, ValidationSeverity
 
@@ -359,7 +359,7 @@ class TestURDFTextEditor:
         assert len(errors) > 0
         assert any("nonexistent" in m.message for m in errors)
 
-    def test_set_content(self):
+    def test_set_content(self) -> None:
         """Test setting content."""
         from model_generation.editor import URDFTextEditor
 
@@ -371,7 +371,7 @@ class TestURDFTextEditor:
 
         assert "modified_robot" in editor.get_content()
 
-    def test_diff_from_original(self):
+    def test_diff_from_original(self) -> None:
         """Test generating diff from original."""
         from model_generation.editor import URDFTextEditor
 
@@ -387,7 +387,7 @@ class TestURDFTextEditor:
         assert diff.additions > 0 or diff.deletions > 0
         assert "modified_robot" in diff.unified_diff
 
-    def test_undo_redo(self):
+    def test_undo_redo(self) -> None:
         """Test undo/redo functionality."""
         from model_generation.editor import URDFTextEditor
 
@@ -408,7 +408,7 @@ class TestURDFTextEditor:
         assert result is True
         assert "<!-- comment -->" in editor.get_content()
 
-    def test_has_unsaved_changes(self):
+    def test_has_unsaved_changes(self) -> None:
         """Test unsaved changes detection."""
         from model_generation.editor import URDFTextEditor
 
@@ -420,7 +420,7 @@ class TestURDFTextEditor:
         editor.set_content(SIMPLE_URDF + "<!-- change -->", validate=False)
         assert editor.has_unsaved_changes()
 
-    def test_find_text(self):
+    def test_find_text(self) -> None:
         """Test text search."""
         from model_generation.editor import URDFTextEditor
 
@@ -434,7 +434,7 @@ class TestURDFTextEditor:
         results = editor.find_text(r"mass\s+value", regex=True)
         assert len(results) > 0
 
-    def test_replace_all(self):
+    def test_replace_all(self) -> None:
         """Test replace all functionality."""
         from model_generation.editor import URDFTextEditor
 
@@ -445,7 +445,7 @@ class TestURDFTextEditor:
         assert count > 0
         assert "LINK" in editor.get_content()
 
-    def test_get_history(self):
+    def test_get_history(self) -> None:
         """Test getting version history."""
         from model_generation.editor import URDFTextEditor
 
@@ -457,7 +457,7 @@ class TestURDFTextEditor:
         history = editor.get_history()
         assert len(history) == 3
 
-    def test_go_to_version(self):
+    def test_go_to_version(self) -> None:
         """Test navigating to specific version."""
         from model_generation.editor import URDFTextEditor
 

--- a/src/tools/model_generation/tests/test_library.py
+++ b/src/tools/model_generation/tests/test_library.py
@@ -9,14 +9,14 @@ from pathlib import Path
 class TestModelLibrary:
     """Tests for ModelLibrary class."""
 
-    def test_library_creation(self):
+    def test_library_creation(self) -> None:
         """Test library instantiation."""
         from model_generation.library import ModelLibrary
 
         library = ModelLibrary()
         assert library is not None
 
-    def test_list_models_empty(self):
+    def test_list_models_empty(self) -> None:
         """Test listing models on fresh library."""
         from model_generation.library import ModelLibrary
 
@@ -25,7 +25,7 @@ class TestModelLibrary:
         # Should return empty or built-in models
         assert isinstance(models, list)
 
-    def test_add_local_model(self):
+    def test_add_local_model(self) -> None:
         """Test adding a local URDF model."""
         from model_generation.library import ModelCategory, ModelLibrary
 
@@ -62,7 +62,7 @@ class TestModelLibrary:
         finally:
             temp_path.unlink()
 
-    def test_list_models_with_filter(self):
+    def test_list_models_with_filter(self) -> None:
         """Test filtering models by category."""
         from model_generation.library import ModelCategory, ModelLibrary
 
@@ -77,7 +77,7 @@ class TestModelLibrary:
 class TestModelCache:
     """Tests for ModelCache class."""
 
-    def test_cache_creation(self):
+    def test_cache_creation(self) -> None:
         """Test cache instantiation."""
         from model_generation.library.cache import CacheConfig, ModelCache
 
@@ -88,7 +88,7 @@ class TestModelCache:
         cache = ModelCache(config)
         assert cache is not None
 
-    def test_cache_put_get(self):
+    def test_cache_put_get(self) -> None:
         """Test adding and retrieving from cache."""
         from model_generation.library.cache import CacheConfig, ModelCache
 
@@ -116,7 +116,7 @@ class TestModelCache:
         assert retrieved is not None
         assert retrieved.model_id == "test_model"
 
-    def test_cache_contains(self):
+    def test_cache_contains(self) -> None:
         """Test cache contains check."""
         from model_generation.library.cache import CacheConfig, ModelCache
 
@@ -132,7 +132,7 @@ class TestModelCache:
         assert cache.contains("existing")
         assert not cache.contains("nonexistent")
 
-    def test_cache_statistics(self):
+    def test_cache_statistics(self) -> None:
         """Test cache statistics."""
         from model_generation.library.cache import CacheConfig, ModelCache
 
@@ -149,7 +149,7 @@ class TestModelCache:
 class TestRepository:
     """Tests for Repository classes."""
 
-    def test_local_repository(self):
+    def test_local_repository(self) -> None:
         """Test LocalRepository."""
         from model_generation.library.repository import LocalRepository
 
@@ -170,7 +170,7 @@ class TestRepository:
         assert "robot1" in names
         assert "robot2" in names
 
-    def test_github_repository_list(self):
+    def test_github_repository_list(self) -> None:
         """Test GitHubRepository model listing (mocked)."""
         from model_generation.library.repository import GitHubRepository
 

--- a/src/tools/model_generation/tests/test_simscape.py
+++ b/src/tools/model_generation/tests/test_simscape.py
@@ -52,14 +52,14 @@ Model {
 class TestMDLParser:
     """Tests for MDLParser class."""
 
-    def test_parser_creation(self):
+    def test_parser_creation(self) -> None:
         """Test parser instantiation."""
         from model_generation.converters.simscape import MDLParser
 
         parser = MDLParser()
         assert parser is not None
 
-    def test_parse_mdl_string(self):
+    def test_parse_mdl_string(self) -> None:
         """Test parsing MDL content from string."""
         from model_generation.converters.simscape import MDLParser
 
@@ -69,7 +69,7 @@ class TestMDLParser:
         assert model is not None
         assert model.name == "test_model"
 
-    def test_parse_body_blocks(self):
+    def test_parse_body_blocks(self) -> None:
         """Test parsing body/solid blocks."""
         from model_generation.converters.simscape import (
             MDLParser,
@@ -92,7 +92,7 @@ class TestMDLParser:
             ]
         )
 
-    def test_parse_joint_blocks(self):
+    def test_parse_joint_blocks(self) -> None:
         """Test parsing joint blocks."""
         from model_generation.converters.simscape import (
             MDLParser,
@@ -105,7 +105,7 @@ class TestMDLParser:
         # Should find at least the revolute joint
         assert len(joints) >= 0  # May be 0 if parsing doesn't find it
 
-    def test_parse_connections(self):
+    def test_parse_connections(self) -> None:
         """Test parsing connections between blocks."""
         from model_generation.converters.simscape import MDLParser
 
@@ -115,7 +115,7 @@ class TestMDLParser:
         # Should have some connections
         assert isinstance(model.connections, list)
 
-    def test_get_block_parameters(self):
+    def test_get_block_parameters(self) -> None:
         """Test extracting block parameters."""
         from model_generation.converters.simscape import MDLParser
 
@@ -133,14 +133,14 @@ class TestMDLParser:
 class TestSimscapeConverter:
     """Tests for SimscapeToURDFConverter class."""
 
-    def test_converter_creation(self):
+    def test_converter_creation(self) -> None:
         """Test converter instantiation."""
         from model_generation.converters.simscape import SimscapeToURDFConverter
 
         converter = SimscapeToURDFConverter()
         assert converter is not None
 
-    def test_convert_simple_mdl(self):
+    def test_convert_simple_mdl(self) -> None:
         """Test converting simple MDL content."""
         from model_generation.converters.simscape import SimscapeToURDFConverter
 
@@ -151,7 +151,7 @@ class TestSimscapeConverter:
         assert result is not None
         assert result.robot_name is not None
 
-    def test_convert_with_config(self):
+    def test_convert_with_config(self) -> None:
         """Test conversion with custom configuration."""
         from model_generation.converters.simscape import (
             ConversionConfig,
@@ -169,7 +169,7 @@ class TestSimscapeConverter:
 
         assert result.robot_name == "custom_name"
 
-    def test_convert_generates_urdf(self):
+    def test_convert_generates_urdf(self) -> None:
         """Test that conversion generates valid URDF string."""
         from model_generation.converters.simscape import SimscapeToURDFConverter
 
@@ -180,7 +180,7 @@ class TestSimscapeConverter:
             assert "<robot" in result.urdf_string
             assert "</robot>" in result.urdf_string
 
-    def test_conversion_result_contents(self):
+    def test_conversion_result_contents(self) -> None:
         """Test conversion result structure."""
         from model_generation.converters.simscape import SimscapeToURDFConverter
 
@@ -195,7 +195,7 @@ class TestSimscapeConverter:
         assert isinstance(result.links, list)
         assert isinstance(result.joints, list)
 
-    def test_unit_conversion(self):
+    def test_unit_conversion(self) -> None:
         """Test unit conversion factors."""
         from model_generation.converters.simscape import (
             ConversionConfig,
@@ -216,7 +216,7 @@ class TestSimscapeConverter:
 class TestConversionConfig:
     """Tests for ConversionConfig class."""
 
-    def test_default_config(self):
+    def test_default_config(self) -> None:
         """Test default configuration values."""
         from model_generation.converters.simscape import ConversionConfig
 
@@ -228,7 +228,7 @@ class TestConversionConfig:
         assert config.include_visual is True
         assert config.include_collision is True
 
-    def test_custom_config(self):
+    def test_custom_config(self) -> None:
         """Test custom configuration."""
         from model_generation.converters.simscape import ConversionConfig
 
@@ -248,7 +248,7 @@ class TestConversionConfig:
 class TestConvenienceFunction:
     """Tests for convenience conversion function."""
 
-    def test_convert_simscape_to_urdf_function(self):
+    def test_convert_simscape_to_urdf_function(self) -> None:
         """Test the convenience function."""
         from model_generation.converters.simscape import convert_simscape_to_urdf
 

--- a/src/tools/video_analyzer/analyzer.py
+++ b/src/tools/video_analyzer/analyzer.py
@@ -71,7 +71,7 @@ class SwingAnalyzer:
         self,
         min_confidence: float = 0.5,
         smoothing_window: int = 5,
-    ):
+    ) -> None:
         """
         Initialize the swing analyzer.
 
@@ -361,7 +361,7 @@ class SwingAnalyzer:
         finish_idx = len(poses) - 1
 
         # Build phase transitions
-        def add_phase(phase: SwingPhase, start: int, end: int):
+        def add_phase(phase: SwingPhase, start: int, end: int) -> None:
             if start < end:
                 phases.append(
                     PhaseTransition(

--- a/src/tools/video_analyzer/pose_estimator.py
+++ b/src/tools/video_analyzer/pose_estimator.py
@@ -79,7 +79,7 @@ class PoseEstimator:
         min_detection_confidence: float = 0.5,
         min_tracking_confidence: float = 0.5,
         smooth_landmarks: bool = True,
-    ):
+    ) -> None:
         """
         Initialize the pose estimator.
 
@@ -292,19 +292,19 @@ class PoseEstimator:
 
         return output
 
-    def close(self):
+    def close(self) -> None:
         """Release resources."""
         if self._pose:
             self._pose.close()
             self._pose = None
             self._initialized = False
 
-    def __enter__(self):
+    def __enter__(self) -> Any:
         """Context manager entry."""
         self.initialize()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         """Context manager exit."""
         self.close()
         return False

--- a/src/tools/video_analyzer/types.py
+++ b/src/tools/video_analyzer/types.py
@@ -252,7 +252,7 @@ class SwingAnalysis:
         """Convert to dictionary for JSON serialization."""
         import dataclasses
 
-        def convert(obj):
+        def convert(obj) -> Any:
             if dataclasses.is_dataclass(obj):
                 return {k: convert(v) for k, v in dataclasses.asdict(obj).items()}  # type: ignore[arg-type]
             if isinstance(obj, Enum):

--- a/src/tools/video_analyzer/video_processor.py
+++ b/src/tools/video_analyzer/video_processor.py
@@ -37,7 +37,7 @@ class VideoProcessor:
 
     SUPPORTED_FORMATS = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".m4v"}
 
-    def __init__(self, video_path: str | None = None):
+    def __init__(self, video_path: str | None = None) -> None:
         """
         Initialize the video processor.
 
@@ -326,18 +326,18 @@ class VideoProcessor:
             logger.error(f"Failed to export clip: {e}")
             return False
 
-    def close(self):
+    def close(self) -> None:
         """Release video resources."""
         if self._cap:
             self._cap.release()
             self._cap = None
             self.video_path = None
 
-    def __enter__(self):
+    def __enter__(self) -> Any:
         """Context manager entry."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         """Context manager exit."""
         self.close()
         return False

--- a/src/unreal_integration/mesh_loader.py
+++ b/src/unreal_integration/mesh_loader.py
@@ -46,7 +46,7 @@ class MeshLoadError(Exception):
 
     def __init__(
         self, message: str, path: str | None = None, cause: Exception | None = None
-    ):
+    ) -> None:
         super().__init__(message)
         self.path = path
         self.cause = cause
@@ -55,7 +55,7 @@ class MeshLoadError(Exception):
 class UnsupportedFormatError(MeshLoadError):
     """Exception raised when mesh format is not supported."""
 
-    def __init__(self, extension: str, path: str | None = None):
+    def __init__(self, extension: str, path: str | None = None) -> None:
         super().__init__(f"Unsupported mesh format: {extension}", path)
         self.extension = extension
 
@@ -377,7 +377,7 @@ class MeshLoader:
         >>> print(f"Loaded {mesh.vertex_count} vertices")
     """
 
-    def __init__(self, enable_cache: bool = True):
+    def __init__(self, enable_cache: bool = True) -> None:
         """Initialize mesh loader.
 
         Args:

--- a/src/unreal_integration/skeleton_mapper.py
+++ b/src/unreal_integration/skeleton_mapper.py
@@ -472,7 +472,7 @@ class SkeletonMapper:
         >>> physics_pose = mapper.apply_pose(mixamo_pose)
     """
 
-    def __init__(self, profile: MappingProfile | None = None):
+    def __init__(self, profile: MappingProfile | None = None) -> None:
         """Initialize skeleton mapper.
 
         Args:

--- a/src/unreal_integration/streaming.py
+++ b/src/unreal_integration/streaming.py
@@ -242,7 +242,7 @@ class FrameBuffer:
         >>> frame = buffer.get()
     """
 
-    def __init__(self, max_size: int = 10):
+    def __init__(self, max_size: int = 10) -> None:
         """Initialize frame buffer.
 
         Args:
@@ -444,7 +444,7 @@ class UnrealStreamingServer:
         ...     await server.broadcast(frame)
     """
 
-    def __init__(self, config: StreamingConfig | None = None):
+    def __init__(self, config: StreamingConfig | None = None) -> None:
         """Initialize streaming server.
 
         Args:
@@ -701,7 +701,7 @@ class SimulationStreamer:
         ...     await streamer.send_state(state, timestamp)
     """
 
-    def __init__(self, server: UnrealStreamingServer):
+    def __init__(self, server: UnrealStreamingServer) -> None:
         """Initialize simulation streamer.
 
         Args:

--- a/src/unreal_integration/viewer_backends.py
+++ b/src/unreal_integration/viewer_backends.py
@@ -182,7 +182,7 @@ class ViewerBackend(ABC):
             - is_initialized reflects actual state
     """
 
-    def __init__(self, config: ViewerConfig | None = None):
+    def __init__(self, config: ViewerConfig | None = None) -> None:
         """Initialize backend.
 
         Args:
@@ -340,7 +340,7 @@ class MeshcatBackend(ViewerBackend):
         ...     backend.render()
     """
 
-    def __init__(self, config: ViewerConfig | None = None):
+    def __init__(self, config: ViewerConfig | None = None) -> None:
         """Initialize Meshcat backend.
 
         Args:
@@ -561,7 +561,7 @@ class MockBackend(ViewerBackend):
     any external dependencies.
     """
 
-    def __init__(self, config: ViewerConfig | None = None):
+    def __init__(self, config: ViewerConfig | None = None) -> None:
         """Initialize mock backend."""
         super().__init__(config)
         self._render_calls = 0

--- a/src/unreal_integration/visualization.py
+++ b/src/unreal_integration/visualization.py
@@ -139,7 +139,7 @@ class ForceVectorRenderer:
         >>> render_data = renderer.render(forces)
     """
 
-    def __init__(self, config: VisualizationConfig | None = None):
+    def __init__(self, config: VisualizationConfig | None = None) -> None:
         """Initialize force vector renderer.
 
         Args:
@@ -296,7 +296,7 @@ class TrajectoryRenderer:
         >>> render_data = renderer.render(points)
     """
 
-    def __init__(self, config: VisualizationConfig | None = None):
+    def __init__(self, config: VisualizationConfig | None = None) -> None:
         """Initialize trajectory renderer.
 
         Args:
@@ -409,7 +409,7 @@ class HUDDataProvider:
         >>> hud_data = provider.get_hud_data(metrics, frame_data)
     """
 
-    def __init__(self, units: str = "metric"):
+    def __init__(self, units: str = "metric") -> None:
         """Initialize HUD data provider.
 
         Args:

--- a/src/unreal_integration/vr_interaction.py
+++ b/src/unreal_integration/vr_interaction.py
@@ -296,7 +296,7 @@ class VRInteractionManager:
     def __init__(
         self,
         locomotion_mode: VRLocomotionMode = VRLocomotionMode.TELEPORT,
-    ):
+    ) -> None:
         """Initialize VR interaction manager.
 
         Args:


### PR DESCRIPTION
Adds -> ReturnType annotations to 1086 functions across 160 files using AST-based inference. Covers __init__ (-> None), setters, getters, and computed returns. 185 remaining are multi-line defs, generators, or docstring examples. Per AGENTS.md typing standards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-hint-only changes across many files; primary risk is accidental signature/annotation mismatch affecting tooling or framework introspection, not runtime logic.
> 
> **Overview**
> Adds explicit return type annotations (e.g., `-> None`, `-> Any`, `-> bool`, `-> tuple`) across a large set of Python functions and methods, including `__init__`, FastAPI route handlers, GUI callbacks, and test fixtures.
> 
> Changes are primarily typing-only updates to align with project standards and improve static analysis; no functional logic or behavior is intended to change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056ce8852b06ecdcb360927da3624b65b0f525fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->