### PR TITLE
fix(ann001): add missing parameter type annotations — waves 7-8

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/Motion_Capture_Plotter.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/Motion_Capture_Plotter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from typing import Any
 
 import matplotlib
 import numpy as np
@@ -385,7 +386,7 @@ class MotionCapturePlotter(QMainWindow):
             if filename:
                 self.load_simscape_csv(filename)
 
-    def on_data_source_changed(self, source) -> None:
+    def on_data_source_changed(self, source: str) -> None:
         """Handle data source change."""
         if not (source is not None):
             raise ValueError("source must be provided")
@@ -427,7 +428,7 @@ class MotionCapturePlotter(QMainWindow):
     _safe_float = staticmethod(safe_float)
     _parse_excel_row = staticmethod(parse_excel_row)
 
-    def _process_excel_sheet(self, filename, sheet_name) -> None:
+    def _process_excel_sheet(self, filename: str, sheet_name: str) -> None:
         """Process a single Excel sheet and store parsed frames in swing_data."""
         if not (filename is not None):
             raise ValueError("filename must be provided")
@@ -438,7 +439,7 @@ class MotionCapturePlotter(QMainWindow):
             self.swing_data[sheet_name] = result
             self.print_data_debug(sheet_name)
 
-    def load_excel_file(self, filename) -> None:
+    def load_excel_file(self, filename: str) -> None:
         """Load and process Excel file."""
         try:
             logger.info(f"Loading file: {filename}")
@@ -470,7 +471,7 @@ class MotionCapturePlotter(QMainWindow):
     _simscape_joint_position_definitions = staticmethod(get_simscape_joint_positions)
     _find_available_joints = staticmethod(find_available_joints)
 
-    def load_simscape_csv(self, filename) -> None:
+    def load_simscape_csv(self, filename: str) -> None:
         """Load and process Simscape CSV file."""
         try:
             logger.info(f"Loading Simscape CSV file: {filename}")
@@ -525,7 +526,7 @@ class MotionCapturePlotter(QMainWindow):
                 self, "Error", f"Failed to load Simscape CSV file: {str(e)}"
             )
 
-    def print_data_debug(self, sheet_name) -> None:
+    def print_data_debug(self, sheet_name: str) -> None:
         """Print debug information about the loaded data."""
         if sheet_name in self.swing_data:
             data = self.swing_data[sheet_name]
@@ -603,14 +604,14 @@ class MotionCapturePlotter(QMainWindow):
             self.frame_slider.setValue(0)
             self.current_frame = 0
 
-    def on_swing_change(self, swing_name) -> None:
+    def on_swing_change(self, swing_name: str) -> None:
         """Handle swing selection change."""
         if swing_name in self.swing_data:
             self.current_swing = swing_name
             self.setup_frame_slider()
             self.update_visualization()
 
-    def on_frame_change(self, frame) -> None:
+    def on_frame_change(self, frame: int) -> None:
         """Handle frame slider change."""
         if not (frame is not None):
             raise ValueError("frame must be provided")
@@ -620,7 +621,7 @@ class MotionCapturePlotter(QMainWindow):
         self.frame_label.setText(str(frame))
         self.update_visualization()
 
-    def on_speed_change(self, speed) -> None:
+    def on_speed_change(self, speed: int) -> None:
         """Handle speed slider change."""
         if not (speed is not None):
             raise ValueError("speed must be provided")
@@ -630,7 +631,7 @@ class MotionCapturePlotter(QMainWindow):
         if self.is_playing:
             self.animation_timer.setInterval(1000 // speed)
 
-    def on_scale_change(self, scale) -> None:
+    def on_scale_change(self, scale: int) -> None:
         """Handle motion scale change."""
         if not (scale is not None):
             raise ValueError("scale must be provided")
@@ -640,7 +641,7 @@ class MotionCapturePlotter(QMainWindow):
         self.scale_label.setText(f"{scale}x")
         self.update_visualization()
 
-    def on_club_length_change(self, length_cm) -> None:
+    def on_club_length_change(self, length_cm: int) -> None:
         """Handle club length change."""
         if not (length_cm is not None):
             raise ValueError("length_cm must be provided")
@@ -767,7 +768,7 @@ class MotionCapturePlotter(QMainWindow):
         # Redraw canvas
         self.canvas.draw()
 
-    def _draw_motion_capture_trajectory_paths(self, data) -> None:
+    def _draw_motion_capture_trajectory_paths(self, data: Any) -> None:
         """Draw mid-hands and club head trajectory paths for motion capture data.
 
         Parameters:
@@ -821,7 +822,7 @@ class MotionCapturePlotter(QMainWindow):
                 label="Club Head Path",
             )
 
-    def visualize_motion_capture_data(self, frame_data, data) -> None:
+    def visualize_motion_capture_data(self, frame_data: Any, data: Any) -> None:
         """Visualize motion capture data (Excel format)."""
         # Use actual mid-hands and club head positions from the data
         # For right-handed golfers: X should be flipped to show proper swing direction
@@ -853,7 +854,7 @@ class MotionCapturePlotter(QMainWindow):
         # Draw trajectory paths
         self._draw_motion_capture_trajectory_paths(data)
 
-    def _extract_joint_positions(self, frame_data) -> dict[str, np.ndarray]:
+    def _extract_joint_positions(self, frame_data: Any) -> dict[str, np.ndarray]:
         """Extract scaled joint positions from a Simscape frame.
 
         Returns a dict mapping joint names to numpy position arrays.
@@ -887,7 +888,9 @@ class MotionCapturePlotter(QMainWindow):
                 )
         return joints
 
-    def _draw_club_with_face_normal(self, club_head_pos, grip_pos) -> None:
+    def _draw_club_with_face_normal(
+        self, club_head_pos: np.ndarray, grip_pos: np.ndarray
+    ) -> None:
         """Draw the club shaft, head sphere, face normal vector, and golf ball.
 
         Parameters:
@@ -937,7 +940,9 @@ class MotionCapturePlotter(QMainWindow):
                 face_normal = face_normal / face_normal_length
                 self._draw_face_normal_and_ball(club_head_pos, face_normal)
 
-    def _draw_face_normal_and_ball(self, club_head_pos, face_normal) -> None:
+    def _draw_face_normal_and_ball(
+        self, club_head_pos: np.ndarray, face_normal: np.ndarray
+    ) -> None:
         """Draw the face normal vector arrow and a golf ball in front of the club.
 
         Parameters:
@@ -1015,7 +1020,9 @@ class MotionCapturePlotter(QMainWindow):
             label="Golf Ball",
         )
 
-    def _draw_body_segments_and_markers(self, joints, segment_definitions) -> None:
+    def _draw_body_segments_and_markers(
+        self, joints: Any, segment_definitions: Any
+    ) -> None:
         """Draw body segment lines and joint marker dots.
 
         Parameters:
@@ -1045,7 +1052,7 @@ class MotionCapturePlotter(QMainWindow):
                 position[0], position[1], position[2], color="black", s=50, alpha=0.8
             )
 
-    def _draw_simscape_trajectory_paths(self, joints, data) -> None:
+    def _draw_simscape_trajectory_paths(self, joints: Any, data: Any) -> None:
         """Draw club head and hands trajectory paths for Simscape data.
 
         Parameters:
@@ -1110,7 +1117,7 @@ class MotionCapturePlotter(QMainWindow):
                     label="Hands Path",
                 )
 
