### PR TITLE
fix(api): add /api/v1/ versioning to local server (closes #2070)

### DIFF
--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -4,6 +4,10 @@ Local-first API server for Golf Modeling Suite.
 Runs entirely on localhost with NO authentication required.
 This is the default mode - free, offline, no accounts needed.
 
+API Versioning (#2070):
+    All routes are served under ``/api/v1/`` for forward compatibility.
+    Legacy ``/api/`` routes are also registered for backward compatibility.
+
 Diagnostic Features:
 - /api/diagnostics - JSON diagnostic report
 - /api/diagnostics/html - Browser-friendly diagnostic page
@@ -61,6 +65,10 @@ logger = logging.getLogger(__name__)
 
 logger = get_logger(__name__)
 
+# API versioning constants (#2070)
+API_VERSION = "v1"
+API_PREFIX = f"/api/{API_VERSION}"
+
 
 # Track startup metrics for diagnostics
 _startup_metrics: dict[str, Any] = {
@@ -103,7 +111,22 @@ def _configure_cors(app: FastAPI) -> None:
 
 
 def _register_api_routers(app: FastAPI) -> None:
-    """Register all API route routers on the app."""
+    """Register all API route routers on the app.
+
+    Routes are mounted at both the versioned prefix (``/api/v1/``) and the
+    legacy prefix (``/api/``) to maintain backward compatibility (#2070).
+    """
+    # Versioned routes: /api/v1/... (canonical, forward-compatible)
+    app.include_router(engines.router, prefix=API_PREFIX, tags=["Engines"])
+    app.include_router(simulation.router, prefix=API_PREFIX, tags=["Simulation"])
+    app.include_router(
+        simulation_ws.router, prefix=API_PREFIX, tags=["Simulation WebSocket"]
+    )
+    app.include_router(chat_ws.router, prefix=API_PREFIX, tags=["Chat"])
+    app.include_router(analysis.router, prefix=API_PREFIX, tags=["Analysis"])
+    app.include_router(export.router, prefix=API_PREFIX, tags=["Export"])
+
+    # Legacy routes: /api/... (deprecated aliases for backward compatibility)
     app.include_router(engines.router, prefix="/api", tags=["Engines"])
     app.include_router(simulation.router, prefix="/api", tags=["Simulation"])
     app.include_router(
@@ -565,11 +588,20 @@ def _mount_static_files_and_spa(app: FastAPI) -> None:
 
 
 def create_local_app() -> FastAPI:
-    """Create FastAPI app configured for local use."""
+    """Create FastAPI app configured for local use.
 
+    Routes are registered at both ``/api/v1/`` (versioned, canonical) and
+    ``/api/`` (legacy, deprecated) for backward compatibility (#2070).
+    """
     app = FastAPI(
         title="Golf Modeling Suite",
-        description="Local physics simulation for golf biomechanics",
+        description=(
+            "Local physics simulation for golf biomechanics.\n\n"
+            "## Versioning\n"
+            f"Current API version: **{API_VERSION}**. "
+            f"All endpoints are available under `{API_PREFIX}/` prefix.\n"
+            "Legacy `/api/` routes are maintained for backward compatibility."
+        ),
         version="2.0.0",
         docs_url="/api/docs",  # Swagger UI available locally
         redoc_url="/api/redoc",

--- a/tests/unit/test_local_server_ui_warning.py
+++ b/tests/unit/test_local_server_ui_warning.py
@@ -1,4 +1,4 @@
-"""Tests for local server UI diagnostics."""
+"""Tests for local server UI diagnostics and API versioning (#2070)."""
 
 from __future__ import annotations
 
@@ -34,3 +34,81 @@ def test_local_server_logs_ui_missing(monkeypatch, tmp_path, caplog) -> None:
         for message in local_server._startup_metrics["errors"]
     )
     assert any("UI build not found" in record.message for record in caplog.records)
+
+
+# ── API Versioning Tests ──────────────────────────────────────────
+
+
+def test_api_version_constants() -> None:
+    """Local server exposes API_VERSION and API_PREFIX constants (#2070)."""
+    assert local_server.API_VERSION == "v1"
+    assert local_server.API_PREFIX == "/api/v1"
+
+
+def test_local_app_registers_versioned_routes(monkeypatch, tmp_path) -> None:
+    """create_local_app registers routes under /api/v1/ prefix (#2070)."""
+    missing_ui_path = tmp_path / "ui" / "dist"
+    monkeypatch.setenv("GOLF_UI_DIST", str(missing_ui_path))
+
+    local_server._startup_metrics.update(
+        {
+            "startup_time": None,
+            "static_files_mounted": False,
+            "ui_path": None,
+            "engines_loaded": [],
+            "errors": [],
+        }
+    )
+
+    app = local_server.create_local_app()
+    route_paths = [getattr(r, "path", "") for r in app.routes if hasattr(r, "path")]
+    versioned = [p for p in route_paths if p.startswith("/api/v1/")]
+    assert len(versioned) > 0, (
+        f"No /api/v1/ routes found. Registered paths: {route_paths[:20]}"
+    )
+
+
+def test_local_app_keeps_legacy_routes(monkeypatch, tmp_path) -> None:
+    """create_local_app keeps legacy /api/ routes for backward compatibility (#2070)."""
+    missing_ui_path = tmp_path / "ui" / "dist"
+    monkeypatch.setenv("GOLF_UI_DIST", str(missing_ui_path))
+
+    local_server._startup_metrics.update(
+        {
+            "startup_time": None,
+            "static_files_mounted": False,
+            "ui_path": None,
+            "engines_loaded": [],
+            "errors": [],
+        }
+    )
+
+    app = local_server.create_local_app()
+    route_paths = [getattr(r, "path", "") for r in app.routes if hasattr(r, "path")]
+    # Legacy routes start with /api/ but NOT /api/v1/
+    legacy = [
+        p for p in route_paths if p.startswith("/api/") and not p.startswith("/api/v1/")
+    ]
+    assert len(legacy) > 0, (
+        f"No legacy /api/ routes found. Registered paths: {route_paths[:20]}"
+    )
+
+
+def test_local_app_description_mentions_versioning(monkeypatch, tmp_path) -> None:
+    """FastAPI app description references the API versioning scheme (#2070)."""
+    missing_ui_path = tmp_path / "ui" / "dist"
+    monkeypatch.setenv("GOLF_UI_DIST", str(missing_ui_path))
+
+    local_server._startup_metrics.update(
+        {
+            "startup_time": None,
+            "static_files_mounted": False,
+            "ui_path": None,
+            "engines_loaded": [],
+            "errors": [],
+        }
+    )
+
+    app = local_server.create_local_app()
+    assert "v1" in app.description
+    assert "/api/v1/" in app.description


### PR DESCRIPTION
## Summary

- Adds `API_VERSION = "v1"` and `API_PREFIX = "/api/v1"` constants to `local_server.py` (mirrors the pattern already in `server.py`)
- Updates `_register_api_routers` to mount all 6 routers at both `/api/v1/` (canonical, versioned) and `/api/` (deprecated backward-compat aliases)
- Updates `create_local_app` FastAPI app description to document the versioning scheme and the deprecated legacy routes
- Updates module docstring to reference the versioning strategy per issue recommendation

## Test plan

- [x] `test_api_version_constants` — `API_VERSION == "v1"`, `API_PREFIX == "/api/v1"`
- [x] `test_local_app_registers_versioned_routes` — at least one route path starts with `/api/v1/`
- [x] `test_local_app_keeps_legacy_routes` — at least one route path starts with `/api/` but not `/api/v1/`
- [x] `test_local_app_description_mentions_versioning` — FastAPI description contains `v1` and `/api/v1/`
- [x] All 5 `test_local_server_ui_warning.py` tests pass
- [x] All 36 `test_api_architecture.py` tests pass (server.py already had versioning)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)