### PR TITLE
feat: Docker training tier and ML integration strategy (Resolve #1558, #1561)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,6 @@ RUN pip install --no-cache-dir \
     qpsolvers \
     osqp \
     myosuite \
-    gymnasium>=0.29.0 \
-    stable-baselines3>=2.0.0 \
     mediapipe>=0.10.0 \
     "imageio[ffmpeg]>=2.31.0" \
     trimesh>=4.0.0 \
@@ -168,4 +166,22 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Default command
+CMD ["/bin/bash"]
+
+
+# Stage 3: Training stage for advanced ML workflows
+FROM runtime AS training
+
+USER root
+
+# Install heavy ML dependencies specifically for training workloads
+RUN pip install --no-cache-dir \
+    gymnasium>=0.29.0 \
+    stable-baselines3>=2.0.0 \
+    "tensorboard>=2.14.0" \
+    "ray[rllib]>=2.9.0" \
+    && echo "Training dependencies installed successfully"
+
+USER ${USER_NAME}
+
 CMD ["/bin/bash"]

--- a/docs/plans/ML_INTEGRATION_STRATEGY.md
+++ b/docs/plans/ML_INTEGRATION_STRATEGY.md
@@ -1,0 +1,28 @@
+# ML Integration Strategy
+
+## Objective
+
+To outline the boundaries and integrations between UpstreamDrift (the core simulation product) and MLProjects (the training ecosystem).
+
+## Problem
+
+Currently, our monolith is bloating due to the mixing of end-user features (simulation, API, visualization) with internal R&D features (RL training loops, large datasets, heavyweight ML dependencies). We need to decouple them.
+
+## The Strategy
+
+1. **Docker Profiles `core` vs `training` (Resolves #1558)**
+   UpstreamDrift now publishes tiers.
+   - `upstream-drift:runtime` (Core) – strictly physics, API, and fast visualization.
+   - `upstream-drift:training` (ML) – built ON TOP of runtime, adding `ray`, `stable-baselines3`, `gymnasium`.
+
+2. **Decoupled Repositories (Resolves #1561)**
+   `UpstreamDrift` consumes models. `MLProjects` produces models.
+
+### Reference Workflow
+
+- **Data Engineering:** Extract states or physics logic out of `UpstreamDrift` to a lightweight dataset.
+- **Training:** Work in `MLProjects` using the `mlprojects/pytorch-gpu:2026.02` ecosystem to crunch data and train humanoid controllers via RL/Imitation.
+- **Artifact Export:** Save the converged model strictly as an ONNX file or TorchScript `.pt` file within the `MLProjects` output registry.
+- **Artifact Import:** In `UpstreamDrift`, load the frozen `.onnx` or `.pt` model using the standalone `onnxruntime` or basic `torch` evaluation module. Since inference dependencies are extremely small compared to full training environments, UpstreamDrift's core footprint remains small.
+
+If a user *must* train directly inside `UpstreamDrift` (e.g., visual humanoid RL loop), they simply execute `docker compose --profile training up` or build the `training` target in the `Dockerfile`.


### PR DESCRIPTION
This PR decouples ML training from the core product by introducing a dedicated  Docker profile that layers on top of . It also documents the formal integration strategy between the UpstreamDrift product and the MLProjects ecosystem, ensuring  stays lightweight for regular users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to Docker image composition and documentation; main risk is build/CI failures or increased image size for the new `training` target.
> 
> **Overview**
> Introduces a separate Docker *training* tier layered on `runtime`, moving `gymnasium`/`stable-baselines3` out of the core install and adding training-only deps (`tensorboard`, `ray[rllib]`) to the new `training` stage.
> 
> Adds `docs/plans/ML_INTEGRATION_STRATEGY.md` describing the intended separation between core simulation (model consumption/inference) and external ML training workflows, including the recommended artifact export/import approach and how to run the training profile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3466fa0b7554994dc22ade6311f3e82d6e1e12fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->