### PR TITLE
fix(installer): correct asset and script paths to use src/ layout

### DIFF
--- a/installer/windows/setup.py
+++ b/installer/windows/setup.py
@@ -95,9 +95,9 @@ build_exe_options = {
         "trace",
     ],
     "include_files": [
-        (str(project_root / "shared" / "urdf"), "shared/urdf"),
-        (str(project_root / "shared" / "meshes"), "shared/meshes"),
-        (str(project_root / "config"), "config"),
+        (str(project_root / "src" / "shared" / "urdf"), "src/shared/urdf"),
+        (str(project_root / "src" / "shared" / "meshes"), "src/shared/meshes"),
+        (str(project_root / "src" / "config"), "src/config"),
         (str(project_root / "docs"), "docs"),
         (str(project_root / "README.md"), "README.md"),
         (str(project_root / "LICENSE"), "LICENSE"),
@@ -112,7 +112,9 @@ bdist_msi_options = {
     "upgrade_code": "{12345678-1234-5678-9012-123456789012}",
     "add_to_path": True,
     "initial_target_dir": r"[ProgramFilesFolder]\UpstreamDrift",
-    "install_icon": str(project_root / "shared" / "icons" / "golf_robot.ico"),
+    "install_icon": str(
+        project_root / "src" / "launchers" / "assets" / "golf_icon.ico"
+    ),
     "summary_data": {
         "author": "UpstreamDrift Team",
         "comments": "Professional biomechanical analysis software",
@@ -123,18 +125,18 @@ bdist_msi_options = {
 # Executables
 executables = [
     Executable(
-        script=str(project_root / "launchers" / "golf_launcher.py"),
+        script=str(project_root / "src" / "launchers" / "golf_launcher.py"),
         base="Win32GUI",
         target_name="GolfModelingSuite.exe",
-        icon=str(project_root / "shared" / "icons" / "golf_robot.ico"),
+        icon=str(project_root / "src" / "launchers" / "assets" / "golf_icon.ico"),
         shortcut_name="UpstreamDrift",
         shortcut_dir="DesktopFolder",
     ),
     Executable(
-        script=str(project_root / "api" / "server.py"),
+        script=str(project_root / "src" / "api" / "server.py"),
         base="Console",
         target_name="GolfAPI.exe",
-        icon=str(project_root / "shared" / "icons" / "golf_robot.ico"),
+        icon=str(project_root / "src" / "launchers" / "assets" / "golf_icon.ico"),
     ),
 ]
 

--- a/setup_golf_suite.py
+++ b/setup_golf_suite.py
@@ -177,9 +177,9 @@ def _find_source_image(repo_root: pathlib.Path) -> pathlib.Path | None:
     """Find the best available source image for icon generation."""
     potential_sources = [
         repo_root / "GolfingRobot.png",
-        repo_root / "launchers" / "assets" / "golf_robot_cropped.png",
-        repo_root / "launchers" / "assets" / "golf_icon.png",
-        repo_root / "launchers" / "assets" / "golf_robot_icon.png",
+        repo_root / "src" / "launchers" / "assets" / "golf_robot_cropped.png",
+        repo_root / "src" / "launchers" / "assets" / "golf_icon.png",
+        repo_root / "src" / "launchers" / "assets" / "golf_robot_icon.png",
     ]
     for src in potential_sources:
         if src.exists():
@@ -205,7 +205,7 @@ def main() -> int:
     # 3. Resolve Paths
     repo_root = get_repo_root()
     source_icon = _find_source_image(repo_root)
-    output_icon = repo_root / "launchers" / "assets" / "golf_suite_unified.ico"
+    output_icon = repo_root / "src" / "launchers" / "assets" / "golf_suite_unified.ico"
     target_launch_script = repo_root / "launch_golf_suite.py"
 
     # 4. Generate Icon
@@ -213,7 +213,7 @@ def main() -> int:
         create_optimized_icon(source_icon, output_icon)
     elif not output_icon.exists():
         # Fallback to existing icon if generation impossible
-        fallback = repo_root / "launchers" / "assets" / "golf_robot_icon.ico"
+        fallback = repo_root / "src" / "launchers" / "assets" / "golf_robot_icon.ico"
         if fallback.exists():
             output_icon = fallback
             logger.info("Using fallback existing icon.")

--- a/tests/unit/test_installer_paths.py
+++ b/tests/unit/test_installer_paths.py
@@ -1,0 +1,120 @@
+"""TDD tests for correct asset path resolution in setup scripts (issue #2495).
+
+Two bugs:
+1. setup_golf_suite.py._find_source_image() searches repo_root / "launchers" / "assets" / ...
+   but the actual assets are under repo_root / "src" / "launchers" / "assets" / ...
+2. installer/windows/setup.py hard-codes project_root / "launchers" / ..., "api" / ...,
+   "shared" / "urdf" / ..., etc. — all the real paths are under "src/".
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# setup_golf_suite.py
+# ---------------------------------------------------------------------------
+
+
+class TestSetupGolfSuiteSourceImagePaths:
+    """_find_source_image() must search the correct src/launchers/assets/ location."""
+
+    def test_find_source_image_searches_src_launchers_assets(self) -> None:
+        """_find_source_image must include paths under src/launchers/assets, not bare launchers/assets."""
+        import inspect
+
+        import setup_golf_suite
+
+        src = inspect.getsource(setup_golf_suite._find_source_image)
+        assert "src" + "/" + "launchers" in src or '"src"' in src, (
+            "_find_source_image does not reference src/launchers/assets — "
+            "the assets were moved to src/launchers/assets but the function still searches launchers/assets"
+        )
+
+    def test_find_source_image_no_bare_launchers_path(self) -> None:
+        """_find_source_image must not search the non-existent bare launchers/assets path."""
+        import inspect
+
+        import setup_golf_suite
+
+        src = inspect.getsource(setup_golf_suite._find_source_image)
+        # The bare "launchers" / "assets" path without "src/" prefix should not appear
+        # We check that "launchers" does not appear without a preceding "src" context
+        lines = src.splitlines()
+        for line in lines:
+            if '"launchers"' in line or "'launchers'" in line:
+                assert '"src"' in line or "'src'" in line or "src" in line, (
+                    f"Line references bare launchers/ path without src/: {line.strip()}"
+                )
+
+    def test_output_icon_path_under_src_launchers(self) -> None:
+        """The output_icon path in main() must reference src/launchers/assets, not launchers/assets."""
+        source = Path("setup_golf_suite.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.BinOp)
+                and isinstance(node.op, ast.Div)
+                and isinstance(node.right, ast.Constant)
+                and node.right.value == "launchers"
+            ):
+                # Find string literals in division chains (Path / "launchers")
+                # Check the left side doesn't skip "src"
+                source_segment = ast.unparse(node)
+                # If "launchers" is directly after repo_root without "src", that's the bug
+                assert "src" in source_segment, (
+                    f"Path construction found 'launchers' without 'src' prefix: {source_segment}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# installer/windows/setup.py
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsInstallerPaths:
+    """installer/windows/setup.py must reference src/ paths for launchers, api, config, shared."""
+
+    def _read_installer_source(self) -> str:
+        return Path("installer/windows/setup.py").read_text()
+
+    def test_launcher_script_path_includes_src(self) -> None:
+        """The golf_launcher.py script path must include 'src/'."""
+        source = self._read_installer_source()
+        # Find lines that reference golf_launcher.py
+        for line in source.splitlines():
+            if "golf_launcher.py" in line:
+                assert '"src"' in line or "'src'" in line or "src" in line, (
+                    f"golf_launcher.py path missing 'src': {line.strip()}"
+                )
+
+    def test_api_server_path_includes_src(self) -> None:
+        """The api/server.py script path must include 'src/'."""
+        source = self._read_installer_source()
+        for line in source.splitlines():
+            if "server.py" in line and "api" in line:
+                assert '"src"' in line or "'src'" in line or "src" in line, (
+                    f"api/server.py path missing 'src': {line.strip()}"
+                )
+
+    def test_shared_urdf_path_includes_src(self) -> None:
+        """The shared/urdf include_files path must reference src/shared/urdf."""
+        source = self._read_installer_source()
+        for line in source.splitlines():
+            if '"urdf"' in line or "'urdf'" in line or "/urdf" in line:
+                assert "src" in line, f"shared/urdf path missing 'src': {line.strip()}"
+
+    def test_config_path_includes_src(self) -> None:
+        """The config include_files path must reference src/config."""
+        source = self._read_installer_source()
+        for line in source.splitlines():
+            if (
+                ('"config"' in line or "'config'" in line)
+                and "include"
+                in source[
+                    max(0, source.find(line) - 200) : source.find(line) + len(line)
+                ]
+                and "project_root" in line
+            ):
+                assert "src" in line, f"config path missing 'src': {line.strip()}"


### PR DESCRIPTION
## Summary
Both `setup_golf_suite.py` and `installer/windows/setup.py` referenced pre-src-layout paths (`launchers/`, `api/`, `config/`, `shared/urdf/`, `shared/icons/`) that no longer exist — all assets moved under `src/`.

**`setup_golf_suite.py`:**
- `_find_source_image()`: `launchers/assets/` → `src/launchers/assets/`
- `main()` output icon and fallback paths updated

**`installer/windows/setup.py`:**
- `include_files`: `shared/urdf` → `src/shared/urdf`, `shared/meshes` → `src/shared/meshes`, `config` → `src/config`
- `install_icon`: `shared/icons/golf_robot.ico` → `src/launchers/assets/golf_icon.ico` (actual ico file)
- `Executable` scripts: `launchers/` → `src/launchers/`, `api/` → `src/api/`
- `Executable` icons updated to match

## Test plan
- [x] 7 TDD tests in `tests/unit/test_installer_paths.py` (all red before, all green after)

Closes #2495

🤖 Generated with [Claude Code](https://claude.com/claude-code)