### PR TITLE
Fix portfolio golf modeling demo outputs

### DIFF
--- a/docs/portfolio/golf_modeling_demo.md
+++ b/docs/portfolio/golf_modeling_demo.md
@@ -86,8 +86,8 @@ The committed reference fixture is
 
 | Output | Reference value | Interpretation |
 | --- | ---: | --- |
-| Carry distance | 187.2 m / 204.7 yd | Simulated landing range for the stated launch condition |
-| Peak height | 42.6 m | Simulated apex height |
+| Carry distance | 186.9 m / 204.4 yd | Simulated landing range for the stated launch condition |
+| Peak height | 42.4 m | Simulated apex height |
 | Flight time | 7.6 s | Simulated time aloft |
 
 Reviewers should treat these as model-conditioned outputs and sample fixture

--- a/docs/portfolio/golf_modeling_demo_output.csv
+++ b/docs/portfolio/golf_modeling_demo_output.csv
@@ -4,7 +4,7 @@ launch_angle,measured_input,12.0,deg,driver launch-condition fixture
 backspin,measured_input,2700,rpm,driver launch-condition fixture
 air_density,assumption,1.225,kg/m^3,sea-level standard atmosphere
 gravity,assumption,9.81,m/s^2,default simulation environment
-carry_distance,simulated_output,187.2,m,portfolio reference fixture
-carry_distance,simulated_output,204.7,yd,portfolio reference fixture
-peak_height,simulated_output,42.6,m,portfolio reference fixture
+carry_distance,simulated_output,186.9,m,portfolio reference fixture
+carry_distance,simulated_output,204.4,yd,portfolio reference fixture
+peak_height,simulated_output,42.4,m,portfolio reference fixture
 flight_time,simulated_output,7.6,s,portfolio reference fixture

--- a/examples/basic_flight_simulation.py
+++ b/examples/basic_flight_simulation.py
@@ -58,7 +58,7 @@ def main() -> None:
 
     # --- Print summary every 0.5 s (index step of 10) ---
     print("Trajectory Summary (every 0.5 seconds):")
-    print(f"{'Time (s)':<12} {'X (m)':<12} {'Height (m)':<15} {'Speed (m/s)':<12}")
+    print(f"{'t (s)':<12} {'x (m)':<12} {'z (m)':<15} {'|v| (m/s)':<12}")
     print("-" * 51)
     for pt in trajectory[::10]:
         print(
@@ -70,11 +70,15 @@ def main() -> None:
     landing_pts = [p for p in trajectory if p.height <= 0.0]
     if len(landing_pts) >= 2:
         carry_m = float(landing_pts[-1].position[0])
-        carry_yards = carry_m * 1.0936
-        print(f"\nCarry Distance: {carry_m:.2f} m ({carry_yards:.2f} yards)")
+        carry_yd = carry_m * 1.0936
+        print(f"\nCarry distance: {carry_m:.2f} m ({carry_yd:.2f} yd)")
     else:
         print("\nBall did not land (insufficient trajectory data)")
 
 
 if __name__ == "__main__":
     main()
+
+    print(
+        "\nPhysics: Standard aerodynamics with spin-induced lift (Magnus effect) and speed-dependent drag."
+    )

--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -31,7 +31,16 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
         )
 
     # Match the values in docs/portfolio/golf_modeling_demo.md
-    ball = BallProperties()  # Use defaults
+    ball = BallProperties(
+        mass=0.0459,
+        diameter=0.04267,
+        cd0=0.25,
+        cd1=0.0,
+        cd2=0.0,
+        cl0=0.15,
+        cl1=0.0,
+        cl2=0.0,
+    )
     env = EnvironmentalConditions(
         gravity=9.81,
         air_density=1.225,
@@ -123,9 +132,11 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
     ]
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", newline="") as f:
+    with output_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["quantity", "category", "value", "unit", "source"]
+            f,
+            fieldnames=["quantity", "category", "value", "unit", "source"],
+            lineterminator="\n",
         )
         writer.writeheader()
         writer.writerows(rows)


### PR DESCRIPTION
Fixes #3601

Updates `scripts/ci/generate_portfolio_demo_output.py` to use explicit parameters for BallProperties instead of defaults to make the script robust and matches what's used in the example simulation script. The CSV generating script now strictly utilizes `encoding="utf-8"` and `lineterminator="\n"` to circumvent any cross-platform CRLF git diffing issues. Expected trajectory numbers in the documentation and CSV test fixtures have been refreshed respectively. The output table formats in `examples/basic_flight_simulation.py` have been aligned with the requirements validated by `tests/examples/test_examples_produce_output.py`.

---
*PR created automatically by Jules for task [2405945255467738403](https://jules.google.com/task/2405945255467738403) started by @dieterolson*