### PR TITLE
fix(api): remove hardcoded /api/ prefix from route modules (double-prefix fix)

### DIFF
--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -24,7 +24,7 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/tools/data-explorer", tags=["data-explorer"])
+router = APIRouter(prefix="/tools/data-explorer", tags=["data-explorer"])
 
 
 # ── Request / Response Models ──

--- a/src/api/routes/launcher.py
+++ b/src/api/routes/launcher.py
@@ -16,7 +16,7 @@ from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
-router = APIRouter(prefix="/api/launcher", tags=["launcher"])
+router = APIRouter(prefix="/launcher", tags=["launcher"])
 
 # Cache the manifest in memory (singleton holder avoids 'global')
 _launcher_state: dict[str, LauncherManifest | None] = {"manifest": None}

--- a/src/api/routes/motion_capture.py
+++ b/src/api/routes/motion_capture.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 
 from src.shared.python.core.contracts import precondition
 
-router = APIRouter(prefix="/api/tools/motion-capture", tags=["motion-capture"])
+router = APIRouter(prefix="/tools/motion-capture", tags=["motion-capture"])
 
 
 # ── Request / Response Models ──

--- a/src/api/routes/putting_green.py
+++ b/src/api/routes/putting_green.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 from src.api.middleware.error_handler import handle_api_errors
 from src.shared.python.core.contracts import precondition
 
-router = APIRouter(prefix="/api/tools/putting-green", tags=["putting-green"])
+router = APIRouter(prefix="/tools/putting-green", tags=["putting-green"])
 
 
 # -- Request / Response Models --

--- a/src/api/routes/terrain.py
+++ b/src/api/routes/terrain.py
@@ -30,7 +30,7 @@ from src.shared.python.physics.terrain import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/terrain", tags=["terrain"])
+router = APIRouter(prefix="/terrain", tags=["terrain"])
 
 
 # ──────────────────────────────────────────────────────────────

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -254,9 +254,10 @@ app.middleware("http")(_tracer.trace_request)
 # Use plugin-style auto-discovery instead of 20+ explicit imports (#1485).
 # Routes are registered both at root (backward compat) and under /api/v1/ (#1488).
 
-# Register all routes at root level (backward compatibility)
-_root_count = register_routes(app, prefix="")
-logger.info("Registered %d route modules at root prefix", _root_count)
+# Register all routes at /api prefix (backward compatibility — previously these modules
+# hardcoded /api/ in their own prefix, so legacy clients expect /api/<resource>).
+_root_count = register_routes(app, prefix="/api")
+logger.info("Registered %d route modules at /api prefix", _root_count)
 
 # Register all routes under /api/v1/ prefix (versioned API)
 _versioned_count = register_routes(app, prefix=API_PREFIX)

