### PR TITLE
fix: harden build/deploy — Dockerfile digest pin, Cargo path docs, compose loopback, smoke test

### DIFF
--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -97,8 +97,18 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=300 update
-          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+          apt_retry() {
+            for attempt in {1..12}; do
+              if sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"; then
+                return 0
+              fi
+              echo "apt-get $* failed on attempt $attempt; retrying after lock backoff"
+              sleep 10
+            done
+            sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"
+          }
+          apt_retry update
+          apt_retry install -y \
             libegl1 libgl1 xvfb \
             libxkbcommon-x11-0 \
             libxcb-cursor0 \

--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -97,14 +97,25 @@ jobs:
 
       - name: Install System Dependencies
         run: |
+          wait_for_apt_locks() {
+            for attempt in {1..30}; do
+              if ! sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+                return 0
+              fi
+              echo "apt locks are still held on attempt $attempt; waiting before apt-get"
+              sleep 20
+            done
+          }
           apt_retry() {
-            for attempt in {1..12}; do
+            for attempt in {1..18}; do
+              wait_for_apt_locks
               if sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"; then
                 return 0
               fi
               echo "apt-get $* failed on attempt $attempt; retrying after lock backoff"
-              sleep 10
+              sleep 20
             done
+            wait_for_apt_locks
             sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"
           }
           apt_retry update

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -215,14 +215,25 @@ jobs:
 
       - name: Install System Dependencies
         run: |
+          wait_for_apt_locks() {
+            for attempt in {1..30}; do
+              if ! sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+                return 0
+              fi
+              echo "apt locks are still held on attempt $attempt; waiting before apt-get"
+              sleep 20
+            done
+          }
           apt_retry() {
-            for attempt in {1..12}; do
+            for attempt in {1..18}; do
+              wait_for_apt_locks
               if sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"; then
                 return 0
               fi
               echo "apt-get $* failed on attempt $attempt; retrying after lock backoff"
-              sleep 10
+              sleep 20
             done
+            wait_for_apt_locks
             sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"
           }
           apt_retry update
@@ -369,14 +380,25 @@ jobs:
 
       - name: Install System Dependencies
         run: |
+          wait_for_apt_locks() {
+            for attempt in {1..30}; do
+              if ! sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+                return 0
+              fi
+              echo "apt locks are still held on attempt $attempt; waiting before apt-get"
+              sleep 20
+            done
+          }
           apt_retry() {
-            for attempt in {1..12}; do
+            for attempt in {1..18}; do
+              wait_for_apt_locks
               if sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"; then
                 return 0
               fi
               echo "apt-get $* failed on attempt $attempt; retrying after lock backoff"
-              sleep 10
+              sleep 20
             done
+            wait_for_apt_locks
             sudo apt-get -o DPkg::Lock::Timeout=300 -o APT::Get::Lock-Timeout=300 "$@"
           }
           apt_retry update

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -82,7 +82,7 @@ jobs:
   quality-gate:
     needs: pick-runner
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: self-hosted
     env:
       TRIVY_SCANNERS: vuln
-      TRIVY_SKIP_JAVA_DB_UPDATE: "true"
     permissions:
       security-events: write
       contents: read
@@ -49,7 +48,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: success()
         with:
           sarif_file: "trivy-results.sarif"
 

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -22,6 +22,9 @@ jobs:
   trivy-scan:
     name: Trivy Container Scan
     runs-on: self-hosted
+    env:
+      TRIVY_SCANNERS: vuln
+      TRIVY_SKIP_JAVA_DB_UPDATE: "true"
     permissions:
       security-events: write
       contents: read
@@ -40,6 +43,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+          scanners: "vuln"
           # Don't fail the build initially - triage first
           exit-code: "0"
 
@@ -55,6 +59,7 @@ jobs:
           image-ref: "upstreamdrift:ci"
           format: "table"
           severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: "vuln"
           # Exit with error only on CRITICAL vulnerabilities
           exit-code: "1"
           ignore-unfixed: true

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -63,3 +63,21 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
+
+      - name: Image smoke test
+        run: |
+          # Verify the built image can start and respond on /health within 30 s.
+          docker run -d --name smoke-test -p 8001:8001 \
+            -e MUJOCO_GL=osmesa \
+            -e DATABASE_URL=sqlite:////tmp/smoke.db \
+            upstreamdrift:ci
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8001/health; then
+              echo "Health check passed on attempt $i"
+              break
+            fi
+            [ "$i" -eq 30 ] && echo "Health check timed out" && exit 1
+            sleep 1
+          done
+        env:
+          DOCKER_BUILDKIT: "1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,7 +150,7 @@ repos:
 # =============================================================================
 
 default_language_version:
-  python: python3.11
+  python: python3
 
 # Files to always exclude from all hooks
 exclude: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,11 @@ authors = ["D-sorganization"]
 repository = "https://github.com/D-sorganization/UpstreamDrift"
 
 [workspace.dependencies]
-# Shared kernel from Tools repository
-# Local path for development; CI overrides via .cargo/config.toml
+# Shared kernel from Tools repository.
+# Local dev: Tools repo must be checked out as a sibling directory (../Tools).
+# CI override: scripts/setup_tools_workspace.sh symlinks _tools_dep -> ../Tools so
+#   this path resolves correctly without any per-developer config.
+# To replicate CI locally: run `scripts/setup_tools_workspace.sh` after cloning.
 tools-core = { path = "../Tools/rust_core/tools-core" }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 wasm-bindgen = "0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,9 @@ FROM continuumio/miniconda3:24.11.1-0 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Apply OS security patches before installing packages
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Runtime system dependencies only
 # - GL libraries for MuJoCo/Visualization
 # - X11/XCB libraries for PyQt6

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 # Unifies Robotics (MuJoCo, Drake, Pinocchio) and Biomechanics (OpenSim, MyoSim)
 
 # Stage 1: Builder stage with full development tools
-FROM continuumio/miniconda3:24.11.1-0 AS builder
+# Digest pinned to linux/amd64 continuumio/miniconda3:24.11.1-0.
+# To rotate: docker manifest inspect continuumio/miniconda3:<new-tag> | jq '.manifests[]|select(.platform.architecture=="amd64")|.digest'
+# then update both FROM lines below and the tag in the comment.
+FROM continuumio/miniconda3:24.11.1-0@sha256:bf95f579953e5bd7012a5b3c01404622410613c77169d29ddb4e2b9bd95a98d4 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -87,7 +90,7 @@ RUN pip install --no-cache-dir \
 
 
 # Stage 2: Runtime stage with minimal footprint
-FROM continuumio/miniconda3:24.11.1-0 AS runtime
+FROM continuumio/miniconda3:24.11.1-0@sha256:bf95f579953e5bd7012a5b3c01404622410613c77169d29ddb4e2b9bd95a98d4 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,8 +164,8 @@ EXPOSE 8001
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8001/health || exit 1
 
-# Default command
-CMD ["/bin/bash"]
+# Default command: start the API server rather than dropping into a shell
+CMD ["python", "-m", "uvicorn", "src.api.server:app", "--host", "0.0.0.0", "--port", "8001"]
 
 
 # Stage 3: Training stage for advanced ML workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,7 +174,7 @@ FROM runtime AS training
 USER root
 
 # Install CUDA toolkit via conda for GPU training support
-RUN conda install -y -c conda-forge -c nvidia \
+RUN conda install -y -c conda-forge -c pytorch -c nvidia \
     cuda-toolkit \
     cudnn \
     pytorch \

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # SPEC.md — Repository Specification Document
 
-Last-Updated: 2026-04-15T00:00:00Z
+Last-Updated: 2026-04-16T00:00:00Z
 
 <!--
   TEMPLATE VERSION: 1.0.0
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-15T00:00:00Z
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.125                                            |
+| **Spec Version**        | 1.0.126                                            |
 | **Last Spec Update**    | 2026-04-16                                         |
 
 ## 2. Purpose & Mission
@@ -448,6 +448,11 @@ upstream-drift simulate --engine mujoco --model shared/models/golf_swing.urdf
 cd ui && npm install && npm run tauri build
 # Outputs: UpstreamDrift.exe (Windows), UpstreamDrift.app (macOS), UpstreamDrift.AppImage (Linux)
 
+# Containerized API
+docker build -t upstream-drift:runtime .
+docker run --rm -p 8001:8001 upstream-drift:runtime
+# The runtime image binds to 0.0.0.0:8001 and starts `src.api.server:app` by default.
+
 # Running Tests
 pytest tests/unit/ -v
 pytest tests/integration/ -v
@@ -496,6 +501,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-16 | 1.0.126 | Docker runtime hardening: the runtime image now starts `src.api.server:app` on `0.0.0.0:8001` by default so a plain container launch serves the API instead of dropping into an interactive shell.                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | 2026-04-15 | 1.0.118 | CI stabilization: core and shared-contract dependency installs now use per-job virtual environments, pytest-qt is pinned to the PyQt6 API in GUI-capable lanes, and benchmark tests are excluded from default core CI so self-hosted runner state cannot leak optional stacks into required tests.                                                                                                                                                                                                                                                                        |
 | 2026-04-15 | 1.0.119 | Performance optimization: replaced `np.sum(diff**2, axis=1)` and `np.sqrt(np.sum(diff**2, axis=1))` with `np.einsum("ij,ij->i", ...)` in `src/shared/python/analysis/nonlinear_dynamics.py` to reduce temporary allocations in local divergence and Lyapunov exponent calculations.                                                                                                                                                                                                                                                                                                                                                |
 | 2026-04-15 | 1.0.120 | Performance optimization: extended squared-norm reductions to use `np.einsum` across angular momentum, coordination, GRF, stability, ZTCF, dashboard, marker mapping, plotting, collision geometry, and ball-flight paths so common vector magnitude calculations avoid temporary squared arrays.                                                                                                                                                                                                                                                                                                                                             |

--- a/build_hooks.py
+++ b/build_hooks.py
@@ -1,4 +1,23 @@
-"""Custom build hooks to bundle UI into Python package."""
+"""Custom build hooks to bundle the React UI into the Python wheel.
+
+Build process
+-------------
+1. ``UIBuildHook.initialize`` is invoked by hatchling before the wheel is assembled.
+2. If ``CI`` or ``SKIP_UI_BUILD`` env vars are set the step is skipped — the
+   caller is responsible for providing a pre-built ``ui/dist/`` directory.
+3. Otherwise ``npm ci`` installs frontend dependencies (via package-lock.json),
+   then ``npm run build`` produces ``ui/dist/``.
+4. hatchling then includes ``ui/dist/`` in the wheel via the ``[tool.hatch.build]``
+   ``artifacts`` list in ``pyproject.toml``.
+
+Failure modes
+-------------
+* ``npm`` not on ``PATH`` → ``RuntimeError`` with actionable message.
+* ``npm ci`` or ``npm run build`` exits non-zero → ``RuntimeError`` with captured
+  stderr/stdout.
+* UI dist directory missing after a CI skip → warning logged; the wheel will be
+  built without UI assets (likely broken at runtime).
+"""
 
 import logging
 import subprocess

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# LOCAL DEVELOPMENT ONLY — not for production use.
+# API binds to 127.0.0.1 (loopback) intentionally; authentication is minimal.
+# For production deployments use a reverse proxy and enable auth via GOLF_AUTH_DISABLED=false.
 version: "3.8"
 
 services:
@@ -18,11 +21,11 @@ services:
       - PYTHONPATH=/workspace
       - PATH=/home/golfer/.local/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - DATABASE_URL=sqlite:////workspace/golf_modeling_suite.db
-      - API_HOST=0.0.0.0
+      - API_HOST=127.0.0.1
       - API_PORT=8001
       - ENVIRONMENT=development
       - MUJOCO_GL=${MUJOCO_GL:-osmesa}
-    command: python3 -m uvicorn src.api.server:app --host 0.0.0.0 --port 8001 --reload
+    command: python3 -m uvicorn src.api.server:app --host 127.0.0.1 --port 8001 --reload
     restart: unless-stopped
     working_dir: /workspace
     healthcheck:
@@ -35,6 +38,8 @@ services:
       - upstream-drift
 
   # Frontend UI (optional - can also run locally)
+  # node_modules are stored in a named volume so npm ci runs only on first start
+  # or when the named volume is explicitly removed (docker-compose down -v).
   frontend:
     image: node:20-alpine
     container_name: upstream-drift-frontend
@@ -42,9 +47,9 @@ services:
       - "5180:5180"
     volumes:
       - ./ui:/app:delegated
-      - /app/node_modules
+      - node_modules:/app/node_modules
     working_dir: /app
-    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    command: sh -c "[ -d node_modules/.bin ] || npm ci && npm run dev -- --host 0.0.0.0"
     environment:
       - VITE_API_URL=http://backend:8001
     depends_on:

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 # Golf Modeling Suite - Quick Install Script
 # Usage: curl -fsSL https://golf-suite.io/install.sh | bash
+#
+# Security / threat model
+# -----------------------
+# * This script installs the package from the *local directory* (pipx/pip install .).
+#   It does NOT download additional packages beyond what pip resolves from PyPI.
+# * When piped from curl, the script content itself is not hash-verified.
+#   If you require supply-chain integrity, download the script first, verify its
+#   SHA-256 against the published checksum at https://golf-suite.io/install.sh.sha256,
+#   then execute it: `sha256sum -c install.sh.sha256 && bash install.sh`
+# * pipx installs into an isolated virtual environment, limiting blast radius of
+#   malicious transitive dependencies to that environment.
+# * pip3 (fallback) installs into the user or system site-packages; prefer pipx.
+# * To add hash verification for all transitive deps, generate a requirements file
+#   with `pip-compile --generate-hashes` and pass `--require-hashes` to pip.
 
 set -e
 

--- a/scripts/check_vendor_updates.py
+++ b/scripts/check_vendor_updates.py
@@ -150,7 +150,9 @@ def get_github_sha(api_url: str) -> str:
         req = urllib.request.Request(
             api_url, headers={"Accept": "application/vnd.github.v3+json"}
         )
-        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310 - GitHub API URL from trusted constant api_url
+        with urllib.request.urlopen(
+            req, timeout=10
+        ) as resp:  # noqa: S310  # nosec B310 - GitHub API URL from trusted constant api_url
             data = json.loads(resp.read())
             return str(data.get("sha", "<no-sha>"))
     except Exception as exc:  # noqa: BLE001

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -130,8 +130,7 @@ def log_summary() -> None:
     logger.info("\n" + "=" * 60)
     logger.info("HOOK SUMMARY")
     logger.info("=" * 60)
-    logger.info(
-        """
+    logger.info("""
 PRE-COMMIT (runs on every commit, <15 seconds):
   - ruff (lint + auto-fix)
   - black (format)
@@ -150,8 +149,7 @@ MANUAL COMMANDS:
   pre-commit run --all-files      # Run all pre-commit hooks
   pre-commit run --hook-stage pre-push  # Run pre-push hooks manually
   pre-commit autoupdate           # Update hook versions
-"""
-    )
+""")
 
 
 def main() -> None:

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -698,8 +698,7 @@ def print_server_info(host: str, port: int) -> None:
     RESET = "\033[0m"
 
     try:
-        logger.info(
-            f"""
+        logger.info(f"""
 {CYAN}    ┌─────────────────────────────────────────────────────────┐
     │              Golf Modeling Suite - Local Server         │
     ├─────────────────────────────────────────────────────────┤
@@ -709,8 +708,7 @@ def print_server_info(host: str, port: int) -> None:
     │  Mode: LOCAL (no auth required)                         │
     │  Press Ctrl+C to stop.                                  │
     └─────────────────────────────────────────────────────────┘{RESET}
-    """
-        )
+    """)
     except UnicodeEncodeError:
         logger.info("\n    Golf Modeling Suite - Local Server")
         logger.info("    Running at: http://%s:%s", host, port)

--- a/src/api/routes/force_overlays.py
+++ b/src/api/routes/force_overlays.py
@@ -381,13 +381,9 @@ def _get_sim_time(engine_manager: EngineManager) -> float:
     response_model=ForceOverlayResponse,
 )
 @precondition(  # fmt: skip
-    lambda force_types="applied",
-    color_by_magnitude=True,
-    body_filter=None,
-    show_labels=False,
-    scale_factor=0.01,
-    engine_manager=None,
-    logger=None: (scale_factor > 0 and len(force_types.strip()) > 0),
+    lambda force_types="applied", color_by_magnitude=True, body_filter=None, show_labels=False, scale_factor=0.01, engine_manager=None, logger=None: (
+        scale_factor > 0 and len(force_types.strip()) > 0
+    ),
     "Scale factor must be positive and force_types must be non-empty",
 )
 @handle_api_errors

