### PR TITLE
fix: remove unnecessary pass statements in analysis_controller.py (issue #2385)

### DIFF
--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/analysis_controller.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/analysis_controller.py
@@ -26,11 +26,9 @@ class AnalysisController:
         try:
             gui._ensure_analyzer_initialized()
             # ... actual logic from _plot_induced_accelerations ...
-            pass
         except (ValueError, RuntimeError, AttributeError) as e:
             logger.error(f"Induced acceleration plotting failed: {e}")
 
     def generate_plot(self) -> None:
         """Main plot dispatcher."""
         # ... logic from _generate_plot ...
-        pass


### PR DESCRIPTION
## Summary

- Removes 2 `PIE790` unnecessary `pass` statements in `analysis_controller.py`
- `pass` after a docstring is redundant (the docstring itself serves as the body)
- These were leftover stubs from incomplete implementation

## Test plan

- [ ] `ruff check .` passes (PIE is in configured rules)
- [ ] `rust-quality-gate` passes

Addresses #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)