### PR TITLE
chore: Docker-first naming and cleanup plan

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -43,7 +43,7 @@ RUN micromamba create -y -f /tmp/environment.yml && \
 
 # Activate environment by default
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-ENV ENV_NAME=golf-suite
+ENV ENV_NAME=upstream-drift
 
 WORKDIR /app
 
@@ -69,4 +69,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
 # Run server
-CMD ["micromamba", "run", "-n", "golf-suite", "golf-suite", "--no-browser"]
+CMD ["micromamba", "run", "-n", "upstream-drift", "upstream-drift", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ git lfs install && git lfs pull
 
 # Create conda environment (most reliable)
 conda env create -f environment.yml
-conda activate golf-suite
+conda activate upstream-drift
 
 # Verify installation
 python scripts/verify_installation.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   # Backend API server with all physics engines
@@ -7,8 +7,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: runtime
-    image: golf-suite:latest
-    container_name: golf-suite-backend
+    image: upstream-drift:runtime
+    container_name: upstream-drift-backend
     ports:
       - "8001:8001"
     volumes:
@@ -32,12 +32,12 @@ services:
       retries: 3
       start_period: 40s
     networks:
-      - golf-suite
+      - upstream-drift
 
   # Frontend UI (optional - can also run locally)
   frontend:
     image: node:20-alpine
-    container_name: golf-suite-frontend
+    container_name: upstream-drift-frontend
     ports:
       - "5180:5180"
     volumes:
@@ -50,10 +50,10 @@ services:
     depends_on:
       - backend
     networks:
-      - golf-suite
+      - upstream-drift
 
 networks:
-  golf-suite:
+  upstream-drift:
     driver: bridge
 
 volumes:

--- a/docs/operations/DOCKER_CLEANUP_RUNBOOK.md
+++ b/docs/operations/DOCKER_CLEANUP_RUNBOOK.md
@@ -1,0 +1,107 @@
+# Docker Cleanup Runbook (Windows + WSL2 + Docker Desktop)
+
+## Purpose
+
+Provide a repeatable, low-risk cleanup process for reclaiming disk space while preserving recoverability.
+
+## Applies To
+
+- Primary machine (current)
+- Secondary machine with similar setup
+
+## Safety Principles
+
+- Capture inventory before deleting anything.
+- Retag before removing legacy names.
+- Remove containers first, then obviously unused images.
+- Keep rollback path documented.
+
+## 0) Pre-Cleanup Inventory (required)
+
+Run in WSL/Linux shell:
+
+```bash
+date
+mkdir -p /tmp/docker-cleanup
+
+docker ps -a > /tmp/docker-cleanup/containers.before.txt
+docker images > /tmp/docker-cleanup/images.before.txt
+docker volume ls > /tmp/docker-cleanup/volumes.before.txt
+docker system df -v > /tmp/docker-cleanup/system-df.before.txt
+```
+
+## 1) Normalize Image Tags (non-destructive)
+
+```bash
+# If legacy images exist, add canonical tags
+(docker image inspect robotics_env:latest >/dev/null 2>&1 && docker tag robotics_env:latest upstream-drift:engine) || true
+(docker image inspect golf-suite:latest >/dev/null 2>&1 && docker tag golf-suite:latest upstream-drift:runtime) || true
+(docker image inspect upstream-drift:engine >/dev/null 2>&1 && docker tag upstream-drift:engine upstream-drift:dev) || true
+```
+
+## 2) Remove Stale Containers and Cache
+
+```bash
+docker container prune -f
+docker builder prune -a -f
+```
+
+## 3) Remove Known Unused/Low-Value Images (safe candidates)
+
+```bash
+# Legacy NGC bases no longer referenced by current MLProjects Dockerfiles
+(docker image rm nvcr.io/nvidia/pytorch:24.05-py3) || true
+(docker image rm nvcr.io/nvidia/tensorflow:24.05-tf2-py3) || true
+
+# Optional management UI images (if unused)
+(docker image rm fnsys/dockhand:latest) || true
+(docker image rm portainer/portainer-ce:latest) || true
+(docker image rm docker/welcome-to-docker:latest) || true
+
+# Remove legacy aliases after canonical tags exist
+(docker image rm robotics_env:latest) || true
+(docker image rm golf-suite:latest) || true
+```
+
+## 4) Optional Volume Cleanup
+
+Only if you are sure no data is needed from old management tools:
+
+```bash
+(docker volume rm dockhand_data) || true
+(docker volume rm portainer_data) || true
+```
+
+## 5) Post-Cleanup Inventory (required)
+
+```bash
+docker ps -a > /tmp/docker-cleanup/containers.after.txt
+docker images > /tmp/docker-cleanup/images.after.txt
+docker volume ls > /tmp/docker-cleanup/volumes.after.txt
+docker system df -v > /tmp/docker-cleanup/system-df.after.txt
+```
+
+## 6) Reclaim Host Disk (Windows VHDX compaction)
+
+Without this, Windows file size often does not shrink even after Docker prune.
+
+Run in **Admin PowerShell**:
+
+```powershell
+wsl --shutdown
+Optimize-VHD -Path "C:\Users\<USER>\AppData\Local\Docker\wsl\disk\docker_data.vhdx" -Mode Full
+```
+
+## Rollback Commands
+
+```bash
+# Restore legacy tags if older scripts expect them
+(docker image inspect upstream-drift:engine >/dev/null 2>&1 && docker tag upstream-drift:engine robotics_env:latest) || true
+(docker image inspect upstream-drift:runtime >/dev/null 2>&1 && docker tag upstream-drift:runtime golf-suite:latest) || true
+```
+
+## Notes for ML Workloads
+
+- Keep ML training images separate from core product runtime.
+- Prefer versioned tags over reusing `latest`.
+- Use a documented artifact handoff into UpstreamDrift instead of embedding all training deps into `upstream-drift:runtime`.

--- a/docs/plans/DOCKER_FIRST_ADOPTION_PLAN.md
+++ b/docs/plans/DOCKER_FIRST_ADOPTION_PLAN.md
@@ -1,0 +1,70 @@
+# UpstreamDrift Docker-First Adoption Plan
+
+## Objective
+
+Standardize UpstreamDrift around a Docker-first workflow with a single image family name (`upstream-drift`) and explicit tags by purpose.
+
+## Canonical Image Contract
+
+- `upstream-drift:engine`
+  Purpose: launcher-driven physics engine execution (MuJoCo/Drake/Pinocchio workflows)
+  Build context: `src/engines/physics_engines/mujoco/`
+
+- `upstream-drift:runtime`
+  Purpose: API/backend runtime used by `docker compose`
+  Build context: repo root `Dockerfile` (`target: runtime`)
+
+- `upstream-drift:dev`
+  Purpose: local test/dev container helper workflows
+  Build context: `src/engines/physics_engines/mujoco/Dockerfile` (or explicit dev Dockerfile in future)
+
+## Why Tags Instead of Multiple Names
+
+Using a single repository name with tags keeps identity consistent while avoiding local clobbering between different Docker build contexts.
+
+## Current Migration Scope (in progress)
+
+- Rename host conda env to `upstream-drift`
+- Move launcher Docker image references to `upstream-drift:engine`
+- Move compose image reference to `upstream-drift:runtime`
+- Add compatibility fallback for legacy local tags (`robotics_env`, `golf-suite`)
+- Update tests/scripts/docs to canonical tags
+
+## Rollout Phases
+
+1. Phase 1: Compatibility Layer (current)
+
+- Keep legacy fallback while emitting warnings.
+- Add retag guidance and migration docs.
+
+2. Phase 2: Default Docker-First UX
+
+- Launcher defaults to Docker mode when available.
+- Local/WSL remain explicit fallback modes.
+
+3. Phase 3: Runtime Tiering
+
+- Keep core product runtime lean.
+- Move heavy training dependencies to optional training profile.
+
+4. Phase 4: Removal of Legacy Names
+
+- Remove fallback aliases after one release cycle and migration completion.
+
+## CI/Quality Gates (required)
+
+- Build and smoke-test `upstream-drift:runtime` in CI.
+- Build and smoke-test `upstream-drift:engine` in CI.
+- Add image-size budget checks with gradual enforcement.
+
+## Reversibility
+
+- Retag commands support rollback at any time:
+  - `docker tag upstream-drift:engine robotics_env:latest`
+  - `docker tag upstream-drift:runtime golf-suite:latest`
+- No destructive migration step should be mandatory.
+
+## Related Issues
+
+- UpstreamDrift: #1555, #1556, #1557, #1558, #1559, #1560, #1561, #1562
+- MLProjects: #160, #161

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -13,7 +13,7 @@ cd Golf_Modeling_Suite
 
 # Create conda environment (handles binary dependencies)
 conda env create -f environment.yml
-conda activate golf-suite
+conda activate upstream-drift
 
 # Verify installation
 python -c "import mujoco; print(f'MuJoCo version: {mujoco.__version__}')"
@@ -302,11 +302,11 @@ For complete isolation and reproducibility:
 
 ```bash
 # Build and run
-docker-compose up golf-suite
+docker compose up backend
 
 # Or build manually
-docker build -t golf-suite .
-docker run -p 8000:8000 golf-suite
+docker build -t upstream-drift:runtime .
+docker run -p 8000:8000 upstream-drift:runtime
 ```
 
 ---

--- a/environment.yml
+++ b/environment.yml
@@ -7,14 +7,14 @@
 # USAGE:
 #   Full installation (all engines):
 #     conda env create -f environment.yml
-#     conda activate golf-suite
+#     conda activate upstream-drift
 #
 #   Light installation (UI development, no heavy engines):
-#     conda env create -f environment.yml --name golf-suite-light --prune
+#     conda env create -f environment.yml --name upstream-drift-light --prune
 #     # Then comment out the 'engines' section before running
 #
 # ACTIVATION:
-#   conda activate golf-suite
+#   conda activate upstream-drift
 #
 # UPDATING:
 #   conda env update -f environment.yml --prune
@@ -22,7 +22,7 @@
 # TROUBLESHOOTING:
 #   See docs/troubleshooting/installation.md for common issues.
 
-name: golf-suite
+name: upstream-drift
 channels:
   - conda-forge
   - defaults

--- a/scripts/check_system_health.py
+++ b/scripts/check_system_health.py
@@ -12,6 +12,14 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+PRIMARY_DOCKER_IMAGE = "upstream-drift:engine"
+LEGACY_DOCKER_IMAGES: tuple[str, ...] = (
+    "robotics_env",
+    "upstream-drift",
+    "upstream-drift:latest",
+    "golf-suite",
+)
+
 
 def log_result(component: str, status: str, message: str = "") -> None:
     """Log a color-coded health check result line."""
@@ -80,8 +88,22 @@ def main() -> None:
 
     # 2. Docker Health
     logger.info("\n--- Docker Environment ---")
-    docker_ok, docker_msg = check_docker_image("robotics_env")
-    log_result("Image: robotics_env", "OK" if docker_ok else "FAIL", docker_msg)
+    resolved_image = PRIMARY_DOCKER_IMAGE
+    docker_ok, docker_msg = check_docker_image(resolved_image)
+
+    if not docker_ok:
+        for legacy_image in LEGACY_DOCKER_IMAGES:
+            legacy_ok, _ = check_docker_image(legacy_image)
+            if legacy_ok:
+                resolved_image = legacy_image
+                docker_ok = True
+                docker_msg = (
+                    f"Found legacy image '{legacy_image}' "
+                    f"(preferred: '{PRIMARY_DOCKER_IMAGE}')"
+                )
+                break
+
+    log_result(f"Image: {resolved_image}", "OK" if docker_ok else "FAIL", docker_msg)
 
     # 3. Pinocchio / Docker Libraries Check
     # We verify if the critical libraries we added (libEGL) are present in the image
@@ -91,7 +113,7 @@ def main() -> None:
                 "docker",
                 "run",
                 "--rm",
-                "robotics_env",
+                resolved_image,
                 "sh",
                 "-c",
                 "dpkg -l libegl1 libxkbcommon-x11-0 libxcb-cursor0",

--- a/scripts/run_dev_container.sh
+++ b/scripts/run_dev_container.sh
@@ -4,7 +4,7 @@
 # This script builds (if missing) and runs the Docker development container
 # for the Golf Modeling Suite.
 
-IMAGE_NAME="golf-suite-dev"
+IMAGE_NAME="upstream-drift:dev"
 
 # 1. Check if image exists, build if needed
 if [[ "$(docker images -q ${IMAGE_NAME} 2> /dev/null)" == "" ]]; then

--- a/scripts/run_tests_in_docker.py
+++ b/scripts/run_tests_in_docker.py
@@ -25,7 +25,7 @@ def main() -> None:
         logger.error(f"Dockerfile not found at {dockerfile_path}")
         sys.exit(1)
 
-    image_name = "golf-suite-dev"
+    image_name = "upstream-drift:dev"
 
     logger.info(f"Building Docker Image: {image_name}")
     # Build image

--- a/src/engines/physics_engines/mujoco/add_defusedxml_to_robotics_env.py
+++ b/src/engines/physics_engines/mujoco/add_defusedxml_to_robotics_env.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Script to add defusedxml to the existing robotics_env Docker image."""
+"""Script to add defusedxml to the existing upstream-drift Docker image."""
 
 import logging
 import os
@@ -11,23 +11,23 @@ logger = logging.getLogger(__name__)
 
 
 def create_minimal_dockerfile() -> str:
-    """Create a minimal Dockerfile to add defusedxml to robotics_env."""
-    dockerfile_content = """# Add defusedxml to existing robotics_env
-FROM robotics_env:latest
+    """Create a minimal Dockerfile to add defusedxml to upstream-drift."""
+    dockerfile_content = """# Add defusedxml to existing upstream-drift
+FROM upstream-drift:engine
 
 # Install missing dependencies in the existing virtual environment
 RUN /opt/mujoco-env/bin/pip install "defusedxml>=0.7.1" "PyQt6>=6.6.0"
 
-# Update PATH to use robotics_env by default
+# Update PATH to use upstream-drift by default
 ENV PATH="/opt/mujoco-env/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/mujoco-env"
 """
     return dockerfile_content
 
 
-def update_robotics_env() -> bool:
-    """Update the robotics_env image with defusedxml."""
-    logger.info("🔧 Adding defusedxml to existing robotics_env Docker image...")
+def update_upstream_drift() -> bool:
+    """Update the upstream-drift image with defusedxml."""
+    logger.info("🔧 Adding defusedxml to existing upstream-drift Docker image...")
 
     # Create temporary directory for Dockerfile
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -40,7 +40,7 @@ def update_robotics_env() -> bool:
         logger.info("📝 Created temporary Dockerfile: %s", dockerfile_path)
 
         # Build the updated image
-        cmd = ["docker", "build", "-t", "robotics_env", "."]
+        cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
 
         try:
             logger.info("🚀 Running: %s", " ".join(cmd))
@@ -50,11 +50,11 @@ def update_robotics_env() -> bool:
 
             subprocess.run(cmd, cwd=temp_dir, check=True, text=True)
 
-            logger.info("✅ Successfully added defusedxml to robotics_env!")
+            logger.info("✅ Successfully added defusedxml to upstream-drift!")
             return True
 
         except subprocess.CalledProcessError as e:
-            logger.error("❌ Failed to update robotics_env: %s", e)
+            logger.error("❌ Failed to update upstream-drift: %s", e)
             return False
         except FileNotFoundError:
             logger.info("❌ Docker not found. Please install Docker Desktop.")
@@ -63,7 +63,7 @@ def update_robotics_env() -> bool:
 
 def test_updated_environment() -> bool:
     """Test that defusedxml is now available in the updated environment."""
-    logger.info("\n🧪 Testing updated robotics_env...")
+    logger.info("\n🧪 Testing updated upstream-drift...")
 
     try:
         # Test defusedxml import
@@ -72,7 +72,7 @@ def test_updated_environment() -> bool:
                 "docker",
                 "run",
                 "--rm",
-                "robotics_env",
+                "upstream-drift:engine",
                 "python",
                 "-c",
                 "import defusedxml; print('✅ defusedxml available')",
@@ -90,7 +90,7 @@ def test_updated_environment() -> bool:
                 "docker",
                 "run",
                 "--rm",
-                "robotics_env",
+                "upstream-drift:engine",
                 "python",
                 "-c",
                 "import defusedxml.ElementTree; "
@@ -106,7 +106,7 @@ def test_updated_environment() -> bool:
         # Show what robotics libraries are available
         logger.info("\n📚 Available robotics libraries:")
         result = subprocess.run(
-            ["docker", "run", "--rm", "robotics_env", "pip", "list"],
+            ["docker", "run", "--rm", "upstream-drift:engine", "pip", "list"],
             capture_output=True,
             text=True,
             check=True,
@@ -146,7 +146,7 @@ def main() -> int:
     logger.info("%s", "=" * 50)
 
     # Update the environment
-    success = update_robotics_env()
+    success = update_upstream_drift()
 
     if success:
         # Test the updated environment
@@ -154,7 +154,7 @@ def main() -> int:
 
         if test_success:
             logger.info(
-                "\n🎉 Success! The robotics_env now has all required dependencies."
+                "\n🎉 Success! The upstream-drift now has all required dependencies."
             )
             logger.info("💡 You can now run MuJoCo, Drake, and Pinocchio simulations!")
         else:
@@ -162,7 +162,9 @@ def main() -> int:
                 "\n⚠️  Update completed but tests failed. Check the output above."
             )
     else:
-        logger.error("\n💥 Failed to update robotics_env. Check error messages above.")
+        logger.error(
+            "\n💥 Failed to update upstream-drift. Check error messages above."
+        )
 
     return 0 if success else 1
 

--- a/src/engines/physics_engines/mujoco/add_qt_dependencies.py
+++ b/src/engines/physics_engines/mujoco/add_qt_dependencies.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Script to add Qt system dependencies to robotics_env."""
+"""Script to add Qt system dependencies to upstream-drift."""
 
 import logging
 import os
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 def create_qt_dockerfile() -> str:
     """Create Dockerfile to add Qt system dependencies."""
-    dockerfile_content = """# Add Qt system dependencies to robotics_env
-FROM robotics_env:latest
+    dockerfile_content = """# Add Qt system dependencies to upstream-drift
+FROM upstream-drift:engine
 
 # Install Qt system dependencies
 RUN apt-get update && apt-get install -y \\
@@ -43,9 +43,9 @@ RUN /opt/mujoco-env/bin/pip install "PyQt6>=6.6.0" "PyQt6-Qt6>=6.6.0"
     return dockerfile_content
 
 
-def update_robotics_env_qt() -> bool:
-    """Update robotics_env with Qt dependencies."""
-    logger.info("🎨 Adding Qt dependencies to robotics_env...")
+def update_upstream_drift_qt() -> bool:
+    """Update upstream-drift with Qt dependencies."""
+    logger.info("🎨 Adding Qt dependencies to upstream-drift...")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         dockerfile_path = os.path.join(temp_dir, "Dockerfile")
@@ -55,7 +55,7 @@ def update_robotics_env_qt() -> bool:
 
         logger.info("📝 Created Qt Dockerfile: %s", dockerfile_path)
 
-        cmd = ["docker", "build", "-t", "robotics_env", "."]
+        cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
 
         try:
             logger.info("🚀 Running: %s", " ".join(cmd))
@@ -63,11 +63,11 @@ def update_robotics_env_qt() -> bool:
 
             subprocess.run(cmd, cwd=temp_dir, check=True, text=True)
 
-            logger.info("✅ Successfully added Qt dependencies to robotics_env!")
+            logger.info("✅ Successfully added Qt dependencies to upstream-drift!")
             return True
 
         except subprocess.CalledProcessError as e:
-            logger.error("❌ Failed to update robotics_env: %s", e)
+            logger.error("❌ Failed to update upstream-drift: %s", e)
             return False
 
 
@@ -84,7 +84,7 @@ def test_qt_environment() -> bool:
                 "--rm",
                 "-e",
                 "QT_QPA_PLATFORM=offscreen",
-                "robotics_env",
+                "upstream-drift:engine",
                 "python",
                 "-c",
                 "from PyQt6 import QtWidgets, QtCore; "
@@ -105,7 +105,7 @@ def test_qt_environment() -> bool:
                 "--rm",
                 "-e",
                 "QT_QPA_PLATFORM=offscreen",
-                "robotics_env",
+                "upstream-drift:engine",
                 "python",
                 "-c",
                 "from PyQt6.QtWidgets import QApplication; "
@@ -131,13 +131,15 @@ def main() -> int:
     logger.info("🤖 Qt Dependencies Installer for Robotics Environment")
     logger.info("%s", "=" * 60)
 
-    success = update_robotics_env_qt()
+    success = update_upstream_drift_qt()
 
     if success:
         test_success = test_qt_environment()
 
         if test_success:
-            logger.info("\n🎉 Success! PyQt6 is now fully functional in robotics_env.")
+            logger.info(
+                "\n🎉 Success! PyQt6 is now fully functional in upstream-drift."
+            )
             logger.info("💡 MuJoCo GUI simulations should now work properly!")
         else:
             logger.error("\n⚠️  Qt installed but tests failed. May work in GUI mode.")

--- a/src/engines/physics_engines/mujoco/docker/Dockerfile
+++ b/src/engines/physics_engines/mujoco/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN conda create -y -n robot-viz -c conda-forge python=3.10 gepetto-viewer gepet
 # 4. Main Python Environment (VirtualEnv)
 # We use a venv to avoid conflicts with system python or base conda.
 # This will be the default environment for your code.
-ENV VIRTUAL_ENV=/opt/robotics_env
+ENV VIRTUAL_ENV=/opt/upstream-drift
 RUN python3.10 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 

--- a/src/engines/physics_engines/mujoco/docker/build_and_run.bat
+++ b/src/engines/physics_engines/mujoco/docker/build_and_run.bat
@@ -5,7 +5,7 @@ echo ==========================================
 echo      Robotics Environment Builder
 echo ==========================================
 
-docker build -t robotics_env .
+docker build -t upstream-drift:engine .
 if %ERRORLEVEL% NEQ 0 (
     echo Build failed!
     pause
@@ -26,4 +26,4 @@ docker run -it --rm ^
   -p 8888:8888 ^
   -v "%~dp0..":/workspace ^
   -w /workspace ^
-  robotics_env
+  upstream-drift:engine

--- a/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
@@ -70,13 +70,13 @@ class DockerMixin:
     def _generate_update_dockerfile() -> str:
         """Generate a minimal Dockerfile to add missing dependencies."""
         return (
-            "# Add missing dependencies to existing robotics_env\n"
-            "FROM robotics_env:latest\n\n"
+            "# Add missing dependencies to existing upstream-drift\n"
+            "FROM upstream-drift:engine\n\n"
             "# Install missing dependencies in the existing virtual "
             "environment\n"
             'RUN /opt/mujoco-env/bin/pip install "defusedxml>=0.7.1" '
             '"PyQt6>=6.6.0"\n\n'
-            "# Update PATH to use robotics_env by default\n"
+            "# Update PATH to use upstream-drift by default\n"
             'ENV PATH="/opt/mujoco-env/bin:$PATH"\n'
             'ENV VIRTUAL_ENV="/opt/mujoco-env"\n'
         )
@@ -102,7 +102,7 @@ class DockerMixin:
             "docker",
             "run",
             "--rm",
-            "robotics_env",
+            "upstream-drift:engine",
             "python",
             "-c",
             "import defusedxml; print('defusedxml confirmed working')",
@@ -114,11 +114,11 @@ class DockerMixin:
             host.root.after(0, host.log, "Update completed but test failed")
 
     def rebuild_docker(self) -> None:
-        """Add missing dependencies to the existing robotics_env Docker image."""
+        """Add missing dependencies to the existing upstream-drift Docker image."""
         host = cast("DockerProtocol", self)
         msg = (
             "This will add missing dependencies (like defusedxml) to the existing "
-            "robotics_env.\n"
+            "upstream-drift.\n"
             "This should be quick since we're just adding packages. Continue?"
         )
         result = messagebox.askyesno(
@@ -129,7 +129,7 @@ class DockerMixin:
         if not result:
             return
 
-        host.log("Updating robotics_env with missing dependencies...")
+        host.log("Updating upstream-drift with missing dependencies...")
         host.btn_rebuild.config(state=tk.DISABLED)
 
         def run_update() -> None:
@@ -142,15 +142,17 @@ class DockerMixin:
                     with open(dockerfile_path, "w") as f:
                         f.write(dockerfile_content)
 
-                    cmd = ["docker", "build", "-t", "robotics_env", "."]
+                    cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
                     host.root.after(0, host.log, f"Running: {' '.join(cmd)}")
-                    host.root.after(0, host.log, "Adding defusedxml to robotics_env...")
+                    host.root.after(
+                        0, host.log, "Adding defusedxml to upstream-drift..."
+                    )
 
                     returncode = self._run_docker_build(temp_dir, cmd)
 
                     if returncode == 0:
                         host.root.after(
-                            0, host.log, "robotics_env updated successfully!"
+                            0, host.log, "upstream-drift updated successfully!"
                         )
                         host.root.after(
                             0,
@@ -197,7 +199,7 @@ class DockerMixin:
 
             cmd.extend(
                 [
-                    "robotics_env",
+                    "upstream-drift:engine",
                     "/opt/mujoco-env/bin/python",
                     "-u",
                     "-m",
@@ -225,7 +227,7 @@ class DockerMixin:
 
             cmd.extend(
                 [
-                    "robotics_env",
+                    "upstream-drift:engine",
                     "/opt/mujoco-env/bin/python",
                     "-m",
                     "mujoco_humanoid_golf",
@@ -288,7 +290,11 @@ class DockerMixin:
                     "SOLUTION: Missing defusedxml dependency. "
                     "Please rebuild Docker image.",
                 )
-                host.root.after(0, host.log, "Run: docker build -t robotics_env .")
+                host.root.after(
+                    0,
+                    host.log,
+                    "Run: docker build -t upstream-drift:engine .",
+                )
             elif "ModuleNotFoundError" in err:
                 host.root.after(
                     0,

--- a/src/engines/physics_engines/mujoco/docker/run_with_viewer.sh
+++ b/src/engines/physics_engines/mujoco/docker/run_with_viewer.sh
@@ -15,5 +15,5 @@ docker run -it --rm \
     -e MUJOCO_GL="glfw" \
     -v "$(pwd)":/workspace \
     -w /workspace \
-    robotics_env \
+    upstream-drift:engine \
     python3 /workspace/example_dynamic_stance.py

--- a/src/engines/physics_engines/mujoco/python/golf_suite_launcher.py
+++ b/src/engines/physics_engines/mujoco/python/golf_suite_launcher.py
@@ -120,7 +120,7 @@ class GolfLauncher(QtWidgets.QMainWindow):
 
         # Docker command to run the GUI
         # Assumes:
-        # 1. 'robotics_env:latest' image is built
+        # 1. 'upstream-drift:engine' image is built
         # 2. X Server (VcXsrv) is running on host at :0
         # 3. Host Repositories are mounted to /workspace
 
@@ -153,7 +153,7 @@ class GolfLauncher(QtWidgets.QMainWindow):
                 "-v",
                 f"{repo_root_host}:/workspace",
                 # Image
-                "robotics_env:latest",
+                "upstream-drift:engine",
                 # Command inside container
                 "python",
                 "UpstreamDrift/engines/physics_engines/drake/python/src/golf_gui.py",

--- a/src/engines/physics_engines/mujoco/python/humanoid_launcher_sim.py
+++ b/src/engines/physics_engines/mujoco/python/humanoid_launcher_sim.py
@@ -83,7 +83,7 @@ class SimulationMixin:
 
         self._append_display_env(cmd)
 
-        cmd.extend(["robotics_env", "/opt/mujoco-env/bin/python", "-u"])
+        cmd.extend(["upstream-drift:engine", "/opt/mujoco-env/bin/python", "-u"])
         cmd.extend(["-m", "humanoid_golf.sim"])
 
         return cmd, None
@@ -192,7 +192,7 @@ class SimulationMixin:
 
             docker_dir = self.repo_path / "docker"
 
-            cmd = ["docker", "build", "-t", "robotics_env", "."]
+            cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
 
             # Start worker for build
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/humanoid_config_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/humanoid_config_tab.py
@@ -572,7 +572,7 @@ class HumanoidConfigTab(QWidget):
         else:
             cmd.extend(["-e", "MUJOCO_GL=osmesa"])
 
-        cmd.extend(["robotics_env", "/opt/mujoco-env/bin/python", "-u"])
+        cmd.extend(["upstream-drift:engine", "/opt/mujoco-env/bin/python", "-u"])
         cmd.extend(["-m", "humanoid_golf.sim"])
         return cmd, None
 
@@ -628,7 +628,7 @@ class HumanoidConfigTab(QWidget):
         if reply == QMessageBox.StandardButton.Yes:
             self._log("Rebuilding Docker environment...")
             docker_dir = self._mujoco_dir / "docker"
-            cmd = ["docker", "build", "-t", "robotics_env", "."]
+            cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
             build_thread = ProcessWorker(cmd, cwd=str(docker_dir))
             build_thread.log_signal.connect(self._log)
             build_thread.finished_signal.connect(

--- a/src/engines/physics_engines/mujoco/rebuild_docker.py
+++ b/src/engines/physics_engines/mujoco/rebuild_docker.py
@@ -16,7 +16,7 @@ logger = setup_script_logging("DockerRebuilder")
 
 
 def rebuild_docker_image() -> bool:
-    """Rebuild the robotics_env Docker image."""
+    """Rebuild the upstream-drift Docker image."""
     logger.info("Rebuilding Docker image with updated dependencies...")
 
     # Get the directory containing this script (should be mujoco engine root)
@@ -30,7 +30,7 @@ def rebuild_docker_image() -> bool:
     logger.info(f"Building from: {docker_dir}")
 
     # Build command
-    cmd = ["docker", "build", "-t", "robotics_env", "."]
+    cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
 
     logger.info("This may take several minutes...")
 

--- a/src/launchers/assets/help.md
+++ b/src/launchers/assets/help.md
@@ -24,7 +24,7 @@ The Golf Modeling Suite is a comprehensive environment for biomechanical simulat
 
 ## Docker Environment
 
-The suite runs within a unified `robotics_env` Docker container to ensure consistent dependencies across all platforms.
+The suite runs within a unified `upstream-drift:engine` Docker container to ensure consistent dependencies across all platforms.
 
 ### Key Dependencies
 

--- a/src/launchers/docker_dialog.py
+++ b/src/launchers/docker_dialog.py
@@ -31,7 +31,7 @@ from .startup import REPOS_ROOT
 
 logger = get_logger(__name__)
 
-DOCKER_IMAGE_NAME = "robotics_env"
+DOCKER_IMAGE_NAME = "upstream-drift:engine"
 
 
 class DockerCheckThread(QThread):

--- a/src/launchers/docker_manager.py
+++ b/src/launchers/docker_manager.py
@@ -18,6 +18,13 @@ from src.shared.python.security.secure_subprocess import (
     secure_run,
 )
 
+LEGACY_DOCKER_IMAGE_ALIASES: tuple[str, ...] = (
+    "robotics_env:latest",
+    "upstream-drift:latest",
+    "upstream-drift",
+    "golf-suite:latest",
+)
+
 
 class DockerCheckThread(QThread):
     """Asynchronous thread to check for Docker availability."""
@@ -48,7 +55,7 @@ class DockerBuildThread(QThread):
     def __init__(
         self,
         target_stage: str = "all",
-        image_name: str = "robotics_env",
+        image_name: str = "upstream-drift:engine",
         context_path: Path | None = None,
     ) -> None:
         """Initialize the build thread."""
@@ -130,7 +137,7 @@ class DockerLauncher:
     """
 
     def __init__(
-        self, repo_root: Path, image_name: str = "robotics_env:latest"
+        self, repo_root: Path, image_name: str = "upstream-drift:engine"
     ) -> None:
         """Initialize the Docker launcher.
 
@@ -156,7 +163,24 @@ class DockerLauncher:
                 capture_output=True,
                 timeout=10,
             )
-            return result.returncode == 0
+            if result.returncode == 0:
+                return True
+
+            for legacy_image in LEGACY_DOCKER_IMAGE_ALIASES:
+                legacy_result = subprocess.run(
+                    ["docker", "image", "inspect", legacy_image],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if legacy_result.returncode == 0:
+                    self.logger.warning(
+                        "Using legacy Docker image '%s'. Retag to '%s' when convenient.",
+                        legacy_image,
+                        self.image_name,
+                    )
+                    self.image_name = legacy_image
+                    return True
+            return False
         except (OSError, ValueError) as e:
             self.logger.warning(f"Failed to check Docker image: {e}")
             return False

--- a/src/launchers/launcher_simulation.py
+++ b/src/launchers/launcher_simulation.py
@@ -323,7 +323,7 @@ except (RuntimeError, TypeError, AttributeError) as e:
                     "Docker Image Not Found",
                     f"The Docker image '{self.docker_launcher.image_name}' is not available.\n\n"
                     "Build it first using:\n"
-                    "  docker build -t robotics_env .\n\n"
+                    "  docker build -t upstream-drift:engine .\n\n"
                     "Or use the Environment dialog to build.",
                 )
                 return

--- a/src/launchers/settings_dialog.py
+++ b/src/launchers/settings_dialog.py
@@ -34,7 +34,7 @@ from .startup import REPOS_ROOT
 
 logger = get_logger(__name__)
 
-DOCKER_IMAGE_NAME = "robotics_env"
+DOCKER_IMAGE_NAME = "upstream-drift:engine"
 
 
 class SettingsDialog(QDialog):

--- a/tests/unit/engines/mujoco/test_docker_venv.py
+++ b/tests/unit/engines/mujoco/test_docker_venv.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 def _check_docker_image_exists() -> bool:
-    """Check whether the robotics_env Docker image is available."""
-    logger.debug("1. Checking if robotics_env Docker image exists...")
+    """Check whether the upstream-drift Docker image is available."""
+    logger.debug("1. Checking if upstream-drift Docker image exists...")
     try:
         result = subprocess.run(
             [
                 "docker",
                 "images",
-                "robotics_env",
+                "upstream-drift:engine",
                 "--format",
                 "{{.Repository}}:{{.Tag}}",
             ],
@@ -27,12 +27,12 @@ def _check_docker_image_exists() -> bool:
             text=True,
             check=True,
         )
-        if "robotics_env" in result.stdout:
-            logger.info("✓ robotics_env Docker image found")
+        if "upstream-drift:engine" in result.stdout:
+            logger.info("✓ upstream-drift Docker image found")
             return True
-        logger.warning("❌ robotics_env Docker image not found")
+        logger.warning("❌ upstream-drift Docker image not found")
         logger.info(
-            "   Run: docker build -t robotics_env . (from docker/ directory)",
+            "   Run: docker build -t upstream-drift:engine . (from docker/ directory)",
         )
         return False
     except (subprocess.CalledProcessError, OSError) as e:
@@ -44,7 +44,7 @@ def _check_python_path() -> None:
     """Verify the container uses the virtual environment Python."""
     logger.info("\n2. Testing Python executable path in container...")
     try:
-        cmd = ["docker", "run", "--rm", "robotics_env", "which", "python"]
+        cmd = ["docker", "run", "--rm", "upstream-drift:engine", "which", "python"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         python_path = result.stdout.strip()
         logger.info(f"   Python path: {python_path}")
@@ -65,7 +65,7 @@ def _check_defusedxml() -> bool:
             "docker",
             "run",
             "--rm",
-            "robotics_env",
+            "upstream-drift:engine",
             "python",
             "-c",
             (
@@ -92,7 +92,7 @@ def _check_defusedxml_elementtree() -> bool:
             "docker",
             "run",
             "--rm",
-            "robotics_env",
+            "upstream-drift:engine",
             "python",
             "-c",
             (
@@ -129,7 +129,7 @@ def _check_module_import() -> bool:
             f"{current_dir}:/workspace",
             "-w",
             "/workspace/python",
-            "robotics_env",
+            "upstream-drift:engine",
             "python",
             "-c",
             (
@@ -180,7 +180,7 @@ def main() -> int:
     if not success:
         logger.info("\n💡 Troubleshooting steps:")
         logger.info(
-            "   1. Rebuild Docker image: docker build -t robotics_env . "
+            "   1. Rebuild Docker image: docker build -t upstream-drift:engine . "
             "(from docker/ directory)",
         )
         logger.info("   2. Check if defusedxml was properly installed during build")


### PR DESCRIPTION
This PR applies upstream-drift Docker naming conventions and includes the cleanup plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily renames image/environment identifiers and updates docs/scripts; behavior change is limited to Docker image resolution/fallback and could only break existing local workflows if tags aren’t updated.
> 
> **Overview**
> Standardizes the project’s Docker/Conda naming around **`upstream-drift`** and explicit tags, replacing legacy names like `robotics_env`/`golf-suite` across Dockerfiles, `docker-compose.yml`, scripts, tests, and user docs.
> 
> Adds a compatibility layer in launcher/runtime helpers (e.g., `DockerLauncher.check_image_exists` and `scripts/check_system_health.py`) to fall back to legacy local image tags with warnings, and introduces new ops docs: a Docker-first adoption plan plus a Windows/WSL2 Docker cleanup runbook (retag/rollback + safe prune guidance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d9a035fb55e256a4a4fddc32a7f4f4bc438bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->