### PR TITLE
fix(physics): drag-crisis-aware Cd(Re) for dimpled spheres (#3504)

### DIFF
--- a/src/shared/python/physics/aerodynamics/__init__.py
+++ b/src/shared/python/physics/aerodynamics/__init__.py
@@ -20,6 +20,7 @@ References:
 from __future__ import annotations
 
 from ._config import AerodynamicsConfig, RandomizationConfig, WindConfig
+from ._drag_curve import drag_coefficient
 from ._engine import AerodynamicsEngine
 from ._environment import EnvironmentRandomizer, EnvironmentSnapshot
 from ._models import DragModel, LiftModel, MagnusModel
@@ -38,4 +39,5 @@ __all__ = [
     "WindConfig",
     "WindGust",
     "WindModel",
+    "drag_coefficient",
 ]

--- a/src/shared/python/physics/aerodynamics/_drag_curve.py
+++ b/src/shared/python/physics/aerodynamics/_drag_curve.py
@@ -1,0 +1,136 @@
+"""Drag-crisis-aware Cd(Re) curve for dimpled spheres.
+
+Provides an empirical drag coefficient as a function of Reynolds number,
+capturing the drag crisis typical of dimpled spheres (golf balls).
+Dimples trip the boundary layer earlier than on a smooth sphere, producing
+a sharp Cd drop near Re ~= 4e4-6e4 followed by a shallow basin and a
+gentle rise into the post-critical regime.
+
+Sources:
+    - Bearman, P.W. & Harvey, J.K. (1976). Golf ball aerodynamics.
+      Aeronautical Quarterly, 27(2), 112-122.
+    - Achenbach, E. (1972). Experiments on the flow past spheres at very
+      high Reynolds numbers. J. Fluid Mech., 54(3), 565-575.
+    - Smits, A.J. & Ogg, S. (2004). Golf ball aerodynamics. Physics Today.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from src.shared.python.core.physics_constants import GOLF_BALL_DRAG_COEFFICIENT
+
+# Empirical lookup table for a dimpled sphere. Anchor points were chosen so
+# np.interp produces a continuous, monotone transition through the crisis
+# region and a smooth rise post-critical.
+_CD_DIMPLED_RE_TABLE: tuple[float, ...] = (
+    1.0e3,
+    1.0e4,
+    3.0e4,
+    4.0e4,
+    5.0e4,
+    6.0e4,
+    8.0e4,
+    1.0e5,
+    1.5e5,
+    2.0e5,
+    2.5e5,
+    3.0e5,
+    5.0e5,
+    1.0e6,
+)
+_CD_DIMPLED_CD_TABLE: tuple[float, ...] = (
+    0.50,
+    0.50,
+    0.48,
+    0.42,
+    0.26,
+    0.22,
+    0.21,
+    0.22,
+    0.23,
+    0.25,
+    0.26,
+    0.27,
+    0.28,
+    0.30,
+)
+
+
+def _cd_dimpled_sphere(re: float) -> float:
+    """Drag coefficient for a dimpled sphere as a function of Reynolds number.
+
+    Uses piecewise-linear interpolation over an empirical lookup table that
+    captures the drag crisis (sharp Cd drop near Re ~= 4e4-6e4) and the
+    subsequent post-crisis rise. Values outside the tabulated range clamp
+    to the nearest endpoint, the standard ``np.interp`` behaviour.
+
+    Args:
+        re: Reynolds number based on ball diameter (must be non-negative
+            and finite).
+
+    Returns:
+        Drag coefficient (dimensionless), clamped to ``[0.10, 0.55]``.
+
+    Raises:
+        ValueError: If ``re`` is negative or non-finite.
+    """
+    re_value = float(re)
+    if not math.isfinite(re_value):
+        raise ValueError(f"Reynolds number must be finite, got {re!r}")
+    if re_value < 0.0:
+        raise ValueError(f"Reynolds number must be non-negative, got {re!r}")
+
+    cd = float(np.interp(re_value, _CD_DIMPLED_RE_TABLE, _CD_DIMPLED_CD_TABLE))
+    # Defensive clamp; np.interp output is already bounded by the table,
+    # but keep the postcondition explicit so future edits cannot silently
+    # break callers.
+    return float(np.clip(cd, 0.10, 0.55))
+
+
+def drag_coefficient(re: float, base_coefficient: float | None = None) -> float:
+    """Public drag coefficient as a function of Reynolds number.
+
+    Returns the dimpled-sphere base curve, optionally rescaled so the
+    high-Re asymptote matches a user-specified ``base_coefficient`` (the
+    Cd value used in the legacy "fully turbulent" regime). The curve
+    shape is preserved across the entire Re range under rescaling, so
+    callers that tune ``base_coefficient`` get a consistent, smooth
+    response.
+
+    Args:
+        re: Reynolds number based on ball diameter.
+        base_coefficient: Optional Cd anchor for the post-critical regime.
+            When ``None``, the canonical project default is used.
+
+    Returns:
+        Drag coefficient (dimensionless).
+    """
+    cd_curve = _cd_dimpled_sphere(re)
+    if base_coefficient is None:
+        return cd_curve
+
+    anchor = float(GOLF_BALL_DRAG_COEFFICIENT)
+    scale = float(base_coefficient) / anchor if anchor > 0 else 1.0
+    return float(np.clip(cd_curve * scale, 0.05, 0.80))
+
+
+def _validate_cd_curve() -> dict[str, float]:
+    """Sanity-check helper: sample the dimpled-sphere Cd(Re) curve.
+
+    Not invoked automatically. Intended for ad-hoc REPL inspection so a
+    human can confirm the curve still respects the empirical bands at
+    canonical Reynolds numbers (pre-crisis, crisis trough, post-crisis
+    basin, post-critical).
+
+    Returns:
+        Mapping ``{regime_label: cd}`` for inspection.
+    """
+    return {
+        "pre_crisis_re_1e4": _cd_dimpled_sphere(1.0e4),
+        "crisis_trough_re_5e4": _cd_dimpled_sphere(5.0e4),
+        "post_crisis_basin_re_1e5": _cd_dimpled_sphere(1.0e5),
+        "post_critical_re_3e5": _cd_dimpled_sphere(3.0e5),
+    }

--- a/src/shared/python/physics/aerodynamics/_models.py
+++ b/src/shared/python/physics/aerodynamics/_models.py
@@ -19,6 +19,8 @@ from src.shared.python.core.physics_constants import (
     MAGNUS_COEFFICIENT,
 )
 
+from ._drag_curve import drag_coefficient
+
 
 class DragModel:
     """Model for aerodynamic drag force.
@@ -88,15 +90,13 @@ class DragModel:
         diameter = 2 * self.ball_radius
         re = air_density * speed * diameter / viscosity
 
-        laminar_cd = 0.5
-        turbulent_cd = self.base_coefficient
-
-        if re < 8e4:
-            return laminar_cd
-        if re < 2e5:
-            fraction = (re - 8e4) / (2e5 - 8e4)
-            return laminar_cd - fraction * (laminar_cd - turbulent_cd)
-        return turbulent_cd
+        # Drag-crisis-aware Cd(Re) for a dimpled sphere. Dimples trip the
+        # boundary layer earlier than on a smooth sphere, producing the
+        # sharp Cd drop near Re ~= 4e4-6e4 followed by a shallow basin
+        # and a gentle rise into the post-critical regime. The curve is
+        # multiplicatively rescaled by ``base_coefficient`` so user
+        # tuning remains continuous across the entire Re range.
+        return drag_coefficient(re, base_coefficient=self.base_coefficient)
 
 
 class LiftModel:

--- a/tests/unit/test_aerodynamics_drag_crisis.py
+++ b/tests/unit/test_aerodynamics_drag_crisis.py
@@ -1,0 +1,92 @@
+"""Drag-crisis-aware Cd(Re) tests for the dimpled-sphere aerodynamics model.
+
+These tests pin the empirical bands a real dimpled golf ball obeys across
+the canonical Reynolds number regimes (pre-crisis, crisis trough,
+post-crisis basin, post-critical) and assert that the curve is continuous
+to within a small jump tolerance over a logarithmic Re sweep.
+
+References:
+    - Bearman, P.W. & Harvey, J.K. (1976). Golf ball aerodynamics.
+    - Achenbach, E. (1972). Experiments on the flow past spheres at very
+      high Reynolds numbers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.physics.aerodynamics import drag_coefficient
+from src.shared.python.physics.aerodynamics._drag_curve import _cd_dimpled_sphere
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("re", "low", "high"),
+    [
+        (1e4, 0.45, 0.55),  # pre-crisis: laminar, Cd ~ 0.5
+        (5e4, 0.18, 0.30),  # drag-crisis trough
+        (1e5, 0.18, 0.28),  # post-crisis basin
+        (3e5, 0.25, 0.32),  # post-critical
+    ],
+)
+def test_drag_coefficient_within_empirical_band(
+    re: float, low: float, high: float
+) -> None:
+    """Cd lies within the empirical band at canonical Reynolds numbers."""
+    cd = drag_coefficient(re)
+    assert low <= cd <= high, f"Cd={cd} out of band [{low}, {high}] at Re={re}"
+
+
+@pytest.mark.unit
+def test_drag_coefficient_continuous() -> None:
+    """No discontinuities > 0.1 Cd between adjacent Re samples (log-spaced)."""
+    res = np.logspace(3, 6, 200)
+    cds = [drag_coefficient(float(r)) for r in res]
+    diffs = np.abs(np.diff(cds))
+    assert diffs.max() < 0.1, f"Max jump {diffs.max()} too large"
+
+
+@pytest.mark.unit
+def test_drag_crisis_drop_present() -> None:
+    """Cd at the crisis trough is markedly below the pre-crisis plateau."""
+    cd_pre = drag_coefficient(1e4)
+    cd_trough = drag_coefficient(6e4)
+    assert cd_pre - cd_trough > 0.20, (
+        f"Expected drag crisis drop > 0.20, got {cd_pre - cd_trough:.3f}"
+    )
+
+
+@pytest.mark.unit
+def test_post_crisis_rises_into_post_critical() -> None:
+    """Cd rises gently from the post-crisis basin into post-critical Re."""
+    cd_basin = drag_coefficient(1e5)
+    cd_post_critical = drag_coefficient(3e5)
+    assert cd_post_critical > cd_basin, (
+        f"Expected post-critical Cd ({cd_post_critical}) > "
+        f"post-crisis basin ({cd_basin})"
+    )
+
+
+@pytest.mark.unit
+def test_helper_rejects_negative_re() -> None:
+    """The internal helper rejects negative Reynolds numbers."""
+    with pytest.raises(ValueError, match="non-negative"):
+        _cd_dimpled_sphere(-1.0)
+
+
+@pytest.mark.unit
+def test_helper_rejects_non_finite_re() -> None:
+    """The internal helper rejects non-finite Reynolds numbers."""
+    with pytest.raises(ValueError, match="finite"):
+        _cd_dimpled_sphere(float("nan"))
+
+
+@pytest.mark.unit
+def test_base_coefficient_rescales_curve() -> None:
+    """Tuning ``base_coefficient`` linearly rescales the dimpled-sphere curve."""
+    re = 1.5e5
+    default_cd = drag_coefficient(re)
+    tuned_cd = drag_coefficient(re, base_coefficient=0.20)
+    # 0.20 / 0.25 (canonical anchor) = 0.8
+    assert tuned_cd == pytest.approx(default_cd * 0.8, rel=1e-6)


### PR DESCRIPTION
## Summary

Replaces the flat-plateau / linear-blend Cd(Re) model with a piecewise-interpolated curve that captures the **drag crisis** near Re≈4e4–6e4 typical for dimpled golf balls. Empirical band based on Bearman & Harvey (1976) and Achenbach (1972).

This is a **partial** fix for #3504. The remaining 4 sub-items (altitude gradient, water hazard, mud ball, turbulence beyond Re=250k) remain tracked under that issue.

## Changes

- **New:** `src/shared/python/physics/aerodynamics/_drag_curve.py` — `drag_coefficient(re, base_coefficient=...)`, `_cd_dimpled_sphere`, `_validate_cd_curve`. `np.interp` over a 14-point table with a defensive `[0.10, 0.55]` clamp. `base_coefficient` overrides rescale the curve multiplicatively so existing tuning is preserved.
- **Modified:** `DragModel.get_effective_coefficient` in `_models.py` — delegates to the new helper instead of the old laminar/linear/turbulent if-ladder.
- **Re-exported:** `drag_coefficient` from the package `__init__.py`.
- **New tests:** `tests/unit/test_aerodynamics_drag_crisis.py` — 10 cases (parametric band assertions at canonical Re, continuity sweep over 200 log-spaced points, drop-magnitude check at the trough, post-critical rise, error handling, base-coefficient rescaling).

### Curve points

| Re | Cd |
|---|---|
| 1e3, 1e4 | 0.50 |
| 3e4 | 0.48 |
| 4e4 | 0.42 |
| 5e4 | 0.26 |
| 6e4 | 0.22 |
| 8e4 | 0.21 |
| 1e5 | 0.22 |
| 1.5e5 | 0.23 |
| 2e5 | 0.25 |
| 2.5e5 | 0.26 |
| 3e5 | 0.27 |
| 5e5 | 0.28 |
| 1e6 | 0.30 |

## Test plan

- [x] `pytest tests/unit/test_aerodynamics_drag_crisis.py` — 10/10 pass
- [x] `pytest tests/unit/test_aerodynamics_package_2506.py` — 25/25 pass; package per-module 300-LOC budget preserved (`_models.py` = 210, `_drag_curve.py` = 136)
- [x] `ruff check --isolated` and `ruff format --isolated --check` — clean
- [x] No existing test bounds needed updating

## Notes

- The issue body referenced lines 296–302 of `src/shared/python/physics/aerodynamics.py` (legacy file). That module is shadowed by the package directory of the same name (extracted under #2506). Fix applied to the **actually-imported** `_models.py`. Legacy file untouched.
- Pre-existing repo issues flagged for separate fixes (not introduced by this PR):
  - `pyproject.toml` line ~185: misplaced `ignore = [...]` under `[tool.ruff.lint.mccabe]` instead of `[tool.ruff.lint]` (from PR #3495). Breaks non-isolated `ruff check`.
  - `tests/unit/test_aerodynamics.py` imports `MIN_AIR_DENSITY_KG_M3` which the package never re-exported during the #2506 split.
  - `scripts/ci/check_file_size_budget.py` has a `parent.parent` path bug.

Partial fix for #3504.

https://claude.ai/code/session_01VFVUB52Jmyh95UmLiv92px

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFVUB52Jmyh95UmLiv92px)_