### PR TITLE
fix(#2480): raise MeshLoadError in _load_gltf_basic instead of placeholder

### DIFF
--- a/src/unreal_integration/mesh_loader.py
+++ b/src/unreal_integration/mesh_loader.py
@@ -739,11 +739,11 @@ class MeshLoader:
         if "meshes" not in gltf or not gltf["meshes"]:
             raise MeshLoadError("No meshes found in GLTF", str(path))
 
-        # For basic loading, create placeholder mesh
-        return LoadedMesh(
-            name=path.stem,
-            vertices=[MeshVertex(position=np.array([0.0, 0.0, 0.0]))],
-            faces=[MeshFace(indices=np.array([0, 0, 0]))],
+        # Full GLTF loading requires accessor/buffer parsing which needs trimesh.
+        # Returning placeholder geometry would silently hide the failure from callers.
+        raise MeshLoadError(
+            "GLTF accessor/buffer parsing requires the trimesh library",
+            str(path),
         )
 
     def _load_fbx(self, path: Path) -> LoadedMesh:

--- a/tests/unit/test_unreal_integration/test_mesh_loader.py
+++ b/tests/unit/test_unreal_integration/test_mesh_loader.py
@@ -584,3 +584,42 @@ class TestMeshLoaderContracts:
         for face in mesh.faces:
             for idx in face.indices:
                 assert 0 <= idx < mesh.vertex_count
+
+
+class TestIssue2480GltfFallbackNoPlaceholder:
+    """Issue #2480: _load_gltf_basic must raise MeshLoadError, not return placeholder."""
+
+    def test_gltf_without_trimesh_raises_not_returns_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        """_load_gltf_basic must raise MeshLoadError rather than silently returning degenerate geometry."""
+        from src.unreal_integration.mesh_loader import MeshLoadError
+
+        gltf_content = {
+            "asset": {"version": "2.0"},
+            "meshes": [{"name": "test", "primitives": [{"attributes": {}}]}],
+        }
+        gltf_file = tmp_path / "test.gltf"
+        gltf_file.write_text(json.dumps(gltf_content))
+
+        loader = MeshLoader()
+
+        import unittest.mock as mock
+
+        with (
+            mock.patch.dict("sys.modules", {"trimesh": None}),
+            pytest.raises(MeshLoadError, match="(?i)gltf|accessor|buffer|trimesh"),
+        ):
+            loader._load_gltf_basic(gltf_file)
+
+    def test_gltf_no_meshes_still_raises(self, tmp_path: Path) -> None:
+        """_load_gltf_basic must raise MeshLoadError when no meshes present."""
+        from src.unreal_integration.mesh_loader import MeshLoadError
+
+        gltf_content = {"asset": {"version": "2.0"}}
+        gltf_file = tmp_path / "empty.gltf"
+        gltf_file.write_text(json.dumps(gltf_content))
+
+        loader = MeshLoader()
+        with pytest.raises(MeshLoadError):
+            loader._load_gltf_basic(gltf_file)


### PR DESCRIPTION
## Summary
- `_load_gltf_basic` now raises `MeshLoadError("GLTF accessor/buffer parsing requires the trimesh library")` instead of silently returning a single-vertex degenerate placeholder mesh
- Downstream callers can now detect and handle the failure rather than receiving invalid geometry

## Test plan
- [x] `test_gltf_without_trimesh_raises_not_returns_placeholder` — `MeshLoadError` raised for valid GLTF with meshes but no trimesh
- [x] `test_gltf_no_meshes_still_raises` — `MeshLoadError` still raised for GLTF with no meshes
- [x] `ruff check` and `ruff format --check` pass

Closes #2480

🤖 Generated with [Claude Code](https://claude.com/claude-code)