### PR TITLE
fix(lod): eliminate 4-level parent chains and 3-level muscle chain

### DIFF
--- a/src/shared/python/biomechanics/multi_muscle.py
+++ b/src/shared/python/biomechanics/multi_muscle.py
@@ -193,6 +193,11 @@ class AntagonistPair:
         ensure(np.isfinite(result), "antagonist pair net torque must be finite", result)
         return result
 
+    @property
+    def muscle_names(self) -> list[str]:
+        """Return all muscle names (agonist + antagonist) without chain traversal."""
+        return list(self.agonist.muscles.keys()) + list(self.antagonist.muscles.keys())
+
 
 def create_elbow_muscle_system() -> AntagonistPair:
     """Factory function to create a simplified elbow muscle system.

--- a/src/shared/python/biomechanics/myosuite_adapter.py
+++ b/src/shared/python/biomechanics/myosuite_adapter.py
@@ -220,8 +220,7 @@ class MuscleDrivenEnv:
     def _get_muscle_names(self) -> list[str]:
         """Get list of muscle names in system."""
         if isinstance(self.muscle_system, AntagonistPair):
-            names = list(self.muscle_system.agonist.muscles.keys())
-            names.extend(self.muscle_system.antagonist.muscles.keys())
+            names = self.muscle_system.muscle_names
         else:
             names = list(self.muscle_system.muscles.keys())
         return names

--- a/src/shared/python/gui_pkg/help_system.py
+++ b/src/shared/python/gui_pkg/help_system.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import QSize, Qt, QUrl
@@ -45,9 +44,10 @@ from PyQt6.QtWidgets import (
 if TYPE_CHECKING:
     pass
 
+from src.shared.python import SUITE_ROOT
+
 # Get paths
-REPOS_ROOT = Path(__file__).parent.parent.parent.parent.resolve()
-DOCS_DIR = REPOS_ROOT / "docs"
+DOCS_DIR = SUITE_ROOT / "docs"
 HELP_DIR = DOCS_DIR / "help"
 USER_MANUAL_PATH = DOCS_DIR / "USER_MANUAL.md"
 

--- a/src/shared/python/gui_pkg/launcher_utils.py
+++ b/src/shared/python/gui_pkg/launcher_utils.py
@@ -16,6 +16,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from src.shared.python import SUITE_ROOT
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.security.subprocess_utils import run_command
 
@@ -93,7 +94,7 @@ def git_sync_repository(repo_path: Path | None = None) -> bool:
         True if sync succeeded, False otherwise.
     """
     if repo_path is None:
-        repo_path = Path(__file__).parent.parent.parent.parent
+        repo_path = SUITE_ROOT
 
     logger.info("Syncing repository with remote...")
     try:
