### PR TITLE
fix: patch mujoco at module level to fix 17 CI test failures

### DIFF
--- a/tests/unit/engines/mujoco/test_telemetry.py
+++ b/tests/unit/engines/mujoco/test_telemetry.py
@@ -43,7 +43,12 @@ def mock_mujoco_model_data() -> tuple:
 def test_telemetry_recorder_init(mock_mujoco_model_data) -> None:
     model, _ = mock_mujoco_model_data
 
-    with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
+    with patch(
+        "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.telemetry.mujoco"
+    ) as mock_mujoco:
+        mock_mujoco.mjtObj = mujoco.mjtObj
+        mock_mujoco.mjtTrn = mujoco.mjtTrn
+        mock_mujoco.mj_id2name = MagicMock(side_effect=lambda m, t, i: f"obj_{i}")
         recorder = TelemetryRecorder(model)
 
     assert len(recorder._body_names) == 2
@@ -54,7 +59,12 @@ def test_telemetry_recorder_init(mock_mujoco_model_data) -> None:
 def test_telemetry_recorder_record_step(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
-    with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
+    with patch(
+        "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.telemetry.mujoco"
+    ) as mock_mujoco:
+        mock_mujoco.mjtObj = mujoco.mjtObj
+        mock_mujoco.mjtTrn = mujoco.mjtTrn
+        mock_mujoco.mj_id2name = MagicMock(side_effect=lambda m, t, i: f"obj_{i}")
         recorder = TelemetryRecorder(model)
         recorder.add_custom_metric("test_metric", 123.45)
         recorder.record_step(data)
@@ -76,7 +86,12 @@ def test_telemetry_recorder_record_step(mock_mujoco_model_data) -> None:
 def test_telemetry_report_generation(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
-    with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
+    with patch(
+        "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.telemetry.mujoco"
+    ) as mock_mujoco:
+        mock_mujoco.mjtObj = mujoco.mjtObj
+        mock_mujoco.mjtTrn = mujoco.mjtTrn
+        mock_mujoco.mj_id2name = MagicMock(side_effect=lambda m, t, i: f"obj_{i}")
         recorder = TelemetryRecorder(model)
 
         # Step 1
@@ -101,7 +116,12 @@ def test_telemetry_report_generation(mock_mujoco_model_data) -> None:
 def test_telemetry_reset(mock_mujoco_model_data) -> None:
     model, data = mock_mujoco_model_data
 
-    with patch("mujoco.mj_id2name", side_effect=lambda m, t, i: f"obj_{i}"):
+    with patch(
+        "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.telemetry.mujoco"
+    ) as mock_mujoco:
+        mock_mujoco.mjtObj = mujoco.mjtObj
+        mock_mujoco.mjtTrn = mujoco.mjtTrn
+        mock_mujoco.mj_id2name = MagicMock(side_effect=lambda m, t, i: f"obj_{i}")
         recorder = TelemetryRecorder(model)
         recorder.record_step(data)
         assert len(recorder.samples) == 1

--- a/tests/unit/engines/mujoco/test_urdf_io.py
+++ b/tests/unit/engines/mujoco/test_urdf_io.py
@@ -17,6 +17,24 @@ from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.urdf_io impo
     import_urdf_to_mujoco,
 )
 
+# Path to the mujoco module reference inside urdf_io
+_URDF_IO_MUJOCO = (
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.urdf_io.mujoco"
+)
+
+
+def _make_mock_mujoco(**overrides: Any) -> MagicMock:
+    """Create a mock mujoco module that preserves enum types but stubs C functions."""
+    mock = MagicMock()
+    # Preserve real enum types so comparisons work
+    mock.mjtObj = mujoco.mjtObj
+    mock.mjtJoint = mujoco.mjtJoint
+    mock.mjtGeom = mujoco.mjtGeom
+    mock.mjtTrn = getattr(mujoco, "mjtTrn", MagicMock())
+    for key, val in overrides.items():
+        setattr(mock, key, val)
+    return mock
+
 
 @pytest.fixture
 def mock_mujoco_model() -> MagicMock:
@@ -102,86 +120,59 @@ def sample_urdf_xml() -> str:
     """
 
 
-def test_urdf_exporter_init(mock_mujoco_model) -> None:
+def test_urdf_exporter_init(mock_mujoco_model: MagicMock) -> None:
     """Test URDFExporter initialization."""
-    with patch("mujoco.MjData", autospec=True) as mock_data_cls:
+    mock_mj = _make_mock_mujoco()
+    mock_mj.MjData.return_value = MagicMock()
+
+    with patch(_URDF_IO_MUJOCO, mock_mj):
         exporter = URDFExporter(mock_mujoco_model)
         assert exporter.model == mock_mujoco_model
-        assert exporter.data == mock_data_cls.return_value
+        assert exporter.data == mock_mj.MjData.return_value
 
 
-def test_export_to_urdf(mock_mujoco_model) -> None:
+def test_export_to_urdf(mock_mujoco_model: MagicMock) -> None:
     """Test exporting a MuJoCo model to URDF format."""
-    with patch("mujoco.MjData", autospec=True):
+
+    def id2name(m: Any, obj_type: int, obj_id: int) -> str:
+        """Map MuJoCo object type and id to a name string."""
+        if obj_type == mujoco.mjtObj.mjOBJ_BODY:
+            return ["world", "link1", "link2"][obj_id]
+        if obj_type == mujoco.mjtObj.mjOBJ_JOINT:
+            return f"joint_{obj_id}"
+        if obj_type == mujoco.mjtObj.mjOBJ_GEOM:
+            return f"geom_{obj_id}"
+        return "obj"
+
+    mock_mj = _make_mock_mujoco(
+        mj_id2name=MagicMock(side_effect=id2name),
+    )
+    mock_mj.MjData.return_value = MagicMock()
+
+    with patch(_URDF_IO_MUJOCO, mock_mj), patch("pathlib.Path.write_text"):
         exporter = URDFExporter(mock_mujoco_model)
+        urdf_str = exporter.export_to_urdf("output.urdf", "test_robot")
 
-        # Mock mj_id2name to return names
-        def id2name(m: Any, obj_type: int, obj_id: int) -> str:
-            """Map MuJoCo object type and id to a name string."""
-            if obj_type == mujoco.mjtObj.mjOBJ_BODY:
-                return ["world", "link1", "link2"][obj_id]
-            if obj_type == mujoco.mjtObj.mjOBJ_JOINT:
-                return f"joint_{obj_id}"
-            return "obj"
-
-        with (
-            patch("mujoco.mj_id2name", side_effect=id2name),
-            patch("pathlib.Path.write_text"),
-        ):
-            urdf_str = exporter.export_to_urdf("output.urdf", "test_robot")
-
-            assert 'robot name="test_robot"' in urdf_str
-            assert 'link name="link1"' in urdf_str
-            assert 'link name="link2"' in urdf_str
-
-            # Check for joint_1 instead of joint_0 because link1 is root (body_id 1)
-            # and joint_0 is attached to link1.
-            # Wait, body_jntadr=[ -1, 0, 1]. body 1 (link1) has joint 0.
-            # In _build_children:
-            #   Iterate children of root (link1).
-            #   Link1 is found as root in _find_root_body because it's first child
-            #   of world.
-            #   So root link is created for Link1.
-            #   Then _build_children for Link1.
-            #   Child is Link2 (parent=1).
-            #   Creates joint between Link1 and Link2.
-            #   Joint is defined by child body (Link2). Link2 has joint 1.
-            #   So we should see joint_1.
-
-            # The joint attached to Link1 (joint 0) is effectively the "root joint"
-            # connecting to world.
-            # URDF roots don't have joints.
-            # But wait, MJCF uses joints inside bodies to define DOF.
-            # If Link1 is floating base, it has free joint.
-            # Here Link1 has HINGE joint (joint 0).
-            # If it's attached to world (parent 0), it should be connected to world
-            # with a fixed joint or the robot base link should be world?
-            # Typically URDF robot "base_link" is the first link.
-            # If MJCF "world" is 0, and Link1 is 1 attached to 0.
-            # Exporter finds root body = Link1.
-            # Creates Link1.
-            # It does NOT create a joint for Link1 because it's the root of the
-            # URDF tree.
-            # So joint 0 is LOST in this export unless we have a dummy world link.
-            # But normally URDF roots are floating or fixed to world implicitly.
-
-            # Joint 1 connects Link1 -> Link2.
-            assert 'joint name="joint_1"' in urdf_str
-            assert 'type="prismatic"' in urdf_str
+        assert 'robot name="test_robot"' in urdf_str
+        assert 'link name="link1"' in urdf_str
+        assert 'link name="link2"' in urdf_str
+        assert 'joint name="joint_1"' in urdf_str
+        assert 'type="prismatic"' in urdf_str
 
 
-def test_export_model_to_urdf_function(mock_mujoco_model) -> None:
+def test_export_model_to_urdf_function(mock_mujoco_model: MagicMock) -> None:
     """Test the export_model_to_urdf convenience function."""
-    with (
-        patch("mujoco.mj_id2name", return_value="test_name"),
-        patch("pathlib.Path.write_text"),
-        patch("mujoco.MjData", autospec=True),
-    ):
+    mock_mj = _make_mock_mujoco(
+        mj_id2name=MagicMock(return_value="test_name"),
+    )
+    mock_mj.MjData.return_value = MagicMock()
+
+    with patch(_URDF_IO_MUJOCO, mock_mj), patch("pathlib.Path.write_text"):
         urdf_str = export_model_to_urdf(mock_mujoco_model, "out.urdf")
         assert len(urdf_str) > 0
 
 
-def test_urdf_importer_import(sample_urdf_xml) -> None:
+def test_urdf_importer_import(sample_urdf_xml: str) -> None:
     """Test importing a URDF file to MJCF format."""
     importer = URDFImporter()
 
@@ -202,7 +193,7 @@ def test_urdf_importer_import(sample_urdf_xml) -> None:
         assert 'pos="1 0 0"' in mjcf_str  # From joint origin
 
 
-def test_import_urdf_to_mujoco_function(sample_urdf_xml) -> None:
+def test_import_urdf_to_mujoco_function(sample_urdf_xml: str) -> None:
     """Test the import_urdf_to_mujoco convenience function."""
     with (
         patch("defusedxml.ElementTree.parse") as mock_parse,
@@ -223,17 +214,18 @@ def test_importer_file_not_found() -> None:
         importer.import_from_urdf("nonexistent.urdf")
 
 
-def test_exporter_no_root_body(mock_mujoco_model) -> None:
+def test_exporter_no_root_body(mock_mujoco_model: MagicMock) -> None:
     """Test exporting a model with only the world body and no root."""
     mock_mujoco_model.nbody = 1  # Only world
 
-    with patch("mujoco.MjData", autospec=True):
+    mock_mj = _make_mock_mujoco(
+        mj_id2name=MagicMock(return_value="world"),
+    )
+    mock_mj.MjData.return_value = MagicMock()
+
+    with patch(_URDF_IO_MUJOCO, mock_mj), patch("pathlib.Path.write_text"):
         exporter = URDFExporter(mock_mujoco_model)
-        with (
-            patch("mujoco.mj_id2name", return_value="world"),
-            patch("pathlib.Path.write_text"),
-        ):
-            urdf_str = exporter.export_to_urdf("out.urdf")
-            # Should just be empty robot tag basically
-            assert "<robot" in urdf_str
-            assert "<link" not in urdf_str
+        urdf_str = exporter.export_to_urdf("out.urdf")
+        # Should just be empty robot tag basically
+        assert "<robot" in urdf_str
+        assert "<link" not in urdf_str

--- a/tests/unit/engines/mujoco/test_video_export.py
+++ b/tests/unit/engines/mujoco/test_video_export.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -22,10 +21,30 @@ from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export
     export_simulation_video,
 )
 
+# Path to the mujoco module reference inside video_export (imported as `mj`)
+_VID_EXPORT_MJ = (
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.mj"
+)
+
 # Mock constants for headless environment
 WIDTH = 640
 HEIGHT = 480
 FPS = 30
+
+
+def _make_mock_mj(**overrides: Any) -> MagicMock:
+    """Create a mock mujoco module that preserves enum types but stubs C functions."""
+    mock = MagicMock()
+    mock.mjtObj = mujoco.mjtObj
+    mock.mjtJoint = mujoco.mjtJoint
+    mock.mjtGeom = mujoco.mjtGeom
+    # Return a dummy black frame from the Renderer mock
+    renderer_inst = MagicMock()
+    renderer_inst.render.return_value = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
+    mock.Renderer.return_value = renderer_inst
+    for key, val in overrides.items():
+        setattr(mock, key, val)
+    return mock
 
 
 @pytest.fixture
@@ -45,37 +64,17 @@ def mock_mujoco() -> tuple[MagicMock, MagicMock]:
 
 
 @pytest.fixture
-def mock_renderer() -> Generator[MagicMock, None, None]:
-    """Mock the MuJoCo Renderer."""
-    with patch("mujoco.Renderer") as mock:
-        renderer = mock.return_value
-        # Return a dummy black frame
-        renderer.render.return_value = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
-        yield mock
-
-
-@pytest.fixture
 def mock_cv2() -> Any:
     """Mock cv2 module."""
-    # Since we mocked it in sys.modules, we can just grab it
     mock = sys.modules["cv2"]
-
-    # Reset mock
     mock.reset_mock()
 
-    # Mock VideoWriter
     writer = MagicMock()
     writer.isOpened.return_value = True
     mock.VideoWriter.return_value = writer
-
-    # Mock cvtColor (pass-through for shape check)
     mock.cvtColor.side_effect = lambda img, code: img
-
-    # Mock constants
     mock.COLOR_RGB2BGR = 1  # type: ignore[attr-defined]
     mock.FONT_HERSHEY_SIMPLEX = 1  # type: ignore[attr-defined]
-
-    # Mock VideoWriter_fourcc to return an int (like real cv2)
     mock.VideoWriter_fourcc.return_value = 0x7634706D  # mp4v
 
     return mock
@@ -92,26 +91,37 @@ def mock_imageio() -> Any:
 class TestVideoExporter:
     """Tests for the VideoExporter class."""
 
-    def test_init(self, mock_mujoco, mock_renderer) -> None:
+    def test_init(self, mock_mujoco: tuple[MagicMock, MagicMock]) -> None:
         """Test VideoExporter initialization."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS)
+        mock_mj = _make_mock_mj()
+
+        with patch(_VID_EXPORT_MJ, mock_mj):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS)
 
         assert exporter.width == WIDTH
         assert exporter.height == HEIGHT
         assert exporter.fps == FPS
         assert exporter.format == VideoFormat.MP4
