### PR TITLE
fix(engines): add capabilities() to Drake, MuJoCo, OpenSim (closes #3052)

### DIFF
--- a/src/engines/physics_engines/drake/python/drake_physics_engine.py
+++ b/src/engines/physics_engines/drake/python/drake_physics_engine.py
@@ -57,6 +57,7 @@ if DRAKE_AVAILABLE:
 
 from src.shared.python.core import constants
 from src.shared.python.core.numerical_constants import EPSILON_TIME_STEP
+from src.shared.python.engine_core.capabilities import Capability
 from src.shared.python.engine_core.interfaces import PhysicsEngine
 
 logger = get_logger(__name__)
@@ -708,3 +709,21 @@ class DrakePhysicsEngine(PhysicsEngine):
             # Restore original state
             self.plant.SetPositions(self.plant_context, saved_q)
             self.plant.SetVelocities(self.plant_context, saved_v)
+
+    def capabilities(self) -> frozenset:
+        """Return the set of Capability members this engine supports.
+
+        Returns:
+            frozenset[Capability] of capabilities implemented by Drake.
+        """
+        return frozenset(
+            {
+                Capability.FORWARD_DYNAMICS,
+                Capability.INVERSE_DYNAMICS,
+                Capability.CONTACT_FORCES,
+                Capability.MASS_MATRIX,
+                Capability.JACOBIAN,
+                Capability.DRIFT_CONTROL,
+                Capability.COUNTERFACTUAL,
+            }
+        )

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/physics_engine.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/physics_engine.py
@@ -26,6 +26,7 @@ from src.shared.python.core.contracts import (
     precondition,
 )
 from src.shared.python.data_io.path_utils import get_repo_root
+from src.shared.python.engine_core.capabilities import Capability
 from src.shared.python.engine_core.interfaces import PhysicsEngine
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.security.security_utils import validate_path
@@ -724,3 +725,21 @@ class MuJoCoPhysicsEngine(PhysicsEngine):
             "velocity": velocity,
             "modal_amplitudes": state["amplitudes"].copy(),
         }
+
+    def capabilities(self) -> frozenset:
+        """Return the set of Capability members this engine supports.
+
+        Returns:
+            frozenset[Capability] of capabilities implemented by MuJoCo.
+        """
+        return frozenset(
+            {
+                Capability.FORWARD_DYNAMICS,
+                Capability.INVERSE_DYNAMICS,
+                Capability.CONTACT_FORCES,
+                Capability.MASS_MATRIX,
+                Capability.JACOBIAN,
+                Capability.DRIFT_CONTROL,
+                Capability.COUNTERFACTUAL,
+            }
+        )

--- a/src/engines/physics_engines/opensim/python/opensim_physics_engine.py
+++ b/src/engines/physics_engines/opensim/python/opensim_physics_engine.py
@@ -20,6 +20,7 @@ from src.shared.python.core.contracts import (
     precondition,
 )
 from src.shared.python.core.numerical_constants import EPSILON_TIME_STEP
+from src.shared.python.engine_core.capabilities import Capability
 from src.shared.python.engine_core.engine_availability import OPENSIM_AVAILABLE
 from src.shared.python.engine_core.interfaces import PhysicsEngine
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -792,3 +793,20 @@ class OpenSimPhysicsEngine(PhysicsEngine):
         except (ValueError, TypeError, RuntimeError) as e:
             logger.error(f"Failed to compute ZVCF: {e}")
             return np.array([])
+
+    def capabilities(self) -> frozenset:
+        """Return the set of Capability members this engine supports.
+
+        Returns:
+            frozenset[Capability] of capabilities implemented by OpenSim.
+        """
+        return frozenset(
+            {
+                Capability.FORWARD_DYNAMICS,
+                Capability.INVERSE_DYNAMICS,
+                Capability.MASS_MATRIX,
+                Capability.JACOBIAN,
+                Capability.DRIFT_CONTROL,
+                Capability.COUNTERFACTUAL,
+            }
+        )

--- a/tests/unit/engines/test_capability_contract.py
+++ b/tests/unit/engines/test_capability_contract.py
@@ -372,3 +372,157 @@ class TestEngineCapabilityContractGeneral:
 
         engine = PendulumPhysicsEngine()
         self._check_engine(engine, np.zeros(2))
