### PR TITLE
fix: use math.hypot for Euclidean distance in video analyzer (#2790)

### DIFF
--- a/src/tools/video_analyzer/analyzer.py
+++ b/src/tools/video_analyzer/analyzer.py
@@ -267,8 +267,8 @@ class SwingAnalyzer:
         bc = (c.x - b.x, c.y - b.y, c.z - b.z)
 
         dot = ba[0] * bc[0] + ba[1] * bc[1] + ba[2] * bc[2]
-        mag_ba = math.sqrt(ba[0] ** 2 + ba[1] ** 2 + ba[2] ** 2)
-        mag_bc = math.sqrt(bc[0] ** 2 + bc[1] ** 2 + bc[2] ** 2)
+        mag_ba = math.hypot(ba[0], ba[1], ba[2])
+        mag_bc = math.hypot(bc[0], bc[1], bc[2])
 
         if mag_ba == 0 or mag_bc == 0:
             return 0
@@ -588,9 +588,7 @@ class SwingAnalyzer:
             max_movement: float = 0.0
             for pose in poses:
                 nose = pose.landmarks[self.NOSE]
-                dist = math.sqrt(
-                    (nose.x - address_nose.x) ** 2 + (nose.y - address_nose.y) ** 2
-                )
+                dist = math.hypot(nose.x - address_nose.x, nose.y - address_nose.y)
                 max_movement = max(max_movement, dist)
             head_stability = max(0.0, 100.0 - max_movement * 500)
 


### PR DESCRIPTION
Closes #2790

## Summary
- Replace `math.sqrt(x**2 + y**2 + z**2)` with `math.hypot(x, y, z)` in `SwingAnalyzer._calculate_angle()` (two 3D vector magnitudes)
- Replace `math.sqrt(dx**2 + dy**2)` with `math.hypot(dx, dy)` in the head stability calculation
- `math.hypot` avoids intermediate overflow for large values and is more readable

## Test plan
- [ ] Ruff lint and format checks pass
- [ ] Existing video analyzer tests pass (no behavioral change — equivalent math)
- [ ] File size budget check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)