### PR TITLE
fix(simscape): handle 3D tensor signals and fix time-range extrapolation

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/functions/dataset_generator/extractLogsoutDataFixed.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/functions/dataset_generator/extractLogsoutDataFixed.m
@@ -79,11 +79,26 @@ try
                             end
                         end
 
-
+                    elseif size(data, ndims(data)) == expected_length
+                        % 3D tensor signal where time is the last dimension
+                        % e.g. [3 1 N] or [3 3 N] — permute so time is first,
+                        % then reshape to (N x prod_other_dims) and add columns.
+                        n_dims = ndims(data);
+                        perm_order = [n_dims, 1:(n_dims-1)];
+                        data_perm = permute(data, perm_order);  % (N x ...)
+                        n_cols = numel(data) / expected_length;
+                        data_2d = reshape(data_perm, expected_length, n_cols);
+                        for col = 1:n_cols
+                            col_data = data_2d(:, col);
+                            data_cells{end+1} = col_data;
+                            var_names{end+1} = sprintf('%s_%d', signalName, col);
+                            fprintf('Debug: Added tensor signal %s_%d from shape [%s] (length: %d)\n', ...
+                                signalName, col, num2str(data_size), expected_length);
+                        end
 
                     else
-                        fprintf('Debug: Skipping signal %s (size [%s] not supported - need time series, [3 1 N], or [3 3 N])\n', ...
-                            signalName, num2str(data_size));
+                        fprintf('Debug: Skipping signal %s (size [%s], no dimension matches expected length %d)\n', ...
+                            signalName, num2str(data_size), expected_length);
                     end
                 else
                     fprintf('Debug: Skipping signal %s (time length mismatch: %d vs %d, or empty data)\n', signalName, length(signal_time), expected_length);
@@ -107,11 +122,24 @@ try
                             fprintf('Debug: Skipping timeseries %s (flattened length mismatch: %d vs %d)\n', signalName, length(flat_data), expected_length);
                         end
 
-
+                    elseif size(data, ndims(data)) == expected_length
+                        % 3D tensor timeseries where time is the last dimension
+                        n_dims = ndims(data);
+                        perm_order = [n_dims, 1:(n_dims-1)];
+                        data_perm = permute(data, perm_order);
+                        n_cols = numel(data) / expected_length;
+                        data_2d = reshape(data_perm, expected_length, n_cols);
+                        for col = 1:n_cols
+                            col_data = data_2d(:, col);
+                            data_cells{end+1} = col_data;
+                            var_names{end+1} = sprintf('%s_%d', signalName, col);
+                            fprintf('Debug: Added tensor timeseries %s_%d from shape [%s] (length: %d)\n', ...
+                                signalName, col, num2str(data_size), expected_length);
+                        end
 
                     else
