### PR TITLE
fix: impact model — smash-factor bound and angular-momentum conservation test

### DIFF
--- a/src/shared/python/physics/_impact_physics.py
+++ b/src/shared/python/physics/_impact_physics.py
@@ -22,6 +22,33 @@ from ..core.physics_constants import (
     TYPICAL_CONTACT_DURATION_S,
 )
 
+SMASH_FACTOR_PHYSICAL_MAX: float = 1.56
+
+
+def check_smash_factor(ball_speed_post: float, club_speed_pre: float) -> None:
+    """Raise ValueError if smash factor exceeds the physical maximum of 1.56.
+
+    Smash factor is ball_speed_post / club_speed_pre (TrackMan standard definition).
+    Values above 1.56 almost always indicate a unit mismatch between velocity inputs
+    or a coding error (wrong sign, wrong axis) in the impact model.
+
+    Args:
+        ball_speed_post: Ball speed after impact [m/s]
+        club_speed_pre: Clubhead speed before impact [m/s]
+
+    Raises:
+        ValueError: If smash factor exceeds SMASH_FACTOR_PHYSICAL_MAX.
+    """
+    if club_speed_pre > 1e-6:
+        smash = ball_speed_post / club_speed_pre
+        if smash > SMASH_FACTOR_PHYSICAL_MAX:
+            raise ValueError(
+                f"Smash factor {smash:.3f} exceeds the physical maximum of "
+                f"{SMASH_FACTOR_PHYSICAL_MAX} (ball_speed_post={ball_speed_post:.2f} m/s, "
+                f"club_speed_pre={club_speed_pre:.2f} m/s) — likely a unit mismatch "
+                "or unrealistic COR > 1"
+            )
+
 
 class ImpactModelType(Enum):
     """Types of impact physics models."""
@@ -338,6 +365,11 @@ class RigidBodyImpactModel(ImpactModel):
             else np.zeros(2)
         )
 
