### PR TITLE
Fixes #3563: Add Portfolio Golf Modeling Demo

### DIFF
--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -123,9 +123,9 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
     ]
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", newline="") as f:
+    with output_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["quantity", "category", "value", "unit", "source"]
+            f, fieldnames=["quantity", "category", "value", "unit", "source"], lineterminator="\n"
         )
         writer.writeheader()
         writer.writerows(rows)

--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -125,7 +125,9 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["quantity", "category", "value", "unit", "source"], lineterminator="\n"
+            f,
+            fieldnames=["quantity", "category", "value", "unit", "source"],
+            lineterminator="\n",
         )
         writer.writeheader()
         writer.writerows(rows)


### PR DESCRIPTION
Fixes #3563: Add Portfolio Golf Modeling Demo

This PR updates the `scripts/ci/generate_portfolio_demo_output.py` artifact generator script to enforce Unix line endings (`\n`) and UTF-8 encoding when writing the `docs/portfolio/golf_modeling_demo_output.csv` fixture. This resolves Git and CI discrepancy issues across operating systems, ensuring reproducibility. Unrelated file modifications by formatters have been reverted, and tests now pass correctly.

---
*PR created automatically by Jules for task [17585682311398962279](https://jules.google.com/task/17585682311398962279) started by @dieterolson*