### PR TITLE
fix: use effective step size when clamping FD states (#2766)

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces/analyzer.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces/analyzer.py
@@ -256,7 +256,8 @@ class KinematicForceAnalyzer:
         club_pos = self._perturb_data.xpos[self.club_head_id].copy()
         epsilon = EPSILON_FINITE_DIFF_JACOBIAN
 
-        self._perturb_data.qpos[:] = self._clamp_to_joint_limits(qpos + epsilon * qvel)
+        qpos_forward = self._clamp_to_joint_limits(qpos + epsilon * qvel)
+        self._perturb_data.qpos[:] = qpos_forward
         self._perturb_data.qvel[:] = qvel
         mujoco.mj_forward(self.model, self._perturb_data)
         jacp_forward, _ = self._compute_jacobian(
@@ -264,14 +265,33 @@ class KinematicForceAnalyzer:
         )
         jacp_forward = jacp_forward.copy()
 
-        self._perturb_data.qpos[:] = self._clamp_to_joint_limits(qpos - epsilon * qvel)
+        qpos_backward = self._clamp_to_joint_limits(qpos - epsilon * qvel)
+        self._perturb_data.qpos[:] = qpos_backward
         self._perturb_data.qvel[:] = qvel
         mujoco.mj_forward(self.model, self._perturb_data)
         jacp_backward, _ = self._compute_jacobian(
             self.club_head_id, data=self._perturb_data
         )
 
-        jacp_dot = (jacp_forward - jacp_backward) / (2.0 * epsilon)
+        # Use the effective post-clamp step along the qvel direction rather than
+        # the nominal 2 * epsilon denominator. Clamping can make one-sided
+        # (or zero-sided) perturbations at joint limits; dividing by the fixed
+        # nominal step then systematically underestimates jacp_dot. Projecting
+        # the actual displacement (qpos_forward - qpos_backward) onto qvel and
+        # dividing by ||qvel||^2 recovers the scalar step along qvel. Falls back
+        # to the nominal denominator when qvel is (near-)zero or the effective
+        # step collapses to zero (both sides clamped to the same limit).
+        qvel_norm_sq = float(np.dot(qvel, qvel))
+        if qvel_norm_sq > EPSILON_SINGULARITY_DETECTION:
+            effective_step = float(
+                np.dot(qpos_forward - qpos_backward, qvel) / qvel_norm_sq
+            )
+            if abs(effective_step) < EPSILON_SINGULARITY_DETECTION:
+                effective_step = 2.0 * epsilon
+        else:
+            effective_step = 2.0 * epsilon
+
+        jacp_dot = (jacp_forward - jacp_backward) / effective_step
         coriolis_accel = jacp_dot @ qvel
 
         club_head_mass = self.model.body_mass[self.club_head_id]

--- a/tests/unit/engines/mujoco/test_kinematic_forces.py
+++ b/tests/unit/engines/mujoco/test_kinematic_forces.py
@@ -242,6 +242,96 @@ class TestKinematicForceAnalyzer:
         for q_sample in observed_qpos:
             assert q_min - 1e-12 <= q_sample[0] <= q_max + 1e-12
 
+    def test_apparent_forces_use_effective_step_when_clamped(
+        self,
+        monkeypatch,
+    ) -> None:
+        """Clamped finite differences must divide by the actual post-clamp step.
+
+        Regression for issue #2766: at a joint limit with outward velocity,
+        clamping produces an asymmetric perturbation (one side pinned to the
+        boundary, the other free). Dividing the Jacobian difference by the
+        nominal 2 * epsilon denominator then systematically underestimates
+        jacp_dot. The fix uses the effective displacement projected onto qvel.
+        """
+        model = create_limited_club_model()
+        # Start at the positive joint limit so forward perturbation clips.
+        qpos_start = np.array([0.1, 0.0, 0.0])
+        data = SimpleNamespace(
+            qpos=qpos_start.copy(),
+            qvel=np.zeros(model.nv),
+            qacc=np.zeros(model.nv),
+            xpos=np.zeros((model.nbody, 3)),
+            ctrl=np.zeros(model.nu),
+            time=0.0,
+        )
+
+        monkeypatch.setattr(
+            mujoco,
+            "MjData",
+            lambda _model: SimpleNamespace(
+                qpos=np.zeros(_model.nq),
+                qvel=np.zeros(_model.nv),
+                qacc=np.zeros(_model.nv),
+                xpos=np.zeros((_model.nbody, 3)),
+                ctrl=np.zeros(_model.nu),
+                time=0.0,
+            ),
+        )
+        monkeypatch.setattr(
+            mujoco,
+            "mj_id2name",
+            lambda _model, _obj, body_id: "club_head" if body_id == 1 else "world",
+        )
+        monkeypatch.setattr(mujoco, "mj_forward", lambda _model, _data: None)
+        analyzer = KinematicForceAnalyzer(model, data)
+
+        # Outward velocity on the first joint means `qpos + epsilon * qvel` is
+        # clamped to the boundary while `qpos - epsilon * qvel` is not.
+        qvel = np.array([1.0, 0.0, 0.0])
+        qacc = np.zeros(model.nv)
+
+        call_count = {"n": 0}
+
+        def fake_compute_jacobian(body_id: int, data=None):
+            """Return a Jacobian that depends linearly on qpos[0].
+
+            With jacp[0,0] = qpos[0], the true dJ/dqpos[0] is 1.0, so
+            jacp_dot @ qvel along qvel = [1, 0, 0] should equal [1, 0, 0].
+            A bug using 2 * epsilon when forward-clamp is active would report
+            a smaller value proportional to the asymmetry.
+            """
+            assert data is not None
+            call_count["n"] += 1
+            jacp = np.zeros((3, model.nv))
+            jacp[0, 0] = float(data.qpos[0])
+            return jacp, np.zeros((3, model.nv))
+
+        monkeypatch.setattr(analyzer, "_compute_jacobian", fake_compute_jacobian)
+        monkeypatch.setattr(
+            analyzer,
+            "compute_coriolis_forces",
+            lambda _qpos, _qvel: np.zeros(model.nv),
+        )
+
+        coriolis, _, _ = analyzer.compute_club_head_apparent_forces(
+            qpos_start.copy(),
+            qvel,
+            qacc,
+        )
+
+        # With true dJ/dqpos[0] = 1 and qvel[0] = 1, coriolis_accel = [1, 0, 0]
+        # and coriolis_force = -club_head_mass * coriolis_accel = [-1, 0, 0].
+        # The buggy 2*epsilon denominator would give a magnitude strictly less
+        # than 1 because the forward perturbation is clipped to the limit.
+        assert call_count["n"] >= 3
+        assert np.isclose(coriolis[0], -1.0, atol=1e-6), (
+            f"expected coriolis force magnitude ~1.0 with effective-step "
+            f"correction, got {coriolis[0]}"
+        )
+        assert np.isclose(coriolis[1], 0.0, atol=1e-9)
+        assert np.isclose(coriolis[2], 0.0, atol=1e-9)
+
     def test_analyze_trajectory(self, model_and_data) -> None:
         """Test analyzing trajectory."""
         model, data = model_and_data


### PR DESCRIPTION
## Summary

Closes #2766.

In `compute_club_head_apparent_forces`, the central-difference `jacp_dot` clamps the perturbed `qpos` to joint limits but still divides by the nominal `2 * epsilon`. Near a joint limit with outward velocity the forward perturbation is pinned to the boundary while the backward side is free, so the Jacobian difference no longer represents a symmetric `2 * epsilon` step and `jacp_dot` (and therefore the coriolis force) is systematically underestimated.

Project the actual post-clamp displacement `(qpos_forward - qpos_backward)` onto the `qvel` direction to recover the true scalar step, and use that as the denominator. Falls back to `2 * epsilon` when `qvel` is (near-)zero or when both sides clamp to the same limit.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] New regression test `test_apparent_forces_use_effective_step_when_clamped` passes; mocks the Jacobian with a known linear dependence on `qpos[0]` and starts at the joint limit with outward velocity so the fix is required to recover the analytic coriolis force
- [x] Existing `test_compute_club_head_apparent_forces_clamps_joint_limits` still passes

Wave 22. spec-exempt.

---

Source comment: https://github.com/D-sorganization/UpstreamDrift/pull/2760#discussion_r3104498582

🤖 Generated with [Claude Code](https://claude.com/claude-code)