### PR TITLE
fix: shrink mypy exclusions and use per-file overrides

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # SPEC.md — Repository Specification Document
 
-Last-Updated: 2026-04-23T12:49:00-07:00
+Last-Updated: 2026-04-23T08:40:00-07:00
 
 <!--
   TEMPLATE VERSION: 1.0.0
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-23T12:49:00-07:00
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.174                                            |
+| **Spec Version**        | 1.0.175                                            |
 | **Last Spec Update**    | 2026-04-23                                         |
 
 ## 2. Purpose & Mission
@@ -508,6 +508,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 ## 12. Change Log
 
+| 2026-04-23 | 1.0.175 | fix(ci): Shrunk `pyproject.toml` mypy exclusion list by promoting previously suppressed modules to per-file overrides, reducing the global `ignore_errors` footprint toward zero. |
 | 2026-04-22 | 1.0.153 | Performance optimization: Replaced `np.linalg.norm(x)` with `np.sqrt(np.vdot(x, x))` and updated `np.sqrt(sum of squares)` to `math.hypot(*x)` for faster array reduction computations. |
 | 2026-04-23 | 1.0.173 | Performance optimization: Replaced `np.linalg.norm` with `math.hypot` for small 2D vectors in putting green engine. |
 | 2026-04-20 | 1.0.95 | Performance optimization: Replaced generator expression `math.sqrt(sum(...))` with `math.dist(a,b)` for distance calculations to push execution entirely into C, resulting in an ~8x speedup. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,45 +219,7 @@ exclude = [
     "installer/",
     "start_api_server.py",
     "setup_golf_suite.py",
-    # numpy-stubs version divergence on self-hosted vs GitHub-hosted runners
-    # These files have pre-existing type issues exposed by numpy>=2.0 stubs
-    "src/shared/python/upstream_drift_tools/process_calculators/optimization.py",
-    "src/shared/python/perturbation/statistics.py",
-    "src/shared/python/model_generation/core/physics_validation.py",
-    "src/learning/imitation/dataset.py",
-    "src/engines/physics_engines/mujoco/docker/",
-    "src/deployment/realtime/controller.py",
-    "src/shared/python/pendulum_simulator/simulation.py",
-    "src/shared/python/club_data/targets.py",
-    "src/shared/python/data_io/marker_mapping.py",
-    "src/shared/python/signal_toolkit/io.py",
-    "src/shared/python/engine_core/checkpoint.py",
-    "src/shared/python/data_io/export.py",
-    "src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_gui.py",
-    "src/shared/python/signal_toolkit/polynomial_generator.py",
-    "src/engines/common/export.py",
-    "src/api/routes/putting_green.py",
-    "src/api/routes/physics.py",
-    "src/api/routes/analysis_tools.py",
-    # numpy-stubs floating/signedinteger type-narrowing divergence (mypy 1.20.1 + numpy 2.2.x)
-    # These files surface new type errors on runners with numpy 2.2.x stubs but pass
-    # on runners with numpy 2.3.x stubs. Excluded until numpy stubs stabilise across runners.
-    "src/shared/python/upstream_drift_tools/process_calculators/syngas_water_calculator.py",
-    "src/deployment/digital_twin/twin.py",
-    "src/shared/python/analysis/nonlinear_dynamics.py",
-    "src/shared/python/optimization/swing_optimizer.py",
-    "src/research/deformable/objects.py",
 ]
-
-# Mypy overrides for modules with pre-existing type issues
-[[tool.mypy.overrides]]
-module = [
-    "src.shared.python.plotting.*",
-    "src.shared.python.ui.*",
-    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.*",
-    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.*",
-]
-ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "src.shared.python.spatial_algebra.*"
@@ -358,3 +320,35 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "htmlcov"
+
+# Mypy overrides for modules with pre-existing type issues
+[[tool.mypy.overrides]]
+module = [
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.grip_modelling_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.core.main_window",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.tabs.controls_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.tabs.humanoid_config_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.tabs.manipulation_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.tabs.plotting_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.gui.tabs.visualization_tab",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine",
+    "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.urdf_io",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.gui_ui_setup",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.analysis_mixin",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.components",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.main_window",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.simulation_mixin",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.ui_setup_mixin",
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.ui.visualization_mixin",
+    "src.shared.python.plotting.renderers.club",
+    "src.shared.python.plotting.renderers.kinematics",
+    "src.shared.python.plotting.renderers.kinetics",
+    "src.shared.python.plotting.renderers.stability",
+    "src.shared.python.ui.loading_button",
+    "src.shared.python.ui.preferences_dialog",
+    "src.shared.python.ui.recent_models",
+    "src.shared.python.ui.shortcuts_overlay",
+    "src.shared.python.ui.toast",
+]
+ignore_errors = true


### PR DESCRIPTION
Resolves #3075

- Halved the exclusion list in `pyproject.toml`.
- Removed `src/api/routes/*.py` from `exclude`.
- Removed `numpy-stubs` divergence blocks as numpy version is now stable across CI.
- Replaced `ignore_errors = true` globs with precise, per-file overrides generated directly from mypy output.