### PR TITLE
fix: resolve contracts.py import ambiguity (#2077)

### DIFF
--- a/src/shared/python/contracts.py
+++ b/src/shared/python/contracts.py
@@ -1,7 +1,18 @@
 """Design by Contract (DbC) enforcement for the Tools platform.
 
-This module provides lightweight helpers and decorators for enforcing
-pre-conditions, post-conditions, and invariants at runtime.
+This is the **canonical** DbC implementation for ``src/shared/python``.
+Domain-specific shims in sub-packages (e.g.
+``humanoid_character_builder.contracts`` and
+``model_generation.core.contracts``) re-export from this module for
+backward compatibility.  All new code should import directly from here::
+
+    from src.shared.python.contracts import require, ensure, precondition
+
+Relationship to ``src/shared/python/core/contracts/``:
+    That package is a separately evolved contracts implementation used by
+    the ``src/shared/python/core/`` sub-system.  The two implementations
+    are intentionally distinct; this module is the authoritative source
+    for the wider platform.
 
 Enforcement Levels (controlled via ``DBC_LEVEL`` environment variable):
   - ``enforce`` (default): Raise ``ContractViolationError`` on failure.

--- a/src/shared/python/humanoid_character_builder/contracts.py
+++ b/src/shared/python/humanoid_character_builder/contracts.py
@@ -5,16 +5,21 @@ at ``src/shared/python/contracts.py`` for backward compatibility.
 
 All contract enforcement, decorators, and exceptions are defined
 in the single source of truth.
+
+.. note::
+    Import directly from ``src.shared.python.contracts`` for new code.
+    This shim exists only for backward compatibility within the
+    ``humanoid_character_builder`` package.
 """
 
 from __future__ import annotations
 
-from contracts import (  # noqa: F401
+from src.shared.python.contracts import (  # noqa: F401
     ContractViolationError,
     postcondition,
     precondition,
 )
-from contracts import (
+from src.shared.python.contracts import (
     class_invariant as invariant,
 )
 

--- a/src/shared/python/model_generation/builders/base_builder.py
+++ b/src/shared/python/model_generation/builders/base_builder.py
@@ -11,10 +11,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from contracts import InvariantError
 from model_generation.core.contracts import precondition
 from model_generation.core.types import Joint, Link
 from model_generation.core.validation import ValidationResult
+
+from src.shared.python.contracts import InvariantError
 
 
 @dataclass

--- a/src/shared/python/model_generation/core/contracts.py
+++ b/src/shared/python/model_generation/core/contracts.py
@@ -5,11 +5,16 @@ at ``src/shared/python/contracts.py`` for backward compatibility.
 
 All contract enforcement, decorators, exceptions, convenience functions,
 and condition predicates are defined in the single source of truth.
+
+.. note::
+    Import directly from ``src.shared.python.contracts`` for new code.
+    This shim exists only for backward compatibility within the
+    ``model_generation`` package.
 """
 
 from __future__ import annotations
 
-from contracts import (  # noqa: F401
+from src.shared.python.contracts import (  # noqa: F401
     CONTRACTS_ENABLED,
     ContractViolationError,
     InvariantError,
@@ -28,7 +33,7 @@ from contracts import (  # noqa: F401
     require_unit_vector,
     set_contracts_enabled,
 )
-from contracts import (
+from src.shared.python.contracts import (
     class_invariant as invariant,
 )
 

--- a/src/shared/python/safe_eval.py
+++ b/src/shared/python/safe_eval.py
@@ -33,15 +33,12 @@ import numpy as np
 try:
     from src.shared.python.contracts import require  # noqa: I001
 except ImportError:
-    try:
-        from contracts import require  # type: ignore[no-redef]  # noqa: I001
-    except ImportError:
 
-        def require(condition: bool, *args: object) -> None:  # type: ignore[misc]
-            """Fallback require() when contracts module is unavailable."""
-            if not condition:
-                msg = args[0] if args else "Precondition violated"
-                raise AssertionError(msg)
+    def require(condition: bool, *args: object) -> None:  # type: ignore[misc]
+        """Fallback require() when contracts module is unavailable."""
+        if not condition:
+            msg = args[0] if args else "Precondition violated"
+            raise AssertionError(msg)
 
 
 __all__ = [

--- a/src/shared/python/signal_toolkit/core.py
+++ b/src/shared/python/signal_toolkit/core.py
@@ -11,10 +11,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-try:
-    from src.shared.python.contracts import require
-except ImportError:
-    from contracts import require  # type: ignore[no-redef]
+from src.shared.python.contracts import require
 
 
 @dataclass

--- a/src/shared/python/upstream_drift_tools/data_io.py
+++ b/src/shared/python/upstream_drift_tools/data_io.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from contracts import ensure, require
+from src.shared.python.contracts import ensure, require
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/tools/model_generation/test_dbc_decorators.py
+++ b/tests/unit/tools/model_generation/test_dbc_decorators.py
@@ -16,7 +16,7 @@ import pytest
 # Ensure contracts are enforced during testing
 os.environ["DBC_LEVEL"] = "enforce"
 
-from contracts import ContractViolationError  # noqa: E402
+from src.shared.python.contracts import ContractViolationError  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Sample URDF fixtures
@@ -457,7 +457,7 @@ class TestBaseURDFBuilderInvariants:
 
     def test_check_invariants_dangling_joint_parent(self):
         """Joint referencing nonexistent parent raises InvariantError."""
-        from contracts import InvariantError
+        from src.shared.python.contracts import InvariantError
 
         ConcreteBuilder, Link, Joint, JointType, Origin, Inertia = (
             self._create_concrete_builder()
@@ -481,7 +481,7 @@ class TestBaseURDFBuilderInvariants:
 
     def test_check_invariants_dangling_joint_child(self):
         """Joint referencing nonexistent child raises InvariantError."""
-        from contracts import InvariantError
+        from src.shared.python.contracts import InvariantError
 
         ConcreteBuilder, Link, Joint, JointType, Origin, Inertia = (
             self._create_concrete_builder()
@@ -505,7 +505,7 @@ class TestBaseURDFBuilderInvariants:
 
     def test_check_invariants_duplicate_link_names(self):
         """Duplicate link names raise InvariantError."""
-        from contracts import InvariantError
+        from src.shared.python.contracts import InvariantError
 
         ConcreteBuilder, Link, Joint, JointType, Origin, Inertia = (
             self._create_concrete_builder()
@@ -523,7 +523,7 @@ class TestBaseURDFBuilderInvariants:
 
     def test_check_invariants_duplicate_joint_names(self):
         """Duplicate joint names raise InvariantError."""
-        from contracts import InvariantError
+        from src.shared.python.contracts import InvariantError
 
         ConcreteBuilder, Link, Joint, JointType, Origin, Inertia = (
             self._create_concrete_builder()


### PR DESCRIPTION
## Summary

- Eliminates PYTHONPATH-dependent bare `from contracts import ...` in all domain-specific shims and callers
- `humanoid_character_builder/contracts.py` and `model_generation/core/contracts.py` now use `from src.shared.python.contracts import ...`
- All other callers (`base_builder.py`, `data_io.py`, `signal_toolkit/core.py`, `safe_eval.py`, test file) updated to the same fully-qualified path
- Updated docstring in `src/shared/python/contracts.py` to document its canonical role and relationship to `core/contracts/`

Closes #2077

## Test plan

- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [x] `pytest tests/unit/test_contracts.py tests/unit/dbc/ tests/unit/tools/model_generation/test_dbc_decorators.py tests/unit/launchers/test_mujoco_launcher_env.py` — 555 passed, 13 skipped
- [x] Exception identity checks in `test_dbc_decorators.py` now pass (both shim and test import from the same module object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)