### PR TITLE
refactor: Phase 2 DRY — shared BaseRenderer format_axis()

### DIFF
--- a/src/shared/python/plotting/renderers/base.py
+++ b/src/shared/python/plotting/renderers/base.py
@@ -1,15 +1,37 @@
-"""Base class for plotting renderers."""
+"""Base class for plotting renderers.
+
+Provides shared axis formatting, grid styling, and legend defaults
+to eliminate duplicated matplotlib boilerplate across all renderers.
+"""
 
 from __future__ import annotations
 
+from typing import Any
+
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from src.shared.python.plotting.config import COLORS
 from src.shared.python.plotting.transforms import DataManager
 
+# ─── Shared Constants ───────────────────────────────────────────
+
+DEFAULT_LABEL_FONTSIZE = 12
+DEFAULT_TITLE_FONTSIZE = 14
+DEFAULT_LABEL_FONTWEIGHT = "bold"
+DEFAULT_GRID_ALPHA = 0.3
+DEFAULT_GRID_STYLE = "--"
+DEFAULT_LEGEND_ALPHA = 0.9
+
 
 class BaseRenderer:
-    """Base class for all plot renderers."""
+    """Base class for all plot renderers.
+
+    Provides:
+    - Shared color palette from config
+    - Standardized axis formatting (labels, titles, grid, legend)
+    - Figure clearing
+    """
 
     def __init__(self, data_manager: DataManager) -> None:
         """Initialize renderer with data manager."""
@@ -19,3 +41,60 @@ class BaseRenderer:
     def clear_figure(self, fig: Figure) -> None:
         """Clear the figure before plotting."""
         fig.clear()
+
+    @staticmethod
+    def format_axis(
+        ax: Axes,
+        *,
+        xlabel: str = "",
+        ylabel: str = "",
+        title: str = "",
+        grid: bool = True,
+        legend: bool = True,
+        legend_loc: str = "best",
+        **kwargs: Any,
+    ) -> None:
+        """Apply standardized formatting to a matplotlib axis.
+
+        This eliminates duplicated fontsize/fontweight/grid/legend
+        boilerplate across all renderers.
+
+        Args:
+            ax: The matplotlib axis to format.
+            xlabel: X-axis label text.
+            ylabel: Y-axis label text.
+            title: Plot title text.
+            grid: Whether to show grid lines.
+            legend: Whether to show legend.
+            legend_loc: Legend location string.
+            **kwargs: Additional axis configuration.
+        """
+        if xlabel:
+            ax.set_xlabel(
+                xlabel,
+                fontsize=kwargs.get("label_fontsize", DEFAULT_LABEL_FONTSIZE),
+                fontweight=kwargs.get("label_fontweight", DEFAULT_LABEL_FONTWEIGHT),
+            )
+        if ylabel:
+            ax.set_ylabel(
+                ylabel,
+                fontsize=kwargs.get("label_fontsize", DEFAULT_LABEL_FONTSIZE),
+                fontweight=kwargs.get("label_fontweight", DEFAULT_LABEL_FONTWEIGHT),
+            )
+        if title:
+            ax.set_title(
+                title,
+                fontsize=kwargs.get("title_fontsize", DEFAULT_TITLE_FONTSIZE),
+                fontweight=kwargs.get("title_fontweight", DEFAULT_LABEL_FONTWEIGHT),
+            )
+        if grid:
+            ax.grid(
+                True,
+                alpha=kwargs.get("grid_alpha", DEFAULT_GRID_ALPHA),
+                linestyle=kwargs.get("grid_style", DEFAULT_GRID_STYLE),
+            )
+        if legend and ax.get_legend_handles_labels()[1]:
+            ax.legend(
+                loc=legend_loc,
+                framealpha=kwargs.get("legend_alpha", DEFAULT_LEGEND_ALPHA),
+            )

