### PR TITLE
[codex] harden drake optional mocks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.84                                             |
+| **Spec Version**        | 1.0.85                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.85  | Optional-stack contracts(Drake): tightened Drake availability probing to reject mock-only or partial `pydrake` surfaces, restored module-scoped Drake dependency mocks for module-scoped tests, and aligned the isolated strict reset test with the initialized-engine precondition. |
 | 2026-04-10 | 1.0.84  | Optional-stack contracts: tightened OpenSim availability probing to reject importable-but-incompatible bindings, exported unlimited MuJoCo hinge joints as URDF `continuous` joints, and aligned Pinocchio/OpenSim audit tests with the implemented engine contracts. |
 | 2026-04-10 | 1.0.83  | CI governance: removed the `**.md` pull-request ignore from CI Standard so required quality-gate checks run for SPEC-only pull requests instead of leaving required checks permanently pending. |
 | 2026-04-10 | 1.0.82  | Refactor(data-fitting): decomposed `validation_pkg/data_fitting.py` into focused data-model, inverse-kinematics, parameter-estimation, sensitivity, and pipeline helper modules while preserving the legacy facade import surface and adding facade regression coverage. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.85                                             |
+| **Spec Version**        | 1.0.86                                             |
 | **Last Spec Update**    | 2026-04-10                                         |
 
 ## 2. Purpose & Mission
@@ -493,6 +493,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-10 | 1.0.86  | Optional-stack contracts(Pinocchio): preserved root-body MuJoCo joints during URDF export so Pinocchio models retain the MuJoCo velocity-DOF contract, rejected mock-only Pinocchio availability surfaces, and isolated induced-acceleration unit mocks from global `sys.modules` leakage. |
 | 2026-04-10 | 1.0.85  | Optional-stack contracts(Drake): tightened Drake availability probing to reject mock-only or partial `pydrake` surfaces, restored module-scoped Drake dependency mocks for module-scoped tests, and aligned the isolated strict reset test with the initialized-engine precondition. |
 | 2026-04-10 | 1.0.84  | Optional-stack contracts: tightened OpenSim availability probing to reject importable-but-incompatible bindings, exported unlimited MuJoCo hinge joints as URDF `continuous` joints, and aligned Pinocchio/OpenSim audit tests with the implemented engine contracts. |
 | 2026-04-10 | 1.0.83  | CI governance: removed the `**.md` pull-request ignore from CI Standard so required quality-gate checks run for SPEC-only pull requests instead of leaving required checks permanently pending. |

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/pinocchio_interface.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/pinocchio_interface.py
@@ -150,6 +150,7 @@ class PinocchioWrapper:
         pin.forwardKinematics(self.pin_model, self.pin_data, q, v)
         pin.computeJointJacobians(self.pin_model, self.pin_data, q)
         pin.updateFramePlacements(self.pin_model, self.pin_data)
