### PR TITLE
⚡ Bolt: [performance improvement] Optimize sum of squares in ball_simulator using einsum

### DIFF
--- a/src/shared/python/physics/ball_simulator.py
+++ b/src/shared/python/physics/ball_simulator.py
@@ -214,7 +214,7 @@ class BallFlightSimulator(TrajectoryAnalysisMixin):
             else self.environment.wind_velocity
         )
         rel_vel = vel - wind
-        speed = np.sqrt(np.sum(rel_vel**2, axis=0))
+        speed = np.sqrt(np.einsum("i...,i...->...", rel_vel, rel_vel))
 
         drag = np.zeros(vel.shape)
         magnus = np.zeros(vel.shape)
@@ -241,7 +241,7 @@ class BallFlightSimulator(TrajectoryAnalysisMixin):
 
         axis = spin_axis.reshape(3, 1)
         cross = np.cross(axis, valid_rel_vel / valid_speed, axis=0)
-        cross_norm = np.sqrt(np.sum(cross**2, axis=0))
+        cross_norm = np.sqrt(np.einsum("i...,i...->...", cross, cross))
         cross_mask = cross_norm > NUMERICAL_EPSILON
 
         if np.any(cross_mask):


### PR DESCRIPTION
Replaced `np.sum(...**2, axis=0)` with `np.einsum('i...,i...->...', ..., ...)` for calculating magnitudes in `_calculate_forces_batch` in `src/shared/python/physics/ball_simulator.py`. This avoids intermediate allocations and provides better performance.

Fixes #3359

---
*PR created automatically by Jules for task [2008865235110354690](https://jules.google.com/task/2008865235110354690) started by @dieterolson*