### PR TITLE
fix: expand secret scan beyond src/ tree (#2764)

### DIFF
--- a/scripts/assess_repository.py
+++ b/scripts/assess_repository.py
@@ -176,22 +176,38 @@ def assess_F():
     findings = []
     score = 8.0
 
-    # Look for actual hardcoded string literal assignments in src/ only.
+    # Look for actual hardcoded string literal assignments across the repo.
     # Pattern requires a string value of 8+ chars to avoid matching docstring
     # examples, type annotations, and function parameter names.
-    # Test files are excluded because they legitimately use fake placeholder values.
+    # Test/fixture/vendored directories are excluded because they legitimately
+    # use fake placeholder values; everything else (src, scripts, tooling) is
+    # scanned so hardcoded credentials outside src/ are not silently ignored.
+    secret_scan_excludes = (
+        "tests",
+        "test",
+        "fixtures",
+        "vendor",
+        "vendored",
+        "third_party",
+        "node_modules",
+        ".venv",
+        "venv",
+    )
     hardcoded_secrets = grep_count(
         REPO_ROOT,
         r'(?:password|secret|api_key|token)\s*=\s*["\'][^"\']{8,}["\']',
-        "src/**/*.py",
+        "**/*.py",
+        exclude_parts=secret_scan_excludes,
     )
     if hardcoded_secrets > 0:
         findings.append(
-            f"Potential hardcoded secrets found in {hardcoded_secrets} src files (needs verification)."
+            f"Potential hardcoded secrets found in {hardcoded_secrets} files (needs verification)."
         )
         score -= 1
     else:
-        findings.append("No obvious hardcoded secrets patterns found in src/ files.")
+        findings.append(
+            "No obvious hardcoded secret patterns found outside of test fixtures."
+        )
 
     recs = [
         "Run bandit security analysis regularly.",

--- a/src/shared/python/assessment/analysis.py
+++ b/src/shared/python/assessment/analysis.py
@@ -111,20 +111,44 @@ def count_files(root: Path, pattern: str) -> int:
     return len(list(root.glob(pattern)))
 
 
-def grep_count(root: Path, pattern: str, file_pattern: str = "**/*.py") -> int:
-    """Count files where a regex pattern is found."""
+def grep_count(
+    root: Path,
+    pattern: str,
+    file_pattern: str = "**/*.py",
+    exclude_parts: tuple[str, ...] = (),
+) -> int:
+    """Count files where a regex pattern is found.
+
+    Args:
+        root: Directory to search from.
+        pattern: Regex pattern to match in file contents.
+        file_pattern: Glob pattern for files to consider.
+        exclude_parts: Path components that disqualify a file when any match a
+            segment of its path relative to ``root`` (e.g. ``("tests",)`` skips
+            anything under a ``tests`` directory). Comparison is done per path
+            segment so ``"test"`` will not match ``"pytest"``.
+    """
     if root is None:
         raise ValueError("root must be provided")
     count = 0
     regex = re.compile(pattern)
+    excluded = {part for part in exclude_parts if part}
     for p in root.glob(file_pattern):
-        if p.is_file():
+        if not p.is_file():
+            continue
+        if excluded:
             try:
-                with p.open(encoding="utf-8", errors="ignore") as f:
-                    if regex.search(f.read()):
-                        count += 1
-            except (FileNotFoundError, PermissionError, OSError) as e:
-                logger.debug("Failed to read %s: %s", p, e)
+                rel_parts = p.relative_to(root).parts
+            except ValueError:
+                rel_parts = p.parts
+            if any(part in excluded for part in rel_parts):
+                continue
+        try:
+            with p.open(encoding="utf-8", errors="ignore") as f:
+                if regex.search(f.read()):
+                    count += 1
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            logger.debug("Failed to read %s: %s", p, e)
     return count
 
 

--- a/tests/unit/shared_python/test_assessment_analysis.py
+++ b/tests/unit/shared_python/test_assessment_analysis.py
@@ -244,6 +244,45 @@ class TestGrepCount:
         with pytest.raises(ValueError):
             grep_count(None, "x")  # type: ignore[arg-type]
 
+    def test_exclude_parts_skips_matching_directories(self, tmp_path: Path) -> None:
+        """Files whose relative path contains an excluded segment are skipped."""
+        src_dir = tmp_path / "src"
+        tests_dir = tmp_path / "tests"
+        src_dir.mkdir()
+        tests_dir.mkdir()
+        (src_dir / "real.py").write_text('password = "supersecretvalue"\n')
+        (tests_dir / "fake.py").write_text('password = "supersecretvalue"\n')
+
+        n_all = grep_count(
+            tmp_path,
+            r'password\s*=\s*"[^"]{8,}"',
+            "**/*.py",
+        )
+        assert n_all == 2
+
+        n_excluding_tests = grep_count(
+            tmp_path,
+            r'password\s*=\s*"[^"]{8,}"',
+            "**/*.py",
+            exclude_parts=("tests",),
+        )
+        assert n_excluding_tests == 1
+
+    def test_exclude_parts_matches_per_segment(self, tmp_path: Path) -> None:
+        """Excluded names match whole path segments, not substrings."""
+        pytest_dir = tmp_path / "pytest_plugin"
+        pytest_dir.mkdir()
+        (pytest_dir / "mod.py").write_text('token = "abcdefghij"\n')
+
+        # "test" must not match "pytest_plugin" (substring safety).
+        n = grep_count(
+            tmp_path,
+            r'token\s*=\s*"[^"]{8,}"',
+            "**/*.py",
+            exclude_parts=("test",),
+        )
+        assert n == 1
+
 
 # ---------------------------------------------------------------------------
 # classify_assessment_category


### PR DESCRIPTION
## Summary

Closes #2764.

`assess_F()` previously limited its hardcoded-secret regex to `src/**/*.py`, so credentials in `scripts/`, tooling, or any other top-level Python file were silently ignored by the repository security assessment. This PR expands the scan across the whole repo while keeping test/fixture exclusions.

## Changes

- `grep_count` gains an `exclude_parts` kwarg that skips any file whose relative path contains one of the given whole segments (so `test` does not match `pytest_plugin`).
- `assess_F()` now scans `**/*.py` repo-wide, excluding `tests`, `test`, `fixtures`, `vendor`, `vendored`, `third_party`, `node_modules`, `.venv`, `venv`.
- New regression tests cover both the expanded inclusion and the substring-safety of the exclusion logic.

## Test plan

- [x] `pytest tests/unit/shared_python/test_assessment_analysis.py`
- [x] `pytest tests/unit/test_assessment_scripts.py`
- [x] `ruff check` clean
- [x] `ruff format --check` clean

spec-exempt: small bug fix with unit-test regression coverage; no spec changes required.

Wave 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)