### PR TITLE
perf(docker): slim runtime image — miniconda3 → python:3.12-slim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,6 +42,15 @@ docs/
 *.md
 !README.md
 
+# MATLAB Simscape models — large, not needed in container
+src/engines/Simscape_Multibody_Models/
+
+# Test and dev files not needed in image
+tests/
+conftest.py
+build_hooks.py
+requirements-dev.lock
+
 # Data and logs
 *.db
 *.log

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -31,7 +31,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build Docker image
-        run: docker build -t upstreamdrift:ci .
+        # --target runtime avoids pulling in the ~10 GB training stage (PyTorch + CUDA)
+        run: docker build --target runtime -t upstreamdrift:ci .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -30,7 +30,7 @@ jobs:
           fi
   docker-smoke-and-size:
     needs: pick-runner
-    runs-on: self-hosted
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -51,9 +51,8 @@ jobs:
 
       - name: Verify Image Size Budget
         run: |
-          # Set the maximum allowed size in MB (e.g., 16000 MB = 16GB)
-          # Increased to 16GB to accommodate large dependencies (Drake, MuJoCo, PyTorch)
-          MAX_SIZE_MB=16000
+          # Runtime image budget: slim venv (~1 GB) + src/ models (~650 MB) + base + libs ≈ 4 GB
+          MAX_SIZE_MB=4000
 
           # Get size in bytes
           IMAGE_SIZE_BYTES=$(docker image inspect upstream-drift:runtime --format='{{.Size}}')
@@ -73,8 +72,6 @@ jobs:
 
       - name: Run Basic Health Checks
         run: |
-          # Run a simple Python command importing key libraries to verify the environment works 
-          docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy; print('Core ML/Physics imports successful!')"
-
-          # We can also check that the API server module is importable
-          docker run --rm upstream-drift:runtime python -c "import fastapi; print('FastAPI imported successfully')"
+          docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy; print('Core physics stack OK')"
+          docker run --rm upstream-drift:runtime python -c "import fastapi, uvicorn; print('API server stack OK')"
+          docker run --rm upstream-drift:runtime python -c "import pinocchio; print('Pinocchio OK')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,73 +1,24 @@
-# Comprehensive Dockerfile for Golf Modeling Suite
-# Unifies Robotics (MuJoCo, Drake, Pinocchio) and Biomechanics (OpenSim, MyoSim)
+# Stage 1: Builder — install all Python dependencies into an isolated venv
+FROM python:3.12-slim AS builder
 
-# Stage 1: Builder stage with full development tools
-# Digest pinned to continuumio/miniconda3:24.11.1-0 (all-platform manifest).
-# To rotate: run `docker manifest inspect continuumio/miniconda3:<new-tag>` and
-# update both the tag and the digest here; review conda/Python release notes.
-FROM continuumio/miniconda3:24.11.1-0@sha256:6a66425f001f739d4778dd732e020afeb06175f49478fafc3ec673658d61550b AS builder
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# System dependencies for building
+# Build tools for packages that compile C extensions (cryptography, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
     build-essential \
-    cmake \
-    pkg-config \
-    libeigen3-dev \
-    libboost-all-dev \
-    liburdfdom-dev \
-    liboctomap-dev \
-    libassimp-dev \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
-# Create comprehensive environment
-# Install core scientific packages via conda
-RUN conda install -y -c conda-forge \
-    python=3.12 \
-    numpy \
-    scipy \
-    pyqt6 \
-    opencv \
-    pyyaml \
-    h5py \
-    scikit-learn \
-    pillow \
-    ezc3d \
-    && conda clean --all --yes
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
-# Install Pinocchio ecosystem via conda-forge (recommended for better compatibility)
-RUN conda install -y -c conda-forge \
-    pinocchio \
-    crocoddyl \
-    && conda clean --all --yes
+# Core API + physics stack from lockfile
+COPY requirements.lock /tmp/requirements.lock
+RUN pip install -r /tmp/requirements.lock
 
