### PR TITLE
fix(simulation-stats): wire real sim loop to authoritative stats (#2469)

### DIFF
--- a/src/api/routes/physics.py
+++ b/src/api/routes/physics.py
@@ -23,7 +23,7 @@ from src.shared.python.logging_pkg.logging_config import (
     get_logger as _get_module_logger,
 )
 
-from ..dependencies import get_engine_manager, get_logger
+from ..dependencies import get_engine_manager, get_logger, get_simulation_service
 from ..models.requests import (
     ActuatorUpdateRequest,
     CameraPresetRequest,
@@ -44,6 +44,8 @@ from ..models.responses import (
 if TYPE_CHECKING:
     from src.shared.python.engine_core.engine_manager import EngineManager
 
+    from ..services.simulation_service import SimulationService
+
 _logger = _get_module_logger(__name__)
 
 router = APIRouter()
@@ -60,10 +62,6 @@ def clear_physics_caches() -> None:
     _CONTROL_INTERFACE_CACHE.clear()
     _FEATURES_REGISTRY_CACHE.clear()
 
-
-# Module-level state is stored in app.state via dependency injection.
-# These defaults are used when no simulation state exists yet.
-_DEFAULT_SPEED_FACTOR = 1.0
 
 # Camera preset definitions (position, target, up vectors)
 CAMERA_PRESETS: dict[str, dict[str, list[float]]] = {
@@ -464,6 +462,7 @@ async def get_control_features(
 @handle_api_errors
 async def get_simulation_stats(
     engine_manager: EngineManager = Depends(get_engine_manager),
+    simulation_service: SimulationService = Depends(get_simulation_service),
 ) -> SimulationStatsResponse:
     """Get simulation runtime statistics.
 
@@ -476,14 +475,9 @@ async def get_simulation_stats(
     if engine is not None:
         sim_time = getattr(engine, "time", 0.0)
 
-    # Retrieve simulation tracking state from engine manager
-    start_time = getattr(engine_manager, "_sim_start_time", time.time())
-    wall_time = time.time() - start_time
-    frame_count = getattr(engine_manager, "_sim_frame_count", 0)
-    speed_factor = getattr(engine_manager, "_speed_factor", _DEFAULT_SPEED_FACTOR)
-    is_recording = getattr(engine_manager, "_is_recording", False)
-
-    fps = frame_count / wall_time if wall_time > 0 else 0.0
+    stats = simulation_service.stats
+    wall_time = time.time() - stats.start_time
+    fps = stats.frame_count / wall_time if wall_time > 0 else 0.0
     real_time_factor = sim_time / wall_time if wall_time > 0 else 0.0
 
     return SimulationStatsResponse(
@@ -491,9 +485,9 @@ async def get_simulation_stats(
         wall_time=wall_time,
         fps=fps,
         real_time_factor=real_time_factor,
-        speed_factor=speed_factor,
-        is_recording=is_recording,
-        frame_count=frame_count,
+        speed_factor=stats.speed_factor,
+        is_recording=stats.is_recording,
+        frame_count=stats.frame_count,
     )
 
 
@@ -501,20 +495,20 @@ async def get_simulation_stats(
 @handle_api_errors
 async def set_simulation_speed(
     request: SpeedControlRequest,
-    engine_manager: EngineManager = Depends(get_engine_manager),
+    simulation_service: SimulationService = Depends(get_simulation_service),
 ) -> SpeedControlResponse:
     """Set simulation speed multiplier.
 
     Args:
         request: Speed control parameters.
-        engine_manager: Injected engine manager.
+        simulation_service: Injected simulation service.
 
     Returns:
         Applied speed factor and status.
     """
     if not (request is not None):
         raise ValueError("request must be provided")
-    engine_manager._speed_factor = request.speed_factor  # type: ignore[attr-defined]
+    simulation_service.set_speed_factor(request.speed_factor)
 
     return SpeedControlResponse(
         speed_factor=request.speed_factor,
@@ -557,14 +551,14 @@ async def set_camera_preset(
 @handle_api_errors
 async def control_recording(
     request: TrajectoryRecordRequest,
-    engine_manager: EngineManager = Depends(get_engine_manager),
+    simulation_service: SimulationService = Depends(get_simulation_service),
     logger: Any = Depends(get_logger),
 ) -> TrajectoryRecordResponse:
     """Control trajectory recording (start, stop, export).
 
     Args:
         request: Recording action and export format.
-        engine_manager: Injected engine manager.
+        simulation_service: Injected simulation service (owns recording state).
         logger: Injected logger.
 
     Returns:
@@ -573,8 +567,7 @@ async def control_recording(
     action = request.action
 
     if action == "start":
-        engine_manager._is_recording = True  # type: ignore[attr-defined]
-        engine_manager._recorded_frames = []  # type: ignore[attr-defined]
+        simulation_service.start_recording()
         return TrajectoryRecordResponse(  # type: ignore[call-arg]
             recording=True,
             frame_count=0,
@@ -582,8 +575,8 @@ async def control_recording(
         )
 
     if action == "stop":
-        engine_manager._is_recording = False  # type: ignore[attr-defined]
-        frame_count = len(getattr(engine_manager, "_recorded_frames", []))
+        simulation_service.stop_recording()
+        frame_count = len(simulation_service.stats.recorded_frames)
         return TrajectoryRecordResponse(  # type: ignore[call-arg]
             recording=False,
             frame_count=frame_count,
@@ -591,7 +584,7 @@ async def control_recording(
         )
 
     if action == "export":
-        recorded = getattr(engine_manager, "_recorded_frames", [])
+        recorded = simulation_service.stats.recorded_frames
         frame_count = len(recorded)
         export_path = None
 
@@ -618,7 +611,7 @@ async def control_recording(
                 )
 
         return TrajectoryRecordResponse(
-            recording=getattr(engine_manager, "_is_recording", False),
+            recording=simulation_service.stats.is_recording,
             frame_count=frame_count,
             status="Trajectory exported" if export_path else "No frames to export",
             export_path=export_path,

--- a/src/api/services/simulation_service.py
+++ b/src/api/services/simulation_service.py
@@ -1,5 +1,7 @@
 """Simulation service for Golf Modeling Suite API."""
 
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from src.shared.python.core.contracts import precondition
@@ -18,6 +20,23 @@ from ..models.responses import SimulationResponse
 
 logger = get_logger(__name__)
 
+_DEFAULT_SPEED_FACTOR = 1.0
+
+
+@dataclass
+class SimulationStats:
+    """Authoritative runtime state for an active simulation session.
+
+    Owned by SimulationService and updated by the real simulation loop.
+    Routes read from this instead of engine_manager private fields.
+    """
+
+    start_time: float = field(default_factory=time.time)
+    frame_count: int = 0
+    speed_factor: float = _DEFAULT_SPEED_FACTOR
+    is_recording: bool = False
+    recorded_frames: list[Any] = field(default_factory=list)
+
 
 class SimulationService:
     """Service for managing physics simulations."""
@@ -29,6 +48,29 @@ class SimulationService:
             engine_manager: Engine manager instance
         """
         self.engine_manager = engine_manager
+        self._stats = SimulationStats()
+
+    @property
+    def stats(self) -> SimulationStats:
+        """Return the authoritative runtime stats for this session."""
+        return self._stats
+
+    def start_recording(self) -> None:
+        """Begin recording trajectory frames. Clears any previously recorded data."""
+        self._stats.is_recording = True
+        self._stats.recorded_frames = []
+
+    def stop_recording(self) -> None:
+        """Stop recording trajectory frames."""
+        self._stats.is_recording = False
+
+    def set_speed_factor(self, value: float) -> None:
+        """Set simulation speed multiplier.
+
+        Args:
+            value: Speed multiplier (>0).
+        """
+        self._stats.speed_factor = value
 
     @precondition(
         lambda self, request: request is not None,
@@ -112,6 +154,7 @@ class SimulationService:
                     engine.set_control(control["torques"])
             engine.step(timestep)
             recorder.record_step()
+            self._stats.frame_count += 1
 
     async def run_simulation(self, request: SimulationRequest) -> SimulationResponse:
         """Run a physics simulation based on request parameters.
@@ -123,6 +166,8 @@ class SimulationService:
             Simulation results and data
         """
         try:
+            self._stats.start_time = time.time()
+            self._stats.frame_count = 0
             engine = self._prepare_engine(request)
             recorder = GenericPhysicsRecorder(engine)
 

--- a/tests/unit/api/test_simulation_service.py
+++ b/tests/unit/api/test_simulation_service.py
@@ -490,3 +490,160 @@ class TestPerformAnalysis:
 
         # Should return empty results without raising
         assert isinstance(results, dict)
+
+
+# ──────────────────────────────────────────────────────────────
+#  SimulationStats — authoritative runtime state (issue #2469)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSimulationStats:
+    """SimulationStats dataclass is the single source of truth for runtime state."""
+
+    def test_can_import(self):
+        from src.api.services.simulation_service import SimulationStats  # noqa: F401
+
+    def test_default_frame_count_is_zero(self):
+        from src.api.services.simulation_service import SimulationStats
+
+        s = SimulationStats()
+        assert s.frame_count == 0
+
+    def test_default_is_not_recording(self):
+        from src.api.services.simulation_service import SimulationStats
+
+        s = SimulationStats()
+        assert s.is_recording is False
+
+    def test_default_recorded_frames_is_empty(self):
+        from src.api.services.simulation_service import SimulationStats
+
+        s = SimulationStats()
+        assert s.recorded_frames == []
+
+    def test_default_speed_factor_is_one(self):
+        from src.api.services.simulation_service import SimulationStats
+
+        s = SimulationStats()
+        assert s.speed_factor == 1.0
+
+    def test_start_time_is_float(self):
+        from src.api.services.simulation_service import SimulationStats
+
+        s = SimulationStats()
+        assert isinstance(s.start_time, float)
+
+
+class TestSimulationServiceStatsTracking:
+    """SimulationService owns stats and wires them through the sim loop."""
+
+    def test_service_exposes_stats_property(self, mock_engine_manager):
+        from src.api.services.simulation_service import (
+            SimulationService,
+            SimulationStats,
+        )
+
+        service = SimulationService(mock_engine_manager)
+        assert isinstance(service.stats, SimulationStats)
+
+    def test_start_recording_sets_flag(self, mock_engine_manager):
+        from src.api.services.simulation_service import SimulationService
+
+        service = SimulationService(mock_engine_manager)
+        service.start_recording()
+        assert service.stats.is_recording is True
+
+    def test_start_recording_clears_frames(self, mock_engine_manager):
+        from src.api.services.simulation_service import SimulationService
+
+        service = SimulationService(mock_engine_manager)
+        # Manually place a frame to verify it gets cleared
+        service.stats.recorded_frames.append({"t": 0.0})
+        service.start_recording()
+        assert service.stats.recorded_frames == []
+
+    def test_stop_recording_clears_flag(self, mock_engine_manager):
+        from src.api.services.simulation_service import SimulationService
+
+        service = SimulationService(mock_engine_manager)
+        service.start_recording()
+        service.stop_recording()
+        assert service.stats.is_recording is False
+
+    def test_set_speed_factor_updates_stats(self, mock_engine_manager):
+        from src.api.services.simulation_service import SimulationService
+
+        service = SimulationService(mock_engine_manager)
+        service.set_speed_factor(2.5)
+        assert service.stats.speed_factor == 2.5
+
+    async def test_frame_count_reflects_simulation_steps(self, mock_engine_manager):
+        """After run_simulation, stats.frame_count equals the steps executed."""
+        from src.api.models.requests import SimulationRequest
+        from src.api.services.simulation_service import SimulationService
+
+        mock_engine = MagicMock(spec=PhysicsEngine)
+        mock_engine.step = MagicMock()
+        mock_engine_manager.get_active_physics_engine = MagicMock(
+            return_value=mock_engine
+        )
+
+        with (
+            patch(
+                "src.api.services.simulation_service.GenericPhysicsRecorder"
+            ) as MockRecorder,
+            patch("src.api.services.simulation_service.EngineType", MockEngineType),
+        ):
+            mock_recorder = MagicMock(spec=_RECORDER_SPEC_ATTRS)
+            mock_recorder.is_recording = False
+            mock_recorder.record_step = MagicMock()
+            mock_recorder.get_time_series = MagicMock(
+                return_value=(np.array([0.0, 0.001]), np.array([[0], [0.1]]))
+            )
+            MockRecorder.return_value = mock_recorder
+
+            service = SimulationService(mock_engine_manager)
+            request = SimulationRequest(
+                engine_type="mujoco",
+                duration=0.01,
+                timestep=0.001,
+            )
+
+            await service.run_simulation(request)
+            # 0.01 / 0.001 = 10 steps
+            assert service.stats.frame_count == 10
+
+    async def test_start_time_reset_on_run_simulation(self, mock_engine_manager):
+        """run_simulation resets start_time so wall_time is accurate."""
+        import time
+
+        from src.api.models.requests import SimulationRequest
+        from src.api.services.simulation_service import SimulationService
+
+        mock_engine = MagicMock(spec=PhysicsEngine)
+        mock_engine.step = MagicMock()
+        mock_engine_manager.get_active_physics_engine = MagicMock(
+            return_value=mock_engine
+        )
+
+        with (
+            patch(
+                "src.api.services.simulation_service.GenericPhysicsRecorder"
+            ) as MockRecorder,
+            patch("src.api.services.simulation_service.EngineType", MockEngineType),
+        ):
+            mock_recorder = MagicMock(spec=_RECORDER_SPEC_ATTRS)
+            mock_recorder.is_recording = False
+            mock_recorder.record_step = MagicMock()
+            mock_recorder.get_time_series = MagicMock(
+                return_value=(np.array([0.0]), np.array([[0]]))
+            )
+            MockRecorder.return_value = mock_recorder
+
+            service = SimulationService(mock_engine_manager)
+            before = time.time()
+            request = SimulationRequest(engine_type="mujoco", duration=0.001)
+            await service.run_simulation(request)
+            after = time.time()
+
+            assert before <= service.stats.start_time <= after


### PR DESCRIPTION
## Summary

- Introduces `SimulationStats` dataclass in `SimulationService` as the single authoritative source of truth for `start_time`, `frame_count`, `speed_factor`, `is_recording`, and `recorded_frames`
- `_execute_simulation_loop` now increments `frame_count` on every step; `run_simulation` resets `start_time`/`frame_count` at the start of each run
- `/simulation/stats`, `/simulation/speed`, and `/simulation/recording` routes now read from `SimulationService.stats` and call its `start_recording()`/`stop_recording()`/`set_speed_factor()` methods instead of accessing fabricated private fields on `EngineManager` via `getattr(..., default)`

Closes #2469

## Test plan

- [x] `TestSimulationStats` — 6 tests verifying dataclass default values and field types
- [x] `TestSimulationServiceStatsTracking` — 7 tests verifying `start_recording`, `stop_recording`, `set_speed_factor`, and that `frame_count` and `start_time` are correctly updated by `run_simulation`
- [x] All pre-existing `TestSimulationService*` tests still pass (1 pre-existing failure in `test_handles_simulation_failure_in_background` is unrelated to this PR and was failing on `staging` before these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)