### PR TITLE
[codex] decompose humanoid URDF generator

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -89,6 +89,12 @@ UpstreamDrift/
 │   │   ├── validators.py           # Shared validation logic
 │   │   ├── utilities.py            # Helper functions
 │   │   └── exceptions.py           # Exception definitions
+│   │   └── python/
+│   │       └── humanoid_character_builder/
+│   │           └── generators/
+│   │               ├── urdf_generator.py      # Public humanoid URDF generator orchestration
+│   │               ├── _urdf_model_builder.py # Internal link/joint/model assembly helpers
+│   │               └── _urdf_xml_writer.py    # Internal URDF XML emission helpers
 │   └── tools/                      # Development and analysis tools
 │       ├── analysis_tools.py       # Biomechanical analysis utilities
 │       └── validation_tools.py     # Cross-engine validation
@@ -147,6 +153,7 @@ UpstreamDrift/
 | Rust Physics Kernels     | `rust_core/upstream-physics/`                     | High-performance compiled physics routines for critical paths                               |
 | Configuration Manager    | `src/config/`                                     | Centralized configuration loading, validation, and environment management                   |
 | Shared Utilities         | `src/shared/`                                     | Cross-engine validators, helpers, and exception definitions                                 |
+| Humanoid URDF Generator  | `src/shared/python/humanoid_character_builder/generators/` | Generates humanoid URDFs via a thin public orchestrator backed by focused model-building and XML-emission helpers |
 | URDF Models              | `shared/models/`                                  | Canonical model definitions (URDF format) for golf swings, human body, pendulums            |
 
 ## 5. Desired Functionality

