### PR TITLE
refactor: remove wildcard imports from shared compatibility shims

### DIFF
--- a/src/shared/python/capabilities.py
+++ b/src/shared/python/capabilities.py
@@ -1,6 +1,5 @@
 """Backward-compatible shim — canonical location: engine_core.capabilities."""
 
-from src.shared.python.engine_core.capabilities import *  # noqa: F401,F403
 from src.shared.python.engine_core.capabilities import (  # noqa: F401
     CapabilityLevel,
     EngineCapabilities,

--- a/src/shared/python/engine_loaders.py
+++ b/src/shared/python/engine_loaders.py
@@ -1,6 +1,5 @@
 """Backward-compatible shim — canonical location: engine_core.engine_loaders."""
 
-from src.shared.python.engine_core.engine_loaders import *  # noqa: F401,F403
 from src.shared.python.engine_core.engine_loaders import LOADER_MAP  # noqa: F401
 
 __all__ = ["LOADER_MAP"]

--- a/src/shared/python/exceptions.py
+++ b/src/shared/python/exceptions.py
@@ -1,6 +1,5 @@
 """Backward-compatible shim — canonical location: core.exceptions."""
 
-from src.shared.python.core.exceptions import *  # noqa: F401,F403
 from src.shared.python.core.exceptions import (
     EngineNotFoundError,
     GolfModelingError,


### PR DESCRIPTION
## Summary
- remove wildcard imports from three shared compatibility shims
- keep explicit compatibility exports via 

## Validation
- 

## Note
- Local pre-push mypy currently fails on existing baseline issues in  unrelated to this change.

Closes #1407

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to import/re-export mechanics; primary risk is a breaking change if any downstream code relied on previously wildcard-exported symbols.
> 
> **Overview**
> Removes wildcard (`import *`) re-exports from three backward-compatibility shim modules and replaces them with explicit imports plus `__all__` in `capabilities.py`, `engine_loaders.py`, and `exceptions.py`.
> 
> This narrows what these shims expose to the intended symbols (`EngineCapabilities`/`CapabilityLevel`, `LOADER_MAP`, and `GolfModelingError`/`EngineNotFoundError`), reducing accidental API surface and lint/mypy noise while preserving the compatibility entry points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e13c787a9fb6ffaad66a3c679bda44fd4d9a38a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->