### PR TITLE
fix: add runtime lock deps for issue 2808

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,9 @@ RUN conda install -y -c conda-forge \
     python=3.12 \
     numpy \
     scipy \
-    matplotlib \
-    pandas \
-    sympy \
     pyqt6 \
     opencv \
     pyyaml \
-    defusedxml \
     h5py \
     scikit-learn \
     pillow \

--- a/requirements.lock
+++ b/requirements.lock
@@ -19,6 +19,8 @@ certifi==2026.1.4
     # via
     #   httpcore
     #   httpx
+defusedxml==0.7.1
+    # via issue #2808 runtime lock
 click==8.3.1
     # via uvicorn
 etils[epath,epy]==1.13.0
@@ -49,11 +51,15 @@ importlib-resources==6.5.2
     # via etils
 mujoco==3.4.0
     # via upstream-drift (pyproject.toml)
+matplotlib==3.10.8
+    # via issue #2808 runtime lock
 numpy==1.26.4
     # via
     #   mujoco
     #   scipy
     #   upstream-drift (pyproject.toml)
+pandas==3.0.2
+    # via issue #2808 runtime lock
 pydantic==2.12.5
     # via
     #   fastapi
@@ -70,6 +76,8 @@ scipy==1.13.1
     # via upstream-drift (pyproject.toml)
 simpleeval==1.0.3
     # via upstream-drift (pyproject.toml)
+sympy==1.14.0
+    # via issue #2808 runtime lock
 starlette==0.50.0
     # via fastapi
 typing-extensions==4.15.0


### PR DESCRIPTION
Closes #2808

## Summary
- Add pandas, matplotlib, sympy, and defusedxml to `requirements.lock`
- Remove the duplicate conda installs for those packages from `Dockerfile`

## Validation
- `uv pip install --python /tmp/upstreamdrift-verify-venv/bin/python --dry-run -r requirements.lock`
- `git diff --check`
- Targeted grep verification for the four lockfile entries and the Dockerfile removals