### PR TITLE
fix(api): filter non-level metadata from engine capabilities (#2797)

### DIFF
--- a/src/api/routes/engines.py
+++ b/src/api/routes/engines.py
@@ -28,6 +28,20 @@ from ..models.responses import (
 )
 from ..utils.path_validation import validate_model_path
 
+# Capability levels that may appear in a CapabilityLevelResponse.
+# See src/shared/python/engine_core/capabilities.py::CapabilityLevel.
+_VALID_CAPABILITY_LEVELS: frozenset[str] = frozenset({"full", "partial", "none"})
+
+# Keys emitted by EngineCapabilities.to_dict() that are metadata and must NOT
+# be surfaced as CapabilityLevelResponse entries. Their values do not follow
+# the capability-level schema (full/partial/none). See issue #2797, #2743.
+_NON_LEVEL_METADATA_KEYS: frozenset[str] = frozenset(
+    {
+        "engine_name",
+        "spatial_jacobian_order",
+    }
+)
+
 
 def _sanitize_for_json(obj: Any) -> Any:
     """Recursively convert numpy arrays and other non-JSON types to native Python."""
@@ -279,11 +293,13 @@ async def get_engine_capabilities(
     capability_list = []
     summary = {"full": 0, "partial": 0, "none": 0}
 
-    valid_levels = {"full", "partial", "none"}
     for key, level in caps_dict.items():
-        if key in ("engine_name", "spatial_jacobian_order"):
+        if key in _NON_LEVEL_METADATA_KEYS:
             continue
-        if level not in valid_levels:
+        # Defensive: skip any value that is not a recognized level. This
+        # filters out future metadata keys that might be added to
+        # EngineCapabilities.to_dict() without an explicit allow-list update.
+        if not isinstance(level, str) or level not in _VALID_CAPABILITY_LEVELS:
             continue
         supported = level != "none"
         capability_list.append(

--- a/tests/api/test_physics_api.py
+++ b/tests/api/test_physics_api.py
@@ -422,6 +422,25 @@ class TestEngineCapabilitiesAPI:
                 assert "supported" in cap
                 assert cap["level"] in ("full", "partial", "none")
 
+    def test_capabilities_exclude_non_level_metadata(self, client) -> None:
+        """Metadata keys like ``spatial_jacobian_order`` must not appear as
+        capability-level entries.
+
+        Regression test for issue #2743 / #2797: ``EngineCapabilities.to_dict``
+        emits a ``spatial_jacobian_order`` key whose value (e.g.
+        ``"angular_linear"``) does not match the capability-level schema. It
+        must be filtered out before being surfaced via the capabilities API.
+        """
+        resp = client.get("/engines/pendulum/capabilities")
+        if resp.status_code != 200:
+            pytest.skip("capabilities endpoint unavailable in this environment")
+        data = resp.json()
+        names = {cap["name"] for cap in data["capabilities"]}
+        assert "spatial_jacobian_order" not in names
+        assert "engine_name" not in names
+        for cap in data["capabilities"]:
+            assert cap["level"] in ("full", "partial", "none")
+
 
 class TestActuatorEndpoints:
     """Test actuator control endpoints (require loaded engine)."""


### PR DESCRIPTION
## Summary

Focused replacement for stale PR #2756 (which touched 116 files). Fixes issue #2797 / #2743: the engine capabilities API was at risk of surfacing non-level metadata like `spatial_jacobian_order = "angular_linear"` as if it were a `CapabilityLevelResponse` entry.

## Changes

- `src/api/routes/engines.py`: promote the level/metadata filter into module-level constants `_VALID_CAPABILITY_LEVELS` and `_NON_LEVEL_METADATA_KEYS`, and harden the value check with `isinstance(level, str)` so future metadata keys cannot leak through even if the allow-list is not updated.
- `tests/api/test_physics_api.py`: add `test_capabilities_exclude_non_level_metadata` regression asserting `spatial_jacobian_order` and `engine_name` never appear as capability names, and all emitted levels are `full` / `partial` / `none`.

No workflow, agent, Docker, or unrelated hygiene changes.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] `pytest tests/api/test_physics_api.py::TestEngineCapabilitiesAPI` — 4/4 pass

Closes #2797.

spec-exempt: behavior-preserving refactor + regression test, no contract change