### PR TITLE
feat: add return type annotations, wave 3 (issue #2385)

### DIFF
--- a/tests/unit/test_activation_dynamics.py
+++ b/tests/unit/test_activation_dynamics.py
@@ -59,7 +59,7 @@ class TestComputeDerivative:
     """Test compute_derivative method."""
 
     @pytest.fixture
-    def dynamics(self):
+    def dynamics(self) -> ActivationDynamics:
         """Create standard activation dynamics instance."""
         return ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
@@ -173,7 +173,7 @@ class TestUpdate:
     """Test update method."""
 
     @pytest.fixture
-    def dynamics(self):
+    def dynamics(self) -> ActivationDynamics:
         """Create standard activation dynamics instance."""
         return ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
@@ -242,7 +242,7 @@ class TestStepResponse:
     """Test step response behavior."""
 
     @pytest.fixture
-    def dynamics(self):
+    def dynamics(self) -> ActivationDynamics:
         """Create standard activation dynamics instance."""
         return ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
@@ -426,7 +426,7 @@ class TestNumericalStability:
     """Test numerical stability and edge cases."""
 
     @pytest.fixture
-    def dynamics(self):
+    def dynamics(self) -> ActivationDynamics:
         """Create standard activation dynamics instance."""
         return ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
@@ -499,7 +499,7 @@ class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
     @pytest.fixture
-    def dynamics(self):
+    def dynamics(self) -> ActivationDynamics:
         """Create standard activation dynamics instance."""
         return ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 

--- a/tests/unit/test_analyze_completist_data.py
+++ b/tests/unit/test_analyze_completist_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import types
 from datetime import datetime
 from pathlib import Path
 
@@ -11,7 +12,7 @@ SCRIPT_PATH = (
 )
 
 
-def _load_module():
+def _load_module() -> types.ModuleType:
     spec = importlib.util.spec_from_file_location(
         "analyze_completist_data", SCRIPT_PATH
     )

--- a/tests/unit/test_api_architecture.py
+++ b/tests/unit/test_api_architecture.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 
@@ -277,7 +279,7 @@ class TestAPIVersioning:
     """Tests for API versioning under /api/v1/ prefix (#1488)."""
 
     @pytest.fixture
-    def client(self):
+    def client(self) -> Generator[Any, None, None]:
         """Create a test client for the API."""
         httpx = pytest.importorskip("httpx")  # noqa: F841
         fastapi = pytest.importorskip("fastapi")  # noqa: F841
@@ -465,7 +467,7 @@ class TestOpenAPIEnhancements:
     """Tests for OpenAPI schema improvements (#1488)."""
 
     @pytest.fixture
-    def client(self):
+    def client(self) -> Generator[Any, None, None]:
         """Create a test client for the API."""
         httpx = pytest.importorskip("httpx")  # noqa: F841
         fastapi = pytest.importorskip("fastapi")  # noqa: F841

--- a/tests/unit/test_api_extended.py
+++ b/tests/unit/test_api_extended.py
@@ -12,7 +12,9 @@ This addresses the API test coverage gap identified in Assessment G.
 """
 
 import io
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -29,7 +31,7 @@ except ImportError as e:
 
 
 @pytest.fixture
-def client():
+def client() -> Generator[Any, None, None]:
     """Create a test client for the API."""
     with TestClient(app) as test_client:
         yield test_client

--- a/tests/unit/test_c3d_export_features.py
+++ b/tests/unit/test_c3d_export_features.py
@@ -1,7 +1,9 @@
 """Tests for C3D export security, versioning, and telemetry features."""
 
 import json
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -21,7 +23,7 @@ class TestC3DExportFeatures:
     """Tests for the enhanced export functionality."""
 
     @pytest.fixture
-    def mock_reader(self):
+    def mock_reader(self) -> C3DDataReader:
         """Create a reader with a mocked get_metadata method."""
         reader = C3DDataReader("test_capture.c3d")
         # Mock underlying data to allow export to proceed (it calls self.get_metadata().units)
@@ -31,7 +33,7 @@ class TestC3DExportFeatures:
         return reader
 
     @pytest.fixture
-    def sample_dataframe(self):
+    def sample_dataframe(self) -> pd.DataFrame:
         """Create a dummy DataFrame for export."""
         return pd.DataFrame(
             {
@@ -45,7 +47,7 @@ class TestC3DExportFeatures:
         )
 
     @pytest.fixture
-    def mock_project_root(self, tmp_path):
+    def mock_project_root(self, tmp_path) -> Generator[Any, None, None]:
         """Make tmp_path appear as the project root."""
         with patch("pathlib.Path.cwd") as mock_cwd:
             mock_cwd.return_value = Path(tmp_path).resolve()

--- a/tests/unit/test_calculators_base.py
+++ b/tests/unit/test_calculators_base.py
@@ -12,13 +12,13 @@ from src.shared.python.upstream_drift_tools.calculators.base import (
 class _ConcreteEngine(BaseCalculationEngine):
     """Minimal concrete implementation for testing the ABC."""
 
-    def calculate(self, *args, **kwargs):
+    def calculate(self, *args, **kwargs) -> dict:
         value = kwargs.get("x", 0.0)
         return {"result": float(value) * 2.0, "status": "ok"}
 
 
 class _AddingEngine(BaseCalculationEngine):
-    def calculate(self, *args, **kwargs):
+    def calculate(self, *args, **kwargs) -> dict:
         a = float(kwargs.get("a", 0.0))
         b = float(kwargs.get("b", 0.0))
         return {"sum": a + b}

--- a/tests/unit/test_config_environment.py
+++ b/tests/unit/test_config_environment.py
@@ -24,7 +24,7 @@ def _set(**kwargs: str) -> patch[dict[str, str]]:
     return patch.dict(os.environ, kwargs)
 
 
-def _unset(*keys: str):
+def _unset(*keys: str) -> patch[dict[str, str]]:
     """Convenience: ensure the given keys are absent from os.environ."""
     env = {k: v for k, v in os.environ.items() if k not in keys}
     return patch.dict(os.environ, env, clear=True)

--- a/tests/unit/test_constraint_solver.py
+++ b/tests/unit/test_constraint_solver.py
@@ -33,7 +33,7 @@ def _make_params() -> GolferParams:
     )
 
 
-def _zero_torque(t):  # noqa: ARG001
+def _zero_torque(t) -> tuple[float, ...]:  # noqa: ARG001
     return (0.0,) * 7
 
 

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 
 from src.shared.python.contracts import (
@@ -26,7 +28,7 @@ _needs_contracts = pytest.mark.skipif(
 
 
 @pytest.fixture(autouse=True)
-def _enforce_contracts():
+def _enforce_contracts() -> Generator[None, None, None]:
     """Force ENFORCE mode by patching the exact module dict that require/ensure read.
 
     set_contract_level() updates sys.modules[__name__], but in a namespace-package
@@ -121,7 +123,7 @@ class TestCheckHelpers:
 class TestPreconditionDecorator:
     def test_decorator_allows_valid_input(self) -> None:
         @precondition(lambda self, x: x > 0, "x must be positive")
-        def compute(self, x):
+        def compute(self, x) -> int:
             return x * 2
 
         assert compute(None, 5) == 10
@@ -132,7 +134,7 @@ class TestPreconditionDecorator:
         try:
 
             @precondition(lambda self, x: x > 0, "x must be positive")
-            def compute(self, x):
+            def compute(self, x) -> int:
                 return x * 2
 
             with pytest.raises((ContractViolationError, AssertionError, ValueError)):

--- a/tests/unit/test_contracts_shared.py
+++ b/tests/unit/test_contracts_shared.py
@@ -6,6 +6,7 @@ This file tests the outer src.shared.python.contracts module.
 
 from __future__ import annotations
 
+import types
 from collections.abc import Generator
 
 import pytest
@@ -30,7 +31,7 @@ def enforce_contracts(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, 
     _contracts.set_contract_level(original_level)
 
 
-def _get_contracts():
+def _get_contracts() -> types.ModuleType:
     """Import after env var is set."""
     import src.shared.python.contracts as c
 

--- a/tests/unit/test_conversion_service_extended.py
+++ b/tests/unit/test_conversion_service_extended.py
@@ -16,6 +16,8 @@ All tests are headless-safe with no heavy dependencies.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -27,7 +29,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def service():
+def service() -> Any:
     """Fresh UnitConversionService for each test."""
     from src.shared.python.upstream_drift_tools.calculators.conversion.service import (
         UnitConversionService,

--- a/tests/unit/test_crba.py
+++ b/tests/unit/test_crba.py
@@ -23,7 +23,7 @@ if MUJOCO_AVAILABLE:
         )
 
 
-def create_random_model(num_bodies=5):
+def create_random_model(num_bodies: int = 5) -> dict:
     """
     Create a random kinematic chain model for testing.
     """

--- a/tests/unit/test_data_fitting.py
+++ b/tests/unit/test_data_fitting.py
@@ -239,7 +239,7 @@ class TestSensitivityAnalyzer:
         analyzer = SensitivityAnalyzer()
 
         # Simple linear model: output = 2 * param
-        def model_func(params):
+        def model_func(params) -> dict:
             return {"output": 2 * params["param"]}
 
         result = analyzer.compute_sensitivity(

--- a/tests/unit/test_data_io.py
+++ b/tests/unit/test_data_io.py
@@ -20,7 +20,7 @@ needs_parquet = pytest.mark.skipif(not HAS_PYARROW, reason="pyarrow not installe
 
 
 @pytest.fixture
-def sample_df():
+def sample_df() -> pd.DataFrame:
     return pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
 
 

--- a/tests/unit/test_data_processing_core_extended.py
+++ b/tests/unit/test_data_processing_core_extended.py
@@ -15,7 +15,15 @@ All tests are headless-safe with no heavy dependencies beyond pandas/numpy.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import pandas as pd
 import pytest
+
+if TYPE_CHECKING:
+    from src.shared.python.upstream_drift_tools.data_processing.core import (
+        DataProcessorEngine,
+    )
 
 pytestmark = pytest.mark.unit
 
@@ -25,10 +33,8 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 
-def _make_df(n: int = 5):
+def _make_df(n: int = 5) -> pd.DataFrame:
     """Return a simple numeric DataFrame with columns a, b."""
-    import pandas as pd
-
     return pd.DataFrame(
         {
             "a": [float(i) for i in range(1, n + 1)],
@@ -37,10 +43,8 @@ def _make_df(n: int = 5):
     )
 
 
-def _make_df_with_group(n: int = 4):
+def _make_df_with_group(n: int = 4) -> pd.DataFrame:
     """Return a DataFrame with numeric columns and a group column."""
-    import pandas as pd
-
     return pd.DataFrame(
         {
             "a": [1.0, 2.0, 3.0, 4.0],
@@ -273,7 +277,7 @@ class TestFitResult:
 
 
 @pytest.fixture
-def engine():
+def engine() -> DataProcessorEngine:
     """Fresh DataProcessorEngine for each test."""
     from src.shared.python.upstream_drift_tools.data_processing.core import (
         DataProcessorEngine,
@@ -283,7 +287,7 @@ def engine():
 
 
 @pytest.fixture
-def loaded_engine():
+def loaded_engine() -> DataProcessorEngine:
     """DataProcessorEngine with a 5-row DataFrame already loaded."""
     from src.shared.python.upstream_drift_tools.data_processing.core import (
         DataProcessorEngine,
@@ -597,10 +601,8 @@ class TestFitCurve:
 class TestSmoothColumn:
     """Tests for DataProcessorEngine.smooth_column."""
 
-    def _long_engine(self):
+    def _long_engine(self) -> DataProcessorEngine:
         """Engine with 20-row data for smoothing."""
-        import pandas as pd
-
         from src.shared.python.upstream_drift_tools.data_processing.core import (
             DataProcessorEngine,
         )

--- a/tests/unit/test_dependency_direction_checker.py
+++ b/tests/unit/test_dependency_direction_checker.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import types
 from pathlib import Path
 
 
-def _load_module():
+def _load_module() -> types.ModuleType:
     script_path = (
         Path(__file__).resolve().parents[2]
         / "scripts"

--- a/tests/unit/test_pendulum_simulation.py
+++ b/tests/unit/test_pendulum_simulation.py
@@ -18,7 +18,7 @@ def _make_params(**kwargs) -> PendulumParams:
     return PendulumParams(**defaults)
 
 
-def _zero_torque(t):
+def _zero_torque(t) -> tuple[float, float]:
     return 0.0, 0.0
 
 

--- a/tests/unit/test_pendulum_simulator_physics.py
+++ b/tests/unit/test_pendulum_simulator_physics.py
@@ -12,6 +12,8 @@ All tests are headless-safe and require only numpy (no Rust extension).
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import pytest
@@ -24,7 +26,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def basic_params():
+def basic_params() -> Any:
     """Standard double-pendulum parameters for golf swing model."""
     from src.shared.python.pendulum_simulator.physics import PendulumParams
 
@@ -32,13 +34,13 @@ def basic_params():
 
 
 @pytest.fixture
-def rest_state():
+def rest_state() -> np.ndarray:
     """State vector at rest in equilibrium (hanging straight down)."""
     return np.array([0.0, 0.0, 0.0, 0.0])
 
 
 @pytest.fixture
-def zero_torque():
+def zero_torque() -> Callable[..., tuple[float, float]]:
     """Zero torque function."""
     return lambda t: (0.0, 0.0)
 
@@ -644,7 +646,7 @@ class TestEquationsOfMotion:
             equations_of_motion,
         )
 
-        def torque(_t):
+        def torque(_t) -> tuple[float, float]:
             return (200.0, 200.0)  # will be clamped
 
         clamp = TorqueClamp(max_torque1=100.0, max_torque2=50.0)

--- a/tests/unit/test_physics_parameters.py
+++ b/tests/unit/test_physics_parameters.py
@@ -9,7 +9,7 @@ from src.shared.python.physics.physics_parameters import (
 
 
 @pytest.fixture
-def registry():
+def registry() -> PhysicsParameterRegistry:
     """Create a fresh registry for testing."""
     return PhysicsParameterRegistry()
 
@@ -22,7 +22,7 @@ def test_registry_initialization(registry) -> None:
 
 
 @pytest.fixture
-def bounded_param():
+def bounded_param() -> PhysicsParameter:
     """Create a bounded parameter for validation tests."""
     return PhysicsParameter(
         name="TEST",

--- a/tests/unit/test_physics_validation_extended.py
+++ b/tests/unit/test_physics_validation_extended.py
@@ -7,6 +7,8 @@ only numpy and model_generation (available via pytest pythonpath).
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -17,7 +19,9 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 
-def _make_inertia(ixx=0.1, iyy=0.1, izz=0.1, ixy=0.0, ixz=0.0, iyz=0.0, mass=1.0):
+def _make_inertia(
+    ixx=0.1, iyy=0.1, izz=0.1, ixy=0.0, ixz=0.0, iyz=0.0, mass=1.0
+) -> Any:
     """Create an Inertia object with given diagonal + off-diagonal elements."""
     from model_generation.core.types import Inertia
 
@@ -25,7 +29,7 @@ def _make_inertia(ixx=0.1, iyy=0.1, izz=0.1, ixy=0.0, ixz=0.0, iyz=0.0, mass=1.0
 
 
 @pytest.fixture
-def validator():
+def validator() -> Any:
     """PhysicsValidator instance with default gravity."""
     from src.shared.python.model_generation.core.physics_validation import (
         PhysicsValidator,

--- a/tests/unit/test_pinocchio_gui.py
+++ b/tests/unit/test_pinocchio_gui.py
@@ -1,5 +1,7 @@
 """Unit tests for Pinocchio GUI logic."""
 
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +17,7 @@ if PYQT6_AVAILABLE:
 
 
 @pytest.fixture(autouse=True, scope="module")
-def mock_pinocchio_gui_dependencies():
+def mock_pinocchio_gui_dependencies() -> Generator[None, None, None]:
     """Fixture to mock pinocchio and meshcat safely for the duration of this module."""
     with patch.dict(
         "sys.modules",
@@ -35,13 +37,13 @@ class TestPinocchioGUI:
     """Test Pinocchio GUI."""
 
     @pytest.fixture
-    def qapp(self):
+    def qapp(self) -> Any:
         """Ensure QApplication exists."""
         app = get_qapp()
         return app
 
     @pytest.fixture
-    def mock_gui(self, qapp):
+    def mock_gui(self, qapp) -> Any:
         """Create a mocked PinocchioGUI instance."""
         from contextlib import ExitStack
 

--- a/tests/unit/test_pinocchio_physics_engine.py
+++ b/tests/unit/test_pinocchio_physics_engine.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -29,7 +31,7 @@ class MockPhysicsEngine:
 
 
 @pytest.fixture(autouse=True, scope="module")
-def mock_pinocchio_dependencies():
+def mock_pinocchio_dependencies() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     """Fixture to mock pinocchio and interfaces safely for the duration of this module."""
     mock_pin = MagicMock()
     mock_interfaces = MagicMock()
@@ -43,7 +45,9 @@ def mock_pinocchio_dependencies():
 
 
 @pytest.fixture(scope="module")
-def PinocchioPhysicsEngineClass(mock_pinocchio_dependencies):
+def PinocchioPhysicsEngineClass(
+    mock_pinocchio_dependencies,
+) -> Generator[type, None, None]:
     """Fixture to provide the PinocchioPhysicsEngine class with mocked dependencies."""
     # Ensure module is imported
     import engines.physics_engines.pinocchio.python.pinocchio_physics_engine as mod
@@ -65,7 +69,7 @@ def PinocchioPhysicsEngineClass(mock_pinocchio_dependencies):
 
 
 @pytest.fixture
-def engine(PinocchioPhysicsEngineClass):
+def engine(PinocchioPhysicsEngineClass) -> Any:
     """Fixture to provide a PinocchioPhysicsEngine instance."""
     return PinocchioPhysicsEngineClass()
 

--- a/tests/unit/test_plot_engine_extras.py
+++ b/tests/unit/test_plot_engine_extras.py
@@ -10,7 +10,7 @@ from src.shared.python.plot_engine.protocols import PlotConverter, PlotRenderer
 
 
 class TestScatterToGrid:
-    def _scatter_paraboloid(self):
+    def _scatter_paraboloid(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         rng = np.random.default_rng(42)
         n = 50
         x = rng.uniform(0, 10, n)

--- a/tests/unit/test_plot_engine_specs.py
+++ b/tests/unit/test_plot_engine_specs.py
@@ -69,7 +69,7 @@ class TestHistogramSpec:
 
 
 class TestTrendline:
-    def _make_linear_data(self):
+    def _make_linear_data(self) -> tuple[np.ndarray, np.ndarray]:
         x = np.linspace(0.0, 10.0, 20)
         y = 2.0 * x + 1.0 + np.random.default_rng(42).normal(0, 0.1, 20)
         return x, y

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -2,6 +2,7 @@
 Unit tests for shared.python.plotting module.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -18,7 +19,7 @@ from src.shared.python.plotting import GolfSwingPlotter, RecorderInterface
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> MagicMock:
     """Create a mock recorder providing time series data."""
     recorder = MagicMock(spec=RecorderInterface)
 
@@ -41,7 +42,7 @@ def mock_recorder():
     pe = GRAVITY_M_S2 * club_pos[:, 2]
     te = ke + pe
 
-    def get_data(field_name):
+    def get_data(field_name) -> tuple[Any, Any]:
         field_map = {
             "joint_positions": positions,
             "joint_velocities": velocities,
@@ -61,13 +62,13 @@ def mock_recorder():
 
 
 @pytest.fixture
-def plotter(mock_recorder):
+def plotter(mock_recorder) -> GolfSwingPlotter:
     """Create a GolfSwingPlotter instance."""
     return GolfSwingPlotter(mock_recorder, joint_names=["Joint1", "Joint2"])
 
 
 @pytest.fixture
-def mock_figure():
+def mock_figure() -> MagicMock:
     """Create a mock Matplotlib figure."""
     fig = MagicMock()
     # Mock add_subplot to return a mock axes
@@ -329,13 +330,15 @@ class MockRecorder(RecorderInterface):
         self.engine = None
         self.analysis_config = {}
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple[np.ndarray, np.ndarray]:
         return self.data.get(field_name, (np.array([]), np.array([])))
 
-    def get_induced_acceleration_series(self, source_name):
+    def get_induced_acceleration_series(
+        self, source_name
+    ) -> tuple[np.ndarray, np.ndarray]:
         return self.data.get(f"induced_{source_name}", (np.array([]), np.array([])))
 
-    def get_counterfactual_series(self, cf_name):
+    def get_counterfactual_series(self, cf_name) -> tuple[np.ndarray, np.ndarray]:
         return self.data.get(f"cf_{cf_name}", (np.array([]), np.array([])))
 
     def set_analysis_config(self, config) -> None:
@@ -343,7 +346,7 @@ class MockRecorder(RecorderInterface):
 
 
 @pytest.fixture
-def sample_recorder():
+def sample_recorder() -> MockRecorder:
     times = np.linspace(0, 1, 100)
     torques = np.random.randn(100, 2)
     velocities = np.random.randn(100, 2)

--- a/tests/unit/test_plotting_coverage.py
+++ b/tests/unit/test_plotting_coverage.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -18,13 +19,13 @@ _skip_no_3d = pytest.mark.skipif(not _HAS_3D, reason="mpl_toolkits.mplot3d unava
 
 
 @pytest.fixture
-def mock_recorder():
+def mock_recorder() -> MagicMock:
     recorder = MagicMock()
 
     # Default behavior: return some dummy data
     times = np.linspace(0, 1, 100)
 
-    def get_time_series(field):
+    def get_time_series(field) -> tuple[Any, Any]:
         if (
             field == "joint_positions"
             or field == "joint_velocities"
@@ -59,7 +60,7 @@ def mock_recorder():
 
 
 @pytest.fixture
-def plotter(mock_recorder):
+def plotter(mock_recorder) -> GolfSwingPlotter:
     return GolfSwingPlotter(
         mock_recorder, joint_names=["Joint 0", "Joint 1", "Joint 2"]
     )

--- a/tests/unit/test_plotting_extras.py
+++ b/tests/unit/test_plotting_extras.py
@@ -13,10 +13,10 @@ from src.shared.python.plotting.kinematics import plot_joint_positions
 class _MockRecorder:
     engine = None
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple[np.ndarray, np.ndarray]:
         return np.linspace(0, 1, 10), np.zeros((10, 3))
 
-    def get_induced_acceleration_series(self, source):
+    def get_induced_acceleration_series(self, source) -> tuple[np.ndarray, np.ndarray]:
         return np.linspace(0, 1, 10), np.zeros((10, 3))
 
     def set_analysis_config(self, config) -> None:

--- a/tests/unit/test_plotting_renderers.py
+++ b/tests/unit/test_plotting_renderers.py
@@ -23,10 +23,10 @@ class _MockRecorder:
 
     engine = None
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple[np.ndarray, np.ndarray]:
         return np.linspace(0, 1, 10), np.zeros((10, 3))
 
-    def get_induced_acceleration_series(self, source):
+    def get_induced_acceleration_series(self, source) -> tuple[np.ndarray, np.ndarray]:
         return np.linspace(0, 1, 10), np.zeros((10, 3))
 
     def set_analysis_config(self, config) -> None:

--- a/tests/unit/test_process_worker.py
+++ b/tests/unit/test_process_worker.py
@@ -6,13 +6,15 @@ regardless of whether PyQt6 is installed.
 
 import importlib
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _force_fallback_signals():
+def _force_fallback_signals() -> Generator[None, None, None]:
     """Force ProcessWorker to use the fallback (non-PyQt6) signal stubs.
 
     This patches PYQT6_AVAILABLE to False and clears the cached module
@@ -36,7 +38,7 @@ def _force_fallback_signals():
 
 
 @pytest.fixture
-def worker_cls():
+def worker_cls() -> type:
     """Import ProcessWorker using fallback signals."""
     mod_key = "src.shared.python.ui.qt.process_worker"
     if mod_key in sys.modules:
@@ -49,7 +51,7 @@ def worker_cls():
 
 
 @pytest.fixture
-def worker(worker_cls):
+def worker(worker_cls) -> Any:
     """Create a ProcessWorker instance with a simple command."""
     return worker_cls(["echo", "hello"])
 

--- a/tests/unit/test_qp_solver_availability.py
+++ b/tests/unit/test_qp_solver_availability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+from typing import Any
 
 from src.robotics.control.whole_body.qp_solver import ScipyQPSolver
 
@@ -11,7 +12,7 @@ def test_scipy_qp_solver_unavailable(monkeypatch) -> None:
     """ScipyQPSolver should report unavailable when scipy import fails."""
     real_import = builtins.__import__
 
-    def fake_import(name: str, *args, **kwargs):
+    def fake_import(name: str, *args, **kwargs) -> Any:
         if name.startswith("scipy"):
             raise ImportError("scipy not available")
         return real_import(name, *args, **kwargs)

--- a/tests/unit/test_quality_gate_scripts.py
+++ b/tests/unit/test_quality_gate_scripts.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import types
 from pathlib import Path
 
 
-def _load_script_module(name: str):
+def _load_script_module(name: str) -> types.ModuleType:
     script_path = Path(__file__).resolve().parents[2] / "scripts" / f"{name}.py"
     spec = importlib.util.spec_from_file_location(name, script_path)
     assert spec is not None and spec.loader is not None

--- a/tests/unit/test_security_and_module_fixes.py
+++ b/tests/unit/test_security_and_module_fixes.py
@@ -11,6 +11,7 @@ Covers issues:
 from __future__ import annotations
 
 import importlib
+import types
 from unittest.mock import patch
 
 import pytest
@@ -173,7 +174,7 @@ class TestAuthCacheCryptoHash:
 class TestMotionTrainingGetattr:
     """Issue #1777: motion_training exports must return real objects, not None."""
 
-    def _import_motion_training(self):
+    def _import_motion_training(self) -> types.ModuleType:
         """Import the motion_training module."""
         return importlib.import_module(
             "src.engines.physics_engines.pinocchio.python.motion_training"

--- a/tests/unit/test_shared_comparative_plotting.py
+++ b/tests/unit/test_shared_comparative_plotting.py
@@ -16,7 +16,7 @@ class TestComparativePlotter:
     """Tests for ComparativePlotter class."""
 
     @pytest.fixture
-    def mock_analyzer(self):
+    def mock_analyzer(self) -> MagicMock:
         """Mock ComparativeSwingAnalyzer."""
         analyzer = MagicMock(spec=ComparativeSwingAnalyzer)
         analyzer.name_a = "Swing A"
@@ -24,12 +24,12 @@ class TestComparativePlotter:
         return analyzer
 
     @pytest.fixture
-    def plotter(self, mock_analyzer):
+    def plotter(self, mock_analyzer) -> ComparativePlotter:
         """Create ComparativePlotter instance."""
         return ComparativePlotter(mock_analyzer)
 
     @pytest.fixture
-    def mock_figure(self):
+    def mock_figure(self) -> MagicMock:
         """Mock matplotlib Figure."""
         fig = MagicMock(spec=matplotlib.figure.Figure)
         # Setup subplot mocks

--- a/tests/unit/test_shared_plotting_advanced.py
+++ b/tests/unit/test_shared_plotting_advanced.py
@@ -33,7 +33,7 @@ class MockRecorder:
         self.joint_positions = np.zeros((100, 2))
         self.joint_velocities = np.zeros((100, 2))
 
-    def get_time_series(self, field_name):
+    def get_time_series(self, field_name) -> tuple[np.ndarray, np.ndarray]:
         if field_name == "cop_position":
             return self.times, self.cop_position
         if field_name == "com_position":
@@ -48,10 +48,12 @@ class MockRecorder:
             return self.times, self.joint_velocities
         raise KeyError(f"Unknown field: {field_name}")
 
-    def get_induced_acceleration_series(self, source_name):
+    def get_induced_acceleration_series(
+        self, source_name
+    ) -> tuple[np.ndarray, np.ndarray]:
         return self.times, np.zeros((100, 3))
 
-    def get_counterfactual_series(self, cf_name):
+    def get_counterfactual_series(self, cf_name) -> tuple[np.ndarray, np.ndarray]:
         return self.times, np.zeros((100, 3))
 
 

--- a/tests/unit/test_shared_statistical_analysis.py
+++ b/tests/unit/test_shared_statistical_analysis.py
@@ -8,7 +8,7 @@ from src.shared.python.validation_pkg.statistical_analysis import (
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> StatisticalAnalyzer:
     N = 100
     times = np.linspace(0, 1.0, N)
     # Simple sine wave for joint positions

--- a/tests/unit/test_shot_tracer.py
+++ b/tests/unit/test_shot_tracer.py
@@ -1,6 +1,8 @@
 """Unit tests for shot tracer module."""
 
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,7 +27,7 @@ with patch.dict(sys.modules, {"flight_models": MagicMock()}):
 
 
 @pytest.fixture
-def mock_flight_models():
+def mock_flight_models() -> Generator[tuple[Any, Any, Any, Any], None, None]:
     with (
         patch.object(shot_tracer_module, "FlightModelRegistry") as mock_registry,
         patch.object(shot_tracer_module, "UnifiedLaunchConditions") as mock_launch,
@@ -53,7 +55,7 @@ def mock_flight_models():
 
 
 @pytest.fixture
-def widget(qtbot, mock_flight_models):
+def widget(qtbot, mock_flight_models) -> Any:
     if PYQT6_AVAILABLE:
         from PyQt6.QtWidgets import QWidget
 

--- a/tests/unit/test_simulation_core.py
+++ b/tests/unit/test_simulation_core.py
@@ -8,12 +8,12 @@ import pytest
 from src.shared.python.pendulum_simulator.simulation_core import integrate_ode
 
 
-def _linear_decay(t, y):
+def _linear_decay(t, y) -> np.ndarray:
     """dy/dt = -y → y = y0 * exp(-t)."""
     return -y
 
 
-def _harmonic(t, y):
+def _harmonic(t, y) -> np.ndarray:
     """Simple harmonic oscillator: [x, v] → [v, -x]."""
     return np.array([y[1], -y[0]])
 


### PR DESCRIPTION
## Summary

Wave 3 of return type annotation work for issue #2385:

- Collected fixes from background agents for 37 more test files
- Fixed F821/UP037/F811/I001 violations from incorrect string annotations
- Uses `TYPE_CHECKING` pattern for lazy imports, `Any` for unavailable types
- Reduces ANN201/ANN202 violations from ~161 → 79
- **Zero violations** in configured ruff rules (`ruff check .`)

Addresses #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)