### PR TITLE
Optimize norm calculation in collision checking

### DIFF
--- a/src/robotics/planning/collision/collision_checker.py
+++ b/src/robotics/planning/collision/collision_checker.py
@@ -6,6 +6,7 @@ for robot motion planning.
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
@@ -391,8 +392,8 @@ class CollisionChecker:
                     point_a = pa
                     point_b = pb
                     diff = pb - pa
-                    # ⚡ Bolt: np.sqrt(np.vdot) is ~1.5x faster and shape/type safe
-                    norm = np.sqrt(np.vdot(diff, diff))
+                    # ⚡ Bolt: math.hypot is faster than np.sqrt(np.vdot) for tiny vectors
+                    norm = float(math.hypot(*diff))
                     if norm > 1e-10:
                         normal = diff / norm
 
@@ -413,8 +414,8 @@ class CollisionChecker:
                         point_a = pa
                         point_b = pb
                         diff = pb - pa
-                        # ⚡ Bolt: np.sqrt(np.vdot) is ~1.5x faster and shape/type safe
-                        norm = np.sqrt(np.vdot(diff, diff))
+                        # ⚡ Bolt: math.hypot is faster than np.sqrt(np.vdot) for tiny vectors
+                        norm = float(math.hypot(*diff))
                         if norm > 1e-10:
                             normal = diff / norm
 


### PR DESCRIPTION
Fixes #3668

Replaced `np.sqrt(np.vdot(diff, diff))` with `math.hypot(*diff)` for calculating the distance norm in `src/robotics/planning/collision/collision_checker.py`. This provides faster performance for tiny arrays while remaining mathematically identical.

---
*PR created automatically by Jules for task [4151767326800091948](https://jules.google.com/task/4151767326800091948) started by @dieterolson*