### PR TITLE
fix: resolve all 62 test collection errors

### DIFF
--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/python/tests/test_example.py
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/python/tests/test_example.py
@@ -73,9 +73,9 @@ class TestLoggerUtils:
         logger_utils.set_seeds(42)  # Reset to same seed
         second_value = np.random.random()
 
-        assert (
-            first_value == second_value
-        ), "Seed setting should produce reproducible results"
+        assert first_value == second_value, (
+            "Seed setting should produce reproducible results"
+        )
 
     def test_set_seeds_custom(self) -> None:
         """Test setting seeds with custom value."""
@@ -91,9 +91,9 @@ class TestLoggerUtils:
         logger_utils.set_seeds(custom_seed)
         second_value = np.random.random()
 
-        assert (
-            first_value == second_value
-        ), "Custom seed should produce reproducible results"
+        assert first_value == second_value, (
+            "Custom seed should produce reproducible results"
+        )
 
     def test_get_logger(self) -> None:
         """Test getting a logger instance."""
@@ -109,9 +109,9 @@ class TestLoggerUtils:
         root_logger = logging.getLogger()
         # After setup_logging, there should be at least one handler
         # or the logging level should be configured
-        assert (
-            root_logger.level != logging.NOTSET or len(root_logger.handlers) > 0
-        ), "setup_logging should configure the logging system"
+        assert root_logger.level != logging.NOTSET or len(root_logger.handlers) > 0, (
+            "setup_logging should configure the logging system"
+        )
 
 
 class TestNegativeCases:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/simple_data_test.py
@@ -140,9 +140,7 @@ def check_required_signals() -> bool:
                     if dataset.shape[1] >= 6:  # At least 6 signals for positions
                         logger.info(f"    ✅ {name} has sufficient signals for GUI")
                     else:
-                        logger.warning(
-                            f"    ⚠️  {name} may be missing required signals"
-                        )
+                        logger.warning(f"    ⚠️  {name} may be missing required signals")
 
         return True
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_data_loading.py
@@ -34,9 +34,7 @@ def test_data_loading() -> dict | None:
 
         return {"baseq": baseq_data, "ztcfq": ztcfq_data, "deltaq": deltaq_data}
 
-    except (
-        Exception
-    ) as e:  # noqa: BLE001 - test helper; data loader may raise various errors
+    except Exception as e:  # noqa: BLE001 - test helper; data loader may raise various errors
         logger.error(f"❌ Data loading failed: {e}")
         return None
 
@@ -71,9 +69,7 @@ def test_gui_launch() -> bool:
             logger.info("❌ No data available for GUI test")
             return False
 
-    except (
-        Exception
-    ) as e:  # noqa: BLE001 - test helper; GUI init may raise various errors
+    except Exception as e:  # noqa: BLE001 - test helper; GUI init may raise various errors
         logger.error(f"❌ GUI launch failed: {e}")
         return False
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/test_signal_bus_compatibility.py
@@ -94,9 +94,7 @@ def test_data_loader() -> bool:
 
         return True
 
-    except (
-        Exception
-    ) as e:  # noqa: BLE001 - test helper; loader may raise various errors
+    except Exception as e:  # noqa: BLE001 - test helper; loader may raise various errors
         logger.error(f"❌ Error in data loader: {e}")
         import traceback
 
@@ -135,9 +133,7 @@ def test_frame_processor() -> bool:
 
         return True
 
-    except (
-        Exception
-    ) as e:  # noqa: BLE001 - test helper; frame processor may raise various errors
+    except Exception as e:  # noqa: BLE001 - test helper; frame processor may raise various errors
         logger.error(f"❌ Error in frame processor: {e}")
         import traceback
 

--- a/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
@@ -449,7 +449,9 @@ class DoublePendulumDynamics:
         )
 
 
