### PR TITLE
Fixes #3567: Align portfolio demo outputs with explicit aerodynamic constants

### DIFF
--- a/examples/basic_flight_simulation.py
+++ b/examples/basic_flight_simulation.py
@@ -78,6 +78,8 @@ def main() -> None:
         print("\nBall did not land (insufficient trajectory data)")
     print("Physics: Simulation incorporates aerodynamic drag and Magnus lift.")
 
+    print("\nPhysics: Drag slows the ball down, while lift (from backspin) keeps it in the air longer.")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/basic_flight_simulation.py
+++ b/examples/basic_flight_simulation.py
@@ -78,7 +78,9 @@ def main() -> None:
         print("\nBall did not land (insufficient trajectory data)")
     print("Physics: Simulation incorporates aerodynamic drag and Magnus lift.")
 
-    print("\nPhysics: Drag slows the ball down, while lift (from backspin) keeps it in the air longer.")
+    print(
+        "\nPhysics: Drag slows the ball down, while lift (from backspin) keeps it in the air longer."
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -31,6 +31,7 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
         )
 
     # Match the values in docs/portfolio/golf_modeling_demo.md
+    # Match the values in examples/basic_flight_simulation.py
     ball = BallProperties(
         mass=0.0459,
         diameter=0.04267,


### PR DESCRIPTION
Fixes #3567.

Addresses PR feedback to align the `generate_portfolio_demo_output.py` script with the explicit aerodynamic coefficients used in `examples/basic_flight_simulation.py` to ensure reproducible and consistent references.
- Updated `scripts/ci/generate_portfolio_demo_output.py` to configure `BallProperties` explicitly.
- Regenerated `docs/portfolio/golf_modeling_demo_output.csv` with updated carry distance and height calculations.
- Updated `docs/portfolio/golf_modeling_demo.md` tabular reference block to match.
- Fixed string unit casing and added required `Physics:` output in `examples/basic_flight_simulation.py` to pass strict integration tests.

---
*PR created automatically by Jules for task [6327802334268273883](https://jules.google.com/task/6327802334268273883) started by @dieterolson*