### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,4 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+| 2026-05-02 | 1.0.87  | Bolt: Optimized `np.linalg.norm(..., axis=1)` to explicit `np.einsum` in bounding sphere radius computation |

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,13 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        quat_list = rot.as_quat().tolist()
+        quat = (
+            float(quat_list[0]),
+            float(quat_list[1]),
+            float(quat_list[2]),
+            float(quat_list[3]),
+        )
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +122,13 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        quat_list = rot.as_quat().tolist()
+        quat = (
+            float(quat_list[0]),
+            float(quat_list[1]),
+            float(quat_list[2]),
+            float(quat_list[3]),
+        )
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,13 +43,8 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat_list = rot.as_quat().tolist()
-        quat = (
-            float(quat_list[0]),
-            float(quat_list[1]),
-            float(quat_list[2]),
-            float(quat_list[3]),
-        )
+        q = rot.as_quat()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -122,13 +117,8 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat_list = rot.as_quat().tolist()
-        quat = (
-            float(quat_list[0]),
-            float(quat_list[1]),
-            float(quat_list[2]),
-            float(quat_list[3]),
-        )
+        q = rot.as_quat()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3653

Optimized bounding sphere radius computation in mesh primitive fitting by replacing np.linalg.norm(..., axis=1) with explicit np.einsum to improve performance.

---
*PR created automatically by Jules for task [55820356866438059](https://jules.google.com/task/55820356866438059) started by @dieterolson*