### PR TITLE
⚡ Bolt: Replace np.linalg.norm with np.vdot for speed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-22T00:00:00-07:00
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.152                                            |
+| **Spec Version**        | 1.0.153                                            |
 | **Last Spec Update**    | 2026-04-22                                         |
 
 ## 2. Purpose & Mission
@@ -500,6 +500,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 - Performance scaling beyond 100-muscle models not yet tested
 
 ## 12. Change Log
+| 2026-04-22 | 1.0.153 | Performance optimization: Replaced `np.linalg.norm(x)` with `np.sqrt(np.vdot(x, x))` and updated `np.sqrt(sum of squares)` to `math.hypot(*x)` for faster array reduction computations. |
 | 2026-04-20 | 1.0.95  | Performance optimization: Replaced generator expression `math.sqrt(sum(...))` with `math.dist(a,b)` for distance calculations to push execution entirely into C, resulting in an ~8x speedup.  |
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/motion_optimization.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/motion_optimization.py
@@ -355,12 +355,8 @@ class SwingOptimizer:
 
         # Accuracy (hit target)
         if self.objectives.target_ball_position is not None:
-            distance_error = float(
-                np.linalg.norm(
-                    metrics["final_club_position"]
-                    - self.objectives.target_ball_position,  # noqa: E501
-                ),
-            )
+            diff = metrics["final_club_position"] - self.objectives.target_ball_position
+            distance_error = float(np.sqrt(np.vdot(diff, diff)))
             objective += self.objectives.weight_accuracy * distance_error
 
         return objective

--- a/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
@@ -267,12 +267,11 @@ class DualHandIKSolver:
             left_current = self.data.oMf[self.left_hand_frame_id]
             right_current = self.data.oMf[self.right_hand_frame_id]
 
-            left_error = np.linalg.norm(
-                left_current.translation - left_target.translation
-            )  # noqa: E501
-            right_error = np.linalg.norm(
-                right_current.translation - right_target.translation
-            )  # noqa: E501
+            left_diff = left_current.translation - left_target.translation
+            right_diff = right_current.translation - right_target.translation
+
+            left_error = np.sqrt(np.vdot(left_diff, left_diff))
+            right_error = np.sqrt(np.vdot(right_diff, right_diff))
 
             # Check convergence
             if left_error < s.position_tolerance and right_error < s.position_tolerance:

--- a/src/engines/physics_engines/putting_green/python/simulator.py
+++ b/src/engines/physics_engines/putting_green/python/simulator.py
@@ -636,7 +636,7 @@ class PuttingGreenSimulator:
         if speed is None:
             raise ValueError("speed must be provided")
         self._wind_speed = speed
-        mag = np.linalg.norm(direction)
+        mag = np.sqrt(np.vdot(direction, direction))
         if mag > 0:
             self._wind_direction = direction / mag
 
@@ -655,7 +655,7 @@ class PuttingGreenSimulator:
         relative_v = (
             self._wind_direction * self._wind_speed - self._ball_state.velocity[:2]
         )
-        rel_speed = np.linalg.norm(relative_v)
+        rel_speed = np.sqrt(np.vdot(relative_v, relative_v))
 
         if rel_speed < 0.1:
             return np.zeros(2)

--- a/src/robotics/planning/collision/collision_types.py
+++ b/src/robotics/planning/collision/collision_types.py
@@ -5,6 +5,7 @@ This module defines data structures for collision queries and results.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
@@ -116,9 +117,7 @@ class DistanceResult:
             # Normalize the normal vector
             # ⚡ Bolt: Element-wise norm computation is faster than np.linalg.norm(..., axis=None) for tiny vectors
             # using math.hypot equivalent
-            norm = float(
-                np.sqrt(self.normal[0] ** 2 + self.normal[1] ** 2 + self.normal[2] ** 2)
-            )
+            norm = float(math.hypot(*self.normal))
             if norm > 1e-10:
                 object.__setattr__(self, "normal", self.normal / norm)
 


### PR DESCRIPTION
💡 What: Replaced `np.linalg.norm(x)` with `np.sqrt(np.vdot(x, x))` and updated `np.sqrt(sum of squares)` to `math.hypot(*x)`.
🎯 Why: To improve performance in calculation of distances/norms of vectors.
📊 Impact: Speeds up calculations and reduces overhead compared to `np.linalg.norm`.
🔬 Measurement: Time the execution of code chunks directly, verifying functionality holds.
Label: `spec-exempt`

---
*PR created automatically by Jules for task [3503390432044280444](https://jules.google.com/task/3503390432044280444) started by @dieterolson*