### PR TITLE
fix: smash-factor physical bound validation in RigidBodyImpactModel

### DIFF
--- a/src/shared/python/physics/_impact_physics.py
+++ b/src/shared/python/physics/_impact_physics.py
@@ -131,6 +131,37 @@ class ImpactModel(ABC):
         ...
 
 
+SMASH_FACTOR_PHYSICAL_MAX: float = 1.56
+"""Physical upper bound on smash factor (ball_speed_post / club_speed_pre).
+
+Corresponds to the maximum COR of 0.83 permitted under R&A/USGA rules at
+the 1.5x smash-factor limit.  Values above this indicate a unit mismatch or
+COR > 1 (energy creation), which is non-physical.
+"""
+
+
+def check_smash_factor(ball_speed_post: float, club_speed_pre: float) -> None:
+    """Raise ValueError if the post-impact smash factor is non-physical.
+
+    Args:
+        ball_speed_post: Ball speed immediately after impact [m/s].
+        club_speed_pre: Clubhead speed immediately before impact [m/s].
+
+    Raises:
+        ValueError: If smash factor exceeds SMASH_FACTOR_PHYSICAL_MAX.
+    """
+    if club_speed_pre > 1e-6:
+        smash = ball_speed_post / club_speed_pre
+        if smash > SMASH_FACTOR_PHYSICAL_MAX:
+            raise ValueError(
+                f"Smash factor {smash:.3f} exceeds the physical maximum of "
+                f"{SMASH_FACTOR_PHYSICAL_MAX} "
+                f"(ball_speed_post={ball_speed_post:.2f} m/s, "
+                f"club_speed_pre={club_speed_pre:.2f} m/s) — likely a unit "
+                "mismatch or unrealistic COR > 1"
+            )
+
+
 class RigidBodyImpactModel(ImpactModel):
     """Rigid body collision with coefficient of restitution.
 
@@ -284,6 +315,11 @@ class RigidBodyImpactModel(ImpactModel):
 
         v_ball_post = pre_state.ball_velocity + (j / GOLF_BALL_MASS_KG) * n
         v_club_post = pre_state.clubhead_velocity - (j / pre_state.clubhead_mass) * n
+
+        check_smash_factor(
+            float(np.linalg.norm(v_ball_post)),
+            float(np.linalg.norm(pre_state.clubhead_velocity)),
+        )
 
         ball_spin = self._compute_friction_spin(
             pre_state,
@@ -545,9 +581,12 @@ class FiniteTimeImpactModel(ImpactModel):
 
 
 @precondition(
-    lambda impact_offset, clubhead_velocity, clubface_normal, gear_factor=0.5, h_scale=100.0, v_scale=50.0: (
-        0 <= gear_factor <= 1
-    ),
+    lambda impact_offset,
+    clubhead_velocity,
+    clubface_normal,
+    gear_factor=0.5,
+    h_scale=100.0,
+    v_scale=50.0: (0 <= gear_factor <= 1),
     "Gear effect factor must be between 0 and 1",
 )
 def compute_gear_effect_spin(

--- a/src/shared/python/physics/impact_model.py
+++ b/src/shared/python/physics/impact_model.py
@@ -23,6 +23,7 @@ Physics implementations are split across:
 from __future__ import annotations
 
 from ._impact_physics import (
+    SMASH_FACTOR_PHYSICAL_MAX,
     FiniteTimeImpactModel,
     ImpactModel,
     ImpactModelType,
@@ -31,6 +32,7 @@ from ._impact_physics import (
     PreImpactState,
     RigidBodyImpactModel,
     SpringDamperImpactModel,
+    check_smash_factor,
     compute_gear_effect_spin,
     create_impact_model,
     validate_energy_balance,
@@ -38,6 +40,7 @@ from ._impact_physics import (
 from ._impact_recorder import ImpactEvent, ImpactRecorder, ImpactSolverAPI
 
 __all__ = [
+    "SMASH_FACTOR_PHYSICAL_MAX",
     "FiniteTimeImpactModel",
     "ImpactEvent",
     "ImpactModel",
@@ -49,6 +52,7 @@ __all__ = [
     "PreImpactState",
     "RigidBodyImpactModel",
     "SpringDamperImpactModel",
+    "check_smash_factor",
     "compute_gear_effect_spin",
     "create_impact_model",
     "validate_energy_balance",

--- a/tests/unit/shared_python/test_impact_model.py
+++ b/tests/unit/shared_python/test_impact_model.py
@@ -275,3 +275,49 @@ def test_create_impact_model() -> None:
         # Use a type annotation to tell mypy we're testing invalid input
         invalid_type: ImpactModelType = "invalid_type"  # type: ignore[assignment]
         create_impact_model(invalid_type)
+
+
+# ---------------------------------------------------------------------------
+# Smash factor bound tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmashFactorBound:
+    def test_valid_smash_accepted(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        check_smash_factor(77.0, 50.0)  # smash = 1.54 — below 1.56 limit
+
+    def test_too_high_smash_raises(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        with pytest.raises(ValueError, match="Smash factor"):
+            check_smash_factor(100.0, 50.0)  # smash = 2.0
+
+    def test_zero_club_speed_no_check(self):
+        from src.shared.python.physics.impact_model import check_smash_factor
+
+        check_smash_factor(50.0, 0.0)  # should not raise
+
+    def test_smash_factor_constant_value(self):
+        from src.shared.python.physics.impact_model import SMASH_FACTOR_PHYSICAL_MAX
+
+        assert pytest.approx(1.56) == SMASH_FACTOR_PHYSICAL_MAX
+
+    def test_rigid_body_model_normal_shot_passes(self):
+        """Normal driver shot should not trigger smash-factor check."""
+        model = RigidBodyImpactModel()
+        pre = PreImpactState(
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+            clubhead_velocity=np.array([50.0, 0.0, 0.0]),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_mass=0.2,
+            clubhead_moi=0.002,
+            clubhead_orientation=np.array([1.0, 0.0, 0.0]),
+            ball_position=np.zeros(3),
+            impact_offset=None,
+        )
+        params = ImpactParameters(cor=0.83, friction_coefficient=0.15)
+        result = model.solve(pre, params)
+        assert result.ball_velocity[0] > 0


### PR DESCRIPTION
## Summary
- Adds `SMASH_FACTOR_PHYSICAL_MAX = 1.56` constant (USGA/R&A rules limit)
- Adds `check_smash_factor(ball_speed_post, club_speed_pre)` guard that raises `ValueError` when the smash factor exceeds the physical maximum
- Calls the guard inside `RigidBodyImpactModel.solve()` immediately after computing post-impact ball velocity
- Exports both via `impact_model.py` public API and `__all__`

## Test plan
- [x] `TestSmashFactorBound` class (5 tests): valid smash accepted, too-high smash raises, zero club speed skips check, constant value correct, normal driver shot passes
- [x] All 13 impact model tests pass locally
- [x] ruff check + format pass

Closes #2700