### PR TITLE
Fix build and installer paths

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.74                                             |
+| **Spec Version**        | 1.0.75                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -430,6 +430,8 @@ Beyond standard tools, CI enforces custom checks:
 git clone https://github.com/D-sorganization/UpstreamDrift.git
 cd UpstreamDrift
 python -m pip install -e ".[dev]"  # Include dev dependencies
+# One-line bootstrap from outside a checkout
+curl -fsSL https://raw.githubusercontent.com/D-sorganization/UpstreamDrift/main/install.sh | bash
 # For desktop app: cargo install tauri-cli
 
 # Running the FastAPI Server
@@ -450,6 +452,12 @@ pytest tests/unit/ -v
 pytest tests/integration/ -v
 pytest tests/ --cov=src --cov-fail-under=70
 ```
+
+### Packaging Notes
+
+- Python packaging expects a prebuilt frontend bundle under `ui/dist/`; CI packaging must provide that bundle or explicitly force a rebuild instead of silently shipping a package with no web UI.
+- The quick-install script supports both local checkout installs and remote `git+https://github.com/D-sorganization/UpstreamDrift.git` installs when run via `curl ... | bash`.
+- Windows setup and MSI packaging resolve launcher assets, config, and shared model data from the active `src/` layout (`src/launchers/assets`, `src/config`, `src/shared/urdf`, `src/shared/meshes`).
 
 ### Build Artifacts
 
@@ -493,6 +501,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.75  | Updated install and packaging behavior in the spec: documented one-line remote bootstrap support in `install.sh`, clarified that CI packaging must ship or rebuild `ui/dist` instead of skipping the frontend bundle, and recorded that Windows setup/MSI packaging resolve assets and manifests from the active `src/` tree.                                                                                                                                                                            |
 | 2026-04-10 | 1.0.74  | API/auth integrity: aligned API-key prefix lookup and API-key creation on the canonical `key_prefix` field, removed the stale auth integration xfail, and added a route-level regression test to ensure newly created API keys persist the hashed prefix used by the fast-path lookup dependency.                                                                                                                                                                                                        |
 | 2026-04-10 | 1.0.73  | Type hygiene(annotation-slice): added explicit return annotations for the JAX optimizer's nested `loss_fn` helpers in `pendulum_simulator/optimizer_gpu.py`, and extended the bounded AST regression test so this optimization source slice stays annotation-complete alongside the earlier explorer and output-manager waves.                                                                                                                                                                                  |
 | 2026-04-10 | 1.0.72  | Type hygiene(annotation-slice): added explicit return annotations for the shared output-manager filename sanitizer and save dispatcher helpers, and extended the bounded AST regression test to keep the source-level output-manager slice annotation-complete alongside the earlier explorer and shim updates.                                                                                                                                                                                                   |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.75                                             |
+| **Spec Version**        | 1.0.76                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission

--- a/build_hooks.py
+++ b/build_hooks.py
@@ -11,6 +11,14 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 logger = logging.getLogger(__name__)
 
 
+def _env_flag(name: str) -> bool:
+    """Return True when an environment variable is set to a truthy value."""
+    value = environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 class UIBuildHook(BuildHookInterface):
     """Build the React UI and include it in the wheel."""
 
@@ -24,17 +32,28 @@ class UIBuildHook(BuildHookInterface):
         ui_dir = Path(self.root) / "ui"
         dist_dir = ui_dir / "dist"
 
-        # Check if we should skip UI build
-        # Always skip UI build in CI environment or if explicitly requested
-        if environ.get("CI") or environ.get("SKIP_UI_BUILD"):
-            logger.warning("Skipping UI build (CI environment or SKIP_UI_BUILD set)")
-            if not dist_dir.exists():
-                logger.warning("Warning: UI dist directory does not exist!")
+        hook_config = self.config
+        force_ui_build = bool(hook_config.get("force_ui_build"))
+        skip_requested = _env_flag("CI") or _env_flag("SKIP_UI_BUILD")
+        dist_exists = dist_dir.exists()
+
+        if dist_exists and not force_ui_build:
+            if skip_requested:
+                logger.info("Using existing UI bundle at %s", dist_dir)
+            else:
+                logger.info("Using existing UI build at %s", dist_dir)
             return
 
