### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2026-05-18 - Optimize bounding sphere radius computation in mesh primitive fitting
+**Learning:** `np.linalg.norm(..., axis=1)` creates an intermediate array allocating memory when computing distances over arrays, making operations slow and expensive.
+**Action:** Replaced `np.linalg.norm` with `np.einsum` to prevent temporary array allocations and redundant memory overhead.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3659

Optimizes bounding sphere radius computation by replacing `np.linalg.norm(vertices, axis=1)` with `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))`. This mathematically identical approach prevents temporary array allocations and reduces redundant memory overhead.

The `.jules/bolt.md` documentation file has also been updated with this performance learning.

---
*PR created automatically by Jules for task [14110380609946708945](https://jules.google.com/task/14110380609946708945) started by @dieterolson*