### PR TITLE
fix(tests): document intentional bare except in assessment test fixture

### DIFF
--- a/tests/unit/shared_python/test_assessment_analysis.py
+++ b/tests/unit/shared_python/test_assessment_analysis.py
@@ -39,11 +39,16 @@ class Foo:
         return "no"
 """
 
+# NOTE: ERROR_PYTHON intentionally contains a bare ``except:`` clause.
+# This string is *test data* for assess_error_handling_content(), which must
+# be able to detect that anti-pattern.  It is NOT an actual exception handler
+# in the codebase; the bare clause lives inside a string literal and is never
+# executed as Python code.
 ERROR_PYTHON = """\
 def danger():
     try:
         pass
-    except:
+    except:  # noqa: E722 - intentional bare except for detection testing
         pass
     try:
         pass


### PR DESCRIPTION
## Summary

- The only `except:` (bare except) in the codebase lives inside the `ERROR_PYTHON` string literal in `tests/unit/shared_python/test_assessment_analysis.py` — it is **test data** fed to `assess_error_handling_content()` to verify detection of the anti-pattern, not an actual exception handler
- Added a block comment above the fixture and a `# noqa: E722` inline comment to make the intent unambiguous and prevent future scanners from re-filing this finding
- Confirmed zero bare `except:` clauses exist anywhere in `src/` (production code)

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/unit/shared_python/test_assessment_analysis.py` — all 48 tests pass
- [x] `TestAssessErrorHandlingContent.test_counts_bare_except` still asserts `bare_except_count == 1` (the detection fixture is preserved, just documented)

Closes #2092

🤖 Generated with [Claude Code](https://claude.com/claude-code)