### PR TITLE
⚡ Bolt: Optimize bounding sphere radius computation in mesh primitive fitting

### DIFF
--- a/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
+++ b/src/shared/python/humanoid_character_builder/mesh/_cg_primitive_fitting.py
@@ -72,7 +72,8 @@ def fit_sphere(mesh: Any) -> PrimitiveFit:
     try:
         center = tuple(mesh.centroid.tolist())
         vertices = mesh.vertices - mesh.centroid
-        radius = float(np.max(np.linalg.norm(vertices, axis=1)))
+        vertices_f = np.asarray(vertices, dtype=np.float64)
+        radius = float(np.sqrt(np.max(np.einsum("ij,ij->i", vertices_f, vertices_f))))
 
         sphere_volume = (4 / 3) * np.pi * radius**3
         volume_ratio = mesh.volume / sphere_volume


### PR DESCRIPTION
Fixes #3653\n\nOptimized bounding sphere radius computation in mesh primitive fitting by replacing np.linalg.norm(..., axis=1) with explicit np.einsum to improve performance.

---
*PR created automatically by Jules for task [8651666965772087620](https://jules.google.com/task/8651666965772087620) started by @dieterolson*