### PR TITLE
feat: wire ProvenanceInfo into production export pipeline

### DIFF
--- a/tests/unit/test_output_manager.py
+++ b/tests/unit/test_output_manager.py
@@ -254,7 +254,7 @@ class TestOutputManager:
         path = output_manager.save_simulation_results(data, filename, OutputFormat.CSV)
         assert path.exists()
 
-        loaded_df = pd.read_csv(path)
+        loaded_df = pd.read_csv(path, comment="#")
         assert len(loaded_df) == 2
         assert list(loaded_df.columns) == ["col1", "col2"]
 


### PR DESCRIPTION
## Summary

Wire  into all production export paths so scientific results carry reproducibility metadata (git commit, timestamp, Python/NumPy versions, model file hashes).

### Changes
- **OutputManager.save_simulation_results**: CSV exports now include provenance header comments; JSON exports embed provenance in metadata
- **OutputManager.export_analysis_report**: JSON reports embed provenance
- **CLI export_csv/export_json**: Batch simulation exports include provenance
- **GUI AnalysisTab**: Interactive CSV/JSON exports include provenance
- **load_simulation_results**: Updated to skip  comment lines when loading CSVs
- **Tests**: Updated for provenance-aware CSV format

### Test plan
- [x] All 25 output/provenance tests pass
- [x] Ruff + Black clean
- [x] Changes address issue requirements

Closes #1283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk format of exported CSV/JSON files by adding headers/fields, which can break downstream parsers that expect raw data or exact schemas; read-path was updated for internal loads but external consumers may need updates.
> 
> **Overview**
> Adds provenance capture (git SHA/branch/dirty, timestamps, and environment) to *all* primary export paths.
> 
> `OutputManager.save_simulation_results` now prepends a `#` comment header to CSV outputs and embeds a `provenance` block in JSON outputs (with optional `model_path`/`parameters` inputs), and `export_analysis_report` JSON exports similarly include provenance. CLI (`cli_runner`) and GUI (`AnalysisTab`) CSV/JSON exports are updated to include the same provenance metadata.
> 
> CSV loading/tests are adjusted to ignore the new header comments via `pd.read_csv(..., comment="#")`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 615e44cb10270174dc9981de84d3ec35ac0cf316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->