### PR TITLE
fix(ci): raise coverage threshold from 10% to 30%

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -193,7 +193,7 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
             --cov-config=pyproject.toml \
-            --cov-fail-under=10 \
+            --cov-fail-under=30 \
             --tb=short \
             -v
 


### PR DESCRIPTION
## Summary

- Raises `--cov-fail-under` in `.github/workflows/ci-standard.yml` from `10` to `30`
- The 10% threshold provided no meaningful regression protection; `pyproject.toml` already targets `fail_under = 45`
- 30% is an intermediate ratchet step toward the 45% target

## Test plan
- [x] Single-line change to CI workflow — no functional code modified
- [x] New threshold (30%) aligns with the phased coverage recovery plan

Closes #2234