### PR TITLE
fix: replace hardcoded pi literals with math.pi (#2171)

### DIFF
--- a/src/engines/physics_engines/drake/python/src/drake_ui_mixin.py
+++ b/src/engines/physics_engines/drake/python/src/drake_ui_mixin.py
@@ -10,6 +10,7 @@ from DrakeSimApp (drake_gui_app.py).
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any
 
 from src.shared.python.engine_core.engine_availability import (
@@ -47,8 +48,8 @@ except ImportError:
     LivePlotWidget = None  # type: ignore[misc, assignment]
 
 # Constants
-JOINT_ANGLE_MIN_RAD = -3.141592653589793
-JOINT_ANGLE_MAX_RAD = 3.141592653589793
+JOINT_ANGLE_MIN_RAD = -math.pi
+JOINT_ANGLE_MAX_RAD = math.pi
 SPINBOX_STEP_RAD = 0.01
 SLIDER_TO_RADIAN = 0.01
 SLIDER_RANGE_MIN = -314

--- a/src/shared/python/humanoid_character_builder/core/segment_definitions.py
+++ b/src/shared/python/humanoid_character_builder/core/segment_definitions.py
@@ -12,6 +12,7 @@ the URDF kinematic tree.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -47,8 +48,8 @@ class GeometryType(Enum):
 class JointLimits:
     """Joint limits specification."""
 
-    lower: float = -3.14159  # radians
-    upper: float = 3.14159
+    lower: float = -math.pi  # radians
+    upper: float = math.pi
     effort: float = 100.0  # N*m
     velocity: float = 10.0  # rad/s
 

--- a/src/shared/python/humanoid_character_builder/mesh/inertia_calculator.py
+++ b/src/shared/python/humanoid_character_builder/mesh/inertia_calculator.py
@@ -16,6 +16,7 @@ using the trimesh library. It supports:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -152,7 +153,7 @@ class InertiaResult:
             raise ValueError("mass must be provided")
         i_default = 0.1 * mass
         # Use volume of a sphere with 1 cm radius as minimum (~4.2e-6 m³)
-        _min_volume = (4.0 / 3.0) * 3.14159265358979 * (0.01**3)
+        _min_volume = (4.0 / 3.0) * math.pi * (0.01**3)
         return cls(
             ixx=i_default,
             iyy=i_default,


### PR DESCRIPTION
## Summary
- Replace `3.14159265358979` with `math.pi` in `inertia_calculator.py`
- Replace `3.14159` defaults with `math.pi` in `segment_definitions.py` JointLimits
- Replace `3.141592653589793` constants with `math.pi` in `drake_ui_mixin.py`

Closes #2171

## Test plan
- [ ] Verify `ruff check` passes
- [ ] Verify `ruff format --check` passes
- [ ] Verify existing tests pass (no behavioral change — math.pi is more precise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)