### PR TITLE
chore: anchor CODEOWNERS src rule to repository root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 scripts/ @dieterolson
 
 # Core / critical surface
-src/ @dieterolson
+/src/ @dieterolson
 
 # No blanket *.py owner — rely on per-package ownership above to reduce
 # bus-factor risk (issue #3074).

--- a/tests/integration/test_engine_api_integration.py
+++ b/tests/integration/test_engine_api_integration.py
@@ -14,10 +14,9 @@ Fixes #1119
 from __future__ import annotations
 
 import time
+import typing
 
 import pytest
-
-import typing
 
 try:
     from fastapi.testclient import TestClient

--- a/tests/integration/test_engine_api_integration.py
+++ b/tests/integration/test_engine_api_integration.py
@@ -17,11 +17,14 @@ import time
 
 import pytest
 
+import typing
+
 try:
     from fastapi.testclient import TestClient
 
     from src.api.server import app
 except ImportError:
+    TestClient = typing.Any  # type: ignore
     pytest.skip("API server deps not available", allow_module_level=True)
 
 from src.shared.python.engine_core.engine_registry import EngineType

--- a/tests/unit/test_c3d_export_features.py
+++ b/tests/unit/test_c3d_export_features.py
@@ -10,9 +10,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import typing
+
 try:
     from c3d_reader import SCHEMA_VERSION, C3DDataReader  # noqa: E402
 except (ImportError, ModuleNotFoundError):
+    C3DDataReader = typing.Any  # type: ignore
     pytest.skip(
         "c3d_reader module not available (requires c3d/ezc3d)",
         allow_module_level=True,

--- a/tests/unit/test_c3d_export_features.py
+++ b/tests/unit/test_c3d_export_features.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
+import typing
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
-
-import typing
 
 try:
     from c3d_reader import SCHEMA_VERSION, C3DDataReader  # noqa: E402


### PR DESCRIPTION
Resolves #3093

Changes the `src/` rule to `/src/` to prevent unintended matching of nested `src` directories.