-    def _draw_segment_traces(self, frame_data, data) -> None:
+    def _draw_segment_traces(self, frame_data: Any, data: Any) -> None:
         """Draw optional per-segment trace paths for Simscape data.
 
         Parameters:
@@ -1166,7 +1173,7 @@ class MotionCapturePlotter(QMainWindow):
                         label=f"{segment_key.replace('_', ' ').title()} Path",
                     )
 
-    def visualize_simscape_data(self, frame_data, data) -> None:
+    def visualize_simscape_data(self, frame_data: Any, data: Any) -> None:
         """Visualize Simscape multibody data (CSV format)."""
         # Define colors for different body segments
         if not (frame_data is not None):
@@ -1206,7 +1213,7 @@ class MotionCapturePlotter(QMainWindow):
         self._draw_simscape_trajectory_paths(joints, data)
         self._draw_segment_traces(frame_data, data)
 
-    def update_info_text(self, frame_data) -> None:
+    def update_info_text(self, frame_data: Any) -> None:
         """Update the information text display."""
         if not (frame_data is not None):
             raise ValueError("frame_data must be provided")
@@ -1270,7 +1277,7 @@ class MotionCapturePlotter(QMainWindow):
 
         self.info_text.setText(info)
 
-    def set_camera_view(self, view) -> None:
+    def set_camera_view(self, view: str) -> None:
         """Set predefined camera views."""
         if not (view is not None):
             raise ValueError("view must be provided")
@@ -1307,7 +1314,7 @@ class MotionCapturePlotter(QMainWindow):
         self.canvas.draw_idle()
         self.canvas.flush_events()
 
-    def on_scroll(self, event) -> None:
+    def on_scroll(self, event: Any) -> None:
         """Handle mouse scroll for zooming."""
         if not (event is not None):
             raise ValueError("event must be provided")
@@ -1344,7 +1351,7 @@ class MotionCapturePlotter(QMainWindow):
         self.canvas.draw()
         logger.info(f"Zooming: factor={zoom_factor}")
 
-    def on_mouse_press(self, event) -> None:
+    def on_mouse_press(self, event: Any) -> None:
         """Handle mouse button press for rotation/panning."""
         if not (event is not None):
             raise ValueError("event must be provided")
@@ -1356,11 +1363,11 @@ class MotionCapturePlotter(QMainWindow):
         self._last_pos = (event.x, event.y)
         logger.info(f"Mouse press: button={event.button}, pos=({event.x}, {event.y})")
 
-    def on_mouse_release(self, event) -> None:
+    def on_mouse_release(self, event: Any) -> None:
         """Handle mouse button release."""
         self._last_pos = None
 
-    def on_mouse_move(self, event) -> None:
+    def on_mouse_move(self, event: Any) -> None:
         """Handle mouse movement for rotation/panning."""
         if not (event is not None):
             raise ValueError("event must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_coordinate_system.py
@@ -10,7 +10,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def _load_excel_frame_data(filename, sheet_name) -> list:
+def _load_excel_frame_data(filename: str, sheet_name: str) -> list:
     """Load and parse frame data from an Excel sheet.
 
     Returns a list of frame data dicts, or an empty list on failure.
@@ -66,7 +66,7 @@ def _load_excel_frame_data(filename, sheet_name) -> list:
     return data
 
 
-def _compute_motion_ranges(data) -> tuple:
+def _compute_motion_ranges(data: list) -> tuple:
     """Compute and log per-axis motion ranges for mid-hands and club head.
 
     Returns (mid_motion_ranges, club_motion_ranges) as lists of [X, Y, Z] range sizes.
@@ -125,7 +125,7 @@ def _compute_motion_ranges(data) -> tuple:
     return mid_motion_ranges, club_motion_ranges
 
 
-def _interpret_swing_motion(mid_motion_ranges, club_motion_ranges) -> None:
+def _interpret_swing_motion(mid_motion_ranges: list, club_motion_ranges: list) -> None:
     """Log interpretation of the swing motion directions and patterns."""
     if not (mid_motion_ranges is not None):
         raise ValueError("mid_motion_ranges must be provided")
@@ -179,7 +179,7 @@ def _interpret_swing_motion(mid_motion_ranges, club_motion_ranges) -> None:
         logger.info("  This seems unusual for a golf swing")
 
 
-def _analyze_key_frame(name, frame) -> None:
+def _analyze_key_frame(name: str, frame: dict) -> None:
     """Analyze and log position, club vector, and rotation matrix for a single frame."""
     if not (name is not None):
         raise ValueError("name must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_simscape_data.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/analyze_simscape_data.py
@@ -13,7 +13,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def _load_csv_data(csv_file) -> pd.DataFrame | None:
+def _load_csv_data(csv_file: str) -> pd.DataFrame | None:
     """Load and validate Simscape CSV data.
 
     Returns the DataFrame on success, or None on failure.
@@ -31,7 +31,7 @@ def _load_csv_data(csv_file) -> pd.DataFrame | None:
         return None
 
 
-def _categorize_columns(columns) -> dict:
+def _categorize_columns(columns: list) -> dict:
     """Categorize CSV columns by data type (position, rotation, etc.).
 
     Returns a dict mapping category names to lists of column names.
@@ -73,7 +73,7 @@ def _categorize_columns(columns) -> dict:
     return categories
 
 
-def _identify_joint_positions(position_columns) -> dict:
+def _identify_joint_positions(position_columns: list) -> dict:
     """Identify key joint center positions from position columns.
 
     Returns a dict mapping joint group names to lists of matching columns.
@@ -225,7 +225,7 @@ def _build_segment_definitions() -> dict:
     }
 
 
-def _check_segment_availability(segments, columns) -> dict:
+def _check_segment_availability(segments: dict, columns: list) -> dict:
     """Check which segments have all required columns available.
 
     Returns a dict of available segment names to their column lists.
@@ -249,7 +249,7 @@ def _check_segment_availability(segments, columns) -> dict:
     return available_segments
 
 
-def _log_data_sample(df, available_segments) -> None:
+def _log_data_sample(df: pd.DataFrame, available_segments: dict) -> None:
     """Log a sample of data from the available segments."""
     if not (df is not None):
         raise ValueError("df must be provided")
@@ -273,7 +273,7 @@ def _log_data_sample(df, available_segments) -> None:
         logger.info("%s", df[sample_cols].head(3).to_string())
 
 
-def analyze_simscape_data(csv_file) -> tuple | None:
+def analyze_simscape_data(csv_file: str) -> tuple | None:
     """Analyze the Simscape CSV file and identify key joint positions."""
 
     logger.info("Analyzing Simscape data file: %s", csv_file)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_main_application.py
@@ -11,6 +11,7 @@ import logging
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 from src.shared.python.logging_pkg.logging_config import (
     configure_gui_logging,
@@ -55,7 +56,7 @@ except ImportError as e:
 class EnhancedGolfVisualizerApp(QApplication):
     """Enhanced main application with advanced features"""
 
-    def __init__(self, argv) -> None:
+    def __init__(self, argv: list) -> None:
         if not (argv is not None):
             raise ValueError("argv must be provided")
         if not (argv is not None):
@@ -744,7 +745,7 @@ def main() -> int:
     """Enhanced main entry point with comprehensive error handling"""
 
     # Setup exception handling
-    def handle_exception(exc_type, exc_value, exc_traceback) -> None:
+    def handle_exception(exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
         """Log uncaught exceptions and show an error dialog."""
         if not (exc_type is not None):
             raise ValueError("exc_type must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_visualizer_implementation.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/golf_gui_r0/golf_visualizer_implementation.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import time
 from dataclasses import dataclass
+from typing import Any
 
 import moderngl as mgl
 import numpy as np
@@ -308,7 +309,7 @@ class OpenGLRenderer:
         }
         """
 
-    def initialize(self, ctx) -> None:
+    def initialize(self, ctx: Any) -> None:
         """Initialize OpenGL context and resources"""
         if not (ctx is not None):
             raise ValueError("ctx must be provided")
@@ -810,7 +811,7 @@ class OpenGLRenderer:
                     proj_matrix,
                 )
 
-    def _render_ground(self, view_matrix, proj_matrix) -> None:
+    def _render_ground(self, view_matrix: np.ndarray, proj_matrix: np.ndarray) -> None:
         """Render infinite ground grid"""
         if not (view_matrix is not None):
             raise ValueError("view_matrix must be provided")
@@ -859,7 +860,13 @@ class OpenGLRenderer:
             self.programs["ground"]["opacity"].value = 1.0
             self.vaos["ground"].render()
 
-    def _render_club(self, frame_data, config, view_matrix, proj_matrix) -> None:
+    def _render_club(
+        self,
+        frame_data: Any,
+        config: Any,
+        view_matrix: np.ndarray,
+        proj_matrix: np.ndarray,
+    ) -> None:
         """Render golf club"""
         if not (frame_data is not None):
             raise ValueError("frame_data must be provided")
@@ -893,7 +900,13 @@ class OpenGLRenderer:
             self.programs["standard"]["opacity"].value = config.body_opacity
             self.vaos["sphere"].render()
 
-    def _render_face_normal(self, frame_data, config, view_matrix, proj_matrix) -> None:
+    def _render_face_normal(
+        self,
+        frame_data: Any,
+        config: Any,
+        view_matrix: np.ndarray,
+        proj_matrix: np.ndarray,
+    ) -> None:
         """Render face normal"""
 
     def _render_arrow(
@@ -1036,7 +1049,7 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
             len(self.frame_times) / sum(self.frame_times) if self.frame_times else 0
         )
 
-    def resizeGL(self, width, height) -> None:
+    def resizeGL(self, width: int, height: int) -> None:
         """Handle window resize"""
         self.ctx.viewport = (0, 0, width, height)
 
@@ -1082,11 +1095,11 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
             self.current_frame = frame_idx
             self.update()
 
-    def mousePressEvent(self, event) -> None:
+    def mousePressEvent(self, event: Any) -> None:
         """Handle mouse press for camera control"""
         self.last_mouse_pos = (event.x(), event.y())
 
-    def mouseMoveEvent(self, event) -> None:
+    def mouseMoveEvent(self, event: Any) -> None:
         """Handle mouse movement for camera control"""
         if self.last_mouse_pos is not None:
             dx = event.x() - self.last_mouse_pos[0]
