### PR TITLE
feat: add return type annotations to 307 functions in tests/scripts/examples (wave 2, issue #2385)

### DIFF
--- a/examples/motion_training_demo.py
+++ b/examples/motion_training_demo.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import Any
 
 # Add the motion_training module to path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -28,7 +29,7 @@ sys.path.insert(
 )
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description="Motion Training Demo - Generate body motion from club trajectory",
@@ -92,7 +93,9 @@ def parse_args():
     return parser.parse_args()
 
 
-def run_trajectory_analysis(trajectory_path: Path, sheet_name: str, output_dir: Path):
+def run_trajectory_analysis(
+    trajectory_path: Path, sheet_name: str, output_dir: Path
+) -> Any:
     """Run trajectory analysis and generate plots."""
     if not (trajectory_path is not None):
         raise ValueError("trajectory_path required")
@@ -123,7 +126,7 @@ def run_trajectory_analysis(trajectory_path: Path, sheet_name: str, output_dir: 
     return trajectory
 
 
-def _parse_and_subsample(trajectory_path, sheet_name, subsample):
+def _parse_and_subsample(trajectory_path: Any, sheet_name: Any, subsample: Any) -> Any:
     if not (trajectory_path is not None):
         raise ValueError("trajectory_path required")
     if not (sheet_name):
@@ -141,7 +144,7 @@ def _parse_and_subsample(trajectory_path, sheet_name, subsample):
     return trajectory
 
 
-def _init_and_solve_ik(urdf_path, trajectory):
+def _init_and_solve_ik(urdf_path: Any, trajectory: Any) -> Any:
     if not (urdf_path is not None):
         raise ValueError("urdf_path required")
     if not (trajectory is not None):
@@ -238,7 +241,7 @@ def run_ik_demo(
     subsample: int = 10,
     visualize: bool = False,
     playback: bool = False,
-):
+) -> Any:
     """Run the full IK demo."""
     if not (trajectory_path is not None):
         raise ValueError("trajectory_path required")

--- a/scripts/assess_repository.py
+++ b/scripts/assess_repository.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 import sys
+from pathlib import Path
 
 from scripts.script_utils import get_repo_root
 
@@ -40,7 +41,7 @@ DOCS_DIR.mkdir(parents=True, exist_ok=True)
 ISSUES_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def assess_A():
+def assess_A() -> Path:
     """Assess code structure and directory organization."""
     # Code Structure
     findings = []
@@ -63,7 +64,7 @@ def assess_A():
     )
 
 
-def assess_B():
+def assess_B() -> Path:
     """Assess documentation quality and coverage."""
     # Documentation
     findings = []
@@ -94,7 +95,7 @@ def assess_B():
     )
 
 
-def assess_C():
+def assess_C() -> Path:
     """Assess test coverage and test file count."""
     # Test Coverage
     findings = []
@@ -116,7 +117,7 @@ def assess_C():
     )
 
 
-def assess_D():
+def assess_D() -> Path:
     """Error Handling assessment."""
     findings = []
     py_files = REPO_ROOT.rglob("*.py")
@@ -151,7 +152,7 @@ def assess_D():
     )
 
 
-def assess_E():
+def assess_E() -> Path:
     """Assess performance profiling practices."""
     # Performance
     findings = []
@@ -170,7 +171,7 @@ def assess_E():
     )
 
 
-def assess_F():
+def assess_F() -> Path:
     """Assess security practices and hardcoded secrets."""
     # Security
     findings = []
@@ -194,7 +195,7 @@ def assess_F():
     )
 
 
-def assess_G():
+def assess_G() -> Path:
     """Assess dependency management and definition files."""
     # Dependencies
     findings = []
@@ -215,7 +216,7 @@ def assess_G():
     )
 
 
-def assess_H():
+def assess_H() -> Path:
     """Assess CI/CD pipeline configuration."""
     # CI/CD
     findings = []
@@ -237,7 +238,7 @@ def assess_H():
     )
 
 
-def assess_I():
+def assess_I() -> Path:
     """Assess code style and linter configuration."""
     # Code Style
     findings = []
@@ -256,7 +257,7 @@ def assess_I():
     )
 
 
-def assess_J():
+def assess_J() -> Path:
     """Assess API design and endpoint documentation."""
     # API Design
     findings = []
@@ -294,7 +295,7 @@ def assess_J():
     )
 
 
-def assess_K():
+def assess_K() -> Path:
     """Assess data handling and validation patterns."""
     # Data Handling
     findings = []
@@ -308,7 +309,7 @@ def assess_K():
     )
 
 
-def assess_L():
+def assess_L() -> Path:
     """Logging assessment."""
     findings = []
     py_files = REPO_ROOT.rglob("*.py")
@@ -345,7 +346,7 @@ def assess_L():
     )
 
 
-def assess_M():
+def assess_M() -> Path:
     """Assess configuration management practices."""
     # Configuration
     findings = []
@@ -360,7 +361,7 @@ def assess_M():
     )
 
 
-def assess_N():
+def assess_N() -> Path:
     """Assess scalability readiness of the architecture."""
     # Scalability
     findings = []
@@ -377,7 +378,7 @@ def assess_N():
     )
 
 
-def assess_O():
+def assess_O() -> Path:
     """Assess code maintainability and complexity metrics."""
     # Maintainability
     findings = []
@@ -404,7 +405,7 @@ def assess_O():
     )
 
 
