### PR TITLE
fix(#2483): validate set_state() sizes and track MyoSuite termination

### DIFF
--- a/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
+++ b/src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py
@@ -69,6 +69,8 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
 
         self._dt = 0.002  # Default
 
+        self._terminated: bool = False  # True after episode termination or truncation
+
     def _reset_loaded_state(self) -> None:
         """Clear all engine state after a failed or closed load attempt."""
         self.env = None
@@ -168,6 +170,7 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
 
         if self.env:
             self.env.reset()
+            self._terminated = False
 
     @precondition(
         lambda self, dt=None: self.env is not None, "Environment must be loaded"
@@ -185,12 +188,23 @@ class MyoSuitePhysicsEngine(PhysicsEngine):
                 "Runtime timestep modification is unsafe in MuJoCo. Ignoring dt override."
             )
 
+        if self._terminated:
+            logger.warning(
+                "step() called on a terminated MyoSuite environment; "
+                "call reset() before stepping again"
+            )
+            return
+
         action = getattr(self, "_last_action", None)
         if action is None:
             # Fallback to zero action
             action = self.env.action_space.sample() * 0.0
 
-        self.env.step(action)
+        result = self.env.step(action)
+        # Gym step returns (obs, reward, terminated, truncated, info)
+        if len(result) >= 4:
+            _obs, _reward, terminated, truncated = result[:4]
+            self._terminated = bool(terminated or truncated)
 
     @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
@@ -181,7 +181,7 @@ class PinocchioPhysicsEngine(BasePhysicsEngine):
         return self.q.copy(), self.v.copy()
 
     def set_state(self, q: np.ndarray, v: np.ndarray) -> None:
-        """Set the current state."""
+        """Set the current state and refresh derived kinematics."""
         if not (q is not None):
             raise ValueError("q must be provided")
         if not (q is not None):
@@ -189,10 +189,14 @@ class PinocchioPhysicsEngine(BasePhysicsEngine):
         if self.model is None:
             return
 
-        if len(q) == self.model.nq:
-            self.q = q.copy()
-        if len(v) == self.model.nv:
-            self.v = v.copy()
+        if len(q) != self.model.nq:
+            raise ValueError(f"q size {len(q)} does not match model nq={self.model.nq}")
+        if len(v) != self.model.nv:
+            raise ValueError(f"v size {len(v)} does not match model nv={self.model.nv}")
+        self.q = q.copy()
+        self.v = v.copy()
+        # Refresh derived kinematics so Jacobians and frame placements are current
+        self.forward()
 
     def set_control(self, u: np.ndarray) -> None:
         """Apply control inputs (torques/forces)."""

--- a/tests/unit/engines/myosuite/test_myosuite_physics_engine.py
+++ b/tests/unit/engines/myosuite/test_myosuite_physics_engine.py
@@ -1,0 +1,62 @@
+"""Tests for MyoSuitePhysicsEngine state-transition invariants (Issue #2483)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+class TestIssue2483MyoSuiteTerminationHandling:
+    """Issue #2483: step() must handle environment termination state."""
+
+    def _make_engine_with_mock_env(self):
+        """Create MyoSuitePhysicsEngine with a mocked Gym environment."""
+        try:
+            from src.engines.physics_engines.myosuite.python.myosuite_physics_engine import (
+                MyoSuitePhysicsEngine,
+            )
+        except ImportError:
+            pytest.skip("MyoSuite not available")
+
+        from unittest.mock import MagicMock
+
+        engine = MyoSuitePhysicsEngine.__new__(MyoSuitePhysicsEngine)
+        engine._dt = 0.002
+        engine._last_action = np.zeros(3)
+        engine._terminated = False
+        engine.env_id = "mock_env"
+        engine.sim = MagicMock()
+
+        mock_env = MagicMock()
+        mock_env.action_space.sample.return_value = np.zeros(3)
+        engine.env = mock_env
+        return engine, mock_env
+
+    def test_step_records_termination_from_env(self) -> None:
+        """step() must record termination state returned by env.step()."""
+        engine, mock_env = self._make_engine_with_mock_env()
+        mock_env.step.return_value = (
+            np.zeros(5),  # obs
+            1.0,  # reward
+            True,  # terminated
+            False,  # truncated
+            {},  # info
+        )
+
+        engine.step()
+
+        assert engine._terminated is True, (
+            "step() must record terminated=True from env.step() return value"
+        )
+
+    def test_step_on_terminated_env_does_not_call_env_step(self) -> None:
+        """step() must not call env.step() when the episode has already terminated."""
+        engine, mock_env = self._make_engine_with_mock_env()
+        engine._terminated = True
+
+        engine.step()
+
+        (
+            mock_env.step.assert_not_called(),
+            ("step() must not forward to env.step() after episode termination"),
+        )

--- a/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
+++ b/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
@@ -14,3 +14,77 @@ def test_import():
         )
     except (ImportError, AttributeError) as e:
         pytest.skip(f"Missing dependencies or import error: {e}")
