### PR TITLE
fix: add coverage.json to .gitignore (closes #2053)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ ruff_report*.txt
 quality_report*.txt
 black_report*.txt
 coverage.xml
+coverage.json
 htmlcov/
 
 # Test output debris (prevent accumulation at root)


### PR DESCRIPTION
## Summary

- Adds \`coverage.json\` to \`.gitignore\` to prevent the 9.9MB generated artifact from being re-introduced into git history
- The file was previously tracked but removed in commit \`d036b9d4\`; \`.gitignore\` was not updated at that time
- \`.gitignore\` already excluded \`coverage.xml\`, \`.coverage\`, and \`htmlcov/\` — this fills the gap for \`coverage.json\`

## Closes

Closes #2053

## Test plan

- [ ] CI passes (no code changes, only \`.gitignore\` update)
- [ ] Verify \`coverage.json\` no longer appears in \`git status\` after a coverage run

🤖 Generated with [Claude Code](https://claude.com/claude-code)