### PR TITLE
Fix #1486: ADRs, onboarding guide, engine selection guide

### DIFF
--- a/docs/adr/0001-fastapi-local-first-api.md
+++ b/docs/adr/0001-fastapi-local-first-api.md
@@ -1,0 +1,56 @@
+# ADR-0001: FastAPI for Local-First API Design
+
+- Status: Accepted
+- Date: 2026-02-18
+- Decision Makers: Core maintainers
+- Related Issues/PRs: #1486
+
+## Context
+
+The golf modeling suite needs a local API server for communication between the UI
+frontend and physics engine backends. The server must handle both traditional
+request/response patterns (model loading, configuration) and real-time streaming
+(simulation state updates, sensor data). Options considered included Flask,
+Django, FastAPI, and a raw WebSocket server.
+
+Key constraints:
+
+- Must support real-time simulation data streaming with low latency
+- Must provide type-safe request/response handling for complex physics payloads
+- Must generate API documentation automatically (multiple engines = large surface area)
+- Must run locally with minimal overhead (not a cloud-deployed service)
+
+## Decision
+
+Use FastAPI with Uvicorn for the local API server because:
+
+- Native async/await support for real-time simulation streaming
+- Automatic OpenAPI documentation generation
+- Pydantic model validation for request/response schemas
+- WebSocket support for real-time data streaming
+- Excellent performance with minimal overhead
+
+## Alternatives Considered
+
+1. **Flask**: Mature ecosystem but lacks native async support. Would require
+   Flask-SocketIO for WebSocket handling and additional libraries for validation.
+2. **Django**: Too heavyweight for a local-first application. ORM and admin
+   features add unnecessary complexity.
+3. **Raw WebSocket server**: Maximum flexibility but requires building request
+   routing, validation, and documentation from scratch.
+
+## Consequences
+
+- **Positive**: Auto-generated API docs at `/docs` and `/redoc` reduce documentation burden
+- **Positive**: Pydantic models enforce type safety at API boundaries, catching errors early
+- **Positive**: Strong middleware ecosystem (CORS, rate limiting, security headers)
+- **Positive**: WebSocket support is first-class, no adapter libraries needed
+- **Negative**: Requires understanding of async programming patterns
+- **Negative**: Some optional dependencies (uvloop) not available on all platforms
+- **Follow-ups**: Establish API versioning strategy as engine capabilities grow
+
+## Validation
+
+- API contract tests in `tests/api/` verify endpoint schemas against Pydantic models
+- Health endpoint (`/api/health`) confirms server is running in CI
+- OpenAPI spec is exported and diffed in CI to detect unintended API changes

--- a/docs/adr/0002-physics-engine-plugin-architecture.md
+++ b/docs/adr/0002-physics-engine-plugin-architecture.md
@@ -1,0 +1,55 @@
+# ADR-0002: Physics Engine Plugin Architecture
+
+- Status: Accepted
+- Date: 2026-02-18
+- Decision Makers: Core maintainers
+- Related Issues/PRs: #1486
+
+## Context
+
+The suite supports 5 physics engines (MuJoCo, Drake, Pinocchio, OpenSim,
+MyoSuite). Each engine has different capabilities, dependencies, and APIs. Users
+may only have a subset of engines installed depending on their use case and
+platform. We need a way to add, remove, or swap engines without modifying core
+application code.
+
+Key constraints:
+
+- Engines have heavy binary dependencies that are difficult to install together
+- Each engine exposes a different Python API with different conventions
+- Not all engines support all capabilities (e.g., muscle modeling, trajectory optimization)
+- New engines may be added in the future
+
+## Decision
+
+Use a Protocol-based plugin architecture:
+
+- Define `PhysicsEngine` protocol in `src/shared/python/engine_core/`
+- Each engine implements the protocol independently in `src/engines/physics_engines/<name>/`
+- Engine availability detected at runtime via `importlib`
+- `EngineManager` provides unified access layer with capability queries
+- Engine capabilities are declared via a structured capability manifest
+
+## Alternatives Considered
+
+1. **Abstract base class hierarchy**: Requires all engines to inherit from a
+   common base. Tight coupling makes it hard to add engines in separate packages.
+2. **Configuration-driven factory**: Register engines via config files. Loses
+   type safety and makes capability discovery harder.
+3. **Monolithic multi-engine module**: All engines in one module with
+   conditional imports. Grows unwieldy as engines are added.
+
+## Consequences
+
+- **Positive**: Engines can be installed independently; missing engines degrade gracefully
+- **Positive**: New engines added without modifying existing code (open/closed principle)
+- **Positive**: Capability queries let the UI adapt to available engines at runtime
+- **Negative**: Engine-specific features require protocol extensions or escape hatches
+- **Negative**: Runtime detection adds startup overhead (mitigated by caching)
+- **Follow-ups**: Define formal engine capability taxonomy as more engines are added
+
+## Validation
+
+- Unit tests mock engine imports to verify graceful degradation when engines are missing
+- Integration tests in `tests/integration/cross_engine/` validate protocol compliance
+- CI matrix tests each engine in isolation and in combination

