### PR TITLE
fix(version): single canonical version source across all API surfaces (#2453)

### DIFF
--- a/src/api/_version.py
+++ b/src/api/_version.py
@@ -1,0 +1,9 @@
+"""Single source of truth for the UpstreamDrift API version.
+
+All version surfaces (server.py OpenAPI metadata, local_server.py, and the
+root endpoint in routes/core.py) import __version__ from here so they stay
+in sync with pyproject.toml.
+"""
+
+#: Canonical API version — must match pyproject.toml [project].version
+__version__ = "2.1.0"

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -45,6 +45,7 @@ from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import HTMLResponse, JSONResponse  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 
+from src.api._version import __version__  # noqa: E402
 from src.api.diagnostics import (  # noqa: E402
     APIDiagnostics,
     get_diagnostic_endpoint_html,
@@ -610,7 +611,7 @@ def create_local_app() -> FastAPI:
             f"All endpoints are available under `{API_PREFIX}/` prefix.\n"
             "Legacy `/api/` routes are maintained for backward compatibility."
         ),
-        version="2.0.0",
+        version=__version__,
         docs_url="/api/docs",  # Swagger UI available locally
         redoc_url="/api/redoc",
     )

--- a/src/api/routes/core.py
+++ b/src/api/routes/core.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends
 from src.api.utils.datetime_compat import iso_format, utc_now
 from src.shared.python.core.contracts import precondition
 
+from .._version import __version__
 from ..dependencies import get_engine_manager
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ async def root() -> dict[str, str]:
     """Root endpoint with API information."""
     return {
         "message": "Golf Modeling Suite API",
-        "version": "1.0.0",
+        "version": __version__,
         "docs": "/docs",
         "status": "running",
     }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -36,6 +36,7 @@ from src.shared.python.engine_core.engine_manager import EngineManager
 # Configure logging - use centralized logging config
 from src.shared.python.logging_pkg.logging_config import get_logger, setup_logging
 
+from ._version import __version__
 from .config import (
     get_allowed_hosts,
     get_cors_origins,
@@ -175,7 +176,7 @@ app = FastAPI(
         f"All endpoints are available under `{API_PREFIX}/` prefix.\n"
         "Legacy un-prefixed routes are maintained for backward compatibility."
     ),
-    version="3.0.0",
+    version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_tags=[

--- a/tests/unit/api/test_version_consistency.py
+++ b/tests/unit/api/test_version_consistency.py
@@ -1,0 +1,105 @@
+"""Tests for version metadata consistency across all surfaces (issue #2453).
+
+The canonical version lives in src/api/_version.py and all other surfaces
+(server.py FastAPI metadata, local_server.py, and the root endpoint in core.py)
+import from there.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parents[3]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _pyproject_version() -> str:
+    """Read the package version from pyproject.toml."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    with open(_PYPROJECT, "rb") as f:
+        data = tomllib.load(f)
+    return str(data["project"]["version"])
+
+
+class TestVersionModuleExists:
+    """src.api._version provides the canonical version."""
+
+    def test_can_import_version_module(self):
+        from src.api._version import __version__  # noqa: F401
+
+    def test_version_is_non_empty_string(self):
+        from src.api._version import __version__
+
+        assert isinstance(__version__, str)
+        assert len(__version__) > 0
+
+    def test_version_matches_pyproject_toml(self):
+        from src.api._version import __version__
+
+        expected = _pyproject_version()
+        assert __version__ == expected, (
+            f"src.api._version.__version__ ({__version__!r}) must match "
+            f"pyproject.toml version ({expected!r})"
+        )
+
+
+class TestVersionSurfacesAligned:
+    """All version surfaces read from the single canonical source."""
+
+    def test_server_py_uses_canonical_version(self):
+        """server.py FastAPI version should not hardcode a stale string."""
+        server_src = (_REPO_ROOT / "src" / "api" / "server.py").read_text(
+            encoding="utf-8"
+        )
+        assert "_version" in server_src or "__version__" in server_src, (
+            "server.py must import __version__ from src.api._version "
+            "instead of hardcoding a version string"
+        )
+
+    def test_server_py_does_not_hardcode_old_version(self):
+        """3.0.0 (old hardcoded value) is not in server.py."""
+        server_src = (_REPO_ROOT / "src" / "api" / "server.py").read_text(
+            encoding="utf-8"
+        )
+        assert '"3.0.0"' not in server_src, (
+            "server.py must not hardcode version '3.0.0'; use __version__ from _version.py"
+        )
+
+    def test_local_server_py_uses_canonical_version(self):
+        """local_server.py FastAPI version should not hardcode a stale string."""
+        local_src = (_REPO_ROOT / "src" / "api" / "local_server.py").read_text(
+            encoding="utf-8"
+        )
+        assert "_version" in local_src or "__version__" in local_src, (
+            "local_server.py must import __version__ from src.api._version"
+        )
+
+    def test_local_server_py_does_not_hardcode_old_version(self):
+        """2.0.0 (old hardcoded value) is not in local_server.py."""
+        local_src = (_REPO_ROOT / "src" / "api" / "local_server.py").read_text(
+            encoding="utf-8"
+        )
+        assert '"2.0.0"' not in local_src, (
+            "local_server.py must not hardcode version '2.0.0'; use __version__"
+        )
+
+    def test_core_route_uses_canonical_version(self):
+        """The root endpoint in core.py must not return a hardcoded version."""
+        core_src = (_REPO_ROOT / "src" / "api" / "routes" / "core.py").read_text(
+            encoding="utf-8"
+        )
+        assert "_version" in core_src or "__version__" in core_src, (
+            "core.py root endpoint must return __version__ from _version.py, "
+            "not a hardcoded string"
+        )
+
+    def test_core_route_does_not_hardcode_old_version(self):
+        """1.0.0 (old hardcoded value) is not in core.py."""
+        core_src = (_REPO_ROOT / "src" / "api" / "routes" / "core.py").read_text(
+            encoding="utf-8"
+        )
+        assert '"1.0.0"' not in core_src, (
+            "core.py must not hardcode version '1.0.0'; use __version__ from _version.py"
+        )


### PR DESCRIPTION
## Summary

- Introduces `src/api/_version.py` as the single source of truth: `__version__ = "2.1.0"` (matches `pyproject.toml`)
- Updates `server.py` (was `"3.0.0"`), `local_server.py` (was `"2.0.0"`), and `routes/core.py` root endpoint (was `"1.0.0"`) to import and use `__version__`

Closes #2453

## Test plan

- [x] `TestVersionModuleExists` — 3 tests verify `_version.py` exports a non-empty string matching `pyproject.toml`
- [x] `TestVersionSurfacesAligned` — 6 tests verify `server.py`, `local_server.py`, and `core.py` import `__version__` and no longer contain their old hardcoded strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)