### PR TITLE
fix(#2479): inject PYTHONPATH in launchers and externalize WSL settings

### DIFF
--- a/src/launchers/golf_suite_launcher.py
+++ b/src/launchers/golf_suite_launcher.py
@@ -12,6 +12,7 @@ or accessible via `sys.executable`.
 It does NOT use Docker. For Docker support, use `golf_launcher.py`.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -388,9 +389,19 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
             return
 
         try:
-            # Launch detached process
-            # Use same python interpreter
-            process = subprocess.Popen([sys.executable, str(path)], cwd=str(cwd))  # noqa: S603
+            # Launch detached process using the same interpreter.
+            # Inject repo root into PYTHONPATH so child scripts can import src.*
+            # regardless of ambient shell state.
+            sep = ";" if os.name == "nt" else ":"
+            existing = os.environ.get("PYTHONPATH", "")
+            repo_str = str(self.suite_root)
+            env = os.environ.copy()
+            env["PYTHONPATH"] = f"{repo_str}{sep}{existing}" if existing else repo_str
+            process = subprocess.Popen(  # noqa: S603
+                [sys.executable, str(path)],
+                cwd=str(cwd),
+                env=env,
+            )
             self.log_message(f"{name} launched successfully (PID: {process.pid})")
             self.status.setText(f"{name} Launched")
         except (OSError, subprocess.SubprocessError) as e:

--- a/src/launchers/launcher_process_manager.py
+++ b/src/launchers/launcher_process_manager.py
@@ -462,16 +462,40 @@ class ProcessManager:
             logger.error(f"Failed to launch {name}: {e}")
             return None
 
+    def _get_wsl_distro(self) -> str:
+        """Return the WSL distro name from WSL_DISTRO env var (default: Ubuntu)."""
+        return os.environ.get("WSL_DISTRO", "Ubuntu")
+
+    def _get_wsl_project_dir(self) -> str:
+        """Return the WSL project directory from WSL_PROJECT_DIR env var.
+
+        Falls back to converting self.repo_root to a WSL path.
+        """
+        if env_val := os.environ.get("WSL_PROJECT_DIR"):
+            return env_val
+        return self._convert_to_wsl_path(str(self.repo_root))
+
+    def _get_wsl_conda_env(self) -> str:
+        """Return the conda environment name from WSL_CONDA_ENV env var (default: base)."""
+        return os.environ.get("WSL_CONDA_ENV", "base")
+
     def launch_in_wsl(
         self,
         script_path: str,
-        project_dir: str = "/mnt/c/Users/diete/Repositories/UpstreamDrift",
+        project_dir: str | None = None,
     ) -> bool:
         """Launch a script in WSL2 Ubuntu environment.
 
+        WSL settings are read from environment variables so this method is
+        portable across developers and machines:
+        - ``WSL_DISTRO``: WSL distro name (default: ``"Ubuntu"``)
+        - ``WSL_PROJECT_DIR``: WSL path to the project root (default: derived
+          from repo_root)
+        - ``WSL_CONDA_ENV``: conda environment name (default: ``"base"``)
+
         Args:
             script_path: Windows path to the script.
-            project_dir: WSL path to the project directory.
+            project_dir: Override WSL project dir (uses WSL_PROJECT_DIR if not set).
 
         Returns:
             True if launch succeeded, False otherwise.
@@ -481,23 +505,29 @@ class ProcessManager:
             raise ValueError("script_path must be provided")
         if not (script_path is not None):
             raise ValueError("script_path must be provided")
+
+        resolved_project_dir = project_dir or self._get_wsl_project_dir()
+        distro = self._get_wsl_distro()
+        conda_env = self._get_wsl_conda_env()
+
         wsl_script_path = self._convert_to_wsl_path(script_path)
 
         # Use shlex.quote to prevent injection of shell metacharacters in the
         # paths that are interpolated into the bash -c script.
-        quoted_project_dir = shlex.quote(project_dir)
+        quoted_project_dir = shlex.quote(resolved_project_dir)
         quoted_wsl_script = shlex.quote(wsl_script_path)
+        quoted_conda_env = shlex.quote(conda_env)
 
         wsl_cmd = (
             "source ~/miniforge3/etc/profile.d/conda.sh\n"
-            "conda activate golf_suite\n"
+            f"conda activate {quoted_conda_env}\n"
             'export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"\n'
             f"export PYTHONPATH={quoted_project_dir}:$PYTHONPATH\n"
             f"cd {quoted_project_dir}\n"
             f"python {quoted_wsl_script}\n"
         )
 
-        cmd = ["wsl", "-d", "Ubuntu-22.04", "--", "bash", "-c", wsl_cmd]
+        cmd = ["wsl", "-d", distro, "--", "bash", "-c", wsl_cmd]
 
         try:
             logger.info(f"Launching in WSL: {script_path}")
@@ -518,14 +548,16 @@ class ProcessManager:
         self,
         module_name: str,
         cwd: Path | None = None,
-        project_dir: str = "/mnt/c/Users/diete/Repositories/UpstreamDrift",
+        project_dir: str | None = None,
     ) -> bool:
         """Launch a Python module in WSL2 Ubuntu environment.
+
+        WSL settings are read from environment variables (see launch_in_wsl).
 
         Args:
             module_name: Python module name to run with -m flag.
             cwd: Optional working directory (Windows Path).
-            project_dir: WSL path to the project directory.
+            project_dir: Override WSL project dir (uses WSL_PROJECT_DIR if not set).
 
         Returns:
             True if launch succeeded, False otherwise.
@@ -543,26 +575,31 @@ class ProcessManager:
             )
             return False
 
