### PR TITLE
fix(p1): symmetry check for right-side limbs + CI runner routing (#2921, #2903-#2906)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -59,7 +59,7 @@ permissions:
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: d-sorg-fleet
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -81,7 +81,7 @@ jobs:
           fi
   quality-gate:
     needs: pick-runner
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -200,7 +200,7 @@ jobs:
 
   tests:
     needs: [pick-runner, quality-gate]
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20 # Prevent runaway tests - hard cutoff
     strategy:
       matrix:
@@ -350,7 +350,7 @@ jobs:
 
   shared-tools-consumer-contracts:
     needs: [pick-runner, quality-gate]
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -427,7 +427,7 @@ jobs:
 
   frontend-tests:
     needs: [pick-runner, quality-gate]
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     defaults:
       run:
         working-directory: ./ui
@@ -464,7 +464,7 @@ jobs:
   # =============================================================================
   matlab-tests:
     needs: [pick-runner, quality-gate]
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     if: false # DISABLED - Requires MATLAB license not available in CI
     continue-on-error: true
     steps:
@@ -483,7 +483,7 @@ jobs:
   # =============================================================================
   arduino-build:
     needs: [pick-runner, quality-gate]
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     if: false # DISABLED - No Arduino components in this project
     steps:
       - uses: actions/checkout@v6
@@ -502,7 +502,7 @@ jobs:
   # =============================================================================
   rust-quality-gate:
     needs: pick-runner
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/src/shared/python/biomechanics/humanoid_urdf_contracts.py
+++ b/src/shared/python/biomechanics/humanoid_urdf_contracts.py
@@ -228,6 +228,19 @@ def _check_bilateral_symmetry(
                     ),
                 )
             )
+
+    # Also catch right-side-only links that have no left_ counterpart.
+    for name in masses:
+        if not name.startswith("right_"):
+            continue
+        mirror = "left_" + name[len("right_") :]
+        if mirror not in masses:
+            violations.append(
+                ContractViolation(
+                    category="asymmetric_limbs",
+                    message=(f"link '{name}' has no mirror '{mirror}'"),
+                )
+            )
     return violations
 
 


### PR DESCRIPTION
## Summary
- **#2921**: Add right-side-only link check in `_check_bilateral_symmetry` — the existing loop only iterated over `left_*` links, so a URDF with `right_*` links but no corresponding `left_*` counterparts would incorrectly pass validation

## Note on #2916
Issue #2916 (Dockerfile `|| true`) is already resolved — the Dockerfile was rewritten in PR #2858 (conda-based) without the `|| true` from #2857, so no separate fix is needed.

## Test plan
- [ ] A URDF with only `right_foot` (no `left_foot`) now produces an `asymmetric_limbs` violation
- [ ] Existing left+right symmetric URDFs still pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)