### PR TITLE
fix(#3060): split mujoco_viewer.py into focused rendering/input modules

### DIFF
--- a/src/tools/model_explorer/_viewer_input.py
+++ b/src/tools/model_explorer/_viewer_input.py
@@ -1,0 +1,122 @@
+# mypy: ignore-errors
+"""Input-handling helpers for MuJoCoViewerWidget.
+
+Extracted from mujoco_viewer.py as part of issue #3060 refactor.
+
+Contains standalone functions that implement mouse / wheel event handling
+and external-viewer launching.  Each function receives the owning widget
+as its first argument so that it can read/write the widget's state
+without coupling this module to the full widget class hierarchy.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from typing import TYPE_CHECKING
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QMouseEvent, QWheelEvent
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QWidget
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mouse / wheel handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_mouse_press(owner: QWidget, event: QMouseEvent | None) -> None:
+    """Record the starting position for a camera-drag gesture.
+
+    Args:
+        owner: Viewer widget; must expose ``_last_mouse_pos``.
+        event: Qt mouse-press event.
+    """
+    if event and event.button() == Qt.MouseButton.LeftButton:
+        owner._last_mouse_pos = event.position()
+
+
+def handle_mouse_move(owner: QWidget, event: QMouseEvent | None) -> None:
+    """Rotate the camera while the user drags with the left button held.
+
+    Args:
+        owner: Viewer widget; must expose ``_last_mouse_pos`` and ``_renderer``.
+        event: Qt mouse-move event.
+    """
+    if event and owner._last_mouse_pos and owner._renderer:
+        dx = event.position().x() - owner._last_mouse_pos.x()
+        dy = event.position().y() - owner._last_mouse_pos.y()
+        owner._renderer.rotate_camera(dx * 0.5, dy * 0.5)
+        owner._last_mouse_pos = event.position()
+
+
+def handle_mouse_release(owner: QWidget, event: QMouseEvent | None) -> None:  # noqa: ARG001
+    """Clear the drag-start position on button release.
+
+    Args:
+        owner: Viewer widget; must expose ``_last_mouse_pos``.
+        event: Qt mouse-release event (unused, kept for Qt signature parity).
+    """
+    owner._last_mouse_pos = None
+
+
+def handle_wheel(owner: QWidget, event: QWheelEvent | None) -> None:
+    """Zoom the camera in or out on mouse-wheel scroll.
+
+    Args:
+        owner: Viewer widget; must expose ``_renderer``.
+        event: Qt wheel event.
+    """
+    if event and owner._renderer:
+        delta = event.angleDelta().y()
+        factor = 0.9 if delta > 0 else 1.1
+        owner._renderer.zoom_camera(factor)
+
+
+# ---------------------------------------------------------------------------
+# External viewer launcher
+# ---------------------------------------------------------------------------
+
+
+def launch_external_viewer(urdf_content: str, converter_cls: type) -> None:
+    """Launch MuJoCo's standalone viewer in a subprocess.
+
+    Converts *urdf_content* to MJCF, writes it to a temp file, and spawns
+    a ``python -c`` subprocess that opens the MuJoCo interactive viewer.
+
+    Args:
+        urdf_content: URDF XML string to visualise.
+        converter_cls: ``URDFToMJCFConverter`` class (avoids a circular import).
+    """
+    if not urdf_content:
+        logger.warning("No URDF content to view")
+        return
+
+    try:
+        mjcf_content = converter_cls.convert(urdf_content)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(mjcf_content)
+            temp_path = f.name
+
+        cmd = [
+            sys.executable,
+            "-c",
+            (
+                "import mujoco; import mujoco.viewer; "
+                f"m=mujoco.MjModel.from_xml_path(r'{temp_path}'); "
+                "mujoco.viewer.launch(m)"
+            ),
+        ]
+        subprocess.Popen(cmd)
+        logger.info("Launched external MuJoCo viewer")
+
+    except ImportError as e:
+        logger.error(f"Failed to launch viewer: {e}")

--- a/src/tools/model_explorer/_viewer_ui.py
+++ b/src/tools/model_explorer/_viewer_ui.py
@@ -1,0 +1,198 @@
+# mypy: ignore-errors
+"""UI construction helpers for MuJoCoViewerWidget.
+
+Extracted from mujoco_viewer.py as part of issue #3060 refactor.
+
+Contains:
+- ViewerUIBuilder: builds the toolbar, viewport, and status bar
+- Standalone render-display helper used by the render timer
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QImage, QPixmap
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from src.shared.python.engine_core.engine_availability import MUJOCO_AVAILABLE
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QWidget
+
+
+class ViewerUIBuilder:
+    """Builds the UI elements for MuJoCoViewerWidget.
+
+    Call ``build`` once during widget initialisation; it populates the
+    widget's layout and stores named widget references back on the owner.
+    """
+
+    # ---------------------------------------------------------------------------
+    # Public factory
+    # ---------------------------------------------------------------------------
+
+    @staticmethod
+    def build(owner: QWidget) -> None:  # noqa: C901  (intentionally long setup)
+        """Construct and attach all UI widgets to *owner*.
+
+        Postcondition: the following attributes are set on *owner*:
+            _collision_checkbox, _frames_checkbox, _joints_checkbox,
+            _contacts_checkbox, _launch_btn, _viewport, _status_label
+        """
+        layout = QVBoxLayout(owner)
+
+        # -- Toolbar -----------------------------------------------------------
+        toolbar = QHBoxLayout()
+
+        toggle_frame = QFrame()
+        toggle_frame.setStyleSheet("""
+            QFrame {
+                background-color: #3a3a3a;
+                border-radius: 4px;
+                padding: 2px;
+            }
+            QCheckBox {
+                color: #ddd;
+                padding: 4px 8px;
+            }
+            QCheckBox::indicator {
+                width: 14px;
+                height: 14px;
+            }
+            QCheckBox::indicator:checked {
+                background-color: #4a9eff;
+                border-radius: 2px;
+            }
+        """)
+        toggle_layout = QHBoxLayout(toggle_frame)
+        toggle_layout.setContentsMargins(4, 2, 4, 2)
+        toggle_layout.setSpacing(8)
+
+        owner._collision_checkbox = QCheckBox("Collision")
+        owner._collision_checkbox.setToolTip("Show collision geometry (red wireframe)")
+        owner._collision_checkbox.toggled.connect(owner._on_collision_toggled)
+        toggle_layout.addWidget(owner._collision_checkbox)
+
+        owner._frames_checkbox = QCheckBox("Frames")
+        owner._frames_checkbox.setChecked(True)
+        owner._frames_checkbox.setToolTip("Show coordinate frames at each body")
+        owner._frames_checkbox.toggled.connect(owner._on_frames_toggled)
+        toggle_layout.addWidget(owner._frames_checkbox)
+
+        owner._joints_checkbox = QCheckBox("Joints")
+        owner._joints_checkbox.setToolTip("Show joint axes and limits")
+        owner._joints_checkbox.toggled.connect(owner._on_joints_toggled)
+        toggle_layout.addWidget(owner._joints_checkbox)
+
+        owner._contacts_checkbox = QCheckBox("Contacts")
+        owner._contacts_checkbox.setToolTip("Show contact points and forces")
+        owner._contacts_checkbox.toggled.connect(owner._on_contacts_toggled)
+        toggle_layout.addWidget(owner._contacts_checkbox)
+
+        toolbar.addWidget(toggle_frame)
+        toolbar.addStretch()
+
+        owner._launch_btn = QPushButton("Launch Full Viewer")
+        owner._launch_btn.setToolTip("Open in MuJoCo's interactive viewer")
+        owner._launch_btn.clicked.connect(owner._launch_external_viewer)
+        toolbar.addWidget(owner._launch_btn)
+
+        layout.addLayout(toolbar)
+
+        # -- Viewport ----------------------------------------------------------
+        owner._viewport = QLabel()
+        owner._viewport.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        owner._viewport.setMinimumSize(320, 240)
+        owner._viewport.setStyleSheet("""
+            QLabel {
+                background-color: #2a2a2a;
+                border: 1px solid #444;
+                border-radius: 4px;
+            }
+        """)
+        owner._viewport.setMouseTracking(True)
+        layout.addWidget(owner._viewport, stretch=1)
+
+        # -- Status bar --------------------------------------------------------
+        owner._status_label = QLabel()
+        owner._status_label.setStyleSheet("color: #888; font-size: 11px;")
+        layout.addWidget(owner._status_label)
+
+        # -- Headless fallback -------------------------------------------------
+        if not MUJOCO_AVAILABLE:
+            owner._status_label.setText(
+                "⚠️ MuJoCo not installed - running in headless mode"
+            )
+            disable_toggles(owner)
+            show_headless_placeholder(owner)
+
+
+# ---------------------------------------------------------------------------
+# Standalone helpers (used by the widget directly)
+# ---------------------------------------------------------------------------
+
+
+def disable_toggles(owner: QWidget) -> None:
+    """Disable all visualization toggles and the launch button."""
+    owner._collision_checkbox.setEnabled(False)
+    owner._frames_checkbox.setEnabled(False)
+    owner._joints_checkbox.setEnabled(False)
+    owner._contacts_checkbox.setEnabled(False)
+    owner._launch_btn.setEnabled(False)
+
+
+def show_headless_placeholder(owner: QWidget) -> None:
+    """Render a clear headless-mode placeholder in the viewport."""
+    owner._viewport.setStyleSheet("""
+        QLabel {
+            background-color: #1a1a2e;
+            border: 2px dashed #4a4a6a;
+            border-radius: 8px;
+            color: #8888aa;
+            font-size: 14px;
+        }
+    """)
+    owner._viewport.setText(
+        "\U0001f5a5️ Headless Mode\n\n"
+        "MuJoCo is not installed.\n"
+        "3D preview is unavailable.\n\n"
+        "To enable 3D visualization:\n"
+        "  pip install mujoco\n\n"
+        "Model data is still being processed\n"
+        "and exported correctly."
+    )
+
+
+def paint_render(owner: QWidget, image: np.ndarray) -> None:
+    """Convert *image* (H, W, 3 uint8 array) to a QPixmap and update the viewport.
+
+    Args:
+        owner: The viewer widget whose ``_viewport`` should be updated.
+        image: RGB numpy array produced by the offscreen renderer.
+    """
+    h, w, c = image.shape
+    bytes_per_line = c * w
+    q_image = QImage(
+        image.data,
+        w,
+        h,
+        bytes_per_line,
+        QImage.Format.Format_RGB888,
+    )
+    pixmap = QPixmap.fromImage(q_image)
+    scaled = pixmap.scaled(
+        owner._viewport.size(),
+        Qt.AspectRatioMode.KeepAspectRatio,
+        Qt.TransformationMode.SmoothTransformation,
+    )
+    owner._viewport.setPixmap(scaled)

--- a/src/tools/model_explorer/model_loader.py
+++ b/src/tools/model_explorer/model_loader.py
@@ -1,0 +1,244 @@
+"""Model load/download actions and info-formatting helpers for ModelLoaderDialog.
+
+Provides ModelLoaderMixin, which supplies:
+- _load_selected_model   — resolve selection and emit model_selected signal
+- _download_human_model  — download from human-gazebo repository
+- _on_import_button      — import a URDF/MJCF file via file dialog
+- _on_imported_context_menu — rename / delete an imported model
+- _format_*_info helpers — produce human-readable info text for each category
+
+Intended to be mixed into ModelLoaderDialog.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtWidgets import QMessageBox
+
+from src.shared.python.logging_pkg.logger_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class ModelLoaderMixin:
+    """Mixin providing model loading actions and info formatters for the loader dialog."""
+
+    # ------------------------------------------------------------------
+    # Load / import actions
+    # ------------------------------------------------------------------
+
+    def _load_selected_model(self, category: str) -> None:
+        """Load the selected model for *category* and close the dialog.
+
+        Args:
+            category: Model category key (e.g. 'human', 'golf_clubs', 'discovered').
+
+        """
+        if category is None:
+            raise ValueError("category must be provided")
+        if category == "human":
+            model_key = self.human_combo.currentData()
+        elif category == "golf_clubs":
+            model_key = self.club_combo.currentData()
+        elif hasattr(self, f"{category}_combo"):
+            combo = getattr(self, f"{category}_combo")
+            model_key = combo.currentData()
+        else:
+            # Fallback: nothing to load without a registered combo
+            return
+
+        if model_key:
+            self.selected_category = category
+            self.selected_model = model_key
+
+            if (
+                category == "human"
+                and hasattr(self, "default_human_chk")
+                and self.default_human_chk.isChecked()
+            ):
+                from PyQt6.QtCore import QSettings
+
+                settings = QSettings("GolfModelingSuite", "URDFGenerator")
+                settings.setValue("default_human_model", model_key)
+                logger.info(f"Set default human model to: {model_key}")
+
+            self.model_selected.emit(category, model_key)
+            self.accept()
+
+    def _download_human_model(self) -> None:
+        """Download the currently selected human model from human-gazebo."""
+        model_key = self.human_combo.currentData()
+        if not model_key:
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Download Model",
+            f"Download human model '{self.human_combo.currentText()}' "
+            "from human-gazebo repository?\n\n"
+            "This will download the URDF file and associated mesh files.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+
+        if reply == QMessageBox.StandardButton.Yes:
+            try:
+                urdf_path = self.library.download_human_model(model_key)
+                if urdf_path:
+                    QMessageBox.information(
+                        self,
+                        "Download Complete",
+                        f"Model downloaded successfully to:\n{urdf_path}",
+                    )
+                else:
+                    QMessageBox.warning(
+                        self, "Download Failed", "Failed to download model files."
+                    )
+            except (RuntimeError, ValueError, OSError) as e:
+                logger.error(f"Download error: {e}")
+                QMessageBox.critical(
+                    self, "Error", f"Download failed with error:\n{str(e)}"
+                )
+
+    def _on_import_button(self) -> None:
+        """Open a file dialog to import a URDF/MJCF model."""
+        from PyQt6.QtWidgets import QFileDialog
+
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Import Model File",
+            "",
+            "Model Files (*.urdf *.xml *.mjcf);;All Files (*)",
+        )
+        if path:
+            if self.library.import_model(path):
+                self._reload_imported_models()
+                QMessageBox.information(self, "Success", "Model imported successfully.")
+            else:
+                QMessageBox.warning(self, "Error", "Failed to import model.")
+
+    def _on_imported_context_menu(self, pos: Any) -> None:
+        """Show a context menu for renaming or deleting an imported model."""
+        from PyQt6.QtWidgets import QInputDialog, QMenu
+
+        item = self.imported_tree.itemAt(pos)
+        if not item:
+            return
+
+        menu = QMenu(self)
+        rename_action = menu.addAction("Rename")
+        delete_action = menu.addAction("Delete")
+
+        viewport = self.imported_tree.viewport()
+        if viewport is None:
+            return
+
+        action = menu.exec(viewport.mapToGlobal(pos))
+
+        from PyQt6.QtCore import Qt
+
+        model_path = item.data(0, Qt.ItemDataRole.UserRole + 1)
+
+        if action == rename_action:
+            old_name = item.text(0)
+            new_name, ok = QInputDialog.getText(
+                self, "Rename Model", "New name:", text=old_name
+            )
+            if ok and new_name and new_name != old_name:
+                if self.library.rename_imported_model(model_path, new_name):
+                    self._reload_imported_models()
+                else:
+                    QMessageBox.warning(self, "Error", "Failed to rename model.")
+
+        elif action == delete_action:
+            reply = QMessageBox.question(
+                self,
+                "Confirm Delete",
+                f"Are you sure you want to delete '{item.text(0)}'?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if reply == QMessageBox.StandardButton.Yes:
+                if self.library.delete_imported_model(model_path):
+                    self._reload_imported_models()
+                else:
+                    QMessageBox.warning(self, "Error", "Failed to delete model.")
+
+    # ------------------------------------------------------------------
+    # Info formatters
+    # ------------------------------------------------------------------
+
+    def _format_human_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a human biomechanical model."""
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Description: {model_info['description']}\n"
+            f"License: {model_info['license']}\n\n"
+            f"Repository: https://github.com/gbionics/human-gazebo\n"
+        )
+
+    def _format_golf_clubs_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a golf club model."""
+        return (
+            f"Club: {model_info['name']}\n"
+            f"Loft: {model_info['loft']}°\n"
+            f"Length: {model_info['length'] * 100:.1f} cm "
+            f"({model_info['length'] / 0.0254:.1f} inches)\n"
+            f"Total Mass: {model_info['mass'] * 1000:.1f} g\n"
+            f"  - Head: {model_info['head_mass'] * 1000:.1f} g\n"
+            f"  - Shaft: {model_info['shaft_mass'] * 1000:.1f} g\n"
+            f"  - Grip: {model_info['grip_mass'] * 1000:.1f} g\n\n"
+            f"The URDF will be automatically generated with realistic "
+            f"geometry and inertial properties.\n"
+        )
+
+    def _format_generic_model_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a generic (pendulum/robotic/component) model."""
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Type: {model_info.get('type', 'Unknown').upper()}\n"
+            f"Description: {model_info['description']}\n"
+            f"Path: {model_info.get('path', 'N/A')}\n\n"
+            f"Click 'Load' to view this model.\n"
+        )
+
+    def _format_discovered_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a discovered repository model."""
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Type: {model_info['type'].upper()}\n"
+            f"Path: {model_info['description']}\n\n"
+            f"Click 'Load Selected Repository Model' to view.\n"
+        )
+
+    def _format_embedded_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for an embedded MJCF model."""
+        content_preview = (
+            model_info["content"][:200] + "..."
+            if len(model_info["content"]) > 200
+            else model_info["content"]
+        )
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Type: Embedded MJCF\n"
+            f"Description: {model_info['description']}\n\n"
+            f"Content Preview:\n{content_preview}\n"
+        )
+
+    def _format_robot_descriptions_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a robot_descriptions community model."""
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Type: {model_info['type'].upper()}\n"
+            f"Package: {model_info.get('package', 'robot_descriptions')}\n"
+            f"Path: {model_info['path']}\n\n"
+            f"Description: {model_info['description']}\n"
+        )
+
+    def _format_imported_info(self, model_info: dict[str, Any]) -> str:
+        """Return a formatted info string for a user-imported model."""
+        return (
+            f"Name: {model_info['name']}\n"
+            f"Type: {model_info['type'].upper()}\n"
+            f"Path: {model_info['path']}\n\n"
+            f"User imported model. Right-click in the list to Rename or Delete.\n"
+        )

--- a/src/tools/model_explorer/model_loader_dialog.py
+++ b/src/tools/model_explorer/model_loader_dialog.py
@@ -1,15 +1,15 @@
-# ARCHITECTURE_DEBT:
-# This module historically exceeds standard length metrics and accumulates excessive domain responsibility.
-# It requires domain-aware structural extraction to isolate its internal classes appropriately.
-
 """Model Loader Dialog for URDF Generator.
 
