### PR TITLE
fix: add RK4 integrator to Pinocchio engine and fix pendulum torque sampling

### DIFF
--- a/src/engines/physics_engines/pendulum/python/golf_swing_physics_engine.py
+++ b/src/engines/physics_engines/pendulum/python/golf_swing_physics_engine.py
@@ -40,6 +40,7 @@ Integration Pattern (how shared tools are incorporated)
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -218,10 +219,21 @@ class GolfSwingPendulumEngine(BasePhysicsEngine):
         self.time = 0.0
         self._tau = np.zeros(2)
 
-    def step(self, dt: float | None = None) -> None:
+    def step(
+        self,
+        dt: float | None = None,
+        torque_callback: Callable[[float], tuple[float, float]] | None = None,
+    ) -> None:
         """Advance state by one RK4 step.
 
-        Precondition: engine must be initialised.
+        Args:
+            dt: Time step [s]. Defaults to 0.01.
+            torque_callback: Optional function ``τ(t) → (τ1, τ2)`` that
+                returns joint torques as a function of time.  When provided,
+                each RK4 stage samples torque at the correct Butcher-tableau
+                time point so time-varying swing controllers are integrated
+                accurately.  When ``None``, the stored ``self._tau`` array is
+                used (constant-torque assumption).
         """
         if not self._is_initialized:
             logger.warning("GolfSwingPendulumEngine: step called before init.")
@@ -231,32 +243,50 @@ class GolfSwingPendulumEngine(BasePhysicsEngine):
 
         from double_pendulum_golf.physics import equations_of_motion  # noqa: PLC0415
 
-        def torque_func(t: float) -> tuple[float, float]:  # noqa: ARG001
-            return float(self._tau[0]), float(self._tau[1])
+        if torque_callback is not None:
+            # Time-varying torque: sample τ at each Butcher stage time
+            def _tau_at(t: float) -> tuple[float, float]:
+                return torque_callback(t)
+        else:
+            # Constant-torque: always return the stored array
+            tau0, tau1 = float(self._tau[0]), float(self._tau[1])
 
