### PR TITLE
fix(server-auth): align auth key_prefix field and register WS routes (#2447, #2448)

### DIFF
--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -108,11 +108,11 @@ def _lookup_api_key_by_prefix(api_key: str, db: Session) -> APIKey:
     try:
         active_keys = (
             db.query(APIKey)
-            .filter(APIKey.is_active, APIKey.prefix_hash == prefix_hash)
+            .filter(APIKey.is_active, APIKey.key_prefix == prefix_hash)
             .all()
         )
     except (RuntimeError, ValueError, OSError):
-        # Fallback: prefix_hash column doesn't exist yet (migration pending)
+        # Fallback: key_prefix column not yet migrated (schema pending)
         active_keys = db.query(APIKey).filter(APIKey.is_active).all()
 
     if not active_keys:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -46,7 +46,9 @@ from .database import init_db
 from .middleware.security_headers import add_security_headers
 from .middleware.upload_limits import validate_upload_size
 from .route_registry import register_routes
+from .routes import chat_ws, simulation_ws
 from .services.analysis_service import AnalysisService
+from .services.chat_service import ChatService
 from .services.simulation_service import SimulationService
 from .task_manager import TaskManager
 from .utils.tracing import RequestTracer
@@ -131,6 +133,7 @@ async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
         # Initialize services and store in app.state for dependency injection
         fastapi_app.state.simulation_service = SimulationService(engine_manager)
         fastapi_app.state.analysis_service = AnalysisService(engine_manager)
+        fastapi_app.state.chat_service = ChatService()
         fastapi_app.state.task_manager = active_tasks
         fastapi_app.state.logger = logger
 
@@ -257,6 +260,13 @@ logger.info("Registered %d route modules at root prefix", _root_count)
 # Register all routes under /api/v1/ prefix (versioned API)
 _versioned_count = register_routes(app, prefix=API_PREFIX)
 logger.info("Registered %d route modules under %s", _versioned_count, API_PREFIX)
+
+# WebSocket routes are excluded from auto-discovery and must be registered explicitly.
+# See route_registry._EXCLUDED_MODULES and issue #2448.
+app.include_router(simulation_ws.router, prefix="")
+app.include_router(chat_ws.router, prefix="")
+app.include_router(simulation_ws.router, prefix=API_PREFIX)
+app.include_router(chat_ws.router, prefix=API_PREFIX)
 
 
 if __name__ == "__main__":

--- a/tests/unit/api/test_auth_dependencies.py
+++ b/tests/unit/api/test_auth_dependencies.py
@@ -1,0 +1,90 @@
+"""Tests for auth/dependencies — API key lookup field alignment (issue #2447).
+
+Verifies that the dependency layer queries APIKey.key_prefix (the real ORM column),
+not the non-existent APIKey.prefix_hash.
+"""
+
+import pytest
+
+try:
+    import sqlalchemy  # noqa: F401
+
+    _HAS_SQLALCHEMY = True
+except ImportError:
+    _HAS_SQLALCHEMY = False
+
+requires_sqlalchemy = pytest.mark.skipif(
+    not _HAS_SQLALCHEMY, reason="sqlalchemy not installed"
+)
+
+
+class TestAPIKeyOrmFieldAlignment:
+    """APIKey ORM model and dependency layer use the same column name."""
+
+    @requires_sqlalchemy
+    def test_apikey_has_key_prefix_column(self):
+        """ORM model defines key_prefix column (not prefix_hash)."""
+        from src.api.auth.models import APIKey
+
+        col_names = {c.key for c in APIKey.__table__.columns}
+        assert "key_prefix" in col_names
+
+    @requires_sqlalchemy
+    def test_apikey_does_not_have_prefix_hash_column(self):
+        """ORM model does not define prefix_hash — that name is wrong."""
+        from src.api.auth.models import APIKey
+
+        col_names = {c.key for c in APIKey.__table__.columns}
+        assert "prefix_hash" not in col_names
+
+    def test_dependency_references_key_prefix_not_prefix_hash(self):
+        """_lookup_api_key_by_prefix uses APIKey.key_prefix in its filter call."""
+        from pathlib import Path
+
+        dep_file = (
+            Path(__file__).parents[3] / "src" / "api" / "auth" / "dependencies.py"
+        )
+        source = dep_file.read_text(encoding="utf-8")
+        # After fix: the filter references key_prefix, not prefix_hash
+        assert "key_prefix" in source, (
+            "dependencies.py must filter on APIKey.key_prefix"
+        )
+
+    def test_dependency_does_not_reference_apikey_prefix_hash(self):
+        """No ORM attribute access APIKey.prefix_hash — that column does not exist."""
+        from pathlib import Path
+
+        dep_file = (
+            Path(__file__).parents[3] / "src" / "api" / "auth" / "dependencies.py"
+        )
+        source = dep_file.read_text(encoding="utf-8")
+        # The local variable "prefix_hash" and function "compute_prefix_hash" are fine;
+        # only the ORM column access APIKey.prefix_hash is wrong (column is key_prefix).
+        assert "APIKey.prefix_hash" not in source, (
+            "dependencies.py must not access APIKey.prefix_hash (non-existent column); "
+            "use APIKey.key_prefix instead"
+        )
+
+    @requires_sqlalchemy
+    def test_lookup_does_not_raise_attribute_error(self):
+        """Filter on key_prefix succeeds; filter on prefix_hash raises AttributeError."""
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+        from sqlalchemy.orm import Session
+
+        from src.api.auth.dependencies import _lookup_api_key_by_prefix
+
+        mock_db = MagicMock(spec=Session)
+        mock_chain = MagicMock()
+        mock_db.query.return_value = mock_chain
+        mock_chain.filter.return_value = mock_chain
+        mock_chain.all.return_value = []  # No matching keys → 401
+
+        # Should raise 401, NOT AttributeError for missing column
+        with pytest.raises(HTTPException) as exc_info:
+            _lookup_api_key_by_prefix("gms_12345678_dummy", mock_db)
+
+        assert exc_info.value.status_code == 401
+        # filter() must have been called (not short-circuited by AttributeError)
+        assert mock_chain.filter.called

--- a/tests/unit/api/test_server_wiring.py
+++ b/tests/unit/api/test_server_wiring.py
@@ -1,0 +1,65 @@
+"""Tests for server.py route registration — WebSocket routes (issue #2448).
+
+The main server must register chat_ws and simulation_ws routers explicitly
+because route_registry.py excludes them from auto-discovery.
+
+These tests read server.py source directly because the server has production
+dependencies (slowapi, uvicorn) that are not installed in the unit test
+environment; the CI environment has them and will also run the integration
+tests that exercise the actual HTTP layer.
+"""
+
+from pathlib import Path
+
+_SERVER_PY = Path(__file__).parents[3] / "src" / "api" / "server.py"
+_SERVER_SRC = _SERVER_PY.read_text(encoding="utf-8")
+
+
+class TestWebSocketRoutesRegistered:
+    """WebSocket routes are registered on the main server app."""
+
+    def test_server_imports_simulation_ws(self):
+        """server.py imports simulation_ws router module."""
+        assert "simulation_ws" in _SERVER_SRC, (
+            "server.py must import simulation_ws to register its WebSocket route"
+        )
+
+    def test_server_imports_chat_ws(self):
+        """server.py imports chat_ws router module."""
+        assert "chat_ws" in _SERVER_SRC, (
+            "server.py must import chat_ws to register its WebSocket route"
+        )
+
+    def test_server_includes_simulation_ws_router(self):
+        """server.py calls app.include_router for simulation_ws.router."""
+        assert "simulation_ws.router" in _SERVER_SRC, (
+            "server.py must call app.include_router(simulation_ws.router, ...) "
+            "to expose the /ws/simulate WebSocket endpoint"
+        )
+
+    def test_server_includes_chat_ws_router(self):
+        """server.py calls app.include_router for chat_ws.router."""
+        assert "chat_ws.router" in _SERVER_SRC, (
+            "server.py must call app.include_router(chat_ws.router, ...) "
+            "to expose the /ws/chat WebSocket endpoint"
+        )
+
+    def test_chat_service_initialised_in_lifespan(self):
+        """server.py lifespan initialises ChatService and stores it in app.state.
+
+        Required by the chat_ws route which reads request.app.state.chat_service.
+        """
+        assert "chat_service" in _SERVER_SRC, (
+            "server.py lifespan must initialise ChatService and store it in "
+            "app.state.chat_service for the chat WebSocket route to work."
+        )
+        assert "ChatService" in _SERVER_SRC, (
+            "server.py must import and instantiate ChatService"
+        )
+
+    def test_route_registry_exclusion_set_contains_websocket_modules(self):
+        """Auto-discovery exclusion list skips chat_ws and simulation_ws."""
+        from src.api.route_registry import _EXCLUDED_MODULES
+
+        assert "chat_ws" in _EXCLUDED_MODULES
+        assert "simulation_ws" in _EXCLUDED_MODULES


### PR DESCRIPTION
## Summary

- **#2447**: `_lookup_api_key_by_prefix` filtered on `APIKey.prefix_hash` — a column that does not exist on the ORM model or in the migration. Both define `key_prefix`. Fixed to use `APIKey.key_prefix`.
- **#2448**: `server.py` called `register_routes()` which auto-excludes `chat_ws` and `simulation_ws`, but never registered them back. Now explicitly includes both routers at root (`""`) and versioned (`/api/v1`) prefixes after auto-discovery. Also initializes `ChatService` in the lifespan so `app.state.chat_service` is available for the chat WebSocket route.

Closes #2447, Closes #2448

## Test plan

- [x] `TestAPIKeyOrmFieldAlignment` (5 tests) — verifies `key_prefix` column exists in ORM, `APIKey.prefix_hash` is never accessed, mock-DB lookup raises 401 cleanly (3 SQLAlchemy-only tests skip locally, run on CI)
- [x] `TestWebSocketRoutesRegistered` (5 tests) — verifies server.py source imports and includes `simulation_ws.router` and `chat_ws.router`, and initializes `ChatService`
- [x] All pre-existing local tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)