### PR TITLE
fix: auth refresh JSON body (#2471) and async sim task failure status (#2467)

### DIFF
--- a/src/api/auth/models.py
+++ b/src/api/auth/models.py
@@ -241,6 +241,12 @@ class APIKeyResponse(BaseModel):
     expires_at: datetime | None = None
 
 
+class RefreshTokenRequest(BaseModel):
+    """Request body for token refresh endpoint."""
+
+    refresh_token: str
+
+
 class UsageQuotas(BaseModel):
     """Usage quotas for different subscription tiers."""
 

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -16,6 +16,7 @@ from src.api.auth.models import (
     APIKeyResponse,
     LoginRequest,
     LoginResponse,
+    RefreshTokenRequest,
     User,
     UserCreate,
     UserResponse,
@@ -130,16 +131,26 @@ async def login(
 
 @router.post("/refresh", response_model=dict)
 @precondition(
-    lambda refresh_token, db=None: (
-        refresh_token is not None and len(refresh_token.strip()) > 0
+    lambda body, db=None: (
+        body is not None
+        and body.refresh_token is not None
+        and len(body.refresh_token.strip()) > 0
     ),
     "Refresh token must be a non-empty string",
 )
 async def refresh_token(
-    refresh_token: str, db: Session = Depends(get_db)
+    body: RefreshTokenRequest, db: Session = Depends(get_db)
 ) -> dict[str, Any]:
-    """Refresh access token using refresh token."""
+    """Refresh access token using refresh token.
 
+    Args:
+        body: Request body containing the refresh token.
+        db: Database session.
+
+    Returns:
+        New access token and metadata.
+    """
+    refresh_token = body.refresh_token
     # Verify refresh token
     payload = security_manager.verify_token(refresh_token, "refresh")
     user_id = payload.get("sub")

--- a/src/api/services/simulation_service.py
+++ b/src/api/services/simulation_service.py
@@ -192,10 +192,16 @@ class SimulationService:
 
             result = await self.run_simulation(request)
 
-            active_tasks[task_id] = {
-                "status": "completed",
-                "result": result.model_dump(),
-            }
+            if result.success:
+                active_tasks[task_id] = {
+                    "status": "completed",
+                    "result": result.model_dump(),
+                }
+            else:
+                active_tasks[task_id] = {
+                    "status": "failed",
+                    "result": result.model_dump(),
+                }
 
         except (GolfSuiteError, ValueError, RuntimeError, OSError) as e:
             active_tasks[task_id] = {"status": "failed", "error": str(e)}

--- a/tests/unit/api/test_auth_models.py
+++ b/tests/unit/api/test_auth_models.py
@@ -322,3 +322,28 @@ class TestSubscriptionQuotas:
         assert pro.api_calls_per_month > free.api_calls_per_month
         assert pro.video_analyses_per_month > free.video_analyses_per_month
         assert pro.simulations_per_month > free.simulations_per_month
+
+
+class TestRefreshTokenRequestContract:
+    """Design by Contract tests for RefreshTokenRequest (issue #2471)."""
+
+    def test_accepts_valid_token(self):
+        """Postcondition: Valid refresh_token is accepted as JSON body field."""
+        from src.api.auth.models import RefreshTokenRequest
+
+        req = RefreshTokenRequest(refresh_token="sometoken123")
+        assert req.refresh_token == "sometoken123"
+
+    def test_requires_refresh_token(self):
+        """Precondition: refresh_token field is required."""
+        from src.api.auth.models import RefreshTokenRequest
+
+        with pytest.raises(ValidationError):
+            RefreshTokenRequest()  # type: ignore[call-arg]
+
+    def test_refresh_token_is_body_field(self):
+        """Postcondition: refresh_token is a JSON body field, not a query param."""
+        from src.api.auth.models import RefreshTokenRequest
+
+        fields = RefreshTokenRequest.model_fields
+        assert "refresh_token" in fields, "refresh_token must be a model field"

--- a/tests/unit/test_api_services.py
+++ b/tests/unit/test_api_services.py
@@ -158,6 +158,60 @@ class TestSimulationService:
         data = service._extract_simulation_data(mock_recorder)
         assert isinstance(data, dict)
 
+    @pytest.mark.asyncio
+    async def test_run_simulation_background_success(
+        self, service: SimulationService
+    ) -> None:
+        """Successful background run stores status=completed (issue #2467)."""
+        active_tasks: dict = {}
+        task_id = "test-task-1"
+        request = SimulationRequest(
+            engine_type="mujoco",
+            duration=0.1,
+            timestep=0.01,
+            model_path=None,
+            initial_state=None,
+            control_inputs=None,
+            analysis_config=None,
+        )
+        with patch.object(
+            service,
+            "run_simulation",
+            return_value=MagicMock(success=True, model_dump=dict),
+        ):
+            await service.run_simulation_background(task_id, request, active_tasks)
+
+        assert active_tasks[task_id]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_run_simulation_background_failure_marks_failed(
+        self, service: SimulationService
+    ) -> None:
+        """Failed background run stores status=failed, not completed (issue #2467)."""
+        active_tasks: dict = {}
+        task_id = "test-task-2"
+        request = SimulationRequest(
+            engine_type="mujoco",
+            duration=0.1,
+            timestep=0.01,
+            model_path=None,
+            initial_state=None,
+            control_inputs=None,
+            analysis_config=None,
+        )
+        with patch.object(
+            service,
+            "run_simulation",
+            return_value=MagicMock(
+                success=False, model_dump=lambda: {"success": False}
+            ),
+        ):
+            await service.run_simulation_background(task_id, request, active_tasks)
+
+        assert active_tasks[task_id]["status"] == "failed", (
+            "Failed simulation must not be stored as 'completed'"
+        )
+
 
 class TestAnalysisService:
     """Tests for AnalysisService."""


### PR DESCRIPTION
## Summary
- **Issue #2471**: `POST /auth/refresh` now accepts `refresh_token` in the JSON request body via a `RefreshTokenRequest` model. Previously it was a scalar FastAPI parameter, causing tokens to be passed as query strings.
- **Issue #2467**: `run_simulation_background()` now stores `status="failed"` when `result.success is False`, instead of always storing `"completed"`. Async task consumers can now reliably distinguish failure from success.

## Changes
- `src/api/auth/models.py`: Added `RefreshTokenRequest` Pydantic model
- `src/api/routes/auth.py`: Updated `/refresh` endpoint to use `RefreshTokenRequest` body
- `src/api/services/simulation_service.py`: Check `result.success` before setting `"completed"` status
- `tests/unit/api/test_auth_models.py`: Added `TestRefreshTokenRequestContract` tests
- `tests/unit/test_api_services.py`: Added background task success/failure status tests

## Test plan
- [ ] `TestRefreshTokenRequestContract` tests pass (valid token, missing token, field existence)
- [ ] `test_run_simulation_background_success` confirms `status="completed"` on success
- [ ] `test_run_simulation_background_failure_marks_failed` confirms `status="failed"` on failure
- [ ] Existing `TestSimulationService` and `TestAnalysisService` tests unaffected

Closes #2471
Closes #2467

🤖 Generated with [Claude Code](https://claude.com/claude-code)