### PR TITLE
fix(security): enforce https downloads and safe binds (staging)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ Last-Updated: 2026-04-25T00:00:00-07:00
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.177                                            |
+| **Spec Version**        | 1.0.179                                            |
 | **Last Spec Update**    | 2026-04-25                                         |
 
 ## 2. Purpose & Mission
@@ -721,6 +721,11 @@ pytest tests/ --cov=src --cov-fail-under=70
 
 ## Changelog
 
+- 2026-04-25: Require `API_ALLOW_PUBLIC_BIND=true` before `API_HOST` can bind to `0.0.0.0`/`::`, defaulting API servers to loopback unless explicitly allowed.
+- 2026-04-25: Enforced HTTPS-only validation for standard model and Model Explorer downloads to block non-TLS URL schemes.
+- 2026-04-25: Marked `check_virtualenv()` advisory in `scripts/ci/verify_installation.py` so non-virtualenv installs can pass while still printing the recommendation.
+- 2026-04-24: Fixed tutorial setup imports to match current UpstreamDrift repository structure and entry points; added documentation regression guard via `check_tutorial_imports.py` wired into CI.
+- 2026-04-24: Fixed SQL injection vulnerability in recording library by replacing f-strings with a hardcoded map of queries.
 - 2026-04-23: Replaced the Rust workspace's sibling `../Tools` path dependency with a pinned git dependency on `tools-core`, documented clean-clone `cargo build` and `maturin develop` steps, added ADR 0005, and removed Rust/Tauri CI symlink workarounds in favor of a clean-clone Rust quickstart lane.
 - 2026-04-23: Moved `pip-audit` waivers into `.github/security/pip-audit-ignore.yml` and added `scripts/check_pip_audit_waivers.py` so CI fails on expired waivers before generating `--ignore-vuln` flags.
 - 2026-04-23: Removed tracked generated analysis artifacts and added a forbidden-artifact guard so CI rejects regenerated reports, coverage dumps, temp IDs, and NumPy scratch outputs before they can re-enter version control.

--- a/docs/assessments/issues/ISSUE_003_B104_BIND_ALL_INTERFACES.md
+++ b/docs/assessments/issues/ISSUE_003_B104_BIND_ALL_INTERFACES.md
@@ -15,3 +15,7 @@ Bandit identified potential security risks where services bind to all network in
 ## Remediation
 
 Bind to localhost (127.0.0.1) unless external access is explicitly required and secured.
+
+## Status
+
+Addressed (2026-04-25): API host binding now requires `API_ALLOW_PUBLIC_BIND=true` before using `0.0.0.0`/`::`, defaulting to loopback otherwise.

--- a/docs/assessments/issues/issue_SECURITY_NET_001.md
+++ b/docs/assessments/issues/issue_SECURITY_NET_001.md
@@ -16,3 +16,7 @@ The application binds to all network interfaces (`0.0.0.0`), which may expose th
 ## Remediation
 
 Bind to `127.0.0.1` (localhost) unless external access is explicitly required and secured. If running in a container, ensure the container port mapping is secure.
+
+## Status
+
+Addressed (2026-04-25): API host binding now requires `API_ALLOW_PUBLIC_BIND=true` before using `0.0.0.0`/`::`, defaulting to loopback otherwise.

--- a/issues/SECURITY_AUDIT_MEDIUM.md
+++ b/issues/SECURITY_AUDIT_MEDIUM.md
@@ -48,6 +48,7 @@ The following medium severity security issues were identified during the automat
 
 **Issue:** Possible binding to all interfaces (`0.0.0.0`). This may expose the service to the network unexpectedly.
 **Remediation:** Bind to localhost (`127.0.0.1`) unless external access is explicitly required and secured.
+**Status:** Addressed (2026-04-25) — API_HOST now falls back to loopback unless API_ALLOW_PUBLIC_BIND=true.
 
 **Affected Files:**
 
@@ -59,6 +60,7 @@ The following medium severity security issues were identified during the automat
 
 **Issue:** Audit url open for permitted schemes. `urllib.request.urlopen` might support `file://` or other schemes that could lead to local file inclusion if user input is allowed.
 **Remediation:** Validate the URL scheme (e.g., ensure it starts with `http://` or `https://`) before calling `urlopen`.
+**Status:** Addressed (2026-04-25) — standard model downloads enforce HTTPS-only validation.
 
 **Affected Files:**
 

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -72,18 +72,35 @@ def get_cors_origins() -> list[str]:
 # API_PORT -- see issue #2068.
 DEFAULT_SERVER_HOST = "127.0.0.1"
 DEFAULT_SERVER_PORT = 8000
+PUBLIC_BIND_ENV = "API_ALLOW_PUBLIC_BIND"
+PUBLIC_BIND_VALUES = {"1", "true", "yes", "on"}
+PUBLIC_BIND_HOSTS = {"0.0.0.0", "::"}
+
+
+def _is_public_bind_allowed() -> bool:
+    """Return True if binding to all interfaces is explicitly allowed."""
+    return os.getenv(PUBLIC_BIND_ENV, "").strip().lower() in PUBLIC_BIND_VALUES
+
+
+def _is_public_bind(host: str) -> bool:
+    """Return True if host represents a public bind address."""
+    return host in PUBLIC_BIND_HOSTS
 
 
 def get_server_host() -> str:
     """Get server host from environment or default.
 
-    Environment Variable:
+    Environment Variables:
         API_HOST: Server bind address (default: 127.0.0.1)
+        API_ALLOW_PUBLIC_BIND: Set to true to allow 0.0.0.0/:: binds
 
     Returns:
         Server host address.
     """
