### PR TITLE
fix: document stub implementations in robotics/learning/research subsystems

### DIFF
--- a/src/learning/imitation/_gail.py
+++ b/src/learning/imitation/_gail.py
@@ -20,8 +20,12 @@ class GAIL(ImitationLearner):
     GAIL uses a discriminator to distinguish between expert and
     policy trajectories, training the policy to fool the discriminator.
 
-    This is a simplified implementation - full GAIL requires
-    integration with RL algorithms like PPO.
+    .. note::
+        **Partial stub** (closes #3061): The discriminator architecture
+        and reward computation (``get_reward``) are fully implemented.
+        The ``train`` method performs discriminator pre-training only;
+        it does not run a real adversarial RL loop.  See the ``train``
+        docstring for the complete list of missing pieces.
     """
 
     def __init__(
@@ -121,15 +125,38 @@ class GAIL(ImitationLearner):
     ) -> dict[str, list[float]]:
         """Train GAIL.
 
-        Note: This is a simplified version. Full GAIL training
-        requires environment interaction and RL algorithm integration.
+        .. note::
+            **Partial stub implementation** (closes #3061): This method
+            performs discriminator pre-training on expert demonstrations
+            but does **not** perform true adversarial RL policy training.
+
+            Full GAIL requires:
+
+            1. An RL environment (e.g. ``gym.Env``) for policy rollouts.
+            2. An RL algorithm (PPO, TRPO, SAC …) to optimise the policy
+               against the GAIL reward ``-log(1 - D(s, a))``.
+            3. Alternating discriminator updates (on expert + rollout
+               data) with RL policy updates.
+
+            The current implementation approximates policy rollouts with
+            noise-perturbed expert trajectories and updates discriminator
+            weights with a simplified weight-decay gradient rather than
+            a proper binary-cross-entropy back-propagation step.  This
+            is sufficient for testing the discriminator architecture and
+            the ``get_reward()`` API, but will **not** produce a trained
+            policy.
+
+            To wire up a real implementation, replace the ``_forward_pass``
+            section below with calls to a proper deep-learning library
+            (PyTorch / JAX) and integrate with an RL training loop.
 
         Args:
             dataset: Expert demonstration dataset.
             validation_split: Fraction for validation.
 
         Returns:
-            Training history.
+            Training history with ``discriminator_loss`` and
+            ``policy_loss`` keys.
         """
         # Get expert data
         if not (dataset is not None):

--- a/src/learning/imitation/learners.py
+++ b/src/learning/imitation/learners.py
@@ -650,8 +650,13 @@ class GAIL(ImitationLearner):
     GAIL uses a discriminator to distinguish between expert and
     policy trajectories, training the policy to fool the discriminator.
 
-    This is a simplified implementation - full GAIL requires
-    integration with RL algorithms like PPO.
+    .. note::
+        **Partial stub** (closes #3061): The discriminator architecture
+        and reward computation (``get_reward``) are fully implemented.
+        The ``train`` method performs discriminator pre-training only;
+        it does not run a real adversarial RL loop.  Full GAIL requires
+        integration with an RL algorithm (PPO/TRPO/SAC) and live
+        environment rollouts.  See the ``train`` docstring for details.
     """
 
     def __init__(
@@ -745,15 +750,31 @@ class GAIL(ImitationLearner):
     ) -> dict[str, list[float]]:
         """Train GAIL.
 
-        Note: This is a simplified version. Full GAIL training
-        requires environment interaction and RL algorithm integration.
+        .. note::
+            **Partial stub implementation** (closes #3061): This method
+            performs discriminator pre-training on expert demonstrations
+            but does **not** perform true adversarial RL policy training.
+
+            Full GAIL requires:
+
+            1. An RL environment (e.g. ``gym.Env``) for policy rollouts.
+            2. An RL algorithm (PPO, TRPO, SAC …) to optimise the policy
+               against the GAIL reward ``-log(1 - D(s, a))``.
+            3. Alternating discriminator updates (on expert + rollout
+               data) with RL policy updates.
+
+            The current implementation approximates policy rollouts with
+            noise-perturbed expert trajectories and updates discriminator
+            weights with a simplified weight-decay step rather than a
+            proper binary-cross-entropy back-propagation step.
 
         Args:
             dataset: Expert demonstration dataset.
             validation_split: Fraction for validation.
 
         Returns:
-            Training history.
+            Training history with ``discriminator_loss`` and
+            ``policy_loss`` keys.
         """
         # Get expert data
         if dataset is None:

--- a/src/robotics/locomotion/zmp_computer.py
+++ b/src/robotics/locomotion/zmp_computer.py
@@ -284,7 +284,18 @@ class ZMPComputer(ContractChecker):
         )
 
     def _get_com_velocity(self) -> NDArray[np.float64]:
-        """Get CoM velocity from engine."""
+        """Get CoM velocity from engine.
+
+        Returns zero velocity when engine does not implement
+        ``HumanoidCapable``.  Callers that require accurate ZMP
+        computation should either:
+
+        - Use an engine that implements :class:`HumanoidCapable`, or
+        - Pass ``com_velocity`` explicitly to :meth:`compute_zmp`.
+
+        Returning zeros here is a conservative fallback that produces
+        valid (but less accurate) ZMP results for quasi-static motions.
+        """
         if self._is_humanoid:
             engine = self._engine
             if isinstance(engine, HumanoidCapable):
@@ -298,9 +309,24 @@ class ZMPComputer(ContractChecker):
     ) -> NDArray[np.float64]:
         """Estimate CoM acceleration.
 
-        Simple estimation assuming quasi-static (zero acceleration).
+        .. note::
+            **Stub implementation** (closes #3061): This method
+            always returns zero acceleration (quasi-static assumption).
+            For dynamic motions this underestimates inertial effects
+            and produces inaccurate ZMP estimates.
+
+            To get accurate results, pass ``com_acceleration`` directly
+            to :meth:`compute_zmp`.  A proper implementation should use
+            finite-difference differentiation of CoM velocity samples or
+            query the engine for centroidal acceleration directly.
+
+            Required work:
+            - Store a rolling buffer of ``(t, com_velocity)`` samples.
+            - Differentiate with a second-order finite-difference scheme.
+            - Or query ``engine.compute_centroidal_momentum()`` and
+              differentiate the linear momentum component.
         """
-        # For now, assume quasi-static
+        # Quasi-static assumption -- see docstring above.
         return np.zeros(3)
 
     def _estimate_mass(self) -> float:


### PR DESCRIPTION
Closes #3061

## Summary
- Audited `src/robotics/`, `src/learning/`, `src/research/` for stub methods returning hardcoded values without documentation
- Added explicit `.. note:: **Partial stub**` blocks documenting exactly what real implementations require
- Key stubs found and documented:
  - `ZMPComputer._estimate_com_acceleration()` — always returns `np.zeros(3)` (quasi-static assumption); now documents the limitation and what a real finite-difference / centroidal-momentum implementation needs
  - `ZMPComputer._get_com_velocity()` — silent zero-velocity fallback; now documents the conservative-fallback behavior
  - `GAIL.train()` (in both `_gail.py` and `learners.py`) — performs discriminator pre-training only, not a real adversarial RL loop; now enumerates the three missing pieces (RL env, RL algorithm, alternating update loop)

## Finding
The robotics/learning/research subsystems are real implementations (not shallow stubs). The only substantive incomplete implementations were the GAIL training loop and the ZMP acceleration estimation, both of which are now clearly marked.