### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/docs/review_archive/review_comments_2026-04-29.md
+++ b/docs/review_archive/review_comments_2026-04-29.md
@@ -1,6 +1,5 @@
 # Review Comments Archive - 2026-04-29
 
-<<<<<<< HEAD
 Generated: 2026-04-29T06:48:42.047744
 
 ## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
@@ -19,34 +18,28 @@ Switching to `math.hypot(*(point - self.center))` narrows accepted input shapes 
 [View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/3440#discussion_r3161491112)
 
 ---
-=======
 Generated: 2026-04-29T08:26:07.292160
 
 ## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
 
 ### PR #3450: src/robotics/planning/collision/_primitive_shapes.py:45
->>>>>>> origin/main
 
 Actionable: Yes
 Has Suggestion: No
 
 ```
-<<<<<<< HEAD
 **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Keep distance checks compatible with row-vector points**
 
 Replacing `np.linalg.norm(point - self.center)` with `math.hypot(*(point - self.center))` changes accepted input shapes: a point shaped `(1, 3)` now raises `TypeError` because `math.hypot` receives a 1D array argument, while the previous implementation returned a valid scalar norm. This is a behavior regression for callers that pass row slices (e.g. `p...
 ```
 
 [View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/3448#discussion_r3161810460)
-=======
 **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Normalize point shape before unpacking into math.hypot**
 
 This `contains_point` path no longer handles row/column vector inputs: `point` is only converted with `np.asarray`, so shapes like `(1, 3)` or `(3, 1)` reach `math.hypot(*(point - self.center))` and raise `TypeError` because unpacked elements are arrays, not scalars. Before this commit, `np.linalg.norm` accepted these common single-point layouts, so th...
 ```
 
 [View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/3450#discussion_r3161871320)
->>>>>>> origin/main
 
 ---
 
->>>>>>> origin/main

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -42,7 +42,7 @@ class Sphere(GeometricPrimitive):
         if not (point is not None):
             raise ValueError("point must be provided")
         point = np.asarray(point).ravel()
-        return math.hypot(*(point - self.center)) <= self.radius
+        return math.hypot(*np.asarray(point - self.center).reshape(-1)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -216,7 +216,7 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point).ravel()
         closest = self._closest_point_on_segment(point)
-        return math.hypot(*(point - closest)) <= self.radius
+        return math.hypot(*np.asarray(point - closest).reshape(-1)) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""


### PR DESCRIPTION
Fixes #3475

---
*PR created automatically by Jules for task [13130599314913288002](https://jules.google.com/task/13130599314913288002) started by @dieterolson*