### PR TITLE
docs: consolidate canonical quality docs and archive policy

### DIFF
--- a/docs/assessments/CANONICAL_QUALITY_STATUS.md
+++ b/docs/assessments/CANONICAL_QUALITY_STATUS.md
@@ -1,0 +1,23 @@
+# Canonical Quality Status
+
+This document defines the single source of truth for current code-quality status.
+
+## Canonical Current Set
+
+- `docs/assessments/README.md` (framework, policy, pointers)
+- `docs/assessments/ARCHITECTURE_QUALITY_ASSESSMENT_2026-02-12.md`
+- `docs/assessments/QUALITATIVE_CODE_QUALITY_ASSESSMENT_2026-02-13.md`
+- `docs/assessments/FOLDER_ORGANIZATION_ASSESSMENT.md`
+
+## Transitional / Historical
+
+All superseded assessment artifacts should move under `docs/assessments/archive/`.
+Use `docs/assessments/archive/INDEX.md` to track historical report locations.
+
+## Update Rule
+
+Every PR that introduces or supersedes a quality assessment must:
+
+1. Update this file.
+2. Update `docs/assessments/README.md`.
+3. Add archive index entries for superseded reports.

--- a/docs/assessments/README.md
+++ b/docs/assessments/README.md
@@ -1,5 +1,14 @@
 # Assessment Framework v2.0
 
+## Canonical Current Quality Status
+
+- Canonical status file: `docs/assessments/CANONICAL_QUALITY_STATUS.md`
+- Archive index: `docs/assessments/archive/INDEX.md`
+
+When assessments are superseded, move old artifacts into `docs/assessments/archive/` and update the archive index.
+
+---
+
 ## Canonical Assessment Taxonomy
 
 - Active framework index: `docs/assessments/README.md` (this file)

--- a/docs/assessments/archive/INDEX.md
+++ b/docs/assessments/archive/INDEX.md
@@ -1,0 +1,13 @@
+# Assessment Archive Index
+
+This index tracks superseded assessment artifacts moved out of the canonical current set.
+
+## Policy
+
+- Keep canonical active assessments at `docs/assessments/` root.
+- Move superseded reports into `docs/assessments/archive/`.
+- Add one index entry per archived report with date and replacement.
+
+## Entries
+
+- (no archived entries registered yet by this index)


### PR DESCRIPTION
## Summary
- define canonical quality status source (`CANONICAL_QUALITY_STATUS.md`)
- add archive index for superseded reports (`docs/assessments/archive/INDEX.md`)
- update assessments README with canonical/archival policy references

Closes #1377

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add pointers and process guidance; no runtime, security, or data-path impact.
> 
> **Overview**
> Introduces `CANONICAL_QUALITY_STATUS.md` as the single source of truth for which assessment documents are considered current, plus an explicit update rule for future PRs.
> 
> Adds `docs/assessments/archive/INDEX.md` and updates the assessments `README.md` to point to the canonical status file and define the process for moving superseded reports into `docs/assessments/archive/` and recording them in the index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ab0dde84ee7eb74aa941257d357ed0a4c09ea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->