### PR TITLE
refactor: wave 4 — return type annotations and test fixture docstrings

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/Motion_Capture_Plotter.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/Motion_Capture_Plotter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -69,8 +71,8 @@ class MotionCapturePlotter(QMainWindow):
         # Try to auto-load the Excel file if it exists
         self.auto_load_excel_file()
 
-    def auto_load_excel_file(self):
-        """Automatically load the Excel file if it exists in the current directory"""
+    def auto_load_excel_file(self) -> None:
+        """Automatically load the Excel file if it exists in the current directory."""
         excel_files = [f for f in os.listdir(".") if f.endswith((".xlsx", ".xls"))]
         if excel_files:
             # Try to load the first Excel file found
@@ -78,8 +80,8 @@ class MotionCapturePlotter(QMainWindow):
             logger.info(f"Auto-loading Excel file: {filename}")
             self.load_excel_file(filename)
 
-    def setup_ui(self):
-        """Setup the main UI"""
+    def setup_ui(self) -> None:
+        """Setup the main UI."""
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
 
@@ -270,8 +272,8 @@ class MotionCapturePlotter(QMainWindow):
 
         return info_group, help_group
 
-    def create_control_panel(self):
-        """Create the left control panel with scroll area"""
+    def create_control_panel(self) -> QScrollArea:
+        """Create the left control panel with scroll area."""
         # Create a scroll area to contain all controls
         scroll_area = QScrollArea()
         scroll_area.setMaximumWidth(400)
@@ -315,8 +317,8 @@ class MotionCapturePlotter(QMainWindow):
         scroll_area.setWidget(panel)
         return scroll_area
 
-    def create_plot_panel(self):
-        """Create the right plot panel"""
+    def create_plot_panel(self) -> QWidget:
+        """Create the right plot panel."""
         panel = QWidget()
         layout = QVBoxLayout(panel)
 
@@ -354,8 +356,8 @@ class MotionCapturePlotter(QMainWindow):
 
         return panel
 
-    def load_file(self):
-        """Load data file based on current data source"""
+    def load_file(self) -> None:
+        """Load data file based on current data source."""
         if self.current_data_source == "Motion Capture (Excel)":
             filename, _ = QFileDialog.getOpenFileName(
                 self, "Load Excel File", "", "Excel Files (*.xlsx *.xls)"
@@ -369,8 +371,8 @@ class MotionCapturePlotter(QMainWindow):
             if filename:
                 self.load_simscape_csv(filename)
 
-    def on_data_source_changed(self, source):
-        """Handle data source change"""
+    def on_data_source_changed(self, source) -> None:
+        """Handle data source change."""
         self.current_data_source = source
         logger.info(f"Data source changed to: {source}")
 
@@ -395,8 +397,8 @@ class MotionCapturePlotter(QMainWindow):
         # Update visualization
         self.update_visualization()
 
-    def auto_load_simscape_csv(self):
-        """Automatically load the Simscape CSV file if it exists"""
+    def auto_load_simscape_csv(self) -> None:
+        """Automatically load the Simscape CSV file if it exists."""
         csv_files = [f for f in os.listdir(".") if f.endswith(".csv")]
         if csv_files:
             filename = csv_files[0]
@@ -474,8 +476,8 @@ class MotionCapturePlotter(QMainWindow):
             logger.debug(f"Successfully loaded {len(data)} frames for {sheet_name}")
             self.print_data_debug(sheet_name)
 
-    def load_excel_file(self, filename):
-        """Load and process Excel file"""
+    def load_excel_file(self, filename) -> None:
+        """Load and process Excel file."""
         try:
             logger.info(f"Loading file: {filename}")
             excel_file = pd.ExcelFile(filename)
@@ -574,8 +576,8 @@ class MotionCapturePlotter(QMainWindow):
                 logger.warning(f"✗ {joint_name}: MISSING {len(missing_cols)} columns")
         return available_joints
 
-    def load_simscape_csv(self, filename):
-        """Load and process Simscape CSV file"""
+    def load_simscape_csv(self, filename) -> None:
+        """Load and process Simscape CSV file."""
         try:
             logger.info(f"Loading Simscape CSV file: {filename}")
 
@@ -629,8 +631,8 @@ class MotionCapturePlotter(QMainWindow):
                 self, "Error", f"Failed to load Simscape CSV file: {str(e)}"
             )
 
-    def print_data_debug(self, sheet_name):
-        """Print debug information about the loaded data"""
+    def print_data_debug(self, sheet_name) -> None:
+        """Print debug information about the loaded data."""
         if sheet_name in self.swing_data:
             data = self.swing_data[sheet_name]
             if not data.empty:
@@ -698,8 +700,8 @@ class MotionCapturePlotter(QMainWindow):
                 logger.info("  Motion scaling applied to make visualization clearer")
                 logger.info("=" * 40)
 
-    def setup_frame_slider(self):
-        """Setup the frame slider"""
+    def setup_frame_slider(self) -> None:
+        """Setup the frame slider."""
         if self.current_swing in self.swing_data:
             data = self.swing_data[self.current_swing]
             max_frame = len(data) - 1
@@ -707,39 +709,39 @@ class MotionCapturePlotter(QMainWindow):
             self.frame_slider.setValue(0)
             self.current_frame = 0
 
-    def on_swing_change(self, swing_name):
-        """Handle swing selection change"""
+    def on_swing_change(self, swing_name) -> None:
+        """Handle swing selection change."""
         if swing_name in self.swing_data:
             self.current_swing = swing_name
             self.setup_frame_slider()
             self.update_visualization()
 
-    def on_frame_change(self, frame):
-        """Handle frame slider change"""
+    def on_frame_change(self, frame) -> None:
+        """Handle frame slider change."""
         self.current_frame = frame
         self.frame_label.setText(str(frame))
         self.update_visualization()
 
-    def on_speed_change(self, speed):
-        """Handle speed slider change"""
+    def on_speed_change(self, speed) -> None:
+        """Handle speed slider change."""
         self.speed_label.setText(str(speed))
         if self.is_playing:
             self.animation_timer.setInterval(1000 // speed)
 
-    def on_scale_change(self, scale):
-        """Handle motion scale change"""
+    def on_scale_change(self, scale) -> None:
+        """Handle motion scale change."""
         self.motion_scale = scale
         self.scale_label.setText(f"{scale}x")
         self.update_visualization()
 
-    def on_club_length_change(self, length_cm):
-        """Handle club length change"""
+    def on_club_length_change(self, length_cm) -> None:
+        """Handle club length change."""
         self.shaft_length = length_cm / 100.0  # Convert cm to meters
         self.club_label.setText(f"{self.shaft_length:.1f}m")
         self.update_visualization()
 
-    def toggle_playback(self):
-        """Toggle play/pause"""
+    def toggle_playback(self) -> None:
+        """Toggle play/pause."""
         if self.is_playing:
             self.animation_timer.stop()
             self.play_btn.setText("Play")
@@ -750,8 +752,8 @@ class MotionCapturePlotter(QMainWindow):
             self.play_btn.setText("Pause")
             self.is_playing = True
 
-    def next_frame(self):
-        """Advance to next frame"""
+    def next_frame(self) -> None:
+        """Advance to next frame."""
         if self.current_swing in self.swing_data:
             data = self.swing_data[self.current_swing]
             if self.current_frame < len(data) - 1:
@@ -762,8 +764,8 @@ class MotionCapturePlotter(QMainWindow):
                 self.current_frame = 0
                 self.frame_slider.setValue(0)
 
-    def setup_3d_scene(self):
-        """Setup the 3D scene with ground plane and ball"""
+    def setup_3d_scene(self) -> None:
+        """Setup the 3D scene with ground plane and ball."""
         self.ax.clear()
 
         # Ground plane - positioned at calculated ground level
@@ -796,12 +798,12 @@ class MotionCapturePlotter(QMainWindow):
         # Set initial view
         self.ax.view_init(elev=15, azim=-45)
 
-    def calculate_ground_level(self):
-        """Set ground level to fixed -2.5 meters"""
+    def calculate_ground_level(self) -> float:
+        """Set ground level to fixed -2.5 meters."""
         return -2.5
 
-    def adjust_plot_limits_to_ground(self):
-        """Adjust plot limits so ground level is at the bottom"""
+    def adjust_plot_limits_to_ground(self) -> None:
+        """Adjust plot limits so ground level is at the bottom."""
         ground_level = self.calculate_ground_level()
 
         # Set Z limits with ground at bottom and reasonable height above
@@ -810,8 +812,8 @@ class MotionCapturePlotter(QMainWindow):
 
         logger.info(f"Ground level set to: {ground_level:.3f}m")
 
-    def update_visualization(self):
-        """Update the 3D visualization with proper coordinate system"""
+    def update_visualization(self) -> None:
+        """Update the 3D visualization with proper coordinate system."""
         # Store current view angles before clearing
         current_elev = self.ax.elev
         current_azim = self.ax.azim
@@ -905,8 +907,8 @@ class MotionCapturePlotter(QMainWindow):
                 label="Club Head Path",
             )
 
-    def visualize_motion_capture_data(self, frame_data, data):
-        """Visualize motion capture data (Excel format)"""
+    def visualize_motion_capture_data(self, frame_data, data) -> None:
+        """Visualize motion capture data (Excel format)."""
         # Use actual mid-hands and club head positions from the data
         # For right-handed golfers: X should be flipped to show proper swing direction
         mid_hands = np.array(
@@ -1220,8 +1222,8 @@ class MotionCapturePlotter(QMainWindow):
                         label=f"{segment_key.replace('_', ' ').title()} Path",
                     )
 
-    def visualize_simscape_data(self, frame_data, data):
-        """Visualize Simscape multibody data (CSV format)"""
+    def visualize_simscape_data(self, frame_data, data) -> None:
+        """Visualize Simscape multibody data (CSV format)."""
         # Define colors for different body segments
         colors = {
             "club": "red",
@@ -1256,8 +1258,8 @@ class MotionCapturePlotter(QMainWindow):
         self._draw_simscape_trajectory_paths(joints, data)
         self._draw_segment_traces(frame_data, data)
 
-    def update_info_text(self, frame_data):
-        """Update the information text display"""
+    def update_info_text(self, frame_data) -> None:
+        """Update the information text display."""
         info = f"Frame: {self.current_frame}\n"
         info += f"Data Source: {self.current_data_source}\n"
         info += f"Motion Scale: {self.motion_scale}x\n\n"
@@ -1316,8 +1318,8 @@ class MotionCapturePlotter(QMainWindow):
 
         self.info_text.setText(info)
 
-    def set_camera_view(self, view):
-        """Set predefined camera views"""
+    def set_camera_view(self, view) -> None:
+        """Set predefined camera views."""
         if view == "face_on":
             # Face-on view: looking at golfer from front (toward +X target line)
             self.ax.view_init(elev=15, azim=90)
@@ -1335,8 +1337,8 @@ class MotionCapturePlotter(QMainWindow):
         self.canvas.draw_idle()
         self.canvas.flush_events()
 
-    def reset_view(self):
-        """Reset the 3D view to the default isometric view and limits"""
+    def reset_view(self) -> None:
+        """Reset the 3D view to the default isometric view and limits."""
         # Reset view angles
         self.ax.view_init(elev=15, azim=-45)
 
@@ -1349,8 +1351,8 @@ class MotionCapturePlotter(QMainWindow):
         self.canvas.draw_idle()
         self.canvas.flush_events()
 
-    def on_scroll(self, event):
-        """Handle mouse scroll for zooming"""
+    def on_scroll(self, event) -> None:
+        """Handle mouse scroll for zooming."""
         if event.inaxes != self.ax:
             return
 
@@ -1385,20 +1387,20 @@ class MotionCapturePlotter(QMainWindow):
         self.canvas.draw()
         logger.info(f"Zooming: factor={zoom_factor}")
 
-    def on_mouse_press(self, event):
-        """Handle mouse button press for rotation/panning"""
+    def on_mouse_press(self, event) -> None:
+        """Handle mouse button press for rotation/panning."""
         if event.inaxes != self.ax:
             return
         # Store initial position for rotation/panning (use screen coordinates)
         self._last_pos = (event.x, event.y)
         logger.info(f"Mouse press: button={event.button}, pos=({event.x}, {event.y})")
 
-    def on_mouse_release(self, event):
-        """Handle mouse button release"""
+    def on_mouse_release(self, event) -> None:
+        """Handle mouse button release."""
         self._last_pos = None
 
-    def on_mouse_move(self, event):
-        """Handle mouse movement for rotation/panning"""
+    def on_mouse_move(self, event) -> None:
+        """Handle mouse movement for rotation/panning."""
         if event.inaxes != self.ax or self._last_pos is None:
             return
 
@@ -1454,7 +1456,7 @@ class MotionCapturePlotter(QMainWindow):
         self._last_pos = (event.x, event.y)
 
 
-def main():
+def main() -> None:
     """Launch the Motion Capture Plotter GUI application."""
     app = QApplication(sys.argv)
     window = MotionCapturePlotter()

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
@@ -4,6 +4,8 @@ Golf Swing Visualizer - Main Application Entry Point
 Complete integration of all components with enhanced features and error handling
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 import time
@@ -178,19 +180,19 @@ class PerformanceMonitor(QThread):
             "frame_rate": 0.0,
         }
 
-    def start_monitoring(self):
+    def start_monitoring(self) -> None:
         """Start performance monitoring"""
         self.monitoring = True
         self.start()
         logger.info("Performance monitoring started")
 
-    def stop_monitoring(self):
+    def stop_monitoring(self) -> None:
         """Stop performance monitoring"""
         self.monitoring = False
         self.wait()
         logger.info("Performance monitoring stopped")
 
-    def run(self):
+    def run(self) -> None:
         """Performance monitoring loop"""
         while self.monitoring:
             try:
@@ -631,7 +633,7 @@ class SessionManager:
         logger.info(f"Created session: {session_id}")
         return session_id
 
-    def save_session(self, session_id: str, filepath: str):
+    def save_session(self, session_id: str, filepath: str) -> None:
         """Save session to file"""
         if session_id in self.sessions:
             import json
@@ -664,12 +666,12 @@ class ExportManager:
         self.export_queue: list[dict] = []
         self.is_exporting = False
 
-    def export_video(self, frames: list, output_path: str, fps: int = 30):
+    def export_video(self, frames: list, output_path: str, fps: int = 30) -> None:
         """Export frames as video"""
         # This would use OpenCV or similar to create video
         logger.info(f"Exporting video: {output_path}")
 
-    def export_data(self, data: dict, output_path: str, format: str = "csv"):
+    def export_data(self, data: dict, output_path: str, format: str = "csv") -> None:
         """Export analysis data"""
         if format.lower() == "csv":
             import pandas as pd
@@ -678,7 +680,7 @@ class ExportManager:
             df.to_csv(output_path, index=False)
         logger.info(f"Exported data: {output_path}")
 
-    def export_images(self, frames: list, output_dir: str, format: str = "png"):
+    def export_images(self, frames: list, output_dir: str, format: str = "png") -> None:
         """Export frame sequence as images"""
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         # Export logic here
@@ -692,13 +694,13 @@ class PluginManager:
         self.plugins: dict[str, object] = {}
         self.plugin_dir = Path("plugins")
 
-    def load_plugins(self):
+    def load_plugins(self) -> None:
         """Load available plugins"""
         if self.plugin_dir.exists():
             logger.info("Loading plugins...")
             # Plugin loading logic here
 
-    def register_plugin(self, name: str, plugin: object):
+    def register_plugin(self, name: str, plugin: object) -> None:
         """Register a plugin"""
         self.plugins[name] = plugin
         logger.info(f"Plugin registered: {name}")
@@ -709,11 +711,11 @@ class PluginManager:
 # ============================================================================
 
 
-def main():
+def main() -> int:
     """Enhanced main entry point with comprehensive error handling"""
 
     # Setup exception handling
-    def handle_exception(exc_type, exc_value, exc_traceback):
+    def handle_exception(exc_type, exc_value, exc_traceback) -> None:
         """Log uncaught exceptions and show an error dialog."""
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_visualizer_implementation.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_visualizer_implementation.py
@@ -8,6 +8,8 @@ Key Technologies:
 - NumPy + Numba for high-performance computations
 """
 
+from __future__ import annotations
+
 # ============================================================================
 # HIGH-PERFORMANCE DATA STRUCTURES
 # ============================================================================
@@ -290,7 +292,7 @@ class OpenGLRenderer:
         }
         """
 
-    def initialize(self, ctx):
+    def initialize(self, ctx) -> None:
         """Initialize OpenGL context and resources"""
         self.ctx = ctx
         self._compile_shaders()
@@ -610,7 +612,7 @@ class OpenGLRenderer:
         config: RenderConfig,
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
-    ):
+    ) -> None:
         """Render complete frame with all elements"""
         self.ctx.clear(0.1, 0.2, 0.3)
         self.ctx.enable(mgl.DEPTH_TEST)
@@ -950,7 +952,7 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
         self.frame_times = []
         self.fps = 0.0
 
-    def initializeGL(self):
+    def initializeGL(self) -> None:
         """Initialize OpenGL context"""
         self.ctx = mgl.create_context()
         self.renderer.initialize(self.ctx)
@@ -960,7 +962,7 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
         logger.info(f"   Vendor: {self.ctx.info['GL_VENDOR']}")
         logger.info(f"   Renderer: {self.ctx.info['GL_RENDERER']}")
 
-    def paintGL(self):
+    def paintGL(self) -> None:
         """Render the current frame"""
         start_time = time.time()
         if self.datasets is None or self.num_frames == 0:
@@ -982,11 +984,11 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
             len(self.frame_times) / sum(self.frame_times) if self.frame_times else 0
         )
 
-    def resizeGL(self, width, height):
+    def resizeGL(self, width, height) -> None:
         """Handle window resize"""
         self.ctx.viewport = (0, 0, width, height)
 
-    def load_data(self, baseq_file: str, ztcfq_file: str, delta_file: str):
+    def load_data(self, baseq_file: str, ztcfq_file: str, delta_file: str) -> None:
         """Load golf swing data"""
         try:
             datasets = self.data_processor.load_matlab_data(
@@ -1004,35 +1006,35 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
         except (RuntimeError, ValueError, OSError) as e:
             logger.info(f"Failed to load data: {e}")
 
-    def play_animation(self):
+    def play_animation(self) -> None:
         """Start animation playback"""
         if not self.is_playing and self.num_frames > 0:
             self.is_playing = True
             interval = int(33 / self.playback_speed)
             self.animation_timer.start(interval)
 
-    def pause_animation(self):
+    def pause_animation(self) -> None:
         """Pause animation playback"""
         self.is_playing = False
         self.animation_timer.stop()
 
-    def next_frame(self):
+    def next_frame(self) -> None:
         """Advance to next frame"""
         if self.num_frames > 0:
             self.current_frame = (self.current_frame + 1) % self.num_frames
             self.update()
 
-    def set_frame(self, frame_idx: int):
+    def set_frame(self, frame_idx: int) -> None:
         """Jump to specific frame"""
         if 0 <= frame_idx < self.num_frames:
             self.current_frame = frame_idx
             self.update()
 
-    def mousePressEvent(self, event):
+    def mousePressEvent(self, event) -> None:
         """Handle mouse press for camera control"""
         self.last_mouse_pos = (event.x(), event.y())
 
-    def mouseMoveEvent(self, event):
+    def mouseMoveEvent(self, event) -> None:
         """Handle mouse movement for camera control"""
         if self.last_mouse_pos is not None:
             dx = event.x() - self.last_mouse_pos[0]
@@ -1044,7 +1046,7 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
             self.last_mouse_pos = (event.x(), event.y())
             self.update()
 
-    def wheelEvent(self, event):
+    def wheelEvent(self, event) -> None:
         """Handle mouse wheel for camera zoom"""
         delta = event.angleDelta().y() / 120
         self.camera_distance = np.clip(self.camera_distance - delta * 0.2, 0.5, 10.0)
@@ -1287,7 +1289,7 @@ class ModernGolfVisualizerApp(QMainWindow):
 # ============================================================================
 # MAIN APPLICATION ENTRY POINT
 # ============================================================================
-def main():
+def main() -> None:
     """Main application entry point"""
     app = QApplication(sys.argv)
     app.setApplicationName("Modern Golf Swing Visualizer")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
@@ -5,6 +5,8 @@ This script will explore the actual structure of the .mat files
 to understand the data format.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 from pathlib import Path
@@ -15,7 +17,7 @@ import scipy.io
 logger = logging.getLogger(__name__)
 
 
-def deep_analyze_matlab_file(filename):
+def deep_analyze_matlab_file(filename) -> bool:
     """Deep analysis of a MATLAB file structure"""
     logger.debug(f"\n=== Deep Analysis of {filename} ===")
 
@@ -98,7 +100,7 @@ def deep_analyze_matlab_file(filename):
         return False
 
 
-def extract_actual_data(filename):
+def extract_actual_data(filename) -> np.ndarray | None:
     """Try to extract the actual data from the MATLAB file"""
     logger.debug(f"\n=== Extracting Data from {filename} ===")
 
@@ -157,7 +159,7 @@ def extract_actual_data(filename):
         return None
 
 
-def main():
+def main() -> None:
     """Main analysis function"""
     logger.info("🔍 Detailed MATLAB Data Structure Analysis")
     logger.info("=" * 60)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/final_robustness_test.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/final_robustness_test.py
@@ -12,7 +12,7 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-def test_data_loading_accuracy():
+def test_data_loading_accuracy() -> bool:
     """Test the accuracy of data loading"""
     logger.info("🔍 TESTING DATA LOADING ACCURACY")
     logger.info("%s", "=" * 60)
@@ -87,7 +87,7 @@ def test_data_loading_accuracy():
         return False
 
 
-def test_data_consistency():
+def test_data_consistency() -> bool:
     """Test consistency between datasets"""
     logger.info("\n🔄 TESTING DATA CONSISTENCY")
     logger.info("%s", "=" * 60)
@@ -148,7 +148,7 @@ def test_data_consistency():
         return False
 
 
-def test_error_handling():
+def test_error_handling() -> bool:
     """Test error handling capabilities"""
     logger.error("\n🛡️ TESTING ERROR HANDLING")
     logger.info("%s", "=" * 60)
@@ -191,7 +191,7 @@ def test_error_handling():
         return False
 
 
-def test_performance():
+def test_performance() -> bool:
     """Test performance characteristics"""
     logger.info("\n⚡ TESTING PERFORMANCE")
     logger.info("%s", "=" * 60)
@@ -238,7 +238,7 @@ def test_performance():
         return False
 
 
-def generate_final_report():
+def generate_final_report() -> bool:
     """Generate the final robustness report"""
     logger.info("📋 FINAL ROBUSTNESS AND ACCURACY ANALYSIS REPORT")
     logger.info("%s", "=" * 80)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
@@ -4,6 +4,8 @@ Golf Swing Visualizer - Core Data Structures and Processing
 High-performance data handling with optimized MATLAB loading and frame processing
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 import time
@@ -188,7 +190,7 @@ class PerformanceStats:
     memory_usage_mb: float = 0.0
     frame_times: list[float] = field(default_factory=list)
 
-    def update_frame_time(self, frame_time: float):
+    def update_frame_time(self, frame_time: float) -> None:
         """Update frame timing statistics"""
         self.frame_times.append(frame_time)
         if len(self.frame_times) > 120:  # Keep last 2 seconds at 60fps
@@ -482,13 +484,13 @@ class FrameProcessor:
         # Track current frame for UI coordination
         self.current_frame = 0
 
-    def set_filter(self, filter_type: str):
+    def set_filter(self, filter_type: str) -> None:
         """Set the data filter and invalidate dynamics cache."""
         if filter_type != self.current_filter:
             self.current_filter = filter_type
             self.invalidate_cache()
 
-    def invalidate_cache(self):
+    def invalidate_cache(self) -> None:
         """Invalidate cached dynamics data."""
         with self._dynamics_cache_lock:
             self.dynamics_cache = {}
@@ -670,18 +672,18 @@ class FrameProcessor:
         """Get time vector."""
         return self.time_vector
 
-    def set_filter_type(self, filter_type: str):
+    def set_filter_type(self, filter_type: str) -> None:
         """Set the current filter type and invalidate cached filtered data"""
         self.set_filter(filter_type)  # Use existing method
 
-    def set_filter_param(self, param_name: str, value):
+    def set_filter_param(self, param_name: str, value) -> None:
         """Set a filter parameter and invalidate cached filtered data"""
         if not hasattr(self, "filter_params"):
             self.filter_params = {}
         self.filter_params[param_name] = value
         self.invalidate_cache()
 
-    def set_vector_visibility(self, vector_type: str, visible: bool):
+    def set_vector_visibility(self, vector_type: str, visible: bool) -> None:
         """Set visibility for calculated vector types"""
         if vector_type == "force":
             self.config.show_calculated_force = visible
@@ -689,7 +691,7 @@ class FrameProcessor:
             self.config.show_calculated_torque = visible
         # Update any other vector types as needed
 
-    def set_vector_scale(self, vector_type: str, scale: float):
+    def set_vector_scale(self, vector_type: str, scale: float) -> None:
         """Set scale for vector rendering"""
         if vector_type == "all":
             self.config.calculated_vector_scale = scale

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
@@ -4,6 +4,8 @@ Golf Swing Visualizer - Tabular GUI Application
 Supports multiple data sources including motion capture and future Simulink models
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 import traceback
@@ -89,7 +91,7 @@ class SmoothPlaybackController(QObject):
         self.is_playing = False
         self.loop_playback = True  # Default to looping
 
-    def load_frame_processor(self, frame_processor: FrameProcessor):
+    def load_frame_processor(self, frame_processor: FrameProcessor) -> None:
         """Load frame processor with motion data"""
         self.frame_processor = frame_processor
         self.stop()
@@ -105,7 +107,7 @@ class SmoothPlaybackController(QObject):
         return self._current_position
 
     @position.setter
-    def position(self, value: float):
+    def position(self, value: float) -> None:
         """Set playback position with interpolation"""
         if self.frame_processor is None:
             return
@@ -122,7 +124,7 @@ class SmoothPlaybackController(QObject):
     # Playback Control
     # ========================================================================
 
-    def play(self):
+    def play(self) -> None:
         """Start smooth playback"""
         if self.frame_processor is None:
             return
@@ -152,7 +154,7 @@ class SmoothPlaybackController(QObject):
 
         self.is_playing = True
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause playback"""
         if not self.is_playing:
             return
@@ -160,20 +162,20 @@ class SmoothPlaybackController(QObject):
         self.animation.pause()
         self.is_playing = False
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop playback and reset to beginning"""
         self.animation.stop()
         self.is_playing = False
         self.seek(0.0)
 
-    def toggle_playback(self):
+    def toggle_playback(self) -> None:
         """Toggle between play and pause"""
         if self.is_playing:
             self.pause()
         else:
             self.play()
 
-    def seek(self, position: float):
+    def seek(self, position: float) -> None:
         """Seek to specific frame position"""
         if self.frame_processor is None:
             return
@@ -188,7 +190,7 @@ class SmoothPlaybackController(QObject):
         if was_playing:
             self.play()
 
-    def set_playback_speed(self, speed: float):
+    def set_playback_speed(self, speed: float) -> None:
         """Set playback speed multiplier (0.5 = half speed, 2.0 = double speed)"""
         self._playback_speed = np.clip(speed, 0.1, 10.0)
 
@@ -918,7 +920,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
         # Set focus policy for keyboard events
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
-    def initializeGL(self):
+    def initializeGL(self) -> None:
         """Initialize OpenGL context"""
         try:
             # Create moderngl context
@@ -940,12 +942,12 @@ class GolfVisualizerWidget(QOpenGLWidget):
             logger.error("❌ OpenGL initialization failed: %s", e)
             traceback.print_exc()
 
-    def resizeGL(self, w: int, h: int):
+    def resizeGL(self, w: int, h: int) -> None:
         """Handle OpenGL widget resize"""
         if self.renderer:
             self.renderer.set_viewport(w, h)
 
-    def paintGL(self):
+    def paintGL(self) -> None:
         """Render the OpenGL scene"""
         if not self.renderer or not self.current_frame_data:
             return
@@ -1056,7 +1058,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
 
     def load_data_from_dataframes(
         self, dataframes: tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
-    ):
+    ) -> None:
         """Load data from pandas DataFrames"""
         try:
             baseq_df, ztcfq_df, deltaq_df = dataframes
