### PR TITLE
fix(ci): quote PR comment transport

### DIFF
--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
           ARCHIVE_ONLY: ${{ inputs.archive_only || 'false' }}
-          TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
+          TARGET_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
         run: |
           # Write Python script to temp file to avoid YAML heredoc issues
           cat > /tmp/process_comments.py << 'SCRIPT_EOF'
@@ -337,7 +337,7 @@ jobs:
       - name: Commit Archive
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-          TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
+          TARGET_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -102,37 +102,26 @@ jobs:
       - name: Analyze Comment
         id: analyze
         if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
+        env:
+          COMMENT_BODY_JSON: ${{ toJson(github.event.comment.body) }}
         run: |
-          # Get comment body
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            COMMENT_BODY="${{ github.event.comment.body }}"
-            COMMENT_PATH="${{ github.event.comment.path }}"
-            COMMENT_LINE="${{ github.event.comment.line }}"
-            COMMENT_TYPE="review"
-          else
-            COMMENT_BODY="${{ github.event.comment.body }}"
-            COMMENT_PATH=""
-            COMMENT_LINE=""
-            COMMENT_TYPE="pr"
-          fi
-
           # Check if comment is actionable (contains request-like words)
-          BODY_LOWER=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')
+          BODY_LOWER=$(printf '%s' "$COMMENT_BODY_JSON" | tr '[:upper:]' '[:lower:]')
 
           IS_ACTIONABLE=false
           for word in "please" "should" "could you" "can you" "fix" "change" "update" "add" "remove" "consider" "suggest" "recommend"; do
-            if echo "$BODY_LOWER" | grep -q "$word"; then
+            if printf '%s' "$BODY_LOWER" | grep -q "$word"; then
               IS_ACTIONABLE=true
               break
             fi
           done
 
           # Also check for question marks (requests for clarification/changes)
-          if echo "$COMMENT_BODY" | grep -q "?"; then
+          if printf '%s' "$COMMENT_BODY_JSON" | grep -q "?"; then
             IS_ACTIONABLE=true
           fi
 
-          echo "is_actionable=$IS_ACTIONABLE" >> $GITHUB_OUTPUT
+          echo "is_actionable=$IS_ACTIONABLE" >> "$GITHUB_OUTPUT"
 
           if [ "$IS_ACTIONABLE" = "false" ]; then
             echo "::notice::Comment does not appear actionable, skipping"
@@ -145,6 +134,7 @@ jobs:
           steps.analyze.outputs.is_actionable == 'true'
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
+          COMMENT_BODY_JSON: ${{ toJson(github.event.comment.body) }}
         run: |
           mkdir -p .jules/pending
           QUEUE_FILE=".jules/pending/pr_comments.json"
@@ -160,14 +150,12 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             COMMENT_ID="${{ github.event.comment.id }}"
-            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
             COMMENT_PATH="${{ github.event.comment.path }}"
             COMMENT_LINE="${{ github.event.comment.line }}"
             COMMENT_TYPE="review"
             COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
           else
             COMMENT_ID="${{ github.event.comment.id }}"
-            COMMENT_BODY=$(echo '${{ toJson(github.event.comment.body) }}')
             COMMENT_PATH=""
             COMMENT_LINE=""
             COMMENT_TYPE="pr"
@@ -180,6 +168,7 @@ jobs:
           import os
 
           queue_file = "$QUEUE_FILE"
+          comment_body = json.loads(os.environ["COMMENT_BODY_JSON"])
 
           # Load existing queue
           try:
@@ -201,7 +190,7 @@ jobs:
                   "pr_number": int("$PR_NUMBER"),
                   "type": "$COMMENT_TYPE",
                   "author": "$COMMENT_AUTHOR",
-                  "body": $COMMENT_BODY,
+                  "body": comment_body,
                   "path": "$COMMENT_PATH" if "$COMMENT_PATH" else None,
                   "line": int("$COMMENT_LINE") if "$COMMENT_LINE" else None,
                   "queued_at": "$TIMESTAMP",


### PR DESCRIPTION
## Summary
- pass PR review comment bodies through JSON environment variables before shell processing
- decode the JSON body in Python when writing the pending comment queue
- avoid embedding raw review comment text in bash assignments, so backticked identifiers like `noise_density` are not executed
- push review-comment archives to the real PR head branch instead of the synthetic `2811/merge` ref

## Validation
- python3 YAML parse for PR-Comment-Responder and Comment-to-Issue-Converter
- actionlint on both touched workflows with existing custom-runner/legacy shellcheck findings ignored
- local shell simulation with backticks, apostrophe, and $(...) in the comment body
- Python JSON queue round-trip for the same sample body