### PR TITLE
Fix: math.hypot 3D vector unpacking shape regression

### DIFF
--- a/src/engines/common/physics.py
+++ b/src/engines/common/physics.py
@@ -379,7 +379,9 @@ class AerodynamicsCalculator:
             raise ValueError("speed must be provided")
         speed = float(speed)
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for 3D vectors
-        spin_mag = math.hypot(*spin)
+        # Normalize array shape before unpacking (fixes #3450)
+        spin_vec = np.asarray(spin, dtype=float).reshape(-1)
+        spin_mag = 0.0 if spin_vec.size == 0 else math.hypot(*spin_vec)
         return self.ball.radius * spin_mag / (speed + 1e-10)
 
 

--- a/src/engines/physics_engines/putting_green/python/ball_roll_physics.py
+++ b/src/engines/physics_engines/putting_green/python/ball_roll_physics.py
@@ -412,7 +412,9 @@ class BallRollPhysics:
 
         # Rotational: 0.5 * I * ω²
         # ⚡ Bolt: math.hypot is faster than np.linalg.norm for 3D vectors
-        spin_mag = math.hypot(state.spin[0], state.spin[1], state.spin[2])
+        # Normalize array shape before unpacking (fixes #3450)
+        spin_vec = np.asarray(state.spin, dtype=float).reshape(-1)
+        spin_mag = 0.0 if spin_vec.size == 0 else math.hypot(*spin_vec)
         rotational = 0.5 * self._moment_of_inertia * spin_mag**2
 
         return float(translational + rotational)


### PR DESCRIPTION
Fixes an unpacking bug (#3477, #3450) where a shape regression occurred when refactoring `np.linalg.norm(spin)` to `math.hypot(*spin)` in `BallPhysics` and `BallRollPhysics`. If `spin` is passed as a nested list or 2D array, unpacking via `*spin` throws a `TypeError`.

This fix reshapes the input vector into a flat array via `np.asarray(..., dtype=float).reshape(-1)` before unpacking it, safely handling `math.hypot(*spin_vec)`. Empty arrays are correctly guarded against to prevent errors. Extraneous scratchpad scripts created during exploration were also removed.

---
*PR created automatically by Jules for task [10100384263482917863](https://jules.google.com/task/10100384263482917863) started by @dieterolson*