### PR TITLE
fix: enforce cyclomatic complexity (McCabe) in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,11 @@ select = [
     "PERF",  # performance anti-patterns
     "RET",   # return statement cleanup
     "BLE",   # blind except (broad-exception-caught)
+    "C90",   # mccabe cyclomatic complexity
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 ignore = [
     "E501",    # line too long (handled by formatter)
     "B008",    # function call in default arg (FastAPI Depends)


### PR DESCRIPTION
Enables the C90 (McCabe) complexity check in Ruff with a threshold of 10 to ensure maintainable code quality across the fleet.