-    return os.getenv("API_HOST", DEFAULT_SERVER_HOST)
+    host = os.getenv("API_HOST", DEFAULT_SERVER_HOST).strip()
+    if _is_public_bind(host) and not _is_public_bind_allowed():
+        return DEFAULT_SERVER_HOST
+    return host
 
 
 def get_server_port() -> int:

--- a/src/shared/python/config/standard_models.py
+++ b/src/shared/python/config/standard_models.py
@@ -14,7 +14,7 @@ from src.shared.python.core.constants import DEG_TO_RAD
 from src.shared.python.data_io.common_utils import GolfModelingError
 from src.shared.python.data_io.io_utils import ensure_directory
 from src.shared.python.logging_pkg.logging_config import get_logger
-from src.shared.python.security.security_utils import validate_url_scheme
+from src.shared.python.security.security_utils import validate_url_https_only
 
 logger = get_logger(__name__)
 
@@ -150,8 +150,10 @@ class StandardModelManager:
                 local_path = human_models_dir / local_filename
 
                 logger.info(f"Downloading {url} -> {local_path}")
-                validate_url_scheme(url)
-                urllib.request.urlretrieve(url, local_path)  # nosec B310 - URL validated by validate_url_scheme() above
+                validate_url_https_only(url)
+                urllib.request.urlretrieve(
+                    url, local_path
+                )  # nosec B310 - URL validated by validate_url_https_only() above
 
             # Download mesh files (this is a simplified approach - in practice you'd want
             # to download the actual mesh files from the repository)

--- a/src/tools/model_explorer/model_library.py
+++ b/src/tools/model_explorer/model_library.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any
 
 from src.shared.python.logging_pkg.logger_utils import get_logger
-from src.shared.python.security.security_utils import validate_url_scheme
+from src.shared.python.security.security_utils import validate_url_https_only
 
 # Resolve project root for model path resolution (no sys.path mutation)
 _project_root = next(
@@ -368,8 +368,10 @@ class ModelLibrary:
         try:
             # Download URDF file
             logger.info(f"Downloading URDF: {model_info['urdf_url']}")
-            validate_url_scheme(model_info["urdf_url"])
-            with urllib.request.urlopen(model_info["urdf_url"]) as response:  # nosec B310 - URL validated by validate_url_scheme() above
+            validate_url_https_only(model_info["urdf_url"])
+            with urllib.request.urlopen(
+                model_info["urdf_url"]
+            ) as response:  # nosec B310 - URL validated by validate_url_https_only() above
                 urdf_content = response.read().decode("utf-8")
                 urdf_path.write_text(urdf_content, encoding="utf-8")
 

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -56,6 +56,12 @@ def test_get_server_host_default() -> None:
 def test_get_server_host_env() -> None:
     with patch.dict(os.environ, {"API_HOST": "0.0.0.0"}):
         host = get_server_host()
+        assert host == DEFAULT_SERVER_HOST
+
+    with patch.dict(
+        os.environ, {"API_HOST": "0.0.0.0", "API_ALLOW_PUBLIC_BIND": "true"}
+    ):
+        host = get_server_host()
         assert host == "0.0.0.0"
 
 

--- a/tests/unit/config/test_standard_models.py
+++ b/tests/unit/config/test_standard_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -79,6 +80,30 @@ class TestGetGolfClubPath:
         mgr = StandardModelManager(suite_root=tmp_path)
         path = mgr.get_golf_club_path("iron_7")
         assert isinstance(path, Path)
+
+
+# ---------------------------------------------------------------------------
+# download_standard_humanoid
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadStandardHumanoid:
+    def test_download_validates_https_only(self, tmp_path: Path) -> None:
+        mgr = StandardModelManager(suite_root=tmp_path)
+        with (
+            patch(
+                "src.shared.python.config.standard_models.validate_url_https_only"
+            ) as validator,
+            patch(
+                "src.shared.python.config.standard_models.urllib.request.urlretrieve"
+            ) as urlretrieve,
+            patch.object(mgr, "_create_temporary_meshes"),
+        ):
+            urlretrieve.return_value = None
+            assert mgr.download_standard_humanoid() is True
+            assert validator.call_count == 2
+            for call_args in validator.call_args_list:
+                assert call_args.args[0].startswith("https://")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_start_api_server.py
+++ b/tests/unit/test_start_api_server.py
@@ -46,7 +46,13 @@ def test_setup_api_environment(monkeypatch) -> None:
     monkeypatch.setattr("start_api_server._validate_security", lambda: True)
 
     with patch.dict(
-        os.environ, {"API_HOST": "0.0.0.0", "API_PORT": "9000"}, clear=True
+        os.environ,
+        {
+            "API_HOST": "0.0.0.0",
+            "API_PORT": "9000",
+            "API_ALLOW_PUBLIC_BIND": "true",
+        },
+        clear=True,
     ):
         host, port = start_api_server.setup_api_environment()
         assert host == "0.0.0.0"


### PR DESCRIPTION
Cherry-pick of commit from PR #3255 (which targeted main instead of staging).

- Require `API_ALLOW_PUBLIC_BIND=true` before `API_HOST` can bind to `0.0.0.0`/`::`, defaulting to loopback
- Enforce HTTPS-only for standard model and Model Explorer downloads
- Mark `check_virtualenv()` advisory in verify_installation.py

Closes #3255 (original PR had 664 merge conflicts from old base)