-def run_all_assessments():
+def run_all_assessments() -> list[Path]:
     """Execute all category assessments and return their reports."""
     assessors = [
         assess_A,

--- a/scripts/check_module_size_budget.py
+++ b/scripts/check_module_size_budget.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 DEFAULT_MAX_LINES = 1500
@@ -36,7 +37,9 @@ def should_skip(path: Path, exclude_parts: set[str]) -> bool:
     return any(part in exclude_parts for part in path.parts)
 
 
-def iter_python_files(include_roots: tuple[str, ...], exclude_parts: set[str]):
+def iter_python_files(
+    include_roots: tuple[str, ...], exclude_parts: set[str]
+) -> Iterator[Path]:
     for root in include_roots:
         root_path = Path(root)
         if not root_path.exists():

--- a/scripts/create_issues_from_assessment.py
+++ b/scripts/create_issues_from_assessment.py
@@ -123,7 +123,7 @@ def process_findings(
     return 0
 
 
-def main():
+def main() -> int:
     """Parse arguments and create GitHub issues from assessment findings."""
     parser = argparse.ArgumentParser(description="Create GitHub issues from assessment")
 

--- a/scripts/finalize_comprehensive_assessment.py
+++ b/scripts/finalize_comprehensive_assessment.py
@@ -7,6 +7,7 @@ import json
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from scripts.script_utils import run_main, setup_script_logging
 
@@ -21,7 +22,7 @@ SUMMARY_JSON = DOCS_DIR / "assessment_summary.json"
 OUTPUT_MD = DOCS_DIR / "Comprehensive_Assessment.md"
 
 
-def load_general_data():
+def load_general_data() -> dict[str, Any] | None:
     """Load the general assessment summary JSON data."""
     if not SUMMARY_JSON.exists():
         logger.error(f"Summary JSON not found: {SUMMARY_JSON}")
@@ -30,7 +31,7 @@ def load_general_data():
         return json.load(f)
 
 
-def load_pragmatic_data():
+def load_pragmatic_data() -> dict[str, Any]:
     """Load the pragmatic programmer review report."""
     if not PRAGMATIC_REPORT.exists():
         logger.warning(f"Pragmatic report not found: {PRAGMATIC_REPORT}")
@@ -39,7 +40,7 @@ def load_pragmatic_data():
         return json.load(f)
 
 
-def load_completist_data():
+def load_completist_data() -> int:
     """Load the completist audit report and extract critical gap count."""
     if not COMPLETIST_REPORT.exists():
         logger.warning(f"Completist report not found: {COMPLETIST_REPORT}")
@@ -52,7 +53,9 @@ def load_completist_data():
     return 0
 
 
-def calculate_scores(general_data, critical_gaps, pragmatic_issues):
+def calculate_scores(
+    general_data: dict[str, Any], critical_gaps: int, pragmatic_issues: list[Any]
+) -> dict[str, float]:
     """Compute general, completist, pragmatic, and unified scores."""
     general_score = general_data.get("overall_score", 0.0)
 
@@ -72,7 +75,9 @@ def calculate_scores(general_data, critical_gaps, pragmatic_issues):
     }
 
 
-def generate_recommendations(general_data, critical_gaps, pragmatic_issues):
+def generate_recommendations(
+    general_data: dict[str, Any], critical_gaps: int, pragmatic_issues: list[Any]
+) -> list[dict[str, Any]]:
     """Generate prioritized improvement recommendations from all assessments."""
     recommendations = []
 

--- a/scripts/generate_assessment_summary.py
+++ b/scripts/generate_assessment_summary.py
@@ -235,7 +235,7 @@ def generate_summary(
     return 0
 
 
-def main():
+def main() -> int:
     """Parse CLI arguments and generate assessment summary."""
     parser = argparse.ArgumentParser(description="Generate assessment summary")
     parser.add_argument(

--- a/scripts/pragmatic_programmer_review.py
+++ b/scripts/pragmatic_programmer_review.py
@@ -24,6 +24,7 @@ import re
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from scripts.script_utils import (
     find_python_files as _find_python_files,
@@ -63,7 +64,7 @@ def compute_file_hash(content: str) -> str:
     return hashlib.md5(normalized.encode(), usedforsecurity=False).hexdigest()
 
 
-def get_detailed_function_metrics(content: str):
+def get_detailed_function_metrics(content: str) -> list[dict[str, Any]]:
     """Simple AST parser to get function metrics."""
     try:
         tree = ast.parse(content)
@@ -219,7 +220,7 @@ def check_testing(root_path: Path) -> list[dict]:
     return issues
 
 
-def run_review(root_path: Path):
+def run_review(root_path: Path) -> dict[str, Any]:
     """Run all pragmatic programmer checks and return aggregated results."""
     logger.info(f"Running Pragmatic Review on {root_path}")
     files = find_python_files(root_path)

--- a/scripts/run_assessment.py
+++ b/scripts/run_assessment.py
@@ -159,7 +159,7 @@ def run_assessment(assessment_id: str, output_path: Path) -> int:
     return 0
 
 
-def main():
+def main() -> int:
     """Parse arguments and run a single repository assessment category."""
     parser = argparse.ArgumentParser(description="Run repository assessment")
     parser.add_argument("--assessment", required=True, choices=list("ABCDEFGHIJKLMNO"))

--- a/scripts/scan_for_incomplete_code.py
+++ b/scripts/scan_for_incomplete_code.py
@@ -3,7 +3,7 @@ import re
 from os.path import join
 
 
-def scan_for_incomplete_code(root_dir):
+def scan_for_incomplete_code(root_dir: str) -> dict[str, list[tuple[int, str, str]]]:
     patterns = {
         "TRACKED_TASK": re.compile(r"TRACKED_TASK"),
         "TRACKED_DEFECT": re.compile(r"TRACKED_DEFECT"),

--- a/tests/acceptance/test_drift_control_decomposition.py
+++ b/tests/acceptance/test_drift_control_decomposition.py
@@ -6,6 +6,8 @@ Refactored for DRY compliance using parameterized engine tests.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -17,7 +19,7 @@ logger = get_logger(__name__)
 SUPERPOSITION_TOLERANCE = 1e-5
 
 
-def _get_engine(engine_name: str):
+def _get_engine(engine_name: str) -> Any:
     """Factory to get the requested physics engine, skipping if not available."""
     if engine_name == "pinocchio":
         try:

--- a/tests/analytical/test_pendulum_lagrangian.py
+++ b/tests/analytical/test_pendulum_lagrangian.py
@@ -19,7 +19,9 @@ from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import 
 )
 
 
-def configure_simple_pendulum(m1_kg: float = 1.0, l1_m: float = 1.0):
+def configure_simple_pendulum(
+    m1_kg: float = 1.0, l1_m: float = 1.0
+) -> tuple[PendulumPhysicsEngine, float, float]:
     """Factory to create a pendulum engine with simplified parameters."""
     from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pendulum import (
         DoublePendulumDynamics,

--- a/tests/api/test_api_parity.py
+++ b/tests/api/test_api_parity.py
@@ -17,6 +17,7 @@ Fixes #1133
 """
 
 import time
+from collections.abc import Generator
 
 import pytest
 
@@ -29,7 +30,7 @@ except ImportError:
 
 
 @pytest.fixture(scope="module")
-def client():
+def client() -> Generator[TestClient, None, None]:
     """Create test client with proper application lifespan."""
     with TestClient(app) as test_client:
         yield test_client

--- a/tests/api/test_engine_loading.py
+++ b/tests/api/test_engine_loading.py
@@ -4,6 +4,8 @@ This test suite ensures all physics engines can be probed and loaded correctly.
 Following TDD approach - tests written first, then implementations.
 """
 
+from collections.abc import Generator
+
 import pytest
 
 try:
@@ -15,7 +17,7 @@ except ImportError:
 
 
 @pytest.fixture(scope="module")
-def client():
+def client() -> Generator[TestClient, None, None]:
     """Test client with proper app lifespan."""
     with TestClient(app) as test_client:
         yield test_client

--- a/tests/api/test_launcher_launch_api.py
+++ b/tests/api/test_launcher_launch_api.py
@@ -11,9 +11,13 @@ Covers:
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
 
 import pytest
 
@@ -52,7 +56,7 @@ def _reset_startup_metrics() -> None:
 
 
 @pytest.fixture()
-def client(_reset_startup_metrics):
+def client(_reset_startup_metrics) -> Generator[TestClient, None, None]:
     """Create a TestClient for the local FastAPI app with mocked process management."""
     from fastapi.testclient import TestClient
 

--- a/tests/api/test_physics_api.py
+++ b/tests/api/test_physics_api.py
@@ -15,6 +15,8 @@ Tests cover:
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 from pydantic import ValidationError
 
@@ -283,7 +285,7 @@ class TestResponseModels:
 #  API Integration Tests (require FastAPI)
 # ──────────────────────────────────────────────────────────────
 @pytest.fixture()
-def client():
+def client() -> Generator[TestClient, None, None]:
     """Create test client."""
     if not HAS_FASTAPI:
         pytest.skip("FastAPI not available")

--- a/tests/benchmarks/test_dynamics_benchmarks.py
+++ b/tests/benchmarks/test_dynamics_benchmarks.py
@@ -32,7 +32,7 @@ else:
     pytest.skip("MuJoCo dynamics modules not available", allow_module_level=True)
 
 
-def create_random_model(num_bodies=10):
+def create_random_model(num_bodies: int = 10) -> dict:
     """
     Create a random kinematic chain model for benchmarking.
     """
@@ -63,7 +63,7 @@ def create_random_model(num_bodies=10):
 
 
 @pytest.fixture
-def dynamics_setup():
+def dynamics_setup() -> tuple:
     """Setup arrays for dynamics benchmarks."""
     nb = 20  # Reasonable size for a humanoid(-ish) robot
     model = create_random_model(nb)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -151,7 +152,7 @@ def pendulum_urdf(tmp_path: Path) -> str:
 
 
 @pytest.fixture
-def clean_pendulum_dynamics():
+def clean_pendulum_dynamics() -> Callable[..., Any]:
     """Fixture to provide standardized DoublePendulumDynamics setup for unit tests."""
     from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pendulum import (
         DoublePendulumDynamics,
@@ -160,7 +161,7 @@ def clean_pendulum_dynamics():
         SegmentProperties,
     )
 
-    def _create(m1_kg=1.0, l1_m=1.0):
+    def _create(m1_kg: float = 1.0, l1_m: float = 1.0) -> Any:
         assert m1_kg is not None, "m1_kg must be provided"
         assert l1_m is not None, "l1_m must be provided"
         assert m1_kg > 0.0, "m1_kg must be positive"
@@ -199,7 +200,7 @@ class MockPhysicsEngine:
 
 
 @pytest.fixture
-def mock_drake_dependencies():
+def mock_drake_dependencies() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     """Fixture to mock pydrake and interfaces safely.
 
     This fixture mocks pydrake modules to allow testing Drake integration
@@ -227,7 +228,7 @@ def mock_drake_dependencies():
 
 
 @pytest.fixture(scope="module")
-def mock_mujoco_dependencies():
+def mock_mujoco_dependencies() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     """Fixture to mock mujoco and interfaces safely.
 
     This fixture mocks mujoco modules to allow testing MuJoCo integration

--- a/tests/deployment/test_safety.py
+++ b/tests/deployment/test_safety.py
@@ -141,7 +141,7 @@ class TestCollisionAvoidance:
             def set_joint_positions(self, q) -> None:
                 pass
 
-            def get_link_positions(self):
+            def get_link_positions(self) -> dict[str, np.ndarray]:
                 return {"link_0": np.array([0.5, 0, 0.5])}
 
         ca = CollisionAvoidance(MockEngine(), safety_distance=0.1)
@@ -211,7 +211,7 @@ class TestCollisionAvoidance:
 class TestIssue2477EStopPositionMode:
     """Issue #2477: E-stop must neutralize position-controlled motion."""
 
-    def _make_monitor_and_state(self):
+    def _make_monitor_and_state(self) -> tuple:
         from src.deployment.realtime import RobotConfig, RobotState
         from src.deployment.safety import SafetyMonitor
 

--- a/tests/heavy_integration/conftest.py
+++ b/tests/heavy_integration/conftest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -70,7 +71,7 @@ def temp_test_dir() -> Path:
 
 
 @pytest.fixture(scope="session")
-def mujoco_model():
+def mujoco_model() -> Any:
     """
     Session-scoped MuJoCo model fixture using the built-in humanoid model.
     Loaded once per test session to amortize startup cost.
@@ -96,7 +97,7 @@ def mujoco_model():
 
 
 @pytest.fixture(scope="session")
-def pinocchio_model():
+def pinocchio_model() -> Any:
     """
     Session-scoped Pinocchio model fixture.
     Returns a simple 1-DOF pendulum model for FK testing.

--- a/tests/heavy_integration/test_drake_real_model_loading.py
+++ b/tests/heavy_integration/test_drake_real_model_loading.py
@@ -9,6 +9,9 @@ All tests skip gracefully when Drake is unavailable.
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -41,7 +44,7 @@ _MINIMAL_URDF = """\
 
 
 @pytest.fixture(scope="module")
-def drake_modules():
+def drake_modules() -> dict[str, Any]:
     """Import required Drake modules or skip the entire module."""
     try:
         from pydrake.all import DiagramBuilder, Parser  # noqa: F401
@@ -59,7 +62,7 @@ def drake_modules():
 
 
 @pytest.fixture(scope="module")
-def minimal_urdf_path(tmp_path_factory):
+def minimal_urdf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Write the minimal URDF to a temp file."""
     tmpdir = tmp_path_factory.mktemp("urdf")
     urdf = tmpdir / "minimal_pendulum.urdf"

--- a/tests/heavy_integration/test_ezdxf_cad_export.py
+++ b/tests/heavy_integration/test_ezdxf_cad_export.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 
 @pytest.fixture(scope="module")
-def ezdxf():
+def ezdxf() -> ModuleType:
     """Import ezdxf or skip the module."""
     ezdxf_mod = pytest.importorskip("ezdxf")
     return ezdxf_mod

--- a/tests/heavy_integration/test_humanoid_mesh_pipeline.py
+++ b/tests/heavy_integration/test_humanoid_mesh_pipeline.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 
 
-def _import_mesh_processor():
+def _import_mesh_processor() -> Any:
     """Import MeshProcessor or skip the test."""
     try:
         from src.shared.python.humanoid_character_builder.mesh.mesh_processor import (
@@ -26,7 +27,7 @@ def _import_mesh_processor():
         pytest.skip(f"humanoid_character_builder not importable: {exc}")
 
 
-def _import_inertia_calculator():
+def _import_inertia_calculator() -> Any:
     """Import InertiaCalculator or skip the test."""
     try:
         from src.shared.python.humanoid_character_builder.mesh.inertia_calculator import (
@@ -38,7 +39,7 @@ def _import_inertia_calculator():
         pytest.skip(f"inertia_calculator not importable: {exc}")
 
 
-def _import_collision_generator():
+def _import_collision_generator() -> Any:
     """Import CollisionGenerator or skip the test."""
     try:
         from src.shared.python.humanoid_character_builder.mesh.collision_generator import (
@@ -51,7 +52,7 @@ def _import_collision_generator():
 
 
 @pytest.fixture(scope="module")
-def sphere_mesh():
+def sphere_mesh() -> Any:
     """Create a unit sphere trimesh or skip if trimesh unavailable."""
     trimesh = pytest.importorskip("trimesh")
     sphere = trimesh.creation.icosphere(subdivisions=2, radius=0.1)

--- a/tests/heavy_integration/test_mediapipe_tasks_api.py
+++ b/tests/heavy_integration/test_mediapipe_tasks_api.py
@@ -7,19 +7,21 @@ All tests skip gracefully when mediapipe is not installed.
 
 from __future__ import annotations
 
+from types import ModuleType
+
 import numpy as np
 import pytest
 
 
 @pytest.fixture(scope="module")
-def mp():
+def mp() -> ModuleType:
     """Import mediapipe or skip the module."""
     mp_mod = pytest.importorskip("mediapipe")
     return mp_mod
 
 
 @pytest.fixture(scope="module")
-def synthetic_rgb_frame():
+def synthetic_rgb_frame() -> np.ndarray:
     """A 480×640 synthetic RGB image (blank white)."""
     return np.ones((480, 640, 3), dtype=np.uint8) * 200
 

--- a/tests/heavy_integration/test_opensim_muscles.py
+++ b/tests/heavy_integration/test_opensim_muscles.py
@@ -11,6 +11,8 @@ Refactored to use shared engine availability module (DRY principle).
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -30,7 +32,7 @@ if OPENSIM_AVAILABLE:
 
 
 @pytest.fixture
-def simple_arm_model():
+def simple_arm_model() -> Any:
     """Create a simple arm model with muscles for testing."""
     if not OPENSIM_AVAILABLE:
         pytest.skip("OpenSim not installed")

--- a/tests/heavy_integration/test_opensim_myosuite_wiring.py
+++ b/tests/heavy_integration/test_opensim_myosuite_wiring.py
@@ -10,8 +10,9 @@ Fixes #1115, #1116
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -298,7 +299,7 @@ class TestAPIRouteConnectivity:
     """Verify OpenSim/MyoSuite are accessible via API routes."""
 
     @pytest.fixture(scope="class")
-    def client(self):
+    def client(self) -> Generator[Any, None, None]:
         """Create test client."""
         try:
             from fastapi.testclient import TestClient

--- a/tests/heavy_integration/test_pinocchio_urdf_loading.py
+++ b/tests/heavy_integration/test_pinocchio_urdf_loading.py
@@ -9,6 +9,7 @@ All tests skip gracefully when pinocchio is not installed.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -19,7 +20,7 @@ GOLFER_URDF = (
 )
 
 
-def _pin():
+def _pin() -> Any:
     """Import pinocchio or skip."""
     try:
         import pinocchio as pin
@@ -30,7 +31,7 @@ def _pin():
 
 
 @pytest.fixture(scope="module")
-def golfer_model():
+def golfer_model() -> Any:
     """Load the golfer URDF; skip if file or pinocchio unavailable."""
     pin = _pin()
     if not GOLFER_URDF.exists():

--- a/tests/heavy_integration/test_pyqt6_gui_components.py
+++ b/tests/heavy_integration/test_pyqt6_gui_components.py
@@ -8,12 +8,14 @@ All tests skip gracefully when PyQt6 is unavailable.
 from __future__ import annotations
 
 import sys
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 
 
 @pytest.fixture(scope="module")
-def qt_app():
+def qt_app() -> Generator[Any, None, None]:
     """Return or create a QApplication singleton for headless tests."""
     try:
         from PyQt6.QtWidgets import QApplication

--- a/tests/heavy_integration/test_real_engine_loading.py
+++ b/tests/heavy_integration/test_real_engine_loading.py
@@ -9,6 +9,7 @@ These tests demonstrate proper integration testing:
 """
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -194,7 +195,7 @@ class TestCrossEngineConsistency:
     """
 
     @pytest.fixture
-    def available_engines(self):
+    def available_engines(self) -> dict[str, Any]:
         """Get list of engines that are actually available (not mocked)."""
         engines = {}
 

--- a/tests/heavy_integration/test_screw_theory_integration.py
+++ b/tests/heavy_integration/test_screw_theory_integration.py
@@ -9,6 +9,8 @@ All tests skip gracefully when optional dependencies are unavailable.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -17,7 +19,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _import_screw_modules():
+def _import_screw_modules() -> Any:
     """Import screw theory modules or skip."""
     try:
         from mujoco_humanoid_golf.screw_theory.adjoint import adjoint_transform

--- a/tests/integration/test_c3d_workflow.py
+++ b/tests/integration/test_c3d_workflow.py
@@ -3,7 +3,10 @@
 TEST-004: Added @pytest.mark.integration markers for test categorization.
 """
 
-from unittest.mock import patch
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -37,7 +40,7 @@ if not C3D_IMPORTS_AVAILABLE:
 
 
 @pytest.fixture
-def mock_c3d_file(tmp_path):
+def mock_c3d_file(tmp_path: Path) -> Path:
     """Create a dummy file path."""
     f = tmp_path / "test.c3d"
     f.touch()
@@ -45,7 +48,7 @@ def mock_c3d_file(tmp_path):
 
 
 @pytest.fixture
-def mock_ezc3d():
+def mock_ezc3d() -> Generator[MagicMock, None, None]:
     """Mock ezc3d module behavior."""
     with patch("c3d_reader.ezc3d") as mock:
         # Construct a fake C3D structure
@@ -148,7 +151,7 @@ def test_export_workflow(mock_c3d_file, mock_ezc3d, tmp_path) -> None:
 
 
 @pytest.fixture(scope="session")
-def qapp():
+def qapp() -> Generator[Any, None, None]:
     """Manage a single QApplication instance for the test session."""
 
     app = get_qapp()

--- a/tests/integration/test_contact_cross_engine.py
+++ b/tests/integration/test_contact_cross_engine.py
@@ -33,7 +33,7 @@ def _skip_if_mujoco_state_unavailable(engine) -> None:
 
 
 @pytest.fixture(scope="module")
-def ball_urdf(tmp_path_factory):
+def ball_urdf(tmp_path_factory: pytest.TempPathFactory) -> str:
     """Create a simple ball URDF for contact testing."""
     # Golf ball: mass = 0.045kg, radius = 0.02135m
     urdf_content = """<?xml version="1.0"?>

--- a/tests/integration/test_engine_api_integration.py
+++ b/tests/integration/test_engine_api_integration.py
@@ -12,6 +12,7 @@ Fixes #1119
 """
 
 import time
+from collections.abc import Generator
 
 import pytest
 
@@ -26,7 +27,7 @@ from src.shared.python.engine_core.engine_registry import EngineType
 
 
 @pytest.fixture(scope="module")
-def client():
+def client() -> Generator[TestClient, None, None]:
     """Create test client with proper application lifespan."""
     with TestClient(app) as c:
         yield c

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -143,7 +143,7 @@ class TestEngineIntegration:
         performance_results = {}
 
         # Mock simulation with realistic timing - moved outside loop to avoid closure
-        def mock_simulate(engine_type):
+        def mock_simulate(engine_type: object) -> dict[str, float]:
             # Simulate different performance characteristics
             if engine_type == EngineType.MUJOCO:
                 time.sleep(0.01)  # Slower but more accurate

--- a/tests/integration/test_engine_loading.py
+++ b/tests/integration/test_engine_loading.py
@@ -21,7 +21,7 @@ _REGISTRATION_SPEC_ATTRS = [
 
 
 @pytest.fixture
-def mock_engine_manager():
+def mock_engine_manager() -> EngineManager:
     """Fixture to provide EngineManager with actual repo root to pass security validation."""
     # Use actual src root so paths pass security validation checks
     return EngineManager(get_src_root())

--- a/tests/integration/test_engine_manager_coverage.py
+++ b/tests/integration/test_engine_manager_coverage.py
@@ -20,7 +20,7 @@ class TestEngineManagerCoverage:
     """Tests to improve coverage of EngineManager."""
 
     @pytest.fixture
-    def mock_manager(self):
+    def mock_manager(self) -> EngineManager:
         """Create an EngineManager with mocked probes and paths."""
         with (
             patch("src.shared.python.engine_core.engine_probes.MuJoCoProbe"),

--- a/tests/integration/test_frontend_api_integration.py
+++ b/tests/integration/test_frontend_api_integration.py
@@ -15,7 +15,7 @@ class TestEnginesEndpoint:
     """Tests for the /api/engines endpoint used by the frontend EngineSelector."""
 
     @pytest.fixture
-    def mock_engine_manager(self):
+    def mock_engine_manager(self) -> MagicMock:
         """Create a mock engine manager."""
         manager = MagicMock(spec=EngineManager)
         manager.get_available_engines.return_value = []

--- a/tests/integration/test_golf_launcher_integration.py
+++ b/tests/integration/test_golf_launcher_integration.py
@@ -3,7 +3,9 @@
 import os
 import sys
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -59,7 +61,7 @@ class MockQtBase:
     def setWordWrap(self, b) -> None:
         pass
 
-    def font(self):
+    def font(self) -> MagicMock:
         return MagicMock()
 
 
@@ -71,7 +73,7 @@ class MockQWidget(MockQtBase):
     def setEnabled(self, b) -> None:
         self._enabled = bool(b)
 
-    def isEnabled(self):
+    def isEnabled(self) -> bool:
         if isinstance(self._enabled, bool):
             return self._enabled
         return False
@@ -164,7 +166,7 @@ mock_widgets.QLineEdit = MockQWidget
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_pyqt_modules():
+def mock_pyqt_modules() -> Generator[None, None, None]:
     """Patch PyQt6 modules in sys.modules for the duration of this test module."""
     with patch.dict(
         sys.modules,
@@ -184,7 +186,7 @@ def mock_pyqt_modules():
 
 
 @pytest.fixture(scope="session")
-def qapp():
+def qapp() -> Generator[Any, None, None]:
     """Create QApplication instance."""
     app = mock_widgets.QApplication.instance()
     if app is None:
@@ -193,7 +195,7 @@ def qapp():
 
 
 @pytest.fixture
-def launcher_env(qapp):
+def launcher_env(qapp) -> Generator[Any, None, None]:
     """Setup launcher environment with temp config."""
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/integration/test_headless_smoke_suite.py
+++ b/tests/integration/test_headless_smoke_suite.py
@@ -5,6 +5,7 @@ without a physical display, suitable for CI/CD environments.
 """
 
 import os
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +20,7 @@ except ImportError:
 
 
 @pytest.fixture
-def mock_loader_thread():
+def mock_loader_thread() -> Generator[MagicMock, None, None]:
     """Mock the C3DLoaderThread to prevent actual thread execution."""
     with patch("apps.c3d_viewer.C3DLoaderThread") as MockThread:
         mock_instance = MockThread.return_value

--- a/tests/integration/test_opensim_muscles.py
+++ b/tests/integration/test_opensim_muscles.py
@@ -11,6 +11,8 @@ Refactored to use shared engine availability module (DRY principle).
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -30,7 +32,7 @@ if OPENSIM_AVAILABLE:
 
 
 @pytest.fixture
-def simple_arm_model():
+def simple_arm_model() -> tuple[Any, Any]:
     """Create a simple arm model with muscles for testing."""
     if not OPENSIM_AVAILABLE:
         pytest.skip("OpenSim not installed")

--- a/tests/integration/test_opensim_myosuite_wiring.py
+++ b/tests/integration/test_opensim_myosuite_wiring.py
@@ -10,8 +10,9 @@ Fixes #1115, #1116
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -298,7 +299,7 @@ class TestAPIRouteConnectivity:
     """Verify OpenSim/MyoSuite are accessible via API routes."""
 
     @pytest.fixture(scope="class")
-    def client(self):
+    def client(self) -> Generator[Any, None, None]:
         """Create test client."""
         try:
             from fastapi.testclient import TestClient

--- a/tests/integration/test_real_engine_loading.py
+++ b/tests/integration/test_real_engine_loading.py
@@ -9,6 +9,7 @@ These tests demonstrate proper integration testing:
 """
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -194,7 +195,7 @@ class TestCrossEngineConsistency:
     """
 
     @pytest.fixture
-    def available_engines(self):
+    def available_engines(self) -> dict[str, Any]:
         """Get list of engines that are actually available (not mocked)."""
         engines = {}
 

--- a/tests/launchers/test_base.py
+++ b/tests/launchers/test_base.py
@@ -14,7 +14,7 @@ from src.launchers.base import BaseLauncher, LaunchItem, run_launcher  # noqa: E
 
 
 class DummyLauncher(BaseLauncher):
-    def get_items(self):
+    def get_items(self) -> list[LaunchItem]:
         return [
             LaunchItem(name="Item1", description="Desc1", path="path1"),
             LaunchItem(
@@ -49,7 +49,7 @@ def test_launch_item_get_full_path() -> None:
 
 
 @pytest.fixture
-def launcher(qapp):
+def launcher(qapp) -> DummyLauncher:
     with patch("src.launchers.base.BaseLauncher.center_window"):
         return DummyLauncher()
 

--- a/tests/launchers/test_docker_dialog.py
+++ b/tests/launchers/test_docker_dialog.py
@@ -11,7 +11,7 @@ from src.launchers.docker_dialog import EnvironmentDialog  # noqa: E402
 
 
 @pytest.fixture
-def dialog(qapp):
+def dialog(qapp) -> EnvironmentDialog:
     """Provide an EnvironmentDialog instance."""
     return EnvironmentDialog()
 

--- a/tests/launchers/test_golf_launcher.py
+++ b/tests/launchers/test_golf_launcher.py
@@ -1,6 +1,7 @@
 """Tests for golf_launcher.py."""
 
 import contextlib  # noqa: E402
+from collections.abc import Generator  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -11,7 +12,7 @@ from src.launchers.ui_components import StartupResults  # noqa: E402
 
 
 @pytest.fixture
-def startup_results():
+def startup_results() -> StartupResults:
     results = StartupResults()
     results.startup_time_ms = 100
     results.docker_available = True
@@ -21,7 +22,7 @@ def startup_results():
 
 
 @contextlib.contextmanager
-def patch_launcher_ui():
+def patch_launcher_ui() -> Generator[None, None, None]:
     with (
         patch("src.launchers.golf_launcher.DockerCheckThread"),
         patch("src.launchers.golf_launcher.QTimer"),

--- a/tests/launchers/test_golf_suite_launcher.py
+++ b/tests/launchers/test_golf_suite_launcher.py
@@ -1,6 +1,7 @@
 """Tests for golf_suite_launcher.py."""
 
 import sys  # noqa: E402
+from collections.abc import Generator  # noqa: E402
 from pathlib import Path  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
@@ -8,7 +9,7 @@ import pytest  # noqa: E402
 
 
 @pytest.fixture
-def mock_pyqt(qapp):
+def mock_pyqt(qapp) -> Generator[tuple[MagicMock, MagicMock], None, None]:
     """Mock PyQt6 components for testing non-UI logic safely."""
     with (
         patch("src.launchers.golf_suite_launcher.PYQT6_AVAILABLE", True),
@@ -22,7 +23,7 @@ def mock_pyqt(qapp):
 
 
 @pytest.fixture
-def launcher(mock_pyqt):
+def launcher(mock_pyqt) -> Generator[MagicMock, None, None]:
     """Provide a minimal instantiated GolfLauncher."""
     with patch("src.launchers.golf_suite_launcher.GolfLauncher._setup_ui"):
         from src.launchers.golf_suite_launcher import GolfLauncher

--- a/tests/launchers/test_help_dialogs.py
+++ b/tests/launchers/test_help_dialogs.py
@@ -16,7 +16,7 @@ from src.launchers.help_dialogs import (  # noqa: E402
 
 
 @pytest.fixture
-def test_model():
+def test_model() -> MagicMock:
     model = MagicMock()
     model.name = "Test Model"
     model.description = "A test model"

--- a/tests/launchers/test_launcher_constants.py
+++ b/tests/launchers/test_launcher_constants.py
@@ -1,4 +1,5 @@
 import importlib  # noqa: E402
+from typing import Any  # noqa: E402
 from unittest.mock import patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -92,7 +93,7 @@ def test_optional_imports_failure() -> None:
     # We mock builtins.__import__ so that it raises ImportError for specific modules
     original_import = __builtins__["__import__"]
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name in (
             "src.shared.python.ai.gui",
             "src.shared.python.help_system",

--- a/tests/launchers/test_launcher_diagnostics.py
+++ b/tests/launchers/test_launcher_diagnostics.py
@@ -207,7 +207,7 @@ def test_check_asset_files_dir_missing(mock_exists) -> None:
 @patch("pathlib.Path.exists", autospec=True)
 @patch("pathlib.Path.iterdir")
 def test_check_asset_files_success(mock_iterdir, mock_exists) -> None:
-    def exists_side_effect(self):
+    def exists_side_effect(self) -> bool:
         # Only some assets exist
         return "mujoco" not in str(self)
 

--- a/tests/launchers/test_launcher_dialogs.py
+++ b/tests/launchers/test_launcher_dialogs.py
@@ -34,7 +34,7 @@ class DummyLauncher(QMainWindow, LauncherDialogsMixin):
 
 
 @pytest.fixture
-def launcher(qapp):
+def launcher(qapp) -> DummyLauncher:
     return DummyLauncher()
 
 

--- a/tests/launchers/test_launcher_layout_manager.py
+++ b/tests/launchers/test_launcher_layout_manager.py
@@ -1,6 +1,7 @@
 """Tests for launcher_layout_manager."""
 
 import json  # noqa: E402
+from collections.abc import Callable  # noqa: E402
 from pathlib import Path  # noqa: E402
 from unittest.mock import MagicMock, mock_open, patch  # noqa: E402
 
@@ -15,7 +16,7 @@ from src.launchers.model_registry import ModelSpec  # noqa: E402
 
 
 @pytest.fixture
-def available_models():
+def available_models() -> dict[str, ModelSpec]:
     return {
         "model_1": ModelSpec(
             id="model_1",
@@ -35,16 +36,16 @@ def available_models():
 
 
 @pytest.fixture
-def get_model_func(available_models):
-    def get_model(model_id):
+def get_model_func(available_models) -> Callable[[str], ModelSpec | None]:
+    def get_model(model_id: str) -> ModelSpec | None:
         return available_models.get(model_id)
 
     return get_model
 
 
 @pytest.fixture
-def create_card_func():
-    def create_card(model):
+def create_card_func() -> Callable[[ModelSpec], MagicMock]:
+    def create_card(model: ModelSpec) -> MagicMock:
         card = MagicMock()
         card.model_id = model.id
         return card
@@ -53,7 +54,7 @@ def create_card_func():
 
 
 @pytest.fixture
-def layout_manager(available_models, get_model_func, create_card_func):
+def layout_manager(available_models, get_model_func, create_card_func) -> LayoutManager:
     return LayoutManager(
         config_file=Path("/fake/config.json"),
         available_models=available_models,

--- a/tests/launchers/test_launcher_model_registry.py
+++ b/tests/launchers/test_launcher_model_registry.py
@@ -15,7 +15,7 @@ from src.launchers.model_registry import (  # noqa: E402
 
 
 @pytest.fixture
-def mock_yaml_data():
+def mock_yaml_data() -> dict:
     return {
         "models": [
             {

--- a/tests/launchers/test_launcher_process_manager.py
+++ b/tests/launchers/test_launcher_process_manager.py
@@ -25,7 +25,7 @@ _VALIDATE_SCRIPT = "src.launchers.launcher_process_manager.validate_script_path"
 
 
 @pytest.fixture
-def manager():
+def manager() -> ProcessManager:
     with patch.object(Path, "mkdir"), patch.object(Path, "exists", return_value=False):
         return ProcessManager(repo_root=PureWindowsPath("/fake/repo"))  # type: ignore[arg-type]
 

--- a/tests/launchers/test_launcher_simulation.py
+++ b/tests/launchers/test_launcher_simulation.py
@@ -40,12 +40,12 @@ class DummyLauncher(QMainWindow, LauncherSimulationMixin):
             "m2": DummyModel("m2", "M2", "matlab_app", path="test.slx"),
         }
 
-    def _get_model(self, model_id):
+    def _get_model(self, model_id: str) -> DummyModel | None:
         return self.models.get(model_id)
 
 
 @pytest.fixture
-def launcher(qapp):
+def launcher(qapp) -> DummyLauncher:
     return DummyLauncher()
 
 

--- a/tests/launchers/test_launcher_ui_setup.py
+++ b/tests/launchers/test_launcher_ui_setup.py
@@ -32,7 +32,7 @@ class DummyLauncher(QMainWindow, LauncherUISetupMixin):
 
 
 @pytest.fixture
-def launcher(qapp):
+def launcher(qapp) -> DummyLauncher:
     return DummyLauncher()
 
 
@@ -160,7 +160,7 @@ def test_setup_ai_panel(launcher) -> None:
 def test_setup_ai_panel_error(launcher) -> None:
     original_import = __import__
 
-    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def mock_import(name, globals=None, locals=None, fromlist=(), level=0) -> object:
         if name == "src.shared.python.ai.gui":
             raise ImportError("test error")
         return original_import(name, globals, locals, fromlist, level)
@@ -202,7 +202,7 @@ def test_init_overlay(launcher) -> None:
 def test_init_overlay_error(launcher) -> None:
     original_import = __import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> object:
         if "vendor" in name or "overlay" in name:
             raise ImportError("test")
         return original_import(name, *args, **kwargs)

--- a/tests/launchers/test_model_card.py
+++ b/tests/launchers/test_model_card.py
@@ -11,14 +11,14 @@ from src.launchers.model_card import DraggableModelCard  # noqa: E402
 
 
 @pytest.fixture
-def parent_launcher():
+def parent_launcher() -> MagicMock:
     launcher = MagicMock()
     launcher.layout_edit_mode = True
     return launcher
 
 
 @pytest.fixture
-def mock_model():
+def mock_model() -> MagicMock:
     model = MagicMock()
     model.id = "mujoco_unified"
     model.name = "MuJoCo"
@@ -218,7 +218,7 @@ def test_refresh_theme(mock_model, parent_launcher, qapp) -> None:
         img = MagicMock()
         img.pixmap.return_value = True
 
-        def find_mock(*args):
+        def find_mock(*args) -> MagicMock:
             if args[1] == "CardImage":
                 return img
             return MagicMock()

--- a/tests/launchers/test_settings_dialog.py
+++ b/tests/launchers/test_settings_dialog.py
@@ -24,7 +24,7 @@ def test_validate_tab_index() -> None:
 
 
 @pytest.fixture
-def parent_launcher(qapp):
+def parent_launcher(qapp) -> QWidget:
     launcher = QWidget()
     launcher.btn_modify_layout = MagicMock()
     launcher.btn_modify_layout.isChecked.return_value = True

--- a/tests/launchers/test_shot_tracer.py
+++ b/tests/launchers/test_shot_tracer.py
@@ -1,5 +1,6 @@
 """Tests for shot_tracer."""
 
+from collections.abc import Generator  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -11,7 +12,7 @@ from src.launchers.shot_tracer import (  # noqa: E402
 
 
 @pytest.fixture
-def mock_flight_models():
+def mock_flight_models() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     class MockModelType:
         value = "mock"
 
@@ -31,7 +32,9 @@ def mock_flight_models():
 
 
 @pytest.fixture
-def tracer_widget(qapp, mock_flight_models):
+def tracer_widget(
+    qapp, mock_flight_models
+) -> Generator[MultiModelShotTracerWidget, None, None]:
     with patch("src.launchers.shot_tracer.PYQTGRAPH_AVAILABLE", False):
         from PyQt6.QtWidgets import QWidget
 

--- a/tests/launchers/test_startup.py
+++ b/tests/launchers/test_startup.py
@@ -1,6 +1,7 @@
 """Tests for startup.py."""
 
 import builtins  # noqa: E402
+from collections.abc import Generator  # noqa: E402
 from pathlib import Path  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
@@ -16,7 +17,7 @@ from src.launchers.startup import (  # noqa: E402
 
 
 @pytest.fixture
-def mock_theme_available():
+def mock_theme_available() -> Generator[None, None, None]:
     import types
 
     colors = types.SimpleNamespace(
@@ -43,7 +44,7 @@ def mock_theme_available():
 
 
 @pytest.fixture
-def mock_theme_unavailable():
+def mock_theme_unavailable() -> Generator[None, None, None]:
     with patch("src.launchers.startup.THEME_AVAILABLE", False):
         yield
 
@@ -62,7 +63,9 @@ def test_get_theme_colors_not_available() -> None:
 
         real_import = builtins.__import__
 
-        def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+        def mock_import(
+            name, globals=None, locals=None, fromlist=(), level=0
+        ) -> object:
             if name == "src.shared.python.theme" and "get_current_colors" in fromlist:
                 raise ImportError("Mocked error")
             return real_import(name, globals, locals, fromlist, level)

--- a/tests/launchers/test_unified_launcher.py
+++ b/tests/launchers/test_unified_launcher.py
@@ -1,7 +1,8 @@
 """Tests for unified_launcher.py."""
 
 import sys  # noqa: E402
-from typing import NoReturn
+from collections.abc import Generator  # noqa: E402
+from typing import Any, NoReturn
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -16,7 +17,7 @@ from src.launchers.unified_launcher import (  # noqa: E402
 
 
 @pytest.fixture
-def clean_sys_modules():
+def clean_sys_modules() -> Generator[None, None, None]:
     """Remove specific modules from sys.modules."""
     modules_to_remove = ["launchers.unified_launcher", "launchers.golf_launcher"]
     for mod in modules_to_remove:
@@ -71,7 +72,7 @@ def test_get_golf_main_absolute_import() -> None:
 
     mock_module.main = fake_main
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if "golf_launcher" in name and not name.startswith("launchers"):
             raise ImportError("fake")
         return orig_import(name, *args, **kwargs)
@@ -103,7 +104,7 @@ def test_get_golf_main_all_imports_fail(clean_sys_modules) -> None:
 
     orig_import = builtins.__import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if "golf_launcher" in name:
             raise ImportError("fake")
         return orig_import(name, *args, **kwargs)
@@ -127,7 +128,7 @@ def test_get_golf_main_legacy_no_main() -> None:
 
     orig_import = builtins.__import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if "golf_launcher" in name and not name.startswith("launchers"):
             raise ImportError("fake")
         return orig_import(name, *args, **kwargs)
@@ -153,7 +154,7 @@ def test_get_golf_main_module_no_main() -> None:
     orig_import = builtins.__import__
 
     # We make the *relative* import fail, jumping to the absolute import
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if "golf_launcher" in name and not name.startswith("launchers"):
             raise ImportError("fake")
         return orig_import(name, *args, **kwargs)
@@ -195,7 +196,7 @@ def test_pyqt6_unavailable_reload(clean_sys_modules) -> None:
 
     orig_import = builtins.__import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name == "PyQt6.QtWidgets":
             raise ImportError("fake")
         return orig_import(name, *args, **kwargs)

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -6,6 +6,9 @@ engine-vs-API consistency testing.
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from typing import Any
+
 import pytest
 
 try:
@@ -17,14 +20,14 @@ except ImportError:
 
 
 @pytest.fixture(scope="module")
-def client():
+def client() -> Generator[TestClient, None, None]:
     """FastAPI test client with full app lifespan."""
     with TestClient(app) as test_client:
         yield test_client
 
 
 @pytest.fixture
-def pendulum_engine():
+def pendulum_engine() -> Any:
     """Fresh PendulumPhysicsEngine instance."""
     from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (
         PendulumPhysicsEngine,

--- a/tests/shared/python/screw_theory/test_ui.py
+++ b/tests/shared/python/screw_theory/test_ui.py
@@ -6,6 +6,8 @@ and provides the expected interface: is_active() and get_target_body().
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from src.shared.python.engine_core.engine_availability import (
@@ -20,14 +22,14 @@ class TestScrewVisualizationTab:
     """Tests for ScrewVisualizationTab widget."""
 
     @pytest.fixture(scope="class")
-    def qapp(self):
+    def qapp(self) -> Any:
         """Ensure QApplication exists for the test class."""
         from src.shared.python.gui_pkg.gui_utils import get_qapp
 
         return get_qapp()
 
     @pytest.fixture
-    def tab(self, qapp):
+    def tab(self, qapp) -> Any:
         """Instantiate a ScrewVisualizationTab for testing."""
         from src.shared.python.screw_theory.ui import ScrewVisualizationTab
 

--- a/tests/shared/python/screw_theory/test_visualization.py
+++ b/tests/shared/python/screw_theory/test_visualization.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from src.shared.python.screw_theory.kinematics import (
+    ScrewAxis,
     Twist,
     compute_screw_axis,
 )
@@ -21,7 +22,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def rotation_screw():
+def rotation_screw() -> ScrewAxis:
     """ScrewAxis for pure rotation about Z-axis."""
     twist = Twist(
         angular=np.array([0.0, 0.0, 1.0]),
@@ -33,7 +34,7 @@ def rotation_screw():
 
 
 @pytest.fixture
-def translation_screw():
+def translation_screw() -> ScrewAxis:
     """ScrewAxis for pure translation along X-axis."""
     twist = Twist(
         angular=np.zeros(3),
@@ -44,7 +45,7 @@ def translation_screw():
     return compute_screw_axis(twist)
 
 
-def _make_mock_ax():
+def _make_mock_ax() -> MagicMock:
     """Create a mock matplotlib 3D axes object."""
     ax = MagicMock()
     return ax

--- a/tests/shared/python/signal_toolkit/test_series.py
+++ b/tests/shared/python/signal_toolkit/test_series.py
@@ -72,7 +72,7 @@ class TestTaylorSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.sin(x)
 
         taylor_func = expansion.taylor_series(f, center=0, n_terms=5)
@@ -85,7 +85,7 @@ class TestTaylorSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.exp(x)
 
         taylor_func = expansion.taylor_series(f, center=0, n_terms=5)
@@ -99,7 +99,7 @@ class TestTaylorSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.cos(x)
 
         taylor_func = expansion.taylor_series(f, center=0, n_terms=5)
@@ -123,7 +123,7 @@ class TestTaylorSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return x**2
 
         with pytest.raises(ValueError):
@@ -147,7 +147,7 @@ class TestMaclaurinSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.sin(x)
 
         maclaurin_func = expansion.maclaurin_series(f, n_terms=5)
@@ -160,7 +160,7 @@ class TestMaclaurinSeriesContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.exp(x)
 
         taylor_func = expansion.taylor_series(f, center=0, n_terms=10)
@@ -184,7 +184,7 @@ class TestGetCoefficientsContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.exp(x)
 
         coeffs = expansion.get_coefficients(f, center=0, n_terms=5)
@@ -197,7 +197,7 @@ class TestGetCoefficientsContract:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.sin(x)
 
         for n in [3, 5, 10]:
@@ -277,7 +277,7 @@ class TestTaylorSeriesFunctional:
         expansion = SeriesExpansion()
 
         # f(x) = 1 + 2x + 3x^2
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return 1 + 2 * x + 3 * x**2
 
         taylor_func = expansion.taylor_series(f, center=0, n_terms=5)
@@ -563,7 +563,7 @@ class TestConvergenceAnalysis:
 
         expansion = SeriesExpansion()
 
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return np.log(1 + x)
 
         # Should diverge for x = 2 (outside |x| < 1)
@@ -749,7 +749,7 @@ class TestUtilityFunctions:
         expansion = SeriesExpansion()
 
         # For polynomial f(x) = x^3, f'(0) = 0, f''(0) = 0, f'''(0) = 6
-        def f(x):
+        def f(x) -> float | np.ndarray:
             return x**3
 
         coeffs = expansion.get_coefficients(f, center=0, n_terms=5)

--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -1,4 +1,6 @@
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -14,7 +16,7 @@ mock_anthropic_module = MagicMock()
 
 
 @pytest.fixture
-def mock_openai_adapter():
+def mock_openai_adapter() -> Generator[Any, None, None]:
     with patch.dict(sys.modules, {"openai": mock_openai_module}):
         from src.shared.python.ai.adapters.openai_adapter import OpenAIAdapter
 
@@ -23,7 +25,7 @@ def mock_openai_adapter():
 
 
 @pytest.fixture
-def mock_anthropic_adapter():
+def mock_anthropic_adapter() -> Generator[Any, None, None]:
     with patch.dict(sys.modules, {"anthropic": mock_anthropic_module}):
         from src.shared.python.ai.adapters.anthropic_adapter import AnthropicAdapter
 
@@ -32,7 +34,7 @@ def mock_anthropic_adapter():
 
 
 @pytest.fixture
-def context():
+def context() -> ConversationContext:
     return ConversationContext(user_expertise=ExpertiseLevel.BEGINNER)
 
 

--- a/tests/test_ai_workflow.py
+++ b/tests/test_ai_workflow.py
@@ -16,7 +16,7 @@ from src.shared.python.ai.workflow_engine import (
 
 class TestAIWorkflowEngine:
     @pytest.fixture
-    def mock_tool_registry(self):
+    def mock_tool_registry(self) -> Mock:
         registry = Mock()
         registry.execute.return_value = ToolResult(
             tool_call_id="mock_id", success=True, result={"data": "test"}
@@ -24,11 +24,11 @@ class TestAIWorkflowEngine:
         return registry
 
     @pytest.fixture
-    def engine(self, mock_tool_registry):
+    def engine(self, mock_tool_registry) -> WorkflowEngine:
         return WorkflowEngine(mock_tool_registry)
 
     @pytest.fixture
-    def basic_workflow(self):
+    def basic_workflow(self) -> Workflow:
         wf = Workflow(
             id="test_workflow",
             name="Test Workflow",
@@ -153,12 +153,12 @@ class TestWorkflowEngineFixIssue2504:
     """TDD tests for #2504: step output propagation and RUNNING-after-completion."""
 
     @pytest.fixture
-    def mock_tool_registry(self):
+    def mock_tool_registry(self) -> Mock:
         registry = Mock()
         return registry
 
     @pytest.fixture
-    def engine(self, mock_tool_registry):
+    def engine(self, mock_tool_registry) -> WorkflowEngine:
         return WorkflowEngine(mock_tool_registry)
 
     def test_step_tool_output_propagated_to_state(

--- a/tests/test_c3d_viewer_headless.py
+++ b/tests/test_c3d_viewer_headless.py
@@ -1,14 +1,17 @@
 """Headless smoke test for C3D Viewer."""
 
+from __future__ import annotations
+
 import importlib
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
 # Handle import of module with invalid identifier (3D_Golf_Model)
-def import_c3d_viewer():
+def import_c3d_viewer() -> types.ModuleType | None:
     """Import the C3D viewer module dynamically."""
     module_name = (
         "engines.Simscape_Multibody_Models.3D_Golf_Model.python.src.apps.c3d_viewer"

--- a/tests/test_dashboard_enhancements.py
+++ b/tests/test_dashboard_enhancements.py
@@ -53,7 +53,7 @@ if PYQT6_AVAILABLE:
         def forward(self) -> None:
             pass
 
-        def get_state(self):
+        def get_state(self) -> tuple[np.ndarray, np.ndarray]:
             return self._q, self._v
 
         def set_state(self, q, v) -> None:
@@ -66,31 +66,31 @@ if PYQT6_AVAILABLE:
         def get_time(self) -> float:
             return self._time
 
-        def compute_mass_matrix(self):
+        def compute_mass_matrix(self) -> np.ndarray:
             return np.eye(10)
 
-        def compute_bias_forces(self):
+        def compute_bias_forces(self) -> np.ndarray:
             return np.zeros(10)
 
-        def compute_gravity_forces(self):
+        def compute_gravity_forces(self) -> np.ndarray:
             return np.zeros(10)
 
-        def compute_inverse_dynamics(self, qacc):
+        def compute_inverse_dynamics(self, qacc) -> np.ndarray:
             return np.zeros(10)
 
         def compute_jacobian(self, body_name) -> None:
             return None
 
-        def compute_drift_acceleration(self):
+        def compute_drift_acceleration(self) -> np.ndarray:
             return np.zeros(10)
 
-        def compute_control_acceleration(self, tau):
+        def compute_control_acceleration(self, tau) -> np.ndarray:
             return np.zeros(10)
 
-        def compute_ztcf(self, q, v):
+        def compute_ztcf(self, q, v) -> np.ndarray:
             return np.zeros(10)
 
-        def compute_zvcf(self, q):
+        def compute_zvcf(self, q) -> np.ndarray:
             return np.zeros(10)
 
     class TestDashboardEnhancements(unittest.TestCase):

--- a/tests/test_golf_gui_tabs.py
+++ b/tests/test_golf_gui_tabs.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import sys
 import unittest
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch as _patch
 
@@ -147,13 +151,13 @@ class MockProperty:
         self.fget = fget
         self.fset = fset
 
-    def setter(self, fset):
+    def setter(self, fset) -> MockProperty:
         self.fset = fset
         return self
 
 
-def mock_pyqt_property(type_):
-    def decorator(func):
+def mock_pyqt_property(type_) -> Callable[[Any], MockProperty]:
+    def decorator(func) -> MockProperty:
         return MockProperty(fget=func)
 
     return decorator

--- a/tests/test_injury_risk.py
+++ b/tests/test_injury_risk.py
@@ -13,11 +13,11 @@ from src.shared.python.injury.injury_risk import (
 
 class TestInjuryRiskScorer:
     @pytest.fixture
-    def scorer(self):
+    def scorer(self) -> InjuryRiskScorer:
         return InjuryRiskScorer()
 
     @pytest.fixture
-    def mock_spinal_result(self):
+    def mock_spinal_result(self) -> Mock:
         result = Mock()
         result.peak_compression_bw = 5.0  # Caution range (4-6)
         result.peak_lateral_shear_bw = 0.8  # Caution range (0.5-1.0)
@@ -29,8 +29,8 @@ class TestInjuryRiskScorer:
         return result
 
     @pytest.fixture
-    def mock_joint_results(self):
-        def create_result(score, impingement=False):
+    def mock_joint_results(self) -> dict[str, Mock]:
+        def create_result(score, impingement=False) -> Mock:
             result = Mock()
             result.risk_score = score
             result.impingement_risk = impingement
@@ -48,7 +48,7 @@ class TestInjuryRiskScorer:
         }
 
     @pytest.fixture
-    def mock_swing_metrics(self):
+    def mock_swing_metrics(self) -> dict[str, float]:
         return {
             "sequence_timing_error": 0.10,  # Middle of range
             "tempo_ratio": 3.5,  # Error of 0.5
@@ -56,7 +56,7 @@ class TestInjuryRiskScorer:
         }
 
     @pytest.fixture
-    def mock_training_load(self):
+    def mock_training_load(self) -> dict[str, float]:
         return {
             "acwr": 1.4,  # High (>1.3)
             "weekly_swings": 800,  # High (500-1000)

--- a/tests/test_joint_stress.py
+++ b/tests/test_joint_stress.py
@@ -12,11 +12,11 @@ class TestJointStressAnalyzer:
     """Test suite for JointStressAnalyzer."""
 
     @pytest.fixture
-    def analyzer(self):
+    def analyzer(self) -> JointStressAnalyzer:
         return JointStressAnalyzer(body_weight=80.0, handedness="right")
 
     @pytest.fixture
-    def mock_data(self):
+    def mock_data(self) -> dict:
         time = np.linspace(0, 1.0, 20)
         zeros = np.zeros_like(time)
         return {

--- a/tests/test_spinal_load_analysis.py
+++ b/tests/test_spinal_load_analysis.py
@@ -13,13 +13,12 @@ class TestSpinalLoadAnalysis:
     """Test suite for SpinalLoadAnalyzer."""
 
     @pytest.fixture
-    def analyzer(self):
+    def analyzer(self) -> SpinalLoadAnalyzer:
         """Create a default analyzer."""
         return SpinalLoadAnalyzer(body_weight=80.0, height=1.80)
 
     @pytest.fixture
-    def example_data(self):
-        """Generate synthetic swing data."""
+    def example_data(self) -> dict:
         time = np.linspace(0, 1.0, 50)
         zeros = np.zeros_like(time)
         return {

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -5,7 +5,7 @@ from src.shared.python.ai.tool_registry import ToolCategory, ToolRegistry
 
 class TestToolRegistry:
     @pytest.fixture
-    def registry(self):
+    def registry(self) -> ToolRegistry:
         return ToolRegistry()
 
     def test_decorator_registration(self, registry) -> None:
@@ -40,7 +40,7 @@ class TestToolRegistry:
 
     def test_execution_param_validation(self, registry) -> None:
         @registry.register("echo", "Echo")
-        def echo(msg: str):
+        def echo(msg: str) -> str:
             return msg
 
         # Missing required

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -19,17 +19,17 @@ Context = namedtuple("Context", ["user_id"])
 
 class TestWorkflowEngine:
     @pytest.fixture
-    def mock_registry(self):
+    def mock_registry(self) -> Mock:
         registry = Mock(spec=ToolRegistry)
         registry.execute.return_value = ToolResult("", True, "success")
         return registry
 
     @pytest.fixture
-    def engine(self, mock_registry):
+    def engine(self, mock_registry) -> WorkflowEngine:
         return WorkflowEngine(mock_registry)
 
     @pytest.fixture
-    def simple_workflow(self):
+    def simple_workflow(self) -> Workflow:
         wf = Workflow(
             id="test_wf",
             name="Test Workflow",

--- a/tests/unit/api/test_acid_gas_dewpoint_mocked.py
+++ b/tests/unit/api/test_acid_gas_dewpoint_mocked.py
@@ -8,6 +8,7 @@ underlying math or logic, which is the responsibility of the `Tools` repository.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_calculator():
+def mock_calculator() -> Generator[MagicMock, None, None]:
     """Mock the AcidGasDewpointCalculator to adhere to Shared Component Strategy."""
     with patch(
         "upstream_drift_tools.process_calculators.acid_gas_dewpoint_calculator.AcidGasDewpointCalculator"

--- a/tests/unit/api/test_analysis_service.py
+++ b/tests/unit/api/test_analysis_service.py
@@ -3,6 +3,7 @@
 These tests verify the analysis service using Design by Contract principles.
 """
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -19,7 +20,7 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def mock_engine_manager():
+def mock_engine_manager() -> MagicMock:
     """Create a mock engine manager."""
     manager = MagicMock()
     manager.get_active_physics_engine = MagicMock(return_value=None)
@@ -27,7 +28,7 @@ def mock_engine_manager():
 
 
 @pytest.fixture
-def analysis_service(mock_engine_manager):
+def analysis_service(mock_engine_manager: MagicMock) -> Any:
     """Create an analysis service instance."""
     from src.api.services.analysis_service import AnalysisService
 

--- a/tests/unit/api/test_baghouse_mocked.py
+++ b/tests/unit/api/test_baghouse_mocked.py
@@ -8,6 +8,7 @@ internal mathematical logic.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_calculator():
+def mock_calculator() -> Generator[MagicMock, None, None]:
     """Mock the BaghouseCalculator securely from Tools."""
     with patch(
         "upstream_drift_tools.process_calculators.BaghouseCalculator"

--- a/tests/unit/api/test_chat_service.py
+++ b/tests/unit/api/test_chat_service.py
@@ -7,6 +7,7 @@ adapter loading, and disk persistence.
 from __future__ import annotations
 
 import time
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +16,7 @@ from src.shared.python.core.error_utils import InvalidRequestError
 
 
 @pytest.fixture
-def chat_service(tmp_path):
+def chat_service(tmp_path) -> Any:
     """Create a ChatService with mocked adapter and temp persist dir."""
     with patch("src.api.services.chat_service.ChatService._load_adapter"):
         from src.api.services.chat_service import ChatService

--- a/tests/unit/api/test_chat_ws.py
+++ b/tests/unit/api/test_chat_ws.py
@@ -6,6 +6,7 @@ and REST fallback endpoints.
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,7 +25,7 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def mock_chat_service():
+def mock_chat_service() -> MagicMock:
     """Create a mock ChatService."""
     svc = MagicMock()
 
@@ -54,7 +55,7 @@ def mock_chat_service():
     ]
 
     # Make stream_response an async generator
-    async def mock_stream(session_id):
+    async def mock_stream(session_id: str) -> AsyncGenerator[str, None]:
         yield "Hello "
         yield "world!"
 
@@ -64,7 +65,7 @@ def mock_chat_service():
 
 
 @pytest.fixture
-def app(mock_chat_service):
+def app(mock_chat_service: MagicMock) -> FastAPI:
     """Create a FastAPI app with chat routes."""
     test_app = FastAPI()
     test_app.state.chat_service = mock_chat_service
@@ -73,7 +74,7 @@ def app(mock_chat_service):
 
 
 @pytest.fixture
-def client(app):
+def client(app: FastAPI) -> TestClient:
     """Create a test client."""
     return TestClient(app)
 

--- a/tests/unit/api/test_db_migrations.py
+++ b/tests/unit/api/test_db_migrations.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -215,7 +216,7 @@ class TestMigrationRoundTrip:
     """Run the initial migration up and back down on an in-memory SQLite DB."""
 
     @pytest.fixture()
-    def alembic_cfg(self, tmp_path):
+    def alembic_cfg(self, tmp_path) -> Any:
         """Return an Alembic Config pointing at a fresh temporary SQLite DB."""
         from alembic.config import Config
 
@@ -289,7 +290,7 @@ class TestDbMigrateCliParser:
     """Test the db_migrate.py CLI argument parser."""
 
     @pytest.fixture()
-    def parser(self):
+    def parser(self) -> Any:
         """Return the argument parser from db_migrate."""
         import importlib.util
 
@@ -352,7 +353,7 @@ class TestDbMigrateFunctions:
     """Test the functional command implementations in db_migrate.py."""
 
     @pytest.fixture()
-    def db_migrate(self):
+    def db_migrate(self) -> ModuleType:
         """Import and return the db_migrate module."""
         import importlib.util
 

--- a/tests/unit/api/test_financial_mocked.py
+++ b/tests/unit/api/test_financial_mocked.py
@@ -8,6 +8,7 @@ internal mathematical logic directly.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_calculator():
+def mock_calculator() -> Generator[MagicMock, None, None]:
     """Mock the scrubber calculators securely from Tools."""
     with patch(
         "upstream_drift_tools.process_calculators.financial_calculator.FinancialModelCalculator"

--- a/tests/unit/api/test_flare_mocked.py
+++ b/tests/unit/api/test_flare_mocked.py
@@ -8,6 +8,7 @@ internal mathematical logic.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_calculator():
+def mock_calculator() -> Generator[MagicMock, None, None]:
     """Mock the FlareCalculator securely from Tools."""
     with patch(
         "upstream_drift_tools.process_calculators.FlareCalculator"

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -20,7 +20,7 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> MagicMock:
     """Create a mock request."""
     request = MagicMock(spec=Request)
     request.url = MagicMock()
@@ -30,7 +30,7 @@ def mock_request():
 
 
 @pytest.fixture
-def mock_response():
+def mock_response() -> MagicMock:
     """Create a mock response."""
     response = MagicMock(spec=Response)
     response.headers = {}
@@ -44,7 +44,7 @@ class TestAddSecurityHeadersContract:
         """Postcondition: Returns a Response."""
         from src.api.middleware.security_headers import add_security_headers
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -60,7 +60,7 @@ class TestAddSecurityHeaders:
         """Test adding X-Content-Type-Options header."""
         from src.api.middleware.security_headers import add_security_headers
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -70,7 +70,7 @@ class TestAddSecurityHeaders:
         """Test adding X-Frame-Options header."""
         from src.api.middleware.security_headers import add_security_headers
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -80,7 +80,7 @@ class TestAddSecurityHeaders:
         """Test adding X-XSS-Protection header."""
         from src.api.middleware.security_headers import add_security_headers
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -90,7 +90,7 @@ class TestAddSecurityHeaders:
         """Test adding Referrer-Policy header."""
         from src.api.middleware.security_headers import add_security_headers
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -104,7 +104,7 @@ class TestAddSecurityHeaders:
 
         mock_request.url.scheme = "https"
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -118,7 +118,7 @@ class TestAddSecurityHeaders:
 
         mock_request.url.scheme = "http"
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await add_security_headers(mock_request, call_next)
@@ -163,7 +163,7 @@ class TestValidateUploadSizeContract:
 
         mock_request.headers = {}
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await validate_upload_size(mock_request, call_next)
@@ -181,7 +181,7 @@ class TestValidateUploadSize:
 
         mock_request.headers = {}
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await validate_upload_size(mock_request, call_next)
@@ -193,7 +193,7 @@ class TestValidateUploadSize:
 
         mock_request.headers = {"content-length": "1000"}  # 1KB
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         result = await validate_upload_size(mock_request, call_next)
@@ -206,7 +206,7 @@ class TestValidateUploadSize:
 
         mock_request.headers = {"content-length": str(MAX_UPLOAD_SIZE_BYTES + 1)}
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return MagicMock()
 
         result = await validate_upload_size(mock_request, call_next)
@@ -220,7 +220,7 @@ class TestValidateUploadSize:
 
         mock_request.headers = {"content-length": "not-a-number"}
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return MagicMock()
 
         result = await validate_upload_size(mock_request, call_next)
@@ -237,7 +237,7 @@ class TestValidateUploadSize:
         mock_request.url = MagicMock()
         mock_request.url.scheme = "https"
 
-        async def call_next(request):
+        async def call_next(request: MagicMock) -> MagicMock:
             return MagicMock()
 
         result = await validate_upload_size(mock_request, call_next)

--- a/tests/unit/api/test_rotation_converter_mocked.py
+++ b/tests/unit/api/test_rotation_converter_mocked.py
@@ -7,6 +7,7 @@ that the API layer correctly implements the contract boundaries.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,7 +30,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_rotation_class():
+def mock_rotation_class() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     """Mock the Rotation class from rotation_converter.converter."""
     with patch(
         "src.shared.python.calc_backend.routers.rotation_converter.Rotation"

--- a/tests/unit/api/test_scrubber_mocked.py
+++ b/tests/unit/api/test_scrubber_mocked.py
@@ -8,7 +8,8 @@ internal mathematical logic directly.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_tools():
+def mock_tools() -> Generator[tuple[MagicMock, ...], None, None]:
     """Mock the scrubber calculators securely from Tools."""
     with (
         patch(

--- a/tests/unit/api/test_simulation_service.py
+++ b/tests/unit/api/test_simulation_service.py
@@ -4,7 +4,7 @@ These tests verify the simulation service using Design by Contract principles.
 """
 
 from enum import Enum
-from typing import NoReturn
+from typing import Any, NoReturn
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -53,7 +53,7 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def mock_engine_manager():
+def mock_engine_manager() -> MagicMock:
     """Create a mock engine manager."""
     manager = MagicMock(spec=EngineManager)
     manager._load_engine = MagicMock()
@@ -62,7 +62,7 @@ def mock_engine_manager():
 
 
 @pytest.fixture
-def simulation_service(mock_engine_manager):
+def simulation_service(mock_engine_manager: MagicMock) -> Any:
     """Create a simulation service instance."""
     from src.api.services.simulation_service import SimulationService
 

--- a/tests/unit/api/test_syngas_water_mocked.py
+++ b/tests/unit/api/test_syngas_water_mocked.py
@@ -8,6 +8,7 @@ internal mathematical logic.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_calculator():
+def mock_calculator() -> Generator[MagicMock, None, None]:
     """Mock the SyngasWaterCalculator securely from Tools."""
     with patch(
         "upstream_drift_tools.process_calculators.syngas_water_calculator.SyngasWaterCalculator"
@@ -33,7 +34,7 @@ def mock_calculator():
 
 
 @pytest.fixture
-def mock_estimate_risk():
+def mock_estimate_risk() -> Generator[MagicMock, None, None]:
     """Mock the estimate_condensation_risk function."""
     with patch(
         "upstream_drift_tools.process_calculators.syngas_water_calculator.estimate_condensation_risk"

--- a/tests/unit/api/test_tracing.py
+++ b/tests/unit/api/test_tracing.py
@@ -335,7 +335,7 @@ class TestRequestTracer:
         mock_response.status_code = 200
 
         # Mock call_next
-        async def mock_call_next(request):
+        async def mock_call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         with patch("src.api.utils.tracing.logger"):
@@ -366,7 +366,7 @@ class TestRequestTracer:
         mock_response.headers = {}
         mock_response.status_code = 200
 
-        async def mock_call_next(request):
+        async def mock_call_next(request: MagicMock) -> MagicMock:
             return mock_response
 
         with patch("src.api.utils.tracing.logger"):

--- a/tests/unit/api/test_wgs_reactor_mocked.py
+++ b/tests/unit/api/test_wgs_reactor_mocked.py
@@ -8,6 +8,7 @@ internal mathematical logic.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,7 @@ client = TestClient(_app)
 
 
 @pytest.fixture
-def mock_engine():
+def mock_engine() -> Generator[MagicMock, None, None]:
     """Mock the WGSReactorEngine securely from Tools."""
     with patch(
         "upstream_drift_tools.process_calculators.WGSReactorEngine"

--- a/tests/unit/core/test_contract_invariants.py
+++ b/tests/unit/core/test_contract_invariants.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from src.shared.python.core.contracts.exceptions import InvariantError
@@ -37,7 +39,7 @@ class TestContractChecker:
             def __init__(self) -> None:
                 self.mass = 1.0
 
-            def _get_invariants(self):
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.mass > 0, "mass must be positive")]
 
         obj = MyClass()
@@ -48,7 +50,7 @@ class TestContractChecker:
             def __init__(self) -> None:
                 self.mass = -1.0
 
-            def _get_invariants(self):
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.mass > 0, "mass must be positive")]
 
         obj = MyClass()
@@ -61,7 +63,7 @@ class TestContractChecker:
                 self.mass = 1.0
                 self.timestep = 0.01
 
-            def _get_invariants(self):
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [
                     (lambda: self.mass > 0, "mass must be positive"),
                     (lambda: self.timestep > 0, "timestep must be positive"),
@@ -84,7 +86,7 @@ class TestInvariantCheckedDecorator:
             def __init__(self) -> None:
                 self.count = 0
 
-            def _get_invariants(self):
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.count >= 0, "count must be non-negative")]
 
             @invariant_checked
@@ -100,7 +102,7 @@ class TestInvariantCheckedDecorator:
             def __init__(self) -> None:
                 self.value = 1.0
 
-            def _get_invariants(self):
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.value > 0, "value must be positive")]
 
             @invariant_checked

--- a/tests/unit/dbc/test_dbc_biomechanics.py
+++ b/tests/unit/dbc/test_dbc_biomechanics.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 
 import numpy as np
 
@@ -68,7 +69,7 @@ class TestMuscleParametersPreconditions(unittest.TestCase):
 class TestForceLengthActivePostconditions(unittest.TestCase):
     """force_length_active must be ~1.0 at optimal length and < 1 elsewhere."""
 
-    def _make_model(self):  # type: ignore[no-untyped-def]
+    def _make_model(self) -> Any:
         from src.shared.python.biomechanics.hill_muscle import (
             HillMuscleModel,
             MuscleParameters,
@@ -101,7 +102,7 @@ class TestForceLengthActivePostconditions(unittest.TestCase):
 class TestForceLengthPassivePostconditions(unittest.TestCase):
     """Passive force must be zero below optimal length, positive above."""
 
-    def _make_model(self):  # type: ignore[no-untyped-def]
+    def _make_model(self) -> Any:
         from src.shared.python.biomechanics.hill_muscle import (
             HillMuscleModel,
             MuscleParameters,
@@ -136,7 +137,7 @@ class TestForceLengthPassivePostconditions(unittest.TestCase):
 class TestForceVelocityPostconditions(unittest.TestCase):
     """force_velocity must satisfy Hill's hyperbola constraints."""
 
-    def _make_model(self):  # type: ignore[no-untyped-def]
+    def _make_model(self) -> Any:
         from src.shared.python.biomechanics.hill_muscle import (
             HillMuscleModel,
             MuscleParameters,
@@ -171,7 +172,7 @@ class TestForceVelocityPostconditions(unittest.TestCase):
 class TestTendonForcePostconditions(unittest.TestCase):
     """Tendon force must be zero when slack, positive when stretched."""
 
-    def _make_model(self):  # type: ignore[no-untyped-def]
+    def _make_model(self) -> Any:
         from src.shared.python.biomechanics.hill_muscle import (
             HillMuscleModel,
             MuscleParameters,
@@ -204,7 +205,7 @@ class TestTendonForcePostconditions(unittest.TestCase):
 class TestComputeForcePostconditions(unittest.TestCase):
     """compute_force must return non-negative total force."""
 
-    def _make_model(self):  # type: ignore[no-untyped-def]
+    def _make_model(self) -> Any:
         from src.shared.python.biomechanics.hill_muscle import (
             HillMuscleModel,
             MuscleParameters,

--- a/tests/unit/dbc/test_dbc_contracts_core.py
+++ b/tests/unit/dbc/test_dbc_contracts_core.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from collections.abc import Callable
 
 import numpy as np
 
@@ -207,7 +208,7 @@ class TestContractChecker(unittest.TestCase):
             def __init__(self) -> None:
                 self.mass = 1.0
 
-            def _get_invariants(self):  # type: ignore[no-untyped-def]
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.mass > 0, "mass must be positive")]
 
         checker = TestChecker()
@@ -220,7 +221,7 @@ class TestContractChecker(unittest.TestCase):
             def __init__(self) -> None:
                 self.mass = -1.0
 
-            def _get_invariants(self):  # type: ignore[no-untyped-def]
+            def _get_invariants(self) -> list[tuple[Callable[[], bool], str]]:
                 return [(lambda: self.mass > 0, "mass must be positive")]
 
         checker = TestChecker()

--- a/tests/unit/dbc/test_dbc_friction_cone.py
+++ b/tests/unit/dbc/test_dbc_friction_cone.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 
 import numpy as np
 
@@ -56,7 +57,7 @@ class TestFrictionConePreconditions(unittest.TestCase):
 class TestFrictionConeContains(unittest.TestCase):
     """FrictionCone.contains() postconditions."""
 
-    def _cone(self, mu: float = 0.5):  # type: ignore[no-untyped-def]
+    def _cone(self, mu: float = 0.5) -> Any:
         from src.robotics.contact.friction_cone import FrictionCone
 
         return FrictionCone(mu=mu, normal=np.array([0.0, 0.0, 1.0]))
@@ -185,7 +186,7 @@ class TestLinearizeFrictionConePostconditions(unittest.TestCase):
 class TestProjectToFrictionCone(unittest.TestCase):
     """project_to_friction_cone postconditions."""
 
-    def _cone(self, mu: float = 0.5):  # type: ignore[no-untyped-def]
+    def _cone(self, mu: float = 0.5) -> Any:
         from src.robotics.contact.friction_cone import FrictionCone
 
         return FrictionCone(mu=mu, normal=np.array([0.0, 0.0, 1.0]))

--- a/tests/unit/dbc/test_dbc_impact_and_flight.py
+++ b/tests/unit/dbc/test_dbc_impact_and_flight.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 
 import numpy as np
 
@@ -108,7 +109,7 @@ class TestRigidBodyImpactPreconditions(unittest.TestCase):
 class TestRigidBodyImpactPostconditions(unittest.TestCase):
     """Physical postconditions for rigid body impact."""
 
-    def _solve(self, clubhead_vel: float = 45.0, cor: float = 0.83):  # type: ignore[no-untyped-def]
+    def _solve(self, clubhead_vel: float = 45.0, cor: float = 0.83) -> Any:
         from src.shared.python.physics.impact_model import RigidBodyImpactModel
 
         model = RigidBodyImpactModel()
@@ -351,7 +352,7 @@ class TestSimulateTrajectoryPreconditions(unittest.TestCase):
 class TestTrajectoryPostconditions(unittest.TestCase):
     """Physical postconditions for trajectory simulation (requires Rust kernel)."""
 
-    def _simulate(self, velocity: float = 50.0, angle: float = 0.2):  # type: ignore[no-untyped-def]
+    def _simulate(self, velocity: float = 50.0, angle: float = 0.2) -> Any:
         from src.shared.python.physics.ball_flight_physics import (
             BallFlightSimulator,
             LaunchConditions,

--- a/tests/unit/dbc/test_dbc_zmp_robotics.py
+++ b/tests/unit/dbc/test_dbc_zmp_robotics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -59,7 +60,7 @@ class TestZMPComputerInvariants(unittest.TestCase):
 class TestComputeZMPPostconditions(unittest.TestCase):
     """compute_zmp() postconditions."""
 
-    def _make_computer(self):  # type: ignore[no-untyped-def]
+    def _make_computer(self) -> Any:
         from src.robotics.locomotion.zmp_computer import ZMPComputer
 
         return ZMPComputer(_make_mock_engine())

--- a/tests/unit/engines/drake/test_drake_perturbation_analyzer.py
+++ b/tests/unit/engines/drake/test_drake_perturbation_analyzer.py
@@ -13,6 +13,8 @@ Design by Contract
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -198,7 +200,7 @@ class TestComparisonReport:
 
 
 @pytest.fixture(scope="module")
-def analyzer():  # type: ignore[no-untyped-def]
+def analyzer() -> Any:  # type: ignore[no-untyped-def]
     from src.engines.physics_engines.drake.python.perturbation.analyzer import (
         DrakePerturbationAnalyzer,
     )
@@ -214,7 +216,7 @@ def simple_profile(analyzer) -> dict:  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture(scope="module")
-def analyzer_with_profile(analyzer, simple_profile):  # type: ignore[no-untyped-def]
+def analyzer_with_profile(analyzer, simple_profile) -> Any:  # type: ignore[no-untyped-def]
     analyzer.set_base_torque_profile(simple_profile)
     return analyzer
 

--- a/tests/unit/engines/mujoco/test_mujoco_perturbation_analyzer.py
+++ b/tests/unit/engines/mujoco/test_mujoco_perturbation_analyzer.py
@@ -11,6 +11,8 @@ Design by Contract
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -198,7 +200,7 @@ class TestComparisonReport:
 
 
 @pytest.fixture(scope="module")
-def analyzer():  # type: ignore[no-untyped-def]
+def analyzer() -> Any:  # type: ignore[no-untyped-def]
     from src.engines.physics_engines.mujoco.python.perturbation.analyzer import (
         MuJoCoPerturbationAnalyzer,
     )
@@ -207,7 +209,7 @@ def analyzer():  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture(scope="module")
-def analyzer_with_profile(analyzer):  # type: ignore[no-untyped-def]
+def analyzer_with_profile(analyzer) -> Any:  # type: ignore[no-untyped-def]
     analyzer.set_base_torque_profile(_ZERO_PROFILE)
     return analyzer
 

--- a/tests/unit/engines/myosuite/test_myosuite_perturbation_analyzer.py
+++ b/tests/unit/engines/myosuite/test_myosuite_perturbation_analyzer.py
@@ -11,6 +11,8 @@ Design by Contract
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -209,7 +211,7 @@ class TestComparisonReport:
 
 
 @pytest.fixture(scope="module")
-def analyzer():  # type: ignore[no-untyped-def]
+def analyzer() -> Any:  # type: ignore[no-untyped-def]
     from src.engines.physics_engines.myosuite.python.perturbation.analyzer import (
         MyoSuitePerturbationAnalyzer,
     )
@@ -219,7 +221,7 @@ def analyzer():  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture(scope="module")
-def analyzer_with_profile(analyzer):  # type: ignore[no-untyped-def]
+def analyzer_with_profile(analyzer) -> Any:  # type: ignore[no-untyped-def]
     analyzer.set_base_torque_profile(_ZERO_PROFILE)
     return analyzer
 

--- a/tests/unit/engines/myosuite/test_myosuite_physics_engine.py
+++ b/tests/unit/engines/myosuite/test_myosuite_physics_engine.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
@@ -9,7 +12,7 @@ import pytest
 class TestIssue2483MyoSuiteTerminationHandling:
     """Issue #2483: step() must handle environment termination state."""
 
-    def _make_engine_with_mock_env(self):
+    def _make_engine_with_mock_env(self) -> tuple[Any, MagicMock]:
         """Create MyoSuitePhysicsEngine with a mocked Gym environment."""
         try:
             from src.engines.physics_engines.myosuite.python.myosuite_physics_engine import (

--- a/tests/unit/engines/opensim/test_opensim_perturbation_analyzer.py
+++ b/tests/unit/engines/opensim/test_opensim_perturbation_analyzer.py
@@ -11,6 +11,8 @@ Design by Contract
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -198,7 +200,7 @@ class TestComparisonReport:
 
 
 @pytest.fixture(scope="module")
-def analyzer():  # type: ignore[no-untyped-def]
+def analyzer() -> Any:  # type: ignore[no-untyped-def]
     from src.engines.physics_engines.opensim.python.perturbation.analyzer import (
         OpenSimPerturbationAnalyzer,
     )
@@ -207,7 +209,7 @@ def analyzer():  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture(scope="module")
-def analyzer_with_profile(analyzer):  # type: ignore[no-untyped-def]
+def analyzer_with_profile(analyzer) -> Any:  # type: ignore[no-untyped-def]
     analyzer.set_base_torque_profile(_ZERO_PROFILE)
     return analyzer
 

--- a/tests/unit/engines/pendulum/test_desktop_state_bugs.py
+++ b/tests/unit/engines/pendulum/test_desktop_state_bugs.py
@@ -13,6 +13,7 @@ Bugs covered:
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import pytest
 from double_pendulum_model.physics.double_pendulum import (
@@ -25,7 +26,7 @@ from src.shared.python.ui.qt.utils import get_qapp
 
 
 @pytest.fixture(scope="module")
-def qapp():
+def qapp() -> Any:
     """Shared QApplication for the module."""
     return get_qapp()
 

--- a/tests/unit/engines/pinocchio/test_pinocchio_perturbation_analyzer.py
+++ b/tests/unit/engines/pinocchio/test_pinocchio_perturbation_analyzer.py
@@ -14,6 +14,7 @@ Design by Contract
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -210,7 +211,7 @@ def urdf_path() -> Path:
 
 
 @pytest.fixture(scope="module")
-def analyzer(urdf_path: Path):  # type: ignore[no-untyped-def]
+def analyzer(urdf_path: Path) -> Any:  # type: ignore[no-untyped-def]
     from src.engines.physics_engines.pinocchio.python.perturbation.analyzer import (
         PinocchioPerturbationAnalyzer,
     )
@@ -225,7 +226,7 @@ def simple_profile(analyzer) -> dict:  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture(scope="module")
-def analyzer_with_profile(analyzer, simple_profile):  # type: ignore[no-untyped-def]
+def analyzer_with_profile(analyzer, simple_profile) -> Any:  # type: ignore[no-untyped-def]
     analyzer.set_base_torque_profile(simple_profile)
     return analyzer
 

--- a/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
+++ b/tests/unit/engines/pinocchio/test_pinocchio_physics_engine.py
@@ -1,5 +1,9 @@
 """Tests for src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 
@@ -19,7 +23,7 @@ def test_import() -> None:
 class TestIssue2483PinocchioSetStateInvariants:
     """Issue #2483: set_state() must validate sizes and refresh derived kinematics."""
 
-    def _make_engine_with_mock_model(self):
+    def _make_engine_with_mock_model(self) -> Any:
         """Create a PinocchioPhysicsEngine with a mocked pinocchio model."""
         try:
             from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (

--- a/tests/unit/engines/pinocchio/test_screw_kinematics.py
+++ b/tests/unit/engines/pinocchio/test_screw_kinematics.py
@@ -7,6 +7,7 @@ availability guard and ``ImportError`` path are always tested.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -211,7 +212,7 @@ class TestWithRealPinocchio:
     """Integration tests that require the real pinocchio package."""
 
     @pytest.fixture
-    def double_pendulum(self):
+    def double_pendulum(self) -> Any:
         """Simple 2-DOF planar double pendulum model in pinocchio."""
         pin = pytest.importorskip("pinocchio")
 

--- a/tests/unit/examples/test_examples.py
+++ b/tests/unit/examples/test_examples.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 EXAMPLES_DIR = Path(__file__).resolve().parent.parent.parent.parent / "examples"
@@ -41,7 +44,7 @@ def test_basic_flight_simulation(monkeypatch) -> None:
             self.vx, self.vy, self.vz = 70.0, 0.0, 10.0
 
     class _FakeResult:
-        def get_points(self):
+        def get_points(self) -> list[Any]:
             return [_FakePoint(i * 0.05, i * 3.0, max(0.0, 20.0 - i)) for i in range(5)]
 
     fake_physics.IntegratorConfig = MagicMock(return_value=object())

--- a/tests/unit/installer/test_build_installer.py
+++ b/tests/unit/installer/test_build_installer.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,7 +13,7 @@ def test_check_prerequisites(monkeypatch) -> None:
     original_import = __import__
 
     # Test failure
-    def mock_import_fail(name, *args, **kwargs):
+    def mock_import_fail(name, *args, **kwargs) -> Any:
         if name == "cx_Freeze":
             raise ImportError
         return original_import(name, *args, **kwargs)
@@ -23,7 +26,7 @@ def test_check_prerequisites(monkeypatch) -> None:
     mock_cx = MagicMock()
     mock_cx.version = "1.0.0"
 
-    def mock_import_success(name, *args, **kwargs):
+    def mock_import_success(name, *args, **kwargs) -> Any:
         if name == "cx_Freeze":
             return mock_cx
         return original_import(name, *args, **kwargs)
@@ -37,7 +40,7 @@ def test_check_prerequisites_logs_cx_freeze_version(monkeypatch, caplog) -> None
     mock_cx = MagicMock()
     mock_cx.version = "9.9.9"
 
-    def mock_import_success(name, *args, **kwargs):
+    def mock_import_success(name, *args, **kwargs) -> Any:
         if name == "cx_Freeze":
             return mock_cx
         return original_import(name, *args, **kwargs)
@@ -82,7 +85,7 @@ def test_install_dependencies_fail(mock_run) -> None:
 
 
 def test_detect_physics_engines(monkeypatch) -> None:
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name in ("mujoco", "pinocchio"):
             return MagicMock()
         raise ImportError

--- a/tests/unit/installer/test_setup_config.py
+++ b/tests/unit/installer/test_setup_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 import pytest
 
@@ -15,7 +15,7 @@ from installer.windows.setup_config import (
 def test_detect_available_engines_core_skips_optional_imports() -> None:
     imported: list[str] = []
 
-    def fake_import(name: str):
+    def fake_import(name: str) -> Any:
         imported.append(name)
         if name == "mujoco":
             return object()
@@ -33,7 +33,7 @@ def test_detect_available_engines_core_skips_optional_imports() -> None:
 def test_detect_available_engines_hybrid_includes_optional_imports() -> None:
     imported: list[str] = []
 
-    def fake_import(name: str):
+    def fake_import(name: str) -> Any:
         imported.append(name)
         if name in {"mujoco", "pydrake", "pinocchio"}:
             return object()
@@ -46,7 +46,7 @@ def test_detect_available_engines_hybrid_includes_optional_imports() -> None:
 
 
 def test_build_setup_configuration_core_omits_api_executable() -> None:
-    def fake_import(name: str):
+    def fake_import(name: str) -> Any:
         if name == "mujoco":
             return object()
         raise ImportError
@@ -59,7 +59,7 @@ def test_build_setup_configuration_core_omits_api_executable() -> None:
 
 
 def test_build_setup_configuration_full_includes_api_executable() -> None:
-    def fake_import(name: str):
+    def fake_import(name: str) -> Any:
         if name in {"mujoco", "pydrake"}:
             return object()
         raise ImportError

--- a/tests/unit/installer/test_windows_setup.py
+++ b/tests/unit/installer/test_windows_setup.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 import types
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 from unittest.mock import MagicMock
 
 from installer.windows import setup_config
@@ -62,7 +64,7 @@ def _fake_setup_configuration(
     )
 
 
-def _load_setup_module(monkeypatch):
+def _load_setup_module(monkeypatch) -> tuple[ModuleType, Any]:
     fake_cx_freeze = types.ModuleType("cx_Freeze")
     fake_cx_freeze.Executable = lambda *args, **kwargs: {
         "args": args,

--- a/tests/unit/perturbation/test_perturbation_base.py
+++ b/tests/unit/perturbation/test_perturbation_base.py
@@ -525,10 +525,10 @@ class TestAbstractMethods:
         """A class missing any abstract method should raise TypeError."""
 
         class Partial(PerturbationAnalyzerBase):
-            def _simulate(self, coeffs):  # type: ignore[override]
+            def _simulate(self, coeffs) -> _StubSimResult:  # type: ignore[override]
                 return _make_stub_result()
 
-            def _get_q_traj(self, r):  # type: ignore[override]
+            def _get_q_traj(self, r) -> np.ndarray:  # type: ignore[override]
                 return r.q_traj
 
             # Missing _get_v_traj and _validate_sim_result_type

--- a/tests/unit/plotting/test_force_vector_renderer.py
+++ b/tests/unit/plotting/test_force_vector_renderer.py
@@ -41,7 +41,7 @@ def mock_data_manager() -> MagicMock:
     # Force vectors: (50, 3, 3) — 50 frames, 3 joints, 3D
     forces = np.random.default_rng(42).uniform(-100, 100, (50, 3, 3))
 
-    def mock_get_series(field_name: str):
+    def mock_get_series(field_name: str) -> tuple[np.ndarray, np.ndarray]:
         if field_name == "joint_world_positions":
             return times, positions
         if field_name == "joint_forces":

--- a/tests/unit/process_calculators/test_analysis_utils.py
+++ b/tests/unit/process_calculators/test_analysis_utils.py
@@ -14,7 +14,7 @@ from src.shared.python.upstream_drift_tools.process_calculators.analysis_utils i
 class _StubEngine:
     """Minimal engine stub: calculate(**params) returns a dict."""
 
-    def calculate(self, **params):
+    def calculate(self, **params) -> dict:
         return {
             "efficiency": 0.75,
             "power": params.get("manual_hhv", 0.0) * 2.0,

--- a/tests/unit/process_calculators/test_multi_param_analysis.py
+++ b/tests/unit/process_calculators/test_multi_param_analysis.py
@@ -13,7 +13,7 @@ from src.shared.python.upstream_drift_tools.process_calculators.multi_param_anal
 class _StubEngine:
     """Simple engine: output = p1 + p2."""
 
-    def calculate(self, **params):
+    def calculate(self, **params) -> dict:
         return {
             "output": params.get("p1", 0.0) + params.get("p2", 0.0),
         }

--- a/tests/unit/process_calculators/test_optimization.py
+++ b/tests/unit/process_calculators/test_optimization.py
@@ -16,7 +16,7 @@ from src.shared.python.upstream_drift_tools.process_calculators.optimization imp
 class _StubEngine:
     """Engine that computes output = Temperature - 0.5 * (O2/Feed Ratio)."""
 
-    def calculate(self, **params):
+    def calculate(self, **params) -> dict:
         temp = params.get("Temperature", 800.0)
         o2 = params.get("O2/Feed Ratio", 0.3)
         return {
@@ -156,7 +156,7 @@ class TestRunAdamOptimization:
 
 
 class TestFindOptimalOnSurface:
-    def _make_grid(self):
+    def _make_grid(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         x = np.linspace(0.0, 10.0, 20)
         y = np.linspace(0.0, 10.0, 20)
         # Z = -(x-5)^2 - (y-5)^2 → max at (5,5)

--- a/tests/unit/shared_python/ai/adapters/test_ai_adapters_base.py
+++ b/tests/unit/shared_python/ai/adapters/test_ai_adapters_base.py
@@ -1,5 +1,7 @@
 """Tests for the base AI adapter module."""
 
+from collections.abc import Iterator
+
 from src.shared.python.ai.adapters.base import BaseAgentAdapter, ToolDeclaration
 from src.shared.python.ai.types import (
     AgentChunk,
@@ -20,7 +22,7 @@ class DummyAdapter(BaseAgentAdapter):
 
     def stream_response(
         self, message: str, context: ConversationContext, tools: list[ToolDeclaration]
-    ):
+    ) -> Iterator[AgentChunk]:
         yield AgentChunk(content="test")
 
     @property

--- a/tests/unit/shared_python/ai/adapters/test_anthropic_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_anthropic_adapter.py
@@ -11,6 +11,7 @@ sys.modules["anthropic"] = anthropic_mock
 # for gemini
 if "anthropic" == "google.generativeai":
     sys.modules["google"] = MagicMock()
+from typing import Any  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -34,7 +35,7 @@ from src.shared.python.ai.types import (  # noqa: E402
 
 
 @pytest.fixture
-def adapter():
+def adapter() -> AnthropicAdapter:
     """Provide a configured AnthropicAdapter."""
     return AnthropicAdapter(api_key="sk-ant", model="claude-3", timeout=30.0)
 
@@ -68,7 +69,7 @@ def test_get_client_import_error() -> None:
 
     real_import = __import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name == "anthropic":
             raise ImportError("No module named 'anthropic'")
         return real_import(name, *args, **kwargs)

--- a/tests/unit/shared_python/ai/adapters/test_gemini_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_gemini_adapter.py
@@ -9,6 +9,7 @@ sys.modules["google"] = MagicMock()
 sys.modules["google.generativeai"] = mock_genai_pkg
 sys.modules["google.generativeai.types"] = MagicMock()
 
+from collections.abc import Generator  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -20,7 +21,7 @@ def reset_mocks() -> None:
 
 
 @pytest.fixture(autouse=True)
-def patch_has_gemini():
+def patch_has_gemini() -> Generator[None, None, None]:
     with patch("src.shared.python.ai.adapters.gemini_adapter.HAS_GEMINI", True):
         yield
 

--- a/tests/unit/shared_python/ai/adapters/test_ollama_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_ollama_adapter.py
@@ -25,6 +25,8 @@ httpx_mock.TimeoutException = MockTimeoutException
 # for gemini
 if "httpx" == "google.generativeai":
     sys.modules["google"] = MagicMock()
+from collections.abc import Iterator  # noqa: E402
+from typing import Any  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -51,7 +53,7 @@ from src.shared.python.ai.types import (  # noqa: E402
 
 
 @pytest.fixture
-def adapter():
+def adapter() -> OllamaAdapter:
     """Provide a configured OllamaAdapter."""
     return OllamaAdapter(
         host="http://localhost:11434", model="llama3.1:8b", timeout=10.0
@@ -71,7 +73,7 @@ def test_get_client_import_error() -> None:
 
     real_import = __import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name == "httpx":
             raise ImportError("No httpx provided")
         return real_import(name, *args, **kwargs)
@@ -263,7 +265,7 @@ def test_stream_response(mock_get_client, adapter) -> None:
                 def raise_for_status(self) -> None:
                     pass
 
-                def iter_lines(self):
+                def iter_lines(self) -> Iterator[str]:
                     yield json.dumps({"message": {"content": "Hel"}})
                     yield json.dumps({"message": {"content": "lo"}, "done": True})
 

--- a/tests/unit/shared_python/ai/adapters/test_openai_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_openai_adapter.py
@@ -11,6 +11,7 @@ sys.modules["openai"] = openai_mock
 # for gemini
 if "openai" == "google.generativeai":
     sys.modules["google"] = MagicMock()
+from typing import Any  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
@@ -32,7 +33,7 @@ from src.shared.python.ai.types import (  # noqa: E402
 
 
 @pytest.fixture
-def adapter():
+def adapter() -> OpenAIAdapter:
     """Provide a configured OpenAIAdapter."""
     return OpenAIAdapter(api_key="sk-test", model="gpt-4-test", timeout=30.0)
 
@@ -67,7 +68,7 @@ def test_get_client_import_error() -> None:
     # Force ImportError when importing OpenAI
     real_import = __import__
 
-    def mock_import(name, *args, **kwargs):
+    def mock_import(name, *args, **kwargs) -> Any:
         if name == "openai":
             raise ImportError("No module named 'openai'")
         return real_import(name, *args, **kwargs)

--- a/tests/unit/shared_python/test_ai_education.py
+++ b/tests/unit/shared_python/test_ai_education.py
@@ -115,10 +115,10 @@ def test_load_data_file_entries(monkeypatch) -> None:
     # Coverage for the try-except logic
 
     # We mock get_core_entries and get_extended_entries
-    def mock_get_core():
+    def mock_get_core() -> list[dict]:
         return [{"key": "core_mock", "term": "Core Mock", "cat": "test", "b": "beg"}]
 
-    def mock_get_ext():
+    def mock_get_ext() -> list[dict]:
         return [{"key": "ext_mock", "term": "Ext Mock", "cat": "test", "i": "int"}]
 
     monkeypatch.setattr(

--- a/tests/unit/shared_python/test_ai_tool_registry.py
+++ b/tests/unit/shared_python/test_ai_tool_registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from src.shared.python.ai.exceptions import ToolExecutionError
@@ -26,7 +28,7 @@ def test_tool_parameter_to_json() -> None:
 
 
 def test_tool_to_json_schema() -> None:
-    def handler(a):
+    def handler(a) -> Any:
         return a
 
     t = Tool(
@@ -43,7 +45,7 @@ def test_tool_to_json_schema() -> None:
 
 
 def test_tool_formats() -> None:
-    def handler(a):
+    def handler(a) -> Any:
         return a
 
     t = Tool(name="tool", description="desc", handler=handler)
@@ -58,7 +60,7 @@ def test_tool_formats() -> None:
 
 
 def test_validate_arguments() -> None:
-    def handler(a, b=1):
+    def handler(a, b=1) -> Any:
         return a + b
 
     t = Tool(
@@ -91,7 +93,7 @@ def test_validate_arguments() -> None:
 
 
 def test_execute() -> None:
-    def handler(a):
+    def handler(a) -> Any:
         if a == 0:
             raise ValueError("bad a")
         return a * 2

--- a/tests/unit/shared_python/test_engine_loaders_coverage.py
+++ b/tests/unit/shared_python/test_engine_loaders_coverage.py
@@ -1,6 +1,7 @@
 """Tests for shared.python.engine_loaders coverage."""
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -61,7 +62,7 @@ def test_load_drake_missing(tmp_path: object) -> None:
             else __import__
         )
 
-        def side_effect(name, *args, **kwargs):
+        def side_effect(name, *args, **kwargs) -> Any:
             if name == "pydrake" or name.startswith("pydrake."):
                 raise ImportError(f"No module named {name}")
             return original_import(name, *args, **kwargs)

--- a/tests/unit/test_model_explorer_temp_file.py
+++ b/tests/unit/test_model_explorer_temp_file.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from types import ModuleType
 from typing import NoReturn
@@ -36,7 +37,7 @@ def _make_qt_stubs() -> dict[str, ModuleType]:
 
 
 @pytest.fixture(scope="module")
-def offscreen_renderer_class():
+def offscreen_renderer_class() -> Generator[type, None, None]:
     """Import MuJoCoOffscreenRenderer with PyQt6 stubbed out."""
     with patch.dict(sys.modules, _make_qt_stubs()):
         from src.tools.model_explorer.mujoco_viewer import MuJoCoOffscreenRenderer
@@ -47,7 +48,7 @@ def offscreen_renderer_class():
 class TestIssue2502TempFileHandling:
     """MuJoCoOffscreenRenderer.load_urdf_file must use a unique temp filename."""
 
-    def _mock_mujoco(self):
+    def _mock_mujoco(self) -> MagicMock:
         mock = MagicMock()
         model = MagicMock()
         model.vis.global_.offwidth = 640

--- a/tests/unit/test_mujoco_physics_engine.py
+++ b/tests/unit/test_mujoco_physics_engine.py
@@ -3,6 +3,8 @@
 Uses shared module-level mocks for the mujoco dependency from conftest.py.
 """
 
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -35,7 +37,7 @@ _MJ_DATA_SPEC = [
 
 
 @pytest.fixture(scope="module")
-def MuJoCoPhysicsEngineClass(mock_mujoco_dependencies):
+def MuJoCoPhysicsEngineClass(mock_mujoco_dependencies) -> Generator[type, None, None]:
     """Fixture to provide the MuJoCoPhysicsEngine class with mocked dependencies."""
     import src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine as mod
 
@@ -50,7 +52,7 @@ def MuJoCoPhysicsEngineClass(mock_mujoco_dependencies):
 
 
 @pytest.fixture
-def mock_mj(mock_mujoco_dependencies):
+def mock_mj(mock_mujoco_dependencies) -> MagicMock:
     """Return the shared mujoco mock **and** reset its call tracking.
 
     This avoids ghostly cross-test state while still using a single mock
@@ -62,7 +64,7 @@ def mock_mj(mock_mujoco_dependencies):
 
 
 @pytest.fixture
-def engine(MuJoCoPhysicsEngineClass):
+def engine(MuJoCoPhysicsEngineClass) -> Any:
     """Fixture to provide a MuJoCoPhysicsEngine instance."""
     return MuJoCoPhysicsEngineClass()
 

--- a/tests/unit/test_muscle_contribution_closure.py
+++ b/tests/unit/test_muscle_contribution_closure.py
@@ -44,7 +44,7 @@ if MYOSUITE_AVAILABLE:
         """Test that muscle contributions sum to total acceleration (closure property)."""
 
         @pytest.fixture
-        def elbow_engine(self):  # type: ignore
+        def elbow_engine(self) -> "_MyoSuitePhysicsEngine":  # type: ignore[return]
             """Create MyoSuite elbow model for testing."""
             engine = _MyoSuitePhysicsEngine()
             # Load simple elbow model (1-DOF, 6 muscles)

--- a/tests/unit/test_muscle_equilibrium.py
+++ b/tests/unit/test_muscle_equilibrium.py
@@ -18,7 +18,7 @@ from src.shared.python.core.contracts import PostconditionError
 
 
 @pytest.fixture
-def standard_muscle():
+def standard_muscle() -> HillMuscleModel:
     """Create a standard muscle for testing."""
     params = MuscleParameters(
         F_max=1000.0,  # N
@@ -31,7 +31,7 @@ def standard_muscle():
 
 
 @pytest.fixture
-def pennated_muscle():
+def pennated_muscle() -> HillMuscleModel:
     """Create a pennated muscle for testing."""
     params = MuscleParameters(
         F_max=1500.0,

--- a/tests/unit/test_myoconverter_integration.py
+++ b/tests/unit/test_myoconverter_integration.py
@@ -23,7 +23,7 @@ from src.shared.python.engine_core.engine_availability import (
 
 
 @pytest.fixture
-def temp_osim_file(tmp_path):
+def temp_osim_file(tmp_path) -> Path:
     """Create a temporary valid OpenSim file."""
     osim_path = tmp_path / "test_model.osim"
 
@@ -36,7 +36,7 @@ def temp_osim_file(tmp_path):
 
 
 @pytest.fixture
-def temp_geometry_folder(tmp_path):
+def temp_geometry_folder(tmp_path) -> Path:
     """Create a temporary geometry folder."""
     geom_path = tmp_path / "Geometry"
     geom_path.mkdir()
@@ -44,7 +44,7 @@ def temp_geometry_folder(tmp_path):
 
 
 @pytest.fixture
-def temp_output_folder(tmp_path):
+def temp_output_folder(tmp_path) -> Path:
     """Create a temporary output folder."""
     output_path = tmp_path / "output"
     return output_path

--- a/tests/unit/test_myosuite_adapter.py
+++ b/tests/unit/test_myosuite_adapter.py
@@ -20,7 +20,7 @@ from src.shared.python.biomechanics.myosuite_adapter import (
 
 
 @pytest.fixture
-def mock_muscle_system():
+def mock_muscle_system() -> MagicMock:
     """Create a mock muscle system."""
     system = MagicMock(spec=MuscleGroup)
     system.muscles = {"muscle1": MagicMock(), "muscle2": MagicMock()}

--- a/tests/unit/test_openpose_estimator.py
+++ b/tests/unit/test_openpose_estimator.py
@@ -2,6 +2,7 @@
 """Unit tests for OpenPose pose estimator."""
 
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -28,7 +29,7 @@ op_module.op = mock_op
 
 
 @pytest.fixture
-def op_mock():
+def op_mock() -> Generator[MagicMock, None, None]:
     """Provide a fresh mock for pyopenpose."""
     mock_op.reset_mock()
     op_module.op = mock_op
@@ -36,14 +37,14 @@ def op_mock():
 
 
 @pytest.fixture
-def mock_op_wrapper(op_mock):
+def mock_op_wrapper(op_mock) -> MagicMock:
     wrapper = MagicMock()
     op_mock.WrapperPython.return_value = wrapper
     return wrapper
 
 
 @pytest.fixture
-def estimator(mock_op_wrapper):
+def estimator(mock_op_wrapper) -> OpenPoseEstimator:
     est = OpenPoseEstimator()
     # Mock loaded state for processing tests
     est.wrapper = mock_op_wrapper

--- a/tests/unit/test_opensim_physics_engine.py
+++ b/tests/unit/test_opensim_physics_engine.py
@@ -54,7 +54,7 @@ with (
 
 
 @pytest.fixture
-def engine():
+def engine() -> OpenSimPhysicsEngine:
     # Reset mock_opensim for each test
     mock_opensim.reset_mock()
     # Ensure the engine module's opensim ref points to our mock
@@ -232,10 +232,10 @@ def test_compute_jacobian_scales_finite_difference_step(engine) -> None:
         def __init__(self, x):
             self._x = x
 
-        def p(self):
+        def p(self) -> list[float]:
             return [self._x, 0.0, 0.0]
 
-        def R(self):
+        def R(self) -> MagicMock:
             return MagicMock()
 
     body = MagicMock()

--- a/tests/unit/test_optimize_arm.py
+++ b/tests/unit/test_optimize_arm.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -55,7 +56,7 @@ def teardown_module(module) -> None:
 
 
 @pytest.fixture
-def mock_casadi():
+def mock_casadi() -> MagicMock:
     opti = MagicMock()
     # Mock variable creation
     mock_var = MagicMock()
@@ -88,7 +89,7 @@ def mock_casadi():
     # Set up value side effect to return appropriate mock data
     call_count = 0
 
-    def value_side_effect(arg):
+    def value_side_effect(arg) -> Any:
         nonlocal call_count
         call_count += 1
         # Return data based on call order: Q, V, U, cost
@@ -113,7 +114,7 @@ def mock_casadi():
 
 
 @pytest.fixture
-def mock_pinocchio():
+def mock_pinocchio() -> MagicMock:
     # Mock model
     model = MagicMock()
     model.nq = 2

--- a/tests/unit/test_output_manager.py
+++ b/tests/unit/test_output_manager.py
@@ -7,6 +7,7 @@ import os
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -47,19 +48,19 @@ def _has_hdf5_support() -> bool | None:
 
 
 @pytest.fixture
-def temp_output_dir(tmp_path):
+def temp_output_dir(tmp_path) -> Path:
     """Create a temporary output directory for testing."""
     return tmp_path / "output"
 
 
 @pytest.fixture
-def output_manager(temp_output_dir):
+def output_manager(temp_output_dir) -> OutputManager:
     """Create an OutputManager instance with temporary directory."""
     return OutputManager(base_path=temp_output_dir)
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> pd.DataFrame:
     """Create sample data for testing."""
     return pd.DataFrame(
         {
@@ -71,7 +72,7 @@ def sample_data():
 
 
 @pytest.fixture
-def sample_dict_data():
+def sample_dict_data() -> dict[str, Any]:
     """Create sample dictionary data for testing."""
     return {
         "metadata": {"version": "1.0"},

--- a/tests/unit/test_pendulum_putter_physics.py
+++ b/tests/unit/test_pendulum_putter_physics.py
@@ -7,6 +7,7 @@ and has correct physical properties.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -94,7 +95,7 @@ class TestModelValidationForEngines:
     """Test that model meets requirements for physics engine loading."""
 
     @pytest.fixture
-    def model_result(self):
+    def model_result(self) -> Any:
         """Build model result for testing."""
         from model_generation.models.pendulum_putter import PendulumPutterModelBuilder
 


### PR DESCRIPTION
## Summary

Wave 2 of return type annotation work for issue #2385:

- Added correct return type annotations to 307 functions in `tests/`, `scripts/`, and `examples/`
- Used `Any` for fixture functions with lazy imports (types only available after `from X import Y` inside the function)
- Imported specific types (`ScrewAxis`, `Generator[T, None, None]`, etc.) where available at module scope
- Fixed F821/UP037/F401 violations introduced by incorrect string annotations in agent-generated fixes
- Reduces ANN201/ANN202 violations from 468 → ~161 (all in remaining uncovered test files)
- **Zero violations** in configured ruff rules (`ruff check .`)

## Test plan

- [ ] `ruff check .` passes (zero violations in configured rules)
- [ ] `ruff format --check .` passes
- [ ] `rust-quality-gate` passes (no Rust changes)

Addresses #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)