### PR TITLE
refactor: decompose 60+ large functions and resolve print() calls

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
@@ -6,66 +6,63 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def analyze_coordinate_system() -> None:
-    """Analyze the coordinate system and golfer orientation in the data"""
+def _load_excel_frame_data(filename, sheet_name):
+    """Load and parse frame data from an Excel sheet.
 
-    # Load the Excel file
-    filename = "Wiffle_ProV1_club_3D_data.xlsx"
-    sheet_name = "TW_wiffle"  # Use one of the available sheets
-
-    logger.info("Analyzing coordinate system for %s", sheet_name)
-    logger.info("%s", "=" * 50)
-
-    # Read the data
+    Returns a list of frame data dicts, or an empty list on failure.
+    """
     df = pd.read_excel(filename, sheet_name=sheet_name, header=None)
 
-    # Get data starting from row 3 - analyze more frames
-    if len(df) > 3:
-        data = []
-        for i in range(3, len(df)):
-            row = df.iloc[i]
-            if len(row) >= 25:
-                try:
-                    frame_data = {
-                        "time": float(row[1]) if pd.notna(row[1]) else i - 3,
-                        "mid_X": float(row[2]) * 0.0254,  # inches to meters
-                        "mid_Y": float(row[3]) * 0.0254,
-                        "mid_Z": float(row[4]) * 0.0254,
-                        "club_X": float(row[14]) * 0.0254,
-                        "club_Y": float(row[15]) * 0.0254,
-                        "club_Z": float(row[16]) * 0.0254,
-                        # Direction cosines for mid-hands
-                        "mid_Xx": float(row[5]),
-                        "mid_Xy": float(row[6]),
-                        "mid_Xz": float(row[7]),
-                        "mid_Yx": float(row[8]),
-                        "mid_Yy": float(row[9]),
-                        "mid_Yz": float(row[10]),
-                        "mid_Zx": float(row[11]),
-                        "mid_Zy": float(row[12]),
-                        "mid_Zz": float(row[13]),
-                        # Direction cosines for club head
-                        "club_Xx": float(row[17]),
-                        "club_Xy": float(row[18]),
-                        "club_Xz": float(row[19]),
-                        "club_Yx": float(row[20]),
-                        "club_Yy": float(row[21]),
-                        "club_Yz": float(row[22]),
-                        "club_Zx": float(row[23]),
-                        "club_Zy": float(row[24]),
-                        "club_Zz": float(row[25]),
-                    }
-                    data.append(frame_data)
-                except (ValueError, TypeError):
-                    continue
+    data = []
+    if len(df) <= 3:
+        return data
 
-    if not data:
-        logger.info("No data found!")
-        return
+    for i in range(3, len(df)):
+        row = df.iloc[i]
+        if len(row) < 25:
+            continue
+        try:
+            frame_data = {
+                "time": float(row[1]) if pd.notna(row[1]) else i - 3,
+                "mid_X": float(row[2]) * 0.0254,  # inches to meters
+                "mid_Y": float(row[3]) * 0.0254,
+                "mid_Z": float(row[4]) * 0.0254,
+                "club_X": float(row[14]) * 0.0254,
+                "club_Y": float(row[15]) * 0.0254,
+                "club_Z": float(row[16]) * 0.0254,
+                # Direction cosines for mid-hands
+                "mid_Xx": float(row[5]),
+                "mid_Xy": float(row[6]),
+                "mid_Xz": float(row[7]),
+                "mid_Yx": float(row[8]),
+                "mid_Yy": float(row[9]),
+                "mid_Yz": float(row[10]),
+                "mid_Zx": float(row[11]),
+                "mid_Zy": float(row[12]),
+                "mid_Zz": float(row[13]),
+                # Direction cosines for club head
+                "club_Xx": float(row[17]),
+                "club_Xy": float(row[18]),
+                "club_Xz": float(row[19]),
+                "club_Yx": float(row[20]),
+                "club_Yy": float(row[21]),
+                "club_Yz": float(row[22]),
+                "club_Zx": float(row[23]),
+                "club_Zy": float(row[24]),
+                "club_Zz": float(row[25]),
+            }
+            data.append(frame_data)
+        except (ValueError, TypeError):
+            continue
 
-    logger.info("Analyzing %s frames", len(data))
+    return data
 
-    # Analyze overall motion patterns
+
+def _compute_motion_ranges(data):
+    """Compute and log per-axis motion ranges for mid-hands and club head.
+
+    Returns (mid_motion_ranges, club_motion_ranges) as lists of [X, Y, Z] range sizes.
+    """
     logger.info("\nOverall motion analysis:")
     logger.info("%s", "-" * 30)
 
@@ -105,7 +102,6 @@ def analyze_coordinate_system() -> None:
         f"(range: {club_z_range[1] - club_z_range[0]:.3f})"
     )
 
-    # Determine primary motion direction
     mid_motion_ranges = [
         mid_x_range[1] - mid_x_range[0],
         mid_y_range[1] - mid_y_range[0],
@@ -118,6 +114,11 @@ def analyze_coordinate_system() -> None:
         club_z_range[1] - club_z_range[0],
     ]
 
+    return mid_motion_ranges, club_motion_ranges
+
+
+def _interpret_swing_motion(mid_motion_ranges, club_motion_ranges):
+    """Log interpretation of the swing motion directions and patterns."""
     logger.info("\nMotion analysis:")
     # Determine the axis with largest motion range using explicit if-elif-else
     # for clarity (avoiding nested ternary operators)
@@ -165,11 +166,93 @@ def analyze_coordinate_system() -> None:
         logger.info("  Primary swing motion is in Z direction (vertical)")
         logger.info("  This seems unusual for a golf swing")
 
+
+def _analyze_key_frame(name, frame):
+    """Analyze and log position, club vector, and rotation matrix for a single frame."""
+    logger.info("%s frame (t=%ss):", name, frame["time"])
+    logger.info(
+        f"  Mid-hands: X={frame['mid_X']:.3f}, Y={frame['mid_Y']:.3f}, "
+        f"Z={frame['mid_Z']:.3f}"
+    )
+    logger.info(
+        f"  Club head: X={frame['club_X']:.3f}, Y={frame['club_Y']:.3f}, "
+        f"Z={frame['club_Z']:.3f}"
+    )
+
+    # Calculate club direction vector
+    club_vector = np.array(
+        [
+            frame["club_X"] - frame["mid_X"],
+            frame["club_Y"] - frame["mid_Y"],
+            frame["club_Z"] - frame["mid_Z"],
+        ]
+    )
+    club_length = np.linalg.norm(club_vector)
+    logger.info("  Club vector: %s", club_vector)
+    logger.info("  Club length: %sm", club_length)
+
+    # Analyze direction cosines for mid-hands
+    logger.info("  Mid-hands direction cosines:")
+    logger.info(
+        f"    X-axis: [{frame['mid_Xx']:.3f}, {frame['mid_Xy']:.3f}, "
+        f"{frame['mid_Xz']:.3f}]"
+    )
+    logger.info(
+        f"    Y-axis: [{frame['mid_Yx']:.3f}, {frame['mid_Yy']:.3f}, "
+        f"{frame['mid_Yz']:.3f}]"
+    )
+    logger.info(
+        f"    Z-axis: [{frame['mid_Zx']:.3f}, {frame['mid_Zy']:.3f}, "
+        f"{frame['mid_Zz']:.3f}]"
+    )
+
+    # Check if direction cosines form a proper rotation matrix
+    X_vec = np.array([frame["mid_Xx"], frame["mid_Xy"], frame["mid_Xz"]])
+    Y_vec = np.array([frame["mid_Yx"], frame["mid_Yy"], frame["mid_Yz"]])
+    Z_vec = np.array([frame["mid_Zx"], frame["mid_Zy"], frame["mid_Zz"]])
+
+    # Check orthogonality
+    dot_XY = np.dot(X_vec, Y_vec)
+    dot_XZ = np.dot(X_vec, Z_vec)
+    dot_YZ = np.dot(Y_vec, Z_vec)
+
+    logger.info(
+        f"    Orthogonality checks (should be ~0): XY={dot_XY:.3f}, "
+        f"XZ={dot_XZ:.3f}, YZ={dot_YZ:.3f}"
+    )
+
+    # Check if this is a right-handed coordinate system
+    cross_product = np.cross(X_vec, Y_vec)
+    dot_cross_Z = np.dot(cross_product, Z_vec)
+    logger.info("    Right-handed check (should be ~1): %s", dot_cross_Z)
+    logger.info("")
+
+
+def analyze_coordinate_system() -> None:
+    """Analyze the coordinate system and golfer orientation in the data"""
+
+    # Load the Excel file
+    filename = "Wiffle_ProV1_club_3D_data.xlsx"
+    sheet_name = "TW_wiffle"  # Use one of the available sheets
+
+    logger.info("Analyzing coordinate system for %s", sheet_name)
+    logger.info("%s", "=" * 50)
+
+    data = _load_excel_frame_data(filename, sheet_name)
+
+    if not data:
+        logger.info("No data found!")
+        return
+
+    logger.info("Analyzing %s frames", len(data))
+
+    mid_motion_ranges, club_motion_ranges = _compute_motion_ranges(data)
+    _interpret_swing_motion(mid_motion_ranges, club_motion_ranges)
+
     # Look at key frames (start, middle, end)
     logger.info("\nKey frame analysis:")
     logger.info("%s", "-" * 30)
 
-    # Find frames at different times
     start_frame = data[0]
     mid_frame = data[len(data) // 2]
     end_frame = data[-1]
@@ -179,63 +262,7 @@ def analyze_coordinate_system() -> None:
         ("Middle", mid_frame),
         ("End", end_frame),
     ]:
-        logger.info("%s frame (t=%ss):", name, frame["time"])
-        logger.info(
-            f"  Mid-hands: X={frame['mid_X']:.3f}, Y={frame['mid_Y']:.3f}, "
-            f"Z={frame['mid_Z']:.3f}"
-        )
-        logger.info(
-            f"  Club head: X={frame['club_X']:.3f}, Y={frame['club_Y']:.3f}, "
-            f"Z={frame['club_Z']:.3f}"
-        )
-
-        # Calculate club direction vector
-        club_vector = np.array(
-            [
-                frame["club_X"] - frame["mid_X"],
-                frame["club_Y"] - frame["mid_Y"],
-                frame["club_Z"] - frame["mid_Z"],
-            ]
-        )
-        club_length = np.linalg.norm(club_vector)
-        logger.info("  Club vector: %s", club_vector)
-        logger.info("  Club length: %sm", club_length)
-
-        # Analyze direction cosines for mid-hands
-        logger.info("  Mid-hands direction cosines:")
-        logger.info(
-            f"    X-axis: [{frame['mid_Xx']:.3f}, {frame['mid_Xy']:.3f}, "
-            f"{frame['mid_Xz']:.3f}]"
-        )
-        logger.info(
-            f"    Y-axis: [{frame['mid_Yx']:.3f}, {frame['mid_Yy']:.3f}, "
-            f"{frame['mid_Yz']:.3f}]"
-        )
-        logger.info(
-            f"    Z-axis: [{frame['mid_Zx']:.3f}, {frame['mid_Zy']:.3f}, "
-            f"{frame['mid_Zz']:.3f}]"
-        )
-
-        # Check if direction cosines form a proper rotation matrix
-        X_vec = np.array([frame["mid_Xx"], frame["mid_Xy"], frame["mid_Xz"]])
-        Y_vec = np.array([frame["mid_Yx"], frame["mid_Yy"], frame["mid_Yz"]])
-        Z_vec = np.array([frame["mid_Zx"], frame["mid_Zy"], frame["mid_Zz"]])
-
-        # Check orthogonality
-        dot_XY = np.dot(X_vec, Y_vec)
-        dot_XZ = np.dot(X_vec, Z_vec)
-        dot_YZ = np.dot(Y_vec, Z_vec)
-
-        logger.info(
-            f"    Orthogonality checks (should be ~0): XY={dot_XY:.3f}, "
-            f"XZ={dot_XZ:.3f}, YZ={dot_YZ:.3f}"
-        )
-
-        # Check if this is a right-handed coordinate system
-        cross_product = np.cross(X_vec, Y_vec)
-        dot_cross_Z = np.dot(cross_product, Z_vec)
-        logger.info("    Right-handed check (should be ~1): %s", dot_cross_Z)
-        logger.info("")
+        _analyze_key_frame(name, frame)
 
 
 if __name__ == "__main__":

--- a/src/engines/physics_engines/mujoco/docker/gui/deepmind_control_suite_MuJoCo_GUI.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/deepmind_control_suite_MuJoCo_GUI.py
@@ -289,8 +289,15 @@ class GolfSimulationGUI:
         main_container = ttk.Frame(self.tab_sim, style="Modern.TFrame")
         main_container.pack(fill="both", expand=True, padx=20, pady=20)
 
-        # Title section
-        title_frame = ttk.Frame(main_container, style="Modern.TFrame")
+        self._setup_sim_title(main_container)
+        self._setup_sim_settings_card(main_container)
+        self._setup_sim_state_card(main_container)
+        self._setup_sim_action_buttons(main_container)
+        self._setup_sim_log_section(main_container)
+
+    def _setup_sim_title(self, parent) -> None:
+        """Create the simulation tab title section."""
+        title_frame = ttk.Frame(parent, style="Modern.TFrame")
         title_frame.pack(fill="x", pady=(0, 20))
 
         title = ttk.Label(
@@ -305,9 +312,10 @@ class GolfSimulationGUI:
         )
         subtitle.pack(anchor="center", pady=(5, 0))
 
-        # Settings card
+    def _setup_sim_settings_card(self, parent) -> None:
+        """Create the simulation settings card with control mode and live view."""
         settings_card = ttk.LabelFrame(
-            main_container, text="⚙️ Simulation Settings", style="Modern.TLabelframe"
+            parent, text="⚙️ Simulation Settings", style="Modern.TLabelframe"
         )
         settings_card.pack(fill="x", pady=(0, 15))
 
@@ -342,9 +350,10 @@ class GolfSimulationGUI:
             style="Modern.TCheckbutton",
         ).pack(side="left")
 
-        # State management card
+    def _setup_sim_state_card(self, parent) -> None:
+        """Create the state management card with load/save path entries."""
         state_card = ttk.LabelFrame(
-            main_container, text="💾 State Management", style="Modern.TLabelframe"
+            parent, text="💾 State Management", style="Modern.TLabelframe"
         )
         state_card.pack(fill="x", pady=(0, 15))
 
@@ -409,9 +418,10 @@ class GolfSimulationGUI:
             style="Modern.TButton",
         ).pack(side="right")
 
-        # Action buttons section
+    def _setup_sim_action_buttons(self, parent) -> None:
+        """Create the simulation control and results action buttons."""
         action_card = ttk.LabelFrame(
-            main_container, text="🎮 Simulation Controls", style="Modern.TLabelframe"
+            parent, text="🎮 Simulation Controls", style="Modern.TLabelframe"
         )
         action_card.pack(fill="x", pady=(0, 15))
 
@@ -513,9 +523,10 @@ class GolfSimulationGUI:
         )
         self.btn_open_data.pack(side="left")
 
-        # Log section
+    def _setup_sim_log_section(self, parent) -> None:
+        """Create the simulation log section with text area and scrollbar."""
         log_card = ttk.LabelFrame(
-            main_container, text="📋 Simulation Log", style="Modern.TLabelframe"
+            parent, text="📋 Simulation Log", style="Modern.TLabelframe"
         )
         log_card.pack(fill="both", expand=True)
 
@@ -590,17 +601,26 @@ class GolfSimulationGUI:
         )
         title.pack(pady=(0, 20))
 
-        # Dimensions card
+        self._setup_dimensions_card(main_container)
+        self._setup_colors_card(main_container)
+        self._setup_appearance_save_button(main_container)
+
+    def _setup_dimensions_card(self, parent: ttk.Frame) -> None:
+        """Create the physical dimensions card with height and weight controls."""
         dimensions_card = ttk.LabelFrame(
-            main_container, text="📏 Physical Dimensions", style="Modern.TLabelframe"
+            parent, text="📏 Physical Dimensions", style="Modern.TLabelframe"
         )
         dimensions_card.pack(fill="x", pady=(0, 20))
 
         dim_inner = ttk.Frame(dimensions_card, style="Modern.TFrame")
         dim_inner.pack(fill="x", padx=20, pady=15)
 
-        # Height control
-        height_frame = ttk.Frame(dim_inner, style="Modern.TFrame")
+        self._setup_height_control(dim_inner)
+        self._setup_weight_control(dim_inner)
+
+    def _setup_height_control(self, parent: ttk.Frame) -> None:
+        """Create the height spinbox control."""
+        height_frame = ttk.Frame(parent, style="Modern.TFrame")
         height_frame.pack(fill="x", pady=(0, 15))
 
         ttk.Label(height_frame, text="Height (meters):", style="Modern.TLabel").pack(
@@ -622,8 +642,9 @@ class GolfSimulationGUI:
         )
         height_spinbox.pack(side="right")
 
-        # Weight control
-        weight_frame = ttk.Frame(dim_inner, style="Modern.TFrame")
+    def _setup_weight_control(self, parent: ttk.Frame) -> None:
+        """Create the weight scale control with label."""
+        weight_frame = ttk.Frame(parent, style="Modern.TFrame")
         weight_frame.pack(fill="x")
 
         weight_label_frame = ttk.Frame(weight_frame, style="Modern.TFrame")
@@ -653,9 +674,10 @@ class GolfSimulationGUI:
         )
         weight_scale.pack(fill="x")
 
-        # Colors card
+    def _setup_colors_card(self, parent: ttk.Frame) -> None:
+        """Create the body colors card with color pickers for each body part."""
         colors_card = ttk.LabelFrame(
-            main_container, text="🎨 Body Colors", style="Modern.TLabelframe"
+            parent, text="🎨 Body Colors", style="Modern.TLabelframe"
         )
         colors_card.pack(fill="x", pady=(0, 20))
 
@@ -664,7 +686,6 @@ class GolfSimulationGUI:
 
         self.color_widgets = {}
 
-        # Color grid
         color_parts = [
             ("👕 Shirt", "shirt"),
             ("👖 Pants", "pants"),
@@ -674,49 +695,56 @@ class GolfSimulationGUI:
         ]
 
         for _, (display_name, part_key) in enumerate(color_parts):
-            color_row = ttk.Frame(colors_inner, style="Modern.TFrame")
-            color_row.pack(fill="x", pady=5)
+            self._create_color_picker_row(colors_inner, display_name, part_key)
 
-            # Label
-            ttk.Label(
-                color_row, text=display_name, style="Modern.TLabel", width=12
-            ).pack(side="left")
+    def _create_color_picker_row(
+        self, parent: ttk.Frame, display_name: str, part_key: str
+    ) -> None:
+        """Create a single color picker row with label, swatch, and pick button."""
+        color_row = ttk.Frame(parent, style="Modern.TFrame")
+        color_row.pack(fill="x", pady=5)
 
-            # Color swatch
-            swatch_frame = ttk.Frame(color_row, style="Modern.TFrame")
-            swatch_frame.pack(side="left", padx=(10, 15))
+        # Label
+        ttk.Label(color_row, text=display_name, style="Modern.TLabel", width=12).pack(
+            side="left"
+        )
 
-            canvas = tk.Canvas(
-                swatch_frame,
-                width=50,
-                height=30,
-                bg="white",
-                relief="solid",
-                borderwidth=2,
-                highlightthickness=0,
-            )
-            canvas.pack()
-            self.color_widgets[part_key] = canvas
-            self.update_swatch(part_key)
+        # Color swatch
+        swatch_frame = ttk.Frame(color_row, style="Modern.TFrame")
+        swatch_frame.pack(side="left", padx=(10, 15))
 
-            # Pick color button
-            color_btn = tk.Button(
-                color_row,
-                text="🎨 Pick Color",
-                command=partial(self.pick_color, part_key),
-                bg="#0078d4",
-                fg="white",
-                font=("Segoe UI", 9),
-                relief="flat",
-                bd=0,
-                padx=15,
-                pady=6,
-                cursor="hand2",
-            )
-            color_btn.pack(side="right")
+        canvas = tk.Canvas(
+            swatch_frame,
+            width=50,
+            height=30,
+            bg="white",
+            relief="solid",
+            borderwidth=2,
+            highlightthickness=0,
+        )
+        canvas.pack()
+        self.color_widgets[part_key] = canvas
+        self.update_swatch(part_key)
 
