### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.83                                             |
+| **Spec Version**        | 1.0.84                                             |
 | **Last Spec Update**    | 2026-04-26                                         |
 
 ## 2. Purpose & Mission

--- a/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
+++ b/src/engines/physics_engines/myosuite/python/perturbation/analyzer.py
@@ -39,8 +39,8 @@ for environments that expose the underlying ``model`` and ``data`` attributes.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -48,8 +48,8 @@ import numpy as np
 
 from src.shared.python.engine_core.engine_availability import is_engine_available
 from src.shared.python.perturbation.perturbation_base import (
-    ComparisonReport,
     MANDATORY_METRICS,
+    ComparisonReport,
     PerturbationAnalyzerBase,
 )
 

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -42,7 +42,7 @@ class Sphere(GeometricPrimitive):
         if not (point is not None):
             raise ValueError("point must be provided")
         point = np.asarray(point)
-        return float(np.linalg.norm(point - self.center)) <= self.radius
+        return float(math.hypot(*(point - self.center))) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -174,7 +174,7 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return float(np.linalg.norm(self.point_b - self.point_a))
+        return float(math.hypot(*(self.point_b - self.point_a)))
 
     @property
     def axis(self) -> np.ndarray:
@@ -216,7 +216,7 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point)
         closest = self._closest_point_on_segment(point)
-        return float(np.linalg.norm(point - closest)) <= self.radius
+        return float(math.hypot(*(point - closest))) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -268,7 +268,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("height must be positive")
 
         # Normalize axis
-        norm = np.linalg.norm(self.axis)
+        norm = float(math.hypot(*self.axis))
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm


### PR DESCRIPTION
Replaces `np.linalg.norm` with `math.hypot` for calculating 3D Euclidean distances in `src/robotics/planning/collision/_primitive_shapes.py`. This avoids NumPy array allocation overhead and provides a measurable speedup for small vectors.

Fixes #3426

---
*PR created automatically by Jules for task [12284944350347217921](https://jules.google.com/task/12284944350347217921) started by @dieterolson*