### PR TITLE
[codex] expand drake strict mock surface

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.78                                             |
+| **Spec Version**        | 1.0.79                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.79  | Test isolation(Drake): expanded the isolated Drake strict-test mock surface to include `pydrake.geometry` and `pydrake.multibody.tree`, reducing cross-test import failures when the optional-stack lane executes strict Drake mocks before the broader Drake wrapper and integration-audit suites. |
 | 2026-04-10 | 1.0.78  | Test framework fix: Refactored `test_panel_builders_helpers.py` to prevent module-level mocking of `run_simulation` from polluting `sys.modules` and causing cascading failures in other test suites. |
 | 2026-04-10 | 1.0.77  | Optimization: Cached difference vectors and their np.linalg.norm results into local variables inside tight collision-checking loops to eliminate redundant vector subtractions and matrix math operations, halving execution time in these hot paths without sacrificing code readability. |
 | 2026-04-10 | 1.0.76  | Simscape + GUI maintenance: fixed the 3D golf dataset generator defaults to target the bundled `GolfSwing3D_Kinetic` model while keeping legacy `verbose` and newer `verbosity` config paths compatible, and decomposed the launcher dashboard plus pendulum GUI builder/toolstrip code into smaller helpers with focused regression coverage. |

--- a/tests/unit/isolated/test_drake_strict.py
+++ b/tests/unit/isolated/test_drake_strict.py
@@ -20,9 +20,11 @@ mock_pydrake = MagicMock()
 module_patches = {
     "pydrake": mock_pydrake,
     "pydrake.all": mock_pydrake,
+    "pydrake.geometry": mock_pydrake,
     "pydrake.multibody": mock_pydrake,
     "pydrake.multibody.parsing": mock_pydrake,
     "pydrake.multibody.plant": mock_pydrake,
+    "pydrake.multibody.tree": mock_pydrake,
     "pydrake.systems": mock_pydrake,
     "pydrake.systems.framework": mock_pydrake,
     "pydrake.systems.analysis": mock_pydrake,


### PR DESCRIPTION
## Summary
- add mocked `pydrake.geometry` and `pydrake.multibody.tree` entries to the isolated Drake strict test harness
- align the strict test mock surface with the imports used by Drake engine code paths

## Validation
- `python3 -m py_compile tests/unit/isolated/test_drake_strict.py`
- `/home/dieterolson/Repositories-WSL/UpstreamDrift/.venv/bin/ruff check tests/unit/isolated/test_drake_strict.py`
- targeted local `pytest` still timed out under the repo test runner in this environment, so CI will provide the real verdict

Targets the optional-stack Drake strict import failures.