### PR TITLE
chore(rust): add Rust CI pipeline and toolchain config (Phase 0)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -256,3 +256,81 @@ jobs:
       - name: Verify Build
         working-directory: ./arduino
         run: pio run -e uno
+
+  # =============================================================================
+  # RUST QUALITY GATE
+  # =============================================================================
+  # Only runs when Rust source files or Cargo manifests change.
+  # Enforces: format (rustfmt), lint (clippy), tests (cargo test).
+  # =============================================================================
+  rust-quality-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for Rust changes
+        id: rust-changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}"
+            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD || true)
+            if [ -z "$BASE_SHA" ]; then
+              BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            fi
+            RUST_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            RUST_FILES=$(git diff --name-only "${{ github.event.before }}" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+          else
+            RUST_FILES=$(git diff --name-only HEAD~1 HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || echo "")
+          fi
+
+          if [ -n "$RUST_FILES" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changed Rust files:"
+            echo "$RUST_FILES"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No Rust changes detected — skipping Rust quality gate."
+          fi
+
+      - name: Install Rust toolchain
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry and build
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Format Check (rustfmt)
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: cargo fmt --all -- --check
+
+      - name: Lint (Clippy)
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run Rust Tests
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: cargo test --all-features
+
+      - name: Rust Quality Gate Summary
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: |
+          echo "## Rust Quality Gate" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ rustfmt: formatted" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ clippy: no warnings" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ cargo test: all tests pass" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,13 @@ CONFIG_ISSUES_QUICK_REFERENCE.md
 INFRASTRUCTURE_REVIEW_INDEX.md
 REVIEW_SUMMARY.txt
 COMPREHENSIVE_REPO_AUDIT_*.md
+
+# ── Rust Build Artifacts ──
+/target/
+*.so
+*.dylib
+*.dll
+*.pyd
+Cargo.lock
+pkg/
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Rust toolchain configuration for UpstreamDrift.
+# Pins the same stable channel as the Tools repository for consistency.
+# See: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Issue #1640: Phase 0 Rust CI/CD Pipeline

Adds Rust quality gate infrastructure to UpstreamDrift, preparing for the Rust shared kernel migration.

### Files
- `rust-toolchain.toml`: Pins stable Rust with WASM target
- `ci-standard.yml`: New `rust-quality-gate` job (rustfmt, clippy, cargo test)
- `.gitignore`: Rust build artifact exclusions

### Notes
- The Rust quality gate only triggers when `.rs` or `Cargo.toml` files change
- No existing tests or CI are affected
- Ready to consume `tools-core` crate when physics migration begins

Closes #1640