### PR TITLE
fix(analysis-tools): raise 501 on unsupported engines instead of fabricating success (#2452)

### DIFF
--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -45,6 +45,73 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
+def _check_position_support(engine: Any) -> None:
+    """Raise HTTPException 501 when the engine supports neither body-position setter.
+
+    Args:
+        engine: Active physics engine instance.
+
+    Raises:
+        HTTPException: 501 if the engine lacks both set_body_position and
+            set_body_rotation, so callers never silently succeed without moving anything.
+    """
+    if not hasattr(engine, "set_body_position") and not hasattr(
+        engine, "set_body_rotation"
+    ):
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "Engine does not support body positioning. "
+                "set_body_position and set_body_rotation are not available."
+            ),
+        )
+
+
+def _get_body_position_vectors(
+    engine: Any, body_a: str, body_b: str
+) -> tuple[list[float], list[float]]:
+    """Return the 3-D positions of two named bodies.
+
+    Args:
+        engine: Active physics engine instance.
+        body_a: Name of the first body.
+        body_b: Name of the second body.
+
+    Returns:
+        Tuple of (pos_a, pos_b) as plain Python float lists.
+
+    Raises:
+        HTTPException: 501 if the engine lacks get_body_position.
+        HTTPException: 400 if either position cannot be retrieved (returns None).
+    """
+    if not hasattr(engine, "get_body_position"):
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "Engine does not support body position queries. "
+                "get_body_position is not available."
+            ),
+        )
+
+    pa = engine.get_body_position(body_a)
+    if pa is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not retrieve position for body '{body_a}'.",
+        )
+
+    pb = engine.get_body_position(body_b)
+    if pb is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not retrieve position for body '{body_b}'.",
+        )
+
+    pos_a: list[float] = pa.tolist() if hasattr(pa, "tolist") else list(pa)
+    pos_b: list[float] = pb.tolist() if hasattr(pb, "tolist") else list(pb)
+    return pos_a, pos_b
+
+
 def _collect_metrics(engine_manager: EngineManager) -> dict[str, Any]:
     """Collect current metrics from the active engine.
 
@@ -390,7 +457,9 @@ async def set_body_position(
     rotation = request.rotation or [0.0, 0.0, 0.0]
 
     try:
-        # Try to set body position via engine API
+        # Raise 501 early if the engine supports neither setter
+        _check_position_support(engine)
+
         if hasattr(engine, "set_body_position"):
             engine.set_body_position(request.body_name, position)
         if hasattr(engine, "set_body_rotation"):
@@ -455,18 +524,10 @@ async def measure_distance(
         )
 
     try:
-        # Get body positions
-        pos_a = [0.0, 0.0, 0.0]
-        pos_b = [0.0, 0.0, 0.0]
-
-        if hasattr(engine, "get_body_position"):
-            pa = engine.get_body_position(request.body_a)
-            if pa is not None:
-                pos_a = pa.tolist() if hasattr(pa, "tolist") else list(pa)
-
-            pb = engine.get_body_position(request.body_b)
-            if pb is not None:
-                pos_b = pb.tolist() if hasattr(pb, "tolist") else list(pb)
+        # Raise 501 if engine doesn't support body position queries
+        pos_a, pos_b = _get_body_position_vectors(
+            engine, request.body_a, request.body_b
+        )
 
         # Compute distance
         delta = [b - a for a, b in zip(pos_a, pos_b, strict=True)]
@@ -480,6 +541,8 @@ async def measure_distance(
             position_b=pos_b,
             delta=delta,
         )
+    except HTTPException:
+        raise
     except (ValueError, RuntimeError, AttributeError) as exc:
         if logger:
             logger.error("Measurement error: %s", exc)

--- a/tests/unit/api/test_analysis_tools_capabilities.py
+++ b/tests/unit/api/test_analysis_tools_capabilities.py
@@ -1,0 +1,92 @@
+"""Tests for analysis_tools route capability checking (issue #2452).
+
+Routes must return 501 Not Implemented (or 400) when the active physics engine
+does not support the requested operation, rather than silently returning
+fabricated success or zero-value measurements.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestBodyPositionSupportCheck:
+    """set_body_position must surface unsupported-engine errors."""
+
+    def test_check_raises_when_engine_has_neither_setter(self):
+        """Engine with no setter methods → HTTPException (not silent success)."""
+        from fastapi import HTTPException
+
+        from src.api.routes.analysis_tools import _check_position_support
+
+        engine = MagicMock()
+        # Remove the setter attributes so hasattr returns False
+        del engine.set_body_position
+        del engine.set_body_rotation
+
+        with pytest.raises(HTTPException) as exc_info:
+            _check_position_support(engine)
+
+        assert exc_info.value.status_code in (400, 501)
+
+    def test_check_passes_when_engine_has_position_setter(self):
+        """Engine with set_body_position → no exception raised."""
+        from src.api.routes.analysis_tools import _check_position_support
+
+        engine = MagicMock(spec=["set_body_position"])
+        _check_position_support(engine)  # should not raise
+
+    def test_check_passes_when_engine_has_rotation_setter(self):
+        """Engine with set_body_rotation alone → no exception raised."""
+        from src.api.routes.analysis_tools import _check_position_support
+
+        engine = MagicMock(spec=["set_body_rotation"])
+        _check_position_support(engine)  # should not raise
+
+
+class TestBodyMeasurementSupportCheck:
+    """measure_distance must raise when engine lacks get_body_position."""
+
+    def test_get_positions_raises_when_engine_has_no_getter(self):
+        """Engine without get_body_position → HTTPException (not zero vectors)."""
+        from fastapi import HTTPException
+
+        from src.api.routes.analysis_tools import _get_body_position_vectors
+
+        engine = MagicMock()
+        del engine.get_body_position  # ensure hasattr returns False
+
+        with pytest.raises(HTTPException) as exc_info:
+            _get_body_position_vectors(engine, "body_a", "body_b")
+
+        assert exc_info.value.status_code in (400, 501)
+
+    def test_get_positions_returns_vectors_when_supported(self):
+        """Engine with get_body_position → returns actual position vectors."""
+        import numpy as np
+
+        from src.api.routes.analysis_tools import _get_body_position_vectors
+
+        engine = MagicMock(spec=["get_body_position"])
+        engine.get_body_position.side_effect = [
+            np.array([1.0, 2.0, 3.0]),
+            np.array([4.0, 5.0, 6.0]),
+        ]
+
+        pos_a, pos_b = _get_body_position_vectors(engine, "body_a", "body_b")
+        assert pos_a == [1.0, 2.0, 3.0]
+        assert pos_b == [4.0, 5.0, 6.0]
+
+    def test_get_positions_handles_none_return(self):
+        """Engine with get_body_position returning None → raises HTTPException."""
+        from fastapi import HTTPException
+
+        from src.api.routes.analysis_tools import _get_body_position_vectors
+
+        engine = MagicMock(spec=["get_body_position"])
+        engine.get_body_position.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            _get_body_position_vectors(engine, "body_a", "body_b")
+
+        assert exc_info.value.status_code in (400, 501)


### PR DESCRIPTION
## Summary

- `set_body_position` was returning `BodyPositionResponse(status="Position set")` even when the engine had neither `set_body_position` nor `set_body_rotation` — the body was never moved. Now raises **HTTP 501** in that case via `_check_position_support(engine)`.
- `measure_distance` was defaulting both body positions to `[0.0, 0.0, 0.0]` when the engine lacked `get_body_position`, producing a fabricated zero-distance result. Now raises **HTTP 501** if the method is absent and **HTTP 400** if a position lookup returns `None`, via `_get_body_position_vectors(engine, body_a, body_b)`.

Closes #2452

## Test plan

- [x] `TestBodyPositionSupportCheck` — 3 tests: engine with no setters raises 501, engine with either setter passes
- [x] `TestBodyMeasurementSupportCheck` — 3 tests: engine without getter raises 501, engine with getter returns correct vectors, `None` return raises 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)