### PR TITLE
assessment: A-O + Pragmatic assessment + physics fixes (2026-03-12)

### DIFF
--- a/docs/assessments/Comprehensive_Assessment_2026-03-12.md
+++ b/docs/assessments/Comprehensive_Assessment_2026-03-12.md
@@ -1,0 +1,348 @@
+# Comprehensive A-O Assessment: 2026-03-12
+
+**Assessor**: Claude (automated)
+**Date**: 2026-03-12
+**Framework Version**: 2.0
+**Scope**: Full repository fresh-read assessment
+
+---
+
+## Executive Summary
+
+The UpstreamDrift Golf Modeling Suite is a large, ambitious multi-engine physics simulation platform.
+The codebase demonstrates high architectural ambition with strong protocol-based design (PhysicsEngine, sub-protocols, DbC decorators) and good test infrastructure. However, the completist report confirms 416 critical implementation gaps (bare stubs returning `...`), 88 TODOs, 32 FIXMEs and 520 documentation gaps.
+
+Overall weighted score: **62/100**
+
+Key risks:
+
+1. **Security (I)**: `AuthCache._cache_lookup_token()` uses Python's `hash()` which is non-deterministic and collision-prone (minor - cache lookup only, bcrypt used for actual auth)
+2. **Testing (G)**: 209 skipped tests, coverage around 50%
+3. **Architecture (A)**: 416 stubs, particularly in physics modules (topography, terrain, flexible shaft, impact model)
+4. **DRY violations**: Launcher code has significant duplication
+5. **Error handling (H)**: Many bare `pass` in exception handlers swallowing errors silently
+
+---
+
+## Category Scores
+
+### A: Architecture & Implementation (2x weight) — 65/100
+
+**Strengths:**
+
+- Strong Protocol-based PhysicsEngine interface with `sub_protocols.py` decomposition
+- Design-by-Contract system (`src/shared/python/core/contracts/`) with `@precondition` decorators
+- Flight models properly abstracted behind `BallFlightModel` ABC with `ConstantCoefficientModel` DRY refactor
+- `AerodynamicsEngine` cleanly separates drag/lift/magnus as orthogonal force models
+- Engine capability reporting via `EngineCapabilities` dataclass
+
+**Issues:**
+
+- 416 critical stubs in `src/shared/python/physics/` (topography, terrain_engine, impact_model, flexible_shaft)
+- `src/shared/python/model_generation/` has 10+ unimplemented builders
+- `src/shared/python/pose_estimation/interface.py` has 3 stub methods
+- `src/shared/python/plot_engine/protocols.py` has 5 stubs
+- Bare `pass` statements in exception handlers in `src/launchers/` swallow errors silently
+
+**Score: 65** (weight 2x, contributes 130/200)
+
+---
+
+### B: Code Quality & Hygiene (1.5x weight) — 70/100
+
+**Strengths:**
+
+- `ruff` linting configured in `pyproject.toml`
+- Pre-commit hooks with bandit and ruff configured
+- Type annotations throughout core APIs
+- `from __future__ import annotations` used consistently
+
+**Issues:**
+
+- 454 pre-existing ruff T201 (print) violations (tracked in CI known failures)
+- Multiple bare `pass` in exception handlers (silent failure)
+- `src/launchers/unified_launcher.py` has 7 bare `pass` statements
+- `AuthCache._cache_lookup_token()` uses `hash()` which is non-cryptographic (documented but warns)
+
+**Score: 70** (weight 1.5x, contributes 105/150)
+
+---
+
+### C: Documentation & Comments (1x weight) — 55/100
+
+**Strengths:**
+
+- Good docstrings on Protocol interfaces
+- `interfaces.py` has detailed Design-by-Contract pre/postcondition docs
+- Aerodynamics module has academic references (Bearman & Harvey 1976, etc.)
+
+**Issues:**
+
+- 520 documentation gaps per completist report
+- Many stub methods have no implementation notes
+- `src/shared/python/calc_backend/` lacks API usage examples
+
+**Score: 55** (weight 1x, contributes 55/100)
+
+---
+
+### D: User Experience & Developer Journey (2x weight) — 60/100
+
+**Strengths:**
+
+- `install.sh` provided
+- `CONTRIBUTING.md` exists
+- Multiple launcher UI implementations
+
+**Issues:**
+
+- Security stub at `security.py:315` was the top-listed critical gap in the completist report (now confirmed as `UsageTracker.__init__` — actually looks implemented)
+- Development setup complexity: requires MuJoCo, Drake, Pinocchio, MATLAB — high barrier
+- No quickstart that works without simulation engines
+
+**Score: 60** (weight 2x, contributes 120/200)
+
+---
+
+### E: Performance & Scalability (1.5x weight) — 65/100
+
+**Strengths:**
+
+- `AuthCache` added to avoid N+1 bcrypt re-hash on every API call
+- `get_full_state()` batched query optimization in PhysicsEngine protocol
+- RK45 ODE solver used with adaptive step-size
+- Physics constants centralized in `physics_constants.py`
+
+**Issues:**
+
+- `TopographyData.to_heightmap()` uses nested Python loops (O(n²)) instead of vectorized numpy
+- `TopographyData.sample_uniform()` also uses nested loops
+- No profiling data or benchmarks visible
+
+**Score: 65** (weight 1.5x, contributes 97.5/150)
+
+---
+
+### F: Installation & Deployment (1.5x weight) — 58/100
+
+**Strengths:**
+
+- Docker support (`docker-compose.yml`, `docker-compose.gpu.yml`)
+- `environment.yml` for conda
+- `requirements.txt` / `requirements.lock`
+
+**Issues:**
+
+- Missing `vendor/ud-tools` submodule causes CI "Backend Parity Reports" failure
+- Multiple engine dependencies (MuJoCo, Drake, Pinocchio) require separate installs
+- No minimal install path for API-only usage
+
+**Score: 58** (weight 1.5x, contributes 87/150)
+
+---
+
+### G: Testing & Validation (2x weight) — 52/100
+
+**Strengths:**
+
+- 400+ test files across `tests/unit/`, `tests/integration/`, `tests/api/`
+- Physics core tests pass: 127/127 for aerodynamics, flight_models, impact_model
+- 128/128 for terrain, terrain_engine, flexible_shaft
+- Hypothesis property-based testing in use
+
+**Issues:**
+
+- 209 skipped tests (GitHub issue #1745)
+- Coverage at ~50% (GitHub issue #1744)
+- 61 Pinocchio test files empty (GitHub issue #1741)
+- `test_thermodynamic_pipeline_contracts.py` has namespace class identity issue in CI
+- No topography-specific tests found for `topography.py`
+
+**Score: 52** (weight 2x, contributes 104/200)
+
+---
+
+### H: Error Handling & Debugging (1.5x weight) — 58/100
+
+**Strengths:**
+
+- Custom exception hierarchy in `src/shared/python/core/exceptions.py`
+- Error codes system with `GMS-XXX-NNN` format in `src/api/utils/error_codes.py`
+- Logging configured via `get_logger()`
+
+**Issues:**
+
+- Multiple silent `except: pass` blocks in launchers
+- `AuthCache` silently clears on size overflow (`self._cache.clear()` with no warning)
+- Bare `pass` in MuJoCo/Drake GUI exception handlers (`sim_widget.py`, `drake_gui_viz.py`)
+- `TopographyData._load_csv` will silently use 0 for missing columns
+
+**Score: 58** (weight 1.5x, contributes 87/150)
+
+---
+
+### I: Security & Input Validation (1.5x weight) — 70/100
+
+**Strengths:**
+
+- bcrypt with ROUNDS=12 for passwords and API keys
+- JWT tokens with type checking (access vs refresh)
+- `SECRET_KEY` env var enforcement — production raises RuntimeError
+- `RoleChecker` with proper hierarchy
+
+**Issues:**
+
+- `AuthCache._cache_lookup_token()` uses Python `hash()` which is hash-randomized (PYTHONHASHSEED) — not cryptographic but documented as intentional
+- No rate limiting visible on auth endpoints
+- Token expiry is 30 days for refresh tokens — long-lived
+
+**Score: 70** (weight 1.5x, contributes 105/150)
+
+---
+
+### J: Extensibility & Plugin Architecture (1x weight) — 68/100
+
+**Strengths:**
+
+- `PhysicsEngine` Protocol enables new engines without modifying core
+- `FlightModelRegistry` with enum-based registration
+- `EngineCapabilities` allows feature detection
+
+**Issues:**
+
+- `model_generation/plugins/__init__.py` has 4 unimplemented stub methods
+- Plugin registration is not documented for external contributors
+
+**Score: 68** (weight 1x, contributes 68/100)
+
+---
+
+### K: Reproducibility & Provenance (1.5x weight) — 72/100
+
+**Strengths:**
+
+- Seeds propagated in `TurbulenceModel`, `WindModel`, `EnvironmentRandomizer`
+- `ConstantCoefficientSpec` immutable frozen dataclass for model parameters
+- `AerodynamicsConfig` frozen dataclass with `with_changes()` pattern
+
+**Issues:**
+
+- `FlightModelRegistry._models` is a class variable — shared state, not reproducible across test runs if mutated
+- No experiment tracking or result versioning
+
+**Score: 72** (weight 1.5x, contributes 108/150)
+
+---
+
+### L: Long-Term Maintainability (1x weight) — 60/100
+
+**Strengths:**
+
+- Assessment framework documented with rolling cycle
+- Change log reviews tracked
+
+**Issues:**
+
+- Large monorepo with 1175+ Python files, 416 stubs — high tech debt ratio
+- CI has known pre-existing failures that are "not blocking"
+- vendor/ud-tools submodule missing breaks reproducibility
+
+**Score: 60** (weight 1x, contributes 60/100)
+
+---
+
+### M: Educational Resources & Tutorials (1x weight) — 45/100
+
+**Strengths:**
+
+- `examples/` directory exists
+- Academic references in physics modules
+
+**Issues:**
+
+- No working end-to-end tutorial for new users
+- No "minimal working example" for each engine
+- `docs/` lacks getting started guide
+
+**Score: 45** (weight 1x, contributes 45/100)
+
+---
+
+### N: Visualization & Export (1x weight) — 62/100
+
+**Strengths:**
+
+- `AerodynamicsEngine` returns structured dict with component forces
+- `FlightResult.to_position_array()` for export
+- C3D file viewer implemented
+
+**Issues:**
+
+- `plot_engine/protocols.py` has 5 unimplemented stubs
+- No unified export format across engines
+
+**Score: 62** (weight 1x, contributes 62/100)
+
+---
+
+### O: CI/CD & DevOps (1x weight) — 55/100
+
+**Strengths:**
+
+- GitHub Actions CI configured
+- Pre-commit hooks with ruff, bandit, pytest
+- `docker-compose.yml` for deployment
+
+**Issues:**
+
+- "Backend Parity Reports" CI job fails due to missing submodule
+- "Quality-gate" CI fails with 454 print violations
+- Scheduled workflows disabled (13 redundant ones disabled per recent commit)
+- No auto-merge on green CI
+
+**Score: 55** (weight 1x, contributes 55/100)
+
+---
+
+## Weighted Total
+
+| Category           | Raw | Weight | Weighted |
+| ------------------ | --- | ------ | -------- |
+| A: Architecture    | 65  | 2x     | 130      |
+| B: Code Quality    | 70  | 1.5x   | 105      |
+| C: Documentation   | 55  | 1x     | 55       |
+| D: UX/Dev Journey  | 60  | 2x     | 120      |
+| E: Performance     | 65  | 1.5x   | 97.5     |
+| F: Installation    | 58  | 1.5x   | 87       |
+| G: Testing         | 52  | 2x     | 104      |
+| H: Error Handling  | 58  | 1.5x   | 87       |
+| I: Security        | 70  | 1.5x   | 105      |
+| J: Extensibility   | 68  | 1x     | 68       |
+| K: Reproducibility | 72  | 1.5x   | 108      |
+| L: Maintainability | 60  | 1x     | 60       |
+| M: Education       | 45  | 1x     | 45       |
+| N: Visualization   | 62  | 1x     | 62       |
+| O: CI/CD           | 55  | 1x     | 55       |
+
+**Total Weighted: 1288.5 / 2075 = 62.1%**
+
+---
+
+## Top 10 Actionable Findings
+
+| Rank | Category | Severity | Finding                                                   | Location                   |
+| ---- | -------- | -------- | --------------------------------------------------------- | -------------------------- |
+| 1    | G        | CRITICAL | 209 skipped tests hiding coverage gaps                    | tests/                     |
+| 2    | A        | MAJOR    | 416 implementation stubs — physics models not implemented | src/shared/python/physics/ |
+| 3    | H        | MAJOR    | Silent `except: pass` blocks swallow errors in launchers  | src/launchers/\*.py        |
+| 4    | E        | MAJOR    | Nested loop performance in TopographyData (O(n²))         | topography.py:560-578      |
+| 5    | G        | MAJOR    | No `test_topography.py` test file for topography module   | tests/                     |
+| 6    | B        | MAJOR    | 454 pre-existing ruff T201 print violations blocking CI   | src/                       |
+| 7    | O        | MAJOR    | Missing vendor/ud-tools submodule breaks CI               | vendor/                    |
+| 8    | H        | MINOR    | AuthCache silent clear on size overflow                   | security.py:442            |
+| 9    | K        | MINOR    | FlightModelRegistry shared class-variable state           | flight_models.py:483       |
+| 10   | D        | MINOR    | No minimal "works without engines" getting started guide  | docs/                      |
+
+---
+
+_Generated by automated A-O assessment framework v2.0 on 2026-03-12._

--- a/docs/assessments/README.md
+++ b/docs/assessments/README.md
@@ -157,6 +157,8 @@ In addition to the standard framework, specialized audits monitor specific quali
 | 2026-03-10 | Consolidated Implementation Gaps         | `docs/assessments/completist/issues/ISSUE_GAPS_AND_INACCURACIES.md`           |
 | 2026-03-11 | Completist Audit Report                  | `docs/assessments/completist/Completist_Report_2026-03-11.md`                 |
 | 2026-03-12 | Completist Audit Report                  | `docs/assessments/completist/Completist_Report_2026-03-12.md`                 |
+| 2026-03-12 | Comprehensive A-O Assessment             | `docs/assessments/Comprehensive_Assessment_2026-03-12.md`                     |
+| 2026-03-12 | Pragmatic Programmer Assessment          | `docs/assessments/pragmatic_programmer/Pragmatic_Assessment_2026-03-12.md`    |
 
 ---
 
@@ -220,20 +222,20 @@ In addition to the standard framework, specialized audits monitor specific quali
 
 ## Version History
 
-| Version | Date    | Changes                                                  |
-| ------- | ------- | -------------------------------------------------------- |
-| 1.0     | 2025-12 | Initial 15-point framework                               |
-| 2.0     | 2026-01 | Reorganized based on UX/strategic gap analysis           |
-| 2.1     | 2026-02 | Added comprehensive multi-framework assessment           |
-| 2.2     | 2026-02 | Added Physics Audit (Specialized Assessment)             |
-| 2.3     | 2026-02 | Added Injury Risk Scoring issue (ISSUE-016)              |
-| 2.4     | 2026-02 | Added Implementation Gaps Report                         |
-| 2.5     | 2026-02 | Updated Gaps Report with Critical Issues                 |
-| 2.6     | 2026-02 | Added Data Copyright and Kinematic Sequence Issues       |
-| 2.7     | 2025-05 | Added Implementation Gaps Review 2025                    |
-| 2.8     | 2026-02 | Updated Completist Report 2026-02-21                     |
-| 2.9     | 2026-02 | Updated Comprehensive Gaps Report (Testing & Patent)     |
-| 3.0     | 2026-02 | Consolidated Implementation Gaps and Inaccuracies Report |
+| Version | Date    | Changes                                                      |
+| ------- | ------- | ------------------------------------------------------------ |
+| 1.0     | 2025-12 | Initial 15-point framework                                   |
+| 2.0     | 2026-01 | Reorganized based on UX/strategic gap analysis               |
+| 2.1     | 2026-02 | Added comprehensive multi-framework assessment               |
+| 2.2     | 2026-02 | Added Physics Audit (Specialized Assessment)                 |
+| 2.3     | 2026-02 | Added Injury Risk Scoring issue (ISSUE-016)                  |
+| 2.4     | 2026-02 | Added Implementation Gaps Report                             |
+| 2.5     | 2026-02 | Updated Gaps Report with Critical Issues                     |
+| 2.6     | 2026-02 | Added Data Copyright and Kinematic Sequence Issues           |
+| 2.7     | 2025-05 | Added Implementation Gaps Review 2025                        |
+| 2.8     | 2026-02 | Updated Completist Report 2026-02-21                         |
+| 2.9     | 2026-02 | Updated Comprehensive Gaps Report (Testing & Patent)         |
+| 3.0     | 2026-02 | Consolidated Implementation Gaps and Inaccuracies Report     |
 | 3.1     | 2026-03 | Removed stale assessments and archives older than 2026-03-08 |
 
 ---

--- a/docs/assessments/pragmatic_programmer/Pragmatic_Assessment_2026-03-12.md
+++ b/docs/assessments/pragmatic_programmer/Pragmatic_Assessment_2026-03-12.md
@@ -1,0 +1,248 @@
+# Pragmatic Programmer Assessment: 2026-03-12
+
+**Assessor**: Claude (automated)
+**Date**: 2026-03-12
+**Framework**: The Pragmatic Programmer (Hunt & Thomas) principles
+
+---
+
+## Summary
+
+This assessment applies the Pragmatic Programmer principles to UpstreamDrift and identifies
+areas where the codebase adheres to or violates the core tenets:
+DRY, DbC, TDD, Orthogonality, Reversibility, and Broken Windows detection.
+
+---
+
+## DRY (Don't Repeat Yourself)
+
+### Violations Found
+
+**1. Flight model derivative computation (MODERATE)**
+
+`WaterlooPennerModel.simulate()` and `MacDonaldHanzelyModel.simulate()` and `ConstantCoefficientModel.simulate()`
+all share nearly identical ODE derivative function structure:
+
+- Same `if speed < MIN_SPEED_THRESHOLD: return [v, 0, 0, -g]` guard
+- Same `acc[2] -= launch.gravity` gravity term
+- Same `np.array([v_val[0], v_val[1], v_val[2], ...])` return format
+
+The `_run_ode_simulation()` consolidation is excellent, but the derivative body is still partially duplicated.
+
+**Location**: `src/shared/python/physics/flight_models.py:287-390`
+
+**2. TopographyData nested loop sampling (MODERATE)**
+
+`to_heightmap()` and `sample_uniform()` both iterate `for i in range(ny): for j in range(nx)`.
+These could be vectorized with `np.vectorize` or meshgrid.
+
+**Location**: `src/shared/python/physics/topography.py:304-322, 560-578`
+
+**3. Launcher UI pass duplication (MINOR)**
+
+`src/launchers/unified_launcher.py` has 7 bare `pass` and several try/except patterns
+that repeat across `launcher_dialogs.py`, `settings_dialog.py`, `golf_launcher.py`.
+
+---
+
+## DbC (Design by Contract)
+
+### Current State
+
+The codebase has a working DbC system in `src/shared/python/core/contracts/`:
+
+- `@precondition` decorator with lambda validators
+- `PreconditionError`, `PostconditionError` exceptions
+- GitHub issue #1755 tracking fleet-wide adoption target (20% preconditions by Q2 2026)
+
+### Coverage Analysis
+
+**Well-Covered (DbC applied):**
+
+- `SecurityManager.hash_password()` — precondition: non-empty string
+- `SecurityManager.verify_password()` — two preconditions
+- `SecurityManager.create_access_token()` — data must contain 'sub'
+- `SecurityManager.verify_token()` — token non-empty, token_type valid
+- `UsageTracker.check_quota()` — resource_type must be valid enum
+- `compute_prefix_hash()` — prefix must be non-empty string
+
+**Missing Contracts (HIGH PRIORITY):**
+
+- `TopographyData.get_elevation_at()` — no precondition on position shape
+- `TopographyData.set_heightmap()` — no precondition on heightmap dimensions
+- `AerodynamicsEngine.compute_forces()` — no precondition on velocity/spin shapes
+- `AerodynamicsEngine.compute_acceleration()` — no precondition that mass > 0
+- `FlightModelRegistry.get_model()` — no postcondition that returned model is not None
+- `ImpactModel.solve()` — no preconditions on pre_state validity
+
+**Example Missing Contract:**
+
+```python
+# Current (no contract):
+def compute_acceleration(self, velocity, spin, mass, ...):
+    forces = self.compute_forces(velocity, spin, ...)
+    return forces["total"] / mass  # Division by zero if mass=0!
+
+# Should be:
+@precondition(lambda self, velocity, spin, mass, ...: mass > 0, "mass must be positive")
+def compute_acceleration(self, velocity, spin, mass, ...):
+    ...
+```
+
+---
+
+## TDD (Test-Driven Development)
+
+### Coverage Gaps
+
+The completist report shows 416 critical stubs. Testing analysis shows:
+
+**Tested and passing:**
+
+- `test_aerodynamics.py`: 65 tests PASS
+- `test_flight_models.py`: 21 tests PASS
+- `test_impact_model.py`: 41 tests PASS
+- `test_terrain.py`: 59 tests PASS
+- `test_terrain_engine.py`: 26 tests PASS
+- `test_flexible_shaft.py`: 43 tests PASS
+
+**Missing Test Coverage:**
+
+- `topography.py` — `TopographyProvider` Protocol is untested
+  - `get_elevation_at()` with out-of-bounds positions
+  - `get_gradient_at()` numerical accuracy
+  - `from_file()` with various formats
+- `plot_engine/protocols.py` — 5 stub methods untested
+- `pose_estimation/interface.py` — 3 stub methods untested
+- `model_generation/plugins/` — 4 stubs untested
+- `model_generation/library/repository.py` — 4 stubs untested
+
+**TDD Principle Violation:**
+The completist report lists `flight_models.py:160,166,172,177` as stubs, but these are actually
+the `BallFlightModel` ABC abstract method docstrings — Protocol stubs by design, not implementation
+gaps. The completist scanner is false-positiving on `...` in abstract method bodies.
+Tests for concrete implementations DO exist and pass.
+
+---
+
+## Orthogonality
+
+### Well-Orthogonal Areas
+
+1. **Force models**: `DragModel`, `LiftModel`, `MagnusModel` are independent components
+   with no shared state. Each calculates one force type. Excellent orthogonality.
+
+2. **Engine sub-protocols**: `Loadable`, `Steppable`, `Queryable`, `DynamicsComputable`,
+   `CounterfactualComputable` are composable sub-protocols. Consumers can depend on only
+   what they need.
+
+3. **TerrainMixin**: Properly uses mixin pattern to add terrain to any engine without
+   modifying base class.
+
+### Coupling Issues
+
+1. **`AuthCache` + `SecurityManager` coupling**: `auth_cache` is a module-level global
+   in `security.py`. Any code importing `security.py` implicitly gets the cache instance.
+   This makes unit testing difficult.
+
+2. **`FlightModelRegistry._models` class variable**: Shared mutable class state means
+   test pollution — if one test mutates the registry, all subsequent tests see the mutation.
+
+3. **`TopographyData._interpolator`**: The interpolator type changes based on data source
+   (RegularGridInterpolator for heightmaps, RBFInterpolator for contours). This requires
+   callers to know which type was used. The `if self._heightmap is not None:` branch in
+   `get_elevation_at()` is a code smell.
+
+---
+
+## Reversibility
+
+### Well-Reversible Areas
+
+1. **`AerodynamicsConfig.with_changes()`**: Returns a new config — immutable pattern.
+2. **Frozen dataclasses**: `AerodynamicsConfig`, `WindConfig`, `ConstantCoefficientSpec`
+   all use `frozen=True`.
+3. **Engine toggles**: All aerodynamic effects can be toggled on/off at runtime.
+
+### Irreversibility Issues
+
+1. **`TopographyData.set_heightmap()`** with `smooth=True` applies Gaussian filter in-place
+   (stores filtered copy). Original data is lost.
+
+2. **`AuthCache.set()`** uses `self._cache.clear()` on overflow — loses all cached entries
+   atomically rather than LRU eviction.
+
+---
+
+## Broken Windows
+
+### Detected Broken Windows
+
+1. **Silent exception handlers** (CRITICAL BROKEN WINDOW):
+
+   ```python
+   try:
+       something()
+   except Exception:
+       pass  # Silent failure
+   ```
+
+   Found in: `sim_widget.py`, `drake_gui_viz.py`, `sim_rendering_mixin.py`, `biomechanics.py`
+
+   These teach contributors that silencing errors is acceptable.
+
+2. **`pass` in abstract-looking class body** (`model_card.py:pass`, `base.py:pass`):
+   Empty class bodies suggest unfinished work.
+
+3. **`launcher_diagnostics.py:pass`** at class body level — unimplemented diagnostic class.
+
+4. **Completist report inflation**: The scanner counts Protocol/ABC `...` as "stubs",
+   which inflates the gap count. This makes the report less actionable — contributors
+   can't tell real gaps from intentional Protocol definitions.
+
+---
+
+## Tracer Bullets
+
+### Incomplete Feature Traces
+
+1. **Gear Effect in Impact Model**: `ImpactParameters.gear_effect_factor` defined but
+   the `_compute_friction_spin()` method has a comment indicating the gear effect
+   calculation is not implemented.
+
+2. **Flexible shaft in engines**: `PhysicsEngine.set_shaft_properties()` returns `False`
+   by default. No concrete engine implementation found that returns `True`.
+
+3. **ZTCF/ZVCF counterfactuals**: Defined in `PhysicsEngine` Protocol with full docs.
+   MockEngine implements them. Unknown if MuJoCo/Drake/Pinocchio implementations pass parity tests.
+
+---
+
+## Recommended Priority Actions
+
+### Immediate (BLOCKER)
+
+- None — no true blockers found in fresh read.
+
+### High Priority (CRITICAL)
+
+1. Add `test_topography.py` with tests for `TopographyData` (missing test coverage)
+2. Add `@precondition(lambda ...: mass > 0)` to `compute_acceleration()` in `AerodynamicsEngine`
+3. Fix silent `except: pass` patterns in MuJoCo/Drake GUI code — at minimum log the error
+4. Add `@precondition` to `AerodynamicsEngine.compute_forces()` for velocity/spin shape
+
+### Medium Priority (MAJOR)
+
+5. Vectorize `TopographyData.to_heightmap()` and `sample_uniform()` — replace nested loops
+6. Make `FlightModelRegistry._models` an instance variable or use `functools.lru_cache`
+7. Move `auth_cache` into a dependency injection pattern
+
+### Low Priority (MINOR)
+
+8. Consolidate derivative computation template in flight models
+9. Document why `TopographyProvider` Protocol has `...` bodies (it's intentional — Protocol)
+10. Add postcondition to `FlightModelRegistry.get_model()`: returned model is never None
+
+---
+
+_Generated by automated Pragmatic Programmer assessment on 2026-03-12._

--- a/src/shared/python/physics/aerodynamics.py
+++ b/src/shared/python/physics/aerodynamics.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import numpy as np
 
+from src.shared.python.core.contracts import precondition
 from src.shared.python.core.physics_constants import (
     AIR_DENSITY_SEA_LEVEL_KG_M3,
     AIR_VISCOSITY_KG_M_S,
@@ -980,6 +981,11 @@ class AerodynamicsEngine:
             "total": total,
         }
 
+    @precondition(
+        lambda self, velocity, spin, mass, t=0.0, position=None, resample=False: mass
+        > 0,
+        "mass must be positive (non-zero, non-negative) to avoid ZeroDivisionError",
+    )
     def compute_acceleration(
         self,
         velocity: np.ndarray,
@@ -994,13 +1000,16 @@ class AerodynamicsEngine:
         Args:
             velocity: Ball velocity [m/s]
             spin: Angular velocity [rad/s]
-            mass: Ball mass [kg]
+            mass: Ball mass [kg] — must be positive
             t: Current time [s]
             position: Current position [m]
             resample: Resample random environment
 
         Returns:
             Acceleration vector [m/s^2]
+
+        Raises:
+            PreconditionError: If mass <= 0
         """
         forces = self.compute_forces(velocity, spin, t, position, resample)
         return forces["total"] / mass

--- a/src/shared/python/physics/topography.py
+++ b/src/shared/python/physics/topography.py
@@ -310,16 +310,7 @@ class TopographyData:
         Returns:
             2D array of elevations [resolution x resolution]
         """
-        x = np.linspace(self._bounds.min_x, self._bounds.max_x, resolution)
-        y = np.linspace(self._bounds.min_y, self._bounds.max_y, resolution)
-
-        heightmap = np.zeros((resolution, resolution))
-
-        for i, yi in enumerate(y):
-            for j, xi in enumerate(x):
-                heightmap[i, j] = self.get_elevation_at(np.array([xi, yi]))
-
-        return heightmap
+        return self.sample_uniform(resolution, resolution)
 
     @classmethod
     def from_file(
@@ -560,6 +551,10 @@ class TopographyData:
     def sample_uniform(self, nx: int, ny: int) -> np.ndarray:
         """Sample elevations on uniform grid.
 
+        Uses vectorized evaluation when available for performance.
+        For a regular-grid interpolator the entire grid is evaluated
+        in a single C-level numpy call instead of O(nx * ny) Python loops.
+
         Args:
             nx: Number of samples in X
             ny: Number of samples in Y
@@ -567,15 +562,27 @@ class TopographyData:
         Returns:
             Array of shape (ny, nx) with elevations
         """
+        if not self._is_loaded or self._interpolator is None:
+            return np.zeros((ny, nx))
+
         x = np.linspace(self._bounds.min_x, self._bounds.max_x, nx)
         y = np.linspace(self._bounds.min_y, self._bounds.max_y, ny)
+        X, Y = np.meshgrid(x, y)
 
-        result = np.zeros((ny, nx))
-        for i, yi in enumerate(y):
-            for j, xi in enumerate(x):
-                result[i, j] = self.get_elevation_at(np.array([xi, yi]))
+        # Clamp to bounds
+        X_clamped = np.clip(X, self._bounds.min_x, self._bounds.max_x)
+        Y_clamped = np.clip(Y, self._bounds.min_y, self._bounds.max_y)
 
-        return result
+        if self._heightmap is not None:
+            # RegularGridInterpolator uses (y, x) ordering
+            pts = np.column_stack([Y_clamped.ravel(), X_clamped.ravel()])
+            result = self._interpolator(pts)
+        else:
+            # RBF/LinearNDInterpolator uses (x, y) ordering
+            pts = np.column_stack([X_clamped.ravel(), Y_clamped.ravel()])
+            result = self._interpolator(pts)
+
+        return result.reshape(ny, nx)
 
     def get_statistics(self) -> dict[str, float]:
         """Get statistics about the topography.

--- a/tests/unit/test_aerodynamics.py
+++ b/tests/unit/test_aerodynamics.py
@@ -933,3 +933,41 @@ class TestAerodynamicsIntegration:
 
         # Should be identical
         np.testing.assert_array_almost_equal(forces1["total"], forces2["total"])
+
+
+class TestAerodynamicsPreconditions:
+    """Tests for DbC preconditions on AerodynamicsEngine.
+
+    Added 2026-03-12 per assessment finding [A-MAJOR] Issue #1774.
+    """
+
+    def test_compute_acceleration_zero_mass_raises(self) -> None:
+        """Precondition: mass > 0 must be enforced."""
+        from src.shared.python.core.contracts.exceptions import PreconditionError
+
+        engine = AerodynamicsEngine()
+        velocity = np.array([60.0, 0.0, 20.0])
+        spin = np.array([0.0, -250.0, 0.0])
+
+        with pytest.raises(PreconditionError):
+            engine.compute_acceleration(velocity, spin, mass=0.0)
+
+    def test_compute_acceleration_negative_mass_raises(self) -> None:
+        """Precondition: negative mass must be rejected."""
+        from src.shared.python.core.contracts.exceptions import PreconditionError
+
+        engine = AerodynamicsEngine()
+        velocity = np.array([60.0, 0.0, 20.0])
+        spin = np.array([0.0, -250.0, 0.0])
+
+        with pytest.raises(PreconditionError):
+            engine.compute_acceleration(velocity, spin, mass=-0.046)
+
+    def test_compute_acceleration_positive_mass_succeeds(self) -> None:
+        """Positive mass should not raise a precondition error."""
+        engine = AerodynamicsEngine()
+        velocity = np.array([60.0, 0.0, 20.0])
+        spin = np.array([0.0, -250.0, 0.0])
+        result = engine.compute_acceleration(velocity, spin, mass=0.046)
+        assert result.shape == (3,)
+        assert np.all(np.isfinite(result))

--- a/tests/unit/test_topography.py
+++ b/tests/unit/test_topography.py
@@ -1,0 +1,376 @@
+"""Tests for src.shared.python.physics.topography module.
+
+Covers:
+- TopographyBounds dataclass properties
+- TopographyData construction and loading
+- Elevation queries (heightmap and contour point paths)
+- Gradient queries (numerical accuracy)
+- Normal vector computation
+- Vectorized sample_uniform / to_heightmap
+- Factory functions (create_flat_terrain, create_sloped_terrain, create_undulating_terrain)
+- TopographyProvider Protocol structural subtyping
+- save_to_file / from_file round-trip (npy, csv, json)
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.shared.python.physics.topography import (
+    ElevationPoint,
+    TopographyBounds,
+    TopographyData,
+    TopographyProvider,
+    create_flat_terrain,
+    create_sloped_terrain,
+    create_undulating_terrain,
+)
+
+# ---------------------------------------------------------------------------
+# TopographyBounds
+# ---------------------------------------------------------------------------
+
+
+class TestTopographyBounds:
+    """Tests for TopographyBounds dataclass."""
+
+    def test_defaults(self) -> None:
+        b = TopographyBounds()
+        assert b.min_x == 0.0
+        assert b.max_x == 100.0
+        assert b.min_y == 0.0
+        assert b.max_y == 100.0
+
+    def test_width_height(self) -> None:
+        b = TopographyBounds(min_x=10.0, max_x=60.0, min_y=5.0, max_y=25.0)
+        assert b.width == pytest.approx(50.0)
+        assert b.height == pytest.approx(20.0)
+
+    def test_elevation_range(self) -> None:
+        b = TopographyBounds(min_z=-2.0, max_z=8.0)
+        assert b.elevation_range == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# TopographyData – unloaded state
+# ---------------------------------------------------------------------------
+
+
+class TestTopographyDataUnloaded:
+    """Unloaded TopographyData should return safe defaults."""
+
+    def test_not_loaded_initially(self) -> None:
+        topo = TopographyData()
+        assert not topo.is_loaded
+
+    def test_get_elevation_returns_zero_when_unloaded(self) -> None:
+        topo = TopographyData()
+        assert topo.get_elevation_at(np.array([5.0, 5.0])) == 0.0
+
+    def test_sample_uniform_returns_zeros_when_unloaded(self) -> None:
+        topo = TopographyData()
+        result = topo.sample_uniform(10, 10)
+        assert result.shape == (10, 10)
+        assert np.all(result == 0.0)
+
+    def test_to_heightmap_returns_zeros_when_unloaded(self) -> None:
+        topo = TopographyData()
+        result = topo.to_heightmap(20)
+        assert result.shape == (20, 20)
+        assert np.all(result == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# TopographyData – heightmap path
+# ---------------------------------------------------------------------------
+
+
+class TestTopographyDataHeightmap:
+    """Tests using set_heightmap (RegularGridInterpolator path)."""
+
+    @pytest.fixture
+    def flat_topo(self) -> TopographyData:
+        """2m elevation everywhere."""
+        topo = TopographyData(TopographyBounds(min_x=0, max_x=10, min_y=0, max_y=10))
+        heightmap = np.full((10, 10), 2.0)
+        topo.set_heightmap(heightmap, smooth=False)
+        return topo
+
+    @pytest.fixture
+    def sloped_topo(self) -> TopographyData:
+        """Linear slope: z = x/10 (0 at x=0, 1 at x=10)."""
+        topo = TopographyData(TopographyBounds(min_x=0, max_x=10, min_y=0, max_y=10))
+        ny, nx = 20, 20
+        x = np.linspace(0, 10, nx)
+        y = np.linspace(0, 10, ny)
+        X, _ = np.meshgrid(x, y)
+        heightmap = X / 10.0
+        topo.set_heightmap(heightmap, smooth=False)
+        return topo
+
+    def test_is_loaded_after_set_heightmap(self, flat_topo: TopographyData) -> None:
+        assert flat_topo.is_loaded
+
+    def test_flat_elevation_at_center(self, flat_topo: TopographyData) -> None:
+        z = flat_topo.get_elevation_at(np.array([5.0, 5.0]))
+        assert z == pytest.approx(2.0, abs=0.01)
+
+    def test_flat_elevation_at_corners(self, flat_topo: TopographyData) -> None:
+        for x, y in [(0, 0), (0, 10), (10, 0), (10, 10)]:
+            z = flat_topo.get_elevation_at(np.array([float(x), float(y)]))
+            assert z == pytest.approx(2.0, abs=0.05), f"Corner ({x},{y}) failed: z={z}"
+
+    def test_flat_gradient_is_near_zero(self, flat_topo: TopographyData) -> None:
+        grad = flat_topo.get_gradient_at(np.array([5.0, 5.0]))
+        assert grad.shape == (2,)
+        assert abs(grad[0]) < 0.1  # nearly flat
+        assert abs(grad[1]) < 0.1
+
+    def test_sloped_elevation_increases_with_x(
+        self, sloped_topo: TopographyData
+    ) -> None:
+        z0 = sloped_topo.get_elevation_at(np.array([0.0, 5.0]))
+        z5 = sloped_topo.get_elevation_at(np.array([5.0, 5.0]))
+        z10 = sloped_topo.get_elevation_at(np.array([10.0, 5.0]))
+        assert z0 < z5 < z10
+
+    def test_sloped_gradient_dzdx_positive(self, sloped_topo: TopographyData) -> None:
+        # For z = x/10, dz/dx = 0.1, dz/dy = 0
+        grad = sloped_topo.get_gradient_at(np.array([5.0, 5.0]))
+        assert grad[0] == pytest.approx(0.1, abs=0.02)  # dz/dx
+        assert abs(grad[1]) < 0.02  # dz/dy ~ 0
+
+    def test_normal_vector_is_unit_length(self, sloped_topo: TopographyData) -> None:
+        normal = sloped_topo.get_normal_at(np.array([5.0, 5.0]))
+        assert normal.shape == (3,)
+        assert np.linalg.norm(normal) == pytest.approx(1.0, abs=1e-9)
+
+    def test_normal_flat_points_up(self, flat_topo: TopographyData) -> None:
+        normal = flat_topo.get_normal_at(np.array([5.0, 5.0]))
+        assert normal[2] > 0.99  # mostly pointing up
+
+    def test_out_of_bounds_position_is_clamped(self, flat_topo: TopographyData) -> None:
+        # Position outside bounds should be clamped and return a finite value
+        z = flat_topo.get_elevation_at(np.array([100.0, 100.0]))
+        assert math.isfinite(z)
+
+    def test_sample_uniform_shape(self, flat_topo: TopographyData) -> None:
+        result = flat_topo.sample_uniform(5, 8)
+        assert result.shape == (8, 5)
+
+    def test_sample_uniform_values_flat(self, flat_topo: TopographyData) -> None:
+        result = flat_topo.sample_uniform(10, 10)
+        # Flat terrain: all values close to 2.0
+        assert np.all(np.abs(result - 2.0) < 0.1)
+
+    def test_to_heightmap_shape(self, flat_topo: TopographyData) -> None:
+        result = flat_topo.to_heightmap(50)
+        assert result.shape == (50, 50)
+
+    def test_to_heightmap_is_consistent_with_sample_uniform(
+        self, sloped_topo: TopographyData
+    ) -> None:
+        h1 = sloped_topo.to_heightmap(20)
+        h2 = sloped_topo.sample_uniform(20, 20)
+        np.testing.assert_array_almost_equal(h1, h2, decimal=10)
+
+    def test_get_statistics_flat(self, flat_topo: TopographyData) -> None:
+        stats = flat_topo.get_statistics()
+        assert "min_elevation" in stats
+        assert "max_elevation" in stats
+        assert "mean_elevation" in stats
+        assert stats["min_elevation"] == pytest.approx(2.0, abs=0.1)
+        assert stats["max_elevation"] == pytest.approx(2.0, abs=0.1)
+
+    def test_smoothing_does_not_crash(self) -> None:
+        topo = TopographyData(TopographyBounds(min_x=0, max_x=10, min_y=0, max_y=10))
+        heightmap = np.random.default_rng(42).standard_normal((20, 20))
+        topo.set_heightmap(heightmap, smooth=True, smooth_sigma=1.5)
+        assert topo.is_loaded
+
+
+# ---------------------------------------------------------------------------
+# TopographyData – contour point path
+# ---------------------------------------------------------------------------
+
+
+class TestTopographyDataContourPoints:
+    """Tests using set_contour_points (RBF/LinearNDInterpolator path)."""
+
+    @pytest.fixture
+    def contour_topo(self) -> TopographyData:
+        """Four corners at different elevations."""
+        points = [
+            ElevationPoint(x=0.0, y=0.0, z=0.0),
+            ElevationPoint(x=10.0, y=0.0, z=1.0),
+            ElevationPoint(x=0.0, y=10.0, z=2.0),
+            ElevationPoint(x=10.0, y=10.0, z=3.0),
+            ElevationPoint(x=5.0, y=5.0, z=1.5),  # center
+        ]
+        topo = TopographyData()
+        topo.set_contour_points(points)
+        return topo
+
+    def test_is_loaded_after_set_contour_points(
+        self, contour_topo: TopographyData
+    ) -> None:
+        assert contour_topo.is_loaded
+
+    def test_elevation_at_known_point(self, contour_topo: TopographyData) -> None:
+        # The center point is set at z=1.5
+        z = contour_topo.get_elevation_at(np.array([5.0, 5.0]))
+        assert math.isfinite(z)
+
+    def test_bounds_set_from_points(self, contour_topo: TopographyData) -> None:
+        b = contour_topo.bounds
+        assert b.min_x == pytest.approx(0.0)
+        assert b.max_x == pytest.approx(10.0)
+        assert b.min_y == pytest.approx(0.0)
+        assert b.max_y == pytest.approx(10.0)
+
+    def test_sample_uniform_contour(self, contour_topo: TopographyData) -> None:
+        result = contour_topo.sample_uniform(5, 5)
+        assert result.shape == (5, 5)
+        assert np.all(np.isfinite(result))
+
+    def test_empty_contour_points_does_not_crash(self) -> None:
+        topo = TopographyData()
+        topo.set_contour_points([])
+        # After setting empty list, is_loaded stays False
+        assert not topo.is_loaded
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunctions:
+    """Tests for create_flat_terrain, create_sloped_terrain, create_undulating_terrain."""
+
+    def test_create_flat_terrain_elevation(self) -> None:
+        topo = create_flat_terrain(width=50.0, height=30.0, elevation=5.0)
+        z = topo.get_elevation_at(np.array([25.0, 15.0]))
+        assert z == pytest.approx(5.0, abs=0.1)
+
+    def test_create_flat_terrain_bounds(self) -> None:
+        topo = create_flat_terrain(width=50.0, height=30.0)
+        assert topo.bounds.width == pytest.approx(50.0)
+        assert topo.bounds.height == pytest.approx(30.0)
+
+    def test_create_sloped_terrain_increases_downhill(self) -> None:
+        # Default slope in +x direction
+        topo = create_sloped_terrain(
+            width=100.0,
+            height=100.0,
+            slope_direction=np.array([1.0, 0.0]),
+            slope_magnitude=0.1,
+            base_elevation=0.0,
+        )
+        z0 = topo.get_elevation_at(np.array([0.0, 50.0]))
+        z50 = topo.get_elevation_at(np.array([50.0, 50.0]))
+        # slope_magnitude=0.1 → slope goes downhill in +x, so z0 > z50
+        assert z0 > z50
+
+    def test_create_undulating_terrain_has_variation(self) -> None:
+        topo = create_undulating_terrain(
+            width=100.0, height=100.0, amplitude=2.0, wavelength=20.0
+        )
+        result = topo.sample_uniform(20, 20)
+        # Undulating terrain should have some variance (not flat)
+        assert np.std(result) > 0.1
+
+    def test_all_factory_outputs_are_loaded(self) -> None:
+        assert create_flat_terrain().is_loaded
+        assert create_sloped_terrain().is_loaded
+        assert create_undulating_terrain().is_loaded
+
+
+# ---------------------------------------------------------------------------
+# File I/O round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestFileIO:
+    """Round-trip tests for save_to_file / from_file."""
+
+    def test_npy_round_trip(self, tmp_path: Path) -> None:
+        topo = create_sloped_terrain(width=20.0, height=20.0, slope_magnitude=0.05)
+        outfile = tmp_path / "terrain.npy"
+        topo.save_to_file(outfile)
+        loaded = TopographyData.from_file(outfile, width=20.0, height=20.0)
+        assert loaded.is_loaded
+        # Elevation at center should be approximately the same
+        z_orig = topo.get_elevation_at(np.array([10.0, 10.0]))
+        z_loaded = loaded.get_elevation_at(np.array([10.0, 10.0]))
+        assert z_loaded == pytest.approx(z_orig, abs=0.05)
+
+    def test_json_round_trip(self, tmp_path: Path) -> None:
+        topo = create_flat_terrain(width=10.0, height=10.0, elevation=3.5)
+        outfile = tmp_path / "terrain.json"
+        topo.save_to_file(outfile)
+        loaded = TopographyData.from_file(outfile)
+        assert loaded.is_loaded
+        z = loaded.get_elevation_at(np.array([5.0, 5.0]))
+        assert z == pytest.approx(3.5, abs=0.1)
+
+    def test_csv_round_trip(self, tmp_path: Path) -> None:
+        # Write CSV manually
+        csv_file = tmp_path / "terrain.csv"
+        csv_file.write_text("x,y,elevation\n0,0,1\n10,0,2\n0,10,3\n10,10,4\n5,5,2.5\n")
+        loaded = TopographyData.from_file(csv_file)
+        assert loaded.is_loaded
+        z = loaded.get_elevation_at(np.array([5.0, 5.0]))
+        assert math.isfinite(z)
+
+    def test_unsupported_format_raises(self, tmp_path: Path) -> None:
+        topo = create_flat_terrain()
+        with pytest.raises(ValueError, match="Unsupported"):
+            topo.save_to_file(tmp_path / "terrain.xyz")
+
+    def test_from_file_unsupported_raises(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "bad.xyz"
+        bad_file.write_text("data")
+        with pytest.raises(ValueError, match="Unsupported"):
+            TopographyData.from_file(bad_file)
+
+
+# ---------------------------------------------------------------------------
+# Protocol structural subtyping
+# ---------------------------------------------------------------------------
+
+
+class TestTopographyProviderProtocol:
+    """Verify TopographyData satisfies TopographyProvider Protocol."""
+
+    def test_topography_data_is_provider(self) -> None:
+        topo = create_flat_terrain()
+        assert isinstance(topo, TopographyProvider)
+
+    def test_protocol_methods_callable(self) -> None:
+        topo = create_flat_terrain()
+        # All Protocol methods must exist and be callable
+        assert callable(topo.get_elevation_at)
+        assert callable(topo.get_gradient_at)
+        _ = topo.bounds  # property access
+
+    def test_custom_provider_satisfies_protocol(self) -> None:
+        """A class with correct method signatures should satisfy the protocol."""
+
+        class MinimalProvider:
+            def get_elevation_at(self, position: np.ndarray) -> float:
+                return 0.0
+
+            def get_gradient_at(self, position: np.ndarray) -> np.ndarray:
+                return np.zeros(2)
+
+            @property
+            def bounds(self) -> TopographyBounds:
+                return TopographyBounds()
+
+        provider = MinimalProvider()
+        assert isinstance(provider, TopographyProvider)


### PR DESCRIPTION
## Summary

- Fresh A-O framework assessment (weighted score: 62/100) and Pragmatic Programmer assessment covering DRY, DbC, TDD, Orthogonality, and Broken Windows detection
- Vectorized `TopographyData.sample_uniform()` and `to_heightmap()` — removes O(n²) Python loops, replaces with numpy meshgrid+vectorized interpolator call
- Added `@precondition(mass > 0)` to `AerodynamicsEngine.compute_acceleration()` enforcing DbC contract and preventing ZeroDivisionError
- New `tests/unit/test_topography.py` with 40 tests (TDD: written to address identified coverage gap)
- 3 new `TestAerodynamicsPreconditions` tests added to `test_aerodynamics.py`

**Closes issues:** #1771 (G-CRITICAL: missing topography tests), partially addresses #1773 (E-MAJOR: O(n²) vectorization) and #1774 (A-MAJOR: DbC preconditions)

## Assessment Highlights

**Scores (weighted):** 62/100 overall
- G Testing: 52/100 — 209 skipped tests, ~50% coverage, no topography tests (→ this PR adds 40)
- A Architecture: 65/100 — 416 stubs (many are intentional Protocol `...` bodies)
- E Performance: 65/100 — vectorized topography sampling (→ this PR fixes)
- I Security: 70/100 — security implementation is solid; bcrypt+JWT properly implemented

**Key Pragmatic Programmer findings:**
- DRY: ODE derivative bodies partially duplicated across flight models
- Broken Windows: Silent `except: pass` in MuJoCo/Drake GUI handlers (see issue #1772)
- Orthogonality: `AerodynamicsEngine` force models are well-orthogonal; `AuthCache` global is a coupling smell
- DbC gap: `compute_acceleration` missing mass > 0 precondition (→ this PR fixes)

## Test plan
- [x] `tests/unit/test_topography.py` — 40 tests, all pass
- [x] `tests/unit/test_aerodynamics.py::TestAerodynamicsPreconditions` — 3 tests, all pass
- [x] `tests/unit/test_terrain.py`, `test_terrain_engine.py`, `test_flexible_shaft.py` — 128 tests, all pass
- [x] `tests/unit/test_aerodynamics.py`, `test_flight_models.py`, `test_impact_model.py` — 127+3 tests, all pass
- [x] All 298 physics tests pass together: `python3 -m pytest tests/unit/test_aerodynamics.py tests/unit/test_topography.py tests/unit/test_terrain.py tests/unit/test_terrain_engine.py tests/unit/test_flexible_shaft.py tests/unit/test_flight_models.py tests/unit/test_impact_model.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)