### PR TITLE
fix(ci): repair main CI baseline — segfaulting Qt test, stale coverage, toolcache corruption

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -238,7 +238,15 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install Core Test Dependencies
-        run: pip install -e ".[dev,gui-test]"
+        # Force-reinstall hypothesis + sortedcontainers: the shared self-
+        # hosted toolcache occasionally carries half-installed versions
+        # where the pip metadata says 2.4.0 but the package namespace is
+        # missing exports (e.g. `SortedSet`). A plain `pip install -e` sees
+        # "Requirement already satisfied" and doesn't repair the cache,
+        # which causes hypothesis to fail its terminal-summary import.
+        run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
+          pip install -e ".[dev,gui-test]"
 
       - name: Document Native Engine Coverage In Core Lane
         run: |
@@ -254,6 +262,16 @@ jobs:
           Xvfb :99 -screen 0 1280x720x24 -ac +extension GLX +render -noreset &
           sleep 1
           echo "DISPLAY=:99" >> $GITHUB_ENV
+
+      - name: Clean Stale Coverage Data
+        # Self-hosted runners reuse workspaces across jobs. A crashed
+        # worker from a prior run can leave behind a partially-written
+        # .coverage.<host>.<pid>.<rand> sqlite file with no 'file' table,
+        # which then causes pytest-cov to abort the next run with
+        # "sqlite3.OperationalError: no such table: file". Remove any
+        # stale coverage artefacts before collecting fresh data.
+        run: |
+          rm -f .coverage .coverage.* coverage.xml || true
 
       - name: Run Core Test Suite
         env:
@@ -352,7 +370,12 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Core Test Dependencies
-        run: pip install -e ".[dev,gui-test]"
+        # See tests/Install Core Test Dependencies for the rationale —
+        # the shared toolcache can carry a stale `sortedcontainers` that
+        # makes hypothesis fail during pytest_terminal_summary.
+        run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
+          pip install -e ".[dev,gui-test]"
       - name: Run Shared Tools Consumer Contracts
         env:
           QT_QPA_PLATFORM: offscreen

--- a/tests/unit/test_golf_launcher_logic.py
+++ b/tests/unit/test_golf_launcher_logic.py
@@ -280,9 +280,13 @@ class TestGolfLauncherLogic:
         src.launchers.ui_components.ContextHelpDock = MagicMock()
         yield
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="GolfLauncher construction hangs in CI (mixed mock/real Qt segfaults)",
+    @pytest.mark.skip(
+        reason=(
+            "GolfLauncher construction segfaults (SIGABRT) under mixed "
+            "mock/real Qt — xfail cannot catch a native abort, so the "
+            "xdist worker crashes and corrupts the coverage .db. Skip "
+            "until tracked in a dedicated issue."
+        ),
     )
     @patch("src.shared.python.config.model_registry.ModelRegistry")
     @patch("src.launchers.golf_launcher.DockerCheckThread")
@@ -309,9 +313,13 @@ class TestGolfLauncherLogic:
         assert hasattr(launcher, "grid_layout")
         assert hasattr(launcher, "btn_launch")
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="GolfLauncher construction hangs in CI (mixed mock/real Qt segfaults)",
+    @pytest.mark.skip(
+        reason=(
+            "GolfLauncher construction segfaults (SIGABRT) under mixed "
+            "mock/real Qt — xfail cannot catch a native abort, so the "
+            "xdist worker crashes and corrupts the coverage .db. Skip "
+            "until tracked in a dedicated issue."
+        ),
     )
     @patch("src.shared.python.config.model_registry.ModelRegistry")
     @patch("src.launchers.golf_launcher.DockerCheckThread")
@@ -355,9 +363,13 @@ class TestGolfLauncherLogic:
         # The button text should contain the NAME, upper case
         assert "TEST MODEL" in launcher.btn_launch.text()
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="GolfLauncher construction hangs in CI (mixed mock/real Qt segfaults)",
+    @pytest.mark.skip(
+        reason=(
+            "GolfLauncher construction segfaults (SIGABRT) under mixed "
+            "mock/real Qt — xfail cannot catch a native abort, so the "
+            "xdist worker crashes and corrupts the coverage .db. Skip "
+            "until tracked in a dedicated issue."
+        ),
     )
     @patch("src.shared.python.config.model_registry.ModelRegistry")
     @patch("src.launchers.golf_launcher.DockerCheckThread")
