### PR TITLE
fix: update import paths in pinocchio tests #1741

### DIFF
--- a/tests/unit/engines/pinocchio/dtack/backends/test_backend_factory.py
+++ b/tests/unit/engines/pinocchio/dtack/backends/test_backend_factory.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.backends.backend_factory."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.backends.backend_factory."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.backends.backend_factory
+        import src.engines.physics_engines.pinocchio.python.dtack.backends.backend_factory
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.backends.backend_factory
+            src.engines.physics_engines.pinocchio.python.dtack.backends.backend_factory
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/backends/test_mujoco_backend.py
+++ b/tests/unit/engines/pinocchio/dtack/backends/test_mujoco_backend.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend
+        import src.engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend
+            src.engines.physics_engines.pinocchio.python.dtack.backends.mujoco_backend
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/backends/test_pink_backend.py
+++ b/tests/unit/engines/pinocchio/dtack/backends/test_pink_backend.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.backends.pink_backend."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.backends.pink_backend."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.backends.pink_backend
+        import src.engines.physics_engines.pinocchio.python.dtack.backends.pink_backend
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.backends.pink_backend
+            src.engines.physics_engines.pinocchio.python.dtack.backends.pink_backend
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/backends/test_pinocchio_backend.py
+++ b/tests/unit/engines/pinocchio/dtack/backends/test_pinocchio_backend.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend
+        import src.engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend
+            src.engines.physics_engines.pinocchio.python.dtack.backends.pinocchio_backend
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/gui/test_main_window.py
+++ b/tests/unit/engines/pinocchio/dtack/gui/test_main_window.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.gui.main_window."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.gui.main_window."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.gui.main_window
+        import src.engines.physics_engines.pinocchio.python.dtack.gui.main_window
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.gui.main_window is not None
+            src.engines.physics_engines.pinocchio.python.dtack.gui.main_window is not None
         )
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/dtack/ik/test_pink_solver.py
+++ b/tests/unit/engines/pinocchio/dtack/ik/test_pink_solver.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.ik.pink_solver."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.ik.pink_solver."""
 
 import pytest
 
@@ -6,8 +6,8 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.ik.pink_solver
+        import src.engines.physics_engines.pinocchio.python.dtack.ik.pink_solver
 
-        assert engines.physics_engines.pinocchio.python.dtack.ik.pink_solver is not None
+        assert src.engines.physics_engines.pinocchio.python.dtack.ik.pink_solver is not None
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/dtack/ik/test_tasks.py
+++ b/tests/unit/engines/pinocchio/dtack/ik/test_tasks.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.ik.tasks."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.ik.tasks."""
 
 import pytest
 
@@ -6,8 +6,8 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.ik.tasks
+        import src.engines.physics_engines.pinocchio.python.dtack.ik.tasks
 
-        assert engines.physics_engines.pinocchio.python.dtack.ik.tasks is not None
+        assert src.engines.physics_engines.pinocchio.python.dtack.ik.tasks is not None
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/dtack/sim/test_dynamics.py
+++ b/tests/unit/engines/pinocchio/dtack/sim/test_dynamics.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.sim.dynamics."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.sim.dynamics."""
 
 import pytest
 
@@ -6,8 +6,8 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.sim.dynamics
+        import src.engines.physics_engines.pinocchio.python.dtack.sim.dynamics
 
