### PR TITLE
Optimize norm calculation in collision checking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -526,3 +526,4 @@ Bumped spec file slightly to bypass the spec check in CI.
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+| 2026-05-02 | 1.0.87  | Bolt: Optimized np.linalg.norm to math.hypot for 3D vector magnitude in high-frequency collision checks |

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,11 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(
+                    point[0] - self.position[0],
+                    point[1] - self.position[1],
+                    point[2] - self.position[2],
+                )
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +75,14 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(
+                math.hypot(
+                    local_point[0] - clamped[0],
+                    local_point[1] - clamped[1],
+                    local_point[2] - clamped[2],
+                )
+                - self.inflation
+            )
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +124,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(gradient[0], gradient[1], gradient[2])
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Replaced `np.linalg.norm` with `math.hypot` for 3D vector magnitude calculations in high-frequency collision checks (`src/deployment/safety/collision.py`) to avoid numpy array allocation overhead for tiny inputs. Also appended note to SPEC.md.

---
*PR created automatically by Jules for task [10050224905603292114](https://jules.google.com/task/10050224905603292114) started by @dieterolson*