### PR TITLE
Fixes #3675: Optimize bounding sphere radius computation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -524,5 +524,6 @@ Bumped spec file slightly to bypass the spec check in CI.
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
 
+| 2026-05-01 | 1.0.87  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in bounding sphere radius computation |
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3675

Replaced the `np.max(np.linalg.norm(vertices, axis=1))` computation with the computationally equivalent but more efficient `np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices)))` for the bounding sphere radius in `src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py`. This avoids intermediate allocations and `linalg.norm` overhead, improving performance. Additionally, updated `SPEC.md` and successfully ran formatters and tests.

---
*PR created automatically by Jules for task [245618672095626614](https://jules.google.com/task/245618672095626614) started by @dieterolson*