### PR TITLE
fix(#2501): enforce variable bounds in NullspaceQPSolver and torque limits in WBC

### DIFF
--- a/src/robotics/control/whole_body/qp_solver.py
+++ b/src/robotics/control/whole_body/qp_solver.py
@@ -353,13 +353,22 @@ class NullspaceQPSolver(QPSolver):
         """Always available (uses numpy only)."""
         return True
 
+    def _apply_variable_bounds(self, x: np.ndarray, problem: QPProblem) -> np.ndarray:
+        """Clamp x to variable bounds [x_lb, x_ub] if set."""
+        if problem.x_lb is not None:
+            x = np.maximum(x, problem.x_lb)
+        if problem.x_ub is not None:
+            x = np.minimum(x, problem.x_ub)
+        return x
+
     def solve(self, problem: QPProblem) -> QPSolution:
         """Solve QP using nullspace method.
 
-        Only handles equality constraints and soft bounds.
+        Handles equality constraints via KKT system. Variable bounds
+        are enforced by post-solve clamping (best-effort).
 
         Args:
-            problem: QP problem (equality constraints only).
+            problem: QP problem.
 
         Returns:
             QP solution.
@@ -396,7 +405,7 @@ class NullspaceQPSolver(QPSolver):
 
             try:
                 solution = np.linalg.solve(KKT, rhs)
-                x = solution[:n]
+                x = self._apply_variable_bounds(solution[:n], problem)
                 dual = solution[n:]
 
                 cost = float(0.5 * x @ problem.H @ x + problem.g @ x)
@@ -423,7 +432,9 @@ class NullspaceQPSolver(QPSolver):
         else:
             # Unconstrained: solve H @ x = -g
             try:
-                x = np.asarray(np.linalg.solve(H, -g), dtype=np.float64)
+                x = self._apply_variable_bounds(
+                    np.asarray(np.linalg.solve(H, -g), dtype=np.float64), problem
+                )
                 cost = float(0.5 * x @ problem.H @ x + problem.g @ x)
 
                 solve_time = time.perf_counter() - start_time

--- a/src/robotics/control/whole_body/wbc_controller.py
+++ b/src/robotics/control/whole_body/wbc_controller.py
@@ -706,6 +706,8 @@ class WholeBodyController:
 
         # Compute torques: tau = M @ qdd + nle - J_c^T @ f_c
         tau = M @ qdd + nle
+        if self._config.torque_limits is not None:
+            tau = np.clip(tau, -self._config.torque_limits, self._config.torque_limits)
         if contact_forces is not None and self._contact_jacobians:
             for i, J_c in enumerate(self._contact_jacobians):
                 if J_c.shape[0] == 6:

--- a/tests/unit/robotics/test_control.py
+++ b/tests/unit/robotics/test_control.py
@@ -772,3 +772,78 @@ class TestIntegration:
 
         solution = wbc.solve()
         assert solution.success
+
+
+class TestIssue2501NullspaceAndTorqueLimits:
+    """Issue #2501: NullspaceQPSolver must respect variable bounds; torque limits enforced."""
+
+    def test_nullspace_solver_respects_variable_bounds(self) -> None:
+        """NullspaceQPSolver must clamp x to [x_lb, x_ub] after solving."""
+        # Unconstrained solution would be [-100, 100]; bounds are [-1, 1]
+        n = 2
+        H = np.eye(n)
+        g = np.array([100.0, -100.0])  # unconstrained min at [-100, 100]
+        x_lb = np.array([-1.0, -1.0])
+        x_ub = np.array([1.0, 1.0])
+
+        problem = QPProblem(H=H, g=g, x_lb=x_lb, x_ub=x_ub)
+        solver = NullspaceQPSolver()
+        solution = solver.solve(problem)
+
+        assert solution.success
+        assert solution.x is not None
+        assert np.all(solution.x >= x_lb - 1e-9), (
+            f"x={solution.x} violates lb={x_lb}: NullspaceQPSolver must clamp to bounds"
+        )
+        assert np.all(solution.x <= x_ub + 1e-9), (
+            f"x={solution.x} violates ub={x_ub}: NullspaceQPSolver must clamp to bounds"
+        )
+
+    def test_torque_limits_enforced_in_wbc_solution(self) -> None:
+        """WBC with torque_limits set must clip joint_torques to those limits."""
+        n_v = 3
+        engine = MockEngine(n_v=n_v)
+        max_tau = 5.0
+        config = WBCConfig(
+            torque_limits=np.full(n_v, max_tau),
+            regularization=1e-3,
+        )
+        wbc = WholeBodyController(engine, config=config)
+
+        # Large tracking error -> large unconstrained torques
+        task = create_posture_task(
+            n_v=n_v,
+            q_target=np.full(n_v, 100.0),
+            q_current=np.zeros(n_v),
+            v_current=np.zeros(n_v),
+            gains=TaskGains(weight=1.0, priority=1, gain_p=1000.0, gain_d=0.0),
+        )
+        wbc.add_task(task)
+        solution = wbc.solve()
+
+        assert solution.success
+        assert solution.joint_torques is not None
+        assert np.all(np.abs(solution.joint_torques) <= max_tau + 1e-9), (
+            f"Torques {solution.joint_torques} exceed limit {max_tau}. "
+            "torque_limits must be enforced."
+        )
+
+    def test_wbc_without_torque_limits_unconstrained(self) -> None:
+        """WBC without torque_limits must not clip torques."""
+        n_v = 3
+        engine = MockEngine(n_v=n_v)
+        config = WBCConfig(regularization=1e-3)
+        wbc = WholeBodyController(engine, config=config)
+
+        task = create_posture_task(
+            n_v=n_v,
+            q_target=np.full(n_v, 100.0),
+            q_current=np.zeros(n_v),
+            v_current=np.zeros(n_v),
+            gains=TaskGains(weight=1.0, priority=1, gain_p=1000.0, gain_d=0.0),
+        )
+        wbc.add_task(task)
+        solution = wbc.solve()
+
+        assert solution.success
+        assert solution.joint_torques is not None


### PR DESCRIPTION
## Summary
- `NullspaceQPSolver` now clamps the solution to `[x_lb, x_ub]` in both the KKT equality-constrained path and the unconstrained direct-solve path via `_apply_variable_bounds`
- `WholeBodyController._build_wbc_solution` clips joint torques to `config.torque_limits` immediately after computing `tau = M @ qdd + nle`
- Three new TDD tests in `TestIssue2501NullspaceAndTorqueLimits`: variable bounds clamping, torque limit enforcement, and a no-limit reference test

## Test plan
- [x] `test_nullspace_solver_respects_variable_bounds` — solution clamped to [-1,1] from [-100,100]
- [x] `test_torque_limits_enforced_in_wbc_solution` — large tracking error produces torques clamped to ±5.0
- [x] `test_wbc_without_torque_limits_unconstrained` — reference: no limits, unconstrained torques allowed
- [x] `ruff check` passes
- [x] `ruff format --check` passes

Closes #2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)