### PR TITLE
Fixes #3651: Optimize norm calculation in collision checks

### DIFF
--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,7 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(*(point - self.position))
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +71,7 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(math.hypot(*(local_point - clamped)) - self.inflation)
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +113,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(*gradient)
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Replaced np.linalg.norm with math.hypot for 3D vector magnitudes in high-frequency collision checks within src/deployment/safety/collision.py. Fixes #3673

---
*PR created automatically by Jules for task [822343365667579904](https://jules.google.com/task/822343365667579904) started by @dieterolson*