### PR TITLE
fix: ISA altitude model, velocity-dependent spin decay, aerodynamics validation tests

### DIFF
--- a/src/shared/python/physics/aerodynamics/_engine.py
+++ b/src/shared/python/physics/aerodynamics/_engine.py
@@ -172,19 +172,39 @@ class AerodynamicsEngine:
         forces = self.compute_forces(velocity, spin, t, position, resample)
         return forces["total"] / mass
 
-    def compute_spin_decay(self, spin: np.ndarray, dt: float) -> np.ndarray:
+    def compute_spin_decay(
+        self,
+        spin: np.ndarray,
+        dt: float,
+        velocity_magnitude: float | None = None,
+    ) -> np.ndarray:
         """Compute spin decay over time step (exponential decay).
+
+        When *velocity_magnitude* is supplied the decay rate is scaled
+        linearly by ``v / V_REF`` so that the stored ``spin_decay_rate``
+        is calibrated at ``V_REF = 70 m/s`` (mid-trajectory driver speed).
+        At lower speeds (e.g. descent) spin decays more slowly; at higher
+        speeds it decays faster — consistent with viscous aerodynamic drag
+        on a spinning sphere.
 
         Args:
             spin: Current angular velocity [rad/s]
             dt: Time step [s]
+            velocity_magnitude: Ball speed [m/s]. If None, uses constant rate.
 
         Returns:
             Updated spin after decay [rad/s]
         """
         if spin is None:
             raise ValueError("spin must be provided")
-        decay_factor = math.exp(-self.config.spin_decay_rate * dt)
+        if velocity_magnitude is not None and velocity_magnitude < 0:
+            raise ValueError("velocity_magnitude must be non-negative")
+        _V_REF = 70.0  # m/s — calibration reference speed
+        if velocity_magnitude is not None:
+            effective_rate = self.config.spin_decay_rate * velocity_magnitude / _V_REF
+        else:
+            effective_rate = self.config.spin_decay_rate
+        decay_factor = math.exp(-effective_rate * dt)
         return spin * decay_factor
 
 

--- a/src/shared/python/physics/ball_launch_conditions.py
+++ b/src/shared/python/physics/ball_launch_conditions.py
@@ -35,6 +35,41 @@ class EnvironmentalConditions:
     altitude: float = 0.0
     temperature: float = 15.0
 
+    @classmethod
+    def from_altitude(
+        cls,
+        altitude_m: float,
+        wind_velocity: np.ndarray | None = None,
+    ) -> EnvironmentalConditions:
+        """Create conditions with ISA-derived air density for the given altitude.
+
+        Uses the International Standard Atmosphere troposphere model
+        (valid 0–11 km).  Air density decreases by ~1.2% per 100 m.
+
+        Args:
+            altitude_m: Altitude above sea level [m]. Must be ≥ 0.
+            wind_velocity: 3-vector wind velocity [m/s]. Defaults to zero.
+
+        Returns:
+            EnvironmentalConditions with density and temperature set from ISA.
+
+        Raises:
+            ValueError: If altitude_m is negative.
+        """
+        if altitude_m < 0:
+            raise ValueError("altitude_m must be non-negative")
+        T0, P0 = 288.15, 101325.0  # K, Pa — ISA sea-level values
+        L, g_isa, M_air, R_gas = 0.0065, 9.80665, 0.0289644, 8.31447
+        T_k = T0 - L * altitude_m
+        P = P0 * (T_k / T0) ** (g_isa * M_air / (R_gas * L))
+        rho = P * M_air / (R_gas * T_k)
+        return cls(
+            air_density=rho,
+            altitude=altitude_m,
+            temperature=T_k - 273.15,
+            wind_velocity=wind_velocity if wind_velocity is not None else np.zeros(3),
+        )
+
 
 @dataclass
 class TrajectoryPoint:

