### PR TITLE
fix(ci): prevent Jules cascade by skipping Jules-generated follow-up issues

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -57,8 +57,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT || secrets.RUNNER_CHECK_TOKEN }}
           LABELS: ${{ toJson(github.event.issue.labels) }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          # LABELS is passed via env to prevent shell injection
+          # LABELS and ISSUE_BODY are passed via env to prevent shell injection
+
+          # Skip issues created by Jules itself (prevents runaway cascade)
+          if echo "$ISSUE_BODY" | grep -q "jules.google.com/task/"; then
+            echo "Skipping - Jules-generated follow-up issue"
+            echo "should_assign=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           # Skip if labeled with 'no-jules', 'question', 'documentation', or 'wontfix'
           SKIP_LABELS="no-jules question documentation wontfix duplicate invalid jules-assigned"


### PR DESCRIPTION
Adds a body-content check to `Jules-Auto-Assign-Issues.yml` that skips any issue whose body contains `jules.google.com/task/` — the fingerprint Jules puts in every follow-up issue it creates.

**Before:** Jules creates a follow-up issue when its PR fails CI → auto-assign workflow picks it up → Jules creates another PR → loop
**After:** Jules-created issues are silently skipped by auto-assign

Dashboard dispatch, assessment-bot issues, and explicit `jules-triage` label triggers are all unaffected.