### PR TITLE
🛡️ Sentinel: [LOW] Replace subprocess.Popen with secure_popen in mujoco_viewer.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,7 @@
 **Vulnerability:** String-based query construction with `f-strings` in `get_unique_values` (Bandit B608).
 **Learning:** Even when input is validated against a whitelist, security scanners will flag string-based SQL query construction. Using a hardcoded mapping of query strings eliminates both the actual risk and the static analysis warnings.
 **Prevention:** Use hardcoded SQL query maps for column names (which cannot be parameterized in standard SQL bindings) instead of dynamic string construction.
+## 2026-04-25 - [LOW] Use of raw `subprocess.Popen` without command validation
+**Vulnerability:** Found `subprocess.Popen` being used to launch external MuJoCo viewers in `src/tools/model_explorer/mujoco_viewer.py`. Even though the commands were constructed as lists (reducing standard injection risks via `shell=True`), directly importing and calling `subprocess` bypasses the centralized security policies and validations, and is flagged by static analysis scanners (Bandit B404/B603).
+**Learning:** Using list-based arguments for `subprocess` isn't enough to satisfy project security requirements. All subprocess creations must pass through the `secure_subprocess` wrapper which guarantees commands are running within approved whitelists, paths, and timeouts.
+**Prevention:** Avoid `import subprocess`. Always import `secure_popen` and `secure_run` from `src.shared.python.security.secure_subprocess` when an external command needs to be executed.

--- a/src/tools/model_explorer/mujoco_viewer.py
+++ b/src/tools/model_explorer/mujoco_viewer.py
@@ -14,7 +14,6 @@ Issue #755: Enhanced visualization toggles for collision, frames, joints, and co
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -39,6 +38,7 @@ from src.shared.python.core.constants import (
 )
 from src.shared.python.engine_core.engine_availability import MUJOCO_AVAILABLE
 from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.security.secure_subprocess import secure_popen
 
 if TYPE_CHECKING:
     from typing import Any
@@ -955,7 +955,7 @@ class MuJoCoViewerWidget(QWidget):
                 f"m=mujoco.MjModel.from_xml_path(r'{temp_path}'); "
                 f"mujoco.viewer.launch(m)",
             ]
-            subprocess.Popen(cmd)
+            secure_popen(cmd)
             logger.info("Launched external MuJoCo viewer")
 
         except ImportError as e:


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: `subprocess.Popen` was used to launch the MuJoCo viewer without routing through the project's centralized security wrappers. While command injection risk was reduced by passing a command list rather than a string with `shell=True`, bypassing centralized security policies circumvents validation checks (e.g., path safelists, command whitelists) and is flagged by Bandit (B404/B603).
🎯 Impact: Circumventing the centralized `secure_subprocess` module could establish bad engineering precedents and potentially allow unverified or unsafe binaries to be executed if parameters drift.
🔧 Fix: Replaced `subprocess.Popen(cmd)` with `secure_popen(cmd)` in `src/tools/model_explorer/mujoco_viewer.py` and removed the raw `import subprocess`. Appended a learning entry to `.jules/sentinel.md`.
✅ Verification: Ran `bandit` specifically on the modified file to confirm 0 issues identified. Code formatted correctly.

---
*PR created automatically by Jules for task [15027121375325192476](https://jules.google.com/task/15027121375325192476) started by @dieterolson*