### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2025-05-18 - Optimize bounding sphere radius computation in mesh primitive fitting
+**Learning:** `np.linalg.norm` evaluates element-wise square roots and allocates intermediate temporary arrays. Since `max` and `sqrt` are commutative for positive numbers, computing the maximum sum-of-squares first using `np.einsum`, then applying `sqrt` avoids memory allocations and performs exactly 1 square root instead of N square roots.
+**Action:** Replace `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` when calculating bounding sphere radii from mesh vertices to improve performance.

--- a/SPEC.md
+++ b/SPEC.md
@@ -523,6 +523,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
+| 2026-05-02 | 1.0.87  | Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using `np.einsum` instead of `np.linalg.norm` |
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,13 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        quat_list = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(quat_list[0]),
+            float(quat_list[1]),
+            float(quat_list[2]),
+            float(quat_list[3]),
+        )
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +122,13 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        quat_list = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(quat_list[0]),
+            float(quat_list[1]),
+            float(quat_list[2]),
+            float(quat_list[3]),
+        )
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,12 +43,12 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat_list = rot.as_quat().tolist()
+        quat_arr: Any = rot.as_quat()
         quat: tuple[float, float, float, float] = (
-            float(quat_list[0]),
-            float(quat_list[1]),
-            float(quat_list[2]),
-            float(quat_list[3]),
+            float(quat_arr[0]),
+            float(quat_arr[1]),
+            float(quat_arr[2]),
+            float(quat_arr[3]),
         )
 
         volume_ratio = mesh.volume / obb.volume
@@ -122,12 +122,12 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat_list = rot.as_quat().tolist()
+        quat_arr: Any = rot.as_quat()
         quat: tuple[float, float, float, float] = (
-            float(quat_list[0]),
-            float(quat_list[1]),
-            float(quat_list[2]),
-            float(quat_list[3]),
+            float(quat_arr[0]),
+            float(quat_arr[1]),
+            float(quat_arr[2]),
+            float(quat_arr[3]),
         )
 
         return PrimitiveFit(


### PR DESCRIPTION
Optimizes bounding sphere radius computation using `np.einsum` instead of `np.linalg.norm` to prevent temporary array allocations and redundant memory overhead. Updates `.jules/bolt.md` with the new performance learning. Fixes #3639

---
*PR created automatically by Jules for task [12088380468616678269](https://jules.google.com/task/12088380468616678269) started by @dieterolson*