-        work_dir = project_dir
+        resolved_project_dir = project_dir or self._get_wsl_project_dir()
+        distro = self._get_wsl_distro()
+        conda_env = self._get_wsl_conda_env()
+
+        work_dir = resolved_project_dir
         if cwd:
             work_dir = self._convert_to_wsl_path(str(cwd))
 
         # Use shlex.quote to prevent injection of shell metacharacters in the
         # paths that are interpolated into the bash -c script.
         # module_name has already been validated against the allowlist regex.
-        quoted_project_dir = shlex.quote(project_dir)
+        quoted_project_dir = shlex.quote(resolved_project_dir)
         quoted_work_dir = shlex.quote(work_dir)
+        quoted_conda_env = shlex.quote(conda_env)
 
         wsl_cmd = (
             "source ~/miniforge3/etc/profile.d/conda.sh\n"
-            "conda activate golf_suite\n"
+            f"conda activate {quoted_conda_env}\n"
             'export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"\n'
             f"export PYTHONPATH={quoted_project_dir}:$PYTHONPATH\n"
             f"cd {quoted_work_dir}\n"
             f"python -m {module_name}\n"
         )
 
-        cmd = ["wsl", "-d", "Ubuntu-22.04", "--", "bash", "-c", wsl_cmd]
+        cmd = ["wsl", "-d", distro, "--", "bash", "-c", wsl_cmd]
 
         try:
             logger.info(f"Launching module in WSL: {module_name}")

