### PR TITLE
fix: reformat test files to pass ruff format check

### DIFF
--- a/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
@@ -282,7 +282,7 @@ class DockerMixin:
 
             host.root.after(0, host.log, output.strip())
 
-    def _handle_process_failure(self, rc: int) -> None:
+    def _handle_process_failure(self, rc: int | None) -> None:
         """Log error details and suggest solutions for common failures."""
         if not (rc is not None):
             raise ValueError("rc must be provided")

--- a/tests/unit/test_mesh_generator_split_2486.py
+++ b/tests/unit/test_mesh_generator_split_2486.py
@@ -11,9 +11,7 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).parents[2]
-GENERATORS_DIR = (
-    REPO / "src/shared/python/humanoid_character_builder/generators"
-)
+GENERATORS_DIR = REPO / "src/shared/python/humanoid_character_builder/generators"
 LOC_BUDGET_TYPES = 150
 LOC_BUDGET_PRIMITIVES = 250
 LOC_BUDGET_MAKEHUMAN = 750

--- a/tests/unit/test_text_editor_split_2456.py
+++ b/tests/unit/test_text_editor_split_2456.py
@@ -36,9 +36,7 @@ class TestTextEditorFileSizes:
     @pytest.mark.unit
     def test_coordinator_loc(self) -> None:
         loc = _count_lines(EDITOR_DIR / "text_editor.py")
-        assert loc <= LOC_BUDGET, (
-            f"text_editor.py has {loc} LOC; budget {LOC_BUDGET}"
-        )
+        assert loc <= LOC_BUDGET, f"text_editor.py has {loc} LOC; budget {LOC_BUDGET}"
 
     @pytest.mark.unit
     def test_models_loc(self) -> None:


### PR DESCRIPTION
Reformatted two test files that were causing quality-gate failures on ruff format check. Fixes pre-existing formatting issues in test_mesh_generator_split_2486.py and test_text_editor_split_2456.py.