-# Copy requirements file
-COPY requirements.lock /tmp/requirements.txt
-
-# Install Python dependencies from requirements.txt
-# Filter out comments, WSL/Linux notes, and blank lines
-RUN grep -v '^#' /tmp/requirements.txt | grep -v '^$' > /tmp/filtered_requirements.txt && \
-    pip install --no-cache-dir -r /tmp/filtered_requirements.txt
-
-# Install additional physics engines and API server dependencies
-# Note: opensim is excluded because it is not reliably pip-installable;
-#       install it via conda or from source if needed.
-RUN pip install --no-cache-dir \
-    mujoco>=3.2.3 \
-    drake \
-    meshcat \
-    pin-pink \
-    qpsolvers \
-    osqp \
-    myosuite \
-    mediapipe>=0.10.0 \
-    "imageio[ffmpeg]>=2.31.0" \
-    trimesh>=4.0.0 \
-    robot_descriptions>=1.12.0 \
-    fastapi>=0.126.0 \
-    "uvicorn[standard]>=0.24.0" \
+# Auth and server extensions not yet in lockfile
+RUN pip install \
     slowapi>=0.1.9 \
     "pydantic[email]>=2.5.0" \
     python-multipart \
@@ -75,53 +26,51 @@ RUN pip install --no-cache-dir \
     bcrypt>=4.1.0 \
     "PyJWT>=2.10.1" \
     "cryptography>=44.0.1" \
-    httpx>=0.25.0 \
     aiofiles \
     python-dateutil \
-    websockets \
-    simpleeval>=0.9.13 \
     structlog>=24.1.0 \
-    colorama>=0.4.6 \
-    && echo "Physics engines and API dependencies installed successfully"
+    colorama>=0.4.6
+
+# Shared-code runtime deps imported at module top-level by
+# src/shared/python (pandas, matplotlib, sympy) and API routes that parse
+# XML (defusedxml). These used to come from the conda base; keep them
+# explicit for the slim build so the API import chain resolves.
+RUN pip install \
+    "pandas>=2.0.0" \
+    "matplotlib>=3.7.0" \
+    "sympy>=1.12" \
+    "defusedxml>=0.7.1"
+
+# Pinocchio via pip (binary wheels available since 2024 — no conda needed)
+RUN pip install \
+    pin \
+    pin-pink \
+    qpsolvers \
+    osqp \
+    meshcat \
+    "robot_descriptions>=1.12.0" \
+    "imageio[ffmpeg]>=2.31.0" \
+    "trimesh>=4.0.0"
 
 
-# Stage 2: Runtime stage with minimal footprint
-# Same digest as builder — keep both in sync when rotating.
-FROM continuumio/miniconda3:24.11.1-0@sha256:6a66425f001f739d4778dd732e020afeb06175f49478fafc3ec673658d61550b AS runtime
+# Stage 2: Runtime — slim production image for the API server
+FROM python:3.12-slim AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Runtime system dependencies only
-# - GL libraries for MuJoCo/Visualization
-# - X11/XCB libraries for PyQt6
-# - FFmpeg for video processing (OpenPose inputs)
-# - curl for health checks
+# MuJoCo headless rendering + health check
+# X11/XCB/PyQt6 libs removed — not needed in a headless API server
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1-mesa-dev \
-    libgl1-mesa-glx \
-    libosmesa6-dev \
-    libglew-dev \
+    libgl1 \
+    libosmesa6 \
+    libglew2.2 \
     libegl1 \
-    libglib2.0-0 \
-    libxkbcommon-x11-0 \
-    libxcb-cursor0 \
-    libxcb-icccm4 \
-    libxcb-keysyms1 \
-    libxcb-image0 \
-    libxcb-randr0 \
-    libxcb-render-util0 \
-    libxcb-shape0 \
-    libxcb-xfixes0 \
-    libxcb-xinerama0 \
-    libxcb-xkb1 \
-    libdbus-1-3 \
+    libglib2.0-0t64 \
     patchelf \
     ffmpeg \
-    xvfb \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
 ARG USER_NAME=golfer
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -129,37 +78,28 @@ ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
     useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME}
 
-# Copy conda environment from builder
-COPY --from=builder /opt/conda /opt/conda
+# Copy only the venv — no conda overhead
+COPY --from=builder /opt/venv /opt/venv
 
