### PR TITLE
[codex] isolate pendulum panel builder fake modules

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.79                                             |
+| **Spec Version**        | 1.0.80                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.80  | Test framework fix: finalized the pendulum panel-builder helper isolation by reloading `panel_builders` under fixture-scoped fake simulation and perturbation modules, preserving richer fake `run_simulation` results, and removing stale merge-conflict artifacts that broke linting on the branch. |
 | 2026-04-10 | 1.0.79  | Test framework fix: tightened pendulum panel-builder helper tests so fake simulation and perturbation modules are fixture-scoped, reload `panel_builders` under the fake environment, and avoid leaking mocked modules or incompatible `run_simulation` signatures into unrelated tests. |
 | 2026-04-10 | 1.0.78  | Test framework fix: Refactored `test_panel_builders_helpers.py` to prevent module-level mocking of `run_simulation` from polluting `sys.modules` and causing cascading failures in other test suites. |
 | 2026-04-10 | 1.0.77  | Optimization: Cached difference vectors and their np.linalg.norm results into local variables inside tight collision-checking loops to eliminate redundant vector subtractions and matrix math operations, halving execution time in these hot paths without sacrificing code readability. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.78                                             |
+| **Spec Version**        | 1.0.79                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.79  | Test framework fix: tightened pendulum panel-builder helper tests so fake simulation and perturbation modules are fixture-scoped, reload `panel_builders` under the fake environment, and avoid leaking mocked modules or incompatible `run_simulation` signatures into unrelated tests. |
 | 2026-04-10 | 1.0.78  | Test framework fix: Refactored `test_panel_builders_helpers.py` to prevent module-level mocking of `run_simulation` from polluting `sys.modules` and causing cascading failures in other test suites. |
 | 2026-04-10 | 1.0.77  | Optimization: Cached difference vectors and their np.linalg.norm results into local variables inside tight collision-checking loops to eliminate redundant vector subtractions and matrix math operations, halving execution time in these hot paths without sacrificing code readability. |
 | 2026-04-10 | 1.0.76  | Simscape + GUI maintenance: fixed the 3D golf dataset generator defaults to target the bundled `GolfSwing3D_Kinetic` model while keeping legacy `verbose` and newer `verbosity` config paths compatible, and decomposed the launcher dashboard plus pendulum GUI builder/toolstrip code into smaller helpers with focused regression coverage. |

--- a/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
+++ b/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import sys
+from importlib import import_module, reload
 from types import ModuleType
 
 import numpy as np
@@ -12,10 +13,11 @@ import pytest
 pytest.importorskip("PyQt6")
 
 
-def _install_fake_simulation_modules() -> None:
+def _make_fake_simulation_modules() -> dict[str, ModuleType]:
     class _FakeResultBase:
         pass
 
+    modules: dict[str, ModuleType] = {}
     for module_name in (
         "src.shared.python.pendulum_simulator.simulation",
         "src.shared.python.pendulum_simulator.simulation_triple",
@@ -23,20 +25,23 @@ def _install_fake_simulation_modules() -> None:
     ):
         module = ModuleType(module_name)
         module.make_polynomial_torque = lambda *args, **kwargs: (args, kwargs)
-        module.run_simulation = lambda *args, **kwargs: kwargs
+<<<<<<< HEAD
+        module.run_simulation = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
         if module_name.endswith(".simulation"):
             module.SimulationResult = _FakeResultBase
         elif module_name.endswith(".simulation_triple"):
             module.TripleSimulationResult = _FakeResultBase
         else:
             module.GolferSimulationResult = _FakeResultBase
-        sys.modules[module_name] = module
+        modules[module_name] = module
+    return modules
 
 
-def _install_fake_perturbation_modules() -> None:
+def _make_fake_perturbation_modules() -> dict[str, ModuleType]:
+    modules: dict[str, ModuleType] = {}
     package = ModuleType("src.shared.python.pendulum_simulator.perturbation")
     package.__path__ = []  # type: ignore[attr-defined]