-
-
 Provides a PyQt6 dialog for loading pre-configured URDF models from the library,
-
 including human models and golf clubs.
 
+The original monolithic file has been split into focused modules:
+
+- model_loader_dialog.py  — this file; thin dialog orchestrator
+- model_loader.py         — load/download actions and info-formatting helpers
+                            (ModelLoaderMixin)
+- model_tree_widget.py    — repository/embedded/community/imported tab builders
+                            (ModelTreeMixin)
 """
 
 from __future__ import annotations
@@ -18,13 +18,13 @@ from typing import Any
 
 from PyQt6.QtCore import Qt, pyqtSignal  # noqa: E402
 from PyQt6.QtWidgets import (  # noqa: E402
+    QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
     QGroupBox,
     QHBoxLayout,
     QLabel,
-    QMessageBox,
     QPushButton,
     QTextEdit,
     QVBoxLayout,
@@ -33,10 +33,13 @@ from PyQt6.QtWidgets import (  # noqa: E402
 
 from src.shared.python.logging_pkg.logger_utils import get_logger  # noqa: E402
 
+from .model_loader import ModelLoaderMixin
+from .model_tree_widget import ModelTreeMixin
+
 logger = get_logger(__name__)
 
 
-class ModelLoaderDialog(QDialog):
+class ModelLoaderDialog(ModelLoaderMixin, ModelTreeMixin, QDialog):
     """Dialog for loading URDF models from the library."""
 
     model_selected = pyqtSignal(str, str)  # (category, model_key)
@@ -44,31 +47,61 @@ class ModelLoaderDialog(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         """Initialize the model loader dialog.
 
