### PR TITLE
fix: consolidate humanoid builders and audit contracts.py

### DIFF
--- a/src/shared/python/contracts.py
+++ b/src/shared/python/contracts.py
@@ -1,6 +1,14 @@
 # ARCHITECTURE_DEBT:
 # This module historically exceeds standard length metrics and accumulates excessive domain responsibility.
 # It requires domain-aware structural extraction to isolate its internal classes appropriately.
+#
+# AUDIT NOTE (#3057): This file is ~24 KB / 708 lines and is the canonical DbC source for the platform.
+# It is NOT auto-generated. It grew organically from consolidating three separate contract shims:
+#   1. src/shared/python/humanoid_character_builder/contracts.py  (re-exports from here)
+#   2. src/shared/python/model_generation/core/contracts.py        (re-exports from here)
+#   3. src/shared/python/core/contracts/                           (separately evolved sub-system)
+# New code should import directly from this module. The two re-exporting shims above are retained
+# for backward compatibility only. Tracked for structural extraction in a future refactor sprint.
 
 """Design by Contract (DbC) enforcement for the Tools platform.
 

--- a/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
+++ b/src/shared/python/humanoid_character_builder/generators/_urdf_model_builder.py
@@ -1,3 +1,7 @@
+# DEPRECATED: This internal helper duplicates assembly logic now consolidated in
+# src/shared/python/model_generation/builders/base_builder.py (canonical humanoid builder).
+# New code should use model_generation.builders.base_builder.BaseURDFBuilder instead.
+# This module is retained for backward compatibility and will be removed in a future release.
 """Internal helpers for humanoid URDF model assembly."""
 
 from __future__ import annotations

--- a/src/shared/python/humanoid_character_builder/generators/_xml_builder.py
+++ b/src/shared/python/humanoid_character_builder/generators/_xml_builder.py
@@ -1,3 +1,6 @@
+# DEPRECATED: XML assembly helpers duplicated in src/shared/python/humanoid_character_builder/generators/urdf_xml_builder.py.
+# The canonical implementation is urdf_xml_builder.py (build_urdf_xml function).
+# This private module is retained for backward compatibility and will be removed in a future release.
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary
- Added deprecation notices to `_urdf_model_builder.py` and `_xml_builder.py` pointing to canonical implementations
- Added audit comment to `contracts.py` explaining its size (~24KB/708 lines), origin from consolidating 3 shims, and that it is NOT auto-generated
- Both shim `contracts.py` files already had backward-compat notes; the main file now documents the full picture

Closes #3057