### PR TITLE
fix(#2477): neutralize position targets and feedforward torque on E-stop

### DIFF
--- a/src/deployment/safety/monitor.py
+++ b/src/deployment/safety/monitor.py
@@ -333,6 +333,15 @@ class SafetyMonitor:
             if safe_command.torque_commands is not None:
                 safe_command.torque_commands *= self._speed_override
 
+        # Enforce E-stop: freeze position to current and zero feedforward torque
+        if self._emergency_stop:
+            if safe_command.position_targets is not None:
+                safe_command.position_targets = state.joint_positions.copy()
+            if safe_command.feedforward_torque is not None:
+                safe_command.feedforward_torque = np.zeros_like(
+                    safe_command.feedforward_torque
+                )
+
         # Clip torque commands
         if safe_command.torque_commands is not None:
             safe_command.torque_commands = np.clip(

--- a/tests/deployment/test_safety.py
+++ b/tests/deployment/test_safety.py
@@ -206,3 +206,86 @@ class TestCollisionAvoidance:
         assert obstacle.obstacle_type == ObstacleType.HUMAN
         np.testing.assert_array_equal(obstacle.position, human.position)
         assert obstacle.inflation > 0  # Extra margin for humans
+
+
+class TestIssue2477EStopPositionMode:
+    """Issue #2477: E-stop must neutralize position-controlled motion."""
+
+    def _make_monitor_and_state(self):
+        from src.deployment.realtime import RobotConfig, RobotState
+        from src.deployment.safety import SafetyMonitor
+
+        n = 7
+        config = RobotConfig(name="test", n_joints=n)
+        monitor = SafetyMonitor(config)
+        state = RobotState(
+            timestamp=0.0,
+            joint_positions=np.ones(n) * 0.5,
+            joint_velocities=np.zeros(n),
+            joint_torques=np.zeros(n),
+        )
+        return monitor, state, n
+
+    def test_estop_zeros_position_targets(self) -> None:
+        """After E-stop, position targets must not pass through unchanged."""
+        from src.deployment.realtime import ControlCommand, ControlMode
+
+        monitor, state, n = self._make_monitor_and_state()
+        monitor.trigger_emergency_stop()
+
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.POSITION,
+            position_targets=np.ones(n) * 2.0,
+        )
+        safe = monitor.compute_safe_command(cmd, state)
+
+        assert safe.position_targets is not None, (
+            "position_targets should be frozen to current position on E-stop"
+        )
+        np.testing.assert_array_almost_equal(
+            safe.position_targets,
+            state.joint_positions,
+            err_msg=(
+                "E-stop must freeze position targets to current joint positions, "
+                "not pass desired targets through"
+            ),
+        )
+
+    def test_estop_zeros_feedforward_torque(self) -> None:
+        """After E-stop, feedforward torque must be zeroed."""
+        from src.deployment.realtime import ControlCommand, ControlMode
+
+        monitor, state, n = self._make_monitor_and_state()
+        monitor.trigger_emergency_stop()
+
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.TORQUE,
+            feedforward_torque=np.ones(n) * 10.0,
+        )
+        safe = monitor.compute_safe_command(cmd, state)
+
+        if safe.feedforward_torque is not None:
+            np.testing.assert_array_equal(
+                safe.feedforward_torque,
+                np.zeros(n),
+                err_msg="E-stop must zero feedforward torque",
+            )
+
+    def test_non_estop_preserves_position_targets(self) -> None:
+        """Without E-stop, position targets must pass through (clipped to limits)."""
+        from src.deployment.realtime import ControlCommand, ControlMode
+
+        monitor, state, n = self._make_monitor_and_state()
+        targets = np.ones(n) * 0.3
+
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.POSITION,
+            position_targets=targets.copy(),
+        )
+        safe = monitor.compute_safe_command(cmd, state)
+
+        assert safe.position_targets is not None
+        np.testing.assert_array_almost_equal(safe.position_targets, targets)


### PR DESCRIPTION
## Summary
- `compute_safe_command()` now freezes `position_targets` to `state.joint_positions` when `_emergency_stop` is `True`
- Zeroes `feedforward_torque` on E-stop in addition to the existing velocity/torque zeroing
- Three new TDD tests in `TestIssue2477EStopPositionMode`

## Test plan
- [x] `test_estop_zeros_position_targets` — position targets frozen to current joint positions
- [x] `test_estop_zeros_feedforward_torque` — feedforward torque zeroed on E-stop
- [x] `test_non_estop_preserves_position_targets` — normal operation unchanged
- [x] `ruff check` and `ruff format --check` pass

Closes #2477

🤖 Generated with [Claude Code](https://claude.com/claude-code)