### PR TITLE
fix(editor): remove dead ET.tostring call and use splitlines()

### DIFF
--- a/src/shared/python/model_generation/editor/_text_editor_validation.py
+++ b/src/shared/python/model_generation/editor/_text_editor_validation.py
@@ -369,11 +369,10 @@ class _URDFValidationMixin:
         # This is a simple heuristic - search for element in content
         if elem is None:
             raise ValueError("elem must be provided")
-        ET.tostring(elem, encoding="unicode")
         tag_start = f"<{elem.tag}"
 
         # Find in content
-        lines = self._content.split("\n")  # type: ignore[attr-defined]
+        lines = self._content.splitlines()  # type: ignore[attr-defined]
         for idx, line in enumerate(lines, 1):
             if tag_start in line:
                 # Check if attributes match

--- a/tests/unit/test_text_editor_validation_fix.py
+++ b/tests/unit/test_text_editor_validation_fix.py
@@ -1,0 +1,130 @@
+"""Tests for _text_editor_validation.py dead-code removal and robustness.
+
+Covers:
+- _find_element_line no longer calls ET.tostring (dead code removal)
+- _find_element_line uses splitlines() for cross-platform compatibility
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import defusedxml.ElementTree as DefusedET
+import pytest
+
+from src.shared.python.model_generation.editor._text_editor_validation import (
+    _URDFValidationMixin,
+)
+from src.shared.python.model_generation.editor._text_editor_models import (
+    ValidationMessage,
+    ValidationSeverity,
+)
+
+
+class TestFindElementLine:
+    """Tests for the _find_element_line heuristic."""
+
+    def test_finds_element_by_tag(self) -> None:
+        """Should return the line number of a known element."""
+        editor = _URDFValidationMixin()
+        editor._content = (
+            '<?xml version="1.0"?>\n'
+            '<robot name="test">\n'
+            '  <link name="base_link"/>\n'
+            '  <link name="arm_link"/>\n'
+            "</robot>\n"
+        )
+        root = DefusedET.fromstring(editor._content)
+        link = root.find("link")
+        assert link is not None
+        line = editor._find_element_line(link)
+        assert line == 3
+
+    def test_finds_element_by_tag_and_name(self) -> None:
+        """Should disambiguate elements with the same tag by name."""
+        editor = _URDFValidationMixin()
+        editor._content = (
+            '<?xml version="1.0"?>\n'
+            '<robot name="test">\n'
+            '  <link name="base_link"/>\n'
+            '  <link name="arm_link"/>\n'
+            "</robot>\n"
+        )
+        root = DefusedET.fromstring(editor._content)
+        links = root.findall("link")
+        assert len(links) == 2
+        line = editor._find_element_line(links[1])
+        assert line == 4
+
+    def test_returns_one_when_not_found(self) -> None:
+        """Should return 1 when the element is not in content."""
+        editor = _URDFValidationMixin()
+        editor._content = "<robot/>"
+        # Create an element that won't match
+        elem = ET.Element("link")
+        elem.set("name", "missing")
+        line = editor._find_element_line(elem)
+        assert line == 1
+
+    def test_raises_on_none_element(self) -> None:
+        """Precondition: elem must not be None."""
+        editor = _URDFValidationMixin()
+        editor._content = "<robot/>"
+        with pytest.raises(ValueError, match="elem must be provided"):
+            editor._find_element_line(None)  # type: ignore[arg-type]
+
+    def test_splitlines_handles_crlf(self) -> None:
+        """splitlines() should handle Windows-style line endings."""
+        editor = _URDFValidationMixin()
+        editor._content = (
+            '<?xml version="1.0"?>\r\n'
+            '<robot name="test">\r\n'
+            '  <link name="base_link"/>\r\n'
+            "</robot>\r\n"
+        )
+        root = DefusedET.fromstring(editor._content)
+        link = root.find("link")
+        assert link is not None
+        line = editor._find_element_line(link)
+        # Even with \r\n, splitlines() gives us correct line count
+        assert line == 3
+
+    def test_no_et_tostring_side_effects(self) -> None:
+        """The method should not mutate the element or content."""
+        editor = _URDFValidationMixin()
+        original_content = (
+            '<?xml version="1.0"?>\n'
+            '<robot name="test">\n'
+            '  <link name="base_link"/>\n'
+            "</robot>\n"
+        )
+        editor._content = original_content
+        root = DefusedET.fromstring(editor._content)
+        link = root.find("link")
+        assert link is not None
+        _ = editor._find_element_line(link)
+        assert editor._content == original_content
+        assert link.get("name") == "base_link"
+
+
+class TestURDFValidationMessages:
+    """Sanity tests for validation message construction."""
+
+    def test_validation_message_str_with_element(self) -> None:
+        msg = ValidationMessage(
+            severity=ValidationSeverity.ERROR,
+            line=10,
+            column=5,
+            message="Test error",
+            element="link",
+        )
+        assert "[ERROR] Line 10, Col 5 (link): Test error" == str(msg)
+
+    def test_validation_message_str_without_element(self) -> None:
+        msg = ValidationMessage(
+            severity=ValidationSeverity.WARNING,
+            line=1,
+            column=0,
+            message="Missing name",
+        )
+        assert "[WARNING] Line 1: Missing name" == str(msg)


### PR DESCRIPTION
## Summary

Removes dead code and improves cross-platform compatibility in the URDF text editor validation mixin.

### Changes

- **Dead code removal**: Removed `ET.tostring(elem, encoding="unicode")` in `_find_element_line()` which computed and immediately discarded a string representation with no side effects.
- **Cross-platform fix**: Replaced `self._content.split("\n")` with `self._content.splitlines()` to correctly handle Windows CRLF line endings.
- **Tests**: Added `tests/unit/test_text_editor_validation_fix.py` with coverage for:
  - Line lookup by tag
  - Disambiguation by `name` attribute
  - Fallback to line 1 when element not found
  - `ValueError` on `None` element (precondition)
  - CRLF handling
  - No side effects on element or content

### Why

The `ET.tostring()` call was a leftover from debugging or an incomplete refactor. It serves no purpose in the current method and only adds unnecessary XML serialization overhead. Using `splitlines()` instead of `split("\n")` ensures correct behavior on Windows where URDF files may use CRLF line endings.

### Verification

- [x] New unit tests added and passing
- [x] Change is localized to `_find_element_line` in `_text_editor_validation.py`
- [x] No API changes

### Related

Refs: #2456 (text_editor.py split follow-up)
