### PR TITLE
⚡ Bolt: Optimize norm calculation in collision checking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,4 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+| 2026-04-30 | 1.0.12  | Bolt: Replaced np.linalg.norm with math.hypot in src/deployment/safety/collision.py for distance computation optimization |

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,7 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(*(point - self.position))
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +71,7 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(math.hypot(*(local_point - clamped)) - self.inflation)
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +113,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(*gradient)
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Fixes #3642 by replacing np.linalg.norm with math.hypot for 3D vector magnitude in high-frequency collision checks, avoiding numpy array allocation overhead for tiny inputs.

---
*PR created automatically by Jules for task [13588275166086454971](https://jules.google.com/task/13588275166086454971) started by @dieterolson*