### PR TITLE
test: signal_toolkit/series.py and spatial_algebra coverage

### DIFF
--- a/tests/unit/shared_python/test_signal_toolkit_series.py
+++ b/tests/unit/shared_python/test_signal_toolkit_series.py
@@ -1,0 +1,239 @@
+"""Unit tests for signal_toolkit/series.py (Taylor/Maclaurin series)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.signal_toolkit.series import (
+    SeriesExpansion,
+    SeriesResult,
+    arctan_series,
+    cos_series,
+    cosh_series,
+    exp_series,
+    geometric_series,
+    ln_series,
+    sin_series,
+    sinh_series,
+)
+
+
+@pytest.fixture
+def se() -> SeriesExpansion:
+    return SeriesExpansion(max_terms=20, h=1e-5)
+
+
+class TestSeriesExpansion:
+    """Tests for SeriesExpansion class."""
+
+    def test_invalid_max_terms_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SeriesExpansion(max_terms=0)
+
+    def test_taylor_sin_at_zero(self, se: SeriesExpansion) -> None:
+        """Taylor series of sin(x) at center=0 should approximate well near 0."""
+        taylor_fn = se.taylor_series(np.sin, center=0.0, n_terms=10)
+        assert np.isclose(taylor_fn(0.0), 0.0, atol=1e-5)
+        assert np.isclose(taylor_fn(np.pi / 4), np.sin(np.pi / 4), atol=0.01)
+
+    def test_taylor_cos_at_zero(self, se: SeriesExpansion) -> None:
+        taylor_fn = se.taylor_series(np.cos, center=0.0, n_terms=10)
+        assert np.isclose(taylor_fn(0.0), 1.0, atol=1e-5)
+
+    def test_taylor_exp(self, se: SeriesExpansion) -> None:
+        taylor_fn = se.taylor_series(np.exp, center=0.0, n_terms=15)
+        assert np.isclose(taylor_fn(1.0), math.e, atol=0.01)
+
+    def test_taylor_non_callable_raises(self, se: SeriesExpansion) -> None:
+        with pytest.raises(TypeError):
+            se.taylor_series(42, center=0.0, n_terms=5)  # type: ignore[arg-type]
+
+    def test_taylor_zero_terms_raises(self, se: SeriesExpansion) -> None:
+        with pytest.raises(ValueError):
+            se.taylor_series(np.sin, center=0.0, n_terms=0)
+
+    def test_maclaurin_is_taylor_at_zero(self, se: SeriesExpansion) -> None:
+        """Maclaurin == Taylor at center=0."""
+        mac_fn = se.maclaurin_series(np.sin, n_terms=10)
+        taylor_fn = se.taylor_series(np.sin, center=0.0, n_terms=10)
+        x_test = np.array([0.0, 0.5, 1.0])
+        assert np.allclose(mac_fn(x_test), taylor_fn(x_test), atol=1e-8)
+
+    def test_get_coefficients_shape(self, se: SeriesExpansion) -> None:
+        coeffs = se.get_coefficients(np.sin, center=0.0, n_terms=8)
+        assert len(coeffs) == 8
+
+    def test_get_series_result(self, se: SeriesExpansion) -> None:
+        result = se.get_series_result(np.exp, center=0.0, n_terms=10)
+        assert isinstance(result, SeriesResult)
+        assert result.n_terms == 10
+        assert result.center == 0.0
+        assert callable(result.function)
+
+    def test_get_series_result_roc(self, se: SeriesExpansion) -> None:
+        """Radius of convergence should be computed (a positive float or None)."""
+        result = se.get_series_result(np.exp, center=0.0, n_terms=15)
+        if result.radius_of_convergence is not None:
+            assert result.radius_of_convergence > 0
+
+    def test_analyze_convergence_sin(self, se: SeriesExpansion) -> None:
+        analysis = se.analyze_convergence(
+            np.sin, center=0.0, x_test=1.0, tolerance=1e-6
+        )
+        assert "convergent" in analysis
+        assert "errors_by_term" in analysis
+        assert len(analysis["errors_by_term"]) > 0
+
+    def test_analyze_convergence_diverges(self, se: SeriesExpansion) -> None:
+        """1/x has a singularity at 0 — non-convergent."""
+
+        def bad_func(x: float) -> float:
+            if abs(x) < 1e-10:
+                raise ValueError("Singularity")
+            return 1.0 / x
+
+        analysis = se.analyze_convergence(bad_func, center=0.0, x_test=0.0)
+        # Should gracefully handle and return non-convergent result
+        assert not analysis["convergent"]
+
+    def test_estimate_error_bound(self, se: SeriesExpansion) -> None:
+        bound = se.estimate_error_bound(np.sin, center=0.0, x_test=0.5, n_terms=5)
+        # Error bound should be a finite positive number
+        assert np.isfinite(bound) and bound >= 0
+
+    def test_estimate_error_zero_nterms(self, se: SeriesExpansion) -> None:
+        bound = se.estimate_error_bound(np.sin, center=0.0, x_test=1.0, n_terms=0)
+        assert bound == float("inf")
+
+    def test_taylor_with_array_input(self, se: SeriesExpansion) -> None:
+        taylor_fn = se.taylor_series(np.cos, center=0.0, n_terms=10)
+        x_arr = np.linspace(-1, 1, 50)
+        result = taylor_fn(x_arr)
+        assert result.shape == x_arr.shape
+
+    def test_taylor_scalar_returns_float(self, se: SeriesExpansion) -> None:
+        taylor_fn = se.taylor_series(np.sin, center=0.0, n_terms=5)
+        result = taylor_fn(0.5)
+        assert isinstance(result, float)
+
+    def test_factorial_zero(self) -> None:
+        assert SeriesExpansion._factorial(0) == 1
+
+    def test_factorial_positive(self) -> None:
+        assert SeriesExpansion._factorial(5) == 120
+
+    def test_factorial_negative_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SeriesExpansion._factorial(-1)
+
+    def test_binomial_basic(self) -> None:
+        assert SeriesExpansion._binomial(5, 2) == 10
+
+    def test_binomial_zero(self) -> None:
+        assert SeriesExpansion._binomial(5, 0) == 1
+
+    def test_binomial_out_of_range(self) -> None:
+        assert SeriesExpansion._binomial(5, 6) == 0
+
+
+class TestSeriesFunctions:
+    """Tests for pre-defined series factory functions."""
+
+    def test_exp_series_at_zero(self) -> None:
+        fn = exp_series(n_terms=20)
+        assert np.isclose(fn(0.0), 1.0, atol=1e-10)
+
+    def test_exp_series_at_one(self) -> None:
+        fn = exp_series(n_terms=20)
+        assert np.isclose(fn(1.0), math.e, atol=0.01)
+
+    def test_exp_series_array(self) -> None:
+        fn = exp_series(n_terms=15)
+        x = np.array([0.0, 0.5, 1.0])
+        result = fn(x)
+        assert np.allclose(result, np.exp(x), atol=0.01)
+
+    def test_sin_series_at_zero(self) -> None:
+        fn = sin_series(n_terms=10)
+        assert np.isclose(fn(0.0), 0.0, atol=1e-10)
+
+    def test_sin_series_at_pi_half(self) -> None:
+        fn = sin_series(n_terms=15)
+        assert np.isclose(fn(np.pi / 2), 1.0, atol=0.01)
+
+    def test_sin_series_array(self) -> None:
+        fn = sin_series(n_terms=15)
+        x = np.linspace(-np.pi, np.pi, 50)
+        assert np.allclose(fn(x), np.sin(x), atol=0.01)
+
+    def test_cos_series_at_zero(self) -> None:
+        fn = cos_series(n_terms=10)
+        assert np.isclose(fn(0.0), 1.0, atol=1e-10)
+
+    def test_cos_series_at_pi(self) -> None:
+        fn = cos_series(n_terms=15)
+        assert np.isclose(fn(np.pi), -1.0, atol=0.05)
+
+    def test_cos_series_array(self) -> None:
+        fn = cos_series(n_terms=15)
+        x = np.linspace(-np.pi, np.pi, 50)
+        assert np.allclose(fn(x), np.cos(x), atol=0.05)
+
+    def test_ln_series_near_zero(self) -> None:
+        """ln(1 + x) series for |x| < 1."""
+        fn = ln_series(n_terms=50)
+        # ln(1 + 0) = 0
+        assert np.isclose(fn(0.0), 0.0, atol=1e-8)
+        # ln(1 + 0.5) ≈ 0.405
+        assert np.isclose(fn(0.5), np.log(1.5), atol=0.01)
+
+    def test_geometric_series_near_zero(self) -> None:
+        """1/(1-x) series for |x| < 1."""
+        fn = geometric_series(n_terms=50)
+        # At x=0: 1/(1-0) = 1
+        assert np.isclose(fn(0.0), 1.0, atol=1e-8)
+        # At x=0.5: 1/(1-0.5) = 2
+        assert np.isclose(fn(0.5), 2.0, atol=0.01)
+
+    def test_arctan_series_at_zero(self) -> None:
+        fn = arctan_series(n_terms=50)
+        assert np.isclose(fn(0.0), 0.0, atol=1e-10)
+
+    def test_arctan_series_at_one(self) -> None:
+        """arctan(1) = pi/4."""
+        fn = arctan_series(n_terms=100)
+        assert np.isclose(fn(1.0), np.pi / 4, atol=0.05)
+
+    def test_sinh_series_at_zero(self) -> None:
+        fn = sinh_series(n_terms=10)
+        assert np.isclose(fn(0.0), 0.0, atol=1e-10)
+
+    def test_sinh_series_at_one(self) -> None:
+        fn = sinh_series(n_terms=15)
+        assert np.isclose(fn(1.0), np.sinh(1.0), atol=0.01)
+
+    def test_sinh_series_array(self) -> None:
+        fn = sinh_series(n_terms=10)
+        x = np.array([0.0, 0.5, 1.0])
+        assert np.allclose(fn(x), np.sinh(x), atol=0.01)
+
+    def test_cosh_series_at_zero(self) -> None:
+        fn = cosh_series(n_terms=10)
+        assert np.isclose(fn(0.0), 1.0, atol=1e-10)
+
+    def test_cosh_series_at_one(self) -> None:
+        fn = cosh_series(n_terms=10)
+        assert np.isclose(fn(1.0), np.cosh(1.0), atol=0.01)
+
+    def test_cosh_series_array(self) -> None:
+        fn = cosh_series(n_terms=10)
+        x = np.array([0.0, 0.5, 1.0])
+        assert np.allclose(fn(x), np.cosh(x), atol=0.01)
+
+    def test_exp_series_scalar_returns_float(self) -> None:
+        fn = exp_series(n_terms=10)
+        result = fn(1.0)
+        assert isinstance(result, float)

--- a/tests/unit/shared_python/test_spatial_algebra.py
+++ b/tests/unit/shared_python/test_spatial_algebra.py
@@ -1,0 +1,384 @@
+"""Unit tests for spatial_algebra modules (spatial_vectors, inertia, joints)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.spatial_algebra.inertia import (
+    mcI,
+    mci,
+    transform_spatial_inertia,
+)
+from src.shared.python.spatial_algebra.joints import (
+    JOINT_AXIS_INDICES,
+    S_PX,
+    S_PY,
+    S_PZ,
+    S_RX,
+    S_RY,
+    S_RZ,
+    jcalc,
+)
+from src.shared.python.spatial_algebra.spatial_vectors import (
+    crf,
+    crm,
+    cross_force,
+    cross_force_fast,
+    cross_motion,
+    cross_motion_axis,
+    cross_motion_fast,
+    skew,
+    spatial_cross,
+)
+
+# ---------------------------------------------------------------------------
+# spatial_vectors.py
+# ---------------------------------------------------------------------------
+
+
+class TestSkew:
+    """Tests for skew-symmetric matrix construction."""
+
+    def test_skew_antisymmetric(self) -> None:
+        v = np.array([1.0, 2.0, 3.0])
+        S = skew(v)
+        assert np.allclose(S + S.T, 0)
+
+    def test_skew_cross_product(self) -> None:
+        """skew(v) @ u == cross(v, u)."""
+        v = np.array([1.0, 2.0, 3.0])
+        u = np.array([4.0, 5.0, 6.0])
+        assert np.allclose(skew(v) @ u, np.cross(v, u))
+
+    def test_skew_shape(self) -> None:
+        v = np.array([0.0, 0.0, 1.0])
+        assert skew(v).shape == (3, 3)
+
+    def test_skew_invalid_shape(self) -> None:
+        with pytest.raises(ValueError):
+            skew(np.array([1.0, 2.0]))
+
+    def test_skew_zero_vector(self) -> None:
+        S = skew(np.zeros(3))
+        assert np.allclose(S, 0)
+
+
+class TestCrm:
+    """Tests for crm: spatial cross product for motion vectors."""
+
+    def test_crm_shape(self) -> None:
+        v = np.zeros(6)
+        assert crm(v).shape == (6, 6)
+
+    def test_crm_antisymmetric_top_left(self) -> None:
+        """Top-left 3x3 block of crm should equal skew of angular part."""
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        C = crm(v)
+        S = skew(v[:3])
+        assert np.allclose(C[:3, :3], S)
+
+    def test_crm_invalid_shape(self) -> None:
+        with pytest.raises(ValueError):
+            crm(np.zeros(5))
+
+
+class TestCrf:
+    """Tests for crf: spatial cross product for force vectors (dual)."""
+
+    def test_crf_shape(self) -> None:
+        v = np.zeros(6)
+        assert crf(v).shape == (6, 6)
+
+    def test_crf_invalid_shape(self) -> None:
+        with pytest.raises(ValueError):
+            crf(np.zeros(5))
+
+    def test_crf_is_negative_transpose_crm(self) -> None:
+        """crf(v) == -crm(v).T for spatial algebra."""
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        assert np.allclose(crf(v), -crm(v).T)
+
+
+class TestCrossMotion:
+    """Tests for cross_motion function."""
+
+    def test_cross_motion_shape(self) -> None:
+        v = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        m = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0])
+        result = cross_motion(v, m)
+        assert result.shape == (6,)
+
+    def test_cross_motion_equals_crm(self) -> None:
+        """cross_motion(v, m) should equal crm(v) @ m."""
+        v = np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+        m = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+        assert np.allclose(cross_motion(v, m), crm(v) @ m)
+
+    def test_cross_motion_invalid_v(self) -> None:
+        with pytest.raises(ValueError):
+            cross_motion(np.zeros(5), np.zeros(6))
+
+    def test_cross_motion_invalid_m(self) -> None:
+        with pytest.raises(ValueError):
+            cross_motion(np.zeros(6), np.zeros(5))
+
+    def test_cross_motion_with_out(self) -> None:
+        v = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        m = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0])
+        out = np.zeros(6)
+        result = cross_motion(v, m, out=out)
+        assert result is out
+
+
+class TestCrossForce:
+    """Tests for cross_force function."""
+
+    def test_cross_force_shape(self) -> None:
+        v = np.zeros(6)
+        f = np.zeros(6)
+        assert cross_force(v, f).shape == (6,)
+
+    def test_cross_force_equals_crf(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+        f = np.array([0.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+        assert np.allclose(cross_force(v, f), crf(v) @ f)
+
+    def test_cross_force_with_out(self) -> None:
+        v = np.zeros(6)
+        f = np.zeros(6)
+        out = np.zeros(6)
+        result = cross_force(v, f, out=out)
+        assert result is out
+
+
+class TestFastCrossProducts:
+    """Tests for cross_motion_fast, cross_force_fast, cross_motion_axis."""
+
+    def test_cross_motion_fast_consistent(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 0.5, 0.5, 0.5])
+        m = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        out_fast = np.zeros(6)
+        cross_motion_fast(v, m, out_fast)
+        out_ref = cross_motion(v, m)
+        assert np.allclose(out_fast, out_ref)
+
+    def test_cross_force_fast_consistent(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 0.5, 0.5, 0.5])
+        f = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        out_fast = np.zeros(6)
+        cross_force_fast(v, f, out_fast)
+        out_ref = cross_force(v, f)
+        assert np.allclose(out_fast, out_ref)
+
+    def test_cross_motion_axis_index_0(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        m_full = np.zeros(6)
+        m_full[0] = 1.0
+        out_axis = np.zeros(6)
+        cross_motion_axis(v, axis_idx=0, val=1.0, out=out_axis)
+        out_ref = cross_motion(v, m_full)
+        assert np.allclose(out_axis, out_ref)
+
+    @pytest.mark.parametrize("axis_idx", [0, 1, 2, 3, 4, 5])
+    def test_cross_motion_axis_all_indices(self, axis_idx: int) -> None:
+        v = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        m = np.zeros(6)
+        m[axis_idx] = 2.0
+        out = np.zeros(6)
+        cross_motion_axis(v, axis_idx=axis_idx, val=2.0, out=out)
+        ref = cross_motion(v, m)
+        assert np.allclose(out, ref)
+
+
+class TestSpatialCross:
+    """Tests for the spatial_cross dispatcher."""
+
+    def test_motion_type(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+        m = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        result = spatial_cross(v, m, cross_type="motion")
+        expected = cross_motion(v, m)
+        assert np.allclose(result, expected)
+
+    def test_force_type(self) -> None:
+        v = np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+        f = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        result = spatial_cross(v, f, cross_type="force")
+        expected = cross_force(v, f)
+        assert np.allclose(result, expected)
+
+    def test_invalid_type_raises(self) -> None:
+        v = np.zeros(6)
+        u = np.zeros(6)
+        with pytest.raises(ValueError):
+            spatial_cross(v, u, cross_type="invalid")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# inertia.py
+# ---------------------------------------------------------------------------
+
+
+class TestMcI:
+    """Tests for mcI and mci functions."""
+
+    @pytest.fixture
+    def sphere_inertia(self) -> tuple:
+        mass = 2.0
+        com = np.zeros(3)
+        I_com = (2.0 / 5.0 * mass) * np.eye(3)
+        return mass, com, I_com
+
+    def test_mci_shape(self, sphere_inertia: tuple) -> None:
+        mass, com, I_com = sphere_inertia
+        M = mcI(mass, com, I_com)
+        assert M.shape == (6, 6)
+
+    def test_mci_symmetric(self, sphere_inertia: tuple) -> None:
+        mass, com, I_com = sphere_inertia
+        M = mcI(mass, com, I_com)
+        assert np.allclose(M, M.T)
+
+    def test_mci_mass_at_origin(self, sphere_inertia: tuple) -> None:
+        mass, com, I_com = sphere_inertia
+        M = mcI(mass, com, I_com)
+        # Bottom-right 3x3 is mass * I
+        assert np.allclose(M[3:, 3:], mass * np.eye(3))
+
+    def test_mci_alias(self, sphere_inertia: tuple) -> None:
+        mass, com, I_com = sphere_inertia
+        assert np.allclose(mcI(mass, com, I_com), mci(mass, com, I_com))
+
+    def test_mci_negative_mass_raises(self) -> None:
+        with pytest.raises(ValueError):
+            mcI(-1.0, np.zeros(3), np.eye(3))
+
+    def test_mci_zero_mass_raises(self) -> None:
+        with pytest.raises(ValueError):
+            mcI(0.0, np.zeros(3), np.eye(3))
+
+    def test_mci_wrong_com_shape(self) -> None:
+        with pytest.raises(ValueError):
+            mcI(1.0, np.zeros(2), np.eye(3))
+
+    def test_mci_wrong_inertia_shape(self) -> None:
+        with pytest.raises(ValueError):
+            mcI(1.0, np.zeros(3), np.eye(4))
+
+    def test_mci_offcentre_mass(self) -> None:
+        """Non-zero COM should add offset inertia via parallel axis theorem."""
+        mass = 1.0
+        com = np.array([1.0, 0.0, 0.0])
+        I_com = np.eye(3)
+        M = mcI(mass, com, I_com)
+        # Should not be same as zero-COM case
+        M_origin = mcI(mass, np.zeros(3), I_com)
+        assert not np.allclose(M, M_origin)
+
+
+class TestTransformSpatialInertia:
+    """Tests for transform_spatial_inertia."""
+
+    def test_identity_transform(self) -> None:
+        mass = 1.0
+        I_mat = mcI(mass, np.zeros(3), np.eye(3))
+        X = np.eye(6)
+        I_transformed = transform_spatial_inertia(I_mat, X)
+        assert np.allclose(I_transformed, I_mat)
+
+    def test_transformed_is_symmetric(self) -> None:
+        mass = 2.0
+        I_mat = mcI(mass, np.array([0.1, 0.2, 0.3]), np.eye(3))
+        X = np.eye(6)
+        X[:3, :3] = np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])  # 90deg rotation
+        I_t = transform_spatial_inertia(I_mat, X)
+        assert np.allclose(I_t, I_t.T)
+
+    def test_invalid_I_shape(self) -> None:
+        with pytest.raises(ValueError):
+            transform_spatial_inertia(np.eye(5), np.eye(6))
+
+    def test_invalid_X_shape(self) -> None:
+        with pytest.raises(ValueError):
+            transform_spatial_inertia(np.eye(6), np.eye(5))
+
+
+# ---------------------------------------------------------------------------
+# joints.py
+# ---------------------------------------------------------------------------
+
+
+class TestJcalc:
+    """Tests for jcalc joint kinematics."""
+
+    @pytest.mark.parametrize(
+        "jtype,expected_s",
+        [
+            ("Rx", S_RX),
+            ("Ry", S_RY),
+            ("Rz", S_RZ),
+            ("Px", S_PX),
+            ("Py", S_PY),
+            ("Pz", S_PZ),
+        ],
+    )
+    def test_motion_subspace(self, jtype: str, expected_s: np.ndarray) -> None:
+        xj, s, dof = jcalc(jtype, q=0.0)
+        assert np.allclose(s, expected_s)
+
+    @pytest.mark.parametrize(
+        "jtype,expected_dof",
+        [
+            ("Rx", 0),
+            ("Ry", 1),
+            ("Rz", 2),
+            ("Px", 3),
+            ("Py", 4),
+            ("Pz", 5),
+        ],
+    )
+    def test_dof_index(self, jtype: str, expected_dof: int) -> None:
+        _, _, dof = jcalc(jtype, q=0.0)
+        assert dof == expected_dof
+
+    def test_Rx_at_zero(self) -> None:
+        """At q=0 Rx should give identity-like rotation in xj."""
+        xj, _, _ = jcalc("Rx", q=0.0)
+        assert xj.shape == (6, 6)
+        # cos(0)=1, sin(0)=0
+        assert np.isclose(xj[1, 1], 1.0)
+        assert np.isclose(xj[1, 2], 0.0)
+
+    def test_Rz_at_pi_half(self) -> None:
+        xj, _, _ = jcalc("Rz", q=np.pi / 2)
+        assert np.isclose(xj[0, 0], 0.0, atol=1e-9)
+        assert np.isclose(xj[0, 1], -1.0, atol=1e-9)
+
+    def test_Px_transform(self) -> None:
+        xj, _, _ = jcalc("Px", q=1.0)
+        assert np.isclose(xj[4, 2], 1.0)
+        assert np.isclose(xj[5, 1], -1.0)
+
+    def test_Py_transform(self) -> None:
+        xj, _, _ = jcalc("Py", q=2.0)
+        assert np.isclose(xj[3, 2], -2.0)
+        assert np.isclose(xj[5, 0], 2.0)
+
+    def test_Pz_transform(self) -> None:
+        xj, _, _ = jcalc("Pz", q=3.0)
+        assert np.isclose(xj[3, 1], 3.0)
+        assert np.isclose(xj[4, 0], -3.0)
+
+    def test_invalid_joint_raises(self) -> None:
+        with pytest.raises(ValueError):
+            jcalc("Xy", q=0.0)
+
+    def test_with_out_buffer(self) -> None:
+        """Should use the provided buffer."""
+        buf = np.zeros((6, 6))
+        xj, _, _ = jcalc("Rx", q=0.5, out=buf)
+        assert xj is buf
+
+    def test_joint_axis_indices_complete(self) -> None:
+        assert set(JOINT_AXIS_INDICES.keys()) == {"Rx", "Ry", "Rz", "Px", "Py", "Pz"}


### PR DESCRIPTION
## Summary

Adds 106 unit tests covering Taylor/Maclaurin series and spatial algebra modules.

## Modules covered
| Module | Tests | Coverage target |
|--------|-------|-----------------|
|  | 45 | SeriesExpansion + 8 factory functions (exp, sin, cos, ln, geometric, arctan, sinh, cosh) |
|  | 31 | skew, crm, crf, cross_motion, cross_force, fast variants, axis-sparse variants, dispatcher |
|  | 12 | mcI, mci, transform_spatial_inertia |
|  | 18 | jcalc for all 6 joint types (Rx/Ry/Rz/Px/Py/Pz), DOF indices, output buffer |

## Quality
- All 106 tests pass locally
- Ruff lint clean (no violations)
- Parametrized tests for all joint types and all axis indices

Part of ongoing signal_toolkit coverage epic.