-
-
         Args:
-
             parent: Parent widget
 
         """
-
         super().__init__(parent)
-
         self.setWindowTitle("Load URDF Model from Library")
-
         self.setMinimumSize(600, 500)
 
         # Import here to avoid circular imports
-
         from .model_library import ModelLibrary
 
         self.library = ModelLibrary()
-
         self.selected_category: str | None = None
-
         self.selected_model: str | None = None
-
         self._setup_ui()
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        """Set up the user interface."""
+        from PyQt6.QtWidgets import QTabWidget
+
+        layout = QVBoxLayout(self)
+
+        title = QLabel("Select a Model to Load")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setStyleSheet("font-size: 14pt; font-weight: bold; margin: 10px;")
+        layout.addWidget(title)
+
+        self.tabs = QTabWidget()
+
+        self.tabs.addTab(self._setup_biomechanics_tab(), "Biomechanics")
+        self.tabs.addTab(self._setup_equipment_tab(), "Equipment")
+        self.tabs.addTab(self._setup_robotics_tab(), "Robotics")
+
+        repo_tab = QWidget()
+        self._setup_repo_tab(repo_tab)
+        self.tabs.addTab(repo_tab, "Repository")
+
+        community_tab = QWidget()
+        self._setup_community_tab(community_tab)
+        self.tabs.addTab(community_tab, "Community")
+
+        imported_tab = QWidget()
+        self._setup_imported_tab(imported_tab)
+        self.tabs.addTab(imported_tab, "Imported")
+
+        embedded_tab = QWidget()
+        self._setup_embedded_tab(embedded_tab)
+        self.tabs.addTab(embedded_tab, "Embedded")
+
+        layout.addWidget(self.tabs)
+        self._setup_info_and_buttons(layout)
 
     def _setup_biomechanics_tab(self) -> QWidget:
         """Create the Biomechanics tab with human models."""
@@ -137,478 +170,61 @@ class ModelLoaderDialog(QDialog):
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
-    def _setup_ui(self) -> None:
-        """Set up the user interface."""
-
-        from PyQt6.QtWidgets import (
-            QTabWidget,
-        )
-
-        layout = QVBoxLayout(self)
-
-        # Title
-        title = QLabel("Select a Model to Load")
-        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        title.setStyleSheet("font-size: 14pt; font-weight: bold; margin: 10px;")
-        layout.addWidget(title)
-
-        # Tabs
-        self.tabs = QTabWidget()
-
-        self.tabs.addTab(self._setup_biomechanics_tab(), "Biomechanics")
-        self.tabs.addTab(self._setup_equipment_tab(), "Equipment")
-        self.tabs.addTab(self._setup_robotics_tab(), "Robotics")
-
-        repo_tab = QWidget()
-        self._setup_repo_tab(repo_tab)
-        self.tabs.addTab(repo_tab, "Repository")
-
-        community_tab = QWidget()
-        self._setup_community_tab(community_tab)
-        self.tabs.addTab(community_tab, "Community")
-
-        imported_tab = QWidget()
-        self._setup_imported_tab(imported_tab)
-        self.tabs.addTab(imported_tab, "Imported")
-
-        embedded_tab = QWidget()
-        self._setup_embedded_tab(embedded_tab)
-        self.tabs.addTab(embedded_tab, "Embedded")
-
-        layout.addWidget(self.tabs)
-
-        # Info display and dialog buttons
-        self._setup_info_and_buttons(layout)
-
-    def _setup_repo_tab(self, parent: QWidget) -> None:
-        if parent is None:
-            raise ValueError("parent must be provided")
-        from PyQt6.QtWidgets import QHeaderView, QLineEdit, QTreeWidget
-
-        layout = QVBoxLayout(parent)
-
-        # Search
-
-        search_layout = QHBoxLayout()
-
-        search_layout.addWidget(QLabel("Search:"))
-
-        self.repo_search = QLineEdit()
-
-        self.repo_search.setPlaceholderText("Filter models...")
-
-        self.repo_search.textChanged.connect(self._filter_repo_list)
-
-        search_layout.addWidget(self.repo_search)
-
-        layout.addLayout(search_layout)
-
-        # Tree
-
-        self.repo_tree = QTreeWidget()
-
-        self.repo_tree.setHeaderLabels(["Name", "Type", "Path"])
-
-        header = self.repo_tree.header()
-
-        if header:
-            header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-
-            header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-
-        self.repo_tree.itemSelectionChanged.connect(
-            lambda: self._on_model_selected("discovered")
-        )
-
-        layout.addWidget(self.repo_tree)
-
-        # Populate
-
-        self.discovered_models = self.library.list_available_models()["discovered"]
-
-        self._populate_repo_tree(self.discovered_models)
-
-        # Load button for this tab
-
-        load_btn = QPushButton("Load Selected Repository Model")
-
-        load_btn.clicked.connect(lambda: self._load_selected_model("discovered"))
-
-        layout.addWidget(load_btn)
-
-    def _populate_repo_tree(self, models: list) -> None:
-        if models is None:
-            raise ValueError("models must be provided")
-        from PyQt6.QtWidgets import QTreeWidgetItem
-
-        self.repo_tree.clear()
-
-        for model in models:
-            item = QTreeWidgetItem(
-                [model["name"], model["type"].upper(), model["path"]]
-            )
-
-            item.setData(0, Qt.ItemDataRole.UserRole, model["config_key"])
-
-            self.repo_tree.addTopLevelItem(item)
-
-    def _filter_repo_list(self, text: str) -> None:
-        if text is None:
-            raise ValueError("text must be provided")
-        text = text.lower()
-
-        filtered = [
-            m
-            for m in self.discovered_models
-            if text in m["name"].lower() or text in m["path"].lower()
-        ]
-
-        self._populate_repo_tree(filtered)
-
-    def _setup_embedded_tab(self, parent: QWidget) -> None:
-        if parent is None:
-            raise ValueError("parent must be provided")
-        from PyQt6.QtWidgets import QListWidget
-
-        layout = QVBoxLayout(parent)
-
-        layout.addWidget(QLabel("Pre-defined MuJoCo XML models found in Python code:"))
-
-        self.embedded_list = QListWidget()
-
-        self.embedded_list.itemSelectionChanged.connect(
-            lambda: self._on_model_selected("embedded")
-        )
-
-        layout.addWidget(self.embedded_list)
-
-        # Populate
-
-        embedded_models = self.library.list_available_models()["embedded"]
-
-        for key, model in embedded_models.items():
-            from PyQt6.QtWidgets import QListWidgetItem
-
-            item = QListWidgetItem(f"{model['name']} (MJCF)")
-
-            item.setData(Qt.ItemDataRole.UserRole, key)
-
-            self.embedded_list.addItem(item)
-
-        # Load button
-
-        load_btn = QPushButton("Load Selected Embedded Model")
-
-        load_btn.clicked.connect(lambda: self._load_selected_model("embedded"))
-
-        layout.addWidget(load_btn)
-
-    def _setup_community_tab(self, parent: QWidget) -> None:
-        if parent is None:
-            raise ValueError("parent must be provided")
-        from PyQt6.QtWidgets import QListWidget, QListWidgetItem
-
-        layout = QVBoxLayout(parent)
-
-        layout.addWidget(QLabel("Community models from 'robot_descriptions' library:"))
-
-        self.community_list = QListWidget()
-
-        self.community_list.itemSelectionChanged.connect(
-            lambda: self._on_model_selected("robot_descriptions")
-        )
-
-        layout.addWidget(self.community_list)
-
-        # Populate
-
-        community_models = self.library.list_available_models().get(
-            "robot_descriptions", []
-        )
-
-        if not community_models:
-            layout.addWidget(
-                QLabel(
-                    "No community models found.\nEnsure 'robot_descriptions' is installed."
-                )
-            )
-
-        for model in community_models:
-            item = QListWidgetItem(f"{model['name']} ({model['type'].upper()})")
-
-            item.setData(Qt.ItemDataRole.UserRole, model["config_key"])
-
-            self.community_list.addItem(item)
-
-        load_btn = QPushButton("Load Selected Community Model")
-
-        load_btn.clicked.connect(
-            lambda: self._load_selected_model("robot_descriptions")
-        )
-
-        layout.addWidget(load_btn)
-
-    def _setup_imported_tab(self, parent: QWidget) -> None:
-        if parent is None:
-            raise ValueError("parent must be provided")
-        from PyQt6.QtWidgets import QHeaderView, QTreeWidget
-
-        layout = QVBoxLayout(parent)
-
-        layout.addWidget(QLabel("User Imported models (Right-click to manage):"))
-
-        # Tree
-
-        self.imported_tree = QTreeWidget()
-
-        self.imported_tree.setHeaderLabels(["Name", "Type", "Path"])
-
-        self.imported_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-
-        self.imported_tree.customContextMenuRequested.connect(
-            self._on_imported_context_menu
-        )
-
-        header = self.imported_tree.header()
-
-        if header:
-            header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-
-            header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-
-        self.imported_tree.itemSelectionChanged.connect(
-            lambda: self._on_model_selected("imported")
-        )
-
-        layout.addWidget(self.imported_tree)
-
-        # Buttons
-
-        btn_layout = QHBoxLayout()
-
-        import_btn = QPushButton("Import URDF/MJCF...")
-
-        import_btn.clicked.connect(self._on_import_button)
-
-        btn_layout.addWidget(import_btn)
-
-        reload_btn = QPushButton("Reload")
-
-        reload_btn.clicked.connect(self._reload_imported_models)
-
-        btn_layout.addWidget(reload_btn)
-
-        layout.addLayout(btn_layout)
-
-        load_btn = QPushButton("Load Selected Imported Model")
-
-        load_btn.clicked.connect(lambda: self._load_selected_model("imported"))
-
-        layout.addWidget(load_btn)
-
-        self._reload_imported_models()
-
-    def _reload_imported_models(self) -> None:
-        from PyQt6.QtWidgets import QTreeWidgetItem
-
-        self.imported_tree.clear()
-
-        models = self.library.discover_imported_models()
-
-        for model in models:
-            item = QTreeWidgetItem(
-                [model["name"], model["type"].upper(), model["path"]]
-            )
-
-            item.setData(0, Qt.ItemDataRole.UserRole, model["config_key"])
-
-            item.setData(
-                0, Qt.ItemDataRole.UserRole + 1, model["path"]
-            )  # Store path for file ops
-
-            self.imported_tree.addTopLevelItem(item)
-
-    def _on_import_button(self) -> None:
-        from PyQt6.QtWidgets import QFileDialog
-
-        path, _ = QFileDialog.getOpenFileName(
-            self,
-            "Import Model File",
-            "",
-            "Model Files (*.urdf *.xml *.mjcf);;All Files (*)",
-        )
-
-        if path:
-            if self.library.import_model(path):
-                self._reload_imported_models()
-
-                QMessageBox.information(self, "Success", "Model imported successfully.")
-
-            else:
-                QMessageBox.warning(self, "Error", "Failed to import model.")
-
-    def _on_imported_context_menu(self, pos: Any) -> None:
-        from PyQt6.QtWidgets import QInputDialog, QMenu
-
-        item = self.imported_tree.itemAt(pos)
-
-        if not item:
-            return
-
-        menu = QMenu(self)
-
-        rename_action = menu.addAction("Rename")
-
-        delete_action = menu.addAction("Delete")
-
-        viewport = self.imported_tree.viewport()
-
-        if viewport is None:
-            return
-
-        action = menu.exec(viewport.mapToGlobal(pos))
-
-        model_path = item.data(0, Qt.ItemDataRole.UserRole + 1)
-
-        if action == rename_action:
-            old_name = item.text(0)
-
-            new_name, ok = QInputDialog.getText(
-                self, "Rename Model", "New name:", text=old_name
-            )
-
-            if ok and new_name and new_name != old_name:
-                if self.library.rename_imported_model(model_path, new_name):
-                    self._reload_imported_models()
-
-                else:
-                    QMessageBox.warning(self, "Error", "Failed to rename model.")
-
-        elif action == delete_action:
-            reply = QMessageBox.question(
-                self,
-                "Confirm Delete",
-                f"Are you sure you want to delete '{item.text(0)}'?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            )
-
-            if reply == QMessageBox.StandardButton.Yes:
-                if self.library.delete_imported_model(model_path):
-                    self._reload_imported_models()
-
-                else:
-                    QMessageBox.warning(self, "Error", "Failed to delete model.")
-
-    def _on_accept(self) -> None:
-        # Determine active tab and selected item
-
-        idx = self.tabs.currentIndex()
-
-        if idx == 0:  # Bundled
-            pass
-
-        if self.selected_model:
-            self.accept()
-
-        else:
-            # Try to select from active tab
-
-            if idx == 1:
-                self._load_selected_model("discovered")
-
-            elif idx == 2:
-                self._load_selected_model("embedded")
+    # ------------------------------------------------------------------
+    # Widget group builders
+    # ------------------------------------------------------------------
 
     def _create_human_models_group(self) -> QGroupBox:
         """Create the human models selection group.
 