-                        fprintf('Debug: Skipping timeseries %s (size [%s] not supported - need time series, [3 1 N], or [3 3 N])\n', ...
-                            signalName, num2str(data_size));
+                        fprintf('Debug: Skipping timeseries %s (size [%s], no dimension matches expected length %d)\n', ...
+                            signalName, num2str(data_size), expected_length);
                     end
                 else
                     fprintf('Debug: Skipping timeseries %s (empty data)\n', signalName);

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/functions/dataset_generator/resampleDataToFrequency.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/functions/dataset_generator/resampleDataToFrequency.m
@@ -21,14 +21,10 @@ function resampled_table = resampleDataToFrequency(data_table, target_freq, sim_
             return;
         end
 
-        % Calculate new time vector
+        % Calculate new time vector anchored to the actual data span
+        % (not 0:dt:sim_time, which would extrapolate before the recording start)
         target_dt = 1 / target_freq;
-        new_time = 0:target_dt:sim_time;
-
-        % Ensure we don't exceed simulation time
-        if new_time(end) > sim_time
-            new_time = new_time(new_time <= sim_time);
-        end
+        new_time = original_time(1):target_dt:original_time(end);
 
         fprintf('Resampling to %d points at %.1f Hz\n', length(new_time), target_freq);
 
@@ -48,15 +44,15 @@ function resampled_table = resampleDataToFrequency(data_table, target_freq, sim_
             if isnumeric(original_data) && length(original_data) == length(original_time)
                 try
                     % Use interp1 for interpolation
-                    resampled_data{col} = interp1(original_time, original_data, new_time, 'linear', 'extrap')';
+                    resampled_data{col} = interp1(original_time, original_data, new_time, 'linear')';
                 catch
                     % Fallback to nearest neighbor if interpolation fails
                     fprintf('Warning: Using nearest neighbor interpolation for column %s\n', data_table.Properties.VariableNames{col});
-                    resampled_data{col} = interp1(original_time, original_data, new_time, 'nearest', 'extrap')';
+                    resampled_data{col} = interp1(original_time, original_data, new_time, 'nearest')';
                 end
             else
                 % For non-numeric or mismatched data, use nearest neighbor
-                resampled_data{col} = interp1(original_time, original_data, new_time, 'nearest', 'extrap')';
+                resampled_data{col} = interp1(original_time, original_data, new_time, 'nearest')';
             end
         end
 

--- a/tests/unit/test_simscape_dataset_contracts.py
+++ b/tests/unit/test_simscape_dataset_contracts.py
@@ -1,0 +1,105 @@
+"""TDD tests for Simscape dataset pipeline contracts (issue #2491).
+
+Two bugs:
+1. extractLogsoutDataFixed.m only accepts signals where size(data,1)==expected_length.
+   Real 3D tensor signals ([3 1 N] or [3 3 N]) where time is the last dimension are
+   silently skipped, producing incomplete datasets.
+2. resampleDataToFrequency.m rebuilds time as 0:dt:sim_time (always starts at 0),
+   then uses interp1(..., 'extrap'), fabricating values outside the recorded data span.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_EXTRACT_FILE = Path(
+    "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/"
+    "functions/dataset_generator/extractLogsoutDataFixed.m"
+)
+_RESAMPLE_FILE = Path(
+    "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/"
+    "functions/dataset_generator/resampleDataToFrequency.m"
+)
+
+
+class TestExtractLogsoutTensorSupport:
+    """extractLogsoutDataFixed.m must handle 3D tensor signals."""
+
+    def _source(self) -> str:
+        return _EXTRACT_FILE.read_text(encoding="utf-8")
+
+    def test_handles_tensor_signals_via_last_dimension(self) -> None:
+        """Script must check the last dimension (not the first) for time-length match."""
+        source = self._source()
+        # The fix must inspect the last/third dimension for tensor signals
+        # This can be done via ndims or size(data, ndims(data)) or size(data, 3)
+        has_last_dim_check = (
+            "ndims(data)" in source
+            or "size(data, ndims" in source
+            or "size(data, 3)" in source
+        )
+        assert has_last_dim_check, (
+            "extractLogsoutDataFixed.m does not check the last dimension for 3D tensor "
+            "signals. 3D tensors [3 1 N] and [3 3 N] have time as the Nth (last) "
+            "dimension. Fix: check size(data, ndims(data)) == expected_length."
+        )
+
+    def test_no_silent_skip_without_unsupported_message(self) -> None:
+        """3D tensor signals must not be silently skipped as 'not supported'."""
+        source = self._source()
+        lines = source.splitlines()
+        # Before fix: skips non-matching sizes with 'not supported' message
+        # After fix: the 'not supported' message should be gone (tensors are handled)
+        skip_unsupported_lines = [
+            line
+            for line in lines
+            if "not supported" in line.lower() and "3 1 N" in line
+        ]
+        assert not skip_unsupported_lines, (
+            "extractLogsoutDataFixed.m still has a 'not supported' skip path for "
+            "[3 1 N] tensors. These are valid 3D signals that must be handled.\n"
+            "Offending lines:\n" + "\n".join(skip_unsupported_lines)
+        )
+
+
+class TestResampleNoExtrapolation:
+    """resampleDataToFrequency.m must not extrapolate beyond the recorded data span."""
+
+    def _source(self) -> str:
+        return _RESAMPLE_FILE.read_text(encoding="utf-8")
+
+    def test_time_vector_uses_actual_data_span(self) -> None:
+        """New time vector must start from original_time(1), not hard-coded 0."""
+        source = self._source()
+        lines = source.splitlines()
+        zero_start_lines = [
+            line
+            for line in lines
+            if (
+                ("0:target_dt:" in line or "0:dt:" in line or "new_time = 0:" in line)
+                and not line.strip().startswith("%")
+            )
+        ]
+        assert not zero_start_lines, (
+            "resampleDataToFrequency.m builds time vector starting at 0. "
+            "This extrapolates before the actual recording start. "
+            "Fix: use original_time(1):target_dt:original_time(end).\n"
+            "Offending lines:\n" + "\n".join(zero_start_lines)
+        )
+
+    def test_no_extrapolation_flag(self) -> None:
+        """interp1 must not use 'extrap' flag — clamp to actual data range instead."""
+        source = self._source()
+        lines = source.splitlines()
+        extrap_lines = [
+            line
+            for line in lines
+            if "'extrap'" in line and not line.strip().startswith("%")
+        ]
+        assert not extrap_lines, (
+            "resampleDataToFrequency.m uses interp1(..., 'extrap'), fabricating "
+            "values outside the recorded data span. "
+            "Fix: remove 'extrap' and use NaN as fill value, or clip the time "
+            "vector to the actual data range.\n"
+            "Offending lines:\n" + "\n".join(extrap_lines)
+        )


### PR DESCRIPTION
## Summary
- `extractLogsoutDataFixed.m`: added handling for 3D tensor signals (`[3 1 N]`, `[3 3 N]`) where time is the **last** dimension — permute then reshape to `(N × cols)` and emit individual columns; previously these were silently skipped as "not supported"
- `resampleDataToFrequency.m`: time vector now starts from `original_time(1)` (not hard-coded `0`), eliminating extrapolation before the recording start; removed `'extrap'` flag from `interp1` calls to prevent fabricating values outside the actual data span
- Added TDD tests in `tests/unit/test_simscape_dataset_contracts.py` (4 source-level inspection tests)

Closes #2491

## Test plan
- [ ] `python3 -m pytest tests/unit/test_simscape_dataset_contracts.py` — 4 tests pass
- [ ] `python3 -m ruff check` — zero violations
- [ ] `rust-quality-gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)