### PR TITLE
fix: mark process isolation tests as slow to prevent CI timeout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,6 +138,7 @@ repos:
           tests/unit/core
           tests/unit/utils
           -x -q --tb=short -m "not slow and not integration"
+          -p no:xvfb
           --override-ini="addopts=-ra -q --strict-markers --strict-config --durations=20"
         language: system
         pass_filenames: false

--- a/tests/unit/test_process_isolation_strict.py
+++ b/tests/unit/test_process_isolation_strict.py
@@ -20,6 +20,8 @@ TEST_PINOCCHIO_STRICT = ISOLATED_TESTS_DIR / "test_pinocchio_strict.py"
 class TestProcessIsolationStrict:
     """Run specific strict unit tests in isolated subprocesses."""
 
+    pytestmark = pytest.mark.slow
+
     def run_isolated_test(self, test_file: Path):
         """Helper to run pytest on a single file in a subprocess."""
         cmd = [sys.executable, "-m", "pytest", str(test_file), "-v", "--no-cov"]


### PR DESCRIPTION
## Summary
- `TestProcessIsolationStrict` in `tests/unit/test_process_isolation_strict.py` spawns subprocess pytest runners that can easily exceed the 60-second CI per-test timeout
- Added `pytestmark = pytest.mark.slow` to the class so it is excluded by the default CI lane (`-m "not slow and not benchmark"`)
- Also added `-p no:xvfb` to the pre-push pytest hook to prevent `XStartTimeoutError` in environments where Xvfb display slots are exhausted

## Test plan
- [ ] CI `tests (3.10/3.11/3.12)` pass without timeout on `test_process_isolation_strict.py`
- [ ] Verify test counts are unchanged (tests still exist, just excluded from fast lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)