-        deriv = equations_of_motion(
-            self._state, self.time, self._pendulum_params, torque_func
+            def _tau_at(t: float) -> tuple[float, float]:  # noqa: ARG001
+                return tau0, tau1
+
+        t0 = self.time
+        t_half = t0 + 0.5 * step_size
+        t_full = t0 + step_size
+
+        def _make_torque_func(t: float) -> Callable[[float], tuple[float, float]]:
+            tau_val = _tau_at(t)
+
+            def _f(_t: float) -> tuple[float, float]:  # noqa: ARG001
+                return tau_val
+
+            return _f
+
+        # RK4 integration — torque sampled at canonical Butcher-tableau times
+        k1 = equations_of_motion(
+            self._state, t0, self._pendulum_params, _make_torque_func(t0)
         )
-
-        # RK4 integration
-        k1 = deriv
         k2 = equations_of_motion(
             self._state + 0.5 * step_size * k1,
-            self.time + 0.5 * step_size,
+            t_half,
             self._pendulum_params,
-            torque_func,
+            _make_torque_func(t_half),
         )
         k3 = equations_of_motion(
             self._state + 0.5 * step_size * k2,
-            self.time + 0.5 * step_size,
+            t_half,
             self._pendulum_params,
-            torque_func,
+            _make_torque_func(t_half),
         )
         k4 = equations_of_motion(
             self._state + step_size * k3,
-            self.time + step_size,
+            t_full,
             self._pendulum_params,
-            torque_func,
+            _make_torque_func(t_full),
         )
 
         self._state = self._state + (step_size / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
@@ -9,7 +9,7 @@ initialization patterns.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 
@@ -147,24 +147,70 @@ class PinocchioPhysicsEngine(BasePhysicsEngine):
             self.forward()
 
     @precondition(
-        lambda self, dt=None: self.is_initialized,
+        lambda self, dt=None, integrator="semi_implicit": self.is_initialized,
         "Engine must be initialized",
     )
-    def step(self, dt: float | None = None) -> None:
-        """Advance the simulation by one time step."""
+    def step(
+        self,
+        dt: float | None = None,
+        integrator: Literal["semi_implicit", "rk4"] = "semi_implicit",
+    ) -> None:
+        """Advance the simulation by one time step.
+
+        Args:
+            dt: Time step size [s]. Defaults to DEFAULT_TIME_STEP.
+            integrator: Integration scheme — ``"semi_implicit"`` (symplectic
+                Euler, O(dt), energy-stable) or ``"rk4"`` (classic 4th-order
+                Runge-Kutta, O(dt^4), more accurate for large dt or
+                validation).
+        """
         if self.model is None or self.data is None:
             return
 
         time_step = dt if dt is not None else DEFAULT_TIME_STEP
 
-        # Explicit Forward Dynamics: a = ABA(q, v, tau)
-        self.a = pin.aba(self.model, self.data, self.q, self.v, self.tau)
+        if integrator == "rk4":
+            self._step_rk4(time_step)
+        else:
+            self._step_semi_implicit(time_step)
 
-        # Semi-implicit Euler integration
+        self.time += time_step
+
+    def _step_semi_implicit(self, time_step: float) -> None:
+        """Symplectic (semi-implicit) Euler: velocity-first, then position."""
+        self.a = pin.aba(self.model, self.data, self.q, self.v, self.tau)
         self.v += self.a * time_step
         self.q = pin.integrate(self.model, self.q, self.v * time_step)
 
-        self.time += time_step
+    def _step_rk4(self, time_step: float) -> None:
+        """Classic RK4 integration over Pinocchio's Lie-group configuration."""
+        q0, v0 = self.q.copy(), self.v.copy()
+        tau = self.tau
+
+        def dv(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+            return pin.aba(self.model, self.data, q, v, tau).copy()
+
+        # k1
+        a1 = dv(q0, v0)
+        # k2
+        v_k2 = v0 + 0.5 * time_step * a1
+        q_k2 = pin.integrate(self.model, q0, 0.5 * time_step * v0)
+        a2 = dv(q_k2, v_k2)
+        # k3
+        v_k3 = v0 + 0.5 * time_step * a2
+        q_k3 = pin.integrate(self.model, q0, 0.5 * time_step * v_k2)
+        a3 = dv(q_k3, v_k3)
+        # k4
+        v_k4 = v0 + time_step * a3
+        q_k4 = pin.integrate(self.model, q0, time_step * v_k3)
+        a4 = dv(q_k4, v_k4)
+
+        # Weighted update — velocity in R^n, position on Lie group
+        dv_weighted = (time_step / 6.0) * (a1 + 2 * a2 + 2 * a3 + a4)
+        dq_weighted = (time_step / 6.0) * (v0 + 2 * v_k2 + 2 * v_k3 + v_k4)
+        self.v = v0 + dv_weighted
+        self.q = pin.integrate(self.model, q0, dq_weighted)
+        self.a = a4
 
     @precondition(lambda self: self.is_initialized, "Engine must be initialized")
     def forward(self) -> None:

--- a/tests/physics_validation/test_energy_conservation.py
+++ b/tests/physics_validation/test_energy_conservation.py
@@ -256,3 +256,70 @@ def test_drake_energy_conservation() -> None:
     logger.info(f"Drake Energy Error: {error:.6f} J")
 
     assert error < 0.01, f"Drake energy conservation failed. Error: {error}"
+
+
+def test_pinocchio_10s_rk4_energy_conservation() -> None:
+    """10-second ballistic free-fall with Pinocchio RK4 integrator.
+
+    Validates that the RK4 path in PinocchioPhysicsEngine.step() conserves
+    energy to within 0.5% over a 10-second integration horizon (10 000 steps
+    at dt=0.001).  Semi-implicit Euler is only expected to oscillate, not
+    drift monotonically, so the same model is run with both integrators and
+    both are checked.
+    """
+    if not is_engine_available(EngineType.PINOCCHIO):
+        pytest.skip("Pinocchio not installed")
+
+    import pinocchio
+
+    if isinstance(pinocchio, MagicMock):
+        pytest.skip("pinocchio is mocked")
+
+    from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
+        PinocchioPhysicsEngine,
+    )
+
+    # Build a minimal single-body free-flyer model
+    model = pinocchio.Model()
+    mass = 1.0
+    joint_id = model.addJoint(
+        0, pinocchio.JointModelFreeFlyer(), pinocchio.SE3.Identity(), "body_joint"
+    )
+    inertia = pinocchio.Inertia.FromSphere(mass, 0.1)
+    model.appendBodyToJoint(joint_id, inertia, pinocchio.SE3.Identity())
+    model.gravity = pinocchio.Motion(np.array([0, 0, -GRAVITY_M_S2, 0, 0, 0]))
+
+    dt = 0.001
+    total_time = 10.0
+    steps = int(total_time / dt)
+
+    for scheme in ("semi_implicit", "rk4"):
+        eng = PinocchioPhysicsEngine()
+        eng.model = model
+        eng.data = model.createData()
+        eng.q = pinocchio.neutral(model)
+        eng.q[2] = 10.0  # start 10 m above ground
+        eng.v = np.zeros(model.nv)
+        eng.a = np.zeros(model.nv)
+        eng.tau = np.zeros(model.nv)
+        eng.time = 0.0
+        eng._is_initialized = True  # noqa: SLF001
+
+        pinocchio.computeKineticEnergy(model, eng.data, eng.q, eng.v)
+        pinocchio.computePotentialEnergy(model, eng.data, eng.q)
+        e0 = eng.data.kinetic_energy + eng.data.potential_energy
+
+        errors = []
+        for _ in range(steps):
+            eng.step(dt=dt, integrator=scheme)  # type: ignore[call-arg]
+            pinocchio.computeKineticEnergy(model, eng.data, eng.q, eng.v)
+            pinocchio.computePotentialEnergy(model, eng.data, eng.q)
+            e = eng.data.kinetic_energy + eng.data.potential_energy
+            errors.append(abs(e - e0))
+
+        max_err = float(np.max(errors))
+        pct = max_err / abs(e0) * 100.0
+        logger.info(f"Pinocchio 10-s energy error [{scheme}]: {pct:.4f}%")
+        # Both schemes must stay within 0.5% over 10 s
+        msg = f"Energy drift too large ({pct:.4f}%) with integrator={scheme!r}"
+        assert pct < 0.5, msg


### PR DESCRIPTION
## Summary
- `PinocchioPhysicsEngine.step()` now accepts `integrator: Literal["semi_implicit", "rk4"]` — RK4 uses Lie-group `pin.integrate()` at each Butcher-tableau stage (k1@t₀, k2/k3@t+dt/2, k4@t+dt)
- `GolfSwingPendulumEngine.step()` accepts an optional `torque_callback(t) → (τ1, τ2)` so time-varying swing controllers sample torque at the correct stage times instead of always using the frozen `self._tau` array
- New `test_pinocchio_10s_rk4_energy_conservation()` runs both integrators over 10 s (10 000 steps at dt=0.001) and asserts <0.5% energy drift

## Test plan
- [x] `ruff check` passes — zero violations
- [x] `ruff format` — no diffs
- [x] Python AST validates (syntax clean)
- [x] `pytest tests/physics_validation/test_energy_conservation.py` — skips locally (no engines), will execute in CI

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)