### PR TITLE
Fixes #3598: Add Portfolio Golf Modeling Demo

### DIFF
--- a/docs/portfolio/golf_modeling_demo_output.csv
+++ b/docs/portfolio/golf_modeling_demo_output.csv
@@ -2,6 +2,8 @@ quantity,category,value,unit,source
 ball_speed,measured_input,70.0,m/s,driver launch-condition fixture
 launch_angle,measured_input,12.0,deg,driver launch-condition fixture
 backspin,measured_input,2700,rpm,driver launch-condition fixture
+cd0,assumption,0.25,dimensionless,ball aerodynamics fixture
+cl0,assumption,0.15,dimensionless,ball aerodynamics fixture
 air_density,assumption,1.225,kg/m^3,sea-level standard atmosphere
 gravity,assumption,9.81,m/s^2,default simulation environment
 carry_distance,simulated_output,186.9,m,portfolio reference fixture

--- a/scripts/ci/generate_portfolio_demo_output.py
+++ b/scripts/ci/generate_portfolio_demo_output.py
@@ -89,6 +89,20 @@ def generate_portfolio_demo_output(output_path: Path | None = None) -> None:
             "source": "driver launch-condition fixture",
         },
         {
+            "quantity": "cd0",
+            "category": "assumption",
+            "value": "0.25",
+            "unit": "dimensionless",
+            "source": "ball aerodynamics fixture",
+        },
+        {
+            "quantity": "cl0",
+            "category": "assumption",
+            "value": "0.15",
+            "unit": "dimensionless",
+            "source": "ball aerodynamics fixture",
+        },
+        {
             "quantity": "air_density",
             "category": "assumption",
             "value": "1.225",


### PR DESCRIPTION
This PR fixes issue #3598 (originating from #3550/#3568) by adding the missing custom aerodynamic coefficients (`cd0` and `cl0`) to the portfolio demo output generated by `scripts/ci/generate_portfolio_demo_output.py`. The updated fixtures are correctly formatted and reflect the assumptions required to accurately reproduce the ball flight demo, effectively resolving the pending review feedback.

---
*PR created automatically by Jules for task [518245800372424415](https://jules.google.com/task/518245800372424415) started by @dieterolson*