### PR TITLE
Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -104,6 +104,7 @@ jobs:
         with: { python-version: "3.11" }
       - name: Install Quality Tools
         run: |
+          python -m ensurepip --upgrade || true
           python -m pip install ruff==0.14.10 "mypy>=1.15.0" bandit==1.7.7 pydocstyle==6.3.0
 
       - name: Lint

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -104,7 +104,6 @@ jobs:
         with: { python-version: "3.11" }
       - name: Install Quality Tools
         run: |
-          python -m ensurepip --upgrade || true
           python -m pip install ruff==0.14.10 "mypy>=1.15.0" bandit==1.7.7 pydocstyle==6.3.0
 
       - name: Lint

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## Optimize Sum of Squares in mesh primitive fitting
+**Learning:** np.max(np.linalg.norm(vertices, axis=1)) allocates intermediate temporary arrays. Replacing it with np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices))) computes exactly 1 square root instead of N square roots and avoids allocations.
+**Action:** Replaced np.max(np.linalg.norm(vertices, axis=1)) with np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices))) inside _cg_primitive_fitting.py

--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,6 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+
+## Performance Optimizations
+* Optimized bounding sphere radius calculation using einsum in _cg_primitive_fitting.py

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,13 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(q[0]),
+            float(q[1]),
+            float(q[2]),
+            float(q[3]),
+        )
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +122,13 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(q[0]),
+            float(q[1]),
+            float(q[2]),
+            float(q[3]),
+        )
 
         return PrimitiveFit(
             primitive_type="cylinder",


### PR DESCRIPTION
Fixes #3650

Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` inside `_cg_primitive_fitting.py` to avoid allocating intermediate temporary arrays and only compute exactly 1 square root instead of N square roots. Also updated the insights to `.jules/bolt.md` and `SPEC.md`.

---
*PR created automatically by Jules for task [15014021735687844051](https://jules.google.com/task/15014021735687844051) started by @dieterolson*