### PR TITLE
test: tighten urdf generator contracts

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -109,8 +109,6 @@ class HumanoidURDFGenerator:
         self, params: BodyParameters, mesh_dir: Path | str | None = None
     ) -> HumanoidModel:
         """Build HumanoidModel from body parameters."""
-        if not (params is not None):
-            raise ValueError("params must be provided")
         errors = params.validate()
         if errors:
             logger.warning(f"Parameter validation warnings: {errors}")
@@ -152,8 +150,6 @@ class HumanoidURDFGenerator:
         mesh_dir: Path | str | None = None,
     ) -> str:
         """Generate URDF from body parameters."""
-        if not (params is not None):
-            raise ValueError("params must be provided")
         self.build_model(params, mesh_dir)
         urdf_xml = build_urdf_xml(
             robot_name=params.name,

--- a/tests/unit/tools/humanoid_character_builder/test_urdf_generator.py
+++ b/tests/unit/tools/humanoid_character_builder/test_urdf_generator.py
@@ -1,11 +1,11 @@
-"""
-Unit tests for URDF generator module.
-"""
+"""Unit tests for URDF generator module."""
 
 import tempfile
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
+import pytest
+from humanoid_character_builder.contracts import ContractViolationError
 from humanoid_character_builder.core.body_parameters import BodyParameters
 from humanoid_character_builder.generators.urdf_generator import (
     HumanoidURDFGenerator,
@@ -250,6 +250,29 @@ class TestHumanoidURDFGenerator:
                 assert "damping" in dynamics.attrib
 
         assert dynamics_count > 0
+
+    def test_build_model_requires_params(self) -> None:
+        """DbC: build_model should reject missing parameters via precondition."""
+        generator = HumanoidURDFGenerator()
+
+        with pytest.raises(ContractViolationError, match="params must not be None"):
+            generator.build_model(None)  # type: ignore[arg-type]
+
+    def test_generate_requires_positive_height(self) -> None:
+        """DbC: generate should reject non-positive heights via precondition."""
+        generator = HumanoidURDFGenerator()
+        params = BodyParameters(height_m=0.0, mass_kg=70.0)
+
+        with pytest.raises(ContractViolationError, match="Height must be positive"):
+            generator.generate(params)
+
+    def test_generate_requires_positive_mass(self) -> None:
+        """DbC: generate should reject non-positive masses via precondition."""
+        generator = HumanoidURDFGenerator()
+        params = BodyParameters(height_m=1.75, mass_kg=0.0)
+
+        with pytest.raises(ContractViolationError, match="Mass must be positive"):
+            generator.generate(params)
 
 
 class TestGenerateHumanoidURDF:


### PR DESCRIPTION
## Summary
- remove duplicated runtime params checks from public URDF generator methods that already have DbC decorators
- add explicit contract tests for missing params and non-positive anthropometry inputs
- keep existing humanoid URDF behavior intact while making the contract layer the single source of truth

## Testing
- python -m pytest tests/unit/tools/humanoid_character_builder/test_urdf_generator.py -q
- python -m ruff check src/shared/python/humanoid_character_builder/generators/urdf_generator.py tests/unit/tools/humanoid_character_builder/test_urdf_generator.py