### PR TITLE
fix(api): harden local server path traversal (#2805)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # SPEC.md — Repository Specification Document
 
-Last-Updated: 2026-04-20T05:00:00Z
+Last-Updated: 2026-04-20T08:56:58.3577735Z
 
 <!--
   TEMPLATE VERSION: 1.0.0
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-20T05:00:00Z
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.136                                            |
+| **Spec Version**        | 1.0.137                                            |
 | **Last Spec Update**    | 2026-04-20                                         |
 
 ## 2. Purpose & Mission
@@ -196,6 +196,9 @@ UpstreamDrift/
 - `POST /trajectory-optimize` — Optimize trajectory subject to constraints
 - `GET /engines` — List available physics engines and their status
 - `POST /export` — Export simulation model to URDF, MATLAB, or other formats
+- `GET /api/launcher/manifest` — Return launcher tile metadata for the UI shell
+- `GET /api/launcher/logos/{logo_name}` — Serve launcher logos only from approved asset roots using traversal-safe path resolution
+- SPA/static asset fallback serving under `ui/dist` resolves requested paths through traversal-safe joins and refuses absolute paths, `..` escapes, NUL bytes, and symlink escapes
 
 **GUI Interface (PyQt6)**:
 
@@ -667,5 +670,6 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 ## Changelog
 
+- 2026-04-20: Hardened local server asset serving by routing launcher logos and SPA/static-file lookups through traversal-safe path joins, closing path traversal and symlink escape vectors in the local UI shell.
 - 2026-04-20: Guarded Pinocchio energy checks behind complete finite-state verification and aligned RK4 torque sampling test coverage in pendulum engine probes.
 - 2026-04-16: Fixed import sorting in analyzer.py, advanced_export.py, and related files; restored completist audit documentation.

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -165,23 +165,60 @@ def _load_launcher_manifest() -> dict[str, Any]:
         return {"version": "1.0.0", "tiles": []}
 
 
+def _safe_join(root: Path, user_path: str) -> Path | None:
+    """Join ``user_path`` onto ``root`` while rejecting traversal.
+
+    Normalizes the combined path and verifies it remains within ``root``.
+    Returns ``None`` if the request is unsafe (absolute path, traversal via
+    ``..``, ``NUL`` byte, symlink escape) so the caller can emit a 404.
+
+    Args:
+        root: Trusted root directory the file must live under.
+        user_path: Caller-supplied relative path fragment.
+
+    Returns:
+        The resolved absolute path if it is inside ``root``, else ``None``.
+    """
+    if not user_path or "\x00" in user_path:
+        return None
+    # Reject explicitly absolute requests. ``Path.is_absolute`` catches
+    # POSIX/Windows absolutes; the drive/root checks catch Windows-style
+    # roots that may not register as absolute on POSIX hosts.
+    candidate = Path(user_path)
+    if candidate.is_absolute() or candidate.drive or candidate.root:
+        return None
+    try:
+        resolved_root = root.resolve(strict=False)
+        resolved = (resolved_root / candidate).resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved
+
+
 def _find_logo_file(logo_name: str) -> Path | None:
     """Search for a logo file in known asset directories.
+
+    The caller-supplied ``logo_name`` is joined onto each candidate root via
+    :func:`_safe_join` so that ``..`` traversal, absolute paths, and symlink
+    escape are rejected before touching the filesystem.
 
     Args:
         logo_name: Filename of the logo to find.
 
     Returns:
-        Path to the logo file, or None if not found.
+        Path to the logo file, or None if not found or rejected as unsafe.
     """
-    logos_dir = Path(__file__).parent.parent.parent / "assets" / "logos"
-    logo_path = logos_dir / logo_name
-    if logo_path.exists() and logo_path.is_file():
-        return logo_path
-    launcher_logos = Path(__file__).parent.parent / "launchers" / "assets"
-    alt_path = launcher_logos / logo_name
-    if alt_path.exists() and alt_path.is_file():
-        return alt_path
+    for root in (
+        Path(__file__).parent.parent.parent / "assets" / "logos",
+        Path(__file__).parent.parent / "launchers" / "assets",
+    ):
+        resolved = _safe_join(root, logo_name)
+        if resolved is not None and resolved.exists() and resolved.is_file():
+            return resolved
     return None
 
 
@@ -470,9 +507,14 @@ def _register_spa_catch_all(app: FastAPI, ui_path: Path) -> None:
                     status_code=404,
                     content={"detail": "API route not found", "path": full_path},
                 )
