### PR TITLE
fix(#2478): restore commanded torques after digital twin predict()

### DIFF
--- a/src/deployment/digital_twin/twin.py
+++ b/src/deployment/digital_twin/twin.py
@@ -168,7 +168,7 @@ class DigitalTwin:
         n_steps = int(horizon / dt)
         n_steps = min(n_steps, len(control_sequence))
 
-        # Save current state
+        # Save current state (positions, velocities, and torques)
         if hasattr(self.sim, "get_joint_positions"):
             initial_q = self.sim.get_joint_positions().copy()
         else:
@@ -179,38 +179,47 @@ class DigitalTwin:
         else:
             initial_v = np.zeros(7)
 
+        if hasattr(self.sim, "get_joint_torques"):
+            initial_tau = self.sim.get_joint_torques().copy()
+        else:
+            initial_tau = None
+
         n_dof = len(initial_q)
         trajectory = np.zeros((n_steps + 1, 2 * n_dof))
         trajectory[0] = np.concatenate([initial_q, initial_v])
 
-        # Roll out simulation
-        for i in range(n_steps):
-            # Apply control
-            if hasattr(self.sim, "set_joint_torques"):
-                self.sim.set_joint_torques(control_sequence[i])
+        try:
+            # Roll out simulation
+            for i in range(n_steps):
+                # Apply control
+                if hasattr(self.sim, "set_joint_torques"):
+                    self.sim.set_joint_torques(control_sequence[i])
 
-            # Step simulation
-            if hasattr(self.sim, "step"):
-                self.sim.step(dt)
+                # Step simulation
+                if hasattr(self.sim, "step"):
+                    self.sim.step(dt)
 
-            # Record state
-            if hasattr(self.sim, "get_joint_positions"):
-                q = self.sim.get_joint_positions()
-            else:
-                q = np.zeros(n_dof)
+                # Record state
+                if hasattr(self.sim, "get_joint_positions"):
+                    q = self.sim.get_joint_positions()
+                else:
+                    q = np.zeros(n_dof)
 
-            if hasattr(self.sim, "get_joint_velocities"):
-                v = self.sim.get_joint_velocities()
-            else:
-                v = np.zeros(n_dof)
+                if hasattr(self.sim, "get_joint_velocities"):
+                    v = self.sim.get_joint_velocities()
+                else:
+                    v = np.zeros(n_dof)
 
-            trajectory[i + 1] = np.concatenate([q, v])
+                trajectory[i + 1] = np.concatenate([q, v])
 
-        # Restore initial state
-        if hasattr(self.sim, "set_joint_positions"):
-            self.sim.set_joint_positions(initial_q)
-        if hasattr(self.sim, "set_joint_velocities"):
-            self.sim.set_joint_velocities(initial_v)
+        finally:
+            # Restore full simulator state including commanded torques
+            if hasattr(self.sim, "set_joint_positions"):
+                self.sim.set_joint_positions(initial_q)
+            if hasattr(self.sim, "set_joint_velocities"):
+                self.sim.set_joint_velocities(initial_v)
+            if initial_tau is not None and hasattr(self.sim, "set_joint_torques"):
+                self.sim.set_joint_torques(initial_tau)
 
         return trajectory
 

--- a/tests/deployment/test_twin.py
+++ b/tests/deployment/test_twin.py
@@ -217,3 +217,61 @@ def test_compute_virtual_forces(mock_sim: MagicMock, mock_real: MagicMock) -> No
     v_forces = twin.compute_virtual_forces()
     assert len(v_forces) == 6
     assert np.allclose(v_forces, np.ones(6) * 5.0)
+
+
+class TestIssue2478PredictStateRestoration:
+    """Issue #2478: predict() must fully restore sim state including torques."""
+
+    def test_predict_restores_torques(
+        self, mock_sim: MagicMock, mock_real: MagicMock
+    ) -> None:
+        """After predict(), sim torques must match pre-prediction torques."""
+        from src.deployment.digital_twin.twin import DigitalTwin
+
+        initial_torques = np.ones(7) * 3.0
+        mock_sim.get_joint_torques.return_value = initial_torques.copy()
+        mock_sim.get_joint_positions.return_value = np.zeros(7)
+        mock_sim.get_joint_velocities.return_value = np.zeros(7)
+
+        twin = DigitalTwin(mock_sim, mock_real)
+        control_sequence = np.ones((5, 7)) * 10.0
+
+        twin.predict(horizon=0.005, control_sequence=control_sequence, dt=0.001)
+
+        mock_sim.set_joint_torques.assert_called()
+        last_restore_call = mock_sim.set_joint_torques.call_args_list[-1]
+        restored_torques = last_restore_call[0][0]
+        np.testing.assert_array_almost_equal(
+            restored_torques,
+            initial_torques,
+            err_msg=(
+                "predict() must restore torques to pre-prediction values; "
+                "sim state was contaminated"
+            ),
+        )
+
+    def test_predict_does_not_leave_prediction_torques_in_sim(
+        self, mock_sim: MagicMock, mock_real: MagicMock
+    ) -> None:
+        """Torques applied during rollout must not remain in sim after predict()."""
+        from src.deployment.digital_twin.twin import DigitalTwin
+
+        initial_torques = np.zeros(7)
+        mock_sim.get_joint_torques.return_value = initial_torques.copy()
+        mock_sim.get_joint_positions.return_value = np.zeros(7)
+        mock_sim.get_joint_velocities.return_value = np.zeros(7)
+
+        twin = DigitalTwin(mock_sim, mock_real)
+        # Large control inputs that differ from initial torques
+        control_sequence = np.ones((3, 7)) * 99.0
+
+        twin.predict(horizon=0.003, control_sequence=control_sequence, dt=0.001)
+
+        # The final set_joint_torques call must be the restoration, not a prediction step
+        last_restore_call = mock_sim.set_joint_torques.call_args_list[-1]
+        restored_torques = last_restore_call[0][0]
+        np.testing.assert_array_almost_equal(
+            restored_torques,
+            initial_torques,
+            err_msg="predict() must restore initial torques, not leave prediction torques in sim",
+        )


### PR DESCRIPTION
## Summary
- `predict()` now saves joint torques before rolling out the simulation and restores them in a `try/finally` block alongside positions and velocities
- Prediction is now side-effect free — the live simulator state is fully restored after any forecast operation

## Test plan
- [x] `test_predict_restores_torques` — verifies final `set_joint_torques` call matches pre-prediction torques
- [x] `test_predict_does_not_leave_prediction_torques_in_sim` — verifies prediction torques don't contaminate live sim
- [x] `ruff check` and `ruff format --check` pass

Closes #2478

🤖 Generated with [Claude Code](https://claude.com/claude-code)