-        # Save button
-        save_frame = ttk.Frame(main_container, style="Modern.TFrame")
+        # Pick color button
+        color_btn = tk.Button(
+            color_row,
+            text="🎨 Pick Color",
+            command=partial(self.pick_color, part_key),
+            bg="#0078d4",
+            fg="white",
+            font=("Segoe UI", 9),
+            relief="flat",
+            bd=0,
+            padx=15,
+            pady=6,
+            cursor="hand2",
+        )
+        color_btn.pack(side="right")
+
+    def _setup_appearance_save_button(self, parent: ttk.Frame) -> None:
+        """Create the save appearance settings button."""
+        save_frame = ttk.Frame(parent, style="Modern.TFrame")
         save_frame.pack(fill="x", pady=20)
 
         save_btn = tk.Button(
@@ -1049,15 +1077,8 @@ class GolfSimulationGUI:
 
         threading.Thread(target=run_update, daemon=True).start()
 
-    def _run_docker_process(self) -> None:
-        """Run the simulation in a subprocess."""
-        # Determine command
-        # If running in windows, we use wsl docker.
-        # If running in linux, we use docker directly.
-        # NOTE: If we are running inside the environment that HAS mujoco/dm_control,
-        # we could just subprocess the python script directly instead of docker run?
-        # But let's stick to the existing architecture.
-
+    def _build_docker_command(self) -> list[str]:
+        """Build the docker run command for the simulation subprocess."""
         if self.is_windows:
             cmd = [
                 "wsl",
@@ -1072,12 +1093,10 @@ class GolfSimulationGUI:
 
             if self.live_view_var.get():
                 # Allow GUI to display on host Windows X Server (VcXsrv)
-                # OVERRIDE osmesa default to allow windowed rendering
                 cmd.extend(["-e", "DISPLAY=host.docker.internal:0"])
                 cmd.extend(["-e", "MUJOCO_GL=glfw"])
                 cmd.extend(["-e", "PYOPENGL_PLATFORM=glx"])
             else:
-                # Headless mode - use osmesa to avoid X11 errors
                 cmd.extend(["-e", "MUJOCO_GL=osmesa"])
 
             cmd.extend(
@@ -1090,7 +1109,6 @@ class GolfSimulationGUI:
                 ]
             )
         else:
-            # Non-Windows path (Linux/Unix)
             cmd = [
                 "docker",
                 "run",
@@ -1102,16 +1120,13 @@ class GolfSimulationGUI:
             ]
 
             if self.live_view_var.get():
-                # Add X11 forwarding args
                 cmd.extend(["-e", f"DISPLAY={os.environ.get('DISPLAY', ':0')}"])
                 cmd.extend(["-e", "MUJOCO_GL=glfw"])
                 cmd.extend(["-e", "PYOPENGL_PLATFORM=glx"])
                 cmd.extend(["-v", "/tmp/.X11-unix:/tmp/.X11-unix"])  # nosec B108
             else:
-                # Headless mode
                 cmd.extend(["-e", "MUJOCO_GL=osmesa"])
 
-            # Append image and command LAST
             cmd.extend(
                 [
                     "robotics_env",
@@ -1121,14 +1136,95 @@ class GolfSimulationGUI:
                 ]
             )
 
+        return cmd
+
+    def _stream_process_output(self) -> None:
+        """Read subprocess stdout via a queue and log lines to the GUI."""
+        q: queue.Queue[str | None] = queue.Queue()
+
+        def enqueue_output(out, output_queue) -> None:
+            """Enqueue output from subprocess."""
+            try:
+                for line in iter(out.readline, ""):
+                    output_queue.put(line)
+                out.close()
+            except (RuntimeError, ValueError, OSError) as e:
+                try:
+                    self.root.after(0, self.log, f"Exception in enqueue_output: {e}")
+                except (RuntimeError, ValueError, AttributeError):
+                    pass
+            output_queue.put(None)  # Sentinel
+
+        t = threading.Thread(
+            target=enqueue_output, args=(self.process.stdout, q), daemon=True
+        )
+        t.start()
+
+        while True:
+            # Check user stop
+            if self.stop_event.is_set():
+                if self.process.poll() is None:
+                    self.process.terminate()
+
+            try:
+                output = q.get(timeout=0.1)
+            except queue.Empty:
+                if self.process.poll() is not None and not t.is_alive():
+                    break
+                continue
+
+            if output is None:  # Sentinel
+                break
+
+            self.root.after(0, self.log, output.strip())
+
+    def _handle_process_failure(self, rc) -> None:
+        """Log error details and suggest solutions for common failures."""
+        self.root.after(0, self.log, f"Process exited with code {rc}")
+        if self.process.stderr:
+            err = self.process.stderr.read()
+            if err:
+                self.root.after(0, self.log, f"ERROR: {err}")
+            # Check for specific common errors and provide solutions
+            if "defusedxml" in err:
+                self.root.after(
+                    0,
+                    self.log,
+                    "SOLUTION: Missing defusedxml dependency. "
+                    "Please rebuild Docker image.",
+                )
+                self.root.after(0, self.log, "Run: docker build -t robotics_env .")
+            elif "ModuleNotFoundError" in err:
+                self.root.after(
+                    0,
+                    self.log,
+                    "SOLUTION: Missing Python dependency. "
+                    "Check Dockerfile and rebuild.",
+                )
+            elif "DISPLAY" in err or "X11" in err:
+                self.root.after(
+                    0,
+                    self.log,
+                    "SOLUTION: X11/Display issue. "
+                    "Try disabling 'Live Interactive View'.",
+                )
+
+    def _reset_buttons_state(self) -> None:
+        """Reset run/stop buttons to their default enabled states."""
+        self.root.after(0, lambda: self.btn_run.config(state=tk.NORMAL))
+        self.root.after(0, lambda: self.btn_stop.config(state=tk.DISABLED))
+
+    def _run_docker_process(self) -> None:
+        """Run the simulation in a subprocess."""
+        cmd = self._build_docker_command()
+
         try:
             self.log(f"Running command: {' '.join(cmd)}")
 
             # Race condition fix: Check stop event before starting
             if self.stop_event.is_set():
                 self.log("Simulation cancelled.")
-                self.root.after(0, lambda: self.btn_run.config(state=tk.NORMAL))
-                self.root.after(0, lambda: self.btn_stop.config(state=tk.DISABLED))
+                self._reset_buttons_state()
                 return
 
             self.process = subprocess.Popen(
@@ -1139,100 +1235,23 @@ class GolfSimulationGUI:
                 bufsize=1,
             )
 
-            # Use a queue to read stdout non-blocking
-            q: queue.Queue[str | None] = queue.Queue()
-
-            def enqueue_output(out, queue) -> None:
-                """Enqueue output from subprocess."""
-                try:
-                    for line in iter(out.readline, ""):
-                        queue.put(line)
-                    out.close()
-                except (RuntimeError, ValueError, OSError) as e:
-                    # Log the exception so it is not silently swallowed
-                    try:
-                        self.root.after(
-                            0, self.log, f"Exception in enqueue_output: {e}"
-                        )
-                    except (RuntimeError, ValueError, AttributeError):
-                        pass
-                queue.put(None)  # Sentinel
-
-            t = threading.Thread(
-                target=enqueue_output, args=(self.process.stdout, q), daemon=True
-            )
-            t.start()
-
-            while True:
-                # Check user stop
-                if self.stop_event.is_set():
-                    if self.process.poll() is None:
-                        self.process.terminate()
-
-                try:
-                    # Non-blocking check with timeout to allow stop_event checking
-                    output = q.get(timeout=0.1)
-                except queue.Empty:
-                    # If process is dead and queue is empty, break
-                    # Actually sentinel is best.
-                    if self.process.poll() is not None and not t.is_alive():
-                        # If thread died without sentinel?
-                        break
-                    continue
-
-                if output is None:  # Sentinel
-                    break
-
-                self.root.after(0, self.log, output.strip())
+            self._stream_process_output()
 
             rc = self.process.poll()
 
             # Check if stopped by user
             if self.stop_event.is_set():
                 self.root.after(0, self.log, "Simulation stopped by user.")
-                self.root.after(0, lambda: self.btn_run.config(state=tk.NORMAL))
-                self.root.after(0, lambda: self.btn_stop.config(state=tk.DISABLED))
+                self._reset_buttons_state()
             elif rc == 0:
                 self.root.after(0, self.on_sim_success)
             else:
-                self.root.after(0, self.log, f"Process exited with code {rc}")
-                # Try reading stderr
-                if self.process.stderr:
-                    err = self.process.stderr.read()
-                    if err:
-                        self.root.after(0, self.log, f"ERROR: {err}")
-                    # Check for specific common errors and provide solutions
-                    if "defusedxml" in err:
-                        self.root.after(
-                            0,
-                            self.log,
-                            "SOLUTION: Missing defusedxml dependency. "
-                            "Please rebuild Docker image.",
-                        )
-                        self.root.after(
-                            0, self.log, "Run: docker build -t robotics_env ."
-                        )
-                    elif "ModuleNotFoundError" in err:
-                        self.root.after(
-                            0,
-                            self.log,
-                            "SOLUTION: Missing Python dependency. "
-                            "Check Dockerfile and rebuild.",
-                        )
-                    elif "DISPLAY" in err or "X11" in err:
-                        self.root.after(
-                            0,
-                            self.log,
-                            "SOLUTION: X11/Display issue. "
-                            "Try disabling 'Live Interactive View'.",
-                        )
-                self.root.after(0, lambda: self.btn_run.config(state=tk.NORMAL))
-                self.root.after(0, lambda: self.btn_stop.config(state=tk.DISABLED))
+                self._handle_process_failure(rc)
+                self._reset_buttons_state()
 
         except ImportError as e:
             self.root.after(0, self.log, f"Failed to run subprocess: {e}")
-            self.root.after(0, lambda: self.btn_run.config(state=tk.NORMAL))
-            self.root.after(0, lambda: self.btn_stop.config(state=tk.DISABLED))
+            self._reset_buttons_state()
 
     def on_sim_success(self) -> None:
         """Handle successful simulation completion."""

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/__main__.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/__main__.py
@@ -37,13 +37,35 @@ class MainWindow(QtWidgets.QMainWindow):
         self.sim_widget = MuJoCoSimWidget(width=800, height=600, fps=60)
         h_layout.addWidget(self.sim_widget, stretch=2)
 
-        # Right: control panel with scroll area
+        # Right: control panel
+        control_panel, control_layout = self._create_control_panel()
+        self._setup_model_selector(control_layout)
+        self._setup_sim_buttons(control_layout)
+        self._setup_actuator_scroll_area(control_layout)
+        h_layout.addWidget(control_panel, stretch=1)
+
+        # Store sliders and labels for dynamic updates
+        self.actuator_sliders: list[QtWidgets.QSlider] = []
+        self.actuator_labels: list[QtWidgets.QLabel] = []
+        self.actuator_groups: list[QtWidgets.QGroupBox] = []
+
+        # Model configurations
+        self.model_configs = self._build_model_configs()
+
+        # Load default model
+        self.load_current_model()
+        self.sim_widget.reset_state()
+
+    def _create_control_panel(self) -> tuple[QtWidgets.QFrame, QtWidgets.QVBoxLayout]:
+        """Create the right-side control panel frame and layout."""
         control_panel = QtWidgets.QFrame(self)
         control_panel.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
         control_layout = QtWidgets.QVBoxLayout(control_panel)
         control_layout.setContentsMargins(8, 8, 8, 8)
+        return control_panel, control_layout
 
-        # Model selector
+    def _setup_model_selector(self, control_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the model selection combo box group."""
         model_group = QtWidgets.QGroupBox("Golf Swing Model")
         model_layout = QtWidgets.QVBoxLayout(model_group)
         self.model_combo = QtWidgets.QComboBox()
@@ -57,7 +79,8 @@ class MainWindow(QtWidgets.QMainWindow):
         model_layout.addWidget(self.model_combo)
         control_layout.addWidget(model_group)
 
-        # Play / Pause / Reset
+    def _setup_sim_buttons(self, control_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the play/pause and reset buttons."""
         buttons_group = QtWidgets.QGroupBox("Simulation Control")
         buttons_layout = QtWidgets.QHBoxLayout(buttons_group)
 
@@ -72,7 +95,10 @@ class MainWindow(QtWidgets.QMainWindow):
         buttons_layout.addWidget(self.reset_btn)
         control_layout.addWidget(buttons_group)
 
-        # Scrollable area for actuator controls
+    def _setup_actuator_scroll_area(
+        self, control_layout: QtWidgets.QVBoxLayout
+    ) -> None:
+        """Create the scrollable area for actuator control sliders."""
         scroll_area = QtWidgets.QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setHorizontalScrollBarPolicy(
@@ -85,15 +111,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
         control_layout.addWidget(scroll_area, stretch=1)
 
-        h_layout.addWidget(control_panel, stretch=1)
-
-        # Store sliders and labels for dynamic updates
-        self.actuator_sliders: list[QtWidgets.QSlider] = []
-        self.actuator_labels: list[QtWidgets.QLabel] = []
-        self.actuator_groups: list[QtWidgets.QGroupBox] = []
-
-        # Model configurations
-        self.model_configs = [
+    @staticmethod
+    def _build_model_configs() -> list[dict]:
+        """Build the list of available model configurations."""
+        return [
             {
                 "name": "chaotic_pendulum",
                 "xml": CHAOTIC_PENDULUM_XML,
@@ -181,10 +202,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 ],
             },
         ]
-
-        # Load default model
-        self.load_current_model()
-        self.sim_widget.reset_state()
 
     # -------- Model management --------
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/manipulation_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/manipulation_tab.py
@@ -35,16 +35,28 @@ class ManipulationTab(QtWidgets.QWidget):
         manip_layout = QtWidgets.QVBoxLayout(self)
         manip_layout.setContentsMargins(8, 8, 8, 8)
 
-        # Global Body Selection
+        manip_layout.addWidget(self._setup_target_selection())
+        manip_layout.addWidget(self._setup_drag_controls())
+        manip_layout.addWidget(self._setup_manual_transform())
+        manip_layout.addWidget(self._setup_constraint_controls())
+        manip_layout.addWidget(self._setup_pose_library())
+        manip_layout.addWidget(self._setup_ik_settings())
+        manip_layout.addWidget(self._setup_instructions())
+
+        manip_layout.addStretch(1)
+
+    def _setup_target_selection(self) -> QtWidgets.QGroupBox:
+        """Create the global body selection group."""
         sel_group = QtWidgets.QGroupBox("Target Selection")
         sel_layout = QtWidgets.QHBoxLayout(sel_group)
         sel_layout.addWidget(QtWidgets.QLabel("Select Body:"))
         self.manip_body_combo = QtWidgets.QComboBox()
         self.manip_body_combo.currentIndexChanged.connect(self.on_manip_body_selected)
         sel_layout.addWidget(self.manip_body_combo, stretch=1)
-        manip_layout.addWidget(sel_group)
+        return sel_group
 
-        # Drag mode controls
+    def _setup_drag_controls(self) -> QtWidgets.QGroupBox:
+        """Create drag mode controls with checkboxes."""
         drag_group = QtWidgets.QGroupBox("Drag Mode")
         drag_layout = QtWidgets.QVBoxLayout(drag_group)
 
@@ -70,9 +82,10 @@ class ManipulationTab(QtWidgets.QWidget):
         )
         drag_layout.addWidget(self.nullspace_posture_cb)
 
-        manip_layout.addWidget(drag_group)
+        return drag_group
 
-        # Manual Transform Controls
+    def _setup_manual_transform(self) -> QtWidgets.QGroupBox:
+        """Create manual position and rotation transform controls."""
         transform_group = QtWidgets.QGroupBox("Manual Transform (Selected Body)")
         transform_layout = QtWidgets.QVBoxLayout(transform_group)
 
@@ -134,9 +147,10 @@ class ManipulationTab(QtWidgets.QWidget):
         self.refresh_trans_btn.clicked.connect(self.update_manual_transform_values)
         transform_layout.addWidget(self.refresh_trans_btn)
 
-        manip_layout.addWidget(transform_group)
+        return transform_group
 
-        # Constraint controls
+    def _setup_constraint_controls(self) -> QtWidgets.QGroupBox:
+        """Create body constraint selection, buttons, and active list."""
         constraint_group = QtWidgets.QGroupBox("Body Constraints")
         constraint_layout = QtWidgets.QVBoxLayout(constraint_group)
 
@@ -206,9 +220,10 @@ class ManipulationTab(QtWidgets.QWidget):
         self.constraints_list.setMaximumHeight(100)
         constraint_layout.addWidget(self.constraints_list)
 
-        manip_layout.addWidget(constraint_group)
+        return constraint_group
 
-        # Pose library controls
+    def _setup_pose_library(self) -> QtWidgets.QGroupBox:
+        """Create pose library save/load/export controls and interpolation."""
         pose_group = QtWidgets.QGroupBox("Pose Library")
         pose_layout = QtWidgets.QVBoxLayout(pose_group)
 
@@ -274,9 +289,10 @@ class ManipulationTab(QtWidgets.QWidget):
 
         pose_layout.addWidget(interp_group)
 
-        manip_layout.addWidget(pose_group)
+        return pose_group
 
-        # IK settings
+    def _setup_ik_settings(self) -> QtWidgets.QGroupBox:
+        """Create IK solver damping and step size controls."""
         ik_group = QtWidgets.QGroupBox("IK Solver Settings (Advanced)")
         ik_layout = QtWidgets.QFormLayout(ik_group)
 
@@ -304,9 +320,10 @@ class ManipulationTab(QtWidgets.QWidget):
         ik_layout.addRow("Step Size:", self.ik_step_slider)
         ik_layout.addRow("", self.ik_step_label)
 
-        manip_layout.addWidget(ik_group)
+        return ik_group
 
-        # Instructions
+    def _setup_instructions(self) -> QtWidgets.QLabel:
+        """Create the quick start instructions label."""
         instructions = QtWidgets.QLabel(
             "<b>Quick Start:</b><br>"
             "• Click and drag any body part to move it<br>"
@@ -318,9 +335,7 @@ class ManipulationTab(QtWidgets.QWidget):
         instructions.setStyleSheet(
             "padding: 10px; background-color: #e8f4f8; border-radius: 5px;"
         )
-        manip_layout.addWidget(instructions)
-
-        manip_layout.addStretch(1)
+        return instructions
 
     def update_body_lists(self) -> None:
         """Update body selection combo boxes."""

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/visualization_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/visualization_tab.py
@@ -30,7 +30,20 @@ class VisualizationTab(QtWidgets.QWidget):
         viz_layout = QtWidgets.QVBoxLayout(self)
         viz_layout.setContentsMargins(8, 8, 8, 8)
 
-        # Camera controls
+        viz_layout.addWidget(self._setup_camera_controls())
+        viz_layout.addWidget(self._setup_background_controls())
+        viz_layout.addWidget(self._setup_meshcat_controls())
+        viz_layout.addWidget(self._setup_swing_plane_controls())
+        force_group, ellipsoid_group = self._setup_force_torque_controls()
+        viz_layout.addWidget(ellipsoid_group)
+        viz_layout.addWidget(force_group)
+        viz_layout.addWidget(self._setup_matrix_analysis())
+        viz_layout.addWidget(self._setup_body_appearance())
+
+        viz_layout.addStretch(1)
+
+    def _setup_camera_controls(self) -> QtWidgets.QGroupBox:
+        """Create camera view preset and advanced camera controls."""
         camera_group = QtWidgets.QGroupBox("Camera View")
         camera_layout = QtWidgets.QVBoxLayout(camera_group)
 
@@ -146,9 +159,10 @@ class VisualizationTab(QtWidgets.QWidget):
         advanced_cam_layout.addRow("", mouse_info)
 
         camera_layout.addWidget(advanced_cam_group)
-        viz_layout.addWidget(camera_group)
+        return camera_group
 
-        # Background color controls
+    def _setup_background_controls(self) -> QtWidgets.QGroupBox:
+        """Create background color controls for sky and ground."""
         bg_group = QtWidgets.QGroupBox("Background Color")
         bg_layout = QtWidgets.QVBoxLayout(bg_group)
 
@@ -185,9 +199,10 @@ class VisualizationTab(QtWidgets.QWidget):
         reset_bg_btn.clicked.connect(self.on_reset_background)
         bg_layout.addWidget(reset_bg_btn)
 
-        viz_layout.addWidget(bg_group)
+        return bg_group
 
-        # Meshcat Visualization
+    def _setup_meshcat_controls(self) -> QtWidgets.QGroupBox:
+        """Create Meshcat web visualization controls."""
         meshcat_group = QtWidgets.QGroupBox("Web Visualization (Meshcat)")
         meshcat_layout = QtWidgets.QVBoxLayout(meshcat_group)
 
@@ -202,9 +217,10 @@ class VisualizationTab(QtWidgets.QWidget):
         btn_meshcat.clicked.connect(self.on_open_meshcat)
         meshcat_layout.addWidget(btn_meshcat)
 
-        viz_layout.addWidget(meshcat_group)
+        return meshcat_group
 
-        # --- Swing Plane & Trajectory Visualization ---
+    def _setup_swing_plane_controls(self) -> QtWidgets.QGroupBox:
+        """Create swing plane and trajectory visualization controls."""
         swing_group = QtWidgets.QGroupBox("Swing Plane & Trajectory")
         swing_layout = QtWidgets.QVBoxLayout(swing_group)
 
@@ -252,9 +268,16 @@ class VisualizationTab(QtWidgets.QWidget):
         reset_traj_btn.clicked.connect(self.on_reset_trajectory)
         swing_layout.addWidget(reset_traj_btn)
 
-        viz_layout.addWidget(swing_group)
+        return swing_group
 
-        # Force/Torque visualization
+    def _setup_force_torque_controls(
+        self,
+    ) -> tuple[QtWidgets.QGroupBox, QtWidgets.QGroupBox]:
+        """Create force, torque, and vector visualization controls.
+
+        Returns a tuple of (force_group, ellipsoid_group) so the caller
+        can place them in the desired layout order.
+        """
         force_group = QtWidgets.QGroupBox("Force & Torque Visualization")
         force_layout = QtWidgets.QVBoxLayout(force_group)
 
@@ -304,7 +327,7 @@ class VisualizationTab(QtWidgets.QWidget):
         force_scale_layout.addRow("", self.force_scale_label)
         force_layout.addLayout(force_scale_layout)
 
-        # --- Advanced Vector Visualization ---
+        # Advanced Vector Visualization
         advanced_vector_group = QtWidgets.QGroupBox("Advanced Vector Overlays")
         av_layout = QtWidgets.QFormLayout(advanced_vector_group)
 
@@ -342,7 +365,6 @@ class VisualizationTab(QtWidgets.QWidget):
         av_layout.addRow(self.show_cf_cb, self.cf_type_combo)
 
         force_layout.addWidget(advanced_vector_group)
-        # -------------------------------------
 
         # Contact forces
         self.show_contacts_cb = QtWidgets.QCheckBox("Show Contact Forces")
@@ -365,11 +387,11 @@ class VisualizationTab(QtWidgets.QWidget):
             self.on_ellipsoid_visualization_changed
         )
         ellipsoid_layout.addWidget(self.show_force_ellipsoid_cb)
-        viz_layout.addWidget(ellipsoid_group)
 
-        viz_layout.addWidget(force_group)
+        return force_group, ellipsoid_group
 
-        # Matrix Analysis
+    def _setup_matrix_analysis(self) -> QtWidgets.QGroupBox:
+        """Create matrix analysis display labels."""
         matrix_group = QtWidgets.QGroupBox("Matrix Analysis")
         matrix_layout = QtWidgets.QFormLayout(matrix_group)
         self.jacobian_cond_label = QtWidgets.QLabel("Condition: --")
@@ -379,9 +401,10 @@ class VisualizationTab(QtWidgets.QWidget):
         matrix_layout.addRow("Jacobian Cond:", self.jacobian_cond_label)
         matrix_layout.addRow("Constraint Rank:", self.constraint_rank_label)
         matrix_layout.addRow("Active Constraints:", self.nefc_label)
-        viz_layout.addWidget(matrix_group)
+        return matrix_group
 
-        # Body Appearance Controls
+    def _setup_body_appearance(self) -> QtWidgets.QGroupBox:
+        """Create body appearance color controls."""
         appearance_group = QtWidgets.QGroupBox("Body Appearance")
         appearance_layout = QtWidgets.QVBoxLayout(appearance_group)
 
@@ -404,9 +427,7 @@ class VisualizationTab(QtWidgets.QWidget):
         color_layout.addWidget(self.viz_reset_color_btn)
 
         appearance_layout.addLayout(color_layout)
-        viz_layout.addWidget(appearance_group)
-
-        viz_layout.addStretch(1)
+        return appearance_group
 
     # -------- Callbacks --------
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/polynomial_generator.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/polynomial_generator.py
@@ -158,7 +158,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
 
         # Left Panel: Controls
         left_panel = QtWidgets.QWidget()
-        left_panel.setFixedWidth(320)  # Slightly wider for better readability
+        left_panel.setFixedWidth(320)
         main_left_layout = QtWidgets.QVBoxLayout(left_panel)
         main_left_layout.setContentsMargins(0, 0, 0, 0)
 
@@ -173,7 +173,26 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setSpacing(10)
 
-        # Joint Selection
+        self._setup_joint_selection(content_layout)
+        self._setup_scale_controls(content_layout)
+        self._setup_input_method_controls(content_layout)
+        self._setup_action_controls(content_layout)
+        self._setup_result_display(content_layout)
+
+        content_layout.addStretch()
+
+        # Add content to scroll area
+        scroll.setWidget(content_widget)
+        main_left_layout.addWidget(scroll)
+
+        layout.addWidget(left_panel)
+
+        # Right Panel: Plot
+        self.canvas = MplCanvas(self, width=5, height=4, dpi=100)
+        layout.addWidget(self.canvas, stretch=1)
+
+    def _setup_joint_selection(self, parent_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the target joint selection group."""
         joint_group = QtWidgets.QGroupBox("Target Joint")
         joint_layout = QtWidgets.QVBoxLayout(joint_group)
         self.joint_combo = QtWidgets.QComboBox()
@@ -181,9 +200,10 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         self.joint_combo.setToolTip("Select the joint to generate the function for")
         self.joint_combo.setAccessibleName("Target Joint Selector")
         joint_layout.addWidget(self.joint_combo)
-        content_layout.addWidget(joint_group)
+        parent_layout.addWidget(joint_group)
 
-        # Plot Settings (Scale)
+    def _setup_scale_controls(self, parent_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the plot scale settings group."""
         scale_group = QtWidgets.QGroupBox("Plot Scale")
         scale_layout = QtWidgets.QGridLayout(scale_group)
 
@@ -202,9 +222,12 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         self.apply_scale_btn = QtWidgets.QPushButton("Apply Scale")
         scale_layout.addWidget(self.apply_scale_btn, 2, 0, 1, 3)
 
-        content_layout.addWidget(scale_group)
+        parent_layout.addWidget(scale_group)
 
-        # Input Methods
+    def _setup_input_method_controls(
+        self, parent_layout: QtWidgets.QVBoxLayout
+    ) -> None:
+        """Create the input method selection group with mode radio buttons."""
         input_group = QtWidgets.QGroupBox("Input Method")
         input_layout = QtWidgets.QVBoxLayout(input_group)
 
@@ -252,9 +275,10 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         radio_layout.addWidget(self.btn_drag, 1, 0, 1, 2)
         input_layout.addLayout(radio_layout)
 
-        content_layout.addWidget(input_group)
+        parent_layout.addWidget(input_group)
 
-        # Actions
+    def _setup_action_controls(self, parent_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the fitting and actions group with order selector and buttons."""
         action_group = QtWidgets.QGroupBox("Fitting & Actions")
         action_layout = QtWidgets.QVBoxLayout(action_group)
 
@@ -290,9 +314,10 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
 
         action_layout.addWidget(self.clear_btn)
         action_layout.addWidget(self.fit_btn)
-        content_layout.addWidget(action_group)
+        parent_layout.addWidget(action_group)
 
-        # Results
+    def _setup_result_display(self, parent_layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the result display group."""
         result_group = QtWidgets.QGroupBox("Result")
         result_layout = QtWidgets.QVBoxLayout(result_group)
         self.result_text = QtWidgets.QTextEdit()
@@ -300,19 +325,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         self.result_text.setMaximumHeight(100)
         self.result_text.setMinimumHeight(60)
         result_layout.addWidget(self.result_text)
-        content_layout.addWidget(result_group)
-
-        content_layout.addStretch()
-
-        # Add content to scroll area
-        scroll.setWidget(content_widget)
-        main_left_layout.addWidget(scroll)
-
-        layout.addWidget(left_panel)
-
-        # Right Panel: Plot
-        self.canvas = MplCanvas(self, width=5, height=4, dpi=100)
-        layout.addWidget(self.canvas, stretch=1)
+        parent_layout.addWidget(result_group)
 
     def _create_spinbox(
         self, min_val: float, max_val: float, val: float, tooltip: str

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/rigid_body_dynamics/aba.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/rigid_body_dynamics/aba.py
@@ -6,6 +6,8 @@ Computes joint accelerations given applied torques.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 from mujoco_humanoid_golf.rigid_body_dynamics.common import (
     DEFAULT_GRAVITY,
@@ -20,7 +22,292 @@ from mujoco_humanoid_golf.spatial_algebra import (
 TOLERANCE = 1e-10  # Numerical tolerance to avoid division by zero
 
 
-def aba(  # noqa: C901, PLR0912, PLR0915
+@dataclass
+class _ModelCache:
+    """Cached model dictionary lookups for tight-loop performance."""
+
+    parent: np.ndarray
+    jtype: list
+    xtree: list
+    inertia: list
+
+    @staticmethod
+    def from_model(model: dict) -> _ModelCache:
+        """Extract and cache model fields to avoid repeated dict lookups."""
+        return _ModelCache(
+            parent=model["parent"],
+            jtype=model["jtype"],
+            xtree=model["Xtree"],
+            inertia=model["I"],
+        )
+
+
+@dataclass
+class _ScratchBuffers:
+    """Pre-allocated scratch buffers to avoid allocations in tight loops."""
+
+    xj_buf: np.ndarray  # (6, 6) - temporary joint transform / outer product
+    cross_buf: np.ndarray  # (6,)   - cross product result
+    scratch_vec: np.ndarray  # (6,)   - general scratch vector
+    scratch_mat: np.ndarray  # (6, 6) - general scratch matrix
+    i_v_buf: np.ndarray  # (6,)   - inertia * velocity product
+    temp_vec: np.ndarray  # (6,)   - temporary vector
+
+    @staticmethod
+    def create() -> _ScratchBuffers:
+        """Create a new set of scratch buffers."""
+        return _ScratchBuffers(
+            xj_buf=np.empty((6, 6)),
+            cross_buf=np.empty(6),
+            scratch_vec=np.empty(6),
+            scratch_mat=np.empty((6, 6)),
+            i_v_buf=np.empty(6),
+            temp_vec=np.empty(6),
+        )
+
+
+def _aba_validate_inputs(
+    model: dict,
+    q: np.ndarray,
+    qd: np.ndarray,
+    tau: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Validate and prepare ABA inputs.
+
+    Returns:
+        Tuple of (q, qd, tau, nb) with raveled arrays and body count.
+    """
+    q = np.asarray(q).ravel()
+    qd = np.asarray(qd).ravel()
+    tau = np.asarray(tau).ravel()
+
+    nb = model["NB"]
+
+    if len(q) != nb:
+        msg = f"q must have length {nb}, got {len(q)}"
+        raise ValueError(msg)
+    if len(qd) != nb:
+        msg = f"qd must have length {nb}, got {len(qd)}"
+        raise ValueError(msg)
+    if len(tau) != nb:
+        msg = f"tau must have length {nb}, got {len(tau)}"
+        raise ValueError(msg)
+
+    return q, qd, tau, nb
+
+
+def _aba_forward_kinematics(
+    nb: int,
+    q: np.ndarray,
+    qd: np.ndarray,
+    f_ext: np.ndarray | None,
+    mdl: _ModelCache,
+    xup: np.ndarray,
+    s_subspace: list[np.ndarray],
+    dof_indices: list[int],
+    v: np.ndarray,
+    c: np.ndarray,
+    pa_bias: np.ndarray,
+    buf: _ScratchBuffers,
+) -> None:
+    """Pass 1: Forward kinematics - compute velocities and bias accelerations."""
+    for i in range(nb):
+        # OPTIMIZATION: Use pre-allocated buffer for jcalc
+        xj_transform, s_vec, dof_idx = jcalc(mdl.jtype[i], q[i], out=buf.xj_buf)
+        s_subspace[i] = s_vec
+        dof_indices[i] = dof_idx
+
+        # OPTIMIZATION: Write directly to pre-allocated xup buffer
+        np.matmul(xj_transform, mdl.xtree[i], out=xup[i])
+
+        if dof_idx != -1:
+            buf.temp_vec.fill(0)
+            buf.temp_vec[dof_idx] = qd[i]
+            vj_velocity = buf.temp_vec
+        else:
+            vj_velocity = s_subspace[i] * qd[i]
+
+        if mdl.parent[i] == -1:
+            v[:, i] = vj_velocity
+            c[:, i] = np.zeros(6)  # No bias for base-connected bodies
+        else:
+            p = mdl.parent[i]
+            # OPTIMIZATION: Use matmul with out directly to v[:, i]
+            np.matmul(xup[i], v[:, p], out=v[:, i])
+            v[:, i] += vj_velocity
+
+            # OPTIMIZATION: Use pre-allocated buffer for cross product
+            cross_motion_fast(v[:, i], vj_velocity, out=c[:, i])
+
+        # Bias force: Coriolis + external forces
+        np.matmul(mdl.inertia[i], v[:, i], out=buf.i_v_buf)
+        cross_force_fast(v[:, i], buf.i_v_buf, out=buf.cross_buf)
+        if f_ext is not None:
+            np.subtract(buf.cross_buf, f_ext[:, i], out=pa_bias[:, i])
+        else:
+            pa_bias[:, i] = buf.cross_buf
+
+
+def _aba_backward_body_inertia(
+    i: int,
+    dof_idx: int,
+    model_parent_i: int,
+    s_subspace_i: np.ndarray,
+    tau_i: float,
+    xup_i: np.ndarray,
+    ia_articulated: np.ndarray,
+    pa_bias: np.ndarray,
+    u_force: np.ndarray,
+    d: np.ndarray,
+    u: np.ndarray,
+    c: np.ndarray,
+    buf: _ScratchBuffers,
+) -> None:
+    """Compute articulated-body inertia update for a single body."""
+    if dof_idx != -1:
+        u_force[:, i] = ia_articulated[i][:, dof_idx]
+    else:
+        np.matmul(ia_articulated[i], s_subspace_i, out=u_force[:, i])
+
+    # Joint-space inertia
+    if dof_idx != -1:
+        d[i] = u_force[dof_idx, i]
+    else:
+        d[i] = np.dot(s_subspace_i, u_force[:, i])
+
+    # Bias torque
+    if dof_idx != -1:
+        u[i] = tau_i - pa_bias[dof_idx, i]
+    else:
+        u[i] = tau_i - np.dot(s_subspace_i, pa_bias[:, i])
+
+    # Articulated-body inertia update for parent
+    if model_parent_i != -1:
+        _aba_propagate_to_parent(
+            i,
+            model_parent_i,
+            xup_i,
+            ia_articulated,
+            pa_bias,
+            u_force,
+            d,
+            u,
+            c,
+            buf,
+        )
+
+
+def _aba_propagate_to_parent(
+    i: int,
+    parent: int,
+    xup_i: np.ndarray,
+    ia_articulated: np.ndarray,
+    pa_bias: np.ndarray,
+    u_force: np.ndarray,
+    d: np.ndarray,
+    u: np.ndarray,
+    c: np.ndarray,
+    buf: _ScratchBuffers,
+) -> None:
+    """Propagate articulated-body quantities from body i to its parent."""
+    if abs(d[i]) < TOLERANCE:
+        d[i] = np.sign(d[i]) * TOLERANCE if d[i] != 0 else TOLERANCE
+
+    dinv = 1 / d[i]
+
+    # OPTIMIZATION: Minimize allocations in the update
+    np.matmul(ia_articulated[i], xup_i, out=buf.scratch_mat)
+    np.matmul(xup_i.T, u_force[:, i], out=buf.scratch_vec)
+
+    # Subtract rank-1 update from scratch_mat
+    np.multiply(u_force[:, i], dinv, out=buf.temp_vec)
+    np.outer(buf.temp_vec, buf.scratch_vec, out=buf.xj_buf)
+    buf.scratch_mat -= buf.xj_buf
+
+    # Add to parent articulated inertia
+    np.matmul(xup_i.T, buf.scratch_mat, out=buf.xj_buf)
+    ia_articulated[parent] += buf.xj_buf
+
+    # Update bias force
+    np.matmul(ia_articulated[i], c[:, i], out=buf.scratch_vec)
+    buf.scratch_vec += pa_bias[:, i]
+    scalar = dinv * u[i]
+    np.multiply(u_force[:, i], scalar, out=buf.temp_vec)
+    buf.scratch_vec += buf.temp_vec
+
+    # Transform and add to parent
+    np.matmul(xup_i.T, buf.scratch_vec, out=buf.cross_buf)
+    pa_bias[:, parent] += buf.cross_buf
+
+
+def _aba_backward_pass(
+    nb: int,
+    tau: np.ndarray,
+    model_parent: np.ndarray,
+    s_subspace: list[np.ndarray],
+    dof_indices: list[int],
+    xup: np.ndarray,
+    ia_articulated: np.ndarray,
+    pa_bias: np.ndarray,
+    u_force: np.ndarray,
+    d: np.ndarray,
+    u: np.ndarray,
+    c: np.ndarray,
+    buf: _ScratchBuffers,
+) -> None:
+    """Pass 2: Backward recursion - compute articulated-body inertias."""
+    for i in range(nb - 1, -1, -1):
+        _aba_backward_body_inertia(
+            i,
+            dof_indices[i],
+            model_parent[i],
+            s_subspace[i],
+            tau[i],
+            xup[i],
+            ia_articulated,
+            pa_bias,
+            u_force,
+            d,
+            u,
+            c,
+            buf,
+        )
+
+
+def _aba_forward_accelerations(
+    nb: int,
+    model_parent: np.ndarray,
+    s_subspace: list[np.ndarray],
+    dof_indices: list[int],
+    xup: np.ndarray,
+    neg_a_grav: np.ndarray,
+    c: np.ndarray,
+    u_force: np.ndarray,
+    d: np.ndarray,
+    u: np.ndarray,
+    a: np.ndarray,
+    qdd: np.ndarray,
+) -> None:
+    """Pass 3: Forward recursion - compute joint and spatial accelerations."""
+    for i in range(nb):
+        if model_parent[i] == -1:
+            np.matmul(xup[i], neg_a_grav, out=a[:, i])
+            a[:, i] += c[:, i]
+        else:
+            p = model_parent[i]
+            np.matmul(xup[i], a[:, p], out=a[:, i])
+            a[:, i] += c[:, i]
+
+        qdd[i] = (u[i] - np.dot(u_force[:, i], a[:, i])) / d[i]
+
+        dof_idx = dof_indices[i]
+        if dof_idx != -1:
+            a[dof_idx, i] += qdd[i]
+        else:
+            a[:, i] += s_subspace[i] * qdd[i]
+
+
+def aba(
     model: dict,
     q: np.ndarray,
     qd: np.ndarray,
@@ -69,22 +356,7 @@ def aba(  # noqa: C901, PLR0912, PLR0915
         >>> tau = np.array([1.5, 0.5])
         >>> qdd = aba(model, q, qd, tau)
     """
-    # Use ravel() to avoid copying data when possible
-    q = np.asarray(q).ravel()
-    qd = np.asarray(qd).ravel()
-    tau = np.asarray(tau).ravel()
-
-    nb = model["NB"]
-
-    if len(q) != nb:
-        msg = f"q must have length {nb}, got {len(q)}"
-        raise ValueError(msg)
-    if len(qd) != nb:
-        msg = f"qd must have length {nb}, got {len(qd)}"
-        raise ValueError(msg)
-    if len(tau) != nb:
-        msg = f"tau must have length {nb}, got {len(tau)}"
-        raise ValueError(msg)
+    q, qd, tau, nb = _aba_validate_inputs(model, q, qd, tau)
 
     # Get gravity vector
     a_grav = model.get("gravity", DEFAULT_GRAVITY)
@@ -95,212 +367,73 @@ def aba(  # noqa: C901, PLR0912, PLR0915
         neg_a_grav = -a_grav
 
     # Initialize arrays
-    # OPTIMIZATION: Pre-allocate 3D arrays instead of lists of arrays
-    # Stores transform from body to parent for each body (NB, 6, 6)
     xup = np.empty((nb, 6, 6))
-
-    # Motion subspaces (NB, 6)
-    # Using list for subspaces is fine (refs to global constants mostly).
-    # Be careful if modifying them (jcalc returns new array/ref).
-    # Stored in list to be consistent with RNEA optimization.
     s_subspace: list[np.ndarray] = [None] * nb  # type: ignore[assignment, list-item]
     dof_indices: list[int] = [-1] * nb
 
-    # OPTIMIZATION: Use 'F' order so columns are contiguous for matmul 'out' args
-    v = np.empty((6, nb), order="F")  # Spatial velocities
-    c = np.empty((6, nb), order="F")  # Velocity-product accelerations (bias)
-
-    # Articulated-body inertias (NB, 6, 6)
-    # OPTIMIZATION: Bulk copy is faster than element-wise copy in loop
+    v = np.empty((6, nb), order="F")
+    c = np.empty((6, nb), order="F")
     ia_articulated = np.array(model["I"], dtype=float)
+    pa_bias = np.zeros((6, nb), order="F")
+    u_force = np.zeros((6, nb), order="F")
+    d = np.zeros(nb)
+    u = np.zeros(nb)
+    a = np.zeros((6, nb), order="F")
+    qdd = np.zeros(nb)
 
-    # OPTIMIZATION: Use 'F' order for these buffers too
-    pa_bias = np.zeros((6, nb), order="F")  # Articulated-body bias forces
-    u_force = np.zeros((6, nb), order="F")  # IA * S
-    d = np.zeros(nb)  # S.T @ U (joint-space inertia)
-    u = np.zeros(nb)  # tau - S.T @ pA (bias force)
-    a = np.zeros((6, nb), order="F")  # Spatial accelerations
-    qdd = np.zeros(nb)  # Joint accelerations
-
-    # Optimization: temporary buffers
-    xj_buf = np.empty((6, 6))
-    cross_buf = np.empty(6)
-    scratch_vec = np.empty(6)
-    scratch_mat = np.empty((6, 6))
-    i_v_buf = np.empty(6)
-    temp_vec = np.empty(6)  # Additional scratch vector
+    # Temporary buffers
+    buf = _ScratchBuffers.create()
 
     # OPTIMIZATION: Cache dictionary lookups to local variables
-    # This avoids repeated hashing and lookup in the tight loops
-    model_parent = model["parent"]
-    model_jtype = model["jtype"]
-    model_xtree = model["Xtree"]
-    model_inertia = model["I"]
+    mdl = _ModelCache.from_model(model)
 
     # --- Pass 1: Forward kinematics ---
-    for i in range(nb):
-        # OPTIMIZATION: Use pre-allocated buffer for jcalc
-        xj_transform, s_vec, dof_idx = jcalc(model_jtype[i], q[i], out=xj_buf)
-        s_subspace[i] = s_vec
-        dof_indices[i] = dof_idx
-
-        # OPTIMIZATION: Write directly to pre-allocated xup buffer
-        np.matmul(xj_transform, model_xtree[i], out=xup[i])
-
-        # vj_velocity = s_subspace[i] * qd[i]  # Joint velocity
-        if dof_idx != -1:
-            temp_vec.fill(0)
-            temp_vec[dof_idx] = qd[i]
-            vj_velocity = temp_vec
-        else:
-            vj_velocity = s_subspace[i] * qd[i]
-
-        if model_parent[i] == -1:
-            v[:, i] = vj_velocity
-            c[:, i] = np.zeros(6)  # No bias for base-connected bodies
-        else:
-            p = model_parent[i]
-            # v[:, i] = xup[i] @ v[:, p] + vj_velocity
-            # OPTIMIZATION: Use matmul with out directly to v[:, i]
-            np.matmul(xup[i], v[:, p], out=v[:, i])
-            v[:, i] += vj_velocity
-
-            # OPTIMIZATION: Use pre-allocated buffer for cross product
-            # Use fast version to avoid overhead
-            cross_motion_fast(v[:, i], vj_velocity, out=c[:, i])
-
-        # Bias force: Coriolis + external forces
-        # pa_bias[:, i] = cross_force(v[:, i], model["I"][i] @ v[:, i]) - f_ext[:, i]
-        # Optimization: Use temporary buffer
-        # i_v = model["I"][i] @ v[:, i]
-        np.matmul(model_inertia[i], v[:, i], out=i_v_buf)
-
-        # Use fast version to avoid overhead
-        cross_force_fast(v[:, i], i_v_buf, out=cross_buf)
-        # pa_bias[:, i] = cross_buf - f_ext[:, i]
-        if f_ext is not None:
-            np.subtract(cross_buf, f_ext[:, i], out=pa_bias[:, i])
-        else:
-            pa_bias[:, i] = cross_buf
+    _aba_forward_kinematics(
+        nb,
+        q,
+        qd,
+        f_ext,
+        mdl,
+        xup,
+        s_subspace,
+        dof_indices,
+        v,
+        c,
+        pa_bias,
+        buf,
+    )
 
     # --- Pass 2: Backward recursion (articulated-body inertias) ---
-    for i in range(nb - 1, -1, -1):
-        dof_idx = dof_indices[i]
-
-        if dof_idx != -1:
-            # Optimized: u_force is just a column of ia_articulated
-            u_force[:, i] = ia_articulated[i][:, dof_idx]
-        else:
-            np.matmul(ia_articulated[i], s_subspace[i], out=u_force[:, i])
-
-        # d[i] = s_subspace[i] @ u_force[:, i]  # Joint-space inertia
-        if dof_idx != -1:
-            d[i] = u_force[dof_idx, i]
-        else:
-            d[i] = np.dot(s_subspace[i], u_force[:, i])
-
-        # u[i] = tau[i] - s_subspace[i] @ pa_bias[:, i]  # Bias torque
-        if dof_idx != -1:
-            u[i] = tau[i] - pa_bias[dof_idx, i]
-        else:
-            u[i] = tau[i] - np.dot(s_subspace[i], pa_bias[:, i])
-
-        # Articulated-body inertia update for parent
-        if model_parent[i] != -1:
-            p = model_parent[i]
-
-            # Inverse of joint-space inertia
-            # For 1-DOF joints, this is just 1/d(i)
-            if abs(d[i]) < TOLERANCE:
-                d[i] = np.sign(d[i]) * TOLERANCE if d[i] != 0 else TOLERANCE
-
-            dinv = 1 / d[i]
-
-            # Update articulated inertia
-            # ia_update = np.outer(u_force[:, i], u_force[:, i]) * dinv
-            # ia_articulated[p] = (
-            #     ia_articulated[p] + xup[i].T @ (ia_articulated[i]-ia_update) @ xup[i]
-            # )
-
-            # OPTIMIZATION: Minimize allocations in the update
-            # 1. ia_prev = ia_articulated[i] - ia_update
-            # We can construct (ia_articulated[i] - ia_update) efficiently
-            # ia_update is rank-1.
-            # Let's compute term1 = (ia_articulated[i] - ia_update) @ xup[i]
-            # term1 = ia_articulated[i] @ xup[i] - ia_update @ xup[i]
-            # term1 = ia_articulated[i] @ xup[i] - u * (u.T @ xup[i]) * dinv
-
-            # scratch_mat = ia_articulated[i] @ xup[i]
-            np.matmul(ia_articulated[i], xup[i], out=scratch_mat)
-
-            # scratch_vec = xup[i].T @ u_force[:, i]  (equiv to u_force.T @ xup[i])
-            np.matmul(xup[i].T, u_force[:, i], out=scratch_vec)
-
-            # Subtract rank-1 update from scratch_mat
-            # scratch_mat -= np.outer(u_force[:, i] * dinv, scratch_vec)
-            # OPTIMIZATION: Avoid temporary allocations
-            np.multiply(u_force[:, i], dinv, out=temp_vec)
-            # Re-use xj_buf as temporary buffer for outer product
-            np.outer(temp_vec, scratch_vec, out=xj_buf)
-            scratch_mat -= xj_buf
-
-            # Now add xup[i].T @ scratch_mat to ia_articulated[p]
-            # This is ia_articulated[p] += xup[i].T @ scratch_mat
-            # Reuse another buffer or just accumulate directly if possible?
-            # We can reuse xj_buf as a temp buffer for the result of matmul
-            np.matmul(xup[i].T, scratch_mat, out=xj_buf)
-            ia_articulated[p] += xj_buf
-
-            # Update bias force
-            # pa_update = (
-            #     pa_bias[:, i]
-            #     + ia_articulated[i] @ c[:, i]
-            #     + u_force[:, i] * dinv * u[i]
-            # )
-            # pa_bias[:, p] = pa_bias[:, p] + xup[i].T @ pa_update
-
-            # OPTIMIZATION:
-            # 1. term = ia_articulated[i] @ c[:, i]
-            np.matmul(ia_articulated[i], c[:, i], out=scratch_vec)
-
-            # 2. Add other terms
-            scratch_vec += pa_bias[:, i]
-            # OPTIMIZATION: Avoid allocation for u_force * scalar
-            scalar = dinv * u[i]
-            np.multiply(u_force[:, i], scalar, out=temp_vec)
-            scratch_vec += temp_vec
-
-            # 3. Transform and add to parent
-            # pa_bias[:, p] += xup[i].T @ scratch_vec
-            # Re-use cross_buf as temp
-            np.matmul(xup[i].T, scratch_vec, out=cross_buf)
-            pa_bias[:, p] += cross_buf
+    _aba_backward_pass(
+        nb,
+        tau,
+        mdl.parent,
+        s_subspace,
+        dof_indices,
+        xup,
+        ia_articulated,
+        pa_bias,
+        u_force,
+        d,
+        u,
+        c,
+        buf,
+    )
 
     # --- Pass 3: Forward recursion (accelerations) ---
-    for i in range(nb):
-        if model_parent[i] == -1:
-            # For base-connected bodies, apply gravity through Xup transform
-            # a[:, i] = xup[i] @ (-a_grav) + c[:, i]
-            # Direct write to a[:, i]
-            np.matmul(xup[i], neg_a_grav, out=a[:, i])
-            a[:, i] += c[:, i]
-        else:
-            p = model_parent[i]
-            # a[:, i] = xup[i] @ a[:, p] + c[:, i]
-            # Direct write to a[:, i]
-            np.matmul(xup[i], a[:, p], out=a[:, i])
-            a[:, i] += c[:, i]
-
-        # qdd[i] = (u[i] - u_force[:, i] @ a[:, i]) / d[i]
-        qdd[i] = (u[i] - np.dot(u_force[:, i], a[:, i])) / d[i]
-
-        # a[:, i] = a[:, i] + s_subspace[i] * qdd[i]
-        dof_idx = dof_indices[i]
-        if dof_idx != -1:
-            # Optimize: a[dof_idx, i] += qdd[i]
-            # But a is (6, nb), so a[:, i] is a 1D slice.
-            a[dof_idx, i] += qdd[i]
-        else:
-            a[:, i] += s_subspace[i] * qdd[i]
+    _aba_forward_accelerations(
+        nb,
+        mdl.parent,
+        s_subspace,
+        dof_indices,
+        xup,
+        neg_a_grav,
+        c,
+        u_force,
+        d,
+        u,
+        a,
+        qdd,
+    )
 
     return qdd

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/rigid_body_dynamics/crba.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/rigid_body_dynamics/crba.py
@@ -6,6 +6,162 @@ import numpy as np
 from mujoco_humanoid_golf.spatial_algebra import jcalc
 
 
+def _crba_forward_pass(
+    nb: int,
+    model_jtype: list,
+    model_xtree: list,
+    q: np.ndarray,
+    xup: np.ndarray,
+    xup_T: np.ndarray,
+    xj_buf: np.ndarray,
+) -> tuple[list[np.ndarray], list[int]]:
+    """Forward pass: compute joint transforms and motion subspaces.
+
+    For each body, computes the joint-to-parent transform (xup) and
+    caches the motion subspace vector and DOF index from jcalc.
+
+    Args:
+        nb: Number of bodies.
+        model_jtype: Joint types list.
+        model_xtree: Joint tree transforms list.
+        q: Joint positions.
+        xup: Output array for joint-to-parent transforms (nb, 6, 6).
+        xup_T: Output array for pre-computed contiguous transposes (nb, 6, 6).
+        xj_buf: Scratch buffer for jcalc output (6, 6).
+
+    Returns:
+        Tuple of (s_subspace, dof_indices) where s_subspace is a list of
+        motion subspace vectors and dof_indices caches active DOF indices.
+    """
+    s_subspace: list[np.ndarray] = []
+    dof_indices: list[int] = []
+
+    for i in range(nb):
+        xj_transform, s_vec, dof_idx = jcalc(model_jtype[i], q[i], out=xj_buf)
+        s_subspace.append(s_vec)
+        dof_indices.append(dof_idx)
+        # Optimized xup[i] = xj_transform @ model_xtree[i]
+        np.matmul(xj_transform, model_xtree[i], out=xup[i])
+        # xup[i] is C-contiguous, .T is strided. Assigning to xup_T[i] makes it
+        # contiguous for fast usage in dot products
+        xup_T[i][:] = xup[i].T
+
+    return s_subspace, dof_indices
+
+
+def _crba_backward_pass(
+    nb: int,
+    model_parent: np.ndarray,
+    model_inertia: list,
+    xup: np.ndarray,
+    xup_T: np.ndarray,
+    tmp_6x6: np.ndarray,
+    xj_buf: np.ndarray,
+) -> np.ndarray:
+    """Backward pass: compute composite inertias by accumulating from leaves to root.
+
+    Initializes composite inertias with body inertias, then propagates each
+    body's composite inertia to its parent frame and accumulates.
+
+    Args:
+        nb: Number of bodies.
+        model_parent: Parent body indices array.
+        model_inertia: Body spatial inertias list.
+        xup: Joint-to-parent transforms (nb, 6, 6).
+        xup_T: Pre-computed contiguous transposes (nb, 6, 6).
+        tmp_6x6: Scratch buffer (6, 6).
+        xj_buf: Scratch buffer (6, 6).
+
+    Returns:
+        Composite inertia array (nb, 6, 6).
+    """
+    # OPTIMIZATION: Bulk copy to 3D array is faster than list comprehension with copy()
+    ic_composite = np.array(model_inertia, dtype=float)
+
+    for i in range(nb - 1, -1, -1):
+        if model_parent[i] != -1:
+            p = model_parent[i]
+            # ic_composite[p] += xup[i].T @ ic_composite[i] @ xup[i]
+            # OPTIMIZATION: Break down to minimize allocation using dot
+            np.dot(ic_composite[i], xup[i], out=tmp_6x6)
+            # OPTIMIZATION: Use pre-computed contiguous transpose xup_T[i]
+            np.dot(xup_T[i], tmp_6x6, out=xj_buf)
+            ic_composite[p] += xj_buf
+
+    return ic_composite
+
+
+def _crba_mass_matrix(
+    nb: int,
+    model_parent: np.ndarray,
+    ic_composite: np.ndarray,
+    s_subspace: list[np.ndarray],
+    dof_indices: list[int],
+    xup_T: np.ndarray,
+    h_matrix: np.ndarray,
+    f_force: np.ndarray,
+    scratch_vec: np.ndarray,
+) -> np.ndarray:
+    """Compute mass matrix elements using composite inertias and motion subspaces.
+
+    Fills the diagonal elements from each body's composite inertia, then
+    propagates forces up the kinematic tree to compute off-diagonal (coupling)
+    elements. The result is symmetric.
+
+    Args:
+        nb: Number of bodies.
+        model_parent: Parent body indices array.
+        ic_composite: Composite inertia array (nb, 6, 6).
+        s_subspace: Motion subspace vectors list.
+        dof_indices: Cached active DOF indices list.
+        xup_T: Pre-computed contiguous transposes (nb, 6, 6).
+        h_matrix: Output mass matrix (nb, nb), should be zero-initialized.
+        f_force: Scratch buffer for force vector (6,).
+        scratch_vec: Scratch buffer for vector operations (6,).
+
+    Returns:
+        Symmetric positive-definite mass matrix H (nb, nb).
+    """
+    for i in range(nb):
+        idx = dof_indices[i]
+        if idx != -1:
+            # OPTIMIZATION: For standard joints, s_subspace is sparse (one 1.0)
+            # f_force = ic_composite[i] @ s_subspace[i] becomes just a column copy
+            f_force[:] = ic_composite[i][:, idx]
+        else:
+            np.dot(ic_composite[i], s_subspace[i], out=f_force)
+
+        # Diagonal element
+        if idx != -1:
+            h_matrix[i, i] = f_force[idx]
+        else:
+            h_matrix[i, i] = np.dot(s_subspace[i], f_force)
+
+        # Propagate force up the tree to compute off-diagonal elements
+        j = i
+        while model_parent[j] != -1:
+            p = model_parent[j]
+
+            # Transform force to parent frame
+            # OPTIMIZATION: Use scratch buffer and pre-computed contiguous transpose
+            np.dot(xup_T[j], f_force, out=scratch_vec)
+            # Swap references to avoid copy (speedup ~15%)
+            f_force, scratch_vec = scratch_vec, f_force
+
+            # Off-diagonal element (hottest part of CRBA, O(n^2))
+            idx_p = dof_indices[p]
+            if idx_p != -1:
+                val = f_force[idx_p]
+            else:
+                val = np.dot(s_subspace[p], f_force)
+
+            h_matrix[i, p] = val
+            h_matrix[p, i] = val  # Symmetric
+            j = p
+
+    return h_matrix
+
+
 def crba(model: dict, q: np.ndarray) -> np.ndarray:
     """
     Composite Rigid Body Algorithm for computing mass matrix.
@@ -43,7 +199,6 @@ def crba(model: dict, q: np.ndarray) -> np.ndarray:
         >>> np.allclose(h_matrix, h_matrix.T)  # Check symmetry
         True
     """
-    # Use ravel() to avoid copying data when possible
     q = np.asarray(q).ravel()
 
     nb = model["NB"]
@@ -51,117 +206,40 @@ def crba(model: dict, q: np.ndarray) -> np.ndarray:
         msg = f"q must have length {nb}, got {len(q)}"
         raise ValueError(msg)
 
-    # Initialize lists (no need to pre-allocate numpy arrays since we replace them)
-    # OPTIMIZATION: Avoid allocating initial zero arrays that are immediately discarded
-    # We use lists and append to avoid Optional[np.ndarray] types for strict typing
-    xup = np.empty((nb, 6, 6))
-    # OPTIMIZATION: Pre-calculate transpose of xup to allow contiguous memory access
-    # in tight loops. xup is C-contiguous, so xup[i].T is strided (slow for np.dot).
-    # xup_T will be C-contiguous, making xup_T[i] fast for np.dot.
-    xup_T = np.empty((nb, 6, 6))
-    s_subspace: list[np.ndarray] = []
-    dof_indices: list[int] = []  # Cache active DOF indices
-
-    h_matrix = np.zeros((nb, nb))
-
-    # Pre-allocate temporary buffers to avoid allocation in loop
-    xj_buf = np.empty((6, 6))
-    tmp_6x6 = np.empty((6, 6))
-    f_force = np.empty(6)
-    scratch_vec = np.empty(6)
-
     # OPTIMIZATION: Cache dictionary lookups to local variables
-    # This avoids repeated hashing and lookup in the tight loops
     model_parent = model["parent"]
     model_jtype = model["jtype"]
     model_xtree = model["Xtree"]
     model_inertia = model["I"]
 
-    # --- Forward pass: compute transforms and motion subspaces ---
-    for i in range(nb):
-        xj_transform, s_vec, dof_idx = jcalc(model_jtype[i], q[i], out=xj_buf)
-        s_subspace.append(s_vec)
-        dof_indices.append(dof_idx)
-        # Optimized xup[i] = xj_transform @ model["Xtree"][i]
-        np.matmul(xj_transform, model_xtree[i], out=xup[i])
-        # Populate xup_T for fast usage in loops
-        # xup[i] is C-contiguous, .T is strided. Assigning to xup_T[i] makes it
-        # contiguous
-        xup_T[i][:] = xup[i].T
+    # Pre-allocate arrays and scratch buffers
+    xup = np.empty((nb, 6, 6))
+    xup_T = np.empty((nb, 6, 6))
+    h_matrix = np.zeros((nb, nb))
+    xj_buf = np.empty((6, 6))
+    tmp_6x6 = np.empty((6, 6))
+    f_force = np.empty(6)
+    scratch_vec = np.empty(6)
 
-    # --- Backward pass: compute composite inertias ---
-    # Initialize composite inertias with body inertias
-    # OPTIMIZATION: Bulk copy to 3D array is faster than list comprehension with copy()
-    # (1.48x speedup for 50 bodies)
-    ic_composite = np.array(model_inertia, dtype=float)
+    # Phase 1: Forward pass - compute transforms and motion subspaces
+    s_subspace, dof_indices = _crba_forward_pass(
+        nb, model_jtype, model_xtree, q, xup, xup_T, xj_buf
+    )
 
-    # Accumulate inertias from children to parents
-    for i in range(nb - 1, -1, -1):
-        if model_parent[i] != -1:
-            p = model_parent[i]
-            # Transform composite inertia to parent frame and add
-            # ic_composite[p] += xup[i].T @ ic_composite[i] @ xup[i]
+    # Phase 2: Backward pass - compute composite inertias
+    ic_composite = _crba_backward_pass(
+        nb, model_parent, model_inertia, xup, xup_T, tmp_6x6, xj_buf
+    )
 
-            # OPTIMIZATION: Break down to minimize allocation using dot
-            # 1. tmp_6x6 = ic_composite[i] @ xup[i]
-            np.dot(ic_composite[i], xup[i], out=tmp_6x6)
-
-            # 2. Add xup[i].T @ tmp_6x6 to ic_composite[p]
-            # Reuse xj_buf as scratch space
-            # OPTIMIZATION: Use pre-computed contiguous transpose xup_T[i]
-            np.dot(xup_T[i], tmp_6x6, out=xj_buf)
-
-            ic_composite[p] += xj_buf
-
-    # --- Compute mass matrix ---
-    # H(i,j) represents the coupling between joints i and j
-    for i in range(nb):
-        # f_force is the force transmitted through joint i due to unit acceleration
-        # at joint i, affecting the composite body rooted at i
-
-        idx = dof_indices[i]
-        if idx != -1:
-            # OPTIMIZATION: For standard joints, s_subspace is sparse (one 1.0)
-            # f_force = ic_composite[i] @ s_subspace[i] becomes just a column copy
-            # This saves 36 muls and 30 adds
-            f_force[:] = ic_composite[i][:, idx]
-        else:
-            # Fallback for generic joints
-            np.dot(ic_composite[i], s_subspace[i], out=f_force)
-
-        # h_matrix[i, i] = s_subspace[i] @ f_force  # Diagonal element
-        if idx != -1:
-            # OPTIMIZATION: sparse dot product
-            h_matrix[i, i] = f_force[idx]
-        else:
-            h_matrix[i, i] = np.dot(s_subspace[i], f_force)
-
-        # Propagate force up the tree to compute off-diagonal elements
-        j = i
-        while model_parent[j] != -1:
-            p = model_parent[j]
-
-            # f_force = xup[j].T @ f_force  # Transform force to parent frame
-            # OPTIMIZATION: Use scratch buffer and pre-computed contiguous transpose
-            # This avoids implicit temporary allocation/buffering in np.dot
-            np.dot(xup_T[j], f_force, out=scratch_vec)
-            # Swap references to avoid copy (speedup ~15%)
-            f_force, scratch_vec = scratch_vec, f_force
-
-            # h_matrix[i, p] = s_subspace[p] @ f_force  # Off-diagonal element
-            # This is the hottest part of CRBA (O(n^2))
-            idx_p = dof_indices[p]
-            if idx_p != -1:
-                # OPTIMIZATION: sparse dot product
-                val = f_force[idx_p]
-            else:
-                val = np.dot(s_subspace[p], f_force)
-
-            h_matrix[i, p] = val
-            h_matrix[p, i] = val  # Symmetric
-            j = p
-
-    # Ensure exact symmetry (numerical precision) - optional but safe
-    # Also cleans up any tiny asymmetries
-    # OPTIMIZATION: Using h_matrix directly as we fill symmetric elements manually
-    return h_matrix
+    # Phase 3: Compute mass matrix from composite inertias
+    return _crba_mass_matrix(
+        nb,
+        model_parent,
+        ic_composite,
+        s_subspace,
+        dof_indices,
+        xup_T,
+        h_matrix,
+        f_force,
+        scratch_vec,
+    )

--- a/src/launchers/golf_suite_launcher.py
+++ b/src/launchers/golf_suite_launcher.py
@@ -85,103 +85,86 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
 
         self._setup_ui()
 
-    def _setup_ui(self) -> None:
-        central = QtWidgets.QWidget()
-        self.setCentralWidget(central)
-        layout = QtWidgets.QVBoxLayout(central)
+    def _create_engine_button(
+        self,
+        label: str,
+        tooltip: str,
+        accessible_name: str,
+        slot: object,
+        icon_pixmap: QtWidgets.QStyle.StandardPixmap = QtWidgets.QStyle.StandardPixmap.SP_MediaPlay,
+    ) -> QtWidgets.QPushButton:
+        """Create a standard engine launch button."""
+        btn = QtWidgets.QPushButton(label)
+        btn.setMinimumHeight(40)
+        btn.setIcon(self.style().standardIcon(icon_pixmap))
+        btn.setToolTip(tooltip)
+        btn.setAccessibleName(accessible_name)
+        btn.clicked.connect(slot)
+        return btn
 
-        title = QtWidgets.QLabel("Golf Modeling Suite (Local)")
-        title.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        font = title.font()
-        font.setPointSize(16)
-        font.setBold(True)
-        title.setFont(font)
-        layout.addWidget(title)
-
-        subtitle = QtWidgets.QLabel(
-            "Launches physics engines using local python environment"
+    def _setup_engine_buttons(self, layout: QtWidgets.QVBoxLayout) -> None:
+        """Create and add all engine launch buttons to the layout."""
+        self.btn_mujoco = self._create_engine_button(
+            "Launch &MuJoCo Engine",
+            "Launch the MuJoCo physics engine interface",
+            "Launch MuJoCo",
+            self._launch_mujoco,
         )
-        subtitle.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(subtitle)
-
-        layout.addSpacing(20)
-
-        # Buttons
-        self.btn_mujoco = QtWidgets.QPushButton("Launch &MuJoCo Engine")
-        self.btn_mujoco.setMinimumHeight(40)
-        self.btn_mujoco.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
-        )
-        self.btn_mujoco.setToolTip("Launch the MuJoCo physics engine interface")
-        self.btn_mujoco.setAccessibleName("Launch MuJoCo")
-        self.btn_mujoco.clicked.connect(self._launch_mujoco)
         layout.addWidget(self.btn_mujoco)
 
-        self.btn_drake = QtWidgets.QPushButton("Launch &Drake Engine")
-        self.btn_drake.setMinimumHeight(40)
-        self.btn_drake.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        self.btn_drake = self._create_engine_button(
+            "Launch &Drake Engine",
+            "Launch the Drake physics engine interface",
+            "Launch Drake",
+            self._launch_drake,
         )
-        self.btn_drake.setToolTip("Launch the Drake physics engine interface")
-        self.btn_drake.setAccessibleName("Launch Drake")
-        self.btn_drake.clicked.connect(self._launch_drake)
         layout.addWidget(self.btn_drake)
 
-        self.btn_pinocchio = QtWidgets.QPushButton("Launch &Pinocchio Engine")
-        self.btn_pinocchio.setMinimumHeight(40)
-        self.btn_pinocchio.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        self.btn_pinocchio = self._create_engine_button(
+            "Launch &Pinocchio Engine",
+            "Launch the Pinocchio physics engine interface",
+            "Launch Pinocchio",
+            self._launch_pinocchio,
         )
-        self.btn_pinocchio.setToolTip("Launch the Pinocchio physics engine interface")
-        self.btn_pinocchio.setAccessibleName("Launch Pinocchio")
-        self.btn_pinocchio.clicked.connect(self._launch_pinocchio)
         layout.addWidget(self.btn_pinocchio)
 
-        self.btn_opensim = QtWidgets.QPushButton("Launch &OpenSim Golf")
-        self.btn_opensim.setMinimumHeight(40)
-        self.btn_opensim.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        self.btn_opensim = self._create_engine_button(
+            "Launch &OpenSim Golf",
+            "Launch OpenSim musculoskeletal modeling",
+            "Launch OpenSim",
+            self._launch_opensim,
         )
-        self.btn_opensim.setToolTip("Launch OpenSim musculoskeletal modeling")
-        self.btn_opensim.setAccessibleName("Launch OpenSim")
-        self.btn_opensim.clicked.connect(self._launch_opensim)
         layout.addWidget(self.btn_opensim)
 
-        self.btn_myosim = QtWidgets.QPushButton("Launch &MyoSim Suite")
-        self.btn_myosim.setMinimumHeight(40)
-        self.btn_myosim.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        self.btn_myosim = self._create_engine_button(
+            "Launch &MyoSim Suite",
+            "Launch MyoSuite muscle-actuated simulation",
+            "Launch MyoSim",
+            self._launch_myosim,
         )
-        self.btn_myosim.setToolTip("Launch MyoSuite muscle-actuated simulation")
-        self.btn_myosim.setAccessibleName("Launch MyoSim")
-        self.btn_myosim.clicked.connect(self._launch_myosim)
         layout.addWidget(self.btn_myosim)
 
-        self.btn_openpose = QtWidgets.QPushButton("Launch Open&Pose Analysis")
-        self.btn_openpose.setMinimumHeight(40)
-        self.btn_openpose.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay)
+        self.btn_openpose = self._create_engine_button(
+            "Launch Open&Pose Analysis",
+            "Launch Pose estimation and motion capture",
+            "Launch OpenPose",
+            self._launch_openpose,
         )
-        self.btn_openpose.setToolTip("Launch Pose estimation and motion capture")
-        self.btn_openpose.setAccessibleName("Launch OpenPose")
-        self.btn_openpose.clicked.connect(self._launch_openpose)
         layout.addWidget(self.btn_openpose)
 
-        self.btn_urdf = QtWidgets.QPushButton("Launch &URDF Generator")
-        self.btn_urdf.setMinimumHeight(40)
-        self.btn_urdf.setIcon(
-            self.style().standardIcon(
-                QtWidgets.QStyle.StandardPixmap.SP_ToolBarHorizontalExtensionButton
-            )
+        self.btn_urdf = self._create_engine_button(
+            "Launch &URDF Generator",
+            "Launch Interactive URDF model builder",
+            "Launch URDF Generator",
+            self._launch_urdf,
+            icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_ToolBarHorizontalExtensionButton,
         )
-        self.btn_urdf.setToolTip("Launch Interactive URDF model builder")
-        self.btn_urdf.setAccessibleName("Launch URDF Generator")
-        self.btn_urdf.clicked.connect(self._launch_urdf)
         layout.addWidget(self.btn_urdf)
 
+    def _setup_shot_tracer_section(self, layout: QtWidgets.QVBoxLayout) -> None:
+        """Add separator and shot tracer button to the layout."""
         layout.addSpacing(10)
 
-        # Separator
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.Shape.HLine)
         separator.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
@@ -189,22 +172,19 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
 
         layout.addSpacing(10)
 
-        # Shot Tracer - Ball Flight Visualization
-        self.btn_shot_tracer = QtWidgets.QPushButton("Launch &Shot Tracer")
-        self.btn_shot_tracer.setMinimumHeight(40)
-        self.btn_shot_tracer.setIcon(
-            self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_ArrowForward)
+        self.btn_shot_tracer = self._create_engine_button(
+            "Launch &Shot Tracer",
+            "Launch the ball flight visualization (Waterloo/Penner model)",
+            "Launch Shot Tracer",
+            self._launch_shot_tracer,
+            icon_pixmap=QtWidgets.QStyle.StandardPixmap.SP_ArrowForward,
         )
-        self.btn_shot_tracer.setToolTip(
-            "Launch the ball flight visualization (Waterloo/Penner model)"
-        )
-        self.btn_shot_tracer.setAccessibleName("Launch Shot Tracer")
-        self.btn_shot_tracer.clicked.connect(self._launch_shot_tracer)
         layout.addWidget(self.btn_shot_tracer)
 
+    def _setup_log_area(self, layout: QtWidgets.QVBoxLayout) -> None:
+        """Create the simulation log group box with copy/clear controls."""
         layout.addSpacing(20)
 
-        # Log area
         log_group = QtWidgets.QGroupBox("Simulation Log")
         log_layout = QtWidgets.QVBoxLayout(log_group)
 
@@ -245,6 +225,36 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
 
         log_layout.addLayout(log_controls)
         layout.addWidget(log_group)
+
+    def _setup_ui(self) -> None:
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        layout = QtWidgets.QVBoxLayout(central)
+
+        title = QtWidgets.QLabel("Golf Modeling Suite (Local)")
+        title.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        font = title.font()
+        font.setPointSize(16)
+        font.setBold(True)
+        title.setFont(font)
+        layout.addWidget(title)
+
+        subtitle = QtWidgets.QLabel(
+            "Launches physics engines using local python environment"
+        )
+        subtitle.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(subtitle)
+
+        layout.addSpacing(20)
+
+        # Engine launch buttons
+        self._setup_engine_buttons(layout)
+
+        # Shot tracer section with separator
+        self._setup_shot_tracer_section(layout)
+
+        # Log area with copy/clear controls
+        self._setup_log_area(layout)
 
         layout.addStretch()
 
@@ -338,9 +348,7 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
         try:
             # Launch detached process
             # Use same python interpreter
-            process = subprocess.Popen(
-                [sys.executable, str(path)], cwd=str(cwd)
-            )  # noqa: S603
+            process = subprocess.Popen([sys.executable, str(path)], cwd=str(cwd))  # noqa: S603
             self.log_message(f"{name} launched successfully (PID: {process.pid})")
             self.status.setText(f"{name} Launched")
         except (OSError, subprocess.SubprocessError) as e:

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -201,15 +201,8 @@ class LauncherUISetupMixin:
         action_about.triggered.connect(self._show_about_dialog)
         help_menu.addAction(action_about)
 
-    def _setup_top_bar(self) -> QHBoxLayout:
-        """Set up the top tool bar."""
-        from src.launchers.launcher_constants import (
-            AI_AVAILABLE,
-            HELP_SYSTEM_AVAILABLE,
-        )
-
-        top_bar = QHBoxLayout()
-
+    def _setup_top_bar_status_and_search(self, top_bar: QHBoxLayout) -> None:
+        """Add status indicator, execution mode label, and search bar to top bar."""
         # Status Indicator
         self.lbl_status = QLabel("Checking Docker...")
         self.lbl_status.setStyleSheet("color: #aaaaaa; font-weight: bold;")
@@ -237,7 +230,8 @@ class LauncherUISetupMixin:
         self.search_input.textChanged.connect(self.update_search_filter)
         top_bar.addWidget(self.search_input)
 
-        # Hidden configuration checkboxes
+    def _setup_top_bar_config_checkboxes(self) -> None:
+        """Create hidden configuration checkboxes and layout controls."""
         self.chk_live = QCheckBox("Live Viz")
         self.chk_live.setChecked(True)
 
@@ -261,6 +255,10 @@ class LauncherUISetupMixin:
         self.btn_customize_tiles = QPushButton("Edit Tiles")
         self.btn_customize_tiles.setEnabled(False)
         self.btn_customize_tiles.clicked.connect(self.open_layout_manager)
+
+    def _setup_top_bar_action_buttons(self, top_bar: QHBoxLayout) -> None:
+        """Add Help, Settings, and AI Assistant buttons to top bar."""
+        from src.launchers.launcher_constants import AI_AVAILABLE
 
         btn_help = QPushButton("Help")
         btn_help.setToolTip("View documentation and user guide (F1)")
@@ -316,37 +314,53 @@ class LauncherUISetupMixin:
                 """)
             top_bar.addWidget(self.btn_ai)
 
+    def _register_top_bar_tooltips(self) -> None:
+        """Register enhanced tooltips for configuration checkboxes."""
+        from src.launchers.launcher_constants import HELP_SYSTEM_AVAILABLE
+
+        if not HELP_SYSTEM_AVAILABLE:
+            return
+
+        from src.shared.python.gui_pkg.help_system import TooltipManager
+
+        TooltipManager.register_tooltip(
+            self.chk_live,
+            "Live Visualization",
+            "Enable real-time 3D visualization during simulation.",
+            "visualization",
+        )
+        TooltipManager.register_tooltip(
+            self.chk_gpu,
+            "GPU Acceleration",
+            "Use GPU for physics computation when available.",
+            "engine_selection",
+        )
+        TooltipManager.register_tooltip(
+            self.chk_docker,
+            "Docker Mode",
+            "Run physics engines in Docker containers.",
+            "engine_selection",
+        )
+        TooltipManager.register_tooltip(
+            self.chk_wsl,
+            "WSL Mode",
+            "Run in WSL2 Ubuntu environment for full Linux engine support.",
+            "engine_selection",
+        )
+
+    def _setup_top_bar(self) -> QHBoxLayout:
+        """Set up the top tool bar."""
+        top_bar = QHBoxLayout()
+
+        self._setup_top_bar_status_and_search(top_bar)
+        self._setup_top_bar_config_checkboxes()
+        self._setup_top_bar_action_buttons(top_bar)
+
         # Context Help Dock
         self._setup_context_help()
 
         # Register enhanced tooltips
-        if HELP_SYSTEM_AVAILABLE:
-            from src.shared.python.gui_pkg.help_system import TooltipManager
-
-            TooltipManager.register_tooltip(
-                self.chk_live,
-                "Live Visualization",
-                "Enable real-time 3D visualization during simulation.",
-                "visualization",
-            )
-            TooltipManager.register_tooltip(
-                self.chk_gpu,
-                "GPU Acceleration",
-                "Use GPU for physics computation when available.",
-                "engine_selection",
-            )
-            TooltipManager.register_tooltip(
-                self.chk_docker,
-                "Docker Mode",
-                "Run physics engines in Docker containers.",
-                "engine_selection",
-            )
-            TooltipManager.register_tooltip(
-                self.chk_wsl,
-                "WSL Mode",
-                "Run in WSL2 Ubuntu environment for full Linux engine support.",
-                "engine_selection",
-            )
+        self._register_top_bar_tooltips()
 
         return top_bar
 

--- a/src/shared/python/ai/education.py
+++ b/src/shared/python/ai/education.py
@@ -62,385 +62,388 @@ class GlossaryEntry:
         return f"Definition for '{self.term}' not available."
 
 
-def _build_default_glossary() -> dict[str, GlossaryEntry]:
-    """Build the default glossary with core biomechanics terms.
+def _build_dynamics_entries() -> dict[str, GlossaryEntry]:
+    """Return inline glossary entries for dynamics concepts."""
+    return {
+        "inverse_dynamics": GlossaryEntry(
+            term="Inverse Dynamics",
+            category="dynamics",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "A way to figure out what forces caused a movement. "
+                    "By watching how someone moved, we can calculate the "
+                    "muscle forces they must have used. Think of it like "
+                    "being a detective - seeing the result and working backwards "
+                    "to find the cause."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "A computational method that calculates joint torques from "
+                    "measured kinematics. Given positions, velocities, and accelerations, "
+                    "inverse dynamics solves for the net torques at each joint."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "The solution of τ = M(q)q̈ + C(q,q̇)q̇ + g(q) for joint torques τ, "
+                    "given measured generalized coordinates q and their derivatives. "
+                    "Requires accurate segment inertial properties."
+                ),
+                ExpertiseLevel.EXPERT: (
+                    "Recursive Newton-Euler formulation: outward kinematics sweep "
+                    "followed by inward dynamics sweep. O(n) complexity for n bodies. "
+                    "Sensitive to noise amplification from numerical differentiation."
+                ),
+            },
+            formula="τ = M(q)q̈ + C(q,q̇) + g(q)",
+            units="N·m",
+            related_terms=["forward_dynamics", "joint_torque", "equations_of_motion"],
+        ),
+        "forward_dynamics": GlossaryEntry(
+            term="Forward Dynamics",
+            category="dynamics",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "Predicting how something will move when you apply forces. "
+                    "Like pushing a swing - you know how hard you pushed, "
+                    "and forward dynamics tells you how the swing will move."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Calculating motion from applied forces. Given joint torques, "
+                    "forward dynamics computes the resulting accelerations, which "
+                    "can be integrated to get velocities and positions."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Solving q̈ = M(q)⁻¹ [τ - C(q,q̇)q̇ - g(q)] for accelerations. "
+                    "Requires mass matrix inversion, typically using Cholesky decomposition."
+                ),
+            },
+            formula="q̈ = M(q)⁻¹ [τ - C(q,q̇) - g(q)]",
+            units="rad/s²",
+            related_terms=["inverse_dynamics", "simulation", "equations_of_motion"],
+        ),
+        "joint_torque": GlossaryEntry(
+            term="Joint Torque",
+            category="dynamics",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "The rotational force at a joint, like your elbow or knee. "
+                    "When you curl a weight, your bicep creates torque at your elbow. "
+                    "More torque means more rotational power."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "The net rotational force acting about a joint axis. "
+                    "Represents the sum of all muscle, ligament, and contact forces "
+                    "causing rotation at that joint."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Generalized force corresponding to a rotational degree of freedom. "
+                    "In inverse dynamics, it's the torque required to produce "
+                    "the observed angular acceleration given the inertial properties."
+                ),
+            },
+            units="N·m (Newton-meters)",
+            related_terms=["inverse_dynamics", "muscle_force", "moment_of_inertia"],
+        ),
+    }
 
-    Returns:
-        Dictionary mapping term names to GlossaryEntry objects.
+
+def _build_kinematics_data_entries() -> dict[str, GlossaryEntry]:
+    """Return inline glossary entries for kinematics and data concepts."""
+    return {
+        "kinematics": GlossaryEntry(
+            term="Kinematics",
+            category="kinematics",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "The study of motion without worrying about forces. "
+                    "It's about describing HOW things move - positions, speeds, "
+                    "and how fast things speed up or slow down."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "The branch of mechanics describing motion through degrees of "
+                    "freedom (joints) without considering forces. Includes position, "
+                    "velocity, and acceleration analysis."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Configuration space analysis: generalized coordinates q(t), "
+                    "generalized velocities q̇(t), and accelerations q̈(t). "
+                    "Foundation for dynamics computations."
+                ),
+            },
+            related_terms=["dynamics", "motion_capture", "joint_angles"],
+        ),
+        "c3d_file": GlossaryEntry(
+            term="C3D File",
+            category="data",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "A file format for storing motion capture data. "
+                    "Contains the 3D positions of markers placed on a person's body "
+                    "during movement, recorded many times per second."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "The standard binary format for 3D biomechanics data. "
+                    "Stores marker trajectories, analog data (like force plates), "
+                    "and metadata about the recording."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Binary format per Motion Lab Systems specification. "
+                    "Contains header (512 bytes), parameter section, and data section. "
+                    "Supports up to 65535 frames and multiple point/analog channels."
+                ),
+            },
+            related_terms=["motion_capture", "marker", "force_plate"],
+        ),
+        "marker": GlossaryEntry(
+            term="Marker",
+            category="data",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "Small reflective balls placed on the body during motion capture. "
+                    "Special cameras track these markers to record exactly how "
+                    "the body moved in 3D space."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Retro-reflective spheres (typically 10-25mm) placed at anatomical "
+                    "landmarks. Their 3D positions are tracked by infrared cameras "
+                    "to reconstruct body motion."
+                ),
+            },
+            related_terms=["c3d_file", "motion_capture", "anatomical_landmark"],
+        ),
+    }
+
+
+def _build_golf_entries() -> dict[str, GlossaryEntry]:
+    """Return inline glossary entries for golf-specific concepts."""
+    return {
+        "kinetic_chain": GlossaryEntry(
+            term="Kinetic Chain",
+            category="golf",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "How energy flows through your body during a golf swing. "
+                    "Power starts from your legs and ground contact, moves through "
+                    "your hips, torso, arms, and finally to the club head."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "The sequential activation and energy transfer from proximal "
+                    "to distal segments. In golf: lower body → trunk → arms → club. "
+                    "Proper timing maximizes club head speed."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Proximal-to-distal kinetic sequence enabling efficient "
+                    "angular momentum transfer. Peak angular velocities occur "
+                    "sequentially: pelvis → thorax → arm → club. "
+                    "Timing disruption reduces performance ~20%."
+                ),
+            },
+            related_terms=["x_factor", "ground_reaction_force", "club_head_speed"],
+        ),
+        "x_factor": GlossaryEntry(
+            term="X-Factor",
+            category="golf",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "The twist between your hips and shoulders at the top of the swing. "
+                    "A bigger X-Factor means you've stored more rotational energy, "
+                    "which can translate to more power."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "The difference between thorax and pelvis rotation angles "
+                    "at the top of backswing. Associated with increased club head speed, "
+                    "though individual optimal values vary."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Angular separation between thorax and pelvis in the transverse plane. "
+                    "Elite PGA: 45-55°. X-Factor Stretch (additional separation into "
+                    "downswing) correlates r=0.7 with ball speed."
+                ),
+            },
+            units="degrees",
+            related_terms=["kinetic_chain", "ground_reaction_force", "club_head_speed"],
+        ),
+        "ground_reaction_force": GlossaryEntry(
+            term="Ground Reaction Force (GRF)",
+            category="forces",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "The push-back from the ground when you push against it. "
+                    "In golf, you push down and the ground pushes back up and "
+                    "sideways, helping you rotate powerfully."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Forces measured by force plates during ground contact. "
+                    "Components: vertical (support weight + acceleration), "
+                    "anterior-posterior, and medio-lateral. Key for understanding "
+                    "how power originates from the ground."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Vector sum of distributed ground pressures. Analyzed as: "
+                    "vertical Fz (typically 1.2-1.5 BW at impact), "
+                    "shear forces Fx/Fy, and center of pressure trajectory. "
+                    "Moment about vertical axis indicates rotational demand."
+                ),
+            },
+            units="N or BW (Body Weight)",
+            related_terms=["kinetic_chain", "force_plate", "center_of_pressure"],
+        ),
+    }
+
+
+def _build_simulation_entries() -> dict[str, GlossaryEntry]:
+    """Return inline glossary entries for physics engine / simulation concepts."""
+    return {
+        "physics_engine": GlossaryEntry(
+            term="Physics Engine",
+            category="simulation",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "Software that simulates how things move and interact, "
+                    "like a virtual physics lab. The Golf Modeling Suite uses "
+                    "several engines to cross-check results for accuracy."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Software library implementing rigid body dynamics. "
+                    "Handles contact, constraints, and integration. "
+                    "Examples: MuJoCo, Drake, Pinocchio."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Numerical solver for constrained multibody dynamics. "
+                    "Core algorithms: articulated body (Featherstone), "
+                    "projected Gauss-Seidel for contacts. Time-stepping via "
+                    "symplectic Euler or semi-implicit RK."
+                ),
+            },
+            related_terms=["mujoco", "drake", "pinocchio", "simulation"],
+        ),
+        "mujoco": GlossaryEntry(
+            term="MuJoCo",
+            category="simulation",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "One of the physics engines we use. It's especially good at "
+                    "handling contacts (like feet on ground or hands on club)."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Multi-Joint dynamics with Contact. Physics engine optimized "
+                    "for robotics and biomechanics. Uses convex contact dynamics "
+                    "and implicit integration."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Recursive dynamics with complementarity contact model. "
+                    "PGS solver for contact forces. GPU-accelerated with MJX. "
+                    "Muscle models: first-order activation dynamics."
+                ),
+            },
+            see_also=["https://mujoco.org"],
+            related_terms=["physics_engine", "drake", "pinocchio"],
+        ),
+        "drake": GlossaryEntry(
+            term="Drake",
+            category="simulation",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "Another physics engine we use. It's especially good at "
+                    "optimization and ensuring physical consistency."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Model-Based Design for Robotics. MIT-developed toolkit for "
+                    "dynamics, control, and optimization. Uses symbolic computation "
+                    "for model analysis."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "AutoDiff-enabled multibody dynamics. Direct collocation "
+                    "and SNOPT integration for trajectory optimization. "
+                    "Focuses on mathematical rigor and guarantees."
+                ),
+            },
+            see_also=["https://drake.mit.edu"],
+            related_terms=["physics_engine", "mujoco", "pinocchio"],
+        ),
+        "pinocchio": GlossaryEntry(
+            term="Pinocchio",
+            category="simulation",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "A lightweight physics engine we use for fast calculations. "
+                    "Named after the famous puppet, it handles articulated bodies."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Efficient rigid body dynamics library. Implements Featherstone's "
+                    "algorithms with analytical derivatives. Focus on speed and "
+                    "differentiability."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "O(n) spatial algebra implementation. Supports CasADi and "
+                    "Ceres for automatic differentiation. Second-order derivatives "
+                    "for optimal control."
+                ),
+            },
+            see_also=["https://github.com/stack-of-tasks/pinocchio"],
+            related_terms=["physics_engine", "mujoco", "drake"],
+        ),
+    }
+
+
+def _build_validation_analysis_entries() -> dict[str, GlossaryEntry]:
+    """Return inline glossary entries for validation and analysis concepts."""
+    return {
+        "cross_engine_validation": GlossaryEntry(
+            term="Cross-Engine Validation",
+            category="validation",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "Checking our results are correct by running the same analysis "
+                    "on multiple physics engines. If they all agree, we can be "
+                    "confident the results are accurate."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Verification method comparing results across MuJoCo, Drake, "
+                    "and Pinocchio. Agreement within tolerance indicates reliable "
+                    "results. Disagreement signals potential issues."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Ensemble validation using heterogeneous solvers. "
+                    "Tolerance thresholds: τ ± 2%, KE ± 0.5%, position ± 1e-6. "
+                    "Discrepancies often indicate contact model differences."
+                ),
+            },
+            related_terms=["physics_engine", "tolerance", "validation"],
+        ),
+        "drift_control_decomposition": GlossaryEntry(
+            term="Drift-Control Decomposition",
+            category="analysis",
+            definitions={
+                ExpertiseLevel.BEGINNER: (
+                    "A way to understand which part of motion is 'passive' "
+                    "(would happen without muscles) versus 'controlled' "
+                    "(actively driven by muscles). Helps identify when "
+                    "muscles are really working versus just going along for the ride."
+                ),
+                ExpertiseLevel.INTERMEDIATE: (
+                    "Separating motion into: drift (gravity, inertia, passive dynamics) "
+                    "and control (active muscle contribution). The Drift-Control Ratio "
+                    "indicates how much active control a movement requires."
+                ),
+                ExpertiseLevel.ADVANCED: (
+                    "Affine decomposition: q̈ = drift(q, q̇) + B(q)u. "
+                    "Control contribution from null-space of drift solutions. "
+                    "DCR = ||control|| / (||drift|| + ||control||). "
+                    "Low DCR → gravity-assisted; High DCR → muscle-dominated."
+                ),
+            },
+            formula="DCR = ||control|| / (||drift|| + ||control||)",
+            related_terms=["inverse_dynamics", "muscle_contribution", "energy"],
+        ),
+    }
+
+
+def _load_data_file_entries(
+    glossary: dict[str, GlossaryEntry],
+) -> None:
+    """Load glossary entries from external data files into *glossary*.
+
+    Entries already present (inline definitions) are not overwritten.
     """
