### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2025-05-18 - Optimize bounding sphere computation
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` is relatively slow for small inner dimensions because of internal overhead in NumPy and intermediate allocations. Replacing it with `np.sqrt(np.max(np.einsum('ij,ij->i', x, x)))` computes the identical L2 norm while avoiding the overhead and allocations, yielding significant performance speedups.
+**Action:** When computing bounding sphere radiuses, use `np.sqrt(np.max(np.einsum('ij,ij->i', x, x)))` instead of `np.max(np.linalg.norm(x, axis=1))` to improve performance.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3655.

Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices)))` inside `_cg_primitive_fitting.py` and added insight to `.jules/bolt.md` to optimize bounding sphere computations and avoid intermediate temporary array allocations.

---
*PR created automatically by Jules for task [1232719599198867822](https://jules.google.com/task/1232719599198867822) started by @dieterolson*