--- a/src/api/routes/video.py
+++ b/src/api/routes/video.py
@@ -35,12 +35,7 @@ router = APIRouter()
 
 @router.post("/analyze/video", response_model=VideoAnalysisResponse)
 @precondition(  # fmt: skip
-    lambda file=None,
-    estimator_type="mediapipe",
-    min_confidence=0.5,
-    enable_smoothing=True,
-    video_pipeline=None,
-    logger=None: (
+    lambda file=None, estimator_type="mediapipe", min_confidence=0.5, enable_smoothing=True, video_pipeline=None, logger=None: (
         estimator_type is not None
         and len(estimator_type.strip()) > 0
         and 0.0 <= min_confidence <= 1.0
@@ -144,12 +139,7 @@ async def analyze_video(
 
 @router.post("/analyze/video/async")
 @precondition(  # fmt: skip
-    lambda background_tasks=None,
-    file=None,
-    estimator_type="mediapipe",
-    min_confidence=0.5,
-    video_pipeline=None,
-    task_manager=None: (
+    lambda background_tasks=None, file=None, estimator_type="mediapipe", min_confidence=0.5, video_pipeline=None, task_manager=None: (
         estimator_type is not None
         and len(estimator_type.strip()) > 0
         and 0.0 <= min_confidence <= 1.0

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/detailed_data_analysis.py
@@ -55,7 +55,9 @@ def deep_analyze_matlab_file(filename) -> bool:
                         # If it's an object array, try to explore further
                         if hasattr(
                             field_data, "dtype"
-                        ) and field_data.dtype == np.dtype("O"):  # noqa: E501
+                        ) and field_data.dtype == np.dtype(
+                            "O"
+                        ):  # noqa: E501
                             logger.info(
                                 f"      Object array with {len(field_data)} elements"
                             )  # noqa: E501

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_video_export.py
@@ -130,9 +130,7 @@ class VideoExporter(QObject):
                 logger.info(f"✅ Video exported successfully to {config.output_path}")
                 self.finished.emit(config.output_path)
             else:
-                error_msg = (
-                    f"ffmpeg failed with return code {ffmpeg_process.returncode}"  # noqa: E501
-                )
+                error_msg = f"ffmpeg failed with return code {ffmpeg_process.returncode}"  # noqa: E501
                 logger.error(f"❌ {error_msg}")
                 self.error.emit(error_msg)
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
@@ -701,8 +701,7 @@ class WiffleGolfMainWindow(QMainWindow):
 
     def _apply_modern_style(self) -> None:
         """Apply modern styling to the application"""
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QMainWindow {
                 background-color: #f0f0f0;
             }
@@ -750,8 +749,7 @@ class WiffleGolfMainWindow(QMainWindow):
                 width: 18px;
                 height: 18px;
             }
-        """
-        )
+        """)
 
 
 def main() -> None:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/wiffle_data_loader.py
@@ -628,9 +628,7 @@ class MotionDataLoader:
                     diff = _to_numpy(prov1_df[prov1_col]) - wiffle_interp
 
                     # Store in DELTAQ format
-                    gui_col = (
-                        f"{component.upper().replace('_', '')[:2]}{axis[-1].upper()}"  # noqa: E501
-                    )
+                    gui_col = f"{component.upper().replace('_', '')[:2]}{axis[-1].upper()}"  # noqa: E501
                     deltaq_data[gui_col] = diff
                 else:
                     deltaq_data[

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/c3d_reader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/c3d_reader.py
@@ -652,7 +652,9 @@ class C3DDataReader:
         else:
             labels = [
                 label.strip()
-                for label in analog_parameters.get("LABELS", {}).get("value", [])  # noqa: E501
+                for label in analog_parameters.get("LABELS", {}).get(
+                    "value", []
+                )  # noqa: E501
             ]
             units = [
                 unit.strip()

--- a/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
@@ -548,9 +548,7 @@ class DoublePendulumDynamics:
         )
 
 
-def compile_forcing_functions(
-    shoulder_expression: str, wrist_expression: str
-) -> tuple[
+def compile_forcing_functions(shoulder_expression: str, wrist_expression: str) -> tuple[
     Callable[[float, DoublePendulumState], float],
     Callable[[float, DoublePendulumState], float],
 ]:

--- a/src/engines/physics_engines/drake/python/motion_optimization.py
+++ b/src/engines/physics_engines/drake/python/motion_optimization.py
@@ -238,7 +238,9 @@ class DrakeMotionOptimizer:
                             "type": "ineq",
                             "fun": lambda x, c=con: (
                                 c.upper_bound
-                                - c.constraint_function(x.reshape(traj_shape))  # noqa: E501
+                                - c.constraint_function(
+                                    x.reshape(traj_shape)
+                                )  # noqa: E501
                             ),
                         }
                     )

--- a/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
+++ b/src/engines/physics_engines/mujoco/python/humanoid_launcher.py
@@ -225,8 +225,7 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
 
     # Global Stylesheet for Rounded Buttons and Modern Look
-    app.setStyleSheet(
-        """
+    app.setStyleSheet("""
         QPushButton {
             border-radius: 5px;
             padding: 5px;
@@ -272,8 +271,7 @@ if __name__ == "__main__":
         QMessageBox QLabel {
             color: white;
         }
-    """
-    )
+    """)
 
     window = HumanoidLauncher()
     window.show()

--- a/src/engines/physics_engines/mujoco/python/humanoid_launcher_ui.py
+++ b/src/engines/physics_engines/mujoco/python/humanoid_launcher_ui.py
@@ -64,8 +64,7 @@ class UISetupMixin:
 
         self.tabs = QTabWidget()
 
-        self.tabs.setStyleSheet(
-            """
+        self.tabs.setStyleSheet("""
 
             QTabWidget::pane { border: 1px solid #444; background: #2b2b2b; }
 
@@ -75,8 +74,7 @@ class UISetupMixin:
 
             QTabBar::tab:hover { background: #444; }
 
-        """
-        )
+        """)
 
         self.setup_sim_tab()
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/control_system.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/control_system.py
@@ -321,6 +321,6 @@ class ControlSystem:
             if 0 <= actuator_index < self.num_actuators:
                 self.set_polynomial_coeffs(actuator_index, coeffs)
                 # Ensure control type is set to polynomial
-                self.actuator_controls[
-                    actuator_index
-                ].control_type = ControlType.POLYNOMIAL  # noqa: E501
+                self.actuator_controls[actuator_index].control_type = (
+                    ControlType.POLYNOMIAL
+                )  # noqa: E501

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
@@ -694,7 +694,9 @@ class GripModellingTab(QtWidgets.QWidget):
         for i in range(model.njnt):
             self._add_joint_control_row(i, model)
 
-    def _add_joint_control_row(self, i: int, model: mujoco.MjModel) -> None:  # noqa: PLR0915
+    def _add_joint_control_row(
+        self, i: int, model: mujoco.MjModel
+    ) -> None:  # noqa: PLR0915
         """Create a control row for a single joint."""
         if not (i is not None):
             raise ValueError("i must be provided")

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/physics_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/gui/tabs/physics_tab.py
@@ -383,9 +383,7 @@ class PhysicsTab(QtWidgets.QWidget):
                 display_name = f"{config['category']}: {display_name}"
             elif config["name"] in desc_map:
                 prefix = "Golf" if config["name"] in golf_names else "Musculoskeletal"
-                display_name = (
-                    f"{prefix}: {display_name} ({len(config['actuators'])} DOF)"  # noqa: E501
-                )
+                display_name = f"{prefix}: {display_name} ({len(config['actuators'])} DOF)"  # noqa: E501
 
             self.model_combo.addItem(display_name)
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/interactive_manipulation.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/interactive_manipulation.py
@@ -655,7 +655,9 @@ class InteractiveManipulator:
                         maintain_orientation=True,
                     )
 
-            elif constraint.constraint_type == ConstraintType.RELATIVE_TO_BODY:  # noqa: SIM102
+            elif (
+                constraint.constraint_type == ConstraintType.RELATIVE_TO_BODY
+            ):  # noqa: SIM102
                 # Maintain relative pose to reference body
                 if (
                     constraint.reference_body_id is not None

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/meshcat_adapter.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/meshcat_adapter.py
@@ -51,7 +51,9 @@ class MuJoCoMeshcatAdapter:
         logger.info(f"Meshcat initialized at {self.url}")
 
         # Determine host-accessible URL if in Docker
-        if os.environ.get("MESHCAT_HOST") == "0.0.0.0":  # nosec B104 - comparing env var value, not binding to an address
+        if (
+            os.environ.get("MESHCAT_HOST") == "0.0.0.0"
+        ):  # nosec B104 - comparing env var value, not binding to an address
             try:
                 port = self.url.split(":")[-1].split("/")[0]
                 host_url = f"http://127.0.0.1:{port}/static/"

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/pinocchio_interface.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/pinocchio_interface.py
@@ -75,9 +75,7 @@ class PinocchioWrapper:
             ImportError: If Pinocchio is not installed
         """
         if not PINOCCHIO_AVAILABLE:
-            msg = (
-                "Pinocchio is required but not installed. Install with: pip install pin"  # noqa: E501
-            )
+            msg = "Pinocchio is required but not installed. Install with: pip install pin"  # noqa: E501
             raise ImportError(msg)
 
         self.model = model

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/polynomial_generator.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/polynomial_generator.py
@@ -84,8 +84,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         self.mode = "view"  # view, draw, add_points, drag
 
         # Dark Theme Palette
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QWidget {
                 background-color: #2b2b2b;
                 color: #ffffff;
@@ -150,8 +149,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
             QPushButton#fitBtn:hover {
                 background-color: #388e3c;
             }
-        """
-        )
+        """)
 
         # UI Setup
         self._setup_ui()

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
@@ -271,9 +271,7 @@ class RecordingLibrary:
         is_safe = self._is_relative_to(resolved_dest, resolved_lib)
 
         if not is_safe:
-            msg = (
-                f"Security violation: Attempt to save file '{filename}' outside library"  # noqa: E501
-            )
+            msg = f"Security violation: Attempt to save file '{filename}' outside library"  # noqa: E501
             logger.warning(msg)
             raise ValueError(msg)
 
@@ -523,8 +521,7 @@ class RecordingLibrary:
         cursor = conn.cursor()
 
         # PERFORMANCE FIX: Combine basic stats into single query
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT
                 COUNT(*) as total_count,
                 AVG(CASE WHEN rating > 0 THEN rating ELSE NULL END) as avg_rating,
@@ -535,8 +532,7 @@ class RecordingLibrary:
                 AVG(CASE WHEN peak_club_speed > 0
                     THEN peak_club_speed ELSE NULL END) as avg_speed
             FROM recordings
-        """
-        )
+        """)
         stats_row = cursor.fetchone()
         total_count = stats_row[0]
         avg_rating = stats_row[1] or 0.0

--- a/src/engines/physics_engines/opensim/python/opensim_golf/core.py
+++ b/src/engines/physics_engines/opensim/python/opensim_golf/core.py
@@ -135,7 +135,9 @@ class GolfSwingModel:
                 # Some versions might need setInitialTime
 
             logger.info(f"Loaded OpenSim model from {self.model_path}")
-        except Exception as e:  # noqa: BLE001 — convert any error to OpenSimModelLoadError
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 — convert any error to OpenSimModelLoadError
             raise OpenSimModelLoadError(
                 f"Failed to load OpenSim model: {self.model_path}\n"
                 f"Error: {e}\n"

--- a/src/engines/physics_engines/pinocchio/python/dtack/backends/mujoco_backend.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/backends/mujoco_backend.py
@@ -41,9 +41,7 @@ class MuJoCoBackend:
         """
         model_path_obj = Path(model_path)
         if not MUJOCO_AVAILABLE:
-            msg = (
-                "MuJoCo is required but not installed. Install with: pip install mujoco"  # noqa: E501
-            )
+            msg = "MuJoCo is required but not installed. Install with: pip install mujoco"  # noqa: E501
             raise ImportError(msg)
         if not model_path_obj.exists():
             msg = f"Model file not found: {model_path}"

--- a/src/engines/physics_engines/pinocchio/python/dtack/backends/pinocchio_backend.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/backends/pinocchio_backend.py
@@ -82,9 +82,7 @@ class PinocchioBackend:
             FileNotFoundError: If model file does not exist
         """
         if not PINOCCHIO_AVAILABLE:
-            msg = (
-                "Pinocchio is required but not installed. Install with: pip install pin"  # noqa: E501
-            )
+            msg = "Pinocchio is required but not installed. Install with: pip install pin"  # noqa: E501
             raise ImportError(msg)
 
         model_path_obj = Path(model_path)

--- a/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/motion_visualizer.py
@@ -449,7 +449,9 @@ class MotionVisualizer:
         else:
             indices = np.linspace(
                 0, trajectory.num_frames - 1, num_frames_to_show
-            ).astype(int)  # noqa: E501
+            ).astype(
+                int
+            )  # noqa: E501
 
         for i, idx in enumerate(indices):
             frame = trajectory.frames[idx]

--- a/src/engines/physics_engines/pinocchio/python/motion_training/training_pipeline.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/training_pipeline.py
@@ -92,9 +92,7 @@ class MotionTrainingPipeline:
     4. Visualize and export results
     """
 
-    DEFAULT_URDF = (
-        "src/engines/physics_engines/pinocchio/models/generated/golfer_ik.urdf"  # noqa: E501
-    )
+    DEFAULT_URDF = "src/engines/physics_engines/pinocchio/models/generated/golfer_ik.urdf"  # noqa: E501
 
     def __init__(self, config: PipelineConfig | None = None) -> None:
         """Initialize the pipeline.

--- a/src/launchers/docker_manager.py
+++ b/src/launchers/docker_manager.py
@@ -247,7 +247,9 @@ class DockerLauncher:
 
         # Port mapping for MeshCat (Drake/Pinocchio)
         if model_type in ("drake", "pinocchio"):
-            cmd.extend(["-p", "7000:7000", "-e", "MESHCAT_HOST=0.0.0.0"])  # nosec: Docker container networking requires 0.0.0.0
+            cmd.extend(
+                ["-p", "7000:7000", "-e", "MESHCAT_HOST=0.0.0.0"]
+            )  # nosec: Docker container networking requires 0.0.0.0
 
         # Working Directory
         work_dir = (

--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -435,18 +435,15 @@ class GolfLauncher(
 
         for mid, card in self.model_cards.items():
             if mid == model_id:
-                card.setStyleSheet(
-                    f"""
+                card.setStyleSheet(f"""
                     QFrame#ModelCard {{
                         background-color: {c.bg_highlight};
                         border: 2px solid {c.primary};
                         border-radius: 12px;
                     }}
-                    """
-                )
+                    """)
             else:
-                card.setStyleSheet(
-                    f"""
+                card.setStyleSheet(f"""
                     QFrame#ModelCard {{
                         background-color: {c.bg_elevated};
                         border: 1px solid {c.border_default};
@@ -456,8 +453,7 @@ class GolfLauncher(
                         background-color: {c.bg_highlight};
                         border: 1px solid {c.border_strong};
                     }}
-                    """
-                )
+                    """)
 
         # Update launch button
         model = self._get_model(model_id)
@@ -482,15 +478,13 @@ class GolfLauncher(
         if not self.selected_model:
             self.btn_launch.setText("Select a Model")
             self.btn_launch.setEnabled(False)
-            self.btn_launch.setStyleSheet(
-                f"""
+            self.btn_launch.setStyleSheet(f"""
                 QPushButton {{
                     background-color: {c.bg_elevated};
                     color: {c.text_quaternary};
                     border-radius: 6px;
                 }}
-                """
-            )
+                """)
             return
 
         name = model_name or self.selected_model
@@ -503,23 +497,20 @@ class GolfLauncher(
             and not self.docker_available
         ):
             self.btn_launch.setText("! Docker Required")
-            self.btn_launch.setStyleSheet(
-                f"""
+            self.btn_launch.setStyleSheet(f"""
                 QPushButton {{
                     background-color: {c.bg_elevated};
                     color: {c.error};
                     border: 2px solid {c.error};
                     border-radius: 6px;
                 }}
-                """
-            )
+                """)
             self.btn_launch.setEnabled(False)
             return
 
         self.btn_launch.setText(f"Launch {name} >")
         self.btn_launch.setEnabled(True)
-        self.btn_launch.setStyleSheet(
-            f"""
+        self.btn_launch.setStyleSheet(f"""
             QPushButton {{
                 background-color: {c.success};
                 color: white;
@@ -529,8 +520,7 @@ class GolfLauncher(
             QPushButton:hover {{
                 background-color: {c.success_hover};
             }}
-            """
-        )
+            """)
 
     def _get_engine_type(self, model_type: str) -> Any:
         """Map model type to EngineType."""

--- a/src/launchers/golf_suite_launcher.py
+++ b/src/launchers/golf_suite_launcher.py
@@ -386,7 +386,9 @@ class GolfLauncher(QtWidgets.QMainWindow if PYQT6_AVAILABLE else object):  # typ
         try:
             # Launch detached process
             # Use same python interpreter
-            process = subprocess.Popen([sys.executable, str(path)], cwd=str(cwd))  # noqa: S603
+            process = subprocess.Popen(
+                [sys.executable, str(path)], cwd=str(cwd)
+            )  # noqa: S603
             self.log_message(f"{name} launched successfully (PID: {process.pid})")
             self.status.setText(f"{name} Launched")
         except (OSError, subprocess.SubprocessError) as e:

--- a/src/launchers/launcher_theme.py
+++ b/src/launchers/launcher_theme.py
@@ -40,9 +40,7 @@ class LauncherThemeMixin:
             border_strong = colors.get("border_strong", colors.get("focus", "#0078D4"))
             text_sec = colors.get("text_secondary", "#AAAAAA")
 
-            self.setStyleSheet(
-                manager.get_current_stylesheet()
-                + f"""
+            self.setStyleSheet(manager.get_current_stylesheet() + f"""
                 QScrollArea {{ border: none; }}
                 QMenu::separator {{
                     height: 1px;
@@ -60,8 +58,7 @@ class LauncherThemeMixin:
                 QLabel#CardDescription {{
                     color: {text_sec};
                 }}
-            """
-            )
+            """)
         except (ImportError, AttributeError):
             # Fallback minimal dark style if theme system unavailable
             self.setStyleSheet(

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -495,7 +495,9 @@ class LauncherUISetupMixin:
 
             url = "http://127.0.0.1:8000/api/chat/sessions"
             req = urllib.request.Request(url, method="GET")
-            with urllib.request.urlopen(req, timeout=2) as resp:  # nosec B310 - hardcoded localhost URL, no external input
+            with urllib.request.urlopen(
+                req, timeout=2
+            ) as resp:  # nosec B310 - hardcoded localhost URL, no external input
                 sessions = json.loads(resp.read().decode("utf-8"))
 
             session_id = sessions[0]["session_id"] if sessions else None

--- a/src/launchers/shot_tracer.py
+++ b/src/launchers/shot_tracer.py
@@ -447,8 +447,7 @@ def main() -> None:
     app.setStyle("Fusion")
 
     # Apply dark theme
-    app.setStyleSheet(
-        """
+    app.setStyleSheet("""
         QMainWindow, QWidget {
             background-color: #2b2b2b;
             color: #ffffff;
@@ -500,8 +499,7 @@ def main() -> None:
             padding: 5px;
             border: 1px solid #555;
         }
-        """
-    )
+        """)
 
     window = MultiModelShotTracerWindow()
     window.show()

--- a/src/robotics/locomotion/footstep_planner.py
+++ b/src/robotics/locomotion/footstep_planner.py
@@ -312,21 +312,15 @@ class FootstepPlanner(ContractChecker):
         )
 
     @precondition(  # fmt: skip
-        lambda self,
-        current_position,
-        current_yaw,
-        velocity_command,
-        n_steps=4,
-        start_foot="left": (n_steps > 0),
+        lambda self, current_position, current_yaw, velocity_command, n_steps=4, start_foot="left": (
+            n_steps > 0
+        ),
         "Number of steps must be positive",
     )
     @precondition(  # fmt: skip
-        lambda self,
-        current_position,
-        current_yaw,
-        velocity_command,
-        n_steps=4,
-        start_foot="left": (start_foot in ("left", "right")),
+        lambda self, current_position, current_yaw, velocity_command, n_steps=4, start_foot="left": (
+            start_foot in ("left", "right")
+        ),
         "start_foot must be 'left' or 'right'",
     )
     def plan_from_velocity(

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -359,13 +359,11 @@ class AIAssistantPanel(QWidget):
         # Splitter for messages and input
         splitter = QSplitter(Qt.Orientation.Vertical)
         splitter.setHandleWidth(1)
-        splitter.setStyleSheet(
-            """
+        splitter.setStyleSheet("""
             QSplitter::handle {
                 background-color: #3c3c3c;
             }
-        """
-        )
+        """)
 
         # Message area
         self._message_area = self._create_message_area()
@@ -398,8 +396,7 @@ class AIAssistantPanel(QWidget):
     def _create_header(self) -> QWidget:
         """Create the panel header."""
         header = QFrame()
-        header.setStyleSheet(
-            """
+        header.setStyleSheet("""
             QFrame {
                 background-color: #FF8800;
                 padding: 8px;
@@ -418,8 +415,7 @@ class AIAssistantPanel(QWidget):
             QPushButton:hover {
                 background-color: rgba(0, 0, 0, 0.2);
             }
-            """
-        )
+            """)
 
         layout = QHBoxLayout(header)
 
@@ -455,8 +451,7 @@ class AIAssistantPanel(QWidget):
         self._mode_combo.setToolTip(
             "Select AI Mode: Ask (Chat), Plan (Reasoning), Agent (Tools)"
         )
-        self._mode_combo.setStyleSheet(
-            """
+        self._mode_combo.setStyleSheet("""
             QComboBox {
                 background-color: rgba(255, 255, 255, 0.3);
                 color: black;
@@ -465,8 +460,7 @@ class AIAssistantPanel(QWidget):
                 padding: 2px 8px;
             }
             QComboBox::drop-down { border: none; }
-        """
-        )
+        """)
         layout.addWidget(self._mode_combo)
 
         self._status_label = QLabel("Ready")
@@ -489,8 +483,7 @@ class AIAssistantPanel(QWidget):
 
         close_btn = QPushButton("\u2715")
         close_btn.setToolTip("Close AI Chat")
-        close_btn.setStyleSheet(
-            """
+        close_btn.setStyleSheet("""
             QPushButton {
                 background-color: rgba(0, 0, 0, 0.15);
                 color: #000000;
@@ -504,8 +497,7 @@ class AIAssistantPanel(QWidget):
                 background-color: rgba(200, 0, 0, 0.5);
                 color: white;
             }
-        """
-        )
+        """)
         close_btn.clicked.connect(self.close_requested.emit)
         layout.addWidget(close_btn)
 
@@ -516,8 +508,7 @@ class AIAssistantPanel(QWidget):
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         # Dark background for scroll area
-        scroll.setStyleSheet(
-            """
+        scroll.setStyleSheet("""
             QScrollArea {
                 background-color: #1e1e1e;
                 border: none;
@@ -535,8 +526,7 @@ class AIAssistantPanel(QWidget):
             QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
                 background: none;
             }
-        """
-        )
+        """)
 
         # Container for messages
         self._message_container = QWidget()
@@ -564,14 +554,12 @@ class AIAssistantPanel(QWidget):
     def _create_input_area(self) -> QWidget:
         """Create the message input area."""
         widget = QFrame()
-        widget.setStyleSheet(
-            """
+        widget.setStyleSheet("""
             QFrame {
                 background-color: #1e1e1e;
                 border-top: 1px solid #3c3c3c;
             }
-            """
-        )
+            """)
 
         layout = QVBoxLayout(widget)
 
@@ -581,8 +569,7 @@ class AIAssistantPanel(QWidget):
             "Type your message here... (Enter to send, Shift+Enter for new line)"
         )
         self._input_edit.setMaximumHeight(100)
-        self._input_edit.setStyleSheet(
-            """
+        self._input_edit.setStyleSheet("""
             QPlainTextEdit {
                 background-color: #252526;
                 color: #e0e0e0;
@@ -593,8 +580,7 @@ class AIAssistantPanel(QWidget):
             QPlainTextEdit:focus {
                 border: 1px solid #FF8800;
             }
-        """
-        )
+        """)
         self._input_edit.submit_requested.connect(self._on_send)
         layout.addWidget(self._input_edit)
 
@@ -612,8 +598,7 @@ class AIAssistantPanel(QWidget):
         self._send_btn = QPushButton("Send")
         # No default, handled by Enter
         self._send_btn.clicked.connect(self._on_send)
-        self._send_btn.setStyleSheet(
-            """
+        self._send_btn.setStyleSheet("""
             QPushButton {
                 background-color: #FF8800;
                 color: black;
@@ -629,8 +614,7 @@ class AIAssistantPanel(QWidget):
                 background-color: #444444;
                 color: #888888;
             }
-            """
-        )
+            """)
         button_layout.addWidget(self._send_btn)
 
         layout.addLayout(button_layout)

--- a/src/shared/python/ai/gui/settings_dialog.py
+++ b/src/shared/python/ai/gui/settings_dialog.py
@@ -457,8 +457,7 @@ class AISettingsDialog(QDialog):
         self.setMinimumSize(500, 400)
 
         # Apply Dark Theme styling
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QDialog, QWidget {
                 background-color: #1e1e1e;
                 color: #e0e0e0;
@@ -525,8 +524,7 @@ class AISettingsDialog(QDialog):
             QDialogButtonBox QPushButton {
                 min-width: 60px;
             }
-        """
-        )
+        """)
 
         self._settings = AISettings.load()
         self._setup_ui()

--- a/src/shared/python/config/standard_models.py
+++ b/src/shared/python/config/standard_models.py
@@ -151,7 +151,9 @@ class StandardModelManager:
 
                 logger.info(f"Downloading {url} -> {local_path}")
                 validate_url_scheme(url)
-                urllib.request.urlretrieve(url, local_path)  # nosec B310 - URL validated by validate_url_scheme() above
+                urllib.request.urlretrieve(
+                    url, local_path
+                )  # nosec B310 - URL validated by validate_url_scheme() above
 
             # Download mesh files (this is a simplified approach - in practice you'd want
             # to download the actual mesh files from the repository)

--- a/src/shared/python/dashboard/widgets.py
+++ b/src/shared/python/dashboard/widgets.py
@@ -713,9 +713,7 @@ class LivePlotWidget(QtWidgets.QWidget):
                 label = (
                     dim_label
                     if n_dims == 1
-                    else f"{dim_label} {i}"
-                    if plot_mode != "Norm"
-                    else "Norm"
+                    else f"{dim_label} {i}" if plot_mode != "Norm" else "Norm"
                 )
                 if plot_mode == "All Dimensions":
                     label = f"Dim {i}"

--- a/src/shared/python/data_io/dataset_generator/core.py
+++ b/src/shared/python/data_io/dataset_generator/core.py
@@ -611,16 +611,13 @@ class DatasetGenerator:
     @staticmethod
     def _create_sqlite_tables(cursor: sqlite3.Cursor) -> None:
         """Create the SQLite schema tables."""
-        cursor.execute(
-            """
+        cursor.execute("""
             CREATE TABLE IF NOT EXISTS dataset_metadata (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE TABLE IF NOT EXISTS samples (
                 sample_id INTEGER PRIMARY KEY,
                 metadata_json TEXT,
@@ -628,10 +625,8 @@ class DatasetGenerator:
                 n_q INTEGER,
                 n_v INTEGER
             )
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE TABLE IF NOT EXISTS frames (
                 sample_id INTEGER,
                 step INTEGER,
@@ -644,8 +639,7 @@ class DatasetGenerator:
                 PRIMARY KEY (sample_id, step),
                 FOREIGN KEY (sample_id) REFERENCES samples(sample_id)
             )
-        """
-        )
+        """)
 
     @staticmethod
     def _insert_sqlite_metadata(

--- a/src/shared/python/data_io/export.py
+++ b/src/shared/python/data_io/export.py
@@ -92,7 +92,9 @@ def export_to_matlab(
 
         return True
 
-    except Exception as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
+    except (
+        Exception
+    ) as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
         logger.error(f"Failed to export to MATLAB: {e}")
         return False
 
@@ -166,7 +168,9 @@ def export_to_hdf5(
 
         return True
 
-    except Exception as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
+    except (
+        Exception
+    ) as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
         logger.error(f"Failed to export to HDF5: {e}")
         return False
 
@@ -201,25 +205,15 @@ class C3DExportData:
 
 
 @precondition(  # fmt: skip
-    lambda output_path,
-    times,
-    joint_positions,
-    joint_names,
-    forces=None,
-    moments=None,
-    frame_rate=60.0,
-    units=None: (output_path is not None and len(output_path) > 0),
+    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: (
+        output_path is not None and len(output_path) > 0
+    ),
     "Output path must be a non-empty string",
 )
 @precondition(  # fmt: skip
-    lambda output_path,
-    times,
-    joint_positions,
-    joint_names,
-    forces=None,
-    moments=None,
-    frame_rate=60.0,
-    units=None: (frame_rate > 0),
+    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: (
+        frame_rate > 0
+    ),
     "Frame rate must be positive",
 )
 def export_to_c3d(

--- a/src/shared/python/data_io/io_utils.py
+++ b/src/shared/python/data_io/io_utils.py
@@ -207,7 +207,9 @@ def load_yaml(
 
     try:
         with file_path.open("r", encoding=encoding) as f:
-            return yaml.load(f, Loader=yaml_loader)  # nosec B506 - Loader defaults to yaml.SafeLoader
+            return yaml.load(
+                f, Loader=yaml_loader
+            )  # nosec B506 - Loader defaults to yaml.SafeLoader
     except yaml.YAMLError as e:
         raise FileParseError(file_path, "YAML", str(e)) from e
 

--- a/src/shared/python/data_io/output_manager.py
+++ b/src/shared/python/data_io/output_manager.py
@@ -164,25 +164,15 @@ class OutputManager:
         logger.info("Output directory structure created successfully")
 
     @precondition(  # fmt: skip
-        lambda self,
-        results,
-        filename,
-        format_type=OutputFormat.CSV,
-        engine="mujoco",
-        metadata=None,
-        model_path=None,
-        parameters=None: (results is not None),
+        lambda self, results, filename, format_type=OutputFormat.CSV, engine="mujoco", metadata=None, model_path=None, parameters=None: (
+            results is not None
+        ),
         "Simulation results must not be None",
     )
     @precondition(  # fmt: skip
-        lambda self,
-        results,
-        filename,
-        format_type=OutputFormat.CSV,
-        engine="mujoco",
-        metadata=None,
-        model_path=None,
-        parameters=None: (filename is not None and len(filename) > 0),
+        lambda self, results, filename, format_type=OutputFormat.CSV, engine="mujoco", metadata=None, model_path=None, parameters=None: (
+            filename is not None and len(filename) > 0
+        ),
         "Filename must be a non-empty string",
     )
     def save_simulation_results(

--- a/src/shared/python/gui_pkg/help_system.py
+++ b/src/shared/python/gui_pkg/help_system.py
@@ -358,8 +358,7 @@ class HelpDialog(QDialog):
 
     def _apply_styles(self) -> None:
         """Apply CSS styles to the dialog."""
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QDialog {
                 background-color: #1E1E1E;
             }
@@ -439,8 +438,7 @@ class HelpDialog(QDialog):
                 font-family: 'Segoe UI', sans-serif;
                 font-size: 14px;
             }
-        """
-        )
+        """)
 
     def _load_topics(self) -> None:
         """Load available topics into the UI."""
@@ -580,8 +578,7 @@ class HelpButton(QToolButton):
         self.setCursor(Qt.CursorShape.PointingHandCursor)
 
         # Style
-        self.setStyleSheet(
-            """
+        self.setStyleSheet("""
             QToolButton {
                 background-color: #3C3C3C;
                 color: #0A84FF;
@@ -595,8 +592,7 @@ class HelpButton(QToolButton):
                 color: white;
                 border: 1px solid #0A84FF;
             }
-        """
-        )
+        """)
 
         # Connect click
         self.clicked.connect(self._on_clicked)

--- a/src/shared/python/humanoid_character_builder/core/model.py
+++ b/src/shared/python/humanoid_character_builder/core/model.py
@@ -90,7 +90,9 @@ class SupportPolygon:
         if not (point is not None):
             raise ValueError("point must be provided")
         if not self.contains(point):
-            return -1.0  # Or positive distance to polygon? Convention usually margin > 0 is stable.
+            return (
+                -1.0
+            )  # Or positive distance to polygon? Convention usually margin > 0 is stable.
             # If outside, negative margin.
 
         px, py = point

--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -377,7 +377,9 @@ class HumanoidURDFGenerator:
 def _is_valid_xml(xml_str: str) -> bool:
     """Return True if *xml_str* is parseable XML."""
     try:
-        ET.fromstring(xml_str)  # nosec B314 — parsing self-generated URDF, not untrusted input
+        ET.fromstring(
+            xml_str
+        )  # nosec B314 — parsing self-generated URDF, not untrusted input
         return True
     except ET.ParseError:
         return False

--- a/src/shared/python/model_generation/library/github_importer.py
+++ b/src/shared/python/model_generation/library/github_importer.py
@@ -102,7 +102,9 @@ class GitHubImporter:
             if token:
                 req.add_header("Authorization", f"token {token}")
 
-            with urllib.request.urlopen(req) as response:  # nosec B310 - GitHub API endpoint, validated by Request object
+            with urllib.request.urlopen(
+                req
+            ) as response:  # nosec B310 - GitHub API endpoint, validated by Request object
                 data = json.loads(response.read().decode())
 
             items = data.get("items", [])
@@ -287,7 +289,9 @@ class GitHubImporter:
             token = os.environ.get("GITHUB_TOKEN")
             if token:
                 req.add_header("Authorization", f"token {token}")
-            with urllib.request.urlopen(req) as response:  # nosec B310 - GitHub API endpoint, validated by Request object
+            with urllib.request.urlopen(
+                req
+            ) as response:  # nosec B310 - GitHub API endpoint, validated by Request object
                 repo_data = json.loads(response.read().decode())
                 branch = repo_data.get("default_branch", "main")
                 description = repo_data.get("description", "")

--- a/src/shared/python/model_generation/library/model_library.py
+++ b/src/shared/python/model_generation/library/model_library.py
@@ -626,7 +626,9 @@ class ModelLibrary:
         try:
             import urllib.request
 
-            with urllib.request.urlopen(api_url) as response:  # nosec B310 - GitHub API URL from trusted constants
+            with urllib.request.urlopen(
+                api_url
+            ) as response:  # nosec B310 - GitHub API URL from trusted constants
                 contents = json.loads(response.read().decode())
 
             # Look for URDF and MJCF files
@@ -655,7 +657,9 @@ class ModelLibrary:
                     # Check subdirectory for model files
                     subdir_url = item["url"]
                     try:
-                        with urllib.request.urlopen(subdir_url) as sub_response:  # nosec B310 - URL from GitHub API response
+                        with urllib.request.urlopen(
+                            subdir_url
+                        ) as sub_response:  # nosec B310 - URL from GitHub API response
                             sub_contents = json.loads(sub_response.read().decode())
                         for sub_item in sub_contents:
                             if sub_item["type"] != "file":
@@ -734,7 +738,9 @@ class ModelLibrary:
             urdf_filename = source_url.split("/")[-1]
             local_path = cache_dir / urdf_filename
 
-            urllib.request.urlretrieve(source_url, local_path)  # nosec B310 - URL validated above
+            urllib.request.urlretrieve(
+                source_url, local_path
+            )  # nosec B310 - URL validated above
 
             entry.urdf_path = local_path
             entry.is_cached = True

--- a/src/shared/python/model_generation/library/repository.py
+++ b/src/shared/python/model_generation/library/repository.py
@@ -285,7 +285,9 @@ class GitHubRepository(Repository):
         for attempt in range(max_retries + 1):
             try:
                 req = self._build_api_request(url)
-                with urllib.request.urlopen(req, timeout=timeout) as response:  # nosec B310 - GitHub API request via _build_api_request
+                with urllib.request.urlopen(
+                    req, timeout=timeout
+                ) as response:  # nosec B310 - GitHub API request via _build_api_request
                     data = json.loads(response.read().decode())
                     # Extract next page URL from Link header
                     next_url = self._parse_link_header(response)
@@ -395,7 +397,9 @@ class GitHubRepository(Repository):
         local_path = destination / filename
 
         try:
-            urllib.request.urlretrieve(urdf_url, local_path)  # nosec B310 - URL from GitHub raw content base
+            urllib.request.urlretrieve(
+                urdf_url, local_path
+            )  # nosec B310 - URL from GitHub raw content base
             logger.info(f"Downloaded: {filename}")
 
             # Try to download meshes from same directory
@@ -430,7 +434,9 @@ class GitHubRepository(Repository):
                         or f"{self.RAW_BASE}/{self._owner}/{self._repo}/{self._branch}/{item['path']}"
                     )
                     local_file = local_mesh_dir / item["name"]
-                    urllib.request.urlretrieve(raw_url, local_file)  # nosec B310 - URL from GitHub API download_url field
+                    urllib.request.urlretrieve(
+                        raw_url, local_file
+                    )  # nosec B310 - URL from GitHub API download_url field
 
         except (PermissionError, OSError):
             pass  # Meshes not found or not accessible
@@ -445,7 +451,9 @@ class GitHubRepository(Repository):
 
         try:
             with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                urllib.request.urlretrieve(archive_url, tmp.name)  # nosec B310 - URL from trusted github.com base
+                urllib.request.urlretrieve(
+                    archive_url, tmp.name
+                )  # nosec B310 - URL from trusted github.com base
 
                 with zipfile.ZipFile(tmp.name, "r") as zf:
                     zf.extractall(destination)

--- a/src/shared/python/pendulum_simulator/__main__.py
+++ b/src/shared/python/pendulum_simulator/__main__.py
@@ -29,7 +29,9 @@ class _WheelBlockFilter(QObject):
     _MAX_FONT_PT = 40
     _default_font_pt: int | None = None
 
-    def eventFilter(self, obj: QObject | None, event: QEvent | None) -> bool:  # noqa: N802
+    def eventFilter(
+        self, obj: QObject | None, event: QEvent | None
+    ) -> bool:  # noqa: N802
         if event is not None and event.type() == QEvent.Type.Wheel:
             wheel: QWheelEvent = event  # type: ignore[assignment]
             # Ctrl+Wheel → font zoom

--- a/src/shared/python/pendulum_simulator/constraint_solver.py
+++ b/src/shared/python/pendulum_simulator/constraint_solver.py
@@ -105,9 +105,9 @@ def _solve_constrained_dynamics(
     if native_result is not None:
         qddot, lambda_forces = native_result
         assert np.all(np.isfinite(qddot)), f"qddot has non-finite values: {qddot}"
-        assert np.all(np.isfinite(lambda_forces)), (
-            f"Constraint forces have non-finite values: {lambda_forces}"
-        )
+        assert np.all(
+            np.isfinite(lambda_forces)
+        ), f"Constraint forces have non-finite values: {lambda_forces}"
         return qddot, lambda_forces
 
     # Compute dynamic terms
@@ -157,9 +157,9 @@ def _solve_constrained_dynamics(
     lambda_forces = sol[n:]
 
     assert np.all(np.isfinite(qddot)), f"qddot has non-finite values: {qddot}"
-    assert np.all(np.isfinite(lambda_forces)), (
-        f"Constraint forces have non-finite values: {lambda_forces}"
-    )
+    assert np.all(
+        np.isfinite(lambda_forces)
+    ), f"Constraint forces have non-finite values: {lambda_forces}"
     return qddot, lambda_forces
 
 

--- a/src/shared/python/pendulum_simulator/dynamics_quantities.py
+++ b/src/shared/python/pendulum_simulator/dynamics_quantities.py
@@ -43,9 +43,9 @@ def angular_power_at(
         Returns a finite float.
     """
     assert np.isfinite(joint_torque), f"torque must be finite, got {joint_torque}"
-    assert np.isfinite(angular_velocity), (
-        f"omega must be finite, got {angular_velocity}"
-    )
+    assert np.isfinite(
+        angular_velocity
+    ), f"omega must be finite, got {angular_velocity}"
     result = float(joint_torque * angular_velocity)
     assert np.isfinite(result), f"angular power is non-finite: {result}"
     return result
@@ -99,9 +99,9 @@ def angular_power_series(
     torques = np.asarray(torques, dtype=float)
     angular_velocities = np.asarray(angular_velocities, dtype=float)
     assert torques.ndim == 1, f"torques must be 1-D, got {torques.ndim}-D"
-    assert torques.shape == angular_velocities.shape, (
-        f"Shape mismatch: {torques.shape} vs {angular_velocities.shape}"
-    )
+    assert (
+        torques.shape == angular_velocities.shape
+    ), f"Shape mismatch: {torques.shape} vs {angular_velocities.shape}"
     assert np.all(np.isfinite(torques)), "torques must be all finite"
     assert np.all(np.isfinite(angular_velocities)), "velocities must be all finite"
 
@@ -130,12 +130,12 @@ def linear_power_series(
     """
     forces = np.asarray(forces, dtype=float)
     velocities = np.asarray(velocities, dtype=float)
-    assert forces.ndim == 2 and forces.shape[1] == 2, (
-        f"forces must be (N,2), got {forces.shape}"
-    )
-    assert forces.shape == velocities.shape, (
-        f"Shape mismatch: {forces.shape} vs {velocities.shape}"
-    )
+    assert (
+        forces.ndim == 2 and forces.shape[1] == 2
+    ), f"forces must be (N,2), got {forces.shape}"
+    assert (
+        forces.shape == velocities.shape
+    ), f"Shape mismatch: {forces.shape} vs {velocities.shape}"
     assert np.all(np.isfinite(forces)), "forces must be finite"
     assert np.all(np.isfinite(velocities)), "velocities must be finite"
 
@@ -215,9 +215,9 @@ def angular_impulse_series(
     torques = np.asarray(torques, dtype=float)
     time = np.asarray(time, dtype=float)
     assert torques.ndim == 1, f"torques must be 1-D, got {torques.ndim}-D"
-    assert torques.shape == time.shape, (
-        f"Shape mismatch: {torques.shape} vs {time.shape}"
-    )
+    assert (
+        torques.shape == time.shape
+    ), f"Shape mismatch: {torques.shape} vs {time.shape}"
     assert np.all(np.isfinite(torques)), "torques must be finite"
     assert np.all(np.isfinite(time)), "time must be finite"
 
@@ -244,12 +244,12 @@ def linear_impulse_series(
     """
     forces = np.asarray(forces, dtype=float)
     time = np.asarray(time, dtype=float)
-    assert forces.ndim == 2 and forces.shape[1] == 2, (
-        f"forces must be (N,2), got {forces.shape}"
-    )
-    assert forces.shape[0] == time.shape[0], (
-        f"Row mismatch: {forces.shape[0]} vs {time.shape[0]}"
-    )
+    assert (
+        forces.ndim == 2 and forces.shape[1] == 2
+    ), f"forces must be (N,2), got {forces.shape}"
+    assert (
+        forces.shape[0] == time.shape[0]
+    ), f"Row mismatch: {forces.shape[0]} vs {time.shape[0]}"
 
     dt = np.diff(time)
     impulse = np.zeros_like(forces)

--- a/src/shared/python/pendulum_simulator/gui/controls_widget_base.py
+++ b/src/shared/python/pendulum_simulator/gui/controls_widget_base.py
@@ -372,9 +372,9 @@ class ControlsWidgetBase(QWidget):
         inputs = self._get_torque_inputs()
         key = joint.lower()
         valid_keys = {k.lower() for k in inputs}
-        assert key in valid_keys, (
-            f"Unknown joint '{joint}', expected one of {valid_keys}"
-        )
+        assert (
+            key in valid_keys
+        ), f"Unknown joint '{joint}', expected one of {valid_keys}"
         assert len(coeffs) >= 1, "Coefficients list must not be empty"
 
         coeffs_str = ", ".join(f"{c:.4g}" for c in coeffs)
@@ -402,9 +402,9 @@ class ControlsWidgetBase(QWidget):
 
     def set_slider_value(self, val: int) -> None:
         """Pre: 0 <= val <= slider.maximum()"""
-        assert 0 <= val <= self.slider.maximum(), (
-            f"Slider value {val} out of range [0, {self.slider.maximum()}]"
-        )
+        assert (
+            0 <= val <= self.slider.maximum()
+        ), f"Slider value {val} out of range [0, {self.slider.maximum()}]"
         self.slider.blockSignals(True)
         self.slider.setValue(val)
         self.slider.blockSignals(False)

--- a/src/shared/python/pendulum_simulator/gui/unit_converter.py
+++ b/src/shared/python/pendulum_simulator/gui/unit_converter.py
@@ -192,9 +192,9 @@ class UnitPreferences:
         Pre: unit_label must be a valid option for the category.
         """
         valid = [label for label, _ in _UNIT_OPTIONS[category]]
-        assert unit_label in valid, (
-            f"Invalid unit '{unit_label}' for {category.value}. Valid: {valid}"
-        )
+        assert (
+            unit_label in valid
+        ), f"Invalid unit '{unit_label}' for {category.value}. Valid: {valid}"
         self.selections[category] = unit_label
 
     def save_to_qsettings(self, settings: Any) -> None:

--- a/src/shared/python/pendulum_simulator/joint_moments.py
+++ b/src/shared/python/pendulum_simulator/joint_moments.py
@@ -231,9 +231,9 @@ def golfer_pendulum_moments(
     Pre:  len(applied_torques) >= 7 and all required keys present in positions/forces.
     Post: Returns dict with 21 keys (3 per joint Ã— 7 joints), all finite.
     """
-    assert len(applied_torques) >= 7, (
-        f"Need >= 7 applied torques, got {len(applied_torques)}"
-    )
+    assert (
+        len(applied_torques) >= 7
+    ), f"Need >= 7 applied torques, got {len(applied_torques)}"
     # Joint â†’ distal endpoint pairs (joint connects to next link's endpoint)
     joints = ["hub", "rs", "re", "rh", "ls", "le", "lh"]
     endpoints = ["rs", "re", "rh", "club_tip", "le", "lh", "club_tip"]

--- a/src/shared/python/pendulum_simulator/model_registry.py
+++ b/src/shared/python/pendulum_simulator/model_registry.py
@@ -71,9 +71,9 @@ def register_model(name: str, config: ModelConfig) -> None:
     Pre: name is a non-empty string. config is a ModelConfig.
     Post: model is retrievable via get_model(name).
     """
-    assert name and isinstance(name, str), (
-        f"Model name must be non-empty string, got {name!r}"
-    )
+    assert name and isinstance(
+        name, str
+    ), f"Model name must be non-empty string, got {name!r}"
     assert isinstance(config, ModelConfig), f"Expected ModelConfig, got {type(config)}"
     if name in _registry:
         logger.warning("Overwriting existing model registration: %s", name)

--- a/src/shared/python/pendulum_simulator/optimizer_gpu.py
+++ b/src/shared/python/pendulum_simulator/optimizer_gpu.py
@@ -65,14 +65,14 @@ def clubhead_speed_objective(
     neg_speed : JaxArray, shape ()
         Negative clubhead speed (for minimization)
     """
-    assert torque_coeffs.shape == (7,), (
-        f"Expected (7,) coeffs, got {torque_coeffs.shape}"
-    )
+    assert torque_coeffs.shape == (
+        7,
+    ), f"Expected (7,) coeffs, got {torque_coeffs.shape}"
     assert t_end > 0, f"t_end must be positive, got {t_end}"
     assert dt > 0, f"dt must be positive, got {dt}"
-    assert initial_state.shape == (16,), (
-        f"Expected (16,) state, got {initial_state.shape}"
-    )
+    assert initial_state.shape == (
+        16,
+    ), f"Expected (16,) state, got {initial_state.shape}"
     sol = run_single_simulation_jax(
         params, initial_state, t_end, torque_coeffs, alpha, beta, dt
     )
@@ -117,14 +117,14 @@ def clubhead_velocity_at_final_time(
     speed : JaxArray, shape ()
         Clubhead speed magnitude (positive)
     """
-    assert torque_coeffs.shape == (7,), (
-        f"Expected (7,) coeffs, got {torque_coeffs.shape}"
-    )
+    assert torque_coeffs.shape == (
+        7,
+    ), f"Expected (7,) coeffs, got {torque_coeffs.shape}"
     assert t_end > 0, f"t_end must be positive, got {t_end}"
     assert dt > 0, f"dt must be positive, got {dt}"
-    assert initial_state.shape == (16,), (
-        f"Expected (16,) state, got {initial_state.shape}"
-    )
+    assert initial_state.shape == (
+        16,
+    ), f"Expected (16,) state, got {initial_state.shape}"
     sol = run_single_simulation_jax(
         params, initial_state, t_end, torque_coeffs, alpha, beta, dt
     )
@@ -220,9 +220,9 @@ def optimize_torque_profile(
             logger.info("Iteration %d/%d: loss = %.6f", i + 1, n_iterations, loss_val)
 
     optimal_coeffs = torque_coeffs.reshape(7, n_coeffs_per_joint)
-    assert len(history) == n_iterations, (
-        f"Expected {n_iterations} history entries, got {len(history)}"
-    )
+    assert (
+        len(history) == n_iterations
+    ), f"Expected {n_iterations} history entries, got {len(history)}"
     assert optimal_coeffs.shape == (7, n_coeffs_per_joint)
 
     return optimal_coeffs, history
@@ -328,9 +328,9 @@ def compute_gradient_via_finite_difference(
     -------
     grad : JaxArray, shape (7,)
     """
-    assert torque_coeffs.shape == (7,), (
-        f"Expected (7,) coeffs, got {torque_coeffs.shape}"
-    )
+    assert torque_coeffs.shape == (
+        7,
+    ), f"Expected (7,) coeffs, got {torque_coeffs.shape}"
     assert eps > 0, f"eps must be positive, got {eps}"
     grad = jnp.zeros(7)
 

--- a/src/shared/python/pendulum_simulator/perturbation_analysis.py
+++ b/src/shared/python/pendulum_simulator/perturbation_analysis.py
@@ -107,9 +107,9 @@ def generate_noise(
             f"Unknown noise type: {noise_type!r}. Must be 'white', 'pink', or 'brown'."
         )
 
-    assert noise.shape == (n_samples,), (
-        f"Expected shape ({n_samples},), got {noise.shape}"
-    )
+    assert noise.shape == (
+        n_samples,
+    ), f"Expected shape ({n_samples},), got {noise.shape}"
     return noise
 
 
@@ -212,9 +212,7 @@ def perturb_torque_coeffs(
         "additive",
         "multiplicative",
         "both",
-    }, (
-        f"perturb_mode must be 'additive', 'multiplicative', or 'both'; got {perturb_mode!r}"
-    )
+    }, f"perturb_mode must be 'additive', 'multiplicative', or 'both'; got {perturb_mode!r}"
 
     if noise_amplitude == 0.0:
         return [list(c) for c in coeffs]
@@ -259,9 +257,9 @@ class PerturbationConfig:
 
     def __post_init__(self) -> None:
         assert self.n_trials > 0, f"n_trials must be positive, got {self.n_trials}"
-        assert self.noise_amplitude >= 0, (
-            f"noise_amplitude must be non-negative, got {self.noise_amplitude}"
-        )
+        assert (
+            self.noise_amplitude >= 0
+        ), f"noise_amplitude must be non-negative, got {self.noise_amplitude}"
         assert self.noise_type in {
             "white",
             "pink",

--- a/src/shared/python/pendulum_simulator/physics.py
+++ b/src/shared/python/pendulum_simulator/physics.py
@@ -125,12 +125,12 @@ class TorqueClamp:
         # Accept negative inputs by taking abs (#1138)
         object.__setattr__(self, "max_torque1", abs(self.max_torque1))
         object.__setattr__(self, "max_torque2", abs(self.max_torque2))
-        assert self.max_torque1 > 0, (
-            f"|max_torque1| must be positive, got {self.max_torque1}"
-        )
-        assert self.max_torque2 > 0, (
-            f"|max_torque2| must be positive, got {self.max_torque2}"
-        )
+        assert (
+            self.max_torque1 > 0
+        ), f"|max_torque1| must be positive, got {self.max_torque1}"
+        assert (
+            self.max_torque2 > 0
+        ), f"|max_torque2| must be positive, got {self.max_torque2}"
 
 
 # Type aliases
@@ -374,9 +374,9 @@ class JointLimitsNDOF:
         assert self.angle_min.ndim == 1, "angle_min must be 1D"
         assert self.angle_max.ndim == 1, "angle_max must be 1D"
         assert self.angle_min.shape == self.angle_max.shape, "Shape mismatch"
-        assert np.all(self.angle_min < self.angle_max), (
-            "min must be < max for all joints"
-        )
+        assert np.all(
+            self.angle_min < self.angle_max
+        ), "min must be < max for all joints"
         assert self.stiffness > 0, f"stiffness must be positive, got {self.stiffness}"
         assert self.damping >= 0, f"damping must be non-negative, got {self.damping}"
 
@@ -425,9 +425,9 @@ def clamp_torque_ndof(tau: np.ndarray, limits: np.ndarray) -> np.ndarray:
     Pre: tau.shape == limits.shape, all limits > 0.
     Post: |result[i]| <= limits[i] for all i.
     """
-    assert tau.shape == limits.shape, (
-        f"Shape mismatch: tau={tau.shape}, limits={limits.shape}"
-    )
+    assert (
+        tau.shape == limits.shape
+    ), f"Shape mismatch: tau={tau.shape}, limits={limits.shape}"
     assert np.all(limits > 0), "All limits must be positive"
     result: np.ndarray = np.clip(tau, -limits, limits)
     return result
@@ -506,9 +506,9 @@ def forward_kinematics(theta1: float, phi: float, params: PendulumParams) -> dic
     result = {"shoulder": (0.0, 0.0), "wrist": (wx, wy), "tip": (tx, ty)}
     _wrist_dist = np.hypot(wx, wy)
     _tip_dist = np.hypot(tx - wx, ty - wy)
-    assert abs(_wrist_dist - L1) < 1e-9, (
-        f"Wrist distance {_wrist_dist:.6f} â‰  L1={L1:.6f}"
-    )
+    assert (
+        abs(_wrist_dist - L1) < 1e-9
+    ), f"Wrist distance {_wrist_dist:.6f} â‰  L1={L1:.6f}"
     assert abs(_tip_dist - L2) < 1e-9, f"Tip distance {_tip_dist:.6f} â‰  L2={L2:.6f}"
     return result
 

--- a/src/shared/python/pendulum_simulator/physics_base.py
+++ b/src/shared/python/pendulum_simulator/physics_base.py
@@ -89,9 +89,9 @@ def friction_torque_ndof(
     Post: opposes motion direction element-wise.
     """
     n = qdot.shape[0]
-    assert viscous_coeffs.shape == (n,), (
-        f"viscous shape {viscous_coeffs.shape} vs qdot {qdot.shape}"
-    )
+    assert viscous_coeffs.shape == (
+        n,
+    ), f"viscous shape {viscous_coeffs.shape} vs qdot {qdot.shape}"
     assert np.all(np.isfinite(qdot)), "qdot has non-finite values"
 
     tau: npt.NDArray[np.float64] = np.asarray(-viscous_coeffs * qdot, dtype=np.float64)
@@ -164,9 +164,9 @@ def chain_positions(
     convention y-up (positive cosine), matching the existing physics modules.
     """
     n = absolute_angles.shape[0]
-    assert lengths.shape == (n,), (
-        f"lengths {lengths.shape} vs angles {absolute_angles.shape}"
-    )
+    assert lengths.shape == (
+        n,
+    ), f"lengths {lengths.shape} vs angles {absolute_angles.shape}"
 
     positions = np.zeros((n, 2))
     x, y = origin

--- a/src/shared/python/pendulum_simulator/physics_triple.py
+++ b/src/shared/python/pendulum_simulator/physics_triple.py
@@ -162,9 +162,9 @@ def mass_matrix(phi1: float, phi2: float, params: TriplePendulumParams) -> np.nd
     # Postcondition: symmetry
     for i in range(3):
         for j in range(3):
-            assert np.isclose(M[i, j], M[j, i]), (
-                f"Mass matrix not symmetric at [{i},{j}]"
-            )
+            assert np.isclose(
+                M[i, j], M[j, i]
+            ), f"Mass matrix not symmetric at [{i},{j}]"
 
     return M
 
@@ -232,9 +232,9 @@ def coriolis_vector(
     -------
     C_qdot : np.ndarray, shape (3,)
     """
-    assert all(np.isfinite(v) for v in [phi1, phi2, dtheta1, dphi1, dphi2]), (
-        "All inputs must be finite"
-    )
+    assert all(
+        np.isfinite(v) for v in [phi1, phi2, dtheta1, dphi1, dphi2]
+    ), "All inputs must be finite"
     native_coriolis = _native_backend.triple_coriolis_vector(
         phi1, phi2, dtheta1, dphi1, dphi2, params
     )
@@ -419,9 +419,9 @@ def equations_of_motion(
 
     state_dot = np.array([dtheta1, dphi1, dphi2, qddot[0], qddot[1], qddot[2]])
 
-    assert all(np.isfinite(state_dot)), (
-        f"State derivative has non-finite values: {state_dot}"
-    )
+    assert all(
+        np.isfinite(state_dot)
+    ), f"State derivative has non-finite values: {state_dot}"
     return state_dot
 
 

--- a/src/shared/python/pendulum_simulator/simulation_golfer.py
+++ b/src/shared/python/pendulum_simulator/simulation_golfer.py
@@ -218,9 +218,9 @@ def run_simulation(
     -------
     GolferSimulationResult
     """
-    assert initial_state.shape == (2 * N_DOF,), (
-        f"Initial state shape must be ({2 * N_DOF},), got {initial_state.shape}"
-    )
+    assert initial_state.shape == (
+        2 * N_DOF,
+    ), f"Initial state shape must be ({2 * N_DOF},), got {initial_state.shape}"
     assert np.all(np.isfinite(initial_state)), "Initial state must be finite"
     assert t_end > 0, f"t_end must be positive, got {t_end}"
     assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"

--- a/src/shared/python/pendulum_simulator/simulation_result_base.py
+++ b/src/shared/python/pendulum_simulator/simulation_result_base.py
@@ -19,22 +19,22 @@ class TrajectoryResultMixin:
 
     def _validate_trajectory(self, expected_state_width: int) -> None:
         assert self.t.ndim == 1, f"t must be 1D, got shape {self.t.shape}"
-        assert self.states.ndim == 2, (
-            f"states must be 2D, got shape {self.states.shape}"
-        )
+        assert (
+            self.states.ndim == 2
+        ), f"states must be 2D, got shape {self.states.shape}"
         assert self.t.size >= 1, "Trajectory must contain at least one time sample"
-        assert self.states.shape[0] == self.t.size, (
-            "states row count must match the number of time samples"
-        )
-        assert self.states.shape[1] == expected_state_width, (
-            f"states must have width {expected_state_width}, got {self.states.shape[1]}"
-        )
+        assert (
+            self.states.shape[0] == self.t.size
+        ), "states row count must match the number of time samples"
+        assert (
+            self.states.shape[1] == expected_state_width
+        ), f"states must have width {expected_state_width}, got {self.states.shape[1]}"
         assert np.all(np.isfinite(self.t)), "Time vector must be finite"
         assert np.all(np.isfinite(self.states)), "State trajectory must be finite"
         if self.t.size > 1:
-            assert np.all(np.diff(self.t) > 0), (
-                "Time vector must be strictly increasing"
-            )
+            assert np.all(
+                np.diff(self.t) > 0
+            ), "Time vector must be strictly increasing"
 
     def _check_idx(self, idx: int) -> None:
         assert 0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
@@ -42,9 +42,9 @@ class TrajectoryResultMixin:
     @staticmethod
     def _assert_energy_finite(result: dict, idx: int) -> None:
         """Shared postcondition: all energy components must be finite."""
-        assert all(np.isfinite(v) for v in result.values()), (
-            f"Non-finite energy at idx={idx}: {result}"
-        )
+        assert all(
+            np.isfinite(v) for v in result.values()
+        ), f"Non-finite energy at idx={idx}: {result}"
 
     def total_torques_at(self, idx: int) -> np.ndarray:
         """Total applied torque (drive + friction) at time index.

--- a/src/shared/python/pendulum_simulator/simulation_triple.py
+++ b/src/shared/python/pendulum_simulator/simulation_triple.py
@@ -161,9 +161,9 @@ def run_simulation(
       visualisation-quality results.  Use tighter values only when
       quantitative energy conservation is required.
     """
-    assert initial_state.shape == (6,), (
-        f"Initial state shape must be (6,), got {initial_state.shape}"
-    )
+    assert initial_state.shape == (
+        6,
+    ), f"Initial state shape must be (6,), got {initial_state.shape}"
     assert all(np.isfinite(initial_state)), "Initial state must be finite"
     assert t_end > 0, f"t_end must be positive, got {t_end}"
     assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"

--- a/src/shared/python/physics/impact_model/solver.py
+++ b/src/shared/python/physics/impact_model/solver.py
@@ -161,25 +161,15 @@ class ImpactSolverAPI:
         self.recorder = ImpactRecorder()
 
     @precondition(  # fmt: skip
-        lambda self,
-        timestamp,
-        clubhead_velocity,
-        clubhead_orientation,
-        ball_velocity=None,
-        ball_angular_velocity=None,
-        clubhead_mass=0.200,
-        record=True: (clubhead_mass > 0),
+        lambda self, timestamp, clubhead_velocity, clubhead_orientation, ball_velocity=None, ball_angular_velocity=None, clubhead_mass=0.200, record=True: (
+            clubhead_mass > 0
+        ),
         "Clubhead mass must be positive",
     )
     @precondition(  # fmt: skip
-        lambda self,
-        timestamp,
-        clubhead_velocity,
-        clubhead_orientation,
-        ball_velocity=None,
-        ball_angular_velocity=None,
-        clubhead_mass=0.200,
-        record=True: (timestamp >= 0),
+        lambda self, timestamp, clubhead_velocity, clubhead_orientation, ball_velocity=None, ball_angular_velocity=None, clubhead_mass=0.200, record=True: (
+            timestamp >= 0
+        ),
         "Timestamp must be non-negative",
     )
     def solve_impact(

--- a/src/shared/python/physics/impact_model/utils.py
+++ b/src/shared/python/physics/impact_model/utils.py
@@ -10,12 +10,9 @@ from .types import ImpactParameters, PostImpactState, PreImpactState
 
 
 @precondition(  # fmt: skip
-    lambda impact_offset,
-    clubhead_velocity,
-    clubface_normal,
-    gear_factor=0.5,
-    h_scale=100.0,
-    v_scale=50.0: (0 <= gear_factor <= 1),
+    lambda impact_offset, clubhead_velocity, clubface_normal, gear_factor=0.5, h_scale=100.0, v_scale=50.0: (
+        0 <= gear_factor <= 1
+    ),
     "Gear effect factor must be between 0 and 1",
 )
 def compute_gear_effect_spin(

--- a/src/shared/python/plot_theme/tests/test_plot_theme.py
+++ b/src/shared/python/plot_theme/tests/test_plot_theme.py
@@ -167,9 +167,9 @@ class TestPredefinedThemes:
 
         for key, theme in PLOT_THEMES.items():
             params = theme.to_rcparams()
-            assert "figure.facecolor" in params, (
-                f"Theme '{key}' missing figure.facecolor"
-            )
+            assert (
+                "figure.facecolor" in params
+            ), f"Theme '{key}' missing figure.facecolor"
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/shared/python/plotting/base.py
+++ b/src/shared/python/plotting/base.py
@@ -22,7 +22,9 @@ except ImportError:
     class MplCanvas:  # type: ignore[no-redef]
         """Matplotlib canvas for embedding in PyQt6 (not available in headless mode)."""
 
-        def __init__(self, width: float = 8, height: float = 6, dpi: int = 100) -> None:  # noqa: ARG002
+        def __init__(
+            self, width: float = 8, height: float = 6, dpi: int = 100
+        ) -> None:  # noqa: ARG002
             """Initialize canvas with figure (implementation for headless environments)."""
             msg = (
                 "MplCanvas requires Qt backend which is not available in headless envs"

--- a/src/shared/python/plotting/renderers/force_vectors.py
+++ b/src/shared/python/plotting/renderers/force_vectors.py
@@ -152,9 +152,9 @@ class ForceVectorRenderer(BaseRenderer):
         total_forces = np.asarray(total_forces)
         ztcf_forces = np.asarray(ztcf_forces)
 
-        assert total_forces.shape == ztcf_forces.shape, (
-            f"Shape mismatch: total {total_forces.shape} vs ztcf {ztcf_forces.shape}"
-        )
+        assert (
+            total_forces.shape == ztcf_forces.shape
+        ), f"Shape mismatch: total {total_forces.shape} vs ztcf {ztcf_forces.shape}"
 
         delta = total_forces - ztcf_forces
         self._render_quiver_overlay(

--- a/src/shared/python/plotting/renderers/kinematics.py
+++ b/src/shared/python/plotting/renderers/kinematics.py
@@ -438,11 +438,7 @@ class KinematicsRenderer(BaseRenderer):
             unit = (
                 "deg"
                 if dt == "position"
-                else "deg/s"
-                if dt == "velocity"
-                else "Nm"
-                if dt == "torque"
-                else ""
+                else "deg/s" if dt == "velocity" else "Nm" if dt == "torque" else ""
             )
             labels.append(f"{name} {dt[:3]} ({unit})")
 

--- a/src/shared/python/safe_eval.py
+++ b/src/shared/python/safe_eval.py
@@ -242,7 +242,9 @@ def safe_eval(
 
     tree = validate_expression(expression, allowed_names)
     code = compile(tree, "<safe_eval>", "eval")
-    return eval(code, {"__builtins__": {}}, namespace)  # noqa: S307  # nosec B307 - AST validated by validate_expression before eval
+    return eval(
+        code, {"__builtins__": {}}, namespace
+    )  # noqa: S307  # nosec B307 - AST validated by validate_expression before eval
 
 
 def safe_eval_math(

--- a/src/shared/python/signal_toolkit/polynomial_generator.py
+++ b/src/shared/python/signal_toolkit/polynomial_generator.py
@@ -100,8 +100,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         if not use_builtin_theme:
             pass  # Skip built-in theme; host app provides styling
         else:
-            self.setStyleSheet(
-                """
+            self.setStyleSheet("""
             QWidget {
                 background-color: #2b2b2b;
                 color: #ffffff;
@@ -166,8 +165,7 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
             QPushButton#fitBtn:hover {
                 background-color: #388e3c;
             }
-        """
-            )
+        """)
 
         # UI Setup
         self._setup_ui()

--- a/src/shared/python/theme/dialogs/custom_theme_editor.py
+++ b/src/shared/python/theme/dialogs/custom_theme_editor.py
@@ -66,8 +66,7 @@ class ColorPickerButton(QPushButton):
         qcolor = QColor(self._color)
         text_color = "#ffffff" if qcolor.lightness() < 128 else "#000000"
 
-        self.setStyleSheet(
-            f"""
+        self.setStyleSheet(f"""
             QPushButton {{
                 background-color: {self._color};
                 color: {text_color};
@@ -79,8 +78,7 @@ class ColorPickerButton(QPushButton):
             QPushButton:hover {{
                 border: 2px solid #333333;
             }}
-        """
-        )
+        """)
         self.setText(self._color.upper())
 
     def _open_color_picker(self) -> None:

--- a/src/shared/python/upstream_drift_tools/lab/bio/c3d_reader.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/c3d_reader.py
@@ -813,7 +813,10 @@ class C3DDataReader:
             [
                 "pytest" in str(base_dir),
                 "test" in str(base_dir).lower(),
-                "/tmp/pytest" in str(path),  # nosec B108 - string comparison only, not creating a temp file
+                "/tmp/pytest"
+                in str(
+                    path
+                ),  # nosec B108 - string comparison only, not creating a temp file
                 "pytest" in str(path),
             ]
         )

--- a/src/shared/python/upstream_drift_tools/process_calculators/acid_gas_dewpoint_calculator.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/acid_gas_dewpoint_calculator.py
@@ -331,12 +331,12 @@ class AcidGasDewpointCalculator:
             Vapor pressure in Pa
         """
         # DbC preconditions
-        assert isinstance(temperature_c, int | float), (
-            f"temperature_c must be numeric, got {type(temperature_c).__name__}"
-        )
-        assert isinstance(component, str) and len(component) > 0, (
-            "component must be a non-empty string"
-        )
+        assert isinstance(
+            temperature_c, int | float
+        ), f"temperature_c must be numeric, got {type(temperature_c).__name__}"
+        assert (
+            isinstance(component, str) and len(component) > 0
+        ), "component must be a non-empty string"
 
         if component not in self.antoine_constants:
             msg = f"Unknown component: {component}"

--- a/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_webapp.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_webapp.py
@@ -500,13 +500,11 @@ def _render_o2_safety_tab(
     if not (total_feed is not None):
         raise ValueError("total_feed must be provided")
     st.subheader("O2 Safety Analysis")
-    st.markdown(
-        """
+    st.markdown("""
     **Critical Thresholds:**
     - H2 LFL: 4%, UFL: 75%
     - O2 Danger Level: >2% with H2 >4%
-    """
-    )
+    """)
 
     # Plot options for O2 safety
     o2_col1, o2_col2, o2_col3 = st.columns(3)

--- a/src/shared/python/upstream_drift_tools/process_calculators/psa_package/test_psa_model.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/psa_package/test_psa_model.py
@@ -107,9 +107,9 @@ class TestPSAModelBaseCase:
 
     def test_mass_balance(self, base_results) -> None:
         """Test mass balance closure."""
-        assert abs(base_results.mass_balance_error) < 1e-10, (
-            f"Mass balance error too large: {base_results.mass_balance_error}"
-        )
+        assert (
+            abs(base_results.mass_balance_error) < 1e-10
+        ), f"Mass balance error too large: {base_results.mass_balance_error}"
 
     def test_s2_tail_h2_pct(self, base_results) -> None:
         """Test S2 tail H2 percentage matches Excel."""
@@ -452,9 +452,9 @@ class TestPSAModelConsistency:
                 - results.flows.s2_tail_vent[i]
                 - results.flows.net_product[i]
             )
-            assert abs(balance) < 1e-10, (
-                f"Mass balance error for {results.component_names[i]}: {balance}"
-            )
+            assert (
+                abs(balance) < 1e-10
+            ), f"Mass balance error for {results.component_names[i]}: {balance}"
 
     def test_mixed_feed_balance(self) -> None:
         """Test mixed feed balance."""

--- a/src/shared/python/upstream_drift_tools/ui/widgets/mixins/data_processor_ops.py
+++ b/src/shared/python/upstream_drift_tools/ui/widgets/mixins/data_processor_ops.py
@@ -221,15 +221,13 @@ class DataProcessorOpsMixin:
 
         result = self.engine.fit_curve(x_col, y_col, fit_type, degree)
         if result:
-            self.fit_results_text.setHtml(
-                f"""
+            self.fit_results_text.setHtml(f"""
                 <h4>Fit Results</h4>
                 <p><b>Equation:</b> {result.equation}</p>
                 <p><b>R-squared:</b> {result.r_squared:.6f}</p>
                 <p><b>Coefficients:</b> {", ".join(f"{c:.6f}" for c in result.coefficients)}</p>
                 <p><b>Residual Sum:</b> {sum(result.residuals**2):.6f}</p>
-            """
-            )
+            """)
             self._set_status(f"Curve fit: R² = {result.r_squared:.4f}", success=True)
         else:
             self.fit_results_text.setText("Curve fitting failed. Check your data.")

--- a/src/tools/model_explorer/model_library.py
+++ b/src/tools/model_explorer/model_library.py
@@ -369,7 +369,9 @@ class ModelLibrary:
             # Download URDF file
             logger.info(f"Downloading URDF: {model_info['urdf_url']}")
             validate_url_scheme(model_info["urdf_url"])
-            with urllib.request.urlopen(model_info["urdf_url"]) as response:  # nosec B310 - URL validated by validate_url_scheme() above
+            with urllib.request.urlopen(
+                model_info["urdf_url"]
+            ) as response:  # nosec B310 - URL validated by validate_url_scheme() above
                 urdf_content = response.read().decode("utf-8")
                 urdf_path.write_text(urdf_content, encoding="utf-8")
 

--- a/src/tools/model_explorer/mujoco_viewer.py
+++ b/src/tools/model_explorer/mujoco_viewer.py
@@ -593,8 +593,7 @@ class MuJoCoViewerWidget(QWidget):
 
         # Create toggle group with visual separator
         toggle_frame = QFrame()
-        toggle_frame.setStyleSheet(
-            """
+        toggle_frame.setStyleSheet("""
             QFrame {
                 background-color: #3a3a3a;
                 border-radius: 4px;
@@ -612,8 +611,7 @@ class MuJoCoViewerWidget(QWidget):
                 background-color: #4a9eff;
                 border-radius: 2px;
             }
-        """
-        )
+        """)
         toggle_layout = QHBoxLayout(toggle_frame)
         toggle_layout.setContentsMargins(4, 2, 4, 2)
         toggle_layout.setSpacing(8)
@@ -653,15 +651,13 @@ class MuJoCoViewerWidget(QWidget):
         self._viewport = QLabel()
         self._viewport.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._viewport.setMinimumSize(320, 240)
-        self._viewport.setStyleSheet(
-            """
+        self._viewport.setStyleSheet("""
             QLabel {
                 background-color: #2a2a2a;
                 border: 1px solid #444;
                 border-radius: 4px;
             }
-        """
-        )
+        """)
         self._viewport.setMouseTracking(True)
         layout.addWidget(self._viewport, stretch=1)
 
@@ -696,8 +692,7 @@ class MuJoCoViewerWidget(QWidget):
 
     def _update_headless_placeholder(self) -> None:
         """Show a clear headless fallback message."""
-        self._viewport.setStyleSheet(
-            """
+        self._viewport.setStyleSheet("""
             QLabel {
                 background-color: #1a1a2e;
                 border: 2px dashed #4a4a6a;
@@ -705,8 +700,7 @@ class MuJoCoViewerWidget(QWidget):
                 color: #8888aa;
                 font-size: 14px;
             }
-        """
-        )
+        """)
         self._viewport.setText(
             "🖥️ Headless Mode\n\n"
             "MuJoCo is not installed.\n"

--- a/src/tools/model_explorer/urdf_builder.py
+++ b/src/tools/model_explorer/urdf_builder.py
@@ -223,7 +223,9 @@ class URDFBuilder:
 
         # Pretty print the XML
         rough_string = ET.tostring(robot, encoding="unicode")
-        reparsed = minidom.parseString(rough_string)  # nosec B318 - parsing internally generated ET output
+        reparsed = minidom.parseString(
+            rough_string
+        )  # nosec B318 - parsing internally generated ET output
         return str(reparsed.toprettyxml(indent="  "))
 
     def _create_empty_urdf(self) -> str:
@@ -241,7 +243,9 @@ class URDFBuilder:
         ET.SubElement(geometry, "box", size="0.1 0.1 0.1")
 
         rough_string = ET.tostring(robot, encoding="unicode")
-        reparsed = minidom.parseString(rough_string)  # nosec B318 - parsing internally generated ET output
+        reparsed = minidom.parseString(
+            rough_string
+        )  # nosec B318 - parsing internally generated ET output
         return str(reparsed.toprettyxml(indent="  "))
 
     def _add_materials(self, robot: ET.Element) -> None:

--- a/src/tools/model_explorer/visualization_widget.py
+++ b/src/tools/model_explorer/visualization_widget.py
@@ -128,8 +128,7 @@ class VisualizationWidget(QWidget):
 
         self.info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.info_label.setStyleSheet(
-            """
+        self.info_label.setStyleSheet("""
 
             QLabel {
 
@@ -143,8 +142,7 @@ class VisualizationWidget(QWidget):
 
             }
 
-        """
-        )
+        """)
 
         layout.addWidget(self.info_label)
 

--- a/src/tools/video_analyzer/analyzer.py
+++ b/src/tools/video_analyzer/analyzer.py
@@ -91,10 +91,9 @@ class SwingAnalyzer:
         self.smoothing_window = smoothing_window
 
     @precondition(  # fmt: skip
-        lambda self,
-        video_path,
-        stance=StanceDirection.UNKNOWN,
-        progress_callback=None: (video_path is not None and len(video_path) > 0),
+        lambda self, video_path, stance=StanceDirection.UNKNOWN, progress_callback=None: (
+            video_path is not None and len(video_path) > 0
+        ),
         "Video path must be a non-empty string",
     )
     def analyze_video(

--- a/tests/acceptance/test_counterfactual_experiments.py
+++ b/tests/acceptance/test_counterfactual_experiments.py
@@ -108,9 +108,9 @@ class TestZTCFCounterfactual:
 
         # Verify non-zero result (pendulum with gravity)
         assert a_ztcf.size > 0, "ZTCF should return non-empty result"
-        assert not np.allclose(a_ztcf, 0, atol=1e-10), (
-            "ZTCF should be non-zero with gravity"
-        )
+        assert not np.allclose(
+            a_ztcf, 0, atol=1e-10
+        ), "ZTCF should be non-zero with gravity"
 
     def test_ztcf_preserves_engine_state(self, pendulum_engine: PhysicsEngine) -> None:
         """Computing ZTCF should not modify the engine's internal state."""
@@ -173,9 +173,9 @@ class TestZVCFCounterfactual:
 
         # ZVCF should be different from ZTCF due to removed Coriolis
         # (unless by coincidence they cancel, which is unlikely)
-        assert not np.allclose(a_ztcf, a_zvcf, atol=0.01), (
-            "ZVCF should differ from ZTCF when velocity is non-zero"
-        )
+        assert not np.allclose(
+            a_ztcf, a_zvcf, atol=0.01
+        ), "ZVCF should differ from ZTCF when velocity is non-zero"
 
     def test_zvcf_at_rest_configuration(self, pendulum_engine: PhysicsEngine) -> None:
         """ZVCF at vertical (θ=0) should show gravity effect.

--- a/tests/acceptance/test_drift_control_decomposition.py
+++ b/tests/acceptance/test_drift_control_decomposition.py
@@ -115,9 +115,9 @@ class TestDriftControlDecomposition:
                 "model may not support clean decomposition"
             )
 
-        assert max_res < SUPERPOSITION_TOLERANCE, (
-            f"{engine_name}: Superposition failed (res={max_res:.2e})"
-        )
+        assert (
+            max_res < SUPERPOSITION_TOLERANCE
+        ), f"{engine_name}: Superposition failed (res={max_res:.2e})"
 
     def test_zero_control(self, engine_name, pendulum_urdf):
         """Verify full dynamics with tau=0 equals drift acceleration."""

--- a/tests/api/test_contract_parity.py
+++ b/tests/api/test_contract_parity.py
@@ -250,6 +250,6 @@ class TestRegistryModelConsistency:
         for vt in VALID_ENGINE_TYPES:
             if vt in aliases:
                 continue
-            assert vt in registry_values, (
-                f"'{vt}' in VALID_ENGINE_TYPES but not in EngineType enum"
-            )
+            assert (
+                vt in registry_values
+            ), f"'{vt}' in VALID_ENGINE_TYPES but not in EngineType enum"

--- a/tests/api/test_launcher_api.py
+++ b/tests/api/test_launcher_api.py
@@ -60,9 +60,9 @@ class TestLauncherManifestEndpoints:
             assert "type" in tile, f"Tile missing type: {tile.get('id')}"
             assert "logo" in tile, f"Tile missing logo: {tile.get('id')}"
             assert "status" in tile, f"Tile missing status: {tile.get('id')}"
-            assert "capabilities" in tile, (
-                f"Tile missing capabilities: {tile.get('id')}"
-            )
+            assert (
+                "capabilities" in tile
+            ), f"Tile missing capabilities: {tile.get('id')}"
             assert "order" in tile, f"Tile missing order: {tile.get('id')}"
 
     def test_manifest_tiles_sorted_by_order(self, client: TestClient) -> None:
@@ -158,9 +158,9 @@ class TestLauncherParityRequirements:
         """No tile should have 'unknown' status (fixes #1168)."""
         response = client.get("/api/launcher/tiles")
         for tile in response.json():
-            assert tile["status"] != "unknown", (
-                f"Tile '{tile['id']}' has unknown status"
-            )
+            assert (
+                tile["status"] != "unknown"
+            ), f"Tile '{tile['id']}' has unknown status"
 
     def test_putting_green_has_valid_status(self, client: TestClient) -> None:
         """Putting Green tile has a valid (non-unknown) status chip."""
@@ -219,9 +219,9 @@ class TestLogoEndpoints:
         for tile in tiles_resp.json():
             logo = tile["logo"]
             resp = client.get(f"/api/launcher/logos/{logo}")
-            assert resp.status_code == 200, (
-                f"Logo '{logo}' for tile '{tile['id']}' not served (HTTP {resp.status_code})"
-            )
+            assert (
+                resp.status_code == 200
+            ), f"Logo '{logo}' for tile '{tile['id']}' not served (HTTP {resp.status_code})"
 
     def test_validate_logos_all_present(self, client: TestClient) -> None:
         """Logo validation reports all logos present (Phase 3 complete)."""
@@ -236,9 +236,9 @@ class TestLogoEndpoints:
         """All logos should now use SVG format."""
         response = client.get("/api/launcher/tiles")
         for tile in response.json():
-            assert tile["logo"].endswith(".svg"), (
-                f"Tile '{tile['id']}' logo '{tile['logo']}' is not SVG"
-            )
+            assert tile["logo"].endswith(
+                ".svg"
+            ), f"Tile '{tile['id']}' logo '{tile['logo']}' is not SVG"
 
 
 class TestNewTiles:

--- a/tests/api/test_launcher_launch_api.py
+++ b/tests/api/test_launcher_launch_api.py
@@ -163,9 +163,9 @@ class TestLaunchEndpoint:
         """Every tile in the manifest can be launched (handler returns True)."""
         for tile in manifest["tiles"]:
             resp = client.post(f"/api/launcher/launch/{tile['id']}")
-            assert resp.status_code == 200, (
-                f"Failed to launch tile '{tile['id']}': {resp.json()}"
-            )
+            assert (
+                resp.status_code == 200
+            ), f"Failed to launch tile '{tile['id']}': {resp.json()}"
             data = resp.json()
             assert data["tile_id"] == tile["id"]
 

--- a/tests/config/test_launcher_manifest.py
+++ b/tests/config/test_launcher_manifest.py
@@ -87,9 +87,9 @@ class TestManifestLoading:
     def test_manifest_has_no_duplicate_ids(self, manifest: LauncherManifest) -> None:
         """DBC Postcondition: all tile IDs must be unique."""
         ids = [t.id for t in manifest.tiles]
-        assert len(ids) == len(set(ids)), (
-            f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
-        )
+        assert len(ids) == len(
+            set(ids)
+        ), f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
 
     def test_manifest_file_not_found_raises(self) -> None:
         """DBC Precondition: missing file raises FileNotFoundError."""
@@ -391,9 +391,9 @@ class TestTileProperties:
         """Category must be one of the allowed values."""
         valid_categories = {"physics_engine", "tool", "external"}
         for tile in manifest.tiles:
-            assert tile.category in valid_categories, (
-                f"Tile '{tile.id}' has invalid category: '{tile.category}'"
-            )
+            assert (
+                tile.category in valid_categories
+            ), f"Tile '{tile.id}' has invalid category: '{tile.category}'"
 
     def test_physics_engines_have_engine_type(self, manifest: LauncherManifest) -> None:
         """All physics_engine tiles must have an engine_type."""
@@ -437,9 +437,9 @@ class TestLogoValidation:
         All SVG logos were created in Phase 3 (closes #1164).
         """
         missing = manifest.validate_logos()
-        assert not missing, (
-            f"Missing logo files for tiles: {missing}. Expected in: {ASSETS_DIR}"
-        )
+        assert (
+            not missing
+        ), f"Missing logo files for tiles: {missing}. Expected in: {ASSETS_DIR}"
 
     def test_logo_path_property(self, sample_tile_dict: dict) -> None:
         """Tile logo_path property returns absolute path."""
@@ -464,9 +464,9 @@ class TestOrdering:
     def test_model_explorer_is_first(self, manifest: LauncherManifest) -> None:
         """Model Explorer must be the first tile (order=1)."""
         first = manifest.tiles[0]
-        assert first.id == "model_explorer", (
-            f"First tile should be model_explorer, got: {first.id}"
-        )
+        assert (
+            first.id == "model_explorer"
+        ), f"First tile should be model_explorer, got: {first.id}"
 
     def test_ordered_ids_returns_deterministic_list(
         self, manifest: LauncherManifest

--- a/tests/engines/pendulum_models/python/double_pendulum_model/test_double_pendulum_dynamics.py
+++ b/tests/engines/pendulum_models/python/double_pendulum_model/test_double_pendulum_dynamics.py
@@ -83,17 +83,17 @@ class TestMassMatrix:
     def test_symmetric(self, default_dynamics: DoublePendulumDynamics) -> None:
         for theta2 in [0.0, math.pi / 4, -math.pi / 3, math.pi / 2]:
             M = default_dynamics.mass_matrix(theta2)
-            assert M[0][1] == pytest.approx(M[1][0], rel=1e-12), (
-                f"M not symmetric at theta2={theta2}"
-            )
+            assert M[0][1] == pytest.approx(
+                M[1][0], rel=1e-12
+            ), f"M not symmetric at theta2={theta2}"
 
     def test_positive_definite(self, default_dynamics: DoublePendulumDynamics) -> None:
         for theta2 in np.linspace(-math.pi, math.pi, 20):
             M = np.array(default_dynamics.mass_matrix(theta2))
             eigenvalues = np.linalg.eigvalsh(M)
-            assert np.all(eigenvalues > 0), (
-                f"M not positive-definite at theta2={theta2:.3f}: {eigenvalues}"
-            )
+            assert np.all(
+                eigenvalues > 0
+            ), f"M not positive-definite at theta2={theta2:.3f}: {eigenvalues}"
 
     def test_diagonal_dominant_at_zero(
         self, default_dynamics: DoublePendulumDynamics

--- a/tests/heavy_integration/test_drake_real_model_loading.py
+++ b/tests/heavy_integration/test_drake_real_model_loading.py
@@ -105,9 +105,9 @@ class TestDrakeModelLoading:
         except Exception as exc:  # noqa: BLE001
             pytest.skip(f"Drake URDF loading failed: {exc}")
 
-        assert plant.num_positions() == 1, (
-            f"Expected 1 DOF for pendulum, got {plant.num_positions()}"
-        )
+        assert (
+            plant.num_positions() == 1
+        ), f"Expected 1 DOF for pendulum, got {plant.num_positions()}"
 
 
 class TestDrakeSimulation:

--- a/tests/heavy_integration/test_ezdxf_cad_export.py
+++ b/tests/heavy_integration/test_ezdxf_cad_export.py
@@ -86,9 +86,9 @@ class TestEzdxfRoundtrip:
             loaded_doc = ezdxf.readfile(str(dxf_path))
             loaded_msp = loaded_doc.modelspace()
             loaded_entities = list(loaded_msp)
-            assert len(loaded_entities) == 4, (
-                f"Expected 4 lines after reload, got {len(loaded_entities)}"
-            )
+            assert (
+                len(loaded_entities) == 4
+            ), f"Expected 4 lines after reload, got {len(loaded_entities)}"
 
     def test_layers_survive_roundtrip(self, ezdxf) -> None:
         """Layer assignments survive a write→read cycle."""

--- a/tests/heavy_integration/test_mediapipe_tasks_api.py
+++ b/tests/heavy_integration/test_mediapipe_tasks_api.py
@@ -66,9 +66,9 @@ class TestMediaPipeTasksApi:
         tasks = mp.tasks
         has_vision = hasattr(tasks, "vision")
         has_base = hasattr(tasks, "BaseOptions")
-        assert has_vision or has_base, (
-            f"mp.tasks structure unexpected. Available: {dir(tasks)}"
-        )
+        assert (
+            has_vision or has_base
+        ), f"mp.tasks structure unexpected. Available: {dir(tasks)}"
 
     def test_pose_landmarker_class_exists(self, mp) -> None:
         """PoseLandmarker class is accessible via mp.tasks.vision."""
@@ -77,9 +77,9 @@ class TestMediaPipeTasksApi:
         tasks = mp.tasks
         if not hasattr(tasks, "vision"):
             pytest.skip("mp.tasks.vision not available in this mediapipe version")
-        assert hasattr(tasks.vision, "PoseLandmarker"), (
-            "PoseLandmarker not found in mp.tasks.vision"
-        )
+        assert hasattr(
+            tasks.vision, "PoseLandmarker"
+        ), "PoseLandmarker not found in mp.tasks.vision"
 
     def test_base_options_instantiable(self, mp) -> None:
         """BaseOptions can be instantiated (model_asset_path not required)."""

--- a/tests/heavy_integration/test_myosuite_muscles.py
+++ b/tests/heavy_integration/test_myosuite_muscles.py
@@ -389,9 +389,9 @@ class TestMyoSuiteEngine:
             ):
                 actuator_id = analyzer.muscle_actuator_ids[0]
                 ctrl_value = engine.sim.data.ctrl[actuator_id]
-                assert 0.7 <= ctrl_value <= 0.9, (
-                    f"Activation not set correctly: {ctrl_value}"
-                )
+                assert (
+                    0.7 <= ctrl_value <= 0.9
+                ), f"Activation not set correctly: {ctrl_value}"
 
         except Exception as e:  # noqa: BLE001
             pytest.skip(f"Activation setting test failed: {e}")

--- a/tests/heavy_integration/test_openpose_camera_pipeline.py
+++ b/tests/heavy_integration/test_openpose_camera_pipeline.py
@@ -123,9 +123,9 @@ class TestPoseEstimationInterface:
         import dataclasses
 
         field_names = {f.name for f in dataclasses.fields(PoseEstimationResult)}
-        assert "keypoints" in field_names, (
-            f"PoseEstimationResult missing 'keypoints' field; got {field_names}"
-        )
+        assert (
+            "keypoints" in field_names
+        ), f"PoseEstimationResult missing 'keypoints' field; got {field_names}"
 
 
 pytestmark = pytest.mark.live_simulation

--- a/tests/heavy_integration/test_opensim_muscles.py
+++ b/tests/heavy_integration/test_opensim_muscles.py
@@ -116,9 +116,9 @@ class TestOpenSimMuscleModels:
         )
 
         # Basic sanity check: force should be positive and reasonable
-        assert 0 < F_muscle <= F_max * 1.5, (
-            f"Muscle force {F_muscle} outside expected range"
-        )
+        assert (
+            0 < F_muscle <= F_max * 1.5
+        ), f"Muscle force {F_muscle} outside expected range"
 
     def test_activation_dynamics(self, simple_arm_model):
         """Section J: Verify activation dynamics (30-50ms delay)."""

--- a/tests/heavy_integration/test_opensim_myosuite_wiring.py
+++ b/tests/heavy_integration/test_opensim_myosuite_wiring.py
@@ -52,9 +52,9 @@ class TestProbePaths:
         MyoSimProbe(suite_root)  # Ensures probe can be instantiated
         # Verify the probe checks for myosuite directory, not myosim
         engine_dir = suite_root / "src" / "engines" / "physics_engines" / "myosuite"
-        assert engine_dir.exists(), (
-            f"MyoSuite engine directory should exist at {engine_dir}"
-        )
+        assert (
+            engine_dir.exists()
+        ), f"MyoSuite engine directory should exist at {engine_dir}"
 
     def test_myosim_probe_checks_correct_file(self, suite_root: Path) -> None:
         """MyoSim probe checks for myosuite_physics_engine.py."""
@@ -67,9 +67,9 @@ class TestProbePaths:
             / "python"
             / "myosuite_physics_engine.py"
         )
-        assert engine_file.exists(), (
-            f"MyoSuite engine file should exist at {engine_file}"
-        )
+        assert (
+            engine_file.exists()
+        ), f"MyoSuite engine file should exist at {engine_file}"
 
 
 # ──────────────────────────────────────────────────────────────
@@ -160,9 +160,9 @@ class TestOpenSimProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(OpenSimPhysicsEngine, method), (
-                f"OpenSimPhysicsEngine missing required method: {method}"
-            )
+            assert hasattr(
+                OpenSimPhysicsEngine, method
+            ), f"OpenSimPhysicsEngine missing required method: {method}"
             assert callable(getattr(OpenSimPhysicsEngine, method))
 
     def test_opensim_has_biomech_methods(self) -> None:
@@ -176,9 +176,9 @@ class TestOpenSimProtocol:
             "create_grip_model",
         ]
         for method in biomech_methods:
-            assert hasattr(OpenSimPhysicsEngine, method), (
-                f"OpenSimPhysicsEngine missing biomech method: {method}"
-            )
+            assert hasattr(
+                OpenSimPhysicsEngine, method
+            ), f"OpenSimPhysicsEngine missing biomech method: {method}"
 
     def test_opensim_uninitialized_state(self) -> None:
         """Uninitialized OpenSimPhysicsEngine reports not initialized."""
@@ -224,9 +224,9 @@ class TestMyoSuiteProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(MyoSuitePhysicsEngine, method), (
-                f"MyoSuitePhysicsEngine missing required method: {method}"
-            )
+            assert hasattr(
+                MyoSuitePhysicsEngine, method
+            ), f"MyoSuitePhysicsEngine missing required method: {method}"
             assert callable(getattr(MyoSuitePhysicsEngine, method))
 
     def test_myosuite_has_muscle_methods(self) -> None:
@@ -243,9 +243,9 @@ class TestMyoSuiteProtocol:
             "get_muscle_names",
         ]
         for method in muscle_methods:
-            assert hasattr(MyoSuitePhysicsEngine, method), (
-                f"MyoSuitePhysicsEngine missing muscle method: {method}"
-            )
+            assert hasattr(
+                MyoSuitePhysicsEngine, method
+            ), f"MyoSuitePhysicsEngine missing muscle method: {method}"
 
     def test_myosuite_uninitialized_state(self) -> None:
         """Uninitialized MyoSuitePhysicsEngine reports not initialized."""

--- a/tests/heavy_integration/test_physics_consistency.py
+++ b/tests/heavy_integration/test_physics_consistency.py
@@ -52,9 +52,9 @@ class TestPendulumAnalytical:
 
         np.testing.assert_allclose(M, M.T, atol=1e-12)
         eigenvalues = np.linalg.eigvalsh(M)
-        assert all(ev > 0 for ev in eigenvalues), (
-            f"M not positive definite: eigs={eigenvalues}"
-        )
+        assert all(
+            ev > 0 for ev in eigenvalues
+        ), f"M not positive definite: eigs={eigenvalues}"
 
     def test_mass_matrix_varies_with_configuration(self) -> None:
         """Mass matrix should change with joint angles (coupled inertia)."""

--- a/tests/heavy_integration/test_pink_ik_integration.py
+++ b/tests/heavy_integration/test_pink_ik_integration.py
@@ -25,9 +25,9 @@ class TestPinkIKSolver:
         except ImportError:
             pytest.skip("pink not installed")
 
-        assert hasattr(pink, "solve_ik") or hasattr(pink, "Configuration"), (
-            f"Pink API unexpected: {[a for a in dir(pink) if not a.startswith('_')]}"
-        )
+        assert hasattr(pink, "solve_ik") or hasattr(
+            pink, "Configuration"
+        ), f"Pink API unexpected: {[a for a in dir(pink) if not a.startswith('_')]}"
 
     def test_pink_configuration_from_pinocchio_model(self) -> None:
         """Pink Configuration wraps a Pinocchio model without error."""
@@ -80,9 +80,9 @@ class TestPinkIKSolver:
             pytest.skip("pink.tasks not available in this version")
 
         task_module = pink.tasks
-        assert hasattr(task_module, "FrameTask") or hasattr(pink, "FrameTask"), (
-            "Pink should provide FrameTask"
-        )
+        assert hasattr(task_module, "FrameTask") or hasattr(
+            pink, "FrameTask"
+        ), "Pink should provide FrameTask"
 
 
 @pytest.mark.live_simulation

--- a/tests/heavy_integration/test_pyvista_vtk_integration.py
+++ b/tests/heavy_integration/test_pyvista_vtk_integration.py
@@ -27,9 +27,9 @@ class TestPyVistaCore:
         assert hasattr(pv, "__version__")
         # We need at least 0.38 for offscreen rendering stability
         major, minor = pv.__version__.split(".")[:2]
-        assert int(major) >= 0 and int(minor) >= 30, (
-            f"PyVista >= 0.30 expected, got {pv.__version__}"
-        )
+        assert (
+            int(major) >= 0 and int(minor) >= 30
+        ), f"PyVista >= 0.30 expected, got {pv.__version__}"
 
     def test_pyvista_create_mesh(self) -> None:
         """PyVista can create basic mesh primitives."""

--- a/tests/heavy_integration/test_real_engine_loading.py
+++ b/tests/heavy_integration/test_real_engine_loading.py
@@ -83,9 +83,9 @@ class TestEngineManagerIntegration:
             # If status says available, path must exist
             status = manager.get_engine_status(engine_type)
             if status == EngineStatus.AVAILABLE or status == EngineStatus.LOADED:
-                assert path.exists(), (
-                    f"{engine_type} marked as {status} but path doesn't exist"
-                )
+                assert (
+                    path.exists()
+                ), f"{engine_type} marked as {status} but path doesn't exist"
 
 
 @pytest.mark.skipif(not SIMPLE_ARM_URDF.exists(), reason="Test asset missing")
@@ -273,9 +273,9 @@ class TestCrossEngineConsistency:
         if len(valid_dofs) >= 2:
             # All engines should agree on DOF count
             dof_values = list(valid_dofs.values())
-            assert all(d == dof_values[0] for d in dof_values), (
-                f"Engines disagree on DOFs: {valid_dofs}"
-            )
+            assert all(
+                d == dof_values[0] for d in dof_values
+            ), f"Engines disagree on DOFs: {valid_dofs}"
 
 
 pytestmark = pytest.mark.live_simulation

--- a/tests/heavy_integration/test_upstream_contracts.py
+++ b/tests/heavy_integration/test_upstream_contracts.py
@@ -96,9 +96,9 @@ class TestPinocchioEngine:
 
         # Prove FK produced a valid SE3 placement
         placement = data.oMi[joint_id]
-        assert placement.isIdentity(prec=1e-6), (
-            "FK at neutral config should be identity"
-        )
+        assert placement.isIdentity(
+            prec=1e-6
+        ), "FK at neutral config should be identity"
 
 
 @pytest.mark.live_simulation
@@ -194,9 +194,9 @@ class TestMediaPipeIntegration:
             # New Tasks API (mediapipe >= 0.10)
             # Just verify the tasks module loads and has PoseLandmarker
             tasks = mp.tasks
-            assert hasattr(tasks, "vision") or hasattr(tasks, "BaseOptions"), (
-                f"mp.tasks has unexpected structure: {dir(tasks)}"
-            )
+            assert hasattr(tasks, "vision") or hasattr(
+                tasks, "BaseOptions"
+            ), f"mp.tasks has unexpected structure: {dir(tasks)}"
         else:
             pytest.skip(
                 f"MediaPipe installed but has unexpected API. "

--- a/tests/integration/putting_green/test_putting_simulation.py
+++ b/tests/integration/putting_green/test_putting_simulation.py
@@ -193,9 +193,9 @@ class TestPhysicsAccuracy:
         # Physics engine produces nearly identical distances for small stimp differences;
         # verify the results are within ~1% of each other (engine precision limit)
         diff = abs(fast_result.total_distance - slow_result.total_distance)
-        assert diff < 0.1, (
-            f"Distances should be similar: fast={fast_result.total_distance}, slow={slow_result.total_distance}"
-        )
+        assert (
+            diff < 0.1
+        ), f"Distances should be similar: fast={fast_result.total_distance}, slow={slow_result.total_distance}"
 
     def test_uphill_vs_downhill(self) -> None:
         """Uphill putts should roll shorter than downhill."""
@@ -240,9 +240,9 @@ class TestPhysicsAccuracy:
         # Physics engine produces nearly identical distances for small slope values;
         # verify the results are within ~1% of each other (engine precision limit)
         diff = abs(downhill_result.total_distance - uphill_result.total_distance)
-        assert diff < 0.1, (
-            f"Distances should be similar: downhill={downhill_result.total_distance}, uphill={uphill_result.total_distance}"
-        )
+        assert (
+            diff < 0.1
+        ), f"Distances should be similar: downhill={downhill_result.total_distance}, uphill={uphill_result.total_distance}"
 
     def test_spin_affects_roll(self) -> None:
         """Backspin should reduce initial roll distance (check effect)."""

--- a/tests/integration/test_conservation_laws.py
+++ b/tests/integration/test_conservation_laws.py
@@ -180,9 +180,9 @@ class TestEnergyConservation:
         )
         logger.info(f"Energy drift: {final_drift_pct:.4f}% (max: {max_drift_pct:.4f}%)")
 
-        assert max_drift_pct < 1.0, (
-            f"Energy drift {max_drift_pct:.2f}% exceeds 1% tolerance (Guideline O3)"
-        )
+        assert (
+            max_drift_pct < 1.0
+        ), f"Energy drift {max_drift_pct:.2f}% exceeds 1% tolerance (Guideline O3)"
 
     @pytest.mark.skipif(not _check_mujoco_available(), reason="MuJoCo not installed")
     def test_pendulum_energy_at_extremes(self) -> None:
@@ -288,9 +288,9 @@ class TestIndexedAccelerationClosure:
         logger.info(f"Residual: {residual}")
 
         TOLERANCE_CLOSURE = 1e-6  # [rad/s²] per Guideline M2
-        assert np.all(residual < TOLERANCE_CLOSURE), (
-            f"Superposition failed: residual {residual} > {TOLERANCE_CLOSURE}"
-        )
+        assert np.all(
+            residual < TOLERANCE_CLOSURE
+        ), f"Superposition failed: residual {residual} > {TOLERANCE_CLOSURE}"
 
     @pytest.mark.skipif(not _check_mujoco_available(), reason="MuJoCo not installed")
     def test_ztcf_equals_drift(self) -> None:
@@ -373,9 +373,9 @@ class TestIndexedAccelerationClosure:
 
         # Also verify physics makes sense: should be negative (restoring force)
         # when theta > 0 (pendulum displaced counter-clockwise)
-        assert qacc_zvcf < 0, (
-            f"Acceleration should be negative (restoring), got {qacc_zvcf:.4f}"
-        )
+        assert (
+            qacc_zvcf < 0
+        ), f"Acceleration should be negative (restoring), got {qacc_zvcf:.4f}"
 
 
 @pytest.mark.integration
@@ -455,9 +455,9 @@ class TestWorkEnergyTheorem:
         TOLERANCE_ABS = 0.001  # 1 mJ absolute tolerance
         TOLERANCE_REL = 0.05  # 5% relative tolerance for numerical integration
         relative_error = error / max(abs(delta_E), TOLERANCE_ABS)
-        assert relative_error < TOLERANCE_REL, (
-            f"Work-energy mismatch: {relative_error * 100:.2f}% > {TOLERANCE_REL * 100}%"
-        )
+        assert (
+            relative_error < TOLERANCE_REL
+        ), f"Work-energy mismatch: {relative_error * 100:.2f}% > {TOLERANCE_REL * 100}%"
 
 
 @pytest.mark.unit

--- a/tests/integration/test_contact_cross_engine.py
+++ b/tests/integration/test_contact_cross_engine.py
@@ -123,9 +123,9 @@ class TestBasicContactPhysics:
         )
 
         # Ball should be near ground (not still at 1m)
-        assert final_height < 0.1, (
-            f"Ball should settle near ground: height={final_height:.3f}m"
-        )
+        assert (
+            final_height < 0.1
+        ), f"Ball should settle near ground: height={final_height:.3f}m"
 
         # Log for cross-engine comparison
         np.sqrt(E_final / E_initial)
@@ -158,9 +158,9 @@ class TestBasicContactPhysics:
         assert isinstance(contact_forces, np.ndarray), "Should return a numpy array"
         assert contact_forces.shape == (3,), "Should return a 3-element force vector"
         # Since it's a known limitation in ABA without constraint solver, we expect 0 natively
-        assert np.all(contact_forces == 0), (
-            "Currently expects zero forces without constraint solver"
-        )
+        assert np.all(
+            contact_forces == 0
+        ), "Currently expects zero forces without constraint solver"
 
 
 class TestCrossEngineContactComparison:

--- a/tests/integration/test_cross_engine_consistency.py
+++ b/tests/integration/test_cross_engine_consistency.py
@@ -387,6 +387,6 @@ class TestThreeWayTriangulation:
 
         # For now, just verify that at least two engines agree closely
         min_deviation = min(deviations.values()) if deviations else float("inf")
-        assert min_deviation < agreement_threshold, (
-            f"No engine pair agrees within threshold: min deviation={min_deviation:.2e}"
-        )
+        assert (
+            min_deviation < agreement_threshold
+        ), f"No engine pair agrees within threshold: min deviation={min_deviation:.2e}"

--- a/tests/integration/test_engine_api_integration.py
+++ b/tests/integration/test_engine_api_integration.py
@@ -103,9 +103,9 @@ class TestEngineRegistryConsistency:
         for engine_type in EngineType:
             if engine_type in skip_types:
                 continue
-            assert engine_type in LOADER_MAP, (
-                f"{engine_type.value} missing from LOADER_MAP"
-            )
+            assert (
+                engine_type in LOADER_MAP
+            ), f"{engine_type.value} missing from LOADER_MAP"
 
     def test_loader_map_values_are_callable(self) -> None:
         """All LOADER_MAP values are callable functions."""

--- a/tests/integration/test_engine_integration.py
+++ b/tests/integration/test_engine_integration.py
@@ -52,9 +52,9 @@ class TestEngineIntegration:
         # For each available engine, verify its path actually exists
         for engine in available_engines:
             engine_path = manager.engine_paths[engine]
-            assert engine_path.exists(), (
-                f"{engine} marked available but path missing: {engine_path}"
-            )
+            assert (
+                engine_path.exists()
+            ), f"{engine} marked available but path missing: {engine_path}"
 
         # For unavailable engines, verify why they're unavailable
         for engine in EngineType:
@@ -64,9 +64,9 @@ class TestEngineIntegration:
                 if engine_path.exists():
                     # Path exists but validation failed - expected for incomplete installations
                     result = manager.validate_engine_configuration(engine)
-                    assert result is False, (
-                        f"{engine} exists but should fail validation"
-                    )
+                    assert (
+                        result is False
+                    ), f"{engine} exists but should fail validation"
 
     @pytest.mark.integration
     def test_engine_probe_consistency(self):

--- a/tests/integration/test_myosuite_muscles.py
+++ b/tests/integration/test_myosuite_muscles.py
@@ -389,9 +389,9 @@ class TestMyoSuiteEngine:
             ):
                 actuator_id = analyzer.muscle_actuator_ids[0]
                 ctrl_value = engine.sim.data.ctrl[actuator_id]
-                assert 0.7 <= ctrl_value <= 0.9, (
-                    f"Activation not set correctly: {ctrl_value}"
-                )
+                assert (
+                    0.7 <= ctrl_value <= 0.9
+                ), f"Activation not set correctly: {ctrl_value}"
 
         except Exception as e:  # noqa: BLE001
             pytest.skip(f"Activation setting test failed: {e}")

--- a/tests/integration/test_opensim_muscles.py
+++ b/tests/integration/test_opensim_muscles.py
@@ -116,9 +116,9 @@ class TestOpenSimMuscleModels:
         )
 
         # Basic sanity check: force should be positive and reasonable
-        assert 0 < F_muscle <= F_max * 1.5, (
-            f"Muscle force {F_muscle} outside expected range"
-        )
+        assert (
+            0 < F_muscle <= F_max * 1.5
+        ), f"Muscle force {F_muscle} outside expected range"
 
     def test_activation_dynamics(self, simple_arm_model):
         """Section J: Verify activation dynamics (30-50ms delay)."""

--- a/tests/integration/test_opensim_myosuite_wiring.py
+++ b/tests/integration/test_opensim_myosuite_wiring.py
@@ -52,9 +52,9 @@ class TestProbePaths:
         MyoSimProbe(suite_root)  # Ensures probe can be instantiated
         # Verify the probe checks for myosuite directory, not myosim
         engine_dir = suite_root / "src" / "engines" / "physics_engines" / "myosuite"
-        assert engine_dir.exists(), (
-            f"MyoSuite engine directory should exist at {engine_dir}"
-        )
+        assert (
+            engine_dir.exists()
+        ), f"MyoSuite engine directory should exist at {engine_dir}"
 
     def test_myosim_probe_checks_correct_file(self, suite_root: Path) -> None:
         """MyoSim probe checks for myosuite_physics_engine.py."""
@@ -67,9 +67,9 @@ class TestProbePaths:
             / "python"
             / "myosuite_physics_engine.py"
         )
-        assert engine_file.exists(), (
-            f"MyoSuite engine file should exist at {engine_file}"
-        )
+        assert (
+            engine_file.exists()
+        ), f"MyoSuite engine file should exist at {engine_file}"
 
 
 # ──────────────────────────────────────────────────────────────
@@ -160,9 +160,9 @@ class TestOpenSimProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(OpenSimPhysicsEngine, method), (
-                f"OpenSimPhysicsEngine missing required method: {method}"
-            )
+            assert hasattr(
+                OpenSimPhysicsEngine, method
+            ), f"OpenSimPhysicsEngine missing required method: {method}"
             assert callable(getattr(OpenSimPhysicsEngine, method))
 
     def test_opensim_has_biomech_methods(self) -> None:
@@ -176,9 +176,9 @@ class TestOpenSimProtocol:
             "create_grip_model",
         ]
         for method in biomech_methods:
-            assert hasattr(OpenSimPhysicsEngine, method), (
-                f"OpenSimPhysicsEngine missing biomech method: {method}"
-            )
+            assert hasattr(
+                OpenSimPhysicsEngine, method
+            ), f"OpenSimPhysicsEngine missing biomech method: {method}"
 
     def test_opensim_uninitialized_state(self) -> None:
         """Uninitialized OpenSimPhysicsEngine reports not initialized."""
@@ -224,9 +224,9 @@ class TestMyoSuiteProtocol:
         ]
 
         for method in required_methods:
-            assert hasattr(MyoSuitePhysicsEngine, method), (
-                f"MyoSuitePhysicsEngine missing required method: {method}"
-            )
+            assert hasattr(
+                MyoSuitePhysicsEngine, method
+            ), f"MyoSuitePhysicsEngine missing required method: {method}"
             assert callable(getattr(MyoSuitePhysicsEngine, method))
 
     def test_myosuite_has_muscle_methods(self) -> None:
@@ -243,9 +243,9 @@ class TestMyoSuiteProtocol:
             "get_muscle_names",
         ]
         for method in muscle_methods:
-            assert hasattr(MyoSuitePhysicsEngine, method), (
-                f"MyoSuitePhysicsEngine missing muscle method: {method}"
-            )
+            assert hasattr(
+                MyoSuitePhysicsEngine, method
+            ), f"MyoSuitePhysicsEngine missing muscle method: {method}"
 
     def test_myosuite_uninitialized_state(self) -> None:
         """Uninitialized MyoSuitePhysicsEngine reports not initialized."""

--- a/tests/integration/test_physics_consistency.py
+++ b/tests/integration/test_physics_consistency.py
@@ -52,9 +52,9 @@ class TestPendulumAnalytical:
 
         np.testing.assert_allclose(M, M.T, atol=1e-12)
         eigenvalues = np.linalg.eigvalsh(M)
-        assert all(ev > 0 for ev in eigenvalues), (
-            f"M not positive definite: eigs={eigenvalues}"
-        )
+        assert all(
+            ev > 0 for ev in eigenvalues
+        ), f"M not positive definite: eigs={eigenvalues}"
 
     def test_mass_matrix_varies_with_configuration(self) -> None:
         """Mass matrix should change with joint angles (coupled inertia)."""

--- a/tests/integration/test_real_engine_loading.py
+++ b/tests/integration/test_real_engine_loading.py
@@ -83,9 +83,9 @@ class TestEngineManagerIntegration:
             # If status says available, path must exist
             status = manager.get_engine_status(engine_type)
             if status == EngineStatus.AVAILABLE or status == EngineStatus.LOADED:
-                assert path.exists(), (
-                    f"{engine_type} marked as {status} but path doesn't exist"
-                )
+                assert (
+                    path.exists()
+                ), f"{engine_type} marked as {status} but path doesn't exist"
 
 
 @pytest.mark.skipif(not SIMPLE_ARM_URDF.exists(), reason="Test asset missing")
@@ -273,6 +273,6 @@ class TestCrossEngineConsistency:
         if len(valid_dofs) >= 2:
             # All engines should agree on DOF count
             dof_values = list(valid_dofs.values())
-            assert all(d == dof_values[0] for d in dof_values), (
-                f"Engines disagree on DOFs: {valid_dofs}"
-            )
+            assert all(
+                d == dof_values[0] for d in dof_values
+            ), f"Engines disagree on DOFs: {valid_dofs}"

--- a/tests/integration/test_terrain_cross_engine.py
+++ b/tests/integration/test_terrain_cross_engine.py
@@ -89,9 +89,9 @@ class TestTerrainConsistency:
         for x, y in test_points:
             normal = sloped_terrain.elevation.get_normal(x, y)
             magnitude = np.linalg.norm(normal)
-            assert abs(magnitude - 1.0) < 1e-6, (
-                f"Normal at ({x}, {y}) not unit: {magnitude}"
-            )
+            assert (
+                abs(magnitude - 1.0) < 1e-6
+            ), f"Normal at ({x}, {y}) not unit: {magnitude}"
 
     def test_gradient_consistency(self, sloped_terrain: Terrain) -> None:
         """Gradient should be consistent with elevation differences."""

--- a/tests/integration/test_tools_integration.py
+++ b/tests/integration/test_tools_integration.py
@@ -48,6 +48,6 @@ class TestCrossRepoImportPaths:
 
         content = pyproject_path.read_text()
         # Check for Tools repo reference
-        assert "Tools" in content or "tools" in content.lower(), (
-            "Tools integration not documented in pyproject.toml"
-        )
+        assert (
+            "Tools" in content or "tools" in content.lower()
+        ), "Tools integration not documented in pyproject.toml"

--- a/tests/integration/test_urdf_generation_smoke.py
+++ b/tests/integration/test_urdf_generation_smoke.py
@@ -85,9 +85,9 @@ class TestURDFStructuralValidity:
             if joint.get("type") == "revolute":
                 limit = joint.find("limit")
                 joint_name = joint.get("name")
-                assert limit is not None, (
-                    f"Revolute joint '{joint_name}' missing <limit>"
-                )
+                assert (
+                    limit is not None
+                ), f"Revolute joint '{joint_name}' missing <limit>"
                 assert "lower" in limit.attrib
                 assert "upper" in limit.attrib
 
@@ -104,12 +104,12 @@ class TestURDFStructuralValidity:
             assert child is not None
             parent_link = parent.get("link")
             child_link = child.get("link")
-            assert parent_link in link_names, (
-                f"Joint '{joint_name}' parent '{parent_link}' not found in links"
-            )
-            assert child_link in link_names, (
-                f"Joint '{joint_name}' child '{child_link}' not found in links"
-            )
+            assert (
+                parent_link in link_names
+            ), f"Joint '{joint_name}' parent '{parent_link}' not found in links"
+            assert (
+                child_link in link_names
+            ), f"Joint '{joint_name}' child '{child_link}' not found in links"
 
     def test_no_xml_declaration(self, default_urdf: str) -> None:
         """URDF output must not carry an XML declaration header."""

--- a/tests/launchers/test_lazy_imports.py
+++ b/tests/launchers/test_lazy_imports.py
@@ -88,6 +88,6 @@ class TestDashboardModulesHaveCallableMain:
     @pytest.mark.parametrize("dashboard_module", _DASHBOARD_MODULES)
     def test_main_is_callable(self, dashboard_module: str) -> None:
         mod = importlib.import_module(dashboard_module)
-        assert callable(getattr(mod, "main", None)), (
-            f"{dashboard_module} does not expose a callable main()"
-        )
+        assert callable(
+            getattr(mod, "main", None)
+        ), f"{dashboard_module} does not expose a callable main()"

--- a/tests/launchers/test_model_card.py
+++ b/tests/launchers/test_model_card.py
@@ -92,13 +92,17 @@ def test_find_image_path(mock_assets_dir, mock_model, parent_launcher, qapp):
     with patch("src.launchers.model_card.Path") as mock_base_path:
         mock_svg = MagicMock()
         mock_svg.exists.return_value = True
-        mock_base_path.return_value.parent.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = mock_svg
+        mock_base_path.return_value.parent.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = (
+            mock_svg
+        )
         assert card._find_image_path("test.png") == mock_svg
 
     with patch("src.launchers.model_card.Path") as mock_base_path:
         mock_svg = MagicMock()
         mock_svg.exists.return_value = False
-        mock_base_path.return_value.parent.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = mock_svg
+        mock_base_path.return_value.parent.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = (
+            mock_svg
+        )
         assert card._find_image_path("test.png") is None
 
     assert card._find_image_path(None) is None

--- a/tests/launchers/test_provider_migration_boundaries.py
+++ b/tests/launchers/test_provider_migration_boundaries.py
@@ -22,6 +22,6 @@ def test_provider_migration_boundary_files_avoid_legacy_repo_path_shortcuts() ->
     for file_path in _BOUNDARY_FILES:
         contents = file_path.read_text(encoding="utf-8")
         for snippet in _DISALLOWED_SNIPPETS:
-            assert snippet not in contents, (
-                f"{file_path.name} contains legacy shortcut: {snippet}"
-            )
+            assert (
+                snippet not in contents
+            ), f"{file_path.name} contains legacy shortcut: {snippet}"

--- a/tests/parity/test_ball_flight_parity.py
+++ b/tests/parity/test_ball_flight_parity.py
@@ -154,9 +154,9 @@ class TestPythonBallFlightBaseline:
         carry_no_drag = sim_no_drag.analyze_trajectory(traj_no_drag)["carry_distance"]
         carry_drag = sim_drag.analyze_trajectory(traj_drag)["carry_distance"]
 
-        assert carry_drag < carry_no_drag, (
-            f"Drag should reduce range: {carry_drag:.1f} vs {carry_no_drag:.1f}"
-        )
+        assert (
+            carry_drag < carry_no_drag
+        ), f"Drag should reduce range: {carry_drag:.1f} vs {carry_no_drag:.1f}"
 
     def test_export_reference_vectors(self) -> None:
         """Export test vectors as JSON for Rust parity verification."""

--- a/tests/parity/test_pendulum_simulation_parity.py
+++ b/tests/parity/test_pendulum_simulation_parity.py
@@ -152,9 +152,9 @@ class TestPendulumEngineDirectly:
         if expected.get("theta1_decreases"):
             # From pi/2, gravity should pull link back toward 0
             theta1_values = [p[0] for p in positions_history]
-            assert theta1_values[-1] < math.pi / 2, (
-                f"theta1 should decrease from pi/2, got {theta1_values[-1]}"
-            )
+            assert (
+                theta1_values[-1] < math.pi / 2
+            ), f"theta1 should decrease from pi/2, got {theta1_values[-1]}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/physics_validation/test_momentum_conservation.py
+++ b/tests/physics_validation/test_momentum_conservation.py
@@ -96,9 +96,9 @@ def test_mujoco_momentum_conservation():
 
     # Tolerance: 1e-12 should be achievable for floating point arithmetic if truly conservative
     # But contact solver might introduce slight drift. Let's start with 1e-6.
-    assert max_deviation < 1e-6, (
-        f"Momentum not conserved. Max deviation: {max_deviation}"
-    )
+    assert (
+        max_deviation < 1e-6
+    ), f"Momentum not conserved. Max deviation: {max_deviation}"
 
 
 def test_pinocchio_momentum_conservation():

--- a/tests/physics_validation/test_pendulum_accuracy.py
+++ b/tests/physics_validation/test_pendulum_accuracy.py
@@ -96,9 +96,9 @@ def test_mujoco_pendulum_accuracy():
     logger.info(f"Max Energy Error (MuJoCo): {max_energy_error:.6f} J")
 
     # Allow small numerical integration error
-    assert max_energy_error < 0.01, (
-        f"MuJoCo pendulum drifted! Max error: {max_energy_error}"
-    )
+    assert (
+        max_energy_error < 0.01
+    ), f"MuJoCo pendulum drifted! Max error: {max_energy_error}"
 
 
 def test_drake_pendulum_accuracy():

--- a/tests/rust_bindings/test_rust_python_numeric_parity.py
+++ b/tests/rust_bindings/test_rust_python_numeric_parity.py
@@ -91,9 +91,9 @@ class TestLerpParity:
         """Rust lerp must match Python lerp within 1 ULP."""
         rust_result = float(upstream_physics.lerp(a, b, t))
         py_result = self._python_lerp(a, b, t)
-        assert abs(rust_result - py_result) < 1e-15, (
-            f"Mismatch: lerp({a}, {b}, {t}) → Rust={rust_result}, Python={py_result}"
-        )
+        assert (
+            abs(rust_result - py_result) < 1e-15
+        ), f"Mismatch: lerp({a}, {b}, {t}) → Rust={rust_result}, Python={py_result}"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/shared_contracts/test_tools_vendoring.py
+++ b/tests/shared_contracts/test_tools_vendoring.py
@@ -51,18 +51,18 @@ def test_tools_vendoring_provider_path(pytestconfig: pytest.Config) -> None:
     provider_file = Path(upstream_drift_tools.__file__).resolve()
 
     if mode == "vendored":
-        assert "ud-tools" in provider_file.parts or "ud-tools" in str(provider_file), (
-            f"Expected a vendored tools path containing 'ud-tools', got {provider_file}"
-        )
+        assert "ud-tools" in provider_file.parts or "ud-tools" in str(
+            provider_file
+        ), f"Expected a vendored tools path containing 'ud-tools', got {provider_file}"
         # Ensure it is definitely not resolving from our local UpstreamDrift/src/shared/python
         assert "upstreamdrift/src/shared/python" not in str(
             provider_file
-        ).lower().replace("\\", "/"), (
-            f"Resolved to local path instead of vendored: {provider_file}"
-        )
+        ).lower().replace(
+            "\\", "/"
+        ), f"Resolved to local path instead of vendored: {provider_file}"
     elif mode == "local":
-        assert str(local_path) in str(provider_file), (
-            f"Expected local tools path {local_path}, got {provider_file}"
-        )
+        assert str(local_path) in str(
+            provider_file
+        ), f"Expected local tools path {local_path}, got {provider_file}"
     else:
         pytest.fail(f"Unknown tools mode configured: {mode}")

--- a/tests/test_aerodynamics_parity.py
+++ b/tests/test_aerodynamics_parity.py
@@ -67,9 +67,9 @@ class TestDragParity:
         expected_mag = 0.5 * 1.225 * expected_cd * ball.area * speed**2
         actual_mag = np.linalg.norm(drag_py)
 
-        assert abs(actual_mag - expected_mag) / expected_mag < 0.01, (
-            f"Laminar drag magnitude mismatch: {actual_mag} vs {expected_mag}"
-        )
+        assert (
+            abs(actual_mag - expected_mag) / expected_mag < 0.01
+        ), f"Laminar drag magnitude mismatch: {actual_mag} vs {expected_mag}"
 
 
 class TestLiftParity:
@@ -147,9 +147,9 @@ class TestCoefficientConsistency:
         """Lift coefficient saturates near Cl_max = 0.4."""
         cl_max = 0.4
         cl_very_high = cl_max * (1 - math.exp(-10.0 / 0.1))
-        assert abs(cl_very_high - 0.4) < 0.01, (
-            f"Cl should saturate near 0.4, got {cl_very_high}"
-        )
+        assert (
+            abs(cl_very_high - 0.4) < 0.01
+        ), f"Cl should saturate near 0.4, got {cl_very_high}"
 
     def test_magnus_coefficient_capped(self) -> None:
         """Magnus coefficient caps at 0.4 * 0.5 = 0.2."""

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -259,6 +259,6 @@ class TestPyprojectTomlConsistency:
 
         deps = data["project"]["dependencies"]
         # Check that structlog is in the dependencies
-        assert any("structlog" in dep for dep in deps), (
-            "structlog must be in core dependencies"
-        )
+        assert any(
+            "structlog" in dep for dep in deps
+        ), "structlog must be in core dependencies"

--- a/tests/test_circular_dependencies.py
+++ b/tests/test_circular_dependencies.py
@@ -97,9 +97,9 @@ class TestApiDoesNotImportLaunchers:
                 "src.launchers.launcher_model_handlers",
                 "src.launchers.launcher_process_manager",
             ]:
-                assert mod_name not in sys.modules, (
-                    f"{mod_name} was imported eagerly by LauncherService module"
-                )
+                assert (
+                    mod_name not in sys.modules
+                ), f"{mod_name} was imported eagerly by LauncherService module"
         finally:
             sys.modules.update(saved)
 
@@ -169,9 +169,10 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.engines", "engines")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert not violations, (
-            "shared/python/ files import from engines at module level:\n"
-            + "\n".join(f"  - {v}" for v in violations)
+        assert (
+            not violations
+        ), "shared/python/ files import from engines at module level:\n" + "\n".join(
+            f"  - {v}" for v in violations
         )
 
     def test_shared_does_not_import_robotics_at_module_level(self):
@@ -186,9 +187,10 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.robotics", "robotics")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert not violations, (
-            "shared/python/ files import from robotics at module level:\n"
-            + "\n".join(f"  - {v}" for v in violations)
+        assert (
+            not violations
+        ), "shared/python/ files import from robotics at module level:\n" + "\n".join(
+            f"  - {v}" for v in violations
         )
 
     def test_api_does_not_import_launchers_at_module_level(self):
@@ -207,7 +209,8 @@ class TestNoCircularImportsStaticAnalysis:
                 if imp.startswith(("src.launchers", "launchers")):
                     violations.append(f"{py_file.relative_to(src_root)}: imports {imp}")
 
-        assert not violations, (
-            "api/ files import from launchers at module level:\n"
-            + "\n".join(f"  - {v}" for v in violations)
+        assert (
+            not violations
+        ), "api/ files import from launchers at module level:\n" + "\n".join(
+            f"  - {v}" for v in violations
         )

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -48,6 +48,7 @@ class TestDockerBuild(unittest.TestCase):
         # Check for required components (multi-stage build with pinned version)
         self.assertIn("FROM continuumio/miniconda3:24.11.1-0 AS builder", content)
         self.assertIn("FROM continuumio/miniconda3:24.11.1-0 AS runtime", content)
+        self.assertIn("-c pytorch -c nvidia", content)
         self.assertIn('ENV PYTHONPATH="/workspace"', content)
         self.assertIn("WORKDIR /workspace", content)
         self.assertIn(

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -50,6 +50,11 @@ class TestDockerBuild(unittest.TestCase):
         self.assertIn("FROM continuumio/miniconda3:24.11.1-0 AS runtime", content)
         self.assertIn('ENV PYTHONPATH="/workspace"', content)
         self.assertIn("WORKDIR /workspace", content)
+        self.assertIn(
+            'CMD ["python", "-m", "uvicorn", "src.api.server:app", '
+            '"--host", "0.0.0.0", "--port", "8001"]',
+            content,
+        )
 
     def test_dockerfile_pythonpath_setup(self):
         """Test that Dockerfile sets up PYTHONPATH correctly."""

--- a/tests/test_launcher_integration.py
+++ b/tests/test_launcher_integration.py
@@ -53,12 +53,11 @@ class TestLauncherIntegration(unittest.TestCase):
     def test_shared_modules_importable(self):
         """Test that shared modules can be imported."""
         try:
-            from src.shared.python.process_worker import ProcessWorker
-
             from src.shared.python.config.configuration_manager import (
                 ConfigurationManager,
             )
             from src.shared.python.engine_core.engine_manager import EngineManager
+            from src.shared.python.process_worker import ProcessWorker
 
             # Test basic instantiation with required arguments
             config_manager = ConfigurationManager(Path("dummy_config.json"))

--- a/tests/test_launcher_integration.py
+++ b/tests/test_launcher_integration.py
@@ -53,11 +53,12 @@ class TestLauncherIntegration(unittest.TestCase):
     def test_shared_modules_importable(self):
         """Test that shared modules can be imported."""
         try:
+            from src.shared.python.process_worker import ProcessWorker
+
             from src.shared.python.config.configuration_manager import (
                 ConfigurationManager,
             )
             from src.shared.python.engine_core.engine_manager import EngineManager
-            from src.shared.python.process_worker import ProcessWorker
 
             # Test basic instantiation with required arguments
             config_manager = ConfigurationManager(Path("dummy_config.json"))

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -49,9 +49,9 @@ class TestParityRK4:
             t += dt
 
         expected = math.exp(-1.0)  # 0.36787944...
-        assert abs(y - expected) < 1e-8, (
-            f"Python RK4 should match exp(-1), got {y}, expected {expected}"
-        )
+        assert (
+            abs(y - expected) < 1e-8
+        ), f"Python RK4 should match exp(-1), got {y}, expected {expected}"
 
     def test_integrator_config_consistency(self) -> None:
         """IntegratorConfig from adapter should have valid defaults."""
@@ -77,9 +77,9 @@ class TestParityContactModel:
         v_out = -cor * v_in
 
         # Energy conservation: |v_out| == |v_in|
-        assert abs(abs(v_out) - abs(v_in)) < 1e-10, (
-            f"Elastic collision should preserve speed: in={v_in}, out={v_out}"
-        )
+        assert (
+            abs(abs(v_out) - abs(v_in)) < 1e-10
+        ), f"Elastic collision should preserve speed: in={v_in}, out={v_out}"
 
     def test_inelastic_collision_python(self) -> None:
         """Python inelastic collision (COR<1) should lose energy."""
@@ -90,9 +90,9 @@ class TestParityContactModel:
 
         # Energy ratio = COR^2
         ke_ratio = (v_out_normal / v_in) ** 2
-        assert abs(ke_ratio - cor**2) < 1e-10, (
-            f"KE ratio should be COR^2={cor**2}, got {ke_ratio}"
-        )
+        assert (
+            abs(ke_ratio - cor**2) < 1e-10
+        ), f"KE ratio should be COR^2={cor**2}, got {ke_ratio}"
 
     def test_contact_params_consistency(self) -> None:
         """ContactParameters from adapter should have valid defaults."""
@@ -142,9 +142,9 @@ class TestParityMathPrimitives:
         a, b, t = 10.0, 20.0, 0.3
         py_lerp = a + t * (b - a)
 
-        assert abs(py_lerp - 13.0) < 1e-10, (
-            f"lerp(10, 20, 0.3) should be 13.0, got {py_lerp}"
-        )
+        assert (
+            abs(py_lerp - 13.0) < 1e-10
+        ), f"lerp(10, 20, 0.3) should be 13.0, got {py_lerp}"
 
     def test_clamp_parity(self) -> None:
         """Clamping: Python vs Rust."""

--- a/tests/unit/api/test_db_migrations.py
+++ b/tests/unit/api/test_db_migrations.py
@@ -78,9 +78,9 @@ class TestAlembicAvailability:
 
         try:
             current = Version(alembic.__version__)
-            assert current >= Version("1.13.0"), (
-                f"Alembic {alembic.__version__} is older than the required 1.13.0"
-            )
+            assert current >= Version(
+                "1.13.0"
+            ), f"Alembic {alembic.__version__} is older than the required 1.13.0"
         except ImportError:
             # packaging not installed — skip version comparison
             pytest.skip("packaging not installed, skipping version check")
@@ -117,9 +117,9 @@ class TestAlembicIni:
         cfg.read(str(ini))
         script_location = cfg.get("alembic", "script_location")
         scripts_dir = REPO_ROOT / script_location
-        assert scripts_dir.is_dir(), (
-            f"script_location '{script_location}' does not exist as a directory"
-        )
+        assert (
+            scripts_dir.is_dir()
+        ), f"script_location '{script_location}' does not exist as a directory"
 
     def test_alembic_ini_versions_dir(self):
         """The versions/ directory referenced in alembic.ini must exist."""
@@ -144,25 +144,25 @@ class TestMigrationsEnvPy:
         """env.py must import Base from src.api.auth.models."""
         env = REPO_ROOT / "src" / "api" / "migrations" / "env.py"
         source = env.read_text()
-        assert "from src.api.auth.models import Base" in source, (
-            "env.py must import Base from src.api.auth.models"
-        )
+        assert (
+            "from src.api.auth.models import Base" in source
+        ), "env.py must import Base from src.api.auth.models"
 
     def test_env_py_sets_target_metadata(self):
         """env.py must assign target_metadata = Base.metadata."""
         env = REPO_ROOT / "src" / "api" / "migrations" / "env.py"
         source = env.read_text()
-        assert "target_metadata = Base.metadata" in source, (
-            "env.py must set target_metadata = Base.metadata"
-        )
+        assert (
+            "target_metadata = Base.metadata" in source
+        ), "env.py must set target_metadata = Base.metadata"
 
     def test_env_py_has_render_as_batch(self):
         """env.py must enable render_as_batch for SQLite ALTER TABLE support."""
         env = REPO_ROOT / "src" / "api" / "migrations" / "env.py"
         source = env.read_text()
-        assert "render_as_batch=True" in source, (
-            "env.py must set render_as_batch=True for SQLite ALTER TABLE emulation"
-        )
+        assert (
+            "render_as_batch=True" in source
+        ), "env.py must set render_as_batch=True for SQLite ALTER TABLE emulation"
 
 
 # ---------------------------------------------------------------------------
@@ -175,9 +175,9 @@ class TestInitialMigrationMetadata:
 
     def test_initial_migration_exists(self):
         """The initial migration file must exist."""
-        assert INITIAL_MIGRATION_PATH.exists(), (
-            f"Initial migration not found at {INITIAL_MIGRATION_PATH}"
-        )
+        assert (
+            INITIAL_MIGRATION_PATH.exists()
+        ), f"Initial migration not found at {INITIAL_MIGRATION_PATH}"
 
     def test_initial_migration_revision_id(self):
         """Initial migration revision must be '0001'."""
@@ -187,23 +187,23 @@ class TestInitialMigrationMetadata:
     def test_initial_migration_no_parent(self):
         """Initial migration must have no parent revision (down_revision is None)."""
         mod = _import_migration_module()
-        assert mod.down_revision is None, (
-            f"Initial migration should have no parent, got {mod.down_revision!r}"
-        )
+        assert (
+            mod.down_revision is None
+        ), f"Initial migration should have no parent, got {mod.down_revision!r}"
 
     def test_initial_migration_has_upgrade(self):
         """Initial migration must define an upgrade() function."""
         mod = _import_migration_module()
-        assert callable(getattr(mod, "upgrade", None)), (
-            "Initial migration must define upgrade()"
-        )
+        assert callable(
+            getattr(mod, "upgrade", None)
+        ), "Initial migration must define upgrade()"
 
     def test_initial_migration_has_downgrade(self):
         """Initial migration must define a downgrade() function."""
         mod = _import_migration_module()
-        assert callable(getattr(mod, "downgrade", None)), (
-            "Initial migration must define downgrade()"
-        )
+        assert callable(
+            getattr(mod, "downgrade", None)
+        ), "Initial migration must define downgrade()"
 
 
 # ---------------------------------------------------------------------------
@@ -256,9 +256,9 @@ class TestMigrationRoundTrip:
             inspector2 = inspect(engine2)
             tables_after_downgrade = set(inspector2.get_table_names())
         for tbl in ("users", "api_keys", "sessions"):
-            assert tbl not in tables_after_downgrade, (
-                f"Table '{tbl}' still present after downgrade to base"
-            )
+            assert (
+                tbl not in tables_after_downgrade
+            ), f"Table '{tbl}' still present after downgrade to base"
 
     def test_idempotent_upgrade(self, alembic_cfg):
         """Applying migrations twice must not raise an error."""

--- a/tests/unit/api/test_error_codes.py
+++ b/tests/unit/api/test_error_codes.py
@@ -84,9 +84,9 @@ class TestErrorMetadata:
 
         for code, metadata in ERROR_METADATA.items():
             status = metadata.get("status_code")
-            assert status in valid_status_codes, (
-                f"Invalid status code {status} for {code}"
-            )
+            assert (
+                status in valid_status_codes
+            ), f"Invalid status code {status} for {code}"
 
     def test_messages_are_non_empty_strings(self):
         """Test that all messages are non-empty strings."""
@@ -119,9 +119,9 @@ class TestErrorMetadata:
             expected_category = code_to_category.get(code_prefix)
 
             if expected_category:
-                assert metadata.get("category") == expected_category, (
-                    f"Category mismatch for {code}"
-                )
+                assert (
+                    metadata.get("category") == expected_category
+                ), f"Category mismatch for {code}"
 
 
 class TestAPIErrorContract:

--- a/tests/unit/core/test_numerical_constants.py
+++ b/tests/unit/core/test_numerical_constants.py
@@ -87,6 +87,6 @@ class TestHumanBodyConstants:
             if isinstance(val, int | float):
                 assert val > 0.0, f"Ratio for '{key}' should be positive"
             elif isinstance(val, list | tuple):
-                assert all(v > 0.0 for v in val), (
-                    f"All ratios for '{key}' should be positive"
-                )
+                assert all(
+                    v > 0.0 for v in val
+                ), f"All ratios for '{key}' should be positive"

--- a/tests/unit/data_io/test_export.py
+++ b/tests/unit/data_io/test_export.py
@@ -48,9 +48,9 @@ class TestGetAvailableExportFormats:
         formats = get_available_export_formats()
         for name, info in formats.items():
             assert "extension" in info, f"Format '{name}' missing extension"
-            assert info["extension"].startswith("."), (
-                f"Extension for '{name}' should start with '.'"
-            )
+            assert info["extension"].startswith(
+                "."
+            ), f"Extension for '{name}' should start with '.'"
 
     def test_each_format_has_name(self) -> None:
         formats = get_available_export_formats()

--- a/tests/unit/engines/drake/test_drake_perturbation_analyzer.py
+++ b/tests/unit/engines/drake/test_drake_perturbation_analyzer.py
@@ -386,9 +386,9 @@ class TestRK4EnergyStability:
 
         assert np.all(np.isfinite(sim.q_traj)), "q_traj contains non-finite values"
         assert np.all(np.isfinite(sim.v_traj)), "v_traj contains non-finite values"
-        assert np.all(np.isfinite(sim.kinetic_energy_traj)), (
-            "kinetic_energy_traj contains non-finite values"
-        )
-        assert np.all(np.isfinite(sim.potential_energy_traj)), (
-            "potential_energy_traj contains non-finite values"
-        )
+        assert np.all(
+            np.isfinite(sim.kinetic_energy_traj)
+        ), "kinetic_energy_traj contains non-finite values"
+        assert np.all(
+            np.isfinite(sim.potential_energy_traj)
+        ), "potential_energy_traj contains non-finite values"

--- a/tests/unit/engines/mujoco/test_counterfactuals.py
+++ b/tests/unit/engines/mujoco/test_counterfactuals.py
@@ -68,9 +68,9 @@ class TestZTCF:
         result = analyzer.ztcf(qpos, qvel, ctrl)
 
         # Torque should increase acceleration (positive delta)
-        assert result.delta_acceleration[0] > 0, (
-            "Upward torque should create positive acceleration delta"
-        )
+        assert (
+            result.delta_acceleration[0] > 0
+        ), "Upward torque should create positive acceleration delta"
 
         # Observed > counterfactual
         assert result.observed_acceleration[0] > result.counterfactual_acceleration[0]
@@ -87,9 +87,9 @@ class TestZTCF:
         result = analyzer.ztcf(qpos, qvel, ctrl)
 
         # Torque opposes motion (negative delta)
-        assert result.delta_acceleration[0] < 0, (
-            "Opposing torque should create negative acceleration delta"
-        )
+        assert (
+            result.delta_acceleration[0] < 0
+        ), "Opposing torque should create negative acceleration delta"
 
     def test_ztcf_delta_scales_with_torque(self, simple_pendulum_model) -> None:
         """Test ZTCF: delta scales linearly with applied torque."""
@@ -126,9 +126,9 @@ class TestZTCF:
         assert result.delta_position is not None
 
         # Observed position should differ from counterfactual
-        assert abs(result.delta_position[0]) > 1e-6, (
-            "Position delta should be non-zero with strong torque"
-        )
+        assert (
+            abs(result.delta_position[0]) > 1e-6
+        ), "Position delta should be non-zero with strong torque"
 
 
 class TestZVCF:
@@ -276,9 +276,9 @@ class TestCounterfactualPhysics:
         # Reconstruction test
         reconstructed = result.counterfactual_acceleration + result.delta_acceleration
 
-        assert np.allclose(result.observed_acceleration, reconstructed, atol=1e-6), (
-            "Physics violation: observed != counterfactual + delta"
-        )
+        assert np.allclose(
+            result.observed_acceleration, reconstructed, atol=1e-6
+        ), "Physics violation: observed != counterfactual + delta"
 
     def test_zvcf_plus_counterfactual_equals_observed(
         self, simple_pendulum_model
@@ -294,9 +294,9 @@ class TestCounterfactualPhysics:
         # Reconstruction test
         reconstructed = result.counterfactual_acceleration + result.delta_acceleration
 
-        assert np.allclose(result.observed_acceleration, reconstructed, atol=1e-6), (
-            "Physics violation: observed != counterfactual + delta"
-        )
+        assert np.allclose(
+            result.observed_acceleration, reconstructed, atol=1e-6
+        ), "Physics violation: observed != counterfactual + delta"
 
     def test_ztcf_reveals_control_authority(self, simple_pendulum_model) -> None:
         """Test that ZTCF correctly identifies control authority."""
@@ -314,9 +314,9 @@ class TestCounterfactualPhysics:
         # Counterfactual: pendulum stays stationary (at bottom, no velocity)
         # Observed: strong upward acceleration from torque
         # Delta should be large and positive
-        assert result.delta_acceleration[0] > 5.0, (
-            "Strong torque should create large positive delta"
-        )
+        assert (
+            result.delta_acceleration[0] > 5.0
+        ), "Strong torque should create large positive delta"
 
         # This delta represents the control authority
         assert result.torque_attributed_effect is not None

--- a/tests/unit/engines/mujoco/test_drift_control.py
+++ b/tests/unit/engines/mujoco/test_drift_control.py
@@ -66,9 +66,9 @@ class TestDriftControlDecomposer:
         )
 
         # Guideline F requires residual < 1e-5
-        assert result.residual < 1e-5, (
-            f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
-        )
+        assert (
+            result.residual < 1e-5
+        ), f"Residual {result.residual:.2e} exceeds Guideline F tolerance 1e-5"
 
     def test_zero_control_gives_drift_only(self, simple_pendulum_model) -> None:
         """Test that zero control gives drift-only acceleration."""
@@ -81,9 +81,9 @@ class TestDriftControlDecomposer:
         result = decomposer.decompose(qpos, qvel, ctrl)
 
         # With zero control, control acceleration should be near zero
-        assert np.allclose(result.control_acceleration, 0, atol=1e-6), (
-            f"Expected zero control acceleration, got {result.control_acceleration}"
-        )
+        assert np.allclose(
+            result.control_acceleration, 0, atol=1e-6
+        ), f"Expected zero control acceleration, got {result.control_acceleration}"
 
         # Full should equal drift
         assert np.allclose(
@@ -175,9 +175,9 @@ class TestDriftControlDecomposer:
 
         # All should satisfy superposition
         for r in results:
-            assert r.residual < 1e-5, (
-                f"Trajectory point failed superposition: residual={r.residual:.2e}"
-            )
+            assert (
+                r.residual < 1e-5
+            ), f"Trajectory point failed superposition: residual={r.residual:.2e}"
 
     def test_decomposition_is_reproducible(self, simple_pendulum_model) -> None:
         """Test that decomposition gives same results with same inputs."""
@@ -222,11 +222,11 @@ class TestDriftControlPhysics:
         result = decomposer.decompose(qpos, qvel, ctrl)
 
         # Control component should dominate and be positive (upward)
-        assert result.control_acceleration[0] > result.drift_acceleration[0], (
-            "Control should dominate drift for strong actuation"
-        )
+        assert (
+            result.control_acceleration[0] > result.drift_acceleration[0]
+        ), "Control should dominate drift for strong actuation"
 
         # Total should be positive (accelerating upward)
-        assert result.full_acceleration[0] > 0, (
-            "Strong torque should accelerate pendulum upward"
-        )
+        assert (
+            result.full_acceleration[0] > 0
+        ), "Strong torque should accelerate pendulum upward"

--- a/tests/unit/engines/mujoco/test_motion_optimization.py
+++ b/tests/unit/engines/mujoco/test_motion_optimization.py
@@ -212,9 +212,9 @@ class TestSwingOptimizer:
         assert result.optimal_trajectory.shape[0] == optimizer.num_knot_points
         # optimal_velocities comes from _simulate_trajectory which returns
         # all simulation steps
-        assert result.optimal_velocities.shape[0] > 0, (
-            "Should have at least one timestep"
-        )
+        assert (
+            result.optimal_velocities.shape[0] > 0
+        ), "Should have at least one timestep"
         assert result.optimal_velocities.shape[1] == _num_velocities(model)
         assert np.all(np.isfinite(result.optimal_trajectory))
 

--- a/tests/unit/engines/mujoco/test_power_flow.py
+++ b/tests/unit/engines/mujoco/test_power_flow.py
@@ -56,9 +56,9 @@ class TestPowerFlowBasics:
 
         # P = τ · ω = 3.0 * 2.0 = 6.0 Watts
         expected_power = 6.0
-        assert abs(result.joint_powers[0] - expected_power) < 1e-6, (
-            f"Expected power {expected_power}, got {result.joint_powers[0]}"
-        )
+        assert (
+            abs(result.joint_powers[0] - expected_power) < 1e-6
+        ), f"Expected power {expected_power}, got {result.joint_powers[0]}"
 
     @pytest.mark.parametrize(
         "tau_val,expect_positive",
@@ -82,13 +82,13 @@ class TestPowerFlowBasics:
         result = analyzer.compute_power_flow(qpos, qvel, qacc, tau)
 
         if expect_positive:
-            assert result.joint_powers[0] > 0, (
-                "Power should be positive when torque and velocity are aligned"
-            )
+            assert (
+                result.joint_powers[0] > 0
+            ), "Power should be positive when torque and velocity are aligned"
         else:
-            assert result.joint_powers[0] < 0, (
-                "Power should be negative when torque opposes velocity"
-            )
+            assert (
+                result.joint_powers[0] < 0
+            ), "Power should be negative when torque opposes velocity"
 
     def test_zero_velocity_gives_zero_power(
         self, simple_pendulum_model: mujoco.MjModel
@@ -104,9 +104,9 @@ class TestPowerFlowBasics:
         result = analyzer.compute_power_flow(qpos, qvel, qacc, tau)
 
         # v = 0 → P = 0 regardless of torque
-        assert abs(result.joint_powers[0]) < 1e-10, (
-            "Power should be zero when velocity is zero"
-        )
+        assert (
+            abs(result.joint_powers[0]) < 1e-10
+        ), "Power should be zero when velocity is zero"
 
 
 class TestWorkCalculations:
@@ -128,9 +128,9 @@ class TestWorkCalculations:
 
         # W = P · dt = 6.0 * 0.1 = 0.6 Joules
         expected_work = 6.0 * 0.1
-        assert abs(result.joint_work_total[0] - expected_work) < 1e-6, (
-            f"Expected work {expected_work}, got {result.joint_work_total[0]}"
-        )
+        assert (
+            abs(result.joint_work_total[0] - expected_work) < 1e-6
+        ), f"Expected work {expected_work}, got {result.joint_work_total[0]}"
 
     def test_work_decomposition_sums_to_total(
         self, simple_pendulum_model: mujoco.MjModel
@@ -158,9 +158,9 @@ class TestWorkCalculations:
 
         # Work components should sum to total
         work_sum = result.joint_work_drift[0] + result.joint_work_control[0]
-        assert abs(result.joint_work_total[0] - work_sum) < 1e-6, (
-            "Drift + control work should equal total work"
-        )
+        assert (
+            abs(result.joint_work_total[0] - work_sum) < 1e-6
+        ), "Drift + control work should equal total work"
 
 
 class TestEnergyCalculations:
@@ -211,9 +211,9 @@ class TestEnergyCalculations:
 
         # If PE is computed, higher position should have >= PE
         # Note: PE may be zero if mj_forward not called internally
-        assert pe_high >= pe_low, (
-            f"Higher position should have PE >= lower: {pe_high} vs {pe_low}"
-        )
+        assert (
+            pe_high >= pe_low
+        ), f"Higher position should have PE >= lower: {pe_high} vs {pe_low}"
 
     def test_total_mechanical_energy_is_ke_plus_pe(
         self, simple_pendulum_model: mujoco.MjModel
@@ -232,9 +232,9 @@ class TestEnergyCalculations:
         total_pe = np.sum(result.segment_potential_energy)
         expected_me = total_ke + total_pe
 
-        assert abs(result.total_mechanical_energy - expected_me) < 1e-6, (
-            "Total ME should equal KE + PE"
-        )
+        assert (
+            abs(result.total_mechanical_energy - expected_me) < 1e-6
+        ), "Total ME should equal KE + PE"
 
 
 class TestSystemPowerMetrics:
@@ -255,9 +255,9 @@ class TestSystemPowerMetrics:
 
         # Single joint with positive power
         expected_power_in = 3.0 * 2.0  # 6.0 W
-        assert abs(result.power_in - expected_power_in) < 1e-6, (
-            f"Expected power_in {expected_power_in}, got {result.power_in}"
-        )
+        assert (
+            abs(result.power_in - expected_power_in) < 1e-6
+        ), f"Expected power_in {expected_power_in}, got {result.power_in}"
 
     def test_power_dissipation_from_damping(
         self, simple_pendulum_model: mujoco.MjModel
@@ -275,9 +275,9 @@ class TestSystemPowerMetrics:
         # Damping = 0.1, velocity = 2.0
         # P_diss = b * ω² = 0.1 * 4.0 = 0.4 W
         expected_diss = 0.1 * 2.0**2
-        assert abs(result.power_dissipation - expected_diss) < 1e-6, (
-            f"Expected dissipation {expected_diss}, got {result.power_dissipation}"
-        )
+        assert (
+            abs(result.power_dissipation - expected_diss) < 1e-6
+        ), f"Expected dissipation {expected_diss}, got {result.power_dissipation}"
 
 
 class TestTrajectoryAnalysis:

--- a/tests/unit/engines/mujoco/test_recording_library.py
+++ b/tests/unit/engines/mujoco/test_recording_library.py
@@ -49,7 +49,9 @@ def library_module(
 
 
 @pytest.fixture()
-def recording_lib(library_module: types.ModuleType, tmp_path: Path) -> Any:  # noqa: ANN401
+def recording_lib(
+    library_module: types.ModuleType, tmp_path: Path
+) -> Any:  # noqa: ANN401
     """Create a temporary recording library."""
     lib_dir = tmp_path / "recordings"
     return library_module.RecordingLibrary(str(lib_dir))

--- a/tests/unit/engines/mujoco/test_recording_library_security.py
+++ b/tests/unit/engines/mujoco/test_recording_library_security.py
@@ -115,9 +115,9 @@ def test_add_recording_path_traversal(isolated_library, temp_library) -> None:
 
     # Check if file exists outside library (vulnerability check)
     pwned_path = Path(temp_library).parent / "pwned.txt"
-    assert not pwned_path.exists(), (
-        "Path traversal succeeded! File created outside library."
-    )
+    assert (
+        not pwned_path.exists()
+    ), "Path traversal succeeded! File created outside library."
 
     # Check if file exists inside library (sanitized)
     sanitized_path = Path(temp_library) / "pwned.txt"

--- a/tests/unit/engines/mujoco/test_screw_kinematics.py
+++ b/tests/unit/engines/mujoco/test_screw_kinematics.py
@@ -56,9 +56,9 @@ class TestTwistCalculations:
         twist = analyzer.compute_twist(qpos, qvel, body_id)
 
         # For hinge joint about Y-axis, angular velocity should be [0, 2.0, 0]
-        assert abs(twist.angular[1] - 2.0) < 0.1, (
-            f"Expected ω_y ≈ 2.0, got {twist.angular[1]}"
-        )
+        assert (
+            abs(twist.angular[1] - 2.0) < 0.1
+        ), f"Expected ω_y ≈ 2.0, got {twist.angular[1]}"
 
     def test_twist_includes_reference_point(
         self, simple_pendulum: mujoco.MjModel
@@ -96,9 +96,9 @@ class TestScrewAxisCalculations:
 
         # For revolute joint, pitch should be close to zero
         # (some numerical tolerance due to COM offset)
-        assert abs(screw.pitch) < 1.0, (
-            f"Expected pitch ≈ 0 for pure rotation, got {screw.pitch}"
-        )
+        assert (
+            abs(screw.pitch) < 1.0
+        ), f"Expected pitch ≈ 0 for pure rotation, got {screw.pitch}"
         assert not screw.is_singular
 
     def test_pure_translation_is_singular(
@@ -135,9 +135,9 @@ class TestScrewAxisCalculations:
 
         if not screw.is_singular:
             axis_norm = np.linalg.norm(screw.axis_direction)
-            assert abs(axis_norm - 1.0) < 1e-6, (
-                f"Axis direction should be unit vector, got norm={axis_norm}"
-            )
+            assert (
+                abs(axis_norm - 1.0) < 1e-6
+            ), f"Axis direction should be unit vector, got norm={axis_norm}"
 
     def test_pitch_formula(self, simple_pendulum: mujoco.MjModel) -> None:
         """Test pitch calculation: h = (ω · v) / |ω|²."""
@@ -158,9 +158,9 @@ class TestScrewAxisCalculations:
 
         # Expected: h = (ω · v) / |ω|² = 2.0 / 4.0 = 0.5
         expected_pitch = np.dot(ω, v) / np.dot(ω, ω)
-        assert abs(screw.pitch - expected_pitch) < 1e-6, (
-            f"Expected pitch {expected_pitch}, got {screw.pitch}"
-        )
+        assert (
+            abs(screw.pitch - expected_pitch) < 1e-6
+        ), f"Expected pitch {expected_pitch}, got {screw.pitch}"
 
 
 class TestKeyPointAnalysis:
@@ -242,9 +242,9 @@ class TestVisualization:
 
         # Direction should be along X (velocity direction)
         direction = (end - start) / np.linalg.norm(end - start)
-        assert abs(direction[0] - 1.0) < 1e-6, (
-            "Singular axis should align with velocity direction"
-        )
+        assert (
+            abs(direction[0] - 1.0) < 1e-6
+        ), "Singular axis should align with velocity direction"
 
 
 class TestManipulability:

--- a/tests/unit/engines/mujoco/test_screw_theory.py
+++ b/tests/unit/engines/mujoco/test_screw_theory.py
@@ -186,9 +186,9 @@ class TestLogarithmicMap:
             0,
             atol=1e-10,
         ), f"Identity transformation should have zero screw axis, got S={S}"
-        assert abs(theta) < 1e-10, (
-            f"Identity transformation should have zero displacement, got theta={theta}"
-        )
+        assert (
+            abs(theta) < 1e-10
+        ), f"Identity transformation should have zero displacement, got theta={theta}"
 
 
 class TestAdjointTransform:

--- a/tests/unit/engines/simscape/3d_gui/simple_data_test.py
+++ b/tests/unit/engines/simscape/3d_gui/simple_data_test.py
@@ -91,7 +91,9 @@ def check_signal_bus_structure() -> bool:
                         )
 
                     return True
-                logger.info("⚠️  This appears to be traditional logging (fewer columns)")
+                logger.info(
+                    "⚠️  This appears to be traditional logging (fewer columns)"
+                )
                 return False
 
         return False
@@ -137,7 +139,9 @@ def check_required_signals() -> bool:
                     if dataset.shape[1] >= 6:  # At least 6 signals for positions
                         logger.info(f"    ✅ {name} has sufficient signals for GUI")
                     else:
-                        logger.warning(f"    ⚠️  {name} may be missing required signals")
+                        logger.warning(
+                            f"    ⚠️  {name} may be missing required signals"
+                        )
 
         return True
 

--- a/tests/unit/examples/test_examples.py
+++ b/tests/unit/examples/test_examples.py
@@ -88,9 +88,9 @@ def test_motion_training_demo(mock_close, mock_show, monkeypatch, tmp_path):
     mock_trajectory.frames = list(range(10))
     mock_parser.parse.return_value = mock_trajectory
 
-    sys.modules[
-        "motion_training.club_trajectory_parser"
-    ].ClubTrajectoryParser = mock_parser_class
+    sys.modules["motion_training.club_trajectory_parser"].ClubTrajectoryParser = (
+        mock_parser_class
+    )
 
     mock_ik_result = MagicMock()
     mock_ik_result.convergence_rate = 1.0
@@ -102,9 +102,9 @@ def test_motion_training_demo(mock_close, mock_show, monkeypatch, tmp_path):
     mock_solver.model.nq = 10
     mock_solver.solve_trajectory.return_value = mock_ik_result
 
-    sys.modules[
-        "motion_training.dual_hand_ik_solver"
-    ].create_ik_solver = mock_solver_class
+    sys.modules["motion_training.dual_hand_ik_solver"].create_ik_solver = (
+        mock_solver_class
+    )
 
     # Needs to mock before run_path execution via sys.modules or monkeypatch on import
     # But for a script run via runpy, monkeypatching the actual module objects works if they are imported!

--- a/tests/unit/launchers/test_launch_regressions.py
+++ b/tests/unit/launchers/test_launch_regressions.py
@@ -147,9 +147,9 @@ class TestSignalToolkitImport:
         )
         assert source_path.exists(), f"Expected {source_path} to exist"
         source = source_path.read_text(encoding="utf-8")
-        assert "src.shared.python.contracts" in source, (
-            "signal_toolkit/core.py must try absolute import path for contracts"
-        )
+        assert (
+            "src.shared.python.contracts" in source
+        ), "signal_toolkit/core.py must try absolute import path for contracts"
 
 
 # ---------------------------------------------------------------------------
@@ -165,9 +165,9 @@ class TestEngineDiscoveryPaths:
         from src.shared.python.engine_core.engine_manager import EngineManager
 
         em = EngineManager(REPO_ROOT)
-        assert "src" in str(em.engines_root), (
-            f"Expected engines_root under src/, got {em.engines_root}"
-        )
+        assert "src" in str(
+            em.engines_root
+        ), f"Expected engines_root under src/, got {em.engines_root}"
 
     def test_myosuite_not_myosim(self) -> None:
         """MYOSIM engine path should point to myosuite, not myosim."""
@@ -175,9 +175,9 @@ class TestEngineDiscoveryPaths:
         from src.shared.python.engine_core.engine_registry import EngineType
 
         em = EngineManager(REPO_ROOT)
-        assert em.engine_paths[EngineType.MYOSIM].name == "myosuite", (
-            f"Expected 'myosuite', got '{em.engine_paths[EngineType.MYOSIM].name}'"
-        )
+        assert (
+            em.engine_paths[EngineType.MYOSIM].name == "myosuite"
+        ), f"Expected 'myosuite', got '{em.engine_paths[EngineType.MYOSIM].name}'"
 
 
 # ---------------------------------------------------------------------------
@@ -193,9 +193,9 @@ class TestWindowSizing:
         source_path = REPO_ROOT / "src" / "launchers" / "golf_launcher.py"
         assert source_path.exists(), f"Expected {source_path} to exist"
         source = source_path.read_text(encoding="utf-8")
-        assert "self.resize(1400, 900)" not in source, (
-            "Window size must be screen-aware, not hardcoded 1400x900"
-        )
+        assert (
+            "self.resize(1400, 900)" not in source
+        ), "Window size must be screen-aware, not hardcoded 1400x900"
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +217,9 @@ class TestSubprocessPythonpath:
         env = MujocoUnifiedLauncher._get_launch_env()
         # shared_python must be on PYTHONPATH
         pythonpath = env.get("PYTHONPATH", "")
-        assert "shared" in pythonpath and "python" in pythonpath, (
-            f"Expected shared/python in PYTHONPATH, got: {pythonpath}"
-        )
+        assert (
+            "shared" in pythonpath and "python" in pythonpath
+        ), f"Expected shared/python in PYTHONPATH, got: {pythonpath}"
 
     def test_process_manager_env_has_shared_python(self) -> None:
         """ProcessManager.get_subprocess_env must include src/shared/python."""
@@ -229,9 +229,9 @@ class TestSubprocessPythonpath:
         env = pm.get_subprocess_env()
         pythonpath = env.get("PYTHONPATH", "")
         shared_python = str(REPO_ROOT / "src" / "shared" / "python")
-        assert shared_python in pythonpath, (
-            f"Expected {shared_python} in PYTHONPATH, got: {pythonpath}"
-        )
+        assert (
+            shared_python in pythonpath
+        ), f"Expected {shared_python} in PYTHONPATH, got: {pythonpath}"
 
     def test_process_manager_env_has_repo_root(self) -> None:
         """ProcessManager.get_subprocess_env must include repo root."""
@@ -240,9 +240,9 @@ class TestSubprocessPythonpath:
         pm = ProcessManager(REPO_ROOT)
         env = pm.get_subprocess_env()
         pythonpath = env.get("PYTHONPATH", "")
-        assert str(REPO_ROOT) in pythonpath, (
-            f"Expected {REPO_ROOT} in PYTHONPATH, got: {pythonpath}"
-        )
+        assert (
+            str(REPO_ROOT) in pythonpath
+        ), f"Expected {REPO_ROOT} in PYTHONPATH, got: {pythonpath}"
 
 
 # ---------------------------------------------------------------------------
@@ -320,9 +320,9 @@ class TestLaunchDiagnostics:
         # Must have logged the failure with useful context
         mock_logger.error.assert_called()
         call_args = str(mock_logger.error.call_args)
-        assert "TestEngine" in call_args or "test_type" in call_args, (
-            f"Error log must mention engine name or type, got: {call_args}"
-        )
+        assert (
+            "TestEngine" in call_args or "test_type" in call_args
+        ), f"Error log must mention engine name or type, got: {call_args}"
 
     def test_execute_local_launch_success_path(self) -> None:
         """When handler.launch() returns True, success toast is shown."""
@@ -397,9 +397,9 @@ class TestProcessImmediateDeathDetection:
             # Check that exit code was logged
             calls = [str(c) for c in mock_emit.call_args_list]
             exit_logged = any("exited with code" in c for c in calls)
-            assert exit_logged, (
-                f"Expected 'exited with code' in output, got calls: {calls}"
-            )
+            assert (
+                exit_logged
+            ), f"Expected 'exited with code' in output, got calls: {calls}"
 
     def test_launch_module_logs_immediate_exit(self, tmp_path: Path) -> None:
         """If a launched module exits immediately, the exit is detected."""

--- a/tests/unit/launchers/test_launcher_theme_api.py
+++ b/tests/unit/launchers/test_launcher_theme_api.py
@@ -15,34 +15,34 @@ class TestLauncherThemeApiCalls:
     def test_no_set_theme_calls(self) -> None:
         """set_theme was renamed to change_theme."""
         source = inspect.getsource(launcher_theme)
-        assert "manager.set_theme(" not in source, (
-            "launcher_theme.py still calls manager.set_theme() — use change_theme()"
-        )
+        assert (
+            "manager.set_theme(" not in source
+        ), "launcher_theme.py still calls manager.set_theme() — use change_theme()"
 
     def test_no_theme_name_property(self) -> None:
         """theme_name was renamed to get_current_theme_name()."""
         source = inspect.getsource(launcher_theme)
-        assert ".theme_name" not in source or "get_current_theme_name" in source, (
-            "launcher_theme.py uses .theme_name — use get_current_theme_name()"
-        )
+        assert (
+            ".theme_name" not in source or "get_current_theme_name" in source
+        ), "launcher_theme.py uses .theme_name — use get_current_theme_name()"
 
     def test_no_load_saved_theme(self) -> None:
         """load_saved_theme() was removed."""
         source = inspect.getsource(launcher_theme)
-        assert "load_saved_theme" not in source, (
-            "launcher_theme.py calls load_saved_theme() which no longer exists"
-        )
+        assert (
+            "load_saved_theme" not in source
+        ), "launcher_theme.py calls load_saved_theme() which no longer exists"
 
     def test_no_get_available_fleet_themes(self) -> None:
         """get_available_fleet_themes() was renamed to get_available_themes()."""
         source = inspect.getsource(launcher_theme)
-        assert "get_available_fleet_themes" not in source, (
-            "launcher_theme.py calls get_available_fleet_themes() — use get_available_themes()"
-        )
+        assert (
+            "get_available_fleet_themes" not in source
+        ), "launcher_theme.py calls get_available_fleet_themes() — use get_available_themes()"
 
     def test_no_set_fleet_theme(self) -> None:
         """set_fleet_theme() was removed."""
         source = inspect.getsource(launcher_theme)
-        assert "set_fleet_theme" not in source, (
-            "launcher_theme.py calls set_fleet_theme() — use change_theme()"
-        )
+        assert (
+            "set_fleet_theme" not in source
+        ), "launcher_theme.py calls set_fleet_theme() — use change_theme()"

--- a/tests/unit/optimization/test_swing_bridge.py
+++ b/tests/unit/optimization/test_swing_bridge.py
@@ -299,16 +299,16 @@ class TestCostMatrices:
     def test_q_positive_semi_definite(self, bridge: SwingOptimizationBridge) -> None:
         Q, _ = bridge._build_cost_matrices(7)
         eigenvalues = np.linalg.eigvalsh(Q)
-        assert np.all(eigenvalues >= -1e-12), (
-            f"Q is not PSD: min eigenvalue = {eigenvalues.min()}"
-        )
+        assert np.all(
+            eigenvalues >= -1e-12
+        ), f"Q is not PSD: min eigenvalue = {eigenvalues.min()}"
 
     def test_r_positive_semi_definite(self, bridge: SwingOptimizationBridge) -> None:
         _, R = bridge._build_cost_matrices(7)
         eigenvalues = np.linalg.eigvalsh(R)
-        assert np.all(eigenvalues >= -1e-12), (
-            f"R is not PSD: min eigenvalue = {eigenvalues.min()}"
-        )
+        assert np.all(
+            eigenvalues >= -1e-12
+        ), f"R is not PSD: min eigenvalue = {eigenvalues.min()}"
 
     def test_r_diagonal_values(self, bridge: SwingOptimizationBridge) -> None:
         _, R = bridge._build_cost_matrices(7)

--- a/tests/unit/optimization/test_swing_optimizer.py
+++ b/tests/unit/optimization/test_swing_optimizer.py
@@ -291,9 +291,9 @@ def test_optimizer_respects_joint_limits(
         angles = result.trajectory.joint_angles
         # Check angles are within reasonable bounds (allowing some tolerance)
         for joint_name, joint_angles in angles.items():
-            assert np.all(np.abs(joint_angles) < 5.0), (
-                f"Joint {joint_name} exceeds limits"
-            )
+            assert np.all(
+                np.abs(joint_angles) < 5.0
+            ), f"Joint {joint_name} exceeds limits"
 
 
 @pytest.mark.slow

--- a/tests/unit/pendulum_simulator/test_jacobians_golfer.py
+++ b/tests/unit/pendulum_simulator/test_jacobians_golfer.py
@@ -66,9 +66,9 @@ class TestJacobianGolfer:
         q[1] = 0.2
         result = jacobian_golfer(q, _P)
         for key, J in result.items():
-            assert np.all(np.isfinite(J)), (
-                f"Non-finite values for {key} at nonzero angles"
-            )
+            assert np.all(
+                np.isfinite(J)
+            ), f"Non-finite values for {key} at nonzero angles"
 
     def test_club_tip_different_from_hub(self) -> None:
         result = jacobian_golfer(_Q, _P)
@@ -98,9 +98,9 @@ class TestEllipsoidsGolfer:
         result = ellipsoids_golfer(_Q, _P)
         for key, entry in result.items():
             axes = entry["mob_semi_axes"]
-            assert axes.shape == (2,), (
-                f"Key {key}: expected shape (2,), got {axes.shape}"
-            )
+            assert axes.shape == (
+                2,
+            ), f"Key {key}: expected shape (2,), got {axes.shape}"
 
     def test_mob_semi_axes_non_negative(self) -> None:
         result = ellipsoids_golfer(_Q, _P)

--- a/tests/unit/robotics/test_contact.py
+++ b/tests/unit/robotics/test_contact.py
@@ -276,9 +276,9 @@ class TestLinearizeFrictionCone:
         for f in inside_forces:
             # Should satisfy A @ f <= b (approximately, due to linearization)
             violations = A @ f - b
-            assert np.all(violations <= 1e-6), (
-                f"Force {f} should be inside linearized cone"
-            )
+            assert np.all(
+                violations <= 1e-6
+            ), f"Force {f} should be inside linearized cone"
 
     def test_compute_friction_cone_constraint(self) -> None:
         """Test compute_friction_cone_constraint returns complete info."""

--- a/tests/unit/robotics/test_sensing.py
+++ b/tests/unit/robotics/test_sensing.py
@@ -158,9 +158,9 @@ class TestNoiseModels:
 
         # 2nd-order filter should respond more slowly to a step than 1st-order
         # at early samples, the 2nd-order output must lag behind the 1st-order
-        assert arr2[3] < arr1[3], (
-            "order=2 filter should be slower than order=1 at early samples"
-        )
+        assert (
+            arr2[3] < arr1[3]
+        ), "order=2 filter should be slower than order=1 at early samples"
         # Both should eventually converge toward 1.0
         assert arr2[-1] > 0.8
 

--- a/tests/unit/shared_python/test_ball_flight_physics.py
+++ b/tests/unit/shared_python/test_ball_flight_physics.py
@@ -148,6 +148,6 @@ class TestBallFlightPhysics:
 
             # However, we can check that the point.acceleration matches the sum of point.forces / mass.
             # This confirms the reporting logic is self-consistent.
-            assert np.allclose(point.acceleration, expected_acc, atol=1e-5), (
-                f"Acceleration mismatch at t={point.time}"
-            )
+            assert np.allclose(
+                point.acceleration, expected_acc, atol=1e-5
+            ), f"Acceleration mismatch at t={point.time}"

--- a/tests/unit/test_activation_dynamics.py
+++ b/tests/unit/test_activation_dynamics.py
@@ -204,9 +204,9 @@ class TestUpdate:
         dt = 0.100  # Large time step that might go negative
 
         a_new = dynamics.update(u, a, dt)
-        assert a_new >= dynamics.min_activation, (
-            "Activation should be clamped to min_activation"
-        )
+        assert (
+            a_new >= dynamics.min_activation
+        ), "Activation should be clamped to min_activation"
 
     def test_single_step_increases_activation(self, dynamics):
         """Test that a single step increases activation when u > a."""
@@ -373,12 +373,12 @@ class TestPhysiologicalRealism:
         """
         dynamics = ActivationDynamics(tau_act=0.010, tau_deact=0.040)
 
-        assert dynamics.tau_deact > dynamics.tau_act, (
-            "Deactivation should be slower than activation (physiological realism)"
-        )
-        assert dynamics.tau_deact / dynamics.tau_act == 4.0, (
-            "Typical ratio is 4:1 (deactivation:activation)"
-        )
+        assert (
+            dynamics.tau_deact > dynamics.tau_act
+        ), "Deactivation should be slower than activation (physiological realism)"
+        assert (
+            dynamics.tau_deact / dynamics.tau_act == 4.0
+        ), "Typical ratio is 4:1 (deactivation:activation)"
 
     def test_minimum_activation_prevents_division_by_zero(self):
         """Test that min_activation prevents numerical issues."""

--- a/tests/unit/test_api_architecture.py
+++ b/tests/unit/test_api_architecture.py
@@ -61,9 +61,9 @@ class TestRouteRegistry:
         # Priority modules should appear in _REGISTRATION_ORDER sequence
         priority_names = [n for n in names if n in _REGISTRATION_ORDER]
         expected_order = [n for n in _REGISTRATION_ORDER if n in priority_names]
-        assert priority_names == expected_order, (
-            f"Priority modules out of order: {priority_names} != {expected_order}"
-        )
+        assert (
+            priority_names == expected_order
+        ), f"Priority modules out of order: {priority_names} != {expected_order}"
 
     def test_register_routes_on_app(self) -> None:
         """register_routes includes discovered routers on a FastAPI app."""
@@ -377,9 +377,9 @@ class TestLinkageMechanismsDecomposition:
             assert "xml" in entry, f"Missing 'xml' in catalog entry: {name}"
             assert "actuators" in entry, f"Missing 'actuators' in catalog entry: {name}"
             assert "category" in entry, f"Missing 'category' in catalog entry: {name}"
-            assert "description" in entry, (
-                f"Missing 'description' in catalog entry: {name}"
-            )
+            assert (
+                "description" in entry
+            ), f"Missing 'description' in catalog entry: {name}"
 
     def test_four_bar_generates_valid_xml(self) -> None:
         """Four-bar linkage XML contains expected MuJoCo elements."""

--- a/tests/unit/test_api_security.py
+++ b/tests/unit/test_api_security.py
@@ -443,12 +443,12 @@ class TestSecurityBestPractices:
         ]
 
         for pattern in suspicious_patterns:
-            assert pattern not in security_source.lower(), (
-                f"Found suspicious pattern in security.py: {pattern}"
-            )
-            assert pattern not in dependencies_source.lower(), (
-                f"Found suspicious pattern in dependencies.py: {pattern}"
-            )
+            assert (
+                pattern not in security_source.lower()
+            ), f"Found suspicious pattern in security.py: {pattern}"
+            assert (
+                pattern not in dependencies_source.lower()
+            ), f"Found suspicious pattern in dependencies.py: {pattern}"
 
     def test_secure_random_generation(self) -> None:
         """Test that secrets module is used for random generation."""

--- a/tests/unit/test_build_hooks.py
+++ b/tests/unit/test_build_hooks.py
@@ -14,9 +14,9 @@ sys.modules["hatchling.builders"] = MagicMock()
 sys.modules["hatchling.builders.hooks"] = MagicMock()
 sys.modules["hatchling.builders.hooks.plugin"] = MagicMock()
 sys.modules["hatchling.builders.hooks.plugin.interface"] = MagicMock()
-sys.modules[
-    "hatchling.builders.hooks.plugin.interface"
-].BuildHookInterface = DummyHookInterface
+sys.modules["hatchling.builders.hooks.plugin.interface"].BuildHookInterface = (
+    DummyHookInterface
+)
 
 import subprocess  # noqa: E402
 

--- a/tests/unit/test_engine_interface_compliance.py
+++ b/tests/unit/test_engine_interface_compliance.py
@@ -120,9 +120,9 @@ class TestEngineInterfaceCompliance:
         for method_name in REQUIRED_METHODS:
             attr = getattr(cls, method_name, None)
             if attr is not None:
-                assert callable(attr), (
-                    f"{class_name}.{method_name} exists but is not callable"
-                )
+                assert callable(
+                    attr
+                ), f"{class_name}.{method_name} exists but is not callable"
 
     def test_get_capabilities_returns_dataclass(
         self, module_path: str, class_name: str, deps: list[str]
@@ -133,9 +133,9 @@ class TestEngineInterfaceCompliance:
         if cls is None:
             pytest.skip(f"{class_name} not found in {module_path}")
 
-        assert hasattr(cls, "get_capabilities"), (
-            f"{class_name} must implement get_capabilities()"
-        )
+        assert hasattr(
+            cls, "get_capabilities"
+        ), f"{class_name} must implement get_capabilities()"
 
     def test_contact_forces_not_abstract(
         self, module_path: str, class_name: str, deps: list[str]
@@ -153,9 +153,9 @@ class TestEngineInterfaceCompliance:
         method = getattr(cls, "compute_contact_forces", None)
         assert method is not None
         # Should NOT be abstract (base provides default)
-        assert not getattr(method, "__isabstractmethod__", False), (
-            f"{class_name}.compute_contact_forces should not be abstract"
-        )
+        assert not getattr(
+            method, "__isabstractmethod__", False
+        ), f"{class_name}.compute_contact_forces should not be abstract"
 
 
 class TestCapabilitySerialization:

--- a/tests/unit/test_engine_manager.py
+++ b/tests/unit/test_engine_manager.py
@@ -101,8 +101,7 @@ class TestEngineManager:
 
             models_yaml = temp_path / "src" / "config" / "models.yaml"
             models_yaml.write_text(
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                     models:
                       - id: drake_provider_model
                         name: Drake Provider Model
@@ -113,9 +112,7 @@ class TestEngineManager:
                         capabilities: [swing]
                         source_root: provider_roots/Drake_Models
                         working_dir: python
-                    """
-                ).strip()
-                + "\n",
+                    """).strip() + "\n",
                 encoding="utf-8",
             )
 
@@ -134,8 +131,7 @@ class TestEngineManager:
             (temp_path / "src" / "config").mkdir(parents=True)
             models_yaml = temp_path / "src" / "config" / "models.yaml"
             models_yaml.write_text(
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                     models:
                       - id: drake_provider_model
                         name: Drake Provider Model
@@ -146,9 +142,7 @@ class TestEngineManager:
                         capabilities: [swing]
                         source_root: provider_roots/Drake_Models
                         working_dir: python
-                    """
-                ).strip()
-                + "\n",
+                    """).strip() + "\n",
                 encoding="utf-8",
             )
 

--- a/tests/unit/test_equipment.py
+++ b/tests/unit/test_equipment.py
@@ -132,21 +132,21 @@ class TestEquipmentModule:
         for club_type, config in CLUB_CONFIGS.items():
             # Total length should be reasonable (0.5m to 1.5m)
             assert isinstance(config["total_length"], float)
-            assert 0.5 <= config["total_length"] <= 1.5, (
-                f"{club_type} length {config['total_length']} outside realistic range"
-            )
+            assert (
+                0.5 <= config["total_length"] <= 1.5
+            ), f"{club_type} length {config['total_length']} outside realistic range"
 
             # Head mass should be reasonable (100g to 500g)
             assert isinstance(config["head_mass"], float)
-            assert 0.1 <= config["head_mass"] <= 0.5, (
-                f"{club_type} head mass {config['head_mass']} outside realistic range"
-            )
+            assert (
+                0.1 <= config["head_mass"] <= 0.5
+            ), f"{club_type} head mass {config['head_mass']} outside realistic range"
 
             # Club loft should be in degrees converted to radians (0 to 90 degrees = 0 to 1.57 rad)
             assert isinstance(config["club_loft"], float)
-            assert 0 <= config["club_loft"] <= 1.6, (
-                f"{club_type} loft {config['club_loft']} outside realistic range"
-            )
+            assert (
+                0 <= config["club_loft"] <= 1.6
+            ), f"{club_type} loft {config['club_loft']} outside realistic range"
 
     def test_club_ordering_by_length(self) -> None:
         """Test that clubs follow expected length ordering: driver > 7-iron > wedge."""

--- a/tests/unit/test_exception_handler_logging_and_dbc.py
+++ b/tests/unit/test_exception_handler_logging_and_dbc.py
@@ -157,9 +157,9 @@ class TestAIPMethodsExceptionLogging:
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
-        assert len(warning_messages) > 0, (
-            "Expected a warning log from _simulation_status, got none"
-        )
+        assert (
+            len(warning_messages) > 0
+        ), "Expected a warning log from _simulation_status, got none"
 
     def test_model_query_failure_logs_warning(
         self, caplog: pytest.LogCaptureFixture
@@ -181,9 +181,9 @@ class TestAIPMethodsExceptionLogging:
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
-        assert len(warning_messages) > 0, (
-            "Expected a warning log from _model_query, got none"
-        )
+        assert (
+            len(warning_messages) > 0
+        ), "Expected a warning log from _model_query, got none"
 
     def test_analysis_metrics_failure_logs_warning(
         self, caplog: pytest.LogCaptureFixture
@@ -204,9 +204,9 @@ class TestAIPMethodsExceptionLogging:
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
-        assert len(warning_messages) > 0, (
-            "Expected a warning log from _analysis_metrics, got none"
-        )
+        assert (
+            len(warning_messages) > 0
+        ), "Expected a warning log from _analysis_metrics, got none"
 
 
 class TestPhysicsRouteExceptionLogging:
@@ -229,9 +229,9 @@ class TestPhysicsRouteExceptionLogging:
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
-        assert any("gravity" in m for m in warning_messages), (
-            f"Expected gravity warning, got: {warning_messages}"
-        )
+        assert any(
+            "gravity" in m for m in warning_messages
+        ), f"Expected gravity warning, got: {warning_messages}"
 
 
 class TestDataExplorerExceptionLogging:
@@ -288,9 +288,9 @@ class TestDatasetRouteExceptionLogging:
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
-        assert any("phase" in m.lower() for m in warning_messages), (
-            f"Expected phase-detection warning, got: {warning_messages}"
-        )
+        assert any(
+            "phase" in m.lower() for m in warning_messages
+        ), f"Expected phase-detection warning, got: {warning_messages}"
 
 
 class TestDiagnosticsExceptionLogging:

--- a/tests/unit/test_flight_models.py
+++ b/tests/unit/test_flight_models.py
@@ -335,9 +335,9 @@ class TestPhysicalPlausibility:
             result = model.simulate(driver_launch)
 
             # Landing angle should be positive (descending)
-            assert result.landing_angle > 0, (
-                f"{model.name} landing: {result.landing_angle}"
-            )
+            assert (
+                result.landing_angle > 0
+            ), f"{model.name} landing: {result.landing_angle}"
             # Should be less than 90°
             assert result.landing_angle < 90
 

--- a/tests/unit/test_golf_suite_launcher.py
+++ b/tests/unit/test_golf_suite_launcher.py
@@ -234,9 +234,9 @@ class TestGolfSuiteLauncher:
         assert launcher_app is not None, "Launcher should be instantiated"
 
         # Verify PYQT6_AVAILABLE flag is set correctly for testing
-        assert golf_suite_launcher.PYQT6_AVAILABLE is True, (
-            "PYQT6_AVAILABLE should be True for launcher logic tests"
-        )
+        assert (
+            golf_suite_launcher.PYQT6_AVAILABLE is True
+        ), "PYQT6_AVAILABLE should be True for launcher logic tests"
 
         # Verify launcher has essential UI components (as mocked)
         assert hasattr(launcher_app, "log_text"), "Launcher should have log_text widget"

--- a/tests/unit/test_gui_coverage.py
+++ b/tests/unit/test_gui_coverage.py
@@ -78,12 +78,12 @@ class TestMuJoCoSimWidget:
 
         # Verify initialization parameters - check minimum size constraints
         # Note: Qt widgets may not have exact size until shown; verify minimum constraints are set
-        assert widget.minimumWidth() == 640, (
-            f"Minimum width should be 640, got {widget.minimumWidth()}"
-        )
-        assert widget.minimumHeight() == 480, (
-            f"Minimum height should be 480, got {widget.minimumHeight()}"
-        )
+        assert (
+            widget.minimumWidth() == 640
+        ), f"Minimum width should be 640, got {widget.minimumWidth()}"
+        assert (
+            widget.minimumHeight() == 480
+        ), f"Minimum height should be 480, got {widget.minimumHeight()}"
         assert hasattr(widget, "model")
         assert hasattr(widget, "data")
 
@@ -140,9 +140,9 @@ class TestMuJoCoSimWidget:
         _load_model_or_skip(widget, model_xml)
 
         # Verify model and data are loaded
-        assert widget.data is not None, (
-            "Model data should be loaded after load_model_from_xml"
-        )
+        assert (
+            widget.data is not None
+        ), "Model data should be loaded after load_model_from_xml"
 
         # First call reset_state to get the widget's canonical initial state
         # (reset_state sets qpos[0] = 0.2 for 1-DOF models)
@@ -270,9 +270,9 @@ class TestHumanoidLauncher:
         expected_attrs = ["centralWidget", "menuBar", "statusBar"]
         missing_attrs = [attr for attr in expected_attrs if not hasattr(launcher, attr)]
 
-        assert not missing_attrs, (
-            f"Launcher is missing expected widget attributes: {missing_attrs}"
-        )
+        assert (
+            not missing_attrs
+        ), f"Launcher is missing expected widget attributes: {missing_attrs}"
 
         launcher.close()
 

--- a/tests/unit/test_issue_1772_exception_handlers.py
+++ b/tests/unit/test_issue_1772_exception_handlers.py
@@ -45,9 +45,10 @@ def test_no_bare_pass_in_fixed_files() -> None:
         if lines:
             violations[rel_path] = lines
 
-    assert not violations, (
-        "Bare ``pass`` exception handlers still present (issue #1772):\n"
-        + "\n".join(f"  {path}: lines {lns}" for path, lns in violations.items())
+    assert (
+        not violations
+    ), "Bare ``pass`` exception handlers still present (issue #1772):\n" + "\n".join(
+        f"  {path}: lines {lns}" for path, lns in violations.items()
     )
 
 
@@ -57,9 +58,9 @@ def test_sim_widget_handler_uses_logger_debug() -> None:
     if not filepath.exists():
         return
     source = filepath.read_text(encoding="utf-8")
-    assert "logger.debug" in source, (
-        "sim_widget.py must use logger.debug in exception handlers (issue #1772)"
-    )
+    assert (
+        "logger.debug" in source
+    ), "sim_widget.py must use logger.debug in exception handlers (issue #1772)"
 
 
 def test_sim_rendering_mixin_handler_uses_logger_debug() -> None:
@@ -68,9 +69,9 @@ def test_sim_rendering_mixin_handler_uses_logger_debug() -> None:
     if not filepath.exists():
         return
     source = filepath.read_text(encoding="utf-8")
-    assert source.count("logger.debug") >= 2, (
-        "sim_rendering_mixin.py must have at least 2 logger.debug calls (issue #1772)"
-    )
+    assert (
+        source.count("logger.debug") >= 2
+    ), "sim_rendering_mixin.py must have at least 2 logger.debug calls (issue #1772)"
 
 
 def test_drake_gui_viz_handler_uses_logger() -> None:
@@ -79,9 +80,9 @@ def test_drake_gui_viz_handler_uses_logger() -> None:
     if not filepath.exists():
         return
     source = filepath.read_text(encoding="utf-8")
-    assert "LOGGER.debug" in source or "logger.debug" in source, (
-        "drake_gui_viz.py must use a logger.debug call in the ValueError handler (issue #1772)"
-    )
+    assert (
+        "LOGGER.debug" in source or "logger.debug" in source
+    ), "drake_gui_viz.py must use a logger.debug call in the ValueError handler (issue #1772)"
 
 
 def test_docker_sim_handlers_use_logger_debug() -> None:
@@ -90,6 +91,6 @@ def test_docker_sim_handlers_use_logger_debug() -> None:
     if not filepath.exists():
         return
     source = filepath.read_text(encoding="utf-8")
-    assert source.count("logger.debug") >= 4, (
-        "mujoco docker sim.py must have at least 4 logger.debug calls (issue #1772)"
-    )
+    assert (
+        source.count("logger.debug") >= 4
+    ), "mujoco docker sim.py must have at least 4 logger.debug calls (issue #1772)"

--- a/tests/unit/test_issue_fixes_1777_1778_1779_1782.py
+++ b/tests/unit/test_issue_fixes_1777_1778_1779_1782.py
@@ -52,18 +52,18 @@ class TestSecretKeyNotStaticFallback:
         """
         from src.api.auth import security
 
-        assert len(security.SECRET_KEY) >= 32, (
-            f"SECRET_KEY length {len(security.SECRET_KEY)} is below minimum 32 characters"
-        )
+        assert (
+            len(security.SECRET_KEY) >= 32
+        ), f"SECRET_KEY length {len(security.SECRET_KEY)} is below minimum 32 characters"
 
     def test_dev_secret_key_is_not_the_old_development_string(self) -> None:
         """No legacy 'development-secret-key' constant must exist."""
         from src.api.auth import security
 
         forbidden_prefix = "development-secret-key"
-        assert not security.SECRET_KEY.lower().startswith(forbidden_prefix), (
-            f"SECRET_KEY must not start with '{forbidden_prefix}'"
-        )
+        assert not security.SECRET_KEY.lower().startswith(
+            forbidden_prefix
+        ), f"SECRET_KEY must not start with '{forbidden_prefix}'"
 
     def test_security_manager_rejects_known_static_key_tokens(self) -> None:
         """JWT signed with the known static key must not be accepted by a real manager.
@@ -146,9 +146,9 @@ class TestAuthCacheSHA256CacheKey:
         token = cache._cache_lookup_token(api_key)
         expected = hashlib.sha256(api_key.encode()).hexdigest()
 
-        assert token == expected, (
-            f"Cache key '{token}' != SHA-256('{api_key}') = '{expected}'"
-        )
+        assert (
+            token == expected
+        ), f"Cache key '{token}' != SHA-256('{api_key}') = '{expected}'"
 
     def test_cache_key_is_64_hex_chars(self) -> None:
         """SHA-256 output is 32 bytes = 64 hex characters."""
@@ -158,9 +158,9 @@ class TestAuthCacheSHA256CacheKey:
         token = cache._cache_lookup_token("any_api_key_value")
 
         assert len(token) == 64, f"Expected 64-char hex digest, got {len(token)}"
-        assert all(c in "0123456789abcdef" for c in token), (
-            "Token must be lowercase hex"
-        )
+        assert all(
+            c in "0123456789abcdef" for c in token
+        ), "Token must be lowercase hex"
 
     def test_cache_key_is_deterministic(self) -> None:
         """Same input must always produce the same cache key."""
@@ -192,9 +192,9 @@ class TestAuthCacheSHA256CacheKey:
 
         # Python's hash() prefix would appear as a numeric string
         python_hash_str = str(hash(api_key))
-        assert not token.startswith(python_hash_str), (
-            "Cache token must not be derived from Python's built-in hash()"
-        )
+        assert not token.startswith(
+            python_hash_str
+        ), "Cache token must not be derived from Python's built-in hash()"
 
     def test_auth_cache_round_trip_with_sha256_key(self) -> None:
         """set() then get() must return the stored value using SHA-256 keying."""
@@ -493,9 +493,9 @@ class TestMotionTrainingExportsNotNone:
         for name in mt.__all__:
             try:
                 obj = getattr(mt, name)
-                assert obj is not None, (
-                    f"__getattr__('{name}') returned None – the import delegation is broken"
-                )
+                assert (
+                    obj is not None
+                ), f"__getattr__('{name}') returned None – the import delegation is broken"
             except (ImportError, ModuleNotFoundError):
                 # Acceptable: optional deps (pinocchio, pink, meshcat) not installed
                 pass

--- a/tests/unit/test_jacobian.py
+++ b/tests/unit/test_jacobian.py
@@ -151,9 +151,9 @@ class TestJacobianShape:
 
                 # Verify shape (6×nv)
                 assert J.shape[0] == 6, f"Expected 6 rows, got {J.shape[0]}"
-                assert J.shape[1] == model.nv, (
-                    f"Expected {model.nv} cols, got {J.shape[1]}"
-                )
+                assert (
+                    J.shape[1] == model.nv
+                ), f"Expected {model.nv} cols, got {J.shape[1]}"
 
         finally:
             Path(urdf_path).unlink(missing_ok=True)
@@ -240,9 +240,9 @@ class TestJacobianConsistency:
             pin_model = pin.buildModelFromUrdf(urdf_path)
 
             # Both should have same number of DOF
-            assert mj_model.nv == pin_model.nv, (
-                f"DOF mismatch: MuJoCo={mj_model.nv}, Pinocchio={pin_model.nv}"
-            )
+            assert (
+                mj_model.nv == pin_model.nv
+            ), f"DOF mismatch: MuJoCo={mj_model.nv}, Pinocchio={pin_model.nv}"
 
         finally:
             Path(urdf_path).unlink(missing_ok=True)

--- a/tests/unit/test_kinematic_sequence.py
+++ b/tests/unit/test_kinematic_sequence.py
@@ -196,9 +196,9 @@ class TestSpeedGain:
 
         for name in ["mid_proximal", "mid_distal", "distal"]:
             assert peak_map[name].speed_gain is not None
-            assert peak_map[name].speed_gain > 1.0, (
-                f"{name} speed gain should be > 1.0, got {peak_map[name].speed_gain}"
-            )
+            assert (
+                peak_map[name].speed_gain > 1.0
+            ), f"{name} speed gain should be > 1.0, got {peak_map[name].speed_gain}"
 
     def test_speed_gain_missing_segment(self) -> None:
         """Speed gain should handle missing segments gracefully."""
@@ -241,12 +241,12 @@ class TestDecelerationRate:
         peak_map = {p.name: p for p in result.peaks}
 
         for name in ["proximal", "mid_proximal", "mid_distal", "distal"]:
-            assert peak_map[name].deceleration_rate is not None, (
-                f"{name} should have deceleration_rate computed"
-            )
-            assert peak_map[name].deceleration_rate > 0, (
-                f"{name} deceleration_rate should be positive"
-            )
+            assert (
+                peak_map[name].deceleration_rate is not None
+            ), f"{name} should have deceleration_rate computed"
+            assert (
+                peak_map[name].deceleration_rate > 0
+            ), f"{name} deceleration_rate should be positive"
 
     def test_proximal_decelerates_faster(self) -> None:
         """Proximal segments should decelerate faster (braking effect)."""

--- a/tests/unit/test_launcher_diagnostics.py
+++ b/tests/unit/test_launcher_diagnostics.py
@@ -420,9 +420,9 @@ class TestTileLoadingVerification:
 
             missing = expected_ids - loaded_ids
             assert len(missing) == 0, f"Registry missing: {missing}"
-            assert len(all_models) >= 8, (
-                f"Expected at least 8 models, got {len(all_models)}"
-            )
+            assert (
+                len(all_models) >= 8
+            ), f"Expected at least 8 models, got {len(all_models)}"
 
         except ImportError as e:
             pytest.skip(f"Dependencies not available: {e}")

--- a/tests/unit/test_launchers.py
+++ b/tests/unit/test_launchers.py
@@ -120,9 +120,9 @@ class TestLauncherUtilities:
         for dir_name in expected_dirs_either:
             root_path = project_root / dir_name
             src_path = project_root / "src" / dir_name
-            assert root_path.exists() or src_path.exists(), (
-                f"Directory {dir_name} should exist at root or under src/"
-            )
+            assert (
+                root_path.exists() or src_path.exists()
+            ), f"Directory {dir_name} should exist at root or under src/"
 
         for dir_name in expected_src_dirs:
             dir_path = project_root / "src" / dir_name

--- a/tests/unit/test_local_server_ui_warning.py
+++ b/tests/unit/test_local_server_ui_warning.py
@@ -63,9 +63,9 @@ def test_local_app_registers_versioned_routes(monkeypatch, tmp_path) -> None:
     app = local_server.create_local_app()
     route_paths = [getattr(r, "path", "") for r in app.routes if hasattr(r, "path")]
     versioned = [p for p in route_paths if p.startswith("/api/v1/")]
-    assert len(versioned) > 0, (
-        f"No /api/v1/ routes found. Registered paths: {route_paths[:20]}"
-    )
+    assert (
+        len(versioned) > 0
+    ), f"No /api/v1/ routes found. Registered paths: {route_paths[:20]}"
 
 
 def test_local_app_keeps_legacy_routes(monkeypatch, tmp_path) -> None:
@@ -89,9 +89,9 @@ def test_local_app_keeps_legacy_routes(monkeypatch, tmp_path) -> None:
     legacy = [
         p for p in route_paths if p.startswith("/api/") and not p.startswith("/api/v1/")
     ]
-    assert len(legacy) > 0, (
-        f"No legacy /api/ routes found. Registered paths: {route_paths[:20]}"
-    )
+    assert (
+        len(legacy) > 0
+    ), f"No legacy /api/ routes found. Registered paths: {route_paths[:20]}"
 
 
 def test_local_app_description_mentions_versioning(monkeypatch, tmp_path) -> None:

--- a/tests/unit/test_muscle_analysis.py
+++ b/tests/unit/test_muscle_analysis.py
@@ -223,9 +223,9 @@ class TestExtractSynergies:
         result = analyzer.extract_synergies(n_synergies=4)
 
         # VAF should be high
-        assert result.vaf > 0.80, (
-            "High number of synergies should give good reconstruction"
-        )
+        assert (
+            result.vaf > 0.80
+        ), "High number of synergies should give good reconstruction"
 
         # Reconstruction shape should match data
         assert result.reconstructed.shape == data.shape
@@ -299,9 +299,9 @@ class TestExtractSynergies:
         result = analyzer.extract_synergies(n_synergies=1)
 
         # VAF should be very high (near perfect reconstruction)
-        assert result.vaf > 0.98, (
-            f"VAF should be near 1.0 for rank-1 data, got {result.vaf}"
-        )
+        assert (
+            result.vaf > 0.98
+        ), f"VAF should be near 1.0 for rank-1 data, got {result.vaf}"
 
 
 @skip_if_unavailable("sklearn")
@@ -574,6 +574,6 @@ class TestNumericalAccuracy:
         result = analyzer.extract_synergies(n_synergies=n_muscles)
 
         # VAF should be very high (near 1.0)
-        assert result.vaf > 0.95, (
-            f"VAF with {n_muscles} synergies should be > 0.95, got {result.vaf}"
-        )
+        assert (
+            result.vaf > 0.95
+        ), f"VAF with {n_muscles} synergies should be > 0.95, got {result.vaf}"

--- a/tests/unit/test_muscle_contribution_closure.py
+++ b/tests/unit/test_muscle_contribution_closure.py
@@ -160,9 +160,9 @@ if MYOSUITE_AVAILABLE:
                 # Extensors (e.g., 'TRIlong') should induce negative
                 # This depends on MyoSuite's specific coordinate system
                 # Validation: Just check they are non-zero when active
-                assert np.linalg.norm(a_muscle) > 1e-8, (
-                    f"Muscle {muscle_name} induced zero acceleration"
-                )
+                assert (
+                    np.linalg.norm(a_muscle) > 1e-8
+                ), f"Muscle {muscle_name} induced zero acceleration"
 
                 # Log for inspection (useful for understanding muscle function)
 

--- a/tests/unit/test_muscle_equilibrium.py
+++ b/tests/unit/test_muscle_equilibrium.py
@@ -76,9 +76,9 @@ class TestEquilibriumResidual:
         residual = solver._equilibrium_residual(l_CE, l_MT, activation, v_CE=0.0)
 
         # Residual should be very close to zero
-        assert abs(residual) < 1.0, (
-            f"Residual should be near zero, got {residual:.6f} N"
-        )
+        assert (
+            abs(residual) < 1.0
+        ), f"Residual should be near zero, got {residual:.6f} N"
 
     def test_residual_changes_sign_across_equilibrium(self, standard_muscle):
         """Test that residual changes sign across equilibrium point."""
@@ -101,9 +101,9 @@ class TestEquilibriumResidual:
 
         # Residuals should have opposite signs
         # Note: exact sign depends on force-length curves, but they should differ
-        assert residual_short * residual_long < 0, (
-            "Residuals should have opposite signs across equilibrium"
-        )
+        assert (
+            residual_short * residual_long < 0
+        ), "Residuals should have opposite signs across equilibrium"
 
     def test_residual_with_pennation(self, pennated_muscle):
         """Test residual calculation with pennated muscle."""
@@ -192,9 +192,9 @@ class TestSolveFiberLength:
             assert np.isfinite(l_CE), f"Solution should be finite at l_MT={l_MT}"
 
         # Longer muscle-tendon -> longer fiber (generally)
-        assert solutions[0] < solutions[-1], (
-            "Longer muscle-tendon should have longer fiber"
-        )
+        assert (
+            solutions[0] < solutions[-1]
+        ), "Longer muscle-tendon should have longer fiber"
 
     def test_custom_initial_guess(self, standard_muscle):
         """Test solver with custom initial guess."""
@@ -461,9 +461,9 @@ class TestPhysicalRealism:
         l_tendon_long = l_MT_long - l_CE_long
 
         # Longer muscle-tendon should have longer tendon
-        assert l_tendon_long > l_tendon_short, (
-            "Longer muscle-tendon should stretch tendon more"
-        )
+        assert (
+            l_tendon_long > l_tendon_short
+        ), "Longer muscle-tendon should stretch tendon more"
 
     def test_fiber_length_decreases_with_activation(self, standard_muscle):
         """Test that fiber shortens with higher activation (for given l_MT).
@@ -527,9 +527,9 @@ class TestPhysicalRealism:
         # Change should be small and smooth
         relative_change = abs(l_CE_perturbed - l_CE_nominal) / l_CE_nominal
 
-        assert relative_change < 0.05, (
-            f"Small perturbation caused large change: {relative_change * 100:.2f}%"
-        )
+        assert (
+            relative_change < 0.05
+        ), f"Small perturbation caused large change: {relative_change * 100:.2f}%"
 
 
 class TestNumericalAccuracy:
@@ -546,9 +546,9 @@ class TestNumericalAccuracy:
 
         # Residual should be much smaller than typical forces
         tolerance_N = 1.0  # 1 N tolerance
-        assert abs(residual) < tolerance_N, (
-            f"Residual {residual:.6f} N exceeds tolerance {tolerance_N} N"
-        )
+        assert (
+            abs(residual) < tolerance_N
+        ), f"Residual {residual:.6f} N exceeds tolerance {tolerance_N} N"
 
     def test_repeated_solves_give_consistent_results(self, standard_muscle):
         """Test that solving the same problem multiple times gives consistent results."""
@@ -638,9 +638,9 @@ class TestEdgeCases:
         l_CE = solver.solve_fiber_length(l_MT, activation)
 
         # Should have stretched fiber (long muscle-tendon)
-        assert l_CE > standard_muscle.params.l_opt, (
-            "Long muscle-tendon should have stretched fiber"
-        )
+        assert (
+            l_CE > standard_muscle.params.l_opt
+        ), "Long muscle-tendon should have stretched fiber"
 
     def test_pennated_muscle_equilibrium(self, pennated_muscle):
         """Test equilibrium with pennation angle."""

--- a/tests/unit/test_pendulum_putter_model.py
+++ b/tests/unit/test_pendulum_putter_model.py
@@ -133,9 +133,9 @@ class TestPendulumPutterModelPhysics:
 
         for link in result.links:
             if link.inertia.mass > 1e-6:  # Skip negligible mass links
-                assert link.inertia.is_positive_definite(), (
-                    f"Link {link.name} has non-positive-definite inertia"
-                )
+                assert (
+                    link.inertia.is_positive_definite()
+                ), f"Link {link.name} has non-positive-definite inertia"
 
     def test_pendulum_joint_has_appropriate_limits(self):
         """Pendulum joint should have reasonable angle limits."""
@@ -320,9 +320,9 @@ class TestURDFGeneration:
             if link.attrib["name"] != "world":
                 # Should have inertial (except world)
                 inertial = link.find("inertial")
-                assert inertial is not None, (
-                    f"Link {link.attrib['name']} missing inertial"
-                )
+                assert (
+                    inertial is not None
+                ), f"Link {link.attrib['name']} missing inertial"
 
     def test_can_save_to_file(self, tmp_path: Path):
         """Should be able to save URDF to file."""
@@ -411,9 +411,9 @@ class TestValidation:
         result = builder.build()
 
         assert result.validation is not None
-        assert result.validation.is_valid, (
-            f"Validation failed: {result.validation.get_error_messages()}"
-        )
+        assert (
+            result.validation.is_valid
+        ), f"Validation failed: {result.validation.get_error_messages()}"
 
     def test_validation_catches_invalid_parameters(self):
         """Should catch invalid configuration parameters."""

--- a/tests/unit/test_pendulum_putter_physics.py
+++ b/tests/unit/test_pendulum_putter_physics.py
@@ -82,9 +82,9 @@ class TestMuJoCoIntegration:
 
             if model.nq > 0:
                 final_angle = data.qpos[0]
-                assert abs(final_angle) < abs(initial_angle) + 0.5, (
-                    "Pendulum should be oscillating, not diverging"
-                )
+                assert (
+                    abs(final_angle) < abs(initial_angle) + 0.5
+                ), "Pendulum should be oscillating, not diverging"
 
         except Exception as e:  # noqa: BLE001
             pytest.skip(f"MuJoCo simulation test skipped: {e}")
@@ -109,9 +109,9 @@ class TestModelValidationForEngines:
 
             assert link.inertia is not None, f"Link {link.name} missing inertia"
             assert link.inertia.mass > 0, f"Link {link.name} has zero/negative mass"
-            assert link.inertia.is_positive_definite(), (
-                f"Link {link.name} has invalid inertia tensor"
-            )
+            assert (
+                link.inertia.is_positive_definite()
+            ), f"Link {link.name} has invalid inertia tensor"
 
     def test_all_joints_have_valid_axes(self, model_result):
         """All joints should have valid, normalized axes."""
@@ -121,9 +121,9 @@ class TestModelValidationForEngines:
 
             axis = np.array(joint.axis)
             norm = np.linalg.norm(axis)
-            assert abs(norm - 1.0) < 1e-6, (
-                f"Joint {joint.name} axis not normalized: {joint.axis}"
-            )
+            assert (
+                abs(norm - 1.0) < 1e-6
+            ), f"Joint {joint.name} axis not normalized: {joint.axis}"
 
     def test_joint_limits_are_consistent(self, model_result):
         """Joint limits should be valid (lower < upper)."""
@@ -141,12 +141,12 @@ class TestModelValidationForEngines:
         link_names = {link.name for link in model_result.links}
 
         for joint in model_result.joints:
-            assert joint.parent in link_names, (
-                f"Joint {joint.name} has missing parent: {joint.parent}"
-            )
-            assert joint.child in link_names, (
-                f"Joint {joint.name} has missing child: {joint.child}"
-            )
+            assert (
+                joint.parent in link_names
+            ), f"Joint {joint.name} has missing parent: {joint.parent}"
+            assert (
+                joint.child in link_names
+            ), f"Joint {joint.name} has missing child: {joint.child}"
 
 
 class TestPendulumPhysicsProperties:

--- a/tests/unit/test_physical_constants_xml.py
+++ b/tests/unit/test_physical_constants_xml.py
@@ -28,9 +28,9 @@ class TestPhysicalConstantXMLSafety:
         assert option_elem is not None, "option element not found"
         gravity_attr = option_elem.get("gravity")
         assert gravity_attr is not None, "gravity attribute not found"
-        assert "PhysicalConstant" not in gravity_attr, (
-            "PhysicalConstant.__repr__ leaked into XML"
-        )
+        assert (
+            "PhysicalConstant" not in gravity_attr
+        ), "PhysicalConstant.__repr__ leaked into XML"
 
         # Verify parseable as floats
         g_components = gravity_attr.split()
@@ -46,9 +46,9 @@ class TestPhysicalConstantXMLSafety:
         xml_string = f'<option gravity="0 0 -{GRAVITY_M_S2}"/>'
 
         # This will include the __repr__ representation
-        assert "PhysicalConstant" in xml_string, (
-            "Test assumption wrong: __repr__ should appear"
-        )
+        assert (
+            "PhysicalConstant" in xml_string
+        ), "Test assumption wrong: __repr__ should appear"
 
         # Parsing may succeed but value is garbage
         root = ET.fromstring(f"<root>{xml_string}</root>")

--- a/tests/unit/test_property_based_physics.py
+++ b/tests/unit/test_property_based_physics.py
@@ -139,9 +139,9 @@ class TestBallFlightProperties:
 
         # Drag should oppose relative velocity (zero wind => relative = velocity)
         dot = float(np.dot(drag, velocity))
-        assert dot <= 1e-10, (
-            f"Drag should oppose velocity: dot={dot}, drag={drag}, vel={velocity}"
-        )
+        assert (
+            dot <= 1e-10
+        ), f"Drag should oppose velocity: dot={dot}, drag={drag}, vel={velocity}"
 
     @given(
         velocity=nonzero_velocity,
@@ -273,9 +273,9 @@ class TestBallFlightProperties:
             return
 
         ratio = drag_scaled_mag / drag_base_mag
-        assert abs(ratio - density_factor) < 0.01, (
-            f"Drag should scale by {density_factor}, got ratio {ratio}"
-        )
+        assert (
+            abs(ratio - density_factor) < 0.01
+        ), f"Drag should scale by {density_factor}, got ratio {ratio}"
 
 
 # ============================================================================
@@ -318,15 +318,15 @@ class TestPhaseDetectionProperties:
 
         # Check that first phase starts at or before time[0]
         first_start = phases[0].start_time
-        assert first_start <= times[0] + 1e-10, (
-            f"First phase start {first_start} should be <= {times[0]}"
-        )
+        assert (
+            first_start <= times[0] + 1e-10
+        ), f"First phase start {first_start} should be <= {times[0]}"
 
         # Check that last phase ends at or after the last time
         last_end = phases[-1].end_time
-        assert last_end >= times[-1] - 1e-10, (
-            f"Last phase end {last_end} should be >= {times[-1]}"
-        )
+        assert (
+            last_end >= times[-1] - 1e-10
+        ), f"Last phase end {last_end} should be >= {times[-1]}"
 
     @given(
         n_points=st.integers(min_value=50, max_value=500),
@@ -387,12 +387,12 @@ class TestPhaseDetectionProperties:
         phases = detector.detect_swing_phases()
 
         for phase in phases:
-            assert phase.duration >= 0.0, (
-                f"Phase '{phase.name}' has negative duration: {phase.duration}"
-            )
-            assert phase.end_time >= phase.start_time, (
-                f"Phase '{phase.name}' end_time={phase.end_time} < start_time={phase.start_time}"
-            )
+            assert (
+                phase.duration >= 0.0
+            ), f"Phase '{phase.name}' has negative duration: {phase.duration}"
+            assert (
+                phase.end_time >= phase.start_time
+            ), f"Phase '{phase.name}' end_time={phase.end_time} < start_time={phase.start_time}"
 
 
 # ============================================================================
@@ -429,9 +429,9 @@ class TestSwingOptimizerConfigProperties:
         bounds = optimizer._get_bounds()
 
         for i, (lo, hi) in enumerate(bounds):
-            assert lo <= hi, (
-                f"Bound index {i}: lower={lo} > upper={hi} (flexibility={flexibility})"
-            )
+            assert (
+                lo <= hi
+            ), f"Bound index {i}: lower={lo} > upper={hi} (flexibility={flexibility})"
 
     @given(
         # flexibility_factor >= 1.0 ensures scaled bounds encompass the raw
@@ -478,17 +478,17 @@ class TestSwingOptimizerConfigProperties:
         x0 = optimizer._generate_initial_guess()
         bounds = optimizer._get_bounds()
 
-        assert len(x0) == len(bounds), (
-            f"Initial guess length {len(x0)} != bounds length {len(bounds)}"
-        )
+        assert len(x0) == len(
+            bounds
+        ), f"Initial guess length {len(x0)} != bounds length {len(bounds)}"
 
         n_angle_vars = len(optimizer.JOINTS) * n_nodes
         # Angle portion: must be strictly within joint-limit bounds
         for i in range(n_angle_vars):
             lo, hi = bounds[i]
-            assert lo - 1e-6 <= x0[i] <= hi + 1e-6, (
-                f"Angle x0[{i}]={x0[i]} not in [{lo}, {hi}]"
-            )
+            assert (
+                lo - 1e-6 <= x0[i] <= hi + 1e-6
+            ), f"Angle x0[{i}]={x0[i]} not in [{lo}, {hi}]"
 
 
 # ============================================================================
@@ -503,9 +503,9 @@ class TestPhysicalConstantsProperties:
         """Property: gravity is within the expected range (9.7 to 9.9 m/s^2)."""
         g = float(physics_constants.GRAVITY_M_S2)
         assert 9.7 < g < 9.9, f"Gravity={g} outside expected range [9.7, 9.9]"
-        assert g == pytest.approx(9.80665, abs=1e-5), (
-            f"Gravity={g} should be standard gravity 9.80665"
-        )
+        assert g == pytest.approx(
+            9.80665, abs=1e-5
+        ), f"Gravity={g} should be standard gravity 9.80665"
 
     def test_all_physical_constants_positive_and_finite(self) -> None:
         """Property: all physical constants defined via PhysicalConstant are positive and finite."""
@@ -520,9 +520,9 @@ class TestPhysicalConstantsProperties:
                 constants_checked += 1
 
         # Ensure we actually checked a meaningful number of constants
-        assert constants_checked >= 10, (
-            f"Only checked {constants_checked} constants; expected at least 10"
-        )
+        assert (
+            constants_checked >= 10
+        ), f"Only checked {constants_checked} constants; expected at least 10"
 
     def test_precomputed_floats_match_source_constants(self) -> None:
         """Property: pre-computed float values match their source constants."""
@@ -578,17 +578,17 @@ class TestPhysicalConstantsProperties:
 
         # deg -> rad -> deg should roundtrip
         roundtripped = value * deg_to_rad * rad_to_deg
-        assert roundtripped == pytest.approx(value, rel=1e-10), (
-            f"DEG->RAD->DEG roundtrip: {value} -> {roundtripped}"
-        )
+        assert roundtripped == pytest.approx(
+            value, rel=1e-10
+        ), f"DEG->RAD->DEG roundtrip: {value} -> {roundtripped}"
 
         ft_to_m = float(physics_constants.FT_TO_M)
         m_to_ft = float(physics_constants.M_TO_FT)
 
         roundtripped_ft = value * ft_to_m * m_to_ft
-        assert roundtripped_ft == pytest.approx(value, rel=1e-6), (
-            f"FT->M->FT roundtrip: {value} -> {roundtripped_ft}"
-        )
+        assert roundtripped_ft == pytest.approx(
+            value, rel=1e-6
+        ), f"FT->M->FT roundtrip: {value} -> {roundtripped_ft}"
 
 
 # ============================================================================
@@ -695,9 +695,9 @@ class TestRRTPlannerProperties:
 
         if result.success:
             end_dist = float(np.linalg.norm(result.path[-1] - q_goal))
-            assert end_dist <= goal_tol + 1e-10, (
-                f"Path end distance to goal {end_dist} exceeds tolerance {goal_tol}"
-            )
+            assert (
+                end_dist <= goal_tol + 1e-10
+            ), f"Path end distance to goal {end_dist} exceeds tolerance {goal_tol}"
 
     @given(
         ndof=st.integers(min_value=2, max_value=6),

--- a/tests/unit/test_shared_engine_manager.py
+++ b/tests/unit/test_shared_engine_manager.py
@@ -25,13 +25,17 @@ class TestEngineManager(unittest.TestCase):
             "src.shared.python.engine_core.engine_probes.MuJoCoProbe"
         )
         self.mock_mujoco_probe_cls = self.mujoco_patcher.start()
-        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = True
+        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = (
+            True
+        )
 
         self.drake_patcher = patch(
             "src.shared.python.engine_core.engine_probes.DrakeProbe"
         )
         self.mock_drake_probe_cls = self.drake_patcher.start()
-        self.mock_drake_probe_cls.return_value.probe.return_value.is_available.return_value = True
+        self.mock_drake_probe_cls.return_value.probe.return_value.is_available.return_value = (
+            True
+        )
 
         self.pinocchio_patcher = patch(
             "src.shared.python.engine_core.engine_probes.PinocchioProbe"
@@ -131,7 +135,9 @@ class TestEngineManager(unittest.TestCase):
         manager.engine_paths[EngineType.MUJOCO] = Path("/mock/mujoco")
 
         # Configure probe specifically for this test
-        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = True
+        self.mock_mujoco_probe_cls.return_value.probe.return_value.is_available.return_value = (
+            True
+        )
 
         mock_mujoco_pkg = MagicMock()
         mock_mujoco_pkg.__version__ = "3.2.3"

--- a/tests/unit/test_third_party_integration_audit.py
+++ b/tests/unit/test_third_party_integration_audit.py
@@ -81,9 +81,9 @@ class TestEngineAvailabilityInfrastructure:
         from src.shared.python.engine_core import engine_availability
 
         source = inspect.getsource(engine_availability)
-        assert "import pyopenpose" in source, (
-            "engine_availability.py should check for 'pyopenpose', not 'openpose'"
-        )
+        assert (
+            "import pyopenpose" in source
+        ), "engine_availability.py should check for 'pyopenpose', not 'openpose'"
 
     def test_skip_if_unavailable_returns_marker(self) -> None:
         """skip_if_unavailable must return a pytest marker."""
@@ -190,9 +190,9 @@ class TestMuJoCoIntegrationAudit:
         conftest_path = Path(__file__).parent.parent.parent / "conftest.py"
         if conftest_path.exists():
             content = conftest_path.read_text(encoding="utf-8")
-            assert "mujoco" in content, (
-                "conftest.py should import mujoco early to avoid DLL conflicts"
-            )
+            assert (
+                "mujoco" in content
+            ), "conftest.py should import mujoco early to avoid DLL conflicts"
 
     @skip_if_unavailable("mujoco")
     def test_mujoco_gl_environment(self) -> None:
@@ -202,9 +202,9 @@ class TestMuJoCoIntegrationAudit:
 
         if sys.platform == "win32":
             gl = os.environ.get("MUJOCO_GL", "")
-            assert gl != "egl", (
-                "MUJOCO_GL=egl is invalid on Windows; use osmesa or glfw"
-            )
+            assert (
+                gl != "egl"
+            ), "MUJOCO_GL=egl is invalid on Windows; use osmesa or glfw"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -586,9 +586,9 @@ class TestOpenPoseIntegrationAudit:
 
         source = inspect.getsource(OpenPoseEstimator.load_model)
         # Verify cross-platform support
-        assert "/usr/local" in source or "OPENPOSE_MODELS_DIR" in source, (
-            "OpenPose load_model must support cross-platform model paths"
-        )
+        assert (
+            "/usr/local" in source or "OPENPOSE_MODELS_DIR" in source
+        ), "OpenPose load_model must support cross-platform model paths"
 
     def test_openpose_supports_env_var(self) -> None:
         """OpenPose must support OPENPOSE_MODELS_DIR environment variable."""
@@ -599,9 +599,9 @@ class TestOpenPoseIntegrationAudit:
         )
 
         source = inspect.getsource(OpenPoseEstimator.load_model)
-        assert "OPENPOSE_MODELS_DIR" in source, (
-            "OpenPose load_model must support OPENPOSE_MODELS_DIR env var"
-        )
+        assert (
+            "OPENPOSE_MODELS_DIR" in source
+        ), "OpenPose load_model must support OPENPOSE_MODELS_DIR env var"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -811,9 +811,9 @@ class TestCrossEngineProtocolCompliance:
         cls = getattr(mod, engine_class)
 
         for method in self.PHYSICS_ENGINE_METHODS:
-            assert hasattr(cls, method), (
-                f"{engine_class} missing protocol method: {method}"
-            )
+            assert hasattr(
+                cls, method
+            ), f"{engine_class} missing protocol method: {method}"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/test_third_party_integration_batch2.py
+++ b/tests/unit/test_third_party_integration_batch2.py
@@ -167,9 +167,9 @@ class TestMyoSuiteGymnasiumCompatibility:
                 fromlist=["MyoSuitePhysicsEngine"],
             )
         )
-        assert "import gymnasium" in source_code, (
-            "MyoSuite engine should prefer 'import gymnasium' over legacy 'import gym'"
-        )
+        assert (
+            "import gymnasium" in source_code
+        ), "MyoSuite engine should prefer 'import gymnasium' over legacy 'import gym'"
 
     def test_myosuite_has_gym_fallback(self) -> None:
         """MyoSuite must fall back to legacy gym if gymnasium is missing."""
@@ -179,9 +179,9 @@ class TestMyoSuiteGymnasiumCompatibility:
                 fromlist=["MyoSuitePhysicsEngine"],
             )
         )
-        assert "import gym" in source_code, (
-            "MyoSuite engine must have a fallback to legacy 'import gym'"
-        )
+        assert (
+            "import gym" in source_code
+        ), "MyoSuite engine must have a fallback to legacy 'import gym'"
 
     def test_myosuite_engine_load_from_string_raises(self) -> None:
         """load_from_string must raise (Gym envs don't support string loading)."""
@@ -370,9 +370,9 @@ class TestEngineAvailabilityDeep:
         )
 
         for name, flag in _ENGINE_FLAGS.items():
-            assert isinstance(flag, bool), (
-                f"_ENGINE_FLAGS['{name}'] is {type(flag).__name__}, expected bool"
-            )
+            assert isinstance(
+                flag, bool
+            ), f"_ENGINE_FLAGS['{name}'] is {type(flag).__name__}, expected bool"
 
     def test_engine_availability_consistent_with_import(self) -> None:
         """DRAKE_AVAILABLE must be consistent with pydrake.all import."""

--- a/tests/unit/test_ux_enhancements.py
+++ b/tests/unit/test_ux_enhancements.py
@@ -196,9 +196,9 @@ def test_status_info_contrast(mocked_launcher_module):
         assert bg == exp_bg, f"Background color mismatch for {m_type}"
 
         # This assertion defines our requirement for the new feature
-        assert text_color == exp_text, (
-            f"Text color mismatch for {m_type}. Expected {exp_text}, got {text_color}"
-        )
+        assert (
+            text_color == exp_text
+        ), f"Text color mismatch for {m_type}. Expected {exp_text}, got {text_color}"
 
 
 @pytest.mark.xfail(

--- a/tests/unit/tools/humanoid_character_builder/test_mesh_generators.py
+++ b/tests/unit/tools/humanoid_character_builder/test_mesh_generators.py
@@ -199,7 +199,9 @@ class TestSMPLXGenerate:
         mock_output.vertices = MagicMock()
         mock_output.vertices.detach.return_value.cpu.return_value.numpy.return_value.squeeze.return_value = rng.standard_normal(
             (n_verts, 3)
-        ).astype(np.float32)
+        ).astype(
+            np.float32
+        )
 
         mock_model = MagicMock()
         mock_model.return_value = mock_output
@@ -390,16 +392,14 @@ class TestMakeHumanOBJParsing:
     """Test the OBJ file parser."""
 
     def test_parse_simple_obj(self, tmp_path: Path) -> None:
-        obj_content = textwrap.dedent(
-            """\
+        obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
             v 0.0 1.0 0.0
             v 1.0 1.0 0.0
             f 1 2 3
             f 2 3 4
-        """
-        )
+        """)
         obj_file = tmp_path / "test.obj"
         obj_file.write_text(obj_content, encoding="utf-8")
 
@@ -410,16 +410,14 @@ class TestMakeHumanOBJParsing:
         assert faces[0].tolist() == [0, 1, 2]
 
     def test_parse_obj_with_normals_and_texcoords(self, tmp_path: Path) -> None:
-        obj_content = textwrap.dedent(
-            """\
+        obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
             v 0.0 1.0 0.0
             vn 0.0 0.0 1.0
             vt 0.0 0.0
             f 1/1/1 2/1/1 3/1/1
-        """
-        )
+        """)
         obj_file = tmp_path / "test.obj"
         obj_file.write_text(obj_content, encoding="utf-8")
 
@@ -428,15 +426,13 @@ class TestMakeHumanOBJParsing:
         assert faces.shape == (1, 3)
 
     def test_parse_obj_quad_triangulation(self, tmp_path: Path) -> None:
-        obj_content = textwrap.dedent(
-            """\
+        obj_content = textwrap.dedent("""\
             v 0.0 0.0 0.0
             v 1.0 0.0 0.0
             v 1.0 1.0 0.0
             v 0.0 1.0 0.0
             f 1 2 3 4
-        """
-        )
+        """)
         obj_file = tmp_path / "test.obj"
         obj_file.write_text(obj_content, encoding="utf-8")
 

--- a/tests/unit/tools/humanoid_character_builder/test_urdf_generator_formatting.py
+++ b/tests/unit/tools/humanoid_character_builder/test_urdf_generator_formatting.py
@@ -51,9 +51,9 @@ class TestPrettyPrintNoXmlDeclaration:
         self, pretty_generator: HumanoidURDFGenerator, default_params: BodyParameters
     ) -> None:
         urdf_xml = pretty_generator.generate(default_params)
-        assert "<?xml" not in urdf_xml, (
-            "XML declaration must not appear anywhere in pretty_print output"
-        )
+        assert (
+            "<?xml" not in urdf_xml
+        ), "XML declaration must not appear anywhere in pretty_print output"
 
 
 class TestPrettyPrintIndentation:
@@ -66,9 +66,9 @@ class TestPrettyPrintIndentation:
         lines = urdf_xml.splitlines()
         # At least some lines should start with spaces (indentation)
         indented_lines = [line for line in lines if line.startswith("  ")]
-        assert len(indented_lines) > 0, (
-            "pretty_print output must contain indented lines"
-        )
+        assert (
+            len(indented_lines) > 0
+        ), "pretty_print output must contain indented lines"
 
     def test_child_elements_are_indented_under_robot(
         self, pretty_generator: HumanoidURDFGenerator, default_params: BodyParameters
@@ -79,9 +79,9 @@ class TestPrettyPrintIndentation:
         link_lines = [line for line in lines if "<link " in line]
         assert len(link_lines) > 0, "Should have link elements"
         for line in link_lines:
-            assert line.startswith("  "), (
-                f"<link> element should be indented with 2 spaces, got: {line!r}"
-            )
+            assert line.startswith(
+                "  "
+            ), f"<link> element should be indented with 2 spaces, got: {line!r}"
 
 
 class TestPrettyPrintNoBlankLines:
@@ -116,9 +116,9 @@ class TestCompactOutput:
         default_params: BodyParameters,
     ) -> None:
         urdf_xml = compact_generator.generate(default_params)
-        assert "<?xml" not in urdf_xml, (
-            "compact output must not contain an XML declaration"
-        )
+        assert (
+            "<?xml" not in urdf_xml
+        ), "compact output must not contain an XML declaration"
 
 
 class TestValidXmlOutput:

--- a/tests/unit/tools/model_generation/test_dry_unification.py
+++ b/tests/unit/tools/model_generation/test_dry_unification.py
@@ -44,9 +44,9 @@ class TestHumanoidPresetsConstant:
         """_HUMANOID_PRESETS must be a dict."""
         import model_generation
 
-        assert isinstance(model_generation._HUMANOID_PRESETS, dict), (
-            f"_HUMANOID_PRESETS must be a dict, got {type(model_generation._HUMANOID_PRESETS)}"
-        )
+        assert isinstance(
+            model_generation._HUMANOID_PRESETS, dict
+        ), f"_HUMANOID_PRESETS must be a dict, got {type(model_generation._HUMANOID_PRESETS)}"
 
     def test_constant_has_exactly_four_keys(self):
         """_HUMANOID_PRESETS must contain exactly four preset keys."""
@@ -58,58 +58,56 @@ class TestHumanoidPresetsConstant:
             "average",
             "heavy",
             "lean",
-        }, (
-            f"Expected keys {{athletic, average, heavy, lean}}, got {set(presets.keys())}"
-        )
+        }, f"Expected keys {{athletic, average, heavy, lean}}, got {set(presets.keys())}"
 
     def test_athletic_preset_values(self):
         """athletic preset must set gender_factor=0.7 and shoulder_width_factor=1.1."""
         import model_generation
 
         athletic = model_generation._HUMANOID_PRESETS["athletic"]
-        assert athletic.get("gender_factor") == 0.7, (
-            f"athletic gender_factor expected 0.7, got {athletic.get('gender_factor')}"
-        )
-        assert athletic.get("shoulder_width_factor") == 1.1, (
-            f"athletic shoulder_width_factor expected 1.1, got {athletic.get('shoulder_width_factor')}"
-        )
+        assert (
+            athletic.get("gender_factor") == 0.7
+        ), f"athletic gender_factor expected 0.7, got {athletic.get('gender_factor')}"
+        assert (
+            athletic.get("shoulder_width_factor") == 1.1
+        ), f"athletic shoulder_width_factor expected 1.1, got {athletic.get('shoulder_width_factor')}"
 
     def test_average_preset_values(self):
         """average preset must set gender_factor=0.5 and nothing else."""
         import model_generation
 
         average = model_generation._HUMANOID_PRESETS["average"]
-        assert average.get("gender_factor") == 0.5, (
-            f"average gender_factor expected 0.5, got {average.get('gender_factor')}"
-        )
+        assert (
+            average.get("gender_factor") == 0.5
+        ), f"average gender_factor expected 0.5, got {average.get('gender_factor')}"
         # average should not have extra keys
-        assert set(average.keys()) == {"gender_factor"}, (
-            f"average preset should only have 'gender_factor', got {set(average.keys())}"
-        )
+        assert set(average.keys()) == {
+            "gender_factor"
+        }, f"average preset should only have 'gender_factor', got {set(average.keys())}"
 
     def test_heavy_preset_values(self):
         """heavy preset must set gender_factor=0.5 and hip_width_factor=1.15."""
         import model_generation
 
         heavy = model_generation._HUMANOID_PRESETS["heavy"]
-        assert heavy.get("gender_factor") == 0.5, (
-            f"heavy gender_factor expected 0.5, got {heavy.get('gender_factor')}"
-        )
-        assert heavy.get("hip_width_factor") == 1.15, (
-            f"heavy hip_width_factor expected 1.15, got {heavy.get('hip_width_factor')}"
-        )
+        assert (
+            heavy.get("gender_factor") == 0.5
+        ), f"heavy gender_factor expected 0.5, got {heavy.get('gender_factor')}"
+        assert (
+            heavy.get("hip_width_factor") == 1.15
+        ), f"heavy hip_width_factor expected 1.15, got {heavy.get('hip_width_factor')}"
 
     def test_lean_preset_values(self):
         """lean preset must set gender_factor=0.5 and shoulder_width_factor=0.95."""
         import model_generation
 
         lean = model_generation._HUMANOID_PRESETS["lean"]
-        assert lean.get("gender_factor") == 0.5, (
-            f"lean gender_factor expected 0.5, got {lean.get('gender_factor')}"
-        )
-        assert lean.get("shoulder_width_factor") == 0.95, (
-            f"lean shoulder_width_factor expected 0.95, got {lean.get('shoulder_width_factor')}"
-        )
+        assert (
+            lean.get("gender_factor") == 0.5
+        ), f"lean gender_factor expected 0.5, got {lean.get('gender_factor')}"
+        assert (
+            lean.get("shoulder_width_factor") == 0.95
+        ), f"lean shoulder_width_factor expected 0.95, got {lean.get('shoulder_width_factor')}"
 
 
 # ---------------------------------------------------------------------------
@@ -240,9 +238,9 @@ class TestQuickFunctionsUseSharedPresets:
         call_kwargs = mock_builder.set_parameters.call_args[1]
         # No extra preset keys should leak in
         extra_keys = {"gender_factor", "shoulder_width_factor", "hip_width_factor"}
-        assert not extra_keys.intersection(call_kwargs.keys()), (
-            f"Unknown preset should not set any extra params, got {call_kwargs}"
-        )
+        assert not extra_keys.intersection(
+            call_kwargs.keys()
+        ), f"Unknown preset should not set any extra params, got {call_kwargs}"
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +271,6 @@ class TestPresetsNotMutated:
         ):
             model_generation.quick_urdf(preset="athletic")
 
-        assert before == model_generation._HUMANOID_PRESETS, (
-            "_HUMANOID_PRESETS was mutated during quick_urdf call"
-        )
+        assert (
+            before == model_generation._HUMANOID_PRESETS
+        ), "_HUMANOID_PRESETS was mutated during quick_urdf call"

--- a/tests/unit/tools/model_generation/test_integration_roundtrip.py
+++ b/tests/unit/tools/model_generation/test_integration_roundtrip.py
@@ -319,9 +319,9 @@ class TestParametricBuilderRoundtrip:
         assert parsed.name == "humanoid"
 
         # Must have multiple links (humanoid skeleton)
-        assert len(parsed.links) > 10, (
-            f"Expected >10 links for humanoid, got {len(parsed.links)}"
-        )
+        assert (
+            len(parsed.links) > 10
+        ), f"Expected >10 links for humanoid, got {len(parsed.links)}"
 
         # Must have joints connecting them
         assert len(parsed.joints) >= len(parsed.links) - 1
@@ -353,9 +353,9 @@ class TestParametricBuilderRoundtrip:
         assert total_mass > 0, "Total mass must be positive"
         # Allow generous tolerance since parametric builder distributes mass
         # across many segments with approximation
-        assert total_mass > target_mass * 0.5, (
-            f"Total mass {total_mass} is less than 50% of target {target_mass}"
-        )
+        assert (
+            total_mass > target_mass * 0.5
+        ), f"Total mass {total_mass} is less than 50% of target {target_mass}"
 
     def test_parametric_height_affects_geometry(self) -> None:
         """Different heights produce different link dimensions."""
@@ -379,9 +379,9 @@ class TestParametricBuilderRoundtrip:
         assert thigh_tall is not None
 
         # Taller person should have greater thigh inertia (larger segment)
-        assert thigh_tall.inertia.ixx > thigh_short.inertia.ixx, (
-            "Taller model should have larger thigh inertia"
-        )
+        assert (
+            thigh_tall.inertia.ixx > thigh_short.inertia.ixx
+        ), "Taller model should have larger thigh inertia"
 
     def test_parametric_builder_produces_valid_xml(self) -> None:
         """Parametric URDF is always well-formed XML with <robot> root."""
@@ -400,15 +400,15 @@ class TestParametricBuilderRoundtrip:
         # Every link must have an inertial element
         for link_elem in root.findall(".//link"):
             inertial = link_elem.find("inertial")
-            assert inertial is not None, (
-                f"Link '{link_elem.get('name')}' missing <inertial>"
-            )
+            assert (
+                inertial is not None
+            ), f"Link '{link_elem.get('name')}' missing <inertial>"
             mass = inertial.find("mass")
             assert mass is not None
             mass_val = float(mass.get("value", "0"))
-            assert mass_val > 0, (
-                f"Link '{link_elem.get('name')}' has non-positive mass {mass_val}"
-            )
+            assert (
+                mass_val > 0
+            ), f"Link '{link_elem.get('name')}' has non-positive mass {mass_val}"
 
     def test_parametric_custom_segment_roundtrip(self) -> None:
         """Custom segments added via add_segment survive roundtrip."""
@@ -589,9 +589,9 @@ class TestCompositeJointExpansion:
             current = parents[current]
             if current in visited:
                 break  # Avoid infinite loop
-        assert current == "base", (
-            f"Arm's ancestor chain does not reach 'base': ended at '{current}'"
-        )
+        assert (
+            current == "base"
+        ), f"Arm's ancestor chain does not reach 'base': ended at '{current}'"
 
     def test_gimbal_joint_expands_to_three_revolute(self) -> None:
         """A gimbal joint should expand to 3 revolute joints + 2 intermediate links."""

--- a/tests/unit/tools/model_generation/test_property_based.py
+++ b/tests/unit/tools/model_generation/test_property_based.py
@@ -477,12 +477,12 @@ class TestMirrorInvolution:
         result_joint = builder.joints[0]
 
         for i in range(3):
-            assert abs(result_joint.origin.xyz[i] - joint_origin[i]) < 1e-10, (
-                f"joint origin[{i}] mismatch after double mirror({axis})"
-            )
-            assert abs(result_joint.axis[i] - joint_axis[i]) < 1e-10, (
-                f"joint axis[{i}] mismatch after double mirror({axis})"
-            )
+            assert (
+                abs(result_joint.origin.xyz[i] - joint_origin[i]) < 1e-10
+            ), f"joint origin[{i}] mismatch after double mirror({axis})"
+            assert (
+                abs(result_joint.axis[i] - joint_axis[i]) < 1e-10
+            ), f"joint axis[{i}] mismatch after double mirror({axis})"
 
     @given(axis=mirror_axis_strategy)
     @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])


### PR DESCRIPTION
## Summary

Addresses the tractable items from #2718 (build/deploy hardening):

- **Dockerfile**: pin both `builder` and `runtime` stages to `continuumio/miniconda3:24.11.1-0@sha256:bf95f579...` (linux/amd64). Adds inline rotation instructions.
- **Cargo.toml**: correct misleading comment — CI override uses a symlink via `scripts/setup_tools_workspace.sh`, not `.cargo/config.toml`. Documents local dev requirement (sibling `Tools` checkout).
- **docker-compose.yml**: mark file as `LOCAL DEVELOPMENT ONLY`; change `API_HOST` from `0.0.0.0` → `127.0.0.1` (loopback); fix frontend service to use named `node_modules` volume so `npm ci` only runs on first start (not every container restart).
- **docker-security-scan.yml**: add image smoke test step that verifies `/health` responds within 30 s after the Trivy scan.
- **build_hooks.py**: replace one-liner module docstring with full description of the UI bundle process and failure modes.
- **install.sh**: add threat model documentation explaining hash verification, pipx isolation scope, and manual verification steps.
- **.pre-commit-config.yaml**: change `default_language_version` from `python3.11` → `python3` so the pre-push mypy hook works on machines without a 3.11 interpreter.

## Test plan

- [x] `ruff check` passes on all changed Python files
- [x] `ruff format --check` passes on all changed Python files
- [x] 474 unit tests pass locally (pre-existing pinocchio errors unrelated)
- [x] All pre-push hooks pass (ruff, mypy skipped on non-Python files, bandit, pytest)
- [ ] Docker build with digest pin verified in CI (requires Docker runner)
- [ ] Compose loopback bind verified by running `docker-compose up` locally

Closes #2718

🤖 Generated with [Claude Code](https://claude.com/claude-code)