### PR TITLE
feat: zero ANN201/ANN202 violations in main codebase (issue #2385 final wave)

### DIFF
--- a/tests/unit/deployment/test_interface.py
+++ b/tests/unit/deployment/test_interface.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import numpy as np
+from numpy.typing import NDArray
 
 from src.deployment.realtime import ControlMode
 from src.deployment.teleoperation.interface import (
@@ -13,16 +16,16 @@ class MockRobot:
         self.ee_pos = np.zeros(3)
         self.contact_forces = np.zeros(6)
 
-    def get_ee_position(self):
+    def get_ee_position(self) -> NDArray:
         return self.ee_pos
 
-    def solve_ik(self, link, target):
+    def solve_ik(self, link: Any, target: Any) -> tuple[NDArray, bool]:
         return np.ones(7), True
 
-    def compute_jacobian(self, link):
+    def compute_jacobian(self, link: Any) -> NDArray:
         return np.eye(6, 7)
 
-    def get_contact_forces(self):
+    def get_contact_forces(self) -> NDArray:
         return self.contact_forces
 
 
@@ -34,16 +37,16 @@ class MockInputDevice:
         self.gripper = 1.0
         self.buttons = {}
 
-    def get_pose(self):
+    def get_pose(self) -> NDArray:
         return self.pose
 
-    def get_twist(self):
+    def get_twist(self) -> NDArray:
         return self.twist
 
-    def get_gripper_state(self):
+    def get_gripper_state(self) -> float:
         return self.gripper
 
-    def get_buttons(self):
+    def get_buttons(self) -> dict[str, Any]:
         return self.buttons
 
 

--- a/tests/unit/test_drake_gui_app.py
+++ b/tests/unit/test_drake_gui_app.py
@@ -5,6 +5,7 @@ and the individual mixin modules (UI, Sim, Viz, Analysis).
 """
 
 import sys
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -36,7 +37,7 @@ _DRAKE_ENGINE_MODULES = [
 
 
 @pytest.fixture(autouse=True, scope="function")
-def _mock_pydrake():
+def _mock_pydrake() -> Generator[None, None, None]:
     """Provide mock pydrake modules only during test execution.
 
     Also cleanup drake engine modules to prevent pollution of test_drake_wrapper.py.

--- a/tests/unit/test_drake_physics_engine.py
+++ b/tests/unit/test_drake_physics_engine.py
@@ -1,4 +1,6 @@
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -56,7 +58,7 @@ def _cleanup_drake_modules() -> None:
 
 
 @pytest.fixture(scope="module")
-def DrakePhysicsEngineClass(mock_drake_dependencies):
+def DrakePhysicsEngineClass(mock_drake_dependencies) -> Generator[Any, None, None]:
     """Fixture to provide the DrakePhysicsEngine class with mocked dependencies."""
     # Ensure module is imported
     import engines.physics_engines.drake.python.drake_physics_engine as mod
@@ -86,7 +88,7 @@ def DrakePhysicsEngineClass(mock_drake_dependencies):
 
 
 @pytest.fixture
-def engine(DrakePhysicsEngineClass):
+def engine(DrakePhysicsEngineClass) -> Any:
     """Fixture to provide an uninitialized DrakePhysicsEngine instance."""
     with patch(
         "engines.physics_engines.drake.python.drake_physics_engine.AddMultibodyPlantSceneGraph"
@@ -103,7 +105,7 @@ def engine(DrakePhysicsEngineClass):
 
 
 @pytest.fixture
-def initialized_engine(engine):
+def initialized_engine(engine) -> Any:
     """Fixture providing a DrakePhysicsEngine that satisfies DBC preconditions.
 
     Sets _is_finalized=True and plant_context so @precondition(is_initialized)

--- a/tests/unit/test_drake_wrapper.py
+++ b/tests/unit/test_drake_wrapper.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,7 +55,7 @@ _DRAKE_PARENT_PACKAGES = [
 
 
 @pytest.fixture(autouse=True)
-def _fix_drake_pollution():
+def _fix_drake_pollution() -> Generator[None, None, None]:
     """Fix Drake parent package pollution before each test.
 
     When test_drake_gui_app or other tests import Drake modules, they may leave
@@ -110,7 +111,7 @@ with patch.dict(sys.modules, _pydrake_mocks):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_drake_module_state():
+def _isolate_drake_module_state() -> Generator[None, None, None]:
     """Prevent module-level Drake mocks from leaking across tests."""
     engine_before = sys.modules.get(_ENGINE_MOD_NAME)
     pydrake_before = {key: sys.modules.get(key) for key in _PYDRAKE_KEYS}

--- a/tests/unit/test_golf_launcher_basic.py
+++ b/tests/unit/test_golf_launcher_basic.py
@@ -7,6 +7,8 @@ We mark them as serial to avoid this.
 """
 
 import sys
+import types
+from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -30,7 +32,7 @@ class MockQThread:
         """Mock wait."""
 
 
-def mock_pyqt_signal(*args):
+def mock_pyqt_signal(*args) -> MagicMock:
     return MagicMock()
 
 
@@ -44,7 +46,7 @@ class MockQWidget:
         """Mock setWindowTitle."""
         self._window_title = title
 
-    def windowTitle(self):
+    def windowTitle(self) -> str:
         """Mock windowTitle."""
         return self._window_title
 
@@ -95,7 +97,7 @@ class MockQVBoxLayout:
 
 
 @pytest.fixture
-def mocked_launcher_module():
+def mocked_launcher_module() -> Generator[types.ModuleType, None, None]:
     """
     Import golf_launcher with mocked Qt modules.
     This fixture ensures that the mocks don't pollute the global sys.modules,

--- a/tests/unit/test_golf_launcher_logic.py
+++ b/tests/unit/test_golf_launcher_logic.py
@@ -3,6 +3,7 @@ Unit tests for GolfLauncher GUI logic (Model selection, Launching).
 """
 
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -22,7 +23,7 @@ class MockQtBase:
     def setWindowTitle(self, title) -> None:
         self._window_title = title
 
-    def windowTitle(self):
+    def windowTitle(self) -> str:
         return self._window_title
 
     def setWindowIcon(self, icon) -> None:
@@ -89,13 +90,13 @@ class MockQWidget(MockQtBase):
     def setWindowTitle(self, title) -> None:
         self._window_title = title
 
-    def windowTitle(self):
+    def windowTitle(self) -> str:
         return self._window_title
 
     def setStyleSheet(self, s) -> None:
         self._style_sheet = s
 
-    def styleSheet(self):
+    def styleSheet(self) -> str:
         return self._style_sheet
 
 
@@ -117,13 +118,13 @@ class MockQPushButton(MockQWidget):
     def setText(self, t) -> None:
         self._text = str(t)  # Ensure it's always a string
 
-    def text(self):
+    def text(self) -> str:
         return self._text
 
     def setEnabled(self, b) -> None:
         self._enabled = bool(b)
 
-    def isEnabled(self):
+    def isEnabled(self) -> bool:
         return self._enabled
 
     def setFont(self, f) -> None:
@@ -141,7 +142,7 @@ class MockQCheckBox(MockQWidget):
     def setChecked(self, b) -> None:
         self.checked = b
 
-    def isChecked(self):
+    def isChecked(self) -> bool:
         return self.checked
 
     def setToolTip(self, t) -> None:
@@ -182,7 +183,7 @@ class MockQLabel(MockQWidget):
 
 
 @pytest.fixture
-def mock_pyqt(monkeypatch):
+def mock_pyqt(monkeypatch) -> Generator[None, None, None]:
     """
     Fixture to patch sys.modules with our local Mock classes.
     This ensures that when 'launchers.golf_launcher' is imported/reloaded,
@@ -232,14 +233,14 @@ def mock_pyqt(monkeypatch):
 
 class TestGolfLauncherLogic:
     @pytest.fixture(autouse=True)
-    def mock_process_manager(self):
+    def mock_process_manager(self) -> Generator[MagicMock, None, None]:
         """Mock ProcessManager to prevent real file I/O side effects in workers."""
         with patch("src.launchers.golf_launcher.ProcessManager") as mock_pm:
             mock_pm.return_value.running_processes = {}
             yield mock_pm
 
     @pytest.fixture(autouse=True)
-    def mock_help_system(self):
+    def mock_help_system(self) -> Generator[MagicMock, None, None]:
         """
         Mock the help system to avoid instantiation of real QWidgets (HelpButton)
         which might trigger TypeErrors with our MockQMainWindow parent.
@@ -253,7 +254,7 @@ class TestGolfLauncherLogic:
             yield mock_btn
 
     @pytest.fixture(autouse=True)
-    def setup_launcher_module(self, mock_pyqt):
+    def setup_launcher_module(self, mock_pyqt) -> Generator[None, None, None]:
         """
         Reload the module to ensure it uses the patched sys.modules.
         After re-import, patch QDockWidget at the module level so the

--- a/tests/unit/test_golf_suite_launcher.py
+++ b/tests/unit/test_golf_suite_launcher.py
@@ -4,7 +4,9 @@ Unit tests for Golf Suite Launcher.
 
 import os
 import sys
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +16,7 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 
 @pytest.fixture(scope="module", autouse=True)
-def cleanup_imports():
+def cleanup_imports() -> Generator[None, None, None]:
     """Clean up imports after tests to prevent mock leakage."""
     yield
     sys.modules.pop("src.launchers.golf_suite_launcher", None)
@@ -44,7 +46,7 @@ class MockQMainWindow:
     def show(self) -> None:
         pass
 
-    def style(self):
+    def style(self) -> MagicMock:
         return MagicMock()
 
 
@@ -88,7 +90,7 @@ class MockQLabel:
     def setAlignment(self, a) -> None:
         pass
 
-    def font(self):
+    def font(self) -> MagicMock:
         return MagicMock()
 
     def setFont(self, f) -> None:
@@ -205,7 +207,7 @@ _STATUS_SPEC = ["setText", "setAlignment", "font", "setFont"]
 
 
 @pytest.fixture
-def mock_subprocess():
+def mock_subprocess() -> Generator[MagicMock, None, None]:
     """Mock subprocess.Popen."""
     with patch("subprocess.Popen") as mock_popen:
         process = MagicMock(
@@ -217,7 +219,7 @@ def mock_subprocess():
 
 
 @pytest.fixture
-def launcher_app():
+def launcher_app() -> Any:
     """Fixture to create the launcher instance."""
     # Ensure PYQT6_AVAILABLE is True for logic testing
     golf_suite_launcher.PYQT6_AVAILABLE = True

--- a/tests/unit/test_gui_coverage.py
+++ b/tests/unit/test_gui_coverage.py
@@ -14,6 +14,8 @@ import os
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 os.environ.setdefault("MUJOCO_GL", "osmesa")
 
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -48,7 +50,7 @@ def _load_model_or_skip(widget, xml_string: str) -> None:
 
 
 @pytest.fixture(scope="module")
-def qapp():
+def qapp() -> Generator[Any, None, None]:
     """Create a QApplication instance for tests that need it."""
     if not PYQT6_AVAILABLE:
         pytest.skip("PyQt6 not available")

--- a/tests/unit/test_injury_analysis_coverage.py
+++ b/tests/unit/test_injury_analysis_coverage.py
@@ -17,7 +17,7 @@ class MockJointResult:
 
 
 @pytest.fixture
-def scorer():
+def scorer() -> InjuryRiskScorer:
     return InjuryRiskScorer()
 
 

--- a/tests/unit/test_issue_fixes_1777_1778_1779_1782.py
+++ b/tests/unit/test_issue_fixes_1777_1778_1779_1782.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import importlib
 import secrets
+import types
+from typing import Any
 
 import numpy as np
 import pytest
@@ -224,7 +226,7 @@ class TestRealTimeControllerSimulationBackend:
     realistic default values.
     """
 
-    def _make_controller(self, comm_type: str = "simulation", n_joints: int = 7):
+    def _make_controller(self, comm_type: str = "simulation", n_joints: int = 7) -> Any:
         """Helper: create and connect a controller with a test robot config."""
         from src.deployment.realtime.controller import RealTimeController, RobotConfig
 
@@ -455,7 +457,7 @@ class TestMotionTrainingExportsNotNone:
 
     _MODULE = "src.engines.physics_engines.pinocchio.python.motion_training"
 
-    def _get_module(self):
+    def _get_module(self) -> types.ModuleType:
         return importlib.import_module(self._MODULE)
 
     def test_club_trajectory_parser_is_importable_and_not_none(self) -> None:

--- a/tests/unit/test_kinematic_sequence.py
+++ b/tests/unit/test_kinematic_sequence.py
@@ -1,5 +1,7 @@
 """Unit tests for kinematic sequence analysis."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -15,7 +17,7 @@ class MockRecorder:
         self.times = times
         self.velocities = velocities
 
-    def get_time_series(self, name):
+    def get_time_series(self, name) -> tuple[np.ndarray | list, np.ndarray | list]:
         if name == "joint_velocities":
             return self.times, self.velocities
         return [], []

--- a/tests/unit/test_launcher_ux.py
+++ b/tests/unit/test_launcher_ux.py
@@ -38,7 +38,7 @@ class TestGolfLauncherUX(unittest.TestCase):
         self.mock_registry.get_all_models.return_value = self.mock_models
         self.mock_registry.__iter__ = lambda x: iter(self.mock_models)
 
-        def mock_get_model(model_id):
+        def mock_get_model(model_id) -> Mock | None:
             for model in self.mock_models:
                 if model.id == model_id:
                     return model

--- a/tests/unit/test_launcher_x11_logic.py
+++ b/tests/unit/test_launcher_x11_logic.py
@@ -6,6 +6,8 @@ presence of LIBGL_ALWAYS_INDIRECT which was identified as a critical regression.
 """
 
 import sys
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -23,7 +25,7 @@ class MockQCheckBox:
     def __init__(self, checked=False):
         self._checked = checked
 
-    def isChecked(self):
+    def isChecked(self) -> bool:
         return self._checked
 
     def setChecked(self, val) -> None:
@@ -38,7 +40,7 @@ class MockModel:
 
 
 @pytest.fixture
-def mocked_launcher():
+def mocked_launcher() -> Generator[Any, None, None]:
     """Import golf_launcher with Qt mocks."""
     mock_modules = {
         "PyQt6": MagicMock(),

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -4,6 +4,7 @@ Unit tests for launcher functionality.
 
 import contextlib
 import os
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -232,7 +233,7 @@ class TestLauncherIntegration:
 
 # Mock fixtures for GUI testing
 @pytest.fixture
-def mock_qt_application():
+def mock_qt_application() -> Generator[Mock, None, None]:
     """Mock Qt application for testing."""
     with patch.dict(
         "sys.modules",
@@ -247,7 +248,7 @@ def mock_qt_application():
 
 
 @pytest.fixture
-def mock_launcher_environment():
+def mock_launcher_environment() -> Generator[None, None, None]:
     """Mock launcher environment."""
     with patch.dict(
         os.environ, {"GOLF_SUITE_HEADLESS": "1", "GOLF_SUITE_TEST_MODE": "1"}

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -1,6 +1,7 @@
 """Tests for lazy import functionality in dependency management."""
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -52,7 +53,7 @@ class TestPolynomialGeneratorLazyImport:
     """Test lazy import of polynomial generator widget."""
 
     @pytest.fixture
-    def mock_launcher(self):
+    def mock_launcher(self) -> Any:
         """Create a mock launcher instance."""
         from PyQt6.QtWidgets import QMainWindow
 

--- a/tests/unit/test_manipulability.py
+++ b/tests/unit/test_manipulability.py
@@ -30,7 +30,7 @@ class MockEngine:
         """Initialize mock engine with optional jacobian dict."""
         self.jacobian_dict = jacobian_dict
 
-    def compute_jacobian(self, body_name):
+    def compute_jacobian(self, body_name) -> dict | None:
         """Return mock Jacobian."""
         return self.jacobian_dict
 

--- a/tests/unit/test_simulation_golfer.py
+++ b/tests/unit/test_simulation_golfer.py
@@ -33,7 +33,7 @@ def _make_params() -> GolferParams:
     )
 
 
-def _zero_torque(t):  # noqa: ARG001
+def _zero_torque(t) -> tuple[float, ...]:  # noqa: ARG001
     return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
 

--- a/tests/unit/test_simulation_triple.py
+++ b/tests/unit/test_simulation_triple.py
@@ -18,7 +18,7 @@ def _make_params(**kwargs) -> TriplePendulumParams:
     return TriplePendulumParams(**defaults)
 
 
-def _zero_torque(t):
+def _zero_torque(t) -> tuple[float, float, float]:
     return 0.0, 0.0, 0.0
 
 

--- a/tests/unit/test_state_manager_extended.py
+++ b/tests/unit/test_state_manager_extended.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -124,7 +125,7 @@ class TestSafeWriteJson:
 
 
 @pytest.fixture
-def manager(tmp_path: Path):
+def manager(tmp_path: Path) -> Any:
     """StateManager instance using a temporary directory."""
     from src.shared.python.upstream_drift_tools.utils.state_manager import StateManager
 

--- a/tests/unit/test_statistical_analysis.py
+++ b/tests/unit/test_statistical_analysis.py
@@ -2,6 +2,8 @@
 Unit tests for shared.python.statistical_analysis module.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -9,7 +11,7 @@ from src.shared.python.validation_pkg.statistical_analysis import StatisticalAna
 
 
 @pytest.fixture
-def sample_data():
+def sample_data() -> dict[str, Any]:
     """Create sample data for testing."""
     times = np.linspace(0, 1.0, 101)  # 101 points, dt=0.01
 
@@ -47,7 +49,7 @@ def sample_data():
 
 
 @pytest.fixture
-def analyzer(sample_data):
+def analyzer(sample_data) -> StatisticalAnalyzer:
     return StatisticalAnalyzer(
         times=sample_data["times"],
         joint_positions=sample_data["positions"],

--- a/tests/unit/test_steam_engine.py
+++ b/tests/unit/test_steam_engine.py
@@ -6,6 +6,8 @@ does not require CoolProp or Cantera, so they run in all environments.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 
@@ -83,7 +85,7 @@ class TestSimplifiedSteamProperties:
     """Tests for the simplified steam property calculations."""
 
     @pytest.fixture
-    def engine(self):
+    def engine(self) -> Any:
         """Create a SteamCalculationEngine."""
         from src.shared.python.upstream_drift_tools.calculators.thermo.steam_engine import (
             SteamCalculationEngine,
@@ -166,7 +168,7 @@ class TestWaterVaporPressure:
     """Tests for water vapor pressure calculation methods."""
 
     @pytest.fixture
-    def engine(self):
+    def engine(self) -> Any:
         """Create engine."""
         from src.shared.python.upstream_drift_tools.calculators.thermo.steam_engine import (
             SteamCalculationEngine,

--- a/tests/unit/test_steam_engine_extended.py
+++ b/tests/unit/test_steam_engine_extended.py
@@ -14,6 +14,8 @@ All tests use the simplified calculation path (no CoolProp / Cantera required).
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -24,7 +26,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def engine():
+def engine() -> Any:
     """SteamCalculationEngine instance."""
     from src.shared.python.upstream_drift_tools.calculators.thermo.steam_engine import (
         SteamCalculationEngine,

--- a/tests/unit/test_terrain_contracts.py
+++ b/tests/unit/test_terrain_contracts.py
@@ -8,6 +8,8 @@ Covers three semantic bugs:
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from src.shared.python.physics.terrain import (
@@ -204,7 +206,7 @@ class TestTerrainEngineOutOfBounds:
 class TestTerrainMixinOutOfBounds:
     """TerrainMixin.get_ground_height must not fabricate 0.0 on out-of-bounds."""
 
-    def _make_mixin_with_terrain(self):  # type: ignore[no-untyped-def]
+    def _make_mixin_with_terrain(self) -> Any:
         from src.shared.python.physics.terrain_mixin import TerrainMixin
 
         class FakeEngine(TerrainMixin):

--- a/tests/unit/test_unified_launcher_coverage.py
+++ b/tests/unit/test_unified_launcher_coverage.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +15,7 @@ if PYQT6_AVAILABLE:
 
 
 @pytest.fixture
-def launcher():
+def launcher() -> Any:
     """Create a UnifiedLauncher instance."""
     return UnifiedLauncher()
 

--- a/tests/unit/test_unreal_integration/test_streaming.py
+++ b/tests/unit/test_unreal_integration/test_streaming.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Generator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -33,7 +34,7 @@ pytest.importorskip("pytest_asyncio", reason="pytest-asyncio not installed")
 
 
 @pytest.fixture
-def event_loop():
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
     """Provide an explicit event loop for sync buffer tests on Python 3.14+."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/tests/unit/test_urdf_io.py
+++ b/tests/unit/test_urdf_io.py
@@ -2,6 +2,7 @@
 Unit tests for URDF I/O module.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import defusedxml.ElementTree as ET
@@ -26,7 +27,7 @@ if MUJOCO_AVAILABLE:
 
 
 @pytest.fixture
-def sample_urdf(tmp_path):
+def sample_urdf(tmp_path) -> Path:
     """Create a sample URDF file."""
     urdf_content = """<?xml version="1.0" ?>
 <robot name="test_robot">
@@ -71,7 +72,7 @@ def sample_urdf(tmp_path):
 
 
 @pytest.fixture
-def mock_mujoco_model():
+def mock_mujoco_model() -> MagicMock:
     """Create a mock MuJoCo model."""
     # Since we can't easily construct a valid MjModel without XML parsing,
     # we'll mock the attributes needed by URDFExporter.

--- a/tests/unit/test_ux_enhancements.py
+++ b/tests/unit/test_ux_enhancements.py
@@ -1,4 +1,6 @@
 import sys
+import types
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -107,7 +109,7 @@ class MockQFrame(MockQWidget):
 
 
 @pytest.fixture
-def mocked_launcher_module():
+def mocked_launcher_module() -> Generator[types.ModuleType, None, None]:
     """Import golf_launcher with mocked Qt modules."""
     mock_qt_core = MagicMock()
     mock_qt_core.Qt = MagicMock()
@@ -211,7 +213,7 @@ def test_escape_shortcut_logic(mocked_launcher_module) -> None:
         patch("src.launchers.golf_launcher.QKeySequence") as MockKeySequence,
     ):
         # Setup QKeySequence to return identifiable mocks
-        def key_seq_side_effect(arg):
+        def key_seq_side_effect(arg) -> MagicMock:
             m = MagicMock()
             m.key_str = arg
             return m

--- a/tests/unit/test_video_pose_pipeline.py
+++ b/tests/unit/test_video_pose_pipeline.py
@@ -1,5 +1,6 @@
 # Import path setup is handled by pyproject.toml and conftest.py
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -39,18 +40,18 @@ with patch.dict(sys.modules, _MOCKED_MODULES):
 
 
 @pytest.fixture
-def mock_cv2():
+def mock_cv2() -> MagicMock:
     return _mock_cv2
 
 
 @pytest.fixture
-def mock_output_manager():
+def mock_output_manager() -> Generator[MagicMock, None, None]:
     with patch("src.shared.python.gui_pkg.video_pose_pipeline.OutputManager") as mock:
         yield mock
 
 
 @pytest.fixture
-def pipeline(mock_cv2, mock_output_manager):
+def pipeline(mock_cv2, mock_output_manager) -> VideoPosePipeline:
     config = VideoProcessingConfig(estimator_type="mediapipe", min_confidence=0.5)
 
     # Ensure MediaPipeEstimator class is a mock

--- a/tests/unit/tools/model_generation/test_dbc_decorators.py
+++ b/tests/unit/tools/model_generation/test_dbc_decorators.py
@@ -10,6 +10,7 @@ while valid inputs still work correctly.
 from __future__ import annotations
 
 import os
+from typing import Any
 
 import pytest
 
@@ -59,7 +60,7 @@ SIMPLE_URDF = """<?xml version="1.0"?>
 
 
 @pytest.fixture
-def editor():
+def editor() -> Any:
     """Create a FrankensteinEditor with a loaded model."""
     from model_generation.editor import FrankensteinEditor
 
@@ -409,13 +410,13 @@ class TestHumanoidGeneratorPreconditions:
 class TestBaseURDFBuilderInvariants:
     """Tests for BaseURDFBuilder._check_invariants method."""
 
-    def _create_concrete_builder(self):
+    def _create_concrete_builder(self) -> Any:
         """Create a concrete subclass of BaseURDFBuilder for testing."""
         from model_generation.builders.base_builder import BaseURDFBuilder, BuildResult
         from model_generation.core.types import Inertia, Joint, JointType, Link, Origin
 
         class ConcreteBuilder(BaseURDFBuilder):
-            def build(self, **kwargs):
+            def build(self, **kwargs) -> Any:
                 return BuildResult(success=True)
 
             def clear(self) -> None:

--- a/tests/unit/tools/model_generation/test_dry_unification.py
+++ b/tests/unit/tools/model_generation/test_dry_unification.py
@@ -9,6 +9,7 @@ Verifies that:
 
 from __future__ import annotations
 
+import types
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
@@ -16,7 +17,7 @@ from unittest.mock import MagicMock, patch
 # ---------------------------------------------------------------------------
 
 
-def _import_model_generation():
+def _import_model_generation() -> types.ModuleType:
     """Import model_generation, returning the live module."""
     import model_generation
 
@@ -120,7 +121,7 @@ class TestHumanoidPresetsConstant:
 class TestQuickFunctionsUseSharedPresets:
     """quick_urdf() and quick_build() must read from _HUMANOID_PRESETS, not a local copy."""
 
-    def _make_builder_mock(self):
+    def _make_builder_mock(self) -> MagicMock:
         """Create a mock ParametricBuilder that records set_parameters calls."""
         mock_builder = MagicMock()
         mock_result = MagicMock()
@@ -204,7 +205,7 @@ class TestQuickFunctionsUseSharedPresets:
         builders = [mock_builder_urdf, mock_builder_build]
         call_count = [0]
 
-        def builder_factory(*a, **kw):
+        def builder_factory(*a, **kw) -> MagicMock:
             idx = call_count[0]
             call_count[0] += 1
             return builders[idx]

--- a/tests/unit/tools/model_generation/test_security_fixes.py
+++ b/tests/unit/tools/model_generation/test_security_fixes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,12 +21,12 @@ import pytest
 class TestAPIKeyAuthentication:
     """API key authentication middleware (X-API-Key header)."""
 
-    def _make_api(self):
+    def _make_api(self) -> Any:
         from model_generation.api.rest_api import ModelGenerationAPI
 
         return ModelGenerationAPI()
 
-    def _health_request(self, api_key: str | None = None):
+    def _health_request(self, api_key: str | None = None) -> Any:
         from model_generation.api.rest_api import APIRequest, HTTPMethod
 
         headers = {}
@@ -71,12 +72,12 @@ class TestAPIKeyAuthentication:
 class TestCORSHeaders:
     """CORS header configuration."""
 
-    def _make_api(self):
+    def _make_api(self) -> Any:
         from model_generation.api.rest_api import ModelGenerationAPI
 
         return ModelGenerationAPI()
 
-    def _health_request(self):
+    def _health_request(self) -> Any:
         from model_generation.api.rest_api import APIRequest, HTTPMethod
 
         return APIRequest(
@@ -127,12 +128,12 @@ class TestCORSHeaders:
 class TestRateLimiting:
     """In-memory rate limiting."""
 
-    def _make_api(self):
+    def _make_api(self) -> Any:
         from model_generation.api.rest_api import ModelGenerationAPI
 
         return ModelGenerationAPI()
 
-    def _health_request(self, client_ip: str = "127.0.0.1"):
+    def _health_request(self, client_ip: str = "127.0.0.1") -> Any:
         from model_generation.api.rest_api import APIRequest, HTTPMethod
 
         return APIRequest(
@@ -185,12 +186,12 @@ class TestRateLimiting:
 class TestInputValidation:
     """Input validation for request bodies."""
 
-    def _make_api(self):
+    def _make_api(self) -> Any:
         from model_generation.api.rest_api import ModelGenerationAPI
 
         return ModelGenerationAPI()
 
-    def _post_request(self, path: str, body: dict | None = None):
+    def _post_request(self, path: str, body: dict | None = None) -> Any:
         from model_generation.api.rest_api import APIRequest, HTTPMethod
 
         return APIRequest(
@@ -229,7 +230,7 @@ class TestInputValidation:
 class TestErrorResponseSanitization:
     """Error responses should not leak stack traces in production."""
 
-    def _make_api(self):
+    def _make_api(self) -> Any:
         from model_generation.api.rest_api import ModelGenerationAPI
 
         return ModelGenerationAPI()


### PR DESCRIPTION
## Summary

Final wave of return type annotation work for issue #2385:

- Annotates the last 31 files with remaining violations
- **Result: 0 ANN201/ANN202 violations** across all of `src/`, `tests/`, `scripts/`, `examples/`
- Zero violations in configured ruff rules (`ruff check .`)
- Zero format issues (`ruff format --check .`)

## Complete wave summary

| Wave | PR | Files | Violations fixed |
|------|-----|-------|-----------------|
| 1 | #2599 | 265 | 2,827 (→ None) |
| 2 | #2600 | 131 | 307 |
| 3 | #2601 | 37 | ~82 |
| 4 | (this) | 31 | ~79 |
| **Total** | | **464** | **3,295** |

Closes #2385 (ANN201/ANN202 portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)