### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector distances

### DIFF
--- a/src/engines/physics_engines/putting_green/python/_practice_mode.py
+++ b/src/engines/physics_engines/putting_green/python/_practice_mode.py
@@ -38,7 +38,10 @@ def simulate_with_feedback(
         raise ValueError("stroke_params must be provided")
     result = sim.simulate_putt(stroke_params)
 
-    distance_from_hole = math.hypot(*(result.final_position - sim.green.hole_position))
+    arr = np.asarray(
+        result.final_position - sim.green.hole_position, dtype=float
+    ).reshape(-1)
+    distance_from_hole = 0.0 if arr.size == 0 else math.hypot(*arr)
 
     feedback = {
         "distance_from_hole": distance_from_hole,
@@ -139,7 +142,8 @@ def compute_aim_line(
 
     aim_point = target - break_info["break_direction"] * break_info["total_break"]
 
-    distance = float(math.hypot(*(target - ball_position)))
+    arr = np.asarray(target - ball_position, dtype=float).reshape(-1)
+    distance = float(0.0 if arr.size == 0 else math.hypot(*arr))
     avg_slope = np.dot(
         break_info["average_slope"], (target - ball_position) / (distance + 1e-10)
     )

--- a/src/engines/physics_engines/putting_green/python/_surface_analysis.py
+++ b/src/engines/physics_engines/putting_green/python/_surface_analysis.py
@@ -91,11 +91,12 @@ class SurfaceAnalysisMixin:
         t_values = np.linspace(0, 1, num_samples)
         positions = [start + t * (end - start) for t in t_values]
 
+        diff_arr = np.asarray(end - start, dtype=float).reshape(-1)
         return {
             "positions": np.array(positions),
             "elevations": np.array([self.get_elevation_at(p) for p in positions]),  # type: ignore[attr-defined]
             "slopes": np.array([self.get_slope_at(p) for p in positions]),  # type: ignore[attr-defined]
-            "distance": math.hypot(*(end - start)),
+            "distance": 0.0 if diff_arr.size == 0 else math.hypot(*diff_arr),
         }
 
     def to_heightmap(self, resolution: int = 100) -> np.ndarray:

--- a/src/engines/physics_engines/putting_green/python/_surface_data.py
+++ b/src/engines/physics_engines/putting_green/python/_surface_data.py
@@ -55,7 +55,8 @@ class SlopeRegion:
             raise ValueError("position must be provided")
         if not (position is not None):
             raise ValueError("position must be provided")
-        distance = math.hypot(*(position[:2] - self.center[:2]))
+        arr = np.asarray(position[:2] - self.center[:2], dtype=float).reshape(-1)
+        distance = 0.0 if arr.size == 0 else math.hypot(*arr)
         return bool(distance <= self.radius)
 
     def get_weight(self, position: np.ndarray) -> float:
@@ -64,7 +65,8 @@ class SlopeRegion:
             raise ValueError("position must be provided")
         if not (position is not None):
             raise ValueError("position must be provided")
-        distance = math.hypot(*(position[:2] - self.center[:2]))
+        arr = np.asarray(position[:2] - self.center[:2], dtype=float).reshape(-1)
+        distance = 0.0 if arr.size == 0 else math.hypot(*arr)
         if distance >= self.radius:
             return 0.0
 

--- a/src/engines/physics_engines/putting_green/python/_surface_geometry.py
+++ b/src/engines/physics_engines/putting_green/python/_surface_geometry.py
@@ -292,7 +292,8 @@ class SurfaceGeometryMixin:
 
         # Distance from line
         closest_on_line = start + projection * line_dir
-        distance = math.hypot(*(position - closest_on_line))
+        arr = np.asarray(position - closest_on_line, dtype=float).reshape(-1)
+        distance = 0.0 if arr.size == 0 else math.hypot(*arr)
 
         if distance > width:
             return 0.0
@@ -313,7 +314,8 @@ class SurfaceGeometryMixin:
         radius = depression["radius"]
         depth = depression["depth"]
 
-        distance = math.hypot(*(position - center))
+        arr = np.asarray(position - center, dtype=float).reshape(-1)
+        distance = 0.0 if arr.size == 0 else math.hypot(*arr)
 
         if distance > radius:
             return 0.0

--- a/src/engines/physics_engines/putting_green/python/green_surface.py
+++ b/src/engines/physics_engines/putting_green/python/green_surface.py
@@ -132,7 +132,8 @@ class GreenSurface(
             raise ValueError("position must be provided")
         if not (position is not None):
             raise ValueError("position must be provided")
-        distance = math.hypot(*(position[:2] - self._hole_position))
+        arr = np.asarray(position[:2] - self._hole_position, dtype=float).reshape(-1)
+        distance = 0.0 if arr.size == 0 else math.hypot(*arr)
 
         if distance > self.hole_radius:
             return False


### PR DESCRIPTION
Fixes #3474

---
*PR created automatically by Jules for task [8581499147901805008](https://jules.google.com/task/8581499147901805008) started by @dieterolson*