### PR TITLE
fix(compose): skip npm install when package-lock unchanged (#2765)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,11 @@ services:
 
   # Frontend UI (optional — can also run locally outside Docker).
   # node_modules are cached in a named volume so `npm install` does not re-run
-  # on every `docker compose up`, while `npm ci` bootstraps fresh volumes and
-  # refreshes dependencies after package-lock.json changes.
+  # on every `docker compose up`. `npm ci` runs only when the volume is empty
+  # (first boot / after `docker compose down -v`) or when package-lock.json is
+  # newer than the cached lockfile snapshot (`node_modules/.package-lock.json`),
+  # which npm writes after every successful install. This preserves cache hits
+  # across restarts and keeps startup fast and offline-capable once populated.
   frontend:
     image: node:20-alpine
     container_name: upstream-drift-frontend
@@ -55,7 +58,15 @@ services:
       # Named volume so npm install is not repeated on every start.
       - frontend_node_modules:/app/node_modules
     working_dir: /app
-    command: sh -c "npm ci && npm run dev -- --host 0.0.0.0"
+    command: >-
+      sh -c "if [ ! -f node_modules/.package-lock.json ] ||
+               [ package-lock.json -nt node_modules/.package-lock.json ]; then
+               echo '[frontend] installing dependencies (first boot or lockfile changed)';
+               npm ci;
+             else
+               echo '[frontend] node_modules cache is up-to-date, skipping npm ci';
+             fi &&
+             npm run dev -- --host 0.0.0.0"
     environment:
       - VITE_API_URL=http://backend:8001
     depends_on:


### PR DESCRIPTION
Closes #2765.

## Summary
Gates `npm ci` in the frontend compose service behind a freshness check against `node_modules/.package-lock.json` (the snapshot npm writes after each successful install). When the cached `frontend_node_modules` named volume is already populated and the lockfile has not changed, startup skips `npm ci` entirely and boots Vite directly. Only first boot (empty volume) or a newer `package-lock.json` triggers a reinstall, so genuine dependency updates still take effect while routine `docker compose up` is fast and offline-capable.

Fleet old-issue triage — wave 25. spec-exempt.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"` passes.
- [ ] Manual: `docker compose up frontend` on a populated volume skips `npm ci` and boots Vite immediately.
- [ ] Manual: `docker compose down -v && docker compose up frontend` reinstalls deps on first boot.
- [ ] Manual: touching `ui/package-lock.json` forces a reinstall on next `up`.