### PR TITLE
fix(scripts): align assessment scripts with current schemas and filenames

### DIFF
--- a/scripts/create_issues_from_assessment.py
+++ b/scripts/create_issues_from_assessment.py
@@ -83,13 +83,13 @@ def process_findings(
 
     summary = json.loads(path.read_text())
 
-    criticals = [
-        i for i in summary.get("critical_issues", []) if i.get("severity") in sevs
-    ]
+    # Support both the current schema key ("issues") and the legacy key ("critical_issues")
+    all_findings = summary.get("issues", []) or summary.get("critical_issues", [])
+    criticals = [i for i in all_findings if i.get("severity") in sevs]
 
     existing = get_existing_issues() if check_exist else []
 
-    for issue in criticals[:20]:
+    for issue in criticals:
         severity = issue.get("severity", "CRITICAL")
 
         desc = issue.get("description", "")

--- a/scripts/finalize_comprehensive_assessment.py
+++ b/scripts/finalize_comprehensive_assessment.py
@@ -16,7 +16,7 @@ logger = setup_script_logging(__name__)
 
 DOCS_DIR = _REPO_ROOT / "docs" / "assessments"
 COMPLETIST_REPORT = DOCS_DIR / "completist" / "COMPLETIST_LATEST.md"
-PRAGMATIC_REPORT = DOCS_DIR / "pragmatic_programmer" / "review_2026-01-31.json"
+PRAGMATIC_REPORT = DOCS_DIR / "pragmatic_programmer" / "review.json"
 SUMMARY_JSON = DOCS_DIR / "assessment_summary.json"
 OUTPUT_MD = DOCS_DIR / "Comprehensive_Assessment.md"
 

--- a/scripts/maintain_workflows.py
+++ b/scripts/maintain_workflows.py
@@ -48,5 +48,7 @@ def refactor_workflow(filepath):
 
 
 if __name__ == "__main__":
-    # This script is just a placeholder for now, I'll use replace_file_content for precision
-    pass
+    raise NotImplementedError(
+        "maintain_workflows.py is not yet implemented. "
+        "Do not call this script until the refactor_workflow function is completed."
+    )

--- a/tests/unit/scripts/test_assessment_scripts.py
+++ b/tests/unit/scripts/test_assessment_scripts.py
@@ -1,0 +1,107 @@
+"""TDD tests for assessment script bugs (issue #2497).
+
+Four bugs:
+1. create_issues_from_assessment.py reads 'critical_issues' key but current
+   assessment_summary.json uses 'issues'. Findings are silently skipped.
+2. Same script caps processing at 20 entries, silently dropping the majority.
+3. finalize_comprehensive_assessment.py hardcodes 'review_2026-01-31.json' which
+   doesn't exist; the current file is 'review.json'.
+4. maintain_workflows.py __main__ block is a silent no-op (ends in `pass`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class TestCreateIssuesSchema:
+    """create_issues_from_assessment.py must read the 'issues' key, not 'critical_issues'."""
+
+    def _source(self) -> str:
+        return Path("scripts/create_issues_from_assessment.py").read_text()
+
+    def test_reads_issues_key(self) -> None:
+        """Script must read 'issues' key from summary JSON (current schema)."""
+        source = self._source()
+        # The fix: script should look up 'issues', not just 'critical_issues'
+        assert 'summary.get("issues"' in source or "summary.get('issues'" in source, (
+            "create_issues_from_assessment.py does not read 'issues' key from summary JSON. "
+            "The current assessment_summary.json uses 'issues', not 'critical_issues'."
+        )
+
+    def test_no_hard_cap_of_20(self) -> None:
+        """Script must not silently cap findings to 20 entries."""
+        source = self._source()
+        lines = source.splitlines()
+        hard_cap_lines = [
+            line
+            for line in lines
+            if "[:20]" in line and not line.strip().startswith("#")
+        ]
+        assert not hard_cap_lines, (
+            "create_issues_from_assessment.py hard-caps processing to 20 entries, "
+            "silently dropping the rest. Remove or replace with a configurable limit.\n"
+            "Offending lines:\n" + "\n".join(hard_cap_lines)
+        )
+
+
+class TestFinalizeAssessmentPath:
+    """finalize_comprehensive_assessment.py must use the current pragmatic review filename."""
+
+    def _source(self) -> str:
+        return Path("scripts/finalize_comprehensive_assessment.py").read_text()
+
+    def test_no_stale_review_filename(self) -> None:
+        """Script must not reference the nonexistent review_2026-01-31.json."""
+        source = self._source()
+        assert "review_2026-01-31.json" not in source, (
+            "finalize_comprehensive_assessment.py references stale filename "
+            "'review_2026-01-31.json' which no longer exists. "
+            "The current file is 'review.json'."
+        )
+
+    def test_uses_current_review_filename(self) -> None:
+        """Script must reference the current review.json filename."""
+        source = self._source()
+        assert '"review.json"' in source or "'review.json'" in source, (
+            "finalize_comprehensive_assessment.py does not reference 'review.json'. "
+            "Update PRAGMATIC_REPORT to point to docs/assessments/pragmatic_programmer/review.json."
+        )
+
+
+class TestMaintainWorkflowsNotSilent:
+    """maintain_workflows.py __main__ block must not be a silent no-op."""
+
+    def _source(self) -> str:
+        return Path("scripts/maintain_workflows.py").read_text()
+
+    def test_main_block_not_only_pass(self) -> None:
+        """__main__ block must do more than `pass`."""
+        source = self._source()
+        lines = source.splitlines()
+        in_main = False
+        main_body_lines = []
+        for line in lines:
+            if line.strip() == 'if __name__ == "__main__":':
+                in_main = True
+                continue
+            if in_main:
+                if (
+                    line.strip()
+                    and not line.startswith(" ")
+                    and not line.startswith("\t")
+                ):
+                    break
+                main_body_lines.append(line.strip())
+
+        # Exclude comments and bare `pass` — only count executable lines
+        executable_body = [
+            line
+            for line in main_body_lines
+            if line and not line.startswith("#") and line != "pass"
+        ]
+        assert executable_body, (
+            "maintain_workflows.py __main__ block contains only `pass`. "
+            "A script that does nothing but exits 0 misleads callers. "
+            "Either implement the logic or raise NotImplementedError."
+        )


### PR DESCRIPTION
## Summary
- `create_issues_from_assessment.py`: reads `'issues'` key (current schema) with fallback to `'critical_issues'` (legacy); removes hard cap of 20 that silently dropped most findings
- `finalize_comprehensive_assessment.py`: updated `PRAGMATIC_REPORT` from stale `review_2026-01-31.json` to current `review.json`
- `maintain_workflows.py`: replaced silent `pass` in `__main__` with `NotImplementedError` so callers get an explicit failure instead of silent no-op
- Added TDD tests in `tests/unit/scripts/test_assessment_scripts.py` (5 source-level inspection tests)

Closes #2497

## Test plan
- [ ] `python3 -m pytest tests/unit/scripts/test_assessment_scripts.py` — 5 tests pass
- [ ] `python3 -m ruff check` — zero violations
- [ ] `rust-quality-gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)