### PR TITLE
Security: Fix insecure subprocess execution in mujoco_viewer

### DIFF
--- a/src/tools/model_explorer/mujoco_viewer.py
+++ b/src/tools/model_explorer/mujoco_viewer.py
@@ -14,7 +14,6 @@ Issue #755: Enhanced visualization toggles for collision, frames, joints, and co
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -39,6 +38,7 @@ from src.shared.python.core.constants import (
 )
 from src.shared.python.engine_core.engine_availability import MUJOCO_AVAILABLE
 from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.security.secure_subprocess import secure_popen
 
 if TYPE_CHECKING:
     from typing import Any
@@ -955,7 +955,7 @@ class MuJoCoViewerWidget(QWidget):
                 f"m=mujoco.MjModel.from_xml_path(r'{temp_path}'); "
                 f"mujoco.viewer.launch(m)",
             ]
-            subprocess.Popen(cmd)
+            secure_popen(cmd)
             logger.info("Launched external MuJoCo viewer")
 
         except ImportError as e:

--- a/tests/unit/tools/model_explorer/test_mujoco_viewer_security.py
+++ b/tests/unit/tools/model_explorer/test_mujoco_viewer_security.py
@@ -1,0 +1,126 @@
+"""Tests for security fix in mujoco_viewer.py (issue #3302).
+
+Validates that _launch_external_viewer uses secure_popen instead of raw
+subprocess.Popen to prevent command injection vulnerabilities.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestMuJoCoViewerSecurity:
+    """Security contract tests for MuJoCoViewerWidget._launch_external_viewer."""
+
+    @pytest.fixture
+    def viewer_module(self):
+        """Import viewer module with Qt stubs to avoid PyQt6 dependency."""
+        qt_mocks = {}
+        for mod_name in (
+            "PyQt6",
+            "PyQt6.QtCore",
+            "PyQt6.QtGui",
+            "PyQt6.QtWidgets",
+        ):
+            mod = MagicMock()
+            mod.__spec__ = MagicMock()
+            qt_mocks[mod_name] = mod
+
+        with patch.dict(sys.modules, qt_mocks):
+            import src.tools.model_explorer.mujoco_viewer as mv
+
+            yield mv
+
+    @pytest.fixture
+    def viewer_widget(self, viewer_module):
+        """Return a MuJoCoViewerWidget instance with mocked parent."""
+        with patch.object(
+            viewer_module.MuJoCoViewerWidget, "__init__", lambda self, parent=None: None
+        ):
+            widget = viewer_module.MuJoCoViewerWidget.__new__(
+                viewer_module.MuJoCoViewerWidget
+            )
+            widget._urdf_content = "<robot></robot>"
+            widget._renderer = None
+            return widget
+
+    @patch("src.tools.model_explorer.mujoco_viewer.secure_popen")
+    def test_launch_external_viewer_uses_secure_popen(
+        self, mock_secure_popen, viewer_widget
+    ) -> None:
+        """_launch_external_viewer must delegate to secure_popen, not raw Popen."""
+        mock_process = MagicMock()
+        mock_secure_popen.return_value = mock_process
+
+        viewer_widget._launch_external_viewer()
+
+        mock_secure_popen.assert_called_once()
+        args, kwargs = mock_secure_popen.call_args
+        cmd = args[0]
+        assert cmd[0] == sys.executable
+        assert cmd[1] == "-c"
+        assert "mujoco" in cmd[2]
+        assert "mujoco.viewer.launch" in cmd[2]
+
+    @patch("src.tools.model_explorer.mujoco_viewer.secure_popen")
+    def test_launch_external_viewer_no_urdf_skips_popen(
+        self, mock_secure_popen, viewer_widget
+    ) -> None:
+        """When no URDF content is set, secure_popen must not be called."""
+        viewer_widget._urdf_content = ""
+
+        viewer_widget._launch_external_viewer()
+
+        mock_secure_popen.assert_not_called()
+
+    @patch("src.tools.model_explorer.mujoco_viewer.secure_popen")
+    def test_launch_external_viewer_command_structure(
+        self, mock_secure_popen, viewer_widget
+    ) -> None:
+        """Verify the command passed to secure_popen is a list with expected structure."""
+        viewer_widget._launch_external_viewer()
+
+        assert mock_secure_popen.called
+        args, _kwargs = mock_secure_popen.call_args
+        cmd = args[0]
+        assert isinstance(cmd, list)
+        assert len(cmd) == 3
+        assert cmd[0] == sys.executable
+        assert cmd[1] == "-c"
+        # The -c argument should contain the inline Python script
+        assert "from_xml_path" in cmd[2]
+        assert "mujoco.viewer.launch" in cmd[2]
+
+    def test_no_raw_subprocess_popen_import(self) -> None:
+        """The module must not import subprocess.Popen directly.
+
+        Bandit B603/B604 flags raw subprocess.Popen calls. By using
+        secure_popen from the shared security module, we avoid these
+        warnings and gain executable validation.
+        """
+        import ast
+
+        source = (
+            Path(__file__).parents[4]
+            / "src"
+            / "tools"
+            / "model_explorer"
+            / "mujoco_viewer.py"
+        ).read_text()
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name != "subprocess", (
+                        "mujoco_viewer.py must not import subprocess directly; "
+                        "use secure_popen from src.shared.python.security.secure_subprocess"
+                    )
+            if isinstance(node, ast.ImportFrom):
+                assert node.module != "subprocess", (
+                    "mujoco_viewer.py must not import from subprocess; "
+                    "use secure_popen from src.shared.python.security.secure_subprocess"
+                )


### PR DESCRIPTION
## Summary

Fixes insecure subprocess execution in `mujoco_viewer.py` that triggers Bandit B603/B604 security warnings (issue #3302).

## Problem

`MuJoCoViewerWidget._launch_external_viewer()` was calling `subprocess.Popen` directly, bypassing the suite's secure subprocess validation. This exposes the application to command execution vulnerabilities if inputs were unvalidated.

## Changes

- **src/tools/model_explorer/mujoco_viewer.py**
  - Removed direct `subprocess` import
  - Added import for `secure_popen` from `src.shared.python.security.secure_subprocess`
  - Replaced `subprocess.Popen(cmd)` with `secure_popen(cmd)`

- **tests/unit/tools/model_explorer/test_mujoco_viewer_security.py** *(new)*
  - Contract tests verifying `_launch_external_viewer` delegates to `secure_popen`
  - AST-level check ensuring no raw `subprocess` import remains
  - Validates command structure passed to secure wrapper

## Verification

- Confirmed via AST analysis that `subprocess` is no longer imported in `mujoco_viewer.py`
- Confirmed no raw `subprocess.Popen` calls remain in the file
- Added dedicated security test suite for regression prevention

## Related

- Addresses issue #3302
