### PR TITLE
feat(engines): add Capability enum to BasePhysicsEngine; fix Pinocchio contract violation

### DIFF
--- a/src/engines/physics_engines/pendulum/python/pendulum_physics_engine.py
+++ b/src/engines/physics_engines/pendulum/python/pendulum_physics_engine.py
@@ -23,6 +23,7 @@ from src.shared.python.core.contracts import (
 from src.shared.python.engine_core.base_physics_engine import (
     BasePhysicsEngine,
 )
+from src.shared.python.engine_core.capabilities import Capability
 from src.shared.python.engine_core.checkpoint import StateCheckpoint
 from src.shared.python.logging_pkg.logging_config import get_logger
 
@@ -318,6 +319,26 @@ class PendulumPhysicsEngine(BasePhysicsEngine):
             self._pendulum_state.theta2 = theta2_orig
             self._pendulum_state.omega1 = omega1_orig
             self._pendulum_state.omega2 = omega2_orig
+
+    def capabilities(self) -> frozenset:
+        """Return the set of capabilities this engine supports.
+
+        The double-pendulum engine implements forward dynamics, mass matrix,
+        inverse dynamics, drift-control decomposition, and counterfactual
+        experiments.  Jacobian and contact-force queries are not supported.
+
+        Returns:
+            frozenset of supported :class:`Capability` members.
+        """
+        return frozenset(
+            {
+                Capability.FORWARD_DYNAMICS,
+                Capability.MASS_MATRIX,
+                Capability.INVERSE_DYNAMICS,
+                Capability.DRIFT_CONTROL,
+                Capability.COUNTERFACTUAL,
+            }
+        )
 
     def compute_zvcf(self, q: np.ndarray) -> np.ndarray:
         """Zero-Velocity Counterfactual - Guideline G2.

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py
@@ -22,6 +22,7 @@ from src.shared.python.core.contracts import (
 from src.shared.python.engine_core.base_physics_engine import (
     BasePhysicsEngine,
 )
+from src.shared.python.engine_core.capabilities import Capability
 from src.shared.python.engine_core.engine_availability import (
     PINOCCHIO_AVAILABLE,
 )
@@ -370,24 +371,29 @@ class PinocchioPhysicsEngine(BasePhysicsEngine):
         return cast(np.ndarray, tau)
 
     @precondition(lambda self: self.is_initialized, "Engine must be initialized")
-    @postcondition(check_finite, "Contact forces must contain finite values")
     def compute_contact_forces(self) -> np.ndarray:
-        """Compute total contact forces (ground reaction force, GRF).
+        """Raise NotImplementedError — contact forces are unsupported.
 
-        Notes:
-            Pinocchio's standard ABA does not compute contact forces
-            without a constraint solver. Return zeros to maintain parity
-            with cross-engine protocol until rigidly implemented.
+        Pinocchio's standard ABA algorithm does not compute contact / ground
+        reaction forces without a dedicated constraint solver.
+        ``CONTACT_FORCES`` is intentionally absent from
+        :meth:`capabilities`; callers **must** check capabilities before
+        invoking this method::
 
-        Returns:
-            f: (3,) vector representing total ground reaction force [N].
+            if Capability.CONTACT_FORCES in engine.capabilities():
+                forces = engine.compute_contact_forces()
+
+        Raises:
+            NotImplementedError: Always.  Use a MuJoCo or OpenSim engine
+                for contact-force queries, or check ``capabilities()``
+                before calling this method.
         """
-        logger.debug(
-            "PinocchioPhysicsEngine.compute_contact_forces is returning zeros. "
-            "Standard ABA dynamics in Pinocchio do not compute contact forces "
-            "without a constraint solver."
+        raise NotImplementedError(
+            "PinocchioPhysicsEngine does not support compute_contact_forces. "
+            "Standard ABA dynamics do not compute contact forces without a "
+            "constraint solver.  Check engine.capabilities() before calling "
+            "this method; CONTACT_FORCES is not in the Pinocchio capability set."
         )
-        return np.zeros(3)
 
     @precondition(
         lambda self, body_name: self.is_initialized,
@@ -554,3 +560,29 @@ class PinocchioPhysicsEngine(BasePhysicsEngine):
         Returns empty dict for parity with unconfigured MuJoCo models.
         """
         return {}
+
+    def capabilities(self) -> frozenset:
+        """Return the set of capabilities this engine supports.
+
+        Pinocchio supports forward dynamics, mass matrix, inverse dynamics,
+        Jacobian computation, drift-control decomposition, and counterfactual
+        experiments via ABA.  Contact forces are **not** supported — standard
+        ABA does not compute constraint reactions without a dedicated contact
+        solver.  Callers must check this set before invoking optional methods::
+
+            if Capability.CONTACT_FORCES in engine.capabilities():
+                forces = engine.compute_contact_forces()
+
+        Returns:
+            frozenset of supported :class:`Capability` members.
+        """
+        return frozenset(
+            {
+                Capability.FORWARD_DYNAMICS,
+                Capability.MASS_MATRIX,
+                Capability.INVERSE_DYNAMICS,
+                Capability.JACOBIAN,
+                Capability.DRIFT_CONTROL,
+                Capability.COUNTERFACTUAL,
+            }
+        )

--- a/src/shared/python/engine_core/base_physics_engine.py
+++ b/src/shared/python/engine_core/base_physics_engine.py
@@ -483,6 +483,21 @@ class BasePhysicsEngine(ContractChecker, PhysicsEngine):
             checkpoint: Checkpoint with engine-specific state data.
         """
 
+    def capabilities(self) -> frozenset:
+        """Return the set of ``Capability`` members this engine supports.
+
+        Callers should check this before invoking optional methods::
+
+            if Capability.CONTACT_FORCES in engine.capabilities():
+                forces = engine.compute_contact_forces()
+
+        Returns:
+            A ``frozenset[Capability]`` of supported capabilities.
+            The base implementation returns an empty frozenset; concrete
+            engines override this to declare what they actually support.
+        """
+        return frozenset()
+
     def __repr__(self) -> str:
         """String representation of engine."""
         status = "initialized" if self._is_initialized else "uninitialized"

--- a/src/shared/python/engine_core/capabilities.py
+++ b/src/shared/python/engine_core/capabilities.py
@@ -25,6 +25,43 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+class Capability(Enum):
+    """Discrete physics-engine capabilities used by ``BasePhysicsEngine.capabilities()``.
+
+    Each member maps to a concrete method that callers may invoke.
+    If a capability is *not* in the set returned by ``capabilities()``,
+    the corresponding method is unsupported and may raise
+    ``NotImplementedError``.
+
+    Usage::
+
+        engine = PinocchioPhysicsEngine()
+        if Capability.CONTACT_FORCES in engine.capabilities():
+            forces = engine.compute_contact_forces()
+
+    Members:
+        FORWARD_DYNAMICS: ``step()`` / ``forward()`` are implemented.
+        INVERSE_DYNAMICS: ``compute_inverse_dynamics()`` is implemented.
+        CONTACT_FORCES: ``compute_contact_forces()`` returns real data.
+        ENERGY_COMPUTATION: kinetic / potential energy queries are available.
+        MASS_MATRIX: ``compute_mass_matrix()`` is implemented.
+        JACOBIAN: ``compute_jacobian()`` is implemented.
+        DRIFT_CONTROL: ``compute_drift_acceleration()`` /
+            ``compute_control_acceleration()`` are implemented.
+        COUNTERFACTUAL: ``compute_ztcf()`` / ``compute_zvcf()`` are
+            implemented.
+    """
+
+    FORWARD_DYNAMICS = auto()
+    INVERSE_DYNAMICS = auto()
+    CONTACT_FORCES = auto()
+    ENERGY_COMPUTATION = auto()
+    MASS_MATRIX = auto()
+    JACOBIAN = auto()
+    DRIFT_CONTROL = auto()
+    COUNTERFACTUAL = auto()
+
+
 class CapabilityLevel(Enum):
     """Support level for an engine capability.
 

--- a/tests/unit/engines/test_capability_contract.py
+++ b/tests/unit/engines/test_capability_contract.py
@@ -1,0 +1,372 @@
+"""Contract tests for the Capability enum and engine capabilities() method.
+
+Issue #3052 — every method listed in an engine's capabilities() set must not
+raise NotImplementedError when called with valid inputs.  Conversely, methods
+that ARE NOT in the capability set may legitimately raise NotImplementedError.
+
+Design by Contract:
+    Invariant: if Capability.X in engine.capabilities(), then the corresponding
+    method must be callable without raising NotImplementedError.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.engine_core.capabilities import Capability
+
+# ---------------------------------------------------------------------------
+# Tests for the Capability enum itself
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityEnum:
+    """Verify the Capability enum members exist and are distinct."""
+
+    def test_forward_dynamics_exists(self) -> None:
+        assert Capability.FORWARD_DYNAMICS is not None
+
+    def test_inverse_dynamics_exists(self) -> None:
+        assert Capability.INVERSE_DYNAMICS is not None
+
+    def test_contact_forces_exists(self) -> None:
+        assert Capability.CONTACT_FORCES is not None
+
+    def test_energy_computation_exists(self) -> None:
+        assert Capability.ENERGY_COMPUTATION is not None
+
+    def test_mass_matrix_exists(self) -> None:
+        assert Capability.MASS_MATRIX is not None
+
+    def test_jacobian_exists(self) -> None:
+        assert Capability.JACOBIAN is not None
+
+    def test_drift_control_exists(self) -> None:
+        assert Capability.DRIFT_CONTROL is not None
+
+    def test_counterfactual_exists(self) -> None:
+        assert Capability.COUNTERFACTUAL is not None
+
+    def test_all_members_distinct(self) -> None:
+        members = list(Capability)
+        assert len(members) == len(set(members))
+
+    def test_capability_is_enum(self) -> None:
+        from enum import Enum
+
+        assert issubclass(Capability, Enum)
+
+
+# ---------------------------------------------------------------------------
+# Tests for BasePhysicsEngine.capabilities()
+# ---------------------------------------------------------------------------
+
+
+class TestBasePhysicsEngineCapabilities:
+    """BasePhysicsEngine.capabilities() must return an empty frozenset by default."""
+
+    def _make_concrete_base(self):  # type: ignore[return]
+        """Create a minimal concrete BasePhysicsEngine for testing."""
+        try:
+            from src.shared.python.engine_core.base_physics_engine import (
+                BasePhysicsEngine,
+            )
+        except ImportError as exc:
+            pytest.skip(f"BasePhysicsEngine not importable: {exc}")
+
+        class _MinimalEngine(BasePhysicsEngine):
+            @property
+            def engine_type(self) -> str:
+                return "minimal"
+
+            def _load_from_path_impl(self, path: str) -> None:
+                pass
+
+            def _load_from_string_impl(self, content: str, extension) -> None:
+                pass
+
+            def reset(self) -> None:
+                pass
+
+            def step(self, dt=None) -> None:
+                pass
+
+            def forward(self) -> None:
+                pass
+
+            def get_state(self):
+                return np.zeros(1), np.zeros(1)
+
+            def set_state(self, q, v) -> None:
+                pass
+
+            def set_control(self, u) -> None:
+                pass
+
+            def compute_mass_matrix(self):
+                return np.eye(1)
+
+            def compute_bias_forces(self):
+                return np.zeros(1)
+
+            def compute_gravity_forces(self):
+                return np.zeros(1)
+
+            def compute_inverse_dynamics(self, qacc):
+                return np.zeros(1)
+
+            def compute_jacobian(self, body_name):
+                return None
+
+            def compute_drift_acceleration(self):
+                return np.zeros(1)
+
+            def compute_control_acceleration(self, tau):
+                return np.zeros(1)
+
+            def compute_ztcf(self, q, v):
+                return np.zeros(1)
+
+            def compute_zvcf(self, q):
+                return np.zeros(1)
+
+        return _MinimalEngine()
+
+    def test_base_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_concrete_base()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_base_capabilities_is_empty(self) -> None:
+        engine = self._make_concrete_base()
+        assert engine.capabilities() == frozenset()
+
+    def test_capabilities_method_exists(self) -> None:
+        engine = self._make_concrete_base()
+        assert callable(engine.capabilities)
+
+
+# ---------------------------------------------------------------------------
+# Tests for PinocchioPhysicsEngine capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestPinocchioCapabilityContract:
+    """Pinocchio engine capability declarations must match its implementations."""
+
+    def _make_pinocchio_engine(self):  # type: ignore[return]
+        try:
+            from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
+                PinocchioPhysicsEngine,
+            )
+        except ImportError as exc:
+            pytest.skip(f"Pinocchio not available: {exc}")
+        return PinocchioPhysicsEngine()
+
+    def test_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_forward_dynamics_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.FORWARD_DYNAMICS in engine.capabilities()
+
+    def test_mass_matrix_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+
+    def test_inverse_dynamics_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+
+    def test_jacobian_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.JACOBIAN in engine.capabilities()
+
+    def test_drift_control_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+
+    def test_counterfactual_declared(self) -> None:
+        engine = self._make_pinocchio_engine()
+        assert Capability.COUNTERFACTUAL in engine.capabilities()
+
+    def test_contact_forces_not_declared(self) -> None:
+        """CONTACT_FORCES must NOT appear in Pinocchio capabilities.
+
+        This is the core fix for issue #3052: callers must be able to
+        determine at capability-check time that contact forces are
+        unsupported, rather than discovering it via a runtime crash.
+        """
+        engine = self._make_pinocchio_engine()
+        assert Capability.CONTACT_FORCES not in engine.capabilities()
+
+    def test_compute_contact_forces_raises_not_implemented(self) -> None:
+        """compute_contact_forces must raise NotImplementedError (not return zeros).
+
+        Returning zeros is a silent lie; raising NotImplementedError with a
+        helpful message forces callers to check capabilities() first.
+        """
+        from unittest.mock import MagicMock
+
+        from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
+            PinocchioPhysicsEngine,
+        )
+
+        engine = PinocchioPhysicsEngine.__new__(PinocchioPhysicsEngine)
+        engine.time = 0.0
+        engine.tau = np.zeros(6)
+        engine.a = np.zeros(6)
+        engine.q = np.zeros(7)
+        engine.v = np.zeros(6)
+        mock_model = MagicMock()
+        mock_model.nq = 7
+        mock_model.nv = 6
+        engine.model = mock_model
+        engine.data = MagicMock()
+        engine._is_initialized = True
+        engine.model_name_str = "test"
+        engine.allowed_dirs = []
+
+        with pytest.raises(NotImplementedError, match="capabilities"):
+            engine.compute_contact_forces()
+
+    def test_compute_contact_forces_error_mentions_capabilities(self) -> None:
+        """The NotImplementedError message must guide callers to capabilities()."""
+        from unittest.mock import MagicMock
+
+        from src.engines.physics_engines.pinocchio.python.pinocchio_physics_engine import (
+            PinocchioPhysicsEngine,
+        )
+
+        engine = PinocchioPhysicsEngine.__new__(PinocchioPhysicsEngine)
+        engine.time = 0.0
+        engine.tau = np.zeros(6)
+        engine.a = np.zeros(6)
+        engine.q = np.zeros(7)
+        engine.v = np.zeros(6)
+        engine.model = MagicMock()
+        engine.data = MagicMock()
+        engine._is_initialized = True
+        engine.model_name_str = "test"
+        engine.allowed_dirs = []
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            engine.compute_contact_forces()
+        assert "capabilities" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests for PendulumPhysicsEngine capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestPendulumCapabilityContract:
+    """Pendulum engine capability declarations must match its implementations."""
+
+    def _make_pendulum_engine(self):  # type: ignore[return]
+        try:
+            from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (
+                PendulumPhysicsEngine,
+            )
+        except ImportError as exc:
+            pytest.skip(f"PendulumPhysicsEngine not available: {exc}")
+        return PendulumPhysicsEngine()
+
+    def test_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_forward_dynamics_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.FORWARD_DYNAMICS in engine.capabilities()
+
+    def test_mass_matrix_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+
+    def test_inverse_dynamics_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+
+    def test_drift_control_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+
+    def test_counterfactual_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.COUNTERFACTUAL in engine.capabilities()
+
+    def test_contact_forces_not_declared(self) -> None:
+        engine = self._make_pendulum_engine()
+        assert Capability.CONTACT_FORCES not in engine.capabilities()
+
+    def test_jacobian_not_declared(self) -> None:
+        """Pendulum Jacobian returns None; it should not be declared as supported."""
+        engine = self._make_pendulum_engine()
+        assert Capability.JACOBIAN not in engine.capabilities()
+
+    def test_declared_mass_matrix_does_not_raise(self) -> None:
+        """MASS_MATRIX is declared; compute_mass_matrix() must not raise NotImplementedError."""
+        engine = self._make_pendulum_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+        result = engine.compute_mass_matrix()
+        assert result is not None
+
+    def test_declared_inverse_dynamics_does_not_raise(self) -> None:
+        """INVERSE_DYNAMICS is declared; compute_inverse_dynamics() must work."""
+        engine = self._make_pendulum_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+        result = engine.compute_inverse_dynamics(np.zeros(2))
+        assert result is not None
+
+    def test_declared_drift_control_does_not_raise(self) -> None:
+        """DRIFT_CONTROL is declared; compute_drift_acceleration() must work."""
+        engine = self._make_pendulum_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+        result = engine.compute_drift_acceleration()
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# General contract: no engine raises NotImplementedError for declared caps
+# ---------------------------------------------------------------------------
+
+
+class TestEngineCapabilityContractGeneral:
+    """Engines must not raise NotImplementedError for any declared capability."""
+
+    _CAPABILITY_METHODS: dict[Capability, str] = {
+        Capability.MASS_MATRIX: "compute_mass_matrix",
+        Capability.INVERSE_DYNAMICS: "compute_inverse_dynamics",
+        Capability.DRIFT_CONTROL: "compute_drift_acceleration",
+    }
+
+    def _check_engine(self, engine, qacc: np.ndarray) -> None:
+        """Assert that every declared capability method is callable."""
+        caps = engine.capabilities()
+
+        if Capability.MASS_MATRIX in caps:
+            result = engine.compute_mass_matrix()
+            assert not isinstance(result, type(NotImplemented)), (
+                "compute_mass_matrix raised NotImplementedError for declared capability"
+            )
+
+        if Capability.INVERSE_DYNAMICS in caps:
+            result = engine.compute_inverse_dynamics(qacc)
+            assert result is not None
+
+        if Capability.DRIFT_CONTROL in caps:
+            result = engine.compute_drift_acceleration()
+            assert result is not None
+
+    def test_pendulum_contract(self) -> None:
+        try:
+            from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (
+                PendulumPhysicsEngine,
+            )
+        except ImportError as exc:
+            pytest.skip(f"Pendulum not available: {exc}")
+
+        engine = PendulumPhysicsEngine()
+        self._check_engine(engine, np.zeros(2))


### PR DESCRIPTION
## Summary

- Add `Capability` enum (8 members) to `engine_core/capabilities.py` so callers can check engine feature support at capability-query time rather than discovering failures at runtime
- Add `capabilities() -> frozenset[Capability]` method to `BasePhysicsEngine` (default: empty frozenset); concrete engines override to declare what they support
- Fix `PinocchioPhysicsEngine.compute_contact_forces()`: was silently returning zeros (a lie) — now raises `NotImplementedError` with a message directing callers to check `capabilities()` first; `CONTACT_FORCES` is intentionally absent from its capability set
- Add `capabilities()` to `PendulumPhysicsEngine`

## Changes

| File | Change |
|------|--------|
| `src/shared/python/engine_core/capabilities.py` | Add `Capability` enum |
| `src/shared/python/engine_core/base_physics_engine.py` | Add `capabilities()` default method |
| `src/engines/physics_engines/pinocchio/python/pinocchio_physics_engine.py` | Add `capabilities()`, fix `compute_contact_forces()` |
| `src/engines/physics_engines/pendulum/python/pendulum_physics_engine.py` | Add `capabilities()` |
| `tests/unit/engines/test_capability_contract.py` | 35 new contract tests |

## Test plan

- [ ] `python3 -m pytest tests/unit/engines/test_capability_contract.py -v` → 35 passed
- [ ] `python3 -m ruff check` → zero violations
- [ ] `python3 -m ruff format --check` → zero diffs
- [ ] Existing capabilities, pinocchio, and pendulum engine tests pass

Closes #3052

🤖 Generated with [Claude Code](https://claude.com/claude-code)