@@ -1098,7 +1111,7 @@ class ModernGolfVisualizerWidget(QOpenGLWidget):
             self.last_mouse_pos = (event.x(), event.y())
             self.update()
 
-    def wheelEvent(self, event) -> None:
+    def wheelEvent(self, event: Any) -> None:
         """Handle mouse wheel for camera zoom"""
         if not (event is not None):
             raise ValueError("event must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import scipy.io
@@ -17,7 +18,7 @@ import scipy.io
 logger = logging.getLogger(__name__)
 
 
-def deep_analyze_matlab_file(filename) -> bool:
+def deep_analyze_matlab_file(filename: Any) -> bool:
     """Deep analysis of a MATLAB file structure"""
     logger.debug(f"\n=== Deep Analysis of {filename} ===")
 
@@ -100,7 +101,7 @@ def deep_analyze_matlab_file(filename) -> bool:
         return False
 
 
-def extract_actual_data(filename) -> np.ndarray | None:
+def extract_actual_data(filename: Any) -> np.ndarray | None:
     """Try to extract the actual data from the MATLAB file"""
     logger.debug(f"\n=== Extracting Data from {filename} ===")
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_data_core.py
@@ -12,6 +12,7 @@ import time
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -700,7 +701,7 @@ class FrameProcessor:
         """Set the current filter type and invalidate cached filtered data"""
         self.set_filter(filter_type)  # Use existing method
 
-    def set_filter_param(self, param_name: str, value) -> None:
+    def set_filter_param(self, param_name: str, value: Any) -> None:
         """Set a filter parameter and invalidate cached filtered data"""
         if not (param_name is not None):
             raise ValueError("param_name must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_application.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from typing import Any
 
 from golf_gui_styles import get_full_modern_style
 from golf_gui_tabs import ComparisonTab, MotionCaptureTab, SimulinkModelTab
@@ -239,7 +240,7 @@ class GolfVisualizerMainWindow(QMainWindow):
         if hasattr(self, "gl_widget") and self.gl_widget:
             self.gl_widget.set_above_view()
 
-    def _toggle_face_normal(self, state) -> None:
+    def _toggle_face_normal(self, state: Any) -> None:
         """Toggle face normal visibility."""
         if (
             hasattr(self, "gl_widget")
@@ -249,7 +250,7 @@ class GolfVisualizerMainWindow(QMainWindow):
             self.gl_widget.current_render_config.show_face_normal = bool(state)
             self.gl_widget.update()
 
-    def _toggle_ball(self, state) -> None:
+    def _toggle_ball(self, state: Any) -> None:
         """Toggle ball visibility."""
         if (
             hasattr(self, "gl_widget")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_tabs.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_gui_tabs.py
@@ -7,6 +7,7 @@ Extracted from golf_gui_application.py for Single Responsibility Principle.
 from __future__ import annotations
 
 import traceback
+from typing import Any
 
 import numpy as np
 from golf_data_core import FrameData, FrameProcessor, RenderConfig
@@ -30,7 +31,7 @@ from wiffle_data_loader import MotionDataLoader
 class MotionCaptureTab(QWidget):
     """Tab for motion capture data visualization with smooth playback."""
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Any = None) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):
@@ -233,7 +234,7 @@ class MotionCaptureTab(QWidget):
 class SimulinkModelTab(QWidget):
     """Tab for Simulink model data visualization."""
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Any = None) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):
@@ -424,7 +425,7 @@ class SimulinkModelTab(QWidget):
 class ComparisonTab(QWidget):
     """Tab for comparing motion capture vs Simulink model data."""
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Any = None) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_inverse_dynamics.py
@@ -5,7 +5,9 @@ from scipy import signal
 from scipy.interpolate import UnivariateSpline
 
 
-def butter_lowpass_filter(data, cutoff, fs, order=4) -> np.ndarray:
+def butter_lowpass_filter(
+    data: np.ndarray, cutoff: float, fs: float, order: int = 4
+) -> np.ndarray:
     """Apply a Butterworth low-pass filter."""
     if not (data is not None):
         raise ValueError("data must be provided")
@@ -18,7 +20,9 @@ def butter_lowpass_filter(data, cutoff, fs, order=4) -> np.ndarray:
     return y
 
 
-def savitzky_golay_filter(data, window_length=9, polyorder=3) -> np.ndarray:
+def savitzky_golay_filter(
+    data: np.ndarray, window_length: int = 9, polyorder: int = 3
+) -> np.ndarray:
     """Apply a Savitzky-Golay filter."""
     if not (data is not None):
         raise ValueError("data must be provided")
@@ -29,12 +33,12 @@ def savitzky_golay_filter(data, window_length=9, polyorder=3) -> np.ndarray:
     return signal.savgol_filter(data, window_length, polyorder)
 
 
-def moving_average_filter(data, window_size=5) -> np.ndarray:
+def moving_average_filter(data: np.ndarray, window_size: int = 5) -> np.ndarray:
     """Apply a moving average filter."""
     return np.convolve(data, np.ones(window_size) / window_size, mode="valid")
 
 
-def calculate_derivatives(data, time) -> tuple:
+def calculate_derivatives(data: np.ndarray, time: np.ndarray) -> tuple:
     """Calculate velocity and acceleration using splines for accuracy."""
     if not (data is not None):
         raise ValueError("data must be provided")
@@ -47,7 +51,11 @@ def calculate_derivatives(data, time) -> tuple:
 
 
 def calculate_inverse_dynamics(
-    position_data, orientation_data, time_vector, club_mass=0.2, eval_offset=0.0
+    position_data: np.ndarray,
+    orientation_data: np.ndarray,
+    time_vector: np.ndarray,
+    club_mass: float = 0.2,
+    eval_offset: float = 0.0,
 ) -> dict:
     """
     Calculate inverse dynamics (forces and torques).

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_opengl_renderer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_opengl_renderer.py
@@ -10,6 +10,7 @@ import logging
 import time
 import traceback
 from dataclasses import dataclass
+from typing import Any
 
 import moderngl as mgl
 import numpy as np
@@ -482,9 +483,9 @@ class OpenGLRenderer:
 
     def render_frame(
         self,
-        frame_data,
-        dynamics_data,
-        render_config,
+        frame_data: Any,
+        dynamics_data: Any,
+        render_config: Any,
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
@@ -609,7 +610,7 @@ class OpenGLRenderer:
             return False
 
     @staticmethod
-    def _build_body_segment_definitions(frame_data) -> list:
+    def _build_body_segment_definitions(frame_data: Any) -> list:
         """Build the list of body segment rendering definitions.
 
         Returns a list of (name, start_point, end_point, radius, color, is_skin) tuples.
