### PR TITLE
feat(#1956): enforce lazy-loading of engine packages in dashboard launchers

### DIFF
--- a/src/launchers/drake_dashboard.py
+++ b/src/launchers/drake_dashboard.py
@@ -1,15 +1,16 @@
 """Drake Dashboard Launcher.
 
 Launches the Unified Dashboard with the Drake Physics Engine.
+
+The Drake engine package is deferred to inside ``main()`` so that
+importing this module does NOT trigger pydrake package loading.  This
+satisfies the lazy-loading requirement from Guideline Issue #1956.
 """
 
 import argparse
 
 from PyQt6.QtWidgets import QFileDialog
 
-from src.engines.physics_engines.drake.python.drake_physics_engine import (
-    DrakePhysicsEngine,
-)
 from src.shared.python.dashboard.launcher import launch_dashboard
 from src.shared.python.ui.qt.utils import get_qapp
 
@@ -34,6 +35,11 @@ def main() -> None:
             selected = dialog.selectedFiles()
             if selected:
                 model_path = selected[0]
+
+    # Deferred import: only loads pydrake when this launcher is actually invoked
+    from src.engines.physics_engines.drake.python.drake_physics_engine import (  # noqa: PLC0415
+        DrakePhysicsEngine,
+    )
 
     launch_dashboard(
         engine_class=DrakePhysicsEngine,  # type: ignore[type-abstract]

--- a/src/launchers/mujoco_dashboard.py
+++ b/src/launchers/mujoco_dashboard.py
@@ -2,16 +2,23 @@
 
 Launches the Unified Dashboard with the MuJoCo Physics Engine.
 This serves as an alternative to the specialized AdvancedGolfAnalysisWindow.
+
+The MuJoCo engine package (``import mujoco``) is intentionally deferred to
+inside ``main()`` so that importing this module at the Python level does NOT
+trigger a heavy MuJoCo DLL load.  This satisfies the lazy-loading requirement
+from Guideline Issue #1956.
 """
 
-from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine import (
-    MuJoCoPhysicsEngine,
-)
 from src.shared.python.dashboard.launcher import launch_dashboard
 
 
 def main() -> None:
     """Main entry point."""
+    # Deferred import: only loads mujoco when this launcher is actually invoked
+    from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine import (  # noqa: PLC0415
+        MuJoCoPhysicsEngine,
+    )
+
     launch_dashboard(
         engine_class=MuJoCoPhysicsEngine,  # type: ignore[type-abstract]
         title="MuJoCo Golf Analysis Dashboard (Unified)",

--- a/src/launchers/pinocchio_dashboard.py
+++ b/src/launchers/pinocchio_dashboard.py
@@ -1,16 +1,22 @@
 """Pinocchio Dashboard Launcher.
 
 Launches the Unified Dashboard with the Pinocchio Physics Engine.
+
+The Pinocchio engine package is deferred to inside ``main()`` so that
+importing this module does NOT trigger pinocchio package loading.  This
+satisfies the lazy-loading requirement from Guideline Issue #1956.
 """
 
-from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
-    PinocchioPhysicsEngine,
-)
 from src.shared.python.dashboard.launcher import launch_dashboard
 
 
 def main() -> None:
     """Main entry point."""
+    # Deferred import: only loads pinocchio when this launcher is actually invoked
+    from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (  # noqa: PLC0415
+        PinocchioPhysicsEngine,
+    )
+
     launch_dashboard(
         engine_class=PinocchioPhysicsEngine,  # type: ignore[type-abstract]
         title="Pinocchio Golf Analysis Dashboard",

--- a/tests/launchers/test_dashboards.py
+++ b/tests/launchers/test_dashboards.py
@@ -1,40 +1,31 @@
 """Tests for various dashboard launchers."""
 
-import sys  # noqa: E402
-from unittest.mock import MagicMock, patch  # noqa: E402
+import sys
+from unittest.mock import MagicMock, patch
 
-from src.engines.physics_engines.drake.python.drake_physics_engine import (  # noqa: E402
-    DrakePhysicsEngine,
-)
-from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine import (  # noqa: E402
-    MuJoCoPhysicsEngine,
-)
-from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (  # noqa: E402
-    PinocchioPhysicsEngine,
-)
-from src.launchers.drake_dashboard import main as drake_main  # noqa: E402
-from src.launchers.matlab_launcher_unified import MatlabLauncher  # noqa: E402
-from src.launchers.matlab_launcher_unified import main as matlab_main  # noqa: E402
-from src.launchers.mujoco_dashboard import main as mujoco_main  # noqa: E402
-from src.launchers.pinocchio_dashboard import main as pinocchio_main  # noqa: E402
+from src.launchers.drake_dashboard import main as drake_main
+from src.launchers.matlab_launcher_unified import MatlabLauncher
+from src.launchers.matlab_launcher_unified import main as matlab_main
+from src.launchers.mujoco_dashboard import main as mujoco_main
+from src.launchers.pinocchio_dashboard import main as pinocchio_main
 
 
 def test_mujoco_dashboard_main():
     with patch("src.launchers.mujoco_dashboard.launch_dashboard") as mock_launch:
         mujoco_main()
-        mock_launch.assert_called_once_with(
-            engine_class=MuJoCoPhysicsEngine,
-            title="MuJoCo Golf Analysis Dashboard (Unified)",
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "MuJoCoPhysicsEngine"
+        assert kwargs["title"] == "MuJoCo Golf Analysis Dashboard (Unified)"
 
 
 def test_pinocchio_dashboard_main():
     with patch("src.launchers.pinocchio_dashboard.launch_dashboard") as mock_launch:
         pinocchio_main()
-        mock_launch.assert_called_once_with(
-            engine_class=PinocchioPhysicsEngine,
-            title="Pinocchio Golf Analysis Dashboard",
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "PinocchioPhysicsEngine"
+        assert kwargs["title"] == "Pinocchio Golf Analysis Dashboard"
 
 
 def test_drake_dashboard_main_no_args():
@@ -54,11 +45,11 @@ def test_drake_dashboard_main_no_args():
 
         mock_qapp.assert_called_once()
         mock_dialog.setNameFilter.assert_called_with("Model Files (*.urdf *.sdf *.xml)")
-        mock_launch.assert_called_once_with(
-            engine_class=DrakePhysicsEngine,
-            title="Drake Golf Analysis Dashboard",
-            model_path="fake_model.urdf",
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "DrakePhysicsEngine"
+        assert kwargs["title"] == "Drake Golf Analysis Dashboard"
+        assert kwargs["model_path"] == "fake_model.urdf"
 
 
 def test_drake_dashboard_main_no_args_dialog_canceled():
@@ -73,11 +64,10 @@ def test_drake_dashboard_main_no_args_dialog_canceled():
         mock_dialog.exec.return_value = False
 
         drake_main()
-        mock_launch.assert_called_once_with(
-            engine_class=DrakePhysicsEngine,
-            title="Drake Golf Analysis Dashboard",
-            model_path=None,
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "DrakePhysicsEngine"
+        assert kwargs["model_path"] is None
 
 
 def test_drake_dashboard_main_no_args_dialog_no_selection():
@@ -93,11 +83,10 @@ def test_drake_dashboard_main_no_args_dialog_no_selection():
         mock_dialog.selectedFiles.return_value = []
 
         drake_main()
-        mock_launch.assert_called_once_with(
-            engine_class=DrakePhysicsEngine,
-            title="Drake Golf Analysis Dashboard",
-            model_path=None,
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "DrakePhysicsEngine"
+        assert kwargs["model_path"] is None
 
 
 def test_drake_dashboard_main_with_args():
@@ -106,11 +95,10 @@ def test_drake_dashboard_main_with_args():
         patch("src.launchers.drake_dashboard.launch_dashboard") as mock_launch,
     ):
         drake_main()
-        mock_launch.assert_called_once_with(
-            engine_class=DrakePhysicsEngine,
-            title="Drake Golf Analysis Dashboard",
-            model_path="my_model.urdf",
-        )
+        mock_launch.assert_called_once()
+        _, kwargs = mock_launch.call_args
+        assert kwargs["engine_class"].__name__ == "DrakePhysicsEngine"
+        assert kwargs["model_path"] == "my_model.urdf"
 
 
 @patch("src.launchers.base.BaseLauncher.__init__", return_value=None)

--- a/tests/launchers/test_lazy_imports.py
+++ b/tests/launchers/test_lazy_imports.py
@@ -1,0 +1,93 @@
+"""Verify strict lazy-loading of engine dependencies in the launcher UI.
+
+Issue #1956: Engine-specific Python packages (mujoco, pydrake, pinocchio, etc.)
+must NOT be imported as a side-effect of importing the dashboard launcher
+modules.  Heavy engine packages should only be loaded when the user explicitly
+activates the corresponding engine entry point.
+
+These tests snapshot ``sys.modules`` before and after importing each dashboard
+module, then assert that none of the physics-engine packages were added.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Heavy engine packages whose module-level presence indicates an eager import
+_ENGINE_PACKAGES = [
+    "mujoco",
+    "pydrake",
+    "pinocchio",
+    "opensim",
+    "myosim",
+]
+
+# Dashboard module names under test
+_DASHBOARD_MODULES = [
+    "src.launchers.mujoco_dashboard",
+    "src.launchers.pinocchio_dashboard",
+    "src.launchers.drake_dashboard",
+]
+
+
+def _engine_packages_in_modules(module_snapshot: set[str]) -> list[str]:
+    """Return any engine packages present in the given module-name set."""
+    return [pkg for pkg in _ENGINE_PACKAGES if pkg in module_snapshot]
+
+
+class TestDashboardModulesDoNotEagerlyImportEngines:
+    """Importing dashboard modules must not pull in heavy engine packages."""
+
+    @pytest.mark.parametrize("dashboard_module", _DASHBOARD_MODULES)
+    def test_importing_dashboard_does_not_load_engine_packages(
+        self, dashboard_module: str
+    ) -> None:
+        """Importing a dashboard module must not trigger engine package imports."""
+        # Remove the module (and any cached import) so we get a fresh import
+        sys.modules.pop(dashboard_module, None)
+
+        # Snapshot of engine packages present BEFORE the import
+        before = {
+            key
+            for key in sys.modules
+            if any(key == p or key.startswith(p + ".") for p in _ENGINE_PACKAGES)
+        }
+
+        # Patch PyQt6 so the import works even in headless environments
+        with patch.dict(
+            "sys.modules",
+            {
+                "PyQt6": sys.modules.get("PyQt6", MagicMock()),
+                "PyQt6.QtWidgets": sys.modules.get("PyQt6.QtWidgets", MagicMock()),
+            },
+        ):
+            importlib.import_module(dashboard_module)
+
+        # Snapshot AFTER the import
+        after = {
+            key
+            for key in sys.modules
+            if any(key == p or key.startswith(p + ".") for p in _ENGINE_PACKAGES)
+        }
+
+        newly_imported = after - before
+        msg = (
+            f"Importing '{dashboard_module}' eagerly loaded engine package(s): "
+            f"{newly_imported}. Move those imports inside the main() function."
+        )
+        assert not newly_imported, msg
+
+
+class TestDashboardModulesHaveCallableMain:
+    """Each dashboard module must expose a callable main() entry point."""
+
+    @pytest.mark.parametrize("dashboard_module", _DASHBOARD_MODULES)
+    def test_main_is_callable(self, dashboard_module: str) -> None:
+        mod = importlib.import_module(dashboard_module)
+        assert callable(getattr(mod, "main", None)), (
+            f"{dashboard_module} does not expose a callable main()"
+        )


### PR DESCRIPTION
## Summary

- `mujoco_dashboard.py`, `pinocchio_dashboard.py`, `drake_dashboard.py`: moved engine class imports from module-level into `main()` — importing these modules no longer triggers heavy DLL loads (mujoco, pydrake, pinocchio)
- `tests/launchers/test_dashboards.py`: removed module-level engine class imports; assertions now check `call_args.kwargs['engine_class'].__name__` instead of object identity so tests remain correct without eager engine loading
- `tests/launchers/test_lazy_imports.py`: new regression test that imports each dashboard module and asserts zero engine packages appear in `sys.modules` as a side-effect

## Test plan

- [x] All 14 new/updated tests pass locally
- [x] `test_importing_dashboard_does_not_load_engine_packages` directly verifies the lazy-loading guarantee
- [x] All pre-push hooks pass: ruff lint, ruff format, mypy, bandit, pytest

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)