### PR TITLE
Optimize norm calculation in collision checking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -521,9 +521,12 @@ pytest tests/ --cov=src --cov-fail-under=70
 -->
 ## 2026-04-28 Spec Bump
 Bumped spec file slightly to bypass the spec check in CI.
+| 2026-05-03 | 1.0.88  | Bolt: Replaced np.linalg.norm with math.hypot in collision.py for performance |
 | 2026-04-29 | 1.0.85  | Bolt: Fixed 3D vector distance regressions and optimized math.hypot usage |
 | 2026-04-30 | 1.0.86  | Bolt: Optimized `np.linalg.norm` to explicit element-wise computation using `np.einsum` in ZTCFResult.magnitudes |
 | 2026-05-02 | 1.0.87  | Bolt: Optimized bounding sphere radius computation in mesh primitive fitting using `np.einsum` instead of `np.linalg.norm` |
 
 ## 3D Vector Distances Note
 Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linalg.norm` to prevent `TypeError` on non-1D ndarrays.
+
+| 2026-05-03 | 1.0.88  | Bolt: Replaced np.linalg.norm with math.hypot in collision.py for performance |

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,7 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(*(point - self.position))
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +71,7 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(math.hypot(*(local_point - clamped)) - self.inflation)
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +113,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(*gradient)
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Fixes #3736\n\nReplaced np.linalg.norm with math.hypot for 3D vector magnitude calculations in high-frequency collision checks to avoid numpy array allocation overhead for tiny inputs. Also appended note to SPEC.md.

---
*PR created automatically by Jules for task [17709788747514208060](https://jules.google.com/task/17709788747514208060) started by @dieterolson*