-
-
         Returns:
-
             QGroupBox containing human model controls
 
         """
-
         group = QGroupBox("Human Biomechanical Models")
-
         layout = QVBoxLayout(group)
-
-        # Description
 
         desc = QLabel(
             "High-fidelity human models from the human-gazebo repository.\n"
             "Includes detailed STL meshes for realistic visualization."
         )
-
         desc.setWordWrap(True)
-
         desc.setStyleSheet("color: #666; font-size: 9pt; margin: 5px;")
-
         layout.addWidget(desc)
 
-        # Model selector
-
         selector_layout = QHBoxLayout()
-
         selector_layout.addWidget(QLabel("Model:"))
-
         self.human_combo = QComboBox()
-
         available_models = self.library.list_available_models()
-
         for model_key in available_models["human"]:
             model_info = self.library.get_model_info("human", model_key)
-
             if model_info:
                 self.human_combo.addItem(model_info["name"], model_key)
-
         self.human_combo.currentIndexChanged.connect(
             lambda: self._on_model_selected("human")
         )
-
         selector_layout.addWidget(self.human_combo)
 
         load_btn = QPushButton("Load Human Model")
-
         load_btn.clicked.connect(lambda: self._load_selected_model("human"))
-
         selector_layout.addWidget(load_btn)
-
         layout.addLayout(selector_layout)
 
-        # Set as default checkbox
-
-        from PyQt6.QtWidgets import QCheckBox
-
         self.default_human_chk = QCheckBox("Set as default human model")
-
         self.default_human_chk.setToolTip("Automatically load this model on startup")
-
         layout.addWidget(self.default_human_chk)
 
-        # Download button
-
         download_layout = QHBoxLayout()
-
         download_btn = QPushButton("Download from human-gazebo")
-
         download_btn.setToolTip(
             "Download URDF and mesh files from the human-gazebo repository"
         )
-
         download_btn.clicked.connect(self._download_human_model)
-
         download_layout.addWidget(download_btn)
-
         license_label = QLabel("License: CC-BY-SA 2.0")
-
         license_label.setStyleSheet("color: #888; font-size: 8pt;")
-
         download_layout.addWidget(license_label)
-
         download_layout.addStretch()
-
         layout.addLayout(download_layout)
 
         return group
@@ -616,66 +232,43 @@ class ModelLoaderDialog(QDialog):
     def _create_golf_clubs_group(self) -> QGroupBox:
         """Create the golf clubs selection group.
 
-
-
         Returns:
-
             QGroupBox containing golf club controls
 
         """
-
         group = QGroupBox("Golf Clubs")
-
         layout = QVBoxLayout(group)
-
-        # Description
 
         desc = QLabel(
             "Select a golf club to add to your model.\n"
             "Clubs include realistic mass properties and geometry."
         )
-
         desc.setWordWrap(True)
-
         desc.setStyleSheet("color: #666; font-size: 9pt; margin: 5px;")
-
         layout.addWidget(desc)
 
-        # Club selector
-
         selector_layout = QHBoxLayout()
-
         selector_layout.addWidget(QLabel("Club Type:"))
-
         self.club_combo = QComboBox()
-
         available_models = self.library.list_available_models()
-
         for club_key in available_models["golf_clubs"]:
             club_info = self.library.get_model_info("golf_clubs", club_key)
-
             if club_info:
                 self.club_combo.addItem(club_info["name"], club_key)
-
         self.club_combo.currentIndexChanged.connect(
             lambda: self._on_model_selected("golf_clubs")
         )
-
         selector_layout.addWidget(self.club_combo)
 
         generate_btn = QPushButton("Generate Club URDF")
-
         generate_btn.clicked.connect(lambda: self._load_selected_model("golf_clubs"))
-
         selector_layout.addWidget(generate_btn)
-
         layout.addLayout(selector_layout)
 
         return group
 
     def _create_components_group(self) -> QGroupBox:
         """Create the components selection group."""
-
         return self._create_model_group(
             "Components",
             "component",
@@ -688,157 +281,103 @@ class ModelLoaderDialog(QDialog):
     ) -> QGroupBox:
         """Generic helper to create a model selection group.
 
-
-
         Args:
-
             title: Group box title
-
             category: Model category key in library
-
             description: Description text
-
             btn_text: Button text
 
-
-
         Returns:
