### PR TITLE
fix(launcher): restore synchronous _cleanup_processes for legacy callers

### DIFF
--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -640,9 +640,12 @@ class GolfLauncher(
             self.lbl_status.setStyleSheet(Styles.STATUS_INACTIVE)
 
     def _cleanup_processes(self) -> None:
-        """Legacy cleanup method. Use _schedule_cleanup instead."""
-        # Kept for backward compatibility with mixins
-        self._schedule_cleanup()
+        """Legacy cleanup method — synchronous for callers that need immediate results."""
+        finished_keys = [
+            key for key, proc in list(self.running_processes.items())
+            if proc.poll() is not None
+        ]
+        self._on_cleanup_finished(finished_keys)
 
     def closeEvent(self, event: QCloseEvent | None) -> None:
         """Handle window close event to save layout."""


### PR DESCRIPTION
## Summary

PR #2930 changed `_cleanup_processes` to delegate to the async `_schedule_cleanup()`, which broke tests expecting synchronous cleanup behavior.

This patch restores `_cleanup_processes` to be synchronous: it computes finished keys inline and calls `_on_cleanup_finished` directly. The timer-based path still uses `_schedule_cleanup` for non-blocking async cleanup.

## Test plan

- [ ] `test_cleanup_processes` passes
- [ ] `test_on_cleanup_finished_updates_running_processes` passes (if it exists)
- [ ] `ProcessCleanupWorker` TypeError is gone

Fixes test regression introduced by PR #2930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)