### PR TITLE
refactor(#2456): split text_editor.py into models/validation/coordinator

### DIFF
--- a/src/shared/python/model_generation/editor/_text_editor_models.py
+++ b/src/shared/python/model_generation/editor/_text_editor_models.py
@@ -1,0 +1,85 @@
+"""Data models for the URDF text editor.
+
+Contains:
+- ValidationSeverity: severity enum for validation messages
+- ValidationMessage: single validation message dataclass
+- DiffHunk: single diff hunk dataclass
+- DiffResult: result of comparing two URDF versions
+- EditorVersion: a versioned snapshot of the document
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class ValidationSeverity(Enum):
+    """Severity levels for validation messages."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class ValidationMessage:
+    """A validation message for URDF content."""
+
+    severity: ValidationSeverity
+    line: int
+    column: int
+    message: str
+    element: str | None = None
+
+    def __str__(self) -> str:
+        prefix = self.severity.value.upper()
+        loc = f"Line {self.line}"
+        if self.column > 0:
+            loc += f", Col {self.column}"
+        if self.element:
+            return f"[{prefix}] {loc} ({self.element}): {self.message}"
+        return f"[{prefix}] {loc}: {self.message}"
+
+
+@dataclass
+class DiffHunk:
+    """A single hunk in a diff."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[str]
+    context_before: list[str] = field(default_factory=list)
+    context_after: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DiffResult:
+    """Result of comparing two URDF versions."""
+
+    original_content: str
+    modified_content: str
+    hunks: list[DiffHunk]
+    unified_diff: str
+    additions: int
+    deletions: int
+    has_changes: bool
+
+    def get_summary(self) -> str:
+        """Get a summary of changes."""
+        if not self.has_changes:
+            return "No changes"
+        return f"{self.additions} additions, {self.deletions} deletions in {len(self.hunks)} hunks"
+
+
+@dataclass
+class EditorVersion:
+    """A version of the document."""
+
+    content: str
+    timestamp: datetime
+    description: str
+    checksum: str

--- a/src/shared/python/model_generation/editor/_text_editor_validation.py
+++ b/src/shared/python/model_generation/editor/_text_editor_validation.py
@@ -1,0 +1,396 @@
+"""URDF validation mixin for the text editor.
+
+Provides :class:`_URDFValidationMixin` which is mixed into
+:class:`URDFTextEditor` to supply all URDF/XML validation methods.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
+
+import defusedxml.ElementTree as DefusedET
+
+from ._text_editor_models import ValidationMessage, ValidationSeverity
+
+if TYPE_CHECKING:
+    pass
+
+
+class _URDFValidationMixin:
+    """Mixin providing URDF and XML validation for URDFTextEditor."""
+
+    # _content is provided by URDFTextEditor.__init__
+
+    def validate(self) -> list[ValidationMessage]:
+        """
+        Validate current URDF content.
+
+        Returns:
+            List of validation messages
+        """
+        messages = []
+
+        # XML validation
+        messages.extend(self._validate_xml())
+
+        if not any(m.severity == ValidationSeverity.ERROR for m in messages):
+            # URDF-specific validation
+            messages.extend(self._validate_urdf())
+
+        return messages
+
+    def _validate_xml(self) -> list[ValidationMessage]:
+        """Validate XML syntax."""
+        messages = []
+
+        try:
+            DefusedET.fromstring(self._content)
+        except ET.ParseError as e:
+            # Parse error message for line/column
+            error_str = str(e)
+            line, col = 1, 0
+
+            # Try to extract line number
+            match = re.search(r"line (\d+)", error_str)
+            if match:
+                line = int(match.group(1))
+
+            match = re.search(r"column (\d+)", error_str)
+            if match:
+                col = int(match.group(1))
+
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.ERROR,
+                    line=line,
+                    column=col,
+                    message=f"XML syntax error: {error_str}",
+                )
+            )
+
+        return messages
+
+    def _validate_urdf(self) -> list[ValidationMessage]:
+        """Validate URDF-specific rules."""
+        messages: list[ValidationMessage] = []
+
+        try:
+            root = DefusedET.fromstring(self._content)
+        except ET.ParseError:
+            return messages  # Already reported in XML validation
+
+        if not self._validate_root_element(root, messages):
+            return messages
+
+        links = self._validate_links(root, messages)
+        self._validate_joints(root, links, messages)
+        self._validate_orphan_links(root, links, messages)
+        return messages
+
+    def _validate_root_element(
+        self,
+        root: ET.Element,
+        messages: list[ValidationMessage],
+    ) -> bool:
+        """Check root is <robot> with a name. Return False to abort."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        if root.tag != "robot":
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.ERROR,
+                    line=1,
+                    column=0,
+                    message=(f"Root element should be 'robot', got '{root.tag}'"),
+                )
+            )
+            return False
+
+        if not root.get("name"):
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.WARNING,
+                    line=1,
+                    column=0,
+                    message="Robot element missing 'name' attribute",
+                    element="robot",
+                )
+            )
+        return True
+
+    def _validate_links(
+        self,
+        root: ET.Element,
+        messages: list[ValidationMessage],
+    ) -> dict[str, ET.Element]:
+        """Validate link elements and return name→element map."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        links: dict[str, ET.Element] = {}
+
+        for link_elem in root.findall("link"):
+            name = link_elem.get("name")
+            if not name:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(link_elem),
+                        column=0,
+                        message="Link element missing 'name' attribute",
+                        element="link",
+                    )
+                )
+            elif name in links:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(link_elem),
+                        column=0,
+                        message=f"Duplicate link name: '{name}'",
+                        element=name,
+                    )
+                )
+            else:
+                links[name] = link_elem
+
+            self._validate_link_inertial(
+                link_elem,
+                name,
+                messages,
+            )
+
+        return links
+
+    def _validate_link_inertial(
+        self,
+        link_elem: ET.Element,
+        name: str | None,
+        messages: list[ValidationMessage],
+    ) -> None:
+        """Validate inertial/mass properties of a link."""
+        if not (link_elem is not None):
+            raise ValueError("link_elem must be provided")
+        if not (link_elem is not None):
+            raise ValueError("link_elem must be provided")
+        inertial = link_elem.find("inertial")
+        if inertial is None:
+            return
+        mass_elem = inertial.find("mass")
+        if mass_elem is None:
+            return
+        mass = mass_elem.get("value")
+        if mass is None:
+            return
+
+        try:
+            mass_val = float(mass)
+        except ValueError:
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.ERROR,
+                    line=self._find_element_line(mass_elem),
+                    column=0,
+                    message=f"Invalid mass value: '{mass}'",
+                    element=name,
+                )
+            )
+            return
+
+        if mass_val < 0:
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.ERROR,
+                    line=self._find_element_line(mass_elem),
+                    column=0,
+                    message=f"Negative mass value: {mass_val}",
+                    element=name,
+                )
+            )
+        elif mass_val == 0:
+            messages.append(
+                ValidationMessage(
+                    severity=ValidationSeverity.WARNING,
+                    line=self._find_element_line(mass_elem),
+                    column=0,
+                    message="Zero mass value",
+                    element=name,
+                )
+            )
+
+    _VALID_JOINT_TYPES = frozenset(
+        {
+            "revolute",
+            "continuous",
+            "prismatic",
+            "fixed",
+            "floating",
+            "planar",
+        }
+    )
+
+    def _validate_joints(
+        self,
+        root: ET.Element,
+        links: dict[str, ET.Element],
+        messages: list[ValidationMessage],
+    ) -> None:
+        """Validate joint elements (type, parent/child, limits)."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        seen: dict[str, ET.Element] = {}
+
+        for joint_elem in root.findall("joint"):
+            name = joint_elem.get("name")
+            if not name:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(joint_elem),
+                        column=0,
+                        message="Joint element missing 'name' attribute",
+                        element="joint",
+                    )
+                )
+            elif name in seen:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(joint_elem),
+                        column=0,
+                        message=f"Duplicate joint name: '{name}'",
+                        element=name,
+                    )
+                )
+            else:
+                seen[name] = joint_elem
+
+            joint_type = joint_elem.get("type")
+            if joint_type not in self._VALID_JOINT_TYPES:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(joint_elem),
+                        column=0,
+                        message=f"Invalid joint type: '{joint_type}'",
+                        element=name,
+                    )
+                )
+
+            self._validate_joint_refs(
+                joint_elem,
+                name,
+                links,
+                messages,
+            )
+
+            if (
+                joint_type in {"revolute", "prismatic"}
+                and joint_elem.find("limit") is None
+            ):
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.WARNING,
+                        line=self._find_element_line(joint_elem),
+                        column=0,
+                        message=(f"{joint_type} joint missing limit element"),
+                        element=name,
+                    )
+                )
+
+    def _validate_joint_refs(
+        self,
+        joint_elem: ET.Element,
+        name: str | None,
+        links: dict[str, ET.Element],
+        messages: list[ValidationMessage],
+    ) -> None:
+        """Validate parent/child link references for a joint."""
+        for role in ("parent", "child"):
+            ref_elem = joint_elem.find(role)
+            if ref_elem is None:
+                messages.append(
+                    ValidationMessage(
+                        severity=ValidationSeverity.ERROR,
+                        line=self._find_element_line(joint_elem),
+                        column=0,
+                        message=f"Joint missing {role} element",
+                        element=name,
+                    )
+                )
+            else:
+                link_name = ref_elem.get("link")
+                if link_name and link_name not in links:
+                    messages.append(
+                        ValidationMessage(
+                            severity=ValidationSeverity.ERROR,
+                            line=self._find_element_line(ref_elem),
+                            column=0,
+                            message=(f"{role.title()} link not found: '{link_name}'"),
+                            element=name,
+                        )
+                    )
+
+    def _validate_orphan_links(
+        self,
+        root: ET.Element,
+        links: dict[str, ET.Element],
+        messages: list[ValidationMessage],
+    ) -> None:
+        """Detect links that are not connected to any joint."""
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        if not (root is not None):
+            raise ValueError("root must be provided")
+        child_links = set()
+        for joint_elem in root.findall("joint"):
+            child_elem = joint_elem.find("child")
+            if child_elem is not None:
+                child_links.add(child_elem.get("link"))
+
+        for link_name in links:
+            if link_name not in child_links:
+                is_parent = any(
+                    (pe := j.find("parent")) is not None and pe.get("link") == link_name
+                    for j in root.findall("joint")
+                )
+                if not is_parent and len(links) > 1:
+                    messages.append(
+                        ValidationMessage(
+                            severity=ValidationSeverity.WARNING,
+                            line=1,
+                            column=0,
+                            message=(
+                                f"Link '{link_name}' is not connected to any joint"
+                            ),
+                            element=link_name,
+                        )
+                    )
+
+    def _find_element_line(self, elem: ET.Element) -> int:
+        """Find the line number of an element (approximate)."""
+        # This is a simple heuristic - search for element in content
+        if not (elem is not None):
+            raise ValueError("elem must be provided")
+        if not (elem is not None):
+            raise ValueError("elem must be provided")
+        ET.tostring(elem, encoding="unicode")
+        tag_start = f"<{elem.tag}"
+
+        # Find in content
+        lines = self._content.split("\n")
+        for idx, line in enumerate(lines, 1):
+            if tag_start in line:
+                # Check if attributes match
+                name = elem.get("name")
+                if name is None or f'name="{name}"' in line or f"name='{name}'" in line:
+                    return idx
+
+        return 1

--- a/src/shared/python/model_generation/editor/text_editor.py
+++ b/src/shared/python/model_generation/editor/text_editor.py
@@ -1,11 +1,14 @@
-"""
-URDF Text Editor with diff view support.
+"""URDF Text Editor with diff view support (coordinator).
 
 Provides text-based editing of URDF files with:
-- Syntax validation
+- Syntax validation (see _text_editor_validation.py)
 - Diff generation between versions (see text_editor_diff_mixin.py)
 - Undo/redo support
 - Real-time validation feedback
+
+Implementation split across:
+- _text_editor_models.py: data classes
+- _text_editor_validation.py: _URDFValidationMixin
 """
 
 from __future__ import annotations
