### PR TITLE
fix: code quality improvements from URDF review

### DIFF
--- a/src/shared/python/model_generation/__init__.py
+++ b/src/shared/python/model_generation/__init__.py
@@ -247,6 +247,18 @@ def __getattr__(name: str) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Shared constants for convenience functions
+# ---------------------------------------------------------------------------
+
+_HUMANOID_PRESETS: dict[str, dict[str, float]] = {
+    "athletic": {"gender_factor": 0.7, "shoulder_width_factor": 1.1},
+    "average": {"gender_factor": 0.5},
+    "heavy": {"gender_factor": 0.5, "hip_width_factor": 1.15},
+    "lean": {"gender_factor": 0.5, "shoulder_width_factor": 0.95},
+}
+
+
+# ---------------------------------------------------------------------------
 # Convenience functions (use lazy imports internally)
 # ---------------------------------------------------------------------------
 
@@ -277,13 +289,7 @@ def quick_urdf(
     builder = ParametricBuilder(robot_name)
 
     if preset:
-        presets = {
-            "athletic": {"gender_factor": 0.7, "shoulder_width_factor": 1.1},
-            "average": {"gender_factor": 0.5},
-            "heavy": {"gender_factor": 0.5, "hip_width_factor": 1.15},
-            "lean": {"gender_factor": 0.5, "shoulder_width_factor": 0.95},
-        }
-        preset_config = presets.get(preset.lower(), {})
+        preset_config = _HUMANOID_PRESETS.get(preset.lower(), {})
         builder.set_parameters(height_m=height_m, mass_kg=mass_kg, **preset_config)
     else:
         builder.set_parameters(height_m=height_m, mass_kg=mass_kg)
@@ -325,13 +331,7 @@ def quick_build(
     builder = ParametricBuilder("humanoid")
 
     if preset:
-        presets = {
-            "athletic": {"gender_factor": 0.7, "shoulder_width_factor": 1.1},
-            "average": {"gender_factor": 0.5},
-            "heavy": {"gender_factor": 0.5, "hip_width_factor": 1.15},
-            "lean": {"gender_factor": 0.5, "shoulder_width_factor": 0.95},
-        }
-        preset_config = presets.get(preset.lower(), {})
+        preset_config = _HUMANOID_PRESETS.get(preset.lower(), {})
         builder.set_parameters(height_m=height_m, mass_kg=mass_kg, **preset_config)
     else:
         builder.set_parameters(height_m=height_m, mass_kg=mass_kg)

--- a/src/shared/python/model_generation/builders/manual_builder.py
+++ b/src/shared/python/model_generation/builders/manual_builder.py
@@ -8,6 +8,8 @@ with validation at each step.
 from __future__ import annotations
 
 import logging
+import math
+from collections import deque
 from enum import Enum
 from typing import Any
 
@@ -398,10 +400,10 @@ class ManualBuilder(BaseURDFBuilder):
     def _get_descendants(self, link_name: str) -> set[str]:
         """Get all descendant link names."""
         descendants: set[str] = set()
-        queue = [link_name]
+        queue: deque[str] = deque([link_name])
 
         while queue:
-            current = queue.pop(0)
+            current = queue.popleft()
             for joint in self._joints:
                 if joint.parent == current and joint.child not in descendants:
                     descendants.add(joint.child)
@@ -435,8 +437,6 @@ class ManualBuilder(BaseURDFBuilder):
         # Handle origin
         origin_data = geom_data.get("position", {}) if geom_data else {}
         orientation_data = geom_data.get("orientation", {}) if geom_data else {}
-        import math
-
         origin = Origin(
             xyz=(
                 origin_data.get("x", 0.0),
@@ -484,8 +484,6 @@ class ManualBuilder(BaseURDFBuilder):
         # Get origin from geometry
         pos = geom_data.get("position", {})
         orient = geom_data.get("orientation", {})
-        import math
-
         origin = Origin(
             xyz=(pos.get("x", 0.0), pos.get("y", 0.0), pos.get("z", 0.0)),
             rpy=(

--- a/src/shared/python/model_generation/builders/urdf_writer.py
+++ b/src/shared/python/model_generation/builders/urdf_writer.py
@@ -8,6 +8,7 @@ including proper formatting, material definitions, and composite joint expansion
 from __future__ import annotations
 
 import logging
+from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
@@ -251,6 +252,10 @@ class URDFWriter:
             lines.append(f'{indent2}<sphere radius="{geometry.dimensions[0]:.6g}"/>')
         elif geometry.geometry_type == GeometryType.CAPSULE:
             # URDF doesn't have capsule, use cylinder approximation
+            logger.warning(
+                "Capsule geometry approximated as cylinder"
+                " (URDF has no native capsule support)"
+            )
             lines.append(
                 f'{indent2}<cylinder radius="{geometry.dimensions[0]:.6g}" '
                 f'length="{geometry.dimensions[1]:.6g}"/>'
@@ -323,11 +328,11 @@ class URDFWriter:
         # BFS to order links
         ordered: list[Link] = []
         link_by_name = {link.name: link for link in links}
-        queue = [link.name for link in roots]
+        queue: deque[str] = deque(link.name for link in roots)
         visited: set[str] = set()
 
         while queue:
-            name = queue.pop(0)
+            name = queue.popleft()
             if name in visited or name not in link_by_name:
                 continue
             visited.add(name)

--- a/src/shared/python/model_generation/core/types.py
+++ b/src/shared/python/model_generation/core/types.py
@@ -7,6 +7,7 @@ the model_generation package for representing URDF elements.
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass, field
 from enum import Enum
@@ -15,6 +16,8 @@ from typing import Any
 import numpy as np
 from model_generation.core.contracts import precondition
 from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
 
 
 class GeometryType(Enum):
@@ -453,6 +456,10 @@ class Geometry:
             return f'<geometry><sphere radius="{self.dimensions[0]:.6g}"/></geometry>'
         if self.geometry_type == GeometryType.CAPSULE:
             # URDF doesn't have capsule, approximate with cylinder
+            logger.warning(
+                "Capsule geometry approximated as cylinder"
+                " (URDF has no native capsule support)"
+            )
             return (
                 f'<geometry><cylinder radius="{self.dimensions[0]:.6g}" '
                 f'length="{self.dimensions[1]:.6g}"/></geometry>'

--- a/src/shared/python/model_generation/editor/editor_modifications.py
+++ b/src/shared/python/model_generation/editor/editor_modifications.py
@@ -48,6 +48,23 @@ class ModificationMixin:
         self, base_name: str, existing_names: set[str]
     ) -> str: ...  # type: ignore[empty-body]
 
+    def _get_writable_model(self, model_id: str) -> ParsedModel | None:
+        """Look up a model by *model_id* and verify it is writable.
+
+        Returns the model if it exists and is not read-only, otherwise logs
+        an error and returns ``None``.
+        """
+        model = self._models.get(model_id)
+        if not model:
+            logger.error(f"Model '{model_id}' not found")
+            return None
+
+        if model.read_only:
+            logger.error(f"Model '{model_id}' is read-only")
+            return None
+
+        return model
+
     # ============================================================
     # Direct Modifications
     # ============================================================
@@ -69,13 +86,8 @@ class ModificationMixin:
         Returns:
             True if deleted
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         link = model.get_link(link_name)
@@ -132,13 +144,8 @@ class ModificationMixin:
         Returns:
             True if deleted
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         subtree = model.get_subtree(root_link)
@@ -190,13 +197,8 @@ class ModificationMixin:
         if old_name == new_name:
             return True  # No-op
 
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         # Check for conflicts
@@ -252,13 +254,8 @@ class ModificationMixin:
         if old_name == new_name:
             return True  # No-op
 
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         # Check for conflicts
@@ -294,13 +291,8 @@ class ModificationMixin:
         Returns:
             True if modified
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         joint = model.get_joint(joint_name)
@@ -373,13 +365,8 @@ class ModificationMixin:
         Returns:
             True if attached
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         # Verify links exist
@@ -433,13 +420,8 @@ class ModificationMixin:
         Returns:
             True if detached
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         joint = self.get_connecting_joint(model_id, link_name)
@@ -478,13 +460,8 @@ class ModificationMixin:
         Returns:
             True if applied
         """
-        model = self._models.get(model_id)
+        model = self._get_writable_model(model_id)
         if not model:
-            logger.error(f"Model '{model_id}' not found")
-            return False
-
-        if model.read_only:
-            logger.error(f"Model '{model_id}' is read-only")
             return False
 
         self._save_state()

--- a/tests/unit/tools/model_generation/test_code_quality_fixes.py
+++ b/tests/unit/tools/model_generation/test_code_quality_fixes.py
@@ -1,0 +1,400 @@
+"""
+Tests for code quality fixes from the URDF review.
+
+Validates:
+1. Deque optimization doesn't break _get_descendants() or _sort_links_by_hierarchy()
+2. Preset extraction works consistently in quick_urdf() and quick_build()
+3. Capsule geometry produces a warning when downgraded to cylinder
+4. _get_writable_model() helper works correctly in editor_modifications
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from model_generation.builders.manual_builder import ManualBuilder
+from model_generation.builders.urdf_writer import URDFWriter
+from model_generation.core.types import (
+    Geometry,
+    Inertia,
+    Joint,
+    JointType,
+    Link,
+)
+
+# ============================================================
+# Issue 1: Deque optimization - _get_descendants()
+# ============================================================
+
+
+class TestGetDescendants:
+    """Validate _get_descendants() returns correct results after deque refactor."""
+
+    def _build_chain(self) -> ManualBuilder:
+        """Build a simple chain: base -> arm -> hand."""
+        builder = ManualBuilder("test_robot", validate_on_add=False)
+        builder.add_link(Link(name="base", inertia=Inertia.from_box(10, 1, 1, 0.5)))
+        builder.add_link(Link(name="arm", inertia=Inertia.from_cylinder(2, 0.05, 0.5)))
+        builder.add_link(Link(name="hand", inertia=Inertia.from_sphere(0.5, 0.05)))
+        builder.add_joint(
+            Joint(
+                name="base_to_arm",
+                joint_type=JointType.REVOLUTE,
+                parent="base",
+                child="arm",
+            )
+        )
+        builder.add_joint(
+            Joint(
+                name="arm_to_hand",
+                joint_type=JointType.REVOLUTE,
+                parent="arm",
+                child="hand",
+            )
+        )
+        return builder
+
+    def test_descendants_of_root(self) -> None:
+        """Root should have all other links as descendants."""
+        builder = self._build_chain()
+        descendants = builder._get_descendants("base")
+        assert descendants == {"arm", "hand"}
+
+    def test_descendants_of_middle(self) -> None:
+        """Middle link should have only its children as descendants."""
+        builder = self._build_chain()
+        descendants = builder._get_descendants("arm")
+        assert descendants == {"hand"}
+
+    def test_descendants_of_leaf(self) -> None:
+        """Leaf node should have no descendants."""
+        builder = self._build_chain()
+        descendants = builder._get_descendants("hand")
+        assert descendants == set()
+
+    def test_descendants_branching(self) -> None:
+        """Test with branching structure: base -> (left_arm, right_arm)."""
+        builder = ManualBuilder("test_robot", validate_on_add=False)
+        builder.add_link(Link(name="base", inertia=Inertia.from_box(10, 1, 1, 0.5)))
+        builder.add_link(
+            Link(name="left_arm", inertia=Inertia.from_cylinder(2, 0.05, 0.5))
+        )
+        builder.add_link(
+            Link(name="right_arm", inertia=Inertia.from_cylinder(2, 0.05, 0.5))
+        )
+        builder.add_link(Link(name="left_hand", inertia=Inertia.from_sphere(0.5, 0.05)))
+        builder.add_joint(
+            Joint(
+                name="base_to_left",
+                joint_type=JointType.REVOLUTE,
+                parent="base",
+                child="left_arm",
+            )
+        )
+        builder.add_joint(
+            Joint(
+                name="base_to_right",
+                joint_type=JointType.REVOLUTE,
+                parent="base",
+                child="right_arm",
+            )
+        )
+        builder.add_joint(
+            Joint(
+                name="left_to_hand",
+                joint_type=JointType.REVOLUTE,
+                parent="left_arm",
+                child="left_hand",
+            )
+        )
+        descendants = builder._get_descendants("base")
+        assert descendants == {"left_arm", "right_arm", "left_hand"}
+
+
+# ============================================================
+# Issue 1: Deque optimization - _sort_links_by_hierarchy()
+# ============================================================
+
+
+class TestSortLinksByHierarchy:
+    """Validate _sort_links_by_hierarchy() returns parents before children."""
+
+    def test_simple_chain(self) -> None:
+        """Parents must appear before children in sorted order."""
+        writer = URDFWriter()
+        links = [
+            Link(name="hand", inertia=Inertia.from_sphere(0.5, 0.05)),
+            Link(name="base", inertia=Inertia.from_box(10, 1, 1, 0.5)),
+            Link(name="arm", inertia=Inertia.from_cylinder(2, 0.05, 0.5)),
+        ]
+        joints = [
+            Joint(
+                name="base_to_arm",
+                joint_type=JointType.REVOLUTE,
+                parent="base",
+                child="arm",
+            ),
+            Joint(
+                name="arm_to_hand",
+                joint_type=JointType.REVOLUTE,
+                parent="arm",
+                child="hand",
+            ),
+        ]
+        sorted_links = writer._sort_links_by_hierarchy(links, joints)
+        names = [link.name for link in sorted_links]
+        assert names.index("base") < names.index("arm")
+        assert names.index("arm") < names.index("hand")
+
+    def test_all_links_present(self) -> None:
+        """All links should be present in sorted output."""
+        writer = URDFWriter()
+        links = [
+            Link(name="a", inertia=Inertia.from_box(1, 0.1, 0.1, 0.1)),
+            Link(name="b", inertia=Inertia.from_box(1, 0.1, 0.1, 0.1)),
+            Link(name="c", inertia=Inertia.from_box(1, 0.1, 0.1, 0.1)),
+        ]
+        joints = [
+            Joint(
+                name="a_to_b",
+                joint_type=JointType.FIXED,
+                parent="a",
+                child="b",
+            ),
+            Joint(
+                name="b_to_c",
+                joint_type=JointType.FIXED,
+                parent="b",
+                child="c",
+            ),
+        ]
+        sorted_links = writer._sort_links_by_hierarchy(links, joints)
+        assert len(sorted_links) == 3
+        assert {link.name for link in sorted_links} == {"a", "b", "c"}
+
+
+# ============================================================
+# Issue 3: Preset duplication - quick_urdf() and quick_build()
+# ============================================================
+
+
+class TestPresetConsistency:
+    """Ensure presets produce consistent results in quick_urdf and quick_build."""
+
+    def test_presets_dict_exists_as_module_constant(self) -> None:
+        """_HUMANOID_PRESETS should be a module-level constant after extraction."""
+        import model_generation
+
+        assert hasattr(model_generation, "_HUMANOID_PRESETS")
+        presets = model_generation._HUMANOID_PRESETS
+        assert "athletic" in presets
+        assert "average" in presets
+        assert "heavy" in presets
+        assert "lean" in presets
+
+    def test_athletic_preset_config(self) -> None:
+        """Athletic preset should have expected parameters."""
+        import model_generation
+
+        presets = model_generation._HUMANOID_PRESETS
+        assert presets["athletic"]["gender_factor"] == 0.7
+        assert presets["athletic"]["shoulder_width_factor"] == 1.1
+
+    @patch("model_generation.builders.parametric_builder.ParametricBuilder")
+    def test_quick_urdf_uses_shared_presets(self, mock_builder_cls: MagicMock) -> None:
+        """quick_urdf should use _HUMANOID_PRESETS, not an inline dict."""
+        mock_builder = MagicMock()
+        mock_builder_cls.return_value = mock_builder
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.urdf_xml = "<robot/>"
+        mock_builder.build.return_value = mock_result
+
+        from model_generation import quick_urdf
+
+        quick_urdf(height_m=1.80, preset="athletic")
+
+        mock_builder.set_parameters.assert_called_once_with(
+            height_m=1.80,
+            mass_kg=75.0,
+            gender_factor=0.7,
+            shoulder_width_factor=1.1,
+        )
+
+    @patch("model_generation.builders.parametric_builder.ParametricBuilder")
+    def test_quick_build_uses_shared_presets(self, mock_builder_cls: MagicMock) -> None:
+        """quick_build should use _HUMANOID_PRESETS, not an inline dict."""
+        mock_builder = MagicMock()
+        mock_builder_cls.return_value = mock_builder
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.urdf_xml = None
+        mock_builder.build.return_value = mock_result
+
+        from model_generation import quick_build
+
+        quick_build(height_m=1.80, preset="athletic")
+
+        mock_builder.set_parameters.assert_called_once_with(
+            height_m=1.80,
+            mass_kg=75.0,
+            gender_factor=0.7,
+            shoulder_width_factor=1.1,
+        )
+
+
+# ============================================================
+# Issue 4: Capsule geometry warning
+# ============================================================
+
+
+class TestCapsuleWarning:
+    """Capsule downgrade to cylinder should produce a warning."""
+
+    def test_urdf_writer_capsule_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """URDFWriter._write_geometry() should warn about capsule approximation."""
+        writer = URDFWriter()
+        capsule = Geometry.capsule(radius=0.05, length=0.3)
+
+        with caplog.at_level(logging.WARNING):
+            lines = writer._write_geometry(capsule, level=0)
+
+        # Should still produce valid cylinder XML
+        xml = "\n".join(lines)
+        assert "cylinder" in xml
+        assert 'radius="0.05"' in xml
+
+        # Should produce a warning
+        assert any(
+            "Capsule geometry approximated as cylinder" in record.message
+            for record in caplog.records
+        ), f"Expected capsule warning, got: {[r.message for r in caplog.records]}"
+
+    def test_geometry_to_urdf_string_capsule_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Geometry.to_urdf_string() should warn about capsule approximation."""
+        capsule = Geometry.capsule(radius=0.05, length=0.3)
+
+        with caplog.at_level(logging.WARNING):
+            result = capsule.to_urdf_string()
+
+        # Should produce cylinder XML
+        assert "cylinder" in result
+
+        # Should produce a warning
+        assert any(
+            "Capsule geometry approximated as cylinder" in record.message
+            for record in caplog.records
+        ), f"Expected capsule warning, got: {[r.message for r in caplog.records]}"
+
+    def test_non_capsule_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Non-capsule geometries should NOT produce the capsule warning."""
+        writer = URDFWriter()
+        cylinder = Geometry.cylinder(radius=0.05, length=0.3)
+
+        with caplog.at_level(logging.WARNING):
+            writer._write_geometry(cylinder, level=0)
+
+        assert not any(
+            "Capsule geometry approximated as cylinder" in record.message
+            for record in caplog.records
+        )
+
+
+# ============================================================
+# Issue 5: _get_writable_model() helper in editor_modifications
+# ============================================================
+
+
+class TestGetWritableModel:
+    """Validate _get_writable_model() helper extraction."""
+
+    def test_helper_exists(self) -> None:
+        """_get_writable_model should exist as a method on ModificationMixin."""
+        from model_generation.editor.editor_modifications import ModificationMixin
+
+        assert hasattr(ModificationMixin, "_get_writable_model")
+
+    def test_helper_returns_none_for_missing_model(self) -> None:
+        """Should return None and log error for missing model."""
+        from model_generation.editor.editor_modifications import ModificationMixin
+
+        mixin = ModificationMixin.__new__(ModificationMixin)
+        mixin._models = {}
+
+        result = mixin._get_writable_model("nonexistent")
+        assert result is None
+
+    def test_helper_returns_none_for_read_only_model(self) -> None:
+        """Should return None and log error for read-only model."""
+        from model_generation.editor.editor_modifications import ModificationMixin
+
+        mixin = ModificationMixin.__new__(ModificationMixin)
+        mock_model = MagicMock()
+        mock_model.read_only = True
+        mixin._models = {"test": mock_model}
+
+        result = mixin._get_writable_model("test")
+        assert result is None
+
+    def test_helper_returns_model_for_writable(self) -> None:
+        """Should return the model for a writable model."""
+        from model_generation.editor.editor_modifications import ModificationMixin
+
+        mixin = ModificationMixin.__new__(ModificationMixin)
+        mock_model = MagicMock()
+        mock_model.read_only = False
+        mixin._models = {"test": mock_model}
+
+        result = mixin._get_writable_model("test")
+        assert result is mock_model
+
+
+# ============================================================
+# Issue 2: Redundant imports - just verify math works at module level
+# ============================================================
+
+
+class TestRedundantImports:
+    """Verify math.radians works correctly after removing inline imports."""
+
+    def test_link_from_dict_uses_math(self) -> None:
+        """_link_from_dict should work correctly with module-level math import."""
+        builder = ManualBuilder("test", validate_on_add=False)
+        data = {
+            "name": "test_link",
+            "geometry": {
+                "shape": "box",
+                "dimensions": {"width": 0.1, "height": 0.2, "length": 0.3},
+                "orientation": {"roll": 90.0, "pitch": 0.0, "yaw": 0.0},
+            },
+        }
+        link = builder._link_from_dict(data)
+        assert link.name == "test_link"
+        # 90 degrees should be approximately pi/2
+        import math
+
+        assert abs(link.visual_origin.rpy[0] - math.pi / 2) < 1e-10
+
+    def test_joint_from_dict_uses_math(self) -> None:
+        """_joint_from_dict should work correctly with module-level math import."""
+        builder = ManualBuilder("test", validate_on_add=False)
+        data = {
+            "name": "child",
+            "parent": "parent",
+            "geometry": {
+                "orientation": {"roll": 0.0, "pitch": 45.0, "yaw": 0.0},
+            },
+            "joint": {"type": "revolute", "limits": {"lower": -90, "upper": 90}},
+        }
+        joint = builder._joint_from_dict(data)
+        import math
+
+        assert abs(joint.origin.rpy[1] - math.radians(45.0)) < 1e-10
+        assert joint.limits is not None
+        assert abs(joint.limits.lower - math.radians(-90)) < 1e-10


### PR DESCRIPTION
## Summary
- **Deque optimization**: Replace `list.pop(0)` (O(n)) with `collections.deque.popleft()` (O(1)) in BFS traversals in `_get_descendants()` and `_sort_links_by_hierarchy()`
- **Redundant imports**: Move `import math` to module level in `manual_builder.py`, removing two inline re-imports inside `_link_from_dict()` and `_joint_from_dict()`
- **Preset duplication**: Extract shared humanoid preset dict to module-level `_HUMANOID_PRESETS` constant, eliminating duplication between `quick_urdf()` and `quick_build()`
- **Capsule geometry warning**: Add `logger.warning()` when capsule geometry is approximated as cylinder (URDF has no native capsule support) in both `URDFWriter._write_geometry()` and `Geometry.to_urdf_string()`
- **DRY helper extraction**: Extract `_get_writable_model()` helper in `editor_modifications.py` to consolidate the repeated model-existence + read-only guard pattern across 8 methods (`delete_link`, `delete_subtree`, `rename_link`, `rename_joint`, `modify_joint`, `attach_link`, `detach_link`, `apply_prefix`)

## Test plan
- [x] 19 new TDD tests in `test_code_quality_fixes.py` covering all changes
- [x] `_get_descendants()` correctness validated for root, middle, leaf, and branching topologies
- [x] `_sort_links_by_hierarchy()` validates parent-before-child ordering
- [x] `_HUMANOID_PRESETS` existence and content verified; mock-based tests confirm both `quick_urdf` and `quick_build` use the shared constant
- [x] Capsule warning captured via `caplog` in both `URDFWriter` and `Geometry.to_urdf_string()`; non-capsule geometries verified to produce no warning
- [x] `_get_writable_model()` helper tested for missing model, read-only model, and writable model
- [x] All 112 existing model_generation tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)