--- a/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
+++ b/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
@@ -1,0 +1,374 @@
+"""Internal helpers for humanoid URDF model assembly."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from humanoid_character_builder.core.anthropometry import get_com_location
+from humanoid_character_builder.core.model import GeneratedJoint, GeneratedLink
+from humanoid_character_builder.core.segment_definitions import (
+    GeometryType,
+    JointDefinition,
+    JointType,
+    SegmentDefinition,
+)
+from humanoid_character_builder.mesh.inertia_calculator import (
+    InertiaMode,
+    InertiaResult,
+    MeshInertiaCalculator,
+)
+from humanoid_character_builder.mesh.primitive_inertia import (
+    PrimitiveInertiaCalculator,
+    estimate_segment_primitive,
+)
+
+if TYPE_CHECKING:
+    from humanoid_character_builder.core.body_parameters import BodyParameters
+    from humanoid_character_builder.generators.urdf_generator import URDFGeneratorConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class URDFModelBuilder:
+    """Assemble generated links, joints, and materials for humanoid URDF output."""
+
+    def __init__(
+        self,
+        config: URDFGeneratorConfig,
+        mesh_inertia_calc: MeshInertiaCalculator,
+        primitive_inertia_calc: PrimitiveInertiaCalculator,
+        links: dict[str, GeneratedLink],
+        joints: list[GeneratedJoint],
+        materials: dict[str, tuple[float, float, float, float]],
+    ) -> None:
+        self.config = config
+        self.mesh_inertia_calc = mesh_inertia_calc
+        self.primitive_inertia_calc = primitive_inertia_calc
+        self.links = links
+        self.joints = joints
+        self.materials = materials
+
+    def apply_proportion_factors(
+        self,
+        dimensions: dict[str, dict[str, float]],
+        params: BodyParameters,
+    ) -> dict[str, dict[str, float]]:
+        """Apply body proportion factors to segment dimensions."""
+        if not (dimensions is not None):
+            raise ValueError("dimensions must be provided")
+        scaled = {}
+
+        for seg_name, dims in dimensions.items():
+            scaled_dims = dims.copy()
+            seg_lower = seg_name.lower()
+
+            if "arm" in seg_lower or "hand" in seg_lower:
+                scaled_dims["length"] *= params.arm_length_factor
+            elif "thigh" in seg_lower or "shin" in seg_lower or "foot" in seg_lower:
+                scaled_dims["length"] *= params.leg_length_factor
+            elif "thorax" in seg_lower or "lumbar" in seg_lower:
+                scaled_dims["length"] *= params.torso_length_factor
+                scaled_dims["width"] *= params.shoulder_width_factor
+            elif "pelvis" in seg_lower:
+                scaled_dims["width"] *= params.hip_width_factor
+            elif "head" in seg_lower:
+                for key in scaled_dims:
+                    scaled_dims[key] *= params.head_scale_factor
+            elif "neck" in seg_lower:
+                scaled_dims["length"] *= params.neck_length_factor
+
+            width_factor = 1.0 + 0.2 * params.muscularity + 0.3 * params.body_fat_factor
+            scaled_dims["width"] = scaled_dims.get("width", 0.05) * width_factor
+            scaled_dims["depth"] = scaled_dims.get("depth", 0.05) * width_factor
+
+            seg_params = params.get_segment_params(seg_name)
+            scale = seg_params.scale.as_tuple()
+            scaled_dims["width"] *= scale[0]
+            scaled_dims["depth"] *= scale[1]
+            scaled_dims["length"] *= scale[2]
+
+            scaled[seg_name] = scaled_dims
+
+        return scaled
+
+    def generate_materials(self, params: BodyParameters) -> None:
+        """Populate reusable material definitions."""
+        if not (params is not None):
+            raise ValueError("params must be provided")
+        self.materials["skin"] = params.appearance.skin_tone.as_tuple()
+        self.materials["default"] = (0.7, 0.7, 0.7, 1.0)
+
+    def generate_link(
+        self,
+        segment_name: str,
+        segment_def: SegmentDefinition,
+        params: BodyParameters,
+        mass: float,
+        dimensions: dict[str, float],
+        gender_factor: float,
+        mesh_dir: Path | str | None,
+    ) -> None:
+        """Generate a single URDF link."""
+        if not (segment_name is not None):
+            raise ValueError("segment_name must be provided")
+        seg_params = params.get_segment_params(segment_name)
+        final_mass = seg_params.mass_kg if seg_params.has_mass_override() else mass
+
+        inertia = self.compute_segment_inertia(
+            segment_name,
+            segment_def,
+            seg_params,
+            final_mass,
+            dimensions,
+            gender_factor,
+            mesh_dir,
+        )
+
+        visual_geom = self.create_geometry_dict(
+            segment_def,
+            dimensions,
+            is_collision=False,
+        )
+        collision_geom = None
+        if self.config.generate_collision:
+            collision_geom = self.create_geometry_dict(
+                segment_def,
+                dimensions,
+                is_collision=True,
+            )
+
+        length = dimensions.get("length", 0.1)
+        com = get_com_location(segment_name, length, gender_factor)
+
+        self.links[segment_name] = GeneratedLink(
+            name=segment_name,
+            mass=final_mass,
+            inertia=inertia,
+            visual_geometry=visual_geom,
+            collision_geometry=collision_geom,
+            origin_xyz=com,
+            origin_rpy=(0.0, 0.0, 0.0),
+        )
+
+    def compute_segment_inertia(
+        self,
+        segment_name: str,
+        segment_def: SegmentDefinition,
+        seg_params: Any,
+        mass: float,
+        dimensions: dict[str, float],
+        gender_factor: float,
+        mesh_dir: Path | str | None,
+    ) -> InertiaResult:
+        """Compute inertia for a segment."""
+        del segment_def, gender_factor
+        if not (segment_name is not None):
+            raise ValueError("segment_name must be provided")
+        if seg_params.has_inertia_override():
+            override = seg_params.inertia_override
+            return MeshInertiaCalculator.create_manual_inertia(
+                ixx=override.get("ixx", 0.01),
+                iyy=override.get("iyy", 0.01),
+                izz=override.get("izz", 0.01),
+                mass=mass,
+                ixy=override.get("ixy", 0.0),
+                ixz=override.get("ixz", 0.0),
+                iyz=override.get("iyz", 0.0),
+            )
+
+        if (
+            self.config.inertia_mode
+            in (InertiaMode.MESH_UNIFORM_DENSITY, InertiaMode.MESH_SPECIFIED_MASS)
+            and mesh_dir
+        ):
+            mesh_path = Path(mesh_dir) / f"{segment_name}.stl"
+            if mesh_path.exists():
+                try:
+                    if self.config.inertia_mode == InertiaMode.MESH_SPECIFIED_MASS:
+                        return self.mesh_inertia_calc.compute_from_mesh(
+                            mesh_path,
+                            mass=mass,
+                        )
+                    return self.mesh_inertia_calc.compute_from_mesh(mesh_path)
+                except (KeyError, TypeError, ValueError) as exc:
+                    logger.warning(
+                        "Mesh inertia calculation failed for %s: %s",
+                        segment_name,
+                        exc,
+                    )
+
+        length = dimensions.get("length", 0.1)
+        width = dimensions.get("width", 0.05)
+        depth = dimensions.get("depth", 0.05)
+        shape, shape_dims = estimate_segment_primitive(segment_name, length, width, depth)
+        return self.primitive_inertia_calc.compute(shape, mass, shape_dims)
+
+    def create_geometry_dict(
+        self,
+        segment_def: SegmentDefinition,
+        dimensions: dict[str, float],
+        is_collision: bool,
+    ) -> dict[str, Any]:
+        """Create a normalized geometry specification dictionary."""
+        if not (segment_def is not None):
+            raise ValueError("segment_def must be provided")
+        geom_spec = (
+            segment_def.get_collision_geometry()
+            if is_collision
+            else segment_def.visual_geometry
+        )
+
+        length = dimensions.get("length", 0.1)
+        width = dimensions.get("width", 0.05)
+        depth = dimensions.get("depth", 0.05)
+
+        if geom_spec.geometry_type == GeometryType.BOX:
+            return {"type": "box", "size": (width, depth, length)}
+        if geom_spec.geometry_type == GeometryType.CYLINDER:
+            return {
+                "type": "cylinder",
+                "radius": (width + depth) / 4,
+                "length": length,
+            }
+        if geom_spec.geometry_type == GeometryType.SPHERE:
+            return {"type": "sphere", "radius": length / 2}
+        if geom_spec.geometry_type == GeometryType.CAPSULE:
+            radius = (width + depth) / 4
+            return {
+                "type": "cylinder",
+                "radius": radius,
+                "length": max(0.01, length - 2 * radius),
+            }
+        if geom_spec.geometry_type == GeometryType.MESH:
+            return {
+                "type": "mesh",
+                "filename": geom_spec.mesh_path,
+                "scale": geom_spec.mesh_scale,
+            }
+        return {"type": "box", "size": (width, depth, length)}
+
+    def generate_joint(
+        self,
+        joint_name: str,
+        joint_def: JointDefinition,
+        dimensions: dict[str, dict[str, float]],
+    ) -> None:
+        """Generate URDF joints from a joint definition."""
+        del dimensions
+        if joint_def.is_composite() and self.config.expand_composite_joints:
+            self.expand_composite_joint(joint_name, joint_def)
+        else:
+            self.generate_single_joint(joint_name, joint_def)
+
+    def generate_single_joint(
+        self,
+        joint_name: str,
+        joint_def: JointDefinition,
+    ) -> None:
+        """Generate a single URDF joint."""
+        if not (joint_name is not None):
+            raise ValueError("joint_name must be provided")
+
+        urdf_type = map_joint_type(joint_def.joint_type)
+        limits = None
+        if urdf_type in ("revolute", "prismatic"):
+            limits = joint_def.limits.as_dict()
+
+        self.joints.append(
+            GeneratedJoint(
+                name=joint_name,
+                joint_type=urdf_type,
+                parent=joint_def.parent_segment,
+                child=joint_def.child_segment,
+                origin_xyz=joint_def.origin_xyz,
+                origin_rpy=joint_def.origin_rpy,
+                axis=joint_def.axis,
+                limits=limits,
+                dynamics={
+                    "damping": joint_def.damping,
+                    "friction": joint_def.friction,
+                },
+            )
+        )
+
+    def expand_composite_joint(
+        self,
+        joint_name: str,
+        joint_def: JointDefinition,
+    ) -> None:
+        """Expand a composite joint into URDF-compatible revolute joints."""
+        if not (joint_name is not None):
+            raise ValueError("joint_name must be provided")
+
+        if joint_def.joint_type == JointType.GIMBAL:
+            axes = [
+                joint_def.axis,
+                joint_def.secondary_axis or (0.0, 1.0, 0.0),
+                joint_def.tertiary_axis or (1.0, 0.0, 0.0),
+            ]
+            suffixes = ["_z", "_y", "_x"]
+        elif joint_def.joint_type == JointType.UNIVERSAL:
+            axes = [
+                joint_def.axis,
+                joint_def.secondary_axis or (0.0, 1.0, 0.0),
+            ]
+            suffixes = ["_1", "_2"]
+        else:
+            self.generate_single_joint(joint_name, joint_def)
+            return
+
+        parent = joint_def.parent_segment
+        for index, (axis, suffix) in enumerate(zip(axes, suffixes, strict=True)):
+            is_last = index == len(axes) - 1
+            child = joint_def.child_segment if is_last else f"{joint_name}{suffix}_link"
+
+            if not is_last:
+                self.links[child] = GeneratedLink(
+                    name=child,
+                    mass=0.001,
+                    inertia=InertiaResult.create_default(0.001),
+                    visual_geometry={"type": "sphere", "radius": 0.001},
+                    collision_geometry=None,
+                    origin_xyz=(0.0, 0.0, 0.0),
+                    origin_rpy=(0.0, 0.0, 0.0),
+                )
+
+            self.joints.append(
+                GeneratedJoint(
+                    name=f"{joint_name}{suffix}",
+                    joint_type="revolute",
+                    parent=parent,
+                    child=child,
+                    origin_xyz=joint_def.origin_xyz if index == 0 else (0.0, 0.0, 0.0),
+                    origin_rpy=joint_def.origin_rpy if index == 0 else (0.0, 0.0, 0.0),
+                    axis=axis,
+                    limits=joint_def.limits.as_dict(),
+                    dynamics={
+                        "damping": joint_def.damping,
+                        "friction": joint_def.friction,
+                    },
+                )
+            )
+
+            parent = child
+
+
+def map_joint_type(joint_type: JointType) -> str:
+    """Map internal joint types to URDF joint type strings."""
+    if not (joint_type is not None):
+        raise ValueError("joint_type must be provided")
+    mapping = {
+        JointType.FIXED: "fixed",
+        JointType.REVOLUTE: "revolute",
+        JointType.CONTINUOUS: "continuous",
+        JointType.PRISMATIC: "prismatic",
+        JointType.FLOATING: "floating",
+        JointType.PLANAR: "planar",
+        JointType.UNIVERSAL: "revolute",
+        JointType.GIMBAL: "revolute",
+        JointType.SPHERICAL: "revolute",
+    }
+    return mapping.get(joint_type, "fixed")

--- a/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
+++ b/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
@@ -203,7 +203,9 @@ class URDFModelBuilder:
         length = dimensions.get("length", 0.1)
         width = dimensions.get("width", 0.05)
         depth = dimensions.get("depth", 0.05)
-        shape, shape_dims = estimate_segment_primitive(segment_name, length, width, depth)
+        shape, shape_dims = estimate_segment_primitive(
+            segment_name, length, width, depth
+        )
         return self.primitive_inertia_calc.compute(shape, mass, shape_dims)
 
     def create_geometry_dict(

--- a/src/shared/python/humanoid_character_builder/generators/_urdf_xml_writer.py
+++ b/src/shared/python/humanoid_character_builder/generators/_urdf_xml_writer.py
@@ -118,7 +118,9 @@ class URDFXMLWriter:
         """Append a URDF joint element."""
         if not (root is not None):
             raise ValueError("root must be provided")
-        joint_elem = ET.SubElement(root, "joint", name=joint.name, type=joint.joint_type)
+        joint_elem = ET.SubElement(
+            root, "joint", name=joint.name, type=joint.joint_type
+        )
         ET.SubElement(joint_elem, "parent", link=joint.parent)
         ET.SubElement(joint_elem, "child", link=joint.child)
         ET.SubElement(

--- a/src/shared/python/humanoid_character_builder/generators/_urdf_xml_writer.py
+++ b/src/shared/python/humanoid_character_builder/generators/_urdf_xml_writer.py
@@ -1,0 +1,154 @@
+"""Internal helpers for URDF XML serialization."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Any
+
+from humanoid_character_builder.core.model import GeneratedJoint, GeneratedLink
+
+if TYPE_CHECKING:
+    from humanoid_character_builder.generators.urdf_generator import URDFGeneratorConfig
+
+
+class URDFXMLWriter:
+    """Serialize generated humanoid model data into URDF XML."""
+
+    def __init__(self, config: URDFGeneratorConfig) -> None:
+        self.config = config
+
+    def build_urdf_xml(
+        self,
+        robot_name: str,
+        materials: dict[str, tuple[float, float, float, float]],
+        links: dict[str, GeneratedLink],
+        joints: list[GeneratedJoint],
+    ) -> str:
+        """Build the complete URDF XML document."""
+        if not (robot_name is not None):
+            raise ValueError("robot_name must be provided")
+        root = ET.Element("robot", name=robot_name)
+
+        for material_name, rgba in materials.items():
+            material = ET.SubElement(root, "material", name=material_name)
+            ET.SubElement(
+                material,
+                "color",
+                rgba=f"{rgba[0]:.4f} {rgba[1]:.4f} {rgba[2]:.4f} {rgba[3]:.4f}",
+            )
+
+        for link in links.values():
+            self.add_link_element(root, link)
+
+        for joint in joints:
+            self.add_joint_element(root, joint)
+
+        if self.config.pretty_print:
+            ET.indent(root, space=self.config.indent)
+        return ET.tostring(root, encoding="unicode")
+
+    def add_link_element(self, root: ET.Element, link: GeneratedLink) -> None:
+        """Append a URDF link element."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        link_elem = ET.SubElement(root, "link", name=link.name)
+
+        inertial = ET.SubElement(link_elem, "inertial")
+        ET.SubElement(
+            inertial,
+            "origin",
+            xyz=f"{link.origin_xyz[0]:.6f} {link.origin_xyz[1]:.6f} {link.origin_xyz[2]:.6f}",
+            rpy=f"{link.origin_rpy[0]:.6f} {link.origin_rpy[1]:.6f} {link.origin_rpy[2]:.6f}",
+        )
+        ET.SubElement(inertial, "mass", value=f"{link.mass:.6f}")
+        ET.SubElement(
+            inertial,
+            "inertia",
+            ixx=f"{link.inertia.ixx:.8f}",
+            ixy=f"{link.inertia.ixy:.8f}",
+            ixz=f"{link.inertia.ixz:.8f}",
+            iyy=f"{link.inertia.iyy:.8f}",
+            iyz=f"{link.inertia.iyz:.8f}",
+            izz=f"{link.inertia.izz:.8f}",
+        )
+
+        visual = ET.SubElement(link_elem, "visual")
+        ET.SubElement(visual, "origin", xyz="0 0 0", rpy="0 0 0")
+        self.add_geometry_element(visual, link.visual_geometry)
+        ET.SubElement(visual, "material", name="skin")
+
+        if link.collision_geometry:
+            collision = ET.SubElement(link_elem, "collision")
+            ET.SubElement(collision, "origin", xyz="0 0 0", rpy="0 0 0")
+            self.add_geometry_element(collision, link.collision_geometry)
+
+    def add_geometry_element(self, parent: ET.Element, geom: dict[str, Any]) -> None:
+        """Append a URDF geometry element."""
+        if not (parent is not None):
+            raise ValueError("parent must be provided")
+        geometry = ET.SubElement(parent, "geometry")
+
+        geom_type = geom["type"]
+        if geom_type == "box":
+            size = geom["size"]
+            ET.SubElement(
+                geometry,
+                "box",
+                size=f"{size[0]:.6f} {size[1]:.6f} {size[2]:.6f}",
+            )
+        elif geom_type == "cylinder":
+            ET.SubElement(
+                geometry,
+                "cylinder",
+                radius=f"{geom['radius']:.6f}",
+                length=f"{geom['length']:.6f}",
+            )
+        elif geom_type == "sphere":
+            ET.SubElement(geometry, "sphere", radius=f"{geom['radius']:.6f}")
+        elif geom_type == "mesh":
+            scale = geom.get("scale", (1.0, 1.0, 1.0))
+            ET.SubElement(
+                geometry,
+                "mesh",
+                filename=geom["filename"],
+                scale=f"{scale[0]:.6f} {scale[1]:.6f} {scale[2]:.6f}",
+            )
+
+    def add_joint_element(self, root: ET.Element, joint: GeneratedJoint) -> None:
+        """Append a URDF joint element."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        joint_elem = ET.SubElement(root, "joint", name=joint.name, type=joint.joint_type)
+        ET.SubElement(joint_elem, "parent", link=joint.parent)
+        ET.SubElement(joint_elem, "child", link=joint.child)
+        ET.SubElement(
+            joint_elem,
+            "origin",
+            xyz=f"{joint.origin_xyz[0]:.6f} {joint.origin_xyz[1]:.6f} {joint.origin_xyz[2]:.6f}",
+            rpy=f"{joint.origin_rpy[0]:.6f} {joint.origin_rpy[1]:.6f} {joint.origin_rpy[2]:.6f}",
+        )
+
+        if joint.joint_type != "fixed":
+            ET.SubElement(
+                joint_elem,
+                "axis",
+                xyz=f"{joint.axis[0]:.6f} {joint.axis[1]:.6f} {joint.axis[2]:.6f}",
+            )
+
+        if joint.limits and joint.joint_type in ("revolute", "prismatic"):
+            ET.SubElement(
+                joint_elem,
+                "limit",
+                lower=f"{joint.limits['lower']:.6f}",
+                upper=f"{joint.limits['upper']:.6f}",
+                effort=f"{joint.limits['effort']:.2f}",
+                velocity=f"{joint.limits['velocity']:.2f}",
+            )
+
+        if joint.dynamics:
+            ET.SubElement(
+                joint_elem,
+                "dynamics",
+                damping=f"{joint.dynamics['damping']:.4f}",
+                friction=f"{joint.dynamics['friction']:.4f}",
+            )

