### PR TITLE
fix: Preserve zero-force fallback for unsupported Pinocchio contact-force queries

### DIFF
--- a/src/shared/python/physics/ground_reaction_forces.py
+++ b/src/shared/python/physics/ground_reaction_forces.py
@@ -508,8 +508,16 @@ def extract_grf_from_contacts(
     total_weighted_pos = np.zeros(3)
 
     # --- Primary path: query the engine's native contact solver -----------
-    contact_force = engine.compute_contact_forces()
-    has_contact_data = float(np.linalg.norm(contact_force)) > 1e-10
+    try:
+        contact_force = engine.compute_contact_forces()
+        has_contact_data = float(np.linalg.norm(contact_force)) > 1e-10
+    except NotImplementedError:
+        # Engine does not support contact force queries (e.g., Pinocchio without contact solver)
+        contact_force = np.zeros(3)
+        has_contact_data = False
+        logger.debug(
+            "Engine does not support contact force queries; falling back to gravity approximation"
+        )
 
     if has_contact_data:
         total_force[: len(contact_force)] = contact_force[:3]


### PR DESCRIPTION
## Summary
Wraps engine.compute_contact_forces() in try-except to gracefully handle NotImplementedError from Pinocchio and other engines that don't support contact-force queries. Falls back to gravity approximation instead of crashing.

Closes #3201