### PR TITLE
fix(#2472): enforce state restoration, validate zero-frame configs, compute potential energy

### DIFF
--- a/src/shared/python/data_io/dataset_generator.py
+++ b/src/shared/python/data_io/dataset_generator.py
@@ -234,6 +234,11 @@ class GeneratorConfig:
             raise ValueError(f"duration must be positive, got {self.duration}")
         if self.timestep <= 0:
             raise ValueError(f"timestep must be positive, got {self.timestep}")
+        if self.duration < self.timestep:
+            raise ValueError(
+                f"duration ({self.duration}) must be >= timestep ({self.timestep}); "
+                "otherwise no steps would be recorded"
+            )
 
 
 @dataclass
@@ -403,42 +408,44 @@ class DatasetGenerator:
             n_steps,
         )
 
-        for i in range(config.num_samples):
-            try:
-                sample = self._run_single_simulation(
-                    sample_id=i,
-                    config=config,
-                    rng=rng,
-                    n_steps=n_steps,
-                    n_q=n_q,
-                    n_v=n_v,
+        try:
+            for i in range(config.num_samples):
+                try:
+                    sample = self._run_single_simulation(
+                        sample_id=i,
+                        config=config,
+                        rng=rng,
+                        n_steps=n_steps,
+                        n_q=n_q,
+                        n_v=n_v,
+                    )
+                    samples.append(sample)
+
+                    if progress_callback is not None:
+                        progress_callback(i + 1, config.num_samples)
+
+                except (RuntimeError, TypeError, ValueError) as e:
+                    logger.warning("Sample %d failed: %s", i, e)
+                    failed_count += 1
+                    continue
+
+            if not samples:
+                raise SimulationError(
+                    f"All {config.num_samples} samples failed during generation"
                 )
-                samples.append(sample)
 
-                if progress_callback is not None:
-                    progress_callback(i + 1, config.num_samples)
+            if failed_count > 0:
+                logger.warning(
+                    "%d/%d samples failed during generation",
+                    failed_count,
+                    config.num_samples,
+                )
 
-            except (RuntimeError, TypeError, ValueError) as e:
-                logger.warning("Sample %d failed: %s", i, e)
-                failed_count += 1
-                continue
-
-        if not samples:
-            raise SimulationError(
-                f"All {config.num_samples} samples failed during generation"
-            )
-
-        if failed_count > 0:
-            logger.warning(
-                "%d/%d samples failed during generation",
-                failed_count,
-                config.num_samples,
-            )
-
-        # Restore original state
-        if self._original_state is not None:
-            with contextlib.suppress(ValueError, RuntimeError, AttributeError):
-                self.engine.set_state(*self._original_state)
+        finally:
+            # Restore original state regardless of success or failure
+            if self._original_state is not None:
+                with contextlib.suppress(ValueError, RuntimeError, AttributeError):
+                    self.engine.set_state(*self._original_state)
 
         dataset = TrainingDataset(
             samples=samples,
@@ -683,6 +690,10 @@ class DatasetGenerator:
             buffers["kinetic_energy"][step] = 0.5 * float(v.T @ M @ v)  # type: ignore[index]
         except (ValueError, RuntimeError, AttributeError):
             pass
+        with contextlib.suppress(ValueError, RuntimeError, AttributeError):
+            buffers["potential_energy"][step] = float(  # type: ignore[index]
+                self.engine.compute_potential_energy()
+            )
 
     def _generate_initial_conditions(
         self,

--- a/tests/unit/test_dataset_generator.py
+++ b/tests/unit/test_dataset_generator.py
@@ -440,3 +440,73 @@ class TestDatasetExport:
             pytest.raises((ValueError, PreconditionError)),
         ):
             generator.export(dataset, Path(tmpdir) / "test", format="invalid")
+
+
+class TestIssue2472DatasetGeneratorInvariants:
+    """Issue #2472: DatasetGenerator must restore state and validate sample integrity."""
+
+    def test_zero_frame_config_raises(self) -> None:
+        """GeneratorConfig with duration < timestep must raise ValueError."""
+        with pytest.raises(ValueError, match="(?i)step|frame|duration|timestep"):
+            GeneratorConfig(
+                num_samples=1,
+                duration=0.001,
+                timestep=0.01,  # timestep > duration → n_steps = 0
+            )
+
+    def test_state_restored_even_when_all_samples_fail(self) -> None:
+        """Engine state must be restored even when SimulationError is raised."""
+        from unittest.mock import MagicMock
+
+        from src.shared.python.data_io.dataset_generator import SimulationError
+
+        engine = MagicMock()
+        initial_state = (np.ones(4), np.zeros(4))
+        engine.get_state.return_value = initial_state
+        engine.model_name = "mock"
+        engine.set_control.side_effect = RuntimeError("all samples fail")
+
+        gen = DatasetGenerator(engine)
+        config = GeneratorConfig(num_samples=2, duration=0.01, timestep=0.005)
+
+        with pytest.raises(SimulationError):
+            gen.generate(config)
+
+        engine.set_state.assert_called()
+        restore_call_args = engine.set_state.call_args[0]
+        np.testing.assert_array_equal(
+            restore_call_args[0],
+            initial_state[0],
+            err_msg="Engine positions must be restored after SimulationError",
+        )
+
+    def test_potential_energy_computed_when_engine_supports_it(self) -> None:
+        """potential_energy buffer must be filled when engine.compute_potential_energy exists."""
+        from src.shared.python.engine_core.mock_engine import MockPhysicsEngine
+
+        engine = MockPhysicsEngine(num_joints=4)
+        engine.load_from_string("<mock/>")
+
+        expected_pe = 9.81
+        engine.compute_potential_energy = lambda: expected_pe
+
+        gen = DatasetGenerator(engine)
+        config = GeneratorConfig(
+            num_samples=1,
+            duration=0.01,
+            timestep=0.005,
+            record_mass_matrix=False,
+            record_bias_forces=False,
+            record_gravity=False,
+            record_contact_forces=False,
+            record_drift_control=False,
+        )
+        dataset = gen.generate(config)
+
+        sample = dataset.samples[0]
+        assert "potential" in sample.energies, (
+            "potential_energy must be present in sample.energies"
+        )
+        assert np.any(sample.energies["potential"] != 0.0), (
+            "potential_energy must not be all zeros when engine provides it"
+        )


### PR DESCRIPTION
## Summary
- `GeneratorConfig.__post_init__` now raises `ValueError` when `duration < timestep` (would produce zero-frame samples)
- `generate()` wraps the simulation loop in `try/finally` so engine state is always restored, even when `SimulationError` is raised
- `_record_dynamics_step` now calls `engine.compute_potential_energy()` (suppressing AttributeError) to fill the `potential_energy` buffer

## Test plan
- [x] `test_zero_frame_config_raises` — `GeneratorConfig(duration=0.001, timestep=0.01)` raises `ValueError`
- [x] `test_state_restored_even_when_all_samples_fail` — `engine.set_state` called after `SimulationError`
- [x] `test_potential_energy_computed_when_engine_supports_it` — non-zero potential energy buffer when engine provides it
- [x] All 33 existing tests still pass
- [x] `ruff check` and `ruff format --check` pass

Closes #2472

🤖 Generated with [Claude Code](https://claude.com/claude-code)