@@ -1086,7 +1088,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
             logger.error("❌ Data loading failed: %s", e)
             traceback.print_exc()
 
-    def update_frame(self, frame_data: FrameData, render_config: RenderConfig):
+    def update_frame(self, frame_data: FrameData, render_config: RenderConfig) -> None:
         """Update the current frame data and render config"""
         self.current_frame_data = frame_data
         self.current_render_config = render_config
@@ -1134,44 +1136,44 @@ class GolfVisualizerWidget(QOpenGLWidget):
             f"distance={self.camera_distance:.2f}"
         )
 
-    def set_face_on_view(self):
+    def set_face_on_view(self) -> None:
         """Set camera to face-on view (looking at golfer from front)"""
         self.camera_azimuth = 0.0
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Face-on view")
 
-    def set_down_the_line_view(self):
+    def set_down_the_line_view(self) -> None:
         """Set camera to down-the-line view (90° from face-on)"""
         self.camera_azimuth = 90.0  # 90° from face-on, not 180°
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Down-the-line view")
 
-    def set_behind_view(self):
+    def set_behind_view(self) -> None:
         """Set camera to behind view (180° from face-on)"""
         self.camera_azimuth = 180.0
         self.camera_elevation = 15.0
         self.update()
         logger.info("📷 Camera: Behind view")
 
-    def set_above_view(self):
+    def set_above_view(self) -> None:
         """Set camera to overhead view"""
         self.camera_azimuth = 0.0
         self.camera_elevation = 80.0
         self.update()
         logger.info("📷 Camera: Overhead view")
 
-    def mousePressEvent(self, event):
+    def mousePressEvent(self, event) -> None:
         """Handle mouse press events"""
         self.last_mouse_pos = event.pos()
         self.mouse_pressed = True
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent(self, event) -> None:
         """Handle mouse release events"""
         self.mouse_pressed = False
 
-    def mouseMoveEvent(self, event):
+    def mouseMoveEvent(self, event) -> None:
         """Handle mouse move events"""
         if not self.mouse_pressed or not self.last_mouse_pos:
             return
@@ -1202,14 +1204,14 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.last_mouse_pos = event.pos()
         self.update()
 
-    def wheelEvent(self, event):
+    def wheelEvent(self, event) -> None:
         """Handle mouse wheel events"""
         zoom_factor = 1.1 if event.angleDelta().y() > 0 else 0.9
         self.camera_distance *= zoom_factor
         self.camera_distance = np.clip(self.camera_distance, 0.1, 50.0)
         self.update()
 
-    def keyPressEvent(self, event):
+    def keyPressEvent(self, event) -> None:
         """Handle keyboard shortcuts"""
         key = event.key()
 
@@ -1634,7 +1636,7 @@ class GolfVisualizerMainWindow(QMainWindow):
 # ============================================================================
 
 
-def main():
+def main() -> None:
     """Main application entry point"""
     app = QApplication(sys.argv)
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
@@ -3,7 +3,7 @@ from scipy import signal
 from scipy.interpolate import UnivariateSpline
 
 
-def butter_lowpass_filter(data, cutoff, fs, order=4):
+def butter_lowpass_filter(data, cutoff, fs, order=4) -> np.ndarray:
     """Apply a Butterworth low-pass filter."""
     nyq = 0.5 * fs
     normal_cutoff = cutoff / nyq
@@ -12,19 +12,19 @@ def butter_lowpass_filter(data, cutoff, fs, order=4):
     return y
 
 
-def savitzky_golay_filter(data, window_length=9, polyorder=3):
+def savitzky_golay_filter(data, window_length=9, polyorder=3) -> np.ndarray:
     """Apply a Savitzky-Golay filter."""
     if window_length % 2 == 0:
         window_length += 1  # Must be odd
     return signal.savgol_filter(data, window_length, polyorder)
 
 
-def moving_average_filter(data, window_size=5):
+def moving_average_filter(data, window_size=5) -> np.ndarray:
     """Apply a moving average filter."""
     return np.convolve(data, np.ones(window_size) / window_size, mode="valid")
 
 
-def calculate_derivatives(data, time):
+def calculate_derivatives(data, time) -> tuple:
     """Calculate velocity and acceleration using splines for accuracy."""
     spline = UnivariateSpline(time, data, s=0)
     velocity = spline.derivative(n=1)(time)
@@ -34,7 +34,7 @@ def calculate_derivatives(data, time):
 
 def calculate_inverse_dynamics(
     position_data, orientation_data, time_vector, club_mass=0.2, eval_offset=0.0
-):
+) -> dict:
     """
     Calculate inverse dynamics (forces and torques).
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
@@ -10,6 +10,8 @@ Features:
 - Background rendering (non-blocking UI)
 """
 
+from __future__ import annotations
+
 import logging
 import subprocess
 from dataclasses import dataclass
@@ -66,7 +68,7 @@ class VideoExporter(QObject):
         self.renderer = renderer
         self.frame_processor = frame_processor
 
-    def export_video(self, config: VideoExportConfig):
+    def export_video(self, config: VideoExportConfig) -> None:
         """
         Export animation to video file
 
@@ -356,7 +358,7 @@ class VideoExportThread(QThread):
         self.frame_processor = frame_processor
         self.config = config
 
-    def run(self):
+    def run(self) -> None:
         """Run export in background thread"""
         exporter = VideoExporter(self.renderer, self.frame_processor)
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
@@ -4,6 +4,8 @@ Performance options for the Golf GUI
 Includes settings for optimizing simulation performance
 """
 
+from __future__ import annotations
+
 import logging
 import tkinter as tk
 from tkinter import ttk
@@ -27,7 +29,7 @@ class PerformanceOptionsDialog:
 
         self.create_dialog()
 
-    def create_dialog(self):
+    def create_dialog(self) -> None:
         """Create the performance options dialog"""
         self.dialog = tk.Toplevel(self.parent)
         self.dialog.title("Simulation Performance Options")
@@ -120,7 +122,7 @@ class PerformanceOptionsDialog:
         # Initialize info display
         self.update_simscape_info()
 
-    def update_simscape_info(self):
+    def update_simscape_info(self) -> None:
         """Update the Simscape option info display"""
         if self.simscape_var.get():
             self.simscape_info.config(
@@ -135,7 +137,7 @@ class PerformanceOptionsDialog:
                 foreground="orange",
             )
 
