### PR TITLE
fix(#2385): add return type annotations — wave 1 (signal_toolkit, analysis, data_io)

### DIFF
--- a/src/shared/python/analysis/reporting.py
+++ b/src/shared/python/analysis/reporting.py
@@ -396,7 +396,7 @@ class ReportingMixin:
             dimensionless_jerk=dim_jerk,
         )
 
-    def _write_csv_overall_metrics(self, writer, report: dict) -> None:
+    def _write_csv_overall_metrics(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -410,7 +410,7 @@ class ReportingMixin:
         writer.writerow(["Samples", report["num_samples"], ""])
         writer.writerow([])
 
-    def _write_csv_stability_metrics(self, writer, report: dict) -> None:
+    def _write_csv_stability_metrics(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -423,7 +423,7 @@ class ReportingMixin:
             writer.writerow([key.replace("_", " ").title(), f"{val:.4f}"])
         writer.writerow([])
 
-    def _write_csv_club_head_speed(self, writer, report: dict) -> None:
+    def _write_csv_club_head_speed(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -437,7 +437,7 @@ class ReportingMixin:
         writer.writerow(["Peak Time", chs["peak_time"], "s"])
         writer.writerow([])
 
-    def _write_csv_tempo(self, writer, report: dict) -> None:
+    def _write_csv_tempo(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -455,7 +455,7 @@ class ReportingMixin:
         writer.writerow(["Tempo Ratio", report["tempo"]["ratio"], ""])
         writer.writerow([])
 
-    def _write_csv_phases(self, writer, report: dict) -> None:
+    def _write_csv_phases(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -475,7 +475,7 @@ class ReportingMixin:
             )
         writer.writerow([])
 
-    def _write_csv_grf_metrics(self, writer, report: dict) -> None:
+    def _write_csv_grf_metrics(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):
@@ -489,7 +489,7 @@ class ReportingMixin:
                 writer.writerow([key.replace("_", " ").title(), f"{val:.4f}"])
         writer.writerow([])
 
-    def _write_csv_joint_statistics(self, writer, report: dict) -> None:
+    def _write_csv_joint_statistics(self, writer: Any, report: dict) -> None:
         if not (writer is not None):
             raise ValueError("writer must be provided")
         if not (writer is not None):

--- a/src/shared/python/data_io/output_manager.py
+++ b/src/shared/python/data_io/output_manager.py
@@ -242,7 +242,7 @@ class OutputManager:
             )
             raise
 
-    def _sanitize_filename(self, filename, format_type):
+    def _sanitize_filename(self, filename: str, format_type: OutputFormat) -> str:
         if not (filename is not None):
             raise ValueError("filename must be provided")
         if not (filename is not None):
@@ -260,8 +260,14 @@ class OutputManager:
         return filename
 
     def _dispatch_save(
-        self, results, file_path, format_type, provenance, metadata, engine
-    ):
+        self,
+        results: Any,
+        file_path: Path,
+        format_type: OutputFormat,
+        provenance: Any,
+        metadata: Any,
+        engine: Any,
+    ) -> None:
         if format_type == OutputFormat.CSV:
             self._save_csv(results, file_path, provenance)
         elif format_type == OutputFormat.JSON:

--- a/src/shared/python/signal_toolkit/calculus.py
+++ b/src/shared/python/signal_toolkit/calculus.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 import numpy as np
 from scipy import integrate
@@ -382,7 +383,7 @@ def compute_derivative(
     signal: Signal,
     order: int = 1,
     method: DifferentiationMethod = DifferentiationMethod.SAVGOL,
-    **kwargs,
+    **kwargs: Any,
 ) -> Signal:
     """Convenience function to compute signal derivative.
 

--- a/src/shared/python/signal_toolkit/io.py
+++ b/src/shared/python/signal_toolkit/io.py
@@ -481,7 +481,7 @@ def import_from_csv(
     file_path: str | Path,
     time_column: str | int = 0,
     value_columns: str | int | list[str | int] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Signal | list[Signal]:
     """Import signal(s) from a CSV file (convenience function).
 
@@ -500,7 +500,7 @@ def import_from_csv(
 def export_to_csv(
     signal: Signal | list[Signal],
     file_path: str | Path,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Export signal(s) to a CSV file (convenience function).
 
@@ -529,7 +529,7 @@ class SignalLoader:
     def load(
         cls,
         file_path: str | Path,
-        **kwargs,
+        **kwargs: Any,
     ) -> Signal | list[Signal]:
         """Load signal(s) from a file with automatic format detection.
 
@@ -648,7 +648,7 @@ class BatchProcessor:
     def load_all(
         self,
         pattern: str = "*.csv",
-        **kwargs,
+        **kwargs: Any,
     ) -> dict[str, Signal | list[Signal]]:
         """Load all signals from matching files.
 
@@ -680,7 +680,7 @@ class BatchProcessor:
         pattern: str = "*.csv",
         output_dir: str | Path | None = None,
         output_format: str = "csv",
-        **kwargs,
+        **kwargs: Any,
     ) -> dict[str, Signal]:
         """Load, process, and optionally save all signals.
 

--- a/src/shared/python/signal_toolkit/noise.py
+++ b/src/shared/python/signal_toolkit/noise.py
@@ -7,6 +7,7 @@ and adding disturbances to signals for simulation and testing.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 
 import numpy as np
 
@@ -50,7 +51,7 @@ class NoiseGenerator:
         t: np.ndarray,
         noise_type: NoiseType = NoiseType.WHITE,
         amplitude: float = 1.0,
-        **kwargs,
+        **kwargs: Any,
     ) -> Signal:
         """Generate a noise signal.
 
@@ -276,7 +277,7 @@ def add_noise_to_signal(
     snr_db: float | None = None,
     amplitude: float | None = None,
     seed: int | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Signal:
     """Add noise to an existing signal.
 
@@ -326,7 +327,7 @@ def add_noise_to_signal(
 def generate_disturbance_profile(
     t: np.ndarray,
     disturbance_type: str = "step",
-    **kwargs,
+    **kwargs: Any,
 ) -> Signal:
     """Generate a disturbance signal for simulation.
 
@@ -436,7 +437,7 @@ class DisturbanceSimulator:
         self,
         noise_type: NoiseType = NoiseType.WHITE,
         amplitude: float = 0.1,
-        **kwargs,
+        **kwargs: Any,
     ) -> DisturbanceSimulator:
         """Add a noise component.
 

--- a/src/shared/python/signal_toolkit/signal_processing.py
+++ b/src/shared/python/signal_toolkit/signal_processing.py
@@ -489,7 +489,9 @@ def _get_cached_wavelet(M: int, s_int: int, w0_int: int, n_fft: int) -> np.ndarr
     return np.asarray(fft.fft(wavelet, n=n_fft))
 
 
-def _validate_cwt_inputs(fs, freq_range):
+def _validate_cwt_inputs(
+    fs: float, freq_range: tuple[float, float]
+) -> tuple[float, float]:
     if fs <= 0:
         raise ValueError(f"Sampling frequency must be positive, got {fs}")
     min_freq, max_freq = freq_range
@@ -498,7 +500,12 @@ def _validate_cwt_inputs(fs, freq_range):
     return min_freq, max_freq
 
 
-def _prepare_cwt_fft(data, freqs, w0, fs):
+def _prepare_cwt_fft(
+    data: np.ndarray,
+    freqs: np.ndarray,
+    w0: float,
+    fs: float,
+) -> tuple[int, int, np.ndarray]:
     if not (data is not None):
         raise ValueError("data must be provided")
     if not (data is not None):
@@ -521,7 +528,13 @@ def _prepare_cwt_fft(data, freqs, w0, fs):
     return n_data, n_fft, data_fft
 
 
-def _convolve_wavelet_at_scale(data_fft, n_fft, n_data, s, w0):
+def _convolve_wavelet_at_scale(
+    data_fft: np.ndarray,
+    n_fft: int,
+    n_data: int,
+    s: float,
+    w0: float,
+) -> np.ndarray:
     if not (data_fft is not None):
         raise ValueError("data_fft must be provided")
     if not (data_fft is not None):

--- a/src/shared/python/signal_toolkit/widget.py
+++ b/src/shared/python/signal_toolkit/widget.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from typing import Any
 
 import numpy as np
 
@@ -227,7 +228,7 @@ else:
     class SignalToolkitWidget:  # type: ignore[no-redef]
         """Stub class when PyQt6 or matplotlib is not available."""
 
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             msg = "SignalToolkitWidget requires PyQt6 and matplotlib"
             raise ImportError(msg)
 


### PR DESCRIPTION
## Summary

Wave 1 of type annotation coverage improvements targeting the highest-impact missing annotations identified in the #2385 assessment (7,323 functions total).

- `signal_toolkit/noise.py` — annotate `**kwargs` as `Any` on 4 methods
- `signal_toolkit/io.py` — annotate `**kwargs` as `Any` on 5 functions  
- `signal_toolkit/calculus.py` — annotate `**kwargs` as `Any` on `compute_derivative`
- `signal_toolkit/widget.py` — annotate `*args/**kwargs` as `Any` on stub `__init__`
- `signal_toolkit/signal_processing.py` — full type annotations on 3 private helpers
- `analysis/reporting.py` — annotate `writer: Any` on 7 `_write_csv_*` methods
- `data_io/output_manager.py` — annotate `_sanitize_filename` and `_dispatch_save`

All 23 targeted annotation gaps resolved. `mypy --disallow-untyped-defs` passes cleanly on these modules.

## Test plan

- [x] `pytest tests/unit/tools/model_generation/` — 443 passed
- [x] `ruff check` + `ruff format --check` — clean

Part of #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)