@@ -120,7 +121,7 @@ def get_repo_root() -> Path:
     Returns:
         Path to the repository root directory.
     """
-    return Path(__file__).parent.parent.parent.parent.absolute()
+    return SUITE_ROOT.resolve()
 
 
 def ensure_environment_var(

--- a/tests/unit/test_lod_violations.py
+++ b/tests/unit/test_lod_violations.py
@@ -1,0 +1,106 @@
+"""TDD tests for LOD (Law of Demeter) violations fixed in issue #2507.
+
+Three violations:
+1. AntagonistPair consumers call muscle_system.agonist.muscles.keys() (3-level chain).
+   Fix: add AntagonistPair.muscle_names property.
+2. help_system.py uses Path(__file__).parent.parent.parent.parent (4-level chain).
+   Fix: import SUITE_ROOT from src.shared.python.
+3. launcher_utils.py duplicates the same 4-level chain.
+   Fix: import SUITE_ROOT from src.shared.python.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+class TestAntagonistPairMuscleNames:
+    """AntagonistPair must expose muscle_names to avoid 3-level chain traversal."""
+
+    def test_muscle_names_property_exists(self) -> None:
+        """AntagonistPair must have a muscle_names property."""
+        source = Path("src/shared/python/biomechanics/multi_muscle.py").read_text()
+        tree = ast.parse(source)
+        pair_class = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.ClassDef) and n.name == "AntagonistPair"
+        )
+        method_names = [
+            n.name
+            for n in ast.walk(pair_class)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        assert "muscle_names" in method_names, (
+            "AntagonistPair must have a muscle_names property to avoid "
+            "3-level chain (muscle_system.agonist.muscles.keys())"
+        )
+
+    def test_myosuite_adapter_uses_muscle_names(self) -> None:
+        """_get_muscle_names in myosuite_adapter.py must not use .agonist.muscles chain."""
+        source = Path("src/shared/python/biomechanics/myosuite_adapter.py").read_text()
+        lines = source.splitlines()
+        violations = [
+            line
+            for line in lines
+            if ".agonist.muscles.keys()" in line and not line.strip().startswith("#")
+        ]
+        assert not violations, (
+            "myosuite_adapter.py still uses 3-level LOD chain .agonist.muscles.keys(). "
+            "Violations:\n" + "\n".join(violations)
+        )
+
+
+class TestHelpSystemPathLOD:
+    """help_system.py must not use 4-level Path.parent chain."""
+
+    def test_help_system_no_four_level_parent_chain(self) -> None:
+        """help_system.py must import SUITE_ROOT instead of chaining 4x .parent."""
+        source = Path("src/shared/python/gui_pkg/help_system.py").read_text()
+        lines = source.splitlines()
+        violations = [
+            line
+            for line in lines
+            if ".parent.parent.parent.parent" in line
+            and not line.strip().startswith("#")
+        ]
+        assert not violations, (
+            "help_system.py still uses 4-level Path.parent chain. "
+            "Violations:\n" + "\n".join(violations)
+        )
+
+    def test_help_system_imports_suite_root(self) -> None:
+        """help_system.py must import SUITE_ROOT from src.shared.python."""
+        source = Path("src/shared/python/gui_pkg/help_system.py").read_text()
+        assert "SUITE_ROOT" in source, (
+            "help_system.py must import and use SUITE_ROOT from src.shared.python "
+            "instead of re-computing 4-level parent chain."
+        )
+
+
+class TestLauncherUtilsPathLOD:
+    """launcher_utils.py must not use 4-level Path.parent chain."""
+
+    def test_launcher_utils_no_four_level_parent_chain(self) -> None:
+        """launcher_utils.py must not chain 4x .parent to find repo root."""
+        source = Path("src/shared/python/gui_pkg/launcher_utils.py").read_text()
+        lines = source.splitlines()
+        violations = [
+            line
+            for line in lines
+            if ".parent.parent.parent.parent" in line
+            and not line.strip().startswith("#")
+        ]
+        assert not violations, (
+            "launcher_utils.py still uses 4-level Path.parent chain. "
+            "Violations:\n" + "\n".join(violations)
+        )
+
+    def test_launcher_utils_imports_suite_root(self) -> None:
+        """launcher_utils.py must import SUITE_ROOT from src.shared.python."""
+        source = Path("src/shared/python/gui_pkg/launcher_utils.py").read_text()
+        assert "SUITE_ROOT" in source, (
+            "launcher_utils.py must import and use SUITE_ROOT from src.shared.python "
+            "instead of re-computing 4-level parent chain."
+        )


### PR DESCRIPTION
## Summary
- Added `AntagonistPair.muscle_names` property to eliminate 3-level chain `muscle_system.agonist.muscles.keys()` in `myosuite_adapter.py`
- Replaced `Path(__file__).parent.parent.parent.parent` in `help_system.py` with `SUITE_ROOT` import (also fixes incorrect path that pointed to `src/` instead of repo root)
- Replaced same 4-level chain in `launcher_utils.py` (two occurrences) with `SUITE_ROOT`
- Added TDD tests in `tests/unit/test_lod_violations.py` (6 source-level inspection tests)

Closes #2507

## Test plan
- [ ] `python3 -m pytest tests/unit/test_lod_violations.py` — 6 tests pass
- [ ] `python3 -m ruff check` — zero violations
- [ ] `rust-quality-gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)