-    def ok_clicked(self):
+    def ok_clicked(self) -> None:
         """Handle OK button click"""
         self.settings = {
             "disable_simscape_results": self.simscape_var.get(),
@@ -145,24 +147,24 @@ class PerformanceOptionsDialog:
         self.result = self.settings
         self.dialog.destroy()
 
-    def cancel_clicked(self):
+    def cancel_clicked(self) -> None:
         """Handle Cancel button click"""
         self.result = None
         self.dialog.destroy()
 
-    def show(self):
+    def show(self) -> dict | None:
         """Show the dialog and return the result"""
         self.dialog.wait_window()
         return self.result
 
 
-def get_performance_options(parent):
+def get_performance_options(parent) -> dict | None:
     """Show performance options dialog and return settings"""
     dialog = PerformanceOptionsDialog(parent)
     return dialog.show()
 
 
-def generate_matlab_performance_script(settings):
+def generate_matlab_performance_script(settings) -> str:
     """Generate MATLAB script with performance settings"""
     script_lines = []
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
@@ -14,7 +14,7 @@ import scipy.io
 logger = logging.getLogger(__name__)
 
 
-def analyze_matlab_files():
+def analyze_matlab_files() -> bool:
     """Analyze the MATLAB data files to understand the current structure"""
     logger.debug("=== Analyzing MATLAB Data Files ===")
 
@@ -60,7 +60,7 @@ def analyze_matlab_files():
     return True
 
 
-def check_signal_bus_structure():
+def check_signal_bus_structure() -> bool:
     """Check if the data structure suggests signal bus logging"""
     logger.debug("\n=== Checking Signal Bus Structure ===")
 
@@ -104,7 +104,7 @@ def check_signal_bus_structure():
         return False
 
 
-def check_required_signals():
+def check_required_signals() -> bool:
     """Check if required signals for GUI are present"""
     logger.debug("\n=== Checking Required Signals ===")
 
@@ -149,7 +149,7 @@ def check_required_signals():
         return False
 
 
-def main():
+def main() -> bool:
     """Main analysis function"""
     logger.info("🚀 Starting Signal Bus Analysis")
     logger.info("=" * 50)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
@@ -3,6 +3,8 @@
 Test script to verify data loading and GUI functionality
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -13,7 +15,7 @@ from wiffle_data_loader import WiffleDataLoader
 logger = logging.getLogger(__name__)
 
 
-def test_data_loading():
+def test_data_loading() -> dict | None:
     """Test the data loading functionality"""
     logger.info("🧪 Testing data loading...")
 
@@ -37,7 +39,7 @@ def test_data_loading():
         return None
 
 
-def test_gui_launch():
+def test_gui_launch() -> bool:
     """Test launching the GUI"""
     logger.info("🧪 Testing GUI launch...")
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_new_data_format.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_new_data_format.py
@@ -11,7 +11,7 @@ import scipy.io
 logger = logging.getLogger(__name__)
 
 
-def test_new_data_files():
+def test_new_data_files() -> bool:
     """Test the newly generated test data files"""
     logger.debug("=== Testing New Data Files ===")
 
@@ -49,7 +49,7 @@ def test_new_data_files():
     return False
 
 
-def main():
+def main() -> bool:
     """Main test function"""
     logger.info("🧪 Testing New Data Format Compatibility")
     logger.info("=" * 50)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
@@ -16,7 +16,7 @@ from golf_data_core import MatlabDataLoader
 logger = logging.getLogger(__name__)
 
 
-def test_matlab_data_structure():
+def test_matlab_data_structure() -> bool:
     """Test the current MATLAB data structure to understand what's available"""
     logger.debug("=== Testing MATLAB Data Structure ===")
 
@@ -61,7 +61,7 @@ def test_matlab_data_structure():
     return True
 
 
-def test_data_loader():
+def test_data_loader() -> bool:
     """Test the MatlabDataLoader with the current data structure"""
     logger.debug("\n=== Testing MatlabDataLoader ===")
 
@@ -102,7 +102,7 @@ def test_data_loader():
         return False
 
 
-def test_frame_processor():
+def test_frame_processor() -> bool:
     """Test the FrameProcessor with the current data"""
     logger.debug("\n=== Testing FrameProcessor ===")
 
@@ -141,7 +141,7 @@ def test_frame_processor():
         return False
 
 
-def analyze_signal_bus_structure():
+def analyze_signal_bus_structure() -> bool:
     """Analyze the signal bus structure to understand the new logging setup"""
     logger.debug("\n=== Analyzing Signal Bus Structure ===")
 
@@ -186,7 +186,7 @@ def analyze_signal_bus_structure():
         return False
 
 
-def main():
+def main() -> bool:
     """Main test function"""
     logger.info("🚀 Starting Signal Bus Compatibility Test")
     logger.info("=" * 50)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_headless_gui.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/tests/test_headless_gui.py
@@ -13,20 +13,20 @@ from apps.core.models import C3DDataModel  # noqa: E402
 
 
 @pytest.fixture
-def app(qtbot):
+def app(qtbot) -> C3DViewerMainWindow:
     """Fixture to provide the main window."""
     window = C3DViewerMainWindow()
     qtbot.addWidget(window)
     return window
 
 
-def test_viewer_startup(app):
+def test_viewer_startup(app) -> None:
     """Smoke test: Verify the application starts up without crashing."""
     assert app.windowTitle() == "C3D Motion Analysis Viewer"
     assert app.tabs.count() == 5  # Ensure all 5 tabs are created
 
 
-def test_load_model_ui_update(app, qtbot):
+def test_load_model_ui_update(app, qtbot) -> None:
     """Verify UI updates when a model is loaded."""
     # Mock data model
     model = C3DDataModel(
@@ -48,7 +48,7 @@ def test_load_model_ui_update(app, qtbot):
 
 
 @patch("apps.c3d_viewer.C3DLoaderThread")
-def test_open_file_dialog_cancel(mock_loader, app, monkeypatch):
+def test_open_file_dialog_cancel(mock_loader, app, monkeypatch) -> None:
     """Test that cancelling the file dialog does nothing."""
     # Mock file dialog to return empty
     monkeypatch.setattr(

--- a/src/engines/pendulum_models/python/double_pendulum_model/tests/test_ui_status.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/tests/test_ui_status.py
@@ -1,3 +1,5 @@
+"""Tests for pendulum UI status label updates."""
+
 import typing
 
 import pytest
@@ -11,6 +13,7 @@ from src.shared.python.ui.qt.utils import get_qapp
 
 @pytest.fixture(scope="module")
 def app() -> QtWidgets.QApplication:
+    """Provide a shared QApplication instance for the test module."""
     app = get_qapp()
     return typing.cast(QtWidgets.QApplication, app)
 

--- a/src/engines/physics_engines/drake/python/tests/test_drake_visualizer.py
+++ b/src/engines/physics_engines/drake/python/tests/test_drake_visualizer.py
@@ -1,5 +1,7 @@
 """Unit tests for Drake Visualizer."""
 
+from __future__ import annotations
+
 import sys
 from unittest.mock import MagicMock
 
@@ -57,21 +59,21 @@ class TestDrakeVisualizer:
     """Test suite for DrakeVisualizer."""
 
     @pytest.fixture
-    def mock_meshcat(self):
+    def mock_meshcat(self) -> MagicMock:
         """Mock Meshcat."""
         return MagicMock()
 
     @pytest.fixture
-    def mock_plant(self):
+    def mock_plant(self) -> MagicMock:
         """Mock MultibodyPlant."""
         return MagicMock()
 
     @pytest.fixture
-    def visualizer(self, mock_meshcat, mock_plant):
+    def visualizer(self, mock_meshcat, mock_plant) -> DrakeVisualizer:
         """Create visualizer instance."""
         return DrakeVisualizer(mock_meshcat, mock_plant)
 
-    def test_initialization(self, visualizer, mock_meshcat, mock_plant):
+    def test_initialization(self, visualizer, mock_meshcat, mock_plant) -> None:
         """Test initialization."""
         assert visualizer.meshcat == mock_meshcat
         assert visualizer.plant == mock_plant
@@ -80,7 +82,7 @@ class TestDrakeVisualizer:
         assert len(visualizer.visible_coms) == 0
         assert len(visualizer.visible_ellipsoids) == 0
 
-    def test_toggle_frame_visible(self, visualizer, mock_meshcat):
+    def test_toggle_frame_visible(self, visualizer, mock_meshcat) -> None:
         """Test enabling frame visualization."""
         body_name = "test_body"
 
@@ -96,7 +98,7 @@ class TestDrakeVisualizer:
         # Verify Transforms were set
         assert mock_meshcat.SetTransform.call_count == 3
 
-    def test_toggle_frame_hidden(self, visualizer, mock_meshcat):
+    def test_toggle_frame_hidden(self, visualizer, mock_meshcat) -> None:
         """Test disabling frame visualization."""
         body_name = "test_body"
         visualizer.visible_frames.add(body_name)
@@ -106,7 +108,9 @@ class TestDrakeVisualizer:
         assert body_name not in visualizer.visible_frames
         mock_meshcat.Delete.assert_called_with(f"visual_overlays/frames/{body_name}")
 
-    def test_update_frame_transforms(self, visualizer, mock_meshcat, mock_plant):
+    def test_update_frame_transforms(
+        self, visualizer, mock_meshcat, mock_plant
+    ) -> None:
         """Test updating frame transforms."""
         body_name = "test_body"
         visualizer.visible_frames.add(body_name)
@@ -128,7 +132,7 @@ class TestDrakeVisualizer:
             f"visual_overlays/frames/{body_name}", X_WB
         )
 
-    def test_toggle_com_visible(self, visualizer, mock_meshcat):
+    def test_toggle_com_visible(self, visualizer, mock_meshcat) -> None:
         """Test enabling COM visualization."""
         body_name = "test_body"
 
@@ -139,7 +143,7 @@ class TestDrakeVisualizer:
         args, _ = mock_meshcat.SetObject.call_args
         assert args[0] == f"visual_overlays/coms/{body_name}"
 
-    def test_toggle_com_hidden(self, visualizer, mock_meshcat):
+    def test_toggle_com_hidden(self, visualizer, mock_meshcat) -> None:
         """Test disabling COM visualization."""
         body_name = "test_body"
         visualizer.visible_coms.add(body_name)
@@ -149,7 +153,7 @@ class TestDrakeVisualizer:
         assert body_name not in visualizer.visible_coms
         mock_meshcat.Delete.assert_called_with(f"visual_overlays/coms/{body_name}")
 
-    def test_update_com_transforms(self, visualizer, mock_meshcat, mock_plant):
+    def test_update_com_transforms(self, visualizer, mock_meshcat, mock_plant) -> None:
         """Test updating COM transforms."""
         body_name = "test_body"
         visualizer.visible_coms.add(body_name)
@@ -183,7 +187,7 @@ class TestDrakeVisualizer:
         # MockRigidTransform eats them, but no crash is good)
         mock_meshcat.SetTransform.assert_called()
 
-    def test_draw_ellipsoid(self, visualizer, mock_meshcat):
+    def test_draw_ellipsoid(self, visualizer, mock_meshcat) -> None:
         """Test drawing ellipsoid."""
         name = "test_ellipsoid"
         rotation_matrix = np.eye(3)
@@ -204,7 +208,7 @@ class TestDrakeVisualizer:
         assert T_arg.shape == (4, 4)
         np.testing.assert_allclose(T_arg[:3, 3], position)
 
-    def test_clear_ellipsoids(self, visualizer, mock_meshcat):
+    def test_clear_ellipsoids(self, visualizer, mock_meshcat) -> None:
         """Test clearing ellipsoids."""
         visualizer.visible_ellipsoids.add("e1")
         visualizer.clear_ellipsoids()
@@ -212,7 +216,7 @@ class TestDrakeVisualizer:
         assert len(visualizer.visible_ellipsoids) == 0
         mock_meshcat.Delete.assert_called_with("visual_overlays/ellipsoids")
 
-    def test_clear_all(self, visualizer, mock_meshcat):
+    def test_clear_all(self, visualizer, mock_meshcat) -> None:
         """Test clearing all overlays."""
         visualizer.visible_frames.add("f1")
         visualizer.visible_coms.add("c1")

--- a/src/engines/physics_engines/drake/python/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/drake/python/tests/test_induced_acceleration.py
@@ -1,5 +1,7 @@
 """Unit tests for Drake Induced Acceleration Analyzer."""
 
+from __future__ import annotations
+
 import sys
 from unittest.mock import MagicMock
 
@@ -22,7 +24,7 @@ class TestDrakeInducedAcceleration:
     """Test suite for DrakeInducedAccelerationAnalyzer."""
 
     @pytest.fixture
-    def mock_plant(self):
+    def mock_plant(self) -> MagicMock:
         """Mock MultibodyPlant."""
         plant = MagicMock()
         # Setup basic mock behavior
@@ -30,15 +32,15 @@ class TestDrakeInducedAcceleration:
         return plant
 
     @pytest.fixture
-    def analyzer(self, mock_plant):
+    def analyzer(self, mock_plant) -> DrakeInducedAccelerationAnalyzer:
         """Create analyzer instance."""
         return DrakeInducedAccelerationAnalyzer(mock_plant)
 
-    def test_initialization(self, analyzer, mock_plant):
+    def test_initialization(self, analyzer, mock_plant) -> None:
         """Test initialization."""
         assert analyzer.plant == mock_plant
 
-    def test_compute_components_basic(self, analyzer, mock_plant):
+    def test_compute_components_basic(self, analyzer, mock_plant) -> None:
         """Test compute_components with simple inputs."""
         context = MagicMock()
 
@@ -78,7 +80,9 @@ class TestDrakeInducedAcceleration:
         mock_plant.CalcGravityGeneralizedForces.assert_called_with(context)
         mock_plant.CalcBiasTerm.assert_called_with(context)
 
-    def test_compute_components_with_non_identity_mass(self, analyzer, mock_plant):
+    def test_compute_components_with_non_identity_mass(
+        self, analyzer, mock_plant
+    ) -> None:
         """Test compute_components with non-identity mass matrix."""
         context = MagicMock()
 
@@ -106,7 +110,7 @@ class TestDrakeInducedAcceleration:
         # total = 0
         np.testing.assert_allclose(results["total"], [0.0, 0.0], atol=1e-10)
 
-    def test_compute_components_structure(self, analyzer, mock_plant):
+    def test_compute_components_structure(self, analyzer, mock_plant) -> None:
         """Verify the result dictionary structure."""
         mock_plant.CalcMassMatrix.return_value = np.eye(2)
         mock_plant.CalcGravityGeneralizedForces.return_value = np.zeros(2)

--- a/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
+++ b/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import json
 import logging
@@ -45,7 +47,7 @@ TARGET_POSE = {
 }
 
 
-def np_encoder(object):
+def np_encoder(object) -> int | float | list:
     """JSON encoder for NumPy types."""
     if isinstance(object, np.generic):
         return object.item()
@@ -270,13 +272,13 @@ class PhysicsEnvWrapper:
 
         return Spec((self._physics.model.nu,))
 
-    def step(self, action) -> "TimeStep":
+    def step(self, action) -> TimeStep:
         """Advance the environment by one step."""
         self._physics.set_control(action)
         self._physics.step()
         return TimeStep(step_type=1)  # MID
 
-    def reset(self) -> "TimeStep":
+    def reset(self) -> TimeStep:
         """Reset the environment."""
         self._physics.reset()
         if self._initializer:
@@ -583,7 +585,7 @@ def run_simulation(
     actuators = utils.get_actuator_indices(physics)
 
     # 4. Setup Initialization Logic
-    def initialize_episode(phys):
+    def initialize_episode(phys) -> None:
         """Initialize episode state from file or default pose."""
         if load_path:
             load_state(phys, load_path)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/tests/unit/test_verification.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/tests/unit/test_verification.py
@@ -1,3 +1,7 @@
+"""Unit tests for Phase 2 verification tools."""
+
+from __future__ import annotations
+
 import mujoco
 import numpy as np
 import pytest
@@ -5,7 +9,8 @@ from mujoco_humanoid_golf.verification import EnergyMonitor, JacobianTester
 
 
 # Helper to create a simple pendulum model if none exists
-def create_pendulum_model():
+def create_pendulum_model() -> mujoco.MjModel:
+    """Create a simple pendulum model for testing."""
     xml = """
     <mujoco>
       <worldbody>
@@ -23,12 +28,13 @@ class TestVerificationEngine:
     """Test suite for Phase 2 Verification Tools."""
 
     @pytest.fixture
-    def model_and_data(self):
+    def model_and_data(self) -> tuple[mujoco.MjModel, mujoco.MjData]:
+        """Create a pendulum model and data pair for testing."""
         model = create_pendulum_model()
         data = mujoco.MjData(model)
         return model, data
 
-    def test_energy_monitor_conservation(self, model_and_data):
+    def test_energy_monitor_conservation(self, model_and_data) -> None:
         """Test EnergyMonitor correctly tracks conservation on a passive pendulum."""
         model, data = model_and_data
         monitor = EnergyMonitor(model, data)
@@ -52,7 +58,7 @@ class TestVerificationEngine:
         assert passed, f"Energy drift too high: {drift}"
         assert len(monitor.history) > 100
 
-    def test_energy_monitor_work_tracking(self, model_and_data):
+    def test_energy_monitor_work_tracking(self, model_and_data) -> None:
         """Test that work input is correctly tracked."""
         model, data = model_and_data
         monitor = EnergyMonitor(model, data)
@@ -74,7 +80,7 @@ class TestVerificationEngine:
         # Work should be positive as we are adding energy
         assert monitor.cumulative_work > 0
 
-    def test_jacobian_tester(self, model_and_data):
+    def test_jacobian_tester(self, model_and_data) -> None:
         """Test that JacobianTester confirms analytical vs FD match."""
         model, _ = model_and_data
         tester = JacobianTester(model)

--- a/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
@@ -1,5 +1,7 @@
 """Tests for counterfactual analysis (Guideline G - MANDATORY)."""
 
+from __future__ import annotations
+
 import mujoco
 import numpy as np
 import pytest
@@ -9,7 +11,7 @@ from mujoco_humanoid_golf.counterfactuals import (
 
 
 @pytest.fixture
-def simple_pendulum_model():
+def simple_pendulum_model() -> mujoco.MjModel:
     """Create simple pendulum for testing."""
     xml = """
     <mujoco>
@@ -31,7 +33,9 @@ def simple_pendulum_model():
 class TestZTCF:
     """Test Zero-Torque Counterfactual (Guideline G1)."""
 
-    def test_ztcf_with_zero_control_gives_zero_delta(self, simple_pendulum_model):
+    def test_ztcf_with_zero_control_gives_zero_delta(
+        self, simple_pendulum_model
+    ) -> None:
         """Test ZTCF: zero control means observed = counterfactual."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -50,7 +54,9 @@ class TestZTCF:
         assert np.allclose(result.delta_acceleration, 0, atol=1e-6)
         assert result.type == "ztcf"
 
-    def test_ztcf_positive_torque_gives_positive_delta(self, simple_pendulum_model):
+    def test_ztcf_positive_torque_gives_positive_delta(
+        self, simple_pendulum_model
+    ) -> None:
         """Test ZTCF: upward torque creates positive acceleration delta."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -69,7 +75,7 @@ class TestZTCF:
         # Observed > counterfactual
         assert result.observed_acceleration[0] > result.counterfactual_acceleration[0]
 
-    def test_ztcf_negative_torque_opposes_gravity(self, simple_pendulum_model):
+    def test_ztcf_negative_torque_opposes_gravity(self, simple_pendulum_model) -> None:
         """Test ZTCF: downward torque opposes upward swing."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -85,7 +91,7 @@ class TestZTCF:
             "Opposing torque should create negative acceleration delta"
         )
 
-    def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model):
+    def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test ZTCF: delta scales linearly with applied torque."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -104,7 +110,7 @@ class TestZTCF:
         ratio = result_large.delta_acceleration[0] / result_small.delta_acceleration[0]
         assert 1.8 < ratio < 2.2, f"Expected ~2x scaling, got {ratio:.2f}x"
 
-    def test_ztcf_trajectory_integration(self, simple_pendulum_model):
+    def test_ztcf_trajectory_integration(self, simple_pendulum_model) -> None:
         """Test ZTCF with trajectory prediction."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -128,7 +134,9 @@ class TestZTCF:
 class TestZVCF:
     """Test Zero-Velocity Counterfactual (Guideline G2)."""
 
-    def test_zvcf_with_zero_velocity_gives_zero_delta(self, simple_pendulum_model):
+    def test_zvcf_with_zero_velocity_gives_zero_delta(
+        self, simple_pendulum_model
+    ) -> None:
         """Test ZVCF: zero velocity means observed = counterfactual."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -146,7 +154,7 @@ class TestZVCF:
         assert np.allclose(result.delta_acceleration, 0, atol=1e-6)
         assert result.type == "zvcf"
 
-    def test_zvcf_nonzero_velocity_creates_delta(self, simple_pendulum_model):
+    def test_zvcf_nonzero_velocity_creates_delta(self, simple_pendulum_model) -> None:
         """Test ZVCF: non-zero velocity creates acceleration delta."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -162,7 +170,7 @@ class TestZVCF:
             "Non-zero velocity should create acceleration delta"
         )
 
-    def test_zvcf_delta_scales_with_velocity(self, simple_pendulum_model):
+    def test_zvcf_delta_scales_with_velocity(self, simple_pendulum_model) -> None:
         """Test ZVCF: delta scales with velocity."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -182,7 +190,7 @@ class TestZVCF:
             result_low.delta_acceleration[0]
         ), "Higher velocity should create larger Coriolis effect"
 
-    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model):
+    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model) -> None:
         """Test ZVCF: counterfactual has only gravity, observed has
         gravity + Coriolis.
         """
@@ -208,7 +216,7 @@ class TestZVCF:
 class TestCounterfactualTrajectoryAnalysis:
     """Test trajectory-level counterfactual analysis."""
 
-    def test_ztcf_trajectory_analysis(self, simple_pendulum_model):
+    def test_ztcf_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test ZTCF analysis on full trajectory."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -227,7 +235,7 @@ class TestCounterfactualTrajectoryAnalysis:
         for r in results:
             assert abs(r.delta_acceleration[0]) > 1e-6
 
-    def test_zvcf_trajectory_analysis(self, simple_pendulum_model):
+    def test_zvcf_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test ZVCF analysis on full trajectory."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -252,7 +260,9 @@ class TestCounterfactualTrajectoryAnalysis:
 class TestCounterfactualPhysics:
     """Integration tests for counterfactual physics validation."""
 
-    def test_ztcf_plus_counterfactual_equals_observed(self, simple_pendulum_model):
+    def test_ztcf_plus_counterfactual_equals_observed(
+        self, simple_pendulum_model
+    ) -> None:
         """Test physics: counterfactual + delta = observed."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -269,7 +279,9 @@ class TestCounterfactualPhysics:
             "Physics violation: observed != counterfactual + delta"
         )
 
-    def test_zvcf_plus_counterfactual_equals_observed(self, simple_pendulum_model):
+    def test_zvcf_plus_counterfactual_equals_observed(
+        self, simple_pendulum_model
+    ) -> None:
         """Test physics: counterfactual + delta = observed."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 
@@ -285,7 +297,7 @@ class TestCounterfactualPhysics:
             "Physics violation: observed != counterfactual + delta"
         )
 
-    def test_ztcf_reveals_control_authority(self, simple_pendulum_model):
+    def test_ztcf_reveals_control_authority(self, simple_pendulum_model) -> None:
         """Test that ZTCF correctly identifies control authority."""
         analyzer = CounterfactualAnalyzer(simple_pendulum_model)
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
@@ -1,5 +1,7 @@
 """Tests for drift-control decomposition (Guideline F - MANDATORY)."""
 
+from __future__ import annotations
+
 import mujoco
 import numpy as np
 import pytest
@@ -10,7 +12,7 @@ from mujoco_humanoid_golf.drift_control import (
 
 
 @pytest.fixture
-def simple_pendulum_model():
+def simple_pendulum_model() -> mujoco.MjModel:
     """Create simple pendulum for testing."""
     xml = """
     <mujoco>
@@ -32,7 +34,7 @@ def simple_pendulum_model():
 class TestDriftControlDecomposer:
     """Test drift-control decomposition implementation."""
 
-    def test_decomposer_initialization(self, simple_pendulum_model):
+    def test_decomposer_initialization(self, simple_pendulum_model) -> None:
         """Test decomposer creates private data structures."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -44,7 +46,7 @@ class TestDriftControlDecomposer:
         assert id(decomposer._data_drift) != id(decomposer._data_control)
         assert id(decomposer._data_drift) != id(decomposer._data_full)
 
-    def test_superposition_principle(self, simple_pendulum_model):
+    def test_superposition_principle(self, simple_pendulum_model) -> None:
         """Test that drift + control = full (Guideline F requirement)."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -68,7 +70,7 @@ class TestDriftControlDecomposer:
             f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
         )
 
-    def test_zero_control_gives_drift_only(self, simple_pendulum_model):
+    def test_zero_control_gives_drift_only(self, simple_pendulum_model) -> None:
         """Test that zero control gives drift-only acceleration."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -88,7 +90,7 @@ class TestDriftControlDecomposer:
             result.full_acceleration, result.drift_acceleration, atol=1e-6
         )
 
-    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model):
+    def test_zvcf_isolates_coriolis_from_gravity(self, simple_pendulum_model) -> None:
         """Test ZVCF: counterfactual has only gravity, observed has
         gravity + Coriolis.
         """
@@ -111,7 +113,9 @@ class TestDriftControlDecomposer:
             result.drift_acceleration, result.drift_gravity_component, atol=1e-6
         )
 
-    def test_gravity_acceleration_matches_mgL_sin_theta(self, simple_pendulum_model):
+    def test_gravity_acceleration_matches_mgL_sin_theta(
+        self, simple_pendulum_model
+    ) -> None:
         """Test gravity acceleration matches analytical solution."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -134,7 +138,7 @@ class TestDriftControlDecomposer:
             "Expected significant gravity acceleration at 30 degrees"
         )
 
-    def test_control_scales_with_torque(self, simple_pendulum_model):
+    def test_control_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test that control acceleration scales linearly with applied torque."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -155,7 +159,7 @@ class TestDriftControlDecomposer:
         )
         assert 1.8 < ratio < 2.2, f"Expected ~2x scaling, got {ratio:.2f}x"
 
-    def test_trajectory_analysis(self, simple_pendulum_model):
+    def test_trajectory_analysis(self, simple_pendulum_model) -> None:
         """Test analyzing full trajectory."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -176,7 +180,7 @@ class TestDriftControlDecomposer:
                 f"Trajectory point failed superposition: residual={r.residual:.2e}"
             )
 
-    def test_decomposition_is_reproducible(self, simple_pendulum_model):
+    def test_decomposition_is_reproducible(self, simple_pendulum_model) -> None:
         """Test that decomposition gives same results with same inputs."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 
@@ -199,13 +203,13 @@ class TestDriftControlPhysics:
 
     def test_passive_pendulum_drift_matches_energy_conservation(
         self, simple_pendulum_model
-    ):
+    ) -> None:
         """Test drift component matches energy-conserving motion."""
         pytest.skip("Requires energy calculation utilities - implement in follow-up")
 
         # (modulo damping losses if present)
 
-    def test_control_enables_upward_swing(self, simple_pendulum_model):
+    def test_control_enables_upward_swing(self, simple_pendulum_model) -> None:
         """Test that control can drive pendulum upward against gravity."""
         decomposer = DriftControlDecomposer(simple_pendulum_model)
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_plotting_analysis.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_plotting_analysis.py
@@ -1,5 +1,7 @@
 """Tests for advanced plotting analysis."""
 
+from __future__ import annotations
+
 import importlib.util
 import os
 import sys
@@ -26,7 +28,8 @@ GolfSwingPlotter = plotting.GolfSwingPlotter
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> MagicMock:
+    """Create a mock data recorder with sample time series data."""
     recorder = MagicMock()
 
     # Mock data
@@ -47,7 +50,7 @@ def mock_recorder():
     ],
     ids=["frequency_analysis", "spectrogram"],
 )
-def test_plot_methods(mock_recorder, method_name, ax_check_attr):
+def test_plot_methods(mock_recorder, method_name, ax_check_attr) -> None:
     """Test plotting methods create axes and call expected rendering."""
     plotter = GolfSwingPlotter(mock_recorder)
     fig = MagicMock()

--- a/src/engines/physics_engines/mujoco/python/tests/test_urdf_io.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_urdf_io.py
@@ -1,3 +1,7 @@
+"""Tests for URDF import and export functionality."""
+
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
 
 import defusedxml.ElementTree as ET
@@ -14,7 +18,7 @@ from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.urdf_io impo
 
 
 @pytest.fixture
-def mock_mujoco_model():
+def mock_mujoco_model() -> MagicMock:
     """Create a mock MuJoCo model."""
     model = MagicMock(spec=mujoco.MjModel)
 
@@ -60,7 +64,8 @@ def mock_mujoco_model():
 
 
 @pytest.fixture
-def sample_urdf_xml():
+def sample_urdf_xml() -> str:
+    """Return a sample URDF XML string for testing."""
     return """
     <robot name="test_robot">
         <link name="base_link">
@@ -96,14 +101,16 @@ def sample_urdf_xml():
     """
 
 
-def test_urdf_exporter_init(mock_mujoco_model):
+def test_urdf_exporter_init(mock_mujoco_model) -> None:
+    """Test URDFExporter initialization."""
     with patch("mujoco.MjData", autospec=True) as mock_data_cls:
         exporter = URDFExporter(mock_mujoco_model)
         assert exporter.model == mock_mujoco_model
         assert exporter.data == mock_data_cls.return_value
 
 
-def test_export_to_urdf(mock_mujoco_model):
+def test_export_to_urdf(mock_mujoco_model) -> None:
+    """Test exporting a MuJoCo model to URDF format."""
     with patch("mujoco.MjData", autospec=True):
         exporter = URDFExporter(mock_mujoco_model)
 
@@ -161,8 +168,8 @@ def test_export_to_urdf(mock_mujoco_model):
             assert 'type="prismatic"' in urdf_str
 
 