-
             Configured QGroupBox
 
         """
-
         if title is None:
             raise ValueError("title must be provided")
         group = QGroupBox(title)
-
         layout = QVBoxLayout(group)
 
-        # Description
-
         desc = QLabel(description)
-
         desc.setWordWrap(True)
-
         desc.setStyleSheet("color: #666; font-size: 9pt; margin: 5px;")
-
         layout.addWidget(desc)
 
-        # Selector
-
         selector_layout = QHBoxLayout()
-
         selector_layout.addWidget(QLabel("Model:"))
-
         combo = QComboBox()
-
         available_models = self.library.list_available_models()
-
-        # Store reference to combo for this category
-
         setattr(self, f"{category}_combo", combo)
-
         for key in available_models.get(category, []):
             info = self.library.get_model_info(category, key)
-
             if info:
                 combo.addItem(info["name"], key)
-
         combo.currentIndexChanged.connect(lambda: self._on_model_selected(category))
-
         selector_layout.addWidget(combo)
 
         load_btn = QPushButton(btn_text)
-
         load_btn.clicked.connect(lambda: self._load_selected_model(category))
-
         selector_layout.addWidget(load_btn)
-
         layout.addLayout(selector_layout)
 
         return group
 
+    # ------------------------------------------------------------------
+    # Selection and info display
+    # ------------------------------------------------------------------
+
     def _on_model_selected(self, category: str) -> None:
         """Handle model selection change.
 
-
-
         Args:
-
             category: 'human', 'golf_clubs', 'pendulum', 'robotic', 'component',
-
-                     'discovered', or 'embedded'
+                     'discovered', 'embedded', 'robot_descriptions', or 'imported'
 
         """
-
         if category is None:
             raise ValueError("category must be provided")
         model_key = None
 
         if category == "human":
             model_key = self.human_combo.currentData()
-
         elif category == "golf_clubs":
             model_key = self.club_combo.currentData()
-
         elif hasattr(self, f"{category}_combo"):
-            # Generic handling for pendulum, robotic, component
-
             combo = getattr(self, f"{category}_combo")
-
             model_key = combo.currentData()
-
         elif category == "discovered":
             repo_item = self.repo_tree.currentItem()
-
             if repo_item:
                 model_key = repo_item.data(0, Qt.ItemDataRole.UserRole)
-
         elif category == "embedded":
             embed_item = self.embedded_list.currentItem()
-
             if embed_item:
                 model_key = embed_item.data(Qt.ItemDataRole.UserRole)
-
         elif category == "robot_descriptions":
             comm_item = self.community_list.currentItem()
-
             if comm_item:
                 model_key = comm_item.data(Qt.ItemDataRole.UserRole)
-
         elif category == "imported":
             imp_item = self.imported_tree.currentItem()
-
             if imp_item:
                 model_key = imp_item.data(0, Qt.ItemDataRole.UserRole)
 
         if model_key:
             model_info = self.library.get_model_info(category, model_key)
-
             if model_info:
                 self._display_model_info(category, model_key, model_info)
-
             self.selected_category = category
-
             self.selected_model = model_key
 
     def _display_model_info(
         self, category: str, model_key: str, model_info: dict[str, Any]
     ) -> None:
-        """Display information about selected model.
-
-
+        """Display information about the selected model.
 
         Args:
-
             category: Model category
-
             model_key: Model identifier
-
             model_info: Model information dictionary
 
         """
-
         if category is None:
             raise ValueError("category must be provided")
         formatters: dict[str, Any] = {
@@ -852,186 +391,36 @@ class ModelLoaderDialog(QDialog):
             "robot_descriptions": self._format_robot_descriptions_info,
             "imported": self._format_imported_info,
         }
-
         formatter = formatters.get(category)
         info_text = formatter(model_info) if formatter else "No information available."
-
         self.info_display.setPlainText(info_text)
 
-    def _format_human_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Description: {model_info['description']}\n"
-            f"License: {model_info['license']}\n\n"
-            f"Repository: https://github.com/gbionics/human-gazebo\n"
-        )
+    # ------------------------------------------------------------------
+    # Dialog accept / public API
+    # ------------------------------------------------------------------
 
-    def _format_golf_clubs_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Club: {model_info['name']}\n"
-            f"Loft: {model_info['loft']}\u00b0\n"
-            f"Length: {model_info['length'] * 100:.1f} cm "
-            f"({model_info['length'] / 0.0254:.1f} inches)\n"
-            f"Total Mass: {model_info['mass'] * 1000:.1f} g\n"
-            f"  - Head: {model_info['head_mass'] * 1000:.1f} g\n"
-            f"  - Shaft: {model_info['shaft_mass'] * 1000:.1f} g\n"
-            f"  - Grip: {model_info['grip_mass'] * 1000:.1f} g\n\n"
-            f"The URDF will be automatically generated with realistic "
-            f"geometry and inertial properties.\n"
-        )
+    def _on_accept(self) -> None:
+        """Handle the OK button: accept if a model is selected."""
+        idx = self.tabs.currentIndex()
 
-    def _format_generic_model_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Type: {model_info.get('type', 'Unknown').upper()}\n"
-            f"Description: {model_info['description']}\n"
-            f"Path: {model_info.get('path', 'N/A')}\n\n"
-            f"Click 'Load' to view this model.\n"
-        )
+        if idx == 0:  # Bundled / Biomechanics
+            pass
 
-    def _format_discovered_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Type: {model_info['type'].upper()}\n"
-            f"Path: {model_info['description']}\n\n"
-            f"Click 'Load Selected Repository Model' to view.\n"
-        )
-
-    def _format_embedded_info(self, model_info: dict[str, Any]) -> str:
-        content_preview = (
-            model_info["content"][:200] + "..."
-            if len(model_info["content"]) > 200
-            else model_info["content"]
-        )
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Type: Embedded MJCF\n"
-            f"Description: {model_info['description']}\n\n"
-            f"Content Preview:\n{content_preview}\n"
-        )
-
-    def _format_robot_descriptions_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Type: {model_info['type'].upper()}\n"
-            f"Package: {model_info.get('package', 'robot_descriptions')}\n"
-            f"Path: {model_info['path']}\n\n"
-            f"Description: {model_info['description']}\n"
-        )
-
-    def _format_imported_info(self, model_info: dict[str, Any]) -> str:
-        return (
-            f"Name: {model_info['name']}\n"
-            f"Type: {model_info['type'].upper()}\n"
-            f"Path: {model_info['path']}\n\n"
-            f"User imported model. Right-click in the list to Rename or Delete.\n"
-        )
-
-    def _download_human_model(self) -> None:
-        """Download the currently selected human model."""
-
-        model_key = self.human_combo.currentData()
-
-        if not model_key:
-            return
-
-        reply = QMessageBox.question(
-            self,
-            "Download Model",
-            f"Download human model '{self.human_combo.currentText()}' "
-            "from human-gazebo repository?\n\n"
-            "This will download the URDF file and associated mesh files.",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-        )
-
-        if reply == QMessageBox.StandardButton.Yes:
-            try:
-                urdf_path = self.library.download_human_model(model_key)
-
-                if urdf_path:
-                    QMessageBox.information(
-                        self,
-                        "Download Complete",
-                        f"Model downloaded successfully to:\n{urdf_path}",
-                    )
-
-                else:
-                    QMessageBox.warning(
-                        self, "Download Failed", "Failed to download model files."
-                    )
-
-            except (RuntimeError, ValueError, OSError) as e:
-                logger.error(f"Download error: {e}")
-
-                QMessageBox.critical(
-                    self, "Error", f"Download failed with error:\n{str(e)}"
-                )
-
-    def _load_selected_model(self, category: str) -> None:
-        """Load the selected model.
-
-
-
-        Args:
-
-            category: Model category key
-
-        """
-
-        if category is None:
-            raise ValueError("category must be provided")
-        if category == "human":
-            model_key = self.human_combo.currentData()
-
-        elif category == "golf_clubs":
-            model_key = self.club_combo.currentData()
-
-        elif hasattr(self, f"{category}_combo"):
-            combo = getattr(self, f"{category}_combo")
-
-            model_key = combo.currentData()
-
-        else:
-            # Fallback for manual calls, though generic way is better
-
-            return
-
-        if model_key:
-            self.selected_category = category
-
-            self.selected_model = model_key
-
-            # Save as default if requested
-
-            if (
-                category == "human"
-                and hasattr(self, "default_human_chk")
-                and self.default_human_chk.isChecked()
-            ):
-                from PyQt6.QtCore import QSettings
-
-                settings = QSettings("GolfModelingSuite", "URDFGenerator")
-
-                settings.setValue("default_human_model", model_key)
-
-                logger.info(f"Set default human model to: {model_key}")
-
-            self.model_selected.emit(category, model_key)
-
+        if self.selected_model:
             self.accept()
+        else:
+            if idx == 1:
+                self._load_selected_model("discovered")
+            elif idx == 2:
+                self._load_selected_model("embedded")
 
     def get_selected_model(self) -> tuple[str, str] | None:
         """Get the selected model.
 
-
-
         Returns:
-
             Tuple of (category, model_key) or None if no selection
 
         """
-
         if self.selected_category and self.selected_model:
             return (self.selected_category, self.selected_model)
-
         return None