-    sys.modules["src.shared.python.pendulum_simulator.perturbation"] = package
+    modules["src.shared.python.pendulum_simulator.perturbation"] = package
 
     config_module = ModuleType(
         "src.shared.python.pendulum_simulator.perturbation.config"
@@ -50,7 +55,7 @@ def _install_fake_perturbation_modules() -> None:
 
     config_module.PerturbationConfig = _FakePerturbationConfig
     config_module.PerturbationSummary = _FakePerturbationSummary
-    sys.modules["src.shared.python.pendulum_simulator.perturbation.config"] = (
+    modules["src.shared.python.pendulum_simulator.perturbation.config"] = (
         config_module
     )
 
@@ -69,7 +74,7 @@ def _install_fake_perturbation_modules() -> None:
             return _FakePerturbationSummary()
 
     analyzer_module.PendulumPerturbationAnalyzer = _FakeAnalyzer
-    sys.modules[
+    modules[
         "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer"
     ] = analyzer_module
 
@@ -77,73 +82,23 @@ def _install_fake_perturbation_modules() -> None:
         "src.shared.python.pendulum_simulator.perturbation_analysis"
     )
     perturbation_analysis_module.variability_summary = lambda *args, **kwargs: None
-    sys.modules["src.shared.python.pendulum_simulator.perturbation_analysis"] = (
+    modules["src.shared.python.pendulum_simulator.perturbation_analysis"] = (
         perturbation_analysis_module
     )
+    return modules
 
 
-_install_fake_simulation_modules()
-_install_fake_perturbation_modules()
+@pytest.fixture
+def panel_builders(monkeypatch: pytest.MonkeyPatch):
+    for module_name, module in {
+        **_make_fake_simulation_modules(),
+        **_make_fake_perturbation_modules(),
+    }.items():
+        monkeypatch.setitem(sys.modules, module_name, module)
 
-
-@pytest.fixture(scope="module", autouse=True)
-def cleanup_fakes():
-    yield
-    for m in [
-        "src.shared.python.pendulum_simulator.simulation",
-        "src.shared.python.pendulum_simulator.simulation_triple",
-        "src.shared.python.pendulum_simulator.simulation_golfer",
-        "src.shared.python.pendulum_simulator.perturbation",
-        "src.shared.python.pendulum_simulator.perturbation.config",
-        "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer",
-        "src.shared.python.pendulum_simulator.perturbation_analysis",
-    ]:
-        sys.modules.pop(m, None)
-
-    # Reload modules that might have been imported with fake submodules
-    if "src.shared.python.pendulum_simulator.gui.panel_builders" in sys.modules:
-        sys.modules.pop("src.shared.python.pendulum_simulator.gui.panel_builders", None)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _cleanup_sys_modules():
-    yield
-    for m in [
-        "src.shared.python.pendulum_simulator.simulation",
-        "src.shared.python.pendulum_simulator.simulation_triple",
-        "src.shared.python.pendulum_simulator.simulation_golfer",
-        "src.shared.python.pendulum_simulator.perturbation",
-        "src.shared.python.pendulum_simulator.perturbation.config",
-        "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer",
-        "src.shared.python.pendulum_simulator.perturbation_analysis",
-    ]:
-        sys.modules.pop(m, None)
-
-
-from src.shared.python.pendulum_simulator.gui import panel_builders  # noqa: E402
-
-for m in [
-    "src.shared.python.pendulum_simulator.simulation",
-    "src.shared.python.pendulum_simulator.simulation_triple",
-    "src.shared.python.pendulum_simulator.simulation_golfer",
-    "src.shared.python.pendulum_simulator.perturbation",
-    "src.shared.python.pendulum_simulator.perturbation.config",
-    "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer",
-    "src.shared.python.pendulum_simulator.perturbation_analysis",
-]:
-    sys.modules.pop(m, None)
-
-
-for m in [
-    "src.shared.python.pendulum_simulator.simulation",
-    "src.shared.python.pendulum_simulator.simulation_triple",
-    "src.shared.python.pendulum_simulator.simulation_golfer",
-    "src.shared.python.pendulum_simulator.perturbation",
-    "src.shared.python.pendulum_simulator.perturbation.config",
-    "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer",
-    "src.shared.python.pendulum_simulator.perturbation_analysis",
-]:
-    sys.modules.pop(m, None)
+<<<<<<< HEAD
+    module = import_module("src.shared.python.pendulum_simulator.gui.panel_builders")
+    return reload(module)
 
 
 class _FakeResult:
@@ -221,7 +176,7 @@ class _FakeOptimizationWidget:
         self.n_torque_params = n_torque_params
 
 
-def test_helper_parsers_and_motion_extraction() -> None:
+def test_helper_parsers_and_motion_extraction(panel_builders) -> None:
     assert panel_builders._parse_coefficients("1.0, 2.5, , 3") == [1.0, 2.5, 3.0]
     assert panel_builders._parse_coefficients("") == [0.0]
     assert panel_builders._chunk_coefficients(np.array([1, 2, 3, 4, 5]), 2) == [
@@ -249,6 +204,7 @@ def test_helper_parsers_and_motion_extraction() -> None:
 
 
 def test_build_double_panel_wires_helper_callbacks(
+    panel_builders,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_pendulum = _FakePendulum()

--- a/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
+++ b/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
@@ -54,9 +54,7 @@ def _make_fake_perturbation_modules() -> dict[str, ModuleType]:
 
     config_module.PerturbationConfig = _FakePerturbationConfig
     config_module.PerturbationSummary = _FakePerturbationSummary
-    modules["src.shared.python.pendulum_simulator.perturbation.config"] = (
-        config_module
-    )
+    modules["src.shared.python.pendulum_simulator.perturbation.config"] = config_module
 
     analyzer_module = ModuleType(
         "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer"
@@ -73,9 +71,9 @@ def _make_fake_perturbation_modules() -> dict[str, ModuleType]:
             return _FakePerturbationSummary()
 
     analyzer_module.PendulumPerturbationAnalyzer = _FakeAnalyzer
-    modules[
-        "src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer"
-    ] = analyzer_module
+    modules["src.shared.python.pendulum_simulator.pendulum_perturbation_analyzer"] = (
+        analyzer_module
+    )
 
     perturbation_analysis_module = ModuleType(
         "src.shared.python.pendulum_simulator.perturbation_analysis"

--- a/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
+++ b/tests/unit/pendulum_simulator/test_panel_builders_helpers.py
@@ -25,7 +25,6 @@ def _make_fake_simulation_modules() -> dict[str, ModuleType]:
     ):
         module = ModuleType(module_name)
         module.make_polynomial_torque = lambda *args, **kwargs: (args, kwargs)
-<<<<<<< HEAD
         module.run_simulation = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
         if module_name.endswith(".simulation"):
             module.SimulationResult = _FakeResultBase
@@ -96,7 +95,6 @@ def panel_builders(monkeypatch: pytest.MonkeyPatch):
     }.items():
         monkeypatch.setitem(sys.modules, module_name, module)
 
-<<<<<<< HEAD
     module = import_module("src.shared.python.pendulum_simulator.gui.panel_builders")
     return reload(module)
 


### PR DESCRIPTION
## Summary
- stop mutating pendulum simulator fake modules in `sys.modules` at test-import time
- scope the fake simulation and perturbation modules to a pytest fixture and reload `panel_builders` inside the test fixture
- make the fake `run_simulation` callable accept positional args so helper tests don’t encode the wrong runtime signature

## Validation
- `python3 -m py_compile tests/unit/pendulum_simulator/test_panel_builders_helpers.py`
- `/home/dieterolson/Repositories-WSL/UpstreamDrift/.venv/bin/ruff check tests/unit/pendulum_simulator/test_panel_builders_helpers.py`
- targeted local pytest subset still timed out under the repo test runner in this environment, but this change directly removes the import-time `sys.modules` pollution visible in CI logs

Related to the shared `tests` lane failures affecting #2569, #2573, and #2574.