### PR TITLE
Fix BandwidthLimitedNoise to respect order parameter

### DIFF
--- a/src/robotics/sensing/noise_models.py
+++ b/src/robotics/sensing/noise_models.py
@@ -187,20 +187,23 @@ class BandwidthLimitedNoise(NoiseModel):
     cutoff_frequency: float = 100.0
     sample_rate: float = 1000.0
     order: int = 2
-    _filter_state: NDArray[np.float64] | None = field(
-        init=False, repr=False, default=None
+    _filter_states: list[NDArray[np.float64] | None] = field(
+        init=False, repr=False, default_factory=list
     )
     _alpha: float = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Initialize filter coefficient."""
+        """Initialize filter coefficient and per-stage states."""
+        if self.order < 1:
+            raise ValueError("order must be >= 1")
         # Simple first-order IIR approximation
         dt = 1.0 / self.sample_rate
         tau = 1.0 / (2 * np.pi * self.cutoff_frequency)
         self._alpha = dt / (tau + dt)
+        self._filter_states = [None] * self.order
 
     def apply(self, signal: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Apply low-pass filter to signal.
+        """Apply nth-order low-pass filter by chaining first-order stages.
 
         Args:
             signal: Input signal.
@@ -210,19 +213,23 @@ class BandwidthLimitedNoise(NoiseModel):
         """
         if not (signal is not None):
             raise ValueError("signal must be provided")
-        if self._filter_state is None:
-            self._filter_state = signal.copy()
-            return signal.copy()
 
-        # First-order IIR filter: y = alpha * x + (1-alpha) * y_prev
-        self._filter_state = (
-            self._alpha * signal + (1 - self._alpha) * self._filter_state
-        )
-        return self._filter_state.copy()
+        result = signal.copy()
+        for stage in range(self.order):
+            if self._filter_states[stage] is None:
+                self._filter_states[stage] = result.copy()
+            else:
+                # First-order IIR filter: y = alpha * x + (1-alpha) * y_prev
+                self._filter_states[stage] = (
+                    self._alpha * result
+                    + (1 - self._alpha) * self._filter_states[stage]
+                )
+                result = self._filter_states[stage].copy()
+        return result
 
     def reset(self) -> None:
         """Reset filter state."""
-        self._filter_state = None
+        self._filter_states = [None] * self.order
 
 
 @dataclass

--- a/tests/unit/robotics/test_sensing.py
+++ b/tests/unit/robotics/test_sensing.py
@@ -137,6 +137,33 @@ class TestNoiseModels:
         assert outputs[1] < 1.0  # Not instant
         assert outputs[-1] > 0.9  # Eventually reaches target
 
+    def test_bandwidth_limited_noise_order2_slower_than_order1(self) -> None:
+        """Higher-order filter has steeper roll-off / slower step response."""
+        order1 = BandwidthLimitedNoise(
+            cutoff_frequency=10.0, sample_rate=100.0, order=1
+        )
+        order2 = BandwidthLimitedNoise(
+            cutoff_frequency=10.0, sample_rate=100.0, order=2
+        )
+
+        outputs1: list[float] = []
+        outputs2: list[float] = []
+        for i in range(50):
+            signal = np.array([1.0]) if i > 0 else np.array([0.0])
+            outputs1.append(order1.apply(signal)[0])
+            outputs2.append(order2.apply(signal)[0])
+
+        arr1 = np.array(outputs1)
+        arr2 = np.array(outputs2)
+
+        # 2nd-order filter should respond more slowly to a step than 1st-order
+        # at early samples, the 2nd-order output must lag behind the 1st-order
+        assert arr2[3] < arr1[3], (
+            "order=2 filter should be slower than order=1 at early samples"
+        )
+        # Both should eventually converge toward 1.0
+        assert arr2[-1] > 0.8
+
     def test_composite_noise(self) -> None:
         """Test composite noise applies all models."""
         composite = CompositeNoise(


### PR DESCRIPTION
## Summary
- **Bug**: `BandwidthLimitedNoise.apply()` ignored the `order` parameter and always ran a single first-order IIR stage, regardless of the requested filter order.
- **Fix**: Chains `order` first-order IIR stages so that higher-order filters produce the expected steeper roll-off. Also validates `order >= 1`.
- **Test**: Adds `test_bandwidth_limited_noise_order2_slower_than_order1` verifying that order=2 has a slower step response than order=1.

## Test plan
- [x] Existing `test_bandwidth_limited_noise` still passes (default order=2 now actually filters at 2nd order)
- [x] New test confirms order=2 lags behind order=1 on a step input
- [x] All 34 tests in `test_sensing.py` pass
- [x] Ruff lint and format clean

Closes #2172

🤖 Generated with [Claude Code](https://claude.com/claude-code)