-    glossary: dict[str, GlossaryEntry] = {}
-
-    # === DYNAMICS ===
-
-    glossary["inverse_dynamics"] = GlossaryEntry(
-        term="Inverse Dynamics",
-        category="dynamics",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "A way to figure out what forces caused a movement. "
-                "By watching how someone moved, we can calculate the "
-                "muscle forces they must have used. Think of it like "
-                "being a detective - seeing the result and working backwards "
-                "to find the cause."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "A computational method that calculates joint torques from "
-                "measured kinematics. Given positions, velocities, and accelerations, "
-                "inverse dynamics solves for the net torques at each joint."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "The solution of τ = M(q)q̈ + C(q,q̇)q̇ + g(q) for joint torques τ, "
-                "given measured generalized coordinates q and their derivatives. "
-                "Requires accurate segment inertial properties."
-            ),
-            ExpertiseLevel.EXPERT: (
-                "Recursive Newton-Euler formulation: outward kinematics sweep "
-                "followed by inward dynamics sweep. O(n) complexity for n bodies. "
-                "Sensitive to noise amplification from numerical differentiation."
-            ),
-        },
-        formula="τ = M(q)q̈ + C(q,q̇) + g(q)",
-        units="N·m",
-        related_terms=["forward_dynamics", "joint_torque", "equations_of_motion"],
-    )
-
-    glossary["forward_dynamics"] = GlossaryEntry(
-        term="Forward Dynamics",
-        category="dynamics",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "Predicting how something will move when you apply forces. "
-                "Like pushing a swing - you know how hard you pushed, "
-                "and forward dynamics tells you how the swing will move."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Calculating motion from applied forces. Given joint torques, "
-                "forward dynamics computes the resulting accelerations, which "
-                "can be integrated to get velocities and positions."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Solving q̈ = M(q)⁻¹ [τ - C(q,q̇)q̇ - g(q)] for accelerations. "
-                "Requires mass matrix inversion, typically using Cholesky decomposition."
-            ),
-        },
-        formula="q̈ = M(q)⁻¹ [τ - C(q,q̇) - g(q)]",
-        units="rad/s²",
-        related_terms=["inverse_dynamics", "simulation", "equations_of_motion"],
-    )
-
-    glossary["joint_torque"] = GlossaryEntry(
-        term="Joint Torque",
-        category="dynamics",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "The rotational force at a joint, like your elbow or knee. "
-                "When you curl a weight, your bicep creates torque at your elbow. "
-                "More torque means more rotational power."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "The net rotational force acting about a joint axis. "
-                "Represents the sum of all muscle, ligament, and contact forces "
-                "causing rotation at that joint."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Generalized force corresponding to a rotational degree of freedom. "
-                "In inverse dynamics, it's the torque required to produce "
-                "the observed angular acceleration given the inertial properties."
-            ),
-        },
-        units="N·m (Newton-meters)",
-        related_terms=["inverse_dynamics", "muscle_force", "moment_of_inertia"],
-    )
-
-    # === KINEMATICS ===
-
-    glossary["kinematics"] = GlossaryEntry(
-        term="Kinematics",
-        category="kinematics",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "The study of motion without worrying about forces. "
-                "It's about describing HOW things move - positions, speeds, "
-                "and how fast things speed up or slow down."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "The branch of mechanics describing motion through degrees of "
-                "freedom (joints) without considering forces. Includes position, "
-                "velocity, and acceleration analysis."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Configuration space analysis: generalized coordinates q(t), "
-                "generalized velocities q̇(t), and accelerations q̈(t). "
-                "Foundation for dynamics computations."
-            ),
-        },
-        related_terms=["dynamics", "motion_capture", "joint_angles"],
-    )
-
-    glossary["c3d_file"] = GlossaryEntry(
-        term="C3D File",
-        category="data",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "A file format for storing motion capture data. "
-                "Contains the 3D positions of markers placed on a person's body "
-                "during movement, recorded many times per second."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "The standard binary format for 3D biomechanics data. "
-                "Stores marker trajectories, analog data (like force plates), "
-                "and metadata about the recording."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Binary format per Motion Lab Systems specification. "
-                "Contains header (512 bytes), parameter section, and data section. "
-                "Supports up to 65535 frames and multiple point/analog channels."
-            ),
-        },
-        related_terms=["motion_capture", "marker", "force_plate"],
-    )
-
-    glossary["marker"] = GlossaryEntry(
-        term="Marker",
-        category="data",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "Small reflective balls placed on the body during motion capture. "
-                "Special cameras track these markers to record exactly how "
-                "the body moved in 3D space."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Retro-reflective spheres (typically 10-25mm) placed at anatomical "
-                "landmarks. Their 3D positions are tracked by infrared cameras "
-                "to reconstruct body motion."
-            ),
-        },
-        related_terms=["c3d_file", "motion_capture", "anatomical_landmark"],
-    )
-
-    # === GOLF-SPECIFIC ===
-
-    glossary["kinetic_chain"] = GlossaryEntry(
-        term="Kinetic Chain",
-        category="golf",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "How energy flows through your body during a golf swing. "
-                "Power starts from your legs and ground contact, moves through "
-                "your hips, torso, arms, and finally to the club head."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "The sequential activation and energy transfer from proximal "
-                "to distal segments. In golf: lower body → trunk → arms → club. "
-                "Proper timing maximizes club head speed."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Proximal-to-distal kinetic sequence enabling efficient "
-                "angular momentum transfer. Peak angular velocities occur "
-                "sequentially: pelvis → thorax → arm → club. "
-                "Timing disruption reduces performance ~20%."
-            ),
-        },
-        related_terms=["x_factor", "ground_reaction_force", "club_head_speed"],
-    )
-
-    glossary["x_factor"] = GlossaryEntry(
-        term="X-Factor",
-        category="golf",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "The twist between your hips and shoulders at the top of the swing. "
-                "A bigger X-Factor means you've stored more rotational energy, "
-                "which can translate to more power."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "The difference between thorax and pelvis rotation angles "
-                "at the top of backswing. Associated with increased club head speed, "
-                "though individual optimal values vary."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Angular separation between thorax and pelvis in the transverse plane. "
-                "Elite PGA: 45-55°. X-Factor Stretch (additional separation into "
-                "downswing) correlates r=0.7 with ball speed."
-            ),
-        },
-        units="degrees",
-        related_terms=["kinetic_chain", "ground_reaction_force", "club_head_speed"],
-    )
-
-    glossary["ground_reaction_force"] = GlossaryEntry(
-        term="Ground Reaction Force (GRF)",
-        category="forces",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "The push-back from the ground when you push against it. "
-                "In golf, you push down and the ground pushes back up and "
-                "sideways, helping you rotate powerfully."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Forces measured by force plates during ground contact. "
-                "Components: vertical (support weight + acceleration), "
-                "anterior-posterior, and medio-lateral. Key for understanding "
-                "how power originates from the ground."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Vector sum of distributed ground pressures. Analyzed as: "
-                "vertical Fz (typically 1.2-1.5 BW at impact), "
-                "shear forces Fx/Fy, and center of pressure trajectory. "
-                "Moment about vertical axis indicates rotational demand."
-            ),
-        },
-        units="N or BW (Body Weight)",
-        related_terms=["kinetic_chain", "force_plate", "center_of_pressure"],
-    )
-
-    # === PHYSICS ENGINES ===
-
-    glossary["physics_engine"] = GlossaryEntry(
-        term="Physics Engine",
-        category="simulation",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "Software that simulates how things move and interact, "
-                "like a virtual physics lab. The Golf Modeling Suite uses "
-                "several engines to cross-check results for accuracy."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Software library implementing rigid body dynamics. "
-                "Handles contact, constraints, and integration. "
-                "Examples: MuJoCo, Drake, Pinocchio."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Numerical solver for constrained multibody dynamics. "
-                "Core algorithms: articulated body (Featherstone), "
-                "projected Gauss-Seidel for contacts. Time-stepping via "
-                "symplectic Euler or semi-implicit RK."
-            ),
-        },
-        related_terms=["mujoco", "drake", "pinocchio", "simulation"],
-    )
-
-    glossary["mujoco"] = GlossaryEntry(
-        term="MuJoCo",
-        category="simulation",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "One of the physics engines we use. It's especially good at "
-                "handling contacts (like feet on ground or hands on club)."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Multi-Joint dynamics with Contact. Physics engine optimized "
-                "for robotics and biomechanics. Uses convex contact dynamics "
-                "and implicit integration."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Recursive dynamics with complementarity contact model. "
-                "PGS solver for contact forces. GPU-accelerated with MJX. "
-                "Muscle models: first-order activation dynamics."
-            ),
-        },
-        see_also=["https://mujoco.org"],
-        related_terms=["physics_engine", "drake", "pinocchio"],
-    )
-
-    glossary["drake"] = GlossaryEntry(
-        term="Drake",
-        category="simulation",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "Another physics engine we use. It's especially good at "
-                "optimization and ensuring physical consistency."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Model-Based Design for Robotics. MIT-developed toolkit for "
-                "dynamics, control, and optimization. Uses symbolic computation "
-                "for model analysis."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "AutoDiff-enabled multibody dynamics. Direct collocation "
-                "and SNOPT integration for trajectory optimization. "
-                "Focuses on mathematical rigor and guarantees."
-            ),
-        },
-        see_also=["https://drake.mit.edu"],
-        related_terms=["physics_engine", "mujoco", "pinocchio"],
-    )
-
-    glossary["pinocchio"] = GlossaryEntry(
-        term="Pinocchio",
-        category="simulation",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "A lightweight physics engine we use for fast calculations. "
-                "Named after the famous puppet, it handles articulated bodies."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Efficient rigid body dynamics library. Implements Featherstone's "
-                "algorithms with analytical derivatives. Focus on speed and "
-                "differentiability."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "O(n) spatial algebra implementation. Supports CasADi and "
-                "Ceres for automatic differentiation. Second-order derivatives "
-                "for optimal control."
-            ),
-        },
-        see_also=["https://github.com/stack-of-tasks/pinocchio"],
-        related_terms=["physics_engine", "mujoco", "drake"],
-    )
-
-    # === VALIDATION ===
-
-    glossary["cross_engine_validation"] = GlossaryEntry(
-        term="Cross-Engine Validation",
-        category="validation",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "Checking our results are correct by running the same analysis "
-                "on multiple physics engines. If they all agree, we can be "
-                "confident the results are accurate."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Verification method comparing results across MuJoCo, Drake, "
-                "and Pinocchio. Agreement within tolerance indicates reliable "
-                "results. Disagreement signals potential issues."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Ensemble validation using heterogeneous solvers. "
-                "Tolerance thresholds: τ ± 2%, KE ± 0.5%, position ± 1e-6. "
-                "Discrepancies often indicate contact model differences."
-            ),
-        },
-        related_terms=["physics_engine", "tolerance", "validation"],
-    )
-
-    glossary["drift_control_decomposition"] = GlossaryEntry(
-        term="Drift-Control Decomposition",
-        category="analysis",
-        definitions={
-            ExpertiseLevel.BEGINNER: (
-                "A way to understand which part of motion is 'passive' "
-                "(would happen without muscles) versus 'controlled' "
-                "(actively driven by muscles). Helps identify when "
-                "muscles are really working versus just going along for the ride."
-            ),
-            ExpertiseLevel.INTERMEDIATE: (
-                "Separating motion into: drift (gravity, inertia, passive dynamics) "
-                "and control (active muscle contribution). The Drift-Control Ratio "
-                "indicates how much active control a movement requires."
-            ),
-            ExpertiseLevel.ADVANCED: (
-                "Affine decomposition: q̈ = drift(q, q̇) + B(q)u. "
-                "Control contribution from null-space of drift solutions. "
-                "DCR = ||control|| / (||drift|| + ||control||). "
-                "Low DCR → gravity-assisted; High DCR → muscle-dominated."
-            ),
-        },
-        formula="DCR = ||control|| / (||drift|| + ||control||)",
-        related_terms=["inverse_dynamics", "muscle_contribution", "energy"],
-    )
-
-    # Load extended glossary entries from data files
     _level_map = {
         "b": ExpertiseLevel.BEGINNER,
         "i": ExpertiseLevel.INTERMEDIATE,
@@ -479,6 +482,23 @@ def _build_default_glossary() -> dict[str, GlossaryEntry]:
         _load_entries(get_extended_entries())
     except ImportError:
         logger.debug("Extended glossary data not available")
+
+
+def _build_default_glossary() -> dict[str, GlossaryEntry]:
+    """Build the default glossary with core biomechanics terms.
+
+    Returns:
+        Dictionary mapping term names to GlossaryEntry objects.
+    """
+    glossary: dict[str, GlossaryEntry] = {}
+
+    glossary.update(_build_dynamics_entries())
+    glossary.update(_build_kinematics_data_entries())
+    glossary.update(_build_golf_entries())
+    glossary.update(_build_simulation_entries())
+    glossary.update(_build_validation_analysis_entries())
+
+    _load_data_file_entries(glossary)
 
     return glossary
 

--- a/src/shared/python/ai/glossary_data_core.py
+++ b/src/shared/python/ai/glossary_data_core.py
@@ -7,14 +7,9 @@ Part of the expanded glossary (Issue #764). Contains ~200 entries across
 from __future__ import annotations
 
 
-def get_core_entries() -> list[dict]:
-    """Return core glossary entries as compact dicts.
-
-    Each dict has: key, term, cat, b (beginner), i (intermediate).
-    Optional: a (advanced), f (formula), u (units), r (related keys list).
-    """
+def _get_dynamics_entries_part1() -> list[dict]:
+    """Return dynamics glossary entries (part 1)."""
     return [
-        # === DYNAMICS (35) ===
         {
             "key": "equations_of_motion",
             "term": "Equations of Motion",
@@ -108,6 +103,12 @@ def get_core_entries() -> list[dict]:
             "u": "N",
             "r": ["coriolis_effect", "angular_velocity"],
         },
+    ]
+
+
+def _get_dynamics_entries_part2() -> list[dict]:
+    """Return dynamics glossary entries (part 2)."""
+    return [
         {
             "key": "gravity_vector",
             "term": "Gravity Vector",
@@ -201,6 +202,12 @@ def get_core_entries() -> list[dict]:
             "u": "J (Joules)",
             "r": ["kinetic_energy", "work_energy_theorem"],
         },
+    ]
+
+
+def _get_dynamics_entries_part3() -> list[dict]:
+    """Return dynamics glossary entries (part 3)."""
+    return [
         {
             "key": "work_energy_theorem",
             "term": "Work-Energy Theorem",
@@ -284,6 +291,12 @@ def get_core_entries() -> list[dict]:
             "i": "Constraint expressible as f(q,t) = 0, depending only on coordinates and time. Joint constraints are typically holonomic.",
             "r": ["nonholonomic_constraint", "constraint_force"],
         },
+    ]
+
+
+def _get_dynamics_entries_part4() -> list[dict]:
+    """Return dynamics glossary entries (part 4)."""
+    return [
         {
             "key": "nonholonomic_constraint",
             "term": "Nonholonomic Constraint",
@@ -326,7 +339,22 @@ def get_core_entries() -> list[dict]:
             "u": "kg\u00b7m\u00b2",
             "r": ["moment_of_inertia", "mass_matrix"],
         },
-        # === KINEMATICS (30) ===
+    ]
+
+
+def _get_dynamics_entries() -> list[dict]:
+    """Return dynamics glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_dynamics_entries_part1())
+    entries.extend(_get_dynamics_entries_part2())
+    entries.extend(_get_dynamics_entries_part3())
+    entries.extend(_get_dynamics_entries_part4())
+    return entries
+
+
+def _get_kinematics_entries_part1() -> list[dict]:
+    """Return kinematics glossary entries (part 1)."""
+    return [
         {
             "key": "position",
             "term": "Position",
@@ -417,6 +445,12 @@ def get_core_entries() -> list[dict]:
             "i": "Convention using 4 parameters per joint (\u03b8, d, a, \u03b1) to define transformations between consecutive links in a kinematic chain.",
             "r": ["forward_kinematics_robot", "serial_chain"],
         },
+    ]
+
+
+def _get_kinematics_entries_part2() -> list[dict]:
+    """Return kinematics glossary entries (part 2)."""
+    return [
         {
             "key": "forward_kinematics_robot",
             "term": "Forward Kinematics",
@@ -500,6 +534,12 @@ def get_core_entries() -> list[dict]:
             "i": "Piecewise polynomial (cubic or quintic) fitting through waypoints with continuity constraints. Used to smooth motion capture data.",
             "r": ["trajectory", "data_smoothing"],
         },
+    ]
+
+
+def _get_kinematics_entries_part3() -> list[dict]:
+    """Return kinematics glossary entries (part 3)."""
+    return [
         {
             "key": "pose",
             "term": "Pose",
@@ -581,7 +621,21 @@ def get_core_entries() -> list[dict]:
             "i": "n-dimensional space of all generalized coordinates q. Each point represents a unique system configuration. Abbreviated C-space.",
             "r": ["generalized_coordinates", "degrees_of_freedom", "phase_space"],
         },
-        # === BIOMECHANICS (35) ===
+    ]
+
+
+def _get_kinematics_entries() -> list[dict]:
+    """Return kinematics glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_kinematics_entries_part1())
+    entries.extend(_get_kinematics_entries_part2())
+    entries.extend(_get_kinematics_entries_part3())
+    return entries
+
+
+def _get_biomechanics_entries_part1() -> list[dict]:
+    """Return biomechanics glossary entries (part 1)."""
+    return [
         {
             "key": "gait_analysis",
             "term": "Gait Analysis",
@@ -666,6 +720,12 @@ def get_core_entries() -> list[dict]:
             "i": "Mass, length, center of mass location, and moments of inertia for each segment. Estimated from regression equations or imaging.",
             "r": ["anthropometry", "segment_inertia"],
         },
+    ]
+
+
+def _get_biomechanics_entries_part2() -> list[dict]:
+    """Return biomechanics glossary entries (part 2)."""
+    return [
         {
             "key": "anthropometry",
             "term": "Anthropometry",
@@ -756,6 +816,12 @@ def get_core_entries() -> list[dict]:
             "i": "Parabolic relationship between muscle fiber length and isometric force. Peak at optimal sarcomere length (~2.7 \u03bcm in humans).",
             "r": ["hill_muscle_model", "sarcomere"],
         },
+    ]
+
+
+def _get_biomechanics_entries_part3() -> list[dict]:
+    """Return biomechanics glossary entries (part 3)."""
+    return [
         {
             "key": "hill_muscle_model",
             "term": "Hill Muscle Model",
@@ -844,6 +910,12 @@ def get_core_entries() -> list[dict]:
             "i": "Muscle assisting the agonist or stabilizing adjacent joints. Multiple synergists provide redundant control strategies.",
             "r": ["agonist", "antagonist"],
         },
+    ]
+
+
+def _get_biomechanics_entries_part4() -> list[dict]:
+    """Return biomechanics glossary entries (part 4)."""
+    return [
         {
             "key": "co_contraction",
             "term": "Co-contraction",
@@ -884,7 +956,22 @@ def get_core_entries() -> list[dict]:
             "i": "Relatively permanent changes in motor behavior through practice. Progresses from cognitive to associative to autonomous stages.",
             "r": ["motor_control", "proprioception"],
         },
-        # === GOLF (40) ===
+    ]
+
+
+def _get_biomechanics_entries() -> list[dict]:
+    """Return biomechanics glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_biomechanics_entries_part1())
+    entries.extend(_get_biomechanics_entries_part2())
+    entries.extend(_get_biomechanics_entries_part3())
+    entries.extend(_get_biomechanics_entries_part4())
+    return entries
+
+
+def _get_golf_entries_part1() -> list[dict]:
+    """Return golf glossary entries (part 1)."""
+    return [
         {
             "key": "club_head_speed",
             "term": "Club Head Speed",
@@ -975,6 +1062,12 @@ def get_core_entries() -> list[dict]:
             "u": "degrees",
             "r": ["club_path", "dynamic_loft"],
         },
+    ]
+
+
+def _get_golf_entries_part2() -> list[dict]:
+    """Return golf glossary entries (part 2)."""
+    return [
         {
             "key": "dynamic_loft",
             "term": "Dynamic Loft",
@@ -1060,6 +1153,12 @@ def get_core_entries() -> list[dict]:
             "i": "Inclined plane best fitting the club head trajectory. Analyzed via SVD/PCA fit. Deviations indicate compensatory patterns.",
             "r": ["club_path", "trajectory"],
         },
+    ]
+
+
+def _get_golf_entries_part3() -> list[dict]:
+    """Return golf glossary entries (part 3)."""
+    return [
         {
             "key": "lie_angle",
             "term": "Lie Angle",
@@ -1147,6 +1246,12 @@ def get_core_entries() -> list[dict]:
             "u": "degrees",
             "r": ["pelvis_tilt", "lateral_bend"],
         },
+    ]
+
+
+def _get_golf_entries_part4() -> list[dict]:
+    """Return golf glossary entries (part 4)."""
+    return [
         {
             "key": "address_position",
             "term": "Address Position",
@@ -1229,7 +1334,22 @@ def get_core_entries() -> list[dict]:
             "u": "degrees\u00b2/s",
             "r": ["lateral_bend", "hip_rotation_golf", "injury_risk_assessment"],
         },
-        # === SIMULATION (30) ===
+    ]
+
+
+def _get_golf_entries() -> list[dict]:
+    """Return golf glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_golf_entries_part1())
+    entries.extend(_get_golf_entries_part2())
+    entries.extend(_get_golf_entries_part3())
+    entries.extend(_get_golf_entries_part4())
+    return entries
+
+
+def _get_simulation_entries_part1() -> list[dict]:
+    """Return simulation glossary entries (part 1)."""
+    return [
         {
             "key": "timestep",
             "term": "Timestep",
@@ -1311,6 +1431,12 @@ def get_core_entries() -> list[dict]:
             "i": "Property that numerical errors remain bounded over time. Stiff systems require implicit methods or very small timesteps for stability.",
             "r": ["timestep", "convergence"],
         },
+    ]
+
+
+def _get_simulation_entries_part2() -> list[dict]:
+    """Return simulation glossary entries (part 2)."""
+    return [
         {
             "key": "convergence",
             "term": "Convergence",
@@ -1391,6 +1517,12 @@ def get_core_entries() -> list[dict]:
             "i": "Mathematical framework where for each pair (z_i, w_i), at least one must be zero. Generalizes LCP to nonlinear (NCP) and mixed (MCP) forms.",
             "r": ["linear_complementarity", "constraint_solver"],
         },
+    ]
+
+
+def _get_simulation_entries_part3() -> list[dict]:
+    """Return simulation glossary entries (part 3)."""
+    return [
         {
             "key": "gauss_seidel",
             "term": "Gauss-Seidel Solver",
@@ -1471,7 +1603,21 @@ def get_core_entries() -> list[dict]:
             "i": "Deterministic but unpredictable behavior with sensitive dependence on initial conditions. Double pendulum is a classic example.",
             "r": ["bifurcation", "numerical_stability"],
         },
-        # === FORCES (30) ===
+    ]
+
+
+def _get_simulation_entries() -> list[dict]:
+    """Return simulation glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_simulation_entries_part1())
+    entries.extend(_get_simulation_entries_part2())
+    entries.extend(_get_simulation_entries_part3())
+    return entries
+
+
+def _get_forces_entries_part1() -> list[dict]:
+    """Return forces glossary entries (part 1)."""
+    return [
         {
             "key": "force_plate",
             "term": "Force Plate",
@@ -1561,6 +1707,12 @@ def get_core_entries() -> list[dict]:
             "u": "N",
             "r": ["external_force"],
         },
+    ]
+
+
+def _get_forces_entries_part2() -> list[dict]:
+    """Return forces glossary entries (part 2)."""
+    return [
         {
             "key": "external_force",
             "term": "External Force",
@@ -1655,6 +1807,12 @@ def get_core_entries() -> list[dict]:
             "f": "\u03b5 = \u0394L/L",
             "r": ["stress_mechanics", "youngs_modulus"],
         },
+    ]
+
+
+def _get_forces_entries_part3() -> list[dict]:
+    """Return forces glossary entries (part 3)."""
+    return [
         {
             "key": "youngs_modulus",
             "term": "Young's Modulus",
@@ -1745,3 +1903,28 @@ def get_core_entries() -> list[dict]:
             "r": ["stress_mechanics", "friction"],
         },
     ]
+
+
+def _get_forces_entries() -> list[dict]:
+    """Return forces glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_forces_entries_part1())
+    entries.extend(_get_forces_entries_part2())
+    entries.extend(_get_forces_entries_part3())
+    return entries
+
+
+def get_core_entries() -> list[dict]:
+    """Return core glossary entries as compact dicts.
+
+    Each dict has: key, term, cat, b (beginner), i (intermediate).
+    Optional: a (advanced), f (formula), u (units), r (related keys list).
+    """
+    entries: list[dict] = []
+    entries.extend(_get_dynamics_entries())
+    entries.extend(_get_kinematics_entries())
+    entries.extend(_get_biomechanics_entries())
+    entries.extend(_get_golf_entries())
+    entries.extend(_get_simulation_entries())
+    entries.extend(_get_forces_entries())
+    return entries

