### PR TITLE
fix: prevent undefined C3DDataReader NameError in skipped dependency mode

### DIFF
--- a/tests/unit/test_c3d_export_features.py
+++ b/tests/unit/test_c3d_export_features.py
@@ -10,9 +10,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import typing
+
 try:
     from c3d_reader import SCHEMA_VERSION, C3DDataReader  # noqa: E402
 except (ImportError, ModuleNotFoundError):
+    C3DDataReader = typing.Any  # type: ignore
     pytest.skip(
         "c3d_reader module not available (requires c3d/ezc3d)",
         allow_module_level=True,


### PR DESCRIPTION
Resolves #2924

Assigns `C3DDataReader = typing.Any` in the `except ImportError` block of `test_c3d_export_features.py` so that evaluated type annotations do not cause a `NameError` at import time when the module is not available. This allows pytest to properly honor the `allow_module_level=True` skip marker.