### PR TITLE
fix(config): web_route round-trip in LauncherTile and normalize JSONDecodeError (#2494)

### DIFF
--- a/src/config/launcher_manifest_loader.py
+++ b/src/config/launcher_manifest_loader.py
@@ -49,6 +49,7 @@ class LauncherTile:
         capabilities: List of capability tags for filtering/display
         order: Display order (1 = first)
         engine_type: Optional engine type identifier for physics engines
+        web_route: Optional URL path for tiles that open web tools
     """
 
     id: str
@@ -62,6 +63,7 @@ class LauncherTile:
     capabilities: tuple[str, ...] = ()
     order: int = 99
     engine_type: str | None = None
+    web_route: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> LauncherTile:
@@ -93,6 +95,7 @@ class LauncherTile:
             capabilities=tuple(data.get("capabilities", [])),
             order=data.get("order", 99),
             engine_type=data.get("engine_type"),
+            web_route=data.get("web_route"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -115,6 +118,8 @@ class LauncherTile:
         }
         if self.engine_type:
             result["engine_type"] = self.engine_type
+        if self.web_route:
+            result["web_route"] = self.web_route
         return result
 
     @property

--- a/src/shared/python/config/configuration_manager.py
+++ b/src/shared/python/config/configuration_manager.py
@@ -115,9 +115,11 @@ class ConfigurationManager(ContractChecker):
             config = SimulationConfig(**filtered_data)
             config.validate()
             return config
+        except json.JSONDecodeError as e:
+            raise GolfModelingError(
+                f"Failed to parse config (malformed JSON): {e}"
+            ) from e
         except (FileNotFoundError, PermissionError, OSError) as e:
-            # Fallback to default if load fails, or raise?
-            # Raising is safer to alert user of corruption
             raise GolfModelingError(f"Failed to load config: {e}") from e
 
     def save(self, config: SimulationConfig) -> None:

--- a/tests/config/test_launcher_manifest.py
+++ b/tests/config/test_launcher_manifest.py
@@ -322,3 +322,71 @@ class TestCategories:
         assert "openpose" in mc.capabilities
         assert "mediapipe" in mc.capabilities
         assert "c3d_viewer" in mc.capabilities
+
+
+class TestWebRouteFieldRoundTrip:
+    """Tests for web_route round-trip preservation (issue #2494)."""
+
+    def test_from_dict_preserves_web_route(self) -> None:
+        """from_dict() must read web_route from the manifest dict."""
+        data = {
+            "id": "test_tile",
+            "name": "Test",
+            "description": "A test tile",
+            "category": "tool",
+            "type": "web",
+            "path": "/some/path",
+            "logo": "logo.png",
+            "status": "gui_ready",
+            "web_route": "/tools/test",
+        }
+        tile = LauncherTile.from_dict(data)
+        assert tile.web_route == "/tools/test"
+
+    def test_to_dict_includes_web_route(self) -> None:
+        """to_dict() must serialize web_route so it survives a round-trip."""
+        data = {
+            "id": "test_tile",
+            "name": "Test",
+            "description": "A test tile",
+            "category": "tool",
+            "type": "web",
+            "path": "/some/path",
+            "logo": "logo.png",
+            "status": "gui_ready",
+            "web_route": "/tools/test",
+        }
+        tile = LauncherTile.from_dict(data)
+        serialized = tile.to_dict()
+        assert "web_route" in serialized
+        assert serialized["web_route"] == "/tools/test"
+
+    def test_web_route_none_by_default(self) -> None:
+        """web_route defaults to None when absent from the manifest dict."""
+        data = {
+            "id": "test_tile",
+            "name": "Test",
+            "description": "A test tile",
+            "category": "physics_engine",
+            "type": "mujoco",
+            "path": "/some/path",
+            "logo": "logo.png",
+            "status": "engine_ready",
+        }
+        tile = LauncherTile.from_dict(data)
+        assert tile.web_route is None
+
+    def test_to_dict_omits_web_route_when_none(self) -> None:
+        """to_dict() must not include web_route key when it is None."""
+        data = {
+            "id": "test_tile",
+            "name": "Test",
+            "description": "A test tile",
+            "category": "physics_engine",
+            "type": "mujoco",
+            "path": "/some/path",
+            "logo": "logo.png",
+        }
+        tile = LauncherTile.from_dict(data)
+        serialized = tile.to_dict()
+        assert "web_route" not in serialized

--- a/tests/unit/test_configuration_manager.py
+++ b/tests/unit/test_configuration_manager.py
@@ -74,3 +74,13 @@ def test_load_nonexistent():
     manager = ConfigurationManager(Path("nonexistent.json"))
     config = manager.load()
     assert config.height_m == 1.8
+
+
+def test_load_malformed_json_raises_golf_error(tmp_path):
+    """Malformed JSON must raise GolfModelingError, not raw JSONDecodeError (#2494)."""
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{not valid json", encoding="utf-8")
+
+    manager = ConfigurationManager(bad_file)
+    with pytest.raises(GolfModelingError, match="malformed JSON"):
+        manager.load()


### PR DESCRIPTION
## Summary
**Issue #2494**: Two config-loading bugs fixed:
1. `LauncherTile` now has a `web_route: str | None` field that is read by `from_dict()` and serialized by `to_dict()`, so web-launch metadata in `launcher_manifest.json` is no longer silently dropped.
2. `ConfigurationManager.load()` now catches `json.JSONDecodeError` and wraps it in `GolfModelingError("Failed to parse config (malformed JSON): ...")`, consistent with the module's own error contract instead of leaking the raw parse exception.

## Changes
- `src/config/launcher_manifest_loader.py`: `web_route` field, `from_dict`/`to_dict` updates
- `src/shared/python/config/configuration_manager.py`: Catch `JSONDecodeError` before the OS error handler
- `tests/config/test_launcher_manifest.py`: 4 round-trip tests for `web_route`
- `tests/unit/test_configuration_manager.py`: 1 test verifying malformed JSON raises `GolfModelingError`

## Test plan
- [ ] `TestWebRouteFieldRoundTrip` (4 tests) pass — verified locally
- [ ] `test_load_malformed_json_raises_golf_error` passes — verified locally

Closes #2494

🤖 Generated with [Claude Code](https://claude.com/claude-code)