### PR TITLE
ci: add ratcheting module-size budget gates

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Changed-File Size Budget Check
         run: python3 scripts/check_file_size_budget.py
 
+      - name: Module Size Budget Check
+        run: python3 scripts/check_module_size_budget.py --max-lines 1500 --include src
+
       - name: Prevent Net-New print() Calls
         run: python3 scripts/check_no_print_calls.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -270,6 +270,17 @@ repos:
         types: [python]
         exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
 
+  # Module size budget check (pre-push)
+  - repo: local
+    hooks:
+      - id: module-size-budget
+        name: "module size budget"
+        stages: [pre-push]
+        entry: python3 scripts/check_module_size_budget.py --max-lines 1500 --include src
+        language: system
+        pass_filenames: false
+        types: [python]
+
   # Radon - Cyclomatic complexity check (pre-push)
   # Note: Using local hook since rubik/radon doesn't provide pre-commit hooks
   # NOTE: Using language: python (not system) for cross-platform compatibility (Windows/Linux)

--- a/scripts/check_module_size_budget.py
+++ b/scripts/check_module_size_budget.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Ratcheting module-size budget for Python source files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_LINES = 1500
+DEFAULT_INCLUDE = ("src",)
+DEFAULT_BASELINE = Path("scripts/config/module_size_budget_baseline.json")
+DEFAULT_EXCLUDE_PARTS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "archive",
+    "legacy",
+    "experimental",
+    "__pycache__",
+    "build",
+    "dist",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+
+
+def count_lines(path: Path) -> int:
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        return sum(1 for _ in handle)
+
+
+def should_skip(path: Path, exclude_parts: set[str]) -> bool:
+    return any(part in exclude_parts for part in path.parts)
+
+
+def iter_python_files(include_roots: tuple[str, ...], exclude_parts: set[str]):
+    for root in include_roots:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for candidate in root_path.rglob("*.py"):
+            if should_skip(candidate, exclude_parts):
+                continue
+            yield candidate
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {str(k): int(v) for k, v in data.items()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES)
+    parser.add_argument("--include", nargs="+", default=list(DEFAULT_INCLUDE))
+    parser.add_argument("--baseline", default=str(DEFAULT_BASELINE))
+    args = parser.parse_args()
+
+    baseline = load_baseline(Path(args.baseline))
+    offenders: list[tuple[Path, int, str]] = []
+
+    for py_file in iter_python_files(tuple(args.include), DEFAULT_EXCLUDE_PARTS):
+        rel = str(py_file).replace("\\", "/")
+        lines = count_lines(py_file)
+        if lines <= args.max_lines:
+            continue
+
+        allowed = baseline.get(rel)
+        if allowed is None:
+            offenders.append((py_file, lines, "new oversized file (not in baseline)"))
+            continue
+        if lines > allowed:
+            offenders.append((py_file, lines, f"grew beyond baseline ({allowed})"))
+
+    if not offenders:
+        sys.stdout.write(
+            f"module-size budget passed (max {args.max_lines}, baseline {args.baseline})\n"
+        )
+        return 0
+
+    sys.stderr.write(
+        f"module-size budget failed (max {args.max_lines}, baseline {args.baseline})\n"
+    )
+    for file_path, line_count, reason in sorted(offenders):
+        sys.stderr.write(f"  {file_path}: {line_count} lines [{reason}]\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/config/module_size_budget_baseline.json
+++ b/scripts/config/module_size_budget_baseline.json
@@ -1,0 +1,7 @@
+{
+  "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py": 1662,
+  "src/engines/physics_engines/drake/python/src/drake_gui_app.py": 2177,
+  "src/engines/physics_engines/mujoco/head_models.py": 1666,
+  "src/engines/physics_engines/mujoco/python/humanoid_launcher.py": 1583,
+  "src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py": 2007
+}


### PR DESCRIPTION
## Summary
- add ratcheting full-repo module-size budget checker (`scripts/check_module_size_budget.py`)
- add baseline snapshot (`scripts/config/module_size_budget_baseline.json`)
- enforce module-size budget in CI quality gate
- enforce module-size budget in pre-push hooks

## Why
- blocks new oversized modules and growth of existing oversized modules while allowing controlled legacy burn-down

## Validation
- `python3 scripts/check_module_size_budget.py --max-lines 1500 --include src`
- `pre-commit validate-config`
- CI workflow YAML parsed successfully

Closes #1376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/pre-commit-only changes that introduce a new guardrail; main risk is developer friction or unexpected failures if the baseline or include/exclude settings are off.
> 
> **Overview**
> Adds a new ratcheting *module-size budget* quality gate that fails when any Python module exceeds `--max-lines` (default 1500) unless it is explicitly grandfathered in a baseline file and does not grow beyond that baseline.
> 
> Enforces the check in `ci-standard.yml` and adds a matching pre-push `pre-commit` hook, along with an initial baseline snapshot in `scripts/config/module_size_budget_baseline.json` for existing oversized modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51c3d4354b3407b4bea39dcbe471dae2a3fd5fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->