+
+
+# ---------------------------------------------------------------------------
+# Tests for MuJoCoPhysicsEngine capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestMuJoCoCapabilityContract:
+    """MuJoCo engine capability declarations must match its implementations."""
+
+    def _make_mujoco_engine(self):  # type: ignore[return]
+        try:
+            from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.physics_engine import (
+                MuJoCoPhysicsEngine,
+            )
+
+            return MuJoCoPhysicsEngine()
+        except ImportError as exc:
+            pytest.skip(f"MuJoCo not available: {exc}")
+
+    def test_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_forward_dynamics_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.FORWARD_DYNAMICS in engine.capabilities()
+
+    def test_inverse_dynamics_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+
+    def test_contact_forces_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.CONTACT_FORCES in engine.capabilities()
+
+    def test_mass_matrix_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+
+    def test_jacobian_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.JACOBIAN in engine.capabilities()
+
+    def test_drift_control_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+
+    def test_counterfactual_declared(self) -> None:
+        engine = self._make_mujoco_engine()
+        assert Capability.COUNTERFACTUAL in engine.capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Tests for DrakePhysicsEngine capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestDrakeCapabilityContract:
+    """Drake engine capability declarations must match its implementations."""
+
+    def _make_drake_engine(self):  # type: ignore[return]
+        try:
+            from src.engines.physics_engines.drake.python.drake_physics_engine import (
+                DrakePhysicsEngine,
+            )
+
+            return DrakePhysicsEngine()
+        except ImportError as exc:
+            pytest.skip(f"Drake not available: {exc}")
+
+    def test_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_drake_engine()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_forward_dynamics_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.FORWARD_DYNAMICS in engine.capabilities()
+
+    def test_inverse_dynamics_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+
+    def test_contact_forces_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.CONTACT_FORCES in engine.capabilities()
+
+    def test_mass_matrix_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+
+    def test_jacobian_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.JACOBIAN in engine.capabilities()
+
+    def test_drift_control_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+
+    def test_counterfactual_declared(self) -> None:
+        engine = self._make_drake_engine()
+        assert Capability.COUNTERFACTUAL in engine.capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Tests for OpenSimPhysicsEngine capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestOpenSimCapabilityContract:
+    """OpenSim engine capability declarations must match its implementations."""
+
+    def _make_opensim_engine(self):  # type: ignore[return]
+        try:
+            from src.engines.physics_engines.opensim.python.opensim_physics_engine import (
+                OpenSimPhysicsEngine,
+            )
+
+            return OpenSimPhysicsEngine()
+        except ImportError as exc:
+            pytest.skip(f"OpenSim not available: {exc}")
+
+    def test_capabilities_returns_frozenset(self) -> None:
+        engine = self._make_opensim_engine()
+        assert isinstance(engine.capabilities(), frozenset)
+
+    def test_forward_dynamics_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.FORWARD_DYNAMICS in engine.capabilities()
+
+    def test_inverse_dynamics_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.INVERSE_DYNAMICS in engine.capabilities()
+
+    def test_contact_forces_not_declared(self) -> None:
+        """OpenSim does not implement compute_contact_forces."""
+        engine = self._make_opensim_engine()
+        assert Capability.CONTACT_FORCES not in engine.capabilities()
+
+    def test_mass_matrix_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.MASS_MATRIX in engine.capabilities()
+
+    def test_jacobian_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.JACOBIAN in engine.capabilities()
+
+    def test_drift_control_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.DRIFT_CONTROL in engine.capabilities()
+
+    def test_counterfactual_declared(self) -> None:
+        engine = self._make_opensim_engine()
+        assert Capability.COUNTERFACTUAL in engine.capabilities()


### PR DESCRIPTION
## Summary

Fixes the LSP violation reported in #3052: Drake, MuJoCo, and OpenSim engines previously fell back to `BasePhysicsEngine.capabilities() → frozenset()` (empty set), making it impossible for callers to query which operations were actually supported.

**Changes:**
- `MuJoCoPhysicsEngine.capabilities()` → declares `FORWARD_DYNAMICS, INVERSE_DYNAMICS, CONTACT_FORCES, MASS_MATRIX, JACOBIAN, DRIFT_CONTROL, COUNTERFACTUAL`
- `DrakePhysicsEngine.capabilities()` → same full set (Drake implements `compute_contact_forces` via `ContactResults` API)
- `OpenSimPhysicsEngine.capabilities()` → same minus `CONTACT_FORCES` (OpenSim does not implement `compute_contact_forces`)
- 24 new contract tests in `tests/unit/engines/test_capability_contract.py`; all skip gracefully when the engine package is absent

`Capability` enum and `BasePhysicsEngine.capabilities()` scaffolding already existed (added in earlier work). Pinocchio and Pendulum were already compliant; this PR completes the remaining three.

## Test plan

- [ ] `python3 -m pytest tests/unit/engines/test_capability_contract.py` — 43 pass, 16 skip (engine packages not installed in CI)
- [ ] `python3 -m ruff check .` — zero violations
- [ ] `python3 -m ruff format --check .` — zero diffs

https://claude.ai/code/session_0183MHDbUfeFeyCJW3U4p8r1

---
_Generated by [Claude Code](https://claude.ai/code/session_0183MHDbUfeFeyCJW3U4p8r1)_