-def compile_forcing_functions(shoulder_expression: str, wrist_expression: str) -> tuple[
+def compile_forcing_functions(
+    shoulder_expression: str, wrist_expression: str
+) -> tuple[
     Callable[[float, DoublePendulumState], float],
     Callable[[float, DoublePendulumState], float],
 ]:

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/control_system.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/control_system.py
@@ -315,6 +315,6 @@ class ControlSystem:
             if 0 <= actuator_index < self.num_actuators:
                 self.set_polynomial_coeffs(actuator_index, coeffs)
                 # Ensure control type is set to polynomial
-                self.actuator_controls[actuator_index].control_type = (
-                    ControlType.POLYNOMIAL
-                )
+                self.actuator_controls[
+                    actuator_index
+                ].control_type = ControlType.POLYNOMIAL

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
@@ -672,9 +672,7 @@ class GripModellingTab(QtWidgets.QWidget):
         for i in range(model.njnt):
             self._add_joint_control_row(i, model)
 
-    def _add_joint_control_row(
-        self, i: int, model: mujoco.MjModel
-    ) -> None:  # noqa: PLR0915
+    def _add_joint_control_row(self, i: int, model: mujoco.MjModel) -> None:  # noqa: PLR0915
         """Create a control row for a single joint."""
         if self.sim_widget.data is None:
             return

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
@@ -625,9 +625,7 @@ class RecordingLibrary:
         cursor = conn.cursor()
 
         # Safe: field is validated against whitelist above (allowed_fields)
-        cursor.execute(
-            f"SELECT DISTINCT {field} FROM recordings WHERE {field} != ''"
-        )  # nosec B608
+        cursor.execute(f"SELECT DISTINCT {field} FROM recordings WHERE {field} != ''")  # nosec B608
         values = [row[0] for row in cursor.fetchall()]
 
         return sorted(values)

--- a/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_counterfactuals.py
@@ -68,9 +68,9 @@ class TestZTCF:
         result = analyzer.ztcf(qpos, qvel, ctrl)
 
         # Torque should increase acceleration (positive delta)
-        assert (
-            result.delta_acceleration[0] > 0
-        ), "Upward torque should create positive acceleration delta"
+        assert result.delta_acceleration[0] > 0, (
+            "Upward torque should create positive acceleration delta"
+        )
 
         # Observed > counterfactual
         assert result.observed_acceleration[0] > result.counterfactual_acceleration[0]
@@ -87,9 +87,9 @@ class TestZTCF:
         result = analyzer.ztcf(qpos, qvel, ctrl)
 
         # Torque opposes motion (negative delta)
-        assert (
-            result.delta_acceleration[0] < 0
-        ), "Opposing torque should create negative acceleration delta"
+        assert result.delta_acceleration[0] < 0, (
+            "Opposing torque should create negative acceleration delta"
+        )
 
     def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test ZTCF: delta scales linearly with applied torque."""
@@ -126,9 +126,9 @@ class TestZTCF:
         assert result.delta_position is not None
 
         # Observed position should differ from counterfactual
-        assert (
-            abs(result.delta_position[0]) > 1e-6
-        ), "Position delta should be non-zero with strong torque"
+        assert abs(result.delta_position[0]) > 1e-6, (
+            "Position delta should be non-zero with strong torque"
+        )
 
 
 class TestZVCF:
@@ -166,9 +166,9 @@ class TestZVCF:
 
         # Velocity creates Coriolis/centrifugal effects
         # Delta should be non-zero
-        assert (
-            abs(result.delta_acceleration[0]) > 1e-3
-        ), "Non-zero velocity should create acceleration delta"
+        assert abs(result.delta_acceleration[0]) > 1e-3, (
+            "Non-zero velocity should create acceleration delta"
+        )
 
     def test_zvcf_delta_scales_with_velocity(self, simple_pendulum_model) -> None:
         """Test ZVCF: delta scales with velocity."""
@@ -204,9 +204,9 @@ class TestZVCF:
         # Counterfactual should have only gravity acceleration
         # (no velocity terms)
         # For pendulum at 45°, gravity creates downward (negative) acceleration
-        assert (
-            result.counterfactual_acceleration[0] < 0
-        ), "Counterfactual should have gravity-driven negative acceleration"
+        assert result.counterfactual_acceleration[0] < 0, (
+            "Counterfactual should have gravity-driven negative acceleration"
+        )
 
         # Delta is the Coriolis contribution
         # (can be positive or negative depending on direction)
@@ -251,9 +251,9 @@ class TestCounterfactualTrajectoryAnalysis:
         # Delta should increase with velocity
         deltas = [abs(r.delta_acceleration[0]) for r in results]
         # Later deltas should generally be larger (higher velocity)
-        assert (
-            deltas[-1] > deltas[0]
-        ), "Delta should increase with velocity in trajectory"
+        assert deltas[-1] > deltas[0], (
+            "Delta should increase with velocity in trajectory"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestCounterfactualPhysics:
         # Reconstruction test
         reconstructed = result.counterfactual_acceleration + result.delta_acceleration
 
-        assert np.allclose(
-            result.observed_acceleration, reconstructed, atol=1e-6
-        ), "Physics violation: observed != counterfactual + delta"
+        assert np.allclose(result.observed_acceleration, reconstructed, atol=1e-6), (
+            "Physics violation: observed != counterfactual + delta"
+        )
 
     def test_zvcf_plus_counterfactual_equals_observed(
         self, simple_pendulum_model
@@ -293,9 +293,9 @@ class TestCounterfactualPhysics:
         # Reconstruction test
         reconstructed = result.counterfactual_acceleration + result.delta_acceleration
 
-        assert np.allclose(
-            result.observed_acceleration, reconstructed, atol=1e-6
-        ), "Physics violation: observed != counterfactual + delta"
+        assert np.allclose(result.observed_acceleration, reconstructed, atol=1e-6), (
+            "Physics violation: observed != counterfactual + delta"
+        )
 
     def test_ztcf_reveals_control_authority(self, simple_pendulum_model) -> None:
         """Test that ZTCF correctly identifies control authority."""
@@ -313,9 +313,9 @@ class TestCounterfactualPhysics:
         # Counterfactual: pendulum stays stationary (at bottom, no velocity)
         # Observed: strong upward acceleration from torque
         # Delta should be large and positive
-        assert (
-            result.delta_acceleration[0] > 5.0
-        ), "Strong torque should create large positive delta"
+        assert result.delta_acceleration[0] > 5.0, (
+            "Strong torque should create large positive delta"
+        )
 
         # This delta represents the control authority
         assert result.torque_attributed_effect is not None

--- a/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_drift_control.py
@@ -66,9 +66,9 @@ class TestDriftControlDecomposer:
         )
 
         # Guideline F requires residual < 1e-5
-        assert (
-            result.residual < 1e-5
-        ), f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
+        assert result.residual < 1e-5, (
+            f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
+        )
 
     def test_zero_control_gives_drift_only(self, simple_pendulum_model) -> None:
         """Test that zero control gives drift-only acceleration."""
@@ -81,9 +81,9 @@ class TestDriftControlDecomposer:
         result = decomposer.decompose(qpos, qvel, ctrl)
 
         # With zero control, control acceleration should be near zero
-        assert np.allclose(
-            result.control_acceleration, 0, atol=1e-6
-        ), f"Expected zero control acceleration, got {result.control_acceleration}"
+        assert np.allclose(result.control_acceleration, 0, atol=1e-6), (
+            f"Expected zero control acceleration, got {result.control_acceleration}"
+        )
 
         # Full should equal drift
         assert np.allclose(
@@ -134,9 +134,9 @@ class TestDriftControlDecomposer:
         result = decomposer.decompose(qpos, qvel, ctrl)
 
         # Gravity component should be non-zero
-        assert (
-            abs(result.drift_gravity_component[0]) > 1.0
-        ), "Expected significant gravity acceleration at 30 degrees"
+        assert abs(result.drift_gravity_component[0]) > 1.0, (
+            "Expected significant gravity acceleration at 30 degrees"
+        )
 
     def test_control_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test that control acceleration scales linearly with applied torque."""
@@ -176,9 +176,9 @@ class TestDriftControlDecomposer:
 
         # All should satisfy superposition
         for r in results:
-            assert (
-                r.residual < 1e-5
-            ), f"Trajectory point failed superposition: residual={r.residual:.2e}"
+            assert r.residual < 1e-5, (
+                f"Trajectory point failed superposition: residual={r.residual:.2e}"
+            )
 
     def test_decomposition_is_reproducible(self, simple_pendulum_model) -> None:
         """Test that decomposition gives same results with same inputs."""
@@ -223,11 +223,11 @@ class TestDriftControlPhysics:
         result = decomposer.decompose(qpos, qvel, ctrl)
 
         # Control component should dominate and be positive (upward)
-        assert (
-            result.control_acceleration[0] > result.drift_acceleration[0]
-        ), "Control should dominate drift for strong actuation"
+        assert result.control_acceleration[0] > result.drift_acceleration[0], (
+            "Control should dominate drift for strong actuation"
+        )
 
         # Total should be positive (accelerating upward)
-        assert (
-            result.full_acceleration[0] > 0
-        ), "Strong torque should accelerate pendulum upward"
+        assert result.full_acceleration[0] > 0, (
+            "Strong torque should accelerate pendulum upward"
+        )

--- a/src/engines/physics_engines/mujoco/python/tests/test_motion_optimization.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_motion_optimization.py
@@ -195,9 +195,9 @@ class TestSwingOptimizer:
         assert result.optimal_trajectory.shape[0] == optimizer.num_knot_points
         # optimal_velocities comes from _simulate_trajectory which returns
         # all simulation steps
-        assert (
-            result.optimal_velocities.shape[0] > 0
-        ), "Should have at least one timestep"
+        assert result.optimal_velocities.shape[0] > 0, (
+            "Should have at least one timestep"
+        )
         assert result.optimal_velocities.shape[1] == model.nv
         assert np.all(np.isfinite(result.optimal_trajectory))
 

--- a/src/engines/physics_engines/mujoco/python/tests/test_power_flow.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_power_flow.py
@@ -56,9 +56,9 @@ class TestPowerFlowBasics:
 
         # P = τ · ω = 3.0 * 2.0 = 6.0 Watts
         expected_power = 6.0
-        assert (
-            abs(result.joint_powers[0] - expected_power) < 1e-6
-        ), f"Expected power {expected_power}, got {result.joint_powers[0]}"
+        assert abs(result.joint_powers[0] - expected_power) < 1e-6, (
+            f"Expected power {expected_power}, got {result.joint_powers[0]}"
+        )
 
     @pytest.mark.parametrize(
         "tau_val,expect_positive",
@@ -82,13 +82,13 @@ class TestPowerFlowBasics:
         result = analyzer.compute_power_flow(qpos, qvel, qacc, tau)
 
         if expect_positive:
-            assert (
-                result.joint_powers[0] > 0
-            ), "Power should be positive when torque and velocity are aligned"
+            assert result.joint_powers[0] > 0, (
+                "Power should be positive when torque and velocity are aligned"
+            )
         else:
-            assert (
-                result.joint_powers[0] < 0
-            ), "Power should be negative when torque opposes velocity"
+            assert result.joint_powers[0] < 0, (
+                "Power should be negative when torque opposes velocity"
+            )
 
     def test_zero_velocity_gives_zero_power(
         self, simple_pendulum_model: mujoco.MjModel
@@ -104,9 +104,9 @@ class TestPowerFlowBasics:
         result = analyzer.compute_power_flow(qpos, qvel, qacc, tau)
 
         # v = 0 → P = 0 regardless of torque
-        assert (
-            abs(result.joint_powers[0]) < 1e-10
-        ), "Power should be zero when velocity is zero"
+        assert abs(result.joint_powers[0]) < 1e-10, (
+            "Power should be zero when velocity is zero"
+        )
 
 
 class TestWorkCalculations:
@@ -128,9 +128,9 @@ class TestWorkCalculations:
 
         # W = P · dt = 6.0 * 0.1 = 0.6 Joules
         expected_work = 6.0 * 0.1
-        assert (
-            abs(result.joint_work_total[0] - expected_work) < 1e-6
-        ), f"Expected work {expected_work}, got {result.joint_work_total[0]}"
+        assert abs(result.joint_work_total[0] - expected_work) < 1e-6, (
+            f"Expected work {expected_work}, got {result.joint_work_total[0]}"
+        )
 
     def test_work_decomposition_sums_to_total(
         self, simple_pendulum_model: mujoco.MjModel
@@ -158,9 +158,9 @@ class TestWorkCalculations:
 
         # Work components should sum to total
         work_sum = result.joint_work_drift[0] + result.joint_work_control[0]
-        assert (
-            abs(result.joint_work_total[0] - work_sum) < 1e-6
-        ), "Drift + control work should equal total work"
+        assert abs(result.joint_work_total[0] - work_sum) < 1e-6, (
+            "Drift + control work should equal total work"
+        )
 
 
 class TestEnergyCalculations:
@@ -206,9 +206,9 @@ class TestEnergyCalculations:
         pe_low = np.sum(result_low.segment_potential_energy)
         pe_high = np.sum(result_high.segment_potential_energy)
 
-        assert (
-            pe_high > pe_low
-        ), f"Higher position should have higher PE: {pe_high} vs {pe_low}"
+        assert pe_high > pe_low, (
+            f"Higher position should have higher PE: {pe_high} vs {pe_low}"
+        )
 
     def test_total_mechanical_energy_is_ke_plus_pe(
         self, simple_pendulum_model: mujoco.MjModel
@@ -227,9 +227,9 @@ class TestEnergyCalculations:
         total_pe = np.sum(result.segment_potential_energy)
         expected_me = total_ke + total_pe
 
-        assert (
-            abs(result.total_mechanical_energy - expected_me) < 1e-6
-        ), "Total ME should equal KE + PE"
+        assert abs(result.total_mechanical_energy - expected_me) < 1e-6, (
+            "Total ME should equal KE + PE"
+        )
 
 
 class TestSystemPowerMetrics:
@@ -250,9 +250,9 @@ class TestSystemPowerMetrics:
 
         # Single joint with positive power
         expected_power_in = 3.0 * 2.0  # 6.0 W
-        assert (
-            abs(result.power_in - expected_power_in) < 1e-6
-        ), f"Expected power_in {expected_power_in}, got {result.power_in}"
+        assert abs(result.power_in - expected_power_in) < 1e-6, (
+            f"Expected power_in {expected_power_in}, got {result.power_in}"
+        )
 
     def test_power_dissipation_from_damping(
         self, simple_pendulum_model: mujoco.MjModel
@@ -270,9 +270,9 @@ class TestSystemPowerMetrics:
         # Damping = 0.1, velocity = 2.0
         # P_diss = b * ω² = 0.1 * 4.0 = 0.4 W
         expected_diss = 0.1 * 2.0**2
-        assert (
-            abs(result.power_dissipation - expected_diss) < 1e-6
-        ), f"Expected dissipation {expected_diss}, got {result.power_dissipation}"
+        assert abs(result.power_dissipation - expected_diss) < 1e-6, (
+            f"Expected dissipation {expected_diss}, got {result.power_dissipation}"
+        )
 
 
 class TestTrajectoryAnalysis:

--- a/src/engines/physics_engines/mujoco/python/tests/test_recording_library.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_recording_library.py
@@ -49,9 +49,7 @@ def library_module(
 
 
 @pytest.fixture()
-def recording_lib(
-    library_module: types.ModuleType, tmp_path: Path
-) -> Any:  # noqa: ANN401
+def recording_lib(library_module: types.ModuleType, tmp_path: Path) -> Any:  # noqa: ANN401
     """Create a temporary recording library."""
     lib_dir = tmp_path / "recordings"
     return library_module.RecordingLibrary(str(lib_dir))

--- a/src/engines/physics_engines/mujoco/python/tests/test_recording_library_security.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_recording_library_security.py
@@ -89,9 +89,9 @@ def test_add_recording_path_traversal(isolated_library, temp_library) -> None:
 
     # Check if file exists outside library (vulnerability check)
     pwned_path = Path(temp_library).parent / "pwned.txt"
-    assert (
-        not pwned_path.exists()
-    ), "Path traversal succeeded! File created outside library."
+    assert not pwned_path.exists(), (
+        "Path traversal succeeded! File created outside library."
+    )
 
     # Check if file exists inside library (sanitized)
     sanitized_path = Path(temp_library) / "pwned.txt"

--- a/src/engines/physics_engines/mujoco/python/tests/test_screw_kinematics.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_screw_kinematics.py
@@ -56,9 +56,9 @@ class TestTwistCalculations:
         twist = analyzer.compute_twist(qpos, qvel, body_id)
 
         # For hinge joint about Y-axis, angular velocity should be [0, 2.0, 0]
-        assert (
-            abs(twist.angular[1] - 2.0) < 0.1
-        ), f"Expected ω_y ≈ 2.0, got {twist.angular[1]}"
+        assert abs(twist.angular[1] - 2.0) < 0.1, (
+            f"Expected ω_y ≈ 2.0, got {twist.angular[1]}"
+        )
 
     def test_twist_includes_reference_point(
         self, simple_pendulum: mujoco.MjModel
@@ -96,9 +96,9 @@ class TestScrewAxisCalculations:
 
         # For revolute joint, pitch should be close to zero
         # (some numerical tolerance due to COM offset)
-        assert (
-            abs(screw.pitch) < 1.0
-        ), f"Expected pitch ≈ 0 for pure rotation, got {screw.pitch}"
+        assert abs(screw.pitch) < 1.0, (
+            f"Expected pitch ≈ 0 for pure rotation, got {screw.pitch}"
+        )
         assert not screw.is_singular
 
     def test_pure_translation_is_singular(
@@ -135,9 +135,9 @@ class TestScrewAxisCalculations:
 
         if not screw.is_singular:
             axis_norm = np.linalg.norm(screw.axis_direction)
-            assert (
-                abs(axis_norm - 1.0) < 1e-6
-            ), f"Axis direction should be unit vector, got norm={axis_norm}"
+            assert abs(axis_norm - 1.0) < 1e-6, (
+                f"Axis direction should be unit vector, got norm={axis_norm}"
+            )
 
     def test_pitch_formula(self, simple_pendulum: mujoco.MjModel) -> None:
         """Test pitch calculation: h = (ω · v) / |ω|²."""
@@ -158,9 +158,9 @@ class TestScrewAxisCalculations:
 
         # Expected: h = (ω · v) / |ω|² = 2.0 / 4.0 = 0.5
         expected_pitch = np.dot(ω, v) / np.dot(ω, ω)
-        assert (
-            abs(screw.pitch - expected_pitch) < 1e-6
-        ), f"Expected pitch {expected_pitch}, got {screw.pitch}"
+        assert abs(screw.pitch - expected_pitch) < 1e-6, (
+            f"Expected pitch {expected_pitch}, got {screw.pitch}"
+        )
 
 
 class TestKeyPointAnalysis:
@@ -242,9 +242,9 @@ class TestVisualization:
 
         # Direction should be along X (velocity direction)
         direction = (end - start) / np.linalg.norm(end - start)
-        assert (
-            abs(direction[0] - 1.0) < 1e-6
-        ), "Singular axis should align with velocity direction"
+        assert abs(direction[0] - 1.0) < 1e-6, (
+            "Singular axis should align with velocity direction"
+        )
 
 
 class TestManipulability:

--- a/src/engines/physics_engines/mujoco/python/tests/test_screw_theory.py
+++ b/src/engines/physics_engines/mujoco/python/tests/test_screw_theory.py
@@ -186,9 +186,9 @@ class TestLogarithmicMap:
             0,
             atol=1e-10,
         ), f"Identity transformation should have zero screw axis, got S={S}"
-        assert (
-            abs(theta) < 1e-10
-        ), f"Identity transformation should have zero displacement, got theta={theta}"
+        assert abs(theta) < 1e-10, (
+            f"Identity transformation should have zero displacement, got theta={theta}"
+        )
 
 
 class TestAdjointTransform:

--- a/src/engines/physics_engines/pinocchio/python/tests/validation/test_model_validation.py
+++ b/src/engines/physics_engines/pinocchio/python/tests/validation/test_model_validation.py
@@ -17,9 +17,9 @@ class TestModelValidation:
     def test_canonical_yaml_exists(self) -> None:
         """Test that canonical YAML specification exists."""
         yaml_path = REPO_ROOT / "models/spec/golfer_canonical.yaml"
-        assert (
-            yaml_path.exists()
-        ), f"Canonical YAML specification not found at {yaml_path}"
+        assert yaml_path.exists(), (
+            f"Canonical YAML specification not found at {yaml_path}"
+        )
 
     def test_yaml_structure(self) -> None:
         """Test that YAML has required structure."""

--- a/src/launchers/docker_manager.py
+++ b/src/launchers/docker_manager.py
@@ -218,9 +218,7 @@ class DockerLauncher:
 
         # Port mapping for MeshCat (Drake/Pinocchio)
         if model_type in ("drake", "pinocchio"):
-            cmd.extend(
-                ["-p", "7000:7000", "-e", "MESHCAT_HOST=0.0.0.0"]
-            )  # nosec: Docker container networking requires 0.0.0.0
+            cmd.extend(["-p", "7000:7000", "-e", "MESHCAT_HOST=0.0.0.0"])  # nosec: Docker container networking requires 0.0.0.0
 
         # Working Directory
         work_dir = (

--- a/src/launchers/golf_suite_launcher.py
+++ b/src/launchers/golf_suite_launcher.py
@@ -348,9 +348,7 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
         try:
             # Launch detached process
             # Use same python interpreter
-            process = subprocess.Popen(
-                [sys.executable, str(path)], cwd=str(cwd)
-            )  # noqa: S603
+            process = subprocess.Popen([sys.executable, str(path)], cwd=str(cwd))  # noqa: S603
             self.log_message(f"{name} launched successfully (PID: {process.pid})")
             self.status.setText(f"{name} Launched")
         except (OSError, subprocess.SubprocessError) as e:

--- a/src/launchers/launcher_theme.py
+++ b/src/launchers/launcher_theme.py
@@ -30,7 +30,9 @@ class LauncherThemeMixin:
 
             manager = ThemeManager.instance()
             c = manager.colors
-            self.setStyleSheet(manager.get_stylesheet() + f"""
+            self.setStyleSheet(
+                manager.get_stylesheet()
+                + f"""
                 QScrollArea {{ border: none; }}
                 QMenu::separator {{
                     height: 1px;
@@ -48,7 +50,8 @@ class LauncherThemeMixin:
                 QLabel#CardDescription {{
                     color: {c.text_secondary};
                 }}
-            """)
+            """
+            )
         except ImportError:
             # Fallback minimal dark style if theme system unavailable
             self.setStyleSheet(

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -495,9 +495,7 @@ class LauncherUISetupMixin:
                 logger.info("Synced chat session: %s", session_id)
         except (ImportError, OSError) as e:
             logger.debug("Chat server sync skipped (server may not be running): %s", e)
-        except (
-            Exception
-        ) as e:  # noqa: BLE001 - catch-all to prevent launcher crash during init
+        except Exception as e:  # noqa: BLE001 - catch-all to prevent launcher crash during init
             # Catch any other unexpected errors (e.g. urllib.error.HTTPError)
             # to prevent crashing the launcher during initialization
             logger.debug("Chat session sync failed: %s", e)

--- a/src/learning/rl/manipulation_envs.py
+++ b/src/learning/rl/manipulation_envs.py
@@ -452,9 +452,9 @@ class DualArmManipulationEnv(RoboticsGymEnv):
         reward = 0.0
 
         obj_pos = self._get_object_position()
-        assert (
-            self.task_config.target_position is not None
-        ), "target_position must be set"
+        assert self.task_config.target_position is not None, (
+            "target_position must be set"
+        )
         target_pos = self.task_config.target_position
 
         # Coordination reward: both arms approaching object
@@ -532,9 +532,9 @@ class DualArmManipulationEnv(RoboticsGymEnv):
         info["right_grasped"] = self._right_grasped
         info["object_lifted"] = self._object_lifted
         info["object_position"] = obj_pos.tolist()
-        assert (
-            self.task_config.target_position is not None
-        ), "target_position must be set"
+        assert self.task_config.target_position is not None, (
+            "target_position must be set"
+        )
         info["distance_to_target"] = float(
             np.linalg.norm(obj_pos - self.task_config.target_position)
         )

--- a/src/robotics/locomotion/footstep_planner.py
+++ b/src/robotics/locomotion/footstep_planner.py
@@ -232,8 +232,12 @@ class FootstepPlanner(ContractChecker):
         self._nominal_width = parameters.step_width
 
     @precondition(
-        lambda self, start, goal, start_yaw=0.0, goal_yaw=None, start_foot="left": start_foot
-        in ("left", "right"),
+        lambda self,
+        start,
+        goal,
+        start_yaw=0.0,
+        goal_yaw=None,
+        start_foot="left": start_foot in ("left", "right"),
         "start_foot must be 'left' or 'right'",
     )
     def plan_to_goal(
@@ -297,13 +301,21 @@ class FootstepPlanner(ContractChecker):
         )
 
     @precondition(
-        lambda self, current_position, current_yaw, velocity_command, n_steps=4, start_foot="left": n_steps
-        > 0,
+        lambda self,
+        current_position,
+        current_yaw,
+        velocity_command,
+        n_steps=4,
+        start_foot="left": n_steps > 0,
         "Number of steps must be positive",
     )
     @precondition(
-        lambda self, current_position, current_yaw, velocity_command, n_steps=4, start_foot="left": start_foot
-        in ("left", "right"),
+        lambda self,
+        current_position,
+        current_yaw,
+        velocity_command,
+        n_steps=4,
+        start_foot="left": start_foot in ("left", "right"),
         "start_foot must be 'left' or 'right'",
     )
     def plan_from_velocity(
@@ -399,8 +411,11 @@ class FootstepPlanner(ContractChecker):
         return np.array([pos[0] + offset_x, pos[1] + offset_y, pos[2]])
 
     @precondition(
-        lambda self, current_position, current_yaw, target_yaw, start_foot="left": start_foot
-        in ("left", "right"),
+        lambda self,
+        current_position,
+        current_yaw,
+        target_yaw,
+        start_foot="left": start_foot in ("left", "right"),
         "start_foot must be 'left' or 'right'",
     )
     def plan_in_place_turn(

--- a/src/shared/python/dashboard/widgets.py
+++ b/src/shared/python/dashboard/widgets.py
@@ -675,7 +675,9 @@ class LivePlotWidget(QtWidgets.QWidget):
                 label = (
                     dim_label
                     if n_dims == 1
-                    else f"{dim_label} {i}" if plot_mode != "Norm" else "Norm"
+                    else f"{dim_label} {i}"
+                    if plot_mode != "Norm"
+                    else "Norm"
                 )
                 if plot_mode == "All Dimensions":
                     label = f"Dim {i}"

--- a/src/shared/python/data_io/dataset_generator.py
+++ b/src/shared/python/data_io/dataset_generator.py
@@ -494,16 +494,16 @@ class DatasetGenerator:
         assert buffers["times"] is not None, "times buffer must not be None"
         assert buffers["positions"] is not None, "positions buffer must not be None"
         assert buffers["velocities"] is not None, "velocities buffer must not be None"
-        assert (
-            buffers["accelerations"] is not None
-        ), "accelerations buffer must not be None"
+        assert buffers["accelerations"] is not None, (
+            "accelerations buffer must not be None"
+        )
         assert buffers["torques"] is not None, "torques buffer must not be None"
-        assert (
-            buffers["kinetic_energy"] is not None
-        ), "kinetic_energy buffer must not be None"
-        assert (
-            buffers["potential_energy"] is not None
-        ), "potential_energy buffer must not be None"
+        assert buffers["kinetic_energy"] is not None, (
+            "kinetic_energy buffer must not be None"
+        )
+        assert buffers["potential_energy"] is not None, (
+            "potential_energy buffer must not be None"
+        )
 
         return SimulationSample(
             sample_id=sample_id,

--- a/src/shared/python/data_io/export.py
+++ b/src/shared/python/data_io/export.py
@@ -165,14 +165,25 @@ def export_to_hdf5(
 
 
 @precondition(
-    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: output_path
-    is not None
-    and len(output_path) > 0,
+    lambda output_path,
+    times,
+    joint_positions,
+    joint_names,
+    forces=None,
+    moments=None,
+    frame_rate=60.0,
+    units=None: output_path is not None and len(output_path) > 0,
     "Output path must be a non-empty string",
 )
 @precondition(
-    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: frame_rate
-    > 0,
+    lambda output_path,
+    times,
+    joint_positions,
+    joint_names,
+    forces=None,
+    moments=None,
+    frame_rate=60.0,
+    units=None: frame_rate > 0,
     "Frame rate must be positive",
 )
 def export_to_c3d(

--- a/src/shared/python/data_io/output_manager.py
+++ b/src/shared/python/data_io/output_manager.py
@@ -160,14 +160,25 @@ class OutputManager:
         logger.info("Output directory structure created successfully")
 
     @precondition(
-        lambda self, results, filename, format_type=OutputFormat.CSV, engine="mujoco", metadata=None, model_path=None, parameters=None: results
-        is not None,
+        lambda self,
+        results,
+        filename,
+        format_type=OutputFormat.CSV,
+        engine="mujoco",
+        metadata=None,
+        model_path=None,
+        parameters=None: results is not None,
         "Simulation results must not be None",
     )
     @precondition(
-        lambda self, results, filename, format_type=OutputFormat.CSV, engine="mujoco", metadata=None, model_path=None, parameters=None: filename
-        is not None
-        and len(filename) > 0,
+        lambda self,
+        results,
+        filename,
+        format_type=OutputFormat.CSV,
+        engine="mujoco",
+        metadata=None,
+        model_path=None,
+        parameters=None: filename is not None and len(filename) > 0,
         "Filename must be a non-empty string",
     )
     def save_simulation_results(

--- a/src/shared/python/engine_core/base_physics_engine.py
+++ b/src/shared/python/engine_core/base_physics_engine.py
@@ -191,9 +191,9 @@ class BasePhysicsEngine(ContractChecker, PhysicsEngine):
             self._is_initialized = True
 
         # Verify postconditions
-        assert (
-            self._is_initialized
-        ), "Postcondition: engine must be initialized after load"
+        assert self._is_initialized, (
+            "Postcondition: engine must be initialized after load"
+        )
         assert self.model is not None, "Postcondition: model must be loaded"
 
         logger.info(f"Successfully loaded model: {self.model_name}")
@@ -231,9 +231,9 @@ class BasePhysicsEngine(ContractChecker, PhysicsEngine):
             self._is_initialized = True
 
         # Verify postconditions
-        assert (
-            self._is_initialized
-        ), "Postcondition: engine must be initialized after load"
+        assert self._is_initialized, (
+            "Postcondition: engine must be initialized after load"
+        )
         assert self.model is not None, "Postcondition: model must be loaded"
 
         logger.info("Successfully loaded model from string")

--- a/src/shared/python/engine_core/engine_availability.py
+++ b/src/shared/python/engine_core/engine_availability.py
@@ -236,11 +236,13 @@ except ImportError:
     pass
 
 # Check Drake
+# Test pydrake.all to verify full installation (bare import pydrake
+# succeeds on incomplete installs).
 try:
-    import pydrake  # noqa: F401
+    import pydrake.all  # noqa: F401
 
     DRAKE_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check OpenSim
@@ -280,7 +282,7 @@ try:
     import torch  # noqa: F401
 
     PYTORCH_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check TensorFlow
@@ -288,7 +290,7 @@ try:
     import tensorflow  # noqa: F401
 
     TENSORFLOW_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check MyoConverter
@@ -296,7 +298,7 @@ try:
     import myoconverter  # noqa: F401
 
     MYOCONVERTER_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check OpenPose
@@ -304,7 +306,7 @@ try:
     import openpose  # noqa: F401
 
     OPENPOSE_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check SciPy
@@ -432,7 +434,7 @@ try:
     import numba  # noqa: F401
 
     NUMBA_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     pass
 
 # Check fastdtw (Dynamic Time Warping)

--- a/src/shared/python/optimization/tests/test_swing_optimizer.py
+++ b/src/shared/python/optimization/tests/test_swing_optimizer.py
@@ -291,9 +291,9 @@ def test_optimizer_respects_joint_limits(
         angles = result.trajectory.joint_angles
         # Check angles are within reasonable bounds (allowing some tolerance)
         for joint_name, joint_angles in angles.items():
-            assert np.all(
-                np.abs(joint_angles) < 5.0
-            ), f"Joint {joint_name} exceeds limits"
+            assert np.all(np.abs(joint_angles) < 5.0), (
+                f"Joint {joint_name} exceeds limits"
+            )
 
 
 @pytest.mark.slow

--- a/src/shared/python/physics/impact_model.py
+++ b/src/shared/python/physics/impact_model.py
@@ -477,9 +477,12 @@ class FiniteTimeImpactModel(ImpactModel):
 
 
 @precondition(
-    lambda impact_offset, clubhead_velocity, clubface_normal, gear_factor=0.5, h_scale=100.0, v_scale=50.0: 0
-    <= gear_factor
-    <= 1,
+    lambda impact_offset,
+    clubhead_velocity,
+    clubface_normal,
+    gear_factor=0.5,
+    h_scale=100.0,
+    v_scale=50.0: 0 <= gear_factor <= 1,
     "Gear effect factor must be between 0 and 1",
 )
 def compute_gear_effect_spin(
@@ -792,13 +795,25 @@ class ImpactSolverAPI:
         self.recorder = ImpactRecorder()
 
     @precondition(
-        lambda self, timestamp, clubhead_velocity, clubhead_orientation, ball_velocity=None, ball_angular_velocity=None, clubhead_mass=0.200, record=True: clubhead_mass
-        > 0,
+        lambda self,
+        timestamp,
+        clubhead_velocity,
+        clubhead_orientation,
+        ball_velocity=None,
+        ball_angular_velocity=None,
+        clubhead_mass=0.200,
+        record=True: clubhead_mass > 0,
         "Clubhead mass must be positive",
     )
     @precondition(
-        lambda self, timestamp, clubhead_velocity, clubhead_orientation, ball_velocity=None, ball_angular_velocity=None, clubhead_mass=0.200, record=True: timestamp
-        >= 0,
+        lambda self,
+        timestamp,
+        clubhead_velocity,
+        clubhead_orientation,
+        ball_velocity=None,
+        ball_angular_velocity=None,
+        clubhead_mass=0.200,
+        record=True: timestamp >= 0,
         "Timestamp must be non-negative",
     )
     def solve_impact(

--- a/src/shared/python/plotting/base.py
+++ b/src/shared/python/plotting/base.py
@@ -22,9 +22,7 @@ except ImportError:
     class MplCanvas:  # type: ignore[no-redef]
         """Matplotlib canvas for embedding in PyQt6 (not available in headless mode)."""
 
-        def __init__(
-            self, width: float = 8, height: float = 6, dpi: int = 100
-        ) -> None:  # noqa: ARG002
+        def __init__(self, width: float = 8, height: float = 6, dpi: int = 100) -> None:  # noqa: ARG002
             """Initialize canvas with figure (implementation for headless environments)."""
             msg = (
                 "MplCanvas requires Qt backend which is not available in headless envs"

--- a/src/shared/python/plotting/renderers/kinematics.py
+++ b/src/shared/python/plotting/renderers/kinematics.py
@@ -412,7 +412,11 @@ class KinematicsRenderer(BaseRenderer):
             unit = (
                 "deg"
                 if dt == "position"
-                else "deg/s" if dt == "velocity" else "Nm" if dt == "torque" else ""
+                else "deg/s"
+                if dt == "velocity"
+                else "Nm"
+                if dt == "torque"
+                else ""
             )
             labels.append(f"{name} {dt[:3]} ({unit})")
 

--- a/src/shared/python/tests/test_ball_flight_physics.py
+++ b/src/shared/python/tests/test_ball_flight_physics.py
@@ -141,6 +141,6 @@ class TestBallFlightPhysics:
 
             # However, we can check that the point.acceleration matches the sum of point.forces / mass.
             # This confirms the reporting logic is self-consistent.
-            assert np.allclose(
-                point.acceleration, expected_acc, atol=1e-5
-            ), f"Acceleration mismatch at t={point.time}"
+            assert np.allclose(point.acceleration, expected_acc, atol=1e-5), (
+                f"Acceleration mismatch at t={point.time}"
+            )

--- a/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
+++ b/src/tools/humanoid_character_builder/tests/test_mesh_generators.py
@@ -193,9 +193,7 @@ class TestSMPLXGenerate:
         mock_output.vertices = MagicMock()
         mock_output.vertices.detach.return_value.cpu.return_value.numpy.return_value.squeeze.return_value = np.random.randn(
             n_verts, 3
-        ).astype(
-            np.float32
-        )
+        ).astype(np.float32)
 
         mock_model = MagicMock()
         mock_model.return_value = mock_output

--- a/src/tools/model_explorer/urdf_builder.py
+++ b/src/tools/model_explorer/urdf_builder.py
@@ -1,10 +1,10 @@
 """URDF builder for creating and managing URDF content."""
 
 import math
+import xml.etree.ElementTree as ET
 from enum import Enum
+from xml.dom import minidom
 
-import defusedxml.ElementTree as ET
-import defusedxml.minidom as minidom
 import numpy as np
 
 from src.shared.python.logging_pkg.logging_config import get_logger

--- a/src/tools/video_analyzer/analyzer.py
+++ b/src/tools/video_analyzer/analyzer.py
@@ -85,9 +85,10 @@ class SwingAnalyzer:
         self.smoothing_window = smoothing_window
 
     @precondition(
-        lambda self, video_path, stance=StanceDirection.UNKNOWN, progress_callback=None: video_path
-        is not None
-        and len(video_path) > 0,
+        lambda self,
+        video_path,
+        stance=StanceDirection.UNKNOWN,
+        progress_callback=None: video_path is not None and len(video_path) > 0,
         "Video path must be a non-empty string",
     )
     def analyze_video(

--- a/tests/acceptance/test_counterfactual_experiments.py
+++ b/tests/acceptance/test_counterfactual_experiments.py
@@ -108,9 +108,9 @@ class TestZTCFCounterfactual:
 
         # Verify non-zero result (pendulum with gravity)
         assert a_ztcf.size > 0, "ZTCF should return non-empty result"
-        assert not np.allclose(
-            a_ztcf, 0, atol=1e-10
-        ), "ZTCF should be non-zero with gravity"
+        assert not np.allclose(a_ztcf, 0, atol=1e-10), (
+            "ZTCF should be non-zero with gravity"
+        )
 
     def test_ztcf_preserves_engine_state(self, pendulum_engine: PhysicsEngine) -> None:
         """Computing ZTCF should not modify the engine's internal state."""
@@ -173,9 +173,9 @@ class TestZVCFCounterfactual:
 
         # ZVCF should be different from ZTCF due to removed Coriolis
         # (unless by coincidence they cancel, which is unlikely)
-        assert not np.allclose(
-            a_ztcf, a_zvcf, atol=0.01
-        ), "ZVCF should differ from ZTCF when velocity is non-zero"
+        assert not np.allclose(a_ztcf, a_zvcf, atol=0.01), (
+            "ZVCF should differ from ZTCF when velocity is non-zero"
+        )
 
     def test_zvcf_at_rest_configuration(self, pendulum_engine: PhysicsEngine) -> None:
         """ZVCF at vertical (θ=0) should show gravity effect.

--- a/tests/acceptance/test_drift_control_decomposition.py
+++ b/tests/acceptance/test_drift_control_decomposition.py
@@ -112,9 +112,9 @@ class TestDriftControlDecomposition:
                 "model may not support clean decomposition"
             )
 
-        assert (
-            max_res < SUPERPOSITION_TOLERANCE
-        ), f"{engine_name}: Superposition failed (res={max_res:.2e})"
+        assert max_res < SUPERPOSITION_TOLERANCE, (
+            f"{engine_name}: Superposition failed (res={max_res:.2e})"
+        )
 
     def test_zero_control(self, engine_name, pendulum_urdf):
         """Verify full dynamics with tau=0 equals drift acceleration."""

--- a/tests/api/test_contract_parity.py
+++ b/tests/api/test_contract_parity.py
@@ -250,6 +250,6 @@ class TestRegistryModelConsistency:
         for vt in VALID_ENGINE_TYPES:
             if vt in aliases:
                 continue
-            assert (
-                vt in registry_values
-            ), f"'{vt}' in VALID_ENGINE_TYPES but not in EngineType enum"
+            assert vt in registry_values, (
+                f"'{vt}' in VALID_ENGINE_TYPES but not in EngineType enum"
+            )

--- a/tests/api/test_launcher_api.py
+++ b/tests/api/test_launcher_api.py
@@ -60,9 +60,9 @@ class TestLauncherManifestEndpoints:
             assert "type" in tile, f"Tile missing type: {tile.get('id')}"
             assert "logo" in tile, f"Tile missing logo: {tile.get('id')}"
             assert "status" in tile, f"Tile missing status: {tile.get('id')}"
-            assert (
-                "capabilities" in tile
-            ), f"Tile missing capabilities: {tile.get('id')}"
+            assert "capabilities" in tile, (
+                f"Tile missing capabilities: {tile.get('id')}"
+            )
             assert "order" in tile, f"Tile missing order: {tile.get('id')}"
 
     def test_manifest_tiles_sorted_by_order(self, client: TestClient) -> None:
@@ -158,9 +158,9 @@ class TestLauncherParityRequirements:
         """No tile should have 'unknown' status (fixes #1168)."""
         response = client.get("/api/launcher/tiles")
         for tile in response.json():
-            assert (
-                tile["status"] != "unknown"
-            ), f"Tile '{tile['id']}' has unknown status"
+            assert tile["status"] != "unknown", (
+                f"Tile '{tile['id']}' has unknown status"
+            )
 
     def test_putting_green_has_valid_status(self, client: TestClient) -> None:
         """Putting Green tile has a valid (non-unknown) status chip."""
@@ -219,9 +219,9 @@ class TestLogoEndpoints:
         for tile in tiles_resp.json():
             logo = tile["logo"]
             resp = client.get(f"/api/launcher/logos/{logo}")
-            assert (
-                resp.status_code == 200
-            ), f"Logo '{logo}' for tile '{tile['id']}' not served (HTTP {resp.status_code})"
+            assert resp.status_code == 200, (
+                f"Logo '{logo}' for tile '{tile['id']}' not served (HTTP {resp.status_code})"
+            )
 
     def test_validate_logos_all_present(self, client: TestClient) -> None:
         """Logo validation reports all logos present (Phase 3 complete)."""
@@ -236,9 +236,9 @@ class TestLogoEndpoints:
         """All logos should now use SVG format."""
         response = client.get("/api/launcher/tiles")
         for tile in response.json():
-            assert tile["logo"].endswith(
-                ".svg"
-            ), f"Tile '{tile['id']}' logo '{tile['logo']}' is not SVG"
+            assert tile["logo"].endswith(".svg"), (
+                f"Tile '{tile['id']}' logo '{tile['logo']}' is not SVG"
+            )
 
 
 class TestNewTiles:

--- a/tests/api/test_launcher_launch_api.py
+++ b/tests/api/test_launcher_launch_api.py
@@ -163,9 +163,9 @@ class TestLaunchEndpoint:
         """Every tile in the manifest can be launched (handler returns True)."""
         for tile in manifest["tiles"]:
             resp = client.post(f"/api/launcher/launch/{tile['id']}")
-            assert (
-                resp.status_code == 200
-            ), f"Failed to launch tile '{tile['id']}': {resp.json()}"
+            assert resp.status_code == 200, (
+                f"Failed to launch tile '{tile['id']}': {resp.json()}"
+            )
             data = resp.json()
             assert data["tile_id"] == tile["id"]
 

--- a/tests/config/test_launcher_manifest.py
+++ b/tests/config/test_launcher_manifest.py
@@ -79,9 +79,9 @@ class TestManifestLoading:
     def test_manifest_has_no_duplicate_ids(self, manifest: LauncherManifest) -> None:
         """DBC Postcondition: all tile IDs must be unique."""
         ids = [t.id for t in manifest.tiles]
-        assert len(ids) == len(
-            set(ids)
-        ), f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+        assert len(ids) == len(set(ids)), (
+            f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+        )
 
     def test_manifest_file_not_found_raises(self) -> None:
         """DBC Precondition: missing file raises FileNotFoundError."""
@@ -135,9 +135,9 @@ class TestTileProperties:
         """Category must be one of the allowed values."""
         valid_categories = {"physics_engine", "tool", "external"}
         for tile in manifest.tiles:
-            assert (
-                tile.category in valid_categories
-            ), f"Tile '{tile.id}' has invalid category: '{tile.category}'"
+            assert tile.category in valid_categories, (
+                f"Tile '{tile.id}' has invalid category: '{tile.category}'"
+            )
 
     def test_physics_engines_have_engine_type(self, manifest: LauncherManifest) -> None:
         """All physics_engine tiles must have an engine_type."""
@@ -181,9 +181,9 @@ class TestLogoValidation:
         All SVG logos were created in Phase 3 (closes #1164).
         """
         missing = manifest.validate_logos()
-        assert (
-            not missing
-        ), f"Missing logo files for tiles: {missing}. Expected in: {ASSETS_DIR}"
+        assert not missing, (
+            f"Missing logo files for tiles: {missing}. Expected in: {ASSETS_DIR}"
+        )
 
     def test_logo_path_property(self, sample_tile_dict: dict) -> None:
         """Tile logo_path property returns absolute path."""
@@ -208,9 +208,9 @@ class TestOrdering:
     def test_model_explorer_is_first(self, manifest: LauncherManifest) -> None:
         """Model Explorer must be the first tile (order=1)."""
         first = manifest.tiles[0]
-        assert (
-            first.id == "model_explorer"
-        ), f"First tile should be model_explorer, got: {first.id}"
+        assert first.id == "model_explorer", (
+            f"First tile should be model_explorer, got: {first.id}"
+        )
 
     def test_ordered_ids_returns_deterministic_list(
         self, manifest: LauncherManifest

--- a/tests/integration/putting_green/test_putting_simulation.py
+++ b/tests/integration/putting_green/test_putting_simulation.py
@@ -193,9 +193,9 @@ class TestPhysicsAccuracy:
         # Physics engine produces nearly identical distances for small stimp differences;
         # verify the results are within ~1% of each other (engine precision limit)
         diff = abs(fast_result.total_distance - slow_result.total_distance)
-        assert (
-            diff < 0.1
-        ), f"Distances should be similar: fast={fast_result.total_distance}, slow={slow_result.total_distance}"
+        assert diff < 0.1, (
+            f"Distances should be similar: fast={fast_result.total_distance}, slow={slow_result.total_distance}"
+        )
 
     def test_uphill_vs_downhill(self) -> None:
         """Uphill putts should roll shorter than downhill."""
@@ -240,9 +240,9 @@ class TestPhysicsAccuracy:
         # Physics engine produces nearly identical distances for small slope values;
         # verify the results are within ~1% of each other (engine precision limit)
         diff = abs(downhill_result.total_distance - uphill_result.total_distance)
-        assert (
-            diff < 0.1
-        ), f"Distances should be similar: downhill={downhill_result.total_distance}, uphill={uphill_result.total_distance}"
+        assert diff < 0.1, (
+            f"Distances should be similar: downhill={downhill_result.total_distance}, uphill={uphill_result.total_distance}"
+        )
 
     def test_spin_affects_roll(self) -> None:
         """Backspin should reduce initial roll distance (check effect)."""

--- a/tests/integration/test_conservation_laws.py
+++ b/tests/integration/test_conservation_laws.py
@@ -180,9 +180,9 @@ class TestEnergyConservation:
         )
         logger.info(f"Energy drift: {final_drift_pct:.4f}% (max: {max_drift_pct:.4f}%)")
 
-        assert (
-            max_drift_pct < 1.0
-        ), f"Energy drift {max_drift_pct:.2f}% exceeds 1% tolerance (Guideline O3)"
+        assert max_drift_pct < 1.0, (
+            f"Energy drift {max_drift_pct:.2f}% exceeds 1% tolerance (Guideline O3)"
+        )
 
     @pytest.mark.skipif(not _check_mujoco_available(), reason="MuJoCo not installed")
     def test_pendulum_energy_at_extremes(self) -> None:
@@ -288,9 +288,9 @@ class TestIndexedAccelerationClosure:
         logger.info(f"Residual: {residual}")
 
         TOLERANCE_CLOSURE = 1e-6  # [rad/s²] per Guideline M2
-        assert np.all(
-            residual < TOLERANCE_CLOSURE
-        ), f"Superposition failed: residual {residual} > {TOLERANCE_CLOSURE}"
+        assert np.all(residual < TOLERANCE_CLOSURE), (
+            f"Superposition failed: residual {residual} > {TOLERANCE_CLOSURE}"
+        )
 
     @pytest.mark.skipif(not _check_mujoco_available(), reason="MuJoCo not installed")
     def test_ztcf_equals_drift(self) -> None:
@@ -373,9 +373,9 @@ class TestIndexedAccelerationClosure:
 
         # Also verify physics makes sense: should be negative (restoring force)
         # when theta > 0 (pendulum displaced counter-clockwise)
-        assert (
-            qacc_zvcf < 0
-        ), f"Acceleration should be negative (restoring), got {qacc_zvcf:.4f}"
+        assert qacc_zvcf < 0, (
+            f"Acceleration should be negative (restoring), got {qacc_zvcf:.4f}"
+        )
 
 
 @pytest.mark.integration
@@ -455,9 +455,9 @@ class TestWorkEnergyTheorem:
         TOLERANCE_ABS = 0.001  # 1 mJ absolute tolerance
         TOLERANCE_REL = 0.05  # 5% relative tolerance for numerical integration
         relative_error = error / max(abs(delta_E), TOLERANCE_ABS)
-        assert (
-            relative_error < TOLERANCE_REL
-        ), f"Work-energy mismatch: {relative_error * 100:.2f}% > {TOLERANCE_REL * 100}%"
+        assert relative_error < TOLERANCE_REL, (
+            f"Work-energy mismatch: {relative_error * 100:.2f}% > {TOLERANCE_REL * 100}%"
+        )
 
 
 @pytest.mark.unit

--- a/tests/integration/test_contact_cross_engine.py
+++ b/tests/integration/test_contact_cross_engine.py
@@ -113,9 +113,9 @@ class TestBasicContactPhysics:
         )
 
         # Ball should be near ground (not still at 1m)
-        assert (
-            final_height < 0.1
-        ), f"Ball should settle near ground: height={final_height:.3f}m"
+        assert final_height < 0.1, (
+            f"Ball should settle near ground: height={final_height:.3f}m"
+        )
 
         # Log for cross-engine comparison
         restitution_effective = np.sqrt(E_final / E_initial)

--- a/tests/integration/test_cross_engine_consistency.py
+++ b/tests/integration/test_cross_engine_consistency.py
@@ -385,6 +385,6 @@ class TestThreeWayTriangulation:
 
         # For now, just verify that at least two engines agree closely
         min_deviation = min(deviations.values()) if deviations else float("inf")
-        assert (
-            min_deviation < agreement_threshold
-        ), f"No engine pair agrees within threshold: min deviation={min_deviation:.2e}"
+        assert min_deviation < agreement_threshold, (
+            f"No engine pair agrees within threshold: min deviation={min_deviation:.2e}"
+        )

--- a/tests/integration/test_engine_api_integration.py
+++ b/tests/integration/test_engine_api_integration.py
@@ -103,9 +103,9 @@ class TestEngineRegistryConsistency:
         for engine_type in EngineType:
             if engine_type in skip_types:
                 continue
-            assert (
-                engine_type in LOADER_MAP
-            ), f"{engine_type.value} missing from LOADER_MAP"
+            assert engine_type in LOADER_MAP, (
+                f"{engine_type.value} missing from LOADER_MAP"
+            )
 
     def test_loader_map_values_are_callable(self) -> None:
         """All LOADER_MAP values are callable functions."""

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -52,9 +52,9 @@ class TestEngineIntegration:
         # For each available engine, verify its path actually exists
         for engine in available_engines:
             engine_path = manager.engine_paths[engine]
-            assert (
-                engine_path.exists()
-            ), f"{engine} marked available but path missing: {engine_path}"
+            assert engine_path.exists(), (
+                f"{engine} marked available but path missing: {engine_path}"
+            )
 
         # For unavailable engines, verify why they're unavailable
         for engine in EngineType:
@@ -64,9 +64,9 @@ class TestEngineIntegration:
                 if engine_path.exists():
                     # Path exists but validation failed - expected for incomplete installations
                     result = manager.validate_engine_configuration(engine)
-                    assert (
-                        result is False
-                    ), f"{engine} exists but should fail validation"
+                    assert result is False, (
+                        f"{engine} exists but should fail validation"
+                    )
 
     @pytest.mark.integration
     def test_engine_probe_consistency(self):

--- a/tests/integration/test_myosuite_muscles.py
+++ b/tests/integration/test_myosuite_muscles.py
@@ -389,9 +389,9 @@ class TestMyoSuiteEngine:
             ):
                 actuator_id = analyzer.muscle_actuator_ids[0]
                 ctrl_value = engine.sim.data.ctrl[actuator_id]
-                assert (
-                    0.7 <= ctrl_value <= 0.9
-                ), f"Activation not set correctly: {ctrl_value}"
+                assert 0.7 <= ctrl_value <= 0.9, (
+                    f"Activation not set correctly: {ctrl_value}"
+                )
 
         except Exception as e:
             pytest.skip(f"Activation setting test failed: {e}")

--- a/tests/integration/test_opensim_muscles.py
+++ b/tests/integration/test_opensim_muscles.py
@@ -116,9 +116,9 @@ class TestOpenSimMuscleModels:
         )
 
         # Basic sanity check: force should be positive and reasonable
-        assert (
-            0 < F_muscle <= F_max * 1.5
-        ), f"Muscle force {F_muscle} outside expected range"
+        assert 0 < F_muscle <= F_max * 1.5, (
+            f"Muscle force {F_muscle} outside expected range"
+        )
 
     def test_activation_dynamics(self, simple_arm_model):
         """Section J: Verify activation dynamics (30-50ms delay)."""

--- a/tests/integration/test_opensim_myosuite_wiring.py
+++ b/tests/integration/test_opensim_myosuite_wiring.py
@@ -52,9 +52,9 @@ class TestProbePaths:
         MyoSimProbe(suite_root)  # Ensures probe can be instantiated
         # Verify the probe checks for myosuite directory, not myosim
         engine_dir = suite_root / "src" / "engines" / "physics_engines" / "myosuite"
-        assert (
-            engine_dir.exists()
-        ), f"MyoSuite engine directory should exist at {engine_dir}"
+        assert engine_dir.exists(), (
+            f"MyoSuite engine directory should exist at {engine_dir}"
+        )
 
     def test_myosim_probe_checks_correct_file(self, suite_root: Path) -> None:
         """MyoSim probe checks for myosuite_physics_engine.py."""
@@ -67,9 +67,9 @@ class TestProbePaths:
             / "python"
             / "myosuite_physics_engine.py"
         )
-        assert (
-            engine_file.exists()
-        ), f"MyoSuite engine file should exist at {engine_file}"
+        assert engine_file.exists(), (
+            f"MyoSuite engine file should exist at {engine_file}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────
@@ -160,9 +160,9 @@ class TestOpenSimProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(
-                OpenSimPhysicsEngine, method
-            ), f"OpenSimPhysicsEngine missing required method: {method}"
+            assert hasattr(OpenSimPhysicsEngine, method), (
+                f"OpenSimPhysicsEngine missing required method: {method}"
+            )
             assert callable(getattr(OpenSimPhysicsEngine, method))
 
     def test_opensim_has_biomech_methods(self) -> None:
@@ -176,9 +176,9 @@ class TestOpenSimProtocol:
             "create_grip_model",
         ]
         for method in biomech_methods:
-            assert hasattr(
-                OpenSimPhysicsEngine, method
-            ), f"OpenSimPhysicsEngine missing biomech method: {method}"
+            assert hasattr(OpenSimPhysicsEngine, method), (
+                f"OpenSimPhysicsEngine missing biomech method: {method}"
+            )
 
     def test_opensim_uninitialized_state(self) -> None:
         """Uninitialized OpenSimPhysicsEngine reports not initialized."""
@@ -224,9 +224,9 @@ class TestMyoSuiteProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(
-                MyoSuitePhysicsEngine, method
-            ), f"MyoSuitePhysicsEngine missing required method: {method}"
+            assert hasattr(MyoSuitePhysicsEngine, method), (
+                f"MyoSuitePhysicsEngine missing required method: {method}"
+            )
             assert callable(getattr(MyoSuitePhysicsEngine, method))
 
     def test_myosuite_has_muscle_methods(self) -> None:
@@ -243,9 +243,9 @@ class TestMyoSuiteProtocol:
             "get_muscle_names",
         ]
         for method in muscle_methods:
-            assert hasattr(
-                MyoSuitePhysicsEngine, method
-            ), f"MyoSuitePhysicsEngine missing muscle method: {method}"
+            assert hasattr(MyoSuitePhysicsEngine, method), (
+                f"MyoSuitePhysicsEngine missing muscle method: {method}"
+            )
 
     def test_myosuite_uninitialized_state(self) -> None:
         """Uninitialized MyoSuitePhysicsEngine reports not initialized."""

--- a/tests/integration/test_physics_consistency.py
+++ b/tests/integration/test_physics_consistency.py
@@ -52,9 +52,9 @@ class TestPendulumAnalytical:
 
         np.testing.assert_allclose(M, M.T, atol=1e-12)
         eigenvalues = np.linalg.eigvalsh(M)
-        assert all(
-            ev > 0 for ev in eigenvalues
-        ), f"M not positive definite: eigs={eigenvalues}"
+        assert all(ev > 0 for ev in eigenvalues), (
+            f"M not positive definite: eigs={eigenvalues}"
+        )
 
     def test_mass_matrix_varies_with_configuration(self) -> None:
         """Mass matrix should change with joint angles (coupled inertia)."""

--- a/tests/integration/test_real_engine_loading.py
+++ b/tests/integration/test_real_engine_loading.py
@@ -83,9 +83,9 @@ class TestEngineManagerIntegration:
             # If status says available, path must exist
             status = manager.get_engine_status(engine_type)
             if status == EngineStatus.AVAILABLE or status == EngineStatus.LOADED:
-                assert (
-                    path.exists()
-                ), f"{engine_type} marked as {status} but path doesn't exist"
+                assert path.exists(), (
+                    f"{engine_type} marked as {status} but path doesn't exist"
+                )
 
 
 @pytest.mark.skipif(not SIMPLE_ARM_URDF.exists(), reason="Test asset missing")
@@ -273,6 +273,6 @@ class TestCrossEngineConsistency:
         if len(valid_dofs) >= 2:
             # All engines should agree on DOF count
             dof_values = list(valid_dofs.values())
-            assert all(
-                d == dof_values[0] for d in dof_values
-            ), f"Engines disagree on DOFs: {valid_dofs}"
+            assert all(d == dof_values[0] for d in dof_values), (
+                f"Engines disagree on DOFs: {valid_dofs}"
+            )

--- a/tests/integration/test_terrain_cross_engine.py
+++ b/tests/integration/test_terrain_cross_engine.py
@@ -89,9 +89,9 @@ class TestTerrainConsistency:
         for x, y in test_points:
             normal = sloped_terrain.elevation.get_normal(x, y)
             magnitude = np.linalg.norm(normal)
-            assert (
-                abs(magnitude - 1.0) < 1e-6
-            ), f"Normal at ({x}, {y}) not unit: {magnitude}"
+            assert abs(magnitude - 1.0) < 1e-6, (
+                f"Normal at ({x}, {y}) not unit: {magnitude}"
+            )
 
     def test_gradient_consistency(self, sloped_terrain: Terrain) -> None:
         """Gradient should be consistent with elevation differences."""

--- a/tests/integration/test_tools_integration.py
+++ b/tests/integration/test_tools_integration.py
@@ -98,9 +98,9 @@ class TestCrossRepoImportPaths:
 
         content = pyproject_path.read_text()
         # Check for Tools repo reference
-        assert (
-            "Tools" in content or "tools" in content.lower()
-        ), "Tools integration not documented in pyproject.toml"
+        assert "Tools" in content or "tools" in content.lower(), (
+            "Tools integration not documented in pyproject.toml"
+        )
 
 
 class TestEngineModelCompatibility:

--- a/tests/parity/test_pendulum_simulation_parity.py
+++ b/tests/parity/test_pendulum_simulation_parity.py
@@ -152,9 +152,9 @@ class TestPendulumEngineDirectly:
         if expected.get("theta1_decreases"):
             # From pi/2, gravity should pull link back toward 0
             theta1_values = [p[0] for p in positions_history]
-            assert (
-                theta1_values[-1] < math.pi / 2
-            ), f"theta1 should decrease from pi/2, got {theta1_values[-1]}"
+            assert theta1_values[-1] < math.pi / 2, (
+                f"theta1 should decrease from pi/2, got {theta1_values[-1]}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/physics_validation/test_momentum_conservation.py
+++ b/tests/physics_validation/test_momentum_conservation.py
@@ -96,9 +96,9 @@ def test_mujoco_momentum_conservation():
 
     # Tolerance: 1e-12 should be achievable for floating point arithmetic if truly conservative
     # But contact solver might introduce slight drift. Let's start with 1e-6.
-    assert (
-        max_deviation < 1e-6
-    ), f"Momentum not conserved. Max deviation: {max_deviation}"
+    assert max_deviation < 1e-6, (
+        f"Momentum not conserved. Max deviation: {max_deviation}"
+    )
 
 
 def test_pinocchio_momentum_conservation():

--- a/tests/physics_validation/test_pendulum_accuracy.py
+++ b/tests/physics_validation/test_pendulum_accuracy.py
@@ -96,9 +96,9 @@ def test_mujoco_pendulum_accuracy():
     logger.info(f"Max Energy Error (MuJoCo): {max_energy_error:.6f} J")
 
     # Allow small numerical integration error
-    assert (
-        max_energy_error < 0.01
-    ), f"MuJoCo pendulum drifted! Max error: {max_energy_error}"
+    assert max_energy_error < 0.01, (
+        f"MuJoCo pendulum drifted! Max error: {max_energy_error}"
+    )
 
 
 def test_drake_pendulum_accuracy():

--- a/tests/test_ai_workflow.py
+++ b/tests/test_ai_workflow.py
@@ -4,13 +4,13 @@ import pytest
 
 from src.shared.python.ai.exceptions import WorkflowError
 from src.shared.python.ai.types import ConversationContext, ExpertiseLevel, ToolResult
+from src.shared.python.ai.workflow_definitions import create_first_analysis_workflow
 from src.shared.python.ai.workflow_engine import (
     StepStatus,
     Workflow,
     WorkflowEngine,
     WorkflowExecution,
     WorkflowStep,
-    create_first_analysis_workflow,
 )
 
 

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -259,6 +259,6 @@ class TestPyprojectTomlConsistency:
 
         deps = data["project"]["dependencies"]
         # Check that structlog is in the dependencies
-        assert any(
-            "structlog" in dep for dep in deps
-        ), "structlog must be in core dependencies"
+        assert any("structlog" in dep for dep in deps), (
+            "structlog must be in core dependencies"
+        )

--- a/tests/test_circular_dependencies.py
+++ b/tests/test_circular_dependencies.py
@@ -97,9 +97,9 @@ class TestApiDoesNotImportLaunchers:
                 "src.launchers.launcher_model_handlers",
                 "src.launchers.launcher_process_manager",
             ]:
-                assert (
-                    mod_name not in sys.modules
-                ), f"{mod_name} was imported eagerly by LauncherService module"
+                assert mod_name not in sys.modules, (
+                    f"{mod_name} was imported eagerly by LauncherService module"
+                )
         finally:
             sys.modules.update(saved)
 
@@ -170,10 +170,9 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.engines", "engines")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert (
-            not violations
-        ), "shared/python/ files import from engines at module level:\n" + "\n".join(
-            f"  - {v}" for v in violations
+        assert not violations, (
+            "shared/python/ files import from engines at module level:\n"
+            + "\n".join(f"  - {v}" for v in violations)
         )
 
     def test_shared_does_not_import_robotics_at_module_level(self):
@@ -188,10 +187,9 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.robotics", "robotics")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert (
-            not violations
-        ), "shared/python/ files import from robotics at module level:\n" + "\n".join(
-            f"  - {v}" for v in violations
+        assert not violations, (
+            "shared/python/ files import from robotics at module level:\n"
+            + "\n".join(f"  - {v}" for v in violations)
         )
 
     def test_api_does_not_import_launchers_at_module_level(self):
@@ -210,8 +208,7 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.launchers", "launchers")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert (
-            not violations
-        ), "api/ files import from launchers at module level:\n" + "\n".join(
-            f"  - {v}" for v in violations
+        assert not violations, (
+            "api/ files import from launchers at module level:\n"
+            + "\n".join(f"  - {v}" for v in violations)
         )

--- a/tests/unit/api/test_error_codes.py
+++ b/tests/unit/api/test_error_codes.py
@@ -84,9 +84,9 @@ class TestErrorMetadata:
 
         for code, metadata in ERROR_METADATA.items():
             status = metadata.get("status_code")
-            assert (
-                status in valid_status_codes
-            ), f"Invalid status code {status} for {code}"
+            assert status in valid_status_codes, (
+                f"Invalid status code {status} for {code}"
+            )
 
     def test_messages_are_non_empty_strings(self):
         """Test that all messages are non-empty strings."""
@@ -119,9 +119,9 @@ class TestErrorMetadata:
             expected_category = code_to_category.get(code_prefix)
 
             if expected_category:
-                assert (
-                    metadata.get("category") == expected_category
-                ), f"Category mismatch for {code}"
+                assert metadata.get("category") == expected_category, (
+                    f"Category mismatch for {code}"
+                )
 
 
 class TestAPIErrorContract:

--- a/tests/unit/robotics/test_contact.py
+++ b/tests/unit/robotics/test_contact.py
@@ -276,9 +276,9 @@ class TestLinearizeFrictionCone:
         for f in inside_forces:
             # Should satisfy A @ f <= b (approximately, due to linearization)
             violations = A @ f - b
-            assert np.all(
-                violations <= 1e-6
-            ), f"Force {f} should be inside linearized cone"
+            assert np.all(violations <= 1e-6), (
+                f"Force {f} should be inside linearized cone"
+            )
 
     def test_compute_friction_cone_constraint(self) -> None:
         """Test compute_friction_cone_constraint returns complete info."""

--- a/tests/unit/test_activation_dynamics.py
+++ b/tests/unit/test_activation_dynamics.py
@@ -203,9 +203,9 @@ class TestUpdate:
         dt = 0.100  # Large time step that might go negative
 
         a_new = dynamics.update(u, a, dt)
-        assert (
-            a_new >= dynamics.min_activation
-        ), "Activation should be clamped to min_activation"
+        assert a_new >= dynamics.min_activation, (
+            "Activation should be clamped to min_activation"
+        )
 
     def test_single_step_increases_activation(self, dynamics):
         """Test that a single step increases activation when u > a."""
@@ -372,12 +372,12 @@ class TestPhysiologicalRealism:
         """
         dynamics = ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
-        assert (
-            dynamics.tau_deact > dynamics.tau_act
-        ), "Deactivation should be slower than activation (physiological realism)"
-        assert (
-            dynamics.tau_deact / dynamics.tau_act == 4.0
-        ), "Typical ratio is 4:1 (deactivation:activation)"
+        assert dynamics.tau_deact > dynamics.tau_act, (
+            "Deactivation should be slower than activation (physiological realism)"
+        )
+        assert dynamics.tau_deact / dynamics.tau_act == 4.0, (
+            "Typical ratio is 4:1 (deactivation:activation)"
+        )
 
     def test_minimum_activation_prevents_division_by_zero(self):
         """Test that min_activation prevents numerical issues."""

--- a/tests/unit/test_api_security.py
+++ b/tests/unit/test_api_security.py
@@ -311,9 +311,7 @@ class TestPasswordSecurity:
                     mock_session.return_value = mock_db
 
                     # Mock query to return no admin user
-                    mock_db.query.return_value.filter.return_value.first.return_value = (
-                        None
-                    )
+                    mock_db.query.return_value.filter.return_value.first.return_value = None
 
                     # This should generate a random password but NOT log it
                     try:
@@ -409,12 +407,12 @@ class TestSecurityBestPractices:
         ]
 
         for pattern in suspicious_patterns:
-            assert (
-                pattern not in security_source.lower()
-            ), f"Found suspicious pattern in security.py: {pattern}"
-            assert (
-                pattern not in dependencies_source.lower()
-            ), f"Found suspicious pattern in dependencies.py: {pattern}"
+            assert pattern not in security_source.lower(), (
+                f"Found suspicious pattern in security.py: {pattern}"
+            )
+            assert pattern not in dependencies_source.lower(), (
+                f"Found suspicious pattern in dependencies.py: {pattern}"
+            )
 
     def test_secure_random_generation(self) -> None:
         """Test that secrets module is used for random generation."""

--- a/tests/unit/test_engine_interface_compliance.py
+++ b/tests/unit/test_engine_interface_compliance.py
@@ -120,9 +120,9 @@ class TestEngineInterfaceCompliance:
         for method_name in REQUIRED_METHODS:
             attr = getattr(cls, method_name, None)
             if attr is not None:
-                assert callable(
-                    attr
-                ), f"{class_name}.{method_name} exists but is not callable"
+                assert callable(attr), (
+                    f"{class_name}.{method_name} exists but is not callable"
+                )
 
     def test_get_capabilities_returns_dataclass(
         self, module_path: str, class_name: str, deps: list[str]
@@ -133,9 +133,9 @@ class TestEngineInterfaceCompliance:
         if cls is None:
             pytest.skip(f"{class_name} not found in {module_path}")
 
-        assert hasattr(
-            cls, "get_capabilities"
-        ), f"{class_name} must implement get_capabilities()"
+        assert hasattr(cls, "get_capabilities"), (
+            f"{class_name} must implement get_capabilities()"
+        )
 
     def test_contact_forces_not_abstract(
         self, module_path: str, class_name: str, deps: list[str]
@@ -153,9 +153,9 @@ class TestEngineInterfaceCompliance:
         method = getattr(cls, "compute_contact_forces", None)
         assert method is not None
         # Should NOT be abstract (base provides default)
-        assert not getattr(
-            method, "__isabstractmethod__", False
-        ), f"{class_name}.compute_contact_forces should not be abstract"
+        assert not getattr(method, "__isabstractmethod__", False), (
+            f"{class_name}.compute_contact_forces should not be abstract"
+        )
 
 
 class TestCapabilitySerialization:

--- a/tests/unit/test_equipment.py
+++ b/tests/unit/test_equipment.py
@@ -132,21 +132,21 @@ class TestEquipmentModule:
         for club_type, config in CLUB_CONFIGS.items():
             # Total length should be reasonable (0.5m to 1.5m)
             assert isinstance(config["total_length"], float)
-            assert (
-                0.5 <= config["total_length"] <= 1.5
-            ), f"{club_type} length {config['total_length']} outside realistic range"
+            assert 0.5 <= config["total_length"] <= 1.5, (
+                f"{club_type} length {config['total_length']} outside realistic range"
+            )
 
             # Head mass should be reasonable (100g to 500g)
             assert isinstance(config["head_mass"], float)
-            assert (
-                0.1 <= config["head_mass"] <= 0.5
-            ), f"{club_type} head mass {config['head_mass']} outside realistic range"
+            assert 0.1 <= config["head_mass"] <= 0.5, (
+                f"{club_type} head mass {config['head_mass']} outside realistic range"
+            )
 
             # Club loft should be in degrees converted to radians (0 to 90 degrees = 0 to 1.57 rad)
             assert isinstance(config["club_loft"], float)
-            assert (
-                0 <= config["club_loft"] <= 1.6
-            ), f"{club_type} loft {config['club_loft']} outside realistic range"
+            assert 0 <= config["club_loft"] <= 1.6, (
+                f"{club_type} loft {config['club_loft']} outside realistic range"
+            )
 
     def test_club_ordering_by_length(self) -> None:
         """Test that clubs follow expected length ordering: driver > 7-iron > wedge."""

--- a/tests/unit/test_flight_models.py
+++ b/tests/unit/test_flight_models.py
@@ -335,9 +335,9 @@ class TestPhysicalPlausibility:
             result = model.simulate(driver_launch)
 
             # Landing angle should be positive (descending)
-            assert (
-                result.landing_angle > 0
-            ), f"{model.name} landing: {result.landing_angle}"
+            assert result.landing_angle > 0, (
+                f"{model.name} landing: {result.landing_angle}"
+            )
             # Should be less than 90°
             assert result.landing_angle < 90
 

--- a/tests/unit/test_golf_suite_launcher.py
+++ b/tests/unit/test_golf_suite_launcher.py
@@ -234,9 +234,9 @@ class TestGolfSuiteLauncher:
         assert launcher_app is not None, "Launcher should be instantiated"
 
         # Verify PYQT6_AVAILABLE flag is set correctly for testing
-        assert (
-            golf_suite_launcher.PYQT6_AVAILABLE is True
-        ), "PYQT6_AVAILABLE should be True for launcher logic tests"
+        assert golf_suite_launcher.PYQT6_AVAILABLE is True, (
+            "PYQT6_AVAILABLE should be True for launcher logic tests"
+        )
 
         # Verify launcher has essential UI components (as mocked)
         assert hasattr(launcher_app, "log_text"), "Launcher should have log_text widget"

--- a/tests/unit/test_gui_coverage.py
+++ b/tests/unit/test_gui_coverage.py
@@ -79,12 +79,12 @@ class TestMuJoCoSimWidget:
 
         # Verify initialization parameters - check minimum size constraints
         # Note: Qt widgets may not have exact size until shown; verify minimum constraints are set
-        assert (
-            widget.minimumWidth() == 640
-        ), f"Minimum width should be 640, got {widget.minimumWidth()}"
-        assert (
-            widget.minimumHeight() == 480
-        ), f"Minimum height should be 480, got {widget.minimumHeight()}"
+        assert widget.minimumWidth() == 640, (
+            f"Minimum width should be 640, got {widget.minimumWidth()}"
+        )
+        assert widget.minimumHeight() == 480, (
+            f"Minimum height should be 480, got {widget.minimumHeight()}"
+        )
         assert hasattr(widget, "model")
         assert hasattr(widget, "data")
 
@@ -141,9 +141,9 @@ class TestMuJoCoSimWidget:
         _load_model_or_skip(widget, model_xml)
 
         # Verify model and data are loaded
-        assert (
-            widget.data is not None
-        ), "Model data should be loaded after load_model_from_xml"
+        assert widget.data is not None, (
+            "Model data should be loaded after load_model_from_xml"
+        )
 
         # First call reset_state to get the widget's canonical initial state
         # (reset_state sets qpos[0] = 0.2 for 1-DOF models)
@@ -271,9 +271,9 @@ class TestHumanoidLauncher:
         expected_attrs = ["centralWidget", "menuBar", "statusBar"]
         missing_attrs = [attr for attr in expected_attrs if not hasattr(launcher, attr)]
 
-        assert (
-            not missing_attrs
-        ), f"Launcher is missing expected widget attributes: {missing_attrs}"
+        assert not missing_attrs, (
+            f"Launcher is missing expected widget attributes: {missing_attrs}"
+        )
 
         launcher.close()
 

--- a/tests/unit/test_jacobian.py
+++ b/tests/unit/test_jacobian.py
@@ -151,9 +151,9 @@ class TestJacobianShape:
 
                 # Verify shape (6×nv)
                 assert J.shape[0] == 6, f"Expected 6 rows, got {J.shape[0]}"
-                assert (
-                    J.shape[1] == model.nv
-                ), f"Expected {model.nv} cols, got {J.shape[1]}"
+                assert J.shape[1] == model.nv, (
+                    f"Expected {model.nv} cols, got {J.shape[1]}"
+                )
 
         finally:
             Path(urdf_path).unlink(missing_ok=True)
@@ -240,9 +240,9 @@ class TestJacobianConsistency:
             pin_model = pin.buildModelFromUrdf(urdf_path)
 
             # Both should have same number of DOF
-            assert (
-                mj_model.nv == pin_model.nv
-            ), f"DOF mismatch: MuJoCo={mj_model.nv}, Pinocchio={pin_model.nv}"
+            assert mj_model.nv == pin_model.nv, (
+                f"DOF mismatch: MuJoCo={mj_model.nv}, Pinocchio={pin_model.nv}"
+            )
 
         finally:
             Path(urdf_path).unlink(missing_ok=True)

--- a/tests/unit/test_kinematic_sequence.py
+++ b/tests/unit/test_kinematic_sequence.py
@@ -196,9 +196,9 @@ class TestSpeedGain:
 
         for name in ["mid_proximal", "mid_distal", "distal"]:
             assert peak_map[name].speed_gain is not None
-            assert (
-                peak_map[name].speed_gain > 1.0
-            ), f"{name} speed gain should be > 1.0, got {peak_map[name].speed_gain}"
+            assert peak_map[name].speed_gain > 1.0, (
+                f"{name} speed gain should be > 1.0, got {peak_map[name].speed_gain}"
+            )
 
     def test_speed_gain_missing_segment(self) -> None:
         """Speed gain should handle missing segments gracefully."""
@@ -241,12 +241,12 @@ class TestDecelerationRate:
         peak_map = {p.name: p for p in result.peaks}
 
         for name in ["proximal", "mid_proximal", "mid_distal", "distal"]:
-            assert (
-                peak_map[name].deceleration_rate is not None
-            ), f"{name} should have deceleration_rate computed"
-            assert (
-                peak_map[name].deceleration_rate > 0
-            ), f"{name} deceleration_rate should be positive"
+            assert peak_map[name].deceleration_rate is not None, (
+                f"{name} should have deceleration_rate computed"
+            )
+            assert peak_map[name].deceleration_rate > 0, (
+                f"{name} deceleration_rate should be positive"
+            )
 
     def test_proximal_decelerates_faster(self) -> None:
         """Proximal segments should decelerate faster (braking effect)."""

--- a/tests/unit/test_launcher_diagnostics.py
+++ b/tests/unit/test_launcher_diagnostics.py
@@ -420,9 +420,9 @@ class TestTileLoadingVerification:
 
             missing = expected_ids - loaded_ids
             assert len(missing) == 0, f"Registry missing: {missing}"
-            assert (
-                len(all_models) >= 8
-            ), f"Expected at least 8 models, got {len(all_models)}"
+            assert len(all_models) >= 8, (
+                f"Expected at least 8 models, got {len(all_models)}"
+            )
 
         except ImportError as e:
             pytest.skip(f"Dependencies not available: {e}")

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -123,9 +123,9 @@ class TestLauncherUtilities:
         for dir_name in expected_dirs_either:
             root_path = project_root / dir_name
             src_path = project_root / "src" / dir_name
-            assert (
-                root_path.exists() or src_path.exists()
-            ), f"Directory {dir_name} should exist at root or under src/"
+            assert root_path.exists() or src_path.exists(), (
+                f"Directory {dir_name} should exist at root or under src/"
+            )
 
         for dir_name in expected_src_dirs:
             dir_path = project_root / "src" / dir_name

--- a/tests/unit/test_muscle_analysis.py
+++ b/tests/unit/test_muscle_analysis.py
@@ -222,9 +222,9 @@ class TestExtractSynergies:
         result = analyzer.extract_synergies(n_synergies=4)
 
         # VAF should be high
-        assert (
-            result.vaf > 0.80
-        ), "High number of synergies should give good reconstruction"
+        assert result.vaf > 0.80, (
+            "High number of synergies should give good reconstruction"
+        )
 
         # Reconstruction shape should match data
         assert result.reconstructed.shape == data.shape
@@ -298,9 +298,9 @@ class TestExtractSynergies:
         result = analyzer.extract_synergies(n_synergies=1)
 
         # VAF should be very high (near perfect reconstruction)
-        assert (
-            result.vaf > 0.98
-        ), f"VAF should be near 1.0 for rank-1 data, got {result.vaf}"
+        assert result.vaf > 0.98, (
+            f"VAF should be near 1.0 for rank-1 data, got {result.vaf}"
+        )
 
 
 @skip_if_unavailable("sklearn")
@@ -573,6 +573,6 @@ class TestNumericalAccuracy:
         result = analyzer.extract_synergies(n_synergies=n_muscles)
 
         # VAF should be very high (near 1.0)
-        assert (
-            result.vaf > 0.95
-        ), f"VAF with {n_muscles} synergies should be > 0.95, got {result.vaf}"
+        assert result.vaf > 0.95, (
+            f"VAF with {n_muscles} synergies should be > 0.95, got {result.vaf}"
+        )

--- a/tests/unit/test_muscle_contribution_closure.py
+++ b/tests/unit/test_muscle_contribution_closure.py
@@ -160,9 +160,9 @@ if MYOSUITE_AVAILABLE:
                 # Extensors (e.g., 'TRIlong') should induce negative
                 # This depends on MyoSuite's specific coordinate system
                 # Validation: Just check they are non-zero when active
-                assert (
-                    np.linalg.norm(a_muscle) > 1e-8
-                ), f"Muscle {muscle_name} induced zero acceleration"
+                assert np.linalg.norm(a_muscle) > 1e-8, (
+                    f"Muscle {muscle_name} induced zero acceleration"
+                )
 
                 # Log for inspection (useful for understanding muscle function)
                 print(f"{muscle_name}: a = {a_muscle[0]:.6f} rad/s²")

--- a/tests/unit/test_muscle_equilibrium.py
+++ b/tests/unit/test_muscle_equilibrium.py
@@ -75,9 +75,9 @@ class TestEquilibriumResidual:
         residual = solver._equilibrium_residual(l_CE, l_MT, activation, v_CE=0.0)
 
         # Residual should be very close to zero
-        assert (
-            abs(residual) < 1.0
-        ), f"Residual should be near zero, got {residual:.6f} N"
+        assert abs(residual) < 1.0, (
+            f"Residual should be near zero, got {residual:.6f} N"
+        )
 
     def test_residual_changes_sign_across_equilibrium(self, standard_muscle):
         """Test that residual changes sign across equilibrium point."""
@@ -100,9 +100,9 @@ class TestEquilibriumResidual:
 
         # Residuals should have opposite signs
         # Note: exact sign depends on force-length curves, but they should differ
-        assert (
-            residual_short * residual_long < 0
-        ), "Residuals should have opposite signs across equilibrium"
+        assert residual_short * residual_long < 0, (
+            "Residuals should have opposite signs across equilibrium"
+        )
 
     def test_residual_with_pennation(self, pennated_muscle):
         """Test residual calculation with pennated muscle."""
@@ -191,9 +191,9 @@ class TestSolveFiberLength:
             assert np.isfinite(l_CE), f"Solution should be finite at l_MT={l_MT}"
 
         # Longer muscle-tendon -> longer fiber (generally)
-        assert (
-            solutions[0] < solutions[-1]
-        ), "Longer muscle-tendon should have longer fiber"
+        assert solutions[0] < solutions[-1], (
+            "Longer muscle-tendon should have longer fiber"
+        )
 
     def test_custom_initial_guess(self, standard_muscle):
         """Test solver with custom initial guess."""
@@ -460,9 +460,9 @@ class TestPhysicalRealism:
         l_tendon_long = l_MT_long - l_CE_long
 
         # Longer muscle-tendon should have longer tendon
-        assert (
-            l_tendon_long > l_tendon_short
-        ), "Longer muscle-tendon should stretch tendon more"
+        assert l_tendon_long > l_tendon_short, (
+            "Longer muscle-tendon should stretch tendon more"
+        )
 
     def test_fiber_length_decreases_with_activation(self, standard_muscle):
         """Test that fiber shortens with higher activation (for given l_MT).
@@ -526,9 +526,9 @@ class TestPhysicalRealism:
         # Change should be small and smooth
         relative_change = abs(l_CE_perturbed - l_CE_nominal) / l_CE_nominal
 
-        assert (
-            relative_change < 0.05
-        ), f"Small perturbation caused large change: {relative_change * 100:.2f}%"
+        assert relative_change < 0.05, (
+            f"Small perturbation caused large change: {relative_change * 100:.2f}%"
+        )
 
 
 class TestNumericalAccuracy:
@@ -545,9 +545,9 @@ class TestNumericalAccuracy:
 
         # Residual should be much smaller than typical forces
         tolerance_N = 1.0  # 1 N tolerance
-        assert (
-            abs(residual) < tolerance_N
-        ), f"Residual {residual:.6f} N exceeds tolerance {tolerance_N} N"
+        assert abs(residual) < tolerance_N, (
+            f"Residual {residual:.6f} N exceeds tolerance {tolerance_N} N"
+        )
 
     def test_repeated_solves_give_consistent_results(self, standard_muscle):
         """Test that solving the same problem multiple times gives consistent results."""
@@ -637,9 +637,9 @@ class TestEdgeCases:
         l_CE = solver.solve_fiber_length(l_MT, activation)
 
         # Should have stretched fiber (long muscle-tendon)
-        assert (
-            l_CE > standard_muscle.params.l_opt
-        ), "Long muscle-tendon should have stretched fiber"
+        assert l_CE > standard_muscle.params.l_opt, (
+            "Long muscle-tendon should have stretched fiber"
+        )
 
     def test_pennated_muscle_equilibrium(self, pennated_muscle):
         """Test equilibrium with pennation angle."""

--- a/tests/unit/test_pendulum_putter_model.py
+++ b/tests/unit/test_pendulum_putter_model.py
@@ -133,9 +133,9 @@ class TestPendulumPutterModelPhysics:
 
         for link in result.links:
             if link.inertia.mass > 1e-6:  # Skip negligible mass links
-                assert (
-                    link.inertia.is_positive_definite()
-                ), f"Link {link.name} has non-positive-definite inertia"
+                assert link.inertia.is_positive_definite(), (
+                    f"Link {link.name} has non-positive-definite inertia"
+                )
 
     def test_pendulum_joint_has_appropriate_limits(self):
         """Pendulum joint should have reasonable angle limits."""
@@ -320,9 +320,9 @@ class TestURDFGeneration:
             if link.attrib["name"] != "world":
                 # Should have inertial (except world)
                 inertial = link.find("inertial")
-                assert (
-                    inertial is not None
-                ), f"Link {link.attrib['name']} missing inertial"
+                assert inertial is not None, (
+                    f"Link {link.attrib['name']} missing inertial"
+                )
 
     def test_can_save_to_file(self, tmp_path: Path):
         """Should be able to save URDF to file."""
@@ -411,9 +411,9 @@ class TestValidation:
         result = builder.build()
 
         assert result.validation is not None
-        assert (
-            result.validation.is_valid
-        ), f"Validation failed: {result.validation.get_error_messages()}"
+        assert result.validation.is_valid, (
+            f"Validation failed: {result.validation.get_error_messages()}"
+        )
 
     def test_validation_catches_invalid_parameters(self):
         """Should catch invalid configuration parameters."""

--- a/tests/unit/test_pendulum_putter_physics.py
+++ b/tests/unit/test_pendulum_putter_physics.py
@@ -82,9 +82,9 @@ class TestMuJoCoIntegration:
 
             if model.nq > 0:
                 final_angle = data.qpos[0]
-                assert (
-                    abs(final_angle) < abs(initial_angle) + 0.5
-                ), "Pendulum should be oscillating, not diverging"
+                assert abs(final_angle) < abs(initial_angle) + 0.5, (
+                    "Pendulum should be oscillating, not diverging"
+                )
 
         except Exception as e:
             pytest.skip(f"MuJoCo simulation test skipped: {e}")
@@ -109,9 +109,9 @@ class TestModelValidationForEngines:
 
             assert link.inertia is not None, f"Link {link.name} missing inertia"
             assert link.inertia.mass > 0, f"Link {link.name} has zero/negative mass"
-            assert (
-                link.inertia.is_positive_definite()
-            ), f"Link {link.name} has invalid inertia tensor"
+            assert link.inertia.is_positive_definite(), (
+                f"Link {link.name} has invalid inertia tensor"
+            )
 
     def test_all_joints_have_valid_axes(self, model_result):
         """All joints should have valid, normalized axes."""
@@ -121,9 +121,9 @@ class TestModelValidationForEngines:
 
             axis = np.array(joint.axis)
             norm = np.linalg.norm(axis)
-            assert (
-                abs(norm - 1.0) < 1e-6
-            ), f"Joint {joint.name} axis not normalized: {joint.axis}"
+            assert abs(norm - 1.0) < 1e-6, (
+                f"Joint {joint.name} axis not normalized: {joint.axis}"
+            )
 
     def test_joint_limits_are_consistent(self, model_result):
         """Joint limits should be valid (lower < upper)."""
@@ -141,12 +141,12 @@ class TestModelValidationForEngines:
         link_names = {link.name for link in model_result.links}
 
         for joint in model_result.joints:
-            assert (
-                joint.parent in link_names
-            ), f"Joint {joint.name} has missing parent: {joint.parent}"
-            assert (
-                joint.child in link_names
-            ), f"Joint {joint.name} has missing child: {joint.child}"
+            assert joint.parent in link_names, (
+                f"Joint {joint.name} has missing parent: {joint.parent}"
+            )
+            assert joint.child in link_names, (
+                f"Joint {joint.name} has missing child: {joint.child}"
+            )
 
 
 class TestPendulumPhysicsProperties:

--- a/tests/unit/test_physical_constants_xml.py
+++ b/tests/unit/test_physical_constants_xml.py
@@ -28,9 +28,9 @@ class TestPhysicalConstantXMLSafety:
         assert option_elem is not None, "option element not found"
         gravity_attr = option_elem.get("gravity")
         assert gravity_attr is not None, "gravity attribute not found"
-        assert (
-            "PhysicalConstant" not in gravity_attr
-        ), "PhysicalConstant.__repr__ leaked into XML"
+        assert "PhysicalConstant" not in gravity_attr, (
+            "PhysicalConstant.__repr__ leaked into XML"
+        )
 
         # Verify parseable as floats
         g_components = gravity_attr.split()
@@ -46,9 +46,9 @@ class TestPhysicalConstantXMLSafety:
         xml_string = f'<option gravity="0 0 -{GRAVITY_M_S2}"/>'
 
         # This will include the __repr__ representation
-        assert (
-            "PhysicalConstant" in xml_string
-        ), "Test assumption wrong: __repr__ should appear"
+        assert "PhysicalConstant" in xml_string, (
+            "Test assumption wrong: __repr__ should appear"
+        )
 
         # Parsing may succeed but value is garbage
         root = ET.fromstring(f"<root>{xml_string}</root>")

--- a/tests/unit/test_property_based_physics.py
+++ b/tests/unit/test_property_based_physics.py
@@ -139,9 +139,9 @@ class TestBallFlightProperties:
 
         # Drag should oppose relative velocity (zero wind => relative = velocity)
         dot = float(np.dot(drag, velocity))
-        assert (
-            dot <= 1e-10
-        ), f"Drag should oppose velocity: dot={dot}, drag={drag}, vel={velocity}"
+        assert dot <= 1e-10, (
+            f"Drag should oppose velocity: dot={dot}, drag={drag}, vel={velocity}"
+        )
 
     @given(
         velocity=nonzero_velocity,
@@ -273,9 +273,9 @@ class TestBallFlightProperties:
             return
 
         ratio = drag_scaled_mag / drag_base_mag
-        assert (
-            abs(ratio - density_factor) < 0.01
-        ), f"Drag should scale by {density_factor}, got ratio {ratio}"
+        assert abs(ratio - density_factor) < 0.01, (
+            f"Drag should scale by {density_factor}, got ratio {ratio}"
+        )
 
 
 # ============================================================================
@@ -318,15 +318,15 @@ class TestPhaseDetectionProperties:
 
         # Check that first phase starts at or before time[0]
         first_start = phases[0].start_time
-        assert (
-            first_start <= times[0] + 1e-10
-        ), f"First phase start {first_start} should be <= {times[0]}"
+        assert first_start <= times[0] + 1e-10, (
+            f"First phase start {first_start} should be <= {times[0]}"
+        )
 
         # Check that last phase ends at or after the last time
         last_end = phases[-1].end_time
-        assert (
-            last_end >= times[-1] - 1e-10
-        ), f"Last phase end {last_end} should be >= {times[-1]}"
+        assert last_end >= times[-1] - 1e-10, (
+            f"Last phase end {last_end} should be >= {times[-1]}"
+        )
 
     @given(
         n_points=st.integers(min_value=50, max_value=500),
@@ -387,12 +387,12 @@ class TestPhaseDetectionProperties:
         phases = detector.detect_swing_phases()
 
         for phase in phases:
-            assert (
-                phase.duration >= 0.0
-            ), f"Phase '{phase.name}' has negative duration: {phase.duration}"
-            assert (
-                phase.end_time >= phase.start_time
-            ), f"Phase '{phase.name}' end_time={phase.end_time} < start_time={phase.start_time}"
+            assert phase.duration >= 0.0, (
+                f"Phase '{phase.name}' has negative duration: {phase.duration}"
+            )
+            assert phase.end_time >= phase.start_time, (
+                f"Phase '{phase.name}' end_time={phase.end_time} < start_time={phase.start_time}"
+            )
 
 
 # ============================================================================
@@ -429,9 +429,9 @@ class TestSwingOptimizerConfigProperties:
         bounds = optimizer._get_bounds()
 
         for i, (lo, hi) in enumerate(bounds):
-            assert (
-                lo <= hi
-            ), f"Bound index {i}: lower={lo} > upper={hi} (flexibility={flexibility})"
+            assert lo <= hi, (
+                f"Bound index {i}: lower={lo} > upper={hi} (flexibility={flexibility})"
+            )
 
     @given(
         # flexibility_factor >= 1.0 ensures scaled bounds encompass the raw
@@ -478,17 +478,17 @@ class TestSwingOptimizerConfigProperties:
         x0 = optimizer._generate_initial_guess()
         bounds = optimizer._get_bounds()
 
-        assert len(x0) == len(
-            bounds
-        ), f"Initial guess length {len(x0)} != bounds length {len(bounds)}"
+        assert len(x0) == len(bounds), (
+            f"Initial guess length {len(x0)} != bounds length {len(bounds)}"
+        )
 
         n_angle_vars = len(optimizer.JOINTS) * n_nodes
         # Angle portion: must be strictly within joint-limit bounds
         for i in range(n_angle_vars):
             lo, hi = bounds[i]
-            assert (
-                lo - 1e-6 <= x0[i] <= hi + 1e-6
-            ), f"Angle x0[{i}]={x0[i]} not in [{lo}, {hi}]"
+            assert lo - 1e-6 <= x0[i] <= hi + 1e-6, (
+                f"Angle x0[{i}]={x0[i]} not in [{lo}, {hi}]"
+            )
 
 
 # ============================================================================
@@ -503,9 +503,9 @@ class TestPhysicalConstantsProperties:
         """Property: gravity is within the expected range (9.7 to 9.9 m/s^2)."""
         g = float(physics_constants.GRAVITY_M_S2)
         assert 9.7 < g < 9.9, f"Gravity={g} outside expected range [9.7, 9.9]"
-        assert g == pytest.approx(
-            9.80665, abs=1e-5
-        ), f"Gravity={g} should be standard gravity 9.80665"
+        assert g == pytest.approx(9.80665, abs=1e-5), (
+            f"Gravity={g} should be standard gravity 9.80665"
+        )
 
     def test_all_physical_constants_positive_and_finite(self) -> None:
         """Property: all physical constants defined via PhysicalConstant are positive and finite."""
@@ -520,9 +520,9 @@ class TestPhysicalConstantsProperties:
                 constants_checked += 1
 
         # Ensure we actually checked a meaningful number of constants
-        assert (
-            constants_checked >= 10
-        ), f"Only checked {constants_checked} constants; expected at least 10"
+        assert constants_checked >= 10, (
+            f"Only checked {constants_checked} constants; expected at least 10"
+        )
 
     def test_precomputed_floats_match_source_constants(self) -> None:
         """Property: pre-computed float values match their source constants."""
@@ -574,17 +574,17 @@ class TestPhysicalConstantsProperties:
 
         # deg -> rad -> deg should roundtrip
         roundtripped = value * deg_to_rad * rad_to_deg
-        assert roundtripped == pytest.approx(
-            value, rel=1e-10
-        ), f"DEG->RAD->DEG roundtrip: {value} -> {roundtripped}"
+        assert roundtripped == pytest.approx(value, rel=1e-10), (
+            f"DEG->RAD->DEG roundtrip: {value} -> {roundtripped}"
+        )
 
         ft_to_m = float(physics_constants.FT_TO_M)
         m_to_ft = float(physics_constants.M_TO_FT)
 
         roundtripped_ft = value * ft_to_m * m_to_ft
-        assert roundtripped_ft == pytest.approx(
-            value, rel=1e-6
-        ), f"FT->M->FT roundtrip: {value} -> {roundtripped_ft}"
+        assert roundtripped_ft == pytest.approx(value, rel=1e-6), (
+            f"FT->M->FT roundtrip: {value} -> {roundtripped_ft}"
+        )
 
 
 # ============================================================================
@@ -691,9 +691,9 @@ class TestRRTPlannerProperties:
 
         if result.success:
             end_dist = float(np.linalg.norm(result.path[-1] - q_goal))
-            assert (
-                end_dist <= goal_tol + 1e-10
-            ), f"Path end distance to goal {end_dist} exceeds tolerance {goal_tol}"
+            assert end_dist <= goal_tol + 1e-10, (
+                f"Path end distance to goal {end_dist} exceeds tolerance {goal_tol}"
+            )
 
     @given(
         ndof=st.integers(min_value=2, max_value=6),

--- a/tests/unit/test_shared_engine_manager.py
+++ b/tests/unit/test_shared_engine_manager.py
@@ -25,17 +25,13 @@ class TestEngineManager(unittest.TestCase):
             "src.shared.python.engine_core.engine_probes.MuJoCoProbe"
         )
         self.mock_mujoco_probe_cls = self.mujoco_patcher.start()
-        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = (
-            True
-        )
+        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = True
 
         self.drake_patcher = patch(
             "src.shared.python.engine_core.engine_probes.DrakeProbe"
         )
         self.mock_drake_probe_cls = self.drake_patcher.start()
-        self.mock_drake_probe_cls.return_value.probe.return_value.is_available.return_value = (
-            True
-        )
+        self.mock_drake_probe_cls.return_value.probe.return_value.is_available.return_value = True
 
         self.pinocchio_patcher = patch(
             "src.shared.python.engine_core.engine_probes.PinocchioProbe"
@@ -135,9 +131,7 @@ class TestEngineManager(unittest.TestCase):
         manager.engine_paths[EngineType.MUJOCO] = Path("/mock/mujoco")
 
         # Configure probe specifically for this test
-        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = (
-            True
-        )
+        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = True
 
         mock_mujoco_pkg = MagicMock()
         mock_mujoco_pkg.__version__ = "3.2.3"

--- a/tests/unit/test_ux_enhancements.py
+++ b/tests/unit/test_ux_enhancements.py
@@ -195,9 +195,9 @@ def test_status_info_contrast(mocked_launcher_module):
         assert bg == exp_bg, f"Background color mismatch for {m_type}"
 
         # This assertion defines our requirement for the new feature
-        assert (
-            text_color == exp_text
-        ), f"Text color mismatch for {m_type}. Expected {exp_text}, got {text_color}"
+        assert text_color == exp_text, (
+            f"Text color mismatch for {m_type}. Expected {exp_text}, got {text_color}"
+        )
 
 
 @pytest.mark.skip(reason="QShortcut mocking with complex imports is flaky")


### PR DESCRIPTION
Fixes #789. Root causes: torch OSError on Windows, incomplete Drake check, defusedxml misuse for XML creation, wrong import path in test_ai_workflow. 4155 tests now collect cleanly (was 3106 with 62 errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactors, but changes to optional dependency probing and the `defusedxml`→stdlib XML switch could alter behavior in edge environments and reduce XML hardening if untrusted inputs are ever parsed.
> 
> **Overview**
> Fixes widespread test collection failures primarily via *compatibility and import-safety tweaks*.
> 
> Key behavior changes: optional dependency detection is hardened (notably Drake now probes `pydrake.all`, and several optional imports tolerate `OSError` as well as `ImportError`, improving Windows behavior), URDF generation switches from `defusedxml` to stdlib `xml.etree`/`minidom`, and the AI workflow test imports `create_first_analysis_workflow` from the correct module.
> 
> The remainder is largely mechanical formatting to satisfy linters/pytest collection (reflowed asserts/excepts, minor function signature wrapping) across tests, launchers, and utilities without altering runtime logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de548808023495023e6dd214cab3794b876abf42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->