### PR TITLE
fix(#2474): fix undefined logger in generated MH script and overlapping SMPLX segments

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
@@ -870,7 +870,7 @@ def generate_human():
         try:
             h.setDetail(key, value)
         except Exception as exc:  # noqa: BLE001
-            logger.info(f'Warning: modifier {{key}}={{value}}: {{exc}}')
+            print(f'Warning: modifier {{key}}={{value}}: {{exc}}')
 
     exportOBJ(h, '{obj_path_str}')
 
@@ -939,22 +939,22 @@ class SMPLXMeshGenerator(MeshGeneratorInterface):
     #: These are estimated based on the 10475-vertex SMPL-X topology.
     #: Values are (start_inclusive, end_exclusive).
     SMPLX_SEGMENT_VERTEX_RANGES: dict[str, tuple[int, int]] = {
-        "head": (8000, 10475),
-        "neck": (7500, 8000),
-        "torso": (4000, 7500),
-        "pelvis": (3000, 4000),
-        "left_upper_arm": (1800, 2400),
-        "right_upper_arm": (5300, 5900),
-        "left_forearm": (2400, 2900),
-        "right_forearm": (5900, 6400),
-        "left_hand": (2900, 3500),
-        "right_hand": (6400, 7000),
-        "left_thigh": (100, 600),
-        "right_thigh": (600, 1100),
-        "left_shin": (1100, 1500),
-        "right_shin": (1500, 1800),
         "left_foot": (0, 100),
-        "right_foot": (50, 150),
+        "right_foot": (100, 200),
+        "left_thigh": (200, 700),
+        "right_thigh": (700, 1200),
+        "left_shin": (1200, 1600),
+        "right_shin": (1600, 1900),
+        "left_upper_arm": (1900, 2500),
+        "left_forearm": (2500, 3000),
+        "left_hand": (3000, 3600),
+        "pelvis": (3600, 4600),
+        "torso": (4600, 5900),
+        "right_upper_arm": (5900, 6500),
+        "right_forearm": (6500, 7000),
+        "right_hand": (7000, 7500),
+        "neck": (7500, 8000),
+        "head": (8000, 10475),
     }
 
     @classmethod
@@ -1005,6 +1005,18 @@ class SMPLXMeshGenerator(MeshGeneratorInterface):
                     actual_vertex_count,
                 )
                 return False
+
+        # Check for overlapping segments
+        range_list = list(cls.SMPLX_SEGMENT_VERTEX_RANGES.items())
+        for i, (name_a, (start_a, end_a)) in enumerate(range_list):
+            for name_b, (start_b, end_b) in range_list[i + 1 :]:
+                if max(start_a, start_b) < min(end_a, end_b):
+                    logger.warning(
+                        "Segments '%s' and '%s' overlap — downstream mass/inertia will be incorrect",
+                        name_a,
+                        name_b,
+                    )
+                    return False
         return True
 
     @classmethod

--- a/tests/unit/tools/humanoid_character_builder/test_mesh_generators.py
+++ b/tests/unit/tools/humanoid_character_builder/test_mesh_generators.py
@@ -637,3 +637,80 @@ class TestGeneratedMeshResult:
         assert result.texture_paths == {}
         assert result.vertex_groups == {}
         assert result.metadata == {}
+
+
+class TestIssue2474MeshGeneratorScriptAndSegments:
+    """Issue #2474: generated MakeHuman script must not use undefined logger; segments must not overlap."""
+
+    def test_generated_script_does_not_use_logger(self) -> None:
+        """_build_mh_script must not emit 'logger' without defining it."""
+        from pathlib import Path
+
+        script = MakeHumanMeshGenerator._build_mh_script(
+            modifiers={"face/age": 0.5},
+            body_obj_path=Path("/tmp/body.obj"),
+            groups_json_path=Path("/tmp/groups.json"),
+        )
+        # Find every reference to 'logger' that isn't a definition
+        import re
+
+        uses = re.findall(r"\blogger\b", script)
+        definitions = re.findall(
+            r"(?:logger\s*=|import\s+\w+\s+as\s+logger|logger\s*:)", script
+        )
+        undefined_uses = len(uses) - len(definitions)
+        assert undefined_uses == 0, (
+            f"Generated script references 'logger' {undefined_uses} time(s) without defining it. "
+            "Use print() or add a logger definition to the generated script."
+        )
+
+    def test_generated_script_is_valid_python_syntax(self) -> None:
+        """_build_mh_script output must be syntactically valid Python."""
+        import ast
+        from pathlib import Path
+
+        script = MakeHumanMeshGenerator._build_mh_script(
+            modifiers={"face/age": 0.3, "body/weight": 0.6},
+            body_obj_path=Path("/tmp/body.obj"),
+            groups_json_path=Path("/tmp/groups.json"),
+        )
+        try:
+            ast.parse(script)
+        except SyntaxError as e:
+            pytest.fail(f"Generated script has syntax error: {e}")
+
+    def test_smplx_segment_ranges_do_not_overlap(self) -> None:
+        """SMPLX_SEGMENT_VERTEX_RANGES must not have overlapping vertex ranges."""
+        ranges = list(SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES.items())
+        for i, (name_a, (start_a, end_a)) in enumerate(ranges):
+            for name_b, (start_b, end_b) in ranges[i + 1 :]:
+                overlap_start = max(start_a, start_b)
+                overlap_end = min(end_a, end_b)
+                assert overlap_start >= overlap_end, (
+                    f"Segments '{name_a}' [{start_a}, {end_a}) and "
+                    f"'{name_b}' [{start_b}, {end_b}) overlap at [{overlap_start}, {overlap_end}). "
+                    "Overlapping segments contaminate mass/inertia calculations."
+                )
+
+    def test_validate_vertex_ranges_detects_overlap(self) -> None:
+        """validate_vertex_ranges must return False when segments overlap."""
+        # Temporarily inject an overlapping range
+        original = SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES.copy()
+        try:
+            SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES = dict(original)
+            SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES["_test_overlap_a"] = (
+                100,
+                300,
+            )
+            SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES["_test_overlap_b"] = (
+                200,
+                400,
+            )
+            result = SMPLXMeshGenerator.validate_vertex_ranges(
+                SMPLXMeshGenerator.SMPLX_EXPECTED_VERTEX_COUNT
+            )
+            assert result is False, (
+                "validate_vertex_ranges must return False when segments overlap"
+            )
+        finally:
+            SMPLXMeshGenerator.SMPLX_SEGMENT_VERTEX_RANGES = original


### PR DESCRIPTION
## Summary
- `_build_mh_script` now emits `print()` instead of the undefined `logger.info()` for modifier warnings
- `SMPLX_SEGMENT_VERTEX_RANGES` is redesigned as a strictly non-overlapping sequential partition over `[0, 10475)` — previously `left_foot/right_foot`, `left_hand/pelvis`, and `torso/right-arm` ranges all overlapped
- `validate_vertex_ranges` now also checks for segment overlaps and returns `False` if any two segments share vertices

## Test plan
- [x] `test_generated_script_does_not_use_logger` — no undefined `logger` references
- [x] `test_generated_script_is_valid_python_syntax` — script parses cleanly
- [x] `test_smplx_segment_ranges_do_not_overlap` — all 16 segments are disjoint
- [x] `test_validate_vertex_ranges_detects_overlap` — `validate_vertex_ranges` returns `False` when overlapping test entries are injected
- [x] All 46 existing mesh generator tests pass (1 skipped due to missing torch DLL)
- [x] `ruff check` and `ruff format --check` pass

Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)