@@ -15,93 +18,31 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any
 
 import defusedxml.ElementTree as DefusedET
 
+# Re-export public names for backward compatibility
+from ._text_editor_models import (
+    DiffHunk,
+    DiffResult,
+    EditorVersion,
+    ValidationMessage,
+    ValidationSeverity,
+)
+from ._text_editor_validation import _URDFValidationMixin
 from .text_editor_diff_mixin import TextEditorDiffMixin
 
 logger = logging.getLogger(__name__)
 
 
-class ValidationSeverity(Enum):
-    """Severity levels for validation messages."""
-
-    ERROR = "error"
-    WARNING = "warning"
-    INFO = "info"
-
-
-@dataclass
-class ValidationMessage:
-    """A validation message for URDF content."""
-
-    severity: ValidationSeverity
-    line: int
-    column: int
-    message: str
-    element: str | None = None
-
-    def __str__(self) -> str:
-        prefix = self.severity.value.upper()
-        loc = f"Line {self.line}"
-        if self.column > 0:
-            loc += f", Col {self.column}"
-        if self.element:
-            return f"[{prefix}] {loc} ({self.element}): {self.message}"
-        return f"[{prefix}] {loc}: {self.message}"
-
-
-@dataclass
-class DiffHunk:
-    """A single hunk in a diff."""
-
-    old_start: int
-    old_count: int
-    new_start: int
-    new_count: int
-    lines: list[str]
-    context_before: list[str] = field(default_factory=list)
-    context_after: list[str] = field(default_factory=list)
-
-
-@dataclass
-class DiffResult:
-    """Result of comparing two URDF versions."""
-
-    original_content: str
-    modified_content: str
-    hunks: list[DiffHunk]
-    unified_diff: str
-    additions: int
-    deletions: int
-    has_changes: bool
-
-    def get_summary(self) -> str:
-        """Get a summary of changes."""
-        if not self.has_changes:
-            return "No changes"
-        return f"{self.additions} additions, {self.deletions} deletions in {len(self.hunks)} hunks"
-
-
-@dataclass
-class EditorVersion:
-    """A version of the document."""
-
-    content: str
-    timestamp: datetime
-    description: str
-    checksum: str
-
-
-class URDFTextEditor(TextEditorDiffMixin):
+class URDFTextEditor(TextEditorDiffMixin, _URDFValidationMixin):
     """Text editor for URDF files with validation and diff support.
 
     Diff operations are provided by :class:`TextEditorDiffMixin`.
+    Validation is provided by :class:`_URDFValidationMixin`.
 
     Example:
         editor = URDFTextEditor()
@@ -368,382 +309,6 @@ class URDFTextEditor(TextEditorDiffMixin):
 
         content = self._content.replace(old_content, new_content, 1)
         return self.set_content(content, f"Replace {element_name}")
-
-    # ============================================================
-    # Validation
-    # ============================================================
-
-    def validate(self) -> list[ValidationMessage]:
-        """
-        Validate current URDF content.
-
-        Returns:
-            List of validation messages
-        """
-        messages = []
-
-        # XML validation
-        messages.extend(self._validate_xml())
-
-        if not any(m.severity == ValidationSeverity.ERROR for m in messages):
-            # URDF-specific validation
-            messages.extend(self._validate_urdf())
-
-        return messages
-
-    def _validate_xml(self) -> list[ValidationMessage]:
-        """Validate XML syntax."""
-        messages = []
-
-        try:
-            DefusedET.fromstring(self._content)
-        except ET.ParseError as e:
-            # Parse error message for line/column
-            error_str = str(e)
-            line, col = 1, 0
-
-            # Try to extract line number
-            match = re.search(r"line (\d+)", error_str)
-            if match:
-                line = int(match.group(1))
-
-            match = re.search(r"column (\d+)", error_str)
-            if match:
-                col = int(match.group(1))
-
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.ERROR,
-                    line=line,
-                    column=col,
-                    message=f"XML syntax error: {error_str}",
-                )
-            )
-
-        return messages
-
-    def _validate_urdf(self) -> list[ValidationMessage]:
-        """Validate URDF-specific rules."""
-        messages: list[ValidationMessage] = []
-
-        try:
-            root = DefusedET.fromstring(self._content)
-        except ET.ParseError:
-            return messages  # Already reported in XML validation
-
-        if not self._validate_root_element(root, messages):
-            return messages
-
-        links = self._validate_links(root, messages)
-        self._validate_joints(root, links, messages)
-        self._validate_orphan_links(root, links, messages)
-        return messages
-
-    def _validate_root_element(
-        self,
-        root: ET.Element,
-        messages: list[ValidationMessage],
-    ) -> bool:
-        """Check root is <robot> with a name. Return False to abort."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        if root.tag != "robot":
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.ERROR,
-                    line=1,
-                    column=0,
-                    message=(f"Root element should be 'robot', got '{root.tag}'"),
-                )
-            )
-            return False
-
-        if not root.get("name"):
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.WARNING,
-                    line=1,
-                    column=0,
-                    message="Robot element missing 'name' attribute",
-                    element="robot",
-                )
-            )
-        return True
-
-    def _validate_links(
-        self,
-        root: ET.Element,
-        messages: list[ValidationMessage],
-    ) -> dict[str, ET.Element]:
-        """Validate link elements and return name→element map."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        links: dict[str, ET.Element] = {}
-
-        for link_elem in root.findall("link"):
-            name = link_elem.get("name")
-            if not name:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(link_elem),
-                        column=0,
-                        message="Link element missing 'name' attribute",
-                        element="link",
-                    )
-                )
-            elif name in links:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(link_elem),
-                        column=0,
-                        message=f"Duplicate link name: '{name}'",
-                        element=name,
-                    )
-                )
-            else:
-                links[name] = link_elem
-
-            self._validate_link_inertial(
-                link_elem,
-                name,
-                messages,
-            )
-
-        return links
-
-    def _validate_link_inertial(
-        self,
-        link_elem: ET.Element,
-        name: str | None,
-        messages: list[ValidationMessage],
-    ) -> None:
-        """Validate inertial/mass properties of a link."""
-        if not (link_elem is not None):
-            raise ValueError("link_elem must be provided")
-        if not (link_elem is not None):
-            raise ValueError("link_elem must be provided")
-        inertial = link_elem.find("inertial")
-        if inertial is None:
-            return
-        mass_elem = inertial.find("mass")
-        if mass_elem is None:
-            return
-        mass = mass_elem.get("value")
-        if mass is None:
-            return
-
-        try:
-            mass_val = float(mass)
-        except ValueError:
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.ERROR,
-                    line=self._find_element_line(mass_elem),
-                    column=0,
-                    message=f"Invalid mass value: '{mass}'",
-                    element=name,
-                )
-            )
-            return
-
-        if mass_val < 0:
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.ERROR,
-                    line=self._find_element_line(mass_elem),
-                    column=0,
-                    message=f"Negative mass value: {mass_val}",
-                    element=name,
-                )
-            )
-        elif mass_val == 0:
-            messages.append(
-                ValidationMessage(
-                    severity=ValidationSeverity.WARNING,
-                    line=self._find_element_line(mass_elem),
-                    column=0,
-                    message="Zero mass value",
-                    element=name,
-                )
-            )
-
-    _VALID_JOINT_TYPES = frozenset(
-        {
-            "revolute",
-            "continuous",
-            "prismatic",
-            "fixed",
-            "floating",
-            "planar",
-        }
-    )
-
-    def _validate_joints(
-        self,
-        root: ET.Element,
-        links: dict[str, ET.Element],
-        messages: list[ValidationMessage],
-    ) -> None:
-        """Validate joint elements (type, parent/child, limits)."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        seen: dict[str, ET.Element] = {}
-
-        for joint_elem in root.findall("joint"):
-            name = joint_elem.get("name")
-            if not name:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(joint_elem),
-                        column=0,
-                        message="Joint element missing 'name' attribute",
-                        element="joint",
-                    )
-                )
-            elif name in seen:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(joint_elem),
-                        column=0,
-                        message=f"Duplicate joint name: '{name}'",
-                        element=name,
-                    )
-                )
-            else:
-                seen[name] = joint_elem
-
-            joint_type = joint_elem.get("type")
-            if joint_type not in self._VALID_JOINT_TYPES:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(joint_elem),
-                        column=0,
-                        message=f"Invalid joint type: '{joint_type}'",
-                        element=name,
-                    )
-                )
-
-            self._validate_joint_refs(
-                joint_elem,
-                name,
-                links,
-                messages,
-            )
-
-            if (
-                joint_type in {"revolute", "prismatic"}
-                and joint_elem.find("limit") is None
-            ):
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.WARNING,
-                        line=self._find_element_line(joint_elem),
-                        column=0,
-                        message=(f"{joint_type} joint missing limit element"),
-                        element=name,
-                    )
-                )
-
-    def _validate_joint_refs(
-        self,
-        joint_elem: ET.Element,
-        name: str | None,
-        links: dict[str, ET.Element],
-        messages: list[ValidationMessage],
-    ) -> None:
-        """Validate parent/child link references for a joint."""
-        for role in ("parent", "child"):
-            ref_elem = joint_elem.find(role)
-            if ref_elem is None:
-                messages.append(
-                    ValidationMessage(
-                        severity=ValidationSeverity.ERROR,
-                        line=self._find_element_line(joint_elem),
-                        column=0,
-                        message=f"Joint missing {role} element",
-                        element=name,
-                    )
-                )
-            else:
-                link_name = ref_elem.get("link")
-                if link_name and link_name not in links:
-                    messages.append(
-                        ValidationMessage(
-                            severity=ValidationSeverity.ERROR,
-                            line=self._find_element_line(ref_elem),
-                            column=0,
-                            message=(f"{role.title()} link not found: '{link_name}'"),
-                            element=name,
-                        )
-                    )
-
-    def _validate_orphan_links(
-        self,
-        root: ET.Element,
-        links: dict[str, ET.Element],
-        messages: list[ValidationMessage],
-    ) -> None:
-        """Detect links that are not connected to any joint."""
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        if not (root is not None):
-            raise ValueError("root must be provided")
-        child_links = set()
-        for joint_elem in root.findall("joint"):
-            child_elem = joint_elem.find("child")
-            if child_elem is not None:
-                child_links.add(child_elem.get("link"))
-
-        for link_name in links:
-            if link_name not in child_links:
-                is_parent = any(
-                    (pe := j.find("parent")) is not None and pe.get("link") == link_name
-                    for j in root.findall("joint")
-                )
-                if not is_parent and len(links) > 1:
-                    messages.append(
-                        ValidationMessage(
-                            severity=ValidationSeverity.WARNING,
-                            line=1,
-                            column=0,
-                            message=(
-                                f"Link '{link_name}' is not connected to any joint"
-                            ),
-                            element=link_name,
-                        )
-                    )
-
-    def _find_element_line(self, elem: ET.Element) -> int:
-        """Find the line number of an element (approximate)."""
-        # This is a simple heuristic - search for element in content
-        if not (elem is not None):
-            raise ValueError("elem must be provided")
-        if not (elem is not None):
-            raise ValueError("elem must be provided")
-        ET.tostring(elem, encoding="unicode")
-        tag_start = f"<{elem.tag}"
-
-        # Find in content
-        lines = self._content.split("\n")
-        for idx, line in enumerate(lines, 1):
-            if tag_start in line:
-                # Check if attributes match
-                name = elem.get("name")
-                if name is None or f'name="{name}"' in line or f"name='{name}'" in line:
-                    return idx
-
-        return 1
 
     # ============================================================
     # History / Undo / Redo
