### PR TITLE
Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,8 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        vertices_f = np.asarray(vertices, dtype=np.float64)
+        radius = float(np.sqrt(np.max(np.einsum('ij,ij->i', vertices_f, vertices_f))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Optimized the computation of bounding sphere radii within the mesh primitive fitting module (`fit_sphere`). 

Previously, `np.max(np.linalg.norm(vertices, axis=1))` was computing intermediate `N`-sized norm arrays and resolving square roots per-vertex prior to reduction. I replaced this logic with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices_f, vertices_f)))`, mapping to pure math equivalence but strictly avoiding excessive N-array allocations and moving the cost of the `sqrt` strictly to the singular maximum magnitude.

Testing on the local environment verifies equivalent outcomes.

Fixes #3670

---
*PR created automatically by Jules for task [17491796708172561982](https://jules.google.com/task/17491796708172561982) started by @dieterolson*