### PR TITLE
Optimize bounding sphere radius computation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+## 2026-05-18 - Optimize bounding sphere radius computation
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` computes norms for all vertices by creating intermediate N-sized array allocations for squared differences before taking the maximum.
+**Action:** Replace `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` to avoid intermediate N-sized array allocations, resulting in faster bounding sphere radius computation.

--- a/SPEC.md
+++ b/SPEC.md
@@ -523,6 +523,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
+| 2026-05-18 | 1.0.87  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in bounding sphere radius computation |
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3667

Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` in `src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py`. This avoids intermediate N-sized array allocations, improving the performance of the bounding sphere radius computation. Also updated `.jules/bolt.md` and `SPEC.md` with the relevant performance insight.

---
*PR created automatically by Jules for task [16157837372526877926](https://jules.google.com/task/16157837372526877926) started by @dieterolson*