### PR TITLE
feat: engine plugin registry with thread-safe ops and entry-point discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,11 @@ all = ["upstream-drift[all-engines,analysis,pose,biomechanics,rl,urdf,dev]"]
 [project.scripts]
 upstream-drift = "launch_golf_suite:main"
 
+[project.entry-points."upstream_drift.engines"]
+# Third-party engines register here via pyproject.toml:
+# [project.entry-points."upstream_drift.engines"]
+# my_engine = "my_package:get_engine_plugin"
+
 [project.urls]
 Homepage = "https://github.com/D-sorganization/UpstreamDrift"
 Documentation = "https://upstream-drift.readthedocs.io"

--- a/src/shared/python/engine_core/__init__.py
+++ b/src/shared/python/engine_core/__init__.py
@@ -11,7 +11,10 @@ Sub-protocols (Interface Segregation):
 __all__: list[str] = [
     "CounterfactualComputable",
     "DynamicsComputable",
+    "EngineLifecycle",
+    "EnginePluginMetadata",
     "Loadable",
+    "PluginRegistry",
     "Queryable",
     "Recordable",
     "Steppable",

--- a/src/shared/python/engine_core/plugin_registry.py
+++ b/src/shared/python/engine_core/plugin_registry.py
@@ -1,0 +1,251 @@
+"""Plugin registry with thread-safe operations and entry-point discovery.
+
+Extends the base EngineRegistry with:
+- Thread-safe registration and unregistration
+- Entry-point based plugin discovery for third-party engines
+- Plugin metadata support
+- Engine lifecycle management (startup/shutdown)
+
+Design by Contract:
+    Invariants:
+        - _registrations dict is never None
+        - _lock is always held during mutations
+        - All registered types are valid EngineType values
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any
+
+from src.shared.python.engine_core.engine_registry import (
+    EngineFactory,
+    EngineRegistration,
+    EngineType,
+)
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "upstream_drift.engines"
+
+
+@dataclass
+class EnginePluginMetadata:
+    """Metadata for a registered engine plugin.
+
+    Attributes:
+        name: Human-readable plugin name.
+        version: Semantic version string.
+        engine_type: The EngineType this plugin provides.
+        author: Plugin author (optional).
+        description: Short description (optional).
+        requires: List of required packages (optional).
+    """
+
+    name: str
+    version: str
+    engine_type: EngineType
+    author: str = ""
+    description: str = ""
+    requires: list[str] = field(default_factory=list)
+
+
+class PluginRegistry:
+    """Thread-safe engine plugin registry with metadata and discovery.
+
+    Extends the engine registry concept with:
+    - Thread-safe read/write via threading.Lock
+    - Unregistration support for testing and dynamic plugins
+    - Plugin metadata storage alongside registrations
+    - Entry-point based discovery
+
+    Design by Contract:
+        Invariants:
+            - _registrations is always a dict[EngineType, EngineRegistration]
+            - _metadata is always a dict[EngineType, EnginePluginMetadata]
+            - Concurrent access is serialized via _lock
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._registrations: dict[EngineType, EngineRegistration] = {}
+        self._metadata: dict[EngineType, EnginePluginMetadata] = {}
+
+    def register(self, registration: EngineRegistration) -> None:
+        """Register an engine (thread-safe, overwrites existing).
+
+        Preconditions:
+            - registration is not None
+            - registration.engine_type is a valid EngineType
+
+        Postconditions:
+            - get(registration.engine_type) returns registration
+        """
+        with self._lock:
+            self._registrations[registration.engine_type] = registration
+
+    def unregister(self, engine_type: EngineType) -> bool:
+        """Remove an engine registration.
+
+        Preconditions:
+            - engine_type is a valid EngineType
+
+        Postconditions:
+            - get(engine_type) returns None
+            - Returns True if engine was registered, False otherwise
+        """
+        with self._lock:
+            if engine_type in self._registrations:
+                del self._registrations[engine_type]
+                self._metadata.pop(engine_type, None)
+                return True
+            return False
+
+    def get(self, engine_type: EngineType) -> EngineRegistration | None:
+        """Get registration for an engine type (thread-safe)."""
+        with self._lock:
+            return self._registrations.get(engine_type)
+
+    def all_types(self) -> list[EngineType]:
+        """Get all registered engine types (thread-safe)."""
+        with self._lock:
+            return list(self._registrations.keys())
+
+    def register_plugin(
+        self,
+        engine_type: EngineType,
+        factory: EngineFactory,
+        metadata: EnginePluginMetadata,
+    ) -> None:
+        """Register a plugin with metadata.
+
+        Preconditions:
+            - engine_type, factory, and metadata are not None
+            - metadata.engine_type matches engine_type
+
+        Postconditions:
+            - get(engine_type) returns an EngineRegistration
+            - get_metadata(engine_type) returns metadata
+        """
+        reg = EngineRegistration(engine_type=engine_type, factory=factory)
+        with self._lock:
+            self._registrations[engine_type] = reg
+            self._metadata[engine_type] = metadata
+
+    def get_metadata(self, engine_type: EngineType) -> EnginePluginMetadata | None:
+        """Get metadata for a registered plugin."""
+        with self._lock:
+            return self._metadata.get(engine_type)
+
+    def load_entry_point_plugins(self) -> int:
+        """Discover and register plugins from entry points.
+
+        Returns:
+            Number of plugins successfully loaded.
+        """
+        plugins = discover_entry_point_plugins()
+        count = 0
+        for plugin_info in plugins:
+            et = plugin_info["engine_type"]
+            factory = plugin_info["factory"]
+            meta = plugin_info.get("metadata")
+            if meta:
+                self.register_plugin(et, factory, meta)
+            else:
+                self.register(EngineRegistration(engine_type=et, factory=factory))
+            count += 1
+        return count
+
+
+class EngineLifecycle:
+    """Tracks active engine instances and manages their lifecycle.
+
+    Ensures engines are properly shut down when replaced or when
+    the application exits.
+
+    Design by Contract:
+        Invariants:
+            - _active is always a dict mapping EngineType to engine instances
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[EngineType, Any] = {}
+
+    def track(self, engine_type: EngineType, engine: Any) -> None:
+        """Start tracking an active engine instance.
+
+        Preconditions:
+            - engine_type is a valid EngineType
+            - engine is not None
+        """
+        self._active[engine_type] = engine
+
+    def is_active(self, engine_type: EngineType) -> bool:
+        """Check if an engine type is currently active."""
+        return engine_type in self._active
+
+    def shutdown(self, engine_type: EngineType) -> None:
+        """Shut down a specific engine if it has a shutdown method.
+
+        Postconditions:
+            - Engine is no longer tracked
+            - shutdown() called if engine supports it
+        """
+        engine = self._active.pop(engine_type, None)
+        if engine is None:
+            return
+        if hasattr(engine, "shutdown") and callable(engine.shutdown):
+            try:
+                engine.shutdown()
+            except Exception:
+                logger.warning(
+                    "Engine shutdown failed for %s", engine_type, exc_info=True
+                )
+
+    def shutdown_all(self) -> None:
+        """Shut down all tracked engines.
+
+        Postconditions:
+            - No engines are active
+        """
+        for engine_type in list(self._active.keys()):
+            self.shutdown(engine_type)
+
+
+def discover_entry_point_plugins() -> list[dict[str, Any]]:
+    """Discover engine plugins registered via entry points.
+
+    Looks for entry points in the ``upstream_drift.engines`` group.
+    Each entry point should resolve to a dict with:
+        - engine_type: EngineType
+        - factory: Callable[[], PhysicsEngine]
+        - metadata: EnginePluginMetadata (optional)
+
+    Returns:
+        List of plugin info dicts. Broken plugins are skipped with a warning.
+    """
+    results: list[dict[str, Any]] = []
+    try:
+        eps = entry_points(group=ENTRY_POINT_GROUP)
+    except TypeError:
+        # Python 3.9 compatibility: entry_points() doesn't accept group kwarg
+        eps = entry_points().get(ENTRY_POINT_GROUP, [])  # type: ignore[union-attr]
+
+    for ep in eps:
+        try:
+            plugin_info = ep.load()
+            if isinstance(plugin_info, dict) and "engine_type" in plugin_info:
+                results.append(plugin_info)
+            else:
+                logger.warning(
+                    "Entry point %s did not return a valid plugin dict", ep.name
+                )
+        except Exception:
+            logger.warning(
+                "Failed to load engine plugin %s", ep.name, exc_info=True
+            )
+
+    return results

--- a/tests/unit/engines/test_plugin_registry.py
+++ b/tests/unit/engines/test_plugin_registry.py
@@ -1,0 +1,399 @@
+"""Tests for the engine plugin registry and discovery system.
+
+TDD: These tests define the contract for the plugin registry before
+implementation. They cover:
+- Thread-safe registration/unregistration
+- Entry-point based plugin discovery
+- Engine lifecycle protocol (shutdown)
+- Plugin metadata
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.shared.python.engine_core.engine_registry import (
+    EngineRegistration,
+    EngineType,
+)
+from src.shared.python.engine_core.plugin_registry import (
+    EngineLifecycle,
+    EnginePluginMetadata,
+    PluginRegistry,
+    discover_entry_point_plugins,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub engine for testing
+# ---------------------------------------------------------------------------
+
+
+class _StubEngine:
+    """Minimal engine that satisfies PhysicsEngine-like interface for tests."""
+
+    def __init__(self) -> None:
+        self._shutdown = False
+
+    @property
+    def model_name(self) -> str:
+        return "stub"
+
+    def load_from_path(self, path: str) -> None:
+        pass
+
+    def load_from_string(self, content: str, extension: str | None = None) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def step(self, dt: float | None = None) -> None:
+        pass
+
+    def forward(self) -> None:
+        pass
+
+    def get_state(self) -> tuple[np.ndarray, np.ndarray]:
+        return np.zeros(2), np.zeros(2)
+
+    def set_state(self, q: np.ndarray, v: np.ndarray) -> None:
+        pass
+
+    def set_control(self, u: np.ndarray) -> None:
+        pass
+
+    def get_time(self) -> float:
+        return 0.0
+
+    def compute_mass_matrix(self) -> np.ndarray:
+        return np.eye(2)
+
+    def compute_bias_forces(self) -> np.ndarray:
+        return np.zeros(2)
+
+    def compute_gravity_forces(self) -> np.ndarray:
+        return np.zeros(2)
+
+    def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:
+        return qacc
+
+    def compute_jacobian(self, body_name: str) -> dict[str, np.ndarray] | None:
+        return None
+
+    def compute_drift_acceleration(self) -> np.ndarray:
+        return np.zeros(2)
+
+    def compute_control_acceleration(self, tau: np.ndarray) -> np.ndarray:
+        return tau
+
+    def compute_ztcf(self, q: np.ndarray, v: np.ndarray) -> np.ndarray:
+        return np.zeros(2)
+
+    def compute_zvcf(self, q: np.ndarray) -> np.ndarray:
+        return np.zeros(2)
+
+    @property
+    def engine_type(self) -> str:
+        return "stub"
+
+    def save_checkpoint(self) -> Any:
+        return {}
+
+    def restore_checkpoint(self, checkpoint: Any) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+
+def _stub_factory() -> _StubEngine:
+    return _StubEngine()
+
+
+# ---------------------------------------------------------------------------
+# PluginRegistry tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRegistryBasics:
+    """Test basic registration and retrieval."""
+
+    def test_register_and_get(self) -> None:
+        registry = PluginRegistry()
+        reg = EngineRegistration(
+            engine_type=EngineType.PENDULUM, factory=_stub_factory
+        )
+        registry.register(reg)
+        assert registry.get(EngineType.PENDULUM) is reg
+
+    def test_get_missing_returns_none(self) -> None:
+        registry = PluginRegistry()
+        assert registry.get(EngineType.DRAKE) is None
+
+    def test_all_types(self) -> None:
+        registry = PluginRegistry()
+        reg = EngineRegistration(
+            engine_type=EngineType.MUJOCO, factory=_stub_factory
+        )
+        registry.register(reg)
+        assert EngineType.MUJOCO in registry.all_types()
+
+    def test_register_overwrites(self) -> None:
+        registry = PluginRegistry()
+        reg1 = EngineRegistration(
+            engine_type=EngineType.PENDULUM, factory=_stub_factory
+        )
+        reg2 = EngineRegistration(
+            engine_type=EngineType.PENDULUM, factory=_stub_factory
+        )
+        registry.register(reg1)
+        registry.register(reg2)
+        assert registry.get(EngineType.PENDULUM) is reg2
+
+
+class TestPluginRegistryUnregister:
+    """Test unregistration support."""
+
+    def test_unregister_existing(self) -> None:
+        registry = PluginRegistry()
+        reg = EngineRegistration(
+            engine_type=EngineType.PENDULUM, factory=_stub_factory
+        )
+        registry.register(reg)
+        result = registry.unregister(EngineType.PENDULUM)
+        assert result is True
+        assert registry.get(EngineType.PENDULUM) is None
+
+    def test_unregister_missing_returns_false(self) -> None:
+        registry = PluginRegistry()
+        result = registry.unregister(EngineType.DRAKE)
+        assert result is False
+
+    def test_unregister_removes_from_all_types(self) -> None:
+        registry = PluginRegistry()
+        reg = EngineRegistration(
+            engine_type=EngineType.MUJOCO, factory=_stub_factory
+        )
+        registry.register(reg)
+        registry.unregister(EngineType.MUJOCO)
+        assert EngineType.MUJOCO not in registry.all_types()
+
+
+class TestPluginRegistryThreadSafety:
+    """Test thread-safe operations."""
+
+    def test_concurrent_register(self) -> None:
+        registry = PluginRegistry()
+        errors: list[Exception] = []
+
+        def register_engine(engine_type: EngineType) -> None:
+            try:
+                reg = EngineRegistration(
+                    engine_type=engine_type, factory=_stub_factory
+                )
+                registry.register(reg)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=register_engine, args=(et,))
+            for et in [EngineType.MUJOCO, EngineType.DRAKE, EngineType.PINOCCHIO]
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert len(registry.all_types()) == 3
+
+    def test_concurrent_read_write(self) -> None:
+        registry = PluginRegistry()
+        reg = EngineRegistration(
+            engine_type=EngineType.PENDULUM, factory=_stub_factory
+        )
+        registry.register(reg)
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            try:
+                for _ in range(100):
+                    registry.get(EngineType.PENDULUM)
+                    registry.all_types()
+            except Exception as e:
+                errors.append(e)
+
+        def writer() -> None:
+            try:
+                for i in range(100):
+                    new_reg = EngineRegistration(
+                        engine_type=EngineType.PENDULUM, factory=_stub_factory
+                    )
+                    registry.register(new_reg)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# EnginePluginMetadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnginePluginMetadata:
+    """Test plugin metadata dataclass."""
+
+    def test_metadata_creation(self) -> None:
+        meta = EnginePluginMetadata(
+            name="test-engine",
+            version="1.0.0",
+            engine_type=EngineType.PENDULUM,
+            author="Test Author",
+            description="A test engine",
+        )
+        assert meta.name == "test-engine"
+        assert meta.version == "1.0.0"
+        assert meta.engine_type is EngineType.PENDULUM
+
+    def test_metadata_defaults(self) -> None:
+        meta = EnginePluginMetadata(
+            name="minimal",
+            version="0.1.0",
+            engine_type=EngineType.MUJOCO,
+        )
+        assert meta.author == ""
+        assert meta.description == ""
+        assert meta.requires == []
+
+    def test_register_with_metadata(self) -> None:
+        registry = PluginRegistry()
+        meta = EnginePluginMetadata(
+            name="test-engine",
+            version="1.0.0",
+            engine_type=EngineType.PENDULUM,
+        )
+        registry.register_plugin(
+            engine_type=EngineType.PENDULUM,
+            factory=_stub_factory,
+            metadata=meta,
+        )
+        assert registry.get(EngineType.PENDULUM) is not None
+        assert registry.get_metadata(EngineType.PENDULUM) is meta
+
+    def test_get_metadata_missing_returns_none(self) -> None:
+        registry = PluginRegistry()
+        assert registry.get_metadata(EngineType.DRAKE) is None
+
+
+# ---------------------------------------------------------------------------
+# EngineLifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestEngineLifecycle:
+    """Test engine lifecycle management."""
+
+    def test_lifecycle_tracks_engine(self) -> None:
+        lifecycle = EngineLifecycle()
+        engine = _StubEngine()
+        lifecycle.track(EngineType.PENDULUM, engine)
+        assert lifecycle.is_active(EngineType.PENDULUM)
+
+    def test_lifecycle_shutdown_single(self) -> None:
+        lifecycle = EngineLifecycle()
+        engine = _StubEngine()
+        lifecycle.track(EngineType.PENDULUM, engine)
+        lifecycle.shutdown(EngineType.PENDULUM)
+        assert engine._shutdown is True
+        assert not lifecycle.is_active(EngineType.PENDULUM)
+
+    def test_lifecycle_shutdown_all(self) -> None:
+        lifecycle = EngineLifecycle()
+        engine1 = _StubEngine()
+        engine2 = _StubEngine()
+        lifecycle.track(EngineType.PENDULUM, engine1)
+        lifecycle.track(EngineType.MUJOCO, engine2)
+        lifecycle.shutdown_all()
+        assert engine1._shutdown is True
+        assert engine2._shutdown is True
+        assert not lifecycle.is_active(EngineType.PENDULUM)
+        assert not lifecycle.is_active(EngineType.MUJOCO)
+
+    def test_lifecycle_shutdown_missing_is_noop(self) -> None:
+        lifecycle = EngineLifecycle()
+        lifecycle.shutdown(EngineType.DRAKE)  # Should not raise
+
+    def test_lifecycle_engine_without_shutdown(self) -> None:
+        """Engines without shutdown() method should still be cleanable."""
+        lifecycle = EngineLifecycle()
+        engine = MagicMock(spec=[])  # No shutdown method
+        lifecycle.track(EngineType.MUJOCO, engine)
+        lifecycle.shutdown(EngineType.MUJOCO)
+        assert not lifecycle.is_active(EngineType.MUJOCO)
+
+
+# ---------------------------------------------------------------------------
+# Entry-point discovery tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointDiscovery:
+    """Test entry-point based plugin discovery."""
+
+    def test_discover_with_no_plugins(self) -> None:
+        """When no entry points are installed, should return empty list."""
+        with patch(
+            "src.shared.python.engine_core.plugin_registry.entry_points",
+            return_value=[],
+        ):
+            plugins = discover_entry_point_plugins()
+            assert plugins == []
+
+    def test_discover_with_valid_plugin(self) -> None:
+        """Should load and return valid plugin registrations."""
+        mock_ep = MagicMock()
+        mock_ep.name = "test_engine"
+        mock_ep.load.return_value = {
+            "engine_type": EngineType.PENDULUM,
+            "factory": _stub_factory,
+            "metadata": EnginePluginMetadata(
+                name="test",
+                version="1.0.0",
+                engine_type=EngineType.PENDULUM,
+            ),
+        }
+
+        with patch(
+            "src.shared.python.engine_core.plugin_registry.entry_points",
+            return_value=[mock_ep],
+        ):
+            plugins = discover_entry_point_plugins()
+            assert len(plugins) == 1
+            assert plugins[0]["engine_type"] is EngineType.PENDULUM
+
+    def test_discover_skips_broken_plugin(self) -> None:
+        """Should skip plugins that fail to load without crashing."""
+        mock_ep = MagicMock()
+        mock_ep.name = "broken_engine"
+        mock_ep.load.side_effect = ImportError("missing dependency")
+
+        with patch(
+            "src.shared.python.engine_core.plugin_registry.entry_points",
+            return_value=[mock_ep],
+        ):
+            plugins = discover_entry_point_plugins()
+            assert plugins == []


### PR DESCRIPTION
## Summary
- **Thread-safe PluginRegistry** with register/unregister/get operations protected by threading.Lock
- **Entry-point based plugin discovery** (`upstream_drift.engines` group) for third-party engines
- **EngineLifecycle manager** for proper engine startup/shutdown tracking
- **EnginePluginMetadata** dataclass for plugin name, version, author, description
- **pyproject.toml entry-points section** for third-party engine registration

## Changes
- New: `src/shared/python/engine_core/plugin_registry.py` (PluginRegistry, EngineLifecycle, EnginePluginMetadata, discover_entry_point_plugins)
- New: `tests/unit/engines/test_plugin_registry.py` (21 TDD tests: basics, unregister, thread-safety, metadata, lifecycle, entry-point discovery)
- Updated: `src/shared/python/engine_core/__init__.py` (exports new classes)
- Updated: `pyproject.toml` (entry-points section for plugin registration)

## Design Principles
- **TDD**: 21 tests written first, all pass
- **DbC**: Preconditions/postconditions documented on all public methods
- **DRY**: Reuses existing EngineRegistration and EngineType from engine_registry module

## Test plan
- [x] 21 new tests pass (thread-safety, lifecycle, discovery)
- [x] No regressions to existing test suite
- [x] Thread-safety verified with concurrent read/write test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive changes (new registry, discovery, and tests) with minimal impact on existing engine loading paths; main risk is future runtime behavior when entry-point discovery is adopted.
> 
> **Overview**
> Introduces a new `PluginRegistry` in `engine_core` that supports thread-safe engine registration/unregistration, optional `EnginePluginMetadata`, and discovery of third-party engines via Python entry points (`upstream_drift.engines`).
> 
> Adds `EngineLifecycle` utilities to track active engine instances and call `shutdown()` safely, exports the new APIs from `engine_core/__init__.py`, documents the entry-point group in `pyproject.toml`, and includes a comprehensive unit test suite covering concurrency, metadata, lifecycle, and discovery behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc5c43e18f7d248182760e0a9f8c0295b61c362b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->