-def test_export_model_to_urdf_function(mock_mujoco_model):
-    # Test convenience function
+def test_export_model_to_urdf_function(mock_mujoco_model) -> None:
+    """Test the export_model_to_urdf convenience function."""
     with (
         patch("mujoco.mj_id2name", return_value="test_name"),
         patch("pathlib.Path.write_text"),
@@ -172,7 +179,8 @@ def test_export_model_to_urdf_function(mock_mujoco_model):
         assert len(urdf_str) > 0
 
 
-def test_urdf_importer_import(sample_urdf_xml):
+def test_urdf_importer_import(sample_urdf_xml) -> None:
+    """Test importing a URDF file to MJCF format."""
     importer = URDFImporter()
 
     with (
@@ -192,7 +200,8 @@ def test_urdf_importer_import(sample_urdf_xml):
         assert 'pos="1 0 0"' in mjcf_str  # From joint origin
 
 
-def test_import_urdf_to_mujoco_function(sample_urdf_xml):
+def test_import_urdf_to_mujoco_function(sample_urdf_xml) -> None:
+    """Test the import_urdf_to_mujoco convenience function."""
     with (
         patch("defusedxml.ElementTree.parse") as mock_parse,
         patch("pathlib.Path.exists", return_value=True),
@@ -205,14 +214,15 @@ def test_import_urdf_to_mujoco_function(sample_urdf_xml):
         assert len(mjcf_str) > 0
 
 
-def test_importer_file_not_found():
+def test_importer_file_not_found() -> None:
+    """Test that importing a non-existent URDF raises FileNotFoundError."""
     importer = URDFImporter()
     with pytest.raises(FileNotFoundError):
         importer.import_from_urdf("nonexistent.urdf")
 
 
-def test_exporter_no_root_body(mock_mujoco_model):
-    # Setup model so find_root_body returns None
+def test_exporter_no_root_body(mock_mujoco_model) -> None:
+    """Test exporting a model with only the world body and no root."""
     mock_mujoco_model.nbody = 1  # Only world
 
     with patch("mujoco.MjData", autospec=True):

--- a/src/engines/physics_engines/mujoco/python/tests/test_video_export.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_video_export.py
@@ -1,4 +1,10 @@
+"""Tests for video export functionality."""
+
+from __future__ import annotations
+
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import mujoco
@@ -23,7 +29,7 @@ FPS = 30
 
 
 @pytest.fixture
-def mock_mujoco():
+def mock_mujoco() -> tuple[MagicMock, MagicMock]:
     """Create mock MuJoCo model and data."""
     model = MagicMock(spec=mujoco.MjModel)
     model.nq = 2
@@ -39,7 +45,7 @@ def mock_mujoco():
 
 
 @pytest.fixture
-def mock_renderer():
+def mock_renderer() -> Generator[MagicMock, None, None]:
     """Mock the MuJoCo Renderer."""
     with patch("mujoco.Renderer") as mock:
         renderer = mock.return_value
@@ -49,7 +55,7 @@ def mock_renderer():
 
 
 @pytest.fixture
-def mock_cv2():
+def mock_cv2() -> Any:
     """Mock cv2 module."""
     # Since we mocked it in sys.modules, we can just grab it
     mock = sys.modules["cv2"]
@@ -73,7 +79,7 @@ def mock_cv2():
 
 
 @pytest.fixture
-def mock_imageio():
+def mock_imageio() -> Any:
     """Mock imageio module."""
     mock = sys.modules["imageio"]
     mock.reset_mock()
@@ -81,7 +87,8 @@ def mock_imageio():
 
 
 class TestVideoExporter:
-    def test_init(self, mock_mujoco, mock_renderer):
+    def test_init(self, mock_mujoco, mock_renderer) -> None:
+        """Test VideoExporter initialization."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS)
 
@@ -91,7 +98,8 @@ class TestVideoExporter:
         assert exporter.format == VideoFormat.MP4
         mock_renderer.assert_called_once_with(model, width=WIDTH, height=HEIGHT)
 
-    def test_start_recording_mp4(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_start_recording_mp4(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+        """Test starting MP4 recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -109,7 +117,10 @@ class TestVideoExporter:
         assert args[3] == (WIDTH, HEIGHT)
         assert exporter.writer is not None
 
-    def test_start_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_start_recording_gif(
+        self, mock_mujoco, mock_renderer, mock_imageio
+    ) -> None:
+        """Test starting GIF recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -123,7 +134,8 @@ class TestVideoExporter:
         assert exporter.frames == []
         assert exporter.writer is None
 
-    def test_add_frame_video(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_add_frame_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+        """Test adding a frame to video recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -140,7 +152,8 @@ class TestVideoExporter:
         exporter.writer.write.assert_called_once()
         assert exporter.frame_count == 1
 
-    def test_add_frame_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_add_frame_gif(self, mock_mujoco, mock_renderer, mock_imageio) -> None:
+        """Test adding a frame to GIF recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -154,7 +167,8 @@ class TestVideoExporter:
         assert len(exporter.frames) == 1
         assert exporter.frame_count == 1
 
-    def test_finish_recording_video(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_finish_recording_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+        """Test finishing video recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -169,7 +183,10 @@ class TestVideoExporter:
         writer.release.assert_called_once()
         assert exporter.writer is None
 
-    def test_finish_recording_gif(self, mock_mujoco, mock_renderer, mock_imageio):
+    def test_finish_recording_gif(
+        self, mock_mujoco, mock_renderer, mock_imageio
+    ) -> None:
+        """Test finishing GIF recording."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
 
@@ -184,7 +201,8 @@ class TestVideoExporter:
         mock_imageio.mimsave.assert_called_once()
         assert exporter.frames == []
 
-    def test_export_recording(self, mock_mujoco, mock_renderer, mock_cv2):
+    def test_export_recording(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+        """Test full export recording workflow."""
         model, data = mock_mujoco
         exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
 
@@ -221,7 +239,8 @@ class TestVideoExporter:
         assert exporter.frame_count > 0
         mock_cv2.VideoWriter.return_value.release.assert_called_once()
 
-    def test_metrics_overlay(self, mock_mujoco, mock_cv2):
+    def test_metrics_overlay(self, mock_mujoco, mock_cv2) -> None:
+        """Test metrics overlay rendering on frames."""
         model, data = mock_mujoco
         frame = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
 
@@ -239,7 +258,8 @@ class TestVideoExporter:
 
     def test_export_simulation_video_function(
         self, mock_mujoco, mock_renderer, mock_cv2
-    ):
+    ) -> None:
+        """Test the export_simulation_video convenience function."""
         model, data = mock_mujoco
 
         N = 10

--- a/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
@@ -278,13 +278,13 @@ class ClubTrajectoryParser:
     def _make_row_accessor(row):
         if hasattr(row, "iloc"):
 
-            def get(i):
+            def get(i) -> object | None:
                 """Return the value at index i from a pandas row."""
                 return row.iloc[i] if i < len(row) else None
 
         else:
 
-            def get(i):
+            def get(i) -> object | None:
                 """Return the value at index i from a list row."""
                 return row[i] if i < len(row) else None
 

--- a/src/engines/physics_engines/pinocchio/python/motion_training/tests/test_motion_training.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/tests/test_motion_training.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 import pytest
 
@@ -18,7 +20,7 @@ from motion_training.club_trajectory_parser import (
 class TestClubFrame:
     """Tests for ClubFrame dataclass."""
 
-    def test_create_frame(self):
+    def test_create_frame(self) -> None:
         """Test creating a club frame."""
         frame = ClubFrame(
             time=0.0,
@@ -37,7 +39,7 @@ class TestClubTrajectory:
     """Tests for ClubTrajectory."""
 
     @pytest.fixture
-    def sample_trajectory(self):
+    def sample_trajectory(self) -> ClubTrajectory:
         """Create a sample trajectory for testing."""
         frames = []
         for i in range(10):
@@ -57,33 +59,33 @@ class TestClubTrajectory:
             events=SwingEventMarkers(address=0, top=3, impact=6, finish=9),
         )
 
-    def test_num_frames(self, sample_trajectory):
+    def test_num_frames(self, sample_trajectory) -> None:
         """Test frame count."""
         assert sample_trajectory.num_frames == 10
 
-    def test_duration(self, sample_trajectory):
+    def test_duration(self, sample_trajectory) -> None:
         """Test duration calculation."""
         assert sample_trajectory.duration == pytest.approx(0.09)
 
-    def test_times_property(self, sample_trajectory):
+    def test_times_property(self, sample_trajectory) -> None:
         """Test times array."""
         times = sample_trajectory.times
         assert len(times) == 10
         assert times[0] == 0.0
         assert times[-1] == pytest.approx(0.09)
 
-    def test_grip_positions_property(self, sample_trajectory):
+    def test_grip_positions_property(self, sample_trajectory) -> None:
         """Test grip positions array."""
         positions = sample_trajectory.grip_positions
         assert positions.shape == (10, 3)
 
-    def test_get_event_frame(self, sample_trajectory):
+    def test_get_event_frame(self, sample_trajectory) -> None:
         """Test getting event frames."""
         impact = sample_trajectory.get_event_frame("impact")
         assert impact is not None
         assert impact.sample_index == 6
 
-    def test_get_frame_at_time(self, sample_trajectory):
+    def test_get_frame_at_time(self, sample_trajectory) -> None:
         """Test interpolation."""
         # Get frame at middle time
         frame = sample_trajectory.get_frame_at_time(0.045)
@@ -101,7 +103,7 @@ class TestClubTrajectory:
 class TestComputeHandPositions:
     """Tests for hand position computation."""
 
-    def test_default_offsets(self):
+    def test_default_offsets(self) -> None:
         """Test hand positions with default offsets."""
         frame = ClubFrame(
             time=0.0,
@@ -119,7 +121,7 @@ class TestComputeHandPositions:
         np.testing.assert_array_almost_equal(left, [0.0, 0.0, 1.04])
         np.testing.assert_array_almost_equal(right, [0.0, 0.0, 0.96])
 
-    def test_custom_offsets(self):
+    def test_custom_offsets(self) -> None:
         """Test hand positions with custom offsets."""
         frame = ClubFrame(
             time=0.0,
@@ -136,131 +138,116 @@ class TestComputeHandPositions:
         np.testing.assert_array_almost_equal(right, [0.0, 0.0, 0.9])
 
 
+_NUM_COLUMNS = 26  # Total columns in the mock Excel data
+
+
+def _pad_row(values: list[object]) -> list[object]:
+    """Pad a row with None values to reach the expected column count.
+
+    Args:
+        values: The non-None prefix values for the row.
+
+    Returns:
+        A list of exactly ``_NUM_COLUMNS`` elements.
+    """
+    return values + [None] * (_NUM_COLUMNS - len(values))
+
+
+def _make_metadata_header_row() -> list[object]:
+    """Build the first row: shot label, swing event indices, and club head speed.
+
+    Returns:
+        A list representing the metadata header row of the Excel sheet.
+    """
+    return _pad_row(
+        ["Wiffle ball", None, "A=", 1, "T=", 3, "I=", 5, "F=", 8, "CHS", 100.0]
+    )
+
+
+def _make_sensor_group_row() -> list[object]:
+    """Build the second row: sensor-group labels (Mid-hands, Center of club face).
+
+    Returns:
+        A list representing the sensor-group sub-header row.
+    """
+    row: list[object] = [None] * _NUM_COLUMNS
+    row[2] = "Mid-hands"
+    row[14] = "Center of club face"
+    return row
+
+
+def _make_column_names_row() -> list[object]:
+    """Build the third row: column names for sample data.
+
+    Returns:
+        A list of column header strings (Sample #, Time, X/Y/Z, rotation components).
+    """
+    prefix = ["Sample #", "Time"]
+    position_and_rotation = [
+        "X",
+        "Y",
+        "Z",
+        "Xx",
+        "Xy",
+        "Xz",
+        "Yx",
+        "Yy",
+        "Yz",
+        "Zx",
+        "Zy",
+        "Zz",
+    ]
+    return prefix + position_and_rotation + position_and_rotation
+
+
+def _make_sample_data_row() -> list[object]:
+    """Build a single data row with sample index 1 at time 0.
+
+    The grip (Mid-hands) is at (0, 50, 100) mm with partial identity rotation.
+    The club face is at (0, 50, 0) mm with partial identity rotation.
+
+    Returns:
+        A list representing one frame of motion capture data.
+    """
+    sample_index = 1
+    time = 0.0
+
+    grip_position = [0.0, 50.0, 100.0]
+    grip_rotation_partial = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, None, None, None]
+
+    face_position = [0.0, 50.0, 0.0]
+    face_rotation_partial = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, None, None, None]
+
+    return (
+        [sample_index, time]
+        + grip_position
+        + grip_rotation_partial
+        + face_position
+        + face_rotation_partial
+    )
+
+
 class TestClubTrajectoryParser:
     """Tests for trajectory parser."""
 
-    def test_init_with_invalid_path(self):
+    def test_init_with_invalid_path(self) -> None:
         """Test initialization with non-existent file."""
         with pytest.raises(FileNotFoundError):
             ClubTrajectoryParser("/nonexistent/path.xlsx")
 
     @pytest.fixture
-    def mock_excel_data(self):
-        """Create mock Excel data for testing."""
+    def mock_excel_data(self) -> np.ndarray:
+        """Create mock Excel data for testing.
+
+        Returns a numpy array with 4 rows: metadata header, sensor-group
+        sub-header, column names, and one data sample.
+        """
         return np.array(
             [
-                [
-                    "Wiffle ball",
-                    None,
-                    "A=",
-                    1,
-                    "T=",
-                    3,
-                    "I=",
-                    5,
-                    "F=",
-                    8,
-                    "CHS",
-                    100.0,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                ],
-                [
-                    None,
-                    None,
-                    "Mid-hands",
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    "Center of club face",
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                ],
-                [
-                    "Sample #",
-                    "Time",
-                    "X",
-                    "Y",
-                    "Z",
-                    "Xx",
-                    "Xy",
-                    "Xz",
-                    "Yx",
-                    "Yy",
-                    "Yz",
-                    "Zx",
-                    "Zy",
-                    "Zz",
-                    "X",
-                    "Y",
-                    "Z",
-                    "Xx",
-                    "Xy",
-                    "Xz",
-                    "Yx",
-                    "Yy",
-                    "Yz",
-                    "Zx",
-                    "Zy",
-                    "Zz",
-                ],
-                [
-                    1,
-                    0.0,
-                    0.0,
-                    50.0,
-                    100.0,
-                    1.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    1.0,
-                    0.0,
-                    None,
-                    None,
-                    None,
-                    0.0,
-                    50.0,
-                    0.0,
-                    1.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    1.0,
-                    0.0,
-                    None,
-                    None,
-                    None,
-                ],
+                _make_metadata_header_row(),
+                _make_sensor_group_row(),
+                _make_column_names_row(),
+                _make_sample_data_row(),
             ]
         )
 
@@ -268,7 +255,7 @@ class TestClubTrajectoryParser:
 class TestSwingEventMarkers:
     """Tests for SwingEventMarkers."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         """Test default marker values."""
         markers = SwingEventMarkers()
         assert markers.address == 0
@@ -277,7 +264,7 @@ class TestSwingEventMarkers:
         assert markers.finish == 0
         assert markers.club_head_speed == 0.0
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         """Test custom marker values."""
         markers = SwingEventMarkers(
             address=10,
@@ -298,7 +285,7 @@ class TestDualHandIKSolver:
     """Tests for dual-hand IK solver."""
 
     @pytest.fixture
-    def mock_model(self):
+    def mock_model(self) -> typing.Any:
         """Create mock Pinocchio model."""
         pin = pytest.importorskip("pinocchio")
 
@@ -306,14 +293,14 @@ class TestDualHandIKSolver:
         model = pin.buildSampleModelManipulator()
         return model
 
-    def test_ik_solver_import(self):
+    def test_ik_solver_import(self) -> None:
         """Test that IK solver can be imported."""
         try:
             pass
         except ImportError as e:
             pytest.skip(f"IK solver dependencies not available: {e}")
 
-    def test_ik_settings_defaults(self):
+    def test_ik_settings_defaults(self) -> None:
         """Test IK settings have reasonable defaults."""
         from motion_training.dual_hand_ik_solver import IKSolverSettings
 
@@ -330,7 +317,7 @@ class TestTrajectoryExporter:
     """Tests for trajectory exporter."""
 
     @pytest.fixture
-    def sample_ik_result(self):
+    def sample_ik_result(self) -> typing.Any:
         """Create sample IK result for testing."""
         from motion_training.dual_hand_ik_solver import TrajectoryIKResult
 
@@ -343,7 +330,7 @@ class TestTrajectoryExporter:
         result.convergence_rate = 0.9
         return result
 
-    def test_exporter_init(self, sample_ik_result):
+    def test_exporter_init(self, sample_ik_result) -> None:
         """Test exporter initialization."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -351,7 +338,7 @@ class TestTrajectoryExporter:
         assert exporter.num_frames == 10
         assert exporter.num_dof == 12
 
-    def test_export_csv(self, sample_ik_result, tmp_path):
+    def test_export_csv(self, sample_ik_result, tmp_path) -> None:
         """Test CSV export."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -361,7 +348,7 @@ class TestTrajectoryExporter:
         assert output_path.exists()
         assert output_path.suffix == ".csv"
 
-    def test_export_npz(self, sample_ik_result, tmp_path):
+    def test_export_npz(self, sample_ik_result, tmp_path) -> None:
         """Test NPZ export."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 
@@ -376,7 +363,7 @@ class TestTrajectoryExporter:
         assert "q" in data
         assert "times" in data
 
-    def test_export_json(self, sample_ik_result, tmp_path):
+    def test_export_json(self, sample_ik_result, tmp_path) -> None:
         """Test JSON export."""
         import json
 
@@ -394,7 +381,7 @@ class TestTrajectoryExporter:
         assert "metadata" in data
         assert "trajectory" in data
 
-    def test_export_unsupported_format(self, sample_ik_result, tmp_path):
+    def test_export_unsupported_format(self, sample_ik_result, tmp_path) -> None:
         """Test that unsupported format raises error."""
         from motion_training.trajectory_exporter import TrajectoryExporter
 

--- a/src/engines/physics_engines/pinocchio/python/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_induced_acceleration.py
@@ -1,6 +1,9 @@
 """Unit tests for Pinocchio Induced Acceleration Analyzer."""
 
+from __future__ import annotations
+
 import sys
+from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -19,7 +22,7 @@ class TestPinocchioInducedAcceleration:
     """Test suite for InducedAccelerationAnalyzer."""
 
     @pytest.fixture(autouse=True)
-    def reset_mocks(self):
+    def reset_mocks(self) -> Generator[None, None, None]:
         """Reset mocks before each test."""
         mock_pin.reset_mock()
         mock_pin.aba.side_effect = None
@@ -27,7 +30,7 @@ class TestPinocchioInducedAcceleration:
         yield
 
     @pytest.fixture
-    def mock_model(self):
+    def mock_model(self) -> MagicMock:
         """Mock Pinocchio Model."""
         model = MagicMock()
         model.nq = 2
@@ -36,23 +39,23 @@ class TestPinocchioInducedAcceleration:
         return model
 
     @pytest.fixture
-    def mock_data(self):
+    def mock_data(self) -> MagicMock:
         """Mock Pinocchio Data."""
         return MagicMock()
 
     @pytest.fixture
-    def analyzer(self, mock_model, mock_data):
+    def analyzer(self, mock_model, mock_data) -> InducedAccelerationAnalyzer:
         """Create analyzer instance."""
         return InducedAccelerationAnalyzer(mock_model, mock_data)
 
-    def test_initialization(self, analyzer, mock_model, mock_data):
+    def test_initialization(self, analyzer, mock_model, mock_data) -> None:
         """Test initialization."""
         assert analyzer.model == mock_model
         assert analyzer.data == mock_data
         assert analyzer._temp_data is not None
         assert analyzer._temp_data != mock_data  # Should be a new instance
 
-    def test_compute_components_logic(self, analyzer, mock_model):
+    def test_compute_components_logic(self, analyzer, mock_model) -> None:
         """Test compute_components logical flow."""
         q = np.array([0.0, 0.0])
         v = np.array([0.1, 0.2])
@@ -91,7 +94,7 @@ class TestPinocchioInducedAcceleration:
         # Verify calls were made
         assert mock_pin.aba.call_count == 3
 
-    def test_compute_specific_control(self, analyzer, mock_model):
+    def test_compute_specific_control(self, analyzer, mock_model) -> None:
         """Test compute_specific_control."""
         q = np.zeros(2)
         specific_tau = np.array([5.0, 5.0])
@@ -112,7 +115,7 @@ class TestPinocchioInducedAcceleration:
         np.testing.assert_allclose(result, [5.0, 5.0])
         assert mock_pin.aba.call_count == 2
 
-    def test_compute_counterfactuals(self, analyzer, mock_model):
+    def test_compute_counterfactuals(self, analyzer, mock_model) -> None:
         """Test compute_counterfactuals."""
         q = np.zeros(2)
         v = np.zeros(2)

--- a/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/test_tasks.py
@@ -1,4 +1,9 @@
+"""Tests for Pinocchio IK task creation."""
+
+from __future__ import annotations
+
 import sys
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -6,7 +11,7 @@ import pytest
 
 
 @pytest.fixture
-def mock_pinocchio_env():
+def mock_pinocchio_env() -> Generator[None, None, None]:
     """Mock pinocchio and pink dependencies."""
     mock_mods = {
         "pink": MagicMock(),

--- a/src/engines/physics_engines/tests/test_induced_acceleration.py
+++ b/src/engines/physics_engines/tests/test_induced_acceleration.py
@@ -1,11 +1,13 @@
 """Tests for Induced Acceleration Analysis across all physics engines."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
 
 # --- PINOCCHIO ---
-def test_pinocchio_iaa():
+def test_pinocchio_iaa() -> None:
     """Test Pinocchio InducedAccelerationAnalyzer."""
     try:
         import pinocchio as pin
@@ -53,7 +55,7 @@ def test_pinocchio_iaa():
 
 
 # --- DRAKE ---
-def test_drake_iaa():
+def test_drake_iaa() -> None:
     """Test DrakeInducedAccelerationAnalyzer."""
     try:
         from unittest.mock import MagicMock
@@ -88,7 +90,7 @@ def test_drake_iaa():
 
 
 # --- MUJOCO ---
-def test_mujoco_iaa_logic():
+def test_mujoco_iaa_logic() -> None:
     """Test MuJoCo IAA helper logic."""
     try:
         import mujoco

--- a/src/launchers/tests/test_environment_dialog_ux.py
+++ b/src/launchers/tests/test_environment_dialog_ux.py
@@ -13,7 +13,7 @@ sys.modules["shared.python.secure_subprocess"] = MagicMock()
 
 
 @pytest.fixture
-def app():
+def app() -> QApplication:
     """Create a Qt application instance."""
     app = QApplication.instance()
     if not app:
@@ -22,7 +22,7 @@ def app():
 
 
 @pytest.fixture
-def dialog(app):
+def dialog(app) -> EnvironmentDialog:
     """Create the EnvironmentDialog instance with mocked parent."""
     with patch("launchers.golf_launcher.DockerBuildThread"):
         dlg = EnvironmentDialog(None)
@@ -30,7 +30,7 @@ def dialog(app):
         dlg.close()
 
 
-def test_build_button_feedback(dialog):
+def test_build_button_feedback(dialog) -> None:
     """Test that the build button text changes during build process."""
 
     # Initial state
@@ -57,7 +57,7 @@ def test_build_button_feedback(dialog):
         assert dialog.btn_build.isEnabled() is True
 
 
-def test_build_button_feedback_failure(dialog):
+def test_build_button_feedback_failure(dialog) -> None:
     """Test that the build button text restores even on failure."""
 
     # Start build

--- a/src/launchers/tests/test_unified_launcher.py
+++ b/src/launchers/tests/test_unified_launcher.py
@@ -11,7 +11,8 @@ from src.launchers.unified_launcher import UnifiedLauncher, launch  # noqa: E402
 
 
 @pytest.fixture
-def mock_qapp():
+def mock_qapp() -> MagicMock:
+    """Mock qapp."""
     with patch("launchers.unified_launcher.QApplication") as mock_app_cls:
         mock_app_instance = MagicMock()
         mock_app_cls.instance.return_value = mock_app_instance
@@ -19,7 +20,8 @@ def mock_qapp():
 
 
 @pytest.fixture
-def mock_golf_launcher():
+def mock_golf_launcher() -> MagicMock:
+    """Mock golf launcher."""
     # unified_launcher imports GolfLauncher from .golf_launcher locally
     # We need to patch the class where it is used.
     # Since it's imported inside __init__, we patch it there?
@@ -31,18 +33,18 @@ def mock_golf_launcher():
     return mock_instance
 
 
-def test_init(mock_qapp, mock_golf_launcher):
+def test_init(mock_qapp, mock_golf_launcher) -> None:
     launcher = UnifiedLauncher()
     assert launcher is not None
 
 
-def test_init_no_pyqt():
+def test_init_no_pyqt() -> None:
     with patch("launchers.unified_launcher.PYQT6_AVAILABLE", False):
         with pytest.raises(ImportError, match="PyQt6 is required"):
             UnifiedLauncher()
 
 
-def test_mainloop(mock_qapp, mock_golf_launcher):
+def test_mainloop(mock_qapp, mock_golf_launcher) -> None:
     launcher = UnifiedLauncher()
     mock_qapp.exec.return_value = 0
 
@@ -54,13 +56,13 @@ def test_mainloop(mock_qapp, mock_golf_launcher):
     sys.modules["launchers.golf_launcher"].main.assert_called_once()
 
 
-def test_launch_function():
+def test_launch_function() -> None:
     with patch("src.launchers.golf_launcher.main") as mock_main:
         launch()
         mock_main.assert_called_once()
 
 
-def test_show_status():
+def test_show_status() -> None:
     with (
         patch("shared.python.engine_core.engine_manager.EngineManager") as mock_mgr_cls,
         patch("builtins.print") as mock_print,
@@ -118,7 +120,7 @@ def test_show_status():
             assert found
 
 
-def test_get_version():
+def test_get_version() -> None:
     with (
         patch("launchers.unified_launcher.QApplication"),
         patch("launchers.golf_launcher.GolfLauncher"),

--- a/src/shared/python/dashboard/tests/test_widgets.py
+++ b/src/shared/python/dashboard/tests/test_widgets.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import numpy as np
 import pytest
+from PyQt6.QtWidgets import QApplication
 
 from src.shared.python.dashboard.widgets import (
     ControlPanel,
@@ -12,7 +15,9 @@ from src.shared.python.engine_core.interfaces import RecorderInterface
 
 
 class MockRecorder(RecorderInterface):
-    def __init__(self):
+    """Mock recorder for widget testing."""
+
+    def __init__(self) -> None:
         self.engine = None
         self.data = {
             "joint_positions": (np.arange(100) * 0.1, np.random.rand(100, 3)),
@@ -20,55 +25,69 @@ class MockRecorder(RecorderInterface):
         }
         self.config = {}
 
-    def get_time_series(self, key):
+    def get_time_series(self, key) -> tuple:
+        """Return time series data for the given key."""
         return self.data.get(key, (np.array([]), None))
 
-    def get_induced_acceleration_series(self, src_idx):
+    def get_induced_acceleration_series(self, src_idx) -> tuple:
+        """Return empty induced acceleration series."""
         return np.array([]), None
 
-    def set_analysis_config(self, config):
+    def set_analysis_config(self, config) -> None:
+        """Set the analysis configuration."""
         self.config = config
 
-    def start(self):
+    def start(self) -> None:
+        """Start recording."""
         pass
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop recording."""
         pass
 
-    def reset(self):
+    def reset(self) -> None:
+        """Reset recorder state."""
         pass
 
-    def record_step(self):
+    def record_step(self) -> None:
+        """Record a single step."""
         pass
 
-    def compute_analysis_post_hoc(self):
+    def compute_analysis_post_hoc(self) -> None:
+        """Compute post-hoc analysis."""
         pass
 
-    def get_counterfactual_series(self, key):
+    def get_counterfactual_series(self, key) -> tuple:
+        """Return empty counterfactual series."""
         return np.array([]), None
 
-    def get_data_dict(self):
+    def get_data_dict(self) -> dict:
+        """Return the data dictionary."""
         # Fix: return the data dict so widget can initialize metrics if it uses this (it doesn't actually use this for init, it uses hardcoded keys, but good practice)
         return self.data
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> QApplication:
+    """Provide the QApplication instance."""
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> MockRecorder:
+    """Create a MockRecorder instance."""
     return MockRecorder()
 
 
-def test_live_plot_widget_init(app, recorder):
+def test_live_plot_widget_init(app, recorder) -> None:
+    """Test LivePlotWidget initializes correctly."""
     widget = LivePlotWidget(recorder)
     assert widget.current_key == "joint_positions"
     assert widget.lbl_stats.text().startswith("Mean:")
 
 
-def test_live_plot_widget_stats_update(app, recorder):
+def test_live_plot_widget_stats_update(app, recorder) -> None:
+    """Test LivePlotWidget stats label updates on plot refresh."""
     widget = LivePlotWidget(recorder)
     widget.update_plot()
 
@@ -80,7 +99,8 @@ def test_live_plot_widget_stats_update(app, recorder):
     assert text != "Mean: 0.00 | Std: 0.00 | Min: 0.00 | Max: 0.00"
 
 
-def test_live_plot_widget_xy_mode(app, recorder):
+def test_live_plot_widget_xy_mode(app, recorder) -> None:
+    """Test LivePlotWidget X-Y scatter plot mode."""
     widget = LivePlotWidget(recorder)
 
     # Enable X-Y mode
@@ -104,7 +124,8 @@ def test_live_plot_widget_xy_mode(app, recorder):
     assert widget.ax2 is None
 
 
-def test_live_plot_widget_freq_analysis(app, recorder):
+def test_live_plot_widget_freq_analysis(app, recorder) -> None:
+    """Test LivePlotWidget frequency analysis dialog launch."""
     widget = LivePlotWidget(recorder)
 
     # Mock QDialog.exec to prevent blocking
@@ -120,7 +141,8 @@ def test_live_plot_widget_freq_analysis(app, recorder):
             # widget.show_freq_analysis instantiates FrequencyAnalysisDialog which calls compute_psd
 
 
-def test_frequency_analysis_dialog(app):
+def test_frequency_analysis_dialog(app) -> None:
+    """Test FrequencyAnalysisDialog initialization."""
     data = np.random.rand(100, 2)
     fs = 10.0
 
@@ -139,12 +161,12 @@ def test_frequency_analysis_dialog(app):
 
 
 @pytest.fixture
-def control_panel(qapp):
+def control_panel(qapp) -> ControlPanel:
     """Fixture for ControlPanel widget."""
     return ControlPanel()
 
 
-def test_control_panel_init(control_panel):
+def test_control_panel_init(control_panel) -> None:
     """Test ControlPanel initializes with all buttons."""
     assert control_panel.btn_start is not None
     assert control_panel.btn_pause is not None
@@ -152,31 +174,31 @@ def test_control_panel_init(control_panel):
     assert control_panel.btn_reset is not None
 
 
-def test_control_panel_start_signal(control_panel, qtbot):
+def test_control_panel_start_signal(control_panel, qtbot) -> None:
     """Test start button emits start_requested signal."""
     with qtbot.waitSignal(control_panel.start_requested, timeout=1000):
         control_panel.btn_start.click()
 
 
-def test_control_panel_pause_signal(control_panel, qtbot):
+def test_control_panel_pause_signal(control_panel, qtbot) -> None:
     """Test pause button emits pause_requested signal."""
     with qtbot.waitSignal(control_panel.pause_requested, timeout=1000):
         control_panel.btn_pause.click()
 
 
-def test_control_panel_stop_signal(control_panel, qtbot):
+def test_control_panel_stop_signal(control_panel, qtbot) -> None:
     """Test stop button emits stop_requested signal."""
     with qtbot.waitSignal(control_panel.stop_requested, timeout=1000):
         control_panel.btn_stop.click()
 
 
-def test_control_panel_reset_signal(control_panel, qtbot):
+def test_control_panel_reset_signal(control_panel, qtbot) -> None:
     """Test reset button emits reset_requested signal."""
     with qtbot.waitSignal(control_panel.reset_requested, timeout=1000):
         control_panel.btn_reset.click()
 
 
-def test_control_panel_pause_checkable(control_panel):
+def test_control_panel_pause_checkable(control_panel) -> None:
     """Test pause button is checkable (toggle state)."""
     assert control_panel.btn_pause.isCheckable()
     control_panel.btn_pause.click()
@@ -185,7 +207,7 @@ def test_control_panel_pause_checkable(control_panel):
     assert not control_panel.btn_pause.isChecked()
 
 
-def test_control_panel_tooltips(control_panel):
+def test_control_panel_tooltips(control_panel) -> None:
     """Test buttons have appropriate tooltips with shortcuts."""
     assert "Ctrl+R" in control_panel.btn_start.toolTip()
     assert "Space" in control_panel.btn_pause.toolTip()
@@ -193,7 +215,7 @@ def test_control_panel_tooltips(control_panel):
     assert "R" in control_panel.btn_reset.toolTip()
 
 
-def test_control_panel_accessibility(control_panel):
+def test_control_panel_accessibility(control_panel) -> None:
     """Test ControlPanel has accessibility attributes."""
     assert control_panel.accessibleName() == "Simulation Control Panel"
     assert "Controls for starting" in control_panel.accessibleDescription()
@@ -204,7 +226,7 @@ def test_control_panel_accessibility(control_panel):
 # =============================================================================
 
 
-def test_live_plot_widget_metric_switching(app, recorder):
+def test_live_plot_widget_metric_switching(app, recorder) -> None:
     """Test switching between different metrics."""
     widget = LivePlotWidget(recorder)
 
@@ -217,7 +239,7 @@ def test_live_plot_widget_metric_switching(app, recorder):
     assert widget.current_key == "joint_positions"
 
 
-def test_live_plot_widget_plot_mode_norm(app, recorder):
+def test_live_plot_widget_plot_mode_norm(app, recorder) -> None:
     """Test 'Norm' plot mode (magnitude of vector)."""
     widget = LivePlotWidget(recorder)
     widget.combo_plot_mode.setCurrentText("Norm")
@@ -227,11 +249,11 @@ def test_live_plot_widget_plot_mode_norm(app, recorder):
     assert len(lines) == 1
 
 
-def test_live_plot_widget_empty_data(app):
+def test_live_plot_widget_empty_data(app) -> None:
     """Test widget handles empty data gracefully."""
 
     class EmptyRecorder(MockRecorder):
-        def get_time_series(self, key):
+        def get_time_series(self, key) -> tuple:
             return np.array([]), None
 
     empty_recorder = EmptyRecorder()
@@ -243,7 +265,7 @@ def test_live_plot_widget_empty_data(app):
     assert "Mean:" in text
 
 
-def test_live_plot_widget_single_dimension(app, recorder):
+def test_live_plot_widget_single_dimension(app, recorder) -> None:
     """Test 'Single Dimension' plot mode with dimension selector."""
     widget = LivePlotWidget(recorder)
     widget.combo_plot_mode.setCurrentText("Single Dimension")
@@ -257,7 +279,7 @@ def test_live_plot_widget_single_dimension(app, recorder):
     assert len(lines) == 1
 
 
-def test_live_plot_widget_snapshot(app, recorder, tmp_path, monkeypatch):
+def test_live_plot_widget_snapshot(app, recorder, tmp_path, monkeypatch) -> None:
     """Test snapshot capture functionality."""
     from PyQt6 import QtWidgets
 

--- a/src/shared/python/optimization/tests/test_swing_optimizer.py
+++ b/src/shared/python/optimization/tests/test_swing_optimizer.py
@@ -28,13 +28,13 @@ from src.shared.python.optimization.swing_optimizer import (
 
 
 @pytest.fixture
-def default_golfer():
+def default_golfer() -> GolferModel:
     """Default golfer model with average parameters."""
     return GolferModel()
 
 
 @pytest.fixture
-def custom_golfer():
+def custom_golfer() -> GolferModel:
     """Custom golfer with specific parameters."""
     return GolferModel(
         height=1.85,
@@ -46,13 +46,13 @@ def custom_golfer():
 
 
 @pytest.fixture
-def default_club():
+def default_club() -> ClubModel:
     """Default driver club model."""
     return ClubModel()
 
 
 @pytest.fixture
-def iron_club():
+def iron_club() -> ClubModel:
     """7-iron club model."""
     return ClubModel(
         total_length=0.95,
@@ -63,7 +63,7 @@ def iron_club():
 
 
 @pytest.fixture
-def basic_config():
+def basic_config() -> OptimizationConfig:
     """Basic optimization config for fast testing."""
     return OptimizationConfig(
         objectives={OptimizationObjective.CLUBHEAD_VELOCITY: 1.0},
@@ -78,7 +78,7 @@ def basic_config():
 # =============================================================================
 
 
-def test_golfer_model_defaults():
+def test_golfer_model_defaults() -> None:
     """Test GolferModel has reasonable defaults."""
     golfer = GolferModel()
     assert golfer.height == 1.75
@@ -87,14 +87,14 @@ def test_golfer_model_defaults():
     assert golfer.flexibility_factor == 1.0
 
 
-def test_golfer_model_custom():
+def test_golfer_model_custom() -> None:
     """Test GolferModel accepts custom parameters."""
     golfer = GolferModel(height=1.90, mass=90.0)
     assert golfer.height == 1.90
     assert golfer.mass == 90.0
 
 
-def test_golfer_model_joint_limits():
+def test_golfer_model_joint_limits() -> None:
     """Test GolferModel joint limits are tuples."""
     golfer = GolferModel()
     assert isinstance(golfer.shoulder_rom, tuple)
@@ -102,7 +102,7 @@ def test_golfer_model_joint_limits():
     assert golfer.shoulder_rom[0] < golfer.shoulder_rom[1]
 
 
-def test_golfer_model_torque_limits_positive():
+def test_golfer_model_torque_limits_positive() -> None:
     """Test GolferModel torque limits are positive."""
     golfer = GolferModel()
     assert golfer.max_shoulder_torque > 0
@@ -117,7 +117,7 @@ def test_golfer_model_torque_limits_positive():
 # =============================================================================
 
 
-def test_club_model_defaults():
+def test_club_model_defaults() -> None:
     """Test ClubModel has reasonable defaults for a driver."""
     club = ClubModel()
     assert club.total_length == 1.15
@@ -125,14 +125,14 @@ def test_club_model_defaults():
     assert club.shaft_flex == "regular"
 
 
-def test_club_model_total_mass():
+def test_club_model_total_mass() -> None:
     """Test ClubModel calculates total mass correctly."""
     club = ClubModel()
     expected_mass = club.head_mass + club.shaft_mass + club.grip_mass
     assert club.total_mass == expected_mass
 
 
-def test_club_model_moment_of_inertia():
+def test_club_model_moment_of_inertia() -> None:
     """Test ClubModel MOI is positive and reasonable."""
     club = ClubModel()
     assert club.club_moi > 0
@@ -145,7 +145,7 @@ def test_club_model_moment_of_inertia():
 # =============================================================================
 
 
-def test_optimization_config_defaults():
+def test_optimization_config_defaults() -> None:
     """Test OptimizationConfig has valid defaults."""
     config = OptimizationConfig()
     assert config.n_nodes >= 10
@@ -153,7 +153,7 @@ def test_optimization_config_defaults():
     assert len(config.objectives) > 0
 
 
-def test_optimization_config_custom_objectives():
+def test_optimization_config_custom_objectives() -> None:
     """Test OptimizationConfig accepts custom objectives."""
     config = OptimizationConfig(
         objectives={
@@ -165,7 +165,7 @@ def test_optimization_config_custom_objectives():
     assert OptimizationObjective.INJURY_RISK in config.objectives
 
 
-def test_optimization_config_constraints():
+def test_optimization_config_constraints() -> None:
     """Test OptimizationConfig accepts constraints."""
     config = OptimizationConfig(
         constraints=[
@@ -182,7 +182,7 @@ def test_optimization_config_constraints():
 # =============================================================================
 
 
-def test_optimizer_init(default_golfer, default_club, basic_config):
+def test_optimizer_init(default_golfer, default_club, basic_config) -> None:
     """Test SwingOptimizer initializes correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert optimizer.golfer == default_golfer
@@ -190,14 +190,16 @@ def test_optimizer_init(default_golfer, default_club, basic_config):
     assert optimizer.config == basic_config
 
 
-def test_optimizer_init_default_config(default_golfer, default_club):
+def test_optimizer_init_default_config(default_golfer, default_club) -> None:
     """Test SwingOptimizer uses default config when not provided."""
     optimizer = SwingOptimizer(default_golfer, default_club)
     assert optimizer.config is not None
     assert isinstance(optimizer.config, OptimizationConfig)
 
 
-def test_optimizer_joint_limits_setup(default_golfer, default_club, basic_config):
+def test_optimizer_joint_limits_setup(
+    default_golfer, default_club, basic_config
+) -> None:
     """Test SwingOptimizer sets up joint limits correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert "hip_rotation" in optimizer.joint_limits
@@ -205,14 +207,16 @@ def test_optimizer_joint_limits_setup(default_golfer, default_club, basic_config
     assert len(optimizer.joint_limits) == len(SwingOptimizer.JOINTS)
 
 
-def test_optimizer_torque_limits_setup(default_golfer, default_club, basic_config):
+def test_optimizer_torque_limits_setup(
+    default_golfer, default_club, basic_config
+) -> None:
     """Test SwingOptimizer sets up torque limits correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     assert "hip_rotation" in optimizer.torque_limits
     assert all(t > 0 for t in optimizer.torque_limits.values())
 
 
-def test_optimizer_lever_length(default_golfer, default_club, basic_config):
+def test_optimizer_lever_length(default_golfer, default_club, basic_config) -> None:
     """Test total lever (arm + club) is calculated correctly."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     expected = default_golfer.arm_length + default_club.total_length
@@ -224,7 +228,7 @@ def test_optimizer_lever_length(default_golfer, default_club, basic_config):
 # =============================================================================
 
 
-def test_swing_trajectory_creation():
+def test_swing_trajectory_creation() -> None:
     """Test SwingTrajectory can be created with valid data."""
     n_nodes = 20
     trajectory = SwingTrajectory(
@@ -245,7 +249,7 @@ def test_swing_trajectory_creation():
 
 
 @pytest.mark.slow
-def test_optimizer_optimize_runs(default_golfer, default_club, basic_config):
+def test_optimizer_optimize_runs(default_golfer, default_club, basic_config) -> None:
     """Test optimize() runs without error (smoke test)."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -253,7 +257,9 @@ def test_optimizer_optimize_runs(default_golfer, default_club, basic_config):
 
 
 @pytest.mark.slow
-def test_optimizer_result_has_trajectory(default_golfer, default_club, basic_config):
+def test_optimizer_result_has_trajectory(
+    default_golfer, default_club, basic_config
+) -> None:
     """Test optimization result contains a trajectory."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -262,7 +268,9 @@ def test_optimizer_result_has_trajectory(default_golfer, default_club, basic_con
 
 
 @pytest.mark.slow
-def test_optimizer_result_has_metrics(default_golfer, default_club, basic_config):
+def test_optimizer_result_has_metrics(
+    default_golfer, default_club, basic_config
+) -> None:
     """Test optimization result contains performance metrics."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -270,7 +278,9 @@ def test_optimizer_result_has_metrics(default_golfer, default_club, basic_config
 
 
 @pytest.mark.slow
-def test_optimizer_respects_joint_limits(default_golfer, default_club, basic_config):
+def test_optimizer_respects_joint_limits(
+    default_golfer, default_club, basic_config
+) -> None:
     """Test optimized trajectory respects joint limits."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     result = optimizer.optimize()
@@ -285,7 +295,7 @@ def test_optimizer_respects_joint_limits(default_golfer, default_club, basic_con
 
 
 @pytest.mark.slow
-def test_optimizer_callback(default_golfer, default_club, basic_config):
+def test_optimizer_callback(default_golfer, default_club, basic_config) -> None:
     """Test optimizer calls callback function."""
     optimizer = SwingOptimizer(default_golfer, default_club, basic_config)
     callback_calls = []
@@ -302,7 +312,7 @@ def test_optimizer_callback(default_golfer, default_club, basic_config):
 # =============================================================================
 
 
-def test_optimizer_with_zero_flexibility(default_club, basic_config):
+def test_optimizer_with_zero_flexibility(default_club, basic_config) -> None:
     """Test optimizer handles golfer with minimal flexibility."""
     stiff_golfer = GolferModel(flexibility_factor=0.5)
     optimizer = SwingOptimizer(stiff_golfer, default_club, basic_config)
@@ -310,7 +320,7 @@ def test_optimizer_with_zero_flexibility(default_club, basic_config):
     assert optimizer.golfer.flexibility_factor == 0.5
 
 
-def test_optimizer_with_heavy_club(default_golfer, basic_config):
+def test_optimizer_with_heavy_club(default_golfer, basic_config) -> None:
     """Test optimizer handles heavy club."""
     heavy_club = ClubModel(head_mass=0.35, shaft_mass=0.12)
     optimizer = SwingOptimizer(default_golfer, heavy_club, basic_config)
@@ -318,13 +328,13 @@ def test_optimizer_with_heavy_club(default_golfer, basic_config):
     assert optimizer.club.head_mass == 0.35
 
 
-def test_optimizer_objectives_enum():
+def test_optimizer_objectives_enum() -> None:
     """Test all optimization objectives are defined."""
     assert len(OptimizationObjective) >= 5
     assert OptimizationObjective.CLUBHEAD_VELOCITY.value == "clubhead_velocity"
 
 
-def test_optimizer_constraints_enum():
+def test_optimizer_constraints_enum() -> None:
     """Test all optimization constraints are defined."""
     assert len(OptimizationConstraint) >= 4
     assert OptimizationConstraint.JOINT_LIMITS.value == "joint_limits"

--- a/src/shared/python/tests/test_advanced_analysis_features.py
+++ b/src/shared/python/tests/test_advanced_analysis_features.py
@@ -1,7 +1,10 @@
 """Tests for Advanced Analysis Features (Wavelet, Swing Plane, Correlation)."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
+from PyQt6.QtWidgets import QApplication
 
 from src.shared.python.dashboard.advanced_analysis import (
     AdvancedAnalysisDialog,
@@ -12,7 +15,10 @@ from src.shared.python.dashboard.advanced_analysis import (
 
 
 class MockRecorder:
-    def get_time_series(self, key: str):
+    """Mock recorder providing synthetic time series data."""
+
+    def get_time_series(self, key: str) -> tuple:
+        """Return synthetic time series for the given key."""
         t = np.linspace(0, 1, 100)
 
         # Base signal
@@ -51,16 +57,19 @@ class MockRecorder:
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> QApplication:
+    """Provide the QApplication instance."""
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> MockRecorder:
+    """Create a MockRecorder instance."""
     return MockRecorder()
 
 
-def test_wavelet_tab(recorder, qtbot):
+def test_wavelet_tab(recorder, qtbot) -> None:
+    """Test WaveletTab initialization and w0 parameter change."""
     tab = WaveletTab(recorder)
     qtbot.addWidget(tab)
 
@@ -73,7 +82,8 @@ def test_wavelet_tab(recorder, qtbot):
     assert len(tab.ax.collections) > 0
 
 
-def test_swing_plane_tab(recorder, qtbot):
+def test_swing_plane_tab(recorder, qtbot) -> None:
+    """Test SwingPlaneTab initialization and subplot creation."""
     tab = SwingPlaneTab(recorder)
     qtbot.addWidget(tab)
 
@@ -87,7 +97,8 @@ def test_swing_plane_tab(recorder, qtbot):
     assert len(ax3d.collections) > 0 or len(ax3d.patches) > 0
 
 
-def test_correlation_tab(recorder, qtbot):
+def test_correlation_tab(recorder, qtbot) -> None:
+    """Test CorrelationTab update and image plotting."""
     tab = CorrelationTab(recorder)
     qtbot.addWidget(tab)
 
@@ -105,7 +116,8 @@ def test_correlation_tab(recorder, qtbot):
     assert len(tab.ax.images) > 0
 
 
-def test_advanced_analysis_dialog_features(recorder, qtbot):
+def test_advanced_analysis_dialog_features(recorder, qtbot) -> None:
+    """Test AdvancedAnalysisDialog contains all expected tabs."""
     dlg = AdvancedAnalysisDialog(None, recorder)
     qtbot.addWidget(dlg)
 

--- a/src/shared/python/tests/test_advanced_features.py
+++ b/src/shared/python/tests/test_advanced_features.py
@@ -1,5 +1,7 @@
 """Tests for advanced features in statistical analysis and plotting."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from matplotlib.figure import Figure
@@ -17,7 +19,9 @@ from src.shared.python.validation_pkg.statistical_analysis import StatisticalAna
 
 
 class MockRecorder(RecorderInterface):
-    def __init__(self, data_dict):
+    """Mock recorder backed by a data dictionary."""
+
+    def __init__(self, data_dict) -> None:
         self.data = data_dict
         # Compatibility with new tests which might pass more args?
         # New tests MockRecorder takes (times, positions, velocities, accelerations, torques)
@@ -25,18 +29,22 @@ class MockRecorder(RecorderInterface):
         # I need to unify or rename the class in appended code.
         # I'll rename the new MockRecorder to MockRecorderNew in appended code.
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple:
+        """Return time series data for the given field."""
         return self.data.get(field_name, ([], []))
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
+        """Return empty induced acceleration series."""
         return np.array([]), np.array([])
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
+        """Return empty counterfactual series."""
         return np.array([]), np.array([])
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> tuple:
+    """Create sample sinusoidal test data."""
     t = np.linspace(0, 1, 100)
     # Simple sine wave
     pos = np.column_stack([np.sin(2 * np.pi * t), np.cos(2 * np.pi * t)])
@@ -50,7 +58,8 @@ def sample_data():
 
 
 @pytest.fixture
-def analyzer(sample_data):
+def analyzer(sample_data) -> StatisticalAnalyzer:
+    """Create a StatisticalAnalyzer from sample data."""
     t, pos, vel, torque = sample_data
     return StatisticalAnalyzer(
         times=t,
@@ -60,7 +69,7 @@ def analyzer(sample_data):
     )
 
 
-def test_joint_stiffness_metrics(analyzer):
+def test_joint_stiffness_metrics(analyzer) -> None:
     """Test computation of joint stiffness."""
     metrics = analyzer.compute_joint_stiffness(0)
     assert metrics is not None
@@ -75,7 +84,7 @@ def test_joint_stiffness_metrics(analyzer):
     assert analyzer.compute_joint_stiffness(99) is None
 
 
-def test_dynamic_stiffness(analyzer):
+def test_dynamic_stiffness(analyzer) -> None:
     """Test computation of rolling stiffness."""
     t, k, r2 = analyzer.compute_dynamic_stiffness(0, window_size=20)
     assert len(t) > 0
@@ -86,7 +95,7 @@ def test_dynamic_stiffness(analyzer):
     assert np.all(r2 > 0.9)
 
 
-def test_fractal_dimension(analyzer):
+def test_fractal_dimension(analyzer) -> None:
     """Test Higuchi Fractal Dimension."""
     # Sine wave is smooth, FD should be close to 1
     # Re-generate clean sine
@@ -103,7 +112,7 @@ def test_fractal_dimension(analyzer):
     assert fd_noise > 1.5
 
 
-def test_sample_entropy(analyzer):
+def test_sample_entropy(analyzer) -> None:
     """Test Sample Entropy."""
     # Sine wave is regular -> low entropy
     t = np.linspace(0, 1, 200)
@@ -118,7 +127,7 @@ def test_sample_entropy(analyzer):
     assert samp_en_noise > 1.0
 
 
-def test_permutation_entropy(analyzer):
+def test_permutation_entropy(analyzer) -> None:
     """Test Permutation Entropy."""
     # Sine wave is regular -> low entropy
     t = np.linspace(0, 1, 200)
@@ -138,7 +147,7 @@ def test_permutation_entropy(analyzer):
     assert pe_noise > 2.0
 
 
-def test_plot_joint_stiffness(sample_data):
+def test_plot_joint_stiffness(sample_data) -> None:
     """Test plotting of joint stiffness."""
     t, pos, vel, torque = sample_data
     recorder = MockRecorder(
@@ -163,7 +172,7 @@ def test_plot_joint_stiffness(sample_data):
     )  # scatter points (collection) + regression line + maybe trajectory line
 
 
-def test_plot_dynamic_stiffness(sample_data):
+def test_plot_dynamic_stiffness(sample_data) -> None:
     """Test plotting of dynamic stiffness."""
     t, pos, vel, torque = sample_data
     recorder = MockRecorder(
@@ -182,7 +191,7 @@ def test_plot_dynamic_stiffness(sample_data):
     assert len(fig.axes) == 2
 
 
-def test_plot_bland_altman(sample_data):
+def test_plot_bland_altman(sample_data) -> None:
     """Test Bland-Altman plot."""
     t, pos, _, _ = sample_data
     # Create two slightly different signals
@@ -210,14 +219,17 @@ def test_plot_bland_altman(sample_data):
 
 
 class MockRecorderNew(RecorderInterface):
-    def __init__(self, times, positions, velocities, accelerations, torques):
+    """Mock recorder with explicit time series arrays."""
+
+    def __init__(self, times, positions, velocities, accelerations, torques) -> None:
         self.times = times
         self.positions = positions
         self.velocities = velocities
         self.accelerations = accelerations
         self.torques = torques
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple:
+        """Return time series data for the given field."""
         if field_name == "joint_positions":
             return self.times, self.positions
         elif field_name == "joint_velocities":
@@ -228,15 +240,19 @@ class MockRecorderNew(RecorderInterface):
             return self.times, self.torques
         return [], []
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
+        """Return empty induced acceleration series."""
         return [], []
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
+        """Return empty counterfactual series."""
         return [], []
 
 
 class TestAdvancedSignalProcessing:
-    def test_compute_jerk(self):
+    """Tests for advanced signal processing functions."""
+
+    def test_compute_jerk(self) -> None:
         """Test jerk computation using cubic polynomial."""
         t = np.linspace(0, 1, 100)
         # Position x(t) = t^3
@@ -253,7 +269,7 @@ class TestAdvancedSignalProcessing:
         valid_jerk = jerk[10:-10]
         np.testing.assert_allclose(valid_jerk, 6.0, rtol=0.05)
 
-    def test_compute_time_shift(self):
+    def test_compute_time_shift(self) -> None:
         """Test time shift detection."""
         fs = 100.0
         t = np.linspace(0, 2, 200)
@@ -275,7 +291,9 @@ class TestAdvancedSignalProcessing:
 
 
 class TestAdvancedStatisticalAnalysis:
-    def test_compute_jerk_metrics(self):
+    """Tests for advanced statistical analysis methods."""
+
+    def test_compute_jerk_metrics(self) -> None:
         """Test jerk metrics computation."""
         t = np.linspace(0, 1, 100)
         accel = 6 * t
@@ -300,7 +318,7 @@ class TestAdvancedStatisticalAnalysis:
         assert metrics.peak_jerk == pytest.approx(6.0, rel=0.1)
         assert metrics.rms_jerk == pytest.approx(6.0, rel=0.1)
 
-    def test_compute_lag_matrix(self):
+    def test_compute_lag_matrix(self) -> None:
         """Test lag matrix computation."""
         t = np.linspace(0, 2, 200)
 
@@ -327,7 +345,7 @@ class TestAdvancedStatisticalAnalysis:
         # matrix[0, 2] = lag(x, z) = 0.2
         assert matrix[0, 2] == pytest.approx(0.2, abs=0.01)
 
-    def test_compute_multiscale_entropy(self):
+    def test_compute_multiscale_entropy(self) -> None:
         """Test MSE computation."""
         # Random noise should have high entropy at scale 1, decay or stay high?
         # White noise: entropy decreases with scale.
@@ -352,7 +370,9 @@ class TestAdvancedStatisticalAnalysis:
 
 
 class TestAdvancedPlotting:
-    def test_plots(self):
+    """Tests for advanced plotting methods."""
+
+    def test_plots(self) -> None:
         """Test that new plots run without error."""
         t = np.linspace(0, 2, 200)
         x = np.sin(2 * np.pi * 2 * t)

--- a/src/shared/python/tests/test_comparative_analysis.py
+++ b/src/shared/python/tests/test_comparative_analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -11,15 +13,17 @@ from src.shared.python.validation_pkg.comparative_analysis import (
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self, data_dict):
+    def __init__(self, data_dict) -> None:
         self.data = data_dict
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> tuple:
+        """Return time series data for the given field."""
         return self.data.get(field_name, (np.array([]), np.array([])))
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> tuple[dict, dict]:
+    """Create sample data for two swings."""
     t = np.linspace(0, 1, 10)
 
     # Swing A: linear
@@ -43,7 +47,8 @@ def sample_data():
     return data_a, data_b
 
 
-def test_align_signals(sample_data):
+def test_align_signals(sample_data) -> None:
+    """Test signal alignment between two swings."""
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)
@@ -73,7 +78,8 @@ def test_align_signals(sample_data):
     assert aligned_oob is None
 
 
-def test_compare_scalars():
+def test_compare_scalars() -> None:
+    """Test scalar value comparison metrics."""
     rec = MockRecorder({})
     analyzer = ComparativeSwingAnalyzer(rec, rec)
 
@@ -84,7 +90,8 @@ def test_compare_scalars():
     assert np.isclose(metric.percent_diff, (2.0 / 9.0) * 100)
 
 
-def test_generate_comparison_report(sample_data):
+def test_generate_comparison_report(sample_data) -> None:
+    """Test full comparison report generation."""
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)
@@ -105,7 +112,8 @@ def test_generate_comparison_report(sample_data):
     assert "CoP Path Length" in metric_names
 
 
-def test_missing_data_report():
+def test_missing_data_report() -> None:
+    """Test comparison report with empty data produces no metrics."""
     rec_empty = MockRecorder({})
     analyzer = ComparativeSwingAnalyzer(rec_empty, rec_empty)
 
@@ -113,7 +121,8 @@ def test_missing_data_report():
     assert len(report["metrics"]) == 0
 
 
-def test_compute_dtw_distance(sample_data):
+def test_compute_dtw_distance(sample_data) -> None:
+    """Test DTW distance computation between two signals."""
     data_a, data_b = sample_data
     rec_a = MockRecorder(data_a)
     rec_b = MockRecorder(data_b)

--- a/src/shared/python/tests/test_comparative_plotting.py
+++ b/src/shared/python/tests/test_comparative_plotting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -15,7 +17,7 @@ from src.shared.python.validation_pkg.comparative_plotting import ComparativePlo
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self, prefix=""):
+    def __init__(self, prefix="") -> None:
         self.prefix = prefix
         self.data = {
             "joint_positions": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
@@ -25,20 +27,22 @@ class MockRecorder(RecorderInterface):
             "kinetic_energy": (np.linspace(0, 1, 10), np.random.rand(10)),
         }
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> tuple:
+        """Return time series data for the given field."""
         return self.data.get(field_name, (np.array([]), np.array([])))
 
-    def get_counterfactual_series(self, field_name: str):
+    def get_counterfactual_series(self, field_name: str) -> tuple:
         """Return counterfactual data series."""
         return np.array([]), np.array([])
 
-    def get_induced_acceleration_series(self, field_name: str | int):
+    def get_induced_acceleration_series(self, field_name: str | int) -> tuple:
         """Return induced acceleration data series."""
         return np.array([]), np.array([])
 
 
 @pytest.fixture
-def mock_analyzer():
+def mock_analyzer() -> MagicMock:
+    """Create a mock ComparativeSwingAnalyzer."""
     rec_a = MockRecorder("A")
     rec_b = MockRecorder("B")
     analyzer = MagicMock(spec=ComparativeSwingAnalyzer)
@@ -88,20 +92,24 @@ def mock_analyzer():
 
 
 @pytest.fixture
-def plotter(mock_analyzer):
+def plotter(mock_analyzer) -> ComparativePlotter:
+    """Create a ComparativePlotter from mock analyzer."""
     return ComparativePlotter(mock_analyzer)
 
 
 @pytest.fixture
-def fig():
+def fig() -> Figure:
+    """Create a matplotlib Figure."""
     return Figure()
 
 
-def test_init(plotter, mock_analyzer):
+def test_init(plotter, mock_analyzer) -> None:
+    """Test ComparativePlotter initialization."""
     assert plotter.analyzer == mock_analyzer
 
 
-def test_plot_comparison(plotter, fig):
+def test_plot_comparison(plotter, fig) -> None:
+    """Test comparison plotting for scalar signals."""
     plotter.plot_comparison(fig, "club_head_speed")
     assert len(fig.axes) > 0  # GridSpec creates axes on fig
 
@@ -112,7 +120,8 @@ def test_plot_comparison(plotter, fig):
     assert len(fig.axes) > 0  # Should show "Data not available"
 
 
-def test_plot_phase_comparison(plotter, fig):
+def test_plot_phase_comparison(plotter, fig) -> None:
+    """Test phase comparison plotting."""
     plotter.plot_phase_comparison(fig, joint_idx=0)
     assert len(fig.axes) > 0
 
@@ -123,7 +132,8 @@ def test_plot_phase_comparison(plotter, fig):
     assert len(fig.axes) == 1
 
 
-def test_plot_3d_trajectory_comparison(plotter, fig):
+def test_plot_3d_trajectory_comparison(plotter, fig) -> None:
+    """Test 3D trajectory comparison plotting."""
     plotter.plot_3d_trajectory_comparison(fig)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
@@ -135,7 +145,8 @@ def test_plot_3d_trajectory_comparison(plotter, fig):
     assert len(fig.axes) > 0  # Text axis
 
 
-def test_plot_dashboard(plotter, fig):
+def test_plot_dashboard(plotter, fig) -> None:
+    """Test full comparison dashboard plotting."""
     # This calls plot_comparison with subfigures
     # Note: Figure.add_subfigure is new in Matplotlib 3.4+
 
@@ -148,12 +159,14 @@ def test_plot_dashboard(plotter, fig):
     assert len(fig.subfigs) >= 2 or len(fig.axes) > 0
 
 
-def test_plot_comparison_with_joint_idx(plotter, fig):
+def test_plot_comparison_with_joint_idx(plotter, fig) -> None:
+    """Test comparison plotting with joint index selection."""
     plotter.plot_comparison(fig, "joint_positions", joint_idx=0)
     assert len(fig.axes) > 0
 
 
-def test_plot_comparison_no_metrics(plotter, fig):
+def test_plot_comparison_no_metrics(plotter, fig) -> None:
+    """Test dashboard plotting with empty metrics list."""
     plotter.analyzer.generate_comparison_report.return_value = {"metrics": []}
     plotter.plot_dashboard(fig)
     # Check that it didn't crash

--- a/src/shared/python/tests/test_dashboard_advanced_analysis.py
+++ b/src/shared/python/tests/test_dashboard_advanced_analysis.py
@@ -1,7 +1,10 @@
 """Tests for Advanced Analysis Dialog."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
+from PyQt6.QtWidgets import QApplication
 
 from src.shared.python.dashboard.advanced_analysis import (
     AdvancedAnalysisDialog,
@@ -12,7 +15,10 @@ from src.shared.python.dashboard.advanced_analysis import (
 
 
 class MockRecorder:
-    def get_time_series(self, key: str):
+    """Mock recorder providing synthetic time series data."""
+
+    def get_time_series(self, key: str) -> tuple:
+        """Return synthetic time series for the given key."""
         t = np.linspace(0, 1, 100)
         data = np.sin(2 * np.pi * 10 * t)
         if key == "joint_positions":
@@ -25,16 +31,19 @@ class MockRecorder:
 
 
 @pytest.fixture
-def app(qapp):
+def app(qapp) -> QApplication:
+    """Provide the QApplication instance."""
     return qapp
 
 
 @pytest.fixture
-def recorder():
+def recorder() -> MockRecorder:
+    """Create a MockRecorder instance."""
     return MockRecorder()
 
 
-def test_spectrogram_tab(recorder, qtbot):
+def test_spectrogram_tab(recorder, qtbot) -> None:
+    """Test SpectrogramTab initialization and metric switching."""
     tab = SpectrogramTab(recorder)
     qtbot.addWidget(tab)
 
@@ -48,7 +57,8 @@ def test_spectrogram_tab(recorder, qtbot):
     assert len(tab.ax.collections) > 0
 
 
-def test_phase_plane_tab(recorder, qtbot):
+def test_phase_plane_tab(recorder, qtbot) -> None:
+    """Test PhasePlaneTab initialization and dimension change."""
     tab = PhasePlaneTab(recorder)
     qtbot.addWidget(tab)
 
@@ -61,7 +71,8 @@ def test_phase_plane_tab(recorder, qtbot):
     assert len(tab.ax.lines) >= 1
 
 
-def test_coherence_tab(recorder, qtbot):
+def test_coherence_tab(recorder, qtbot) -> None:
+    """Test CoherenceTab initialization and signal switching."""
     tab = CoherenceTab(recorder)
     qtbot.addWidget(tab)
 
@@ -73,7 +84,8 @@ def test_coherence_tab(recorder, qtbot):
     assert len(tab.ax.lines) > 0
 
 
-def test_advanced_analysis_dialog(recorder, qtbot):
+def test_advanced_analysis_dialog(recorder, qtbot) -> None:
+    """Test AdvancedAnalysisDialog contains all expected tabs."""
     dlg = AdvancedAnalysisDialog(None, recorder)
     qtbot.addWidget(dlg)
 

--- a/src/shared/python/tests/test_dashboard_recorder.py
+++ b/src/shared/python/tests/test_dashboard_recorder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -6,138 +8,181 @@ from src.shared.python.engine_core.interfaces import PhysicsEngine
 
 
 class MockPhysicsEngine(PhysicsEngine):
-    def __init__(self):
+    """Mock physics engine for recorder tests."""
+
+    def __init__(self) -> None:
         # self.model_name = "MockEngine" # Handled by property
         self._time = 0.0
         self._q = np.array([0.0, 0.0])
         self._v = np.array([0.0, 0.0])
 
     def get_time(self) -> float:
+        """Return current simulation time."""
         return self._time
 
     def get_state(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return current state as (positions, velocities)."""
         return self._q, self._v
 
-    def set_state(self, q, v):
+    def set_state(self, q, v) -> None:
+        """Set the engine state."""
         self._q = q
         self._v = v
 
-    def forward(self):
+    def forward(self) -> None:
+        """Advance the engine forward."""
         pass
 
-    def set_control(self, u):
+    def set_control(self, u) -> None:
+        """Set control input."""
         pass
 
-    def compute_mass_matrix(self):
+    def compute_mass_matrix(self) -> np.ndarray:
+        """Return the identity mass matrix."""
         return np.eye(2)
 
-    def compute_ztcf(self, q, v):
+    def compute_ztcf(self, q, v) -> np.ndarray:
+        """Return mock zero-torque counterfactual values."""
         return np.array([0.1, 0.2])
 
-    def compute_zvcf(self, q):
+    def compute_zvcf(self, q) -> np.ndarray:
+        """Return mock zero-velocity counterfactual values."""
         return np.array([0.3, 0.4])
 
-    def compute_drift_acceleration(self):
+    def compute_drift_acceleration(self) -> np.ndarray:
+        """Return mock drift acceleration."""
         return np.array([0.01, 0.02])
 
-    def compute_control_acceleration(self, tau):
+    def compute_control_acceleration(self, tau) -> np.ndarray:
+        """Return control acceleration equal to input torque."""
         return tau  # Identity for simplicity
 
     # Implement other required abstract methods with dummy implementations
-    def compute_gravity_forces(self):
+    def compute_gravity_forces(self) -> np.ndarray:
+        """Return zero gravity forces."""
         return np.zeros(2)
 
-    def compute_jacobian(self, body_name):
+    def compute_jacobian(self, body_name) -> dict:
+        """Return empty Jacobian dictionary."""
         return {}
 
-    def compute_coriolis_centrifugal_forces(self):
+    def compute_coriolis_centrifugal_forces(self) -> np.ndarray:
+        """Return zero Coriolis/centrifugal forces."""
         return np.zeros(2)
 
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
+        """Return zero inverse dynamics."""
         return np.zeros(2)
 
-    def compute_forward_dynamics(self, q, v, tau):
+    def compute_forward_dynamics(self, q, v, tau) -> np.ndarray:
+        """Return zero forward dynamics."""
         return np.zeros(2)
 
-    def compute_bias_forces(self):
+    def compute_bias_forces(self) -> np.ndarray:
+        """Return zero bias forces."""
         return np.zeros(2)
 
-    def load_from_path(self, path):
+    def load_from_path(self, path) -> None:
+        """Load model from path (no-op)."""
         pass
 
     def load_from_string(self, content: str, extension: str | None = None) -> None:
+        """Load model from string (no-op)."""
         pass
 
     @property
-    def model_name(self):
+    def model_name(self) -> str:
+        """Return mock engine name."""
         return "MockEngine"
 
     def step(self, dt: float | None = None) -> None:
+        """Advance simulation by one step."""
         if dt is not None:
             self._time += dt
 
-    def reset(self):
+    def reset(self) -> None:
+        """Reset engine to initial state."""
         self._time = 0.0
 
-    def get_joint_names(self):
+    def get_joint_names(self) -> list[str]:
+        """Return joint names."""
         return ["j1", "j2"]
 
-    def get_actuator_names(self):
+    def get_actuator_names(self) -> list[str]:
+        """Return actuator names."""
         return ["a1", "a2"]
 
-    def get_body_names(self):
+    def get_body_names(self) -> list[str]:
+        """Return body names."""
         return ["b1"]
 
-    def get_body_mass(self, body_name):
+    def get_body_mass(self, body_name) -> float:
+        """Return unit body mass."""
         return 1.0
 
-    def get_body_inertia(self, body_name):
+    def get_body_inertia(self, body_name) -> np.ndarray:
+        """Return identity inertia matrix."""
         return np.eye(3)
 
-    def get_body_position(self, body_name):
+    def get_body_position(self, body_name) -> np.ndarray:
+        """Return zero body position."""
         return np.zeros(3)
 
-    def get_body_rotation(self, body_name):
+    def get_body_rotation(self, body_name) -> np.ndarray:
+        """Return identity rotation matrix."""
         return np.eye(3)
 
-    def get_body_velocity(self, body_name):
+    def get_body_velocity(self, body_name) -> np.ndarray:
+        """Return zero body velocity."""
         return np.zeros(6)
 
-    def get_contact_forces(self):
+    def get_contact_forces(self) -> list:
+        """Return empty contact forces."""
         return []
 
-    def get_joint_limits(self):
+    def get_joint_limits(self) -> np.ndarray:
+        """Return zero joint limits."""
         return np.zeros((2, 2))
 
-    def get_actuator_limits(self):
+    def get_actuator_limits(self) -> np.ndarray:
+        """Return zero actuator limits."""
         return np.zeros((2, 2))
 
-    def get_dof(self):
+    def get_dof(self) -> int:
+        """Return number of degrees of freedom."""
         return 2
 
-    def get_num_actuators(self):
+    def get_num_actuators(self) -> int:
+        """Return number of actuators."""
         return 2
 
-    def get_num_bodies(self):
+    def get_num_bodies(self) -> int:
+        """Return number of bodies."""
         return 1
 
 
 class TestGenericPhysicsRecorder:
+    """Tests for GenericPhysicsRecorder."""
+
     @pytest.fixture
-    def engine(self):
+    def engine(self) -> MockPhysicsEngine:
+        """Create a MockPhysicsEngine instance."""
         return MockPhysicsEngine()
 
     @pytest.fixture
-    def recorder(self, engine):
+    def recorder(self, engine) -> GenericPhysicsRecorder:
+        """Create a GenericPhysicsRecorder instance."""
         return GenericPhysicsRecorder(engine, max_samples=100)
 
-    def test_initialization(self, recorder):
+    def test_initialization(self, recorder) -> None:
+        """Test recorder initializes with correct defaults."""
         assert recorder.current_idx == 0
         assert not recorder.is_recording
         assert not recorder._buffers_initialized
         assert "times" in recorder.data
 
-    def test_recording_cycle(self, recorder, engine):
+    def test_recording_cycle(self, recorder, engine) -> None:
+        """Test full recording start-record-stop cycle."""
         recorder.start()
         assert recorder.is_recording
 
@@ -159,7 +204,8 @@ class TestGenericPhysicsRecorder:
         assert len(pos) == 10
         assert pos[9, 0] == 9.0
 
-    def test_buffer_allocation_on_first_step(self, recorder, engine):
+    def test_buffer_allocation_on_first_step(self, recorder, engine) -> None:
+        """Test buffer allocation happens on first recorded step."""
         recorder.start()
         recorder.record_step()
 
@@ -167,7 +213,8 @@ class TestGenericPhysicsRecorder:
         # Dynamic buffer sizing: starts at 1000 (or max_samples if smaller)
         assert recorder.data["joint_positions"].shape == (1000, 2)
 
-    def test_buffer_full(self, engine):
+    def test_buffer_full(self, engine) -> None:
+        """Test recorder behavior when buffer is full."""
         # Test with initial_capacity=5 to match max_samples
         recorder = GenericPhysicsRecorder(engine, max_samples=5, initial_capacity=5)
         recorder.start()
@@ -181,7 +228,8 @@ class TestGenericPhysicsRecorder:
         assert recorder.current_idx == 5
         assert not recorder.is_recording  # Auto-stopped when buffer full
 
-    def test_analysis_config_allocation(self, recorder, engine):
+    def test_analysis_config_allocation(self, recorder, engine) -> None:
+        """Test analysis config enables additional buffer allocation."""
         recorder.start()
         recorder.record_step()  # Initialize buffers
 
@@ -194,7 +242,8 @@ class TestGenericPhysicsRecorder:
         recorder.record_step()
         assert recorder.data["ztcf_accel"][1, 0] == 0.1  # Mock value
 
-    def test_post_hoc_analysis(self, recorder, engine):
+    def test_post_hoc_analysis(self, recorder, engine) -> None:
+        """Test post-hoc analysis computation."""
         recorder.start()
         for _i in range(5):
             recorder.record_step(control_input=np.array([1.0, 1.0]))
@@ -207,7 +256,8 @@ class TestGenericPhysicsRecorder:
         assert len(times) == 5
         assert len(vals) == 5
 
-    def test_get_data_dict(self, recorder, engine):
+    def test_get_data_dict(self, recorder, engine) -> None:
+        """Test get_data_dict returns correct structure."""
         recorder.start()
         recorder.record_step()
 

--- a/src/shared/python/tests/test_hill_muscle.py
+++ b/src/shared/python/tests/test_hill_muscle.py
@@ -11,7 +11,7 @@ from src.shared.python.biomechanics.hill_muscle import (
 
 
 @pytest.fixture
-def muscle_params():
+def muscle_params() -> MuscleParameters:
     """Default muscle parameters for testing."""
     return MuscleParameters(
         F_max=1000.0, l_opt=0.10, l_slack=0.20, v_max=1.0, pennation_angle=0.0
@@ -19,18 +19,18 @@ def muscle_params():
 
 
 @pytest.fixture
-def muscle_model(muscle_params):
+def muscle_model(muscle_params) -> HillMuscleModel:
     """Hill muscle model instance."""
     return HillMuscleModel(muscle_params)
 
 
-def test_force_length_active_at_optimal(muscle_model):
+def test_force_length_active_at_optimal(muscle_model) -> None:
     """Test active force at optimal length."""
     # At optimal length (norm = 1.0), force multiplier should be 1.0
     assert np.isclose(muscle_model.force_length_active(1.0), 1.0)
 
 
-def test_force_length_active_bell_curve(muscle_model):
+def test_force_length_active_bell_curve(muscle_model) -> None:
     """Test bell curve shape of active force-length relationship."""
     # Force should be lower at shorter and longer lengths
     l_short = 0.5
@@ -45,7 +45,7 @@ def test_force_length_active_bell_curve(muscle_model):
     assert f_long > 0
 
 
-def test_force_length_passive(muscle_model):
+def test_force_length_passive(muscle_model) -> None:
     """Test passive force-length relationship."""
     # No passive force below optimal length
     assert muscle_model.force_length_passive(0.9) == 0.0
@@ -59,7 +59,7 @@ def test_force_length_passive(muscle_model):
     assert f_1_5 > f_1_2
 
 
-def test_force_velocity_isometric(muscle_model):
+def test_force_velocity_isometric(muscle_model) -> None:
     """Test force-velocity at isometric conditions."""
     # At v=0, force multiplier is not 1.0 in this implementation?
     # Wait, the formula says:
@@ -68,7 +68,7 @@ def test_force_velocity_isometric(muscle_model):
     assert np.isclose(muscle_model.force_velocity(0.0), 1.0)
 
 
-def test_force_velocity_shortening(muscle_model):
+def test_force_velocity_shortening(muscle_model) -> None:
     """Test force-velocity during shortening (concentric).
 
     Standard Hill model: Force decreases as shortening velocity increases.
@@ -84,7 +84,7 @@ def test_force_velocity_shortening(muscle_model):
     assert f_v > 0.0  # Force should still be positive
 
 
-def test_tendon_force(muscle_model):
+def test_tendon_force(muscle_model) -> None:
     """Test tendon force-strain relationship."""
     # Slack length strain <= 0 -> Force 0
     assert muscle_model.tendon_force(1.0) == 0.0  # At slack length
@@ -95,7 +95,7 @@ def test_tendon_force(muscle_model):
     assert f_stretch > 0
 
 
-def test_compute_muscle_force_isometric_max(muscle_model, muscle_params):
+def test_compute_muscle_force_isometric_max(muscle_model, muscle_params) -> None:
     """Test max isometric force computation."""
     # At optimal length with full activation and zero velocity
     state = MuscleState(
@@ -110,7 +110,7 @@ def test_compute_muscle_force_isometric_max(muscle_model, muscle_params):
     assert np.isclose(force, muscle_params.F_max, rtol=0.1)
 
 
-def test_compute_muscle_force_pennation(muscle_params):
+def test_compute_muscle_force_pennation(muscle_params) -> None:
     """Test effect of pennation angle."""
     angle = np.pi / 3  # 60 degrees, cos = 0.5
     muscle_params.pennation_angle = angle

--- a/src/shared/python/tests/test_impact_model.py
+++ b/src/shared/python/tests/test_impact_model.py
@@ -1,5 +1,7 @@
 """Tests for the impact model implementation."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -18,12 +20,14 @@ from src.shared.python.physics.impact_model import (
 
 
 @pytest.fixture
-def default_impact_params():
+def default_impact_params() -> ImpactParameters:
+    """Create default impact parameters."""
     return ImpactParameters(cor=0.8, friction_coefficient=0.4)
 
 
 @pytest.fixture
-def basic_pre_state():
+def basic_pre_state() -> PreImpactState:
+    """Create a basic pre-impact state for a driver swing."""
     return PreImpactState(
         clubhead_velocity=np.array([45.0, 0.0, 0.0]),  # 45 m/s (~100 mph)
         clubhead_angular_velocity=np.zeros(3),
@@ -37,7 +41,7 @@ def basic_pre_state():
     )
 
 
-def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params):
+def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params) -> None:
     """Test momentum conservation in rigid body impact."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -56,7 +60,7 @@ def test_rigid_body_impact_conservation(basic_pre_state, default_impact_params):
     np.testing.assert_allclose(p_initial, p_final, atol=1e-5)
 
 
-def test_rigid_body_impact_cor(basic_pre_state, default_impact_params):
+def test_rigid_body_impact_cor(basic_pre_state, default_impact_params) -> None:
     """Test coefficient of restitution logic."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -79,7 +83,7 @@ def test_rigid_body_impact_cor(basic_pre_state, default_impact_params):
     assert np.isclose(v_sep, expected_v_sep)
 
 
-def test_rigid_body_friction_spin(basic_pre_state, default_impact_params):
+def test_rigid_body_friction_spin(basic_pre_state, default_impact_params) -> None:
     """Test spin generation from glancing impact."""
     # Modify pre-state to have tangential velocity component
     # Club moving slightly up (launch angle)
@@ -180,7 +184,7 @@ def test_rigid_body_friction_spin(basic_pre_state, default_impact_params):
     assert post_state.ball_angular_velocity[1] == 0
 
 
-def test_finite_time_model(basic_pre_state, default_impact_params):
+def test_finite_time_model(basic_pre_state, default_impact_params) -> None:
     """Test finite time model delegates to rigid body but sets duration."""
     model = FiniteTimeImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -192,7 +196,7 @@ def test_finite_time_model(basic_pre_state, default_impact_params):
     np.testing.assert_array_equal(post_state.ball_velocity, rigid_post.ball_velocity)
 
 
-def test_spring_damper_model(basic_pre_state, default_impact_params):
+def test_spring_damper_model(basic_pre_state, default_impact_params) -> None:
     """Test spring damper model produces physical results."""
     # Use softer params for stability in test to avoid numerical blow-up
     # Stiff springs (1e7) require very small dt (<< 1e-6) for stability with simple integrators.
@@ -226,7 +230,7 @@ def test_spring_damper_model(basic_pre_state, default_impact_params):
     assert post_state.contact_duration > 0
 
 
-def test_gear_effect_spin():
+def test_gear_effect_spin() -> None:
     """Test gear effect spin calculation."""
     v_club = np.array([45.0, 0.0, 0.0])
     normal = np.array([1.0, 0.0, 0.0])
@@ -249,7 +253,7 @@ def test_gear_effect_spin():
     assert spin_heel[2] > 0
 
 
-def test_validate_energy_balance(basic_pre_state, default_impact_params):
+def test_validate_energy_balance(basic_pre_state, default_impact_params) -> None:
     """Test energy balance validation function."""
     model = RigidBodyImpactModel()
     post_state = model.solve(basic_pre_state, default_impact_params)
@@ -263,7 +267,7 @@ def test_validate_energy_balance(basic_pre_state, default_impact_params):
     assert analysis["energy_lost"] > 0  # Inelastic collision (COR < 1)
 
 
-def test_create_impact_model():
+def test_create_impact_model() -> None:
     """Test factory function."""
     assert isinstance(
         create_impact_model(ImpactModelType.RIGID_BODY), RigidBodyImpactModel

--- a/src/shared/python/tests/test_openpose_gui_coverage.py
+++ b/src/shared/python/tests/test_openpose_gui_coverage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from unittest.mock import patch
 
@@ -24,7 +26,8 @@ if PYQT6_AVAILABLE:
 
 # Helper fixture to ensure QApplication exists
 @pytest.fixture(scope="session")
-def qapp():
+def qapp() -> QApplication:
+    """Provide the QApplication instance for the session."""
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
@@ -32,26 +35,30 @@ def qapp():
 
 
 @pytest.fixture
-def gui(qapp, qtbot):
+def gui(qapp, qtbot) -> OpenPoseGUI:
+    """Create an OpenPoseGUI instance."""
     window = OpenPoseGUI()
     qtbot.addWidget(window)
     return window
 
 
-def test_initial_state(gui):
+def test_initial_state(gui) -> None:
+    """Test OpenPoseGUI initial widget state."""
     assert gui.lbl_file.text() == "No file selected."
     assert not gui.btn_run.isEnabled()
     assert gui.progress.value() == 0
 
 
-def test_load_video_cancel(gui):
+def test_load_video_cancel(gui) -> None:
+    """Test loading video when user cancels file dialog."""
     with patch.object(QFileDialog, "getOpenFileName", return_value=("", "")):
         gui.load_video()
         assert gui.lbl_file.text() == "No file selected."
         assert not gui.btn_run.isEnabled()
 
 
-def test_load_video_success(gui):
+def test_load_video_success(gui) -> None:
+    """Test successful video file loading."""
     test_file = "/path/to/video.mp4"
     with patch.object(
         QFileDialog,
@@ -64,7 +71,8 @@ def test_load_video_success(gui):
         assert "Loaded video" in gui.log_area.toPlainText()
 
 
-def test_run_analysis(gui, qtbot):
+def test_run_analysis(gui, qtbot) -> None:
+    """Test running analysis workflow."""
     # Setup state
     gui.lbl_file.setText("/path/to/video.mp4")
     gui.btn_run.setEnabled(True)
@@ -91,6 +99,7 @@ def test_run_analysis(gui, qtbot):
         mock_msg.assert_called_once()
 
 
-def test_log(gui):
+def test_log(gui) -> None:
+    """Test log message appending."""
     gui.log("Test message")
     assert "Test message" in gui.log_area.toPlainText()

--- a/src/shared/python/tests/test_output_manager.py
+++ b/src/shared/python/tests/test_output_manager.py
@@ -1,5 +1,7 @@
 """Tests for the output manager."""
 
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -14,14 +16,14 @@ from src.shared.python.data_io.output_manager import (
 
 
 @pytest.fixture
-def temp_output_dir(tmp_path):
+def temp_output_dir(tmp_path) -> OutputManager:
     """Create a temporary output manager."""
     manager = OutputManager(base_path=tmp_path)
     manager.create_output_structure()
     return manager
 
 
-def test_initialization(tmp_path):
+def test_initialization(tmp_path) -> None:
     """Test directory creation."""
     manager = OutputManager(base_path=tmp_path)
     manager.create_output_structure()
@@ -32,7 +34,7 @@ def test_initialization(tmp_path):
     assert (tmp_path / "simulations" / "mujoco").exists()
 
 
-def test_save_load_csv(temp_output_dir):
+def test_save_load_csv(temp_output_dir) -> None:
     """Test saving and loading CSV."""
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     path = temp_output_dir.save_simulation_results(
@@ -48,7 +50,7 @@ def test_save_load_csv(temp_output_dir):
     pd.testing.assert_frame_equal(df, loaded)
 
 
-def test_save_load_json(temp_output_dir):
+def test_save_load_json(temp_output_dir) -> None:
     """Test saving and loading JSON."""
     # When saving raw list, it wraps it in {results: [...]}
     data = [1, 2, 3]
@@ -80,7 +82,7 @@ def test_save_load_json(temp_output_dir):
     assert loaded2 == data_struct
 
 
-def test_save_load_parquet(temp_output_dir):
+def test_save_load_parquet(temp_output_dir) -> None:
     """Test saving and loading Parquet."""
     try:
         import pyarrow  # noqa: F401
@@ -104,14 +106,14 @@ def test_save_load_parquet(temp_output_dir):
     pd.testing.assert_frame_equal(df, loaded)
 
 
-def test_save_pickle_disabled(temp_output_dir):
+def test_save_pickle_disabled(temp_output_dir) -> None:
     """Test that pickle is disabled for security."""
     data = [1, 2, 3]
     with pytest.raises(ValueError, match="Security: Pickle format is disabled"):
         temp_output_dir.save_simulation_results(data, "test", OutputFormat.PICKLE)
 
 
-def test_export_report_html(temp_output_dir):
+def test_export_report_html(temp_output_dir) -> None:
     """Test HTML report generation."""
     data = {"accuracy": 0.95, "speed": 100}
     path = temp_output_dir.export_analysis_report(data, "test_report", "html")
@@ -123,7 +125,7 @@ def test_export_report_html(temp_output_dir):
     assert "0.95" in content
 
 
-def test_cleanup_old_files(temp_output_dir):
+def test_cleanup_old_files(temp_output_dir) -> None:
     """Test file cleanup logic."""
     # Create an old file
     old_file = temp_output_dir.directories["simulations"] / "old.csv"
@@ -147,7 +149,7 @@ def test_cleanup_old_files(temp_output_dir):
     assert new_file.exists()
 
 
-def test_convenience_functions(tmp_path, monkeypatch):
+def test_convenience_functions(tmp_path, monkeypatch) -> None:
     """Test the top-level save_results and load_results functions."""
     # The convenience functions create a new OutputManager internally.
     # We can test them by using unittest.mock.patch as a context manager.

--- a/src/shared/python/tests/test_physics_parameters.py
+++ b/src/shared/python/tests/test_physics_parameters.py
@@ -11,12 +11,14 @@ from src.shared.python.physics.physics_parameters import (
 
 
 class TestPhysicsParameters:
+    """Tests for physics parameter registry."""
+
     @pytest.fixture
-    def registry(self):
+    def registry(self) -> PhysicsParameterRegistry:
         """Create a new registry for each test."""
         return PhysicsParameterRegistry()
 
-    def test_parameter_validation(self):
+    def test_parameter_validation(self) -> None:
         """Test parameter validation logic."""
         param = PhysicsParameter(
             name="TEST_PARAM",
@@ -56,7 +58,7 @@ class TestPhysicsParameters:
         assert not valid
         assert "constant" in msg
 
-    def test_registry_initialization(self, registry):
+    def test_registry_initialization(self, registry) -> None:
         """Test that default parameters are loaded."""
         assert len(registry.parameters) > 0
 
@@ -65,7 +67,7 @@ class TestPhysicsParameters:
         assert registry.get("BALL_MASS") is not None
         assert registry.get("CLUB_LENGTH") is not None
 
-    def test_get_set_parameter(self, registry):
+    def test_get_set_parameter(self, registry) -> None:
         """Test getting and setting parameters."""
         # Get
         param = registry.get("CLUB_LENGTH")
@@ -88,7 +90,7 @@ class TestPhysicsParameters:
         assert not success
         assert "not found" in msg
 
-    def test_get_by_category(self, registry):
+    def test_get_by_category(self, registry) -> None:
         """Test filtering by category."""
         ball_params = registry.get_by_category(ParameterCategory.BALL)
         assert len(ball_params) > 0
@@ -98,7 +100,7 @@ class TestPhysicsParameters:
         env_params = registry.get_by_category(ParameterCategory.ENVIRONMENT)
         assert len(env_params) > 0
 
-    def test_export_import_json(self, registry, tmp_path):
+    def test_export_import_json(self, registry, tmp_path) -> None:
         """Test JSON export and import."""
         # Export
         json_path = tmp_path / "params.json"
@@ -120,14 +122,14 @@ class TestPhysicsParameters:
         assert count > 0
         assert registry.get("CLUB_LENGTH").value == 1.0
 
-    def test_get_summary(self, registry):
+    def test_get_summary(self, registry) -> None:
         """Test summary string generation."""
         summary = registry.get_summary()
         assert "Physics Parameter Registry" in summary
         assert "GRAVITY" in summary
         assert "BALL_MASS" in summary
 
-    def test_global_registry(self):
+    def test_global_registry(self) -> None:
         """Test singleton accessor."""
         reg1 = get_registry()
         reg2 = get_registry()

--- a/src/shared/python/tests/test_plotting.py
+++ b/src/shared/python/tests/test_plotting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import numpy as np
@@ -10,7 +12,7 @@ from src.shared.python.plotting import GolfSwingPlotter, RecorderInterface
 class MockRecorder(RecorderInterface):
     """Mock recorder for testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.data = {
             "joint_positions": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
             "joint_velocities": (np.linspace(0, 1, 10), np.random.rand(10, 3)),
@@ -28,34 +30,41 @@ class MockRecorder(RecorderInterface):
         self.induced_acc = {"gravity": (np.linspace(0, 1, 10), np.random.rand(10, 3))}
         self.counterfactuals = {"ztcf": (np.linspace(0, 1, 10), np.random.rand(10, 3))}
 
-    def get_time_series(self, field_name: str):
+    def get_time_series(self, field_name: str) -> tuple:
+        """Return time series data for the given field."""
         return self.data.get(field_name, (np.array([]), np.array([])))
 
-    def get_induced_acceleration_series(self, source_name: str | int):
+    def get_induced_acceleration_series(self, source_name: str | int) -> tuple:
+        """Return induced acceleration series for the given source."""
         if not isinstance(source_name, str):
             return np.array([]), np.array([])
         return self.induced_acc.get(source_name, (np.array([]), np.array([])))
 
-    def get_counterfactual_series(self, cf_name: str):
+    def get_counterfactual_series(self, cf_name: str) -> tuple:
+        """Return counterfactual series for the given name."""
         return self.counterfactuals.get(cf_name, (np.array([]), np.array([])))
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> MockRecorder:
+    """Create a MockRecorder instance."""
     return MockRecorder()
 
 
 @pytest.fixture
-def plotter(mock_recorder):
+def plotter(mock_recorder) -> GolfSwingPlotter:
+    """Create a GolfSwingPlotter with mock recorder."""
     return GolfSwingPlotter(mock_recorder, joint_names=["Joint1", "Joint2", "Joint3"])
 
 
 @pytest.fixture
-def fig():
+def fig() -> Figure:
+    """Create a matplotlib Figure."""
     return Figure()
 
 
-def test_init(mock_recorder):
+def test_init(mock_recorder) -> None:
+    """Test GolfSwingPlotter initialization."""
     plotter = GolfSwingPlotter(mock_recorder)
     assert plotter.recorder == mock_recorder
     assert plotter.joint_names == []
@@ -64,13 +73,15 @@ def test_init(mock_recorder):
     assert plotter_named.joint_names == ["J1"]
 
 
-def test_get_joint_name(plotter):
+def test_get_joint_name(plotter) -> None:
+    """Test joint name lookup by index."""
     assert plotter.get_joint_name(0) == "Joint1"
     assert plotter.get_joint_name(1) == "Joint2"
     assert plotter.get_joint_name(99) == "Joint 99"
 
 
-def test_get_aligned_label(plotter):
+def test_get_aligned_label(plotter) -> None:
+    """Test aligned label resolution for floating base offsets."""
     # Perfect match
     assert plotter._get_aligned_label(0, 3) == "Joint1"
 
@@ -82,7 +93,8 @@ def test_get_aligned_label(plotter):
     assert plotter._get_aligned_label(0, 7) == "DoF 0"
 
 
-def test_plot_joint_angles(plotter, fig):
+def test_plot_joint_angles(plotter, fig) -> None:
+    """Test joint angles plotting."""
     plotter.plot_joint_angles(fig)
     assert len(fig.axes) > 0
 
@@ -93,54 +105,64 @@ def test_plot_joint_angles(plotter, fig):
     assert len(fig.axes) > 0  # Should still create axes to show "No data" text
 
 
-def test_plot_joint_velocities(plotter, fig):
+def test_plot_joint_velocities(plotter, fig) -> None:
+    """Test joint velocities plotting."""
     plotter.plot_joint_velocities(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_joint_torques(plotter, fig):
+def test_plot_joint_torques(plotter, fig) -> None:
+    """Test joint torques plotting."""
     plotter.plot_joint_torques(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_actuator_powers(plotter, fig):
+def test_plot_actuator_powers(plotter, fig) -> None:
+    """Test actuator powers plotting."""
     plotter.plot_actuator_powers(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_energy_analysis(plotter, fig):
+def test_plot_energy_analysis(plotter, fig) -> None:
+    """Test energy analysis plotting."""
     plotter.plot_energy_analysis(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_club_head_speed(plotter, fig):
+def test_plot_club_head_speed(plotter, fig) -> None:
+    """Test club head speed plotting."""
     plotter.plot_club_head_speed(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_club_head_trajectory(plotter, fig):
+def test_plot_club_head_trajectory(plotter, fig) -> None:
+    """Test 3D club head trajectory plotting."""
     plotter.plot_club_head_trajectory(fig)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_phase_diagram(plotter, fig):
+def test_plot_phase_diagram(plotter, fig) -> None:
+    """Test phase diagram plotting."""
     plotter.plot_phase_diagram(fig, joint_idx=0)
     assert len(fig.axes) > 0
 
 
-def test_plot_torque_comparison(plotter, fig):
+def test_plot_torque_comparison(plotter, fig) -> None:
+    """Test torque comparison plotting."""
     plotter.plot_torque_comparison(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_frequency_analysis(plotter, fig):
+def test_plot_frequency_analysis(plotter, fig) -> None:
+    """Test frequency analysis plotting."""
     with patch("scipy.signal.welch", return_value=(np.array([1, 2]), np.array([1, 2]))):
         plotter.plot_frequency_analysis(fig, joint_idx=0)
         assert len(fig.axes) > 0
 
 
-def test_plot_spectrogram(plotter, fig):
+def test_plot_spectrogram(plotter, fig) -> None:
+    """Test spectrogram plotting."""
     with patch(
         "scipy.signal.spectrogram",
         return_value=(np.array([1]), np.array([1]), np.array([[1]])),
@@ -149,30 +171,35 @@ def test_plot_spectrogram(plotter, fig):
         assert len(fig.axes) > 0
 
 
-def test_plot_summary_dashboard(plotter, fig):
+def test_plot_summary_dashboard(plotter, fig) -> None:
+    """Test summary dashboard multi-panel plotting."""
     plotter.plot_summary_dashboard(fig)
     # Should have multiple axes
     assert len(fig.axes) >= 6
 
 
-def test_plot_kinematic_sequence(plotter, fig):
+def test_plot_kinematic_sequence(plotter, fig) -> None:
+    """Test kinematic sequence plotting."""
     segments = {"Seg1": 0, "Seg2": 1}
     plotter.plot_kinematic_sequence(fig, segments)
     assert len(fig.axes) > 0
 
 
-def test_plot_3d_phase_space(plotter, fig):
+def test_plot_3d_phase_space(plotter, fig) -> None:
+    """Test 3D phase space plotting."""
     plotter.plot_3d_phase_space(fig, joint_idx=0)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_correlation_matrix(plotter, fig):
+def test_plot_correlation_matrix(plotter, fig) -> None:
+    """Test correlation matrix plotting."""
     plotter.plot_correlation_matrix(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_swing_plane(plotter, fig):
+def test_plot_swing_plane(plotter, fig) -> None:
+    """Test swing plane fitting and plotting."""
     # Need enough points for fit
     N = 10
     positions = np.random.rand(N, 3)
@@ -185,38 +212,45 @@ def test_plot_swing_plane(plotter, fig):
     assert fig.axes[0].name == "3d"
 
 
-def test_plot_angular_momentum(plotter, fig):
+def test_plot_angular_momentum(plotter, fig) -> None:
+    """Test angular momentum plotting."""
     plotter.plot_angular_momentum(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_cop_trajectory(plotter, fig):
+def test_plot_cop_trajectory(plotter, fig) -> None:
+    """Test center of pressure trajectory plotting."""
     plotter.plot_cop_trajectory(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_cop_vector_field(plotter, fig):
+def test_plot_cop_vector_field(plotter, fig) -> None:
+    """Test center of pressure vector field plotting."""
     plotter.plot_cop_vector_field(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_radar_chart(plotter, fig):
+def test_plot_radar_chart(plotter, fig) -> None:
+    """Test radar chart plotting."""
     metrics = {"A": 0.5, "B": 0.8, "C": 0.2}
     plotter.plot_radar_chart(fig, metrics)
     assert len(fig.axes) > 0
     assert fig.axes[0].name == "polar"
 
 
-def test_plot_power_flow(plotter, fig):
+def test_plot_power_flow(plotter, fig) -> None:
+    """Test power flow plotting."""
     plotter.plot_power_flow(fig)
     assert len(fig.axes) > 0
 
 
-def test_plot_induced_acceleration(plotter, fig):
+def test_plot_induced_acceleration(plotter, fig) -> None:
+    """Test induced acceleration plotting."""
     plotter.plot_induced_acceleration(fig, "gravity")
     assert len(fig.axes) > 0
 
 
-def test_plot_counterfactual_comparison(plotter, fig):
+def test_plot_counterfactual_comparison(plotter, fig) -> None:
+    """Test counterfactual comparison plotting."""
     plotter.plot_counterfactual_comparison(fig, "ztcf")
     assert len(fig.axes) > 0

--- a/src/shared/python/tests/test_plotting_extended.py
+++ b/src/shared/python/tests/test_plotting_extended.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -9,7 +11,8 @@ from src.shared.python.tests.test_plotting import MockRecorder
 
 
 @pytest.fixture
-def extended_plotter():
+def extended_plotter() -> GolfSwingPlotter:
+    """Create a GolfSwingPlotter with extended mock data."""
     # Seed for reproducible test data generation
     np.random.seed(42)
     recorder = MockRecorder()
@@ -19,11 +22,13 @@ def extended_plotter():
 
 
 @pytest.fixture
-def fig():
+def fig() -> Figure:
+    """Create a matplotlib Figure."""
     return Figure()
 
 
-def test_plot_dynamic_correlation(extended_plotter, fig):
+def test_plot_dynamic_correlation(extended_plotter, fig) -> None:
+    """Test dynamic correlation plotting."""
     extended_plotter.plot_dynamic_correlation(
         fig, joint_idx_1=0, joint_idx_2=1, window_size=5
     )
@@ -33,7 +38,8 @@ def test_plot_dynamic_correlation(extended_plotter, fig):
     assert ax.get_title().startswith("Dynamic Correlation")
 
 
-def test_plot_synergy_trajectory(extended_plotter, fig):
+def test_plot_synergy_trajectory(extended_plotter, fig) -> None:
+    """Test synergy trajectory plotting."""
     # Mock synergy result
     synergy_result = MagicMock()
     synergy_result.activations = np.random.rand(2, 10)
@@ -44,7 +50,8 @@ def test_plot_synergy_trajectory(extended_plotter, fig):
     assert ax.get_title() == "Synergy Space Trajectory"
 
 
-def test_plot_3d_vector_field(extended_plotter, fig):
+def test_plot_3d_vector_field(extended_plotter, fig) -> None:
+    """Test 3D vector field plotting."""
     # Setup recorder with necessary data
     # Angular momentum and CoM position
     extended_plotter.recorder.data["angular_momentum"] = (
@@ -63,7 +70,8 @@ def test_plot_3d_vector_field(extended_plotter, fig):
     assert ax.get_title().startswith("3D Vector Field")
 
 
-def test_plot_local_stability(extended_plotter, fig):
+def test_plot_local_stability(extended_plotter, fig) -> None:
+    """Test local stability plotting."""
     # Setup data
     extended_plotter.recorder.data["joint_velocities"] = (
         np.linspace(0, 1, 50),
@@ -80,7 +88,8 @@ def test_plot_local_stability(extended_plotter, fig):
     assert ax.get_title().startswith("Local Stability")
 
 
-def test_plot_dynamic_correlation_insufficient_data(extended_plotter, fig):
+def test_plot_dynamic_correlation_insufficient_data(extended_plotter, fig) -> None:
+    """Test dynamic correlation with insufficient data shows message."""
     extended_plotter.recorder.data["joint_velocities"] = (np.array([]), np.array([]))
     extended_plotter.plot_dynamic_correlation(fig, 0, 1)
     assert len(fig.axes) > 0

--- a/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
+++ b/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
@@ -54,14 +54,14 @@ def _default_params(**overrides: Any) -> BodyParameters:
 class TestSMPLXBetaConversion:
     """Test BodyParameters -> SMPL-X beta parameter conversion."""
 
-    def test_default_params_produce_near_zero_betas(self):
+    def test_default_params_produce_near_zero_betas(self) -> None:
         params = BodyParameters()  # 1.75 m, 75 kg, average
         betas = SMPLXMeshGenerator._convert_params_to_betas(params)
         assert betas.shape == (SMPLXMeshGenerator.NUM_BETAS,)
         # Default body close to SMPL-X mean -> betas should be small
         assert np.abs(betas).max() < 5.0
 
-    def test_tall_heavy_person(self):
+    def test_tall_heavy_person(self) -> None:
         params = _default_params(height_m=2.00, mass_kg=110.0)
         betas = SMPLXMeshGenerator._convert_params_to_betas(params)
         # beta[0] should be positive (tall)
@@ -69,14 +69,14 @@ class TestSMPLXBetaConversion:
         # beta[1] should be positive (high BMI)
         assert betas[1] > 0
 
-    def test_short_light_person(self):
+    def test_short_light_person(self) -> None:
         params = _default_params(height_m=1.50, mass_kg=45.0)
         betas = SMPLXMeshGenerator._convert_params_to_betas(params)
         assert betas[0] < 0  # shorter than mean
         # BMI = 45 / 1.50^2 = 20.0, below mean of 22 -> negative beta
         assert betas[1] < 0  # lower BMI
 
-    def test_proportion_factors_map(self):
+    def test_proportion_factors_map(self) -> None:
         params = _default_params(
             shoulder_width_factor=1.2,
             hip_width_factor=0.9,
@@ -91,7 +91,7 @@ class TestSMPLXBetaConversion:
         assert betas[5] > 0  # longer legs
         assert betas[6] > 0  # longer torso
 
-    def test_muscularity_mapping(self):
+    def test_muscularity_mapping(self) -> None:
         lean = _default_params(muscularity=0.1)
         buff = _default_params(muscularity=0.9)
         b_lean = SMPLXMeshGenerator._convert_params_to_betas(lean)
@@ -102,15 +102,15 @@ class TestSMPLXBetaConversion:
 class TestSMPLXGenderString:
     """Test gender string selection."""
 
-    def test_male(self):
+    def test_male(self) -> None:
         params = BodyParameters(gender_model=GenderModel.MALE)
         assert SMPLXMeshGenerator._gender_string(params) == "male"
 
-    def test_female(self):
+    def test_female(self) -> None:
         params = BodyParameters(gender_model=GenderModel.FEMALE)
         assert SMPLXMeshGenerator._gender_string(params) == "female"
 
-    def test_neutral(self):
+    def test_neutral(self) -> None:
         params = BodyParameters(gender_model=GenderModel.NEUTRAL)
         assert SMPLXMeshGenerator._gender_string(params) == "neutral"
 
@@ -118,7 +118,7 @@ class TestSMPLXGenderString:
 class TestSMPLXSegmentMesh:
     """Test the static _segment_mesh helper."""
 
-    def test_segment_extracts_correct_vertices(self):
+    def test_segment_extracts_correct_vertices(self) -> None:
         verts = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [2, 2, 2]])
         faces = np.array([[0, 1, 2], [1, 2, 3], [2, 3, 4]])
 
@@ -127,7 +127,7 @@ class TestSMPLXSegmentMesh:
         assert seg_v.shape[0] == 4
         assert seg_f.shape[0] == 2
 
-    def test_empty_segment(self):
+    def test_empty_segment(self) -> None:
         verts = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
         faces = np.array([[0, 1, 2]])
 
@@ -139,7 +139,7 @@ class TestSMPLXSegmentMesh:
 class TestSMPLXAvailability:
     """Test is_available and error paths."""
 
-    def test_unavailable_when_smplx_missing(self):
+    def test_unavailable_when_smplx_missing(self) -> None:
         with patch(
             "humanoid_character_builder.generators.mesh_generator.SMPLX_AVAILABLE",
             False,
@@ -147,7 +147,7 @@ class TestSMPLXAvailability:
             gen = SMPLXMeshGenerator()
             assert gen.is_available is False
 
-    def test_unavailable_when_model_dir_missing(self):
+    def test_unavailable_when_model_dir_missing(self) -> None:
         with patch(
             "humanoid_character_builder.generators.mesh_generator.SMPLX_AVAILABLE",
             True,
@@ -155,7 +155,7 @@ class TestSMPLXAvailability:
             gen = SMPLXMeshGenerator(model_dir="/nonexistent/path")
             assert gen.is_available is False
 
-    def test_returns_error_result_when_smplx_missing(self):
+    def test_returns_error_result_when_smplx_missing(self) -> None:
         with patch(
             "humanoid_character_builder.generators.mesh_generator.SMPLX_AVAILABLE",
             False,
@@ -165,7 +165,7 @@ class TestSMPLXAvailability:
             assert result.success is False
             assert "smplx" in result.error_message.lower()
 
-    def test_returns_error_when_trimesh_missing(self):
+    def test_returns_error_when_trimesh_missing(self) -> None:
         with (
             patch(
                 "humanoid_character_builder.generators.mesh_generator.SMPLX_AVAILABLE",
@@ -209,7 +209,7 @@ class TestSMPLXGenerate:
     @patch("humanoid_character_builder.generators.mesh_generator._trimesh_module")
     def test_generate_produces_stl_files(
         self, mock_trimesh, mock_smplx, tmp_path: Path
-    ):
+    ) -> None:
         """Verify that generate produces per-segment STL files."""
         import torch  # noqa: F401
 
@@ -224,13 +224,15 @@ class TestSMPLXGenerate:
                 self.vertices = vertices
                 self.faces = faces
 
-            def export(self, path: str):
+            def export(self, path: str) -> None:
+                """Export."""
                 Path(path).parent.mkdir(parents=True, exist_ok=True)
                 Path(path).touch()
                 exported_files.append(path)
 
             @property
-            def convex_hull(self):
+            def convex_hull(self) -> FakeTrimesh:
+                """Convex hull."""
                 return self
 
         mock_trimesh.Trimesh = FakeTrimesh
@@ -254,7 +256,7 @@ class TestSMPLXGenerate:
     @patch(
         "humanoid_character_builder.generators.mesh_generator.TRIMESH_AVAILABLE", True
     )
-    def test_generate_handles_exception_gracefully(self, tmp_path: Path):
+    def test_generate_handles_exception_gracefully(self, tmp_path: Path) -> None:
         """Verify graceful failure when SMPL-X forward pass throws."""
         model_dir = tmp_path / "models"
         model_dir.mkdir()
@@ -274,7 +276,7 @@ class TestSMPLXGenerate:
 class TestSMPLXSupportedSegments:
     """Test get_supported_segments."""
 
-    def test_returns_expected_segments(self):
+    def test_returns_expected_segments(self) -> None:
         gen = SMPLXMeshGenerator()
         segments = gen.get_supported_segments()
         assert "head" in segments
@@ -291,7 +293,7 @@ class TestSMPLXSupportedSegments:
 class TestMakeHumanParamConversion:
     """Test BodyParameters -> MakeHuman modifier conversion."""
 
-    def test_default_params_conversion(self):
+    def test_default_params_conversion(self) -> None:
         params = BodyParameters()
         modifiers = MakeHumanMeshGenerator._convert_params_to_makehuman(params)
 
@@ -301,7 +303,7 @@ class TestMakeHumanParamConversion:
         assert "macrodetails-universal/Weight" in modifiers
         assert "__height_scale__" in modifiers
 
-    def test_gender_mapping(self):
+    def test_gender_mapping(self) -> None:
         male = BodyParameters(gender_model=GenderModel.MALE)
         female = BodyParameters(gender_model=GenderModel.FEMALE)
 
@@ -311,7 +313,7 @@ class TestMakeHumanParamConversion:
         assert m["macrodetails/Gender"] == 1.0
         assert f["macrodetails/Gender"] == 0.0
 
-    def test_age_normalisation(self):
+    def test_age_normalisation(self) -> None:
         young = BodyParameters()
         young.appearance.age_years = 20.0
         old = BodyParameters()
@@ -323,12 +325,12 @@ class TestMakeHumanParamConversion:
         assert m_young["macrodetails/Age"] < m_old["macrodetails/Age"]
         assert 0.0 <= m_young["macrodetails/Age"] <= 1.0
 
-    def test_height_scale(self):
+    def test_height_scale(self) -> None:
         tall = _default_params(height_m=1.90)
         modifiers = MakeHumanMeshGenerator._convert_params_to_makehuman(tall)
         assert modifiers["__height_scale__"] > 1.0
 
-    def test_proportion_modifiers(self):
+    def test_proportion_modifiers(self) -> None:
         params = _default_params(
             shoulder_width_factor=1.2,
             hip_width_factor=0.9,
@@ -345,17 +347,17 @@ class TestMakeHumanParamConversion:
 class TestMakeHumanAvailability:
     """Test is_available for MakeHuman."""
 
-    def test_unavailable_when_not_installed(self):
+    def test_unavailable_when_not_installed(self) -> None:
         gen = MakeHumanMeshGenerator(makehuman_path="/nonexistent/makehuman")
         assert gen.is_available is False
 
-    def test_available_when_path_exists(self, tmp_path: Path):
+    def test_available_when_path_exists(self, tmp_path: Path) -> None:
         mh_dir = tmp_path / "makehuman"
         mh_dir.mkdir()
         gen = MakeHumanMeshGenerator(makehuman_path=mh_dir)
         assert gen.is_available is True
 
-    def test_returns_error_when_unavailable(self):
+    def test_returns_error_when_unavailable(self) -> None:
         gen = MakeHumanMeshGenerator(makehuman_path="/nonexistent")
         result = gen.generate(_default_params(), Path("/tmp/out"))
         assert result.success is False
@@ -365,7 +367,7 @@ class TestMakeHumanAvailability:
 class TestMakeHumanOBJParsing:
     """Test the OBJ file parser."""
 
-    def test_parse_simple_obj(self, tmp_path: Path):
+    def test_parse_simple_obj(self, tmp_path: Path) -> None:
         obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
@@ -383,7 +385,7 @@ class TestMakeHumanOBJParsing:
         # OBJ is 1-indexed, so first face should be [0, 1, 2]
         assert faces[0].tolist() == [0, 1, 2]
 
-    def test_parse_obj_with_normals_and_texcoords(self, tmp_path: Path):
+    def test_parse_obj_with_normals_and_texcoords(self, tmp_path: Path) -> None:
         obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
@@ -399,7 +401,7 @@ class TestMakeHumanOBJParsing:
         assert vertices.shape == (3, 3)
         assert faces.shape == (1, 3)
 
-    def test_parse_obj_quad_triangulation(self, tmp_path: Path):
+    def test_parse_obj_quad_triangulation(self, tmp_path: Path) -> None:
         obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
@@ -419,7 +421,7 @@ class TestMakeHumanOBJParsing:
 class TestMakeHumanScriptGeneration:
     """Test MakeHuman scripted-mode script generation."""
 
-    def test_script_contains_modifiers(self):
+    def test_script_contains_modifiers(self) -> None:
         modifiers = {
             "macrodetails/Gender": 1.0,
             "macrodetails/Age": 0.5,
@@ -442,7 +444,9 @@ class TestMakeHumanGenerate:
         "humanoid_character_builder.generators.mesh_generator.TRIMESH_AVAILABLE", True
     )
     @patch("humanoid_character_builder.generators.mesh_generator._trimesh_module")
-    def test_generate_with_mocked_subprocess(self, mock_trimesh, tmp_path: Path):
+    def test_generate_with_mocked_subprocess(
+        self, mock_trimesh, tmp_path: Path
+    ) -> None:
         """Test end-to-end generation with mocked MakeHuman subprocess."""
         mh_dir = tmp_path / "makehuman"
         mh_dir.mkdir()
@@ -458,13 +462,15 @@ class TestMakeHumanGenerate:
                 self.vertices = vertices
                 self.faces = faces
 
-            def export(self, path: str):
+            def export(self, path: str) -> None:
+                """Export."""
                 Path(path).parent.mkdir(parents=True, exist_ok=True)
                 Path(path).touch()
                 exported_files.append(path)
 
             @property
-            def convex_hull(self):
+            def convex_hull(self) -> FakeTrimesh:
+                """Convex hull."""
                 return self
 
         mock_trimesh.Trimesh = FakeTrimesh
@@ -491,7 +497,7 @@ class TestMakeHumanGenerate:
         assert result.success is True
         assert result.metadata["backend"] == "makehuman"
 
-    def test_generate_fails_when_script_fails(self, tmp_path: Path):
+    def test_generate_fails_when_script_fails(self, tmp_path: Path) -> None:
         """Test that generation fails gracefully when MakeHuman script fails."""
         mh_dir = tmp_path / "makehuman"
         mh_dir.mkdir()
@@ -509,7 +515,7 @@ class TestMakeHumanGenerate:
 class TestMakeHumanSupportedSegments:
     """Test get_supported_segments."""
 
-    def test_returns_all_mapped_segments(self):
+    def test_returns_all_mapped_segments(self) -> None:
         gen = MakeHumanMeshGenerator()
         segments = gen.get_supported_segments()
         assert "head" in segments
@@ -521,11 +527,11 @@ class TestMakeHumanSupportedSegments:
 class TestMakeHumanVertexGroupMap:
     """Test that the vertex group map is complete."""
 
-    def test_all_values_unique(self):
+    def test_all_values_unique(self) -> None:
         values = list(MakeHumanMeshGenerator.MH_VERTEX_GROUP_MAP.values())
         assert len(values) == len(set(values)), "Duplicate segment names in map"
 
-    def test_all_keys_unique(self):
+    def test_all_keys_unique(self) -> None:
         keys = list(MakeHumanMeshGenerator.MH_VERTEX_GROUP_MAP.keys())
         assert len(keys) == len(set(keys)), "Duplicate MH group names in map"
 
@@ -538,29 +544,29 @@ class TestMakeHumanVertexGroupMap:
 class TestMeshGeneratorFactory:
     """Test the MeshGenerator factory class."""
 
-    def test_create_smplx(self):
+    def test_create_smplx(self) -> None:
         gen = MeshGenerator.create(MeshGeneratorBackend.SMPLX)
         assert isinstance(gen, SMPLXMeshGenerator)
         assert gen.backend_name == "smplx"
 
-    def test_create_makehuman(self):
+    def test_create_makehuman(self) -> None:
         gen = MeshGenerator.create(MeshGeneratorBackend.MAKEHUMAN)
         assert isinstance(gen, MakeHumanMeshGenerator)
         assert gen.backend_name == "makehuman"
 
-    def test_create_from_string(self):
+    def test_create_from_string(self) -> None:
         gen = MeshGenerator.create("smplx")
         assert isinstance(gen, SMPLXMeshGenerator)
 
-    def test_create_from_string_case_insensitive(self):
+    def test_create_from_string_case_insensitive(self) -> None:
         gen = MeshGenerator.create("SMPLX")
         assert isinstance(gen, SMPLXMeshGenerator)
 
-    def test_create_unknown_backend_raises(self):
+    def test_create_unknown_backend_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown backend"):
             MeshGenerator.create(MeshGeneratorBackend.CUSTOM)
 
-    def test_interface_compliance(self):
+    def test_interface_compliance(self) -> None:
         """Verify both generators implement the full interface."""
         for cls in [SMPLXMeshGenerator, MakeHumanMeshGenerator]:
             gen = cls()
@@ -578,7 +584,7 @@ class TestMeshGeneratorFactory:
 class TestGeneratedMeshResult:
     """Test the result dataclass."""
 
-    def test_successful_result(self):
+    def test_successful_result(self) -> None:
         result = GeneratedMeshResult(
             success=True,
             mesh_paths={"head": Path("/tmp/head.stl")},
@@ -586,7 +592,7 @@ class TestGeneratedMeshResult:
         assert result.success is True
         assert result.error_message is None
 
-    def test_failed_result(self):
+    def test_failed_result(self) -> None:
         result = GeneratedMeshResult(
             success=False,
             error_message="Something went wrong",
@@ -594,7 +600,7 @@ class TestGeneratedMeshResult:
         assert result.success is False
         assert result.error_message == "Something went wrong"
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         result = GeneratedMeshResult(success=True)
         assert result.mesh_paths == {}
         assert result.collision_paths == {}

--- a/src/tools/video_analyzer/pose_estimator.py
+++ b/src/tools/video_analyzer/pose_estimator.py
@@ -5,6 +5,8 @@ Provides real-time pose estimation for golf swing analysis,
 extracting 33 body landmarks from video frames.
 """
 
+from __future__ import annotations
+
 import logging
 
 import cv2
@@ -292,7 +294,7 @@ class PoseEstimator:
 
         return output
 
-    def close(self):
+    def close(self) -> None:
         """Release resources."""
         if self._pose:
             self._pose.close()

--- a/src/tools/video_analyzer/types.py
+++ b/src/tools/video_analyzer/types.py
@@ -5,6 +5,8 @@ These types mirror the TypeScript definitions used in the web frontend
 for consistent data exchange between Python backend and JavaScript frontend.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -265,7 +267,7 @@ class SwingAnalysis:
         return convert(self)
 
     @classmethod
-    def from_dict(cls, data: dict) -> "SwingAnalysis":
+    def from_dict(cls, data: dict) -> SwingAnalysis:
         """Create from dictionary (e.g., from JSON)."""
         # This would need full implementation for production
         return cls(**data)

--- a/src/tools/video_analyzer/video_processor.py
+++ b/src/tools/video_analyzer/video_processor.py
@@ -5,6 +5,8 @@ Handles video file loading, frame extraction, and processing
 pipeline for swing analysis.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -326,7 +328,7 @@ class VideoProcessor:
             logger.error(f"Failed to export clip: {e}")
             return False
 
-    def close(self):
+    def close(self) -> None:
         """Release video resources."""
         if self._cap:
             self._cap.release()


### PR DESCRIPTION
## Summary
- Add return type annotations to ~595 functions across 55 files, bringing type coverage from 91.3% toward near-complete
- Add docstrings to test fixtures and helper functions in shared/python test files (124 previously missing)
- Covers production code (Simscape GUI, engines, tools) and test code (shared, engines, launchers)

## Details
**Wave 4 targets** (identified via AST-based assessment after wave 3 merge):
- **Return type annotations**: 595 missing (120 production, 475 test) — all addressed
- **Test fixture docstrings**: 145 missing non-test docstrings (124 in shared/python test fixtures) — all addressed
- **Function decomposition**: 3 remaining >100-line functions verified as already decomposed in previous waves

**Files changed**: 55 files, +1266/-821 lines

## Test plan
- [x] All pre-commit hooks pass (ruff lint, ruff format, no wildcards, no debug)
- [x] 565 tests pass locally with `--timeout=30`
- [x] 41 tests skipped (expected — missing optional dependencies)
- [ ] CI quality-gate
- [ ] CI tests (3.11)
- [ ] CI frontend-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly annotation/docstring-only changes, but it also refactors MuJoCo forward-dynamics (ABA) internals where subtle allocation/shape mistakes could affect simulation results and downstream analyses.
> 
> **Overview**
> **Broad typing/doc hygiene pass:** adds `from __future__ import annotations`, return type hints, and docstring punctuation/fixture docstrings across the golf GUIs, physics engines (Drake/MuJoCo/OpenSim/Pinocchio), utilities, and a large set of tests.
> 
> **Targeted refactors bundled in:** MuJoCo’s ABA implementation replaces the dict-based working-buffer allocation with a typed `_ABAArrays` dataclass and consolidates the three algorithm passes into `_aba_run_passes`; Drake’s `pose_editor_tab` `_setup_ui` is decomposed into helper builders for header/actions/joint controls/library without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ced5b9efbe470c5ee13a6d2ed5be281596534ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->