### PR TITLE
fix: stabilize drake wrapper test isolation and constants compatibility

### DIFF
--- a/src/shared/python/core/constants.py
+++ b/src/shared/python/core/constants.py
@@ -6,6 +6,7 @@ Pre-computed float values are provided to avoid repeated conversions.
 
 from pathlib import Path
 
+from . import physics_constants as _physics_constants
 from .physics_constants import (
     GOLF_BALL_DIAMETER_M,
     GOLF_BALL_MASS_KG,
@@ -14,6 +15,14 @@ from .physics_constants import (
     GRAVITY_M_S2,
     PhysicalConstant,
 )
+
+# Backward compatibility: re-export physics constants from canonical module.
+__all__ = getattr(
+    _physics_constants,
+    "__all__",
+    [name for name in dir(_physics_constants) if not name.startswith("_")],
+)
+globals().update({name: getattr(_physics_constants, name) for name in __all__})
 
 # Pre-computed float values for commonly used constants
 # (Avoids repeated float() conversions from PhysicalConstant in multiple modules)


### PR DESCRIPTION
## Summary
- restore backward-compatible physics constant exports from `core/constants.py`
- add autouse isolation fixture in `test_drake_wrapper.py` to prevent `sys.modules` and mock leakage across tests
- preserve no-wildcard-import policy while restoring API compatibility

## Validation
- direct import check for `DEG_TO_RAD`, `PI`, `PI_HALF`, and `GRAVITY_M_S2`
- `python3 -m pytest tests/unit/test_drake_wrapper.py -q` (tests skip in this environment when Drake runtime is unavailable)

Closes #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to constant re-exports and test isolation logic; primary risk is unexpected namespace pollution from the re-export, but it is intentionally constrained to `physics_constants`’ public API.
> 
> **Overview**
> Restores backward compatibility for imports from `core/constants.py` by re-exporting the full public surface of `physics_constants` (via `__all__` and `globals().update`), while keeping the existing precomputed float convenience values.
> 
> Stabilizes `tests/unit/test_drake_wrapper.py` by adding an autouse `pytest` fixture that snapshots and restores relevant `sys.modules` entries (engine module + `pydrake` keys), preventing module-level mocks/patches from polluting other tests when run in different orders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afd691634bfd0b897023bdfbf5d147cefa844243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->