### PR TITLE
ci: add Docker smoke tests and size budget checks (Resolve #1559)

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -1,0 +1,57 @@
+name: Docker Size and Health Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  docker-smoke-and-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image (runtime)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          load: true # Load image into local docker engine
+          tags: upstream-drift:runtime
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify Image Size Budget
+        run: |
+          # Set the maximum allowed size in MB (e.g., 4000 MB = 4GB)
+          MAX_SIZE_MB=4000
+
+          # Get size in bytes
+          IMAGE_SIZE_BYTES=$(docker image inspect upstream-drift:runtime --format='{{.Size}}')
+          
+          # Convert to MB
+          IMAGE_SIZE_MB=$((IMAGE_SIZE_BYTES / 1024 / 1024))
+          
+          echo "Image size: ${IMAGE_SIZE_MB} MB"
+          echo "Budget: ${MAX_SIZE_MB} MB"
+          
+          if [ "$IMAGE_SIZE_MB" -gt "$MAX_SIZE_MB" ]; then
+            echo "::error::Image size (${IMAGE_SIZE_MB} MB) exceeds budget (${MAX_SIZE_MB} MB)!"
+            exit 1
+          else
+            echo "Image size is within budget."
+          fi
+
+      - name: Run Basic Health Checks
+        run: |
+          # Run a simple Python command importing key libraries to verify the environment works 
+          docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy; print('Core ML/Physics imports successful!')"
+          
+          # We can also check that the API server module is importable
+          docker run --rm upstream-drift:runtime python -c "import fastapi; print('FastAPI imported successfully')"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds the canonical Docker image, checks its size against a 4000MB budget, and runs a basic python environment smoke test. This resolves #1559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that doesn’t affect production runtime behavior, but may introduce new build-time failures if the image grows or imports break.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`docker-size-gates.yml`) that builds the `Dockerfile` `runtime` stage on pushes/PRs to `main`, loads it locally, and caches build layers.
> 
> The workflow fails CI if the built image exceeds a **4000MB** size budget and runs basic container smoke checks by importing `mujoco`, `numpy`, `scipy`, and `fastapi` inside the image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5bda46bb2379c9310de1b83c5fb687a73360d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->