--- a/src/launchers/motion_capture_launcher.py
+++ b/src/launchers/motion_capture_launcher.py
@@ -6,10 +6,29 @@ Central hub for C3D visualization and Markerless Pose Estimation.
 Refactored to use BaseLauncher to eliminate DRY violations.
 """
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 from src.launchers.base import REPO_ROOT, BaseLauncher, LaunchItem, run_launcher
+
+
+def _make_subprocess_env(repo_root: Path) -> dict[str, str]:
+    """Build an environment dict that injects *repo_root* into PYTHONPATH.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        A copy of the current environment with repo_root prepended to PYTHONPATH.
+    """
+    env = os.environ.copy()
+    sep = ";" if os.name == "nt" else ":"
+    existing = env.get("PYTHONPATH", "")
+    repo_str = str(repo_root)
+    env["PYTHONPATH"] = f"{repo_str}{sep}{existing}" if existing else repo_str
+    return env
 
 
 class MoCapLauncher(BaseLauncher):
@@ -68,7 +87,12 @@ class MoCapLauncher(BaseLauncher):
             return
 
         try:
-            subprocess.Popen([sys.executable, str(script_path)], cwd=REPO_ROOT)
+            env = _make_subprocess_env(REPO_ROOT)
+            subprocess.Popen(  # noqa: S603
+                [sys.executable, str(script_path)],
+                cwd=REPO_ROOT,
+                env=env,
+            )
         except (FileNotFoundError, PermissionError, OSError) as e:
             self.show_error("Launch Error", str(e))
 

--- a/tests/launchers/test_launcher_env_injection.py
+++ b/tests/launchers/test_launcher_env_injection.py
@@ -1,0 +1,152 @@
+"""Tests for launcher PYTHONPATH injection and WSL portability (issue #2479).
+
+Launchers that spawn nested subprocesses must inject the repo root into
+PYTHONPATH so child scripts can import src.* regardless of the ambient shell
+state.  WSL helpers must read distro, project dir, and conda env from
+environment variables rather than hard-coded developer-specific paths.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestMotionCaptureLauncherPythonpath:
+    """motion_capture_launcher._launch_script must inject PYTHONPATH."""
+
+    def test_popen_receives_env_with_pythonpath(self) -> None:
+        """_make_subprocess_env must return a dict with repo root in PYTHONPATH."""
+        from src.launchers.motion_capture_launcher import (
+            REPO_ROOT,
+            _make_subprocess_env,
+        )
+
+        env = _make_subprocess_env(REPO_ROOT)
+        assert "PYTHONPATH" in env, "env dict must contain PYTHONPATH"
+        assert str(REPO_ROOT) in env["PYTHONPATH"], (
+            f"REPO_ROOT ({REPO_ROOT}) must appear in PYTHONPATH"
+        )
+
+    def test_popen_env_injects_pythonpath_in_subprocess_call(self) -> None:
+        """_launch_script must pass env= to subprocess.Popen."""
+        import inspect
+
+        import src.launchers.motion_capture_launcher as mod
+
+        src_text = inspect.getsource(mod)
+        # The Popen call must pass env= keyword argument
+        assert "env=" in src_text, (
+            "subprocess.Popen(...) call must pass env= to inject PYTHONPATH"
+        )
+
+
+class TestGolfSuiteLauncherPythonpath:
+    """golf_suite_launcher._launch_script must inject PYTHONPATH."""
+
+    def test_popen_env_injects_pythonpath_in_subprocess_call(self) -> None:
+        """_launch_script must pass env= to subprocess.Popen."""
+
+        # We read source rather than importing, as PyQt6 may not be installed.
+        launcher_src = (
+            Path(__file__).parents[2] / "src" / "launchers" / "golf_suite_launcher.py"
+        )
+        src_text = launcher_src.read_text(encoding="utf-8")
+        # The Popen call in _launch_script must pass env=
+        assert "env=" in src_text, (
+            "subprocess.Popen(...) in _launch_script must pass env= to inject PYTHONPATH"
+        )
+
+
+class TestProcessManagerWslConfig:
+    """launch_in_wsl / launch_module_in_wsl must read settings from env vars."""
+
+    def _make_manager(self) -> object:
+        from src.launchers.launcher_process_manager import ProcessManager
+
+        return ProcessManager(repo_root=Path("/tmp/fake_repo"))
+
+    def test_wsl_distro_reads_from_env(self) -> None:
+        """WSL distro must be read from WSL_DISTRO env var, not hard-coded."""
+        with patch.dict(os.environ, {"WSL_DISTRO": "MyDistro"}, clear=False):
+            mgr = self._make_manager()
+            distro = mgr._get_wsl_distro()
+            assert distro == "MyDistro", (
+                f"Expected distro 'MyDistro' from env, got '{distro}'"
+            )
+
+    def test_wsl_distro_defaults_to_fallback_when_unset(self) -> None:
+        """WSL distro must have a safe fallback when WSL_DISTRO is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("WSL_DISTRO", None)
+            mgr = self._make_manager()
+            distro = mgr._get_wsl_distro()
+            assert isinstance(distro, str) and len(distro) > 0, (
+                "_get_wsl_distro must return a non-empty string fallback"
+            )
+
+    def test_wsl_project_dir_reads_from_env(self) -> None:
+        """WSL project dir must be read from WSL_PROJECT_DIR env var."""
+        with patch.dict(os.environ, {"WSL_PROJECT_DIR": "/mnt/d/MyRepo"}, clear=False):
+            mgr = self._make_manager()
+            proj_dir = mgr._get_wsl_project_dir()
+            assert proj_dir == "/mnt/d/MyRepo"
+
+    def test_wsl_conda_env_reads_from_env(self) -> None:
+        """Conda env name must be read from WSL_CONDA_ENV env var."""
+        with patch.dict(os.environ, {"WSL_CONDA_ENV": "my_env"}, clear=False):
+            mgr = self._make_manager()
+            conda_env = mgr._get_wsl_conda_env()
+            assert conda_env == "my_env"
+
+    def test_wsl_conda_env_defaults_to_fallback_when_unset(self) -> None:
+        """Conda env must have a safe fallback when WSL_CONDA_ENV is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("WSL_CONDA_ENV", None)
+            mgr = self._make_manager()
+            conda_env = mgr._get_wsl_conda_env()
+            assert isinstance(conda_env, str) and len(conda_env) > 0
+
+    def test_no_hardcoded_developer_path_in_source(self) -> None:
+        """Hard-coded developer path /mnt/c/Users/diete must not appear in source."""
+        src_file = (
+            Path(__file__).parents[2]
+            / "src"
+            / "launchers"
+            / "launcher_process_manager.py"
+        )
+        src_text = src_file.read_text(encoding="utf-8")
+        assert "/mnt/c/Users/diete" not in src_text, (
+            "Hard-coded developer path '/mnt/c/Users/diete' found in source. "
+            "Use WSL_PROJECT_DIR env var instead."
+        )
+
+    def test_no_hardcoded_distro_in_source(self) -> None:
+        """Hard-coded distro 'Ubuntu-22.04' must not appear in source."""
+        src_file = (
+            Path(__file__).parents[2]
+            / "src"
+            / "launchers"
+            / "launcher_process_manager.py"
+        )
+        src_text = src_file.read_text(encoding="utf-8")
+        assert "Ubuntu-22.04" not in src_text, (
+            "Hard-coded distro 'Ubuntu-22.04' found in source. "
+            "Use WSL_DISTRO env var instead."
+        )
+
+    def test_no_hardcoded_conda_env_in_source(self) -> None:
+        """Hard-coded conda env 'golf_suite' in WSL command must not appear in source."""
+        src_file = (
+            Path(__file__).parents[2]
+            / "src"
+            / "launchers"
+            / "launcher_process_manager.py"
+        )
+        src_text = src_file.read_text(encoding="utf-8")
+        # The string 'golf_suite' was the hard-coded conda env name
+        assert "conda activate golf_suite" not in src_text, (
+            "Hard-coded conda env 'golf_suite' found in source. "
+            "Use WSL_CONDA_ENV env var instead."
+        )


### PR DESCRIPTION
## Summary
- `motion_capture_launcher._launch_script` now injects repo root into PYTHONPATH via a new `_make_subprocess_env()` helper and passes `env=` to `subprocess.Popen`
- `golf_suite_launcher._launch_script` builds an env dict prepending `suite_root` to PYTHONPATH before each Popen call
- `launcher_process_manager.launch_in_wsl` / `launch_module_in_wsl` no longer hard-code `/mnt/c/Users/diete/...`, `Ubuntu-22.04`, or `golf_suite` — three new helper methods read from env vars: `WSL_DISTRO` (default: Ubuntu), `WSL_PROJECT_DIR` (default: derived from repo_root), `WSL_CONDA_ENV` (default: base)

## Test plan
- [x] 11 new TDD tests in `tests/launchers/test_launcher_env_injection.py`
- [x] All 44 existing `test_launcher_process_manager.py` tests pass (no regressions)
- [x] `ruff check` and `ruff format --check` pass

Closes #2479

🤖 Generated with [Claude Code](https://claude.com/claude-code)