### PR TITLE
test: DRY up URDF smoke assertions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.33                                             |
+| **Spec Version**        | 1.0.34                                             |
 | **Last Spec Update**    | 2026-04-06                                         |
 
 ## 2. Purpose & Mission
@@ -307,6 +307,7 @@ UpstreamDrift employs a comprehensive test pyramid with multiple specialized cat
 - [ ] Trajectory optimization improves cost function by >20% over initial guess
 - [ ] Muscle dynamics simulation produces realistic activation patterns
 - [ ] Cross-platform build (Windows, macOS, Linux) produces functional binaries
+- [x] Integration: URDF smoke tests reuse a shared parsed fixture for structural assertions and skip Pinocchio loading cleanly when `buildModelFromUrdf` is unavailable
 
 ## 8. Quality Standards
 
@@ -474,6 +475,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-06 | 1.0.34  | test(urdf): reduced duplication in `tests/integration/test_urdf_generation_smoke.py` by reusing a shared parsed XML fixture for structural assertions and documenting the Pinocchio smoke-test skip path when `buildModelFromUrdf` is unavailable in the installed wheel.                                                                                                                                                                                                                                                                                                                                                         |
 | 2026-04-06 | 1.0.33  | refactor(urdf): decompose 761-line `urdf_generator.py` into four focused sub-modules: `urdf_config.py` (URDFGeneratorConfig dataclass), `urdf_geometry.py` (geometry dict creation and XML rendering), `urdf_joints.py` (joint-type mapping and composite joint expansion), `urdf_xml_builder.py` (full XML tree assembly). Public API fully preserved; backward-compat shims added for all private methods. Added "Generated URDF must be valid XML" postcondition. Closes #2370.                                                                                                                                                    |
 | 2026-04-06 | 1.0.32  | test(urdf): add 20-test cross-engine URDF generation and load smoke test covering XML structural validity, file persistence, config variants, and optional MuJoCo/Drake/Pinocchio loading paths (gracefully skipped when engine is absent). Closes #2369.                                                                                                                                                                                                                                                                                                                                                                             |
 | 2026-04-06 | 1.0.31  | CI: Added `ci-optional-stack.yml` — the optional-stack verification lane (issue #2368). Installs Pinocchio, Pink, Crocoddyl, PyQt6, and full API extras so that tests guarded by `try: import X` run without being skipped. Includes skip-visibility report in job summary. SPEC.md updated with new lane in module map and CI/CD pipeline table.                                                                                                                                                                                                                                                                                     |

--- a/tests/integration/test_urdf_generation_smoke.py
+++ b/tests/integration/test_urdf_generation_smoke.py
@@ -33,6 +33,12 @@ def default_urdf() -> str:
 
 
 @pytest.fixture(scope="module")
+def default_urdf_root(default_urdf: str) -> ET.Element:
+    """Parse the default URDF once for read-only structural assertions."""
+    return ET.fromstring(default_urdf)
+
+
+@pytest.fixture(scope="module")
 def default_urdf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Write the default URDF to a temp file and return its path."""
     params = BodyParameters(name="smoke_test_robot")
@@ -45,44 +51,37 @@ def default_urdf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
 class TestURDFStructuralValidity:
     """Verify the generated URDF is structurally well-formed."""
 
-    def test_is_parseable_xml(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        assert root.tag == "robot"
+    def test_is_parseable_xml(self, default_urdf_root: ET.Element) -> None:
+        assert default_urdf_root.tag == "robot"
 
-    def test_has_robot_name(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        assert root.get("name") == "smoke_test_robot"
+    def test_has_robot_name(self, default_urdf_root: ET.Element) -> None:
+        assert default_urdf_root.get("name") == "smoke_test_robot"
 
-    def test_has_links(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        links = root.findall("link")
+    def test_has_links(self, default_urdf_root: ET.Element) -> None:
+        links = default_urdf_root.findall("link")
         assert len(links) >= 10, f"Expected >=10 links, got {len(links)}"
 
-    def test_has_joints(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        joints = root.findall("joint")
+    def test_has_joints(self, default_urdf_root: ET.Element) -> None:
+        joints = default_urdf_root.findall("joint")
         assert len(joints) >= 10, f"Expected >=10 joints, got {len(joints)}"
 
-    def test_all_links_have_inertial(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        for link in root.findall("link"):
+    def test_all_links_have_inertial(self, default_urdf_root: ET.Element) -> None:
+        for link in default_urdf_root.findall("link"):
             inertial = link.find("inertial")
             link_name = link.get("name")
             assert inertial is not None, f"Link '{link_name}' missing <inertial>"
             assert inertial.find("mass") is not None
             assert inertial.find("inertia") is not None
 
-    def test_all_links_have_visual(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        for link in root.findall("link"):
+    def test_all_links_have_visual(self, default_urdf_root: ET.Element) -> None:
+        for link in default_urdf_root.findall("link"):
             visual = link.find("visual")
             link_name = link.get("name")
             assert visual is not None, f"Link '{link_name}' missing <visual>"
             assert visual.find("geometry") is not None
 
-    def test_revolute_joints_have_limits(self, default_urdf: str) -> None:
-        root = ET.fromstring(default_urdf)
-        for joint in root.findall("joint"):
+    def test_revolute_joints_have_limits(self, default_urdf_root: ET.Element) -> None:
+        for joint in default_urdf_root.findall("joint"):
             if joint.get("type") == "revolute":
                 limit = joint.find("limit")
                 joint_name = joint.get("name")
@@ -92,11 +91,14 @@ class TestURDFStructuralValidity:
                 assert "lower" in limit.attrib
                 assert "upper" in limit.attrib
 
-    def test_joint_parent_child_reference_valid_links(self, default_urdf: str) -> None:
+    def test_joint_parent_child_reference_valid_links(
+        self, default_urdf_root: ET.Element
+    ) -> None:
         """Every joint parent and child must reference an existing link."""
-        root = ET.fromstring(default_urdf)
-        link_names = {link.get("name") for link in root.findall("link")}
-        for joint in root.findall("joint"):
+        link_names = {
+            link.get("name") for link in default_urdf_root.findall("link")
+        }
+        for joint in default_urdf_root.findall("joint"):
             joint_name = joint.get("name")
             parent = joint.find("parent")
             child = joint.find("child")
@@ -233,6 +235,10 @@ class TestURDFPinocchioLoad:
         if not hasattr(pin, "__version__"):
             pytest.skip(
                 "pinocchio appears to be a stub/mock -- skipping Pinocchio URDF load smoke test"
+            )
+        if not hasattr(pin, "buildModelFromUrdf"):
+            pytest.skip(
+                "pinocchio buildModelFromUrdf not available in this build"
             )
         try:
             model = pin.buildModelFromUrdf(str(default_urdf_path))

--- a/tests/integration/test_urdf_generation_smoke.py
+++ b/tests/integration/test_urdf_generation_smoke.py
@@ -95,9 +95,7 @@ class TestURDFStructuralValidity:
         self, default_urdf_root: ET.Element
     ) -> None:
         """Every joint parent and child must reference an existing link."""
-        link_names = {
-            link.get("name") for link in default_urdf_root.findall("link")
-        }
+        link_names = {link.get("name") for link in default_urdf_root.findall("link")}
         for joint in default_urdf_root.findall("joint"):
             joint_name = joint.get("name")
             parent = joint.find("parent")
@@ -237,9 +235,7 @@ class TestURDFPinocchioLoad:
                 "pinocchio appears to be a stub/mock -- skipping Pinocchio URDF load smoke test"
             )
         if not hasattr(pin, "buildModelFromUrdf"):
-            pytest.skip(
-                "pinocchio buildModelFromUrdf not available in this build"
-            )
+            pytest.skip("pinocchio buildModelFromUrdf not available in this build")
         try:
             model = pin.buildModelFromUrdf(str(default_urdf_path))
             assert model is not None


### PR DESCRIPTION
## Summary
- reuse a parsed URDF XML fixture across structural smoke assertions
- keep the Pinocchio smoke test green on environments where buildModelFromUrdf is unavailable by skipping cleanly
- preserve the existing structural and cross-engine coverage while reducing repeated parsing logic

## Testing
- python -m pytest tests/integration/test_urdf_generation_smoke.py -q
- python -m ruff check tests/integration/test_urdf_generation_smoke.py