### PR TITLE
Optimize norm calculations in collision queries

### DIFF
--- a/src/robotics/planning/collision/_distance_queries.py
+++ b/src/robotics/planning/collision/_distance_queries.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import math
-
 import numpy as np
 
 from ._primitive_shapes import Capsule, Sphere
@@ -60,7 +58,7 @@ def _sphere_sphere_distance(
     if not (sphere_a is not None):
         raise ValueError("sphere_a must be provided")
     diff = sphere_b.center - sphere_a.center
-    center_dist = math.hypot(*diff)
+    center_dist = float(np.sqrt(np.vdot(diff, diff)))
 
     if center_dist < 1e-10:
         # Concentric spheres
@@ -89,7 +87,7 @@ def _sphere_capsule_distance(
 
     # Now it's sphere-sphere distance
     diff = sphere.center - closest_on_axis
-    center_dist = math.hypot(*diff)
+    center_dist = float(np.sqrt(np.vdot(diff, diff)))
 
     if center_dist < 1e-10:
         # Sphere center on capsule axis
@@ -121,7 +119,7 @@ def _capsule_capsule_distance(
     )
 
     diff = closest_b - closest_a
-    center_dist = math.hypot(*diff)
+    center_dist = float(np.sqrt(np.vdot(diff, diff)))
 
     if center_dist < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
@@ -207,10 +205,10 @@ def _gjk_distance(
     direction = prim_b.compute_support(np.array([1, 0, 0])) - prim_a.compute_support(
         np.array([-1, 0, 0])
     )
-    if math.hypot(*direction) < 1e-10:
+    if float(np.sqrt(np.vdot(direction, direction))) < 1e-10:
         direction = np.array([1.0, 0.0, 0.0])
     else:
-        direction = direction / math.hypot(*direction)
+        direction = direction / float(np.sqrt(np.vdot(direction, direction)))
 
     # Simplex vertices
     simplex: list[np.ndarray] = []
@@ -226,7 +224,7 @@ def _gjk_distance(
         if np.dot(support, direction) < 0 and len(simplex) == 0:
             # Return distance between supports
             diff = support_b - support_a
-            dist = float(math.hypot(*diff))
+            dist = float(np.sqrt(np.vdot(diff, diff)))
             return dist, support_a, support_b
 
         simplex.append(support)
@@ -234,7 +232,7 @@ def _gjk_distance(
         # Update simplex and direction
         if len(simplex) == 1:
             direction = -simplex[0]
-            norm = math.hypot(*direction)
+            norm = float(np.sqrt(np.vdot(direction, direction)))
             if norm < 1e-10:
                 # Origin at support point (collision)
                 return 0.0, support_a, support_b
@@ -246,7 +244,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(math.hypot(*closest))
+            dist = float(np.sqrt(np.vdot(closest, closest)))
             if dist < 1e-6:
                 # Origin very close to simplex (collision)
                 return 0.0, support_a, support_b
@@ -259,7 +257,7 @@ def _gjk_distance(
             t = np.dot(ao, ab) / (np.dot(ab, ab) + 1e-10)
             t = np.clip(t, 0.0, 1.0)
             closest = simplex[0] + t * ab
-            dist = float(math.hypot(*closest))
+            dist = float(np.sqrt(np.vdot(closest, closest)))
             if dist < 1e-6:
                 return 0.0, support_a, support_b
             direction = -closest / dist
@@ -268,7 +266,7 @@ def _gjk_distance(
     support_a = prim_a.compute_support(direction)
     support_b = prim_b.compute_support(-direction)
     diff = support_b - support_a
-    return float(math.hypot(*diff)), support_a, support_b
+    return float(np.sqrt(np.vdot(diff, diff))), support_a, support_b
 
 
 def check_primitive_collision(

--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -43,7 +42,7 @@ class Sphere(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point)
         diff = np.ravel(point - self.center)
-        return math.hypot(*np.ravel(diff)) <= self.radius
+        return float(np.sqrt(np.vdot(diff, diff))) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -52,7 +51,7 @@ class Sphere(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = float(np.sqrt(np.vdot(direction, direction)))
         if norm < 1e-10:
             return self.center.copy()
         return self.center + self.radius * direction / norm
@@ -175,13 +174,15 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return math.hypot(*np.ravel(self.point_b - self.point_a))
+        return float(
+            np.sqrt(np.vdot(self.point_b - self.point_a, self.point_b - self.point_a))
+        )
 
     @property
     def axis(self) -> np.ndarray:
         """Get capsule axis direction (normalized)."""
         diff = self.point_b - self.point_a
-        length = math.hypot(*np.ravel(diff))
+        length = float(np.sqrt(np.vdot(diff, diff)))
         if length < 1e-10:
             return np.array([0.0, 0.0, 1.0])
         return diff / length
@@ -218,7 +219,7 @@ class Capsule(GeometricPrimitive):
         point = np.asarray(point)
         closest = self._closest_point_on_segment(point)
         diff = np.ravel(point - closest)
-        return math.hypot(*np.ravel(diff)) <= self.radius
+        return float(np.sqrt(np.vdot(diff, diff))) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -227,7 +228,7 @@ class Capsule(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = float(np.sqrt(np.vdot(direction, direction)))
         if norm < 1e-10:
             return self.point_a.copy()
         d = direction / norm
@@ -271,7 +272,7 @@ class Cylinder(GeometricPrimitive):
 
         # Normalize axis
         diff = np.ravel(self.axis)
-        norm = math.hypot(*np.ravel(diff))
+        norm = float(np.sqrt(np.vdot(diff, diff)))
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm
@@ -319,7 +320,7 @@ class Cylinder(GeometricPrimitive):
 
         # Check radius (perpendicular distance)
         perp = to_point - along_axis * self.axis
-        return math.hypot(*np.ravel(perp)) <= self.radius
+        return float(np.sqrt(np.vdot(perp, perp))) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -328,7 +329,7 @@ class Cylinder(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = float(np.sqrt(np.vdot(direction, direction)))
         if norm < 1e-10:
             return self.center.copy()
 
@@ -346,7 +347,7 @@ class Cylinder(GeometricPrimitive):
             axis_support = self.center - self.half_height * self.axis
 
         # Support on radius (perpendicular)
-        perp_norm = math.hypot(*np.ravel(d_perp))
+        perp_norm = float(np.sqrt(np.vdot(d_perp, d_perp)))
         if perp_norm > 1e-10:
             return axis_support + self.radius * d_perp / perp_norm
 
@@ -400,7 +401,7 @@ class ConvexHull(GeometricPrimitive):
         # Simple heuristic: point is inside if closer to center than
         # all vertices in the same direction
         to_point = point - self.center
-        norm = math.hypot(*np.ravel(to_point))
+        norm = float(np.sqrt(np.vdot(to_point, to_point)))
         if norm < 1e-10:
             return True  # At center
 

--- a/src/robotics/planning/collision/collision_types.py
+++ b/src/robotics/planning/collision/collision_types.py
@@ -5,7 +5,6 @@ This module defines data structures for collision queries and results.
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
@@ -120,7 +119,7 @@ class DistanceResult:
             # ⚡ Bolt: Element-wise norm computation is faster than np.linalg.norm(..., axis=None) for tiny vectors
             # using math.hypot equivalent
             arr = np.ravel(self.normal)
-            norm = 0.0 if arr.size == 0 else math.hypot(*arr)
+            norm = 0.0 if arr.size == 0 else float(np.sqrt(np.vdot(arr, arr)))
             if norm > 1e-10:
                 object.__setattr__(self, "normal", self.normal / norm)
 


### PR DESCRIPTION
Replaced the use of `math.hypot(*np.ravel(x))` and `math.hypot(*x)` with `float(np.sqrt(np.vdot(x, x)))` across the collision query modules (`_distance_queries.py`, `_primitive_shapes.py`, `collision_types.py`). This provides significant performance improvements by avoiding array allocations and the overhead of element-wise evaluation.

Fixes #3696

---
*PR created automatically by Jules for task [16895367986673486886](https://jules.google.com/task/16895367986673486886) started by @dieterolson*