### PR TITLE
feat: add TrackMan and FlightScope CSV ingestion API

### DIFF
--- a/src/shared/python/launch_monitor/__init__.py
+++ b/src/shared/python/launch_monitor/__init__.py
@@ -1,0 +1,22 @@
+"""Launch monitor ingestion API.
+
+Adapters that parse TrackMan and FlightScope CSV / JSON exports and
+normalise the data into :class:`LaunchMonitorShot` — the single source
+of truth for all post-import analysis.
+
+Usage::
+
+    from src.shared.python.launch_monitor import TrackManAdapter, FlightScopeAdapter
+
+    shots = TrackManAdapter.from_csv("session.csv")
+    lc = shots[0].to_launch_conditions()
+"""
+
+from .adapters import FlightScopeAdapter, TrackManAdapter
+from .types import LaunchMonitorShot
+
+__all__ = [
+    "FlightScopeAdapter",
+    "LaunchMonitorShot",
+    "TrackManAdapter",
+]

--- a/src/shared/python/launch_monitor/adapters.py
+++ b/src/shared/python/launch_monitor/adapters.py
@@ -1,0 +1,374 @@
+"""TrackMan and FlightScope CSV adapters.
+
+Each adapter reads a device-specific CSV export and returns a list of
+:class:`~src.shared.python.launch_monitor.types.LaunchMonitorShot`
+objects normalised to SI units.
+
+Column name mappings follow the default export format of each device
+as of 2024.  Unrecognised columns are preserved in ``shot.extra``.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import math
+from pathlib import Path
+
+from .types import LaunchMonitorShot
+
+_MPH_TO_MPS = 0.44704
+_YARDS_TO_METERS = 0.9144
+
+
+def _float_or_none(value: str) -> float | None:
+    try:
+        return float(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _require_float(value: str, field: str) -> float:
+    result = _float_or_none(value)
+    if result is None:
+        raise ValueError(
+            f"Required field {field!r} is missing or non-numeric: {value!r}"
+        )
+    return result
+
+
+class TrackManAdapter:
+    """Parse TrackMan IV / Performance Studio CSV exports.
+
+    TrackMan exports a single-header CSV where each row is one shot.
+    Column names use the long-form English labels (e.g. "Ball Speed",
+    "Launch Angle").  Values are in US customary units (mph, yards,
+    degrees, rpm).
+
+    Example::
+
+        shots = TrackManAdapter.from_csv("session.csv")
+        for shot in shots:
+            lc = shot.to_launch_conditions()
+    """
+
+    # Mapping: internal attribute name → list of recognised column headers
+    # (checked case-insensitively; first match wins)
+    _COLUMN_MAP: dict[str, list[str]] = {
+        "club": ["Club", "Club Type"],
+        "ball_speed_mph": ["Ball Speed", "Ball Spd", "BallSpeed"],
+        "club_speed_mph": ["Club Speed", "Club Spd", "ClubSpeed", "Swing Speed"],
+        "smash_factor": ["Smash Factor", "Smash Fac", "SmashFactor"],
+        "launch_angle_deg": ["Launch Angle", "Lnch Angle", "LaunchAngle"],
+        "launch_direction_deg": ["Launch Direction", "Lnch Dir", "LaunchDirection"],
+        "back_spin_rpm": ["Back Spin", "BackSpin"],
+        "side_spin_rpm": ["Side Spin", "SideSpin"],
+        "spin_axis_deg": ["Spin Axis", "SpinAxis"],
+        "total_spin_rpm": ["Total Spin", "TotalSpin", "Spin Rate"],
+        "carry_yards": ["Carry", "Carry Dist"],
+        "total_yards": ["Total", "Total Dist"],
+        "max_height_yards": ["Height", "Max Height", "Apex"],
+        "landing_angle_deg": ["Descent Angle", "Desc Angle", "Landing Angle"],
+        "flight_time_s": ["Time of Flight", "Flight Time"],
+        "attack_angle_deg": ["Attack Angle", "Atk Angle"],
+        "dynamic_loft_deg": ["Dyn. Loft", "Dynamic Loft", "DynLoft"],
+        "club_path_deg": ["Club Path", "Path"],
+        "face_angle_deg": ["Face Angle", "Face Ang"],
+    }
+
+    @classmethod
+    def _build_index(cls, headers: list[str]) -> dict[str, int]:
+        lower_headers = [h.strip().lower() for h in headers]
+        index: dict[str, int] = {}
+        for attr, candidates in cls._COLUMN_MAP.items():
+            for candidate in candidates:
+                try:
+                    col_idx = lower_headers.index(candidate.lower())
+                    index[attr] = col_idx
+                    break
+                except ValueError:
+                    continue
+        return index
+
+    @classmethod
+    def _parse_row(
+        cls,
+        row: list[str],
+        col_idx: dict[str, int],
+        headers: list[str],
+        shot_id: str,
+    ) -> LaunchMonitorShot | None:
+        def get(attr: str) -> str:
+            idx = col_idx.get(attr)
+            return row[idx].strip() if idx is not None and idx < len(row) else ""
+
+        ball_speed_mph = _float_or_none(get("ball_speed_mph"))
+        club_speed_mph = _float_or_none(get("club_speed_mph"))
+        total_spin = _float_or_none(get("total_spin_rpm"))
+        carry_yards = _float_or_none(get("carry_yards"))
+
+        # Skip rows that are clearly empty / header repetitions
+        if ball_speed_mph is None and total_spin is None:
+            return None
+
+        ball_speed_mps = (ball_speed_mph or 0.0) * _MPH_TO_MPS
+        club_speed_mps = (club_speed_mph or 0.0) * _MPH_TO_MPS
+        smash_raw = _float_or_none(get("smash_factor"))
+        smash = (
+            smash_raw
+            if smash_raw is not None
+            else (ball_speed_mps / club_speed_mps if club_speed_mps > 1e-6 else 0.0)
+        )
+
+        back_spin = _float_or_none(get("back_spin_rpm")) or 0.0
+        side_spin = _float_or_none(get("side_spin_rpm")) or 0.0
+        spin_axis = _float_or_none(get("spin_axis_deg")) or 0.0
+        if total_spin is None:
+            total_spin = math.hypot(back_spin, side_spin)
+
+        max_h_yards = _float_or_none(get("max_height_yards"))
+        total_yards = _float_or_none(get("total_yards"))
+
+        # Collect unrecognised columns into extra
+        known_indices = set(col_idx.values())
+        extra = {
+            headers[i].strip(): row[i].strip()
+            for i in range(len(row))
+            if i not in known_indices and i < len(headers)
+        }
+
+        return LaunchMonitorShot(
+            club=get("club") or "Unknown",
+            ball_speed_mps=ball_speed_mps,
+            club_speed_mps=club_speed_mps,
+            smash_factor=smash,
+            launch_angle_deg=_float_or_none(get("launch_angle_deg")) or 0.0,
+            launch_direction_deg=_float_or_none(get("launch_direction_deg")) or 0.0,
+            back_spin_rpm=back_spin,
+            side_spin_rpm=side_spin,
+            spin_axis_deg=spin_axis,
+            total_spin_rpm=total_spin,
+            carry_m=(carry_yards or 0.0) * _YARDS_TO_METERS,
+            total_m=total_yards * _YARDS_TO_METERS if total_yards is not None else None,
+            max_height_m=max_h_yards * _YARDS_TO_METERS
+            if max_h_yards is not None
+            else None,
+            landing_angle_deg=_float_or_none(get("landing_angle_deg")),
+            flight_time_s=_float_or_none(get("flight_time_s")),
+            attack_angle_deg=_float_or_none(get("attack_angle_deg")) or 0.0,
+            dynamic_loft_deg=_float_or_none(get("dynamic_loft_deg")),
+            club_path_deg=_float_or_none(get("club_path_deg")),
+            face_angle_deg=_float_or_none(get("face_angle_deg")),
+            source="TrackMan",
+            shot_id=shot_id,
+            extra=extra,
+        )
+
+    @classmethod
+    def from_csv(cls, path: str | Path) -> list[LaunchMonitorShot]:
+        """Parse a TrackMan CSV file and return a list of shots.
+
+        Args:
+            path: Path to the TrackMan CSV export.
+
+        Returns:
+            List of :class:`LaunchMonitorShot` objects.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file has no recognised ball-speed column.
+        """
+        text = Path(path).read_text(encoding="utf-8-sig")
+        return cls.from_string(text)
+
+    @classmethod
+    def from_string(cls, text: str) -> list[LaunchMonitorShot]:
+        """Parse a TrackMan CSV from a string.
+
+        Args:
+            text: Raw CSV content.
+
+        Returns:
+            List of :class:`LaunchMonitorShot` objects.
+        """
+        reader = csv.reader(io.StringIO(text))
+        rows = list(reader)
+        if not rows:
+            return []
+
+        headers = rows[0]
+        col_idx = cls._build_index(headers)
+
+        shots: list[LaunchMonitorShot] = []
+        for row_num, row in enumerate(rows[1:], start=2):
+            shot = cls._parse_row(row, col_idx, headers, shot_id=str(row_num))
+            if shot is not None:
+                shots.append(shot)
+        return shots
+
+
+class FlightScopeAdapter:
+    """Parse FlightScope Mevo / X2 / X3 CSV exports.
+
+    FlightScope uses slightly different column names and exports in
+    SI or US customary depending on device settings.  This adapter
+    handles the most common US-customary export format.
+
+    Example::
+
+        shots = FlightScopeAdapter.from_csv("session.csv")
+    """
+
+    _COLUMN_MAP: dict[str, list[str]] = {
+        "club": ["Club", "Club Name", "Selection"],
+        "ball_speed_mph": ["Ball Speed (mph)", "Ball Speed", "BallSpeed"],
+        "club_speed_mph": ["Club Speed (mph)", "Club Speed", "ClubHead Speed"],
+        "smash_factor": ["Smash Factor", "SmashFactor"],
+        "launch_angle_deg": [
+            "Launch Angle (deg)",
+            "Launch Angle",
+            "Vert. Launch Angle",
+        ],
+        "launch_direction_deg": [
+            "Launch Direction (deg)",
+            "Launch Direction",
+            "Horiz. Launch Angle",
+        ],
+        "back_spin_rpm": ["Backspin (rpm)", "Backspin", "Back Spin"],
+        "side_spin_rpm": ["Sidespin (rpm)", "Sidespin", "Side Spin"],
+        "spin_axis_deg": ["Spin Axis (deg)", "Spin Axis"],
+        "total_spin_rpm": ["Total Spin (rpm)", "Total Spin", "Spin Rate"],
+        "carry_yards": ["Carry (yds)", "Carry Distance", "Carry"],
+        "total_yards": ["Total (yds)", "Total Distance", "Total"],
+        "max_height_yards": ["Max Height (yds)", "Apex (yds)", "Max Height"],
+        "landing_angle_deg": ["Descent Angle (deg)", "Landing Angle", "Descent"],
+        "flight_time_s": ["Hang Time (s)", "Hang Time", "Flight Time"],
+        "attack_angle_deg": ["Attack Angle (deg)", "Attack Angle", "AoA"],
+        "dynamic_loft_deg": ["Dynamic Loft (deg)", "Dynamic Loft"],
+        "club_path_deg": ["Club Path (deg)", "Club Path"],
+        "face_angle_deg": ["Face Angle (deg)", "Face Angle"],
+    }
+
+    @classmethod
+    def _build_index(cls, headers: list[str]) -> dict[str, int]:
+        lower_headers = [h.strip().lower() for h in headers]
+        index: dict[str, int] = {}
+        for attr, candidates in cls._COLUMN_MAP.items():
+            for candidate in candidates:
+                try:
+                    col_idx = lower_headers.index(candidate.lower())
+                    index[attr] = col_idx
+                    break
+                except ValueError:
+                    continue
+        return index
+
+    @classmethod
+    def from_csv(cls, path: str | Path) -> list[LaunchMonitorShot]:
+        """Parse a FlightScope CSV file and return a list of shots.
+
+        Args:
+            path: Path to the FlightScope CSV export.
+
+        Returns:
+            List of :class:`LaunchMonitorShot` objects.
+        """
+        text = Path(path).read_text(encoding="utf-8-sig")
+        return cls.from_string(text)
+
+    @classmethod
+    def from_string(cls, text: str) -> list[LaunchMonitorShot]:
+        """Parse a FlightScope CSV from a string.
+
+        Args:
+            text: Raw CSV content.
+
+        Returns:
+            List of :class:`LaunchMonitorShot` objects.
+        """
+        reader = csv.reader(io.StringIO(text))
+        rows = list(reader)
+        if not rows:
+            return []
+
+        headers = rows[0]
+        col_idx = cls._build_index(headers)
+        known_indices = set(col_idx.values())
+
+        def _cell(row: list[str], attr: str) -> str:
+            idx = col_idx.get(attr)
+            return row[idx].strip() if idx is not None and idx < len(row) else ""
+
+        shots: list[LaunchMonitorShot] = []
+        for row_num, row in enumerate(rows[1:], start=2):
+            if len(row) < 2:
+                continue
+
+            ball_speed_mph = _float_or_none(_cell(row, "ball_speed_mph"))
+            total_spin = _float_or_none(_cell(row, "total_spin_rpm"))
+            if ball_speed_mph is None and total_spin is None:
+                continue
+
+            club_speed_mph = _float_or_none(_cell(row, "club_speed_mph")) or 0.0
+            ball_speed_mps = (ball_speed_mph or 0.0) * _MPH_TO_MPS
+            club_speed_mps = club_speed_mph * _MPH_TO_MPS
+            smash_raw = _float_or_none(_cell(row, "smash_factor"))
+            smash = (
+                smash_raw
+                if smash_raw is not None
+                else (ball_speed_mps / club_speed_mps if club_speed_mps > 1e-6 else 0.0)
+            )
+
+            back_spin = _float_or_none(_cell(row, "back_spin_rpm")) or 0.0
+            side_spin = _float_or_none(_cell(row, "side_spin_rpm")) or 0.0
+            spin_axis = _float_or_none(_cell(row, "spin_axis_deg")) or 0.0
+            if total_spin is None:
+                total_spin = math.hypot(back_spin, side_spin)
+
+            carry_yards = _float_or_none(_cell(row, "carry_yards"))
+            total_yards = _float_or_none(_cell(row, "total_yards"))
+            max_h_yards = _float_or_none(_cell(row, "max_height_yards"))
+
+            extra = {
+                headers[i].strip(): row[i].strip()
+                for i in range(len(row))
+                if i not in known_indices and i < len(headers)
+            }
+
+            shots.append(
+                LaunchMonitorShot(
+                    club=_cell(row, "club") or "Unknown",
+                    ball_speed_mps=ball_speed_mps,
+                    club_speed_mps=club_speed_mps,
+                    smash_factor=smash,
+                    launch_angle_deg=_float_or_none(_cell(row, "launch_angle_deg"))
+                    or 0.0,
+                    launch_direction_deg=(
+                        _float_or_none(_cell(row, "launch_direction_deg")) or 0.0
+                    ),
+                    back_spin_rpm=back_spin,
+                    side_spin_rpm=side_spin,
+                    spin_axis_deg=spin_axis,
+                    total_spin_rpm=total_spin,
+                    carry_m=(carry_yards or 0.0) * _YARDS_TO_METERS,
+                    total_m=total_yards * _YARDS_TO_METERS
+                    if total_yards is not None
+                    else None,
+                    max_height_m=(
+                        max_h_yards * _YARDS_TO_METERS
+                        if max_h_yards is not None
+                        else None
+                    ),
+                    landing_angle_deg=_float_or_none(_cell(row, "landing_angle_deg")),
+                    flight_time_s=_float_or_none(_cell(row, "flight_time_s")),
+                    attack_angle_deg=_float_or_none(_cell(row, "attack_angle_deg"))
+                    or 0.0,
+                    dynamic_loft_deg=_float_or_none(_cell(row, "dynamic_loft_deg")),
+                    club_path_deg=_float_or_none(_cell(row, "club_path_deg")),
+                    face_angle_deg=_float_or_none(_cell(row, "face_angle_deg")),
+                    source="FlightScope",
+                    shot_id=str(row_num),
+                    extra=extra,
+                )
+            )
+        return shots

--- a/src/shared/python/launch_monitor/types.py
+++ b/src/shared/python/launch_monitor/types.py
@@ -1,0 +1,114 @@
+"""Normalised launch-monitor shot dataclass."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from src.shared.python.physics.ball_flight_physics import LaunchConditions
+
+# Conversion factors
+_MPH_TO_MPS = 0.44704
+_YARDS_TO_METERS = 0.9144
+_RPM_TO_RAD_S = 2.0 * math.pi / 60.0
+
+
+@dataclass
+class LaunchMonitorShot:
+    """Normalised representation of a single launch-monitor shot.
+
+    All velocities are in m/s, distances in metres, angles in degrees,
+    and spin rates in rpm — the units used internally throughout the
+    simulation suite.  Adapters are responsible for unit conversion.
+
+    Attributes:
+        club: Club name (e.g. "Driver", "7-Iron", "PW").
+        ball_speed_mps: Ball speed immediately post-impact [m/s].
+        club_speed_mps: Clubhead speed at impact [m/s].
+        smash_factor: ball_speed / club_speed (dimensionless).
+        launch_angle_deg: Vertical launch angle [degrees].
+        launch_direction_deg: Horizontal launch direction relative to
+            target line [degrees]; positive = right for right-handed player.
+        back_spin_rpm: Backspin component [rpm]; positive = backspin.
+        side_spin_rpm: Sidespin component [rpm]; positive = fade (right).
+        spin_axis_deg: Spin axis tilt [degrees]; convention matches TrackMan
+            (positive = draw / right-to-left axis for RH player).
+        total_spin_rpm: Resultant spin magnitude [rpm].
+        carry_m: Carry distance [metres].
+        total_m: Total distance including run [metres]; ``None`` if not recorded.
+        max_height_m: Apex height [metres]; ``None`` if not recorded.
+        landing_angle_deg: Descent angle at landing [degrees]; ``None`` if not recorded.
+        flight_time_s: Ball flight time [seconds]; ``None`` if not recorded.
+        attack_angle_deg: Club attack angle at impact [degrees]; negative = down.
+        dynamic_loft_deg: Dynamic loft at impact [degrees]; ``None`` if not recorded.
+        club_path_deg: Club path direction [degrees]; ``None`` if not recorded.
+        face_angle_deg: Face angle at impact [degrees]; ``None`` if not recorded.
+        source: Name of the launch monitor that produced this shot.
+        shot_id: Optional shot identifier from the source file.
+        extra: Any extra fields from the source file, keyed by column name.
+    """
+
+    club: str
+    ball_speed_mps: float
+    club_speed_mps: float
+    smash_factor: float
+    launch_angle_deg: float
+    launch_direction_deg: float
+    back_spin_rpm: float
+    side_spin_rpm: float
+    spin_axis_deg: float
+    total_spin_rpm: float
+    carry_m: float
+    total_m: float | None = None
+    max_height_m: float | None = None
+    landing_angle_deg: float | None = None
+    flight_time_s: float | None = None
+    attack_angle_deg: float = 0.0
+    dynamic_loft_deg: float | None = None
+    club_path_deg: float | None = None
+    face_angle_deg: float | None = None
+    source: str = ""
+    shot_id: str | None = None
+    extra: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.ball_speed_mps < 0:
+            raise ValueError("ball_speed_mps must be non-negative")
+        if self.club_speed_mps < 0:
+            raise ValueError("club_speed_mps must be non-negative")
+        if self.carry_m < 0:
+            raise ValueError("carry_m must be non-negative")
+        if self.total_spin_rpm < 0:
+            raise ValueError("total_spin_rpm must be non-negative")
+
+    def to_launch_conditions(self) -> LaunchConditions:
+        """Convert to :class:`~src.shared.python.physics.ball_flight_physics.LaunchConditions`.
+
+        The spin axis is decomposed into a unit vector in the XZ plane
+        (ball travels in +X, vertical is +Z) rotated by ``spin_axis_deg``
+        around the +X axis.  Back-spin (positive) creates a spin vector
+        pointing in the -Y direction (matches the convention in the Rust
+        kernel).
+
+        Returns:
+            LaunchConditions compatible with BallFlightSimulator.
+        """
+        from src.shared.python.physics.ball_flight_physics import LaunchConditions
+
+        axis_rad = math.radians(self.spin_axis_deg)
+        spin_axis = np.array([0.0, -math.cos(axis_rad), math.sin(axis_rad)])
+        norm = float(np.linalg.norm(spin_axis))
+        if norm > 1e-10:
+            spin_axis /= norm
+
+        return LaunchConditions(
+            velocity=self.ball_speed_mps,
+            launch_angle=math.radians(self.launch_angle_deg),
+            azimuth_angle=math.radians(self.launch_direction_deg),
+            spin_rate=self.total_spin_rpm,
+            spin_axis=spin_axis,
+        )

