### PR TITLE
Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2025-05-19 - Optimize max norm calculation
+**Learning:** When finding the maximum vector magnitude (e.g., for bounding sphere radii), computing the maximum of squared distances first using `np.max(np.einsum('ij,ij->i', vectors, vectors))` and applying a single `np.sqrt()` is mathematically equivalent to `np.max(np.linalg.norm(vectors, axis=1))` but significantly faster. It avoids intermediate N-sized array allocations and only computes 1 square root instead of N.
+**Action:** Replace `np.max(np.linalg.norm(vectors, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vectors, vectors)))` when calculating bounding sphere radii or maximum vector magnitudes.

--- a/SPEC.md
+++ b/SPEC.md
@@ -523,6 +523,8 @@ pytest tests/ --cov=src --cov-fail-under=70
 Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
+| 2026-05-19 | 1.0.87  | Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using `np.einsum` |
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+| 2026-05-19 | 1.0.87  | Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using np.einsum |

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3644

Fixes #3639
Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` inside `_cg_primitive_fitting.py`. This avoids allocating intermediate temporary arrays and only computes exactly 1 square root instead of $N$ square roots. Also updated the insights to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7063375577362834181](https://jules.google.com/task/7063375577362834181) started by @dieterolson*