### PR TITLE
Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2026-05-18 - Optimize bounding sphere radius computation
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` creates an intermediate array of distances before finding the max. Replacing it with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` computes the max squared distance directly, avoiding temporary array allocation overhead.
+**Action:** When computing maximum vector magnitudes (e.g. for bounding spheres), use `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` instead of `np.max(np.linalg.norm(vertices, axis=1))` to avoid intermediate temporary array allocations.

--- a/SPEC.md
+++ b/SPEC.md
@@ -523,6 +523,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
+| 2026-05-18 | 1.0.87  | Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using `np.einsum` |
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -43,7 +43,8 @@ def fit_box(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         volume_ratio = mesh.volume / obb.volume
         error = 1.0 - volume_ratio
@@ -116,7 +117,8 @@ def fit_cylinder(mesh: Any) -> PrimitiveFit:
         from scipy.spatial.transform import Rotation
 
         rot = Rotation.from_matrix(transform[:3, :3])
-        quat = tuple(rot.as_quat().tolist())
+        q = rot.as_quat().tolist()
+        quat = (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
 
         return PrimitiveFit(
             primitive_type="cylinder",

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3662

Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` inside `_cg_primitive_fitting.py` to optimize bounding sphere computations and avoid intermediate temporary array allocations. Added insights to `.jules/bolt.md` and documented the optimization in `SPEC.md`.

---
*PR created automatically by Jules for task [17711369045046179337](https://jules.google.com/task/17711369045046179337) started by @dieterolson*