### PR TITLE
chore: remove black formatter config and scripts references (#2717)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ dev = [
     "alembic>=1.13.0",
     # Security: requests>=2.33.0 fixes CVE-2024-47081 and CVE-2026-25645
     "requests>=2.33.0",
-    # Security: black>=26.3.1 fixes CVE-2026-32274
-    "black>=26.3.1",
     # Security: bokeh>=3.8.2 fixes CVE-2026-21883
     "bokeh>=3.8.2",
     # Security: flask>=3.1.3 fixes CVE-2026-27205
@@ -175,7 +173,7 @@ select = [
     "RET",   # return statement cleanup
 ]
 ignore = [
-    "E501",    # line too long (handled by black)
+    "E501",    # line too long (handled by ruff format)
     "B008",    # function call in default arg (FastAPI Depends)
     "RET504",  # unnecessary assign before return (often clearer)
     "PERF203", # try-except in loop (unavoidable in some patterns)
@@ -186,19 +184,6 @@ ignore = [
 "scripts/**" = ["T201"]
 "tests/**" = ["T201"]
 "examples/**" = ["T201"]
-
-[tool.black]
-line-length = 88
-target-version = ["py310"]
-# Exclude third-party model files (legacy Python 2 scripts from OpenSim)
-exclude = '''
-/(
-    src/shared/models/opensim/opensim-models
-  | shared/models/opensim/opensim-models
-  | shared/models/myosuite
-  | vendor/ud-tools
-)/
-'''
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/assess_repository.py
+++ b/scripts/assess_repository.py
@@ -258,7 +258,7 @@ def assess_I():
         findings.append("No explicit Ruff config in pyproject.toml.")
         score -= 1
 
-    recs = ["Enforce linting in CI.", "Use black for formatting."]
+    recs = ["Enforce linting in CI.", "Use ruff format for formatting."]
     return generate_markdown_report(
         "I", CATEGORIES["I"], score, "\n".join(findings), recs, DOCS_DIR
     )

--- a/scripts/run_assessment.py
+++ b/scripts/run_assessment.py
@@ -48,13 +48,13 @@ def _assess_architecture(py_files: list) -> tuple[list[str], int]:
 def _assess_hygiene() -> tuple[list[str], int]:
     """Run hygiene & quality assessment (B)."""
     ruff = run_tool_check(["ruff", "check", ".", "--statistics"])
-    black = run_tool_check(["black", "--check", "--quiet", "."])
+    ruff_fmt = run_tool_check(["ruff", "format", "--check", "."])
     findings = [
         f"- Ruff check: {_CHECK + ' passed' if ruff['exit_code'] == 0 else _CROSS + ' issues found'}",
-        f"- Black formatting: {_CHECK + ' formatted' if black['exit_code'] == 0 else _CROSS + ' needs formatting'}",
+        f"- Ruff format: {_CHECK + ' formatted' if ruff_fmt['exit_code'] == 0 else _CROSS + ' needs formatting'}",
     ]
     penalty = (0 if ruff["exit_code"] == 0 else 2) + (
-        0 if black["exit_code"] == 0 else 1
+        0 if ruff_fmt["exit_code"] == 0 else 1
     )
     return findings, 10 - penalty
 

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -93,7 +93,6 @@ def install_dev_dependencies() -> None:
     logger.info("\n[4/4] Installing hook dependencies...")
     deps = [
         "ruff>=0.14.0",
-        "black>=26.0.0",
         "mypy>=1.13.0",
         "bandit>=1.7.0",
         "types-requests",
@@ -133,7 +132,7 @@ def log_summary() -> None:
     logger.info("""
 PRE-COMMIT (runs on every commit, <15 seconds):
   - ruff (lint + auto-fix)
-  - black (format)
+  - ruff format
   - no-wildcard-imports
   - quality-check (no TODOs/FIXMEs)
   - no-debug-statements

--- a/scripts/validate_phase1_upgrades.py
+++ b/scripts/validate_phase1_upgrades.py
@@ -108,7 +108,6 @@ class Phase1Validator:
             required_sections = [
                 "build-system",
                 "project",
-                "tool.black",
                 "tool.ruff",
                 "tool.mypy",
                 "tool.pytest.ini_options",
@@ -344,7 +343,6 @@ class Phase1Validator:
             content = pyproject_path.read_text()
 
             required_tools = [
-                "[tool.black]",
                 "[tool.ruff]",
                 "[tool.mypy]",
                 "[tool.pytest.ini_options]",


### PR DESCRIPTION
## Summary

Closes part of #2717 (item 1: formatter drift).

Completes the formatter consolidation deferred in wave 4 (PR #2812).
`ci-standard.yml` and `.pre-commit-config.yaml` already use `ruff format`
exclusively; this PR removes the remaining black vestiges:

- `pyproject.toml`: drop `[tool.black]` section and `black>=26.3.1` from
  the `dev` optional-dependencies; update the `E501` ignore comment to
  reference `ruff format`
- `scripts/run_assessment.py`: swap `black --check` for `ruff format --check`
- `scripts/validate_phase1_upgrades.py`: drop `tool.black` / `[tool.black]`
  from the required-sections assertions so the validator matches reality
- `scripts/setup_hooks.py`: drop `black>=26.0.0` from installed dev deps
  and remove the `- black (format)` line from the pre-commit summary log
- `scripts/assess_repository.py`: recommend ruff format, not black

Jules-* bot workflows still reference black and are intentionally left
untouched (live automation, deferred per wave 4 scope).

## Test plan

- [x] `ruff format --check` passes on modified files
- [x] `ruff check` passes on modified files
- [x] `scripts/check_formatter_guidance.py` (anti-regression guard) still exits 0
- [x] All modified Python files parse (`ast.parse`)
- [ ] CI green on PR

Fleet old-issue triage — wave 7.