### PR TITLE
fix: MyoSuite Gym protocol mismatch and unsafe runtime timestep modification

### DIFF
--- a/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
+++ b/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
@@ -159,58 +159,24 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
         lambda self, dt=None: self.env is not None, "Environment must be loaded"
     )
     def step(self, dt: float | None = None) -> None:
-        """Step simulation."""
+        """Step simulation.
 
+        Bridges Gym interface properly to pass set_control values as actions.
+        """
         if not self.env:
             return
 
-        # Gym steps by fixed internal dt (usually frame_skip * model_dt).
+        if dt is not None and dt != getattr(self, "_dt", None):
+            logger.warning(
+                "Runtime timestep modification is unsafe in MuJoCo. Ignoring dt override."
+            )
 
-        # We can't easily force arbitrary dt without hacking the sim.
+        action = getattr(self, "_last_action", None)
+        if action is None:
+            # Fallback to zero action
+            action = self.env.action_space.sample() * 0.0
 
-        # We'll just call step(). Controls should be set beforehand.
-
-        # We need the action.
-
-        # In PhysicsEngine protocol, set_control() sets the action buffer?
-
-        # But Gym step() TAKES the action.
-
-        # This is a protocol mismatch.
-
-        # Capability: If self.sim is present, we can just step self.sim directly?
-
-        # But that bypasses MyoSuite's muscle activation dynamics (if implemented in python steps).
-
-        # MyoSuite generally puts muscle dynamics in the MuJoCo model or usage of sim.step().
-
-        # Strategy: Use sim.step() if available to respect 'PhysicsEngine' low-level vibe,
-
-        # preserving state.
-
-        if self.sim:
-            # Handle dt override if possible
-
-            if dt is not None:
-                old_dt = self.sim.model.opt.timestep
-
-                self.sim.model.opt.timestep = dt
-
-                self.sim.step()
-
-                self.sim.model.opt.timestep = old_dt
-
-            else:
-                self.sim.step()
-
-        else:
-            # Fallback to env.step() with zero action if we can't control it
-
-            # (Bad, but fallback)
-
-            zero_action = self.env.action_space.sample() * 0
-
-            self.env.step(zero_action)
+        self.env.step(action)
 
     @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:
@@ -288,6 +254,7 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
 
     def set_control(self, u: np.ndarray) -> None:
         """Set control (ctrl)."""
+        self._last_action = np.array(u).copy()
 
         if not self.sim:
             return
@@ -797,7 +764,6 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
 
         except (ValueError, TypeError, RuntimeError) as e:
             logger.error(f"Failed to compute ZTCF: {e}")
-
             return np.array([])
 
     def compute_zvcf(self, q: np.ndarray) -> np.ndarray:
@@ -894,3 +860,15 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
             return []
 
         return list(analyzer.muscle_names)
+
+
+def main() -> None:
+    """Entry point for standalone execution."""
+    logger.error("MyoSuite does not have a standalone GUI. Use the web UI.")
+    import sys
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/physics_engines/opensim/python/opensim_gui.py
+++ b/src/engines/physics_engines/opensim/python/opensim_gui.py
@@ -391,7 +391,8 @@ For more help, see the documentation in docs/ folder.
         """.strip()
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Launch the OpenSim Golf GUI."""
     app = QApplication(sys.argv)
 
     # Check for command line model path
@@ -400,3 +401,7 @@ if __name__ == "__main__":
     window = OpenSimGolfGUI(model_path=model_path)
     window.show()
     sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/python/launcher_factory.py
+++ b/src/shared/python/launcher_factory.py
@@ -16,8 +16,8 @@ ENGINE_MODULES: dict[str, str] = {
     "mujoco": "src.engines.physics_engines.mujoco.python.humanoid_launcher",
     "drake": "src.engines.physics_engines.drake.python.src.drake_gui_app",
     "pinocchio": "src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui",
-    "opensim": "src.engines.physics_engines.opensim.python.opensim_launcher",
-    "myosim": "src.engines.physics_engines.myosim.python.myosim_launcher",
+    "opensim": "src.engines.physics_engines.opensim.python.opensim_gui",
+    "myosuite": "src.engines.physics_engines.myosuite.python.myosuite_physics_engine",
     "pendulum": "src.engines.pendulum_models.python.pendulum_launcher",
 }
 


### PR DESCRIPTION
## Summary
Fixed Gym env.step() protocol mismatch in MyoSuite to apply simulated controls as actions instead of ignoring them.
Removed unsafe runtime timestep modification to prevent undefined MuJoCo behavior.
Added OpenSim and MyoSuite to launcher ENGINE_MODULES so they no longer fail silently.

## Test plan
- [x] Local linting passes
- [x] Handled missing capabilities properly

Closes #1715