### PR TITLE
fix: prevent test_paths_utils false failure from /tmp/pyproject.toml

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-15T00:00:00Z
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.111                                            |
+| **Spec Version**        | 1.0.112                                            |
 | **Last Spec Update**    | 2026-04-15                                         |
 
 ## 2. Purpose & Mission
@@ -636,3 +636,4 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | 2026-04-13 | 1.0.91 | Bolt: Optimized np.sum(..., axis=1) square reductions to np.einsum in Drake PerturbationAnalyzer to improve performance and avoid temporary array allocations. |
 | 2026-04-14 | 1.0.93 | Bolt: Optimized np.sum(np.square(..., dtype=float), axis=1) to np.einsum in 3D_Golf_Model marker statistics analysis to improve performance and avoid type casting errors. |
+| 2026-04-14 | 1.0.112 | fix: prevent test_paths_utils false failure from /tmp/pyproject.toml — test now uses a clean isolated tmp directory instead of relying on /tmp state. |

--- a/tests/unit/upstream_drift_tools/test_paths_utils.py
+++ b/tests/unit/upstream_drift_tools/test_paths_utils.py
@@ -38,8 +38,17 @@ class TestGetRepoRoot:
             found = get_repo_root(subdir)
             assert found == root
 
-    def test_no_root_found_raises_file_not_found(self, tmp_path: Path) -> None:
-        # tmp_path is a fresh directory with no markers
+    def test_no_root_found_raises_file_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Patch markers to a sentinel that does not exist anywhere on disk so
+        # upward traversal cannot accidentally match a runner-level file (e.g.
+        # /tmp/pyproject.toml created by editable installs on self-hosted CI).
+        import src.shared.python.upstream_drift_tools.utils.paths as paths_mod
+
+        monkeypatch.setattr(
+            paths_mod, "_REPO_ROOT_MARKERS", (".THIS_MARKER_DOES_NOT_EXIST_ANYWHERE",)
+        )
         deep = tmp_path / "a" / "b" / "c"
         deep.mkdir(parents=True)
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary
- `test_no_root_found_raises_file_not_found` fails on self-hosted runners when `/tmp/pyproject.toml` exists (left by prior editable installs)
- The `get_repo_root` upward search finds `/tmp/pyproject.toml` before exhausting `_MAX_SEARCH_DEPTH`, causing the test to not raise `FileNotFoundError`
- Fix: monkeypatch `_REPO_ROOT_MARKERS` to a non-existent sentinel so the test is independent of runner filesystem state

## Test plan
- [ ] CI `tests (3.10/3.11/3.12)` pass without the `test_paths_utils.py` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)