### PR TITLE
refactor: replace broad exception catches with typed domain errors

### DIFF
--- a/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
+++ b/src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py
@@ -150,7 +150,7 @@ class LQRController(BaseController):
                     if joint in physics.named.data.qpos:
                         physics.named.data.qpos[joint] = angle
                 except KeyError:
-                    pass
+                    logger.debug("Joint %r not found in qpos, skipping", joint)
 
             self.qpos_targ = physics.data.qpos.copy()
             self.qvel_targ = np.zeros(physics.model.nv)

--- a/src/launchers/launcher_layout_manager.py
+++ b/src/launchers/launcher_layout_manager.py
@@ -161,8 +161,8 @@ class LayoutManager:
 
             return layout_data
 
-        except ImportError as e:
-            logger.error(f"Failed to load layout: {e}")
+        except (json.JSONDecodeError, OSError, KeyError) as e:
+            logger.error(f"Failed to load layout from {self.config_file}: {e}")
             return None
 
     def sync_model_cards(self) -> None:

--- a/src/launchers/model_registry.py
+++ b/src/launchers/model_registry.py
@@ -51,8 +51,15 @@ class ModelRegistry:
             self._loaded = True
             logger.info(f"Loaded {len(self.models)} models from registry")
 
-        except ImportError as e:
-            logger.error(f"Failed to load model registry: {e}")
+        except yaml.YAMLError as e:
+            logger.error(f"YAML parsing error in {full_config_path}: {e}")
+            raise
+        except TypeError as e:
+            logger.error(f"Invalid model specification in {full_config_path}: {e}")
+            raise
+        except OSError as e:
+            logger.error(f"Failed to read model registry {full_config_path}: {e}")
+            raise
 
     def get_all_models(self) -> list[ModelSpec]:
         """Get all registered models."""

--- a/src/shared/python/config/model_registry.py
+++ b/src/shared/python/config/model_registry.py
@@ -105,8 +105,10 @@ class ModelRegistry(ContractChecker):
 
         except yaml.YAMLError as e:
             logger.error(f"YAML parsing error in {self.config_path}: {e}")
+            raise
         except OSError as e:
             logger.error(f"Failed to read registry file {self.config_path}: {e}")
+            raise
 
     def get_model(self, model_id: str) -> ModelConfig | None:
         """

--- a/src/shared/python/data_io/dataset_generator.py
+++ b/src/shared/python/data_io/dataset_generator.py
@@ -43,6 +43,7 @@ from typing import Any
 import numpy as np
 
 from src.shared.python.core.contracts import invariant, postcondition, precondition
+from src.shared.python.core.error_utils import SimulationError
 from src.shared.python.engine_core.interfaces import PhysicsEngine
 from src.shared.python.logging_pkg.logging_config import get_logger
 
@@ -408,7 +409,7 @@ class DatasetGenerator:
                 continue
 
         if not samples:
-            raise RuntimeError(
+            raise SimulationError(
                 f"All {config.num_samples} samples failed during generation"
             )
 
@@ -694,7 +695,10 @@ class DatasetGenerator:
                         if 0 <= idx < n_q:
                             q0[idx] = pr.sample(rng)
                     except ValueError:
-                        pass
+                        logger.debug(
+                            "Skipping position range %r: not a valid joint index",
+                            pr.name,
+                        )
         elif config.vary_initial_positions:
             q0 = rng.uniform(-0.5, 0.5, n_q)  # type: ignore[assignment]
         else:
@@ -712,7 +716,10 @@ class DatasetGenerator:
                         if 0 <= idx < n_v:
                             v0[idx] = vr.sample(rng)
                     except ValueError:
-                        pass
+                        logger.debug(
+                            "Skipping velocity range %r: not a valid joint index",
+                            vr.name,
+                        )
         elif config.vary_initial_velocities:
             v0 = rng.uniform(-0.1, 0.1, n_v)  # type: ignore[assignment]
         else:

--- a/src/shared/python/data_io/import_utils.py
+++ b/src/shared/python/data_io/import_utils.py
@@ -180,6 +180,6 @@ def check_minimum_version(
                 f"{module_name} {current_version} does not meet minimum {minimum_version}"
             )
         return meets_requirement
-    except (RuntimeError, ValueError, OSError) as e:
-        logger.error(f"Failed to compare versions: {e}")
+    except ValueError as e:
+        logger.error(f"Failed to compare versions for {module_name}: {e}")
         return False

--- a/src/shared/python/gui_pkg/video_pose_pipeline.py
+++ b/src/shared/python/gui_pkg/video_pose_pipeline.py
@@ -15,6 +15,7 @@ from typing import Any
 import cv2
 import numpy as np
 
+from src.shared.python.core.contracts import StateError
 from src.shared.python.data_io.io_utils import ensure_directory
 from src.shared.python.data_io.marker_mapping import (
     MarkerToModelMapper,
@@ -134,14 +135,14 @@ class VideoPosePipeline:
             raise FileNotFoundError(f"Video file not found: {video_path}")
 
         if self.estimator is None:
-            raise RuntimeError("Estimator not loaded")
+            raise StateError("Estimator not loaded")
 
         logger.info(f"Processing video: {video_path}")
 
         # Get video info
         cap = cv2.VideoCapture(str(video_path))
         if not cap.isOpened():
-            raise RuntimeError(f"Could not open video: {video_path}")
+            raise FileNotFoundError(f"Could not open video: {video_path}")
 
         total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         cap.release()

--- a/src/shared/python/physics/energy_monitor.py
+++ b/src/shared/python/physics/energy_monitor.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from src.shared.python.core.contracts import StateError
+from src.shared.python.core.error_utils import SimulationError
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -142,7 +144,7 @@ class ConservationMonitor:
             ...     drift_pct = monitor.check_and_warn()  # Warns if drift > 1%
         """
         if self.E_initial is None:
