### PR TITLE
fix(tauri): add Content Security Policy

### DIFF
--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://ipc.localhost; worker-src 'self' blob:"
     }
   },
   "bundle": {


### PR DESCRIPTION
Batch 5: Tauri CSP security fix and issue closures.

## Changes
- Add restrictive Content Security Policy to Tauri config (#1542)

## Issues Closed
- #1542: Tauri CSP null -> restrictive policy
- #1547: Print statements (all in docstrings/examples)
- #1580: README coverage tracked via fleet KI
- #1648, #1574, #1549: Stale weekly CI digests superseded

Closes #1542
