### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/src/api/routes/engines.py
+++ b/src/api/routes/engines.py
@@ -60,8 +60,6 @@ _NON_LEVEL_METADATA_KEYS: frozenset[str] = frozenset(
 )
 
 
-
-
 router = APIRouter()
 
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/grip_modelling_tab.py
@@ -36,7 +36,6 @@ from .sim_widget import MuJoCoSimWidget
 logger = get_logger(__name__)
 
 
-
 class GripModellingTab(QtWidgets.QWidget):
     """Tab for manipulating advanced hand models (Shadow, Allegro)."""
 

--- a/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
+++ b/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
@@ -39,8 +39,8 @@ for environments that expose the underlying ``model`` and ``data`` attributes.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -48,8 +48,8 @@ import numpy as np
 
 from src.shared.python.engine_core.engine_availability import is_engine_available
 from src.shared.python.perturbation.perturbation_base import (
-    ComparisonReport,
     MANDATORY_METRICS,
+    ComparisonReport,
     PerturbationAnalyzerBase,
 )
 

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -42,7 +42,8 @@ class Sphere(GeometricPrimitive):
         if not (point is not None):
             raise ValueError("point must be provided")
         point = np.asarray(point)
-        return float(np.linalg.norm(point - self.center)) <= self.radius
+        diff = point - self.center
+        return math.hypot(*diff) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -174,7 +175,8 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return float(np.linalg.norm(self.point_b - self.point_a))
+        diff = self.point_b - self.point_a
+        return math.hypot(*diff)
 
     @property
     def axis(self) -> np.ndarray:
@@ -216,7 +218,8 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point)
         closest = self._closest_point_on_segment(point)
-        return float(np.linalg.norm(point - closest)) <= self.radius
+        diff = point - closest
+        return math.hypot(*diff) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -268,7 +271,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("height must be positive")
 
         # Normalize axis
-        norm = np.linalg.norm(self.axis)
+        norm = math.hypot(*self.axis)
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm

--- a/src/shared/python/data_io/export.py
+++ b/src/shared/python/data_io/export.py
@@ -95,8 +95,8 @@ def export_to_matlab(
         return True
 
     except (
-        Exception  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
-    ) as e:
+        Exception
+    ) as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
         logger.error(f"Failed to export to MATLAB: {e}")
         return False
 
@@ -173,8 +173,8 @@ def export_to_hdf5(
         return True
 
     except (
-        Exception  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
-    ) as e:
+        Exception
+    ) as e:  # noqa: BLE001  # broad-catch intentional: any I/O error returns False
         logger.error(f"Failed to export to HDF5: {e}")
         return False
 
@@ -209,25 +209,15 @@ class C3DExportData:
 
 
 @precondition(  # fmt: skip
-    lambda output_path,
-    times,
-    joint_positions,
-    joint_names,
-    forces=None,
-    moments=None,
-    frame_rate=60.0,
-    units=None: (output_path is not None and len(output_path) > 0),
+    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: (
+        output_path is not None and len(output_path) > 0
+    ),
     "Output path must be a non-empty string",
 )
 @precondition(  # fmt: skip
-    lambda output_path,
-    times,
-    joint_positions,
-    joint_names,
-    forces=None,
-    moments=None,
-    frame_rate=60.0,
-    units=None: (frame_rate > 0),
+    lambda output_path, times, joint_positions, joint_names, forces=None, moments=None, frame_rate=60.0, units=None: (
+        frame_rate > 0
+    ),
     "Frame rate must be positive",
 )
 def export_to_c3d(

--- a/src/shared/python/upstream_drift_tools/calculators/conversion/service.py
+++ b/src/shared/python/upstream_drift_tools/calculators/conversion/service.py
@@ -398,7 +398,6 @@ class UnitConversionService(
         # Invalidate cache as new unit might conflict or resolve previously unknown units
         self._normalized_cache.clear()
 
-
     def _user_unit_warnings(
         self,
         from_category: str | None,

--- a/tests/unit/test_calc_backend_protocols.py
+++ b/tests/unit/test_calc_backend_protocols.py
@@ -35,7 +35,6 @@ class TestCalculationEngineProtocol:
     def test_protocol_structural_check(self) -> None:
         """A class with calculate() should satisfy the protocol at runtime."""
 
-
         class FakeRequest(BaseModel):
             value: float
 

--- a/tests/unit/test_dataset_generator.py
+++ b/tests/unit/test_dataset_generator.py
@@ -502,9 +502,9 @@ class TestIssue2472DatasetGeneratorInvariants:
         dataset = gen.generate(config)
 
         sample = dataset.samples[0]
-        assert "potential" in sample.energies, (
-            "potential_energy must be present in sample.energies"
-        )
-        assert np.any(sample.energies["potential"] != 0.0), (
-            "potential_energy must not be all zeros when engine provides it"
-        )
+        assert (
+            "potential" in sample.energies
+        ), "potential_energy must be present in sample.energies"
+        assert np.any(
+            sample.energies["potential"] != 0.0
+        ), "potential_energy must not be all zeros when engine provides it"

--- a/tests/unit/test_dataset_generator_split_2456.py
+++ b/tests/unit/test_dataset_generator_split_2456.py
@@ -36,23 +36,23 @@ class TestDatasetGeneratorFileSizes:
     @pytest.mark.unit
     def test_coordinator_loc(self) -> None:
         loc = _count_lines(DATA_IO_DIR / "dataset_generator/core.py")
-        assert loc <= LOC_BUDGET, (
-            f"dataset_generator.py has {loc} LOC; budget {LOC_BUDGET}"
-        )
+        assert (
+            loc <= LOC_BUDGET
+        ), f"dataset_generator.py has {loc} LOC; budget {LOC_BUDGET}"
 
     @pytest.mark.unit
     def test_models_loc(self) -> None:
         loc = _count_lines(DATA_IO_DIR / "_dataset_models.py")
-        assert loc <= LOC_BUDGET, (
-            f"_dataset_models.py has {loc} LOC; budget {LOC_BUDGET}"
-        )
+        assert (
+            loc <= LOC_BUDGET
+        ), f"_dataset_models.py has {loc} LOC; budget {LOC_BUDGET}"
 
     @pytest.mark.unit
     def test_export_mixin_loc(self) -> None:
         loc = _count_lines(DATA_IO_DIR / "_dataset_export_mixin.py")
-        assert loc <= LOC_BUDGET, (
-            f"_dataset_export_mixin.py has {loc} LOC; budget {LOC_BUDGET}"
-        )
+        assert (
+            loc <= LOC_BUDGET
+        ), f"_dataset_export_mixin.py has {loc} LOC; budget {LOC_BUDGET}"
 
 
 class TestDatasetGeneratorPublicAPI:


### PR DESCRIPTION
Replaced np.linalg.norm with math.hypot for 3D vector length computations. Fixes #3426.

---
*PR created automatically by Jules for task [2879512737095007608](https://jules.google.com/task/2879512737095007608) started by @dieterolson*