-            raise RuntimeError(
+            raise StateError(
                 "ConservationMonitor not initialized. Call initialize() first."
             )
 
@@ -236,7 +238,7 @@ class ConservationMonitor:
             significant (slow motion), this approximation is poor.
         """
         if self.E_initial is None:
-            raise RuntimeError(
+            raise StateError(
                 "ConservationMonitor not initialized. Call initialize() first."
             )
 
@@ -260,5 +262,5 @@ class ConservationMonitor:
         )
 
 
-class IntegrationFailureError(Exception):
+class IntegrationFailureError(SimulationError):
     """Raised when energy drift indicates integration failure (>5% drift)."""

--- a/src/shared/python/pose_estimation/mediapipe_estimator.py
+++ b/src/shared/python/pose_estimation/mediapipe_estimator.py
@@ -20,6 +20,7 @@ except ImportError:
     cv2 = None  # type: ignore[assignment]
 import numpy as np
 
+from src.shared.python.core.contracts import StateError
 from src.shared.python.engine_core.engine_availability import MEDIAPIPE_AVAILABLE
 from src.shared.python.logging_pkg.logging_config import get_logger
 
@@ -165,7 +166,7 @@ class MediaPipeEstimator(PoseEstimator):
             PoseEstimationResult containing joint angles and keypoints
         """
         if not self._is_loaded:
-            raise RuntimeError("Model not loaded. Call load_model() first.")
+            raise StateError("Model not loaded. Call load_model() first.")
 
         # Convert BGR to RGB for MediaPipe
         rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -174,7 +175,7 @@ class MediaPipeEstimator(PoseEstimator):
         if self.pose_detector is not None:
             results = self.pose_detector.process(rgb_image)
         else:
-            raise RuntimeError("MediaPipe pose detector not initialized")
+            raise StateError("MediaPipe pose detector not initialized")
 
         if results.pose_landmarks is None:
             # No pose detected
@@ -226,13 +227,13 @@ class MediaPipeEstimator(PoseEstimator):
             List of results for each frame with temporal smoothing
         """
         if not self._is_loaded:
-            raise RuntimeError("Model not loaded. Call load_model() first.")
+            raise StateError("Model not loaded. Call load_model() first.")
 
         results = []
         cap = cv2.VideoCapture(str(video_path))
 
         if not cap.isOpened():
-            raise RuntimeError(f"Could not open video file: {video_path}")
+            raise FileNotFoundError(f"Could not open video file: {video_path}")
 
         fps = cap.get(cv2.CAP_PROP_FPS)
         frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))

--- a/src/shared/python/pose_estimation/openpose_estimator.py
+++ b/src/shared/python/pose_estimation/openpose_estimator.py
@@ -10,6 +10,7 @@ from typing import Any, ClassVar
 
 import numpy as np
 
+from src.shared.python.core.contracts import StateError
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 # Try to import pyopenpose. If not found, we will fall back to mock/error behavior
@@ -117,7 +118,7 @@ class OpenPoseEstimator(PoseEstimator):
     def estimate_from_image(self, image: np.ndarray) -> PoseEstimationResult:
         """Process a single image frame."""
         if not self._is_loaded or self.wrapper is None:
-            raise RuntimeError("OpenPose model not loaded. Call load_model() first.")
+            raise StateError("OpenPose model not loaded. Call load_model() first.")
 
         try:
             datum = op.Datum()

--- a/src/shared/python/security/subprocess_utils.py
+++ b/src/shared/python/security/subprocess_utils.py
@@ -410,7 +410,7 @@ def kill_process_tree(pid: int, timeout: float = 5.0) -> bool:
 
             os.kill(pid, signal.SIGTERM)
             return True
-        except ImportError as e:
+        except OSError as e:
             logger.error(f"Failed to kill process {pid}: {e}")
             return False
 

--- a/src/unreal_integration/viewer_backends.py
+++ b/src/unreal_integration/viewer_backends.py
@@ -1007,7 +1007,7 @@ class UnrealBridgeBackend(ViewerBackend):
                     except Empty:
                         await asyncio.sleep(0.001)
 
-                except Exception as e:
+                except (OSError, RuntimeError) as e:
                     logger.error(f"Error in streaming loop: {e}")
                     await asyncio.sleep(1.0)  # Backoff on error
 

--- a/tests/unit/test_energy_monitor.py
+++ b/tests/unit/test_energy_monitor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from src.shared.python.core.contracts import StateError
 from src.shared.python.physics.energy_monitor import (
     ENERGY_DRIFT_CRITICAL_PCT,
     ENERGY_DRIFT_TOLERANCE_PCT,
@@ -232,7 +233,7 @@ class TestCheckAndWarn:
         engine = MockPhysicsEngine()
         monitor = ConservationMonitor(as_physics_engine(engine))
 
-        with pytest.raises(RuntimeError, match="not initialized"):
+        with pytest.raises(StateError, match="not initialized"):
             monitor.check_and_warn()
 
     def test_zero_drift_returns_zero(self):
@@ -486,7 +487,7 @@ class TestProjectToEnergyManifold:
         engine = MockPhysicsEngine()
         monitor = ConservationMonitor(as_physics_engine(engine))
 
-        with pytest.raises(RuntimeError, match="not initialized"):
+        with pytest.raises(StateError, match="not initialized"):
             monitor.project_to_energy_manifold()
 
     def test_projection_scales_velocity(self):
@@ -607,7 +608,7 @@ class TestIntegrationFailureError:
         try:
             raise IntegrationFailureError(msg)
         except IntegrationFailureError as e:
-            assert str(e) == msg
+            assert msg in str(e)
 
 
 class TestPhysicalRealism:

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -59,16 +59,15 @@ class TestModelRegistry:
         assert len(registry.models) == 0
 
     def test_load_malformed_yaml(self):
-        """Test loading a malformed YAML file."""
+        """Test loading a malformed YAML file raises yaml.YAMLError."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "models.yaml"
             # Write invalid YAML (tab character instead of spaces)
             with open(config_path, "w", encoding="utf-8") as f:
                 f.write("models:\n\t- id: test")
 
-            registry = ModelRegistry(config_path)
-            # Should handle exception gracefully (log error) and have 0 models
-            assert len(registry.models) == 0
+            with pytest.raises(yaml.YAMLError):
+                ModelRegistry(config_path)
 
     def test_load_invalid_model_format(self):
         """Test loading registry with invalid model structure."""

--- a/tests/unit/test_openpose_estimator.py
+++ b/tests/unit/test_openpose_estimator.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from src.shared.python.core.contracts import StateError
+
 # Mock pyopenpose using patch.dict (auto-cleans) BEFORE importing the estimator,
 # so the try/except import in the module succeeds.
 mock_op = MagicMock()
@@ -81,7 +83,7 @@ def test_load_model_failure(estimator, op_mock):
 
 def test_estimate_from_image_not_loaded():
     est = OpenPoseEstimator()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(StateError):
         est.estimate_from_image(np.zeros((100, 100, 3)))
 
 

--- a/tests/unit/test_shared_model_registry.py
+++ b/tests/unit/test_shared_model_registry.py
@@ -85,12 +85,13 @@ class TestModelRegistry(unittest.TestCase):
     @patch("pathlib.Path.exists")
     @patch("builtins.open", new_callable=mock_open)
     def test_load_registry_yaml_error(self, mock_file, mock_exists):
-        """Test loading registry with YAML syntax error."""
+        """Test loading registry with YAML syntax error raises."""
         mock_exists.return_value = True
-        with patch("yaml.safe_load", side_effect=yaml.YAMLError("Error")):
-            registry = ModelRegistry("dummy_path.yaml")
-
-        self.assertEqual(len(registry.models), 0)
+        with (
+            patch("yaml.safe_load", side_effect=yaml.YAMLError("Error")),
+            self.assertRaises(yaml.YAMLError),
+        ):
+            ModelRegistry("dummy_path.yaml")
 
     @patch("pathlib.Path.exists")
     @patch("builtins.open", new_callable=mock_open)


### PR DESCRIPTION
## Summary
- Replace broad/wrong exception catches with typed domain errors across 12 source files
- Narrow `except Exception` to specific types (`OSError`, `RuntimeError`) in streaming loops
- Replace incorrect `except ImportError` with `yaml.YAMLError`, `TypeError`, `OSError`, `json.JSONDecodeError` in model registries and layout manager
- Add fail-fast `raise` after logging in config `model_registry._load_config()` to surface corrupt YAML and IO errors
- Replace generic `RuntimeError` with domain-specific `StateError` for "not initialized/loaded" precondition violations in `energy_monitor`, `mediapipe_estimator`, `openpose_estimator`, `video_pose_pipeline`
- Replace `RuntimeError` with `FileNotFoundError` for video-open failures
- Change `IntegrationFailureError` base from `Exception` to `SimulationError`
- Replace `RuntimeError` with `SimulationError` for dataset generation failures
- Change impossible `except ImportError` to `except OSError` in `subprocess_utils` (`os.kill`)
- Narrow overly broad `except (RuntimeError, ValueError, OSError)` to `except ValueError` in `import_utils` version check
- Add debug logging to silent `except KeyError: pass` and `except ValueError: pass` blocks
- Update 4 test files to match new exception types

## Files changed (16)
**Source files (12):**
- `src/unreal_integration/viewer_backends.py` - narrow streaming loop catch
- `src/engines/physics_engines/mujoco/docker/src/humanoid_golf/sim.py` - log silent KeyError
- `src/shared/python/config/model_registry.py` - fail-fast on YAML/IO errors
- `src/launchers/model_registry.py` - typed exceptions for YAML loading
- `src/shared/python/data_io/dataset_generator.py` - SimulationError + debug logging
- `src/shared/python/data_io/import_utils.py` - narrow to ValueError only
- `src/shared/python/security/subprocess_utils.py` - fix impossible ImportError
- `src/launchers/launcher_layout_manager.py` - typed JSON/OS errors
- `src/shared/python/physics/energy_monitor.py` - StateError + SimulationError hierarchy
- `src/shared/python/pose_estimation/mediapipe_estimator.py` - StateError + FileNotFoundError
- `src/shared/python/pose_estimation/openpose_estimator.py` - StateError
- `src/shared/python/gui_pkg/video_pose_pipeline.py` - StateError + FileNotFoundError

**Test files (4):**
- `tests/unit/test_energy_monitor.py` - expect StateError, relaxed message assert
- `tests/unit/test_model_registry.py` - expect yaml.YAMLError on malformed YAML
- `tests/unit/test_shared_model_registry.py` - expect yaml.YAMLError on YAML errors
- `tests/unit/test_openpose_estimator.py` - expect StateError

## What was NOT changed (per guidelines)
- GUI event handlers (Qt signal/slot exception isolation)
- Lines annotated with `# noqa: BLE001` (intentionally broad catches)
- Plugin/optional-import loading code (legitimate graceful degradation)
- No bare `except:` blocks found (none existed)

## Test plan
- [x] All 64 directly affected unit tests pass
- [x] Full unit test suite: 4267 passed, 2 pre-existing failures (MuJoCo GL context), 110 skipped
- [x] Ruff lint and format pass on all 16 files
- [x] Pre-commit hooks pass (ruff, ruff-format, semgrep, radon, module budget)
- [ ] CI/CD pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily changes exception types/propagation and narrows catch blocks, which can alter runtime control flow and break callers that relied on prior swallowing of errors. Risk is contained to error-handling paths but touches simulation, config loading, and streaming loops.
> 
> **Overview**
> Refactors error handling across the codebase to use **typed, domain-specific exceptions** and to avoid overly broad or incorrect `except` clauses. Several components now raise `StateError` for “not initialized/loaded” conditions, `SimulationError` for simulation-wide failures, and `FileNotFoundError` for video open failures, with unit tests updated to match.
> 
> Configuration/load paths were tightened to catch the right failure modes and surface corrupt configs: the launcher `model_registry` and shared `config/model_registry` now log and **re-raise** YAML/IO/type errors (fail-fast), and the launcher `LayoutManager` handles JSON/OS/key errors with improved logging. Misc cleanup narrows generic catches in streaming (`viewer_backends`), fixes an impossible `ImportError` catch around `os.kill`, restricts version-compare error handling, and replaces silent `pass` blocks with targeted debug logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d19d1990aaa19620dbcddb9d94dfa402768a6f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->