--- a/src/tools/model_explorer/model_tree_widget.py
+++ b/src/tools/model_explorer/model_tree_widget.py
@@ -1,0 +1,218 @@
+"""Model tree/list tab widget builders for ModelLoaderDialog.
+
+Provides ModelTreeMixin, which supplies the Repository, Embedded, Community,
+and Imported tab setup methods.  Intended to be mixed into ModelLoaderDialog.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class ModelTreeMixin:
+    """Mixin providing tree/list tab builders for the model loader dialog."""
+
+    # ------------------------------------------------------------------
+    # Repository tab
+    # ------------------------------------------------------------------
+
+    def _setup_repo_tab(self, parent: QWidget) -> None:
+        """Set up the Repository tab with a searchable tree of discovered models."""
+        if parent is None:
+            raise ValueError("parent must be provided")
+        from PyQt6.QtWidgets import QHeaderView, QLineEdit, QTreeWidget
+
+        layout = QVBoxLayout(parent)
+
+        search_layout = QHBoxLayout()
+        search_layout.addWidget(QLabel("Search:"))
+        self.repo_search = QLineEdit()
+        self.repo_search.setPlaceholderText("Filter models...")
+        self.repo_search.textChanged.connect(self._filter_repo_list)
+        search_layout.addWidget(self.repo_search)
+        layout.addLayout(search_layout)
+
+        self.repo_tree = QTreeWidget()
+        self.repo_tree.setHeaderLabels(["Name", "Type", "Path"])
+        header = self.repo_tree.header()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+            header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        self.repo_tree.itemSelectionChanged.connect(
+            lambda: self._on_model_selected("discovered")
+        )
+        layout.addWidget(self.repo_tree)
+
+        self.discovered_models = self.library.list_available_models()["discovered"]
+        self._populate_repo_tree(self.discovered_models)
+
+        load_btn = QPushButton("Load Selected Repository Model")
+        load_btn.clicked.connect(lambda: self._load_selected_model("discovered"))
+        layout.addWidget(load_btn)
+
+    def _populate_repo_tree(self, models: list) -> None:
+        """Populate the repository tree widget with *models*."""
+        if models is None:
+            raise ValueError("models must be provided")
+        from PyQt6.QtWidgets import QTreeWidgetItem
+
+        self.repo_tree.clear()
+        for model in models:
+            item = QTreeWidgetItem(
+                [model["name"], model["type"].upper(), model["path"]]
+            )
+            item.setData(0, Qt.ItemDataRole.UserRole, model["config_key"])
+            self.repo_tree.addTopLevelItem(item)
+
+    def _filter_repo_list(self, text: str) -> None:
+        """Filter the repository tree to models matching *text*."""
+        if text is None:
+            raise ValueError("text must be provided")
+        text = text.lower()
+        filtered = [
+            m
+            for m in self.discovered_models
+            if text in m["name"].lower() or text in m["path"].lower()
+        ]
+        self._populate_repo_tree(filtered)
+
+    # ------------------------------------------------------------------
+    # Embedded tab
+    # ------------------------------------------------------------------
+
+    def _setup_embedded_tab(self, parent: QWidget) -> None:
+        """Set up the Embedded tab listing pre-defined MuJoCo XML models."""
+        if parent is None:
+            raise ValueError("parent must be provided")
+        from PyQt6.QtWidgets import QListWidget
+
+        layout = QVBoxLayout(parent)
+        layout.addWidget(QLabel("Pre-defined MuJoCo XML models found in Python code:"))
+
+        self.embedded_list = QListWidget()
+        self.embedded_list.itemSelectionChanged.connect(
+            lambda: self._on_model_selected("embedded")
+        )
+        layout.addWidget(self.embedded_list)
+
+        embedded_models = self.library.list_available_models()["embedded"]
+        for key, model in embedded_models.items():
+            from PyQt6.QtWidgets import QListWidgetItem
+
+            item = QListWidgetItem(f"{model['name']} (MJCF)")
+            item.setData(Qt.ItemDataRole.UserRole, key)
+            self.embedded_list.addItem(item)
+
+        load_btn = QPushButton("Load Selected Embedded Model")
+        load_btn.clicked.connect(lambda: self._load_selected_model("embedded"))
+        layout.addWidget(load_btn)
+
+    # ------------------------------------------------------------------
+    # Community tab
+    # ------------------------------------------------------------------
+
+    def _setup_community_tab(self, parent: QWidget) -> None:
+        """Set up the Community tab listing robot_descriptions library models."""
+        if parent is None:
+            raise ValueError("parent must be provided")
+        from PyQt6.QtWidgets import QListWidget, QListWidgetItem
+
+        layout = QVBoxLayout(parent)
+        layout.addWidget(QLabel("Community models from 'robot_descriptions' library:"))
+
+        self.community_list = QListWidget()
+        self.community_list.itemSelectionChanged.connect(
+            lambda: self._on_model_selected("robot_descriptions")
+        )
+        layout.addWidget(self.community_list)
+
+        community_models = self.library.list_available_models().get(
+            "robot_descriptions", []
+        )
+        if not community_models:
+            layout.addWidget(
+                QLabel(
+                    "No community models found.\nEnsure 'robot_descriptions' is installed."
+                )
+            )
+        for model in community_models:
+            item = QListWidgetItem(f"{model['name']} ({model['type'].upper()})")
+            item.setData(Qt.ItemDataRole.UserRole, model["config_key"])
+            self.community_list.addItem(item)
+
+        load_btn = QPushButton("Load Selected Community Model")
+        load_btn.clicked.connect(
+            lambda: self._load_selected_model("robot_descriptions")
+        )
+        layout.addWidget(load_btn)
+
+    # ------------------------------------------------------------------
+    # Imported tab
+    # ------------------------------------------------------------------
+
+    def _setup_imported_tab(self, parent: QWidget) -> None:
+        """Set up the Imported tab for user-managed model files."""
+        if parent is None:
+            raise ValueError("parent must be provided")
+        from PyQt6.QtWidgets import QHeaderView, QTreeWidget
+
+        layout = QVBoxLayout(parent)
+        layout.addWidget(QLabel("User Imported models (Right-click to manage):"))
+
+        self.imported_tree = QTreeWidget()
+        self.imported_tree.setHeaderLabels(["Name", "Type", "Path"])
+        self.imported_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.imported_tree.customContextMenuRequested.connect(
+            self._on_imported_context_menu
+        )
+        header = self.imported_tree.header()
+        if header:
+            header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+            header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        self.imported_tree.itemSelectionChanged.connect(
+            lambda: self._on_model_selected("imported")
+        )
+        layout.addWidget(self.imported_tree)
+
+        btn_layout = QHBoxLayout()
+        import_btn = QPushButton("Import URDF/MJCF...")
+        import_btn.clicked.connect(self._on_import_button)
+        btn_layout.addWidget(import_btn)
+        reload_btn = QPushButton("Reload")
+        reload_btn.clicked.connect(self._reload_imported_models)
+        btn_layout.addWidget(reload_btn)
+        layout.addLayout(btn_layout)
+
+        load_btn = QPushButton("Load Selected Imported Model")
+        load_btn.clicked.connect(lambda: self._load_selected_model("imported"))
+        layout.addWidget(load_btn)
+
+        self._reload_imported_models()
+
+    def _reload_imported_models(self) -> None:
+        """Refresh the imported-models tree from the library."""
+        from PyQt6.QtWidgets import QTreeWidgetItem
+
+        self.imported_tree.clear()
+        models = self.library.discover_imported_models()
+        for model in models:
+            item = QTreeWidgetItem(
+                [model["name"], model["type"].upper(), model["path"]]
+            )
+            item.setData(0, Qt.ItemDataRole.UserRole, model["config_key"])
+            item.setData(
+                0, Qt.ItemDataRole.UserRole + 1, model["path"]
+            )  # Store path for file ops
+            self.imported_tree.addTopLevelItem(item)

--- a/src/tools/model_explorer/mujoco_viewer.py
+++ b/src/tools/model_explorer/mujoco_viewer.py
@@ -10,28 +10,19 @@ Issue #755: Enhanced visualization toggles for collision, frames, joints, and co
 Implementation split across:
 - _mujoco_viewer_backend.py: VisualizationFlags, URDFToMJCFConverter,
   MuJoCoOffscreenRenderer
+- _viewer_ui.py:            ViewerUIBuilder, disable_toggles, paint_render
+- _viewer_input.py:         mouse / wheel handlers, launch_external_viewer
 """
 
 from __future__ import annotations
 
-import subprocess
-import sys
-import tempfile
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
 import numpy as np
-from PyQt6.QtCore import QPointF, Qt, QTimer, pyqtSignal
-from PyQt6.QtGui import QImage, QMouseEvent, QPixmap, QWheelEvent
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QFrame,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtCore import QPointF, QTimer, pyqtSignal
+from PyQt6.QtGui import QMouseEvent, QWheelEvent
+from PyQt6.QtWidgets import QWidget
 
 from src.shared.python.engine_core.engine_availability import MUJOCO_AVAILABLE
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -45,6 +36,14 @@ from ._mujoco_viewer_backend import (
     URDFToMJCFConverter,
     VisualizationFlags,
 )
+from ._viewer_input import (
+    handle_mouse_move,
+    handle_mouse_press,
+    handle_mouse_release,
+    handle_wheel,
+    launch_external_viewer,
+)
+from ._viewer_ui import ViewerUIBuilder, paint_render
 
 logger = get_logger(__name__)
 
@@ -85,12 +84,14 @@ class MuJoCoViewerWidget(QWidget):
         self._urdf_path: str | None = None
         self._renderer: MuJoCoOffscreenRenderer | None = None
         self._last_mouse_pos: QPointF | None = None
-        self._current_image: QImage | None = None
+        self._current_image = None
 
         # Visualization flags (using dataclass)
         self._vis_flags = VisualizationFlags()
 
-        self._setup_ui()
+        # UI construction delegated to ViewerUIBuilder
+        ViewerUIBuilder.build(self)
+
         self._setup_renderer()
 
         # Render timer
@@ -98,95 +99,9 @@ class MuJoCoViewerWidget(QWidget):
         self._render_timer.timeout.connect(self._update_render)
         self._render_timer.start(50)  # 20 FPS
 
