### PR TITLE
perf: add functools.lru_cache/cache to hot-path pure functions

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/club_configurations.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/club_configurations.py
@@ -5,6 +5,7 @@ Provides realistic club specifications for different club types.
 
 from __future__ import annotations
 
+import functools
 import json
 from dataclasses import dataclass
 from typing import Any, cast  # noqa: ICN003
@@ -461,6 +462,7 @@ SHAFT_FLEX_DATA: dict[str, dict[str, Any]] = {
 }
 
 
+@functools.lru_cache(maxsize=256)
 def get_recommended_flex(swing_speed_mph: float) -> str:
     """Get recommended shaft flex for swing speed.
 

--- a/src/shared/python/config/environment.py
+++ b/src/shared/python/config/environment.py
@@ -29,6 +29,7 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import os
 from typing import TypeVar
 
@@ -287,6 +288,7 @@ def get_env_list(
     return items
 
 
+@functools.cache
 def get_environment() -> str:
     """Get the current deployment environment.
 
@@ -451,6 +453,7 @@ def require_env(name: str) -> str:
     return result
 
 
+@functools.cache
 def is_docker() -> bool:
     """Check if running inside a Docker container.
 
@@ -465,6 +468,7 @@ def is_docker() -> bool:
     )
 
 
+@functools.cache
 def is_wsl() -> bool:
     """Check if running in Windows Subsystem for Linux (WSL).
 

--- a/src/shared/python/engine_core/engine_availability.py
+++ b/src/shared/python/engine_core/engine_availability.py
@@ -238,6 +238,7 @@ def get_engine_error(engine_name: str) -> Exception | None:
     return _engine_error_cache.get(engine_name.lower())
 
 
+@functools.lru_cache(maxsize=128)
 def is_engine_available(engine_name: str) -> bool:
     """Check if a physics engine or library is available."""
     return get_engine_status(engine_name) == EngineStatus.AVAILABLE

--- a/src/shared/python/model_generation/inertia/primitives.py
+++ b/src/shared/python/model_generation/inertia/primitives.py
@@ -7,9 +7,11 @@ tensors of common geometric primitives.
 
 from __future__ import annotations
 
+import functools
 import math
 
 
+@functools.lru_cache(maxsize=512)
 def box_inertia(
     mass: float,
     size_x: float,
@@ -46,6 +48,7 @@ def box_inertia(
     }
 
 
+@functools.lru_cache(maxsize=512)
 def cylinder_inertia(
     mass: float,
     radius: float,
@@ -103,6 +106,7 @@ def cylinder_inertia(
     }
 
 
+@functools.lru_cache(maxsize=512)
 def sphere_inertia(mass: float, radius: float) -> dict[str, float]:
     """
     Compute inertia tensor for a solid sphere.
@@ -130,6 +134,7 @@ def sphere_inertia(mass: float, radius: float) -> dict[str, float]:
     }
 
 
+@functools.lru_cache(maxsize=512)
 def capsule_inertia(
     mass: float,
     radius: float,
@@ -214,6 +219,7 @@ def capsule_inertia(
     }
 
 
+@functools.lru_cache(maxsize=512)
 def ellipsoid_inertia(
     mass: float,
     a: float,
@@ -251,6 +257,7 @@ def ellipsoid_inertia(
     }
 
 
+@functools.lru_cache(maxsize=512)
 def hollow_cylinder_inertia(
     mass: float,
     inner_radius: float,
@@ -308,6 +315,7 @@ def hollow_cylinder_inertia(
     }
 
 
+@functools.lru_cache(maxsize=512)
 def cone_inertia(
     mass: float,
     radius: float,


### PR DESCRIPTION
## Summary

Closes #2060.

- `inertia/primitives.py`: Added @functools.lru_cache(maxsize=512) to all 7 primitive inertia formulae. Pure math functions called in loops when building URDF models.
- `engine_core/engine_availability.py`: Added @functools.lru_cache(maxsize=128) to is_engine_available(). Reduces repeated call overhead on every launcher startup.
- `config/environment.py`: Added @functools.cache to get_environment(), is_docker(), and is_wsl(). Stable system state that never changes within a process.
- `club_configurations.py`: Added @functools.lru_cache(maxsize=256) to get_recommended_flex(). Iterates static dict for every swing-speed lookup.

## Test plan

- ruff check and ruff format check pass
- 164 targeted unit tests pass

Generated with Claude Code