--- a/tests/physics_validation/test_aerodynamics_calibration.py
+++ b/tests/physics_validation/test_aerodynamics_calibration.py
@@ -1,0 +1,85 @@
+"""Aerodynamics calibration validation tests.
+
+Validates the ISA altitude model (EnvironmentalConditions.from_altitude)
+and velocity-dependent spin decay (AerodynamicsEngine.compute_spin_decay).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.physics.ball_launch_conditions import EnvironmentalConditions
+
+
+class TestISAAltitudeModel:
+    def test_sea_level_density(self):
+        ec = EnvironmentalConditions.from_altitude(0.0)
+        assert abs(ec.air_density - 1.225) < 0.01
+
+    def test_denver_density(self):
+        ec = EnvironmentalConditions.from_altitude(1609.0)
+        assert abs(ec.air_density - 1.045) < 0.015
+
+    def test_density_monotone_decrease(self):
+        rhos = [
+            EnvironmentalConditions.from_altitude(float(h)).air_density
+            for h in range(0, 5000, 500)
+        ]
+        assert all(rhos[i] > rhos[i + 1] for i in range(len(rhos) - 1))
+
+    def test_temperature_decrease_with_altitude(self):
+        ec_low = EnvironmentalConditions.from_altitude(0.0)
+        ec_high = EnvironmentalConditions.from_altitude(5000.0)
+        assert ec_high.temperature < ec_low.temperature
+
+    def test_altitude_stored(self):
+        ec = EnvironmentalConditions.from_altitude(2000.0)
+        assert ec.altitude == pytest.approx(2000.0)
+
+    def test_negative_altitude_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            EnvironmentalConditions.from_altitude(-1.0)
+
+    def test_wind_velocity_passed_through(self):
+        wind = np.array([3.0, 0.0, 0.0])
+        ec = EnvironmentalConditions.from_altitude(500.0, wind_velocity=wind)
+        np.testing.assert_array_almost_equal(ec.wind_velocity, wind)
+
+    def test_default_wind_is_zero(self):
+        ec = EnvironmentalConditions.from_altitude(500.0)
+        np.testing.assert_array_equal(ec.wind_velocity, np.zeros(3))
+
+
+class TestVelocityDependentSpinDecay:
+    @pytest.fixture()
+    def engine(self):
+        from src.shared.python.physics.aerodynamics._config import AerodynamicsConfig
+        from src.shared.python.physics.aerodynamics._engine import AerodynamicsEngine
+
+        cfg = AerodynamicsConfig(spin_decay_rate=0.01)
+        return AerodynamicsEngine(cfg)
+
+    def test_reference_speed_matches_constant_rate(self, engine):
+        spin = np.array([0.0, -100.0, 0.0])
+        dt = 0.1
+        result_const = engine.compute_spin_decay(spin, dt)
+        result_vref = engine.compute_spin_decay(spin, dt, velocity_magnitude=70.0)
+        np.testing.assert_array_almost_equal(result_const, result_vref, decimal=6)
+
+    def test_high_speed_decays_faster(self, engine):
+        spin = np.array([0.0, -100.0, 0.0])
+        dt = 0.1
+        result_ref = engine.compute_spin_decay(spin, dt, velocity_magnitude=70.0)
+        result_fast = engine.compute_spin_decay(spin, dt, velocity_magnitude=140.0)
+        assert np.linalg.norm(result_fast) < np.linalg.norm(result_ref)
+
+    def test_zero_velocity_no_decay(self, engine):
+        spin = np.array([0.0, -100.0, 0.0])
+        result = engine.compute_spin_decay(spin, 1.0, velocity_magnitude=0.0)
+        np.testing.assert_array_almost_equal(result, spin, decimal=6)
+
+    def test_negative_velocity_raises(self, engine):
+        spin = np.array([0.0, -100.0, 0.0])
+        with pytest.raises(ValueError, match="non-negative"):
+            engine.compute_spin_decay(spin, 0.1, velocity_magnitude=-1.0)


### PR DESCRIPTION
## Summary
- `EnvironmentalConditions.from_altitude(altitude_m)` — new classmethod using ISA troposphere model; derives air density and temperature from altitude
- `AerodynamicsEngine.compute_spin_decay(..., velocity_magnitude=None)` — optional kwarg scales decay rate by v/70 m/s; spin decays faster at high ball speed (launch), slower during descent
- 12 validation tests in `tests/physics_validation/test_aerodynamics_calibration.py`

## Test plan
- [x] `ruff check` — zero violations
- [x] `ruff format` — no diffs
- [x] `pytest tests/physics_validation/test_aerodynamics_calibration.py` — 12/12 pass

Closes #2701

🤖 Generated with [Claude Code](https://claude.com/claude-code)