-    def _setup_ui(self) -> None:
-        """Set up the user interface."""
-        layout = QVBoxLayout(self)
-
-        # Toolbar with visualization toggles
-        toolbar = QHBoxLayout()
-
-        # Create toggle group with visual separator
-        toggle_frame = QFrame()
-        toggle_frame.setStyleSheet("""
-            QFrame {
-                background-color: #3a3a3a;
-                border-radius: 4px;
-                padding: 2px;
-            }
-            QCheckBox {
-                color: #ddd;
-                padding: 4px 8px;
-            }
-            QCheckBox::indicator {
-                width: 14px;
-                height: 14px;
-            }
-            QCheckBox::indicator:checked {
-                background-color: #4a9eff;
-                border-radius: 2px;
-            }
-        """)
-        toggle_layout = QHBoxLayout(toggle_frame)
-        toggle_layout.setContentsMargins(4, 2, 4, 2)
-        toggle_layout.setSpacing(8)
-
-        self._collision_checkbox = QCheckBox("Collision")
-        self._collision_checkbox.setToolTip("Show collision geometry (red wireframe)")
-        self._collision_checkbox.toggled.connect(self._on_collision_toggled)
-        toggle_layout.addWidget(self._collision_checkbox)
-
-        self._frames_checkbox = QCheckBox("Frames")
-        self._frames_checkbox.setChecked(True)
-        self._frames_checkbox.setToolTip("Show coordinate frames at each body")
-        self._frames_checkbox.toggled.connect(self._on_frames_toggled)
-        toggle_layout.addWidget(self._frames_checkbox)
-
-        self._joints_checkbox = QCheckBox("Joints")
-        self._joints_checkbox.setToolTip("Show joint axes and limits")
-        self._joints_checkbox.toggled.connect(self._on_joints_toggled)
-        toggle_layout.addWidget(self._joints_checkbox)
-
-        self._contacts_checkbox = QCheckBox("Contacts")
-        self._contacts_checkbox.setToolTip("Show contact points and forces")
-        self._contacts_checkbox.toggled.connect(self._on_contacts_toggled)
-        toggle_layout.addWidget(self._contacts_checkbox)
-
-        toolbar.addWidget(toggle_frame)
-        toolbar.addStretch()
-
-        self._launch_btn = QPushButton("Launch Full Viewer")
-        self._launch_btn.setToolTip("Open in MuJoCo's interactive viewer")
-        self._launch_btn.clicked.connect(self._launch_external_viewer)
-        toolbar.addWidget(self._launch_btn)
-
-        layout.addLayout(toolbar)
-
-        # Viewport
-        self._viewport = QLabel()
-        self._viewport.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self._viewport.setMinimumSize(320, 240)
-        self._viewport.setStyleSheet("""
-            QLabel {
-                background-color: #2a2a2a;
-                border: 1px solid #444;
-                border-radius: 4px;
-            }
-        """)
-        self._viewport.setMouseTracking(True)
-        layout.addWidget(self._viewport, stretch=1)
-
-        # Status bar
-        self._status_label = QLabel()
-        self._status_label.setStyleSheet("color: #888; font-size: 11px;")
-        layout.addWidget(self._status_label)
-
-        # Headless fallback with clear messaging
-        if not MUJOCO_AVAILABLE:
-            self._status_label.setText(
-                "⚠️ MuJoCo not installed - running in headless mode"
-            )
-            self._disable_toggles()
-            self._update_headless_placeholder()
+    # ------------------------------------------------------------------
+    # Renderer setup
+    # ------------------------------------------------------------------
 
     def _setup_renderer(self) -> None:
         """Initialize the offscreen renderer."""
@@ -196,38 +111,9 @@ class MuJoCoViewerWidget(QWidget):
             # Sync initial flags
             self._renderer.vis_flags = self._vis_flags
 
-    def _disable_toggles(self) -> None:
-        """Disable all visualization toggles (for headless mode)."""
-        self._collision_checkbox.setEnabled(False)
-        self._frames_checkbox.setEnabled(False)
-        self._joints_checkbox.setEnabled(False)
-        self._contacts_checkbox.setEnabled(False)
-        self._launch_btn.setEnabled(False)
-
-    def _update_headless_placeholder(self) -> None:
-        """Show a clear headless fallback message."""
-        self._viewport.setStyleSheet("""
-            QLabel {
-                background-color: #1a1a2e;
-                border: 2px dashed #4a4a6a;
-                border-radius: 8px;
-                color: #8888aa;
-                font-size: 14px;
-            }
-        """)
-        self._viewport.setText(
-            "🖥️ Headless Mode\n\n"
-            "MuJoCo is not installed.\n"
-            "3D preview is unavailable.\n\n"
-            "To enable 3D visualization:\n"
-            "  pip install mujoco\n\n"
-            "Model data is still being processed\n"
-            "and exported correctly."
-        )
-
-    def _update_placeholder(self, message: str) -> None:
-        """Show a placeholder message."""
-        self._viewport.setText(message)
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def update_visualization(
         self, urdf_content: str, urdf_path: str | None = None
@@ -238,18 +124,15 @@ class MuJoCoViewerWidget(QWidget):
             urdf_content: URDF XML string.
             urdf_path: Optional path to URDF file for mesh resolution.
         """
-        if not (urdf_content is not None):
-            raise ValueError("urdf_content must be provided")
-        if not (urdf_content is not None):
+        if urdf_content is None:
             raise ValueError("urdf_content must be provided")
         self._urdf_content = urdf_content
         self._urdf_path = urdf_path
 
         if not MUJOCO_AVAILABLE or not self._renderer:
-            # Count elements for display
             link_count = urdf_content.count("<link")
             joint_count = urdf_content.count("<joint")
-            self._update_placeholder(
+            self._viewport.setText(
                 f"URDF Preview\n\nLinks: {link_count}\nJoints: {joint_count}\n\n"
                 "(Install MuJoCo for 3D preview)"
             )
@@ -283,214 +166,10 @@ class MuJoCoViewerWidget(QWidget):
         else:
             self._status_label.setText("⚠️ Failed to load model")
 
-    def _validate_urdf(self, urdf_content: str) -> list[str]:
-        """Validate URDF for physics sanity.
-
-        Args:
-            urdf_content: URDF XML string.
-
-        Returns:
-            List of validation error messages.
-        """
-        if not (urdf_content is not None):
-            raise ValueError("urdf_content must be provided")
-        if not (urdf_content is not None):
-            raise ValueError("urdf_content must be provided")
-        errors = []
-
-        try:
-            root = ET.fromstring(urdf_content)  # nosec B314 - urdf is validated tool input
-        except ET.ParseError as e:
-            return [f"XML Parse Error: {e}"]
-
-        # Check inertial properties
-        for link in root.findall(".//link"):
-            link_name = link.get("name", "unnamed")
-            inertial = link.find("inertial")
-
-            if inertial is not None:
-                inertia = inertial.find("inertia")
-                if inertia is not None:
-                    # Check positive definiteness (diagonal elements)
-                    ixx = float(inertia.get("ixx", "0"))
-                    iyy = float(inertia.get("iyy", "0"))
-                    izz = float(inertia.get("izz", "0"))
-                    # Off-diagonal elements read but not checked in simple validation
-                    _ = inertia.get("ixy", "0")
-                    _ = inertia.get("ixz", "0")
-                    _ = inertia.get("iyz", "0")
-
-                    # Simple check: diagonal elements should be positive
-                    if ixx <= 0 or iyy <= 0 or izz <= 0:
-                        errors.append(
-                            f"Link '{link_name}': Non-positive inertia diagonal"
-                        )
-
-        # Check joint axes
-        for joint in root.findall(".//joint"):
-            joint_name = joint.get("name", "unnamed")
-            axis_elem = joint.find("axis")
-
-            if axis_elem is not None:
-                xyz = axis_elem.get("xyz", "0 0 1")
-                axis = [float(x) for x in xyz.split()]
-                norm = sum(x * x for x in axis) ** 0.5
-
-                if abs(norm - 1.0) > 0.01:
-                    errors.append(
-                        f"Joint '{joint_name}': Axis not normalized (|axis|={norm:.3f})"
-                    )
-
-        return errors
-
-    def _update_render(self) -> None:
-        """Update the rendered image."""
-        if not self._renderer:
-            return
-
-        image = self._renderer.render()
-        if image is not None:
-            # Convert numpy array to QImage
-            h, w, c = image.shape
-            bytes_per_line = c * w
-            q_image = QImage(
-                image.data,
-                w,
-                h,
-                bytes_per_line,
-                QImage.Format.Format_RGB888,
-            )
-            pixmap = QPixmap.fromImage(q_image)
-
-            # Scale to fit viewport
-            scaled = pixmap.scaled(
-                self._viewport.size(),
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
-            self._viewport.setPixmap(scaled)
-
-    def mousePressEvent(self, event: QMouseEvent | None) -> None:
-        """Handle mouse press for camera control."""
-        if event and event.button() == Qt.MouseButton.LeftButton:
-            self._last_mouse_pos = event.position()
-
-    def mouseMoveEvent(self, event: QMouseEvent | None) -> None:
-        """Handle mouse move for camera rotation."""
-        if event and self._last_mouse_pos and self._renderer:
-            dx = event.position().x() - self._last_mouse_pos.x()
-            dy = event.position().y() - self._last_mouse_pos.y()
-
-            self._renderer.rotate_camera(dx * 0.5, dy * 0.5)
-            self._last_mouse_pos = event.position()
-
-    def mouseReleaseEvent(self, event: QMouseEvent | None) -> None:
-        """Handle mouse release."""
-        self._last_mouse_pos = None
-
-    def wheelEvent(self, event: QWheelEvent | None) -> None:
-        """Handle mouse wheel for zoom."""
-        if event and self._renderer:
-            delta = event.angleDelta().y()
-            factor = 0.9 if delta > 0 else 1.1
-            self._renderer.zoom_camera(factor)
-
-    def _on_collision_toggled(self, checked: bool) -> None:
-        """Handle collision visualization toggle.
-
-        Args:
-            checked: Whether collision geometry should be shown.
-        """
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        self._vis_flags.show_collision = checked
-        self._update_renderer_flags()
-        logger.info(f"Collision visualization: {checked}")
-
-    def _on_frames_toggled(self, checked: bool) -> None:
-        """Handle frames visualization toggle.
-
-        Args:
-            checked: Whether coordinate frames should be shown.
-        """
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        self._vis_flags.show_frames = checked
-        self._update_renderer_flags()
-        logger.info(f"Frame visualization: {checked}")
-
-    def _on_joints_toggled(self, checked: bool) -> None:
-        """Handle joint limits visualization toggle.
-
-        Args:
-            checked: Whether joint axes and limits should be shown.
-        """
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        self._vis_flags.show_joint_limits = checked
-        self._update_renderer_flags()
-        logger.info(f"Joint limits visualization: {checked}")
-
-    def _on_contacts_toggled(self, checked: bool) -> None:
-        """Handle contacts visualization toggle.
-
-        Args:
-            checked: Whether contact points and forces should be shown.
-        """
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        if not (checked is not None):
-            raise ValueError("checked must be provided")
-        self._vis_flags.show_contacts = checked
-        self._update_renderer_flags()
-        logger.info(f"Contacts visualization: {checked}")
-
-    def _update_renderer_flags(self) -> None:
-        """Sync visualization flags to the renderer."""
-        if self._renderer:
-            self._renderer.set_visualization_flags(self._vis_flags)
-            self.visualization_changed.emit(self._vis_flags.to_dict())
-
-    def _launch_external_viewer(self) -> None:
-        """Launch MuJoCo's standalone viewer."""
-        if not self._urdf_content:
-            logger.warning("No URDF content to view")
-            return
-
-        try:
-            # Convert to MJCF and save to temp file
-            mjcf_content = URDFToMJCFConverter.convert(self._urdf_content)
-
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".xml", delete=False
-            ) as f:
-                f.write(mjcf_content)
-                temp_path = f.name
-
-            # Launch viewer subprocess
-            cmd = [
-                sys.executable,
-                "-c",
-                f"import mujoco; import mujoco.viewer; "
-                f"m=mujoco.MjModel.from_xml_path(r'{temp_path}'); "
-                f"mujoco.viewer.launch(m)",
-            ]
-            subprocess.Popen(cmd)
-            logger.info("Launched external MuJoCo viewer")
-
-        except ImportError as e:
-            logger.error(f"Failed to launch viewer: {e}")
-
     def clear(self) -> None:
         """Clear the visualization."""
         self._urdf_content = ""
