### PR TITLE
fix(ci): create stub ui/dist before editable install to fix build_hooks RuntimeError

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -52,6 +52,8 @@ jobs:
         run: ruff format --check .
 
       - run: pip install mypy types-PyYAML types-requests
+      - name: Create stub ui/dist for editable install (quality checks only)
+        run: mkdir -p ui/dist
       - run: pip install -e .[dev]
       # Baseline mypy check across all of src/
       - run: mypy src --config-file pyproject.toml
@@ -158,6 +160,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Create stub ui/dist for editable install
+        run: mkdir -p ui/dist
       - name: Install Core Test Dependencies
         run: pip install -e ".[dev,gui-test]"
 
@@ -257,6 +261,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - name: Create stub ui/dist for editable install
+        run: mkdir -p ui/dist
       - name: Install Core Test Dependencies
         run: pip install -e ".[dev,gui-test]"
       - name: Run Shared Tools Consumer Contracts


### PR DESCRIPTION
## Problem

Since #2554 added a RuntimeError in `build_hooks.py` when `CI=1` and `ui/dist` is absent, the `quality-gate` and `tests` CI jobs fail on `pip install -e .[dev]` because they don't pre-create the `ui/dist` directory.

This blocks all PRs targeting staging from passing the quality-gate check.

## Fix

Add `mkdir -p ui/dist` before each `pip install -e .[dev]` / `pip install -e ".[dev,gui-test]"` step in the three affected CI jobs:
- `quality-gate`  
- `tests`
- `shared-tools-consumer-contracts`

The stub directory satisfies `build_hooks.py`'s check that `ui/dist` exists when `CI=1`, allowing the editable install to proceed without packaging the UI bundle.

## Test Plan
- [ ] quality-gate passes on this PR
- [ ] tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)