--- a/src/shared/python/plotting/renderers/kinematics.py
+++ b/src/shared/python/plotting/renderers/kinematics.py
@@ -44,11 +44,12 @@ class KinematicsRenderer(BaseRenderer):
                 label = self.data.get_aligned_label(idx, positions.shape[1])
                 ax.plot(times, np.rad2deg(positions[:, idx]), label=label, linewidth=2)
 
-        ax.set_xlabel("Time (s)", fontsize=12, fontweight="bold")
-        ax.set_ylabel("Joint Angle (degrees)", fontsize=12, fontweight="bold")
-        ax.set_title("Joint Angles vs Time", fontsize=14, fontweight="bold")
-        ax.legend(loc="best", framealpha=0.9)
-        ax.grid(True, alpha=0.3, linestyle="--")
+        self.format_axis(
+            ax,
+            xlabel="Time (s)",
+            ylabel="Joint Angle (degrees)",
+            title="Joint Angles vs Time",
+        )
         fig.tight_layout()
 
     def plot_joint_velocities(
@@ -83,11 +84,12 @@ class KinematicsRenderer(BaseRenderer):
                 label = self.data.get_aligned_label(idx, velocities.shape[1])
                 ax.plot(times, np.rad2deg(velocities[:, idx]), label=label, linewidth=2)
 
-        ax.set_xlabel("Time (s)", fontsize=12, fontweight="bold")
-        ax.set_ylabel("Angular Velocity (deg/s)", fontsize=12, fontweight="bold")
-        ax.set_title("Joint Velocities vs Time", fontsize=14, fontweight="bold")
-        ax.legend(loc="best", framealpha=0.9)
-        ax.grid(True, alpha=0.3, linestyle="--")
+        self.format_axis(
+            ax,
+            xlabel="Time (s)",
+            ylabel="Angular Velocity (deg/s)",
+            title="Joint Velocities vs Time",
+        )
         fig.tight_layout()
 
     def plot_angle_angle_diagram(
@@ -145,13 +147,12 @@ class KinematicsRenderer(BaseRenderer):
         name1 = self.data.get_joint_name(joint_idx_1)
         name2 = self.data.get_joint_name(joint_idx_2)
 
-        ax.set_xlabel(f"{name1} Angle (deg)", fontsize=12, fontweight="bold")
-        ax.set_ylabel(f"{name2} Angle (deg)", fontsize=12, fontweight="bold")
-        ax.set_title(
-            title or f"Coordination: {name1} vs {name2}", fontsize=14, fontweight="bold"
+        self.format_axis(
+            ax,
+            xlabel=f"{name1} Angle (deg)",
+            ylabel=f"{name2} Angle (deg)",
+            title=title or f"Coordination: {name1} vs {name2}",
         )
-        ax.legend(loc="best")
-        ax.grid(True, alpha=0.3, linestyle="--")
         fig.colorbar(sc, ax=ax, label="Time (s)")
         fig.tight_layout()
 
@@ -204,11 +205,12 @@ class KinematicsRenderer(BaseRenderer):
         )
 
         joint_name = self.data.get_joint_name(joint_idx)
-        ax.set_xlabel(f"{joint_name} Angle (degrees)", fontsize=12, fontweight="bold")
-        ax.set_ylabel(f"{joint_name} Velocity (deg/s)", fontsize=12, fontweight="bold")
-        ax.set_title(f"Phase Diagram: {joint_name}", fontsize=14, fontweight="bold")
-        ax.legend(loc="best")
-        ax.grid(True, alpha=0.3, linestyle="--")
+        self.format_axis(
+            ax,
+            xlabel=f"{joint_name} Angle (degrees)",
+            ylabel=f"{joint_name} Velocity (deg/s)",
+            title=f"Phase Diagram: {joint_name}",
+        )
         fig.colorbar(sc, ax=ax, label="Time (s)")
         fig.tight_layout()
 
@@ -566,10 +568,12 @@ class KinematicsRenderer(BaseRenderer):
         )
 
         joint_name = self.data.get_joint_name(joint_idx)
-        ax.set_xlabel(f"{joint_name} Angle (deg)", fontsize=12, fontweight="bold")
-        ax.set_ylabel(f"{joint_name} Velocity (deg/s)", fontsize=12, fontweight="bold")
-        ax.set_title(
-            f"Phase Space Density: {joint_name}", fontsize=14, fontweight="bold"
+        self.format_axis(
+            ax,
+            xlabel=f"{joint_name} Angle (deg)",
+            ylabel=f"{joint_name} Velocity (deg/s)",
+            title=f"Phase Space Density: {joint_name}",
+            legend=False,
         )
 
         fig.colorbar(h[3], ax=ax, label="Count")

--- a/tests/unit/test_base_renderer.py
+++ b/tests/unit/test_base_renderer.py
@@ -1,0 +1,168 @@
+"""Tests for the shared base renderer module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python.plotting.renderers.base import (
+    DEFAULT_GRID_ALPHA,
+    DEFAULT_GRID_STYLE,
+    DEFAULT_LABEL_FONTSIZE,
+    DEFAULT_LABEL_FONTWEIGHT,
+    DEFAULT_LEGEND_ALPHA,
+    DEFAULT_TITLE_FONTSIZE,
+    BaseRenderer,
+)
+
+
+@pytest.fixture()
+def mock_data_manager() -> MagicMock:
+    """Create a mock DataManager."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def renderer(mock_data_manager: MagicMock) -> BaseRenderer:
+    """Create a BaseRenderer with mock data manager."""
+    return BaseRenderer(mock_data_manager)
+
+
+class TestBaseRendererInit:
+    """Test BaseRenderer initialization."""
+
+    def test_stores_data_manager(
+        self, renderer: BaseRenderer, mock_data_manager: MagicMock
+    ) -> None:
+        """Test that data manager is stored."""
+        assert renderer.data is mock_data_manager
+
+    def test_loads_colors(self, renderer: BaseRenderer) -> None:
+        """Test that colors are loaded from config."""
+        assert renderer.colors is not None
+
+
+class TestBaseRendererClearFigure:
+    """Test figure clearing."""
+
+    def test_clears_figure(self, renderer: BaseRenderer) -> None:
+        """Test that clear_figure delegates to figure.clear()."""
+        mock_fig = MagicMock()
+        renderer.clear_figure(mock_fig)
+        mock_fig.clear.assert_called_once()
+
+
+class TestFormatAxis:
+    """Test the format_axis static method."""
+
+    def test_sets_xlabel(self) -> None:
+        """Test that xlabel is set with default formatting."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, xlabel="Time (s)")
+        ax.set_xlabel.assert_called_once_with(
+            "Time (s)",
+            fontsize=DEFAULT_LABEL_FONTSIZE,
+            fontweight=DEFAULT_LABEL_FONTWEIGHT,
+        )
+
+    def test_sets_ylabel(self) -> None:
+        """Test that ylabel is set with default formatting."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, ylabel="Angle (deg)")
+        ax.set_ylabel.assert_called_once_with(
+            "Angle (deg)",
+            fontsize=DEFAULT_LABEL_FONTSIZE,
+            fontweight=DEFAULT_LABEL_FONTWEIGHT,
+        )
+
+    def test_sets_title(self) -> None:
+        """Test that title is set with default formatting."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, title="Joint Angles vs Time")
+        ax.set_title.assert_called_once_with(
+            "Joint Angles vs Time",
+            fontsize=DEFAULT_TITLE_FONTSIZE,
+            fontweight=DEFAULT_LABEL_FONTWEIGHT,
+        )
+
+    def test_sets_grid(self) -> None:
+        """Test that grid is set with defaults."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, grid=True)
+        ax.grid.assert_called_once_with(
+            True,
+            alpha=DEFAULT_GRID_ALPHA,
+            linestyle=DEFAULT_GRID_STYLE,
+        )
+
+    def test_no_grid_when_disabled(self) -> None:
+        """Test that grid is not set when disabled."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, grid=False)
+        ax.grid.assert_not_called()
+
+    def test_legend_when_handles_exist(self) -> None:
+        """Test that legend is shown when there are legend handles."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([MagicMock()], ["label1"])
+        BaseRenderer.format_axis(ax, legend=True)
+        ax.legend.assert_called_once_with(
+            loc="best",
+            framealpha=DEFAULT_LEGEND_ALPHA,
+        )
+
+    def test_no_legend_when_no_handles(self) -> None:
+        """Test that legend is skipped when there are no legend handles."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, legend=True)
+        ax.legend.assert_not_called()
+
+    def test_no_legend_when_disabled(self) -> None:
+        """Test that legend is skipped when disabled."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([MagicMock()], ["label1"])
+        BaseRenderer.format_axis(ax, legend=False)
+        ax.legend.assert_not_called()
+
+    def test_empty_labels_skipped(self) -> None:
+        """Test that empty labels are not set."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax)
+        ax.set_xlabel.assert_not_called()
+        ax.set_ylabel.assert_not_called()
+        ax.set_title.assert_not_called()
+
+    def test_custom_fontsize(self) -> None:
+        """Test that custom fontsize overrides default."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([], [])
+        BaseRenderer.format_axis(ax, xlabel="X", label_fontsize=16)
+        ax.set_xlabel.assert_called_once_with(
+            "X",
+            fontsize=16,
+            fontweight=DEFAULT_LABEL_FONTWEIGHT,
+        )
+
+    def test_full_formatting(self) -> None:
+        """Test applying all formatting at once."""
+        ax = MagicMock()
+        ax.get_legend_handles_labels.return_value = ([MagicMock()], ["data"])
+        BaseRenderer.format_axis(
+            ax,
+            xlabel="Time (s)",
+            ylabel="Angle (deg)",
+            title="Test Plot",
+        )
+        assert ax.set_xlabel.called
+        assert ax.set_ylabel.called
+        assert ax.set_title.called
+        assert ax.grid.called
+        assert ax.legend.called


### PR DESCRIPTION
## Summary
Phase 2.4 DRY consolidation: Enhanced the shared BaseRenderer with a format_axis() method that standardizes matplotlib axis formatting across all renderers.

### Changes
- **`renderers/base.py`** — Enhanced with:
  - `format_axis()` static method with keyword-only params (xlabel, ylabel, title, grid, legend)
  - Named constants: DEFAULT_LABEL_FONTSIZE (12), DEFAULT_TITLE_FONTSIZE (14), DEFAULT_GRID_ALPHA (0.3), etc.
  - Intelligent legend: only shows legend when handles exist

- **`renderers/kinematics.py`** — Migrated 5 methods to use format_axis():
  - `plot_joint_angles()`, `plot_joint_velocities()`, `plot_angle_angle_diagram()`
  - `plot_phase_diagram()`, `plot_phase_space_density()`
  - Eliminates ~25 lines of duplicated fontsize/fontweight/grid boilerplate

- **`tests/unit/test_base_renderer.py`** — 14 tests covering all format_axis combinations

### Test Plan
- [x] 14 new unit tests pass
- [x] Ruff lint + format passes
- [x] Pattern ready for adoption by remaining 10+ renderer modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly DRY refactoring of plot presentation code with added unit tests; main risk is minor visual/regression differences in axis/legend styling.
> 
> **Overview**
> Introduces a standardized axis-formatting helper on `BaseRenderer` via `format_axis()` plus named defaults (label/title font settings, grid style/alpha, legend alpha), including a *smart legend* that only renders when labels exist.
> 
> Refactors several `KinematicsRenderer` plotting methods to use `format_axis()` instead of duplicating matplotlib label/title/grid/legend boilerplate (and disables legends where inappropriate, e.g. density plots). Adds unit coverage in `tests/unit/test_base_renderer.py` for formatting behavior, default values, and on/off toggles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 351cd49fbf1c1bb48abfe6b13050e3141883984f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->