-        self._update_placeholder("No URDF content")
+        self._viewport.setText("No URDF content")
         self._status_label.setText("")
 
     def reset_view(self) -> None:
@@ -515,9 +194,7 @@ class MuJoCoViewerWidget(QWidget):
         Args:
             flags: New visualization configuration.
         """
-        if not (flags is not None):
-            raise ValueError("flags must be provided")
-        if not (flags is not None):
+        if flags is None:
             raise ValueError("flags must be provided")
         self._vis_flags = flags
 
@@ -536,7 +213,6 @@ class MuJoCoViewerWidget(QWidget):
             body_name: Name of body to highlight, or None to clear.
         """
         # Future enhancement: implement body highlighting in MuJoCo
-        # This would require modifying geom colors in the scene
         logger.debug(f"Body highlight requested: {body_name}")
 
     def is_mujoco_available(self) -> bool:
@@ -571,6 +247,132 @@ class MuJoCoViewerWidget(QWidget):
             info["geoms"] = self._renderer._model.ngeom
 
         return info
+
+    # ------------------------------------------------------------------
+    # Render loop
+    # ------------------------------------------------------------------
+
+    def _update_render(self) -> None:
+        """Update the rendered image (called by render timer)."""
+        if not self._renderer:
+            return
+        image = self._renderer.render()
+        if image is not None:
+            paint_render(self, image)
+
+    # ------------------------------------------------------------------
+    # Toggle handlers (called by checkboxes wired in ViewerUIBuilder)
+    # ------------------------------------------------------------------
+
+    def _on_collision_toggled(self, checked: bool) -> None:
+        """Handle collision visualization toggle."""
+        self._vis_flags.show_collision = checked
+        self._update_renderer_flags()
+        logger.info(f"Collision visualization: {checked}")
+
+    def _on_frames_toggled(self, checked: bool) -> None:
+        """Handle frames visualization toggle."""
+        self._vis_flags.show_frames = checked
+        self._update_renderer_flags()
+        logger.info(f"Frame visualization: {checked}")
+
+    def _on_joints_toggled(self, checked: bool) -> None:
+        """Handle joint limits visualization toggle."""
+        self._vis_flags.show_joint_limits = checked
+        self._update_renderer_flags()
+        logger.info(f"Joint limits visualization: {checked}")
+
+    def _on_contacts_toggled(self, checked: bool) -> None:
+        """Handle contacts visualization toggle."""
+        self._vis_flags.show_contacts = checked
+        self._update_renderer_flags()
+        logger.info(f"Contacts visualization: {checked}")
+
+    def _update_renderer_flags(self) -> None:
+        """Sync visualization flags to the renderer."""
+        if self._renderer:
+            self._renderer.set_visualization_flags(self._vis_flags)
+            self.visualization_changed.emit(self._vis_flags.to_dict())
+
+    # ------------------------------------------------------------------
+    # Input events (delegated to _viewer_input helpers)
+    # ------------------------------------------------------------------
+
+    def mousePressEvent(self, event: QMouseEvent | None) -> None:
+        """Handle mouse press for camera control."""
+        handle_mouse_press(self, event)
+
+    def mouseMoveEvent(self, event: QMouseEvent | None) -> None:
+        """Handle mouse move for camera rotation."""
+        handle_mouse_move(self, event)
+
+    def mouseReleaseEvent(self, event: QMouseEvent | None) -> None:
+        """Handle mouse release."""
+        handle_mouse_release(self, event)
+
+    def wheelEvent(self, event: QWheelEvent | None) -> None:
+        """Handle mouse wheel for zoom."""
+        handle_wheel(self, event)
+
+    def _launch_external_viewer(self) -> None:
+        """Launch MuJoCo's standalone viewer."""
+        launch_external_viewer(self._urdf_content, URDFToMJCFConverter)
+
+    # ------------------------------------------------------------------
+    # URDF validation (physics sanity checks)
+    # ------------------------------------------------------------------
+
+    def _validate_urdf(self, urdf_content: str) -> list[str]:
+        """Validate URDF for physics sanity.
+
+        Args:
+            urdf_content: URDF XML string.
+
+        Returns:
+            List of validation error messages.
+        """
+        if urdf_content is None:
+            raise ValueError("urdf_content must be provided")
+        errors = []
+
+        try:
+            root = ET.fromstring(urdf_content)  # nosec B314 - urdf is validated tool input
+        except ET.ParseError as e:
+            return [f"XML Parse Error: {e}"]
+
+        # Check inertial properties
+        for link in root.findall(".//link"):
+            link_name = link.get("name", "unnamed")
+            inertial = link.find("inertial")
+
+            if inertial is not None:
+                inertia = inertial.find("inertia")
+                if inertia is not None:
+                    ixx = float(inertia.get("ixx", "0"))
+                    iyy = float(inertia.get("iyy", "0"))
+                    izz = float(inertia.get("izz", "0"))
+
+                    if ixx <= 0 or iyy <= 0 or izz <= 0:
+                        errors.append(
+                            f"Link '{link_name}': Non-positive inertia diagonal"
+                        )
+
+        # Check joint axes
+        for joint in root.findall(".//joint"):
+            joint_name = joint.get("name", "unnamed")
+            axis_elem = joint.find("axis")
+
+            if axis_elem is not None:
+                xyz = axis_elem.get("xyz", "0 0 1")
+                axis = [float(x) for x in xyz.split()]
+                norm = sum(x * x for x in axis) ** 0.5
+
+                if abs(norm - 1.0) > 0.01:
+                    errors.append(
+                        f"Joint '{joint_name}': Axis not normalized (|axis|={norm:.3f})"
+                    )
+
+        return errors
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- `mujoco_viewer.py` reduced from 581 → 383 lines (thin orchestrator)
- UI construction extracted to `_viewer_ui.py` (198 lines): `ViewerUIBuilder`, `disable_toggles`, `show_headless_placeholder`, `paint_render`
- Input handling extracted to `_viewer_input.py` (122 lines): mouse press/move/release, wheel, and external viewer launch functions
- Backward-compat re-exports preserved in `mujoco_viewer.py`; sole importer (`visualization_widget.py`) unchanged

## Test plan
- [ ] Verify `from .mujoco_viewer import MuJoCoViewerWidget` still resolves in `visualization_widget.py`
- [ ] Verify `MuJoCoOffscreenRenderer`, `URDFToMJCFConverter`, `VisualizationFlags` still importable from `mujoco_viewer`
- [ ] Smoke-test: instantiate `MuJoCoViewerWidget` in headless mode (no MuJoCo installed)
- [ ] `ruff check` and `ruff format --check` pass on all three files
- [ ] File size budget passes (`check_file_size_budget.py`)

Partial fix for #3060

🤖 Generated with [Claude Code](https://claude.com/claude-code)