### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -42,7 +42,7 @@ class Sphere(GeometricPrimitive):
         if not (point is not None):
             raise ValueError("point must be provided")
         point = np.asarray(point)
-        return float(np.linalg.norm(point - self.center)) <= self.radius
+        return math.hypot(*(point - self.center)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -174,7 +174,7 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return float(np.linalg.norm(self.point_b - self.point_a))
+        return math.hypot(*(self.point_b - self.point_a))
 
     @property
     def axis(self) -> np.ndarray:
@@ -216,7 +216,7 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point)
         closest = self._closest_point_on_segment(point)
-        return float(np.linalg.norm(point - closest)) <= self.radius
+        return math.hypot(*(point - closest)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -268,7 +268,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("height must be positive")
 
         # Normalize axis
-        norm = np.linalg.norm(self.axis)
+        norm = math.hypot(*self.axis)
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm


### PR DESCRIPTION
This PR replaces `np.linalg.norm` with `math.hypot` for calculating 3D Euclidean distances in `src/robotics/planning/collision/_primitive_shapes.py`. 

This change avoids NumPy array allocation overhead and provides a measurable speedup for small vectors. Redundant `float()` casts have also been safely removed, as `math.hypot` natively returns a Python `float`.

Fixes #3433

---
*PR created automatically by Jules for task [8796372484610047337](https://jules.google.com/task/8796372484610047337) started by @dieterolson*