### PR TITLE
fix: harden logo file endpoint against path-traversal attacks (#2805)

### DIFF
--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -165,22 +165,55 @@ def _load_launcher_manifest() -> dict[str, Any]:
         return {"version": "1.0.0", "tiles": []}
 
 
+def _is_safe_path(candidate: Path, allowed_root: Path) -> bool:
+    """Return True if *candidate* resolves within *allowed_root*.
+
+    Rejects path-traversal attempts (``..``), absolute path injections,
+    URL-encoded separators, and symlink escapes by comparing resolved paths.
+
+    Args:
+        candidate: The path to validate.
+        allowed_root: The directory the candidate must reside inside.
+
+    Returns:
+        True when *candidate* is strictly inside *allowed_root*, False otherwise.
+    """
+    try:
+        resolved = candidate.resolve()
+        allowed_resolved = allowed_root.resolve()
+        resolved.relative_to(allowed_resolved)
+    except (ValueError, OSError):
+        return False
+    return True
+
+
 def _find_logo_file(logo_name: str) -> Path | None:
     """Search for a logo file in known asset directories.
 
+    Validates *logo_name* against each allowed root to prevent path-traversal
+    attacks before checking whether the file exists.
+
     Args:
-        logo_name: Filename of the logo to find.
+        logo_name: Filename of the logo to find (must not escape its directory).
 
     Returns:
-        Path to the logo file, or None if not found.
+        Path to the logo file, or None if not found or traversal detected.
     """
     logos_dir = Path(__file__).parent.parent.parent / "assets" / "logos"
     logo_path = logos_dir / logo_name
-    if logo_path.exists() and logo_path.is_file():
+    if (
+        _is_safe_path(logo_path, logos_dir)
+        and logo_path.exists()
+        and logo_path.is_file()
+    ):
         return logo_path
     launcher_logos = Path(__file__).parent.parent / "launchers" / "assets"
     alt_path = launcher_logos / logo_name
-    if alt_path.exists() and alt_path.is_file():
+    if (
+        _is_safe_path(alt_path, launcher_logos)
+        and alt_path.exists()
+        and alt_path.is_file()
+    ):
         return alt_path
     return None
 

--- a/tests/unit/test_local_server_ui_warning.py
+++ b/tests/unit/test_local_server_ui_warning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -112,3 +113,50 @@ def test_local_app_description_mentions_versioning(monkeypatch, tmp_path) -> Non
     app = local_server.create_local_app()
     assert "v1" in app.description
     assert "/api/v1/" in app.description
+
+
+# ── Path-traversal hardening tests (#2805) ───────────────────────────────────
+
+
+class TestIsSafePath:
+    """Verify _is_safe_path blocks traversal and allows safe paths."""
+
+    def test_allows_file_inside_root(self, tmp_path: Path) -> None:
+        """A regular file inside the allowed root is accepted."""
+        logo = tmp_path / "logo.png"
+        logo.touch()
+        assert local_server._is_safe_path(logo, tmp_path)
+
+    def test_allows_nested_file_inside_root(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        nested = sub / "icon.svg"
+        nested.touch()
+        assert local_server._is_safe_path(nested, tmp_path)
+
+    def test_rejects_dotdot_traversal(self, tmp_path: Path) -> None:
+        """Path with '..' that escapes the allowed root is rejected."""
+        outside = tmp_path / ".." / "escape.txt"
+        assert not local_server._is_safe_path(outside, tmp_path)
+
+    def test_rejects_absolute_path_outside_root(self, tmp_path: Path) -> None:
+        """An absolute path outside the allowed root is rejected."""
+        import tempfile
+        from pathlib import Path as PathClass
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            outside = PathClass(f.name)
+        assert not local_server._is_safe_path(outside, tmp_path)
+
+
+class TestFindLogoFile:
+    """_find_logo_file must reject traversal attempts without errors."""
+
+    def test_traversal_name_returns_none(self, tmp_path: Path) -> None:
+        """A traversal-style logo name must return None, not serve a file."""
+        result = local_server._find_logo_file("../../etc/passwd")
+        assert result is None
+
+    def test_nonexistent_logo_returns_none(self) -> None:
+        result = local_server._find_logo_file("does_not_exist_xyz.png")
+        assert result is None


### PR DESCRIPTION
Closes #2805

## Summary
- Add `_is_safe_path(candidate, allowed_root)` helper that uses `Path.resolve()` + `relative_to()` to reject traversal, absolute-path injection, and symlink escapes
- Update `_find_logo_file` to call `_is_safe_path` before checking file existence for both asset directories
- Add `TestIsSafePath` (4 cases) and `TestFindLogoFile` (2 cases) unit tests

## Problem
`GET /api/launcher/logos/{logo_name:path}` passed the user-supplied `logo_name` directly to `Path / logo_name` without validation. An attacker could request `../../etc/passwd` or any absolute path on the local filesystem.

## Solution
`_is_safe_path` resolves both the candidate and the allowed root, then calls `.relative_to()`. If the candidate escapes the root (raising `ValueError`) or if any OS error occurs, it returns `False`. The existing file-existence check is gated behind this validation.

## Test plan
- [ ] `python3 -m pytest tests/unit/test_local_server_ui_warning.py -v` — 11 tests pass (6 new)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `_find_logo_file("../../etc/passwd")` returns `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)