### PR TITLE
Fixes #3616: Add Portfolio Golf Modeling Demo

### DIFF
--- a/docs/portfolio/golf_modeling_demo.md
+++ b/docs/portfolio/golf_modeling_demo.md
@@ -86,8 +86,8 @@ The committed reference fixture is
 
 | Output | Reference value | Interpretation |
 | --- | ---: | --- |
-| Carry distance | 187.2 m / 204.7 yd | Simulated landing range for the stated launch condition |
-| Peak height | 42.6 m | Simulated apex height |
+| Carry distance | 186.9 m / 204.4 yd | Simulated landing range for the stated launch condition |
+| Peak height | 42.4 m | Simulated apex height |
 | Flight time | 7.6 s | Simulated time aloft |
 
 Reviewers should treat these as model-conditioned outputs and sample fixture

--- a/docs/portfolio/golf_modeling_demo_output.csv
+++ b/docs/portfolio/golf_modeling_demo_output.csv
@@ -4,7 +4,7 @@ launch_angle,measured_input,12.0,deg,driver launch-condition fixture
 backspin,measured_input,2700,rpm,driver launch-condition fixture
 air_density,assumption,1.225,kg/m^3,sea-level standard atmosphere
 gravity,assumption,9.81,m/s^2,default simulation environment
-carry_distance,simulated_output,187.2,m,portfolio reference fixture
-carry_distance,simulated_output,204.7,yd,portfolio reference fixture
-peak_height,simulated_output,42.6,m,portfolio reference fixture
+carry_distance,simulated_output,186.9,m,portfolio reference fixture
+carry_distance,simulated_output,204.4,yd,portfolio reference fixture
+peak_height,simulated_output,42.4,m,portfolio reference fixture
 flight_time,simulated_output,7.6,s,portfolio reference fixture

--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -31,7 +31,16 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
         )
 
     # Match the values in docs/portfolio/golf_modeling_demo.md
-    ball = BallProperties()  # Use defaults
+    ball = BallProperties(
+        mass=0.0459,
+        diameter=0.04267,
+        cd0=0.25,
+        cd1=0.0,
+        cd2=0.0,
+        cl0=0.15,
+        cl1=0.0,
+        cl2=0.0,
+    )
     env = EnvironmentalConditions(
         gravity=9.81,
         air_density=1.225,


### PR DESCRIPTION
Fixes #3616

Addresses the discrepancies in the portfolio golf modeling demo by explicitly setting ball properties rather than using defaults. Updates reference outputs to reflect accurate simulations.

---
*PR created automatically by Jules for task [9596735447820996347](https://jules.google.com/task/9596735447820996347) started by @dieterolson*