-        hook_config = self.config
-        force_ui_build = hook_config.get("force_ui_build")
-        if not dist_dir.exists() or force_ui_build:
+        if skip_requested and not force_ui_build:
+            msg = (
+                f"UI bundle is missing at {dist_dir} and UI build is disabled "
+                "by CI/SKIP_UI_BUILD. Build ui/dist before packaging or set "
+                "force_ui_build=true to rebuild it."
+            )
+            logger.error(msg)
+            raise RuntimeError(msg)
+
+        if not dist_exists or force_ui_build:
             logger.info("Building UI...")
 
             # Check if npm is available

--- a/build_hooks.py
+++ b/build_hooks.py
@@ -45,6 +45,12 @@ class UIBuildHook(BuildHookInterface):
             return
 
         if skip_requested and not force_ui_build:
+            if version == "editable":
+                logger.warning(
+                    "Skipping UI bundle enforcement for editable build without %s",
+                    dist_dir,
+                )
+                return
             msg = (
                 f"UI bundle is missing at {dist_dir} and UI build is disabled "
                 "by CI/SKIP_UI_BUILD. Build ui/dist before packaging or set "

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
-# Golf Modeling Suite - Quick Install Script
-# Usage: curl -fsSL https://golf-suite.io/install.sh | bash
+# UpstreamDrift - Quick Install Script
+#
+# Supported execution models:
+#   curl -fsSL https://raw.githubusercontent.com/D-sorganization/UpstreamDrift/main/install.sh | bash
+#   bash install.sh
+#   UPSTREAM_DRIFT_INSTALL_SOURCE=/path/to/checkout bash install.sh
+#
+# When the script is run from a checkout that contains pyproject.toml, it
+# installs from the local tree. Otherwise it installs from the Git repository.
 
-set -e
+set -euo pipefail
+
+REPO_URL="https://github.com/D-sorganization/UpstreamDrift.git"
+INSTALL_SOURCE="${UPSTREAM_DRIFT_INSTALL_SOURCE:-}"
 
 echo "╔═══════════════════════════════════════════════════════════════╗"
-echo "║         Golf Modeling Suite - Installation Script             ║"
+echo "║         UpstreamDrift - Installation Script                   ║"
 echo "╚═══════════════════════════════════════════════════════════════╝"
 echo
 
@@ -18,8 +28,8 @@ echo "Detected: $OS $ARCH"
 # Check for Python 3.11+
 if command -v python3 &> /dev/null; then
     PY_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-    PY_MAJOR=$(echo $PY_VERSION | cut -d. -f1)
-    PY_MINOR=$(echo $PY_VERSION | cut -d. -f2)
+    PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+    PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
 
     if [ "$PY_MAJOR" -ge 3 ] && [ "$PY_MINOR" -ge 11 ]; then
         echo "✓ Python $PY_VERSION found"
@@ -34,32 +44,42 @@ else
     exit 1
 fi
 
-# Check for pipx (recommended) or pip
+if [ -z "$INSTALL_SOURCE" ]; then
+    if [ -f "./pyproject.toml" ]; then
+        INSTALL_SOURCE="."
+    else
+        INSTALL_SOURCE="git+${REPO_URL}"
+    fi
+fi
+
+if [ "$INSTALL_SOURCE" = "." ]; then
+    echo "Using local checkout at $(pwd)"
+else
+    echo "Using remote install source: $INSTALL_SOURCE"
+fi
+
 if command -v pipx &> /dev/null; then
     echo "✓ pipx found - using isolated installation"
-    INSTALL_CMD="pipx install ."
-elif command -v pip3 &> /dev/null; then
-    echo "⚠ pipx not found - using pip (consider installing pipx)"
-    INSTALL_CMD="pip3 install ."
+    INSTALL_CMD=(pipx install "$INSTALL_SOURCE")
 else
-    echo "✗ Neither pipx nor pip found"
-    exit 1
+    echo "⚠ pipx not found - using python3 -m pip (consider installing pipx)"
+    INSTALL_CMD=(python3 -m pip install --user "$INSTALL_SOURCE")
 fi
 
 echo
-echo "Installing Golf Modeling Suite..."
-echo "  Command: $INSTALL_CMD"
+echo "Installing UpstreamDrift..."
+echo "  Command: ${INSTALL_CMD[*]}"
 echo
 
-$INSTALL_CMD
+"${INSTALL_CMD[@]}"
 
 echo
 echo "╔═══════════════════════════════════════════════════════════════╗"
 echo "║                    Installation Complete!                     ║"
 echo "╠═══════════════════════════════════════════════════════════════╣"
 echo "║                                                               ║"
-echo "║   To start:   upstream-drift                                      ║"
-echo "║   Help:       upstream-drift --help                               ║"
+echo "║   To start:   upstream-drift                                  ║"
+echo "║   Help:       upstream-drift --help                           ║"
 echo "║                                                               ║"
 echo "║   The app will open in your browser at localhost:8000         ║"
 echo "║                                                               ║"

--- a/installer/windows/setup.py
+++ b/installer/windows/setup.py
@@ -12,7 +12,7 @@ _installer_dir = _this_file.parent
 project_root = _installer_dir.parent.parent
 # Import version and metadata
 try:
-    from shared.python.version import (  # type: ignore[import-not-found]
+    from src.shared.python.core.version import (  # type: ignore[import-not-found]
         __description__,
         __version__,
     )

--- a/installer/windows/setup_config.py
+++ b/installer/windows/setup_config.py
@@ -126,10 +126,11 @@ def build_executable_specs(
     profile: PackagingProfile,
 ) -> tuple[ExecutableSpec, ...]:
     """Build executable metadata for the selected packaging profile."""
-    icon_path = str(project_root / "shared" / "icons" / "golf_robot.ico")
+    src_root = project_root / "src"
+    icon_path = str(src_root / "launchers" / "assets" / "golf_robot_icon.ico")
     executables = [
         ExecutableSpec(
-            script=str(project_root / "launchers" / "golf_launcher.py"),
+            script=str(project_root / "launch_golf_suite.py"),
             base="Win32GUI",
             target_name="GolfModelingSuite.exe",
             icon=icon_path,
@@ -140,7 +141,7 @@ def build_executable_specs(
     if profile.include_api_executable:
         executables.append(
             ExecutableSpec(
-                script=str(project_root / "api" / "server.py"),
+                script=str(project_root / "start_api_server.py"),
                 base="Console",
                 target_name="GolfAPI.exe",
                 icon=icon_path,
@@ -157,6 +158,8 @@ def build_setup_configuration(
 ) -> SetupProfileConfiguration:
     """Resolve the full cx_Freeze setup configuration for the selected profile."""
     profile = get_packaging_profile(profile_name)
+    src_root = project_root / "src"
+    launchers_assets_dir = src_root / "launchers" / "assets"
     available_engines = detect_available_engines(profile, importer=importer)
     packages = list(BASE_PACKAGES)
     for engine_id in available_engines:
@@ -166,9 +169,10 @@ def build_setup_configuration(
         "packages": packages,
         "excludes": list(EXCLUDES),
         "include_files": [
-            (str(project_root / "shared" / "urdf"), "shared/urdf"),
-            (str(project_root / "shared" / "meshes"), "shared/meshes"),
-            (str(project_root / "config"), "config"),
+            (str(src_root / "shared" / "urdf"), "src/shared/urdf"),
+            (str(src_root / "shared" / "meshes"), "src/shared/meshes"),
+            (str(launchers_assets_dir), "src/launchers/assets"),
+            (str(src_root / "config"), "src/config"),
             (str(project_root / "docs"), "docs"),
             (str(project_root / "README.md"), "README.md"),
             (str(project_root / "LICENSE"), "LICENSE"),
@@ -182,7 +186,7 @@ def build_setup_configuration(
         "upgrade_code": "{12345678-1234-5678-9012-123456789012}",
         "add_to_path": True,
         "initial_target_dir": rf"[ProgramFilesFolder]\UpstreamDrift\{profile.profile_id}",
-        "install_icon": str(project_root / "shared" / "icons" / "golf_robot.ico"),
+        "install_icon": str(launchers_assets_dir / "golf_robot_icon.ico"),
         "summary_data": {
             "author": "UpstreamDrift Team",
             "comments": profile.description,

--- a/setup_golf_suite.py
+++ b/setup_golf_suite.py
@@ -175,11 +175,14 @@ def create_shortcut_windows(
 
 def _find_source_image(repo_root: pathlib.Path) -> pathlib.Path | None:
     """Find the best available source image for icon generation."""
+    asset_dir = repo_root / "src" / "launchers" / "assets"
     potential_sources = [
+        asset_dir / "golf_robot_cropped.png",
+        asset_dir / "golf_robot_icon.png",
+        asset_dir / "golf_icon.png",
+        asset_dir / "golf_robot_windows_optimized.png",
+        asset_dir / "golf_robot_ultra_sharp.png",
         repo_root / "GolfingRobot.png",
-        repo_root / "launchers" / "assets" / "golf_robot_cropped.png",
-        repo_root / "launchers" / "assets" / "golf_icon.png",
-        repo_root / "launchers" / "assets" / "golf_robot_icon.png",
     ]
     for src in potential_sources:
         if src.exists():
@@ -205,18 +208,19 @@ def main() -> int:
     # 3. Resolve Paths
     repo_root = get_repo_root()
     source_icon = _find_source_image(repo_root)
-    output_icon = repo_root / "launchers" / "assets" / "golf_suite_unified.ico"
+    output_icon = repo_root / "src" / "launchers" / "assets" / "golf_suite_unified.ico"
     target_launch_script = repo_root / "launch_golf_suite.py"
+    fallback_icon = repo_root / "src" / "launchers" / "assets" / "golf_robot_icon.ico"
 
     # 4. Generate Icon
     if source_icon:
-        create_optimized_icon(source_icon, output_icon)
-    elif not output_icon.exists():
-        # Fallback to existing icon if generation impossible
-        fallback = repo_root / "launchers" / "assets" / "golf_robot_icon.ico"
-        if fallback.exists():
-            output_icon = fallback
+        if not create_optimized_icon(source_icon, output_icon) and fallback_icon.exists():
+            output_icon = fallback_icon
             logger.info("Using fallback existing icon.")
+    elif not output_icon.exists() and fallback_icon.exists():
+        # Fallback to existing icon if generation impossible
+        output_icon = fallback_icon
+        logger.info("Using fallback existing icon.")
 
     # 5. Create Desktop Shortcut (Windows only)
     if platform.system() == "Windows":

--- a/setup_golf_suite.py
+++ b/setup_golf_suite.py
@@ -214,7 +214,10 @@ def main() -> int:
 
     # 4. Generate Icon
     if source_icon:
-        if not create_optimized_icon(source_icon, output_icon) and fallback_icon.exists():
+        if (
+            not create_optimized_icon(source_icon, output_icon)
+            and fallback_icon.exists()
+        ):
             output_icon = fallback_icon
             logger.info("Using fallback existing icon.")
     elif not output_icon.exists() and fallback_icon.exists():

--- a/tests/unit/installer/test_windows_setup.py
+++ b/tests/unit/installer/test_windows_setup.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from installer.windows import setup_config
+from installer.windows.packaging_profiles import get_packaging_profile
+
+
+def _fake_setup_configuration(project_root: Path) -> setup_config.SetupProfileConfiguration:
+    return setup_config.SetupProfileConfiguration(
+        profile=get_packaging_profile(None),
+        available_engines=(),
+        build_exe_options={
+            "include_files": [
+                (str(project_root / "src" / "config"), "src/config"),
+                (str(project_root / "src" / "shared" / "urdf"), "src/shared/urdf"),
+                (
+                    str(project_root / "src" / "launchers" / "assets"),
+                    "src/launchers/assets",
+                ),
+            ]
+        },
+        bdist_msi_options={
+            "install_icon": str(
+                project_root / "src" / "launchers" / "assets" / "golf_robot_icon.ico"
+            )
+        },
+        executables=(
+            setup_config.ExecutableSpec(
+                script=str(project_root / "launch_golf_suite.py"),
+                base="Win32GUI",
+                target_name="GolfModelingSuite.exe",
+                icon=str(
+                    project_root
+                    / "src"
+                    / "launchers"
+                    / "assets"
+                    / "golf_robot_icon.ico"
+                ),
+                shortcut_name="UpstreamDrift",
+                shortcut_dir="DesktopFolder",
+            ),
+            setup_config.ExecutableSpec(
+                script=str(project_root / "start_api_server.py"),
+                base="Console",
+                target_name="GolfAPI.exe",
+                icon=str(
+                    project_root
+                    / "src"
+                    / "launchers"
+                    / "assets"
+                    / "golf_robot_icon.ico"
+                ),
+            ),
+        ),
+    )
+
+
+def _load_setup_module(monkeypatch):
+    fake_cx_freeze = types.ModuleType("cx_Freeze")
+    fake_cx_freeze.Executable = lambda *args, **kwargs: {
+        "args": args,
+        "kwargs": kwargs,
+    }
+    fake_cx_freeze.setup = MagicMock()
+    monkeypatch.setitem(sys.modules, "cx_Freeze", fake_cx_freeze)
+    monkeypatch.setattr(
+        setup_config,
+        "build_setup_configuration",
+        lambda project_root, profile_name: _fake_setup_configuration(project_root),
+    )
+    sys.modules.pop("installer.windows.setup", None)
+    module = importlib.import_module("installer.windows.setup")
+    return module, fake_cx_freeze
+
+
+def test_setup_module_uses_real_src_layout(monkeypatch):
+    module, _fake = _load_setup_module(monkeypatch)
+    project_root = module.project_root
+    config = setup_config.build_setup_configuration(
+        project_root,
+        None,
+        importer=lambda name: object(),
+    )
+
+    include_files = config.build_exe_options["include_files"]
+    assert (str(project_root / "src" / "config"), "src/config") in include_files
+    assert (
+        str(project_root / "src" / "shared" / "urdf"),
+        "src/shared/urdf",
+    ) in include_files
+    assert (
+        str(project_root / "src" / "launchers" / "assets"),
+        "src/launchers/assets",
+    ) in include_files
+    assert config.bdist_msi_options["install_icon"] == str(
+        project_root / "src" / "launchers" / "assets" / "golf_robot_icon.ico"
+    )
+
+
+def test_setup_main_builds_using_src_paths(monkeypatch):
+    module, fake_cx_freeze = _load_setup_module(monkeypatch)
+    fake_cx_freeze.setup.assert_called_once()
+
+    kwargs = fake_cx_freeze.setup.call_args.kwargs
+    build_exe_options = kwargs["options"]["build_exe"]
+    executable_scripts = [item["kwargs"]["script"] for item in kwargs["executables"]]
+
+    assert str(module.project_root / "launch_golf_suite.py") in executable_scripts
+    assert str(module.project_root / "start_api_server.py") in executable_scripts
+    assert (
+        str(module.project_root / "src" / "config"),
+        "src/config",
+    ) in build_exe_options["include_files"]
+    assert (
+        str(module.project_root / "src" / "launchers" / "assets"),
+        "src/launchers/assets",
+    ) in build_exe_options["include_files"]

--- a/tests/unit/installer/test_windows_setup.py
+++ b/tests/unit/installer/test_windows_setup.py
@@ -10,7 +10,9 @@ from installer.windows import setup_config
 from installer.windows.packaging_profiles import get_packaging_profile
 
 
-def _fake_setup_configuration(project_root: Path) -> setup_config.SetupProfileConfiguration:
+def _fake_setup_configuration(
+    project_root: Path,
+) -> setup_config.SetupProfileConfiguration:
     return setup_config.SetupProfileConfiguration(
         profile=get_packaging_profile(None),
         available_engines=(),

--- a/tests/unit/installer/test_windows_setup.py
+++ b/tests/unit/installer/test_windows_setup.py
@@ -73,7 +73,9 @@ def _load_setup_module(monkeypatch):
     monkeypatch.setattr(
         setup_config,
         "build_setup_configuration",
-        lambda project_root, profile_name: _fake_setup_configuration(project_root),
+        lambda project_root, profile_name, **kwargs: _fake_setup_configuration(
+            project_root
+        ),
     )
     sys.modules.pop("installer.windows.setup", None)
     module = importlib.import_module("installer.windows.setup")

--- a/tests/unit/test_build_hooks.py
+++ b/tests/unit/test_build_hooks.py
@@ -33,6 +33,7 @@ class DummyConfig:
 
 def test_ui_build_hook_ci_env(monkeypatch, tmp_path):
     monkeypatch.setenv("CI", "true")
+    (tmp_path / "ui" / "dist").mkdir(parents=True)
     hook = build_hooks.UIBuildHook(str(tmp_path), {})
     hook.initialize("1.0.0", {})
     # Should skip, no error
@@ -40,9 +41,20 @@ def test_ui_build_hook_ci_env(monkeypatch, tmp_path):
 
 def test_ui_build_hook_skip_env(monkeypatch, tmp_path):
     monkeypatch.setenv("SKIP_UI_BUILD", "1")
+    (tmp_path / "ui" / "dist").mkdir(parents=True)
     hook = build_hooks.UIBuildHook(str(tmp_path), {})
     hook.initialize("1.0.0", {})
     # Should skip, no error
+
+
+def test_ui_build_hook_ci_env_without_bundle_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("CI", "true")
+    hook = build_hooks.UIBuildHook(str(tmp_path), {})
+
+    with pytest.raises(RuntimeError) as exc:
+        hook.initialize("1.0.0", {})
+
+    assert "UI bundle is missing" in str(exc.value)
 
 
 @patch("build_hooks.subprocess.run")

--- a/tests/unit/test_build_hooks.py
+++ b/tests/unit/test_build_hooks.py
@@ -57,6 +57,12 @@ def test_ui_build_hook_ci_env_without_bundle_fails(monkeypatch, tmp_path):
     assert "UI bundle is missing" in str(exc.value)
 
 
+def test_ui_build_hook_editable_ci_without_bundle_skips(monkeypatch, tmp_path):
+    monkeypatch.setenv("CI", "true")
+    hook = build_hooks.UIBuildHook(str(tmp_path), {})
+    hook.initialize("editable", {})
+
+
 @patch("build_hooks.subprocess.run")
 def test_ui_build_hook_builds(mock_run, monkeypatch, tmp_path):
     monkeypatch.delenv("CI", raising=False)

--- a/tests/unit/test_install_script.py
+++ b/tests/unit/test_install_script.py
@@ -71,7 +71,9 @@ def test_install_script_defaults_to_remote_repo(tmp_path: Path) -> None:
     )
 
     assert "Using remote install source" in stdout
-    assert "pipx:install git+https://github.com/D-sorganization/UpstreamDrift.git" in calls
+    assert (
+        "pipx:install git+https://github.com/D-sorganization/UpstreamDrift.git" in calls
+    )
 
 
 def test_install_script_uses_local_checkout_when_present(tmp_path: Path) -> None:

--- a/tests/unit/test_install_script.py
+++ b/tests/unit/test_install_script.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "install.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_install_script(
+    tmp_path: Path, *, include_pipx: bool, include_checkout: bool
+) -> tuple[str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls.log"
+
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [[ "$1" == "-c" ]]; then
+  echo "3.11"
+  exit 0
+fi
+printf 'python3:%s\\n' "$*" >> "{calls}"
+exit 0
+""",
+    )
+
+    if include_pipx:
+        _write_executable(
+            bin_dir / "pipx",
+            f"""#!/bin/bash
+printf 'pipx:%s\\n' "$*" >> "{calls}"
+exit 0
+""",
+        )
+
+    cwd = tmp_path / "checkout" if include_checkout else tmp_path / "work"
+    cwd.mkdir()
+    if include_checkout:
+        (cwd / "pyproject.toml").write_text(
+            "[project]\nname = 'upstream-drift'\nversion = '0.0.0'\n",
+            encoding="utf-8",
+        )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SCRIPT)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    return calls.read_text(encoding="utf-8"), result.stdout
+
+
+def test_install_script_defaults_to_remote_repo(tmp_path: Path) -> None:
+    calls, stdout = _run_install_script(
+        tmp_path, include_pipx=True, include_checkout=False
+    )
+
+    assert "Using remote install source" in stdout
+    assert "pipx:install git+https://github.com/D-sorganization/UpstreamDrift.git" in calls
+
+
+def test_install_script_uses_local_checkout_when_present(tmp_path: Path) -> None:
+    calls, stdout = _run_install_script(
+        tmp_path, include_pipx=False, include_checkout=True
+    )
+
+    assert "Using local checkout" in stdout
+    assert "python3:-m pip install --user ." in calls

--- a/tests/unit/test_setup_golf_suite.py
+++ b/tests/unit/test_setup_golf_suite.py
@@ -57,7 +57,8 @@ def test_find_source_image(tmp_path):
     res = setup_golf_suite._find_source_image(tmp_path)
     assert res is None
 
-    src = tmp_path / "GolfingRobot.png"
+    src = tmp_path / "src" / "launchers" / "assets" / "golf_robot_cropped.png"
+    src.parent.mkdir(parents=True)
     src.touch()
     res = setup_golf_suite._find_source_image(tmp_path)
     assert res == src
@@ -70,12 +71,19 @@ def test_main(mock_create_icon, mock_chk_deps, mock_sync, tmp_path, monkeypatch)
     monkeypatch.setattr("setup_golf_suite.get_repo_root", lambda: tmp_path)
     mock_chk_deps.return_value = True
 
+    source = tmp_path / "src" / "launchers" / "assets" / "golf_robot_icon.png"
+    source.parent.mkdir(parents=True)
+    source.touch()
+
     # Needs to not attempt creation of actual shortcuts on CI, but we mock the platform or function.
     monkeypatch.setattr(
         "setup_golf_suite.create_shortcut_windows", lambda *args, **kwargs: True
     )
 
     assert setup_golf_suite.main() == 0
+    mock_create_icon.assert_called_once_with(
+        source, tmp_path / "src" / "launchers" / "assets" / "golf_suite_unified.ico"
+    )
 
 
 @patch("setup_golf_suite.git_sync_repository")


### PR DESCRIPTION
## Summary
- fail packaging early when `ui/dist` is missing instead of silently shipping a broken UI
- make `install.sh` work both from a checkout and from `curl ... | bash`
- point Windows setup/MSI packaging at the real `src/...` asset and config layout
- add focused regression coverage and update `SPEC.md` for the packaging behavior

## Validation
- `/tmp/upstreamdrift-tools/bin/ruff check build_hooks.py setup_golf_suite.py installer/windows/setup.py installer/windows/setup_config.py tests/unit/test_build_hooks.py tests/unit/test_setup_golf_suite.py tests/unit/installer/test_windows_setup.py tests/unit/test_install_script.py`
- `bash -n install.sh`
- `python3 -m compileall build_hooks.py setup_golf_suite.py installer/windows/setup.py installer/windows/setup_config.py tests/unit/test_build_hooks.py tests/unit/test_setup_golf_suite.py tests/unit/installer/test_windows_setup.py tests/unit/test_install_script.py`
- direct build-hook smoke checks for existing `ui/dist` and CI-without-bundle failure
- direct install-script harness checks for remote and local install sources
- direct Windows installer `setup_config` smoke check for `src/...` include paths and entry scripts

## Notes
- `pytest` was hanging in this shell even for single-file runs, so validation here used deterministic direct harness checks plus lint/compile validation.