@@ -1070,3 +635,13 @@ class URDFTextEditor(TextEditorDiffMixin):
                 }
 
         return None
+
+
+__all__ = [
+    "DiffHunk",
+    "DiffResult",
+    "EditorVersion",
+    "URDFTextEditor",
+    "ValidationMessage",
+    "ValidationSeverity",
+]

--- a/tests/unit/test_text_editor_split_2456.py
+++ b/tests/unit/test_text_editor_split_2456.py
@@ -1,0 +1,99 @@
+"""Contract tests for #2456: text_editor.py split.
+
+Tests run red before the split and green after.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parents[2]
+EDITOR_DIR = REPO / "src/shared/python/model_generation/editor"
+LOC_BUDGET = 700
+
+
+def _count_lines(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+class TestTextEditorSplitStructure:
+    """Split modules must exist after refactor."""
+
+    @pytest.mark.unit
+    def test_models_module_exists(self) -> None:
+        assert (EDITOR_DIR / "_text_editor_models.py").exists()
+
+    @pytest.mark.unit
+    def test_validation_module_exists(self) -> None:
+        assert (EDITOR_DIR / "_text_editor_validation.py").exists()
+
+
+class TestTextEditorFileSizes:
+    """Each file must be under 700 LOC after split."""
+
+    @pytest.mark.unit
+    def test_coordinator_loc(self) -> None:
+        loc = _count_lines(EDITOR_DIR / "text_editor.py")
+        assert loc <= LOC_BUDGET, (
+            f"text_editor.py has {loc} LOC; budget {LOC_BUDGET}"
+        )
+
+    @pytest.mark.unit
+    def test_models_loc(self) -> None:
+        loc = _count_lines(EDITOR_DIR / "_text_editor_models.py")
+        assert loc <= LOC_BUDGET, (
+            f"_text_editor_models.py has {loc} LOC; budget {LOC_BUDGET}"
+        )
+
+    @pytest.mark.unit
+    def test_validation_loc(self) -> None:
+        loc = _count_lines(EDITOR_DIR / "_text_editor_validation.py")
+        assert loc <= LOC_BUDGET, (
+            f"_text_editor_validation.py has {loc} LOC; budget {LOC_BUDGET}"
+        )
+
+
+class TestTextEditorPublicAPI:
+    """Public API must remain importable from text_editor (backward compat)."""
+
+    @pytest.mark.unit
+    def test_import_validation_severity(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import (
+            ValidationSeverity,
+        )
+
+        assert ValidationSeverity is not None
+
+    @pytest.mark.unit
+    def test_import_validation_message(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import (
+            ValidationMessage,
+        )
+
+        assert ValidationMessage is not None
+
+    @pytest.mark.unit
+    def test_import_diff_hunk(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import DiffHunk
+
+        assert DiffHunk is not None
+
+    @pytest.mark.unit
+    def test_import_diff_result(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import DiffResult
+
+        assert DiffResult is not None
+
+    @pytest.mark.unit
+    def test_import_editor_version(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import EditorVersion
+
+        assert EditorVersion is not None
+
+    @pytest.mark.unit
+    def test_import_urdf_text_editor(self) -> None:
+        from src.shared.python.model_generation.editor.text_editor import URDFTextEditor
+
+        assert URDFTextEditor is not None


### PR DESCRIPTION
## Summary
- Splits 1072-LOC `text_editor.py` into three focused modules
- Extracts 5 data classes (`ValidationSeverity`, `ValidationMessage`, `DiffHunk`, `DiffResult`, `EditorVersion`) to `_text_editor_models.py` (86 LOC)
- Extracts all validation methods to `_URDFValidationMixin` in `_text_editor_validation.py` (397 LOC)
- Slims coordinator `text_editor.py` to 651 LOC; `URDFTextEditor` inherits from `TextEditorDiffMixin` + `_URDFValidationMixin`
- All public names re-exported for backward compatibility
- TDD contract tests: 11 tests covering structure existence, LOC budgets, and all public API imports

## Test plan
- [x] `_text_editor_models.py` and `_text_editor_validation.py` exist
- [x] All three files ≤ 700 LOC
- [x] All 6 public symbols importable from `text_editor` (backward compat)
- [x] `ruff check` — zero violations
- [x] `ruff format --check` — zero diffs
- [x] `scripts/check_file_size_budget.py` — OK
- [x] 11/11 pytest tests GREEN

Closes part of #2456

🤖 Generated with [Claude Code](https://claude.com/claude-code)