--- a/src/shared/python/ai/glossary_data_extended.py
+++ b/src/shared/python/ai/glossary_data_extended.py
@@ -7,10 +7,9 @@ Part of the expanded glossary (Issue #764). ~310 entries across 14 categories.
 from __future__ import annotations
 
 
-def get_extended_entries() -> list[dict]:  # noqa: C901
-    """Return extended glossary entries as compact dicts."""
+def _get_analysis_entries_part1() -> list[dict]:
+    """Return analysis glossary entries (part 1)."""
     return [
-        # === ANALYSIS (30) ===
         {
             "key": "drift_metric",
             "term": "Drift Metric",
@@ -92,6 +91,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Vector x satisfying Ax = lambda*x. Eigenvectors of the inertia tensor define principal axes of rotation.",
             "r": ["eigenvalue"],
         },
+    ]
+
+
+def _get_analysis_entries_part2() -> list[dict]:
+    """Return analysis glossary entries (part 2)."""
+    return [
         {
             "key": "principal_component_analysis",
             "term": "Principal Component Analysis (PCA)",
@@ -173,6 +178,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "u": "Hz",
             "r": ["low_pass_filter", "nyquist_frequency"],
         },
+    ]
+
+
+def _get_analysis_entries_part3() -> list[dict]:
+    """Return analysis glossary entries (part 3)."""
+    return [
         {
             "key": "sampling_rate",
             "term": "Sampling Rate",
@@ -255,7 +266,21 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "System output when input changes from 0 to 1 instantaneously. Integral of impulse response. Reveals damping and natural frequency.",
             "r": ["impulse_response", "transfer_function"],
         },
-        # === VALIDATION (20) ===
+    ]
+
+
+def _get_analysis_entries() -> list[dict]:
+    """Return analysis glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_analysis_entries_part1())
+    entries.extend(_get_analysis_entries_part2())
+    entries.extend(_get_analysis_entries_part3())
+    return entries
+
+
+def _get_validation_entries_part1() -> list[dict]:
+    """Return validation glossary entries (part 1)."""
+    return [
         {
             "key": "benchmark",
             "term": "Benchmark",
@@ -332,6 +357,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "CV = (std/mean)*100%. Expresses variability relative to the mean. Used to assess movement consistency across trials.",
             "f": "CV = (sigma/mu)*100%",
         },
+    ]
+
+
+def _get_validation_entries_part2() -> list[dict]:
+    """Return validation glossary entries (part 2)."""
+    return [
         {
             "key": "standard_error_measurement",
             "term": "Standard Error of Measurement",
@@ -407,7 +438,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "f": "F1 = 2PR/(P+R)",
             "r": ["precision_metric", "recall_metric"],
         },
-        # === CONTROL (25) ===
+    ]
+
+
+def _get_validation_entries() -> list[dict]:
+    """Return validation glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_validation_entries_part1())
+    entries.extend(_get_validation_entries_part2())
+    return entries
+
+
+def _get_control_entries_part1() -> list[dict]:
+    """Return control glossary entries (part 1)."""
+    return [
         {
             "key": "pid_controller",
             "term": "PID Controller",
@@ -488,6 +532,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Finding optimal state and control trajectories minimizing a cost functional. Methods: direct collocation, shooting, dynamic programming.",
             "r": ["direct_collocation", "shooting_method", "optimal_control"],
         },
+    ]
+
+
+def _get_control_entries_part2() -> list[dict]:
+    """Return control glossary entries (part 2)."""
+    return [
         {
             "key": "direct_collocation",
             "term": "Direct Collocation",
@@ -568,6 +618,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "V(s) = E[sum of future rewards from state s]. State-value V(s) and action-value Q(s,a) functions. Learned via temporal difference methods.",
             "r": ["bellman_equation", "reward_function"],
         },
+    ]
+
+
+def _get_control_entries_part3() -> list[dict]:
+    """Return control glossary entries (part 3)."""
+    return [
         {
             "key": "state_estimation",
             "term": "State Estimation",
@@ -608,7 +664,21 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Adjusting effective stiffness for safe interaction. Active compliance uses force feedback; passive uses mechanical elements.",
             "r": ["impedance_control"],
         },
-        # === ROBOTICS (20) ===
+    ]
+
+
+def _get_control_entries() -> list[dict]:
+    """Return control glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_control_entries_part1())
+    entries.extend(_get_control_entries_part2())
+    entries.extend(_get_control_entries_part3())
+    return entries
+
+
+def _get_robotics_entries_part1() -> list[dict]:
+    """Return robotics glossary entries (part 1)."""
+    return [
         {
             "key": "end_effector",
             "term": "End Effector",
@@ -688,6 +758,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "A motor with built-in position feedback for precise movement control.",
             "i": "Motor with integrated encoder and control loop for accurate position/velocity tracking. Used in robotic joints and motion platforms.",
         },
+    ]
+
+
+def _get_robotics_entries_part2() -> list[dict]:
+    """Return robotics glossary entries (part 2)."""
+    return [
         {
             "key": "rotary_encoder",
             "term": "Rotary Encoder",
@@ -765,7 +841,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "Simultaneous Localization And Mapping: building a map of the environment while tracking your position in it.",
             "i": "Simultaneous Localization and Mapping. Estimates sensor pose while building environment map. Used for autonomous navigation.",
         },
-        # === MATH (30) ===
+    ]
+
+
+def _get_robotics_entries() -> list[dict]:
+    """Return robotics glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_robotics_entries_part1())
+    entries.extend(_get_robotics_entries_part2())
+    return entries
+
+
+def _get_math_entries_part1() -> list[dict]:
+    """Return math glossary entries (part 1)."""
+    return [
         {
             "key": "matrix_algebra",
             "term": "Matrix",
@@ -842,6 +931,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "Flipping a matrix along its diagonal, swapping rows and columns.",
             "i": "A^T where (A^T)_ij = A_ji. For orthogonal matrices (rotations), the transpose equals the inverse.",
         },
+    ]
+
+
+def _get_math_entries_part2() -> list[dict]:
+    """Return math glossary entries (part 2)."""
+    return [
         {
             "key": "symmetric_matrix",
             "term": "Symmetric Matrix",
@@ -923,6 +1018,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "div(F) = dF_x/dx + dF_y/dy + dF_z/dz. Scalar field measuring net outward flux density.",
             "r": ["curl_operator"],
         },
+    ]
+
+
+def _get_math_entries_part3() -> list[dict]:
+    """Return math glossary entries (part 3)."""
+    return [
         {
             "key": "curl_operator",
             "term": "Curl",
@@ -1004,7 +1105,21 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "f": "R = I + sin(t)K + (1-cos(t))K^2",
             "r": ["exponential_map", "rotation_matrix"],
         },
-        # === DATA (20) ===
+    ]
+
+
+def _get_math_entries() -> list[dict]:
+    """Return math glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_math_entries_part1())
+    entries.extend(_get_math_entries_part2())
+    entries.extend(_get_math_entries_part3())
+    return entries
+
+
+def _get_data_entries_part1() -> list[dict]:
+    """Return data glossary entries (part 1)."""
+    return [
         {
             "key": "motion_capture_system",
             "term": "Motion Capture System",
@@ -1084,6 +1199,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Analog low-pass filter with cutoff below Nyquist frequency. Applied before A/D conversion to prevent aliasing artifacts.",
             "r": ["aliasing", "nyquist_frequency"],
         },
+    ]
+
+
+def _get_data_entries_part2() -> list[dict]:
+    """Return data glossary entries (part 2)."""
+    return [
         {
             "key": "data_acquisition",
             "term": "Data Acquisition (DAQ)",
@@ -1162,7 +1283,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Filtering or curve-fitting to reduce measurement noise. Methods: Butterworth filter, splines, Savitzky-Golay, moving average.",
             "r": ["butterworth_filter", "savitzky_golay_filter"],
         },
-        # === AI (25) ===
+    ]
+
+
+def _get_data_entries() -> list[dict]:
+    """Return data glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_data_entries_part1())
+    entries.extend(_get_data_entries_part2())
+    return entries
+
+
+def _get_ai_entries_part1() -> list[dict]:
+    """Return ai glossary entries (part 1)."""
+    return [
         {
             "key": "neural_network",
             "term": "Neural Network",
@@ -1241,6 +1375,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "Breaking text into smaller pieces (tokens) that a language model can process.",
             "i": "Splitting input into sub-word units using BPE, WordPiece, or SentencePiece. Vocabulary size trades expressiveness vs efficiency.",
         },
+    ]
+
+
+def _get_ai_entries_part2() -> list[dict]:
+    """Return ai glossary entries (part 2)."""
+    return [
         {
             "key": "prompt_engineering",
             "term": "Prompt Engineering",
@@ -1315,6 +1455,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Probabilistic autoencoder learning latent distribution. Enables sampling and interpolation in latent space for motion generation.",
             "r": ["autoencoder"],
         },
+    ]
+
+
+def _get_ai_entries_part3() -> list[dict]:
+    """Return ai glossary entries (part 3)."""
+    return [
         {
             "key": "bayesian_inference",
             "term": "Bayesian Inference",
@@ -1353,7 +1499,21 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Efficient gradient computation via chain rule through the computational graph. Enables gradient-based training of deep networks.",
             "r": ["gradient_descent", "neural_network"],
         },
-        # === VISUALIZATION (15) ===
+    ]
+
+
+def _get_ai_entries() -> list[dict]:
+    """Return ai glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_ai_entries_part1())
+    entries.extend(_get_ai_entries_part2())
+    entries.extend(_get_ai_entries_part3())
+    return entries
+
+
+def _get_visualization_entries_part1() -> list[dict]:
+    """Return visualization glossary entries (part 1)."""
+    return [
         {
             "key": "three_d_rendering",
             "term": "3D Rendering",
@@ -1425,6 +1585,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "Drawing the path that a body part or club follows through space over time.",
             "i": "Rendering 3D curves of marker or joint trajectories. Color-coding by time or velocity reveals swing dynamics.",
         },
+    ]
+
+
+def _get_visualization_entries_part2() -> list[dict]:
+    """Return visualization glossary entries (part 2)."""
+    return [
         {
             "key": "time_series_plot",
             "term": "Time Series Plot",
@@ -1460,7 +1626,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "Assigning colors to numerical values for intuitive visualization of data patterns.",
             "i": "Mapping scalar values to color via transfer functions (colormaps). Perceptually uniform maps (viridis) preferred for quantitative data.",
         },
-        # === MATERIALS (15) ===
+    ]
+
+
+def _get_visualization_entries() -> list[dict]:
+    """Return visualization glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_visualization_entries_part1())
+    entries.extend(_get_visualization_entries_part2())
+    return entries
+
+
+def _get_materials_entries_part1() -> list[dict]:
+    """Return materials glossary entries (part 1)."""
+    return [
         {
             "key": "bone_tissue",
             "term": "Bone",
@@ -1536,6 +1715,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Material with identical properties regardless of direction. Described by two constants (E, nu). Simplifying assumption for some tissues.",
             "r": ["anisotropic_material"],
         },
+    ]
+
+
+def _get_materials_entries_part2() -> list[dict]:
+    """Return materials glossary entries (part 2)."""
+    return [
         {
             "key": "composite_material",
             "term": "Composite Material",
@@ -1575,7 +1760,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "u": "MPa",
             "r": ["yield_strength"],
         },
-        # === INJURY (15) ===
+    ]
+
+
+def _get_materials_entries() -> list[dict]:
+    """Return materials glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_materials_entries_part1())
+    entries.extend(_get_materials_entries_part2())
+    return entries
+
+
+def _get_injury_entries_part1() -> list[dict]:
+    """Return injury glossary entries (part 1)."""
+    return [
         {
             "key": "injury_risk_assessment",
             "term": "Injury Risk Assessment",
@@ -1656,6 +1854,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Grade II-III muscle strain with macroscopic fiber disruption. Oblique abdominal and hamstring tears occur in golf from high rotational demands.",
             "r": ["muscle_strain_injury", "acute_injury"],
         },
+    ]
+
+
+def _get_injury_entries_part2() -> list[dict]:
+    """Return injury glossary entries (part 2)."""
+    return [
         {
             "key": "fatigue_failure",
             "term": "Fatigue Failure",
@@ -1695,7 +1899,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "b": "The process of safely getting back to sport after an injury, using objective criteria.",
             "i": "Graduated protocol for resuming sport after injury. Criteria-based progression using strength, ROM, functional, and sport-specific tests.",
         },
-        # === ANATOMY (25) ===
+    ]
+
+
+def _get_injury_entries() -> list[dict]:
+    """Return injury glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_injury_entries_part1())
+    entries.extend(_get_injury_entries_part2())
+    return entries
+
+
+def _get_anatomy_entries_part1() -> list[dict]:
+    """Return anatomy glossary entries (part 1)."""
+    return [
         {
             "key": "pelvis_anatomy",
             "term": "Pelvis",
@@ -1770,6 +1987,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Segmental spinal bone: body (load-bearing), arch (neural protection), processes (muscle/ligament attachment). 33 total (24 mobile).",
             "r": ["lumbar_spine", "thoracic_spine", "cervical_spine"],
         },
+    ]
+
+
+def _get_anatomy_entries_part2() -> list[dict]:
+    """Return anatomy glossary entries (part 2)."""
+    return [
         {
             "key": "lumbar_spine",
             "term": "Lumbar Spine",
@@ -1847,6 +2070,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Radiocarpal + midcarpal joints allowing flexion/extension, radial/ulnar deviation. Wrist mechanics directly affect club face angle at impact.",
             "r": ["wrist_cock", "wrist_release"],
         },
+    ]
+
+
+def _get_anatomy_entries_part3() -> list[dict]:
+    """Return anatomy glossary entries (part 3)."""
+    return [
         {
             "key": "glenohumeral_joint",
             "term": "Glenohumeral Joint",
@@ -1887,7 +2116,21 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Fibrocartilaginous structure between vertebral bodies. Nucleus pulposus (gel core) + annulus fibrosus (layered rings). Subject to injury in golf.",
             "r": ["lumbar_spine", "vertebra"],
         },
-        # === OPTIMIZATION (20) ===
+    ]
+
+
+def _get_anatomy_entries() -> list[dict]:
+    """Return anatomy glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_anatomy_entries_part1())
+    entries.extend(_get_anatomy_entries_part2())
+    entries.extend(_get_anatomy_entries_part3())
+    return entries
+
+
+def _get_optimization_entries_part1() -> list[dict]:
+    """Return optimization glossary entries (part 1)."""
+    return [
         {
             "key": "cost_function",
             "term": "Cost Function",
@@ -1967,6 +2210,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Quasi-Newton method building approximate Hessian from gradient evaluations. Superlinear convergence. L-BFGS variant for large-scale problems.",
             "r": ["newton_optimization", "gradient_based_optimization"],
         },
+    ]
+
+
+def _get_optimization_entries_part2() -> list[dict]:
+    """Return optimization glossary entries (part 2)."""
+    return [
         {
             "key": "newton_optimization",
             "term": "Newton's Method (Optimization)",
@@ -2046,7 +2295,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "In multi-objective optimization, a point on the Pareto front where no objective can improve without degrading another. Represents optimal trade-offs.",
             "r": ["objective_function"],
         },
-        # === SIGNAL PROCESSING (15) ===
+    ]
+
+
+def _get_optimization_entries() -> list[dict]:
+    """Return optimization glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_optimization_entries_part1())
+    entries.extend(_get_optimization_entries_part2())
+    return entries
+
+
+def _get_signal_processing_entries_part1() -> list[dict]:
+    """Return signal processing glossary entries (part 1)."""
+    return [
         {
             "key": "signal_noise",
             "term": "Signal and Noise",
@@ -2127,6 +2389,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Estimating derivatives from discrete data: central differences, polynomial fitting, or Savitzky-Golay. Amplifies high-frequency noise.",
             "r": ["savitzky_golay_filter"],
         },
+    ]
+
+
+def _get_signal_processing_entries_part2() -> list[dict]:
+    """Return signal processing glossary entries (part 2)."""
+    return [
         {
             "key": "numerical_integration_signal",
             "term": "Numerical Integration (Signal)",
@@ -2165,7 +2433,20 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Creates analytic signal z(t) = x(t) + jH{x(t)}. Envelope: |z(t)|. Instantaneous frequency: d(arg(z))/dt. Used for EMG and vibration analysis.",
             "r": ["signal_envelope"],
         },
-        # === MUSCLE (20) ===
+    ]
+
+
+def _get_signal_processing_entries() -> list[dict]:
+    """Return signal processing glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_signal_processing_entries_part1())
+    entries.extend(_get_signal_processing_entries_part2())
+    return entries
+
+
+def _get_muscle_entries_part1() -> list[dict]:
+    """Return muscle glossary entries (part 1)."""
+    return [
         {
             "key": "sarcomere",
             "term": "Sarcomere",
@@ -2247,6 +2528,12 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "i": "Intrafusal fiber receptor detecting muscle length changes. Primary (Ia) afferents sensitive to length and velocity; secondary (II) to length only.",
             "r": ["proprioception", "golgi_tendon_organ"],
         },
+    ]
+
+
+def _get_muscle_entries_part2() -> list[dict]:
+    """Return muscle glossary entries (part 2)."""
+    return [
         {
             "key": "golgi_tendon_organ",
             "term": "Golgi Tendon Organ",
@@ -2337,3 +2624,31 @@ def get_extended_entries() -> list[dict]:  # noqa: C901
             "r": ["motor_unit", "muscle_architecture"],
         },
     ]
+
+
+def _get_muscle_entries() -> list[dict]:
+    """Return muscle glossary entries."""
+    entries: list[dict] = []
+    entries.extend(_get_muscle_entries_part1())
+    entries.extend(_get_muscle_entries_part2())
+    return entries
+
+
+def get_extended_entries() -> list[dict]:
+    """Return extended glossary entries as compact dicts."""
+    entries: list[dict] = []
+    entries.extend(_get_analysis_entries())
+    entries.extend(_get_validation_entries())
+    entries.extend(_get_control_entries())
+    entries.extend(_get_robotics_entries())
+    entries.extend(_get_math_entries())
+    entries.extend(_get_data_entries())
+    entries.extend(_get_ai_entries())
+    entries.extend(_get_visualization_entries())
+    entries.extend(_get_materials_entries())
+    entries.extend(_get_injury_entries())
+    entries.extend(_get_anatomy_entries())
+    entries.extend(_get_optimization_entries())
+    entries.extend(_get_signal_processing_entries())
+    entries.extend(_get_muscle_entries())
+    return entries

--- a/src/shared/python/club_data/club_data_tab.py
+++ b/src/shared/python/club_data/club_data_tab.py
@@ -78,7 +78,16 @@ class ClubDataTab(QtWidgets.QWidget):  # type: ignore[misc]
         splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         main_layout.addWidget(splitter)
 
-        # -------- Club Data Section --------
+        splitter.addWidget(self._create_club_data_section())
+        splitter.addWidget(self._create_player_target_section())
+        splitter.addWidget(self._create_target_overlay_section())
+        splitter.addWidget(self._create_tracking_section())
+
+        # Set initial sizes
+        splitter.setSizes([200, 250, 150, 100])
+
+    def _create_club_data_section(self) -> QtWidgets.QGroupBox:
+        """Create the club specifications section."""
         club_group = QtWidgets.QGroupBox("Club Specifications")
         club_layout = QtWidgets.QVBoxLayout(club_group)
 
@@ -128,9 +137,10 @@ class ClubDataTab(QtWidgets.QWidget):  # type: ignore[misc]
         details_layout.addRow("MOI:", self.lbl_club_moi)
 
         club_layout.addLayout(details_layout)
-        splitter.addWidget(club_group)
+        return club_group
 
-        # -------- Player Target Section --------
+    def _create_player_target_section(self) -> QtWidgets.QGroupBox:
+        """Create the professional player targets section."""
         player_group = QtWidgets.QGroupBox("Professional Player Targets")
         player_layout = QtWidgets.QVBoxLayout(player_group)
 
@@ -172,9 +182,10 @@ class ClubDataTab(QtWidgets.QWidget):  # type: ignore[misc]
         metrics_layout.addRow("Smash Factor:", self.lbl_smash)
 
         player_layout.addWidget(metrics_group)
-        splitter.addWidget(player_group)
+        return player_group
 
-        # -------- Target Overlay Section --------
+    def _create_target_overlay_section(self) -> QtWidgets.QGroupBox:
+        """Create the target visualization overlay section."""
         overlay_group = QtWidgets.QGroupBox("Target Visualization")
         overlay_layout = QtWidgets.QVBoxLayout(overlay_group)
 
@@ -237,9 +248,10 @@ class ClubDataTab(QtWidgets.QWidget):  # type: ignore[misc]
 
         overlay_layout.addLayout(color_layout)
 
-        splitter.addWidget(overlay_group)
+        return overlay_group
 
-        # -------- Tracking Section --------
+    def _create_tracking_section(self) -> QtWidgets.QGroupBox:
+        """Create the real-time tracking error section."""
         tracking_group = QtWidgets.QGroupBox("Real-time Tracking Error")
         tracking_layout = QtWidgets.QFormLayout(tracking_group)
 
@@ -251,10 +263,7 @@ class ClubDataTab(QtWidgets.QWidget):  # type: ignore[misc]
         tracking_layout.addRow("Velocity Error:", self.lbl_velocity_error)
         tracking_layout.addRow("Current Phase:", self.lbl_phase)
 
-        splitter.addWidget(tracking_group)
-
-        # Set initial sizes
-        splitter.setSizes([200, 250, 150, 100])
+        return tracking_group
 
     def _auto_load_data(self) -> None:
         """Automatically load data from default location if available."""

--- a/src/shared/python/physics/physics_parameters.py
+++ b/src/shared/python/physics/physics_parameters.py
@@ -95,7 +95,14 @@ class PhysicsParameterRegistry:
 
     def _load_default_parameters(self) -> None:
         """Load default parameters from various sources."""
-        # Ball parameters (USGA Rules)
+        self._load_ball_parameters()
+        self._load_club_parameters()
+        self._load_environment_parameters()
+        self._load_biomechanics_parameters()
+        self._load_simulation_parameters()
+
+    def _load_ball_parameters(self) -> None:
+        """Load ball parameters (USGA Rules)."""
         self.register(
             PhysicsParameter(
                 name="BALL_MASS",
@@ -138,7 +145,22 @@ class PhysicsParameterRegistry:
             )
         )
 
-        # Club parameters
+        self.register(
+            PhysicsParameter(
+                name="DRAG_COEFFICIENT",
+                value=constants.GOLF_BALL_DRAG_COEFFICIENT,
+                unit="dimensionless",
+                category=ParameterCategory.BALL,
+                description="Golf ball drag coefficient (typical)",
+                source="Golf ball aerodynamics literature",
+                min_value=0.20,
+                max_value=0.30,
+                is_constant=False,
+            )
+        )
+
+    def _load_club_parameters(self) -> None:
+        """Load club parameters."""
         self.register(
             PhysicsParameter(
                 name="CLUB_MASS",
@@ -181,14 +203,15 @@ class PhysicsParameterRegistry:
             )
         )
 
-        # Environment parameters
+    def _load_environment_parameters(self) -> None:
+        """Load environment parameters."""
         self.register(
             PhysicsParameter(
                 name="GRAVITY",
                 value=constants.GRAVITY_M_S2,
-                unit="m/s²",
+                unit="m/s\u00b2",
                 category=ParameterCategory.ENVIRONMENT,
-                description="Standard gravity (sea level, 45° latitude)",
+                description="Standard gravity (sea level, 45\u00b0 latitude)",
                 source="NIST",
                 min_value=constants.GRAVITY_M_S2,
                 max_value=constants.GRAVITY_M_S2,
@@ -200,9 +223,9 @@ class PhysicsParameterRegistry:
             PhysicsParameter(
                 name="AIR_DENSITY",
                 value=constants.AIR_DENSITY_SEA_LEVEL_KG_M3,
-                unit="kg/m³",
+                unit="kg/m\u00b3",
                 category=ParameterCategory.ENVIRONMENT,
-                description="Air density at sea level, 15°C",
+                description="Air density at sea level, 15\u00b0C",
                 source="ISA Standard Atmosphere",
                 min_value=0.9,  # High altitude
                 max_value=1.3,  # Sea level, cold
@@ -210,21 +233,8 @@ class PhysicsParameterRegistry:
             )
         )
 
-        self.register(
-            PhysicsParameter(
-                name="DRAG_COEFFICIENT",
-                value=constants.GOLF_BALL_DRAG_COEFFICIENT,
-                unit="dimensionless",
-                category=ParameterCategory.BALL,
-                description="Golf ball drag coefficient (typical)",
-                source="Golf ball aerodynamics literature",
-                min_value=0.20,
-                max_value=0.30,
-                is_constant=False,
-            )
-        )
-
-        # Biomechanics parameters
+    def _load_biomechanics_parameters(self) -> None:
+        """Load biomechanics parameters."""
         self.register(
             PhysicsParameter(
                 name="HUMAN_HEIGHT",
@@ -253,7 +263,8 @@ class PhysicsParameterRegistry:
             )
         )
 
-        # Simulation parameters
+    def _load_simulation_parameters(self) -> None:
+        """Load simulation parameters."""
         self.register(
             PhysicsParameter(
                 name="TIMESTEP",

--- a/src/shared/python/theme/theme_manager.py
+++ b/src/shared/python/theme/theme_manager.py
@@ -445,6 +445,22 @@ class ThemeManager:
             CSS-like stylesheet string for Qt widgets
         """
         c = self._current_theme