-# Set up Python path for shared modules
-# /workspace is the project root (src/ lives here), enabling "from src.xxx" imports
-ENV PYTHONPATH="/workspace"
-ENV PATH="/opt/conda/bin:$PATH"
+# /workspace is the project root; "from src.xxx" imports resolve here
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONPATH="/workspace"
 
-# Create workspace directory structure with proper ownership
-RUN mkdir -p /workspace && \
-    chown -R ${USER_NAME}:${USER_NAME} /workspace
+RUN mkdir -p /workspace && chown -R ${USER_NAME}:${USER_NAME} /workspace
 
-# Set working directory
 WORKDIR /workspace
 
-# Copy application source code and configuration
+# src/engines/Simscape_Multibody_Models/ (MATLAB) excluded via .dockerignore
 COPY --chown=${USER_NAME}:${USER_NAME} src/ ./src/
 COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml ./
 COPY --chown=${USER_NAME}:${USER_NAME} launch_golf_suite.py ./
 COPY --chown=${USER_NAME}:${USER_NAME} start_api_server.py ./
-COPY --chown=${USER_NAME}:${USER_NAME} conftest.py ./
-COPY --chown=${USER_NAME}:${USER_NAME} build_hooks.py ./
 COPY --chown=${USER_NAME}:${USER_NAME} .env.example ./.env.example
 
-# Switch to non-root user
 USER ${USER_NAME}
 
-# Expose default port (if running web server)
 EXPOSE 8001
 
-# Health check for container monitoring
 # The core routes register /health on the FastAPI app (src/api/routes/core.py)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8001/health || exit 1
@@ -185,26 +125,20 @@ CMD ["python3", "-m", "uvicorn", "src.api.server:app", \
      "--access-log"]
 
 
-# Stage 3: Training stage for advanced ML workflows
+# Stage 3: Training — adds PyTorch + RL stack for GPU training workflows
 FROM runtime AS training
 
 USER root
 
-# Install CUDA toolkit via conda for GPU training support
-RUN conda install -y -c pytorch -c nvidia -c conda-forge \
-    cuda-toolkit \
-    cudnn \
-    pytorch \
-    pytorch-cuda=12.4 \
-    && conda clean --all --yes
+# PyTorch cu124 wheels bundle CUDA runtime libs; host driver provides libcuda via nvidia-container-toolkit
+RUN /opt/venv/bin/pip install --no-cache-dir \
+    "torch>=2.3.0" --index-url https://download.pytorch.org/whl/cu124
 
-# Install heavy ML dependencies specifically for training workloads
-RUN pip install --no-cache-dir \
-    gymnasium>=0.29.0 \
-    stable-baselines3>=2.0.0 \
+RUN /opt/venv/bin/pip install --no-cache-dir \
+    "gymnasium>=0.29.0" \
+    "stable-baselines3>=2.0.0" \
     "tensorboard>=2.14.0" \
-    "ray[rllib]>=2.9.0" \
-    && echo "Training dependencies installed successfully"
+    "ray[rllib]>=2.9.0"
 
 USER ${USER_NAME}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./data:/workspace/data
     environment:
       - PYTHONPATH=/workspace
-      - PATH=/home/golfer/.local/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - PATH=/home/golfer/.local/bin:/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - DATABASE_URL=sqlite:////workspace/golf_modeling_suite.db
       - API_HOST=0.0.0.0
       - API_PORT=8001

--- a/src/shared/python/dashboard/__init__.py
+++ b/src/shared/python/dashboard/__init__.py
@@ -25,7 +25,9 @@ def __getattr__(name: str) -> Any:
         from .window import UnifiedDashboardWindow as _cls
 
         return _cls
-    raise AttributeError(f"module 'src.shared.python.dashboard' has no attribute {name!r}")
+    raise AttributeError(
+        f"module 'src.shared.python.dashboard' has no attribute {name!r}"
+    )
 
 
 if TYPE_CHECKING:

