### PR TITLE
fix: update URDF models to anthropometry-derived inertias and add right-hand grip

### DIFF
--- a/src/engines/physics_engines/pinocchio/models/generated/golfer.urdf
+++ b/src/engines/physics_engines/pinocchio/models/generated/golfer.urdf
@@ -857,6 +857,22 @@
     <limit lower="0.0" upper="1.57" effort="1000.0" velocity="10.0"/>
     <dynamics damping="0.5"/>
   </joint>
+  <!-- right_grip_attachment: massless hook point at the top of the grip where the right
+       hand contacts the shaft (approx. 0.03 m below left-hand grip origin).
+       URDF is a tree — this link establishes the right-hand kinematic attachment point.
+       Closed-loop enforcement (right_grip_attachment ↔ club_shaft) must be applied by
+       the physics engine as a loop-closure constraint (e.g., Pinocchio RigidConstraint). -->
+  <joint name="hand_right_to_right_grip_attachment" type="fixed">
+    <parent link="hand_right"/>
+    <child link="right_grip_attachment"/>
+    <origin xyz="0.0 0.0 -0.12" rpy="0.0 0.0 0.0"/>
+  </joint>
+  <link name="right_grip_attachment">
+    <inertial>
+      <mass value="0.001"/>
+      <inertia ixx="1e-06" ixy="0.0" ixz="0.0" iyy="1e-06" iyz="0.0" izz="1e-06"/>
+    </inertial>
+  </link>
   <link name="fingers_right">
     <inertial>
       <mass value="0.2"/>

--- a/src/shared/urdf/simple_humanoid.urdf
+++ b/src/shared/urdf/simple_humanoid.urdf
@@ -1,4 +1,12 @@
 <?xml version="1.0"?>
+<!--
+  smoke_test_humanoid: Minimal 5-DOF humanoid for parser/API smoke tests ONLY.
+  NOT suitable for biomechanical simulation — no elbows, knees, wrists, or spine.
+  Mass properties derived from de Leva 1996 (Table 4, male) at 70 kg reference body mass.
+  Inertia tensors computed analytically from the link geometries below.
+  Source: de Leva P (1996). "Adjustments to Zatsiorsky-Seluyanov's segment inertia
+  parameters." J Biomech 29(9): 1223-1230.
+-->
 <robot name="simple_humanoid">
 
   <!-- Materials -->
@@ -9,7 +17,8 @@
     <color rgba="1 1 1 1"/>
   </material>
 
-  <!-- Torso -->
+  <!-- Torso: 43.46% BM = 30.42 kg (de Leva 1996 male trunk).
+       Box 0.2 x 0.4 x 0.6 m. ixx=m(y²+z²)/12, iyy=m(x²+z²)/12, izz=m(x²+y²)/12 -->
   <link name="torso">
     <visual>
       <geometry>
@@ -25,12 +34,13 @@
       <origin rpy="0 0 0" xyz="0 0 0.3"/>
     </collision>
     <inertial>
-      <mass value="10"/>
-      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
+      <mass value="30.42"/>
+      <inertia ixx="1.318" ixy="0.0" ixz="0.0" iyy="1.014" iyz="0.0" izz="0.507"/>
     </inertial>
   </link>
 
-  <!-- Head -->
+  <!-- Head: 6.94% BM = 4.86 kg (de Leva 1996 male head).
+       Sphere r=0.12 m. I = 2/5 * m * r² -->
   <link name="head">
     <visual>
       <geometry>
@@ -46,8 +56,8 @@
       <origin rpy="0 0 0" xyz="0 0 0.12"/>
     </collision>
     <inertial>
-      <mass value="2"/>
-      <inertia ixx="0.02" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.02"/>
+      <mass value="4.86"/>
+      <inertia ixx="0.028" ixy="0.0" ixz="0.0" iyy="0.028" iyz="0.0" izz="0.028"/>
     </inertial>
   </link>
 
@@ -59,7 +69,9 @@
     <limit lower="-1.57" upper="1.57" effort="10" velocity="1"/>
   </joint>
 
-  <!-- Right Arm -->
+  <!-- Right Arm: 2.80% BM = 1.96 kg (de Leva 1996 male upper arm).
+       Cylinder r=0.05 m, l=0.3 m, long axis along x (rpy="0 1.57 0").
+       ixx=0.5*m*r², iyy=izz=m(3r²+l²)/12 -->
   <link name="right_upper_arm">
     <visual>
       <geometry>
@@ -75,8 +87,8 @@
       <origin rpy="0 1.57 0" xyz="0.15 0 0"/>
     </collision>
     <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.005"/>
+      <mass value="1.96"/>
+      <inertia ixx="0.0025" ixy="0.0" ixz="0.0" iyy="0.016" iyz="0.0" izz="0.016"/>
     </inertial>
   </link>
 
@@ -88,7 +100,7 @@
     <limit lower="-3.14" upper="3.14" effort="30" velocity="1"/>
   </joint>
 