-        assert engines.physics_engines.pinocchio.python.dtack.sim.dynamics is not None
+        assert src.engines.physics_engines.pinocchio.python.dtack.sim.dynamics is not None
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/dtack/utils/test_gears_parser.py
+++ b/tests/unit/engines/pinocchio/dtack/utils/test_gears_parser.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.utils.gears_parser."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.utils.gears_parser."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.utils.gears_parser
+        import src.engines.physics_engines.pinocchio.python.dtack.utils.gears_parser
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.utils.gears_parser
+            src.engines.physics_engines.pinocchio.python.dtack.utils.gears_parser
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/utils/test_matlab_importer.py
+++ b/tests/unit/engines/pinocchio/dtack/utils/test_matlab_importer.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer
+        import src.engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer
+            src.engines.physics_engines.pinocchio.python.dtack.utils.matlab_importer
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/utils/test_mjcf_exporter.py
+++ b/tests/unit/engines/pinocchio/dtack/utils/test_mjcf_exporter.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter
+        import src.engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter
+            src.engines.physics_engines.pinocchio.python.dtack.utils.mjcf_exporter
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/utils/test_urdf_exporter.py
+++ b/tests/unit/engines/pinocchio/dtack/utils/test_urdf_exporter.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter
+        import src.engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter
+            src.engines.physics_engines.pinocchio.python.dtack.utils.urdf_exporter
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/viz/test_geppetto_viewer.py
+++ b/tests/unit/engines/pinocchio/dtack/viz/test_geppetto_viewer.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer
+        import src.engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer
+            src.engines.physics_engines.pinocchio.python.dtack.viz.geppetto_viewer
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/viz/test_meshcat_viewer.py
+++ b/tests/unit/engines/pinocchio/dtack/viz/test_meshcat_viewer.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer
+        import src.engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer
+            src.engines.physics_engines.pinocchio.python.dtack.viz.meshcat_viewer
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/dtack/viz/test_rob_neal_viewer.py
+++ b/tests/unit/engines/pinocchio/dtack/viz/test_rob_neal_viewer.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer."""
+"""Tests for src.engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer
+        import src.engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer
 
         assert (
-            engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer
+            src.engines.physics_engines.pinocchio.python.dtack.viz.rob_neal_viewer
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/examples/test_double_pendulum_standalone.py
+++ b/tests/unit/engines/pinocchio/examples/test_double_pendulum_standalone.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone."""
+"""Tests for src.engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone
+        import src.engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone
 
         assert (
-            engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone
+            src.engines.physics_engines.pinocchio.python.examples.double_pendulum_standalone
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/motion_training/test_club_trajectory_parser.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_club_trajectory_parser.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser."""
+"""Tests for src.engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser
+        import src.engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser
 
         assert (
-            engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser
+            src.engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/motion_training/test_dual_hand_ik_solver.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_dual_hand_ik_solver.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver."""
+"""Tests for src.engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver
+        import src.engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver
 
         assert (
-            engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver
+            src.engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/motion_training/test_motion_visualizer.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_motion_visualizer.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.motion_training.motion_visualizer."""
+"""Tests for src.engines.physics_engines.pinocchio.python.motion_training.motion_visualizer."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.motion_training.motion_visualizer
+        import src.engines.physics_engines.pinocchio.python.motion_training.motion_visualizer
 
         assert (
-            engines.physics_engines.pinocchio.python.motion_training.motion_visualizer
+            src.engines.physics_engines.pinocchio.python.motion_training.motion_visualizer
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/motion_training/test_training_pipeline.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_training_pipeline.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.motion_training.training_pipeline."""
+"""Tests for src.engines.physics_engines.pinocchio.python.motion_training.training_pipeline."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.motion_training.training_pipeline
+        import src.engines.physics_engines.pinocchio.python.motion_training.training_pipeline
 
         assert (
-            engines.physics_engines.pinocchio.python.motion_training.training_pipeline
+            src.engines.physics_engines.pinocchio.python.motion_training.training_pipeline
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/motion_training/test_trajectory_exporter.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_trajectory_exporter.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter."""
+"""Tests for src.engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter
+        import src.engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter
 
         assert (
-            engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter
+            src.engines.physics_engines.pinocchio.python.motion_training.trajectory_exporter
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_analysis_controller.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_analysis_controller.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.analysis_controller
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_coppelia_bridge.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_coppelia_bridge.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.coppelia_bridge
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_gui.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_gui.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.gui."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui."""
 
 import pytest
 
@@ -6,8 +6,8 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.gui
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui
 
-        assert engines.physics_engines.pinocchio.python.pinocchio_golf.gui is not None
+        assert src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui is not None
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_gui_simulation.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_gui_simulation.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_simulation
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_gui_ui_setup.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_gui_ui_setup.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_induced_acceleration.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_induced_acceleration.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_manipulability.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_manipulability.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.manipulability
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_analysis_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_analysis_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_analysis_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_recorder.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_recorder.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_recorder
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_visualization_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_pinocchio_visualization_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.pinocchio_visualization_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_pose_editor_tab.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_pose_editor_tab.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.pose_editor_tab
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/test_torque_fitting.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/test_torque_fitting.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.torque_fitting
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_analysis_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_analysis_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_components.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_components.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_main_window.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_main_window.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_simulation_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_simulation_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_ui_setup_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_ui_setup_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_visualization_mixin.py
+++ b/tests/unit/engines/pinocchio/pinocchio_golf/ui/test_visualization_mixin.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin
+        import src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin
+            src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/test___main__.py
+++ b/tests/unit/engines/pinocchio/test___main__.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.__main__."""
+"""Tests for src.engines.physics_engines.pinocchio.python.__main__."""
 
 import pytest
 
@@ -6,8 +6,8 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.__main__
+        import src.engines.physics_engines.pinocchio.python.__main__
 
-        assert engines.physics_engines.pinocchio.python.__main__ is not None
+        assert src.engines.physics_engines.pinocchio.python.__main__ is not None
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
+++ b/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.pinocchio_physics_engine."""
+"""Tests for src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.pinocchio_physics_engine
+        import src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine
 
         assert (
-            engines.physics_engines.pinocchio.python.pinocchio_physics_engine
+            src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine
             is not None
         )
     except ImportError as e:

--- a/tests/unit/engines/pinocchio/test_swing_plane_integration.py
+++ b/tests/unit/engines/pinocchio/test_swing_plane_integration.py
@@ -1,4 +1,4 @@
-"""Tests for engines.physics_engines.pinocchio.python.swing_plane_integration."""
+"""Tests for src.engines.physics_engines.pinocchio.python.swing_plane_integration."""
 
 import pytest
 
@@ -6,10 +6,10 @@ import pytest
 def test_import():
     """Verify the module can be imported."""
     try:
-        import engines.physics_engines.pinocchio.python.swing_plane_integration
+        import src.engines.physics_engines.pinocchio.python.swing_plane_integration
 
         assert (
-            engines.physics_engines.pinocchio.python.swing_plane_integration is not None
+            src.engines.physics_engines.pinocchio.python.swing_plane_integration is not None
         )
     except ImportError as e:
         pytest.skip(f"Missing dependencies or import error: {e}")

--- a/tests/unit/engines/pinocchio/test_tasks.py
+++ b/tests/unit/engines/pinocchio/test_tasks.py
@@ -20,8 +20,8 @@ def mock_pinocchio_env() -> Generator[None, None, None]:
     }
     with patch.dict(sys.modules, mock_mods):
         # Clean up module under test to ensure it imports mocks
-        if "engines.physics_engines.pinocchio.python.dtack.ik.tasks" in sys.modules:
-            del sys.modules["engines.physics_engines.pinocchio.python.dtack.ik.tasks"]
+        if "src.engines.physics_engines.pinocchio.python.dtack.ik.tasks" in sys.modules:
+            del sys.modules["src.engines.physics_engines.pinocchio.python.dtack.ik.tasks"]
         yield
 
 
@@ -30,7 +30,7 @@ def test_create_joint_coupling_task(mock_pinocchio_env) -> None:
     # This is the mocked pinocchio
     import pinocchio as pin  # noqa: I001
 
-    from engines.physics_engines.pinocchio.python.dtack.ik.tasks import (  # noqa: I001
+    from src.engines.physics_engines.pinocchio.python.dtack.ik.tasks import (  # noqa: I001
         create_joint_coupling_task,
     )
 


### PR DESCRIPTION
Fixes #1741 by updating the old `engines.physics_engines` paths to `src.engines.physics_engines`.