@@ -667,8 +668,8 @@ class OpenGLRenderer:
 
     def _render_body_segments(
         self,
-        frame_data,
-        render_config,
+        frame_data: Any,
+        render_config: Any,
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,
@@ -852,7 +853,7 @@ class OpenGLRenderer:
             logger.error("[WARN] Sphere render error: %s", e)
 
     @staticmethod
-    def _compute_club_face_normal(frame_data) -> np.ndarray:
+    def _compute_club_face_normal(frame_data: Any) -> np.ndarray:
         """Compute the club face normal vector from shaft direction.
 
         Returns a unit vector perpendicular to the shaft direction.
@@ -871,7 +872,9 @@ class OpenGLRenderer:
 
         return face_normal
 
-    def _render_club_face_normal(self, frame_data, face_normal, program) -> None:
+    def _render_club_face_normal(
+        self, frame_data: Any, face_normal: np.ndarray, program: Any
+    ) -> None:
         """Render the club face normal vector arrow."""
         if not (frame_data is not None):
             raise ValueError("frame_data must be provided")
@@ -896,7 +899,9 @@ class OpenGLRenderer:
             "normal_arrow", normal_end, 0.005, normal_color, 0.8, program
         )
 
-    def _render_club_ball(self, frame_data, face_normal, program) -> None:
+    def _render_club_ball(
+        self, frame_data: Any, face_normal: np.ndarray, program: Any
+    ) -> None:
         """Render the golf ball positioned for center strike."""
         if not (frame_data is not None):
             raise ValueError("frame_data must be provided")
@@ -913,8 +918,8 @@ class OpenGLRenderer:
 
     def _render_club(
         self,
-        frame_data,
-        render_config,
+        frame_data: Any,
+        render_config: Any,
         view_matrix: np.ndarray,
         proj_matrix: np.ndarray,
         view_position: np.ndarray,

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_playback_controller.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_playback_controller.py
@@ -6,6 +6,7 @@ Extracted from golf_gui_application.py for Single Responsibility Principle.
 from __future__ import annotations
 
 from copy import copy
+from typing import Any
 
 import numpy as np
 from golf_data_core import FrameData, FrameProcessor
@@ -32,7 +33,7 @@ class SmoothPlaybackController(QObject):
     frameUpdated = pyqtSignal(FrameData)  # Emits interpolated frame data
     positionChanged = pyqtSignal(float)  # Emits current position (0.0 to total_frames)
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Any = None) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
@@ -16,6 +16,7 @@ import logging
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from golf_data_core import RenderConfig
@@ -63,7 +64,7 @@ class VideoExporter(QObject):
     finished = pyqtSignal(str)  # output_path
     error = pyqtSignal(str)  # error_message
 
-    def __init__(self, renderer, frame_processor) -> None:
+    def __init__(self, renderer: Any, frame_processor: Any) -> None:
         if not (renderer is not None):
             raise ValueError("renderer must be provided")
         if not (renderer is not None):
@@ -209,7 +210,7 @@ class VideoExporter(QObject):
         )
 
     def _render_frame_to_buffer(
-        self, frame_data, resolution: tuple[int, int]
+        self, frame_data: Any, resolution: tuple[int, int]
     ) -> np.ndarray:
         """
         Render frame to RGB buffer
@@ -372,7 +373,9 @@ class VideoExportThread(QThread):
     finished = pyqtSignal(str)
     error = pyqtSignal(str)
 
-    def __init__(self, renderer, frame_processor, config: VideoExportConfig) -> None:
+    def __init__(
+        self, renderer: Any, frame_processor: Any, config: VideoExportConfig
+    ) -> None:
         if not (renderer is not None):
             raise ValueError("renderer must be provided")
         if not (renderer is not None):
@@ -408,7 +411,7 @@ class VideoExportDialog(QDialog):
     Simply create and show this dialog when user wants to export
     """
 
-    def __init__(self, parent, renderer, frame_processor) -> None:
+    def __init__(self, parent: Any, renderer: Any, frame_processor: Any) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):
@@ -575,7 +578,7 @@ class VideoExportDialog(QDialog):
         self.export_thread.start()
         progress_dialog.exec()
 
-    def _on_export_finished(self, progress_dialog, output_path) -> None:
+    def _on_export_finished(self, progress_dialog: Any, output_path: str) -> None:
         """Handle export completion"""
         if not (progress_dialog is not None):
             raise ValueError("progress_dialog must be provided")
@@ -590,7 +593,7 @@ class VideoExportDialog(QDialog):
             f"You can now play the video in any media player.",
         )
 
-    def _on_export_error(self, progress_dialog, error_msg) -> None:
+    def _on_export_error(self, progress_dialog: Any, error_msg: str) -> None:
         """Handle export error"""
         if not (progress_dialog is not None):
             raise ValueError("progress_dialog must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_visualizer_widget.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_visualizer_widget.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import traceback
+from typing import Any
 
 import moderngl as mgl
 import numpy as np
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 class GolfVisualizerWidget(QOpenGLWidget):
     """OpenGL widget for 3D golf swing visualization."""
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Any = None) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):
@@ -296,7 +297,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.update()
         logger.info("Camera: Overhead view")
 
-    def mousePressEvent(self, event) -> None:
+    def mousePressEvent(self, event: Any) -> None:
         """Handle mouse press events."""
         if not (event is not None):
             raise ValueError("event must be provided")
@@ -305,11 +306,11 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.last_mouse_pos = event.pos()
         self.mouse_pressed = True
 
-    def mouseReleaseEvent(self, event) -> None:
+    def mouseReleaseEvent(self, event: Any) -> None:
         """Handle mouse release events."""
         self.mouse_pressed = False
 
-    def mouseMoveEvent(self, event) -> None:
+    def mouseMoveEvent(self, event: Any) -> None:
         """Handle mouse move events."""
         if not (event is not None):
             raise ValueError("event must be provided")
@@ -344,7 +345,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.last_mouse_pos = event.pos()
         self.update()
 
-    def wheelEvent(self, event) -> None:
+    def wheelEvent(self, event: Any) -> None:
         """Handle mouse wheel events."""
         if not (event is not None):
             raise ValueError("event must be provided")
@@ -355,7 +356,7 @@ class GolfVisualizerWidget(QOpenGLWidget):
         self.camera_distance = np.clip(self.camera_distance, 0.1, 50.0)
         self.update()
 
-    def keyPressEvent(self, event) -> None:
+    def keyPressEvent(self, event: Any) -> None:
         """Handle keyboard shortcuts."""
         if not (event is not None):
             raise ValueError("event must be provided")

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
@@ -7,6 +7,7 @@ Enhanced main application with Excel data loading and advanced visualization
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -442,7 +443,7 @@ class WiffleGolfMainWindow(QMainWindow):
         self.progress_text.append(message)
         self.statusBar().showMessage(message)
 
-    def _on_data_loaded(self, baseq, ztcfq, deltaq) -> None:
+    def _on_data_loaded(self, baseq: Any, ztcfq: Any, deltaq: Any) -> None:
         """Handle successful data loading"""
         if not (baseq is not None):
             raise ValueError("baseq must be provided")
@@ -582,7 +583,7 @@ class WiffleGolfMainWindow(QMainWindow):
         except (RuntimeError, ValueError, OSError) as e:
             self.metrics_label.setText(f"Error calculating metrics: {str(e)}")
 
-    def _calculate_max_speed(self, data) -> float:
+    def _calculate_max_speed(self, data: Any) -> float:
         """Calculate maximum clubhead speed"""
         try:
             # Calculate velocity from position data

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/gui_performance_options.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class PerformanceOptionsDialog:
     """Dialog for configuring simulation performance options"""
 
-    def __init__(self, parent) -> None:
+    def __init__(self, parent: tk.Tk) -> None:
         if not (parent is not None):
             raise ValueError("parent must be provided")
         if not (parent is not None):
@@ -162,13 +162,13 @@ class PerformanceOptionsDialog:
         return self.result
 
 
-def get_performance_options(parent) -> dict | None:
+def get_performance_options(parent: tk.Tk) -> dict | None:
     """Show performance options dialog and return settings"""
     dialog = PerformanceOptionsDialog(parent)
     return dialog.show()
 
 
-def generate_matlab_performance_script(settings) -> str:
+def generate_matlab_performance_script(settings: dict) -> str:
     """Generate MATLAB script with performance settings"""
     script_lines = []
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
@@ -201,7 +201,7 @@ class MotionDataLoader:
         except (RuntimeError, TypeError, ValueError) as e:
             raise RuntimeError(f"Error loading Excel data: {e}") from e
 
-    def _extract_time_column(self, data_df, sheet_name) -> pd.Series:
+    def _extract_time_column(self, data_df: pd.DataFrame, sheet_name: str) -> pd.Series:
         """Extract or create the time column from processed sheet data.
 
         Returns a pandas Series for the time column.
@@ -219,7 +219,9 @@ class MotionDataLoader:
         )
         return pd.Series(np.linspace(0, 1, len(data_df)))
 
-    def _extract_clubhead_position(self, data_df, processed_data, sheet_name) -> None:
+    def _extract_clubhead_position(
+        self, data_df: pd.DataFrame, processed_data: pd.DataFrame, sheet_name: str
+    ) -> None:
         """Extract clubhead XYZ position columns from the sheet data.
 
         Modifies processed_data in place by adding clubhead_x/y/z columns.
@@ -266,7 +268,7 @@ class MotionDataLoader:
                 processed_data["clubhead_y"] = np.linspace(0, 1, len(processed_data))
                 processed_data["clubhead_z"] = np.linspace(0, 1, len(processed_data))
 
-    def _apply_post_processing(self, processed_data) -> pd.DataFrame:
+    def _apply_post_processing(self, processed_data: pd.DataFrame) -> pd.DataFrame:
         """Apply normalization, noise filtering, and interpolation to processed data.
 
         Returns the post-processed DataFrame.

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
@@ -1,6 +1,7 @@
 """Service for loading C3D files into application data models."""
 
 import os
+from typing import Any
 
 import numpy as np
 
@@ -9,7 +10,7 @@ from ...logger_utils import log_execution_time
 from ..core.models import AnalogData, C3DDataModel, MarkerData
 
 
-def _build_markers(df_points, marker_names: list[str]) -> dict[str, MarkerData]:
+def _build_markers(df_points: Any, marker_names: list[str]) -> dict[str, MarkerData]:
     """Build marker data dictionary from points dataframe.
 
     Args:
@@ -39,7 +40,7 @@ def _build_markers(df_points, marker_names: list[str]) -> dict[str, MarkerData]:
     return markers
 
 
-def _build_analog(df_analog, metadata_obj) -> dict[str, AnalogData]:
+def _build_analog(df_analog: Any, metadata_obj: Any) -> dict[str, AnalogData]:
     """Build analog channel data dictionary from analog dataframe.
 
     Args:
