### PR TITLE
Fix #3347: Adopt semantic branch naming

### DIFF
--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Create consolidated fix branch
         run: |
           # HARDENING: Single branch for all fixes
-          BRANCH_NAME="jules/auto-fix-consolidated-$(date +%Y%m%d)"
+          BRANCH_NAME="fix/auto-fix-consolidated-$(date +%Y%m%d)"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -95,7 +95,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
         run: |
           # Check for existing open PR from this workflow
           EXISTING_PR=$(gh pr list --state open --json number,headRefName,title \
-            --jq '[.[] | select(.headRefName | startswith("jules/code-quality-fix-"))] | .[0]')
+            --jq '[.[] | select(.headRefName | startswith("fix/code-quality-"))] | .[0]')
 
           if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
             # Reuse existing branch
@@ -108,7 +108,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
             echo "existing_pr_num=$PR_NUM" >> $GITHUB_OUTPUT
           else
             # Create new branch
-            BRANCH_NAME="jules/code-quality-fix-$(date +%Y%m%d-%H%M%S)"
+            BRANCH_NAME="fix/code-quality-$(date +%Y%m%d-%H%M%S)"
             git checkout -b "$BRANCH_NAME"
             echo "reusing_pr=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -188,7 +188,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
       - name: Create Processing Branch
         if: steps.queue.outputs.has_comments == 'true' && inputs.dry_run != 'true'
         run: |
-          BRANCH_NAME="jules/comment-fixes-$(date +%Y%m%d-%H%M)"
+          BRANCH_NAME="fix/comment-fixes-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -221,7 +221,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
       - name: Create Working Branch
         if: steps.select.outputs.skip != 'true'
         run: |
-          BRANCH_NAME="jules/critics-comments-$(date +%Y%m%d-%H%M)"
+          BRANCH_NAME="docs/critics-comments-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -109,7 +109,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
         run: |
           # Check for existing open PR from this workflow
           EXISTING_PR=$(gh pr list --state open --json number,headRefName,title \
-            --jq '[.[] | select(.headRefName | startswith("jules/issue-resolver-"))] | .[0]')
+            --jq '[.[] | select(.headRefName | startswith("fix/issue-resolver-"))] | .[0]')
 
           if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
             # Reuse existing branch
@@ -122,7 +122,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
             echo "existing_pr_num=$PR_NUM" >> $GITHUB_OUTPUT
           else
             # Create new branch
-            BRANCH_NAME="jules/issue-resolver-$(date +%Y%m%d-%H%M)"
+            BRANCH_NAME="fix/issue-resolver-$(date +%Y%m%d-%H%M)"
             git checkout -b "$BRANCH_NAME"
             echo "reusing_pr=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -221,7 +221,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
       - name: Create Working Branch
         if: steps.select.outputs.skip != 'true'
         run: |
-          BRANCH_NAME="jules/laymans-terms-$(date +%Y%m%d-%H%M)"
+          BRANCH_NAME="docs/laymans-terms-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -91,7 +91,7 @@ jobs:
           # Find Jules-generated PRs (by branch name pattern)
           JULES_PRS=$(gh pr list --state open --json number,title,headRefName,updatedAt,labels \
             --jq "[.[] | select(
-              (.headRefName | test(\"^jules/|^fix/.*jules|^fix/pragmatic|^fix/code-quality\")) and
+              (.headRefName | test(\"^jules/|^fix/.*jules|^fix/pragmatic|^fix/code-quality|^fix/auto-fix-consolidated-|^fix/comment-fixes-|^docs/critics-comments-|^fix/issue-resolver-|^docs/laymans-terms-|^fix/compiled-\")) and
               (.updatedAt < \"$CUTOFF_DATE\") and
               (.labels | map(.name) | contains([\"jules-keep\"]) | not)
             )]")

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -163,7 +163,7 @@ if ! [[ "$ONLINE" =~ ^[0-9]+$ ]]; then ONLINE=0; fi
               # Create compiled branch name
               date_str = datetime.now().strftime('%Y-%m-%d')
               category_short = category.replace('jules:', '').replace('-', '_')
-              compiled_branch = f"jules/compiled-{category_short}-{date_str}"
+              compiled_branch = f"fix/compiled-{category_short}-{date_str}"
 
               # Check if a compiled PR for this category already exists
               # Note: This checks if ANY PR with this category label is open.

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -88,7 +88,7 @@ jobs:
 
           # Find open Jules PRs
           JULES_PRS=$(gh pr list --state open --json number,title,headRefName,files \
-            --jq '[.[] | select(.headRefName | test("^jules/|^fix/.*jules|^fix/pragmatic|^fix/code-quality"))]')
+            --jq '[.[] | select(.headRefName | test("^jules/|^fix/.*jules|^fix/pragmatic|^fix/code-quality|^fix/auto-fix-consolidated-|^fix/comment-fixes-|^docs/critics-comments-|^fix/issue-resolver-|^docs/laymans-terms-|^fix/compiled-"))]')
 
           echo "Found $(echo "$JULES_PRS" | jq 'length') open Jules PRs"
 


### PR DESCRIPTION
This PR resolves the issue where machine-generated branches lacked semantic naming, making them hard to trace and potentially causing them to be ignored by cleanup scripts. 
- Modified workflows (Jules-Assessment-AutoFix.yml, Jules-Code-Quality-Fixer.yml, Jules-Comment-Processor.yml, Jules-Critics-Comments.yml, Jules-Issue-Resolver.yml, Jules-Laymans-Terms-Writer.yml, Jules-PR-Compiler.yml) to use semantic prefixes (e.g. fix/ or docs/) for auto-generated branch names.
- Updated the jq regular expressions in Jules-PR-Cleanup.yml and Jules-Supersede-Check.yml to correctly identify these new semantic branch prefixes, ensuring that stale machine-generated branches can be identified and automatically closed or superseded properly.

Fixes #3357

---
*PR created automatically by Jules for task [17013487507865568195](https://jules.google.com/task/17013487507865568195) started by @dieterolson*