--- a/tests/unit/launch_monitor/test_launch_monitor_api.py
+++ b/tests/unit/launch_monitor/test_launch_monitor_api.py
@@ -1,0 +1,186 @@
+"""Tests for the launch-monitor ingestion API."""
+
+from __future__ import annotations
+
+import math
+import textwrap
+
+import numpy as np
+import pytest
+
+from src.shared.python.launch_monitor import (
+    FlightScopeAdapter,
+    LaunchMonitorShot,
+    TrackManAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture CSV strings
+# ---------------------------------------------------------------------------
+
+_TRACKMAN_CSV = textwrap.dedent("""\
+    Club,Ball Speed,Club Speed,Smash Factor,Launch Angle,Launch Direction,Back Spin,Side Spin,Spin Axis,Total Spin,Carry,Total,Height,Descent Angle,Time of Flight,Attack Angle,Dyn. Loft,Club Path,Face Angle
+    Driver,174.3,112.5,1.55,10.4,1.2,2545,-120,2.7,2548,282.0,305.0,105.0,38.0,6.5,-1.5,14.2,2.1,0.8
+    7-Iron,123.0,90.5,1.36,16.3,-0.5,7097,200,-1.6,7100,176.0,180.0,102.0,50.0,5.8,-4.2,21.5,-0.3,-0.2
+    """)
+
+_FLIGHTSCOPE_CSV = textwrap.dedent("""\
+    Club Name,Ball Speed (mph),Club Speed (mph),Smash Factor,Launch Angle (deg),Launch Direction (deg),Backspin (rpm),Sidespin (rpm),Spin Axis (deg),Total Spin (rpm),Carry (yds),Total (yds),Max Height (yds),Descent Angle (deg),Hang Time (s),Attack Angle (deg)
+    Driver,172.0,110.0,1.56,10.8,0.5,2600,-80,1.8,2601,278.0,300.0,100.0,37.0,6.3,-1.2
+    PW,102.0,75.0,1.36,24.0,-1.0,9300,150,-0.9,9301,141.0,143.0,93.0,52.0,5.5,-5.1
+    """)
+
+_TRACKMAN_MINIMAL_CSV = textwrap.dedent("""\
+    Club,Ball Speed,Total Spin,Carry
+    Driver,174.3,2548,282.0
+    """)
+
+_TRACKMAN_EMPTY_CSV = "Club,Ball Speed,Total Spin,Carry\n"
+
+
+# ---------------------------------------------------------------------------
+# TrackMan adapter
+# ---------------------------------------------------------------------------
+
+
+class TestTrackManAdapter:
+    def test_parses_two_shots(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        assert len(shots) == 2
+
+    def test_driver_ball_speed_converted(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        driver = shots[0]
+        expected = 174.3 * 0.44704
+        assert abs(driver.ball_speed_mps - expected) < 0.01
+
+    def test_driver_carry_converted(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        driver = shots[0]
+        expected = 282.0 * 0.9144
+        assert abs(driver.carry_m - expected) < 0.01
+
+    def test_club_name_preserved(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        assert shots[0].club == "Driver"
+        assert shots[1].club == "7-Iron"
+
+    def test_source_is_trackman(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        assert all(s.source == "TrackMan" for s in shots)
+
+    def test_spin_fields(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        driver = shots[0]
+        assert driver.back_spin_rpm == pytest.approx(2545.0)
+        assert driver.side_spin_rpm == pytest.approx(-120.0)
+        assert driver.total_spin_rpm == pytest.approx(2548.0)
+
+    def test_optional_fields_parsed(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        driver = shots[0]
+        assert driver.max_height_m is not None
+        assert driver.landing_angle_deg == pytest.approx(38.0)
+        assert driver.flight_time_s == pytest.approx(6.5)
+        assert driver.dynamic_loft_deg == pytest.approx(14.2)
+
+    def test_minimal_csv_works(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_MINIMAL_CSV)
+        assert len(shots) == 1
+        assert shots[0].total_m is None
+
+    def test_empty_csv_returns_empty_list(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_EMPTY_CSV)
+        assert shots == []
+
+    def test_smash_computed_when_missing(self):
+        csv = "Club,Ball Speed,Club Speed,Carry\nDriver,174.3,112.5,282.0\n"
+        shots = TrackManAdapter.from_string(csv)
+        expected = (174.3 * 0.44704) / (112.5 * 0.44704)
+        assert shots[0].smash_factor == pytest.approx(expected, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# FlightScope adapter
+# ---------------------------------------------------------------------------
+
+
+class TestFlightScopeAdapter:
+    def test_parses_two_shots(self):
+        shots = FlightScopeAdapter.from_string(_FLIGHTSCOPE_CSV)
+        assert len(shots) == 2
+
+    def test_driver_ball_speed(self):
+        shots = FlightScopeAdapter.from_string(_FLIGHTSCOPE_CSV)
+        expected = 172.0 * 0.44704
+        assert abs(shots[0].ball_speed_mps - expected) < 0.01
+
+    def test_source_is_flightscope(self):
+        shots = FlightScopeAdapter.from_string(_FLIGHTSCOPE_CSV)
+        assert all(s.source == "FlightScope" for s in shots)
+
+    def test_pw_smash_factor(self):
+        shots = FlightScopeAdapter.from_string(_FLIGHTSCOPE_CSV)
+        pw = shots[1]
+        assert pw.smash_factor == pytest.approx(1.36)
+
+
+# ---------------------------------------------------------------------------
+# LaunchMonitorShot type
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchMonitorShot:
+    @pytest.fixture()
+    def driver_shot(self) -> LaunchMonitorShot:
+        return LaunchMonitorShot(
+            club="Driver",
+            ball_speed_mps=77.9,
+            club_speed_mps=50.3,
+            smash_factor=1.549,
+            launch_angle_deg=10.4,
+            launch_direction_deg=1.2,
+            back_spin_rpm=2545,
+            side_spin_rpm=-120,
+            spin_axis_deg=2.7,
+            total_spin_rpm=2548,
+            carry_m=257.8,
+        )
+
+    def test_negative_ball_speed_raises(self):
+        with pytest.raises(ValueError, match="ball_speed_mps"):
+            LaunchMonitorShot(
+                club="Driver",
+                ball_speed_mps=-1.0,
+                club_speed_mps=50.0,
+                smash_factor=1.4,
+                launch_angle_deg=10.0,
+                launch_direction_deg=0.0,
+                back_spin_rpm=2500,
+                side_spin_rpm=0,
+                spin_axis_deg=0.0,
+                total_spin_rpm=2500,
+                carry_m=250.0,
+            )
+
+    def test_to_launch_conditions_velocity(self, driver_shot):
+        lc = driver_shot.to_launch_conditions()
+        assert lc.velocity == pytest.approx(driver_shot.ball_speed_mps)
+
+    def test_to_launch_conditions_launch_angle(self, driver_shot):
+        lc = driver_shot.to_launch_conditions()
+        assert lc.launch_angle == pytest.approx(math.radians(10.4), rel=1e-4)
+
+    def test_to_launch_conditions_spin_axis_unit_vector(self, driver_shot):
+        lc = driver_shot.to_launch_conditions()
+        norm = float(np.linalg.norm(lc.spin_axis))
+        assert abs(norm - 1.0) < 1e-10
+
+    def test_to_launch_conditions_spin_rate(self, driver_shot):
+        lc = driver_shot.to_launch_conditions()
+        assert lc.spin_rate == pytest.approx(2548.0)
+
+    def test_extra_fields_stored(self):
+        shots = TrackManAdapter.from_string(_TRACKMAN_CSV)
+        # All known columns should be consumed; no extra expected for this CSV
+        assert isinstance(shots[0].extra, dict)


### PR DESCRIPTION
## Summary
- Adds `src/shared/python/launch_monitor/` module with `TrackManAdapter`, `FlightScopeAdapter`, and `LaunchMonitorShot` dataclass
- Both adapters parse device-specific CSV exports and normalise all values to SI units (m/s, metres, rpm)
- `LaunchMonitorShot.to_launch_conditions()` bridges to `BallFlightSimulator`'s `LaunchConditions`
- 20 unit tests covering unit conversions, optional fields, computed smash factor, and spin axis normalisation
- Rebased cleanly onto current staging (resolves conflict in superseded PR #2877)

## Test plan
- [x] `ruff check` passes (zero violations)
- [x] `ruff format` applied
- [x] `pytest tests/unit/launch_monitor/test_launch_monitor_api.py` — 20/20 pass

Closes #2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)