### PR TITLE
feat(ci): add performance benchmark scaffolding (#3510)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,9 +28,36 @@ permissions:
   contents: read
 
 jobs:
+  # Dispatcher: route to self-hosted if available (matches ci-optional-stack.yml).
+  pick-runner:
+    runs-on: d-sorg-fleet
+    timeout-minutes: 2
+    outputs:
+      runner: ${{ steps.check.outputs.runner }}
+    steps:
+      - name: Check for self-hosted runner
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
+        run: |
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            mkdir -p "$(dirname "$GITHUB_OUTPUT")"
+          fi
+          ONLINE=$(gh api -H "Accept: application/vnd.github+json" /orgs/${{ github.repository_owner }}/actions/runners --paginate \
+            --jq 'if .runners then [.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length else 0 end' \
+            2>/dev/null || echo "0")
+          if [[ "$ONLINE" =~ ^[0-9]+$ ]] && [[ "$ONLINE" -gt 0 ]]; then
+            echo "runner=d-sorg-fleet" >> "$GITHUB_OUTPUT"
+            echo "Self-hosted runner online - routing locally"
+          else
+            echo "::error::No local self-hosted runner available; failing closed"
+            exit 1
+          fi
+
   benchmarks:
     name: Run pytest-benchmark suite
-    runs-on: ubuntu-latest
+    needs: pick-runner
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
     # Do not block PRs while we are still establishing baseline data.
     continue-on-error: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,73 @@
+name: Performance Benchmarks
+
+# ---------------------------------------------------------------------------
+# Performance benchmarks (issue #3510).
+#
+# Runs the pytest-benchmark suite under tests/benchmarks/ and uploads the
+# JSON results as an artifact. This workflow is intentionally NON-BLOCKING:
+# regression thresholds are not enforced yet. A follow-up PR will add
+# baseline comparison + fail-on-regression once we have a few runs of
+# historical data to set sensible thresholds against.
+# ---------------------------------------------------------------------------
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    name: Run pytest-benchmark suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Do not block PRs while we are still establishing baseline data.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Create stub ui/dist for editable install
+        run: mkdir -p ui/dist
+
+      - name: Install dev dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e .[dev]
+          # Belt-and-braces: ensure pytest-benchmark is present even if the
+          # extras resolution above is partial.
+          python3 -m pip install "pytest-benchmark>=4.0"
+
+      - name: Run benchmarks
+        run: |
+          python3 -m pytest tests/benchmarks \
+            -m benchmark \
+            --benchmark-only \
+            --benchmark-json=benchmark.json \
+            --no-cov
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: benchmark.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/PERFORMANCE_BASELINES.md
+++ b/docs/PERFORMANCE_BASELINES.md
@@ -1,0 +1,83 @@
+# Performance Baselines
+
+This page documents how the project records and (eventually) regresses on
+runtime performance for hot physics paths. Tracked under
+[issue #3510](https://github.com/D-sorganization/UpstreamDrift/issues/3510).
+
+## Status
+
+- **Harness landed:** yes -- [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/)
+  is wired up via the `benchmark` pytest marker and a dedicated CI workflow
+  (`.github/workflows/benchmarks.yml`).
+- **Regression thresholds enforced:** **not yet.** The benchmarks workflow
+  records results but does not fail the build on slowdowns. Thresholds will be
+  introduced in a follow-up PR once we have several runs of baseline data.
+- **Baseline numbers committed to the repo:** none yet, by design. We do not
+  want stale or fabricated numbers checked in. Live results live in CI
+  artifacts (see below).
+
+## Running locally
+
+Make sure dev dependencies are installed (this includes `pytest-benchmark`):
+
+```bash
+python3 -m pip install -e '.[dev]'
+```
+
+Run only the benchmark-marked tests:
+
+```bash
+python3 -m pytest tests/benchmarks -m benchmark --benchmark-only
+```
+
+For a quick smoke run of just the scaffolding benchmarks:
+
+```bash
+python3 -m pytest tests/benchmarks/test_benchmarks_smoke.py -m benchmark --benchmark-only
+```
+
+To save a JSON report locally (same format CI uploads):
+
+```bash
+python3 -m pytest tests/benchmarks -m benchmark --benchmark-only \
+    --benchmark-json=benchmark.json
+```
+
+## Where CI results land
+
+The `Performance Benchmarks` workflow (`.github/workflows/benchmarks.yml`)
+runs on every pull request and on manual `workflow_dispatch`. It uploads
+`benchmark.json` as a GitHub Actions artifact named
+`benchmark-results-<sha>` with a 30-day retention. To inspect:
+
+1. Open the PR's **Checks** tab.
+2. Select the *Performance Benchmarks* workflow run.
+3. Download the `benchmark-results-<sha>` artifact from the run summary.
+
+## Adding a new benchmark
+
+Drop a test into `tests/benchmarks/`, mark it `@pytest.mark.benchmark`, and
+use the `benchmark` fixture:
+
+```python
+import pytest
+
+@pytest.mark.benchmark
+def test_my_hot_path(benchmark):
+    result = benchmark(my_function, *args)
+    assert result is not None
+```
+
+If the target imports a heavy optional engine (MuJoCo, Drake, Pinocchio),
+guard the import with `pytest.importorskip` so the benchmark skips cleanly
+in lean environments rather than erroring.
+
+## Roadmap
+
+1. (this PR) Land the harness, smoke benchmarks, CI workflow, artifact upload.
+2. Collect a handful of runs on `main` to characterise noise floor.
+3. Add `--benchmark-compare` against a stored baseline and turn the workflow
+   into a blocking check with a tunable regression threshold (likely 15-20%
+   on mean to start).
+4. Expand benchmark coverage to include trajectory integration, terrain
+   queries, and any Rust-kernel-backed paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,7 @@ markers = [
     "headless_safe: marks tests verified to work in headless mode",
     "slow_numba: Tests that require numba JIT or are heavy",
     "asyncio: marks tests as async tests",
-    "benchmark: marks tests as performance benchmarks",
+    "benchmark: performance benchmarks executed via pytest-benchmark; tracked in CI for regression detection (#3510)",
     "serial: marks tests that must not run in parallel (sys.modules manipulation)",
     "requires_network: marks tests that require network access (skip with '-m not requires_network')",
     "requires_gpu: marks tests that require a GPU (skip with '-m not requires_gpu')",

--- a/tests/benchmarks/test_benchmarks_smoke.py
+++ b/tests/benchmarks/test_benchmarks_smoke.py
@@ -1,0 +1,53 @@
+"""Smoke benchmarks for the performance harness (issue #3510).
+
+These two micro-benchmarks exercise lightweight, deterministic physics
+helpers so the pytest-benchmark harness has at least one real workload
+to record. They are intentionally cheap (~microseconds each) so they
+complete quickly in CI and serve as scaffolding for richer benchmarks
+added in follow-up PRs.
+
+Run locally with:
+
+    python3 -m pytest tests/benchmarks -m benchmark --benchmark-only
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# pytest-benchmark provides the ``benchmark`` fixture used below. Skip the
+# whole module gracefully if it isn't installed (e.g. minimal dev installs).
+pytest.importorskip("pytest_benchmark")
+
+# numpy backs the aerodynamics force vectors. If it isn't available there's
+# nothing meaningful to benchmark here.
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.benchmark
+def test_drag_model_calculate(benchmark: pytest.fixture) -> None:
+    """Benchmark DragModel.calculate on a representative velocity vector."""
+    try:
+        from src.shared.python.physics.aerodynamics import DragModel
+    except ImportError:
+        pytest.skip("aerodynamics module not available")
+
+    model = DragModel()
+    velocity = np.array([50.0, 0.0, 5.0])
+    result = benchmark(model.calculate, velocity)
+    assert result.shape == (3,)
+
+
+@pytest.mark.benchmark
+def test_lift_model_calculate(benchmark: pytest.fixture) -> None:
+    """Benchmark LiftModel.calculate with backspin around the +Y axis."""
+    try:
+        from src.shared.python.physics.aerodynamics import LiftModel
+    except ImportError:
+        pytest.skip("aerodynamics module not available")
+
+    model = LiftModel()
+    velocity = np.array([50.0, 0.0, 5.0])
+    spin = np.array([0.0, -300.0, 0.0])
+    result = benchmark(model.calculate, velocity, spin)
+    assert result.shape == (3,)

--- a/tests/benchmarks/test_benchmarks_smoke.py
+++ b/tests/benchmarks/test_benchmarks_smoke.py
@@ -24,14 +24,15 @@ pytest.importorskip("pytest_benchmark")
 np = pytest.importorskip("numpy")
 
 
+# Import the modules under benchmark at collection time so a real import
+# regression in src.shared.python.physics.aerodynamics fails the benchmark
+# suite loudly rather than silently skipping. Per review on PR #3516.
+from src.shared.python.physics.aerodynamics import DragModel, LiftModel  # noqa: E402
+
+
 @pytest.mark.benchmark
 def test_drag_model_calculate(benchmark: pytest.fixture) -> None:
     """Benchmark DragModel.calculate on a representative velocity vector."""
-    try:
-        from src.shared.python.physics.aerodynamics import DragModel
-    except ImportError:
-        pytest.skip("aerodynamics module not available")
-
     model = DragModel()
     velocity = np.array([50.0, 0.0, 5.0])
     result = benchmark(model.calculate, velocity)
@@ -41,11 +42,6 @@ def test_drag_model_calculate(benchmark: pytest.fixture) -> None:
 @pytest.mark.benchmark
 def test_lift_model_calculate(benchmark: pytest.fixture) -> None:
     """Benchmark LiftModel.calculate with backspin around the +Y axis."""
-    try:
-        from src.shared.python.physics.aerodynamics import LiftModel
-    except ImportError:
-        pytest.skip("aerodynamics module not available")
-
     model = LiftModel()
     velocity = np.array([50.0, 0.0, 5.0])
     spin = np.array([0.0, -300.0, 0.0])


### PR DESCRIPTION
## Summary

Lays the foundation for performance regression detection in CI. Future PRs can add a benchmark in one line and have it recorded as an artifact.

- `tests/benchmarks/test_benchmarks_smoke.py` — two smoke benchmarks against `DragModel.calculate` and `LiftModel.calculate` from `src/shared/python/physics/aerodynamics.py`. Both pure-NumPy, deterministic, no heavy engine deps. Gated with `pytest.importorskip` for `pytest_benchmark`/`numpy`.
- `.github/workflows/benchmarks.yml` — runs on `pull_request` (docs paths ignored) and `workflow_dispatch`, uploads `benchmark.json` as an artifact (30-day retention). `continue-on-error: true` — does **not** block PRs yet.
- `docs/PERFORMANCE_BASELINES.md` — how-to-run, status, roadmap. No fabricated baseline numbers.
- `pyproject.toml` — refined `benchmark` marker description; `pytest-benchmark>=4.0` was already in `[project.optional-dependencies].dev`.

Regression thresholds are intentionally **not** enforced in this PR. That's a follow-up.

## Test plan

- [x] `python3 -m pytest tests/benchmarks -m benchmark --no-cov` — passes locally (~1.3s wall; drag ~4.2µs mean, lift ~26.6µs mean)
- [x] `ruff check --isolated` and `ruff format --check --isolated` clean on the new files
- [ ] CI benchmarks workflow runs and uploads artifact (verify on this PR)

Note: `pyproject.toml` has a pre-existing TOML parse failure at line ~185 (introduced in PR #3495) where `ignore = [...]` is misplaced under `[tool.ruff.lint.mccabe]`. Reproduces on clean `main`. Not addressed here — flagged for a separate fix.

Fixes #3510

https://claude.ai/code/session_01VFVUB52Jmyh95UmLiv92px

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFVUB52Jmyh95UmLiv92px)_