### PR TITLE
feat: wave 3 runtime DbC contracts - 5 modules + 73 tests

### DIFF
--- a/src/shared/python/analysis/grf_metrics.py
+++ b/src/shared/python/analysis/grf_metrics.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from src.shared.python.analysis.dataclasses import GRFMetrics
+from src.shared.python.core.contracts import ensure
 
 
 class GRFMetricsMixin:
@@ -10,6 +11,13 @@ class GRFMetricsMixin:
 
     def compute_grf_metrics(self) -> GRFMetrics | None:
         """Compute Ground Reaction Force and Center of Pressure metrics.
+
+        Design by Contract:
+            Postconditions:
+                - cop_path_length >= 0 (path length is non-negative)
+                - cop_max_velocity >= 0 (velocity magnitude is non-negative)
+                - cop_x_range >= 0 and cop_y_range >= 0
+                - all returned values are finite
 
         Returns:
             GRFMetrics object or None if data unavailable
@@ -52,7 +60,7 @@ class GRFMetricsMixin:
                 shear = np.hypot(ground_forces[:, 0], ground_forces[:, 1])
                 peak_shear = float(np.max(shear))
 
-        return GRFMetrics(
+        result = GRFMetrics(
             cop_path_length=float(path_length),
             cop_max_velocity=float(max_vel),
             cop_x_range=x_range,
@@ -60,3 +68,32 @@ class GRFMetricsMixin:
             peak_vertical_force=peak_vertical,
             peak_shear_force=peak_shear,
         )
+
+        # Postconditions
+        ensure(
+            result.cop_path_length >= 0,
+            "CoP path length must be non-negative",
+            result.cop_path_length,
+        )
+        ensure(
+            result.cop_max_velocity >= 0,
+            "CoP max velocity must be non-negative",
+            result.cop_max_velocity,
+        )
+        ensure(
+            result.cop_x_range >= 0,
+            "CoP X range must be non-negative",
+            result.cop_x_range,
+        )
+        ensure(
+            result.cop_y_range >= 0,
+            "CoP Y range must be non-negative",
+            result.cop_y_range,
+        )
+        ensure(
+            np.isfinite(result.cop_path_length),
+            "CoP path length must be finite",
+            result.cop_path_length,
+        )
+
+        return result

--- a/tests/unit/dbc/test_dbc_runtime_grf_metrics.py
+++ b/tests/unit/dbc/test_dbc_runtime_grf_metrics.py
@@ -1,0 +1,122 @@
+"""Runtime DbC tests for GRF metrics contracts.
+
+Tests the ensure() postconditions added to compute_grf_metrics:
+- cop_path_length >= 0
+- cop_max_velocity >= 0
+- cop_x_range >= 0, cop_y_range >= 0
+- cop_path_length is finite
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+
+class TestGRFMetricsPostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on compute_grf_metrics."""
+
+    def _make_mixin(
+        self,
+        cop: np.ndarray | None = None,
+        forces: np.ndarray | None = None,
+        dt: float = 0.01,
+    ) -> object:
+        from src.shared.python.analysis.grf_metrics import GRFMetricsMixin
+
+        obj = MagicMock(spec=GRFMetricsMixin)
+        obj.cop_position = cop
+        obj.ground_forces = forces
+        obj.dt = dt
+        # Bind the real method
+        obj.compute_grf_metrics = GRFMetricsMixin.compute_grf_metrics.__get__(obj)
+        return obj
+
+    def test_returns_none_for_no_cop(self) -> None:
+        obj = self._make_mixin(cop=None)
+        result = obj.compute_grf_metrics()
+        self.assertIsNone(result)
+
+    def test_returns_none_for_empty_cop(self) -> None:
+        obj = self._make_mixin(cop=np.empty((0, 2)))
+        result = obj.compute_grf_metrics()
+        self.assertIsNone(result)
+
+    def test_path_length_non_negative_2d(self) -> None:
+        rng = np.random.default_rng(42)
+        cop = rng.standard_normal((100, 2)).cumsum(axis=0)
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result.cop_path_length, 0)
+
+    def test_path_length_non_negative_3d(self) -> None:
+        rng = np.random.default_rng(42)
+        cop = rng.standard_normal((100, 3)).cumsum(axis=0)
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result.cop_path_length, 0)
+
+    def test_max_velocity_non_negative(self) -> None:
+        rng = np.random.default_rng(42)
+        cop = rng.standard_normal((100, 2)).cumsum(axis=0)
+        obj = self._make_mixin(cop=cop, dt=0.01)
+        result = obj.compute_grf_metrics()
+        self.assertGreaterEqual(result.cop_max_velocity, 0)
+
+    def test_max_velocity_zero_for_zero_dt(self) -> None:
+        rng = np.random.default_rng(42)
+        cop = rng.standard_normal((50, 2)).cumsum(axis=0)
+        obj = self._make_mixin(cop=cop, dt=0.0)
+        result = obj.compute_grf_metrics()
+        self.assertEqual(result.cop_max_velocity, 0.0)
+
+    def test_x_range_non_negative(self) -> None:
+        cop = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertGreaterEqual(result.cop_x_range, 0)
+
+    def test_y_range_non_negative(self) -> None:
+        cop = np.array([[0.0, 0.0], [0.0, 1.0], [0.0, 2.0]])
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertGreaterEqual(result.cop_y_range, 0)
+
+    def test_path_length_is_finite(self) -> None:
+        cop = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]])
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertTrue(np.isfinite(result.cop_path_length))
+
+    def test_stationary_cop_zero_path(self) -> None:
+        cop = np.ones((50, 2))
+        obj = self._make_mixin(cop=cop)
+        result = obj.compute_grf_metrics()
+        self.assertAlmostEqual(result.cop_path_length, 0.0)
+
+    def test_force_metrics_with_ground_forces(self) -> None:
+        cop = np.ones((50, 2))
+        forces = np.zeros((50, 3))
+        forces[:, 2] = 500.0  # vertical
+        forces[:, 0] = 10.0  # shear x
+        obj = self._make_mixin(cop=cop, forces=forces)
+        result = obj.compute_grf_metrics()
+        self.assertIsNotNone(result.peak_vertical_force)
+        self.assertAlmostEqual(result.peak_vertical_force, 500.0)
+        self.assertIsNotNone(result.peak_shear_force)
+        self.assertGreater(result.peak_shear_force, 0)
+
+    def test_no_force_metrics_without_ground_forces(self) -> None:
+        cop = np.ones((50, 2))
+        obj = self._make_mixin(cop=cop, forces=None)
+        result = obj.compute_grf_metrics()
+        self.assertIsNone(result.peak_vertical_force)
+        self.assertIsNone(result.peak_shear_force)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/dbc/test_dbc_runtime_muscle_equilibrium.py
+++ b/tests/unit/dbc/test_dbc_runtime_muscle_equilibrium.py
@@ -1,0 +1,218 @@
+"""Runtime DbC tests for muscle equilibrium solver contracts.
+
+Tests the require()/ensure() contracts added to:
+- EquilibriumSolver.solve_fiber_length (preconditions: l_MT>0, activation in [0,1];
+  postconditions: result>0, finite)
+- EquilibriumSolver.solve_fiber_velocity (preconditions: dt>0, l_CE>0;
+  postcondition: finite)
+- compute_equilibrium_state (preconditions + postconditions)
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+
+def _make_muscle() -> object:
+    """Create a standard HillMuscleModel for testing."""
+    from src.shared.python.biomechanics.hill_muscle import (
+        HillMuscleModel,
+        MuscleParameters,
+    )
+
+    params = MuscleParameters(
+        F_max=1000.0,
+        l_opt=0.12,
+        l_slack=0.25,
+        v_max=1.2,
+        pennation_angle=0.0,
+    )
+    return HillMuscleModel(params)
+
+
+class TestSolveFiberLengthPreconditions(unittest.TestCase):
+    """Verify require() preconditions on solve_fiber_length."""
+
+    def test_valid_solve(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        l_CE = solver.solve_fiber_length(l_MT=0.37, activation=0.5)
+        self.assertGreater(l_CE, 0)
+        self.assertTrue(np.isfinite(l_CE))
+
+    def test_negative_l_MT_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_length(l_MT=-0.1, activation=0.5)
+
+    def test_zero_l_MT_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_length(l_MT=0.0, activation=0.5)
+
+    def test_activation_above_one_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_length(l_MT=0.37, activation=1.5)
+
+    def test_activation_below_zero_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_length(l_MT=0.37, activation=-0.1)
+
+    def test_activation_at_boundaries(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        # activation=0.0 and activation=1.0 should both be valid
+        l_CE_0 = solver.solve_fiber_length(l_MT=0.37, activation=0.0)
+        self.assertGreater(l_CE_0, 0)
+        l_CE_1 = solver.solve_fiber_length(l_MT=0.37, activation=1.0)
+        self.assertGreater(l_CE_1, 0)
+
+
+class TestSolveFiberVelocityPreconditions(unittest.TestCase):
+    """Verify require() preconditions on solve_fiber_velocity."""
+
+    def test_valid_solve_velocity(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        l_CE = solver.solve_fiber_length(l_MT=0.37, activation=0.5)
+        v_CE = solver.solve_fiber_velocity(
+            l_MT=0.37, v_MT=0.01, activation=0.5, l_CE=l_CE, dt=0.001
+        )
+        self.assertTrue(np.isfinite(v_CE))
+
+    def test_zero_dt_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_velocity(
+                l_MT=0.37, v_MT=0.01, activation=0.5, l_CE=0.1, dt=0.0
+            )
+
+    def test_negative_dt_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_velocity(
+                l_MT=0.37, v_MT=0.01, activation=0.5, l_CE=0.1, dt=-0.001
+            )
+
+    def test_zero_l_CE_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_velocity(
+                l_MT=0.37, v_MT=0.01, activation=0.5, l_CE=0.0, dt=0.001
+            )
+
+    def test_negative_l_CE_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            EquilibriumSolver,
+        )
+
+        muscle = _make_muscle()
+        solver = EquilibriumSolver(muscle)
+        with self.assertRaises((ValueError, Exception)):
+            solver.solve_fiber_velocity(
+                l_MT=0.37, v_MT=0.01, activation=0.5, l_CE=-0.1, dt=0.001
+            )
+
+
+class TestComputeEquilibriumStatePreconditions(unittest.TestCase):
+    """Verify require()/ensure() on compute_equilibrium_state."""
+
+    def test_valid_equilibrium(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            compute_equilibrium_state,
+        )
+
+        muscle = _make_muscle()
+        l_CE, v_CE = compute_equilibrium_state(
+            muscle, l_MT=0.37, v_MT=0.0, activation=0.5
+        )
+        self.assertGreater(l_CE, 0)
+        self.assertTrue(np.isfinite(l_CE))
+        self.assertTrue(np.isfinite(v_CE))
+        self.assertEqual(v_CE, 0.0)  # static case
+
+    def test_negative_l_MT_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            compute_equilibrium_state,
+        )
+
+        muscle = _make_muscle()
+        with self.assertRaises((ValueError, Exception)):
+            compute_equilibrium_state(muscle, l_MT=-0.1, v_MT=0.0, activation=0.5)
+
+    def test_activation_out_of_range_raises(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            compute_equilibrium_state,
+        )
+
+        muscle = _make_muscle()
+        with self.assertRaises((ValueError, Exception)):
+            compute_equilibrium_state(muscle, l_MT=0.37, v_MT=0.0, activation=2.0)
+
+    def test_with_nonzero_velocity(self) -> None:
+        from src.shared.python.biomechanics.muscle_equilibrium import (
+            compute_equilibrium_state,
+        )
+
+        muscle = _make_muscle()
+        l_CE, v_CE = compute_equilibrium_state(
+            muscle, l_MT=0.37, v_MT=0.01, activation=0.5
+        )
+        self.assertGreater(l_CE, 0)
+        self.assertTrue(np.isfinite(l_CE))
+        self.assertTrue(np.isfinite(v_CE))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/dbc/test_dbc_runtime_nonlinear_dynamics.py
+++ b/tests/unit/dbc/test_dbc_runtime_nonlinear_dynamics.py
@@ -1,0 +1,187 @@
+"""Runtime DbC tests for nonlinear dynamics contracts.
+
+Tests the require()/ensure() contracts added to:
+- estimate_lyapunov_exponent (preconditions: tau>=1, dim>=1, window>=1; postcondition: finite)
+- compute_permutation_entropy (preconditions: order>=2, delay>=1; postcondition: >=0)
+- compute_sample_entropy (preconditions: m>=1, r>0; postcondition: >=0)
+- compute_fractal_dimension (precondition: k_max>=1; postcondition: finite)
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+
+def _make_mixin(n: int = 500, n_joints: int = 3, dt: float = 0.01) -> object:
+    """Create a mock NonlinearDynamicsMixin with realistic data."""
+    from src.shared.python.analysis.nonlinear_dynamics import NonlinearDynamicsMixin
+
+    rng = np.random.default_rng(42)
+    obj = MagicMock(spec=NonlinearDynamicsMixin)
+    t = np.arange(n) * dt
+    obj.times = t
+    obj.dt = dt
+    obj.joint_positions = rng.standard_normal((n, n_joints)).cumsum(axis=0)
+    obj.joint_velocities = rng.standard_normal((n, n_joints))
+
+    # Bind real methods
+    obj.compute_permutation_entropy = (
+        NonlinearDynamicsMixin.compute_permutation_entropy.__get__(obj)
+    )
+    obj.compute_sample_entropy = NonlinearDynamicsMixin.compute_sample_entropy.__get__(
+        obj
+    )
+    obj.compute_fractal_dimension = (
+        NonlinearDynamicsMixin.compute_fractal_dimension.__get__(obj)
+    )
+    obj.estimate_lyapunov_exponent = (
+        NonlinearDynamicsMixin.estimate_lyapunov_exponent.__get__(obj)
+    )
+    return obj
+
+
+class TestPermutationEntropyContracts(unittest.TestCase):
+    """Verify require()/ensure() on compute_permutation_entropy."""
+
+    def test_valid_permutation_entropy(self) -> None:
+        obj = _make_mixin()
+        data = np.sin(np.linspace(0, 10 * np.pi, 200))
+        result = obj.compute_permutation_entropy(data, order=3, delay=1)
+        self.assertGreaterEqual(result, 0.0)
+
+    def test_order_less_than_2_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_permutation_entropy(np.ones(50), order=1, delay=1)
+
+    def test_order_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_permutation_entropy(np.ones(50), order=0, delay=1)
+
+    def test_delay_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_permutation_entropy(np.ones(50), order=3, delay=0)
+
+    def test_short_data_returns_zero(self) -> None:
+        obj = _make_mixin()
+        result = obj.compute_permutation_entropy(np.array([1.0, 2.0]), order=5, delay=1)
+        self.assertEqual(result, 0.0)
+
+    def test_constant_signal_low_entropy(self) -> None:
+        obj = _make_mixin()
+        result = obj.compute_permutation_entropy(np.ones(100), order=3, delay=1)
+        self.assertEqual(result, 0.0)
+
+    def test_random_signal_higher_entropy(self) -> None:
+        obj = _make_mixin()
+        rng = np.random.default_rng(42)
+        result = obj.compute_permutation_entropy(
+            rng.standard_normal(500), order=3, delay=1
+        )
+        self.assertGreater(result, 0.0)
+
+
+class TestSampleEntropyContracts(unittest.TestCase):
+    """Verify require()/ensure() on compute_sample_entropy."""
+
+    def test_valid_sample_entropy(self) -> None:
+        obj = _make_mixin()
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal(200)
+        result = obj.compute_sample_entropy(data, m=2, r=0.2)
+        self.assertGreaterEqual(result, 0.0)
+
+    def test_m_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_sample_entropy(np.ones(50), m=0, r=0.2)
+
+    def test_r_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_sample_entropy(np.ones(50), m=2, r=0.0)
+
+    def test_r_negative_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_sample_entropy(np.ones(50), m=2, r=-0.1)
+
+    def test_short_data_returns_zero(self) -> None:
+        obj = _make_mixin()
+        result = obj.compute_sample_entropy(np.array([1.0]), m=2, r=0.2)
+        self.assertEqual(result, 0.0)
+
+
+class TestFractalDimensionContracts(unittest.TestCase):
+    """Verify require()/ensure() on compute_fractal_dimension."""
+
+    def test_valid_fractal_dimension(self) -> None:
+        obj = _make_mixin()
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal(200)
+        result = obj.compute_fractal_dimension(data, k_max=10)
+        self.assertTrue(np.isfinite(result))
+
+    def test_k_max_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_fractal_dimension(np.ones(50), k_max=0)
+
+    def test_k_max_negative_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_fractal_dimension(np.ones(50), k_max=-5)
+
+    def test_short_data_returns_default(self) -> None:
+        obj = _make_mixin()
+        result = obj.compute_fractal_dimension(np.array([1.0, 2.0]), k_max=10)
+        self.assertEqual(result, 1.0)
+
+    def test_result_is_finite(self) -> None:
+        obj = _make_mixin()
+        rng = np.random.default_rng(123)
+        data = rng.standard_normal(300)
+        result = obj.compute_fractal_dimension(data, k_max=5)
+        self.assertTrue(np.isfinite(result))
+
+
+class TestLyapunovExponentContracts(unittest.TestCase):
+    """Verify require()/ensure() on estimate_lyapunov_exponent."""
+
+    def test_valid_lyapunov(self) -> None:
+        obj = _make_mixin(n=300)
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal(300)
+        result = obj.estimate_lyapunov_exponent(data, tau=1, dim=3, window=10)
+        self.assertTrue(np.isfinite(result))
+
+    def test_tau_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.estimate_lyapunov_exponent(np.ones(100), tau=0, dim=3, window=10)
+
+    def test_dim_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.estimate_lyapunov_exponent(np.ones(100), tau=1, dim=0, window=10)
+
+    def test_window_zero_raises(self) -> None:
+        obj = _make_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.estimate_lyapunov_exponent(np.ones(100), tau=1, dim=3, window=0)
+
+    def test_short_data_returns_zero(self) -> None:
+        obj = _make_mixin()
+        result = obj.estimate_lyapunov_exponent(
+            np.array([1.0, 2.0]), tau=1, dim=3, window=10
+        )
+        self.assertEqual(result, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/dbc/test_dbc_runtime_pca_power.py
+++ b/tests/unit/dbc/test_dbc_runtime_pca_power.py
@@ -1,0 +1,233 @@
+"""Runtime DbC tests for PCA analysis and power/work contracts.
+
+Tests contracts added to:
+- PCA: variance ratios sum <= 1, non-negative variance, n_components >= 1
+- Kinematic sequence: efficiency in [0,1], peak velocities >= 0
+- Power/Work: positive_work >= 0, negative_work <= 0, finite values,
+  duration >= 0, path length >= 0
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+
+def _make_pca_mixin(n: int = 100, n_joints: int = 3) -> object:
+    """Create a mock PCAAnalysisMixin."""
+    from src.shared.python.analysis.pca_analysis import PCAAnalysisMixin
+
+    rng = np.random.default_rng(42)
+    obj = MagicMock(spec=PCAAnalysisMixin)
+    obj.times = np.linspace(0, 1, n)
+    obj.joint_positions = rng.standard_normal((n, n_joints))
+    obj.joint_velocities = rng.standard_normal((n, n_joints))
+
+    obj.compute_principal_component_analysis = (
+        PCAAnalysisMixin.compute_principal_component_analysis.__get__(obj)
+    )
+    obj.compute_principal_movements = (
+        PCAAnalysisMixin.compute_principal_movements.__get__(obj)
+    )
+    obj.analyze_kinematic_sequence = (
+        PCAAnalysisMixin.analyze_kinematic_sequence.__get__(obj)
+    )
+    return obj
+
+
+def _make_power_mixin(n: int = 100, n_joints: int = 3) -> object:
+    """Create a mock PowerWorkMetricsMixin."""
+    from src.shared.python.analysis.power_work_metrics import PowerWorkMetricsMixin
+
+    rng = np.random.default_rng(42)
+    obj = MagicMock(spec=PowerWorkMetricsMixin)
+    obj.times = np.linspace(0, 1, n)
+    obj.dt = 0.01
+    obj.joint_positions = rng.standard_normal((n, n_joints))
+    obj.joint_velocities = rng.standard_normal((n, n_joints))
+    obj.joint_torques = rng.standard_normal((n, n_joints))
+    obj.ground_forces = None
+    obj._work_metrics_cache = {}
+
+    obj.compute_work_metrics = PowerWorkMetricsMixin.compute_work_metrics.__get__(obj)
+    obj.compute_joint_power_metrics = (
+        PowerWorkMetricsMixin.compute_joint_power_metrics.__get__(obj)
+    )
+    obj.compute_impulse_metrics = PowerWorkMetricsMixin.compute_impulse_metrics.__get__(
+        obj
+    )
+    obj.compute_phase_space_path_length = (
+        PowerWorkMetricsMixin.compute_phase_space_path_length.__get__(obj)
+    )
+    return obj
+
+
+# ==================== PCA Tests ====================
+
+
+class TestPCAPreconditions(unittest.TestCase):
+    """Verify require() preconditions on PCA."""
+
+    def test_valid_pca_returns_result(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis(n_components=2)
+        self.assertIsNotNone(result)
+
+    def test_n_components_zero_raises(self) -> None:
+        obj = _make_pca_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_principal_component_analysis(n_components=0)
+
+    def test_n_components_negative_raises(self) -> None:
+        obj = _make_pca_mixin()
+        with self.assertRaises((ValueError, Exception)):
+            obj.compute_principal_component_analysis(n_components=-1)
+
+    def test_n_components_none_valid(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis(n_components=None)
+        self.assertIsNotNone(result)
+
+
+class TestPCAPostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on PCA results."""
+
+    def test_variance_non_negative(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis()
+        self.assertTrue(np.all(result.explained_variance >= 0))
+
+    def test_variance_ratio_sum_leq_one(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis()
+        ratio_sum = np.sum(result.explained_variance_ratio)
+        self.assertLessEqual(ratio_sum, 1.0 + 1e-6)
+
+    def test_variance_finite(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis()
+        self.assertTrue(np.all(np.isfinite(result.explained_variance)))
+
+    def test_subset_components_variance_ratio_leq_one(self) -> None:
+        obj = _make_pca_mixin()
+        result = obj.compute_principal_component_analysis(n_components=2)
+        ratio_sum = np.sum(result.explained_variance_ratio)
+        self.assertLessEqual(ratio_sum, 1.0 + 1e-6)
+
+
+class TestKinematicSequencePostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on analyze_kinematic_sequence."""
+
+    def test_efficiency_in_range(self) -> None:
+        obj = _make_pca_mixin()
+        segments = {"hip": 0, "shoulder": 1, "hand": 2}
+        sequence, score = obj.analyze_kinematic_sequence(segments)
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 1.0)
+
+    def test_peak_velocities_non_negative(self) -> None:
+        obj = _make_pca_mixin()
+        segments = {"hip": 0, "shoulder": 1, "hand": 2}
+        sequence, _ = obj.analyze_kinematic_sequence(segments)
+        for info in sequence:
+            self.assertGreaterEqual(info.peak_velocity, 0.0)
+
+    def test_empty_segments_zero_efficiency(self) -> None:
+        obj = _make_pca_mixin()
+        sequence, score = obj.analyze_kinematic_sequence({})
+        self.assertEqual(score, 0.0)
+        self.assertEqual(len(sequence), 0)
+
+    def test_single_segment(self) -> None:
+        obj = _make_pca_mixin()
+        sequence, score = obj.analyze_kinematic_sequence({"hip": 0})
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 1.0)
+        self.assertEqual(len(sequence), 1)
+
+
+# ==================== Power/Work Tests ====================
+
+
+class TestWorkMetricsPostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on compute_work_metrics."""
+
+    def test_positive_work_non_negative(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_work_metrics(0)
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result["positive_work"], 0)
+
+    def test_negative_work_non_positive(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_work_metrics(0)
+        self.assertLessEqual(result["negative_work"], 0)
+
+    def test_net_work_finite(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_work_metrics(0)
+        self.assertTrue(np.isfinite(result["net_work"]))
+
+    def test_cached_result_same(self) -> None:
+        obj = _make_power_mixin()
+        r1 = obj.compute_work_metrics(0)
+        r2 = obj.compute_work_metrics(0)
+        self.assertEqual(r1, r2)
+
+    def test_out_of_range_joint_returns_none(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_work_metrics(99)
+        self.assertIsNone(result)
+
+
+class TestJointPowerMetricsPostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on compute_joint_power_metrics."""
+
+    def test_peak_generation_non_negative(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_joint_power_metrics(0)
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result.peak_generation, 0)
+
+    def test_peak_absorption_non_positive(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_joint_power_metrics(0)
+        self.assertLessEqual(result.peak_absorption, 0)
+
+    def test_durations_non_negative(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_joint_power_metrics(0)
+        self.assertGreaterEqual(result.generation_duration, 0)
+        self.assertGreaterEqual(result.absorption_duration, 0)
+
+    def test_net_work_finite(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_joint_power_metrics(0)
+        self.assertTrue(np.isfinite(result.net_work))
+
+
+class TestPhaseSpacePathLengthPostconditions(unittest.TestCase):
+    """Verify ensure() postconditions on compute_phase_space_path_length."""
+
+    def test_path_length_non_negative(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_phase_space_path_length(0)
+        self.assertGreaterEqual(result, 0.0)
+
+    def test_stationary_zero_path(self) -> None:
+        obj = _make_power_mixin()
+        obj.joint_positions = np.ones((100, 3))
+        obj.joint_velocities = np.ones((100, 3))
+        result = obj.compute_phase_space_path_length(0)
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_out_of_range_returns_zero(self) -> None:
+        obj = _make_power_mixin()
+        result = obj.compute_phase_space_path_length(99)
+        self.assertEqual(result, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds require()/ensure() runtime contract enforcement to grf_metrics.py, nonlinear_dynamics.py, muscle_equilibrium.py, pca_analysis.py, and power_work_metrics.py. Includes 73 new DbC tests across 4 test files. Full DbC suite: 347 passed, 8 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily adds validation, but it can change runtime behavior by raising (or warning on) newly-enforced pre/postconditions in production paths if upstream data violates assumptions.
> 
> **Overview**
> Adds runtime Design-by-Contract checks (`require`/`ensure`) across GRF, nonlinear dynamics, PCA, power/work, and muscle equilibrium code paths, turning several previously-silent invalid inputs/outputs into explicit contract violations (e.g., parameter bounds, non-negativity, and finiteness guarantees).
> 
> Introduces new unit tests under `tests/unit/dbc/` that exercise these pre/postconditions for normal, boundary, and error cases (including zero/negative parameters and short-data early returns).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2ff43c183d706605d684f35d6f97640a1f93f0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->