### PR TITLE
fix(ci): exclude vendor/ from Bandit security scan

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -172,7 +172,7 @@ jobs:
       # Blocking on medium+ severity, medium+ confidence findings (Issue #2067)
       - name: Bandit Security Scan
         run: |
-          bandit_output="$(bandit -r . -x ./tests,./archive,./legacy,./.git -ll -ii --format txt 2>&1)"
+          bandit_output="$(bandit -r . -x ./tests,./archive,./legacy,./.git,./vendor -ll -ii --format txt 2>&1)"
           exit_code=$?
           echo "$bandit_output"
           echo "## Security Scan Results" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Bandit security scan in the `quality-gate` job has been failing on main because the `vendor/ud-tools/` submodule (vendored Tools repo) contains 35 High + 43 Medium severity findings — mostly `subprocess_popen_with_shell_equals_true` (B602) in tool launchers.

Bandit exits 1 when ANY findings at or above the `-ll` (low+) severity filter are present, which fails the job.

## Fix

Add `./vendor` to Bandit's `-x` exclude list, matching the vendor exclusion we already have for the Verify No Placeholders step.

## Test plan

- [x] Local reproduction: `bandit -r . -x ./tests,./archive,./legacy,./.git,./vendor -ll -ii` → "No issues identified" / exit 0
- [x] Without vendor exclusion: exit 1 with 78 medium+ findings all in `./vendor/ud-tools/`
- [ ] CI `quality-gate` green on this PR
- [ ] Unblocks #2672 and any other PRs failing Bandit

🤖 Generated with [Claude Code](https://claude.com/claude-code)