### PR TITLE
fix: restore print() in CLI diagnostics output function

### DIFF
--- a/src/launchers/launcher_diagnostics.py
+++ b/src/launchers/launcher_diagnostics.py
@@ -683,10 +683,10 @@ def reset_layout_config() -> bool:
 
 def run_cli_diagnostics() -> None:
     """Run diagnostics and print results to console."""
-    logger.info("=" * 60)
-    logger.info("Golf Modeling Suite - Launcher Diagnostics")
-    logger.info("=" * 60)
-    logger.info()
+    print("=" * 60)  # noqa: T201
+    print("Golf Modeling Suite - Launcher Diagnostics")  # noqa: T201
+    print("=" * 60)  # noqa: T201
+    print()  # noqa: T201
 
     diag = LauncherDiagnostics()
     results = diag.run_all_checks()
@@ -694,11 +694,11 @@ def run_cli_diagnostics() -> None:
     # Print summary
     summary = results["summary"]
     status_icon = "✅" if summary["status"] == "healthy" else "⚠️"
-    logger.info(f"{status_icon} Status: {summary['status'].upper()}")
-    logger.info(f"   Passed: {summary['passed']}")
-    logger.info(f"   Failed: {summary['failed']}")
-    logger.info(f"   Warnings: {summary['warnings']}")
-    logger.info()
+    print(f"{status_icon} Status: {summary['status'].upper()}")  # noqa: T201
+    print(f"   Passed: {summary['passed']}")  # noqa: T201
+    print(f"   Failed: {summary['failed']}")  # noqa: T201
+    print(f"   Warnings: {summary['warnings']}")  # noqa: T201
+    print()  # noqa: T201
 
     # Print each check
     for check in results["checks"]:
@@ -709,7 +709,7 @@ def run_cli_diagnostics() -> None:
         else:
             icon = "⚠️"
 
-        logger.info(f"{icon} {check['name']}: {check['message']}")
+        print(f"{icon} {check['name']}: {check['message']}")  # noqa: T201
 
         # Print key details for failures/warnings
         if check["status"] in ("fail", "warning"):
@@ -720,15 +720,15 @@ def run_cli_diagnostics() -> None:
                 "missing_from_registry",
             ]:
                 if key in details and details[key]:
-                    logger.info(f"     {key}: {details[key]}")
+                    print(f"     {key}: {details[key]}")  # noqa: T201
 
-    logger.info()
-    logger.info("Recommendations:")
+    print()  # noqa: T201
+    print("Recommendations:")  # noqa: T201
     for rec in results["recommendations"]:
-        logger.info(f"  \u2192 {rec}")
+        print(f"  \u2192 {rec}")  # noqa: T201
 
-    logger.info("")
-    logger.info("%s", "=" * 60)
+    print()  # noqa: T201
+    print("=" * 60)  # noqa: T201
 
 
 if __name__ == "__main__":
@@ -749,6 +749,6 @@ if __name__ == "__main__":
     elif args.json:
         diag = LauncherDiagnostics()
         results = diag.run_all_checks()
-        logger.info(json.dumps(results, indent=2))
+        print(json.dumps(results, indent=2))  # noqa: T201
     else:
         run_cli_diagnostics()


### PR DESCRIPTION
Fixes test_run_cli_diagnostics_no_errors failure.\n\nThe automated print→logging conversion (PR #1306) replaced print() with logger.info() in run_cli_diagnostics(), which is a CLI function that outputs directly to stdout for user consumption. logger.info() requires at least one argument, unlike print(), causing TypeError.\n\nAlso, the test asserts output via capsys.readouterr().out — which captures stdout (print), NOT logging output.\n\nRestored print() with noqa: T201 comments since this is intentional CLI output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI output plumbing; no business logic or data handling is affected, but it changes where diagnostics output is emitted (stdout vs logging).
> 
> **Overview**
> `run_cli_diagnostics()` now writes its banner, per-check results, and recommendations to stdout using `print()` instead of `logger.info()`, keeping this command as user-facing CLI output.
> 
> The `--json` CLI path also prints the JSON report to stdout. All `print()` calls are annotated with `# noqa: T201` to explicitly allow console output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370624863bfb6df757a2960a1cd5dbfdfe60d361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->