### PR TITLE
fix: low-severity batch #2171-#2174

### DIFF
--- a/src/robotics/locomotion/zmp_computer.py
+++ b/src/robotics/locomotion/zmp_computer.py
@@ -11,6 +11,7 @@ Design by Contract:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -20,6 +21,8 @@ from numpy.typing import NDArray
 from src.robotics.core.protocols import HumanoidCapable, RoboticsCapable
 from src.shared.python.core.constants import GRAVITY_FLOAT as _GRAVITY_CONST
 from src.shared.python.core.contracts import ContractChecker
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -281,7 +284,12 @@ class ZMPComputer(ContractChecker):
             if isinstance(engine, HumanoidCapable):
                 return engine.get_com_position()
 
-        # Fallback: use origin
+        # Fallback: use origin — this is a rough default and may produce
+        # inaccurate ZMP results for non-trivial poses.
+        logger.warning(
+            "COM position unavailable from engine; using fallback [0, 0, 1]. "
+            "ZMP accuracy may be degraded."
+        )
         return np.array([0.0, 0.0, 1.0])
 
     def _get_com_velocity(self) -> NDArray[np.float64]:

--- a/src/robotics/sensing/noise_models.py
+++ b/src/robotics/sensing/noise_models.py
@@ -187,7 +187,8 @@ class BandwidthLimitedNoise(NoiseModel):
     Attributes:
         cutoff_frequency: Filter cutoff frequency [Hz].
         sample_rate: Sampling rate [Hz].
-        order: Filter order.
+        order: Filter order (currently unused; only first-order IIR
+            is implemented).
     """
 
     cutoff_frequency: float = 100.0

--- a/src/shared/python/humanoid_character_builder/core/segment_definitions.py
+++ b/src/shared/python/humanoid_character_builder/core/segment_definitions.py
@@ -12,6 +12,7 @@ the URDF kinematic tree.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -47,8 +48,8 @@ class GeometryType(Enum):
 class JointLimits:
     """Joint limits specification."""
 
-    lower: float = -3.14159  # radians
-    upper: float = 3.14159
+    lower: float = -math.pi  # radians
+    upper: float = math.pi
     effort: float = 100.0  # N*m
     velocity: float = 10.0  # rad/s
 

--- a/src/shared/python/humanoid_character_builder/mesh/inertia_calculator.py
+++ b/src/shared/python/humanoid_character_builder/mesh/inertia_calculator.py
@@ -16,6 +16,7 @@ using the trimesh library. It supports:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -147,14 +148,16 @@ class InertiaResult:
         (zero-size) geometry. Volume is set to a small non-zero value to
         prevent downstream division-by-zero in density calculations.
         """
-        # Default to 0.1 kg*m^2 (reasonable for small-medium rigid body)
+        # Default inertia: 0.1 * mass [kg*m^2].  This is a conservative
+        # fallback for degenerate geometry; for better accuracy, scale by
+        # actual segment dimensions (I ~ m * r^2).
         if not (mass is not None):
             raise ValueError("mass must be provided")
         if not (mass is not None):
             raise ValueError("mass must be provided")
         i_default = 0.1 * mass
         # Use volume of a sphere with 1 cm radius as minimum (~4.2e-6 m³)
-        _min_volume = (4.0 / 3.0) * 3.14159265358979 * (0.01**3)
+        _min_volume = (4.0 / 3.0) * math.pi * (0.01**3)
         return cls(
             ixx=i_default,
             iyy=i_default,

--- a/src/shared/python/model_generation/core/constants.py
+++ b/src/shared/python/model_generation/core/constants.py
@@ -36,8 +36,9 @@ FAT_DENSITY_KG_M3: float = 900.0
 # Default density for mesh-based inertia calculation (kg/m^3)
 DEFAULT_DENSITY_KG_M3: float = TISSUE_DENSITY_KG_M3
 
-# Default inertia value when not specified (kg*m^2)
-# Suitable for small to medium rigid bodies
+# Default inertia value when not specified (kg*m^2).
+# This is a conservative fallback for small to medium rigid bodies.
+# For better accuracy, scale by segment mass: I ~ 0.1 * m_segment.
 DEFAULT_INERTIA_KG_M2: float = 0.1
 
 # Default minimum mass for intermediate/virtual links (kg)


### PR DESCRIPTION
## Summary
- **#2171**: Replace hardcoded `3.14159...` literals with `math.pi` in `inertia_calculator.py` and `segment_definitions.py`.
- **#2172**: Document that `BandwidthLimitedNoise.order` parameter is currently unused (only first-order IIR is implemented).
- **#2173**: Add comments noting default inertia fallback (0.1) is conservative and should be scaled by segment mass for accuracy.
- **#2174**: Add `logger.warning()` when ZMP computer falls back to `[0, 0, 1]` COM position.

## Test plan
- [ ] CI passes (ruff check, ruff format, pytest)
- [ ] No behavioral changes -- only documentation, warnings, and constant replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)