### PR TITLE
chore: remove stale file-size budget exceptions (mesh_generator, pressure_drop_interface)

### DIFF
--- a/scripts/config/file_size_budget.json
+++ b/scripts/config/file_size_budget.json
@@ -68,18 +68,6 @@
       "expires_on": "2027-03-09"
     },
     {
-      "path": "src/shared/python/humanoid_character_builder/generators/mesh_generator.py",
-      "owner": "@character-builder",
-      "reason": "Mesh generation logic (1641 lines) consolidates geometry, UV-mapping, and LOD pipelines. Decomposition into mesh_geometry, mesh_uv, and mesh_lod submodules planned. Tracked in issue #2051.",
-      "expires_on": "2027-03-23"
-    },
-    {
-      "path": "src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_interface.py",
-      "owner": "@upstream-drift-tools",
-      "reason": "Pressure drop interface (1400 lines) grew due to multi-regime flow models and validation logic. Decomposition into regime-specific calculator modules planned. Tracked in issue #2051.",
-      "expires_on": "2027-03-23"
-    },
-    {
       "path": "src/shared/python/physics/terrain.py",
       "owner": "@physics-core",
       "reason": "Terrain module at 1239 lines due to multi-surface model implementations. Decomposition pending.",


### PR DESCRIPTION
## Summary

- Removes the budget exception for `mesh_generator.py` (now 110 LOC, was 1641)
- Removes the budget exception for `pressure_drop_interface.py` (now 515 LOC, was 1400)
- Both files were decomposed as part of issue #2486 P0 splits; their exception entries are stale and no longer needed

## Test plan

- [ ] `python3 scripts/check_file_size_budget.py` passes (confirmed locally)
- [ ] No production code changed — JSON config only

Closes part of #2486

🤖 Generated with [Claude Code](https://claude.com/claude-code)