-  <!-- Left Arm -->
+  <!-- Left Arm: 2.80% BM = 1.96 kg (de Leva 1996 male upper arm). Same geometry. -->
   <link name="left_upper_arm">
     <visual>
       <geometry>
@@ -104,8 +116,8 @@
       <origin rpy="0 -1.57 0" xyz="-0.15 0 0"/>
     </collision>
     <inertial>
-      <mass value="1"/>
-      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.005"/>
+      <mass value="1.96"/>
+      <inertia ixx="0.0025" ixy="0.0" ixz="0.0" iyy="0.016" iyz="0.0" izz="0.016"/>
     </inertial>
   </link>
 
@@ -117,7 +129,9 @@
     <limit lower="-3.14" upper="3.14" effort="30" velocity="1"/>
   </joint>
 
-  <!-- Right Leg -->
+  <!-- Right Leg: 10.00% BM = 7.0 kg (de Leva 1996 male thigh).
+       Cylinder r=0.07 m, l=0.4 m, long axis along z.
+       izz=0.5*m*r², ixx=iyy=m(3r²+l²)/12 -->
   <link name="right_upper_leg">
     <visual>
       <geometry>
@@ -133,8 +147,8 @@
       <origin rpy="0 0 0" xyz="0 0 -0.2"/>
     </collision>
     <inertial>
-      <mass value="3"/>
-      <inertia ixx="0.05" ixy="0.0" ixz="0.0" iyy="0.05" iyz="0.0" izz="0.01"/>
+      <mass value="7.0"/>
+      <inertia ixx="0.102" ixy="0.0" ixz="0.0" iyy="0.102" iyz="0.0" izz="0.017"/>
     </inertial>
   </link>
 
@@ -146,7 +160,7 @@
     <limit lower="-1.57" upper="1.57" effort="50" velocity="1"/>
   </joint>
 
-  <!-- Left Leg -->
+  <!-- Left Leg: 10.00% BM = 7.0 kg (de Leva 1996 male thigh). Same geometry. -->
   <link name="left_upper_leg">
     <visual>
       <geometry>
@@ -162,8 +176,8 @@
       <origin rpy="0 0 0" xyz="0 0 -0.2"/>
     </collision>
     <inertial>
-      <mass value="3"/>
-      <inertia ixx="0.05" ixy="0.0" ixz="0.0" iyy="0.05" iyz="0.0" izz="0.01"/>
+      <mass value="7.0"/>
+      <inertia ixx="0.102" ixy="0.0" ixz="0.0" iyy="0.102" iyz="0.0" izz="0.017"/>
     </inertial>
   </link>
 

--- a/tests/test_urdf_tools.py
+++ b/tests/test_urdf_tools.py
@@ -1,10 +1,18 @@
 import os
 import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import pytest
 
 from src.shared.python.data_io.common_utils import get_shared_urdf_path
 from src.shared.python.engine_core.engine_availability import PYQT6_AVAILABLE
+
+_REPO_ROOT = Path(__file__).parent.parent
+_SIMPLE_HUMANOID = _REPO_ROOT / "src/shared/urdf/simple_humanoid.urdf"
+_GOLFER_URDF = (
+    _REPO_ROOT / "src/engines/physics_engines/pinocchio/models/generated/golfer.urdf"
+)
 
 # Check if display is available for Qt tests
 HAS_DISPLAY = os.environ.get("DISPLAY") is not None or sys.platform == "win32"
@@ -48,6 +56,115 @@ def test_urdf_scanning_logic():
     names = [u.stem for u in urdfs]
     assert "simple_humanoid" in names
     assert "arm" in names
