### PR TITLE
Fix pre-push pytest hook to use module invocation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -241,7 +241,7 @@ repos:
       - id: pytest-unit
         name: "pytest (Python tests)"
         stages: [pre-push]
-        entry: pytest
+        entry: python3 -m pytest
         args:
           [
             "tests/unit/api",


### PR DESCRIPTION
## Summary
- update pre-push pytest-unit hook entry from bare pytest to python3 -m pytest
- eliminates PATH dependency on pytest executable
- aligns pre-push behavior with issue acceptance criteria

Closes #1352

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tooling change to the pre-push test hook; minimal impact beyond making local test invocation more reliable across environments.
> 
> **Overview**
> Updates the pre-push `pytest-unit` pre-commit hook to invoke tests via `python3 -m pytest` instead of calling `pytest` directly, reducing reliance on a `pytest` executable being on `PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea0d0a26580557eb1091401ef8c3b854849dac11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->