### PR TITLE
test(launchers): implement Wave 11 with 100% tests for docker and help dialogs

### DIFF
--- a/tests/launchers/test_docker_dialog.py
+++ b/tests/launchers/test_docker_dialog.py
@@ -1,0 +1,140 @@
+"""Tests for docker_dialog.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure PyQt classes are available
+pytest.importorskip("PyQt6")
+
+from src.launchers.docker_dialog import EnvironmentDialog
+
+
+@pytest.fixture
+def dialog(qapp):
+    """Provide an EnvironmentDialog instance."""
+    return EnvironmentDialog()
+
+
+def test_init(dialog):
+    """Test dialog initialization."""
+    assert dialog.windowTitle() == "Manage Environment"
+    assert dialog.build_thread is None
+    assert dialog._build_start_time == 0.0
+    assert dialog._elapsed_timer_id is None
+
+
+def test_setup_ui(dialog):
+    """Test UI setup."""
+    assert dialog.combo_stage is not None
+    assert dialog.btn_build is not None
+    assert dialog.btn_cancel is not None
+    assert dialog.build_status_label is not None
+    assert dialog.console is not None
+    assert dialog.btn_cancel.isEnabled() is False
+
+
+@patch("src.launchers.docker_dialog.DockerBuildThread")
+def test_start_build(mock_thread_cls, dialog):
+    """Test starting the build process."""
+    mock_thread = MagicMock()
+    mock_thread_cls.return_value = mock_thread
+
+    # Make startTimer a mock or track it
+    with patch.object(dialog, "startTimer", return_value=123) as mock_timer:
+        dialog.start_build()
+
+        assert dialog.btn_build.isEnabled() is False
+        assert dialog.btn_cancel.isEnabled() is True
+        assert dialog._elapsed_timer_id == 123
+        mock_timer.assert_called_once_with(1000)
+
+        # Ensure the thread was created and started
+        mock_thread_cls.assert_called_once()
+        mock_thread.start.assert_called_once()
+        assert dialog.build_thread == mock_thread
+
+
+def test_on_build_log(dialog):
+    """Test appending to log."""
+    # Append creates text without changing read-only
+    with patch.object(dialog.console, "append") as mock_append:
+        dialog._on_build_log("test log")
+        mock_append.assert_called_once_with("test log")
+
+    # Test when verticalScrollBar is None
+    with patch.object(dialog.console, "verticalScrollBar", return_value=None):
+        dialog._on_build_log("test log 2")
+
+
+def test_on_build_finished_success(dialog):
+    """Test handling a successful build finish."""
+    dialog._build_start_time = 1.0
+    dialog._elapsed_timer_id = 999
+
+    with (
+        patch("src.launchers.docker_dialog.time.monotonic", return_value=3.0),
+        patch.object(dialog, "killTimer") as mock_kill,
+    ):
+        dialog._on_build_finished(True, "Done!")
+
+        assert dialog.btn_build.isEnabled() is True
+        assert dialog.btn_cancel.isEnabled() is False
+        mock_kill.assert_called_once_with(999)
+        assert dialog._elapsed_timer_id is None
+        assert "SUCCESS" in dialog.build_status_label.text()
+        assert "Done!" in dialog.build_status_label.text()
+
+
+def test_on_build_finished_failure(dialog):
+    """Test handling a failed build finish."""
+    dialog._build_start_time = 0.0
+    dialog._elapsed_timer_id = None
+
+    with patch.object(dialog, "killTimer") as mock_kill:
+        dialog._on_build_finished(False, "Error!")
+
+        assert dialog.btn_build.isEnabled() is True
+        assert dialog.btn_cancel.isEnabled() is False
+        mock_kill.assert_not_called()
+        assert "FAILED" in dialog.build_status_label.text()
+        assert "Error!" in dialog.build_status_label.text()
+
+
+def test_cancel_build(dialog):
+    """Test canceling an active build."""
+    mock_thread = MagicMock()
+    mock_thread.isRunning.return_value = True
+    dialog.build_thread = mock_thread
+    dialog._elapsed_timer_id = 111
+
+    with patch.object(dialog, "killTimer") as mock_kill:
+        dialog._cancel_build()
+
+        mock_thread.terminate.assert_called_once()
+        assert dialog.btn_build.isEnabled() is True
+        assert dialog.btn_cancel.isEnabled() is False
+        mock_kill.assert_called_once_with(111)
+        assert dialog._elapsed_timer_id is None
+        assert dialog.build_status_label.text() == "Build cancelled."
+
+    # Test canceling when _elapsed_timer_id is None
+    mock_thread.reset_mock()
+    dialog._cancel_build()
+    mock_thread.terminate.assert_called_once()
+    assert dialog._elapsed_timer_id is None
+
+
+def test_cancel_build_no_thread(dialog):
+    """Test canceling when no build thread is active."""
+    dialog.build_thread = None
+    dialog._cancel_build()
+    # Nothing should crash
+
+
+def test_timer_event(dialog):
+    """Test timer event updates elapsed time."""
+    dialog._build_start_time = 5.0
+    with patch("src.launchers.docker_dialog.time.monotonic", return_value=15.0):
+        dialog.timerEvent(MagicMock())
+        assert "10s elapsed" in dialog.build_status_label.text()

--- a/tests/launchers/test_golf_suite_launcher.py
+++ b/tests/launchers/test_golf_suite_launcher.py
@@ -8,7 +8,7 @@ import pytest
 
 
 @pytest.fixture
-def mock_pyqt():
+def mock_pyqt(qapp):
     """Mock PyQt6 components for testing non-UI logic safely."""
     with (
         patch("src.launchers.golf_suite_launcher.PYQT6_AVAILABLE", True),

--- a/tests/launchers/test_help_dialogs.py
+++ b/tests/launchers/test_help_dialogs.py
@@ -1,0 +1,146 @@
+"""Tests for help_dialogs.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure PyQt classes are available
+pytest.importorskip("PyQt6")
+from PyQt6.QtCore import Qt
+
+from src.launchers.help_dialogs import (
+    ContextHelpDock,
+    HelpDialog,
+    LayoutManagerDialog,
+)
+
+
+@pytest.fixture
+def test_model():
+    model = MagicMock()
+    model.name = "Test Model"
+    model.description = "A test model"
+    model.id = "test_id"
+    return model
+
+
+def test_help_dialog_file_exists(qapp):
+    """Test HelpDialog when help.md exists."""
+    with (
+        patch("src.launchers.help_dialogs.Path.exists", return_value=True),
+        patch("src.launchers.help_dialogs.Path.read_text", return_value="# Help"),
+    ):
+        dialog = HelpDialog()
+        assert dialog.windowTitle() == "Golf Suite - Help"
+        assert "Help" in dialog.text_area.toPlainText()
+
+
+def test_help_dialog_file_missing(qapp):
+    """Test HelpDialog when help.md is missing."""
+    with patch("src.launchers.help_dialogs.Path.exists", return_value=False):
+        dialog = HelpDialog()
+        assert "not found" in dialog.text_area.toPlainText()
+
+
+def test_layout_manager_dialog(qapp, test_model):
+    """Test LayoutManagerDialog initialization and selection."""
+    models = {"test_id": test_model}
+    active = ["test_id"]
+
+    dialog = LayoutManagerDialog(models, active, None)
+    assert dialog.windowTitle() == "Customize Launcher Tiles"
+    assert dialog.list_widget.count() == 1
+
+    item = dialog.list_widget.item(0)
+    assert item.checkState() == Qt.CheckState.Checked
+
+    assert dialog.selected_ids() == ["test_id"]
+
+
+def test_layout_manager_dialog_unchecked(qapp, test_model):
+    """Test LayoutManagerDialog with unchecked items."""
+    models = {"test_id": test_model}
+    active = []
+
+    dialog = LayoutManagerDialog(models, active, None)
+    item = dialog.list_widget.item(0)
+    assert item.checkState() == Qt.CheckState.Unchecked
+    assert dialog.selected_ids() == []
+
+
+def test_layout_manager_dialog_no_model_id(qapp, test_model):
+    """Test LayoutManagerDialog with a checked item having no role data."""
+    models = {"test_id": test_model}
+    active = ["test_id"]
+
+    dialog = LayoutManagerDialog(models, active, None)
+    item = dialog.list_widget.item(0)
+    item.setData(Qt.ItemDataRole.UserRole, None)
+    assert dialog.selected_ids() == []
+
+
+def test_context_help_dock_init(qapp):
+    """Test ContextHelpDock initialization."""
+    dock = ContextHelpDock()
+    assert dock.windowTitle() == "Quick Help"
+    assert "Context Aware Help" in dock.text_area.toPlainText()
+
+
+def test_update_context_no_id(qapp):
+    """Test update_context with None."""
+    dock = ContextHelpDock()
+    dock.update_context(None)
+    assert "Context Aware Help" in dock.text_area.toPlainText()
+
+
+def test_update_context_valid_file(qapp):
+    """Test update_context when doc file exists."""
+    dock = ContextHelpDock()
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+    mock_path.read_text.return_value = "Valid doc content"
+
+    with patch.object(dock, "_get_doc_file", return_value=mock_path):
+        dock.update_context("some_id")
+        assert "Valid doc content" in dock.text_area.toPlainText()
+
+
+def test_update_context_read_error(qapp):
+    """Test update_context when doc file exists but cannot be read."""
+    dock = ContextHelpDock()
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+    mock_path.read_text.side_effect = OSError("Read failed")
+
+    with patch.object(dock, "_get_doc_file", return_value=mock_path):
+        dock.update_context("some_id")
+        assert (
+            "Failed to load documentation: Read failed" in dock.text_area.toPlainText()
+        )
+
+
+def test_update_context_no_file(qapp):
+    """Test update_context when doc file does not exist."""
+    dock = ContextHelpDock()
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = False
+
+    with patch.object(dock, "_get_doc_file", return_value=mock_path):
+        dock.update_context("missing_id")
+        assert "missing_id" in dock.text_area.toPlainText()
+        assert "No specific documentation available" in dock.text_area.toPlainText()
+
+
+def test_get_doc_file(qapp):
+    """Test _get_doc_file mapping."""
+    dock = ContextHelpDock()
+
+    assert "mujoco.md" in str(dock._get_doc_file("mujoco_model"))
+    assert "drake.md" in str(dock._get_doc_file("drake_model"))
+    assert "pinocchio.md" in str(dock._get_doc_file("pinocchio_model"))
+    assert "matlab.md" in str(dock._get_doc_file("matlab_model"))
+    assert "urdf_generator" in str(dock._get_doc_file("urdf_model"))
+    assert dock._get_doc_file("unknown_model") is None


### PR DESCRIPTION
This PR achieves 100% test coverage for the src/launchers/docker_dialog.py and src/launchers/help_dialogs.py modules, alongside a fix for PyQt test hanging from Wave 10.