### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+## 2025-05-19 - Optimize bounding sphere radius computation using einsum
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` computes the norms for all vertices, allocating intermediate memory which is slow.
+**Action:** Replace `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` when finding the maximum distance from center (e.g., in bounding sphere computation) to prevent intermediate array allocations and improve performance.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,8 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        # ⚡ Bolt: Using np.einsum is faster than np.linalg.norm for magnitudes
+        radius = float(np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Optimizes bounding sphere radius computation using np.einsum instead of np.linalg.norm to prevent temporary array allocations and redundant memory overhead. Updates .jules/bolt.md with the new performance learning. Fixes #3640

---
*PR created automatically by Jules for task [228433794656841206](https://jules.google.com/task/228433794656841206) started by @dieterolson*