### PR TITLE
Fixes #3694: Preserve float accumulation in bounding sphere radius computation

### DIFF
--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,8 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        v_f = np.asarray(vertices, dtype=np.float64)
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", v_f, v_f))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3694: Preserve float accumulation in bounding sphere radius computation

Casts vertices to `np.float64` before using `np.einsum('ij,ij->i', v_f, v_f)` to avoid integer overflows and subsequent `NaN` errors during the `np.sqrt` bounding sphere radius computation.

---
*PR created automatically by Jules for task [12772731033717389246](https://jules.google.com/task/12772731033717389246) started by @dieterolson*