### PR TITLE
Fix SQL injection in recording_library

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,7 @@
 **Vulnerability:** String-based query construction with `f-strings` in `get_unique_values` (Bandit B608).
 **Learning:** Even when input is validated against a whitelist, security scanners will flag string-based SQL query construction. Using a hardcoded mapping of query strings eliminates both the actual risk and the static analysis warnings.
 **Prevention:** Use hardcoded SQL query maps for column names (which cannot be parameterized in standard SQL bindings) instead of dynamic string construction.
+## 2026-01-20 - Fix SQL Injection in recording_library.py
+**Vulnerability:** String-based query construction allows potential SQL injection (Bandit B608).
+**Learning:** For dynamic column selection where parameterization is not possible, hardcoded query mapping prevents SQL injection and satisfies static analysis without needing nosec annotations.
+**Prevention:** Use dictionary mapping with static SQL strings for queries that depend on variable column names.

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/recording_library.py
@@ -651,13 +651,18 @@ class RecordingLibrary:
             raise ValueError("field must be provided")
         if not (field is not None):
             raise ValueError("field must be provided")
-        allowed_fields = {
-            "golfer_name",
-            "club_type",
-            "model_name",
-            "swing_type",
-            "tags",
-            "notes",
+
+        query_map = {
+            "golfer_name": "SELECT DISTINCT golfer_name "
+            "FROM recordings WHERE golfer_name != ''",
+            "club_type": "SELECT DISTINCT club_type "
+            "FROM recordings WHERE club_type != ''",
+            "model_name": "SELECT DISTINCT model_name "
+            "FROM recordings WHERE model_name != ''",
+            "swing_type": "SELECT DISTINCT swing_type "
+            "FROM recordings WHERE swing_type != ''",
+            "tags": "SELECT DISTINCT tags FROM recordings WHERE tags != ''",
+            "notes": "SELECT DISTINCT notes FROM recordings WHERE notes != ''",
         }
 
         if field not in query_map:
@@ -666,8 +671,8 @@ class RecordingLibrary:
         conn = self._get_connection()
         cursor = conn.cursor()
 
-        # Safe: field is validated against whitelist above (allowed_fields)
-        cursor.execute(f"SELECT DISTINCT {field} FROM recordings WHERE {field} != ''")  # nosec B608
+        # Safe: uses hardcoded query strings to prevent SQL injection
+        cursor.execute(query_map[field])
         values = [row[0] for row in cursor.fetchall()]
 
         return sorted(values)

--- a/tests/unit/engines/mujoco/test_recording_library.py
+++ b/tests/unit/engines/mujoco/test_recording_library.py
@@ -132,3 +132,32 @@ def test_normal_operations(
 
     assert recording_lib.delete_recording(rec_id, delete_file=True)
     assert recording_lib.get_recording(rec_id) is None
+
+
+def test_get_unique_values(
+    library_module: types.ModuleType,
+    recording_lib: Any,
+    tmp_path: Path,
+) -> None:
+    """Test get_unique_values for various fields."""
+    RecordingMetadata = library_module.RecordingMetadata
+
+    # Create dummy data files
+    data_file = tmp_path / "data.json"
+    data_file.write_text("{}")
+
+    # Add recordings with different golfer names and club types
+    recording_lib.add_recording(str(data_file), RecordingMetadata(golfer_name="Alice", club_type="Driver"))
+    recording_lib.add_recording(str(data_file), RecordingMetadata(golfer_name="Bob", club_type="Putter"))
+    recording_lib.add_recording(str(data_file), RecordingMetadata(golfer_name="Alice", club_type="Iron"))
+
+    # Test unique golfer names
+    golfers = recording_lib.get_unique_values("golfer_name")
+    assert golfers == ["Alice", "Bob"]
+
+    # Test unique club types
+    clubs = recording_lib.get_unique_values("club_type")
+    assert clubs == ["Driver", "Iron", "Putter"]
+
+    # Test invalid field
+    assert recording_lib.get_unique_values("invalid_field") == []


### PR DESCRIPTION
Fixed a Bandit B608 (SQL Injection) vulnerability in the RecordingLibrary by replacing string-based SQL query construction with hardcoded query strings. Tested via pytest and logged in sentinel journal.

---
*PR created automatically by Jules for task [6644800199846057012](https://jules.google.com/task/6644800199846057012) started by @dieterolson*