### PR TITLE
chore(deps): upgrade black, bokeh, flask, requests to fix 5 CVEs

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -148,29 +148,21 @@ jobs:
           # rather than all ambient packages in the shared runner toolcache.
           # The shared self-hosted runner toolcache accumulates stale packages from
           # multiple projects; auditing the full environment produces false positives.
-          # Ignore CVEs with no fix version available or transitive dependencies:
+          # Ignore CVEs with no fix version available:
           # - CVE-2024-23342 (ecdsa): No fix version available
           # - CVE-2026-0994 (protobuf): No fix version available - transitive dep from dm_control
           # - CVE-2026-1703 (pip): pip upgrade may not persist in GHA runner env
           # - CVE-2026-4539 (pygments): No fix version available at time of writing
           # - CVE-2025-71176 (pytest): Fix in pytest>=9.0.3; pyproject.toml updated to require >=9.0.3
-          # - CVE-2026-32274 (black): Transitive runner-env dep; not a direct project dep
-          # - CVE-2026-21883 (bokeh): Transitive runner-env dep; not a direct project dep
-          # - CVE-2026-27205 (flask): Transitive runner-env dep; not a direct project dep
-          # - CVE-2024-47081 (requests): Transitive dep; fix in requests>=2.32.4
-          # - CVE-2026-25645 (requests): Transitive dep; fix in requests>=2.33.0
           # - CVE-2026-40192 (pillow): Transitive dep via opencv/imageio; fix in pillow>=12.2.0
+          # Resolved CVEs (issue #2653): black>=26.3.1, bokeh>=3.8.2, flask>=3.1.3, requests>=2.33.0
+          # are now pinned in pyproject.toml dev deps and requirements-dev.lock.
           pip-audit -r requirements-dev.lock \
             --ignore-vuln CVE-2024-23342 \
             --ignore-vuln CVE-2026-0994 \
             --ignore-vuln CVE-2026-1703 \
             --ignore-vuln CVE-2026-4539 \
             --ignore-vuln CVE-2025-71176 \
-            --ignore-vuln CVE-2026-32274 \
-            --ignore-vuln CVE-2026-21883 \
-            --ignore-vuln CVE-2026-27205 \
-            --ignore-vuln CVE-2024-47081 \
-            --ignore-vuln CVE-2026-25645 \
             --ignore-vuln CVE-2026-40192
 
       # SECURITY: Bandit static security analysis (Issue #782)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,14 @@ dev = [
     "hypothesis>=6.0.0",
     # Required for database migration tooling (issue #2078)
     "alembic>=1.13.0",
+    # Security: requests>=2.33.0 fixes CVE-2024-47081 and CVE-2026-25645
+    "requests>=2.33.0",
+    # Security: black>=26.3.1 fixes CVE-2026-32274
+    "black>=26.3.1",
+    # Security: bokeh>=3.8.2 fixes CVE-2026-21883
+    "bokeh>=3.8.2",
+    # Security: flask>=3.1.3 fixes CVE-2026-27205
+    "flask>=3.1.3",
 ]
 
 # GUI testing (requires PyQt6)

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -15,6 +15,10 @@ anyio==4.12.1
     #   httpx
     #   starlette
     #   watchfiles
+black==26.3.1
+    # via upstream-drift (pyproject.toml)
+bokeh==3.8.2
+    # via upstream-drift (pyproject.toml)
 build==1.4.0
     # via upstream-drift (pyproject.toml)
 certifi==2026.1.4
@@ -30,6 +34,8 @@ exceptiongroup==1.3.1
     #   anyio
     #   pytest
 fastapi==0.128.0
+    # via upstream-drift (pyproject.toml)
+flask==3.1.3
     # via upstream-drift (pyproject.toml)
 fsspec==2026.1.0
     # via etils
@@ -92,6 +98,8 @@ python-dotenv==1.2.1
     # via uvicorn
 pyyaml==6.0.3
     # via uvicorn
+requests==2.33.0
+    # via upstream-drift (pyproject.toml)
 ruff==0.14.14
     # via upstream-drift (pyproject.toml)
 scipy==1.15.3


### PR DESCRIPTION
## Summary

Closes #2653.

- Add `black>=26.3.1`, `bokeh>=3.8.2`, `flask>=3.1.3`, `requests>=2.33.0` to `pyproject.toml` dev extras with security comments referencing each CVE
- Pin the same versions in `requirements-dev.lock` so pip-audit sees the safe versions when auditing the declared dependency set
- Remove the 5 corresponding `--ignore-vuln` flags from the Security Audit step in `.github/workflows/ci-standard.yml`

CVEs resolved:
| Package | Version | CVE |
|---------|---------|-----|
| black | 26.3.1 | CVE-2026-32274 |
| bokeh | 3.8.2 | CVE-2026-21883 |
| flask | 3.1.3 | CVE-2026-27205 |
| requests | 2.33.0 | CVE-2024-47081 |
| requests | 2.33.0 | CVE-2026-25645 |

The remaining `--ignore-vuln` flags (CVE-2024-23342, CVE-2026-0994, CVE-2026-1703, CVE-2026-4539, CVE-2025-71176, CVE-2026-40192) are kept as-is — those have no fix available or are already tracked separately.

**Note:** If CI shows sortedcontainers/hypothesis failures, those are pre-existing and tracked separately — not caused by this PR.

## Test plan

- [ ] CI Security Audit passes without the removed `--ignore-vuln` flags
- [ ] No regressions in ruff lint/format checks
- [ ] pip-audit reports no unignored CVEs for the 5 packages above

🤖 Generated with [Claude Code](https://claude.com/claude-code)