### PR TITLE
Optimize norm calculation in collision checking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -471,6 +471,7 @@ pytest tests/ --cov=src --cov-fail-under=70
 ## 12. Change Log
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| 2026-05-02 | 1.0.89  | Optimized norm calculation in collision checking using `math.hypot`. |
 | 2026-04-30 | 1.0.88  | Added an offline GitHub Actions supply-chain guard that rejects external workflow actions not pinned to commit SHAs. |
 | 2026-04-30 | 1.0.87  | Added source-backed golf ball-flight and impact validation contracts, including explicit altitude bounds for air-density computations and portfolio-facing golf modeling documentation. |
 | 2026-04-27 | 1.0.83  | Fixed Bandit B604 false positive alerts in test files by adding nosec annotations. |

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -60,7 +61,7 @@ class Obstacle:
             raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
-                np.linalg.norm(point - self.position)
+                math.hypot(*(point - self.position))
                 - self.dimensions[0]
                 - self.inflation
             )
@@ -70,7 +71,7 @@ class Obstacle:
             half_dims = self.dimensions / 2
             local_point = point - self.position
             clamped = np.clip(local_point, -half_dims, half_dims)
-            return float(np.linalg.norm(local_point - clamped) - self.inflation)
+            return float(math.hypot(*(local_point - clamped)) - self.inflation)
 
         if self.obstacle_type == ObstacleType.CYLINDER:
             # Cylinder distance (axis along z)
@@ -112,7 +113,7 @@ class Obstacle:
         )
         gradient = (dist_plus - dist_minus) / (2 * eps)
 
-        norm = np.linalg.norm(gradient)
+        norm = math.hypot(*gradient)
         if norm > eps:
             gradient /= norm
 


### PR DESCRIPTION
Fixes #3746\n\nReplaced np.linalg.norm with math.hypot for 3D vector magnitudes in high-frequency collision checks within src/deployment/safety/collision.py.

---
*PR created automatically by Jules for task [5391380098728033037](https://jules.google.com/task/5391380098728033037) started by @dieterolson*