### PR TITLE
ci: fix quality-gate mypy install failure on self-hosted runner

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -89,7 +89,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with: { python-version: "3.11" }
-      - run: pip install ruff==0.14.10 mypy>=1.15.0 bandit==1.7.7 pydocstyle==6.3.0
+      - run: pip install ruff==0.14.10 bandit==1.7.7 pydocstyle==6.3.0
+      - run: pip install --ignore-installed mypy>=1.15.0
 
       # FIX: Less aggressive Ruff (Errors, Warnings, Imports only)
       - name: Lint


### PR DESCRIPTION
## Summary

- Split the mypy pip install into a separate step using `--ignore-installed` to bypass the broken uninstall step on the self-hosted runner
- The self-hosted runner has a mypy installation with no RECORD file, causing `pip install mypy==...` to fail with: `× Cannot uninstall mypy None — The package's contents are unknown: no RECORD file was found`
- This fix uses `pip install --ignore-installed mypy>=1.15.0` which overwrites the existing installation without attempting an uninstall first

## Root cause

The self-hosted runner has mypy installed without proper pip metadata (no RECORD file). This typically happens when mypy was installed via a system package manager or by extracting a wheel directly. When pip tries to upgrade/reinstall, it first attempts to uninstall the old version, which fails.

## Test plan

- [ ] Verify `quality-gate` job passes on this PR after merge
- [ ] Confirm mypy type-checking still runs correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)