+        sections = [
+            self._stylesheet_base_widgets(c),
+            self._stylesheet_buttons(c),
+            self._stylesheet_inputs(c),
+            self._stylesheet_item_views(c),
+            self._stylesheet_scrollbars(c),
+            self._stylesheet_menus(c),
+            self._stylesheet_tabs_and_status(c),
+            self._stylesheet_containers(c),
+            self._stylesheet_indicators_and_sliders(c),
+        ]
+        return "\n".join(sections)
+
+    @staticmethod
+    def _stylesheet_base_widgets(c: ThemeColors) -> str:
+        """Generate styles for base widgets (QWidget, QMainWindow, QDialog)."""
         return f"""
             QWidget {{
                 background-color: {c.bg_base};
@@ -459,7 +475,12 @@ class ThemeManager:
             QDialog {{
                 background-color: {c.bg_surface};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_buttons(c: ThemeColors) -> str:
+        """Generate styles for QPushButton states."""
+        return f"""
             QPushButton {{
                 background-color: {c.primary};
                 color: {c.text_primary};
@@ -480,7 +501,12 @@ class ThemeManager:
                 background-color: {c.bg_elevated};
                 color: {c.text_quaternary};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_inputs(c: ThemeColors) -> str:
+        """Generate styles for text inputs and combo boxes."""
+        return f"""
             QLineEdit, QTextEdit, QPlainTextEdit {{
                 background-color: {c.bg_surface};
                 color: {c.text_primary};
@@ -508,7 +534,12 @@ class ThemeManager:
             QComboBox::drop-down {{
                 border: none;
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_item_views(c: ThemeColors) -> str:
+        """Generate styles for list, tree, and table widgets."""
+        return f"""
             QListWidget, QTreeWidget, QTableWidget {{
                 background-color: {c.bg_surface};
                 color: {c.text_primary};
@@ -518,7 +549,12 @@ class ThemeManager:
             QListWidget::item:selected, QTreeWidget::item:selected {{
                 background-color: {c.primary_muted};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_scrollbars(c: ThemeColors) -> str:
+        """Generate styles for scrollbars."""
+        return f"""
             QScrollBar:vertical {{
                 background-color: {c.bg_base};
                 width: 12px;
@@ -533,7 +569,12 @@ class ThemeManager:
             QScrollBar::handle:vertical:hover {{
                 background-color: {c.border_strong};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_menus(c: ThemeColors) -> str:
+        """Generate styles for menu bar and menus."""
+        return f"""
             QMenuBar {{
                 background-color: {c.bg_surface};
                 color: {c.text_primary};
@@ -552,7 +593,12 @@ class ThemeManager:
             QMenu::item:selected {{
                 background-color: {c.primary_muted};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_tabs_and_status(c: ThemeColors) -> str:
+        """Generate styles for tabs, status bar, and labels."""
+        return f"""
             QTabWidget::pane {{
                 border: 1px solid {c.border_default};
                 background-color: {c.bg_surface};
@@ -578,7 +624,12 @@ class ThemeManager:
             QLabel {{
                 color: {c.text_primary};
             }}
+        """
 
+    @staticmethod
+    def _stylesheet_containers(c: ThemeColors) -> str:
+        """Generate styles for group boxes and tooltips."""
+        return f"""
             QGroupBox {{
                 border: 1px solid {c.border_subtle};
                 border-radius: 4px;
@@ -592,6 +643,18 @@ class ThemeManager:
                 left: 10px;
             }}
 
+            QToolTip {{
+                background-color: {c.bg_surface};
+                color: {c.text_primary};
+                border: 1px solid {c.border_default};
+                padding: 4px;
+            }}
+        """
+
+    @staticmethod
+    def _stylesheet_indicators_and_sliders(c: ThemeColors) -> str:
+        """Generate styles for checkboxes, radio buttons, progress bars, and sliders."""
+        return f"""
             QCheckBox::indicator, QRadioButton::indicator {{
                 width: 16px;
                 height: 16px;
@@ -620,13 +683,6 @@ class ThemeManager:
                 height: 16px;
                 margin: -6px 0;
                 border-radius: 8px;
-            }}
-
-            QToolTip {{
-                background-color: {c.bg_surface};
-                color: {c.text_primary};
-                border: 1px solid {c.border_default};
-                padding: 4px;
             }}
         """
 

--- a/src/tools/humanoid_character_builder/core/segment_definitions.py
+++ b/src/tools/humanoid_character_builder/core/segment_definitions.py
@@ -218,11 +218,10 @@ SEGMENT_HIERARCHY = {
 }
 
 
-def _create_segment_definitions() -> dict[str, SegmentDefinition]:
-    """Create the standard humanoid segment definitions."""
-    segments = {}
+def _create_torso_segments() -> dict[str, SegmentDefinition]:
+    """Create torso segment definitions (pelvis, lumbar, thorax, neck, head)."""
+    segments: dict[str, SegmentDefinition] = {}
 
-    # === Torso ===
     segments["pelvis"] = SegmentDefinition(
         name="pelvis",
         parent=None,
@@ -269,7 +268,14 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         is_end_effector=True,
     )
 
-    # === Shoulders ===
+    return segments
+
+
+def _create_arm_segments() -> dict[str, SegmentDefinition]:
+    """Create shoulder, arm, and hand segment definitions."""
+    segments: dict[str, SegmentDefinition] = {}
+
+    # Shoulders
     segments["left_shoulder"] = SegmentDefinition(
         name="left_shoulder",
         parent="thorax",
@@ -288,7 +294,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group="shoulder.R",
     )
 
-    # === Arms ===
+    # Upper arms
     segments["left_upper_arm"] = SegmentDefinition(
         name="left_upper_arm",
         parent="left_shoulder",
@@ -307,6 +313,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group="upperarm.R",
     )
 
+    # Forearms
     segments["left_forearm"] = SegmentDefinition(
         name="left_forearm",
         parent="left_upper_arm",
@@ -325,6 +332,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group="forearm.R",
     )
 
+    # Hands
     segments["left_hand"] = SegmentDefinition(
         name="left_hand",
         parent="left_forearm",
@@ -345,7 +353,14 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         is_end_effector=True,
     )
 
-    # === Hips (virtual segments for joint placement) ===
+    return segments
+
+
+def _create_leg_segments() -> dict[str, SegmentDefinition]:
+    """Create hip, leg, and foot segment definitions."""
+    segments: dict[str, SegmentDefinition] = {}
+
+    # Hips (virtual segments for joint placement)
     segments["left_hip"] = SegmentDefinition(
         name="left_hip",
         parent="pelvis",
@@ -364,7 +379,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group=None,
     )
 
-    # === Legs ===
+    # Thighs
     segments["left_thigh"] = SegmentDefinition(
         name="left_thigh",
         parent="left_hip",
@@ -383,6 +398,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group="thigh.R",
     )
 
+    # Shins
     segments["left_shin"] = SegmentDefinition(
         name="left_shin",
         parent="left_thigh",
@@ -401,6 +417,7 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
         vertex_group="shin.R",
     )
 
+    # Feet
     segments["left_foot"] = SegmentDefinition(
         name="left_foot",
         parent="left_shin",
@@ -424,11 +441,19 @@ def _create_segment_definitions() -> dict[str, SegmentDefinition]:
     return segments
 
 
-def _create_joint_definitions() -> dict[str, JointDefinition]:
-    """Create the standard humanoid joint definitions."""
-    joints = {}
+def _create_segment_definitions() -> dict[str, SegmentDefinition]:
+    """Create the standard humanoid segment definitions."""
+    segments: dict[str, SegmentDefinition] = {}
+    segments.update(_create_torso_segments())
+    segments.update(_create_arm_segments())
+    segments.update(_create_leg_segments())
+    return segments
 
-    # === Spine Joints ===
+
+def _create_spine_joints() -> dict[str, JointDefinition]:
+    """Create spine and neck joint definitions."""
+    joints: dict[str, JointDefinition] = {}
+
     joints["pelvis_to_lumbar"] = JointDefinition(
         name="pelvis_to_lumbar",
         joint_type=JointType.UNIVERSAL,
@@ -474,7 +499,14 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-1.0, upper=1.0),
     )
 
-    # === Shoulder Joints ===
+    return joints
+
+
+def _create_arm_joints() -> dict[str, JointDefinition]:
+    """Create shoulder, elbow, and wrist joint definitions."""
+    joints: dict[str, JointDefinition] = {}
+
+    # Shoulder joints (fixed attachment to thorax)
     joints["thorax_to_left_shoulder"] = JointDefinition(
         name="thorax_to_left_shoulder",
         joint_type=JointType.FIXED,
@@ -491,7 +523,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         origin_xyz=(-0.15, 0.0, 0.12),
     )
 
-    # === Arm Joints ===
+    # Shoulder-to-upper-arm (gimbal)
     joints["left_shoulder_to_upper_arm"] = JointDefinition(
         name="left_shoulder_to_upper_arm",
         joint_type=JointType.GIMBAL,
@@ -516,6 +548,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-2.5, upper=2.5),
     )
 
+    # Elbows
     joints["left_elbow"] = JointDefinition(
         name="left_elbow",
         joint_type=JointType.REVOLUTE,
@@ -536,6 +569,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=0.0, upper=2.5),
     )
 
+    # Wrists
     joints["left_wrist"] = JointDefinition(
         name="left_wrist",
         joint_type=JointType.UNIVERSAL,
@@ -558,7 +592,14 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-1.2, upper=1.2),
     )
 
-    # === Hip Joints ===
+    return joints
+
+
+def _create_leg_joints() -> dict[str, JointDefinition]:
+    """Create hip, knee, and ankle joint definitions."""
+    joints: dict[str, JointDefinition] = {}
+
+    # Hip joints (fixed attachment to pelvis)
     joints["pelvis_to_left_hip"] = JointDefinition(
         name="pelvis_to_left_hip",
         joint_type=JointType.FIXED,
@@ -575,7 +616,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         origin_xyz=(-0.09, 0.0, -0.05),
     )
 
-    # === Leg Joints ===
+    # Hip-to-thigh (gimbal)
     joints["left_hip_joint"] = JointDefinition(
         name="left_hip_joint",
         joint_type=JointType.GIMBAL,
@@ -600,6 +641,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-2.0, upper=2.0),
     )
 
+    # Knees
     joints["left_knee"] = JointDefinition(
         name="left_knee",
         joint_type=JointType.REVOLUTE,
@@ -620,6 +662,7 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-2.5, upper=0.0),
     )
 
+    # Ankles
     joints["left_ankle"] = JointDefinition(
         name="left_ankle",
         joint_type=JointType.UNIVERSAL,
@@ -642,6 +685,15 @@ def _create_joint_definitions() -> dict[str, JointDefinition]:
         limits=JointLimits(lower=-0.8, upper=0.8),
     )
 
+    return joints
+
+
+def _create_joint_definitions() -> dict[str, JointDefinition]:
+    """Create the standard humanoid joint definitions."""
+    joints: dict[str, JointDefinition] = {}
+    joints.update(_create_spine_joints())
+    joints.update(_create_arm_joints())
+    joints.update(_create_leg_joints())
     return joints
 
 

--- a/src/tools/model_explorer/model_loader_dialog.py
+++ b/src/tools/model_explorer/model_loader_dialog.py
@@ -66,10 +66,73 @@ class ModelLoaderDialog(QDialog):
 
         self._setup_ui()
 
+    def _setup_biomechanics_tab(self) -> QWidget:
+        """Create the Biomechanics tab with human models."""
+        biomech_tab = QWidget()
+        biomech_layout = QVBoxLayout(biomech_tab)
+        human_group = self._create_human_models_group()
+        biomech_layout.addWidget(human_group)
+        biomech_layout.addStretch()
+        return biomech_tab
+
+    def _setup_equipment_tab(self) -> QWidget:
+        """Create the Equipment tab with golf clubs and components."""
+        equipment_tab = QWidget()
+        equip_layout = QVBoxLayout(equipment_tab)
+        golf_group = self._create_golf_clubs_group()
+        equip_layout.addWidget(golf_group)
+        component_group = self._create_components_group()
+        equip_layout.addWidget(component_group)
+        equip_layout.addStretch()
+        return equipment_tab
+
+    def _setup_robotics_tab(self) -> QWidget:
+        """Create the Robotics tab with pendulums and manipulators."""
+        robotics_tab = QWidget()
+        robotics_layout = QVBoxLayout(robotics_tab)
+
+        pendulum_group = self._create_model_group(
+            "Simplified Physics Models",
+            "pendulum",
+            "Simple pendulum models for understanding swing mechanics.",
+            "Load Physics Model",
+        )
+        robotics_layout.addWidget(pendulum_group)
+
+        robot_group = self._create_model_group(
+            "Robotic Manipulators",
+            "robotic",
+            "Industrial robot arms with golf attachments.",
+            "Load Robot Model",
+        )
+        robotics_layout.addWidget(robot_group)
+
+        robotics_layout.addStretch()
+        return robotics_tab
+
+    def _setup_info_and_buttons(self, layout: QVBoxLayout) -> None:
+        """Set up the model info display and OK/Cancel buttons."""
+        info_label = QLabel("Model Information:")
+        info_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
+        layout.addWidget(info_label)
+
+        self.info_display = QTextEdit()
+        self.info_display.setReadOnly(True)
+        self.info_display.setMaximumHeight(150)
+        self.info_display.setPlainText(
+            "Select a model above to see its specifications..."
+        )
+        layout.addWidget(self.info_display)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
     def _setup_ui(self) -> None:
         """Set up the user interface."""
-
-        # Update imports needed for UI changes
 
         from PyQt6.QtWidgets import (
             QTabWidget,
@@ -78,153 +141,40 @@ class ModelLoaderDialog(QDialog):
         layout = QVBoxLayout(self)
 
         # Title
-
         title = QLabel("Select a Model to Load")
-
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
         title.setStyleSheet("font-size: 14pt; font-weight: bold; margin: 10px;")
-
         layout.addWidget(title)
 
         # Tabs
-
         self.tabs = QTabWidget()
 
-        # Tab 1: Biomechanics (Human Models)
-
-        biomech_tab = QWidget()
-
-        biomech_layout = QVBoxLayout(biomech_tab)
-
-        human_group = self._create_human_models_group()
-
-        biomech_layout.addWidget(human_group)
-
-        biomech_layout.addStretch()
-
-        self.tabs.addTab(biomech_tab, "Biomechanics")
-
-        # Tab 2: Equipment (Clubs & Components)
-
-        equipment_tab = QWidget()
-
-        equip_layout = QVBoxLayout(equipment_tab)
-
-        golf_group = self._create_golf_clubs_group()
-
-        equip_layout.addWidget(golf_group)
-
-        # Components Group
-
-        component_group = self._create_components_group()
-
-        equip_layout.addWidget(component_group)
-
-        equip_layout.addStretch()
-
-        self.tabs.addTab(equipment_tab, "Equipment")
-
-        # Tab 3: Robotics (Pendulums & Manipulators)
-
-        robotics_tab = QWidget()
-
-        robotics_layout = QVBoxLayout(robotics_tab)
-
-        # Pendulums
-
-        pendulum_group = self._create_model_group(
-            "Simplified Physics Models",
-            "pendulum",
-            "Simple pendulum models for understanding swing mechanics.",
-            "Load Physics Model",
-        )
-
-        robotics_layout.addWidget(pendulum_group)
-
-        # Manipulators
-
-        robot_group = self._create_model_group(
-            "Robotic Manipulators",
-            "robotic",
-            "Industrial robot arms with golf attachments.",
-            "Load Robot Model",
-        )
-
-        robotics_layout.addWidget(robot_group)
-
-        robotics_layout.addStretch()
-
-        self.tabs.addTab(robotics_tab, "Robotics")
-
-        # Tab 4: Repository Models (Discovered)
+        self.tabs.addTab(self._setup_biomechanics_tab(), "Biomechanics")
+        self.tabs.addTab(self._setup_equipment_tab(), "Equipment")
+        self.tabs.addTab(self._setup_robotics_tab(), "Robotics")
 
         repo_tab = QWidget()
-
         self._setup_repo_tab(repo_tab)
-
         self.tabs.addTab(repo_tab, "Repository")
 
-        # Tab 5: Community Models (robot_descriptions)
-
         community_tab = QWidget()
-
         self._setup_community_tab(community_tab)
-
         self.tabs.addTab(community_tab, "Community")
 
-        # Tab 6: Imported Models (User managed)
-
         imported_tab = QWidget()
-
         self._setup_imported_tab(imported_tab)
-
         self.tabs.addTab(imported_tab, "Imported")
 
-        # Tab 7: Embedded Models (Python defined)
-
         embedded_tab = QWidget()
-
         self._setup_embedded_tab(embedded_tab)
-
         self.tabs.addTab(embedded_tab, "Embedded")
 
         layout.addWidget(self.tabs)
 
-        # Info display
-
-        info_label = QLabel("Model Information:")
-
-        info_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
-
-        layout.addWidget(info_label)
-
-        self.info_display = QTextEdit()
-
-        self.info_display.setReadOnly(True)
-
-        self.info_display.setMaximumHeight(150)
-
-        self.info_display.setPlainText(
-            "Select a model above to see its specifications..."
-        )
-
-        layout.addWidget(self.info_display)
-
-        # Button box
-
-        button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
-        )
-
-        button_box.accepted.connect(self._on_accept)
-
-        button_box.rejected.connect(self.reject)
-
-        layout.addWidget(button_box)
+        # Info display and dialog buttons
+        self._setup_info_and_buttons(layout)
 
     def _setup_repo_tab(self, parent: QWidget) -> None:
-
         from PyQt6.QtWidgets import QHeaderView, QLineEdit, QTreeWidget
 
         layout = QVBoxLayout(parent)
@@ -254,7 +204,6 @@ class ModelLoaderDialog(QDialog):
         header = self.repo_tree.header()
 
         if header:
-
             header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
 
             header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
@@ -280,13 +229,11 @@ class ModelLoaderDialog(QDialog):
         layout.addWidget(load_btn)
 
     def _populate_repo_tree(self, models: list) -> None:
-
         from PyQt6.QtWidgets import QTreeWidgetItem
 
         self.repo_tree.clear()
 
         for model in models:
-
             item = QTreeWidgetItem(
                 [model["name"], model["type"].upper(), model["path"]]
             )
@@ -296,7 +243,6 @@ class ModelLoaderDialog(QDialog):
             self.repo_tree.addTopLevelItem(item)
 
     def _filter_repo_list(self, text: str) -> None:
-
         text = text.lower()
 
         filtered = [
@@ -308,7 +254,6 @@ class ModelLoaderDialog(QDialog):
         self._populate_repo_tree(filtered)
 
     def _setup_embedded_tab(self, parent: QWidget) -> None:
-
         from PyQt6.QtWidgets import QListWidget
 
         layout = QVBoxLayout(parent)
@@ -328,7 +273,6 @@ class ModelLoaderDialog(QDialog):
         embedded_models = self.library.list_available_models()["embedded"]
 
         for key, model in embedded_models.items():
-
             from PyQt6.QtWidgets import QListWidgetItem
 
             item = QListWidgetItem(f"{model['name']} (MJCF)")
@@ -346,7 +290,6 @@ class ModelLoaderDialog(QDialog):
         layout.addWidget(load_btn)
 
     def _setup_community_tab(self, parent: QWidget) -> None:
-
         from PyQt6.QtWidgets import QListWidget, QListWidgetItem
 
         layout = QVBoxLayout(parent)
@@ -368,7 +311,6 @@ class ModelLoaderDialog(QDialog):
         )
 
         if not community_models:
-
             layout.addWidget(
                 QLabel(
                     "No community models found.\nEnsure 'robot_descriptions' is installed."
@@ -376,7 +318,6 @@ class ModelLoaderDialog(QDialog):
             )
 
         for model in community_models:
-
             item = QListWidgetItem(f"{model['name']} ({model['type'].upper()})")
 
             item.setData(Qt.ItemDataRole.UserRole, model["config_key"])
@@ -392,7 +333,6 @@ class ModelLoaderDialog(QDialog):
         layout.addWidget(load_btn)
 
     def _setup_imported_tab(self, parent: QWidget) -> None:
-
         from PyQt6.QtWidgets import QHeaderView, QTreeWidget
 
         layout = QVBoxLayout(parent)
@@ -414,7 +354,6 @@ class ModelLoaderDialog(QDialog):
         header = self.imported_tree.header()
 
         if header:
-
             header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
 
             header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
@@ -452,7 +391,6 @@ class ModelLoaderDialog(QDialog):
         self._reload_imported_models()
 
     def _reload_imported_models(self) -> None:
-
         from PyQt6.QtWidgets import QTreeWidgetItem
 
         self.imported_tree.clear()
@@ -460,7 +398,6 @@ class ModelLoaderDialog(QDialog):
         models = self.library.discover_imported_models()
 
         for model in models:
-
             item = QTreeWidgetItem(
                 [model["name"], model["type"].upper(), model["path"]]
             )
@@ -474,7 +411,6 @@ class ModelLoaderDialog(QDialog):
             self.imported_tree.addTopLevelItem(item)
 
     def _on_import_button(self) -> None:
-
         from PyQt6.QtWidgets import QFileDialog
 
         path, _ = QFileDialog.getOpenFileName(
@@ -485,25 +421,20 @@ class ModelLoaderDialog(QDialog):
         )
 
         if path:
-
             if self.library.import_model(path):
-
                 self._reload_imported_models()
 
                 QMessageBox.information(self, "Success", "Model imported successfully.")
 
             else:
-
                 QMessageBox.warning(self, "Error", "Failed to import model.")
 
     def _on_imported_context_menu(self, pos: Any) -> None:
-
         from PyQt6.QtWidgets import QInputDialog, QMenu
 
         item = self.imported_tree.itemAt(pos)
 
         if not item:
-
             return
 
         menu = QMenu(self)
@@ -515,7 +446,6 @@ class ModelLoaderDialog(QDialog):
         viewport = self.imported_tree.viewport()
 
         if viewport is None:
-
             return
 
         action = menu.exec(viewport.mapToGlobal(pos))
@@ -523,7 +453,6 @@ class ModelLoaderDialog(QDialog):
         model_path = item.data(0, Qt.ItemDataRole.UserRole + 1)
 
         if action == rename_action:
-
             old_name = item.text(0)
 
             new_name, ok = QInputDialog.getText(
@@ -531,17 +460,13 @@ class ModelLoaderDialog(QDialog):
             )
 
             if ok and new_name and new_name != old_name:
-
                 if self.library.rename_imported_model(model_path, new_name):
-
                     self._reload_imported_models()
 
                 else:
-
                     QMessageBox.warning(self, "Error", "Failed to rename model.")
 
         elif action == delete_action:
-
             reply = QMessageBox.question(
                 self,
                 "Confirm Delete",
@@ -550,39 +475,30 @@ class ModelLoaderDialog(QDialog):
             )
 
             if reply == QMessageBox.StandardButton.Yes:
-
                 if self.library.delete_imported_model(model_path):
-
                     self._reload_imported_models()
 
                 else:
-
                     QMessageBox.warning(self, "Error", "Failed to delete model.")
 
     def _on_accept(self) -> None:
-
         # Determine active tab and selected item
 
         idx = self.tabs.currentIndex()
 
         if idx == 0:  # Bundled
-
             pass
 
         if self.selected_model:
-
             self.accept()
 
         else:
-
             # Try to select from active tab
 
             if idx == 1:
-
                 self._load_selected_model("discovered")
 
             elif idx == 2:
-
                 self._load_selected_model("embedded")
 
     def _create_human_models_group(self) -> QGroupBox:
@@ -624,11 +540,9 @@ class ModelLoaderDialog(QDialog):
         available_models = self.library.list_available_models()
 
         for model_key in available_models["human"]:
-
             model_info = self.library.get_model_info("human", model_key)
 
             if model_info:
-
                 self.human_combo.addItem(model_info["name"], model_key)
 
         self.human_combo.currentIndexChanged.connect(
@@ -720,11 +634,9 @@ class ModelLoaderDialog(QDialog):
         available_models = self.library.list_available_models()
 
         for club_key in available_models["golf_clubs"]:
-
             club_info = self.library.get_model_info("golf_clubs", club_key)
 
             if club_info:
-
                 self.club_combo.addItem(club_info["name"], club_key)
 
         self.club_combo.currentIndexChanged.connect(
@@ -807,11 +719,9 @@ class ModelLoaderDialog(QDialog):
         setattr(self, f"{category}_combo", combo)
 
         for key in available_models.get(category, []):
-
             info = self.library.get_model_info(category, key)
 
             if info:
-
                 combo.addItem(info["name"], key)
 
         combo.currentIndexChanged.connect(lambda: self._on_model_selected(category))
@@ -844,15 +754,12 @@ class ModelLoaderDialog(QDialog):
         model_key = None
 
         if category == "human":
-
             model_key = self.human_combo.currentData()
 
         elif category == "golf_clubs":
-
             model_key = self.club_combo.currentData()
 
         elif hasattr(self, f"{category}_combo"):
-
             # Generic handling for pendulum, robotic, component
 
             combo = getattr(self, f"{category}_combo")
@@ -860,43 +767,33 @@ class ModelLoaderDialog(QDialog):
             model_key = combo.currentData()
 
         elif category == "discovered":
-
             repo_item = self.repo_tree.currentItem()
 
             if repo_item:
-
                 model_key = repo_item.data(0, Qt.ItemDataRole.UserRole)
 
         elif category == "embedded":
-
             embed_item = self.embedded_list.currentItem()
 
             if embed_item:
-
                 model_key = embed_item.data(Qt.ItemDataRole.UserRole)
 
         elif category == "robot_descriptions":
-
             comm_item = self.community_list.currentItem()
 
             if comm_item:
-
                 model_key = comm_item.data(Qt.ItemDataRole.UserRole)
 
         elif category == "imported":
-
             imp_item = self.imported_tree.currentItem()
 
             if imp_item:
-
                 model_key = imp_item.data(0, Qt.ItemDataRole.UserRole)
 
         if model_key:
-
             model_info = self.library.get_model_info(category, model_key)
 
             if model_info:
-
                 self._display_model_info(category, model_key, model_info)
 
             self.selected_category = category
@@ -921,7 +818,6 @@ class ModelLoaderDialog(QDialog):
         """
 
         if category == "human":
-
             info_text = f"""Name: {model_info["name"]}
 
 Description: {model_info["description"]}
@@ -935,7 +831,6 @@ Repository: https://github.com/gbionics/human-gazebo
 """
 
         elif category == "golf_clubs":
-
             info_text = f"""Club: {model_info["name"]}
 
 Loft: {model_info["loft"]}°
@@ -957,7 +852,6 @@ The URDF will be automatically generated with realistic geometry and inertial pr
 """
 
         elif category in ["pendulum", "robotic", "component"]:
-
             info_text = f"""Name: {model_info["name"]}
 
 Type: {model_info.get("type", "Unknown").upper()}
@@ -973,7 +867,6 @@ Click 'Load' to view this model.
 """
 
         elif category == "discovered":
-
             info_text = f"""Name: {model_info["name"]}
 
 Type: {model_info["type"].upper()}
@@ -987,7 +880,6 @@ Click 'Load Selected Repository Model' to view.
 """
 
         elif category == "embedded":
-
             content_preview = (
                 model_info["content"][:200] + "..."
                 if len(model_info["content"]) > 200
@@ -1009,7 +901,6 @@ Content Preview:
 """
 
         elif category == "robot_descriptions":
-
             info_text = f"""Name: {model_info["name"]}
 
 Type: {model_info["type"].upper()}
@@ -1025,7 +916,6 @@ Description: {model_info["description"]}
 """
 
         elif category == "imported":
-
             info_text = f"""Name: {model_info["name"]}
 
 Type: {model_info["type"].upper()}
@@ -1039,7 +929,6 @@ User imported model. Right-click in the list to Rename or Delete.
 """
 
         else:
-
             info_text = "No information available."
 
         self.info_display.setPlainText(info_text)
@@ -1050,7 +939,6 @@ User imported model. Right-click in the list to Rename or Delete.
         model_key = self.human_combo.currentData()
 
         if not model_key:
-
             return
 
         reply = QMessageBox.question(
@@ -1063,13 +951,10 @@ User imported model. Right-click in the list to Rename or Delete.
         )
 
         if reply == QMessageBox.StandardButton.Yes:
-
             try:
-
                 urdf_path = self.library.download_human_model(model_key)
 
                 if urdf_path:
-
                     QMessageBox.information(
                         self,
                         "Download Complete",
@@ -1077,13 +962,11 @@ User imported model. Right-click in the list to Rename or Delete.
                     )
 
                 else:
-
                     QMessageBox.warning(
                         self, "Download Failed", "Failed to download model files."
                     )
 
             except (RuntimeError, ValueError, OSError) as e:
-
                 logger.error(f"Download error: {e}")
 
                 QMessageBox.critical(
@@ -1102,27 +985,22 @@ User imported model. Right-click in the list to Rename or Delete.
         """
 
         if category == "human":
-
             model_key = self.human_combo.currentData()
 
         elif category == "golf_clubs":
-
             model_key = self.club_combo.currentData()
 
         elif hasattr(self, f"{category}_combo"):
-
             combo = getattr(self, f"{category}_combo")
 
             model_key = combo.currentData()
 
         else:
-
             # Fallback for manual calls, though generic way is better
 
             return
 
         if model_key:
-
             self.selected_category = category
 
             self.selected_model = model_key
@@ -1134,7 +1012,6 @@ User imported model. Right-click in the list to Rename or Delete.
                 and hasattr(self, "default_human_chk")
                 and self.default_human_chk.isChecked()
             ):
-
                 from PyQt6.QtCore import QSettings
 
                 settings = QSettings("GolfModelingSuite", "URDFGenerator")
@@ -1159,7 +1036,6 @@ User imported model. Right-click in the list to Rename or Delete.
         """
 
         if self.selected_category and self.selected_model:
-
             return (self.selected_category, self.selected_model)
 
         return None

--- a/src/tools/model_generation/cli/main.py
+++ b/src/tools/model_generation/cli/main.py
@@ -556,23 +556,8 @@ def cmd_inertia(args: argparse.Namespace) -> int:
     return 0
 
 
-def create_parser() -> argparse.ArgumentParser:
-    """Create the argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="model-gen",
-        description="URDF Model Generation and Manipulation Tools",
-    )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose output"
-    )
-    parser.add_argument(
-        "-q", "--quiet", action="store_true", help="Suppress non-error output"
-    )
-    parser.add_argument("--version", action="version", version="model-gen 1.0.0")
-
-    subparsers = parser.add_subparsers(dest="command", help="Available commands")
-
-    # Generate command
+def _add_generate_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'generate' subcommand parser."""
     gen_parser = subparsers.add_parser(
         "generate", aliases=["gen"], help="Generate URDF from parameters"
     )
@@ -586,7 +571,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     gen_parser.set_defaults(func=cmd_generate)
 
-    # Convert command
+
+def _add_convert_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'convert' subcommand parser."""
     conv_parser = subparsers.add_parser(
         "convert", aliases=["conv"], help="Convert between model formats"
     )
@@ -609,7 +596,9 @@ def create_parser() -> argparse.ArgumentParser:
     conv_parser.add_argument("-n", "--name", help="Override robot name")
     conv_parser.set_defaults(func=cmd_convert)
 
-    # Validate command
+
+def _add_validate_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'validate' subcommand parser."""
     val_parser = subparsers.add_parser(
         "validate", aliases=["val"], help="Validate URDF file"
     )
@@ -623,7 +612,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     val_parser.set_defaults(func=cmd_validate)
 
-    # Diff command
+
+def _add_diff_and_info_subparsers(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'diff' and 'info' subcommand parsers."""
     diff_parser = subparsers.add_parser("diff", help="Compare two URDF files")
     diff_parser.add_argument("file_a", help="First file")
     diff_parser.add_argument("file_b", help="Second file")
@@ -638,13 +629,14 @@ def create_parser() -> argparse.ArgumentParser:
     )
     diff_parser.set_defaults(func=cmd_diff)
 
-    # Info command
     info_parser = subparsers.add_parser("info", help="Show model information")
     info_parser.add_argument("input", help="URDF file")
     info_parser.add_argument("--json", action="store_true", help="Output as JSON")
     info_parser.set_defaults(func=cmd_info)
 
-    # Library commands
+
+def _add_library_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'library' subcommand parser with its sub-subcommands."""
     lib_parser = subparsers.add_parser(
         "library", aliases=["lib"], help="Model library operations"
     )
@@ -677,7 +669,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     lib_download.set_defaults(func=cmd_library_download)
 
-    # Compose command
+
+def _add_compose_and_inertia_subparsers(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'compose' and 'inertia' subcommand parsers."""
     compose_parser = subparsers.add_parser(
         "compose", help="Compose model from multiple sources"
     )
@@ -698,7 +692,6 @@ def create_parser() -> argparse.ArgumentParser:
     )
     compose_parser.set_defaults(func=cmd_edit_compose)
 
-    # Inertia calculator
     inertia_parser = subparsers.add_parser(
         "inertia", help="Calculate inertia for primitive shapes"
     )
@@ -716,6 +709,30 @@ def create_parser() -> argparse.ArgumentParser:
     )
     inertia_parser.add_argument("--json", action="store_true", help="Output as JSON")
     inertia_parser.set_defaults(func=cmd_inertia)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="model-gen",
+        description="URDF Model Generation and Manipulation Tools",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress non-error output"
+    )
+    parser.add_argument("--version", action="version", version="model-gen 1.0.0")
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    _add_generate_subparser(subparsers)
+    _add_convert_subparser(subparsers)
+    _add_validate_subparser(subparsers)
+    _add_diff_and_info_subparsers(subparsers)
+    _add_library_subparser(subparsers)
+    _add_compose_and_inertia_subparsers(subparsers)
 
     return parser
 


### PR DESCRIPTION
## Summary
- Decomposes 60+ functions exceeding 100 lines into focused, single-responsibility helpers across the entire codebase (addresses #1354)
- Analyzes print() calls — only 24 actual calls exist, all in myosuite CLI example scripts where print is appropriate (resolves #1349)
- All decompositions preserve public APIs and behavior exactly — pure refactoring with no functional changes

### Areas Decomposed
| Area | Functions Decomposed | Key Examples |
|------|---------------------|--------------|
| Glossary data | 3 | `get_extended_entries` (2330→14 helpers), `get_core_entries` (1738→6 helpers) |
| Drake/Pinocchio | 6 | `generate()`, `_setup_ui()`, `_game_loop()` |
| MuJoCo GUI | 10+ | visualization, manipulation, plotting, physics tabs |
| MuJoCo physics | 4 | `aba` (284→3 phases), `crba`, `run_simulation` |
| API/launcher | 11 | `create_local_app` (417→5 helpers), `simulation_stream` |
| Shared modules | 8 | theme, club_data, physics_parameters, widgets, recorder |
| Simscape | 12+ | analyze/visualize data, coordinate system, renderer |
| Tools | 5 | parametric_builder, segment_definitions, text_editor |

## Test plan
- [x] All 565 tests pass locally (41 skipped)
- [x] Pre-commit hooks (ruff lint, ruff format) pass
- [x] All decomposed functions verified with AST parsing to confirm <100 lines
- [ ] CI/CD pipeline passes

Closes #1354
Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily refactoring, but it touches core runtime paths (WebSocket simulation loop, local API startup/mounting, URDF generation, and GUI simulation loops) where small control-flow differences could change behavior or error handling.
> 
> **Overview**
> This PR is a broad **refactor-only decomposition** that splits multiple 100+ line functions into focused helper methods across the API server, WebSocket simulation streaming, URDF/model generation, and multiple Python GUI tools.
> 
> On the API side, `create_local_app` is reorganized into discrete steps (CORS, router registration, launcher endpoints, health/diagnostics, static UI mounting), URDF tree parsing in `model_explorer` is split into link/joint parsing helpers, and `simulation_ws` extracts engine loading and the run/pause/stop simulation loop into reusable async helpers.
> 
> In the various simulator/GUI utilities (Simscape plotters/analyzers, Drake GUI, MuJoCo examples and GUI, OpenGL renderer, and data loaders), large UI-building, rendering, parsing, and loop routines are similarly decomposed into smaller private helpers, with minor logging/structure cleanup but no intended feature changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bdff5e4deb866aba052b2d07a4be50f0014a268. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->