### PR TITLE
⚡ Bolt: [performance improvement] Replace np.linalg.norm with math.hypot for collision queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,4 +4,6 @@
 
 ## 2024-04-26 - Optimize Mean Squared Error calculations
 **Learning:** When computing Mean Squared Error (MSE) across arrays, `np.vdot(diff, diff) / diff.size` is significantly faster (~2x) than `np.mean(diff**2)` because it leverages optimized C code and completely bypasses the memory allocation overhead of creating a temporary squared array.
-**Action:** Use `np.vdot(diff, diff) / diff.size` instead of `np.mean(diff**2)` when calculating MSE in hot paths.
+**Action:** Use `np.vdot(diff, diff) / diff.size` instead of `np.mean(diff**2)` when calculating MSE in hot paths.## 2025-04-27 - [Optimize norm calculation for collision checking]
+**Learning:** Element-wise norm computations or generic `np.linalg.norm(..., axis=None)` applied to 3D arrays are slower than leveraging `math.hypot(*v)`. Since robotics frequently computes distances between points, optimizing Euclidean distance computation brings measurable speedups.
+**Action:** Replace `np.linalg.norm(v)` with `math.hypot(*v)` where `v` is a small fixed-length vector (e.g., 3D point) in high-frequency distance queries like collision checks.

--- a/SPEC.md
+++ b/SPEC.md
@@ -469,6 +469,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------- |
 | 2026-04-27 | 1.0.83  | Fixed Bandit B604 false positive alerts in test files by adding nosec annotations. |
+| 2026-04-27 | 1.0.84  | Bolt: Replace np.linalg.norm with math.hypot in collision queries. |
 | 2026-04-26 | 1.0.81  | fix: Restore missing jobs in `Code-Metrics.yml` and `release.yml`; correct non-UTF-8 characters in 55 workflows causing 0s CI failures. |
 | 2026-04-26 | 1.0.80  | fix: Harden `pick-runner` logic across all workflows to handle `gh api` JSON errors; implement tool invocation loop for AI chat service (fixes #3162); resolve massive conflict-marker corruption in `src` and `tests` by restoring from `origin/main`. |
 | 2026-04-26 | 1.0.80  | Bolt: Optimize Mean Squared Error calculations in system_identification.py |

--- a/src/robotics/planning/collision/_distance_queries.py
+++ b/src/robotics/planning/collision/_distance_queries.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from ._primitive_shapes import Capsule, Sphere
@@ -58,7 +60,7 @@ def _sphere_sphere_distance(
     if not (sphere_a is not None):
         raise ValueError("sphere_a must be provided")
     diff = sphere_b.center - sphere_a.center
-    center_dist = np.linalg.norm(diff)
+    center_dist = math.hypot(*diff)
 
     if center_dist < 1e-10:
         # Concentric spheres
@@ -87,7 +89,7 @@ def _sphere_capsule_distance(
 
     # Now it's sphere-sphere distance
     diff = sphere.center - closest_on_axis
-    center_dist = np.linalg.norm(diff)
+    center_dist = math.hypot(*diff)
 
     if center_dist < 1e-10:
         # Sphere center on capsule axis
@@ -119,7 +121,7 @@ def _capsule_capsule_distance(
     )
 
     diff = closest_b - closest_a
-    center_dist = np.linalg.norm(diff)
+    center_dist = math.hypot(*diff)
 
     if center_dist < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
@@ -205,10 +207,10 @@ def _gjk_distance(
     direction = prim_b.compute_support(np.array([1, 0, 0])) - prim_a.compute_support(
         np.array([-1, 0, 0])
     )
-    if np.linalg.norm(direction) < 1e-10:
+    if math.hypot(*direction) < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
     else:
-        direction = direction / np.linalg.norm(direction)
+        direction = direction / math.hypot(*direction)
 
     # Simplex vertices
     simplex: list[np.ndarray] = []
@@ -224,7 +226,7 @@ def _gjk_distance(
         if np.dot(support, direction) < 0 and len(simplex) == 0:
             # Return distance between supports
             diff = support_b - support_a
-            dist = float(np.linalg.norm(diff))
+            dist = float(math.hypot(*diff))
             return dist, support_a, support_b
 
         simplex.append(support)
@@ -232,7 +234,7 @@ def _gjk_distance(
         # Update simplex and direction
         if len(simplex) == 1:
             direction = -simplex[0]
-            norm = np.linalg.norm(direction)
+            norm = math.hypot(*direction)
             if norm < 1e-10:
                 # Origin at support point (collision)
                 return 0.0, support_a, support_b
@@ -244,7 +246,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(np.linalg.norm(closest))
+            dist = float(math.hypot(*closest))
             if dist < 1e-6:
                 # Origin very close to simplex (collision)
                 return 0.0, support_a, support_b
@@ -257,7 +259,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(np.linalg.norm(closest))
+            dist = float(math.hypot(*closest))
             if dist < 1e-6:
                 return 0.0, support_a, support_b
             direction = -closest / dist
@@ -266,7 +268,7 @@ def _gjk_distance(
     support_a = prim_a.compute_support(direction)
     support_b = prim_b.compute_support(-direction)
     diff = support_b - support_a
-    return float(np.linalg.norm(diff)), support_a, support_b
+    return float(math.hypot(*diff)), support_a, support_b
 
 
 def check_primitive_collision(

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -50,7 +51,7 @@ class Sphere(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = np.linalg.norm(direction)
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
         return self.center + self.radius * direction / norm
@@ -179,7 +180,7 @@ class Capsule(GeometricPrimitive):
     def axis(self) -> np.ndarray:
         """Get capsule axis direction (normalized)."""
         diff = self.point_b - self.point_a
-        length = np.linalg.norm(diff)
+        length = math.hypot(*diff)
         if length < 1e-10:
             return np.array([0.0, 0.0, 1.0])
         return diff / length
@@ -224,7 +225,7 @@ class Capsule(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = np.linalg.norm(direction)
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.point_a.copy()
         d = direction / norm
@@ -315,7 +316,7 @@ class Cylinder(GeometricPrimitive):
 
         # Check radius (perpendicular distance)
         perp = to_point - along_axis * self.axis
-        return float(np.linalg.norm(perp)) <= self.radius
+        return float(math.hypot(*perp)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -324,7 +325,7 @@ class Cylinder(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = np.linalg.norm(direction)
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
 
@@ -342,7 +343,7 @@ class Cylinder(GeometricPrimitive):
             axis_support = self.center - self.half_height * self.axis
 
         # Support on radius (perpendicular)
-        perp_norm = np.linalg.norm(d_perp)
+        perp_norm = math.hypot(*d_perp)
         if perp_norm > 1e-10:
             return axis_support + self.radius * d_perp / perp_norm
 
@@ -396,7 +397,7 @@ class ConvexHull(GeometricPrimitive):
         # Simple heuristic: point is inside if closer to center than
         # all vertices in the same direction
         to_point = point - self.center
-        norm = np.linalg.norm(to_point)
+        norm = math.hypot(*to_point)
         if norm < 1e-10:
             return True  # At center
 


### PR DESCRIPTION
Replaces array-level norm calculations in the collision planner modules with the much faster C-backed scalar arithmetic `math.hypot` for rapid geometric checks.

---
*PR created automatically by Jules for task [3599448975143382091](https://jules.google.com/task/3599448975143382091) started by @dieterolson*