### PR TITLE
fix(contracts): async-aware postcondition decorator (#2470)

### DIFF
--- a/src/shared/python/core/contracts/decorators.py
+++ b/src/shared/python/core/contracts/decorators.py
@@ -136,8 +136,41 @@ def postcondition(
         raise ValueError(_ERR_CONDITION_REQUIRED)
     from .level import get_contract_level  # read live state via function
 
+    def _check_postcondition(result: Any, func_name: str) -> Any:
+        """Evaluate the postcondition against result and handle violations."""
+        try:
+            check_result = condition(result)
+        except (RuntimeError, TypeError, ValueError) as e:
+            _handle_violation(
+                "Postcondition",
+                f"Failed to evaluate postcondition: {e}",
+                function_name=func_name,
+                value=result,
+            )
+            return result
+        if not check_result:
+            _handle_violation(
+                "Postcondition",
+                message,
+                function_name=func_name,
+                value=result,
+            )
+        return result
+
     def decorator(func: F) -> F:
         """Wrap the function with postcondition checking logic."""
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                """Execute async function and verify its postcondition."""
+                if not enabled or get_contract_level() == ContractLevel.OFF:
+                    return await func(*args, **kwargs)
+                result = await func(*args, **kwargs)
+                return _check_postcondition(result, func.__qualname__)
+
+            return cast(F, async_wrapper)
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -145,30 +178,8 @@ def postcondition(
             # Check level at call time so runtime changes to contract level take effect
             if not enabled or get_contract_level() == ContractLevel.OFF:
                 return func(*args, **kwargs)
-
             result = func(*args, **kwargs)
-
-            # Evaluate the postcondition
-            try:
-                check_result = condition(result)
-            except (RuntimeError, TypeError, ValueError) as e:
-                _handle_violation(
-                    "Postcondition",
-                    f"Failed to evaluate postcondition: {e}",
-                    function_name=func.__qualname__,
-                    value=result,
-                )
-                return result
-
-            if not check_result:
-                _handle_violation(
-                    "Postcondition",
-                    message,
-                    function_name=func.__qualname__,
-                    value=result,
-                )
-
-            return result
+            return _check_postcondition(result, func.__qualname__)
 
         return cast(F, wrapper)
 

--- a/tests/unit/core/test_contract_decorators.py
+++ b/tests/unit/core/test_contract_decorators.py
@@ -164,6 +164,51 @@ class TestFiniteResultDecorator:
             make_nan()
 
 
+class TestAsyncPostconditionDecorator:
+    """Tests for async-aware postcondition handling (issue #2470)."""
+
+    def setup_method(self) -> None:
+        self._saved_level = get_contract_level()
+        set_contract_level(ContractLevel.ENFORCE)
+
+    def teardown_method(self) -> None:
+        set_contract_level(self._saved_level)
+
+    @pytest.mark.asyncio
+    async def test_async_postcondition_receives_awaited_result(self) -> None:
+        """Postcondition must evaluate the awaited result, not the coroutine."""
+
+        @postcondition(lambda r: r > 0, "result must be positive")
+        async def get_value() -> int:
+            return 42
+
+        result = await get_value()
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_async_postcondition_raises_on_violation(self) -> None:
+        """Postcondition raises PostconditionError for async function violations."""
+        from src.shared.python.core.contracts.exceptions import PostconditionError
+
+        @postcondition(lambda r: r > 0, "result must be positive")
+        async def get_negative() -> int:
+            return -1
+
+        with pytest.raises(PostconditionError):
+            await get_negative()
+
+    @pytest.mark.asyncio
+    async def test_async_postcondition_disabled_skips_check(self) -> None:
+        """Disabled postcondition does not check async results."""
+
+        @postcondition(lambda r: r > 0, "result must be positive", enabled=False)
+        async def get_negative() -> int:
+            return -1
+
+        result = await get_negative()
+        assert result == -1
+
+
 class TestNonEmptyResultDecorator:
     def setup_method(self) -> None:
         self._saved_level = get_contract_level()

--- a/tests/unit/test_api_services.py
+++ b/tests/unit/test_api_services.py
@@ -177,10 +177,6 @@ class TestAnalysisService:
         service = AnalysisService(mock_engine_manager)
         assert service.engine_manager is mock_engine_manager
 
-    @pytest.mark.xfail(
-        reason="DbC @ensure postcondition breaks async: evaluates coroutine not result",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_analyze_biomechanics_basic(self, service: AnalysisService) -> None:
         """Test basic biomechanics analysis."""
@@ -198,10 +194,6 @@ class TestAnalysisService:
         result = await service.analyze_biomechanics(request)
         assert result is not None
 
-    @pytest.mark.xfail(
-        reason="DbC @ensure postcondition breaks async: evaluates coroutine not result",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_analyze_biomechanics_missing_data(
         self, service: AnalysisService
@@ -230,10 +222,6 @@ class TestServiceIntegration:
         manager.get_active_physics_engine.return_value = mock_engine
         return manager
 
-    @pytest.mark.xfail(
-        reason="DbC @ensure postcondition breaks async: evaluates coroutine not result",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_simulation_to_analysis_flow(
         self, mock_engine_manager: MagicMock


### PR DESCRIPTION
## Summary
- **Issue #2470**: `@postcondition` wrapper now detects async functions via `inspect.iscoroutinefunction` and creates an async wrapper that `await`s the result before evaluating the postcondition condition. Previously it evaluated the condition against the raw coroutine object, defeating contract checks on all async service methods.
- Extracted shared `_check_postcondition` helper to avoid duplicating the violation-handling logic between sync and async paths.
- Removed three `xfail` markers from `TestAnalysisService` that were entrenching the broken behavior.

## Changes
- `src/shared/python/core/contracts/decorators.py`: Async-aware `postcondition` decorator
- `tests/unit/core/test_contract_decorators.py`: Added `TestAsyncPostconditionDecorator` with 3 tests
- `tests/unit/test_api_services.py`: Removed xfail markers from `analyze_biomechanics` tests

## Test plan
- [ ] All sync `TestPostconditionDecorator` tests still pass
- [ ] `TestAsyncPostconditionDecorator` tests pass on CI (require pytest-asyncio)
- [ ] `test_analyze_biomechanics_basic` and `test_analyze_biomechanics_missing_data` pass without xfail

Closes #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)