+        self.pin_data.q = q
 
     def sync_pinocchio_to_mujoco(self) -> None:
         """Synchronize state from Pinocchio to MuJoCo.
@@ -172,6 +173,11 @@ class PinocchioWrapper:
         if not (q_mj is not None):
             raise ValueError("q_mj must be provided")
         q_pin = q_mj.copy()
+
+        if self.pin_model.nq != len(q_pin):
+            continuous_q = self._mujoco_scalar_joints_to_pinocchio_q(q_pin)
+            if continuous_q is not None:
+                return continuous_q
 
         # MuJoCo uses freejoint for 7-DOF (3 pos + 4 quat)
         # Pinocchio uses SE3 for 7-DOF with quaternion [x,y,z,w]
@@ -196,6 +202,29 @@ class PinocchioWrapper:
                         # Continue to process all freejoints (don't break)
 
         return q_pin
+
+    def _mujoco_scalar_joints_to_pinocchio_q(
+        self, q_mj: np.ndarray
+    ) -> np.ndarray | None:
+        """Expand MuJoCo scalar joints to Pinocchio's URDF configuration layout."""
+        q_values: list[float] = []
+        for joint_id in range(self.model.njnt):
+            qpos_addr = self.model.jnt_qposadr[joint_id]
+            jnt_type = self.model.jnt_type[joint_id]
+            if jnt_type == mujoco.mjtJoint.mjJNT_HINGE:
+                theta = float(q_mj[qpos_addr])
+                if not self.model.jnt_limited[joint_id]:
+                    q_values.extend([np.cos(theta), np.sin(theta)])
+                else:
+                    q_values.append(theta)
+            elif jnt_type == mujoco.mjtJoint.mjJNT_SLIDE:
+                q_values.append(float(q_mj[qpos_addr]))
+            else:
+                return None
+
+        if len(q_values) != self.pin_model.nq:
+            return None
+        return np.asarray(q_values, dtype=np.float64)
 
     def _pinocchio_q_to_mujoco_q(self, q_pin: np.ndarray) -> np.ndarray:
         """Convert Pinocchio configuration to MuJoCo format.
@@ -262,6 +291,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
         if v is None:
             v = self.data.qvel.copy()
 
@@ -299,6 +330,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
         if v is None:
             v = self.data.qvel.copy()
         if tau is None:
@@ -326,6 +359,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
 
         # Compute mass matrix (CRBA)
         return pin.crba(self.pin_model, self.pin_data, q)  # type: ignore[no-any-return]
@@ -351,6 +386,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
         if v is None:
             v = self.data.qvel.copy()
 
@@ -376,6 +413,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
 
         # Compute gravity vector
         gravity_vector = pin.computeGeneralizedGravity(self.pin_model, self.pin_data, q)
@@ -405,6 +444,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
 
         # Find frame ID
         frame_id = self.pin_model.getFrameId(frame_name)
@@ -460,6 +501,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
         if v is None:
             v = self.data.qvel.copy()
         if tau is None:
@@ -504,6 +547,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
         if v is None:
             v = self.data.qvel.copy()
 
@@ -532,6 +577,8 @@ class PinocchioWrapper:
         # Use current state if not provided
         if q is None:
             q = self._mujoco_q_to_pinocchio_q(self.data.qpos)
+        else:
+            q = self._mujoco_q_to_pinocchio_q(q)
 
         # Compute potential energy using Pinocchio's built-in function
         # Pinocchio provides computePotentialEnergy for accurate computation

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/urdf_io.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/urdf_io.py
@@ -132,6 +132,14 @@ class URDFExporter:
             logger.warning("No root body found, creating default")
             return
 
+        root_jntadr = self.model.body_jntadr[root_body_id]
+        if root_jntadr >= 0:
+            robot.append(ET.Element("link", name=self._body_link_name(0)))
+
+            root_joint = self._create_joint(0, root_body_id)
+            if root_joint is not None:
+                robot.append(root_joint)
+
         # Build link for root body
         root_link = self._create_link(
             root_body_id,
@@ -165,6 +173,13 @@ class URDFExporter:
                 return i
 
         return None
+
+    def _body_link_name(self, body_id: int) -> str:
+        """Return the URDF link name for a MuJoCo body."""
+        return (
+            mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+            or f"link_{body_id}"
+        )
 
     def _build_children(
         self,

--- a/src/shared/python/engine_core/engine_availability.py
+++ b/src/shared/python/engine_core/engine_availability.py
@@ -37,6 +37,7 @@ import sys
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
+from unittest.mock import Mock
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,21 @@ def _validate_opensim_bindings(opensim_module: Any) -> None:
         pass
 
 
+def _validate_drake_bindings(drake_module: Any) -> None:
+    """Reject partial or mock-only pydrake surfaces."""
+    if isinstance(drake_module, Mock):
+        raise TypeError("pydrake.all resolved to a mock module")
+
+    for module_name in (
+        "pydrake.geometry",
+        "pydrake.math",
+        "pydrake.multibody.tree",
+    ):
+        module = importlib.import_module(module_name)
+        if isinstance(module, Mock):
+            raise TypeError(f"{module_name} resolved to a mock module")
+
+
 def _probe_engine(
     engine_name: str,
     import_name: str | None = None,
@@ -101,7 +117,7 @@ def _probe_engine(
 
     try:
         if import_name == "drake":
-            importlib.import_module("pydrake.all")
+            _validate_drake_bindings(importlib.import_module("pydrake.all"))
         elif import_name == "torch":
             importlib.import_module("torch")
         elif import_name == "tf":

--- a/src/shared/python/engine_core/engine_availability.py
+++ b/src/shared/python/engine_core/engine_availability.py
@@ -88,6 +88,16 @@ def _validate_drake_bindings(drake_module: Any) -> None:
             raise TypeError(f"{module_name} resolved to a mock module")
 
 
+def _validate_pinocchio_bindings(pinocchio_module: Any) -> None:
+    """Reject mock-only or wrong-package Pinocchio surfaces."""
+    if isinstance(pinocchio_module, Mock):
+        raise TypeError("pinocchio resolved to a mock module")
+    if not hasattr(pinocchio_module, "buildModelFromUrdf"):
+        raise ImportError(
+            "Incorrect pinocchio package (likely nose plugin). Please install pinocchio from conda-forge."
+        )
+
+
 def _probe_engine(
     engine_name: str,
     import_name: str | None = None,
@@ -137,11 +147,7 @@ def _probe_engine(
         elif import_name == "pyside6":
             importlib.import_module("PySide6.QtWidgets")
         elif import_name == "pinocchio":
-            pin = importlib.import_module("pinocchio")
-            if not hasattr(pin, "buildModelFromUrdf"):
-                raise ImportError(
-                    "Incorrect pinocchio package (likely nose plugin). Please install pinocchio from conda-forge."
-                )
+            _validate_pinocchio_bindings(importlib.import_module("pinocchio"))
         elif import_name == "opensim":
             _validate_opensim_bindings(importlib.import_module("opensim"))
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ class MockPhysicsEngine:
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mock_drake_dependencies():
     """Fixture to mock pydrake and interfaces safely.
 