--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -13,6 +13,7 @@ and does not depend on other Golf Modeling Suite modules.
 from __future__ import annotations
 
 import logging
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast

--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -13,7 +13,6 @@ and does not depend on other Golf Modeling Suite modules.
 from __future__ import annotations
 
 import logging
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -22,7 +21,6 @@ from humanoid_character_builder.contracts import postcondition, precondition
 from humanoid_character_builder.core.anthropometry import (
     estimate_segment_dimensions,
     estimate_segment_masses,
-    get_com_location,
 )
 from humanoid_character_builder.core.body_parameters import BodyParameters
 from humanoid_character_builder.core.model import (
@@ -33,11 +31,15 @@ from humanoid_character_builder.core.model import (
 from humanoid_character_builder.core.segment_definitions import (
     HUMANOID_JOINTS,
     HUMANOID_SEGMENTS,
-    GeometryType,
     JointDefinition,
     JointType,
     SegmentDefinition,
 )
+from humanoid_character_builder.generators._urdf_model_builder import (
+    URDFModelBuilder,
+    map_joint_type,
+)
+from humanoid_character_builder.generators._urdf_xml_writer import URDFXMLWriter
 from humanoid_character_builder.mesh.inertia_calculator import (
     InertiaMode,
     InertiaResult,
@@ -45,7 +47,6 @@ from humanoid_character_builder.mesh.inertia_calculator import (
 )
 from humanoid_character_builder.mesh.primitive_inertia import (
     PrimitiveInertiaCalculator,
-    estimate_segment_primitive,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,15 @@ class HumanoidURDFGenerator:
         self._links: dict[str, GeneratedLink] = {}
         self._joints: list[GeneratedJoint] = []
         self._materials: dict[str, tuple[float, float, float, float]] = {}
+        self._model_builder = URDFModelBuilder(
+            config=self.config,
+            mesh_inertia_calc=self.mesh_inertia_calc,
+            primitive_inertia_calc=self.primitive_inertia_calc,
+            links=self._links,
+            joints=self._joints,
+            materials=self._materials,
+        )
+        self._xml_writer = URDFXMLWriter(self.config)
 
     @precondition(
         lambda params: params is not None,
@@ -248,57 +258,11 @@ class HumanoidURDFGenerator:
         params: BodyParameters,
     ) -> dict[str, dict[str, float]]:
         """Apply proportion factors to segment dimensions."""
-        if not (dimensions is not None):
-            raise ValueError("dimensions must be provided")
-        scaled = {}
-
-        for seg_name, dims in dimensions.items():
-            scaled_dims = dims.copy()
-
-            # Apply segment-specific factors
-            seg_lower = seg_name.lower()
-
-            if "arm" in seg_lower or "hand" in seg_lower:
-                scaled_dims["length"] *= params.arm_length_factor
-            elif "thigh" in seg_lower or "shin" in seg_lower or "foot" in seg_lower:
-                scaled_dims["length"] *= params.leg_length_factor
-            elif "thorax" in seg_lower or "lumbar" in seg_lower:
-                scaled_dims["length"] *= params.torso_length_factor
-                scaled_dims["width"] *= params.shoulder_width_factor
-            elif "pelvis" in seg_lower:
-                scaled_dims["width"] *= params.hip_width_factor
-            elif "head" in seg_lower:
-                for key in scaled_dims:
-                    scaled_dims[key] *= params.head_scale_factor
-            elif "neck" in seg_lower:
-                scaled_dims["length"] *= params.neck_length_factor
-
-            # Apply muscularity/body fat to widths
-            width_factor = 1.0 + 0.2 * params.muscularity + 0.3 * params.body_fat_factor
-            scaled_dims["width"] = scaled_dims.get("width", 0.05) * width_factor
-            scaled_dims["depth"] = scaled_dims.get("depth", 0.05) * width_factor
-
-            # Apply individual segment overrides
-            seg_params = params.get_segment_params(seg_name)
-            scale = seg_params.scale.as_tuple()
-            scaled_dims["width"] *= scale[0]
-            scaled_dims["depth"] *= scale[1]
-            scaled_dims["length"] *= scale[2]
-
-            scaled[seg_name] = scaled_dims
-
-        return scaled
+        return self._model_builder.apply_proportion_factors(dimensions, params)
 
     def _generate_materials(self, params: BodyParameters) -> None:
         """Generate material definitions."""
-        # Skin material
-        if not (params is not None):
-            raise ValueError("params must be provided")
-        skin = params.appearance.skin_tone
-        self._materials["skin"] = skin.as_tuple()
-
-        # Default material
-        self._materials["default"] = (0.7, 0.7, 0.7, 1.0)
+        self._model_builder.generate_materials(params)
 
     def _generate_link(
         self,
@@ -311,46 +275,14 @@ class HumanoidURDFGenerator:
         mesh_dir: Path | str | None,
     ) -> None:
         """Generate a single URDF link."""
-        if not (segment_name is not None):
-            raise ValueError("segment_name must be provided")
-        seg_params = params.get_segment_params(segment_name)
-
-        # Determine mass
-        final_mass = seg_params.mass_kg if seg_params.has_mass_override() else mass
-
-        # Compute inertia
-        inertia = self._compute_segment_inertia(
+        self._model_builder.generate_link(
             segment_name,
             segment_def,
-            seg_params,
-            final_mass,
+            params,
+            mass,
             dimensions,
             gender_factor,
             mesh_dir,
-        )
-
-        # Generate geometry
-        visual_geom = self._create_geometry_dict(
-            segment_def, dimensions, is_collision=False
-        )
-        collision_geom = None
-        if self.config.generate_collision:
-            collision_geom = self._create_geometry_dict(
-                segment_def, dimensions, is_collision=True
-            )
-
-        # Get center of mass
-        length = dimensions.get("length", 0.1)
-        com = get_com_location(segment_name, length, gender_factor)
-
-        self._links[segment_name] = GeneratedLink(
-            name=segment_name,
-            mass=final_mass,
-            inertia=inertia,
-            visual_geometry=visual_geom,
-            collision_geometry=collision_geom,
-            origin_xyz=com,
-            origin_rpy=(0.0, 0.0, 0.0),
         )
 
     def _compute_segment_inertia(
@@ -364,49 +296,15 @@ class HumanoidURDFGenerator:
         mesh_dir: Path | str | None,
     ) -> InertiaResult:
         """Compute inertia for a segment."""
-        # Check for manual override
-        if not (segment_name is not None):
-            raise ValueError("segment_name must be provided")
-        if seg_params.has_inertia_override():
-            override = seg_params.inertia_override
-            return MeshInertiaCalculator.create_manual_inertia(
-                ixx=override.get("ixx", 0.01),
-                iyy=override.get("iyy", 0.01),
-                izz=override.get("izz", 0.01),
-                mass=mass,
-                ixy=override.get("ixy", 0.0),
-                ixz=override.get("ixz", 0.0),
-                iyz=override.get("iyz", 0.0),
-            )
-
-        # Try mesh-based calculation
-        if (
-            self.config.inertia_mode
-            in (InertiaMode.MESH_UNIFORM_DENSITY, InertiaMode.MESH_SPECIFIED_MASS)
-            and mesh_dir
-        ):
-            mesh_path = Path(mesh_dir) / f"{segment_name}.stl"
-            if mesh_path.exists():
-                try:
-                    if self.config.inertia_mode == InertiaMode.MESH_SPECIFIED_MASS:
-                        return self.mesh_inertia_calc.compute_from_mesh(
-                            mesh_path, mass=mass
-                        )
-                    return self.mesh_inertia_calc.compute_from_mesh(mesh_path)
-                except (KeyError, ValueError, TypeError) as e:
-                    logger.warning(
-                        f"Mesh inertia calculation failed for {segment_name}: {e}"
-                    )
-
-        # Fall back to primitive approximation
-        length = dimensions.get("length", 0.1)
-        width = dimensions.get("width", 0.05)
-        depth = dimensions.get("depth", 0.05)
-
-        shape, shape_dims = estimate_segment_primitive(
-            segment_name, length, width, depth
+        return self._model_builder.compute_segment_inertia(
+            segment_name,
+            segment_def,
+            seg_params,
+            mass,
+            dimensions,
+            gender_factor,
+            mesh_dir,
         )
-        return self.primitive_inertia_calc.compute(shape, mass, shape_dims)
 
     def _create_geometry_dict(
         self,
@@ -415,55 +313,11 @@ class HumanoidURDFGenerator:
         is_collision: bool,
     ) -> dict[str, Any]:
         """Create geometry specification dictionary."""
-        if not (segment_def is not None):
-            raise ValueError("segment_def must be provided")
-        geom_spec = (
-            segment_def.get_collision_geometry()
-            if is_collision
-            else segment_def.visual_geometry
+        return self._model_builder.create_geometry_dict(
+            segment_def,
+            dimensions,
+            is_collision,
         )
-
-        length = dimensions.get("length", 0.1)
-        width = dimensions.get("width", 0.05)
-        depth = dimensions.get("depth", 0.05)
-
-        # Scale dimensions based on geometry type
-        if geom_spec.geometry_type == GeometryType.BOX:
-            return {
-                "type": "box",
-                "size": (width, depth, length),
-            }
-        if geom_spec.geometry_type == GeometryType.CYLINDER:
-            radius = (width + depth) / 4
-            return {
-                "type": "cylinder",
-                "radius": radius,
-                "length": length,
-            }
-        if geom_spec.geometry_type == GeometryType.SPHERE:
-            radius = length / 2
-            return {
-                "type": "sphere",
-                "radius": radius,
-            }
-        if geom_spec.geometry_type == GeometryType.CAPSULE:
-            radius = (width + depth) / 4
-            return {
-                "type": "cylinder",  # URDF doesn't have capsule, use cylinder
-                "radius": radius,
-                "length": max(0.01, length - 2 * radius),
-            }
-        if geom_spec.geometry_type == GeometryType.MESH:
-            return {
-                "type": "mesh",
-                "filename": geom_spec.mesh_path,
-                "scale": geom_spec.mesh_scale,
-            }
-        # Default to box
-        return {
-            "type": "box",
-            "size": (width, depth, length),
-        }
 
     def _generate_joint(
         self,
@@ -472,11 +326,7 @@ class HumanoidURDFGenerator:
         dimensions: dict[str, dict[str, float]],
     ) -> None:
         """Generate URDF joint(s) from joint definition."""
-        if joint_def.is_composite() and self.config.expand_composite_joints:
-            # Expand to multiple revolute joints
-            self._expand_composite_joint(joint_name, joint_def, dimensions)
-        else:
-            self._generate_single_joint(joint_name, joint_def)
+        self._model_builder.generate_joint(joint_name, joint_def, dimensions)
 
     def _generate_single_joint(
         self,
@@ -484,32 +334,7 @@ class HumanoidURDFGenerator:
         joint_def: JointDefinition,
     ) -> None:
         """Generate a single URDF joint."""
-        # Map joint type
-        if not (joint_name is not None):
-            raise ValueError("joint_name must be provided")
-        urdf_type = self._map_joint_type(joint_def.joint_type)
-
-        # Get limits for non-fixed joints
-        limits = None
-        if urdf_type in ("revolute", "prismatic"):
-            limits = joint_def.limits.as_dict()
-
-        self._joints.append(
-            GeneratedJoint(
-                name=joint_name,
-                joint_type=urdf_type,
-                parent=joint_def.parent_segment,
-                child=joint_def.child_segment,
-                origin_xyz=joint_def.origin_xyz,
-                origin_rpy=joint_def.origin_rpy,
-                axis=joint_def.axis,
-                limits=limits,
-                dynamics={
-                    "damping": joint_def.damping,
-                    "friction": joint_def.friction,
-                },
-            )
-        )
+        self._model_builder.generate_single_joint(joint_name, joint_def)
 
     def _expand_composite_joint(
         self,
@@ -518,225 +343,33 @@ class HumanoidURDFGenerator:
         dimensions: dict[str, dict[str, float]],
     ) -> None:
         """Expand composite joint into multiple revolute joints."""
-        if not (joint_name is not None):
-            raise ValueError("joint_name must be provided")
-        if joint_def.joint_type == JointType.GIMBAL:
-            axes = [
-                joint_def.axis,
-                joint_def.secondary_axis or (0.0, 1.0, 0.0),
-                joint_def.tertiary_axis or (1.0, 0.0, 0.0),
-            ]
-            suffixes = ["_z", "_y", "_x"]
-        elif joint_def.joint_type == JointType.UNIVERSAL:
-            axes = [
-                joint_def.axis,
-                joint_def.secondary_axis or (0.0, 1.0, 0.0),
-            ]
-            suffixes = ["_1", "_2"]
-        else:
-            # Not composite, generate single joint
-            self._generate_single_joint(joint_name, joint_def)
-            return
-
-        # Create intermediate links for composite joints
-        parent = joint_def.parent_segment
-
-        for i, (axis, suffix) in enumerate(zip(axes, suffixes, strict=True)):
-            is_last = i == len(axes) - 1
-            child = joint_def.child_segment if is_last else f"{joint_name}{suffix}_link"
-
-            # Create intermediate link if not last
-            if not is_last:
-                self._links[child] = GeneratedLink(
-                    name=child,
-                    mass=0.001,  # Minimal mass for intermediate link
-                    inertia=InertiaResult.create_default(0.001),
-                    visual_geometry={"type": "sphere", "radius": 0.001},
-                    collision_geometry=None,
-                    origin_xyz=(0.0, 0.0, 0.0),
-                    origin_rpy=(0.0, 0.0, 0.0),
-                )
-
-            # Origin only for first joint
-            origin_xyz = joint_def.origin_xyz if i == 0 else (0.0, 0.0, 0.0)
-            origin_rpy = joint_def.origin_rpy if i == 0 else (0.0, 0.0, 0.0)
-
-            self._joints.append(
-                GeneratedJoint(
-                    name=f"{joint_name}{suffix}",
-                    joint_type="revolute",
-                    parent=parent,
-                    child=child,
-                    origin_xyz=origin_xyz,
-                    origin_rpy=origin_rpy,
-                    axis=axis,
-                    limits=joint_def.limits.as_dict(),
-                    dynamics={
-                        "damping": joint_def.damping,
-                        "friction": joint_def.friction,
-                    },
-                )
-            )
-
-            parent = child
+        del dimensions
+        self._model_builder.expand_composite_joint(joint_name, joint_def)
 
     def _map_joint_type(self, joint_type: JointType) -> str:
         """Map internal joint type to URDF joint type string."""
-        if not (joint_type is not None):
-            raise ValueError("joint_type must be provided")
-        mapping = {
-            JointType.FIXED: "fixed",
-            JointType.REVOLUTE: "revolute",
-            JointType.CONTINUOUS: "continuous",
-            JointType.PRISMATIC: "prismatic",
-            JointType.FLOATING: "floating",
-            JointType.PLANAR: "planar",
-            JointType.UNIVERSAL: "revolute",  # Expanded separately
-            JointType.GIMBAL: "revolute",  # Expanded separately
-            JointType.SPHERICAL: "revolute",  # Expanded separately
-        }
-        return mapping.get(joint_type, "fixed")
+        return map_joint_type(joint_type)
 
     def _build_urdf_xml(self, robot_name: str) -> str:
         """Build the complete URDF XML."""
-        if not (robot_name is not None):
-            raise ValueError("robot_name must be provided")
-        root = ET.Element("robot", name=robot_name)
-
-        # Add materials
-        for mat_name, rgba in self._materials.items():
-            material = ET.SubElement(root, "material", name=mat_name)
-            ET.SubElement(
-                material,
-                "color",
-                rgba=f"{rgba[0]:.4f} {rgba[1]:.4f} {rgba[2]:.4f} {rgba[3]:.4f}",
-            )
-
-        # Add links
-        for link_data in self._links.values():
-            self._add_link_element(root, link_data)
-
-        # Add joints
-        for joint_data in self._joints:
-            self._add_joint_element(root, joint_data)
-
-        # Format XML
-        if self.config.pretty_print:
-            ET.indent(root, space=self.config.indent)
-            return ET.tostring(root, encoding="unicode")
-        return ET.tostring(root, encoding="unicode")
+        return self._xml_writer.build_urdf_xml(
+            robot_name,
+            self._materials,
+            self._links,
+            self._joints,
+        )
 
     def _add_link_element(self, root: ET.Element, link: GeneratedLink) -> None:
         """Add a link element to the URDF."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        link_elem = ET.SubElement(root, "link", name=link.name)
-
-        # Inertial
-        inertial = ET.SubElement(link_elem, "inertial")
-        ET.SubElement(
-            inertial,
-            "origin",
-            xyz=f"{link.origin_xyz[0]:.6f} {link.origin_xyz[1]:.6f} {link.origin_xyz[2]:.6f}",
-            rpy=f"{link.origin_rpy[0]:.6f} {link.origin_rpy[1]:.6f} {link.origin_rpy[2]:.6f}",
-        )
-        ET.SubElement(inertial, "mass", value=f"{link.mass:.6f}")
-
-        inertia = link.inertia
-        ET.SubElement(
-            inertial,
-            "inertia",
-            ixx=f"{inertia.ixx:.8f}",
-            ixy=f"{inertia.ixy:.8f}",
-            ixz=f"{inertia.ixz:.8f}",
-            iyy=f"{inertia.iyy:.8f}",
-            iyz=f"{inertia.iyz:.8f}",
-            izz=f"{inertia.izz:.8f}",
-        )
-
-        # Visual
-        visual = ET.SubElement(link_elem, "visual")
-        ET.SubElement(visual, "origin", xyz="0 0 0", rpy="0 0 0")
-        self._add_geometry_element(visual, link.visual_geometry)
-        ET.SubElement(visual, "material", name="skin")
-
-        # Collision
-        if link.collision_geometry:
-            collision = ET.SubElement(link_elem, "collision")
-            ET.SubElement(collision, "origin", xyz="0 0 0", rpy="0 0 0")
-            self._add_geometry_element(collision, link.collision_geometry)
+        self._xml_writer.add_link_element(root, link)
 
     def _add_geometry_element(self, parent: ET.Element, geom: dict[str, Any]) -> None:
         """Add geometry element."""
-        if not (parent is not None):
-            raise ValueError("parent must be provided")
-        geometry = ET.SubElement(parent, "geometry")
-
-        geom_type = geom["type"]
-        if geom_type == "box":
-            size = geom["size"]
-            ET.SubElement(
-                geometry, "box", size=f"{size[0]:.6f} {size[1]:.6f} {size[2]:.6f}"
-            )
-        elif geom_type == "cylinder":
-            ET.SubElement(
-                geometry,
-                "cylinder",
-                radius=f"{geom['radius']:.6f}",
-                length=f"{geom['length']:.6f}",
-            )
-        elif geom_type == "sphere":
-            ET.SubElement(geometry, "sphere", radius=f"{geom['radius']:.6f}")
-        elif geom_type == "mesh":
-            scale = geom.get("scale", (1.0, 1.0, 1.0))
-            ET.SubElement(
-                geometry,
-                "mesh",
-                filename=geom["filename"],
-                scale=f"{scale[0]:.6f} {scale[1]:.6f} {scale[2]:.6f}",
-            )
+        self._xml_writer.add_geometry_element(parent, geom)
 
     def _add_joint_element(self, root: ET.Element, joint: GeneratedJoint) -> None:
         """Add a joint element to the URDF."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        joint_elem = ET.SubElement(
-            root, "joint", name=joint.name, type=joint.joint_type
-        )
-
-        ET.SubElement(joint_elem, "parent", link=joint.parent)
-        ET.SubElement(joint_elem, "child", link=joint.child)
-        ET.SubElement(
-            joint_elem,
-            "origin",
-            xyz=f"{joint.origin_xyz[0]:.6f} {joint.origin_xyz[1]:.6f} {joint.origin_xyz[2]:.6f}",
-            rpy=f"{joint.origin_rpy[0]:.6f} {joint.origin_rpy[1]:.6f} {joint.origin_rpy[2]:.6f}",
-        )
-
-        if joint.joint_type != "fixed":
-            ET.SubElement(
-                joint_elem,
-                "axis",
-                xyz=f"{joint.axis[0]:.6f} {joint.axis[1]:.6f} {joint.axis[2]:.6f}",
-            )
-
-        if joint.limits and joint.joint_type in ("revolute", "prismatic"):
-            ET.SubElement(
-                joint_elem,
-                "limit",
-                lower=f"{joint.limits['lower']:.6f}",
-                upper=f"{joint.limits['upper']:.6f}",
-                effort=f"{joint.limits['effort']:.2f}",
-                velocity=f"{joint.limits['velocity']:.2f}",
-            )
-
-        if joint.dynamics:
-            ET.SubElement(
-                joint_elem,
-                "dynamics",
-                damping=f"{joint.dynamics['damping']:.4f}",
-                friction=f"{joint.dynamics['friction']:.4f}",
-            )
+        self._xml_writer.add_joint_element(root, joint)
 
 
 def generate_humanoid_urdf(


### PR DESCRIPTION
## Summary
- split `HumanoidURDFGenerator` internals into focused model-assembly and XML-writer helper modules
- keep `urdf_generator.py` as the public orchestration layer so existing imports and call sites stay stable
- update `SPEC.md` to document the new generator boundaries and helper modules

## Validation
- python3 -m pytest tests/unit/tools/humanoid_character_builder/test_urdf_generator.py -q
- python3 -m pytest tests/unit/tools/humanoid_character_builder/test_urdf_generator_formatting.py -q
- python3 -m pytest tests/unit/tools/humanoid_character_builder -q

Closes #2370