-        mock_renderer.assert_called_once_with(model, width=WIDTH, height=HEIGHT)
+        mock_mj.Renderer.assert_called_once_with(model, width=WIDTH, height=HEIGHT)
 
-    def test_start_recording_mp4(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+    def test_start_recording_mp4(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
+    ) -> None:
         """Test starting MP4 recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
             success = exporter.start_recording("test.mp4")
 
         assert success
@@ -123,82 +133,119 @@ class TestVideoExporter:
         assert exporter.writer is not None
 
     def test_start_recording_gif(
-        self, mock_mujoco, mock_renderer, mock_imageio
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_imageio: Any,
     ) -> None:
         """Test starting GIF recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
             success = exporter.start_recording("test.gif")
 
         assert success
         assert exporter.frames == []
         assert exporter.writer is None
 
-    def test_add_frame_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+    def test_add_frame_video(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
+    ) -> None:
         """Test adding a frame to video recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
             exporter.start_recording("test.mp4")
             exporter.add_frame()
 
-        mock_renderer.return_value.update_scene.assert_called_with(data, camera=None)
-        mock_renderer.return_value.render.assert_called_once()
+        renderer = mock_mj.Renderer.return_value
+        renderer.update_scene.assert_called_with(data, camera=None)
+        renderer.render.assert_called_once()
         mock_cv2.cvtColor.assert_called_once()
         exporter.writer.write.assert_called_once()
         assert exporter.frame_count == 1
 
-    def test_add_frame_gif(self, mock_mujoco, mock_renderer, mock_imageio) -> None:
+    def test_add_frame_gif(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_imageio: Any,
+    ) -> None:
         """Test adding a frame to GIF recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
             exporter.start_recording("test.gif")
             exporter.add_frame()
 
         assert len(exporter.frames) == 1
         assert exporter.frame_count == 1
 
-    def test_finish_recording_video(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+    def test_finish_recording_video(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
+    ) -> None:
         """Test finishing video recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
             exporter.start_recording("test.mp4")
-            writer = exporter.writer  # Capture the writer before it's cleared
+            writer = exporter.writer
             exporter.finish_recording()
 
         writer.release.assert_called_once()
         assert exporter.writer is None
 
     def test_finish_recording_gif(
-        self, mock_mujoco, mock_renderer, mock_imageio
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_imageio: Any,
     ) -> None:
         """Test finishing GIF recording."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
+        mock_mj = _make_mock_mj()
 
-        with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
-            True,
+        with (
+            patch(_VID_EXPORT_MJ, mock_mj),
+            patch(
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.IMAGEIO_AVAILABLE",
+                True,
+            ),
         ):
+            exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.GIF)
             exporter.start_recording("test.gif")
             exporter.add_frame()
             exporter.finish_recording("test.gif")
@@ -206,10 +253,14 @@ class TestVideoExporter:
         mock_imageio.mimsave.assert_called_once()
         assert exporter.frames == []
 
-    def test_export_recording(self, mock_mujoco, mock_renderer, mock_cv2) -> None:
+    def test_export_recording(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
+    ) -> None:
         """Test full export recording workflow."""
         model, data = mock_mujoco
-        exporter = VideoExporter(model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4)
+        mock_mj = _make_mock_mj()
 
         initial_state = np.zeros(4)  # nq=2 + nv=2
 
@@ -221,23 +272,20 @@ class TestVideoExporter:
             """No-op progress callback."""
 
         with (
-            patch("mujoco.mj_forward"),
-            patch("mujoco.mj_step"),
+            patch(_VID_EXPORT_MJ, mock_mj),
             patch(
-                "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
                 True,
             ),
         ):
-            # We need to capture the writer after start_recording is called inside
-            # export_recording
-            # But we can't easily access it from outside.
-            # We can verify the mock_cv2.VideoWriter().release() was called.
-
+            success = exporter = VideoExporter(
+                model, data, WIDTH, HEIGHT, FPS, VideoFormat.MP4
+            )
             success = exporter.export_recording(
                 "test.mp4",
                 initial_state,
                 control_func,
-                duration=0.1,  # Short duration -> few frames
+                duration=0.1,
                 progress_callback=progress_cb,
             )
 
@@ -245,7 +293,11 @@ class TestVideoExporter:
         assert exporter.frame_count > 0
         mock_cv2.VideoWriter.return_value.release.assert_called_once()
 
-    def test_metrics_overlay(self, mock_mujoco, mock_cv2) -> None:
+    def test_metrics_overlay(
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
+    ) -> None:
         """Test metrics overlay rendering on frames."""
         model, data = mock_mujoco
         frame = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
@@ -253,20 +305,22 @@ class TestVideoExporter:
         metrics = {"Test Metric": lambda d: 42.0}
 
         with patch(
-            "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+            "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
             True,
         ):
             out_frame = create_metrics_overlay(frame, 1.0, data, metrics)
 
-        # Check that putText was called for time and metric
         assert mock_cv2.putText.call_count >= 2
-        assert out_frame is not frame  # Should return a copy or modified frame
+        assert out_frame is not frame
 
     def test_export_simulation_video_function(
-        self, mock_mujoco, mock_renderer, mock_cv2
+        self,
+        mock_mujoco: tuple[MagicMock, MagicMock],
+        mock_cv2: Any,
     ) -> None:
         """Test the export_simulation_video convenience function."""
         model, data = mock_mujoco
+        mock_mj = _make_mock_mj()
 
         N = 10
         states = np.zeros((N, 4))
@@ -274,10 +328,9 @@ class TestVideoExporter:
         times = np.linspace(0, 1, N)
 
         with (
-            patch("mujoco.mj_forward"),
-            patch("mujoco.mj_name2id", return_value=-1),
+            patch(_VID_EXPORT_MJ, mock_mj),
             patch(
-                "engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
+                "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.video_export.CV2_AVAILABLE",
                 True,
             ),
         ):
@@ -295,5 +348,4 @@ class TestVideoExporter:
             )
 
         assert success
-        # Verify VideoExporter usage implicitly via mock_cv2
         mock_cv2.VideoWriter.assert_called_once()


### PR DESCRIPTION
Batch 10: Fix 17 pre-existing MuJoCo test failures on CI.

## Root Cause

MuJoCo's Python bindings use pybind11, which validates C-level argument types
**before** Python's `unittest.mock` can intercept. On CI (Python 3.11/Linux),
`mujoco.mj_id2name(MagicMock(), ...)` fails with `TypeError: incompatible
function arguments` because pybind11 rejects the MagicMock before the patch
can intercept.

## Fix

Patch the entire `mujoco` module reference inside each test module's namespace
rather than patching individual C functions:

- `test_telemetry.py` → patch `telemetry.mujoco` (4 tests)
- `test_urdf_io.py` → patch `urdf_io.mujoco` (4 tests)
- `test_video_export.py` → patch `video_export.mj` (9 tests)

## DRY Helpers

- `_make_mock_mujoco()`: Preserves real enum types (mjtObj, mjtJoint, mjtGeom, mjtTrn) while stubbing C extension functions
- `_make_mock_mj()`: Same pattern with embedded Renderer mock for video tests

Closes #1635
