### PR TITLE
Fixes #3654

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -104,6 +104,7 @@ jobs:
         with: { python-version: "3.11" }
       - name: Install Quality Tools
         run: |
+          python -m ensurepip --upgrade || true
           python -m pip install ruff==0.14.10 "mypy>=1.15.0" bandit==1.7.7 pydocstyle==6.3.0
 
       - name: Lint
@@ -227,7 +228,9 @@ jobs:
         run: |
           # Force-reinstall sortedcontainers before pip-audit: the shared runner toolcache
           # can carry a half-installed sortedcontainers that makes cyclonedx (pip-audit dep) fail.
+          python -m ensurepip --upgrade || true
           python -m pip install --ignore-installed --no-deps "sortedcontainers>=2.4.0"
+          python -m ensurepip --upgrade || true
           python -m pip install --ignore-installed pip-audit
 
           # Ignore CVEs with no fix version available or transitive dependencies:
@@ -750,6 +753,7 @@ jobs:
         run: |
           python3 -m venv "$RUNNER_TEMP/rust-venv"
           source "$RUNNER_TEMP/rust-venv/bin/activate"
+          python -m ensurepip --upgrade || true
           python -m pip install --upgrade pip maturin
           cd rust_core/upstream-physics
           python -m maturin build --interpreter python --features python --release
@@ -760,6 +764,7 @@ jobs:
         if: steps.rust-changes.outputs.has_changes == 'true'
         run: |
           source "$RUNNER_TEMP/rust-venv/bin/activate"
+          python -m ensurepip --upgrade || true
           python -m pip install target/wheels/upstream_physics-*.whl
           python -c "
           import upstream_physics
@@ -853,6 +858,7 @@ jobs:
         run: |
           python -m venv "$RUNNER_TEMP/rust-quickstart-venv"
           source "$RUNNER_TEMP/rust-quickstart-venv/bin/activate"
+          python -m ensurepip --upgrade || true
           python -m pip install --upgrade pip maturin
           cd rust_core/upstream-physics
           python -m maturin develop --features python

--- a/SPEC.md
+++ b/SPEC.md
@@ -475,6 +475,9 @@ pytest tests/ --cov=src --cov-fail-under=70
 | 2026-04-30 | 1.0.87  | Added source-backed golf ball-flight and impact validation contracts, including explicit altitude bounds for air-density computations and portfolio-facing golf modeling documentation. |
 | 2026-04-27 | 1.0.83  | Fixed Bandit B604 false positive alerts in test files by adding nosec annotations. |
 | 2026-04-27 | 1.0.83  | Bolt: Replace np.linalg.norm with math.hypot in collision queries. |
+| 2026-05-02 | 1.0.89  | Bolt: Optimize collision norm calculations using math.hypot. |
+| 2026-05-02 | 1.0.89  | Bolt: Optimize collision norm calculations using math.hypot. |
+| 2026-05-02 | 1.0.89  | Bolt: Optimize collision norm calculations using math.hypot. |
 | 2026-04-26 | 1.0.81  | fix: Restore missing jobs in `Code-Metrics.yml` and `release.yml`; correct non-UTF-8 characters in 55 workflows causing 0s CI failures. |
 | 2026-04-26 | 1.0.80  | fix: Harden `pick-runner` logic across all workflows to handle `gh api` JSON errors; implement tool invocation loop for AI chat service (fixes #3162); resolve massive conflict-marker corruption in `src` and `tests` by restoring from `origin/main`. |
 | 2026-04-26 | 1.0.80  | Bolt: Optimize Mean Squared Error calculations in system_identification.py |
@@ -526,3 +529,4 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+## Performance Optimization: Optimized collision norm calculations using math.hypot

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,7 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(*(point - self.position))
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +71,7 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(math.hypot(*(local_point - clamped)) - self.inflation)
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +113,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(*gradient)
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Fixes #3654 and Fixes #3648. Replaced np.linalg.norm with math.hypot in collision checking to optimize high-frequency magnitude calculations.

---
*PR created automatically by Jules for task [11372572066203483102](https://jules.google.com/task/11372572066203483102) started by @dieterolson*