+
+
+class TestIssue2483PinocchioSetStateInvariants:
+    """Issue #2483: set_state() must validate sizes and refresh derived kinematics."""
+
+    def _make_engine_with_mock_model(self):
+        """Create a PinocchioPhysicsEngine with a mocked pinocchio model."""
+        try:
+            from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
+                PinocchioPhysicsEngine,
+            )
+        except ImportError:
+            pytest.skip("Pinocchio not available")
+
+        from unittest.mock import MagicMock
+
+        import numpy as np
+
+        engine = PinocchioPhysicsEngine.__new__(PinocchioPhysicsEngine)
+        engine._initialized = True
+        engine.time = 0.0
+        engine.tau = np.zeros(6)
+        engine.a = np.zeros(6)
+
+        mock_model = MagicMock()
+        mock_model.nq = 7
+        mock_model.nv = 6
+        engine.model = mock_model
+
+        mock_data = MagicMock()
+        engine.data = mock_data
+        engine.q = np.zeros(7)
+        engine.v = np.zeros(6)
+
+        return engine
+
+    def test_set_state_raises_for_wrong_q_size(self) -> None:
+        """set_state() must raise ValueError when q has wrong size."""
+        import numpy as np
+
+        engine = self._make_engine_with_mock_model()
+        wrong_q = np.zeros(5)  # model.nq == 7
+        correct_v = np.zeros(6)
+
+        with pytest.raises(ValueError, match="(?i)size|shape|nq|dimension|q"):
+            engine.set_state(wrong_q, correct_v)
+
+    def test_set_state_raises_for_wrong_v_size(self) -> None:
+        """set_state() must raise ValueError when v has wrong size."""
+        import numpy as np
+
+        engine = self._make_engine_with_mock_model()
+        correct_q = np.zeros(7)
+        wrong_v = np.zeros(3)  # model.nv == 6
+
+        with pytest.raises(ValueError, match="(?i)size|shape|nv|dimension|v"):
+            engine.set_state(correct_q, wrong_v)
+
+    def test_set_state_calls_forward_kinematics_after_setting(self) -> None:
+        """set_state() must refresh derived kinematics after updating q and v."""
+        from unittest.mock import patch
+
+        import numpy as np
+
+        engine = self._make_engine_with_mock_model()
+        new_q = np.ones(7) * 0.1
+        new_v = np.ones(6) * 0.2
+
+        with patch.object(engine, "forward") as mock_forward:
+            engine.set_state(new_q, new_v)
+            mock_forward.assert_called_once()
+
+        np.testing.assert_array_almost_equal(engine.q, new_q)
+        np.testing.assert_array_almost_equal(engine.v, new_v)


### PR DESCRIPTION
## Summary
- `PinocchioPhysicsEngine.set_state()` now raises `ValueError` for mismatched q/v sizes (previously silently ignored) and calls `self.forward()` after setting state to refresh derived kinematics
- `MyoSuitePhysicsEngine.step()` captures `terminated/truncated` from `env.step()`, stores `_terminated`, and returns early without stepping if the episode has already ended
- `reset()` clears `_terminated`

## Test plan
- [x] `test_set_state_raises_for_wrong_q_size` — ValueError on wrong-sized q
- [x] `test_set_state_raises_for_wrong_v_size` — ValueError on wrong-sized v  
- [x] `test_set_state_calls_forward_kinematics_after_setting` — forward() called after set_state
- [x] `test_step_records_termination_from_env` — terminated flag captured from env.step
- [x] `test_step_on_terminated_env_does_not_call_env_step` — env.step not called when already terminated
- [x] `ruff check` and `ruff format --check` pass

Closes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)