### PR TITLE
fix(robotics): restore engine state after speculative contact check; fix collision distance early exit

### DIFF
--- a/src/robotics/contact/contact_manager.py
+++ b/src/robotics/contact/contact_manager.py
@@ -126,15 +126,18 @@ class ContactManager(ContractChecker):
         Raises:
             ContactError: If contact detection fails.
         """
-        # Set configuration if provided
+        # Set configuration if provided, restoring afterwards
         if q is not None:
             current_q, current_v = self._engine.get_state()
             self._engine.set_state(q, current_v)
-
-        contacts: list[ContactState] = []
-
-        # Fallback: no contact detection available
-        contacts = self._detect_from_engine() if self._is_contact_capable else []
+            try:
+                contacts = (
+                    self._detect_from_engine() if self._is_contact_capable else []
+                )
+            finally:
+                self._engine.set_state(current_q, current_v)
+        else:
+            contacts = self._detect_from_engine() if self._is_contact_capable else []
 
         self._contact_cache = contacts
         return contacts

--- a/src/robotics/planning/collision/collision_checker.py
+++ b/src/robotics/planning/collision/collision_checker.py
@@ -394,10 +394,6 @@ class CollisionChecker:
                     if np.linalg.norm(pb - pa) > 1e-10:
                         normal = (pb - pa) / np.linalg.norm(pb - pa)
 
-                    # Early exit if max_distance exceeded
-                    if min_distance > query.max_distance:
-                        break
-
             # Check environment
             body_names = self._engine.get_body_names()
             for body_name in body_names:

--- a/tests/unit/robotics/test_contact.py
+++ b/tests/unit/robotics/test_contact.py
@@ -526,3 +526,78 @@ class TestContactManagerIntegration:
         # On edge (may be inside or outside depending on implementation)
         # Just verify it doesn't crash
         _point_in_polygon(np.array([0.5, 0]), triangle)
+
+
+class TestIssue2499ContactManagerStateRestoration:
+    """Issue #2499: detect_contacts(q) must restore the original engine state."""
+
+    @pytest.fixture
+    def mock_engine(self) -> object:
+        """Engine mock that satisfies RoboticsCapable runtime check."""
+        from unittest.mock import MagicMock
+
+        from src.robotics.core.protocols import RoboticsCapable
+
+        engine = MagicMock(spec=RoboticsCapable)
+        # Track internal state
+        state: dict[str, np.ndarray] = {
+            "q": np.zeros(3),
+            "v": np.zeros(3),
+        }
+
+        def get_state() -> tuple[np.ndarray, np.ndarray]:
+            return state["q"].copy(), state["v"].copy()
+
+        def set_state(q: np.ndarray, v: np.ndarray) -> None:
+            state["q"] = q.copy()
+            state["v"] = v.copy()
+
+        engine.get_state.side_effect = get_state
+        engine.set_state.side_effect = set_state
+        engine._state = state  # expose for assertions
+        return engine
+
+    def test_detect_contacts_restores_q_after_speculative_call(
+        self, mock_engine: object
+    ) -> None:
+        """After detect_contacts(q_new), engine must return to original q."""
+        from src.robotics.contact.contact_manager import ContactManager
+
+        q_orig = np.array([1.0, 2.0, 3.0])
+        mock_engine.set_state(q_orig, np.zeros(3))
+
+        manager = ContactManager(mock_engine)
+        manager.detect_contacts(q=np.array([9.0, 9.0, 9.0]))
+
+        q_after, _ = mock_engine.get_state()
+        np.testing.assert_array_equal(q_after, q_orig)
+
+    def test_detect_contacts_restores_v_after_speculative_call(
+        self, mock_engine: object
+    ) -> None:
+        """After detect_contacts(q_new), engine must return to original v."""
+        from src.robotics.contact.contact_manager import ContactManager
+
+        v_orig = np.array([0.1, 0.2, 0.3])
+        mock_engine.set_state(np.zeros(3), v_orig)
+
+        manager = ContactManager(mock_engine)
+        manager.detect_contacts(q=np.array([9.0, 9.0, 9.0]))
+
+        _, v_after = mock_engine.get_state()
+        np.testing.assert_array_equal(v_after, v_orig)
+
+    def test_detect_contacts_without_q_does_not_change_state(
+        self, mock_engine: object
+    ) -> None:
+        """detect_contacts() with no q argument must leave engine state unchanged."""
+        from src.robotics.contact.contact_manager import ContactManager
+
+        q_orig = np.array([5.0, 6.0, 7.0])
+        mock_engine.set_state(q_orig, np.zeros(3))
+
+        manager = ContactManager(mock_engine)
+        manager.detect_contacts()
+
+        q_after, _ = mock_engine.get_state()
+        np.testing.assert_array_equal(q_after, q_orig)

