### PR TITLE
fix(tests): replace xfail tech debt with tests for intended behavior

### DIFF
--- a/tests/unit/test_api_architecture.py
+++ b/tests/unit/test_api_architecture.py
@@ -32,13 +32,33 @@ class TestRouteRegistry:
             assert hasattr(router, "routes")  # APIRouter has .routes
 
     def test_discover_routes_excludes_websocket_modules(self) -> None:
-        """WebSocket-only modules are excluded by default."""
+        """WebSocket-only modules are excluded from auto-discovery (handled explicitly)."""
         from src.api.route_registry import discover_routes
 
         routes = discover_routes()
         module_names = {name for name, _ in routes}
         assert "chat_ws" not in module_names
         assert "simulation_ws" not in module_names
+
+    def test_websocket_modules_registered_explicitly_in_server(self) -> None:
+        """WebSocket modules must be explicitly registered in server.py.
+
+        They are excluded from auto-discovery but must still be served —
+        this test protects against accidental removal of the explicit registration.
+        """
+        source = (
+            __import__("pathlib").Path("src/api/server.py").read_text(encoding="utf-8")
+        )
+        assert "chat_ws" in source, (
+            "server.py does not register chat_ws router. "
+            "WebSocket modules are excluded from auto-discovery and must be "
+            "explicitly included in server.py."
+        )
+        assert "simulation_ws" in source, (
+            "server.py does not register simulation_ws router. "
+            "WebSocket modules are excluded from auto-discovery and must be "
+            "explicitly included in server.py."
+        )
 
     def test_discover_routes_custom_exclude(self) -> None:
         """Custom exclusion set is respected."""

--- a/tests/unit/test_api_security.py
+++ b/tests/unit/test_api_security.py
@@ -144,10 +144,6 @@ class TestBcryptAPIKeyVerification:
         assert cost_factor >= 12, f"Bcrypt cost factor {cost_factor} is too low"
 
     @requires_bcrypt
-    @pytest.mark.xfail(
-        reason="APIKey model lacks prefix_hash column (schema migration needed)",
-        strict=False,
-    )
     async def test_api_key_verification_integration(self) -> None:
         """Test full API key verification flow."""
         from fastapi import HTTPException


### PR DESCRIPTION
## Summary
- Added `test_websocket_modules_registered_explicitly_in_server` to complement the ws exclusion test: verifies that `chat_ws` and `simulation_ws` ARE registered in `server.py` (the intended behavior) rather than only testing their exclusion from auto-discovery
- Removed stale `@pytest.mark.xfail` from `test_api_key_verification_integration`: the schema migration was already done (column `key_prefix` exists in `APIKey` model), the xfail reason referencing `prefix_hash` was obsolete

Closes #2455

## Test plan
- [ ] `python3 -m pytest tests/unit/test_api_architecture.py tests/unit/test_api_security.py` — all tests pass
- [ ] `python3 -m ruff check` — zero violations
- [ ] `rust-quality-gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)