### PR TITLE
security: fix insecure subprocess execution (B603)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@
 **Vulnerability:** String-based query construction with `f-strings` in `get_unique_values` (Bandit B608).
 **Learning:** Even when input is validated against a whitelist, security scanners will flag string-based SQL query construction. Using a hardcoded mapping of query strings eliminates both the actual risk and the static analysis warnings.
 **Prevention:** Use hardcoded SQL query maps for column names (which cannot be parameterized in standard SQL bindings) instead of dynamic string construction.
+
+## 2026-04-25 - Prevent Insecure Subprocess Execution (B603)
+**Vulnerability:** Directly calling `subprocess.run` or `subprocess.Popen` without restrictions can lead to command injection and unauthorized program execution, which triggers Bandit B603 warnings.
+**Learning:** Security scanners will flag direct use of the `subprocess` module when executing commands. Using a centralized, secure wrapper ensures that all executed commands and paths are strictly validated against allowlists.
+**Prevention:** Instead of using the standard `subprocess` module directly, import and use the custom secure wrappers `secure_run` and `secure_popen` from `src.shared.python.security.secure_subprocess`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -748,3 +748,4 @@ pytest tests/ --cov=src --cov-fail-under=70
 - Mounted production quota route dependencies consistently and deferred auth-mode bypass decisions to request time so local/test API requests preserve endpoint validation semantics while cloud-mode simulation and video routes reject unauthenticated access.
 - Restored legacy `/api/...` API route registration for launcher, terrain, and other existing clients while preserving root and `/api/v1/...` route coverage.
 - Enforced streamed upload byte-limit validation in upload-related API handlers and tests for robust production quota enforcement.
+| 2026-04-25 | 1.1.20       | Secured subprocess execution wrappers across tools          |

--- a/src/tools/model_explorer/mujoco_viewer.py
+++ b/src/tools/model_explorer/mujoco_viewer.py
@@ -14,7 +14,6 @@ Issue #755: Enhanced visualization toggles for collision, frames, joints, and co
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -39,6 +38,7 @@ from src.shared.python.core.constants import (
 )
 from src.shared.python.engine_core.engine_availability import MUJOCO_AVAILABLE
 from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.security.secure_subprocess import secure_popen
 
 if TYPE_CHECKING:
     from typing import Any
@@ -955,7 +955,7 @@ class MuJoCoViewerWidget(QWidget):
                 f"m=mujoco.MjModel.from_xml_path(r'{temp_path}'); "
                 f"mujoco.viewer.launch(m)",
             ]
-            subprocess.Popen(cmd)
+            secure_popen(cmd)
             logger.info("Launched external MuJoCo viewer")
 
         except ImportError as e:

--- a/tests/verify_changes.py
+++ b/tests/verify_changes.py
@@ -1,8 +1,9 @@
 # Import paths configured at test runner level via pyproject.toml/conftest.py
 
-import subprocess
 import sys
 import unittest
+
+from src.shared.python.security.secure_subprocess import secure_run
 
 
 class TestVerification(unittest.TestCase):
@@ -78,7 +79,7 @@ class TestVerification(unittest.TestCase):
 
         for file_path in files_to_check:
             if exists(file_path):
-                result = subprocess.run(
+                result = secure_run(
                     [sys.executable, tool_path, file_path],
                     capture_output=True,
                     text=True,


### PR DESCRIPTION
This PR addresses Bandit B603 warnings ("subprocess call - check for execution of untrusted input") by replacing direct standard library `subprocess` calls with the repository's custom, secure alternatives (`secure_run` and `secure_popen`). This change ensures all executed commands run through centralized security allowlists.

### Severity
Low

### Vulnerability
Directly calling `subprocess.run` or `subprocess.Popen` without restrictions can lead to command injection if untrusted inputs are passed. It also bypasses application-level control over which executables are allowed to run.

### Impact
Although currently low severity given the context (tests and internal tool wrappers), securing these execution paths prevents accidental escalation if these tools are later exposed to external or untrusted data sources.

### Fix
- Replaced `subprocess.run` with `secure_run` in `tests/verify_changes.py`.
- Replaced `subprocess.Popen` with `secure_popen` in `src/tools/model_explorer/mujoco_viewer.py`.
- Removed unused `import subprocess` statements.
- Added a learning entry to `.jules/sentinel.md` regarding B603 prevention.

### Verification Details
- `bandit` scanning confirmed no remaining B603 issues in the modified files.
- `ruff` formatting and linting completed without errors.
- The Python test suite (`pytest tests/verify_changes.py tests/integration/test_phase1_security_integration.py tests/unit/test_secure_subprocess.py`) successfully executed and passed.

---
*PR created automatically by Jules for task [6435571225468278501](https://jules.google.com/task/6435571225468278501) started by @dieterolson*