### PR TITLE
fix(robotics): reset stance_foot/next_stance_foot in emergency_stop

### DIFF
--- a/src/robotics/locomotion/gait_state_machine.py
+++ b/src/robotics/locomotion/gait_state_machine.py
@@ -223,6 +223,8 @@ class GaitStateMachine(ContractChecker):
         self._state.phase = GaitPhase.DOUBLE_SUPPORT
         self._state.support_state = SupportState.DOUBLE_SUPPORT_CENTERED
         self._state.phase_time = 0.0
+        self._state.stance_foot = "both"
+        self._state.next_stance_foot = "both"
         self._invoke_callbacks("gait_change", GaitEvent.EMERGENCY_STOP)
 
     def update(self, dt: float) -> GaitState:

--- a/tests/unit/robotics/test_locomotion.py
+++ b/tests/unit/robotics/test_locomotion.py
@@ -357,6 +357,44 @@ class TestGaitStateMachine:
         assert not gait.is_walking
         assert gait.state.phase == GaitPhase.DOUBLE_SUPPORT
 
+    def test_emergency_stop_resets_stance_foot(self) -> None:
+        """E-stop must reset stance_foot to 'both' (#2503)."""
+        params = GaitParameters(step_duration=0.5)
+        gait = GaitStateMachine(params)
+        gait.start_walking()
+        gait.update(0.2)  # Advance to single-support (stance_foot != 'both')
+
+        gait.emergency_stop()
+
+        assert gait.state.stance_foot == "both"
+
+    def test_emergency_stop_resets_next_stance_foot(self) -> None:
+        """E-stop must reset next_stance_foot to 'both' (#2503)."""
+        params = GaitParameters(step_duration=0.5)
+        gait = GaitStateMachine(params)
+        gait.start_walking()
+        gait.update(0.2)
+
+        gait.emergency_stop()
+
+        assert gait.state.next_stance_foot == "both"
+
+    def test_emergency_stop_full_state_consistency(self) -> None:
+        """After E-stop all stance fields must reflect double-support standing (#2503)."""
+        params = GaitParameters(step_duration=0.5)
+        gait = GaitStateMachine(params)
+        gait.start_walking()
+        gait.update(0.3)
+
+        gait.emergency_stop()
+
+        state = gait.state
+        assert not state.is_walking
+        assert state.gait_type == GaitType.STAND
+        assert state.phase == GaitPhase.DOUBLE_SUPPORT
+        assert state.stance_foot == "both"
+        assert state.next_stance_foot == "both"
+
     def test_update_advances_time(self) -> None:
         """Test update advances phase time."""
         gait = GaitStateMachine()


### PR DESCRIPTION
## Summary
- `emergency_stop()` now resets `stance_foot` and `next_stance_foot` to `"both"` (bilateral support), matching the double-support state already set for `phase`, `support_state`, and `gait_type`
- Previously, these fields retained their pre-emergency values (e.g. `"left"` or `"right"`), causing stale/inconsistent state

Closes #2503

## Test plan
- [x] `test_emergency_stop_resets_stance_foot` — asserts `stance_foot == "both"` after E-stop
- [x] `test_emergency_stop_resets_next_stance_foot` — asserts `next_stance_foot == "both"` after E-stop
- [x] `test_emergency_stop_full_state_consistency` — asserts full double-support standing state
- [x] All 48 locomotion unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)