### PR TITLE
fix: pin mypy to ==1.13.0 and update setup-node for fleet consistency

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
-      - run: pip install ruff==0.14.10 mypy>=1.15.0 bandit==1.7.7 pydocstyle==6.3.0
+      - run: pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pydocstyle==6.3.0
 
       # FIX: Less aggressive Ruff (Errors, Warnings, Imports only)
       - name: Lint
@@ -278,7 +278,7 @@ jobs:
         working-directory: ./ui
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"


### PR DESCRIPTION
## Summary
- Pin mypy from >=1.15.0 to ==1.13.0 to match fleet-wide version standard
- Update setup-node @v4 -> @v6

## Test plan
- [ ] CI standard workflow passes with pinned mypy version
- [ ] Frontend tests work with setup-node@v6

🤖 Generated with [Claude Code](https://claude.com/claude-code)