### PR TITLE
docs: first-class humanoid tutorials and choose-your-engine user guide

### DIFF
--- a/docs/tutorials/choose_your_engine.md
+++ b/docs/tutorials/choose_your_engine.md
@@ -1,0 +1,167 @@
+# Choose Your Engine: A User Guide
+
+This guide helps you select the right physics engine for your UpstreamDrift simulation task.
+For a quick hands-on demo, see [`examples/choose_engine_demo.py`](../../examples/choose_engine_demo.py).
+
+---
+
+## Quick Decision Flowchart
+
+```
+Do you need Hill-type muscle models?
+  YES → MuJoCo + MyoSuite
+  NO  ↓
+Do you need trajectory optimisation (e.g. golf swing)?
+  YES → Drake
+  NO  ↓
+Do you need fast kinematics / algorithmic differentiation?
+  YES → Pinocchio
+  NO  ↓
+Do you need clinical biomechanics / OpenSim .osim models?
+  YES → OpenSim
+  NO  → MuJoCo  (safe general default)
+```
+
+---
+
+## Engine Profiles
+
+### MuJoCo
+
+**Best for:** Contact-heavy simulations, muscle-driven models, general-purpose robotics.
+
+| Property       | Value                    |
+| -------------- | ------------------------ |
+| Model format   | MJCF XML, URDF           |
+| Muscle support | Via MyoSuite (Hill-type) |
+| Contact model  | Soft contact (mature)    |
+| Speed          | Fast                     |
+| Installation   | `pip install mujoco`     |
+
+```python
+from src.shared.python.engine_manager import EngineManager
+manager = EngineManager()
+engine = manager.load_engine("mujoco")
+```
+
+### Pinocchio
+
+**Best for:** Fast rigid-body kinematics, algorithmic differentiation, lightweight footprint.
+
+| Property       | Value                                                   |
+| -------------- | ------------------------------------------------------- |
+| Model format   | URDF                                                    |
+| Muscle support | None                                                    |
+| Contact model  | Basic                                                   |
+| Speed          | Very fast (~20 % faster than MuJoCo on pure kinematics) |
+| Installation   | `conda install pinocchio -c conda-forge`                |
+
+```python
+engine = manager.load_engine("pinocchio")
+```
+
+### Drake
+
+**Best for:** Trajectory optimisation, motion planning, contact planning with Trajopt.
+
+| Property       | Value               |
+| -------------- | ------------------- |
+| Model format   | URDF, SDF           |
+| Muscle support | Manual only         |
+| Contact model  | Good                |
+| Speed          | Medium              |
+| Installation   | `pip install drake` |
+
+```python
+engine = manager.load_engine("drake")
+```
+
+### OpenSim
+
+**Best for:** Clinical biomechanics, existing `.osim` model libraries, joint reaction analysis.
+
+| Property       | Value                                                           |
+| -------------- | --------------------------------------------------------------- |
+| Model format   | .osim                                                           |
+| Muscle support | Excellent (built-in)                                            |
+| Contact model  | Basic                                                           |
+| Speed          | Slow                                                            |
+| Installation   | See [opensim-core](https://github.com/opensim-org/opensim-core) |
+
+```python
+engine = manager.load_engine("opensim")
+```
+
+---
+
+## Feature Comparison Matrix
+
+| Feature                     | MuJoCo       | Pinocchio | Drake     | OpenSim    |
+| --------------------------- | ------------ | --------- | --------- | ---------- |
+| Forward dynamics            | Yes          | Yes       | Yes       | Yes        |
+| Inverse dynamics            | Yes          | Yes       | Yes       | Limited    |
+| Hill-type muscles           | Via MyoSuite | No        | No        | Yes        |
+| Trajectory optimisation     | Basic        | Crocoddyl | Excellent | No         |
+| URDF loading                | Yes          | Yes       | Yes       | No (.osim) |
+| Algorithmic differentiation | No           | Yes       | Yes       | No         |
+| GPU support                 | Limited      | No        | No        | No         |
+
+---
+
+## Humanoid Simulation Scenarios
+
+### Scenario 1: Walking / running gait
+
+Recommended: **MuJoCo** or **Pinocchio**.
+MuJoCo for contact fidelity; Pinocchio if you need fast Jacobian sweeps for an outer
+optimisation loop.
+
+### Scenario 2: Golf swing optimisation
+
+Recommended: **Drake** (Trajopt) or **MuJoCo** (quick prototyping).
+
+### Scenario 3: Injury-risk analysis
+
+Recommended: **OpenSim** (joint reaction forces from .osim models) or
+**MuJoCo + MyoSuite** (muscle-driven fatigue modelling).
+
+### Scenario 4: RL policy training
+
+Recommended: **MuJoCo** (fastest step time) or **MuJoCo + MyoSuite**
+(physiologically realistic action space).
+
+---
+
+## Switching Engines at Runtime
+
+The `EngineManager` provides a unified interface so you can swap engines without
+changing your simulation code:
+
+```python
+from src.shared.python.engine_manager import EngineManager
+
+manager = EngineManager()
+
+# Load your preferred engine by name
+for engine_name in ["mujoco", "pinocchio", "drake"]:
+    try:
+        engine = manager.load_engine(engine_name)
+        engine.load_from_path("models/humanoid.urdf")
+        engine.reset()
+        for _ in range(100):
+            engine.step()
+        print(f"{engine_name}: OK")
+    except ImportError:
+        print(f"{engine_name}: not installed, skipping")
+```
+
+See `examples/choose_engine_demo.py` for a runnable version of this pattern.
+
+---
+
+## Further Reading
+
+- [`docs/engines/engine_capabilities.md`](../engines/engine_capabilities.md) — detailed capability tables
+- [`docs/engines/engine_selection_guide.md`](../engines/engine_selection_guide.md) — concise decision matrix
+- [`docs/tutorials/content/03_engine_comparison.md`](content/03_engine_comparison.md) — cross-engine validation tutorial
+- [`docs/adr/0002-physics-engine-plugin-architecture.md`](../adr/0002-physics-engine-plugin-architecture.md) — architecture decision record

--- a/examples/choose_engine_demo.py
+++ b/examples/choose_engine_demo.py
@@ -1,0 +1,122 @@
+"""
+Example: Choose Your Engine Demo
+
+Demonstrates how to iterate over available physics engines (MuJoCo, Pinocchio,
+Drake, OpenSim) through the unified EngineManager interface, load a simple
+humanoid model in each, run a short simulation loop, and compare basic outputs.
+
+This example is the companion to:
+    docs/tutorials/choose_your_engine.md
+
+Usage::
+
+    python3 examples/choose_engine_demo.py
+
+If an engine is not installed it is skipped gracefully.  Install engines with:
+    pip install mujoco          # MuJoCo
+    conda install pinocchio     # Pinocchio (conda-forge)
+    pip install drake           # Drake
+    # OpenSim: see https://github.com/opensim-org/opensim-core
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s  %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Bundled humanoid model included with the repository
+HUMANOID_URDF = (
+    Path(__file__).resolve().parents[1] / "src/shared/urdf/simple_humanoid.urdf"
+)
+
+# Engines to attempt in order of recommendation
+ENGINES_TO_TRY: list[str] = ["mujoco", "pinocchio", "drake", "opensim"]
+
+# Number of simulation steps to run for each engine
+SIM_STEPS: int = 200
+
+
+def run_demo() -> None:
+    """Load each available engine, run a short sim loop, and report results."""
+    try:
+        from src.shared.python.engine_manager import (
+            EngineManager,  # type: ignore[import]
+        )
+    except ImportError as exc:
+        logger.error(
+            "Could not import EngineManager — is the package installed? (%s)", exc
+        )
+        sys.exit(1)
+
+    manager = EngineManager()
+    results: dict[str, str] = {}
+
+    for engine_name in ENGINES_TO_TRY:
+        logger.info("--- Trying engine: %s ---", engine_name)
+        try:
+            engine = manager.load_engine(engine_name)
+        except ImportError as exc:
+            logger.warning("  %s not installed, skipping. (%s)", engine_name, exc)
+            results[engine_name] = "not installed"
+            continue
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("  Failed to load %s: %s", engine_name, exc, exc_info=True)
+            results[engine_name] = f"load error: {exc}"
+            continue
+
+        model_path = HUMANOID_URDF
+        if not model_path.exists():
+            logger.warning(
+                "  Bundled URDF not found at %s; skipping %s", model_path, engine_name
+            )
+            results[engine_name] = "model file missing"
+            continue
+
+        try:
+            engine.load_from_path(str(model_path))
+            engine.reset()
+
+            for _ in range(SIM_STEPS):
+                engine.step()
+
+            t = engine.get_time()
+            q = engine.get_configuration()
+            logger.info(
+                "  %s: completed %d steps, t=%.4f s, q[0]=%.6f",
+                engine_name,
+                SIM_STEPS,
+                t,
+                q[0] if len(q) > 0 else float("nan"),
+            )
+            results[engine_name] = f"OK  t={t:.4f}s"
+        except NotImplementedError as exc:
+            logger.warning(
+                "  %s has unimplemented adapter methods: %s", engine_name, exc
+            )
+            results[engine_name] = f"partial (NotImplementedError: {exc})"
+        except Exception as exc:  # noqa: BLE001
+            logger.error("  %s simulation error: %s", engine_name, exc, exc_info=True)
+            results[engine_name] = f"error: {exc}"
+
+    # Summary table
+    print("\n" + "=" * 50)
+    print("Engine Demo Summary")
+    print("=" * 50)
+    for name, status in results.items():
+        print(f"  {name:<12}  {status}")
+    print("=" * 50)
+    print(
+        "\nSee docs/tutorials/choose_your_engine.md for guidance on selecting "
+        "the right engine for your use case."
+    )
+
+
+if __name__ == "__main__":
+    run_demo()


### PR DESCRIPTION
## Summary
- Created `docs/tutorials/choose_your_engine.md` — comprehensive guide for selecting between MuJoCo, Pinocchio, Drake, and OpenSim with decision flowchart, engine profiles, feature matrix, and scenario recommendations
- Created `examples/choose_engine_demo.py` — runnable demo that iterates over all available engines, loads the bundled simple humanoid URDF, runs a 200-step sim loop, and prints a summary table; gracefully skips uninstalled engines

Closes #3050