@@ -66,7 +67,7 @@ def _build_analog(df_analog, metadata_obj) -> dict[str, AnalogData]:
     return analog
 
 
-def _build_metadata_ui(filepath: str, metadata_obj) -> dict[str, str]:
+def _build_metadata_ui(filepath: str, metadata_obj: Any) -> dict[str, str]:
     """Build UI-friendly metadata dictionary from C3D metadata.
 
     Args:

--- a/src/engines/physics_engines/drake/python/motion_optimization.py
+++ b/src/engines/physics_engines/drake/python/motion_optimization.py
@@ -7,7 +7,7 @@ simulations, matching the functionality available in the MuJoCo engine.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -274,7 +274,7 @@ class DrakeMotionOptimizer:
 
     def _build_optimization_result(
         self,
-        opt_result,
+        opt_result: Any,
         optimal_trajectory: np.ndarray,
         objective_values: dict[str, float],
         constraint_violations: dict[str, float],

--- a/src/engines/physics_engines/drake/python/src/drake_visualization_mixin.py
+++ b/src/engines/physics_engines/drake/python/src/drake_visualization_mixin.py
@@ -141,7 +141,7 @@ class DrakeVisualizationMixin:
             if self.meshcat is not None:
                 self.meshcat.SetLineSegments(path, points, 2.0, Rgba(0, 1, 0, 1))
 
-    def _resolve_induced_accels(self: Any, analyzer, source) -> Any:
+    def _resolve_induced_accels(self: Any, analyzer: Any, source: str) -> Any:
         if not (analyzer is not None):
             raise ValueError("analyzer must be provided")
         if not (analyzer is not None):
@@ -175,7 +175,7 @@ class DrakeVisualizationMixin:
 
         return accels
 
-    def _draw_induced_vectors_viz(self: Any, analyzer) -> None:
+    def _draw_induced_vectors_viz(self: Any, analyzer: Any) -> None:
         if not (analyzer is not None):
             raise ValueError("analyzer must be provided")
         if not (analyzer is not None):
@@ -184,7 +184,7 @@ class DrakeVisualizationMixin:
         accels = self._resolve_induced_accels(analyzer, source)
         self._draw_accel_vectors(accels, "induced", Rgba(1, 0, 1, 1))
 
-    def _draw_counterfactual_vectors(self: Any, analyzer) -> None:
+    def _draw_counterfactual_vectors(self: Any, analyzer: Any) -> None:
         if not (analyzer is not None):
             raise ValueError("analyzer must be provided")
         if not (analyzer is not None):

--- a/src/engines/physics_engines/drake/python/src/manipulability.py
+++ b/src/engines/physics_engines/drake/python/src/manipulability.py
@@ -6,6 +6,7 @@ Computes Force and Mobility ellipsoids/matrices using Drake's MultibodyPlant.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -92,7 +93,9 @@ class DrakeManipulabilityAnalyzer:
 
         return sorted(bodies, key=sort_key)
 
-    def _compute_translational_jacobian(self, context: Context, body) -> np.ndarray:
+    def _compute_translational_jacobian(
+        self, context: Context, body: Any
+    ) -> np.ndarray:
         return self.plant.CalcJacobianTranslationalVelocity(
             context,
             JacobianWrtVariable.kV,
@@ -103,7 +106,7 @@ class DrakeManipulabilityAnalyzer:
         )
 
     def _decompose_mobility_matrix(
-        self, mobility_matrix
+        self, mobility_matrix: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
         if not (mobility_matrix is not None):
             raise ValueError("mobility_matrix must be provided")
@@ -116,7 +119,7 @@ class DrakeManipulabilityAnalyzer:
         radii_v = np.sqrt(np.maximum(eigvals_v, 1e-9))
         return radii_v, eigvecs_v
 
-    def _check_condition_number(self, name, cond) -> bool:
+    def _check_condition_number(self, name: str, cond: float) -> bool:
         if not (name is not None):
             raise ValueError("name must be provided")
         if not (name is not None):
@@ -137,7 +140,13 @@ class DrakeManipulabilityAnalyzer:
         return True
 
     def _build_result_for_body(
-        self, context: Context, name, body, radii_v, eigvecs_v, cond
+        self,
+        context: Context,
+        name: str,
+        body: Any,
+        radii_v: np.ndarray,
+        eigvecs_v: np.ndarray,
+        cond: float,
     ) -> ManipulabilityResult:
         if not (context is not None):
             raise ValueError("context must be provided")

--- a/src/engines/physics_engines/mujoco/docker/example_golf_swing.py
+++ b/src/engines/physics_engines/mujoco/docker/example_golf_swing.py
@@ -1,6 +1,7 @@
 """Example: simulate a golf swing motion with MuJoCo."""
 
 import logging
+from typing import Any
 
 import imageio
 from dm_control import suite
@@ -87,7 +88,7 @@ SWING_SEQUENCE = ["Address", "Backswing", "Downswing", "Impact", "FollowThrough"
 DURATION = [50, 60, 20, 10, 60]  # ticks per phase
 
 
-def get_cmu_joint_names(env) -> list[str]:
+def get_cmu_joint_names(env: Any) -> list[str]:
     """Retrieve joint names for the CMU model."""
     # This is a best-effort inspection.
     # If explicit names aren't in named.data, we might need a hardcoded
@@ -99,7 +100,9 @@ def get_cmu_joint_names(env) -> list[str]:
         return []
 
 
-def interpolate_pose(start_pose, end_pose, alpha) -> dict[str, float]:
+def interpolate_pose(
+    start_pose: dict[str, float], end_pose: dict[str, float], alpha: float
+) -> dict[str, float]:
     """Linearly interpolate between two poses."""
     if not (start_pose is not None):
         raise ValueError("start_pose must be provided")
@@ -186,7 +189,7 @@ def main() -> None:
     logger.info("Saved to %s", filename)
 
 
-def colorize_humanoid(env) -> None:
+def colorize_humanoid(env: Any) -> None:
     """Apply custom colors to the humanoid key body parts."""
     logger.info("Applying custom outfit colors...")
     # Colors (R, G, B, A)

--- a/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 import tempfile
 import threading
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 if TYPE_CHECKING:
     import queue
@@ -245,7 +245,7 @@ class DockerMixin:
         host = cast("DockerProtocol", self)
         q: queue.Queue[str | None] = queue.Queue()
 
-        def enqueue_output(out, output_queue) -> None:
+        def enqueue_output(out: Any, output_queue: Any) -> None:
             """Enqueue output from subprocess."""
             if not (out is not None):
                 raise ValueError("out must be provided")
@@ -282,7 +282,7 @@ class DockerMixin:
 
             host.root.after(0, host.log, output.strip())
 
-    def _handle_process_failure(self, rc) -> None:
+    def _handle_process_failure(self, rc: int) -> None:
         """Log error details and suggest solutions for common failures."""
         if not (rc is not None):
             raise ValueError("rc must be provided")

--- a/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -295,23 +295,23 @@ class ClubTrajectoryParser:
         return events
 
     @staticmethod
-    def _make_row_accessor(row) -> object:
+    def _make_row_accessor(row: Any) -> object:
         if hasattr(row, "iloc"):
 
-            def get(i) -> object | None:
+            def get(i: int) -> object | None:
                 """Return the value at index i from a pandas row."""
                 return row.iloc[i] if i < len(row) else None
 
         else:
 
-            def get(i) -> object | None:
+            def get(i: int) -> object | None:
                 """Return the value at index i from a list row."""
                 return row[i] if i < len(row) else None
 
         return get
 
     @staticmethod
-    def _orthogonalize_axes(x_axis, y_axis) -> NDArray:
+    def _orthogonalize_axes(x_axis: NDArray, y_axis: NDArray) -> NDArray:
         if not (x_axis is not None):
             raise ValueError("x_axis must be provided")
         if not (x_axis is not None):
@@ -322,7 +322,7 @@ class ClubTrajectoryParser:
         z_axis = np.cross(x_axis, y_axis)
         return np.column_stack([x_axis, y_axis, z_axis])
 
-    def _parse_grip_data(self, get) -> tuple[NDArray, NDArray]:
+    def _parse_grip_data(self, get: Any) -> tuple[NDArray, NDArray]:
         if not (get is not None):
             raise ValueError("get must be provided")
         if not (get is not None):
@@ -353,7 +353,9 @@ class ClubTrajectoryParser:
 
         return grip_pos, grip_rot
 
-    def _parse_club_face_data(self, get, grip_pos, grip_rot) -> tuple[NDArray, NDArray]:
+    def _parse_club_face_data(
+        self, get: Any, grip_pos: NDArray, grip_rot: NDArray
+    ) -> tuple[NDArray, NDArray]:
         if not (get is not None):
             raise ValueError("get must be provided")
         if not (get is not None):
@@ -392,7 +394,7 @@ class ClubTrajectoryParser:
 
         return face_pos, face_rot
 
-    def _parse_row(self, row) -> ClubFrame | None:
+    def _parse_row(self, row: Any) -> ClubFrame | None:
         """Parse a single data row into ClubFrame."""
         if not (row is not None):
             raise ValueError("row must be provided")

--- a/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
@@ -277,7 +277,7 @@ class MotionVisualizer:
 
     def add_club_at_frame(
         self,
-        frame,
+        frame: Any,
         name: str = "club",
     ) -> None:
         """Add club visualization at a specific frame."""
@@ -304,7 +304,7 @@ class MotionVisualizer:
         # Position the club based on grip frame
         self._update_club_transform(frame, name)
 
-    def _update_club_transform(self, frame, name: str = "club") -> None:
+    def _update_club_transform(self, frame: Any, name: str = "club") -> None:
         """Update club transform based on frame data."""
         if not (frame is not None):
             raise ValueError("frame must be provided")
@@ -476,7 +476,7 @@ class MotionVisualizer:
 
     def _add_ghost_club(
         self,
-        frame,
+        frame: Any,
         name: str,
         alpha: float,
     ) -> None:

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -9,7 +9,7 @@ context help, and AI panel setup methods.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import (
@@ -110,7 +110,7 @@ class LauncherUISetupMixin:
         self._setup_tools_menu(menubar)
         self._setup_help_menu(menubar)
 
-    def _setup_file_menu(self, menubar) -> None:
+    def _setup_file_menu(self, menubar: Any) -> None:
         if not (menubar is not None):
             raise ValueError("menubar must be provided")
         if not (menubar is not None):
@@ -129,7 +129,7 @@ class LauncherUISetupMixin:
         action_exit.triggered.connect(self.close)
         file_menu.addAction(action_exit)
 
-    def _setup_view_menu(self, menubar) -> None:
+    def _setup_view_menu(self, menubar: Any) -> None:
         if not (menubar is not None):
             raise ValueError("menubar must be provided")
         if not (menubar is not None):
@@ -164,7 +164,7 @@ class LauncherUISetupMixin:
         theme_menu = view_menu.addMenu("&Theme")
         self._setup_theme_menu(theme_menu)
 
-    def _setup_tools_menu(self, menubar) -> None:
+    def _setup_tools_menu(self, menubar: Any) -> None:
         if not (menubar is not None):
             raise ValueError("menubar must be provided")
         if not (menubar is not None):
@@ -179,7 +179,7 @@ class LauncherUISetupMixin:
         action_diag.triggered.connect(lambda: self._open_settings(tab=2))
         tools_menu.addAction(action_diag)
 
-    def _setup_help_menu(self, menubar) -> None:
+    def _setup_help_menu(self, menubar: Any) -> None:
         if not (menubar is not None):
             raise ValueError("menubar must be provided")
         if not (menubar is not None):

--- a/src/learning/sim2real/system_identification.py
+++ b/src/learning/sim2real/system_identification.py
@@ -339,7 +339,7 @@ class SystemIdentifier:
 
     def _coordinate_descent(
         self,
-        objective,
+        objective: Any,
         best_params: NDArray[np.floating],
         best_error: float,
         lower_bounds: NDArray[np.floating],

--- a/src/reinforcement_learning/trajectory_funnel_benchmark.py
+++ b/src/reinforcement_learning/trajectory_funnel_benchmark.py
@@ -18,14 +18,16 @@ class TrajectoryFunnelBenchmark:
     will drastically outperform agents using a clock-synchronized static destination reward.
     """
 
