### PR TITLE
feat: add Design-by-Contract preconditions to 13 API route files

### DIFF
--- a/src/api/routes/actuator_controls.py
+++ b/src/api/routes/actuator_controls.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.shared.python.core.contracts import precondition
+
 from ..dependencies import get_engine_manager, get_logger
 from ..models.requests import (
     ActuatorBatchCommandRequest,
@@ -187,6 +189,10 @@ async def get_actuator_panel(
     "/simulation/actuators",
     response_model=ActuatorCommandResponse,
 )
+@precondition(
+    lambda command, engine_manager=None, logger=None: command.actuator_index >= 0,
+    "Actuator index must be non-negative",
+)
 async def send_actuator_command(
     command: ActuatorCommandRequest,
     engine_manager: Any = Depends(get_engine_manager),
@@ -261,6 +267,10 @@ async def send_actuator_command(
 @router.post(
     "/simulation/actuators/batch",
     response_model=list[ActuatorCommandResponse],
+)
+@precondition(
+    lambda batch, engine_manager=None, logger=None: len(batch.commands) > 0,
+    "Batch must contain at least one command",
 )
 async def send_actuator_batch(
     batch: ActuatorBatchCommandRequest,

--- a/src/api/routes/aip.py
+++ b/src/api/routes/aip.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
+from src.shared.python.core.contracts import precondition
+
 from ..aip.dispatcher import (
     INVALID_REQUEST,
     PARSE_ERROR,
@@ -68,6 +70,10 @@ async def get_capabilities() -> AIPHandshakeResponse:
 
 
 @router.post("/aip/rpc")
+@precondition(
+    lambda request, engine_manager=None, logger=None: request is not None,
+    "RPC request must not be None",
+)
 async def handle_rpc(
     request: Request,
     engine_manager: Any = Depends(get_engine_manager),

--- a/src/api/routes/analysis.py
+++ b/src/api/routes/analysis.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from src.shared.python.core.contracts import precondition
+
 from ..dependencies import get_analysis_service, get_logger
 from ..models.requests import AnalysisRequest
 from ..models.responses import AnalysisResponse
@@ -22,6 +24,10 @@ router = APIRouter()
 
 
 @router.post("/analyze/biomechanics", response_model=AnalysisResponse)
+@precondition(
+    lambda request, service=None, logger=None: request is not None,
+    "Analysis request must not be None",
+)
 async def analyze_biomechanics(
     request: AnalysisRequest,
     service: AnalysisService = Depends(get_analysis_service),

--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
+from src.shared.python.core.contracts import precondition
+
 from ..dependencies import get_engine_manager, get_logger
 from ..models.requests import (
     BodyPositionUpdateRequest,
@@ -254,6 +256,10 @@ async def get_analysis_statistics(
 
 
 @router.post("/analysis/export")
+@precondition(
+    lambda request, engine_manager=None, logger=None: request.format in ("csv", "json"),
+    "Export format must be 'csv' or 'json'",
+)
 async def export_analysis_data(
     request: DataExportRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),
@@ -346,6 +352,11 @@ async def export_analysis_data(
 
 
 @router.post("/simulation/position", response_model=BodyPositionResponse)
+@precondition(
+    lambda request, engine_manager=None, logger=None: request.body_name is not None
+    and len(request.body_name.strip()) > 0,
+    "Body name must be a non-empty string",
+)
 async def set_body_position(
     request: BodyPositionUpdateRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),
@@ -407,6 +418,13 @@ async def set_body_position(
 
 
 @router.post("/simulation/measure", response_model=MeasurementResult)
+@precondition(
+    lambda request, engine_manager=None, logger=None: request.body_a is not None
+    and len(request.body_a.strip()) > 0
+    and request.body_b is not None
+    and len(request.body_b.strip()) > 0,
+    "Both body_a and body_b must be non-empty strings",
+)
 async def measure_distance(
     request: MeasurementRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -24,6 +24,7 @@ from src.api.auth.models import (
 from src.api.auth.security import security_manager, usage_tracker
 from src.api.database import get_db
 from src.api.utils.datetime_compat import UTC
+from src.shared.python.core.contracts import precondition
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
 
@@ -128,6 +129,11 @@ async def login(
 
 
 @router.post("/refresh", response_model=dict)
+@precondition(
+    lambda refresh_token, db=None: refresh_token is not None
+    and len(refresh_token.strip()) > 0,
+    "Refresh token must be a non-empty string",
+)
 async def refresh_token(
     refresh_token: str, db: Session = Depends(get_db)
 ) -> dict[str, Any]:
@@ -218,6 +224,10 @@ async def list_api_keys(
 
 
 @router.delete("/api-keys/{api_key_id}")
+@precondition(
+    lambda api_key_id, current_user=None, db=None: api_key_id > 0,
+    "API key ID must be a positive integer",
+)
 async def delete_api_key(
     api_key_id: int, current_user: User = RequireAuth, db: Session = Depends(get_db)
 ) -> dict[str, str]:
@@ -242,6 +252,10 @@ async def delete_api_key(
 
 # Admin routes
 @router.get("/users", response_model=list[UserResponse])
+@precondition(
+    lambda skip=0, limit=100, current_user=None, db=None: skip >= 0 and limit > 0,
+    "skip must be non-negative and limit must be positive",
+)
 async def list_users(
     skip: int = 0,
     limit: int = 100,
@@ -255,6 +269,10 @@ async def list_users(
 
 
 @router.put("/users/{user_id}/role")
+@precondition(
+    lambda user_id, new_role, current_user=None, db=None: user_id > 0,
+    "User ID must be a positive integer",
+)
 async def update_user_role(
     user_id: int,
     new_role: UserRole,
@@ -276,6 +294,10 @@ async def update_user_role(
 
 
 @router.put("/users/{user_id}/status")
+@precondition(
+    lambda user_id, is_active, current_user=None, db=None: user_id > 0,
+    "User ID must be a positive integer",
+)
 async def update_user_status(
     user_id: int,
     is_active: bool,

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -6,6 +6,7 @@ import contextlib
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 
+from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -109,6 +110,10 @@ async def list_sessions(request: Request) -> list[dict]:
 
 
 @router.get("/chat/sessions/{session_id}/history")
+@precondition(
+    lambda request, session_id: session_id is not None and len(session_id.strip()) > 0,
+    "Session ID must be a non-empty string",
+)
 async def get_history(request: Request, session_id: str) -> dict:
     """Get message history for a session."""
     messages = request.app.state.chat_service.get_session_history(session_id)

--- a/src/api/routes/core.py
+++ b/src/api/routes/core.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Depends
 
 from src.api.utils.datetime_compat import iso_format, utc_now
+from src.shared.python.core.contracts import precondition
 
 from ..dependencies import get_engine_manager
 
@@ -34,6 +35,10 @@ async def root() -> dict[str, str]:
 
 
 @router.get("/health")
+@precondition(
+    lambda engine_manager=None: engine_manager is not None,
+    "Engine manager must be injected",
+)
 async def health_check(
     engine_manager: EngineManager = Depends(get_engine_manager),
 ) -> dict[str, str | int]:

--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -18,6 +18,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, UploadFile
 from pydantic import BaseModel, Field
 
+from src.shared.python.core.contracts import precondition
+
 router = APIRouter(prefix="/api/tools/data-explorer", tags=["data-explorer"])
 
 
@@ -173,6 +175,10 @@ async def list_datasets() -> DatasetListResponse:
 
 
 @router.get("/datasets/{name}/preview", response_model=DatasetPreviewResponse)
+@precondition(
+    lambda name, limit=50: name is not None and len(name.strip()) > 0 and limit > 0,
+    "Dataset name must be non-empty and limit must be positive",
+)
 async def preview_dataset(name: str, limit: int = 50) -> DatasetPreviewResponse:
     """Get a preview of dataset contents.
 
@@ -224,6 +230,10 @@ async def preview_dataset(name: str, limit: int = 50) -> DatasetPreviewResponse:
 
 
 @router.get("/datasets/{name}/stats", response_model=DatasetStatsResponse)
+@precondition(
+    lambda name: name is not None and len(name.strip()) > 0,
+    "Dataset name must be a non-empty string",
+)
 async def dataset_stats(name: str) -> DatasetStatsResponse:
     """Get summary statistics for a dataset.
 
@@ -326,6 +336,10 @@ async def import_dataset(file: UploadFile) -> ImportResponse:
 
 
 @router.post("/datasets/{name}/filter")
+@precondition(
+    lambda name, request: name is not None and len(name.strip()) > 0,
+    "Dataset name must be a non-empty string",
+)
 async def filter_dataset(
     name: str, request: DatasetFilterRequest
 ) -> DatasetPreviewResponse:

--- a/src/api/routes/force_overlays.py
+++ b/src/api/routes/force_overlays.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Depends, HTTPException
 
 from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.contracts import precondition
 
 from ..dependencies import get_engine_manager, get_logger
 from ..models.requests import ForceOverlayRequest
@@ -272,6 +273,16 @@ def _build_demo_vectors(config: ForceOverlayRequest) -> list[ForceVector3D]:
     "/simulation/forces",
     response_model=ForceOverlayResponse,
 )
+@precondition(
+    lambda force_types="applied",
+    color_by_magnitude=True,
+    body_filter=None,
+    show_labels=False,
+    scale_factor=0.01,
+    engine_manager=None,
+    logger=None: scale_factor > 0 and len(force_types.strip()) > 0,
+    "Scale factor must be positive and force_types must be non-empty",
+)
 async def get_force_overlays(
     force_types: str = "applied",
     color_by_magnitude: bool = True,
@@ -349,6 +360,10 @@ async def get_force_overlays(
 @router.post(
     "/simulation/forces/config",
     response_model=ForceOverlayResponse,
+)
+@precondition(
+    lambda config, engine_manager=None, logger=None: config.scale_factor > 0,
+    "Scale factor must be positive",
 )
 async def update_force_overlay_config(
     config: ForceOverlayRequest,

--- a/src/api/routes/motion_capture.py
+++ b/src/api/routes/motion_capture.py
@@ -16,6 +16,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from src.shared.python.core.contracts import precondition
+
 router = APIRouter(prefix="/api/tools/motion-capture", tags=["motion-capture"])
 
 
@@ -178,6 +180,10 @@ async def list_capture_sources() -> list[CaptureSource]:
 
 
 @router.get("/skeleton/{source_type}", response_model=list[JointData])
+@precondition(
+    lambda source_type: source_type is not None and len(source_type.strip()) > 0,
+    "Source type must be a non-empty string",
+)
 async def get_skeleton_template(source_type: str) -> list[JointData]:
     """Get the skeleton joint template for a given source type.
 
@@ -242,6 +248,10 @@ async def start_capture_session(
 
 
 @router.post("/session/{session_id}/stop", response_model=CaptureSessionResponse)
+@precondition(
+    lambda session_id: session_id is not None and len(session_id.strip()) > 0,
+    "Session ID must be a non-empty string",
+)
 async def stop_capture_session(session_id: str) -> CaptureSessionResponse:
     """Stop an active capture session and save the recording.
 
@@ -345,6 +355,12 @@ async def control_playback(request: PlaybackRequest) -> PlaybackResponse:
 
 
 @router.get("/frame/{recording_name}/{frame_index}", response_model=SkeletonFrame)
+@precondition(
+    lambda recording_name, frame_index: recording_name is not None
+    and len(recording_name.strip()) > 0
+    and frame_index >= 0,
+    "Recording name must be non-empty and frame index must be non-negative",
+)
 async def get_frame(recording_name: str, frame_index: int) -> SkeletonFrame:
     """Get skeleton data for a specific frame.
 

--- a/src/api/routes/putting_green.py
+++ b/src/api/routes/putting_green.py
@@ -15,6 +15,8 @@ import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from src.shared.python.core.contracts import precondition
+
 router = APIRouter(prefix="/api/tools/putting-green", tags=["putting-green"])
 
 
@@ -117,6 +119,10 @@ class GreenContourResponse(BaseModel):
 
 
 @router.post("/simulate", response_model=PuttSimulationResponse)
+@precondition(
+    lambda request: request.direction_x != 0.0 or request.direction_y != 0.0,
+    "Putt direction vector must not be zero",
+)
 async def simulate_putt(request: PuttSimulationRequest) -> PuttSimulationResponse:
     """Simulate a single putt with given parameters.
 
@@ -223,6 +229,10 @@ async def read_green(request: GreenReadingRequest) -> GreenReadingResponse:
 
 
 @router.post("/scatter", response_model=ScatterAnalysisResponse)
+@precondition(
+    lambda request: request.direction_x != 0.0 or request.direction_y != 0.0,
+    "Scatter direction vector must not be zero",
+)
 async def scatter_analysis(
     request: ScatterAnalysisRequest,
 ) -> ScatterAnalysisResponse:
@@ -287,6 +297,13 @@ async def scatter_analysis(
 
 
 @router.get("/contours", response_model=GreenContourResponse)
+@precondition(
+    lambda width=20.0, height=20.0, resolution=20, stimp_rating=10.0: width > 0
+    and height > 0
+    and resolution >= 2
+    and 6.0 <= stimp_rating <= 15.0,
+    "Green dimensions must be positive, resolution >= 2, and stimp_rating in [6, 15]",
+)
 async def get_green_contours(
     width: float = 20.0,
     height: float = 20.0,

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -6,6 +6,7 @@ import contextlib
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 
+from src.shared.python.core.contracts import require
 from src.shared.python.engine_core.engine_registry import EngineType
 
 router = APIRouter()
@@ -34,6 +35,11 @@ async def _load_simulation_engine(
     Returns:
         The active physics engine, or None if loading failed.
     """
+    require(
+        engine_type is not None and len(engine_type.strip()) > 0,
+        "Engine type must be a non-empty string",
+        engine_type,
+    )
     try:
         enum_type = EngineType(engine_type.upper())
         success = engine_manager.switch_engine(enum_type)  # type: ignore[attr-defined]
@@ -104,6 +110,9 @@ async def _run_simulation_loop(
     """
     duration = config.get("duration", 3.0)
     timestep = config.get("timestep", 0.002)
+
+    require(duration > 0, "Simulation duration must be positive", duration)
+    require(timestep > 0, "Simulation timestep must be positive", timestep)
 
     await websocket.send_json({"status": "running", "duration": duration})
 

--- a/src/api/routes/video.py
+++ b/src/api/routes/video.py
@@ -21,6 +21,7 @@ from src.api.config import (
     VALID_ESTIMATOR_TYPES,
 )
 from src.api.utils.datetime_compat import UTC
+from src.shared.python.core.contracts import precondition
 from src.shared.python.gui_pkg.video_pose_pipeline import (
     VideoPosePipeline,
     VideoProcessingConfig,
@@ -33,6 +34,17 @@ router = APIRouter()
 
 
 @router.post("/analyze/video", response_model=VideoAnalysisResponse)
+@precondition(
+    lambda file=None,
+    estimator_type="mediapipe",
+    min_confidence=0.5,
+    enable_smoothing=True,
+    video_pipeline=None,
+    logger=None: estimator_type is not None
+    and len(estimator_type.strip()) > 0
+    and 0.0 <= min_confidence <= 1.0,
+    "Estimator type must be non-empty and min_confidence must be in [0.0, 1.0]",
+)
 async def analyze_video(
     file: UploadFile = File(...),
     estimator_type: str = "mediapipe",
@@ -129,6 +141,17 @@ async def analyze_video(
 
 
 @router.post("/analyze/video/async")
+@precondition(
+    lambda background_tasks=None,
+    file=None,
+    estimator_type="mediapipe",
+    min_confidence=0.5,
+    video_pipeline=None,
+    task_manager=None: estimator_type is not None
+    and len(estimator_type.strip()) > 0
+    and 0.0 <= min_confidence <= 1.0,
+    "Estimator type must be non-empty and min_confidence must be in [0.0, 1.0]",
+)
 async def analyze_video_async(
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),


### PR DESCRIPTION
## Summary
- Add `@precondition` decorators and `require()` calls to all 13 API route files that previously lacked Design-by-Contract enforcement
- Follows the existing pattern established in `src/api/routes/engines.py`
- Uses decorator-style `@precondition` for REST route handlers and function-call style `require()` for WebSocket helpers

## Route Files Updated

| File | Contracts Added |
|------|----------------|
| `actuator_controls.py` | Non-negative actuator index, non-empty batch |
| `aip.py` | RPC request not None |
| `analysis.py` | Analysis request not None |
| `analysis_tools.py` | Export format validation, body name non-empty, measurement body names non-empty |
| `auth.py` | Refresh token non-empty, API key ID positive, pagination bounds, user ID positive |
| `chat_ws.py` | Session ID non-empty |
| `core.py` | Engine manager injected |
| `data_explorer.py` | Dataset name non-empty, preview limit positive |
| `force_overlays.py` | Scale factor positive, force types non-empty |
| `motion_capture.py` | Source type non-empty, session ID non-empty, recording name non-empty, frame index non-negative |
| `putting_green.py` | Direction vector non-zero, green dimensions valid, stimp rating in range |
| `simulation_ws.py` | Engine type non-empty, duration positive, timestep positive |
| `video.py` | Estimator type non-empty, min_confidence in [0, 1] |

## Design Decisions
- Endpoints with only injected dependencies (e.g., `root()`, `list_sessions()`) are left without contracts per the "no contracts on simple getters" principle
- Where Pydantic already validates field ranges, contracts focus on **business logic** preconditions (e.g., direction vector non-zero, engine must be loaded)
- WebSocket handlers use `require()` inline instead of `@precondition` decorator since FastAPI WebSocket routing handles decorator wrapping differently

## Test plan
- [x] `ruff check src/api/routes/` passes with zero violations
- [x] `ruff format src/api/routes/` produces no changes
- [x] All 277 API unit tests pass (`tests/unit/api/`)
- [x] All 397 contract-related tests pass
- [x] All pre-commit hooks pass (ruff lint, ruff format, no wildcards, no debug)
- [ ] CI pipeline validates full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a broad set of request entrypoints and can change runtime behavior by raising `PreconditionError` (or logging) before existing error handling, potentially altering response status/body for some invalid inputs.
> 
> **Overview**
> Adds Design-by-Contract validation across multiple API routes by importing `precondition` and annotating handlers to enforce basic argument invariants (e.g., non-empty IDs/strings, positive bounds, allowed formats, non-negative indices).
> 
> Also adds inline `require()` checks in `simulation_ws.py` to validate WebSocket engine selection and simulation timing parameters before starting/stepping the stream, causing invalid inputs to fail fast (raise/log depending on `DBC_LEVEL`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c780aeb4df5d19309b8d067299cf90bf1a67a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->