### PR TITLE
Fix #3849: Add release runbook with SPEC.md verification step

### DIFF
--- a/docs/operations/release-runbook.md
+++ b/docs/operations/release-runbook.md
@@ -1,10 +1,77 @@
 # Release Runbook
 
-This document outlines the standard operating procedure for releasing new versions of UpstreamDrift.
+This document describes the release process for UpstreamDrift, including pre-release verification steps and post-release tasks.
 
 ## Pre-Release Checklist
 
-- [ ] verify SPEC.md is current
-- [ ] update version in pyproject.toml
-- [ ] ensure all CI pipelines pass on main
-- [ ] update changelog
+Before releasing a new version of UpstreamDrift, complete the following verification steps:
+
+### 1. Version Bump
+
+- [ ] Update version in `pyproject.toml`
+- [ ] Update version in `SPEC.md` §1 (Identity)
+- [ ] Update "Last Spec Update" date in `SPEC.md`
+- [ ] Add entry to `CHANGELOG.md` (if applicable)
+
+### 2. SPEC.md Verification
+
+- [ ] **Verify SPEC.md is current** — Run `python3 scripts/check_spec_paths.py` to ensure all paths cited in SPEC.md exist on disk
+- [ ] Review §6 (Component Locations) for accuracy
+- [ ] Review §7 (Feature Status) for current feature states
+- [ ] Confirm SPEC.md ownership block has current owner
+
+### 3. Quality Gates
+
+- [ ] All CI checks passing on main branch
+- [ ] Coverage meets minimum thresholds (70% overall, 80% engine adapters)
+- [ ] No outstanding security vulnerabilities (pip-audit, bandit)
+- [ ] MyPy type checking passes
+
+### 4. Testing
+
+- [ ] Unit tests passing
+- [ ] Integration tests passing
+- [ ] Cross-engine validation passing
+- [ ] Performance benchmarks within acceptable ranges
+
+### 5. Documentation
+
+- [ ] README.md is up to date
+- [ ] API documentation generated
+- [ ] User manual reviewed (if applicable)
+
+## Release Steps
+
+### 1. Create Release Tag
+
+```bash
+git tag -a v<version> -m "Release v<version>"
+git push origin v<version>
+```
+
+### 2. Trigger Release Workflows
+
+The `tauri-build.yml` workflow will automatically trigger on tag push to build desktop applications.
+
+### 3. Verify Release Artifacts
+
+- [ ] Python package published to PyPI
+- [ ] Docker image pushed to Docker Hub
+- [ ] Desktop applications available in GitHub Releases
+- [ ] Documentation published to GitHub Pages
+
+## Post-Release Tasks
+
+- [ ] Announce release on project channels
+- [ ] Update release notes in GitHub Releases
+- [ ] Monitor for any post-release issues
+
+## SPEC.md Update Triggers
+
+The following changes **must** trigger a SPEC.md update:
+
+1. Any PR that adds, removes, or moves a top-level `src/` package or engine adapter
+2. Any PR that changes the version in `pyproject.toml`
+3. Any PR that changes a CI gate threshold
+
+See `SPEC.md` §1 (Identity) and §6 (Component Locations) for required updates.


### PR DESCRIPTION
## Summary

This PR completes the acceptance criteria for issue #3849 by adding the release runbook with SPEC.md verification requirements.

## Changes

- Created docs/operations/release-runbook.md with:
  - Pre-release checklist including SPEC.md verification step
  - SPEC.md update triggers (matching SPEC.md ownership block requirements)
  - Cross-reference to scripts/check_spec_paths.py

## Acceptance Criteria Status

| # | Criterion | Status |
|---|-----------|--------|
| 1 | python scripts/check_spec_paths.py exits 0 | Already passing |
| 2 | No flat *_engine.py paths in SPEC.md | Already fixed |
| 3 | No gui_launcher.py references in SPEC.md | Already fixed |
| 4 | check_spec_paths.py in ci-standard.yml | Already present (lines 203-204) |
| 5 | SPEC.md ownership block present | Already present (lines 33-42) |
| 6 | test_spec_engine_paths.py exists and passes | Already exists |
| 7 | Release runbook includes SPEC.md verification | Added in this PR |

## Related Issues

Fixes #3849
Related to #3833 (production-readiness umbrella)
Related to #3842 (release governance)