### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/src/robotics/core/types.py
+++ b/src/robotics/core/types.py
@@ -11,6 +11,7 @@ Design by Contract:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
@@ -146,7 +147,7 @@ class ContactState:
             )
 
         # Normalize normal vector
-        norm = np.linalg.norm(self.normal)
+        norm = math.hypot(*self.normal)
         if norm > 1e-10:
             object.__setattr__(self, "normal", self.normal / norm)
 
@@ -174,7 +175,7 @@ class ContactState:
         if not (tolerance is not None):
             raise ValueError("tolerance must be provided")
         friction_limit = self.friction_coefficient * self.normal_force
-        friction_mag = float(np.linalg.norm(self.friction_force))
+        friction_mag = float(math.hypot(*self.friction_force))
         return friction_mag >= friction_limit - tolerance
 
     def with_force(


### PR DESCRIPTION
Replaced np.linalg.norm with math.hypot for 3D vector length computations. Fixes #3455.

---
*PR created automatically by Jules for task [13214973597056296318](https://jules.google.com/task/13214973597056296318) started by @dieterolson*