### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## Optimize bounding sphere radius computation
+**Learning:** Computing bounding sphere radius with `np.max(np.linalg.norm(vertices, axis=1))` allocates intermediate memory arrays, which degrades performance.
+**Action:** Use `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` to optimize bounding sphere radius computation and avoid intermediate array allocations.

--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,6 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+
+## Performance Optimizations
+- Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using np.einsum

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,8 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +117,8 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,8 +43,13 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        q = rot.as_quat().tolist()
-        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
+        quat_arr = rot.as_quat()
+        quat = (
+            float(quat_arr[0]),
+            float(quat_arr[1]),
+            float(quat_arr[2]),
+            float(quat_arr[3]),
+        )
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -117,8 +122,13 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        q = rot.as_quat().tolist()
-        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
+        quat_arr = rot.as_quat()
+        quat = (
+            float(quat_arr[0]),
+            float(quat_arr[1]),
+            float(quat_arr[2]),
+            float(quat_arr[3]),
+        )
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3641. Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` inside `_cg_primitive_fitting.py` to optimize bounding sphere radius computation and avoid intermediate temporary array allocations. Added optimization insight to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10719702666484091487](https://jules.google.com/task/10719702666484091487) started by @dieterolson*