### PR TITLE
Fixes #3647: Optimize norm calculation in collision checking

### DIFF
--- a/src/robotics/planning/collision/_primitive_shapes.py
+++ b/src/robotics/planning/collision/_primitive_shapes.py
@@ -42,8 +42,8 @@ class Sphere(GeometricPrimitive):
         if not (point is not None):
             raise ValueError("point must be provided")
         point = np.asarray(point)
-        diff = np.ravel(point - self.center)
-        return math.hypot(*np.ravel(diff)) <= self.radius
+        diff = point - self.center
+        return math.hypot(*diff) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -52,7 +52,7 @@ class Sphere(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
         return self.center + self.radius * direction / norm
@@ -175,13 +175,13 @@ class Capsule(GeometricPrimitive):
     @property
     def length(self) -> float:
         """Get capsule length (distance between endpoints)."""
-        return math.hypot(*np.ravel(self.point_b - self.point_a))
+        return math.hypot(*(self.point_b - self.point_a))
 
     @property
     def axis(self) -> np.ndarray:
         """Get capsule axis direction (normalized)."""
         diff = self.point_b - self.point_a
-        length = math.hypot(*np.ravel(diff))
+        length = math.hypot(*diff)
         if length < 1e-10:
             return np.array([0.0, 0.0, 1.0])
         return diff / length
@@ -217,8 +217,8 @@ class Capsule(GeometricPrimitive):
             raise ValueError("point must be provided")
         point = np.asarray(point)
         closest = self._closest_point_on_segment(point)
-        diff = np.ravel(point - closest)
-        return math.hypot(*np.ravel(diff)) <= self.radius
+        diff = point - closest
+        return math.hypot(*diff) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -227,7 +227,7 @@ class Capsule(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.point_a.copy()
         d = direction / norm
@@ -270,8 +270,8 @@ class Cylinder(GeometricPrimitive):
             raise ValueError("height must be positive")
 
         # Normalize axis
-        diff = np.ravel(self.axis)
-        norm = math.hypot(*np.ravel(diff))
+        diff = self.axis
+        norm = math.hypot(*diff)
         if norm < 1e-10:
             raise ValueError("axis must be non-zero")
         self.axis = self.axis / norm
@@ -319,7 +319,7 @@ class Cylinder(GeometricPrimitive):
 
         # Check radius (perpendicular distance)
         perp = to_point - along_axis * self.axis
-        return math.hypot(*np.ravel(perp)) <= self.radius
+        return math.hypot(*perp) <= self.radius
 
     def compute_support(self, direction: np.ndarray) -> np.ndarray:
         """Compute support point."""
@@ -328,7 +328,7 @@ class Cylinder(GeometricPrimitive):
         if not (direction is not None):
             raise ValueError("direction must be provided")
         direction = np.asarray(direction)
-        norm = math.hypot(*np.ravel(direction))
+        norm = math.hypot(*direction)
         if norm < 1e-10:
             return self.center.copy()
 
@@ -346,7 +346,7 @@ class Cylinder(GeometricPrimitive):
             axis_support = self.center - self.half_height * self.axis
 
         # Support on radius (perpendicular)
-        perp_norm = math.hypot(*np.ravel(d_perp))
+        perp_norm = math.hypot(*d_perp)
         if perp_norm > 1e-10:
             return axis_support + self.radius * d_perp / perp_norm
 
@@ -400,7 +400,7 @@ class ConvexHull(GeometricPrimitive):
         # Simple heuristic: point is inside if closer to center than
         # all vertices in the same direction
         to_point = point - self.center
-        norm = math.hypot(*np.ravel(to_point))
+        norm = math.hypot(*to_point)
         if norm < 1e-10:
             return True  # At center
 

--- a/src/robotics/planning/collision/collision_types.py
+++ b/src/robotics/planning/collision/collision_types.py
@@ -119,8 +119,7 @@ class DistanceResult:
             # Normalize the normal vector
             # ⚡ Bolt: Element-wise norm computation is faster than np.linalg.norm(..., axis=None) for tiny vectors
             # using math.hypot equivalent
-            arr = np.ravel(self.normal)
-            norm = 0.0 if arr.size == 0 else math.hypot(*arr)
+            norm = math.hypot(*self.normal)
             if norm > 1e-10:
                 object.__setattr__(self, "normal", self.normal / norm)
 


### PR DESCRIPTION
Fixes #3647

This PR replaces `np.linalg.norm` and `math.hypot(*np.ravel(diff))` with `math.hypot(*diff)` for 3D vector magnitude in high-frequency collision checks, avoiding numpy array allocation overhead for tiny inputs.

---
*PR created automatically by Jules for task [3445611008383539962](https://jules.google.com/task/3445611008383539962) started by @dieterolson*