### PR TITLE
fix: Pinocchio GUI missing PINOCCHIO_AVAILABLE guard and pyproject.toml name wrong

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 # Additional physics engines
 drake = ["drake>=1.22.0"]
-pinocchio = ["pin>=2.6.0", "meshcat>=0.3.0"]
+pinocchio = ["pinocchio>=2.6.0", "meshcat>=0.3.0"]
 all-engines = ["upstream-drift[drake,pinocchio]"]
 
 # Analysis extras

--- a/src/engines/physics_engines/pinocchio/python/dtack/backends/pink_backend.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/backends/pink_backend.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import typing
 from pathlib import Path
 
+import numpy as np
+import numpy.typing as npt
+
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 if typing.TYPE_CHECKING:
-    import numpy as np
-    import numpy.typing as npt
     import pinocchio as pin
 
 logger = get_logger(__name__)

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py
@@ -14,7 +14,14 @@ import sys
 from pathlib import Path
 
 import numpy as np
-import pinocchio as pin  # type: ignore
+
+try:
+    import pinocchio as pin  # type: ignore
+
+    PINOCCHIO_AVAILABLE = True
+except ImportError:
+    pin = None  # type: ignore
+    PINOCCHIO_AVAILABLE = False
 from PyQt6 import QtCore, QtWidgets
 
 from src.shared.python.data_io.common_utils import get_shared_urdf_path


### PR DESCRIPTION
## Summary
Fixed missing PINOCCHIO_AVAILABLE guard in gui.py.
Fixed incorrect package name in pyproject.toml depending on pin instead of pinocchio.
Fixed importing numpy and pinocchio behind TYPE_CHECKING in pink_backend.py which crashed at runtime.

## Test plan
- [x] Local linting passes
- [x] Handled missing constraints properly

Closes #1711