### PR TITLE
fix(#3165): update glossary pointer in AI adapter system prompts

### DIFF
--- a/src/shared/python/ai/adapters/anthropic_adapter.py
+++ b/src/shared/python/ai/adapters/anthropic_adapter.py
@@ -450,10 +450,9 @@ class AnthropicAdapter(BaseAgentAdapter):
             f"4. Guide users through workflows step by step\n"
             f"5. Acknowledge uncertainty and cite limitations\n"
             f"6. Be precise about physical units (SI: m, kg, s, rad, N, N·m)\n\n"
-            f"When explaining physics/biomechanics terms, use the explain_concept "
-            f"tool to pull canonical UpstreamDrift glossary definitions. Prefer "
-            f"multi-level explanations (beginner -> advanced) based on the "
-            f"user's expertise_level if set."
+            f"When explaining physics or biomechanics terms, use the explain_concept "
+            f"tool to provide accurate, multi-level UpstreamDrift definitions "
+            f"tailored to the user's expertise level."
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:

--- a/src/shared/python/ai/adapters/openai_adapter.py
+++ b/src/shared/python/ai/adapters/openai_adapter.py
@@ -425,10 +425,9 @@ class OpenAIAdapter(BaseAgentAdapter):
             f"2. Suggest appropriate analyses for their goals\n"
             f"3. Execute using available tools\n"
             f"4. Interpret results with scientific rigor\n\n"
-            f"When explaining physics/biomechanics terms, use the explain_concept "
-            f"tool to pull canonical UpstreamDrift glossary definitions. Prefer "
-            f"multi-level explanations (beginner -> advanced) based on the "
-            f"user's expertise_level if set."
+            f"When explaining physics or biomechanics terms, use the explain_concept "
+            f"tool to provide accurate, multi-level UpstreamDrift definitions "
+            f"tailored to the user's expertise level."
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:


### PR DESCRIPTION
## Summary

- Updates the explain_concept tool instruction in both openai_adapter.py and anthropic_adapter.py system message builders to use standardized phrasing from issue #3165
- Wording changed to: "physics or biomechanics terms ... provide accurate, multi-level UpstreamDrift definitions tailored to the user's expertise level"
- scripts/check_glossary_coverage.py already exists on staging with a comprehensive implementation; no new file needed

Closes #3165

## Test plan

- [x] scripts/check_glossary_coverage.py runs successfully (exits 0, informational output)
- [x] ruff check passes on both adapter files
- [x] Both adapter system prompts now use consistent, issue-aligned glossary pointer language

🤖 Generated with [Claude Code](https://claude.com/claude-code)