### PR TITLE
fix(#2473): terrain bounds, region serialization, and out-of-bounds correctness

### DIFF
--- a/src/shared/python/physics/terrain.py
+++ b/src/shared/python/physics/terrain.py
@@ -443,14 +443,23 @@ class ElevationMap:
         return gx, gy
 
     def _check_bounds(self, x: float, y: float) -> None:
-        """Check if coordinates are within bounds."""
-        if x < self.origin_x or x > self.origin_x + self.width:
+        """Check if coordinates are within the actual grid extent.
+
+        The valid range is [origin, origin + (n-1)*resolution] where n is the
+        number of grid nodes in that axis.  Coordinates equal to
+        ``origin + width`` (or length) are *beyond* the last grid node and must
+        be rejected so callers never receive silently-clamped values.
+        """
+        n_rows, n_cols = self.data.shape
+        max_x = self.origin_x + (n_cols - 1) * self.resolution
+        max_y = self.origin_y + (n_rows - 1) * self.resolution
+        if x < self.origin_x or x > max_x:
             raise ValueError(
-                f"X coordinate {x} out of bounds [{self.origin_x}, {self.origin_x + self.width}]"
+                f"X coordinate {x} out of bounds [{self.origin_x}, {max_x}]"
             )
-        if y < self.origin_y or y > self.origin_y + self.length:
+        if y < self.origin_y or y > max_y:
             raise ValueError(
-                f"Y coordinate {y} out of bounds [{self.origin_y}, {self.origin_y + self.length}]"
+                f"Y coordinate {y} out of bounds [{self.origin_y}, {max_y}]"
             )
 
     def get_elevation(self, x: float, y: float) -> float:
@@ -786,7 +795,7 @@ class TerrainRegion:
         return MATERIALS[material_name]
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize region to dictionary."""
+        """Serialize region to dictionary, preserving all SurfaceMaterial fields."""
         result: dict[str, Any] = {
             "terrain_type": self.terrain_type.name.lower(),
             "shape_type": self.shape_type,
@@ -795,8 +804,15 @@ class TerrainRegion:
         if self.material is not None:
             result["material"] = {
                 "name": self.material.name,
-                "friction": self.material.friction_coefficient,
+                "friction_coefficient": self.material.friction_coefficient,
+                "rolling_resistance": self.material.rolling_resistance,
                 "restitution": self.material.restitution,
+                "hardness": self.material.hardness,
+                "grass_height_m": self.material.grass_height_m,
+                "compressibility": self.material.compressibility,
+                "compression_damping": self.material.compression_damping,
+                "turf_density": self.material.turf_density,
+                "moisture_content": self.material.moisture_content,
             }
         return result
 
@@ -809,12 +825,7 @@ class TerrainRegion:
             raise ValueError("data must be provided")
         material = None
         if "material" in data:
-            mat = data["material"]
-            material = SurfaceMaterial(
-                name=mat["name"],
-                friction_coefficient=mat["friction"],
-                restitution=mat["restitution"],
-            )
+            material = SurfaceMaterial(**data["material"])
         return cls(
             terrain_type=TerrainType[data["terrain_type"].upper()],
             shape_type=data["shape_type"],

--- a/src/shared/python/physics/terrain_engine.py
+++ b/src/shared/python/physics/terrain_engine.py
@@ -113,11 +113,7 @@ class TerrainAwareEngine:
         if self.terrain is None:
             return 0.0
 
-        try:
-            return self.terrain.get_elevation(x, y)
-        except ValueError:
-            # Out of bounds - return edge value
-            return 0.0
+        return self.terrain.get_elevation(x, y)
 
     def get_contact_normal(self, x: float, y: float) -> np.ndarray:
         """Get terrain contact normal at a position.

--- a/src/shared/python/physics/terrain_mixin.py
+++ b/src/shared/python/physics/terrain_mixin.py
@@ -122,10 +122,7 @@ class TerrainMixin:
         if self._terrain is None:
             return 0.0
 
-        try:
-            return self._terrain.get_elevation(x, y)
-        except ValueError:
-            return 0.0
+        return self._terrain.get_elevation(x, y)
 
     def get_terrain_normal(self, x: float, y: float) -> np.ndarray:
         """Get terrain surface normal at a position.

--- a/tests/unit/test_terrain.py
+++ b/tests/unit/test_terrain.py
@@ -171,9 +171,10 @@ class TestElevationMap:
         # Height should increase in X direction
         assert elev.get_elevation(50, 50) > elev.get_elevation(0, 50)
 
-        # Approximate height change: 100m * tan(5°) ≈ 8.75m
-        expected_rise = 100.0 * math.tan(math.radians(5.0))
-        actual_rise = elev.get_elevation(100, 50) - elev.get_elevation(0, 50)
+        # Grid has 100 nodes at resolution 1m: valid range is [0, 99].
+        # Height change over 99 nodes: 99m * tan(5°) ≈ 8.66m
+        expected_rise = 99.0 * math.tan(math.radians(5.0))
+        actual_rise = elev.get_elevation(99, 50) - elev.get_elevation(0, 50)
         assert abs(actual_rise - expected_rise) < 0.1
 
     def test_elevation_interpolation(self) -> None:
@@ -520,9 +521,9 @@ class TestTerrainFactories:
             terrain_type=TerrainType.FAIRWAY,
         )
 
-        # Check slope exists in Y direction
+        # Grid: 200 nodes at 1m resolution → valid Y range [0, 199].
         h1 = terrain.elevation.get_elevation(50.0, 0.0)
-        h2 = terrain.elevation.get_elevation(50.0, 200.0)
+        h2 = terrain.elevation.get_elevation(50.0, 199.0)
         assert h2 > h1
 
     def test_create_terrain_from_config(self, tmp_path: Path) -> None:

--- a/tests/unit/test_terrain_contracts.py
+++ b/tests/unit/test_terrain_contracts.py
@@ -1,0 +1,231 @@
+"""Tests for terrain API correctness (issue #2473).
+
+Covers three semantic bugs:
+1. ElevationMap._check_bounds accepts coordinates beyond the actual grid extent.
+2. TerrainRegion.to_dict/from_dict drops material physics fields on round-trip.
+3. terrain_engine / terrain_mixin return fabricated 0.0 on out-of-bounds queries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.physics.terrain import (
+    ElevationMap,
+    SurfaceMaterial,
+    TerrainRegion,
+    TerrainType,
+)
+
+
+class TestElevationMapBounds:
+    """ElevationMap must reject coordinates beyond the actual grid extent."""
+
+    def _make_map(self) -> ElevationMap:
+        """10×10m grid with 1m resolution → nodes at 0..9 in each axis."""
+        return ElevationMap.flat(width=10.0, length=10.0, resolution=1.0)
+
+    def test_query_at_origin_succeeds(self) -> None:
+        """First grid node (0, 0) must be accepted."""
+        em = self._make_map()
+        em.get_elevation(0.0, 0.0)  # must not raise
+
+    def test_query_at_last_grid_node_succeeds(self) -> None:
+        """Last grid node (9, 9) must be accepted."""
+        em = self._make_map()
+        em.get_elevation(9.0, 9.0)  # must not raise
+
+    def test_query_beyond_grid_extent_raises(self) -> None:
+        """Coordinate == width (10.0) is beyond the last node (9.0) — must raise."""
+        em = self._make_map()
+        with pytest.raises(ValueError, match="out of bounds"):
+            em.get_elevation(10.0, 5.0)
+
+    def test_query_beyond_length_raises(self) -> None:
+        """Coordinate == length (10.0) is beyond the last node (9.0) — must raise."""
+        em = self._make_map()
+        with pytest.raises(ValueError, match="out of bounds"):
+            em.get_elevation(5.0, 10.0)
+
+    def test_negative_x_raises(self) -> None:
+        """Negative X coordinate is always out of bounds."""
+        em = self._make_map()
+        with pytest.raises(ValueError):
+            em.get_elevation(-0.1, 5.0)
+
+    def test_negative_y_raises(self) -> None:
+        """Negative Y coordinate is always out of bounds."""
+        em = self._make_map()
+        with pytest.raises(ValueError):
+            em.get_elevation(5.0, -0.1)
+
+
+class TestTerrainRegionSerializationRoundTrip:
+    """TerrainRegion to_dict/from_dict must preserve all SurfaceMaterial fields."""
+
+    def _custom_material(self) -> SurfaceMaterial:
+        return SurfaceMaterial(
+            name="custom_rough",
+            friction_coefficient=0.8,
+            rolling_resistance=0.15,
+            restitution=0.4,
+            hardness=0.6,
+            grass_height_m=0.02,
+            compressibility=0.1,
+            compression_damping=0.5,
+            turf_density=500.0,
+            moisture_content=0.2,
+        )
+
+    def _make_region(self) -> TerrainRegion:
+        return TerrainRegion.circle(
+            terrain_type=TerrainType.ROUGH,
+            center_x=10.0,
+            center_y=20.0,
+            radius=5.0,
+            material=self._custom_material(),
+        )
+
+    def test_friction_preserved(self) -> None:
+        """friction_coefficient must survive to_dict → from_dict round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.friction_coefficient == pytest.approx(0.8)
+
+    def test_rolling_resistance_preserved(self) -> None:
+        """rolling_resistance must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.rolling_resistance == pytest.approx(0.15)
+
+    def test_restitution_preserved(self) -> None:
+        """restitution must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.restitution == pytest.approx(0.4)
+
+    def test_hardness_preserved(self) -> None:
+        """hardness must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.hardness == pytest.approx(0.6)
+
+    def test_grass_height_preserved(self) -> None:
+        """grass_height_m must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.grass_height_m == pytest.approx(0.02)
+
+    def test_compressibility_preserved(self) -> None:
+        """compressibility must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.compressibility == pytest.approx(0.1)
+
+    def test_compression_damping_preserved(self) -> None:
+        """compression_damping must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.compression_damping == pytest.approx(0.5)
+
+    def test_turf_density_preserved(self) -> None:
+        """turf_density must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.turf_density == pytest.approx(500.0)
+
+    def test_moisture_content_preserved(self) -> None:
+        """moisture_content must survive round-trip."""
+        region = self._make_region()
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is not None
+        assert restored.material.moisture_content == pytest.approx(0.2)
+
+    def test_no_material_round_trips_as_none(self) -> None:
+        """Region without custom material must round-trip without materialkey."""
+        region = TerrainRegion.circle(
+            terrain_type=TerrainType.FAIRWAY,
+            center_x=0.0,
+            center_y=0.0,
+            radius=5.0,
+        )
+        restored = TerrainRegion.from_dict(region.to_dict())
+        assert restored.material is None
+
+
+class TestTerrainEngineOutOfBounds:
+    """terrain_engine.get_ground_height must not fabricate 0.0 on out-of-bounds."""
+
+    def test_get_ground_height_raises_on_oob(self) -> None:
+        """Out-of-bounds query must raise ValueError, not return 0.0."""
+        from src.shared.python.physics.terrain_engine import TerrainAwareEngine
+
+        engine = TerrainAwareEngine()
+        elevation = ElevationMap.flat(width=10.0, length=10.0, resolution=1.0)
+        from src.shared.python.physics.terrain import Terrain
+
+        terrain = Terrain(name="test", elevation=elevation)
+        engine.set_terrain(terrain)
+
+        with pytest.raises(ValueError, match="out of bounds"):
+            engine.get_ground_height(100.0, 100.0)
+
+    def test_get_ground_height_in_bounds_still_works(self) -> None:
+        """In-bounds query must still return the correct elevation."""
+        from src.shared.python.physics.terrain_engine import TerrainAwareEngine
+
+        engine = TerrainAwareEngine()
+        elevation = ElevationMap.flat(
+            width=10.0, length=10.0, resolution=1.0, base_elevation=3.5
+        )
+        from src.shared.python.physics.terrain import Terrain
+
+        terrain = Terrain(name="test", elevation=elevation)
+        engine.set_terrain(terrain)
+
+        assert engine.get_ground_height(5.0, 5.0) == pytest.approx(3.5)
+
+    def test_get_ground_height_no_terrain_returns_zero(self) -> None:
+        """Without a terrain attached, 0.0 is the correct sentinel."""
+        from src.shared.python.physics.terrain_engine import TerrainAwareEngine
+
+        engine = TerrainAwareEngine()
+        assert engine.get_ground_height(100.0, 100.0) == pytest.approx(0.0)
+
+
+class TestTerrainMixinOutOfBounds:
+    """TerrainMixin.get_ground_height must not fabricate 0.0 on out-of-bounds."""
+
+    def _make_mixin_with_terrain(self):  # type: ignore[no-untyped-def]
+        from src.shared.python.physics.terrain_mixin import TerrainMixin
+
+        class FakeEngine(TerrainMixin):
+            pass
+
+        engine = FakeEngine()
+        elevation = ElevationMap.flat(width=10.0, length=10.0, resolution=1.0)
+        from src.shared.python.physics.terrain import Terrain
+
+        terrain = Terrain(name="test", elevation=elevation)
+        engine.set_terrain(terrain)
+        return engine
+
+    def test_get_ground_height_raises_on_oob(self) -> None:
+        """Out-of-bounds query must raise ValueError, not return 0.0."""
+        engine = self._make_mixin_with_terrain()
+        with pytest.raises(ValueError, match="out of bounds"):
+            engine.get_ground_height(100.0, 100.0)
+
+    def test_get_ground_height_in_bounds_still_works(self) -> None:
+        """In-bounds query must still return the correct elevation."""
+        engine = self._make_mixin_with_terrain()
+        # flat at base_elevation=0.0 by default
+        assert engine.get_ground_height(5.0, 5.0) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- `ElevationMap._check_bounds` now uses actual grid extent `[origin, origin+(n-1)*resolution]` — coordinates equal to `origin+width` were previously accepted and silently clamped, returning wrong values
- `TerrainRegion.to_dict`/`from_dict` now preserves all `SurfaceMaterial` fields (`rolling_resistance`, `hardness`, `grass_height_m`, `compressibility`, `compression_damping`, `turf_density`, `moisture_content`) using the correct `friction_coefficient` key, matching `TerrainPatch` serialization
- `terrain_engine.get_ground_height` and `terrain_mixin.get_ground_height` no longer swallow `ValueError` and return fabricated `0.0` for out-of-bounds queries — `ValueError` now propagates so callers can detect true OOB conditions

## Test plan
- [x] 21 new TDD tests in `tests/unit/test_terrain_contracts.py` covering all three bugs
- [x] Updated 2 existing tests in `tests/unit/test_terrain.py` that were querying out-of-bounds coordinates (x=100 on a 100-node grid, y=200 on a 200-node grid)
- [x] All 80 terrain tests pass (59 existing + 21 new)
- [x] `ruff check` and `ruff format --check` pass

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)