### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2026-05-18 - [Optimize bounding sphere radius computation]
+**Learning:** `np.max(np.linalg.norm(vertices, axis=1))` computes the norms using intermediate memory allocations. Replacing it with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` delays the square root to after the max operation, avoiding allocating the full norms array while gaining performance speedups.
+**Action:** Use `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` when finding the maximum norm of a vector array to optimize computation speed.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3706
Fixes #3658

Replaced `np.max(np.linalg.norm(vertices, axis=1))` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` inside `_cg_primitive_fitting.py`. Also added the insight to the performance journal `.jules/bolt.md`. This change speeds up bounding sphere radius computation by reducing intermediate array allocations and square roots.

---
*PR created automatically by Jules for task [17637716140286678877](https://jules.google.com/task/17637716140286678877) started by @dieterolson*