### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-05-01 - [Optimize UI re-rendering and data resorting during filtering]
 **Learning:** In React, typing rapidly into an input field (like a data filter) that triggers state updates at the root component level can cause severe performance lag if expensive operations like array sorting (`[...rows].sort()`) or rendering large child components (like a `DataTable`) are executed synchronously on every single keystroke render cycle.
 **Action:** Always wrap expensive derived computations in `useMemo()` with appropriate dependency arrays so they only re-compute when their specific inputs change, and wrap large, purely presentational child components in `React.memo()` so they don't blindly re-render when a parent's unrelated state (like the filter input text) changes.
+
+## 2026-05-18 - Optimize bounding sphere radius computation
+**Learning:** `np.linalg.norm(..., axis=1)` creates temporary array allocations which are costly for computing norms of small, inner dimensions across large outer dimensions (like a large array of 3D vertices).
+**Action:** In `fit_sphere` or similar situations, compute bounding sphere radii using `np.sqrt(np.max(np.einsum('ij,ij->i', vertices, vertices)))` instead of `np.max(np.linalg.norm(vertices, axis=1))` to prevent temporary array allocations and redundant memory overhead.

--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,7 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices, vertices))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3707

Optimizes bounding sphere radius computation using np.einsum instead of np.linalg.norm to prevent temporary array allocations and redundant memory overhead. Updates .jules/bolt.md with the new performance learning.

---
*PR created automatically by Jules for task [12869315745087065270](https://jules.google.com/task/12869315745087065270) started by @dieterolson*