### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -516,14 +516,10 @@ pytest tests/ --cov=src --cov-fail-under=70
 -->
 ## 2026-04-28 Spec Bump
 Bumped spec file slightly to bypass the spec check in CI.
-<<<<<<< HEAD
 | 2026-04-29 | 1.0.84  | Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances |
-=======
-<<<<<<< HEAD
 
 ## Performance Optimizations
 - Replaced `np.linalg.norm` with `math.hypot` in 3D distance calculations in `src/robotics/planning/collision/_primitive_shapes.py` to improve performance.
-=======
 | 2026-04-29 | 1.0.11  | Bolt: Replaced np.linalg.norm with math.hypot in collision shapes for 3D vector distance optimization |
->>>>>>> origin/main
->>>>>>> origin/main
+|
+| 2026-04-29 | 1.0.85  | Bolt: Fix math.hypot unpacking for non-1D ndarrays |

--- a/src/robotics/planning/collision/_distance_queries.py
+++ b/src/robotics/planning/collision/_distance_queries.py
@@ -60,7 +60,7 @@ def _sphere_sphere_distance(
     if not (sphere_a is not None):
         raise ValueError("sphere_a must be provided")
     diff = sphere_b.center - sphere_a.center
-    center_dist = math.hypot(*diff)
+    center_dist = math.hypot(*np.asarray(diff).reshape(-1))
 
     if center_dist < 1e-10:
         # Concentric spheres
@@ -89,7 +89,7 @@ def _sphere_capsule_distance(
 
     # Now it's sphere-sphere distance
     diff = sphere.center - closest_on_axis
-    center_dist = math.hypot(*diff)
+    center_dist = math.hypot(*np.asarray(diff).reshape(-1))
 
     if center_dist < 1e-10:
         # Sphere center on capsule axis
@@ -121,7 +121,7 @@ def _capsule_capsule_distance(
     )
 
     diff = closest_b - closest_a
-    center_dist = math.hypot(*diff)
+    center_dist = math.hypot(*np.asarray(diff).reshape(-1))
 
     if center_dist < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
@@ -207,10 +207,10 @@ def _gjk_distance(
     direction = prim_b.compute_support(np.array([1, 0, 0])) - prim_a.compute_support(
         np.array([-1, 0, 0])
     )
-    if math.hypot(*direction) < 1e-10:
+    if math.hypot(*np.asarray(direction).reshape(-1)) < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
     else:
-        direction = direction / math.hypot(*direction)
+        direction = direction / math.hypot(*np.asarray(direction).reshape(-1))
 
     # Simplex vertices
     simplex: list[np.ndarray] = []
@@ -226,7 +226,7 @@ def _gjk_distance(
         if np.dot(support, direction) < 0 and len(simplex) == 0:
             # Return distance between supports
             diff = support_b - support_a
-            dist = float(math.hypot(*diff))
+            dist = float(math.hypot(*np.asarray(diff).reshape(-1)))
             return dist, support_a, support_b
 
         simplex.append(support)
@@ -234,7 +234,7 @@ def _gjk_distance(
         # Update simplex and direction
         if len(simplex) == 1:
             direction = -simplex[0]
-            norm = math.hypot(*direction)
+            norm = math.hypot(*np.asarray(direction).reshape(-1))
             if norm < 1e-10:
                 # Origin at support point (collision)
                 return 0.0, support_a, support_b
@@ -246,7 +246,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(math.hypot(*closest))
+            dist = float(math.hypot(*np.asarray(closest).reshape(-1)))
             if dist < 1e-6:
                 # Origin very close to simplex (collision)
                 return 0.0, support_a, support_b
@@ -259,7 +259,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(math.hypot(*closest))
+            dist = float(math.hypot(*np.asarray(closest).reshape(-1)))
             if dist < 1e-6:
                 return 0.0, support_a, support_b
             direction = -closest / dist
@@ -268,7 +268,7 @@ def _gjk_distance(
     support_a = prim_a.compute_support(direction)
     support_b = prim_b.compute_support(-direction)
     diff = support_b - support_a
-    return float(math.hypot(*diff)), support_a, support_b
+    return float(math.hypot(*np.asarray(diff).reshape(-1))), support_a, support_b
 
 
 def check_primitive_collision(

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -41,7 +41,7 @@ class Sphere(GeometricPrimitive):
             raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
-        point = np.asarray(point)
+        point = np.asarray(point).reshape(-1)
         return math.hypot(*(point - self.center)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
@@ -50,7 +50,7 @@ class Sphere(GeometricPrimitive):
             raise ValueError("direction must be provided")
         if not (direction is not None):
             raise ValueError("direction must be provided")
-        direction = np.asarray(direction)
+        direction = np.asarray(direction).reshape(-1)
         norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
@@ -117,7 +117,7 @@ class Box(GeometricPrimitive):
             raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
-        point = np.asarray(point)
+        point = np.asarray(point).reshape(-1)
         # Transform to local frame
         local_point = self.rotation.T @ (point - self.center)
         return bool(np.all(np.abs(local_point) <= self.half_extents))
@@ -128,7 +128,7 @@ class Box(GeometricPrimitive):
             raise ValueError("direction must be provided")
         if not (direction is not None):
             raise ValueError("direction must be provided")
-        direction = np.asarray(direction)
+        direction = np.asarray(direction).reshape(-1)
         # Transform direction to local frame
         local_dir = self.rotation.T @ direction
         # Support in local frame
@@ -174,13 +174,13 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return math.hypot(*(self.point_b - self.point_a))
+        return math.hypot(*np.asarray(self.point_b - self.point_a).reshape(-1))
 
     @property
     def axis(self) -> np.ndarray:
         """Get capsule axis direction (normalized)."""
         diff = self.point_b - self.point_a
-        length = math.hypot(*diff)
+        length = math.hypot(*np.asarray(diff).reshape(-1))
         if length < 1e-10:
             return np.array([0.0, 0.0, 1.0])
         return diff / length
@@ -214,7 +214,7 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
-        point = np.asarray(point)
+        point = np.asarray(point).reshape(-1)
         closest = self._closest_point_on_segment(point)
         return math.hypot(*(point - closest)) <= self.radius
 
@@ -224,7 +224,7 @@ class Capsule(GeometricPrimitive):
             raise ValueError("direction must be provided")
         if not (direction is not None):
             raise ValueError("direction must be provided")
-        direction = np.asarray(direction)
+        direction = np.asarray(direction).reshape(-1)
         norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.point_a.copy()
@@ -268,7 +268,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("height must be positive")
 
         # Normalize axis
-        norm = math.hypot(*self.axis)
+        norm = math.hypot(*np.asarray(self.axis).reshape(-1))
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm
@@ -305,7 +305,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
-        point = np.asarray(point)
+        point = np.asarray(point).reshape(-1)
         # Project onto axis
         to_point = point - self.center
         along_axis = np.dot(to_point, self.axis)
@@ -316,7 +316,7 @@ class Cylinder(GeometricPrimitive):
 
         # Check radius (perpendicular distance)
         perp = to_point - along_axis * self.axis
-        return math.hypot(*perp) <= self.radius
+        return math.hypot(*np.asarray(perp).reshape(-1)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -324,7 +324,7 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("direction must be provided")
         if not (direction is not None):
             raise ValueError("direction must be provided")
-        direction = np.asarray(direction)
+        direction = np.asarray(direction).reshape(-1)
         norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
@@ -343,7 +343,7 @@ class Cylinder(GeometricPrimitive):
             axis_support = self.center - self.half_height * self.axis
 
         # Support on radius (perpendicular)
-        perp_norm = math.hypot(*d_perp)
+        perp_norm = math.hypot(*np.asarray(d_perp).reshape(-1))
         if perp_norm > 1e-10:
             return axis_support + self.radius * d_perp / perp_norm
 
@@ -393,11 +393,11 @@ class ConvexHull(GeometricPrimitive):
             raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
-        point = np.asarray(point)
+        point = np.asarray(point).reshape(-1)
         # Simple heuristic: point is inside if closer to center than
         # all vertices in the same direction
         to_point = point - self.center
-        norm = math.hypot(*to_point)
+        norm = math.hypot(*np.asarray(to_point).reshape(-1))
         if norm < 1e-10:
             return True  # At center
 
@@ -412,7 +412,7 @@ class ConvexHull(GeometricPrimitive):
             raise ValueError("direction must be provided")
         if not (direction is not None):
             raise ValueError("direction must be provided")
-        direction = np.asarray(direction)
+        direction = np.asarray(direction).reshape(-1)
         # Find vertex with maximum dot product
         dots = self.vertices @ direction
         idx = np.argmax(dots)

--- a/src/robotics/planning/collision/collision_types.py
+++ b/src/robotics/planning/collision/collision_types.py
@@ -119,7 +119,7 @@ class DistanceResult:
             # Normalize the normal vector
             # ⚡ Bolt: Element-wise norm computation is faster than np.linalg.norm(..., axis=None) for tiny vectors
             # using math.hypot equivalent
-            norm = float(math.hypot(*self.normal))
+            norm = float(math.hypot(*np.asarray(self.normal).reshape(-1)))
             if norm > 1e-10:
                 object.__setattr__(self, "normal", self.normal / norm)
 


### PR DESCRIPTION
Fixes #3470

This PR updates `np.linalg.norm` replacements with `math.hypot` to ensure non-1D ndarrays do not raise `TypeError`. Shapes are explicitely handled by `np.asarray(...).reshape(-1)` to safely flatten shapes prior to unpacking into `math.hypot(*var)` arguments.

---
*PR created automatically by Jules for task [14120942555581041138](https://jules.google.com/task/14120942555581041138) started by @dieterolson*