### PR TITLE
refactor(#2456): split grip_modelling_tab.py into widgets/coordinator modules

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_grip_modelling_widgets.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_grip_modelling_widgets.py
@@ -1,0 +1,213 @@
+"""Sub-widgets for the GripModellingTab.
+
+Contains:
+- PressureVisualizationWidget: 2D heatmap of grip pressure distribution
+- ContactMetricsWidget: summary metrics for contact forces
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.physics.grip_contact_model import PressureVisualizationData
+
+logger = get_logger(__name__)
+
+
+class PressureVisualizationWidget(QtWidgets.QWidget):
+    """Widget for visualizing grip pressure distribution.
+
+    Issue #757: Pressure distribution visualization available in the UI.
+    Displays pressure as a 2D heatmap (unwrapped grip cylinder).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        """Initialize pressure visualization widget."""
+        super().__init__(parent)
+        self.setMinimumSize(200, 150)
+        self.pressure_data: PressureVisualizationData | None = None
+
+        # Color map (blue -> green -> yellow -> red)
+        self.color_stops = [
+            (0.0, QtGui.QColor(0, 0, 255)),  # Blue (low)
+            (0.33, QtGui.QColor(0, 255, 0)),  # Green
+            (0.66, QtGui.QColor(255, 255, 0)),  # Yellow
+            (1.0, QtGui.QColor(255, 0, 0)),  # Red (high)
+        ]
+
+    def update_pressure(self, data: PressureVisualizationData) -> None:
+        """Update displayed pressure data.
+
+        Args:
+            data: New pressure visualization data
+        """
+        if not (data is not None):
+            raise ValueError("data must be provided")
+        if not (data is not None):
+            raise ValueError("data must be provided")
+        self.pressure_data = data
+        self.update()
+
+    def clear(self) -> None:
+        """Clear pressure display."""
+        self.pressure_data = None
+        self.update()
+
+    def _get_color_for_value(self, normalized_value: float) -> QtGui.QColor:
+        """Get color from gradient for normalized value [0, 1]."""
+        if not (normalized_value is not None):
+            raise ValueError("normalized_value must be provided")
+        if not (normalized_value is not None):
+            raise ValueError("normalized_value must be provided")
+        normalized_value = max(0.0, min(1.0, normalized_value))
+
+        # Find surrounding color stops
+        for i in range(len(self.color_stops) - 1):
+            t1, c1 = self.color_stops[i]
+            t2, c2 = self.color_stops[i + 1]
+
+            if t1 <= normalized_value <= t2:
+                # Interpolate
+                t = (normalized_value - t1) / (t2 - t1) if t2 > t1 else 0
+                r = int(c1.red() + t * (c2.red() - c1.red()))
+                g = int(c1.green() + t * (c2.green() - c1.green()))
+                b = int(c1.blue() + t * (c2.blue() - c1.blue()))
+                return QtGui.QColor(r, g, b)
+
+        return self.color_stops[-1][1]
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        """Paint the pressure visualization."""
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+
+        rect = self.rect()
+        painter.fillRect(rect, QtGui.QColor(40, 40, 40))
+
+        if self.pressure_data is None or len(self.pressure_data.pressures) == 0:
+            painter.setPen(QtGui.QColor(150, 150, 150))
+            painter.drawText(
+                rect, QtCore.Qt.AlignmentFlag.AlignCenter, "No contact data"
+            )
+            return
+
+        # Draw title
+        painter.setPen(QtGui.QColor(255, 255, 255))
+        painter.drawText(10, 20, f"Max: {self.pressure_data.max_pressure:.0f} Pa")
+        painter.drawText(10, 35, f"Mean: {self.pressure_data.mean_pressure:.0f} Pa")
+
+        # Draw pressure points
+        margin = 50
+        plot_rect = rect.adjusted(margin, margin, -margin, -20)
+
+        if plot_rect.width() <= 0 or plot_rect.height() <= 0:
+            return
+
+        # Map grip axis position to x, angular position to y
+        axis_pos = self.pressure_data.grip_axis_positions
+        angles = self.pressure_data.angular_positions
+
+        if len(axis_pos) == 0:
+            return
+
+        # Normalize positions for display
+        axis_min, axis_max = np.min(axis_pos), np.max(axis_pos)
+        axis_range = axis_max - axis_min if axis_max > axis_min else 1.0
+
+        for i in range(len(self.pressure_data.pressures)):
+            # Map to widget coordinates
+            x_norm = (axis_pos[i] - axis_min) / axis_range
+            y_norm = (angles[i] + np.pi) / (2 * np.pi)
+
+            x = int(plot_rect.left() + x_norm * plot_rect.width())
+            y = int(plot_rect.top() + y_norm * plot_rect.height())
+
+            # Size based on pressure (larger = more pressure)
+            size = int(5 + 15 * self.pressure_data.normalized_pressures[i])
+
+            # Color based on pressure
+            norm_val = self.pressure_data.normalized_pressures[i]
+            color = self._get_color_for_value(norm_val)
+            painter.setBrush(QtGui.QBrush(color))
+            painter.setPen(QtCore.Qt.PenStyle.NoPen)
+            painter.drawEllipse(x - size // 2, y - size // 2, size, size)
+
+        # Draw axes labels
+        painter.setPen(QtGui.QColor(200, 200, 200))
+        painter.drawText(plot_rect.left(), rect.bottom() - 5, "Butt")
+        painter.drawText(plot_rect.right() - 20, rect.bottom() - 5, "Tip")
+
+        # Draw color legend
+        legend_rect = QtCore.QRect(rect.right() - 30, margin, 15, plot_rect.height())
+        for i in range(legend_rect.height()):
+            t = i / legend_rect.height()
+            color = self._get_color_for_value(1.0 - t)  # Flip so high is at top
+            painter.setPen(color)
+            painter.drawLine(
+                legend_rect.left(),
+                legend_rect.top() + i,
+                legend_rect.right(),
+                legend_rect.top() + i,
+            )
+
+
+class ContactMetricsWidget(QtWidgets.QWidget):
+    """Widget displaying contact metrics summary.
+
+    Issue #757: Shows contact forces, slip detection status.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        """Initialize metrics widget."""
+        super().__init__(parent)
+        layout = QtWidgets.QFormLayout(self)
+
+        self.lbl_normal_force = QtWidgets.QLabel("0.0 N")
+        self.lbl_tangent_force = QtWidgets.QLabel("0.0 N")
+        self.lbl_num_contacts = QtWidgets.QLabel("0")
+        self.lbl_slip_status = QtWidgets.QLabel("No slip")
+        self.lbl_slip_margin = QtWidgets.QLabel("N/A")
+        self.lbl_equilibrium = QtWidgets.QLabel("Unknown")
+
+        layout.addRow("Normal Force:", self.lbl_normal_force)
+        layout.addRow("Tangent Force:", self.lbl_tangent_force)
+        layout.addRow("Active Contacts:", self.lbl_num_contacts)
+        layout.addRow("Slip Status:", self.lbl_slip_status)
+        layout.addRow("Min Slip Margin:", self.lbl_slip_margin)
+        layout.addRow("Equilibrium:", self.lbl_equilibrium)
+
+    def update_metrics(
+        self,
+        normal_force: float,
+        tangent_force: float,
+        num_contacts: int,
+        num_slipping: int,
+        slip_margin: float,
+        equilibrium: bool,
+    ) -> None:
+        """Update displayed metrics."""
+        if not (normal_force is not None):
+            raise ValueError("normal_force must be provided")
+        if not (normal_force is not None):
+            raise ValueError("normal_force must be provided")
+        self.lbl_normal_force.setText(f"{normal_force:.1f} N")
+        self.lbl_tangent_force.setText(f"{tangent_force:.1f} N")
+        self.lbl_num_contacts.setText(str(num_contacts))
+
+        if num_slipping > 0:
+            self.lbl_slip_status.setText(f"SLIPPING ({num_slipping})")
+            self.lbl_slip_status.setStyleSheet("color: red; font-weight: bold;")
+        else:
+            self.lbl_slip_status.setText("No slip")
+            self.lbl_slip_status.setStyleSheet("color: green;")
+
+        self.lbl_slip_margin.setText(f"{slip_margin:.2%}")
+
+        if equilibrium:
+            self.lbl_equilibrium.setText("Stable")
+            self.lbl_equilibrium.setStyleSheet("color: green;")
+        else:
+            self.lbl_equilibrium.setText("Unstable")
+            self.lbl_equilibrium.setStyleSheet("color: orange;")

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
@@ -1,6 +1,9 @@
 """Grip Modelling Tab for Advanced Hand Models.
 
 Issue #757: Contact-based hand-grip model in MuJoCo with pressure visualization.
+
+Implementation split across:
+- _grip_modelling_widgets.py: PressureVisualizationWidget, ContactMetricsWidget
 """
 
 from __future__ import annotations
@@ -12,217 +15,21 @@ from typing import Any
 
 import mujoco
 import numpy as np
-from PyQt6 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.physics.grip_contact_model import (
     GripContactExporter,
     GripContactModel,
     GripParameters,
-    PressureVisualizationData,
     compute_pressure_visualization,
 )
 
+# Re-export public names for backward compatibility
+from ._grip_modelling_widgets import ContactMetricsWidget, PressureVisualizationWidget
 from .sim_widget import MuJoCoSimWidget
 
 logger = get_logger(__name__)
-
-
-class PressureVisualizationWidget(QtWidgets.QWidget):
-    """Widget for visualizing grip pressure distribution.
-
-    Issue #757: Pressure distribution visualization available in the UI.
-    Displays pressure as a 2D heatmap (unwrapped grip cylinder).
-    """
-
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        """Initialize pressure visualization widget."""
-        super().__init__(parent)
-        self.setMinimumSize(200, 150)
-        self.pressure_data: PressureVisualizationData | None = None
-
-        # Color map (blue -> green -> yellow -> red)
-        self.color_stops = [
-            (0.0, QtGui.QColor(0, 0, 255)),  # Blue (low)
-            (0.33, QtGui.QColor(0, 255, 0)),  # Green
-            (0.66, QtGui.QColor(255, 255, 0)),  # Yellow
-            (1.0, QtGui.QColor(255, 0, 0)),  # Red (high)
-        ]
-
-    def update_pressure(self, data: PressureVisualizationData) -> None:
-        """Update displayed pressure data.
-
-        Args:
-            data: New pressure visualization data
-        """
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        self.pressure_data = data
-        self.update()
-
-    def clear(self) -> None:
-        """Clear pressure display."""
-        self.pressure_data = None
-        self.update()
-
-    def _get_color_for_value(self, normalized_value: float) -> QtGui.QColor:
-        """Get color from gradient for normalized value [0, 1]."""
-        if not (normalized_value is not None):
-            raise ValueError("normalized_value must be provided")
-        if not (normalized_value is not None):
-            raise ValueError("normalized_value must be provided")
-        normalized_value = max(0.0, min(1.0, normalized_value))
-
-        # Find surrounding color stops
-        for i in range(len(self.color_stops) - 1):
-            t1, c1 = self.color_stops[i]
-            t2, c2 = self.color_stops[i + 1]
-
-            if t1 <= normalized_value <= t2:
-                # Interpolate
-                t = (normalized_value - t1) / (t2 - t1) if t2 > t1 else 0
-                r = int(c1.red() + t * (c2.red() - c1.red()))
-                g = int(c1.green() + t * (c2.green() - c1.green()))
-                b = int(c1.blue() + t * (c2.blue() - c1.blue()))
-                return QtGui.QColor(r, g, b)
-
-        return self.color_stops[-1][1]
-
-    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
-        """Paint the pressure visualization."""
-        painter = QtGui.QPainter(self)
-        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
-
-        rect = self.rect()
-        painter.fillRect(rect, QtGui.QColor(40, 40, 40))
-
-        if self.pressure_data is None or len(self.pressure_data.pressures) == 0:
-            painter.setPen(QtGui.QColor(150, 150, 150))
-            painter.drawText(
-                rect, QtCore.Qt.AlignmentFlag.AlignCenter, "No contact data"
-            )
-            return
-
-        # Draw title
-        painter.setPen(QtGui.QColor(255, 255, 255))
-        painter.drawText(10, 20, f"Max: {self.pressure_data.max_pressure:.0f} Pa")
-        painter.drawText(10, 35, f"Mean: {self.pressure_data.mean_pressure:.0f} Pa")
-
-        # Draw pressure points
-        margin = 50
-        plot_rect = rect.adjusted(margin, margin, -margin, -20)
-
-        if plot_rect.width() <= 0 or plot_rect.height() <= 0:
-            return
-
-        # Map grip axis position to x, angular position to y
-        axis_pos = self.pressure_data.grip_axis_positions
-        angles = self.pressure_data.angular_positions
-
-        if len(axis_pos) == 0:
-            return
-
-        # Normalize positions for display
-        axis_min, axis_max = np.min(axis_pos), np.max(axis_pos)
-        axis_range = axis_max - axis_min if axis_max > axis_min else 1.0
-
-        for i in range(len(self.pressure_data.pressures)):
-            # Map to widget coordinates
-            x_norm = (axis_pos[i] - axis_min) / axis_range
-            y_norm = (angles[i] + np.pi) / (2 * np.pi)
-
-            x = int(plot_rect.left() + x_norm * plot_rect.width())
-            y = int(plot_rect.top() + y_norm * plot_rect.height())
-
-            # Size based on pressure (larger = more pressure)
-            size = int(5 + 15 * self.pressure_data.normalized_pressures[i])
-
-            # Color based on pressure
-            norm_val = self.pressure_data.normalized_pressures[i]
-            color = self._get_color_for_value(norm_val)
-            painter.setBrush(QtGui.QBrush(color))
-            painter.setPen(QtCore.Qt.PenStyle.NoPen)
-            painter.drawEllipse(x - size // 2, y - size // 2, size, size)
-
-        # Draw axes labels
-        painter.setPen(QtGui.QColor(200, 200, 200))
-        painter.drawText(plot_rect.left(), rect.bottom() - 5, "Butt")
-        painter.drawText(plot_rect.right() - 20, rect.bottom() - 5, "Tip")
-
-        # Draw color legend
-        legend_rect = QtCore.QRect(rect.right() - 30, margin, 15, plot_rect.height())
-        for i in range(legend_rect.height()):
-            t = i / legend_rect.height()
-            color = self._get_color_for_value(1.0 - t)  # Flip so high is at top
-            painter.setPen(color)
-            painter.drawLine(
-                legend_rect.left(),
-                legend_rect.top() + i,
-                legend_rect.right(),
-                legend_rect.top() + i,
-            )
-
-
-class ContactMetricsWidget(QtWidgets.QWidget):
-    """Widget displaying contact metrics summary.
-
-    Issue #757: Shows contact forces, slip detection status.
-    """
-
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        """Initialize metrics widget."""
-        super().__init__(parent)
-        layout = QtWidgets.QFormLayout(self)
-
-        self.lbl_normal_force = QtWidgets.QLabel("0.0 N")
-        self.lbl_tangent_force = QtWidgets.QLabel("0.0 N")
-        self.lbl_num_contacts = QtWidgets.QLabel("0")
-        self.lbl_slip_status = QtWidgets.QLabel("No slip")
-        self.lbl_slip_margin = QtWidgets.QLabel("N/A")
-        self.lbl_equilibrium = QtWidgets.QLabel("Unknown")
-
-        layout.addRow("Normal Force:", self.lbl_normal_force)
-        layout.addRow("Tangent Force:", self.lbl_tangent_force)
-        layout.addRow("Active Contacts:", self.lbl_num_contacts)
-        layout.addRow("Slip Status:", self.lbl_slip_status)
-        layout.addRow("Min Slip Margin:", self.lbl_slip_margin)
-        layout.addRow("Equilibrium:", self.lbl_equilibrium)
-
-    def update_metrics(
-        self,
-        normal_force: float,
-        tangent_force: float,
-        num_contacts: int,
-        num_slipping: int,
-        slip_margin: float,
-        equilibrium: bool,
-    ) -> None:
-        """Update displayed metrics."""
-        if not (normal_force is not None):
-            raise ValueError("normal_force must be provided")
-        if not (normal_force is not None):
-            raise ValueError("normal_force must be provided")
-        self.lbl_normal_force.setText(f"{normal_force:.1f} N")
-        self.lbl_tangent_force.setText(f"{tangent_force:.1f} N")
-        self.lbl_num_contacts.setText(str(num_contacts))
-
-        if num_slipping > 0:
-            self.lbl_slip_status.setText(f"SLIPPING ({num_slipping})")
-            self.lbl_slip_status.setStyleSheet("color: red; font-weight: bold;")
-        else:
-            self.lbl_slip_status.setText("No slip")
-            self.lbl_slip_status.setStyleSheet("color: green;")
-
-        self.lbl_slip_margin.setText(f"{slip_margin:.2%}")
-
-        if equilibrium:
-            self.lbl_equilibrium.setText("Stable")
-            self.lbl_equilibrium.setStyleSheet("color: green;")
-        else:
-            self.lbl_equilibrium.setText("Unstable")
-            self.lbl_equilibrium.setStyleSheet("color: orange;")
 
 
 class GripModellingTab(QtWidgets.QWidget):
@@ -294,7 +101,7 @@ class GripModellingTab(QtWidgets.QWidget):
         self.chk_contact_monitor = QtWidgets.QCheckBox("Monitor Contacts")
         self.chk_contact_monitor.setToolTip(
             "Enable contact force and slip monitoring (Issue #757)"
-        )
+        )  # noqa: E501
         self.chk_contact_monitor.setChecked(False)
         self.chk_contact_monitor.toggled.connect(self._on_contact_monitor_toggled)
         self.control_layout.addWidget(self.chk_contact_monitor)
@@ -408,7 +215,7 @@ class GripModellingTab(QtWidgets.QWidget):
 
     def _prepare_scene_xml(
         self, scene_path: Path, folder_path: Path, is_both: bool = False
-    ) -> str:
+    ) -> str:  # noqa: E501
         """Read scene file and inject absolute paths and cylinder object."""
         if not (scene_path is not None):
             raise ValueError("scene_path must be provided")
@@ -419,7 +226,7 @@ class GripModellingTab(QtWidgets.QWidget):
         # 1. Inline hand XML includes and extract worldbodies
         xml_content = self._inline_hand_includes(
             xml_content, scene_path, folder_path, is_both
-        )
+        )  # noqa: E501
 
         # 2. Ensure offscreen framebuffer is large enough for renderer
         xml_content = self._ensure_offscreen_visual(xml_content)
@@ -432,7 +239,7 @@ class GripModellingTab(QtWidgets.QWidget):
 
         logger.info(
             "Successfully prepared scene XML with movable hands and mocap bodies."
-        )
+        )  # noqa: E501
         return xml_content
 
     def _get_hand_content(
@@ -483,7 +290,7 @@ class GripModellingTab(QtWidgets.QWidget):
                     new_name = f"{hand_prefix}_{class_name}"
                     content = content.replace(
                         f'class="{class_name}"', f'class="{new_name}"'
-                    )
+                    )  # noqa: E501
 
             return content
         except (RuntimeError, ValueError, OSError):
@@ -512,15 +319,15 @@ class GripModellingTab(QtWidgets.QWidget):
                 raise ValueError("filename must be provided")
             content = self._get_hand_content(
                 folder_path, filename, body_pattern, is_both
-            )
+            )  # noqa: E501
             bodies_match = re.search(
                 r"<worldbody[^>]*>(.*?)</worldbody>", content, re.DOTALL
-            )
+            )  # noqa: E501
             if bodies_match:
                 extracted_bodies.append(bodies_match.group(1))
                 content = re.sub(
                     r"<worldbody[^>]*>.*?</worldbody>", "", content, flags=re.DOTALL
-                )
+                )  # noqa: E501
             return content
 
         if is_both:
@@ -562,7 +369,7 @@ class GripModellingTab(QtWidgets.QWidget):
             bodies_str = "\n".join(extracted_bodies)
             xml_content = re.sub(
                 r"(<worldbody[^>]*>)", r"\1\n" + bodies_str, xml_content, count=1
-            )
+            )  # noqa: E501
 
         return xml_content
 
@@ -582,7 +389,7 @@ class GripModellingTab(QtWidgets.QWidget):
 
                 xml_content = re.sub(
                     r"<global([^>]*)>", update_global_tag, xml_content, count=1
-                )
+                )  # noqa: E501
             else:
                 xml_content = xml_content.replace(
                     "<visual>",
@@ -632,7 +439,7 @@ class GripModellingTab(QtWidgets.QWidget):
         # Right Hand Mocap (only add if not already present)
         if (
             is_both or "right" in str(scene_path).lower()
-        ) and 'name="rh_mocap"' not in xml_content:
+        ) and 'name="rh_mocap"' not in xml_content:  # noqa: E501
             mocap_xml += """
     <body name="rh_mocap" mocap="true" pos="0 0 0">
         <geom type="box" size="0.02 0.02 0.02" rgba="0 1 0 0.5" contype="0"
@@ -647,7 +454,7 @@ class GripModellingTab(QtWidgets.QWidget):
         # Left Hand Mocap (only add if not already present)
         if (
             is_both or "left" in str(scene_path).lower()
-        ) and 'name="lh_mocap"' not in xml_content:
+        ) and 'name="lh_mocap"' not in xml_content:  # noqa: E501
             mocap_xml += """
     <body name="lh_mocap" mocap="true" pos="0 0 0">
         <geom type="box" size="0.02 0.02 0.02" rgba="1 0 0 0.5" contype="0"
@@ -676,11 +483,11 @@ class GripModellingTab(QtWidgets.QWidget):
             equality_content = (
                 equality_xml.strip()
                 .replace("<equality>", "")
-                .replace("</equality>", "")
+                .replace("</equality>", "")  # noqa: E501
             )
             xml_content = xml_content.replace(
                 "</equality>", f"{equality_content}\n  </equality>"
-            )
+            )  # noqa: E501
         else:
             xml_content = xml_content.replace("</mujoco>", f"{equality_xml}\n</mujoco>")
 
@@ -989,7 +796,7 @@ class GripModellingTab(QtWidgets.QWidget):
 
         positions, normals, forces, velocities, body_names = (
             self._extract_hand_contacts(model, data)
-        )
+        )  # noqa: E501
 
         if not positions:
             self.pressure_widget.clear()
@@ -1063,4 +870,11 @@ class GripModellingTab(QtWidgets.QWidget):
             logger.exception("Failed to export contact data")
             QtWidgets.QMessageBox.critical(
                 self, "Export Failed", f"Failed to export: {e}"
-            )
+            )  # noqa: E501
+
+
+__all__ = [
+    "ContactMetricsWidget",
+    "GripModellingTab",
+    "PressureVisualizationWidget",
+]

--- a/tests/unit/test_grip_modelling_split_2456.py
+++ b/tests/unit/test_grip_modelling_split_2456.py
@@ -1,0 +1,77 @@
+"""Contract tests for #2456: grip_modelling_tab.py split.
+
+Tests run red before the split and green after.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parents[2]
+GRIP_DIR = REPO / "src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf"
+LOC_BUDGET_WIDGETS = 400
+LOC_BUDGET_COORDINATOR = 900
+
+_mujoco_available = importlib.util.find_spec("mujoco") is not None
+
+
+def _count_lines(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+class TestGripModellingSplitStructure:
+    """Split modules must exist after refactor."""
+
+    @pytest.mark.unit
+    def test_widgets_module_exists(self) -> None:
+        assert (GRIP_DIR / "_grip_modelling_widgets.py").exists()
+
+
+class TestGripModellingFileSizes:
+    """Each file must be within LOC budget after split."""
+
+    @pytest.mark.unit
+    def test_coordinator_loc(self) -> None:
+        loc = _count_lines(GRIP_DIR / "grip_modelling_tab.py")
+        assert loc <= LOC_BUDGET_COORDINATOR, (
+            f"grip_modelling_tab.py has {loc} LOC; budget {LOC_BUDGET_COORDINATOR}"
+        )
+
+    @pytest.mark.unit
+    def test_widgets_loc(self) -> None:
+        loc = _count_lines(GRIP_DIR / "_grip_modelling_widgets.py")
+        assert loc <= LOC_BUDGET_WIDGETS, (
+            f"_grip_modelling_widgets.py has {loc} LOC; budget {LOC_BUDGET_WIDGETS}"
+        )
+
+
+@pytest.mark.skipif(not _mujoco_available, reason="mujoco not installed")
+class TestGripModellingPublicAPI:
+    """Public API must remain importable from grip_modelling_tab (backward compat)."""
+
+    @pytest.mark.unit
+    def test_import_pressure_visualization_widget(self) -> None:
+        from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.grip_modelling_tab import (
+            PressureVisualizationWidget,
+        )
+
+        assert PressureVisualizationWidget is not None
+
+    @pytest.mark.unit
+    def test_import_contact_metrics_widget(self) -> None:
+        from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.grip_modelling_tab import (
+            ContactMetricsWidget,
+        )
+
+        assert ContactMetricsWidget is not None
+
+    @pytest.mark.unit
+    def test_import_grip_modelling_tab(self) -> None:
+        from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.grip_modelling_tab import (
+            GripModellingTab,
+        )
+
+        assert GripModellingTab is not None


### PR DESCRIPTION
## Summary
- Splits 1066-LOC `grip_modelling_tab.py` into two focused modules
- Extracts `PressureVisualizationWidget` + `ContactMetricsWidget` to `_grip_modelling_widgets.py` (213 LOC)
- Slims coordinator `grip_modelling_tab.py` to ~884 LOC (retains `GripModellingTab` + re-exports)
- All public names re-exported for backward compatibility
- TDD contract tests: 3 passed (structure + LOC budget), 3 skipped (mujoco not in test env)

## Test plan
- [x] `_grip_modelling_widgets.py` exists
- [x] Both files within LOC budget
- [x] `ruff check` — zero violations
- [x] `ruff format --check` — zero diffs
- [x] `scripts/check_file_size_budget.py` — OK
- [x] 3/3 structure+budget tests GREEN (3 API tests skip — mujoco not in CI unit test env)

Closes part of #2456

🤖 Generated with [Claude Code](https://claude.com/claude-code)