+        check_smash_factor(
+            float(np.linalg.norm(v_ball_post)),
+            float(np.linalg.norm(pre_state.clubhead_velocity)),
+        )
+
         return PostImpactState(
             ball_velocity=v_ball_post,
             ball_angular_velocity=ball_spin,
@@ -545,12 +577,9 @@ class FiniteTimeImpactModel(ImpactModel):
 
 
 @precondition(
-    lambda impact_offset,
-    clubhead_velocity,
-    clubface_normal,
-    gear_factor=0.5,
-    h_scale=100.0,
-    v_scale=50.0: (0 <= gear_factor <= 1),
+    lambda impact_offset, clubhead_velocity, clubface_normal, gear_factor=0.5, h_scale=100.0, v_scale=50.0: (
+        0 <= gear_factor <= 1
+    ),
     "Gear effect factor must be between 0 and 1",
 )
 def compute_gear_effect_spin(

--- a/src/shared/python/physics/impact_model.py
+++ b/src/shared/python/physics/impact_model.py
@@ -23,6 +23,7 @@ Physics implementations are split across:
 from __future__ import annotations
 
 from ._impact_physics import (
+    SMASH_FACTOR_PHYSICAL_MAX,
     FiniteTimeImpactModel,
     ImpactModel,
     ImpactModelType,
@@ -31,6 +32,7 @@ from ._impact_physics import (
     PreImpactState,
     RigidBodyImpactModel,
     SpringDamperImpactModel,
+    check_smash_factor,
     compute_gear_effect_spin,
     create_impact_model,
     validate_energy_balance,
@@ -38,6 +40,7 @@ from ._impact_physics import (
 from ._impact_recorder import ImpactEvent, ImpactRecorder, ImpactSolverAPI
 
 __all__ = [
+    "SMASH_FACTOR_PHYSICAL_MAX",
     "FiniteTimeImpactModel",
     "ImpactEvent",
     "ImpactModel",
@@ -49,6 +52,7 @@ __all__ = [
     "PreImpactState",
     "RigidBodyImpactModel",
     "SpringDamperImpactModel",
+    "check_smash_factor",
     "compute_gear_effect_spin",
     "create_impact_model",
     "validate_energy_balance",

--- a/tests/unit/shared_python/test_impact_model.py
+++ b/tests/unit/shared_python/test_impact_model.py
@@ -275,3 +275,84 @@ def test_create_impact_model() -> None:
         # Use a type annotation to tell mypy we're testing invalid input
         invalid_type: ImpactModelType = "invalid_type"  # type: ignore[assignment]
         create_impact_model(invalid_type)
+
+
+class TestAngularMomentumConservation:
+    """Verify that the rigid body impact conserves total angular momentum."""
+
+    def test_l_pre_equals_l_post_within_tolerance(
+        self, basic_pre_state, default_impact_params
+    ):
+        from src.shared.python.core.physics_constants import (
+            DRIVER_MOI_KG_M2,
+            GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+        )
+
+        model = RigidBodyImpactModel()
+        post = model.solve(basic_pre_state, default_impact_params)
+
+        r_ball = basic_pre_state.ball_position
+
+        L_club_pre = (
+            DRIVER_MOI_KG_M2 * basic_pre_state.clubhead_angular_velocity
+            + basic_pre_state.clubhead_mass
+            * np.cross(np.zeros(3), basic_pre_state.clubhead_velocity)
+        )
+        L_ball_pre = (
+            GOLF_BALL_MASS_KG * np.cross(r_ball, basic_pre_state.ball_velocity)
+            + GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 * basic_pre_state.ball_angular_velocity
+        )
+
+        L_club_post = (
+            basic_pre_state.clubhead_moi * post.clubhead_angular_velocity
+            + basic_pre_state.clubhead_mass
+            * np.cross(np.zeros(3), post.clubhead_velocity)
+        )
+        L_ball_post = (
+            GOLF_BALL_MASS_KG * np.cross(r_ball, post.ball_velocity)
+            + GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 * post.ball_angular_velocity
+        )
+
+        L_pre = L_club_pre + L_ball_pre
+        L_post = L_club_post + L_ball_post
+        np.testing.assert_allclose(L_pre, L_post, atol=1e-6)
+
+
+class TestSmashFactorBound:
+    """check_smash_factor() enforces the 1.56 physical ceiling.
+
+    Smash factor = ball_speed_post / club_speed_pre (TrackMan standard).
+    Physical hard limit 1.56 is derived from COR=1, m_club → ∞.
+    """
+
+    def test_valid_smash_accepted(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        check_smash_factor(ball_speed_post=63.0, club_speed_pre=45.0)  # ≈ 1.40
+
+    def test_smash_above_limit_raises(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        with pytest.raises(ValueError, match="Smash factor"):
+            check_smash_factor(ball_speed_post=100.0, club_speed_pre=45.0)  # ≈ 2.22
+
+    def test_zero_club_speed_no_check(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        check_smash_factor(ball_speed_post=0.0, club_speed_pre=0.0)
+
+    def test_normal_driver_swing_smash_within_limit(self):
+        model = RigidBodyImpactModel()
+        params = ImpactParameters(cor=0.8, friction_coefficient=0.4)
+        pre = PreImpactState(
+            clubhead_velocity=np.array([45.0, 0.0, 0.0]),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=np.array([1.0, 0.0, 0.0]),
+            ball_position=np.array([0.05, 0.0, 0.0]),
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+            clubhead_mass=0.2,
+        )
+        post = model.solve(pre, params)
+        ball_speed = float(np.linalg.norm(post.ball_velocity))
+        assert ball_speed / 45.0 <= 1.56


### PR DESCRIPTION
## Summary

Addresses two findings from issue #2700 (impact model correctness defects):

- **Smash-factor physical bound**: Extract `check_smash_factor(ball_speed_post, club_speed_pre)` as a public utility in `models.py`. Raises `ValueError` when smash factor (TrackMan standard: ball_speed_post / club_speed_pre) exceeds 1.56 — the physical hard limit derived from COR=1, m_club→∞. Called inside `RigidBodyImpactModel.solve()` after computing post-impact ball velocity. `SMASH_FACTOR_PHYSICAL_MAX = 1.56` exported as module constant.
- **Angular momentum conservation test**: `TestAngularMomentumConservation` verifies `|L_pre − L_post| < 1e-6` for a full driver swing, including rotational contributions of both club and ball.

## Test plan

- [x] All 14 `tests/unit/shared_python/test_impact_model.py` tests pass
- [x] `ruff format --check` clean
- [x] check_smash_factor tested directly (3 cases) and via solve() integration

Partially closes #2700 (smash bound + angular-momentum conservation test added; gear-effect derivation doc and full 3-D inertia tensor follow-on).