-            static_file = ui_path / full_path
-            if full_path and static_file.exists() and static_file.is_file():
-                return FileResponse(str(static_file))
+            if full_path:
+                static_file = _safe_join(ui_path, full_path)
+                if (
+                    static_file is not None
+                    and static_file.exists()
+                    and static_file.is_file()
+                ):
+                    return FileResponse(str(static_file))
             return FileResponse(str(index_html))
 
 

--- a/tests/unit/test_local_server_path_traversal.py
+++ b/tests/unit/test_local_server_path_traversal.py
@@ -1,0 +1,85 @@
+"""Tests for local server path traversal hardening (#2805).
+
+These tests verify that the local server's logo lookup and SPA static file
+helpers refuse traversal, absolute paths, NUL bytes, and symlink escape so
+that callers cannot read files outside the intended asset/UI roots.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+local_server = pytest.importorskip("src.api.local_server")
+
+
+class TestSafeJoin:
+    """Unit tests for :func:`_safe_join` path traversal rejection."""
+
+    def test_valid_relative_path_returns_resolved(self, tmp_path: Path) -> None:
+        """A simple relative filename resolves under the root."""
+        target = tmp_path / "logo.png"
+        target.write_bytes(b"ok")
+        resolved = local_server._safe_join(tmp_path, "logo.png")
+        assert resolved is not None
+        assert resolved == target.resolve()
+
+    def test_valid_nested_relative_path(self, tmp_path: Path) -> None:
+        """Nested relative paths under the root are allowed."""
+        nested = tmp_path / "sub" / "logo.png"
+        nested.parent.mkdir()
+        nested.write_bytes(b"ok")
+        resolved = local_server._safe_join(tmp_path, "sub/logo.png")
+        assert resolved is not None
+        assert resolved == nested.resolve()
+
+    def test_rejects_parent_traversal(self, tmp_path: Path) -> None:
+        """``..`` segments that escape the root are rejected."""
+        assert local_server._safe_join(tmp_path, "../secret.txt") is None
+
+    def test_rejects_deep_parent_traversal(self, tmp_path: Path) -> None:
+        """Deeply nested traversal is still rejected after normalization."""
+        assert local_server._safe_join(tmp_path, "sub/../../escape.txt") is None
+
+    def test_rejects_absolute_posix_path(self, tmp_path: Path) -> None:
+        """Absolute POSIX paths are rejected regardless of root."""
+        assert local_server._safe_join(tmp_path, "/etc/passwd") is None
+
+    def test_rejects_empty_path(self, tmp_path: Path) -> None:
+        """An empty path fragment is refused."""
+        assert local_server._safe_join(tmp_path, "") is None
+
+    def test_rejects_nul_byte(self, tmp_path: Path) -> None:
+        """NUL byte injection is refused before filesystem access."""
+        assert local_server._safe_join(tmp_path, "logo.png\x00.txt") is None
+
+    def test_rejects_symlink_escape(self, tmp_path: Path) -> None:
+        """A symlink pointing outside the root must not be served."""
+        outside = tmp_path.parent / "outside-secret.txt"
+        outside.write_bytes(b"secret")
+        root = tmp_path / "root"
+        root.mkdir()
+        link = root / "escape"
+        try:
+            os.symlink(outside, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlinks are not supported in this environment")
+        assert local_server._safe_join(root, "escape") is None
+
+
+class TestFindLogoFile:
+    """Behavior tests for :func:`_find_logo_file` with unsafe inputs."""
+
+    def test_traversal_returns_none(self) -> None:
+        """Traversal attempts should not resolve to any file."""
+        assert local_server._find_logo_file("../../etc/passwd") is None
+
+    def test_absolute_path_returns_none(self) -> None:
+        """Absolute paths are rejected before the filesystem is checked."""
+        assert local_server._find_logo_file("/etc/passwd") is None
+
+    def test_nul_byte_returns_none(self) -> None:
+        """NUL byte injection is rejected."""
+        assert local_server._find_logo_file("logo\x00.png") is None


### PR DESCRIPTION
PR created from fleet sync. Adds a ``_safe_join`` helper that normalizes caller-supplied path fragments
against a trusted root and refuses absolute paths, ``..`` traversal, NUL
byte injection, and symlink escape. Applies it to the launcher logo lookup
and the SPA static-file catch-all so ``/api/launcher/logos/...`` and the
``/{full_path:path}`` route can no longer be coerced into reading files
outside the intended asset and UI roots.

Adds unit tests covering each rejection path plus valid nested filenames
so the hardening keeps honest requests working.

Wave 30. Rebuild of stale PR #2721 scoped to the security-relevant change.

Closes #2805

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>