### PR TITLE
fix: add .env to .gitignore to prevent accidental secret commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Environment secrets
+.env
+.env.*
+!.env.example
+!.env.docker.example
+!.env.*.example
+
 # Merge conflict artifacts
 *.ours
 *.theirs


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.*` patterns to `.gitignore` to prevent accidental commits of environment files containing secrets
- Preserve tracked `.env.example` and `.env.docker.example` template files via negation patterns

Closes #2233

## Test plan
- [ ] Verify `.env` and `.env.local` etc. are ignored by git
- [ ] Verify `.env.example` and `.env.docker.example` remain tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)