@@ -405,9 +417,13 @@ class TestGolfLauncherLogic:
             idx = args.index("-w")
             assert args[idx + 1] == "/workspace"
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="GolfLauncher construction hangs in CI (mixed mock/real Qt segfaults)",
+    @pytest.mark.skip(
+        reason=(
+            "GolfLauncher construction segfaults (SIGABRT) under mixed "
+            "mock/real Qt — xfail cannot catch a native abort, so the "
+            "xdist worker crashes and corrupts the coverage .db. Skip "
+            "until tracked in a dedicated issue."
+        ),
     )
     @patch("src.shared.python.config.model_registry.ModelRegistry")
     @patch("src.launchers.golf_launcher.DockerCheckThread")


### PR DESCRIPTION
## Summary

Main CI has been failing on every push and every PR for days because of three compounding issues. After #2660 fixed the Xvfb/startup failures, tests actually start — but they then crash a worker, corrupt the coverage database, and fail. This PR addresses the three root causes identified in the most recent Bolt PR run (https://github.com/D-sorganization/UpstreamDrift/actions/runs/24396783672):

- **Segfaulting Qt test** (`tests/unit/test_golf_launcher_logic.py::TestGolfLauncherLogic::*`). All four tests in the class build a real `GolfLauncher` under a mixed mock/real PyQt6 import tree and SIGABRT inside `_setup_process_console` (`QPlainTextEdit`). They were marked `@pytest.mark.xfail(strict=False)`, but xfail only handles Python exceptions, not a native abort. The crash brings down the xdist worker (`[gw*] node down: Not properly terminated`), visible in the run above as a `Fatal Python error: Aborted` traceback pointing at `launcher_ui_setup.py:406`. Converted the four xfails to `@pytest.mark.skip` so the process never enters the crashing path. Verified locally: the file goes from "SIGABRT" to "4 skipped".
- **Stale `.coverage.*` data on the self-hosted runner workspace.** Once a worker crashes mid-run, it leaves behind a partially-written `.coverage.<host>.<pid>.<rand>` sqlite file. The next pytest-cov invocation aborts with `sqlite3.OperationalError: no such table: file` when it tries to combine that file, which becomes the xdist `worker_internal_error` that turns the entire job red. Added a "Clean Stale Coverage Data" step that runs `rm -f .coverage .coverage.* coverage.xml` before each test run.
- **Stale `sortedcontainers` in the shared toolcache.** On `shared-tools-consumer-contracts`, the pip-install step reports `sortedcontainers 2.4.0` as already satisfied, yet `from sortedcontainers import SortedSet` fails during `pytest_terminal_summary`, killing the job with exit 1 even after the tests passed. Force-reinstall `sortedcontainers` and `hypothesis` with `--force-reinstall --no-deps` before the editable install so the namespace is repaired.

No coverage thresholds were lowered; no tests were disabled except those already marked as broken (xfail → skip).

## Why This Unblocks Bolts

Bolt PRs #2661, #2662, #2663, #2664 all inherit main's CI baseline. After this merges and main goes green, rebasing those PRs should produce green CI for them too (assuming the Bolt changes themselves are fine).

## Test plan

- [x] `python3 -m pytest tests/unit/test_golf_launcher_logic.py -v --timeout=30` → 4 skipped, no SIGABRT
- [x] `ruff check tests/unit/test_golf_launcher_logic.py` → pass
- [x] `ruff format --check tests/unit/test_golf_launcher_logic.py` → pass
- [x] `ruff check .` → All checks passed!
- [x] `ruff format --check .` → 2415 files already formatted
- [x] `python3 scripts/check_file_size_budget.py` → OK
- [ ] CI on this PR: tests (3.10 / 3.11 / 3.12) should go green
- [ ] CI on this PR: shared-tools-consumer-contracts should go green
- [ ] After merge + rebase: Bolt PRs #2661-#2664 go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)