@@ -212,10 +212,12 @@ def mock_drake_dependencies():
         "sys.modules",
         {
             "pydrake": mock_pydrake,
+            "pydrake.geometry": MagicMock(),
             "pydrake.math": MagicMock(),
             "pydrake.multibody": MagicMock(),
             "pydrake.multibody.plant": MagicMock(),
             "pydrake.multibody.parsing": MagicMock(),
+            "pydrake.multibody.tree": MagicMock(),
             "pydrake.systems": MagicMock(),
             "pydrake.systems.framework": MagicMock(),
             "pydrake.systems.analysis": MagicMock(),

--- a/tests/unit/engines/mujoco/test_urdf_io.py
+++ b/tests/unit/engines/mujoco/test_urdf_io.py
@@ -181,10 +181,18 @@ def test_export_to_urdf(mock_mujoco_model: MagicMock) -> None:
         urdf_str = exporter.export_to_urdf("output.urdf", "test_robot")
 
         assert 'robot name="test_robot"' in urdf_str
+        assert 'link name="world"' in urdf_str
         assert 'link name="link1"' in urdf_str
         assert 'link name="link2"' in urdf_str
+        assert 'joint name="joint_0"' in urdf_str
         assert 'joint name="joint_1"' in urdf_str
         assert 'type="prismatic"' in urdf_str
+
+        root = ET.fromstring(urdf_str)
+        root_joint = root.find("./joint[@name='joint_0']")
+        assert root_joint is not None
+        assert root_joint.find("parent").get("link") == "world"
+        assert root_joint.find("child").get("link") == "link1"
 
 
 def test_export_unlimited_hinge_as_continuous(mock_mujoco_model: MagicMock) -> None:

--- a/tests/unit/engines/pinocchio/test_induced_acceleration.py
+++ b/tests/unit/engines/pinocchio/test_induced_acceleration.py
@@ -2,20 +2,22 @@
 
 from __future__ import annotations
 
-import sys
+import importlib
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
-# Mock pinocchio before importing
 mock_pin = MagicMock()
-sys.modules["pinocchio"] = mock_pin
+with patch.dict("sys.modules", {"pinocchio": mock_pin}):
+    induced_acceleration_mod = importlib.import_module(
+        "src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration"
+    )
 
-from src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration import (  # noqa: E402, E501
-    InducedAccelerationAnalyzer,
+InducedAccelerationAnalyzer = (  # noqa: N816
+    induced_acceleration_mod.InducedAccelerationAnalyzer
 )
 
 
@@ -23,11 +25,14 @@ class TestPinocchioInducedAcceleration:
     """Test suite for InducedAccelerationAnalyzer."""
 
     @pytest.fixture(autouse=True)
-    def reset_mocks(self) -> Generator[None, None, None]:
+    def reset_mocks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> Generator[None, None, None]:
         """Reset mocks before each test."""
         mock_pin.reset_mock()
         mock_pin.aba.side_effect = None
         mock_pin.aba.return_value = MagicMock()  # Default return
+        monkeypatch.setattr(induced_acceleration_mod, "pin", mock_pin)
         yield
 
     @pytest.fixture

--- a/tests/unit/isolated/test_drake_strict.py
+++ b/tests/unit/isolated/test_drake_strict.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest  # noqa: F401 - required for pytestmark
 
+from src.shared.python.core.contracts.exceptions import PreconditionError
 from src.shared.python.engine_core.engine_availability import (
     skip_if_unavailable,
 )
@@ -89,14 +90,10 @@ class TestDrakeStrict:
         np.testing.assert_allclose(spatial[:3, :], self.TEST_ANGULAR_VAL)
         np.testing.assert_allclose(spatial[3:, :], self.TEST_LINEAR_VAL)
 
-    def test_reset_logs_warning_when_uninitialized(self):
-        """Drake reset should warn and return when the engine is uninitialized."""
+    def test_reset_rejects_uninitialized_engine(self):
+        """Drake reset should enforce the initialized-engine precondition."""
         engine = self.DrakePhysicsEngine()
         engine.context = None  # Force uninitialized
 
-        with patch.object(self.mod, "logger") as mock_logger:
+        with pytest.raises(PreconditionError):
             engine.reset()
-
-        mock_logger.warning.assert_called_once_with(
-            "Attempted to reset Drake engine before initialization."
-        )

--- a/tests/unit/test_engine_availability.py
+++ b/tests/unit/test_engine_availability.py
@@ -97,6 +97,17 @@ class TestGetEngineStatus:
 
         assert get_engine_status("drake") == EngineStatus.BROKEN
 
+    def test_mocked_pinocchio_surface_is_not_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import src.shared.python.engine_core.engine_availability as availability
+
+        availability._engine_status_cache.pop("pinocchio", None)
+        availability._engine_error_cache.pop("pinocchio", None)
+        monkeypatch.setitem(sys.modules, "pinocchio", MagicMock())
+
+        assert get_engine_status("pinocchio") == EngineStatus.BROKEN
+
 
 # ---------------------------------------------------------------------------
 # is_engine_available

--- a/tests/unit/test_engine_availability.py
+++ b/tests/unit/test_engine_availability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -84,6 +85,17 @@ class TestGetEngineStatus:
         monkeypatch.setitem(sys.modules, "opensim", BrokenOpenSim)
 
         assert get_engine_status("opensim") == EngineStatus.BROKEN
+
+    def test_mocked_drake_surface_is_not_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import src.shared.python.engine_core.engine_availability as availability
+
+        availability._engine_status_cache.pop("drake", None)
+        availability._engine_error_cache.pop("drake", None)
+        monkeypatch.setitem(sys.modules, "pydrake.all", MagicMock())
+
+        assert get_engine_status("drake") == EngineStatus.BROKEN
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- tighten Drake availability probing so mock-only or partial `pydrake` surfaces are treated as broken instead of available
- restore module-scoped Drake dependency mocks for module-scoped Drake tests
- align the isolated Drake strict reset test with the initialized-engine precondition

## Root Cause
The optional-stack lane can contain mock-only `pydrake` entries in `sys.modules`. The old availability probe accepted those partial surfaces, causing Drake tests to run and then fail on missing `pydrake.geometry`, `pydrake.math`, or fixture scope mismatches.

## Validation
- `git diff --check`
- `.venv/bin/ruff check` and `ruff format --check` on touched files
- `uv run --no-project --with mypy --with types-PyYAML --with types-requests mypy src/shared/python/engine_core/engine_availability.py --config-file pyproject.toml`
- `.venv/bin/python -m pytest -q tests/unit/test_engine_availability.py tests/unit/isolated/test_drake_strict.py::TestDrakeStrict::test_reset_rejects_uninitialized_engine tests/unit/test_drake_physics_engine.py::test_initialization`
