### PR TITLE
fix(#2449): auth-bypass default changed to remote for safe-by-default posture

### DIFF
--- a/src/shared/python/config/environment.py
+++ b/src/shared/python/config/environment.py
@@ -504,11 +504,15 @@ def get_golf_port(default: int = 8000) -> int:
     )
 
 
-def get_golf_suite_mode(default: str = "local") -> str:
+def get_golf_suite_mode(default: str = "remote") -> str:
     """Get the Golf Suite operating mode.
 
+    Defaults to ``"remote"`` (auth-required) when ``GOLF_SUITE_MODE`` is not
+    set.  Set ``GOLF_SUITE_MODE=local`` explicitly to enable auth bypass for
+    local development — do not rely on the absence of the variable.
+
     Args:
-        default: Default mode (``"local"``).
+        default: Default mode (``"remote"``).
 
     Returns:
         Mode string (e.g., ``"local"``, ``"remote"``).

--- a/tests/unit/api/test_auth_default_secure.py
+++ b/tests/unit/api/test_auth_default_secure.py
@@ -1,0 +1,74 @@
+"""Tests for auth-bypass default security (issue #2449).
+
+Engine mutation endpoints must require authentication by default.
+Auth bypass must only activate when GOLF_SUITE_MODE=local is explicitly set,
+not when the variable is absent.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+class TestAuthDefaultIsSecure:
+    """When no environment is configured, auth must be required (not bypassed)."""
+
+    def test_is_auth_disabled_returns_false_when_env_unset(self) -> None:
+        """Auth must NOT be disabled when GOLF_SUITE_MODE is absent."""
+        from src.shared.python.config.environment import is_auth_disabled
+
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_auth_disabled() is False, (
+                "Auth should be required when GOLF_SUITE_MODE is not set. "
+                "Deployers must explicitly opt-in to local/auth-free mode."
+            )
+
+    def test_get_golf_suite_mode_defaults_to_remote(self) -> None:
+        """Suite mode must default to 'remote' (auth-required) when env var is absent."""
+        from src.shared.python.config.environment import get_golf_suite_mode
+
+        with patch.dict(os.environ, {}, clear=True):
+            mode = get_golf_suite_mode()
+            assert mode == "remote", (
+                f"Default suite mode should be 'remote', got '{mode}'. "
+                "The default must be secure (auth-required), not 'local'."
+            )
+
+    def test_is_local_mode_returns_false_when_env_unset(self) -> None:
+        """is_local_mode() must return False when no env vars are configured."""
+        from src.api.auth.middleware import is_local_mode
+
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_local_mode() is False, (
+                "Local (auth-bypass) mode must not be active by default."
+            )
+
+    def test_auth_disabled_only_when_explicitly_set_local(self) -> None:
+        """Auth bypass only activates when GOLF_SUITE_MODE=local is explicit."""
+        from src.shared.python.config.environment import is_auth_disabled
+
+        with patch.dict(os.environ, {"GOLF_SUITE_MODE": "local"}, clear=True):
+            assert is_auth_disabled() is True
+
+    def test_auth_required_when_suite_mode_is_remote(self) -> None:
+        """Auth is required when GOLF_SUITE_MODE=remote."""
+        from src.shared.python.config.environment import is_auth_disabled
+
+        with patch.dict(
+            os.environ,
+            {"GOLF_SUITE_MODE": "remote", "GOLF_AUTH_DISABLED": "false"},
+            clear=True,
+        ):
+            assert is_auth_disabled() is False
+
+    def test_auth_disabled_flag_still_overrides(self) -> None:
+        """GOLF_AUTH_DISABLED=true must still override even in remote mode."""
+        from src.shared.python.config.environment import is_auth_disabled
+
+        with patch.dict(
+            os.environ,
+            {"GOLF_SUITE_MODE": "remote", "GOLF_AUTH_DISABLED": "true"},
+            clear=True,
+        ):
+            assert is_auth_disabled() is True

--- a/tests/unit/api/test_auth_middleware.py
+++ b/tests/unit/api/test_auth_middleware.py
@@ -59,13 +59,13 @@ class TestIsLocalMode:
         ):
             assert is_local_mode() is False
 
-    def test_defaults_to_local_mode(self):
-        """Test defaulting to local mode when env vars not set."""
+    def test_defaults_to_remote_mode(self):
+        """Test defaulting to remote (auth-required) mode when env vars not set."""
         from src.api.auth.middleware import is_local_mode
 
         with patch.dict(os.environ, {}, clear=True):
-            # When not set, defaults to "local"
-            assert is_local_mode() is True
+            # When not set, defaults to "remote" (secure default — issue #2449)
+            assert is_local_mode() is False
 
 
 class TestLocalUserContract:


### PR DESCRIPTION
## Summary
- `get_golf_suite_mode()` defaulted to `"local"`, silently disabling auth when `GOLF_SUITE_MODE` was absent
- Changed default from `"local"` to `"remote"` so engine mutation endpoints require authentication unless `GOLF_SUITE_MODE=local` is explicitly set
- `GOLF_AUTH_DISABLED=true` override still works for explicit opt-out
- `local_server.py` already sets `GOLF_SUITE_MODE=local` explicitly — no change needed there

## Test plan
- [x] 6 new TDD tests in `tests/unit/api/test_auth_default_secure.py` covering the secure default behavior
- [x] Updated `test_defaults_to_local_mode` → `test_defaults_to_remote_mode` in `test_auth_middleware.py` to match new contract
- [x] All 18 middleware tests pass; all 37 environment config tests pass
- [x] `ruff check` and `ruff format --check` pass

Closes #2449

🤖 Generated with [Claude Code](https://claude.com/claude-code)