### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+## 2026-05-19 - Optimize bounding sphere radius computation
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` allocates intermediate temporary arrays. Computing the squared distances using `np.einsum` and then finding the maximum avoids allocating N-sized arrays for norms, making it faster.
+**Action:** Replace `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` to optimize bounding sphere computations and avoid intermediate temporary array allocations.

--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,4 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+| 2026-05-19 | 1.0.87  | Bolt: Optimize bounding sphere radius computation in mesh primitive fitting using np.einsum |

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,12 +43,12 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        q = rot.as_quat().tolist()
+        q_arr = rot.as_quat()
         quat: tuple[float, float, float, float] = (
-            float(q[0]),
-            float(q[1]),
-            float(q[2]),
-            float(q[3]),
+            float(q_arr[0]),
+            float(q_arr[1]),
+            float(q_arr[2]),
+            float(q_arr[3]),
         )
 
         volume_ratio = mesh.volume / obb.volume
@@ -122,12 +122,12 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        q = rot.as_quat().tolist()
+        q_arr = rot.as_quat()
         quat: tuple[float, float, float, float] = (
-            float(q[0]),
-            float(q[1]),
-            float(q[2]),
-            float(q[3]),
+            float(q_arr[0]),
+            float(q_arr[1]),
+            float(q_arr[2]),
+            float(q_arr[3]),
         )
 
         return PrimitiveFit(

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,13 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(q[0]),
+            float(q[1]),
+            float(q[2]),
+            float(q[3]),
+        )
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +122,13 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat: tuple[float, float, float, float] = (
+            float(q[0]),
+            float(q[1]),
+            float(q[2]),
+            float(q[3]),
+        )
 
         return PrimitiveFit(
             primitive_type="cylinder",


### PR DESCRIPTION
Fixes #3641. Fixes #3639. Replaced np.max(np.linalg.norm(vertices, axis=1)) with np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices))) inside _cg_primitive_fitting.py and added insight to .jules/bolt.md to optimize bounding sphere computations and avoid intermediate temporary array allocations.

---
*PR created automatically by Jules for task [15092679821655160897](https://jules.google.com/task/15092679821655160897) started by @dieterolson*