### PR TITLE
⚡ Bolt: Optimize norm computation in ball trajectory analysis

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2026-05-02 - Optimize norm computation in ball trajectory analysis
+**Learning:** `np.linalg.norm(v[:2])` and `np.sqrt(x**2 + y**2)` allocate a temporary array in memory or evaluate slowly, making them slower than `math.hypot` for 2D vector magnitude computations.
+**Action:** Replace `np.linalg.norm(v[:2])` and `np.sqrt(x**2 + y**2)` with `math.hypot(x, y)` to avoid numpy array overhead and allocations, making it significantly faster for small 2D vectors in high-frequency calculations.

--- a/SPEC.md
+++ b/SPEC.md
@@ -522,6 +522,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 ## 2026-04-28 Spec Bump
 Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
+| 2026-05-02 | 1.0.86  | Bolt: Optimize norm computation in ball trajectory analysis |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
 
 ## 3D Vector Distances Note

--- a/src/shared/python/physics/ball_trajectory_analysis.py
+++ b/src/shared/python/physics/ball_trajectory_analysis.py
@@ -8,6 +8,8 @@ decomposition (issue #2486).
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from src.shared.python.physics.ball_launch_conditions import TrajectoryPoint
@@ -24,7 +26,7 @@ class TrajectoryAnalysisMixin:
         if not trajectory:
             return 0.0
         last_pos = trajectory[-1].position
-        return float(np.sqrt(last_pos[0] ** 2 + last_pos[1] ** 2))
+        return float(math.hypot(last_pos[0], last_pos[1]))
 
     def calculate_max_height(self, trajectory: list[TrajectoryPoint]) -> float:
         """Calculate maximum height achieved in meters."""
@@ -49,7 +51,7 @@ class TrajectoryAnalysisMixin:
         if len(trajectory) < 2:
             return 0.0
         v = trajectory[-1].velocity
-        v_horiz = np.linalg.norm(v[:2])
+        v_horiz = float(math.hypot(v[0], v[1]))
         if v_horiz < NUMERICAL_EPSILON:
             return 90.0
         return float(np.degrees(np.arctan2(-v[2], v_horiz)))


### PR DESCRIPTION
Fixes #3704

Optimized norm computation by replacing `np.linalg.norm(v[:2])` and `np.sqrt(x**2 + y**2)` with `math.hypot(x, y)` in `ball_trajectory_analysis.py`.

---
*PR created automatically by Jules for task [17050010519422199123](https://jules.google.com/task/17050010519422199123) started by @dieterolson*