### PR TITLE
fix(#3055): replace silent except-pass with debug logging in perturbation analyzers

### DIFF
--- a/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
+++ b/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
@@ -423,8 +423,10 @@ class MyoSuitePerturbationAnalyzer(PerturbationAnalyzerBase):
                         mujoco.mj_energyVel(mj_model, mj_data)
                         pe = float(mj_data.energy[0])
                         ke = float(mj_data.energy[1])
-                    except Exception:  # noqa: BLE001  # noqa: BLE001
-                        pass
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "Energy computation skipped (optional metric): %s", exc
+                        )
 
             t_list.append(t)
             qpos_list.append(qpos)

--- a/src/engines/physics_engines/opensim/python/perturbation/analyzer.py
+++ b/src/engines/physics_engines/opensim/python/perturbation/analyzer.py
@@ -428,8 +428,8 @@ class OpenSimPerturbationAnalyzer(PerturbationAnalyzerBase):
                     force_obj.setControls(
                         osim.Vector(1, ctrl), model.updDefaultControls()
                     )
-                except Exception:  # noqa: BLE001  # noqa: BLE001
-                    pass
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Actuator control update skipped: %s", exc)
 
             # Realize to acceleration
             with contextlib.suppress(Exception):
@@ -484,8 +484,8 @@ class OpenSimPerturbationAnalyzer(PerturbationAnalyzerBase):
                 model.realizeVelocity(state)
                 ke = float(model.calcKineticEnergy(state))
                 pe = float(model.calcPotentialEnergy(state))
-            except Exception:  # noqa: BLE001  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Energy computation skipped (optional metric): %s", exc)
 
             t_list.append(t)
             qpos_list.append(q)
@@ -510,8 +510,10 @@ class OpenSimPerturbationAnalyzer(PerturbationAnalyzerBase):
                         new_val = q[k] + qdot[k] * dt
                         coord.setValue(state, new_val)
                         coord.setSpeedValue(state, qdot[k])
-                    except Exception:  # noqa: BLE001  # noqa: BLE001
-                        pass
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "Coordinate update skipped in Euler fallback: %s", exc
+                        )
 
         t_arr = np.array(t_list)
         qpos_arr = np.array(qpos_list)


### PR DESCRIPTION
## Summary

- Replace 4 bare `except Exception: pass` blocks in `MyoSuitePerturbationAnalyzer` and `OpenSimPerturbationAnalyzer` with `logger.debug(...)` calls
- Affected locations: MuJoCo energy computation (MyoSuite), actuator control update (OpenSim), energy computation (OpenSim), coordinate update in Euler fallback (OpenSim)
- Observable behavior is unchanged — errors are still swallowed at non-debug log levels, but are now visible when `DEBUG` logging is enabled

## Test plan

- [ ] `ruff check` passes on changed files
- [ ] `ruff format --check` passes on changed files
- [ ] Existing unit tests pass (no behavior change)
- [ ] Confirm `logger.debug` calls appear in logs when exceptions occur during integration

Closes #3055

https://claude.ai/code/session_0183MHDbUfeFeyCJW3U4p8r1

---
_Generated by [Claude Code](https://claude.ai/code/session_0183MHDbUfeFeyCJW3U4p8r1)_