### PR TITLE
Expand CI test matrix to Python 3.10-3.12

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 20 # Prevent runaway tests - hard cutoff
     strategy:
       matrix:
-        python: ["3.11"]
+        python: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
       - name: Install System Dependencies


### PR DESCRIPTION
## Summary
- Expands the CI test matrix from Python 3.11 only to include 3.10, 3.11, and 3.12
- Aligns CI coverage with the `pyproject.toml` classifiers and `requires-python >= 3.10`

Closes #2237

## Test plan
- [ ] CI runs pass on all three Python versions (3.10, 3.11, 3.12)
- [ ] No regressions in existing test suite

Note: The CI workflow has `paths-ignore: .github/**` on push/PR triggers, so CI may need to be triggered manually via workflow_dispatch for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)