### PR TITLE
fix: remove duplicate GRAVITY constant in favor of GRAVITY_FLOAT

### DIFF
--- a/src/api/routes/force_overlays.py
+++ b/src/api/routes/force_overlays.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Depends
 
 from src.api.middleware.error_handler import handle_api_errors
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.core.contracts import precondition
 
 from ..dependencies import get_engine_manager, get_logger
@@ -233,7 +233,7 @@ def _build_gravity_vectors(
             continue
 
         y_pos = 0.5 + i * 0.3
-        gravity_mag = GRAVITY * (0.5 + 0.1 * i)
+        gravity_mag = GRAVITY_FLOAT * (0.5 + 0.1 * i)
         vectors.append(
             ForceVector3D(
                 body_name=body_name,
@@ -338,7 +338,7 @@ def _build_demo_vectors(config: ForceOverlayRequest) -> list[ForceVector3D]:
             )
 
         if "gravity" in config.force_types or "all" in config.force_types:
-            grav_mag = GRAVITY * (1.0 + 0.2 * i)
+            grav_mag = GRAVITY_FLOAT * (1.0 + 0.2 * i)
             vectors.append(
                 ForceVector3D(
                     body_name=body,

--- a/src/engines/common/physics.py
+++ b/src/engines/common/physics.py
@@ -26,7 +26,7 @@ from typing import Protocol
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.core.contracts import postcondition, precondition
 
 # ─── Physical Constants ────────────────────────────────────────────────
@@ -407,7 +407,7 @@ class BallPhysics:
         self.ball = ball or BallProperties()
         self.aero = AerodynamicsCalculator(self.ball, air)
         self.gravity = (
-            gravity if gravity is not None else np.array([0.0, 0.0, -GRAVITY])
+            gravity if gravity is not None else np.array([0.0, 0.0, -GRAVITY_FLOAT])
         )
 
     @precondition(

--- a/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
+++ b/src/engines/physics_engines/drake/python/src/pose_editor_tab.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.engine_core.engine_availability import (
     DRAKE_AVAILABLE,
     PYQT6_AVAILABLE,
@@ -84,7 +84,7 @@ class DrakePoseEditor(BasePoseEditor):
         super().__init__()
         self._plant = plant
         self._context = context
-        self._original_gravity_vector = np.array([0, 0, -GRAVITY])
+        self._original_gravity_vector = np.array([0, 0, -GRAVITY_FLOAT])
         self._update_callback: Any = None
 
         if plant and context:
@@ -360,7 +360,7 @@ class DrakePoseEditor(BasePoseEditor):
     def _get_gravity_magnitude(self) -> float:
         """Get current gravity magnitude."""
         if self._plant is None:
-            return GRAVITY
+            return GRAVITY_FLOAT
 
         gravity = self._plant.gravity_field().gravity_vector()
         return float(np.linalg.norm(gravity))

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.engine_core.engine_availability import (
     PINOCCHIO_AVAILABLE,
     PYQT6_AVAILABLE,
@@ -77,7 +77,7 @@ class PinocchioPoseEditor(BasePoseEditor):
         self._data = data
         self._q = q
         self._v = v
-        self._original_gravity = np.array([0, 0, -GRAVITY])  # type: ignore[assignment]
+        self._original_gravity = np.array([0, 0, -GRAVITY_FLOAT])  # type: ignore[assignment]
         self._update_callback: Any = None
         self._viz: Any = None  # Visualizer reference
 
@@ -346,7 +346,7 @@ class PinocchioPoseEditor(BasePoseEditor):
     def _get_gravity_magnitude(self) -> float:
         """Get current gravity magnitude."""
         if self._model is None:
-            return GRAVITY
+            return GRAVITY_FLOAT
         return float(np.linalg.norm(self._model.gravity.linear))
 
     def update_visualization(self) -> None:

--- a/src/research/deformable/objects.py
+++ b/src/research/deformable/objects.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -469,7 +469,7 @@ class Cable(DeformableObject):
         total_forces = internal_forces + self._external_forces
 
         # Gravity
-        gravity = np.array([0.0, 0.0, -GRAVITY])
+        gravity = np.array([0.0, 0.0, -GRAVITY_FLOAT])
         node_mass = self._material.density * self._total_rest_length / self.n_nodes
         total_forces += node_mass * gravity
 
@@ -649,7 +649,7 @@ class Cloth(DeformableObject):
         total_forces = internal_forces + self._external_forces
 
         # Gravity
-        gravity = np.array([0.0, 0.0, -GRAVITY])
+        gravity = np.array([0.0, 0.0, -GRAVITY_FLOAT])
         node_mass = self._material.density * 0.01  # Assume thin cloth
         total_forces += node_mass * gravity
 

--- a/src/research/mpc/specialized.py
+++ b/src/research/mpc/specialized.py
@@ -12,7 +12,7 @@ from src.research.mpc.controller import (
     ModelPredictiveController,
     MPCResult,
 )
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -78,7 +78,7 @@ class CentroidalMPC(ModelPredictiveController):
 
         # Physical parameters
         self._mass = 50.0  # kg
-        self._gravity = np.array([0, 0, -GRAVITY])
+        self._gravity = np.array([0, 0, -GRAVITY_FLOAT])
 
         # Contact positions (updated from model)
         self._contact_positions: list[NDArray[np.floating]] = [

--- a/src/robotics/locomotion/zmp_computer.py
+++ b/src/robotics/locomotion/zmp_computer.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from src.robotics.core.protocols import HumanoidCapable, RoboticsCapable
-from src.shared.python.core.constants import GRAVITY as _GRAVITY_CONST
+from src.shared.python.core.constants import GRAVITY_FLOAT as _GRAVITY_CONST
 from src.shared.python.core.contracts import ContractChecker
 
 

--- a/src/robotics/sensing/imu_sensor.py
+++ b/src/robotics/sensing/imu_sensor.py
@@ -22,7 +22,7 @@ from src.robotics.sensing.noise_models import (
     CompositeNoise,
     GaussianNoise,
 )
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 
 
 @dataclass
@@ -51,7 +51,7 @@ class IMUSensorConfig:
     accel_bias_drift: float = 0.0001
     gyro_bias_drift: float = 0.00001
     gravity: NDArray[np.float64] = field(
-        default_factory=lambda: np.array([0.0, 0.0, -GRAVITY])
+        default_factory=lambda: np.array([0.0, 0.0, -GRAVITY_FLOAT])
     )
     cutoff_frequency: float = 200.0
     sample_rate: float = 1000.0

--- a/src/shared/python/core/constants.py
+++ b/src/shared/python/core/constants.py
@@ -54,7 +54,6 @@ globals().update({name: getattr(_physics_constants, name) for name in __all__})
 # Pre-computed float values for commonly used constants
 # (Avoids repeated float() conversions from PhysicalConstant in multiple modules)
 GRAVITY_FLOAT: float = float(GRAVITY_M_S2)
-GRAVITY: float = 9.81  # Approximate gravity for general simulation use
 GOLF_BALL_MASS_FLOAT: float = float(GOLF_BALL_MASS_KG)
 GOLF_BALL_RADIUS_FLOAT: float = float(GOLF_BALL_RADIUS_M)
 GOLF_BALL_DIAMETER_FLOAT: float = float(GOLF_BALL_DIAMETER_M)

--- a/src/shared/python/engine_core/mock_engine.py
+++ b/src/shared/python/engine_core/mock_engine.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -326,7 +326,7 @@ class MockPhysicsEngine:
             Gravity force vector (n,)
         """
         g = np.zeros(self.num_joints)
-        g[0] = -GRAVITY  # First joint feels gravity
+        g[0] = -GRAVITY_FLOAT  # First joint feels gravity
         return g
 
     def compute_inverse_dynamics(self, qacc: np.ndarray) -> np.ndarray:

--- a/src/shared/python/physics/terrain_engine.py
+++ b/src/shared/python/physics/terrain_engine.py
@@ -29,7 +29,7 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.physics.terrain import (
     MATERIALS,
@@ -574,7 +574,7 @@ class CompressibleTurfModel:
         terrain_type = self.terrain.get_terrain_type(x, y)
 
         # Ball weight creates compression
-        ball_weight = 0.04593 * GRAVITY  # Golf ball weight in N
+        ball_weight = 0.04593 * GRAVITY_FLOAT  # Golf ball weight in N
 
         # Effective sitting depth based on compression
         max_compression = material.get_max_compression_depth()

--- a/src/shared/python/pose_editor/core.py
+++ b/src/shared/python/pose_editor/core.py
@@ -12,7 +12,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
-from src.shared.python.core.constants import GRAVITY
+from src.shared.python.core.constants import GRAVITY_FLOAT
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -240,7 +240,7 @@ class BasePoseEditor(ABC):
         """Initialize the pose editor."""
         self._state = PoseEditorState()
         self._joint_info: list[JointInfo] = []
-        self._original_gravity: float = GRAVITY
+        self._original_gravity: float = GRAVITY_FLOAT
         self._callbacks: dict[str, list[Any]] = {
             "pose_changed": [],
             "gravity_changed": [],


### PR DESCRIPTION
## Summary
- Removed `GRAVITY: float = 9.81` from `constants.py`, eliminating the dual gravity constant problem
- Updated all 11 consumer files across the codebase to import `GRAVITY_FLOAT` (9.80665, standard gravity) instead of the approximate `GRAVITY` (9.81)
- `zmp_computer.py` used an alias (`GRAVITY as _GRAVITY_CONST`) which was updated to `GRAVITY_FLOAT as _GRAVITY_CONST` -- internal class attribute name unchanged

## Test plan
- [x] Verified ruff check and ruff format pass on all 12 modified files
- [x] ZMP robotics DbC tests pass (test_dbc_zmp_robotics.py)
- [ ] Full CI suite validates no remaining references to removed constant

Closes #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)