### PR TITLE
fix(matlab/2d/Scripts): self-locating paths instead of cd(matlabdrive)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_AllPlots.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_AllPlots.m
@@ -1,28 +1,24 @@
 %Master Script Plot:
 PauseTime=0;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_BaseData Scripts'/;
+scriptDir = fileparts(mfilename('fullpath'));
+
+cd(fullfile(scriptDir, '_BaseData Scripts'));
 MASTER_SCRIPT_BaseDataCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZTCF Scripts';
+cd(fullfile(scriptDir, '_ZTCF Scripts'));
 MASTER_SCRIPT_ZTCFCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_Delta Scripts';
+cd(fullfile(scriptDir, '_Delta Scripts'));
 MASTER_SCRIPT_DeltaCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_Comparison Scripts';
+cd(fullfile(scriptDir, '_Comparison Scripts'));
 MASTER_SCRIPT_ComparisonCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/';
+cd(scriptDir);
 SCRIPT_ResultsFolderGeneration;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 MASTER_SCRIPT_ZVCF_CHARTS;
 
 clear PauseTime;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_QTableTimeChange.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_QTableTimeChange.m
@@ -83,8 +83,7 @@ clear BASEQTime;
 clear DELTAQTime;
 clear ZTCFQTime;
 
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(fileparts(mfilename('fullpath'))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASEQ.mat',"BASEQ");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_ResultsFolderGeneration.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_ResultsFolderGeneration.m
@@ -3,30 +3,26 @@ warning('off', 'MATLAB:MKDIR:DirectoryExists');
 
 %Create a folder named results with organized plots and backup data to
 %rerun each trial is located:
-cd(matlabdrive);
-cd '2DModel';
+scriptDir = fileparts(mfilename('fullpath'));
+modelDir = fileparts(scriptDir);
+cd(modelDir);
 mkdir 'Model Output';
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 cd 'Model Output';
 mkdir 'Scripts';
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 cd 'Model Output';
 mkdir 'Model and Parameters';
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 cd 'Model Output';
 mkdir 'Charts';
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 cd 'Model Output';
 mkdir 'Tables';
 
 %Write to the charts folder: How do I make these copy file from a location
 %specified in matlab drive using the matlab function?
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 copyfile 'Scripts/_BaseData Scripts/BaseData Charts' 'Model Output/Charts/';
 copyfile 'Scripts/_BaseData Scripts/BaseData Quiver Plots' 'Model Output/Charts/';
 copyfile 'Scripts/_ZTCF Scripts/ZTCF Charts' 'Model Output/Charts/';
@@ -40,21 +36,18 @@ copyfile 'Scripts/_ZVCF Scripts/ZVCF Quiver Plots' 'Model Output/Charts/';
 
 
 %Write to the Model and Parameters folder:
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 copyfile 'GolfSwing.slx' 'Model Output/Model and Parameters';
 copyfile 'ModelInputs.mat' 'Model Output/Model and Parameters';
 copyfile 'GolfSwingZVCF.slx' 'Model Output/Model and Parameters';
 copyfile 'ModelInputsZVCF.mat' 'Model Output/Model and Parameters';
 
 %Write to the Scripts folder:
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 copyfile 'Scripts/' 'Model Output/Scripts';
 
 %Write to the Tables folder on Model Output
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 copyfile 'Tables/BASE.mat' 'Model Output/Tables/';
 copyfile 'Tables/ZTCF.mat' 'Model Output/Tables/';
 copyfile 'Tables/DELTA.mat' 'Model Output/Tables/';
@@ -67,5 +60,4 @@ copyfile 'Tables/ClubQuiverAlphaReversal.mat' 'Model Output/Tables/';
 copyfile 'Tables/ClubQuiverMaxCHS.mat' 'Model Output/Tables/';
 copyfile 'Tables/SummaryTable.mat' 'Model Output/Tables/';
 
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_TotalWorkandPowerCalculation.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_TotalWorkandPowerCalculation.m
@@ -143,8 +143,7 @@ BASEQ.DELTAQLWFractionalPower=DELTAQ.TotalLWPower./BASEQ.TotalLWPower;
 BASEQ.DELTAQRWFractionalPower=DELTAQ.TotalRWPower./BASEQ.TotalRWPower;
 
 %Resave the Files to The Tables Folder in Model Output
-cd(matlabdrive)
-cd '2DModel';
+cd(fileparts(fileparts(mfilename('fullpath'))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASE.mat',"BASE");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_ZVCF_GENERATOR.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_ZVCF_GENERATOR.m
@@ -18,8 +18,9 @@
 % applied as constant values and the joint interaction forces are
 % calculated at time zero and tabulated. 
 
-cd(matlabdrive);
-cd '2DModel';
+scriptDir = fileparts(mfilename('fullpath'));
+modelDir = fileparts(scriptDir);
+cd(modelDir);
 warning off Simulink:cgxe:LeakedJITEngine;
 
 % Copy the model inputs file that was used to generate the ZTCF and run the
@@ -30,26 +31,21 @@ cd 'Scripts/_ZVCF Scripts/';
 % Rename the file using the movefile function
 movefile 'ModelInputs.mat' 'ModelInputsZVCF.mat';
 % Move the file using the copyfile function
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 copyfile Scripts/'_ZVCF Scripts'/'ModelInputsZVCF.mat';
 
 % Delete the file that was copied into the ZVCF Scripts folder
-cd(matlabdrive);
-cd '2DModel/Scripts/';
-cd '_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 delete 'ModelInputsZVCF.mat';
 
 
 % Go back to the main folder. Open GolfSwingZVCF model. The model is set to
 % look for ModelInputsZVCF when it is opened.
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 GolfSwingZVCF
 
 % Load mdlWks for ZVCF Model from File
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 mdlWks=get_param('GolfSwingZVCF','ModelWorkspace');
 mdlWks.DataSource = 'MAT-File';
 mdlWks.FileName = 'ModelInputsZVCF.mat';
@@ -74,8 +70,7 @@ assignin(mdlWks,'StopTime',Simulink.Parameter(0.05));
 out=sim("GolfSwingZVCF");
 
 % Run Table Generation Script on "out"
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(scriptDir);
 SCRIPT_TableGeneration;
 
 % Copy Data to ZTCF Table to Get Variable Names
@@ -204,11 +199,9 @@ ZVCFTable(:,:)=[]; %Delete All Data in ZTCF Table and Replace with Blanks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Generate the Q Table By Running Script
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 SCRIPT_ZVCF_QTableGenerate;
-cd(matlabdrive);
-cd '2DModel';
+cd(modelDir);
 
 
     

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_mdlWks_Generate.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/SCRIPT_mdlWks_Generate.m
@@ -1,9 +1,9 @@
 %SCRIPT_mdlWksGenerate.m;
-cd(matlabdrive);
-cd '2DModel';
+scriptDir = fileparts(mfilename('fullpath'));
+modelDir = fileparts(scriptDir);
+cd(modelDir);
 mdlWks=get_param('GolfSwing','ModelWorkspace');
 mdlWks.DataSource = 'MAT-File';
 mdlWks.FileName = 'ModelInputs.mat';
-cd(matlabdrive); 
-cd '2DModel'%added to see if it fixes things
+cd(modelDir); %added to see if it fixes things
 mdlWks.reload;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_BaseData Scripts/MASTER_SCRIPT_BaseDataCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_BaseData Scripts/MASTER_SCRIPT_BaseDataCharts.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_BaseData Scripts';
+cd(fileparts(mfilename('fullpath')));
 
 % PauseTime=0;
 

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Comparison Scripts/MASTER_SCRIPT_ComparisonCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Comparison Scripts/MASTER_SCRIPT_ComparisonCharts.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Comparison Scripts';
+cd(fileparts(mfilename('fullpath')));
 % PauseTime=1;
 
 SCRIPT_701_QUIVER_Comparison_NetForceEquivalentCouple;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Data Scripts/MASTER_SCRIPT_DataCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Data Scripts/MASTER_SCRIPT_DataCharts.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Data Scripts';
+cd(fileparts(mfilename('fullpath')));
 PauseTime=0;
 
 SCRIPT_TableGeneration;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Data Scripts/SCRIPT_QTableTimeChange.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Data Scripts/SCRIPT_QTableTimeChange.m
@@ -82,7 +82,7 @@ clear BASEQTime;
 clear DELTAQTime;
 clear ZTCFQTime;
 
-cd(matlabdrive);
+cd(fileparts(fileparts(fileparts(mfilename('fullpath')))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASEQ.mat',"BASEQ");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Delta Scripts/MASTER_SCRIPT_DeltaCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_Delta Scripts/MASTER_SCRIPT_DeltaCharts.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Delta Scripts';
+cd(fileparts(mfilename('fullpath')));
 %PauseTime=0;
 
 SCRIPT_501_PLOT_DELTA_AngularWork;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZTCF Scripts/MASTER_SCRIPT_ZTCFCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZTCF Scripts/MASTER_SCRIPT_ZTCFCharts.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZTCF Scripts';
+cd(fileparts(mfilename('fullpath')));
 %PauseTime=0;
 
 SCRIPT_301_PLOT_ZTCF_AngularWork;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZVCF Scripts/MASTER_SCRIPT_ZVCF_CHARTS.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZVCF Scripts/MASTER_SCRIPT_ZVCF_CHARTS.m
@@ -1,5 +1,4 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+cd(fileparts(mfilename('fullpath')));
 % PauseTime=1;
 
 SCRIPT_ZVCF_QUIVER_LWRWForce;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZVCF Scripts/SCRIPT_ZVCF_QTableGenerate.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/_ZVCF Scripts/SCRIPT_ZVCF_QTableGenerate.m
@@ -45,8 +45,7 @@ ZVCFTableQ.Time=ZVCFTableQTime;
 
 clear ZVCFTableQTime;
 
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(fileparts(fileparts(mfilename('fullpath')))));
 mkdir 'Tables';
 cd 'Tables/';
 save('ZVCFTableQ.mat',"ZVCFTableQ");


### PR DESCRIPTION
## Summary
- Replaces `cd(matlabdrive)` + hardcoded `'2DModel/...'` navigation in 14 MATLAB scripts under `src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Scripts/` with `mfilename('fullpath')`-based self-locating navigation.
- Uses `fullfile()` for path construction so scripts work on Windows + Linux, whether run from MATLAB Drive or a cloned repo.
- Applies the patterns from the closed GitHub issue's prescription (own-dir, sibling-subdir, parent, bare).

## Files touched (14)
- `SCRIPT_AllPlots.m`
- `SCRIPT_mdlWks_Generate.m`
- `SCRIPT_QTableTimeChange.m`
- `SCRIPT_ResultsFolderGeneration.m`
- `SCRIPT_TotalWorkandPowerCalculation.m`
- `SCRIPT_ZVCF_GENERATOR.m`
- `_BaseData Scripts/MASTER_SCRIPT_BaseDataCharts.m`
- `_Comparison Scripts/MASTER_SCRIPT_ComparisonCharts.m`
- `_Data Scripts/MASTER_SCRIPT_DataCharts.m`
- `_Data Scripts/SCRIPT_QTableTimeChange.m`
- `_Delta Scripts/MASTER_SCRIPT_DeltaCharts.m`
- `_ZTCF Scripts/MASTER_SCRIPT_ZTCFCharts.m`
- `_ZVCF Scripts/MASTER_SCRIPT_ZVCF_CHARTS.m`
- `_ZVCF Scripts/SCRIPT_ZVCF_QTableGenerate.m`

## Verification
- `grep matlabdrive` across the touched tree -> 0 matches
- `grep "'2DModel"` across the touched tree -> 0 matches
- `mfilename('fullpath')` present in all 14 fixed files

## Test plan
- [ ] Open any of the 14 scripts in MATLAB from a fresh clone and confirm `cd` resolves to a real directory under `2D_Golf_Model/matlab/`.
- [ ] Run `SCRIPT_AllPlots.m` end-to-end to validate the chained sibling-subdir navigation still drives the chart MASTER scripts correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)