-    def __init__(self, mode="transverse") -> None:
+    def __init__(self, mode: str = "transverse") -> None:
         assert mode in [
             "transverse",
             "setpoint",
         ], "Mode must be 'transverse' or 'setpoint'"
         self.mode = mode
 
-    def setpoint_reward(self, current_state, target_state) -> float:
+    def setpoint_reward(
+        self, current_state: np.ndarray, target_state: np.ndarray
+    ) -> float:
         """
         Classical control approach: Drive Euclidean distance to the destination to zero.
         Ignores path geometry, heavily penalizes phase asynchrony.
@@ -36,7 +38,10 @@ class TrajectoryFunnelBenchmark:
         return -np.sum(error**2)
 
     def trajectory_funnel_reward(
-        self, current_state, reference_trajectory, current_phase
+        self,
+        current_state: np.ndarray,
+        reference_trajectory: np.ndarray,
+        current_phase: int,
     ) -> float:
         """
         Geometric approach: Reward confinement to the trajectory tube (orbital stability).

--- a/src/shared/models/opensim/examples/build_simple_arm_model.py
+++ b/src/shared/models/opensim/examples/build_simple_arm_model.py
@@ -61,7 +61,7 @@ def _create_arm_bodies() -> tuple[Any, Any]:
     return humerus, radius
 
 
-def _create_arm_joints(arm, humerus, radius) -> tuple[Any, Any]:
+def _create_arm_joints(arm: Any, humerus: Any, radius: Any) -> tuple[Any, Any]:
     if not (arm is not None):
         raise ValueError("arm must be provided")
     if not (arm is not None):
@@ -88,7 +88,7 @@ def _create_arm_joints(arm, humerus, radius) -> tuple[Any, Any]:
     return shoulder, elbow
 
 
-def _create_biceps_muscle(humerus, radius) -> Any:
+def _create_biceps_muscle(humerus: Any, radius: Any) -> Any:
     if not (humerus is not None):
         raise ValueError("humerus must be provided")
     if not (humerus is not None):
@@ -105,14 +105,14 @@ def _create_biceps_muscle(humerus, radius) -> Any:
     return biceps
 
 
-def _create_controller(biceps) -> Any:
+def _create_controller(biceps: Any) -> Any:
     brain = osim.PrescribedController()
     brain.addActuator(biceps)
     brain.prescribeControlForActuator("biceps", osim.StepFunction(0.5, 3.0, 0.3, 1.0))
     return brain
 
 
-def _add_reporter(arm, biceps, elbow) -> None:
+def _add_reporter(arm: Any, biceps: Any, elbow: Any) -> None:
     if not (arm is not None):
         raise ValueError("arm must be provided")
     if not (arm is not None):
@@ -125,7 +125,7 @@ def _add_reporter(arm, biceps, elbow) -> None:
     arm.addComponent(reporter)
 
 
-def _attach_body_visualization(body, name) -> None:
+def _attach_body_visualization(body: Any, name: str) -> None:
     if not (body is not None):
         raise ValueError("body must be provided")
     if not (body is not None):

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -434,7 +434,7 @@ class AIAssistantPanel(QWidget):
 
         return header
 
-    def _add_header_title_widgets(self, layout) -> None:
+    def _add_header_title_widgets(self, layout: Any) -> None:
         if not (layout is not None):
             raise ValueError("layout must be provided")
         if not (layout is not None):
@@ -453,7 +453,7 @@ class AIAssistantPanel(QWidget):
 
         layout.addSpacing(10)
 
-    def _add_header_mode_and_status(self, layout) -> None:
+    def _add_header_mode_and_status(self, layout: Any) -> None:
         if not (layout is not None):
             raise ValueError("layout must be provided")
         if not (layout is not None):
@@ -483,7 +483,7 @@ class AIAssistantPanel(QWidget):
         )
         layout.addWidget(self._status_label)
 
-    def _add_header_action_buttons(self, layout) -> None:
+    def _add_header_action_buttons(self, layout: Any) -> None:
         if not (layout is not None):
             raise ValueError("layout must be provided")
         if not (layout is not None):

--- a/src/shared/python/ai/gui/chat_dock_widget.py
+++ b/src/shared/python/ai/gui/chat_dock_widget.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from PyQt6.QtCore import Qt, QTimer, QUrl
 from PyQt6.QtWebSockets import QWebSocket
@@ -377,7 +378,7 @@ class ChatDockWidget(QDockWidget):
 
     # ── Cleanup ──────────────────────────────────────────────────────
 
-    def closeEvent(self, event) -> None:  # type: ignore[override]
+    def closeEvent(self, event: Any) -> None:  # type: ignore[override]
         """Clean up WebSocket on close."""
         if not (event is not None):
             raise ValueError("event must be provided")

--- a/src/shared/python/ai/sample_tools.py
+++ b/src/shared/python/ai/sample_tools.py
@@ -152,7 +152,7 @@ def _register_load_c3d_tool(registry: ToolRegistry) -> None:  # type: ignore[ret
     return load_c3d
 
 
