### PR TITLE
[codex] widen drake test fixture scope

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.78                                             |
+| **Spec Version**        | 1.0.79                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.79  | Test framework fix: widened the shared Drake dependency fixture to module scope and expanded its mocked `pydrake` surface so module-scoped Drake tests can import consistently in optional-stack CI without fixture-scope or missing-submodule failures. |
 | 2026-04-10 | 1.0.78  | Test framework fix: Refactored `test_panel_builders_helpers.py` to prevent module-level mocking of `run_simulation` from polluting `sys.modules` and causing cascading failures in other test suites. |
 | 2026-04-10 | 1.0.77  | Optimization: Cached difference vectors and their np.linalg.norm results into local variables inside tight collision-checking loops to eliminate redundant vector subtractions and matrix math operations, halving execution time in these hot paths without sacrificing code readability. |
 | 2026-04-10 | 1.0.76  | Simscape + GUI maintenance: fixed the 3D golf dataset generator defaults to target the bundled `GolfSwing3D_Kinetic` model while keeping legacy `verbose` and newer `verbosity` config paths compatible, and decomposed the launcher dashboard plus pendulum GUI builder/toolstrip code into smaller helpers with focused regression coverage. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ class MockPhysicsEngine:
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mock_drake_dependencies():
     """Fixture to mock pydrake and interfaces safely.
 
@@ -216,6 +216,8 @@ def mock_drake_dependencies():
             "pydrake.multibody": MagicMock(),
             "pydrake.multibody.plant": MagicMock(),
             "pydrake.multibody.parsing": MagicMock(),
+            "pydrake.multibody.tree": MagicMock(),
+            "pydrake.geometry": MagicMock(),
             "pydrake.systems": MagicMock(),
             "pydrake.systems.framework": MagicMock(),
             "pydrake.systems.analysis": MagicMock(),


### PR DESCRIPTION
## Summary
- make `mock_drake_dependencies` module-scoped so it can legally back the module-scoped `DrakePhysicsEngineClass` fixture
- add mocked `pydrake.geometry` and `pydrake.multibody.tree` modules to match the import surface used by Drake tests

## Validation
- `python3 -m py_compile tests/conftest.py`
- `/home/dieterolson/Repositories-WSL/UpstreamDrift/.venv/bin/ruff check tests/conftest.py`
- targeted local `pytest` for `tests/unit/test_drake_physics_engine.py` still timed out under this repo test runner in my environment, so I am relying on CI for the real check result

Targets the shared optional-stack Drake fixture failures seen across open PRs.