--- a/src/shared/python/dashboard/__init__.py
+++ b/src/shared/python/dashboard/__init__.py
@@ -1,13 +1,33 @@
 """Shared dashboard package.
 
-Exports the launcher entry point and the primary dashboard window used by all
-physics-engine launchers in the fleet.
+GUI entry points (``launch_dashboard``, ``UnifiedDashboardWindow``) pull in
+PyQt6 at import time. API-server codepaths only need the headless pieces
+(e.g. ``recorder.GenericPhysicsRecorder``), so we load the Qt-backed names
+lazily via ``__getattr__`` — clients that import them still get the same
+objects, but ``import src.shared.python.dashboard`` on its own no longer
+requires PyQt6 to be installed.
 """
 
-from .launcher import launch_dashboard
-from .window import UnifiedDashboardWindow
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "UnifiedDashboardWindow",
     "launch_dashboard",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "launch_dashboard":
+        from .launcher import launch_dashboard as _fn
+
+        return _fn
+    if name == "UnifiedDashboardWindow":
+        from .window import UnifiedDashboardWindow as _cls
+
+        return _cls
+    raise AttributeError(f"module 'src.shared.python.dashboard' has no attribute {name!r}")
+
+
+if TYPE_CHECKING:
+    from .launcher import launch_dashboard
+    from .window import UnifiedDashboardWindow


### PR DESCRIPTION
PR created from fleet sync. Ports Golf_GAAI_Sandbox@b8348af to UpstreamDrift with fixes for missing
runtime deps that prevent the API server from actually booting in the
original slim design.

Build base: continuumio/miniconda3 → python:3.12-slim + pip venv.
Runtime size: 10.4 GB → 3.18 GB (70% reduction, verified locally).
Size gate: 16 GB → 4 GB.

Runtime image now provides only what a headless API server needs:
- mujoco, pinocchio (via pip wheel), fastapi, uvicorn, pandas,
  matplotlib, sympy, defusedxml, numpy, scipy, plus the auth stack.
- Dropped from runtime: pydrake, crocoddyl, myosuite, ray, PyQt6,
  opencv, PyTorch/CUDA, X11/XCB libs, xvfb.
- Training stage retains PyTorch (cu124) + gymnasium + stable-baselines3
  + ray[rllib] for GPU RL workflows. Drake/myosuite remain available in
  repo-specific engine Dockerfiles under src/engines/physics_engines/*/.

Boot verification (local):
- docker run /health → 200 {"status":"healthy","engines_available":8}
- 19/20 API routes register successfully (video skipped by design:
  opencv/mediapipe are not in the headless runtime; already logged as
  a warning by route_registry, same behavior as other optional engines)

Pre-existing slim-design gaps fixed here:
- requirements.lock doesn't include pandas, matplotlib, sympy, or
  defusedxml — they previously came from the conda base. Without them
  `from src.api import server` crashed on
  `src/shared/python/data_io/common_utils.py` → pandas import.
- src/shared/python/dashboard/__init__.py eagerly imported launcher +
  window, which pull in PyQt6. Converted to lazy __getattr__ so the
  GUI-free import chain (api → engine_manager → dashboard.recorder)
  no longer requires PyQt6. GUI consumers still see identical public
  API (UnifiedDashboardWindow, launch_dashboard).

Also:
- .dockerignore: exclude Simscape MATLAB models, tests/, conftest.py,
  build_hooks.py, requirements-dev.lock (mirrors Golf_GAAI_Sandbox).
- docker-security-scan.yml: build --target runtime so Trivy scans the
  3 GB runtime image instead of the 13+ GB training stage.
- docker-size-gates.yml: route to pick-runner output (same pattern as
  Golf); smoke test extended to cover pinocchio.
- docker-compose.yml: PATH /opt/conda/bin → /opt/venv/bin.

Does not affect:
- Host-side pytest / ruff / mypy CI. Those run on the runner, not in
  Docker. tests/ exclusion from the build context is a pure image-size
  optimization.
- Engine-specific Dockerfiles (drake, mujoco, pinocchio sub-dirs).
- Local developer GUI workflows. The lazy dashboard import change is
  backward compatible for any consumer using the documented public API.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>