### PR TITLE
chore: route workflows off hosted runners

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Conflict-Fix.yml
+++ b/.github/workflows/Jules-Conflict-Fix.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Physics-Auditor.yml
+++ b/.github/workflows/Jules-Physics-Auditor.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Tech-Debt-Assessor.yml
+++ b/.github/workflows/Jules-Tech-Debt-Assessor.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-kill-switch:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   trivy-scan:
     name: Trivy Container Scan
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/jules-kill-switch.yml
+++ b/.github/workflows/jules-kill-switch.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   control:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/pdf-size-guard.yml
+++ b/.github/workflows/pdf-size-guard.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-pdf-size:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
This PR removes GitHub-hosted runner labels from active workflows and routes all active jobs to the local self-hosted runner label `d-sorg-fleet`.

Validation:
- `python scripts/check_local_only_workflows.py`
- `git diff --check`

This keeps the repo fail-closed on self-hosted routing and prevents hosted runner fallback in active workflow definitions.