### PR TITLE
Fixes #3643: Optimize bounding sphere radius computation

### DIFF
--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,8 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        v = np.asarray(vertices, dtype=np.float64)
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", v, v))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3643

Replaces standard bounding sphere radius computation logic with an optimized einsum implementation that avoids intermediate memory allocations.

---
*PR created automatically by Jules for task [9055007782785171893](https://jules.google.com/task/9055007782785171893) started by @dieterolson*