--- a/docs/adr/0003-websocket-realtime-simulation.md
+++ b/docs/adr/0003-websocket-realtime-simulation.md
@@ -1,0 +1,56 @@
+# ADR-0003: WebSocket Protocol for Real-Time Simulation
+
+- Status: Accepted
+- Date: 2026-02-18
+- Decision Makers: Core maintainers
+- Related Issues/PRs: #1486
+
+## Context
+
+Physics simulations produce continuous state data (joint angles, forces, torques,
+contact points) that needs to be streamed to the UI in real-time for
+visualization and interactive control. HTTP request/response polling would
+introduce unacceptable latency for 60+ Hz simulation updates. The protocol must
+also support bidirectional communication so users can adjust simulation
+parameters while it is running.
+
+Key constraints:
+
+- Simulation state updates at 60-1000 Hz depending on engine and model complexity
+- UI must render smoothly without dropped frames or lag spikes
+- Users need interactive control (pause, resume, parameter adjustment) during simulation
+- Multiple simultaneous simulations may run for cross-engine comparison
+
+## Decision
+
+Use WebSocket connections for real-time simulation data streaming:
+
+- Each simulation session gets its own WebSocket connection
+- Binary messages (MessagePack) for high-frequency state updates to minimize serialization overhead
+- JSON messages for control commands and configuration changes
+- Server-side rate limiting to prevent client overwhelm when simulation runs faster than render rate
+- Structured message types with a `type` field for routing
+
+## Alternatives Considered
+
+1. **HTTP long polling**: Simple to implement but adds per-request overhead.
+   Not suitable for high-frequency updates.
+2. **Server-Sent Events (SSE)**: Server-to-client only; cannot send control
+   commands back without a separate HTTP channel.
+3. **gRPC streaming**: Excellent performance but adds protobuf compilation step
+   and is harder to debug from browser-based tools.
+
+## Consequences
+
+- **Positive**: Low-latency simulation visualization (sub-millisecond message delivery)
+- **Positive**: Bidirectional communication enables interactive parameter tuning
+- **Positive**: Per-session connections provide natural isolation for multi-engine comparison
+- **Negative**: Connection management complexity (reconnection, error handling, cleanup)
+- **Negative**: Requires careful handling of connection lifecycle and resource cleanup
+- **Follow-ups**: Define message schema versioning strategy for protocol evolution
+
+## Validation
+
+- WebSocket integration tests in `tests/api/` verify message round-trip latency
+- Load tests simulate multiple concurrent WebSocket connections
+- Connection lifecycle tests verify proper cleanup on disconnect and server shutdown

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,15 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 - Every ADR must include Status, Date, and validation notes.
 - Superseded ADRs must link to the replacing ADR.
 
-## Initial ADR Backlog
+## Index
+
+| ADR                                                | Title                                       | Status   | Date       |
+| -------------------------------------------------- | ------------------------------------------- | -------- | ---------- |
+| [0001](0001-fastapi-local-first-api.md)            | FastAPI for Local-First API Design          | Accepted | 2026-02-18 |
+| [0002](0002-physics-engine-plugin-architecture.md) | Physics Engine Plugin Architecture          | Accepted | 2026-02-18 |
+| [0003](0003-websocket-realtime-simulation.md)      | WebSocket Protocol for Real-Time Simulation | Accepted | 2026-02-18 |
+
+## ADR Backlog
 
 1. Engine adapter boundary ownership and contract lifecycle.
 2. UI/API orchestration boundaries and dependency direction.

