### PR TITLE
fix: centralize gravity constant (#1388)

### DIFF
--- a/src/api/routes/force_overlays.py
+++ b/src/api/routes/force_overlays.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.shared.python.core.constants import GRAVITY
+
 from ..dependencies import get_engine_manager, get_logger
 from ..models.requests import ForceOverlayRequest
 from ..models.responses import (
@@ -152,7 +154,7 @@ def _build_gravity_vectors(
             continue
 
         y_pos = 0.5 + i * 0.3
-        gravity_mag = 9.81 * (0.5 + 0.1 * i)
+        gravity_mag = GRAVITY * (0.5 + 0.1 * i)
         vectors.append(
             ForceVector3D(
                 body_name=body_name,
@@ -250,7 +252,7 @@ def _build_demo_vectors(config: ForceOverlayRequest) -> list[ForceVector3D]:
             )
 
         if "gravity" in config.force_types or "all" in config.force_types:
-            grav_mag = 9.81 * (1.0 + 0.2 * i)
+            grav_mag = GRAVITY * (1.0 + 0.2 * i)
             vectors.append(
                 ForceVector3D(
                     body_name=body,

--- a/src/engines/common/physics.py
+++ b/src/engines/common/physics.py
@@ -20,6 +20,7 @@ from typing import Protocol
 
 import numpy as np
 
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.core.contracts import postcondition, precondition
 
 # ─── Physical Constants ────────────────────────────────────────────────
@@ -364,7 +365,9 @@ class BallPhysics:
         """
         self.ball = ball or BallProperties()
         self.aero = AerodynamicsCalculator(self.ball, air)
-        self.gravity = gravity if gravity is not None else GRAVITY_VECTOR.copy()
+        self.gravity = (
+            gravity if gravity is not None else np.array([0.0, 0.0, -GRAVITY])
+        )
 
     @precondition(
         lambda self, velocity, spin: velocity.shape == (3,),

--- a/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
+++ b/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import numpy as np
 
-from src.engines.common.physics import GRAVITY_VECTOR
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.engine_core.engine_availability import (
     DRAKE_AVAILABLE,
     PYQT6_AVAILABLE,
@@ -80,7 +80,7 @@ class DrakePoseEditor(BasePoseEditor):
         super().__init__()
         self._plant = plant
         self._context = context
-        self._original_gravity_vector = GRAVITY_VECTOR.copy()
+        self._original_gravity_vector = np.array([0, 0, -GRAVITY])
         self._update_callback: Any = None
 
         if plant and context:
@@ -328,7 +328,7 @@ class DrakePoseEditor(BasePoseEditor):
     def _get_gravity_magnitude(self) -> float:
         """Get current gravity magnitude."""
         if self._plant is None:
-            return float(np.linalg.norm(GRAVITY_VECTOR))
+            return GRAVITY
 
         gravity = self._plant.gravity_field().gravity_vector()
         return float(np.linalg.norm(gravity))

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import numpy as np
 
-from src.engines.common.physics import GRAVITY_VECTOR
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.engine_core.engine_availability import (
     PINOCCHIO_AVAILABLE,
     PYQT6_AVAILABLE,
@@ -73,7 +73,7 @@ class PinocchioPoseEditor(BasePoseEditor):
         self._data = data
         self._q = q
         self._v = v
-        self._original_gravity: np.ndarray = GRAVITY_VECTOR.copy()  # type: ignore[assignment]
+        self._original_gravity = np.array([0, 0, -GRAVITY])
         self._update_callback: Any = None
         self._viz: Any = None  # Visualizer reference
 
@@ -318,7 +318,7 @@ class PinocchioPoseEditor(BasePoseEditor):
     def _get_gravity_magnitude(self) -> float:
         """Get current gravity magnitude."""
         if self._model is None:
-            return float(np.linalg.norm(GRAVITY_VECTOR))
+            return GRAVITY
         return float(np.linalg.norm(self._model.gravity.linear))
 
     def update_visualization(self) -> None:

--- a/src/research/deformable/objects.py
+++ b/src/research/deformable/objects.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from src.shared.python.core.constants import GRAVITY
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -434,8 +436,8 @@ class Cable(DeformableObject):
         internal_forces = self.compute_internal_forces()
         total_forces = internal_forces + self._external_forces
 
-        # Gravity (standard approximation)
-        gravity = np.array([0.0, 0.0, -9.81])
+        # Gravity
+        gravity = np.array([0.0, 0.0, -GRAVITY])
         node_mass = self._material.density * self._total_rest_length / self.n_nodes
         total_forces += node_mass * gravity
 
@@ -606,8 +608,8 @@ class Cloth(DeformableObject):
         internal_forces = self.compute_internal_forces()
         total_forces = internal_forces + self._external_forces
 
-        # Gravity (standard approximation)
-        gravity = np.array([0.0, 0.0, -9.81])
+        # Gravity
+        gravity = np.array([0.0, 0.0, -GRAVITY])
         node_mass = self._material.density * 0.01  # Assume thin cloth
         total_forces += node_mass * gravity
 

--- a/src/research/mpc/specialized.py
+++ b/src/research/mpc/specialized.py
@@ -12,6 +12,7 @@ from src.research.mpc.controller import (
     ModelPredictiveController,
     MPCResult,
 )
+from src.shared.python.core.constants import GRAVITY
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -73,7 +74,7 @@ class CentroidalMPC(ModelPredictiveController):
 
         # Physical parameters
         self._mass = 50.0  # kg
-        self._gravity = np.array([0, 0, -9.81])
+        self._gravity = np.array([0, 0, -GRAVITY])
 
         # Contact positions (updated from model)
         self._contact_positions: list[NDArray[np.floating]] = [

--- a/src/robotics/locomotion/zmp_computer.py
+++ b/src/robotics/locomotion/zmp_computer.py
@@ -18,6 +18,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from src.robotics.core.protocols import HumanoidCapable, RoboticsCapable
+from src.shared.python.core.constants import GRAVITY as _GRAVITY_CONST
 from src.shared.python.core.contracts import ContractChecker
 
 
@@ -69,7 +70,7 @@ class ZMPComputer(ContractChecker):
         ...     print(f"ZMP at {result.zmp_position[:2]}")
     """
 
-    GRAVITY = 9.81  # m/s² — see also src.engines.common.physics.GRAVITY_APPROX
+    GRAVITY = _GRAVITY_CONST
 
     def __init__(
         self,

--- a/src/robotics/sensing/imu_sensor.py
+++ b/src/robotics/sensing/imu_sensor.py
@@ -22,6 +22,7 @@ from src.robotics.sensing.noise_models import (
     CompositeNoise,
     GaussianNoise,
 )
+from src.shared.python.core.constants import GRAVITY
 
 
 @dataclass
@@ -50,7 +51,7 @@ class IMUSensorConfig:
     accel_bias_drift: float = 0.0001
     gyro_bias_drift: float = 0.00001
     gravity: NDArray[np.float64] = field(
-        default_factory=lambda: np.array([0.0, 0.0, -9.81])  # GRAVITY_APPROX
+        default_factory=lambda: np.array([0.0, 0.0, -GRAVITY])
     )
     cutoff_frequency: float = 200.0
     sample_rate: float = 1000.0

--- a/src/shared/python/core/constants.py
+++ b/src/shared/python/core/constants.py
@@ -18,6 +18,7 @@ from .physics_constants import (
 # Pre-computed float values for commonly used constants
 # (Avoids repeated float() conversions from PhysicalConstant in multiple modules)
 GRAVITY_FLOAT: float = float(GRAVITY_M_S2)
+GRAVITY: float = 9.81  # Approximate gravity for general simulation use
 GOLF_BALL_MASS_FLOAT: float = float(GOLF_BALL_MASS_KG)
 GOLF_BALL_RADIUS_FLOAT: float = float(GOLF_BALL_RADIUS_M)
 GOLF_BALL_DIAMETER_FLOAT: float = float(GOLF_BALL_DIAMETER_M)

--- a/src/shared/python/engine_core/mock_engine.py
+++ b/src/shared/python/engine_core/mock_engine.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import numpy as np
 
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -309,7 +310,7 @@ class MockPhysicsEngine:
             Gravity force vector (n,)
         """
         g = np.zeros(self.num_joints)
-        g[0] = -9.81  # First joint feels gravity
+        g[0] = -GRAVITY  # First joint feels gravity
         return g
 
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:

--- a/src/shared/python/physics/terrain_engine.py
+++ b/src/shared/python/physics/terrain_engine.py
@@ -25,6 +25,7 @@ from typing import Any, Protocol
 
 import numpy as np
 
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.physics.terrain import (
     MATERIALS,
@@ -512,10 +513,8 @@ class CompressibleTurfModel:
         material = self.terrain.get_material(x, y)
         terrain_type = self.terrain.get_terrain_type(x, y)
 
-        # Ball weight creates compression (mass * g)
-        ball_weight = (
-            0.04593 * 9.81
-        )  # Golf ball weight in N (BallProperties.mass * GRAVITY_APPROX)
+        # Ball weight creates compression
+        ball_weight = 0.04593 * GRAVITY  # Golf ball weight in N
 
         # Effective sitting depth based on compression
         max_compression = material.get_max_compression_depth()

--- a/src/shared/python/pose_editor/core.py
+++ b/src/shared/python/pose_editor/core.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -239,7 +240,7 @@ class BasePoseEditor(ABC):
         """Initialize the pose editor."""
         self._state = PoseEditorState()
         self._joint_info: list[JointInfo] = []
-        self._original_gravity: float = 9.81  # m/s² (GRAVITY_APPROX)
+        self._original_gravity: float = GRAVITY
         self._callbacks: dict[str, list[Any]] = {
             "pose_changed": [],
             "gravity_changed": [],

--- a/src/tools/model_generation/converters/mjcf_converter.py
+++ b/src/tools/model_generation/converters/mjcf_converter.py
@@ -23,6 +23,7 @@ from model_generation.core.types import (
     Origin,
 )
 
+from src.shared.python.core.constants import GRAVITY
 from src.shared.python.core.contracts import precondition
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class MJCFConfig:
     inertiafromgeom: bool = False
 
     # Option settings
-    gravity: tuple[float, float, float] = (0.0, 0.0, -9.81)  # GRAVITY_APPROX
+    gravity: tuple[float, float, float] = (0.0, 0.0, -GRAVITY)
     timestep: float = 0.002
 
     # Visual settings


### PR DESCRIPTION
## Summary
- Adds `GRAVITY: float = 9.81` constant to `src/shared/python/core/constants.py`
- Replaces all 15 hardcoded `9.81` values across 12 source files with imports of the shared `GRAVITY` constant
- Docstring examples and comments mentioning `9.81` are left unchanged (they document physics, not define it)

## Files changed
| File | Change |
|------|--------|
| `src/shared/python/core/constants.py` | Added `GRAVITY = 9.81` |
| `src/robotics/locomotion/zmp_computer.py` | Class constant now references shared `GRAVITY` |
| `src/robotics/sensing/imu_sensor.py` | Default gravity vector uses `GRAVITY` |
| `src/research/deformable/objects.py` | Two gravity vectors use `GRAVITY` |
| `src/research/mpc/specialized.py` | Gravity vector uses `GRAVITY` |
| `src/api/routes/force_overlays.py` | Two gravity magnitude calculations use `GRAVITY` |
| `src/engines/physics_engines/pinocchio/.../pose_editor_tab.py` | Gravity vector and fallback use `GRAVITY` |
| `src/engines/physics_engines/drake/.../pose_editor_tab.py` | Gravity vector and fallback use `GRAVITY` |
| `src/engines/common/physics.py` | Default gravity vector uses `GRAVITY` |
| `src/shared/python/engine_core/mock_engine.py` | Mock gravity uses `GRAVITY` |
| `src/shared/python/pose_editor/core.py` | Base editor gravity uses `GRAVITY` |
| `src/shared/python/physics/terrain_engine.py` | Ball weight calculation uses `GRAVITY` |
| `src/tools/model_generation/converters/mjcf_converter.py` | MJCF config default uses `GRAVITY` |

## Test plan
- [x] All 2905 unit tests pass (`python3 -m pytest tests/unit/ --ignore=tests/integration/ -x -q`)
- [x] Pre-commit hooks (ruff lint + format) pass
- [ ] Verify no behavioral changes (value remains 9.81 everywhere)

Closes #1388

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical constant wiring with the same numeric value; low risk aside from potential import/name collisions or slight behavior change where modules previously used different gravity variants.
> 
> **Overview**
> Centralizes the simulation gravity value by introducing `GRAVITY` in `src/shared/python/core/constants.py` and replacing hardcoded `9.81` usages with imports across API overlays, physics/pose editors (Drake/Pinocchio), robotics (ZMP/IMU), research simulations (deformables/MPC), terrain, model conversion, and the mock engine.
> 
> This is primarily a consistency/maintainability change; behavior should remain the same (still ~9.81 m/s²) while reducing drift between modules’ gravity defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ea71d12731054baa24dea60d9a2c18654cdfda2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->