### PR TITLE
test: fix client fixture discovery in API diagnostics tests

### DIFF
--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -316,20 +316,21 @@ class TestAPIDiagnosticsPerformance:
 
 
 # Integration test with local_server
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create test client for local server."""
+    try:
+        from src.api.local_server import create_local_app
+
+        app = create_local_app()
+        with TestClient(app, base_url="http://localhost") as test_client:
+            yield test_client
+    except ImportError:
+        pytest.skip("local_server not available")
+
+
 class TestLocalServerDiagnostics:
     """Integration tests for local_server diagnostic endpoints."""
-
-    @pytest.fixture
-    def client(self) -> Generator[TestClient, None, None]:
-        """Create test client for local server."""
-        try:
-            from src.api.local_server import create_local_app
-
-            app = create_local_app()
-            with TestClient(app, base_url="http://localhost") as test_client:
-                yield test_client
-        except ImportError:
-            pytest.skip("local_server not available")
 
     def test_diagnostics_endpoint_json(self, client: TestClient) -> None:
         """Test /api/diagnostics returns JSON."""


### PR DESCRIPTION
## Summary
- move `client` fixture in `tests/unit/test_api_diagnostics.py` from class scope to module scope
- enables pytest fixture discovery for `TestLocalServerDiagnostics`

## Validation
- local run collected module but skipped due unavailable optional `local_server` dependency in this environment

Closes #1412

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that changes fixture scope; low risk outside of potentially altering test collection/skip behavior.
> 
> **Overview**
> Fixes pytest fixture discovery for local_server integration tests by moving the `client` `TestClient` fixture out of `TestLocalServerDiagnostics` to module scope in `tests/unit/test_api_diagnostics.py`.
> 
> This makes the diagnostics/debug endpoint integration tests consistently able to request the `client` fixture (or cleanly skip when `local_server` is unavailable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48d79a2d66d1996974ae24ea60ae802b6a2b474f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->