--- a/docs/development/FIRST_CONTRIBUTION.md
+++ b/docs/development/FIRST_CONTRIBUTION.md
@@ -1,0 +1,123 @@
+# Your First Contribution
+
+Welcome to UpstreamDrift! This guide will help you go from zero to your first PR.
+
+## Prerequisites
+
+- Python 3.11+ (Python 3.13 recommended)
+- Git with Git LFS
+- A GitHub account with fork permissions
+
+## Setup (10 minutes)
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/D-sorganization/UpstreamDrift.git
+   cd UpstreamDrift
+   git lfs install && git lfs pull
+   ```
+
+2. Create a virtual environment:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+3. Install dependencies:
+
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+4. Install pre-commit hooks:
+
+   ```bash
+   pre-commit install
+   pre-commit install --hook-type pre-push
+   ```
+
+5. Run the test suite to verify your setup:
+
+   ```bash
+   pytest tests/unit -x -q --tb=short
+   ```
+
+   If all tests pass, you are ready to contribute.
+
+## Architecture Overview
+
+The codebase is organized into layers:
+
+- **src/api/**: FastAPI server with REST and WebSocket endpoints
+- **src/engines/**: Physics engine adapters (MuJoCo, Drake, Pinocchio, OpenSim, MyoSuite)
+- **src/shared/**: Common utilities, contracts, logging, physics models
+- **src/tools/**: Development and analysis tools
+- **src/launchers/**: Application entry points (unified launcher)
+- **tests/**: Unit, integration, and API tests
+
+For more detail, see [Architecture](architecture.md) and the
+[ADRs](../adr/README.md) for key design decisions.
+
+## Making Your First Change
+
+1. Create a feature branch from `main`:
+
+   ```bash
+   git checkout main && git pull
+   git checkout -b feature/your-change-description
+   ```
+
+2. Make your changes following our code style (enforced by pre-commit hooks).
+
+3. Run tests locally:
+
+   ```bash
+   pytest tests/unit -x -q
+   ```
+
+4. Commit and push:
+
+   ```bash
+   git add your-files
+   git commit -m "feat: description of your change"
+   git push -u origin feature/your-change-description
+   ```
+
+5. Create a PR on GitHub. The CI pipeline will run automatically.
+
+## Commit Message Format
+
+We use conventional commits:
+
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation only
+- `refactor:` Code refactoring (no behavior change)
+- `test:` Adding or updating tests
+- `ci:` CI/CD configuration changes
+- `chore:` Maintenance tasks (dependency updates, etc.)
+
+## Common Development Tasks
+
+The Makefile provides shortcuts for frequent operations:
+
+```bash
+make help      # Show all available targets
+make install   # Install dependencies
+make check     # Run linters and tests
+make format    # Format code with ruff
+```
+
+## Good First Issues
+
+Look for issues labeled
+[`good first issue`](https://github.com/D-sorganization/UpstreamDrift/labels/good%20first%20issue)
+on GitHub. These are specifically chosen to be approachable for new contributors.
+
+## Need Help?
+
+- Check the [Troubleshooting Guide](../troubleshooting/README.md) for common issues
+- Read through existing [docs/](../README.md) for more guides
+- Open a GitHub issue if you are stuck

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,9 +1,10 @@
 # Development
 
-Documentation for developers contributing to the Golf Modeling Suite.
+Documentation for developers contributing to UpstreamDrift.
 
 ## Contents
 
+- **[First Contribution](FIRST_CONTRIBUTION.md)**: New here? Start with this onboarding guide.
 - **[Architecture](architecture.md)**: Understanding the system design.
 - **[Contributing](contributing.md)**: How to submit changes.
 - **[Testing](testing.md)**: Running the test suite.

--- a/docs/engine_selection_guide.md
+++ b/docs/engine_selection_guide.md
@@ -1,0 +1,163 @@
+# Engine Selection Guide
+
+UpstreamDrift supports 5 physics engines, each with different strengths. This
+guide helps you choose the right engine for your use case.
+
+## Quick Decision Matrix
+
+| Capability              | MuJoCo     | Drake     | Pinocchio | OpenSim    | MyoSuite   |
+| ----------------------- | ---------- | --------- | --------- | ---------- | ---------- |
+| Real-time performance   | Excellent  | Good      | Excellent | Fair       | Good       |
+| Muscle modeling         | Limited    | No        | No        | Excellent  | Excellent  |
+| Contact physics         | Excellent  | Good      | Good      | Fair       | Good       |
+| Trajectory optimization | Good       | Excellent | Good      | Fair       | Fair       |
+| Inverse kinematics      | Good       | Excellent | Excellent | Good       | Fair       |
+| Python API quality      | Excellent  | Good      | Excellent | Fair       | Good       |
+| Install complexity      | Easy       | Medium    | Easy      | Hard       | Medium     |
+| License                 | Apache 2.0 | BSD 3     | BSD 2     | Apache 2.0 | Apache 2.0 |
+
+## When to Use Each Engine
+
+### MuJoCo (Recommended Default)
+
+**Best for**: General-purpose physics simulation, real-time visualization,
+contact-rich scenarios, and getting started quickly.
+
+MuJoCo is the most well-rounded engine in the suite. It offers excellent
+real-time performance, robust contact physics, and the simplest installation
+path. If you are unsure which engine to use, start here.
+
+```bash
+pip install mujoco
+```
+
+Key strengths:
+
+- Fast and stable contact simulation
+- Excellent Python bindings with NumPy integration
+- Good documentation and large user community
+- MyoSuite builds on top of MuJoCo for muscle modeling
+
+### Drake
+
+**Best for**: Trajectory optimization, mathematical rigor, formal verification,
+and model-based control design.
+
+Drake excels at optimization-based approaches. If your workflow involves solving
+optimal control problems or you need mathematically rigorous dynamics
+formulations, Drake is the right choice.
+
+```bash
+pip install drake
+```
+
+Key strengths:
+
+- State-of-the-art trajectory optimization solvers
+- Mathematical program formulation for control design
+- Formal plant/controller separation
+- Strong URDF/SDF model support
+
+### Pinocchio
+
+**Best for**: Rigid body dynamics, inverse kinematics, analytical Jacobians,
+and robot control research.
+
+Pinocchio provides the fastest analytical rigid body dynamics computations. It is
+ideal for control algorithms that need fast Jacobian and dynamics evaluations.
+
+```bash
+pip install pin
+```
+
+Key strengths:
+
+- Fastest analytical rigid body algorithms (RNEA, ABA, CRBA)
+- Efficient Jacobian and derivative computations
+- PINK inverse kinematics integration
+- Lightweight with minimal dependencies
+
+### OpenSim
+
+**Best for**: Musculoskeletal modeling, biomechanics research, and validation
+against established biomechanics literature.
+
+OpenSim is the gold standard for musculoskeletal modeling in biomechanics
+research. Use it when you need to validate results against published studies or
+work with existing OpenSim models.
+
+```bash
+conda install -c opensim-org opensim
+```
+
+Key strengths:
+
+- Validated musculoskeletal models (MoBL-ARMS, Rajagopal)
+- Large library of existing models and motion data
+- Established in biomechanics research community
+- Muscle-tendon dynamics with Hill-type models
+
+### MyoSuite
+
+**Best for**: Muscle-actuated simulations, reinforcement learning with
+musculoskeletal models, and high-fidelity muscle dynamics.
+
+MyoSuite extends MuJoCo with realistic muscle models. Use it when you need
+muscle-level actuation with reinforcement learning or when studying muscle
+coordination patterns.
+
+```bash
+pip install myosuite
+```
+
+Key strengths:
+
+- 290-muscle full body models
+- Hill-type muscle dynamics (force-length-velocity relationships)
+- Built-in reinforcement learning task suite
+- Builds on MuJoCo's fast simulation core
+
+## Choosing by Use Case
+
+| Use Case                 | Recommended Engine | Alternative  |
+| ------------------------ | ------------------ | ------------ |
+| Quick prototyping        | MuJoCo             | Pinocchio    |
+| Biomechanics research    | OpenSim            | MyoSuite     |
+| Optimal control          | Drake              | MuJoCo       |
+| Muscle coordination      | MyoSuite           | OpenSim      |
+| Robot control algorithms | Pinocchio          | Drake        |
+| Contact-rich simulation  | MuJoCo             | Drake        |
+| RL with muscles          | MyoSuite           | MuJoCo       |
+| Model validation         | OpenSim            | Cross-engine |
+
+## Cross-Engine Validation
+
+One of UpstreamDrift's key features is the ability to compare results across
+engines. This is useful for validating that your simulation results are not
+engine-specific artifacts.
+
+Run the cross-engine validation tests:
+
+```bash
+pytest tests/integration/cross_engine/ -v
+```
+
+For known differences between engines, see
+[Troubleshooting: Cross-Engine Deviations](troubleshooting/cross_engine_deviations.md).
+
+## Installing Multiple Engines
+
+To install all available engines at once:
+
+```bash
+pip install -e ".[engines]"
+```
+
+Or install specific engines:
+
+```bash
+pip install -e ".[mujoco,drake,pinocchio]"
+```
+
+For engines that require conda (OpenSim), see
+[Installation Guide](troubleshooting/installation.md).

--- a/docs/troubleshooting/FAQ.md
+++ b/docs/troubleshooting/FAQ.md
@@ -1,0 +1,141 @@
+# Frequently Asked Questions
+
+Quick answers to the most common questions. For detailed troubleshooting, see
+[common-issues.md](common-issues.md).
+
+## Setup and Installation
+
+### Q: Which Python version do I need?
+
+Python 3.11 or newer. Python 3.13 is recommended. Check with:
+
+```bash
+python3 --version
+```
+
+### Q: Do I need all 5 physics engines installed?
+
+No. You can install only the engines you need. MuJoCo is the recommended
+default. The suite degrades gracefully when engines are missing. See the
+[Engine Selection Guide](../engine_selection_guide.md) to choose.
+
+### Q: How do I install in development mode?
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+pre-commit install --hook-type pre-push
+```
+
+## Engines
+
+### Q: I get `EngineNotAvailableError: Engine 'mujoco' not found`
+
+The engine is not installed in your current environment. Solutions:
+
+1. Check that the engine is installed: `python3 -c "import mujoco; print(mujoco.__version__)"`
+2. Verify your virtual environment is active: `which python3`
+3. Reinstall: `pip install -e ".[mujoco]"`
+
+### Q: Which engine should I start with?
+
+MuJoCo. It has the easiest installation, best documentation, and covers the
+widest range of use cases. See the [Engine Selection Guide](../engine_selection_guide.md).
+
+### Q: Can I run simulations without any physics engine?
+
+Yes, for UI development. Set `GOLF_USE_MOCK_ENGINE=1` to use the mock engine:
+
+```bash
+export GOLF_USE_MOCK_ENGINE=1
+python3 launch_golf_suite.py
+```
+
+## API and WebSocket
+
+### Q: The simulation stream disconnects after ~30 seconds
+
+This is usually a WebSocket timeout. Solutions:
+
+1. Check the server is running: `curl http://localhost:8000/api/health`
+2. Increase timeout in client configuration
+3. Check that your firewall is not blocking WebSocket upgrades
+
+### Q: Where are the API docs?
+
+When the server is running, visit:
+
+- Swagger UI: `http://localhost:8000/docs`
+- ReDoc: `http://localhost:8000/redoc`
+
+## Development
+
+### Q: Pre-commit hooks reject my commit
+
+Run hooks manually to see the full output:
+
+```bash
+pre-commit run --all-files
+```
+
+Common fixes:
+
+- Formatting: `ruff format src/`
+- Lint errors: `ruff check src/ --fix`
+
+### Q: Tests fail locally but pass in CI (or vice versa)
+
+Common causes:
+
+1. Missing optional dependencies: `pip install -e ".[all-engines]"`
+2. Stale pytest cache: `pytest --cache-clear`
+3. Order-dependent tests: `pytest --randomly-seed=last`
+4. Platform differences (e.g., headless Linux needs `xvfb-run pytest`)
+
+### Q: I get `ModuleNotFoundError` when importing project modules
+
+Ensure the package is installed in development mode:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Check that you are using the correct Python:
+
+```bash
+which python3
+```
+
+### Q: How do I run only a subset of tests?
+
+```bash
+# Unit tests only (fast)
+pytest tests/unit -x -q
+
+# Specific test file
+pytest tests/unit/test_engine_manager.py -v
+
+# Tests matching a keyword
+pytest -k "mujoco" -v
+```
+
+## Performance
+
+### Q: Simulation is running slowly
+
+1. Use headless mode for batch runs (no rendering overhead)
+2. Reduce visualization frequency if rendering every frame
+3. Check that you are not running inside a debugger
+
+### Q: High memory usage (>4GB)
+
+1. Load models on-demand instead of all at startup
+2. Clear cached models when switching between simulations
+3. Check for large data arrays being kept in memory
+
+## Still Stuck?
+
+1. Search [GitHub Issues](https://github.com/D-sorganization/UpstreamDrift/issues)
+2. Read the detailed [Common Issues Guide](common-issues.md)
+3. Check [Cross-Engine Deviations](cross_engine_deviations.md) for engine-specific quirks
+4. Open a new issue with your Python version, OS, and full error traceback

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,11 +1,12 @@
 # Troubleshooting
 
-This directory contains troubleshooting guides for the Golf Modeling Suite.
+This directory contains troubleshooting guides for UpstreamDrift.
 
 ## Contents
 
 | Document                                                 | Description                                           |
 | -------------------------------------------------------- | ----------------------------------------------------- |
+| [FAQ.md](FAQ.md)                                         | Quick answers to frequently asked questions           |
 | [common-issues.md](common-issues.md)                     | Comprehensive guide for common problems and solutions |
 | [cross_engine_deviations.md](cross_engine_deviations.md) | Known differences between physics engines             |
 
@@ -13,22 +14,23 @@ This directory contains troubleshooting guides for the Golf Modeling Suite.
 
 ### By Category
 
-- **Installation Problems?** → [common-issues.md#installation-issues](common-issues.md#installation-issues)
-- **Engine Not Working?** → [common-issues.md#engine-issues](common-issues.md#engine-issues)
-- **GUI Crashes?** → [common-issues.md#guilauncher-issues](common-issues.md#guilauncher-issues)
-- **Slow Performance?** → [common-issues.md#performance-issues](common-issues.md#performance-issues)
-- **CI/CD Failures?** → [common-issues.md#cicd-issues](common-issues.md#cicd-issues)
+- **Quick FAQ?** --> [FAQ.md](FAQ.md)
+- **Installation Problems?** --> [common-issues.md#installation-issues](common-issues.md#installation-issues)
+- **Engine Not Working?** --> [common-issues.md#engine-issues](common-issues.md#engine-issues)
+- **GUI Crashes?** --> [common-issues.md#guilauncher-issues](common-issues.md#guilauncher-issues)
+- **Slow Performance?** --> [common-issues.md#performance-issues](common-issues.md#performance-issues)
+- **CI/CD Failures?** --> [common-issues.md#cicd-issues](common-issues.md#cicd-issues)
 
 ### Quick Diagnostics
 
 Run this command to get a diagnostic report:
 
 ```bash
-python -c "from shared.python import EngineManager; print(EngineManager().get_diagnostic_report())"
+python3 -c "from shared.python import EngineManager; print(EngineManager().get_diagnostic_report())"
 ```
 
 ### Still Need Help?
 
-1. Check [GitHub Issues](https://github.com/dieterolson/UpstreamDrift/issues)
+1. Check [GitHub Issues](https://github.com/D-sorganization/UpstreamDrift/issues)
 2. Review [assessment documents](../assessments/)
 3. Open a new issue with full details


### PR DESCRIPTION
## Summary
- Add 3 Architecture Decision Records following existing ADR template:
  - ADR-0001: FastAPI for Local-First API Design
  - ADR-0002: Physics Engine Plugin Architecture
  - ADR-0003: WebSocket Protocol for Real-Time Simulation
- Create first-contribution onboarding guide (`docs/development/FIRST_CONTRIBUTION.md`)
- Create engine selection decision matrix and use-case guide (`docs/engine_selection_guide.md`)
- Create troubleshooting FAQ (`docs/troubleshooting/FAQ.md`) complementing existing common-issues guide
- Update ADR, development, and troubleshooting index pages with links to new docs

## Test plan
- [ ] All markdown files render correctly on GitHub
- [ ] Links between documents are valid
- [ ] ADR format follows existing ADR_TEMPLATE.md conventions
- [ ] Tables render properly in engine selection guide

Closes #1486

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior; main risk is broken links or outdated guidance.
> 
> **Overview**
> Adds three new ADRs documenting architectural decisions around using `FastAPI` for a local API, a protocol-based physics engine plugin architecture, and a WebSocket-based real-time simulation protocol.
> 
> Improves contributor and user documentation by adding a first-contribution onboarding guide, an engine selection decision matrix/use-case guide, and a troubleshooting FAQ; updates `docs/adr/README.md`, `docs/development/README.md`, and `docs/troubleshooting/README.md` to index these docs and fixes a couple of project/link/command references (e.g., `python3`, GitHub org URL).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a68549cff36427c3c8e83c77fcc66c457aeb7c4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->