### PR TITLE
refactor: eliminate wildcard imports in shared constants layer

### DIFF
--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/constants_file.py
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/constants_file.py
@@ -3,5 +3,12 @@ DEPRECATED: Use shared.python.physics_constants instead.
 This file is maintained for backward compatibility.
 """
 
-# Re-export everything from the central source of truth
-from src.shared.python.core.physics_constants import *  # noqa: F403
+from src.shared.python.core import physics_constants as _physics_constants
+
+__all__ = getattr(
+    _physics_constants,
+    "__all__",
+    [name for name in dir(_physics_constants) if not name.startswith("_")],
+)
+
+globals().update({name: getattr(_physics_constants, name) for name in __all__})

--- a/src/shared/python/core/constants.py
+++ b/src/shared/python/core/constants.py
@@ -6,13 +6,13 @@ Pre-computed float values are provided to avoid repeated conversions.
 
 from pathlib import Path
 
-from .physics_constants import *  # noqa: F403
 from .physics_constants import (
     GOLF_BALL_DIAMETER_M,
     GOLF_BALL_MASS_KG,
     GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
     GOLF_BALL_RADIUS_M,
     GRAVITY_M_S2,
+    PhysicalConstant,
 )
 
 # Pre-computed float values for commonly used constants


### PR DESCRIPTION
## Summary
- remove wildcard compatibility imports from shared constants modules
- use explicit imports in `src/shared/python/core/constants.py`
- use dynamic compatibility re-export in legacy `constants_file.py`

## Impact
- eliminates remaining Python `import *` usage in shared constants layer
- improves static-analysis signal and namespace clarity

## Validation
- `python3 -m compileall -q src/shared/python/core/constants.py src/engines/Simscape_Multibody_Models/2D_Golf_Model/constants_file.py`

Closes #1362

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to import/re-export mechanics with no behavioral logic changes expected, but it could break consumers that relied on unintended names previously leaked by wildcard imports.
> 
> **Overview**
> Removes wildcard re-exports from the shared constants layer to improve namespace clarity and static analysis.
> 
> `src/shared/python/core/constants.py` now explicitly imports only the physics constants it uses (including `PhysicalConstant`) instead of `from .physics_constants import *`.
> 
> The legacy `2D_Golf_Model/constants_file.py` replaces `import *` with a dynamic re-export: it imports `physics_constants` as a module, derives `__all__`, and updates `globals()` to maintain backward-compatible names without wildcard imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa0979d319f45b474d0b6de7fecb996d88f06219. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->