-def _register_marker_info_tool(registry: ToolRegistry, load_c3d_fn) -> None:
+def _register_marker_info_tool(registry: ToolRegistry, load_c3d_fn: Any) -> None:
     @registry.register(
         name="get_marker_info",
         description=(

--- a/src/shared/python/gui_pkg/draggable_tabs.py
+++ b/src/shared/python/gui_pkg/draggable_tabs.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from PyQt6.QtCore import QEvent, QObject, QPoint, Qt, pyqtSignal
 from PyQt6.QtGui import QAction, QCursor, QIcon, QMouseEvent
@@ -449,7 +450,7 @@ class DetachedTabWindow(QMainWindow):
         else:
             super().mouseDoubleClickEvent(event)
 
-    def closeEvent(self, event) -> None:  # type: ignore[override]
+    def closeEvent(self, event: Any) -> None:  # type: ignore[override]
         """On close: offer redock instead of losing the tab."""
         if not (event is not None):
             raise ValueError("event must be provided")

--- a/src/shared/python/humanoid_character_builder/tests/test_contracts.py
+++ b/src/shared/python/humanoid_character_builder/tests/test_contracts.py
@@ -11,7 +11,7 @@ from humanoid_character_builder.contracts import (
 
 def test_precondition_valid() -> None:
     @precondition(lambda x: x > 0)
-    def func(x) -> int:
+    def func(x: int) -> int:
         return x
 
     assert func(5) == 5
@@ -19,7 +19,7 @@ def test_precondition_valid() -> None:
 
 def test_precondition_invalid() -> None:
     @precondition(lambda x: x > 0)
-    def func(x) -> int:
+    def func(x: int) -> int:
         return x
 
     with pytest.raises(ContractViolationError):
@@ -28,7 +28,7 @@ def test_precondition_invalid() -> None:
 
 def test_precondition_argument_binding() -> None:
     @precondition(lambda y: y > 0)
-    def func(x, y) -> int:
+    def func(x: int, y: int) -> int:
         return x + y
 
     assert func(1, 2) == 3
@@ -39,7 +39,7 @@ def test_precondition_argument_binding() -> None:
 
 def test_precondition_with_kwargs() -> None:
     @precondition(lambda y: y > 0)
-    def func(x, y=10) -> int:
+    def func(x: int, y: int = 10) -> int:
         return x + y
 
     assert func(1) == 11
@@ -51,7 +51,7 @@ def test_precondition_with_kwargs() -> None:
 
 def test_postcondition_valid() -> None:
     @postcondition(lambda r: r > 0)
-    def func(x) -> int:
+    def func(x: int) -> int:
         return x * x
 
     assert func(2) == 4
@@ -59,7 +59,7 @@ def test_postcondition_valid() -> None:
 
 def test_postcondition_invalid() -> None:
     @postcondition(lambda r: r > 0)
-    def func(x) -> int:
+    def func(x: int) -> int:
         return x
 
     with pytest.raises(ContractViolationError):
@@ -69,7 +69,7 @@ def test_postcondition_invalid() -> None:
 def test_invariant() -> None:
     @invariant(lambda self: self.value > 0)
     class Counter:
-        def __init__(self, value) -> None:
+        def __init__(self, value: int) -> None:
             self.value = value
 
         def increment(self) -> int:
@@ -93,7 +93,7 @@ def test_invariant() -> None:
 
 def test_precondition_message() -> None:
     @precondition(lambda x: x > 0, "X must be positive")
-    def func(x) -> int:
+    def func(x: int) -> int:
         return x
 
     with pytest.raises(ContractViolationError, match="X must be positive"):

--- a/src/shared/python/humanoid_character_builder/tests/test_physics_validator.py
+++ b/src/shared/python/humanoid_character_builder/tests/test_physics_validator.py
@@ -32,13 +32,17 @@ class TestPhysicsValidator:
             origin_rpy=(0, 0, 0),
         )
 
-    def test_validate_inertia_valid(self, validator, mock_link) -> None:
+    def test_validate_inertia_valid(
+        self, validator: PhysicsValidator, mock_link: GeneratedLink
+    ) -> None:
         # Default inertia is valid (sphere approximation)
         result = validator.validate_inertia(mock_link)
         assert result.is_valid
         assert not result.messages
 
-    def test_validate_inertia_not_symmetric(self, validator, mock_link) -> None:
+    def test_validate_inertia_not_symmetric(
+        self, validator: PhysicsValidator, mock_link: GeneratedLink
+    ) -> None:
         # Manually set invalid inertia
         inertia_mat = np.eye(3)
         inertia_mat[0, 1] = 0.5  # Asymmetric
@@ -53,13 +57,17 @@ class TestPhysicsValidator:
 
         # Let's skip asymmetry test or mock as_matrix
 
-    def test_validate_inertia_not_positive_definite(self, validator, mock_link) -> None:
+    def test_validate_inertia_not_positive_definite(
+        self, validator: PhysicsValidator, mock_link: GeneratedLink
+    ) -> None:
         mock_link.inertia.ixx = -1.0  # Invalid
         result = validator.validate_inertia(mock_link)
         assert not result.is_valid
         assert "positive definite" in result.messages[0]
 
-    def test_validate_inertia_triangle_inequality(self, validator, mock_link) -> None:
+    def test_validate_inertia_triangle_inequality(
+        self, validator: PhysicsValidator, mock_link: GeneratedLink
+    ) -> None:
         # Ixx + Iyy < Izz
         # e.g. 1 + 1 < 3
         mock_link.inertia.ixx = 1.0
@@ -71,7 +79,7 @@ class TestPhysicsValidator:
         assert result.is_valid
         assert any("triangle inequality" in msg for msg in result.messages)
 
-    def test_static_stability_stable(self, validator) -> None:
+    def test_static_stability_stable(self, validator: PhysicsValidator) -> None:
         # Create a model with COM inside support
         # Two feet at (-1, 0, 0) and (1, 0, 0)
         # Root (pelvis) at (0, 0, 1)
@@ -136,7 +144,7 @@ class TestPhysicsValidator:
         assert result.is_stable
         assert result.margin > 0
 
-    def test_static_stability_unstable(self, validator) -> None:
+    def test_static_stability_unstable(self, validator: PhysicsValidator) -> None:
         # COM far outside
         # Pelvis at (10, 0, 1) relative to feet? No, feet relative to pelvis.
         # If I move pelvis origin, but joints are relative.
@@ -187,7 +195,7 @@ class TestPhysicsValidator:
         result = validator.check_static_stability(model)
         assert not result.is_stable
 
-    def test_collision_detected(self, validator) -> None:
+    def test_collision_detected(self, validator: PhysicsValidator) -> None:
         # Two boxes overlapping
         link1 = GeneratedLink(
             "link1",

--- a/src/shared/python/humanoid_character_builder/tests/test_urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/tests/test_urdf_generator.py
@@ -257,7 +257,7 @@ class TestProportionFactors:
         # Instead, we can inspect the generated link lengths in the generator logic?
         # Or check the <cylinder length="..."> in the XML.
 
-        def get_total_cylinder_length(xml_str) -> float:
+        def get_total_cylinder_length(xml_str: str) -> float:
             root = ET.fromstring(xml_str)
             total = 0.0
             for geom in root.findall(".//geometry/cylinder"):

--- a/src/shared/python/model_generation/converters/simscape/mdl_parser.py
+++ b/src/shared/python/model_generation/converters/simscape/mdl_parser.py
@@ -342,7 +342,7 @@ class MDLParser:
 
         return model
 
-    def _parse_slx_xml(self, file, model: SimscapeModel) -> None:
+    def _parse_slx_xml(self, file: Any, model: SimscapeModel) -> None:
         """Parse SLX model XML content."""
         if not (file is not None):
             raise ValueError("file must be provided")

--- a/src/shared/python/model_generation/tests/test_api.py
+++ b/src/shared/python/model_generation/tests/test_api.py
@@ -2,6 +2,8 @@
 Tests for the REST API module.
 """
 
+from typing import Any
+
 SIMPLE_URDF = """<?xml version="1.0"?>
 <robot name="test_robot">
     <link name="base_link">
@@ -381,7 +383,7 @@ class TestRoute:
         """Test Route creation."""
         from model_generation.api import HTTPMethod, Route
 
-        def dummy_handler(request) -> None:
+        def dummy_handler(request: Any) -> None:
             return None
 
         route = Route(

--- a/src/shared/python/model_generation/tests/test_github_importer.py
+++ b/src/shared/python/model_generation/tests/test_github_importer.py
@@ -18,12 +18,14 @@ class TestGitHubImporter:
         return MagicMock()
 
     @pytest.fixture
-    def importer(self, mock_library) -> GitHubImporter:
+    def importer(self, mock_library: MagicMock) -> GitHubImporter:
         """Create importer with mock library."""
         return GitHubImporter(library=mock_library)
 
     @patch("urllib.request.urlopen")
-    def test_import_from_search_dry_run(self, mock_urlopen, importer) -> None:
+    def test_import_from_search_dry_run(
+        self, mock_urlopen: MagicMock, importer: GitHubImporter
+    ) -> None:
         """Test search with dry_run."""
         # Mock GitHub response
         mock_response = MagicMock()
@@ -55,7 +57,9 @@ class TestGitHubImporter:
         importer.library.add_repository.assert_not_called()
 
     @patch("urllib.request.urlopen")
-    def test_import_from_search_import(self, mock_urlopen, importer) -> None:
+    def test_import_from_search_import(
+        self, mock_urlopen: MagicMock, importer: GitHubImporter
+    ) -> None:
         """Test search and import."""
         # Mock GitHub response
         mock_response = MagicMock()
@@ -88,7 +92,9 @@ class TestGitHubImporter:
         importer.library.refresh_repository.assert_called_once()
 
     @patch("urllib.request.urlopen")
-    def test_import_from_urls(self, mock_urlopen, importer) -> None:
+    def test_import_from_urls(
+        self, mock_urlopen: MagicMock, importer: GitHubImporter
+    ) -> None:
         """Test import from URLs."""
         # Mock repo metadata response
         mock_response = MagicMock()
@@ -121,7 +127,7 @@ class TestGitHubImporter:
             description="Desc",
         )
 
-    def test_import_from_urls_existing(self, importer) -> None:
+    def test_import_from_urls_existing(self, importer: GitHubImporter) -> None:
         """Test skipping existing repositories."""
         importer.library._repositories = {"github_owner_repo": {}}
 

--- a/src/shared/python/output_manager.py
+++ b/src/shared/python/output_manager.py
@@ -17,7 +17,7 @@ from src.shared.python.data_io.output_manager import (
 
 
 def save_results(
-    results, filename: str, format_type: str = "csv", engine: str = "mujoco"
+    results: Any, filename: str, format_type: str = "csv", engine: str = "mujoco"
 ) -> str:
     """Backward-compatible convenience save helper."""
     if not (results is not None):

--- a/src/shared/python/pendulum_simulator/optimizer_gpu.py
+++ b/src/shared/python/pendulum_simulator/optimizer_gpu.py
@@ -9,6 +9,7 @@ JAX's automatic differentiation and optax optimizers.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 try:
     import jax
@@ -198,7 +199,7 @@ def optimize_torque_profile(
 
     @jax.jit
     @jax.value_and_grad
-    def loss_fn(coeffs) -> float:
+    def loss_fn(coeffs: Any) -> float:
         coeffs_reshaped = coeffs.reshape(7, n_coeffs_per_joint)
         # Use mean torque across coefficients as the single torque profile
         torque_simple = jnp.mean(coeffs_reshaped, axis=1)
@@ -279,7 +280,7 @@ def optimize_simple_torque_profile(
 
     @jax.jit
     @jax.value_and_grad
-    def loss_fn(coeffs) -> float:
+    def loss_fn(coeffs: Any) -> float:
         return clubhead_speed_objective(
             coeffs, params, initial_state, t_end, alpha, beta, dt
         )

--- a/src/shared/python/plotting/renderers/force_vectors.py
+++ b/src/shared/python/plotting/renderers/force_vectors.py
@@ -23,6 +23,8 @@ Color/style configuration is centralized in module-level constants.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from matplotlib.figure import Figure
 
@@ -378,7 +380,7 @@ class ForceVectorRenderer(BaseRenderer):
 
     def _draw_quiver_on_axes(
         self,
-        ax,
+        ax: Any,
         *,
         positions: np.ndarray,
         vectors: np.ndarray,
@@ -413,7 +415,7 @@ class ForceVectorRenderer(BaseRenderer):
         )
 
     @staticmethod
-    def _format_3d_axes(ax) -> None:
+    def _format_3d_axes(ax: Any) -> None:
         """Apply standard formatting to a 3-D axes."""
         ax.set_xlabel("X (m)", fontsize=10)
         ax.set_ylabel("Y (m)", fontsize=10)

--- a/src/shared/python/plotting/renderers/kinematics.py
+++ b/src/shared/python/plotting/renderers/kinematics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -475,7 +477,9 @@ class KinematicsRenderer(BaseRenderer):
         fig.tight_layout()
 
     @staticmethod
-    def _get_embedding_signal(data, signal_type: str) -> tuple[np.ndarray, np.ndarray]:
+    def _get_embedding_signal(
+        data: Any, signal_type: str
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Retrieve and convert the signal for phase space embedding.
 
         Args:

--- a/src/shared/python/upstream_drift_tools/tests/calculators/electrical/test_electrical_model.py
+++ b/src/shared/python/upstream_drift_tools/tests/calculators/electrical/test_electrical_model.py
@@ -18,13 +18,15 @@ class TestElectricalModel:
         glass = GlassPropertiesInterface()
         return ThreePhaseElectricalModelEnhanced(config, glass)
 
-    def test_initialization(self, model) -> None:
+    def test_initialization(self, model: ThreePhaseElectricalModelEnhanced) -> None:
         assert len(model.electrode_positions) == 3
         np.testing.assert_allclose(
             model.electrode_positions, [0, 2.094395, 4.18879], rtol=1e-4
         )
 
-    def test_calculate_system_state(self, model) -> None:
+    def test_calculate_system_state(
+        self, model: ThreePhaseElectricalModelEnhanced
+    ) -> None:
         depths = np.array([10.0, 10.0, 10.0])
         voltages = np.array([100.0, 100.0, 100.0])
 
@@ -43,7 +45,9 @@ class TestElectricalModel:
         assert "current_distribution" in result
         assert len(result["actual_currents"]) == 3
 
-    def test_parallel_resistance(self, model) -> None:
+    def test_parallel_resistance(
+        self, model: ThreePhaseElectricalModelEnhanced
+    ) -> None:
         r1 = 100.0
         r2 = 100.0
         rp = model._parallel_resistance(r1, r2)

--- a/src/shared/python/upstream_drift_tools/tests/lab/bio/test_c3d_reader_fixed.py
+++ b/src/shared/python/upstream_drift_tools/tests/lab/bio/test_c3d_reader_fixed.py
@@ -51,7 +51,9 @@ class TestC3DDataReader:
         reader = C3DDataReader("test.c3d")
         assert reader.file_path == Path("test.c3d")
 
-    def test_metadata_extraction(self, mock_ezc3d, sample_c3d_data) -> None:
+    def test_metadata_extraction(
+        self, mock_ezc3d: MagicMock, sample_c3d_data: dict[str, Any]
+    ) -> None:
         mock_ezc3d.c3d.return_value = sample_c3d_data
 
         # Mock file existence
@@ -65,7 +67,9 @@ class TestC3DDataReader:
             assert len(metadata.events) == 2
             assert abs(metadata.duration - 100 / 120.0) < 1e-6
 
-    def test_points_dataframe(self, mock_ezc3d, sample_c3d_data) -> None:
+    def test_points_dataframe(
+        self, mock_ezc3d: MagicMock, sample_c3d_data: dict[str, Any]
+    ) -> None:
         mock_ezc3d.c3d.return_value = sample_c3d_data
 
         with patch("pathlib.Path.exists", return_value=True):
@@ -79,7 +83,9 @@ class TestC3DDataReader:
             assert "marker" in df.columns
             assert set(df["marker"].unique()) == {"Marker1", "Marker2"}
 
-    def test_analog_dataframe(self, mock_ezc3d, sample_c3d_data) -> None:
+    def test_analog_dataframe(
+        self, mock_ezc3d: MagicMock, sample_c3d_data: dict[str, Any]
+    ) -> None:
         mock_ezc3d.c3d.return_value = sample_c3d_data
 
         with patch("pathlib.Path.exists", return_value=True):

--- a/src/shared/python/upstream_drift_tools/utils/logging.py
+++ b/src/shared/python/upstream_drift_tools/utils/logging.py
@@ -63,7 +63,12 @@ class LogExecutionTime:
         self.logger.debug(f"Starting {self.name}...")
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
         duration = __import__("time").time() - self.start_time
         self.logger.info(f"{self.name} completed in {duration:.4f}s")
 


### PR DESCRIPTION
## Summary

- Fixed ~256 ANN001 violations across 46 files in waves 7 and 8
- Covered Simscape MATLAB GUI files (Motion_Capture_Plotter, golf_opengl_renderer, golf_inverse_dynamics, etc.)
- Fixed OpenSim, Drake, Pinocchio examples and utilities
- Annotated test fixture parameters across multiple test suites
- Fixed reinforcement learning, sim2real, and AI GUI files
- Annotated plotting renderers, output managers, PSA test helpers
- All 31 remaining violations are in Jupyter notebooks (.ipynb) — deferred

## Test plan

- [ ] `ruff check` passes with zero violations on all modified .py files
- [ ] `ruff format --check` passes with zero diffs
- [ ] `rust-quality-gate` passes
- [ ] No functional changes — annotation-only fixes

Closes part of #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)