+
+
+class TestSimpleHumanoidAnthropometry:
+    """Verify simple_humanoid.urdf uses de Leva 1996 anthropometry-derived values."""
+
+    def _get_link_mass(self, root: ET.Element, link_name: str) -> float:
+        for link in root.iter("link"):
+            if link.get("name") == link_name:
+                inertial = link.find("inertial")
+                if inertial is None:
+                    pytest.fail(f"Link {link_name!r} has no <inertial>")
+                mass_el = inertial.find("mass")
+                if mass_el is None:
+                    pytest.fail(f"Link {link_name!r} has no <mass>")
+                return float(mass_el.get("value", "0"))
+        pytest.fail(f"Link {link_name!r} not found in URDF")
+
+    def _get_link_inertia(self, root: ET.Element, link_name: str) -> dict:
+        for link in root.iter("link"):
+            if link.get("name") == link_name:
+                inertial = link.find("inertial")
+                assert inertial is not None
+                inertia_el = inertial.find("inertia")
+                assert inertia_el is not None
+                return {k: float(inertia_el.get(k, "0")) for k in ("ixx", "iyy", "izz")}
+        pytest.fail(f"Link {link_name!r} not found")
+
+    @pytest.fixture()
+    def urdf_root(self):
+        assert _SIMPLE_HUMANOID.exists(), f"Missing {_SIMPLE_HUMANOID}"
+        return ET.parse(_SIMPLE_HUMANOID).getroot()
+
+    def test_torso_mass_is_de_leva_1996(self, urdf_root):
+        mass = self._get_link_mass(urdf_root, "torso")
+        assert abs(mass - 30.42) < 0.1, (
+            f"torso mass {mass} not near de Leva 1996 value 30.42 kg"
+        )
+
+    def test_head_mass_is_de_leva_1996(self, urdf_root):
+        mass = self._get_link_mass(urdf_root, "head")
+        assert abs(mass - 4.86) < 0.05, (
+            f"head mass {mass} not near de Leva 1996 value 4.86 kg"
+        )
+
+    def test_upper_arm_mass_is_de_leva_1996(self, urdf_root):
+        for link_name in ("right_upper_arm", "left_upper_arm"):
+            mass = self._get_link_mass(urdf_root, link_name)
+            assert abs(mass - 1.96) < 0.05, f"{link_name} mass {mass} not near 1.96 kg"
+
+    def test_upper_leg_mass_is_de_leva_1996(self, urdf_root):
+        for link_name in ("right_upper_leg", "left_upper_leg"):
+            mass = self._get_link_mass(urdf_root, link_name)
+            assert abs(mass - 7.0) < 0.1, f"{link_name} mass {mass} not near 7.0 kg"
+
+    def test_torso_inertia_consistent_with_geometry(self, urdf_root):
+        inertia = self._get_link_inertia(urdf_root, "torso")
+        # Box 0.2x0.4x0.6 m at 30.42 kg: ixx=m(b²+c²)/12, iyy=m(a²+c²)/12, izz=m(a²+b²)/12
+        assert abs(inertia["ixx"] - 1.318) < 0.01
+        assert abs(inertia["iyy"] - 1.014) < 0.01
+        assert abs(inertia["izz"] - 0.507) < 0.01
+
+    def test_inertia_values_are_not_round_numbers(self, urdf_root):
+        for link_name in ("torso", "head", "right_upper_arm", "right_upper_leg"):
+            inertia = self._get_link_inertia(urdf_root, link_name)
+            for axis, val in inertia.items():
+                msg = f"{link_name}.{axis}={val} is a suspiciously round number"
+                assert val != round(val, 1) or val < 0.01, msg
+
+
+class TestGolferUrdfRightHandGrip:
+    """Verify golfer.urdf has a right-hand grip attachment joint/link."""
+
+    @pytest.fixture()
+    def urdf_root(self):
+        assert _GOLFER_URDF.exists(), f"Missing {_GOLFER_URDF}"
+        return ET.parse(_GOLFER_URDF).getroot()
+
+    def test_right_grip_attachment_link_exists(self, urdf_root):
+        names = {el.get("name") for el in urdf_root.iter("link")}
+        assert "right_grip_attachment" in names, (
+            "golfer.urdf missing right_grip_attachment link"
+        )
+
+    def test_right_grip_joint_connects_to_hand_right(self, urdf_root):
+        for joint in urdf_root.iter("joint"):
+            if joint.get("name") == "hand_right_to_right_grip_attachment":
+                parent = joint.find("parent")
+                child = joint.find("child")
+                assert parent is not None and parent.get("link") == "hand_right"
+                assert (
+                    child is not None and child.get("link") == "right_grip_attachment"
+                )
+                return
+        pytest.fail(
+            "joint hand_right_to_right_grip_attachment not found in golfer.urdf"
+        )
+
+    def test_right_grip_joint_is_fixed(self, urdf_root):
+        for joint in urdf_root.iter("joint"):
+            if joint.get("name") == "hand_right_to_right_grip_attachment":
+                assert joint.get("type") == "fixed"
+                return
+        pytest.fail("joint hand_right_to_right_grip_attachment not found")
+
+    def test_left_hand_club_shaft_joint_still_present(self, urdf_root):
+        names = {el.get("name") for el in urdf_root.iter("joint")}
+        assert "hand_left_to_club_shaft" in names, (
+            "left-hand grip was accidentally removed"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **simple_humanoid.urdf**: Replace hand-tuned round-number inertias with de Leva 1996 (Table 4, male, 70 kg reference) values. Torso 30.42 kg, head 4.86 kg, upper arms 1.96 kg, thighs 7.0 kg. Inertia tensors computed analytically from existing link geometries. Header comment cites the source paper.
- **golfer.urdf**: Add `right_grip_attachment` massless link connected via fixed joint from `hand_right`, establishing the kinematic attachment point for the right hand on the club. Closed-loop constraint (right_grip_attachment ↔ club_shaft) must be enforced by Pinocchio `RigidConstraint` at runtime — noted in URDF comment.
- **tests/test_urdf_tools.py**: Add `TestSimpleHumanoidAnthropometry` (6 tests, verifies masses and inertia tensors) and `TestGolferUrdfRightHandGrip` (4 tests, verifies joint structure and connectivity).

## Test plan

- [x] `pytest tests/test_urdf_tools.py` passes all 10 tests
- [x] `ruff format --check` clean
- [x] Left-hand grip joint (`hand_left_to_club_shaft`) preserved
- [x] Mass properties traceable to published anthropometry (de Leva 1996)

Closes #2702