--- a/tests/unit/robotics/test_planning_collision.py
+++ b/tests/unit/robotics/test_planning_collision.py
@@ -778,3 +778,61 @@ class TestCollisionCheckerConfig:
         """Test invalid configuration values."""
         with pytest.raises(ValueError, match=match):
             CollisionCheckerConfig(**kwargs)
+
+
+class TestIssue2499CollisionDistanceEarlyExit:
+    """Issue #2499: compute_distance must not exit before checking closer pairs."""
+
+    @pytest.fixture
+    def engine_with_spread_pairs(self) -> MockCollisionEngine:
+        """Engine where (link1, link2) is far but (link1, link3) is close."""
+        engine = MockCollisionEngine()
+        # link1 at z=0.5, link2 far at z=5.0, link3 close at z=0.65
+        engine._bodies["link1"]["position"] = np.array([0.0, 0.0, 0.5])
+        engine._bodies["link2"]["position"] = np.array([0.0, 0.0, 5.0])
+        engine._bodies["link3"]["position"] = np.array([0.0, 0.0, 0.65])
+        return engine
+
+    def test_compute_distance_finds_closer_pair_after_far_pair(
+        self,
+        engine_with_spread_pairs: MockCollisionEngine,
+    ) -> None:
+        """compute_distance must check all pairs, not exit when first is far."""
+        checker = CollisionChecker(engine_with_spread_pairs)
+        # Both pairs auto-setup; max_distance below link1-link2 gap but above link1-link3
+        q = np.zeros(7)
+        query = CollisionQuery(
+            query_type=CollisionQueryType.DISTANCE,
+            max_distance=2.0,
+        )
+        result_limited = checker.compute_distance(q, query=query)
+        result_unlimited = checker.compute_distance(q)
+
+        # Both must find the same closest pair (link1 ↔ link3)
+        assert result_limited.closest_pair is not None
+        assert result_unlimited.closest_pair is not None
+        lim_names = {
+            result_limited.closest_pair.body_a,
+            result_limited.closest_pair.body_b,
+        }
+        unl_names = {
+            result_unlimited.closest_pair.body_a,
+            result_unlimited.closest_pair.body_b,
+        }
+        assert lim_names == unl_names
+
+    def test_compute_distance_consistent_with_and_without_max_distance(
+        self,
+        engine_with_spread_pairs: MockCollisionEngine,
+    ) -> None:
+        """compute_distance result must not change just because max_distance is set."""
+        checker = CollisionChecker(engine_with_spread_pairs)
+        q = np.zeros(7)
+        result_no_limit = checker.compute_distance(q)
+        result_with_limit = checker.compute_distance(
+            q,
+            query=CollisionQuery(
+                query_type=CollisionQueryType.DISTANCE, max_distance=2.0
+            ),
+        )
+        assert abs(result_no_limit.distance - result_with_limit.distance) < 1e-6


### PR DESCRIPTION
## Summary
- `ContactManager.detect_contacts(q)` now wraps the engine mutation in a `try/finally` that restores the original `(q, v)`, so speculative posture queries no longer permanently alter the live simulation state
- `CollisionChecker.compute_distance()` removed the premature `break` that stopped checking collision pairs as soon as one exceeded `max_distance`; all pairs are now checked so the true minimum distance is always returned

Closes #2499

## Test plan
- [x] `test_detect_contacts_restores_q_after_speculative_call`
- [x] `test_detect_contacts_restores_v_after_speculative_call`
- [x] `test_detect_contacts_without_q_does_not_change_state`
- [x] `test_compute_distance_finds_closer_pair_after_far_pair`
- [x] `test_compute_distance_consistent_with_and_without_max_distance`
- [x] All 103 contact and collision tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)