--- a/tests/unit/api/test_route_prefixes.py
+++ b/tests/unit/api/test_route_prefixes.py
@@ -1,0 +1,131 @@
+"""TDD tests for API route prefix consistency (issue #2451).
+
+Five route modules hardcode the "/api/" segment in their APIRouter prefix.
+When the server also registers these routers under "/api/v1/", the versioned
+path becomes "/api/v1/api/<resource>" — double "/api/".
+
+The fix: remove "/api/" from each router prefix so:
+  - root registration (prefix="") yields /launcher/... etc.
+  - versioned registration (prefix="/api/v1") yields /api/v1/launcher/... (no double)
+
+The server must also change the root-level registration to use prefix="/api"
+so that legacy "/api/launcher/..." clients still work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestRouterPrefixesNoHardcodedApiSegment:
+    """Route module APIRouter instances must NOT include '/api' in their prefix.
+
+    The server is responsible for injecting the '/api' or '/api/v1' segment.
+    Modules that embed '/api' force double-prefixing when registered under the
+    versioned path.
+    """
+
+    def test_launcher_router_prefix_no_api(self) -> None:
+        """launcher.router prefix must not start with /api."""
+        from src.api.routes.launcher import router
+
+        assert not router.prefix.startswith("/api"), (
+            f"launcher router prefix starts with /api: {router.prefix!r}. "
+            "Remove /api — the server injects this."
+        )
+
+    def test_terrain_router_prefix_no_api(self) -> None:
+        """terrain.router prefix must not start with /api."""
+        from src.api.routes.terrain import router
+
+        assert not router.prefix.startswith("/api"), (
+            f"terrain router prefix starts with /api: {router.prefix!r}."
+        )
+
+    @pytest.mark.skipif(
+        not __import__("importlib").util.find_spec("multipart"),
+        reason="python-multipart not installed; data_explorer imports UploadFile",
+    )
+    def test_data_explorer_router_prefix_no_api(self) -> None:
+        """data_explorer.router prefix must not start with /api."""
+        from src.api.routes.data_explorer import router
+
+        assert not router.prefix.startswith("/api"), (
+            f"data_explorer router prefix starts with /api: {router.prefix!r}."
+        )
+
+    def test_motion_capture_router_prefix_no_api(self) -> None:
+        """motion_capture.router prefix must not start with /api."""
+        from src.api.routes.motion_capture import router
+
+        assert not router.prefix.startswith("/api"), (
+            f"motion_capture router prefix starts with /api: {router.prefix!r}."
+        )
+
+    def test_putting_green_router_prefix_no_api(self) -> None:
+        """putting_green.router prefix must not start with /api."""
+        from src.api.routes.putting_green import router
+
+        assert not router.prefix.startswith("/api"), (
+            f"putting_green router prefix starts with /api: {router.prefix!r}."
+        )
+
+
+class TestVersionedRoutePathsNoDoubleApi:
+    """When routes are registered under /api/v1/, the resulting path must not contain /api/v1/api/."""
+
+    def test_launcher_prefix_under_versioned_no_double(self) -> None:
+        """launcher router's prefix joined with /api/v1 must not produce /api/v1/api/."""
+        from src.api.routes.launcher import router
+
+        simulated_path = "/api/v1" + router.prefix
+        assert "/api/v1/api" not in simulated_path, (
+            f"Joining launcher prefix with /api/v1 gives double-api: {simulated_path!r}"
+        )
+
+    def test_terrain_prefix_under_versioned_no_double(self) -> None:
+        """terrain router's prefix joined with /api/v1 must not produce /api/v1/api/."""
+        from src.api.routes.terrain import router
+
+        simulated_path = "/api/v1" + router.prefix
+        assert "/api/v1/api" not in simulated_path, (
+            f"Joining terrain prefix with /api/v1 gives double-api: {simulated_path!r}"
+        )
+
+    def test_data_explorer_prefix_under_versioned_no_double(self) -> None:
+        """data_explorer router prefix literal must not start with /api (source-level check)."""
+        import ast
+        from pathlib import Path
+
+        source = Path("src/api/routes/data_explorer.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(getattr(node.func, "attr", None), str)
+                and node.func.attr == "APIRouter"  # type: ignore[union-attr]
+            ):
+                for kw in node.keywords:
+                    if kw.arg == "prefix" and isinstance(kw.value, ast.Constant):
+                        prefix_val: str = kw.value.value
+                        assert not prefix_val.startswith("/api"), (
+                            f"data_explorer APIRouter prefix starts with /api: {prefix_val!r}"
+                        )
+
+    def test_motion_capture_prefix_under_versioned_no_double(self) -> None:
+        """motion_capture router's prefix joined with /api/v1 must not produce /api/v1/api/."""
+        from src.api.routes.motion_capture import router
+
+        simulated_path = "/api/v1" + router.prefix
+        assert "/api/v1/api" not in simulated_path, (
+            f"Joining motion_capture prefix with /api/v1 gives double-api: {simulated_path!r}"
+        )
+
+    def test_putting_green_prefix_under_versioned_no_double(self) -> None:
+        """putting_green router's prefix joined with /api/v1 must not produce /api/v1/api/."""
+        from src.api.routes.putting_green import router
+
+        simulated_path = "/api/v1" + router.prefix
+        assert "/api/v1/api" not in simulated_path, (
+            f"Joining putting_green prefix with /api/v1 gives double-api: {simulated_path!r}"
+        )


### PR DESCRIPTION
## Summary
Five FastAPI route modules hardcoded `/api/` in their `APIRouter(prefix=...)`. When the server registered these routers under `/api/v1/`, the effective versioned path became `/api/v1/api/<resource>` — a double `/api/`.

**Affected modules:** `launcher`, `terrain`, `data_explorer`, `motion_capture`, `putting_green`

**Fix:**
- Remove `/api/` from each router's prefix: e.g. `/api/launcher` → `/launcher`
- Update server root-level registration from `prefix=""` to `prefix="/api"` so legacy clients using `/api/<resource>` continue to work (backward compatibility)
- Versioned registration at `/api/v1/` now yields clean `/api/v1/<resource>` paths with no double prefix

## Test plan
- [x] 10 TDD tests in `tests/unit/api/test_route_prefixes.py` (9 pass, 1 skipped — `data_explorer` requires `python-multipart` which is not installed locally; replaced with AST-level source check)
- [x] No ruff lint/format issues

Closes #2451

🤖 Generated with [Claude Code](https://claude.com/claude-code)