### PR TITLE
fix(matlab/misc): self-locating paths in 4 outlier scripts

### DIFF
--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/2D GUI/config/model_config.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/2D GUI/config/model_config.m
@@ -23,9 +23,10 @@ function config = model_config()
     config.sample_time = 0.0001;
     config.interpolation_method = 'spline';
 
-    % File paths
-    config.base_path = matlabdrive;
-    config.model_path = fullfile(config.base_path, '2DModel');
+    % File paths (self-locating: this config lives at <matlab>/2D GUI/config/)
+    config.config_path = fileparts(mfilename('fullpath'));
+    config.model_path = fileparts(fileparts(config.config_path));
+    config.base_path = config.model_path;
     config.scripts_path = fullfile(config.model_path, 'Scripts');
     config.tables_path = fullfile(config.model_path, 'Tables');
     config.output_path = fullfile(config.model_path, 'Model Output');

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/MASTER_SCRIPT_ZTCF_ZVCF_PLOT_GENERATOR.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/MASTER_SCRIPT_ZTCF_ZVCF_PLOT_GENERATOR.m
@@ -6,12 +6,10 @@
 % determined for the time in which the model has the same position and
 % velocity as in the swing but the joint torques are zero.
 
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(mfilename('fullpath')));
 GolfSwing
 
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_mdlWks_Generate;
 
 % Turn on / off dampening in the killswitch
@@ -42,8 +40,7 @@ set_param(GolfSwing,"MaxStep","0.001");
 out=sim(GolfSwing);
 
 % Run Table Generation Script on "out"
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_TableGeneration;
 
 % Create table called BaseData with the "Data" Table from run with no
@@ -203,42 +200,35 @@ clear ZTCFTime;
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run the correction program for linear work and linear impulse for ZTCF and
 % DELTA.
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_UpdateCalcsforImpulseandWork;
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run the Q spacing program for the plots:
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_QTableTimeChange;
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run the Calculation for Total Work and Power at Each Joint
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_TotalWorkandPowerCalculation;
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Generate Club and Hand Path Vectors in the Tables
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_CHPandMPPCalculation;
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run Table of Values Script and Generate Data for Shaft Quivers at Times
 % of interest
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_TableofValues;
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Save the tables
-cd(matlabdrive)
-cd '2DModel'
+cd(fileparts(mfilename('fullpath')));
 mkdir 'Tables';
-cd(matlabdrive);
-cd '2DModel/Tables/';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Tables'));
 save('BASE.mat',"BASE");
 save('ZTCF.mat',"ZTCF");
 save('DELTA.mat',"DELTA");
@@ -253,30 +243,25 @@ save("SummaryTable.mat","SummaryTable");
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run the ZVCF Script:
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_ZVCF_GENERATOR;
 
 % Save the ZVCF Tables
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(mfilename('fullpath')));
 mkdir 'Tables';
-cd(matlabdrive);
-cd '2DModel/Tables/';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Tables'));
 save('ZVCFTable.mat',"ZVCFTable");
 save('ZVCFTableQ.mat',"ZVCFTableQ");
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Run the Plotting Script:
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'));
 SCRIPT_AllPlots;
 
 clear ZTCFPercentComplete;
 
-%Retun to 2DModel home page on matlab drive
-cd(matlabdrive);
-cd '2DModel';
+%Retun to 2DModel home page
+cd(fileparts(mfilename('fullpath')));
 
 clear ClubQuiverAlphaReversal;
 clear ClubQuiverMaxCHS;

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/2D GUI/config/model_config.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/2D GUI/config/model_config.m
@@ -23,9 +23,11 @@ function config = model_config()
     config.sample_time = 0.0001;
     config.interpolation_method = 'spline';
 
-    % File paths
-    config.base_path = matlabdrive;
-    config.model_path = fullfile(config.base_path, '2DModel');
+    % File paths (self-locating: this config lives at
+    % <matlab>/src/apps/golf_gui/2D GUI/config/)
+    config.config_path = fileparts(mfilename('fullpath'));
+    config.model_path = fileparts(fileparts(fileparts(fileparts(fileparts(config.config_path)))));
+    config.base_path = config.model_path;
     config.scripts_path = fullfile(config.model_path, 'Scripts');
     config.tables_path = fullfile(config.model_path, 'Tables');
     config.output_path = fullfile(config.model_path, 'Model Output');

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/scripts/plotting/PLOT_ModelData_Plots.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/scripts/plotting/PLOT_ModelData_Plots.m
@@ -1,4 +1,9 @@
 function PLOT__Plots()
+% Self-locating: this function lives at <matlab>/src/scripts/plotting/.
+% modelRoot points to the model's matlab/ folder (the repo equivalent of
+% the legacy MATLAB Drive 3D model directory).
+modelRoot = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+
 %%% ====== Start of SCRIPT_901_3D_PLOT_Data_AngularWork.m ======
 figure(901);
 hold on;
@@ -17,8 +22,7 @@ legend('Location','southeast');
 title('Angular Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Angular Work');
 pause(PauseTime);
 %Close Figure
@@ -44,8 +48,7 @@ legend('Location','southeast');
 title('Angular Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Angular Power');
 pause(PauseTime);
 %Close Figure
@@ -71,8 +74,7 @@ legend('Location','southeast');
 title('Linear Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Linear Power');
 pause(PauseTime);
 %Close Figure
@@ -98,8 +100,7 @@ legend('Location','southeast');
 title('Linear Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Linear Work on Distal');
 pause(PauseTime);
 %Close Figure
@@ -151,8 +152,7 @@ legend('Location','southeast');
 title('Joint Torque Inputs');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Joint Torque Inputs');
 pause(PauseTime);
 %Close Figure
@@ -178,8 +178,7 @@ legend('Location','southeast');
 title('Total Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Total Work');
 pause(PauseTime);
 %Close Figure
@@ -205,8 +204,7 @@ legend('Location','southeast');
 title('Total Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Total Power');
 pause(PauseTime);
 %Close Figure
@@ -227,8 +225,7 @@ legend('Location','southeast');
 title('Force Along Hand Path');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Force Along Hand Path');
 pause(PauseTime);
 %Close Figure
@@ -251,8 +248,7 @@ legend('Location','southeast');
 title('Clubhead and Hand Speed');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - CHS and Hand Speed');
 pause(PauseTime);
 %Close Figure
@@ -276,8 +272,7 @@ title('Force Along Hand Path');
 subtitle('Data');
 %subtitle('Left Hand, Right Hand, Total');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Force Along Hand Path - LH RH Total');
 pause(PauseTime);
 %Close Figure
@@ -298,8 +293,7 @@ legend('Location','southeast');
 title('Linear Impulse');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Linear Impulse');
 pause(PauseTime);
 %Close Figure
@@ -323,8 +317,7 @@ title('Linear Work');
 subtitle('Data');
 %subtitle('Left Hand, Right Hand, Total');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Linear Work');
 pause(PauseTime);
 %Close Figure
@@ -348,8 +341,7 @@ title('Linear Impulse');
 subtitle('Data');
 %subtitle('Left Hand, Right Hand, Total');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Linear Impulse LH,RH,Total');
 pause(PauseTime);
 %Close Figure
@@ -375,8 +367,7 @@ legend('Location','southeast');
 title('Equivalent Couple, Moment of Force, Sum of Moments');
 subtitle('Data - Grip Reference Frame');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Plot - Equivalent Couple and MOF');
 pause(PauseTime);
 %Close Figure
@@ -399,8 +390,7 @@ legend('Location','southeast');
 title('Left Shoulder Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Shoulder Work');
 pause(PauseTime);
 %Close Figure
@@ -423,8 +413,7 @@ legend('Location','southeast');
 title('Left Shoulder Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Shoulder Power');
 pause(PauseTime);
 %Close Figure
@@ -447,8 +436,7 @@ legend('Location','southeast');
 title('Right Shoulder Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Shoulder Work');
 pause(PauseTime);
 %Close Figure
@@ -471,8 +459,7 @@ legend('Location','southeast');
 title('Right Shoulder Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Shoulder Power');
 pause(PauseTime);
 %Close Figure
@@ -495,8 +482,7 @@ legend('Location','southeast');
 title('Left Elbow Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Elbow Work');
 pause(PauseTime);
 %Close Figure
@@ -519,8 +505,7 @@ legend('Location','southeast');
 title('Left Elbow Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Elbow Power');
 pause(PauseTime);
 %Close Figure
@@ -543,8 +528,7 @@ legend('Location','southeast');
 title('Right Elbow Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Elbow Work');
 pause(PauseTime);
 %Close Figure
@@ -567,8 +551,7 @@ legend('Location','southeast');
 title('Right Elbow Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Elbow Power');
 pause(PauseTime);
 %Close Figure
@@ -591,8 +574,7 @@ legend('Location','southeast');
 title('Left Wrist Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Hand Work');
 pause(PauseTime);
 %Close Figure
@@ -615,8 +597,7 @@ legend('Location','southeast');
 title('Left Wrist Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Left Wrist Power');
 pause(PauseTime);
 %Close Figure
@@ -639,8 +620,7 @@ legend('Location','southeast');
 title('Right Wrist Work on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Wrist Work');
 pause(PauseTime);
 %Close Figure
@@ -663,8 +643,7 @@ legend('Location','southeast');
 title('Right Wrist Power on Distal Segment');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Right Wrist Power');
 pause(PauseTime);
 %Close Figure
@@ -690,8 +669,7 @@ legend('Location','southeast');
 title('Local Hand Forces on Club');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-cd '3DModel';
+cd(modelRoot);
 savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Local Hand Forces');
 pause(PauseTime);
 %Close Figure
@@ -762,8 +740,8 @@ legend('Location','southeast');
 title('Joint Torque Inputs');
 subtitle('Data');
 %Save Figure
-cd(matlabdrive);
-savefig('3DModel/Scripts/_Model Data Scripts/Data Charts/Data_Plot - Joint Torque Inputs');
+cd(modelRoot);
+savefig('Scripts/_Model Data Scripts/Data Charts/Data_Plot - Joint Torque Inputs');
 pause(PauseTime);
 %Close Figure
 close(950);


### PR DESCRIPTION
## Summary

Four MATLAB files outside the `Scripts/` trees still relied on
`cd(matlabdrive)` + hardcoded `'2DModel'` / `'3DModel'` directory names
inherited from MATLAB Drive. Each is converted to use
`mfilename('fullpath')` so the scripts locate themselves relative to
their own location in the repo.

## Files

- `src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/MASTER_SCRIPT_ZTCF_ZVCF_PLOT_GENERATOR.m` (8 cd blocks)
- `src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/2D GUI/config/model_config.m` (base_path)
- `src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/2D GUI/config/model_config.m` (base_path)
- `src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/scripts/plotting/PLOT_ModelData_Plots.m` (21 cd blocks, factored to one `modelRoot` variable)

## Patterns used

- Script's own folder: `cd(fileparts(mfilename('fullpath')))`
- Subdir under script's folder: `cd(fullfile(fileparts(mfilename('fullpath')), 'Scripts'))`
- 3D plot helper navigates 3 levels up (plotting → scripts → src → matlab) via cached `modelRoot`.
- model_config.m: `config.base_path` now derived from the file's own location instead of `matlabdrive`.

## Verification

```
matlabdrive/2DModel/3DModel literal count: 0 across all 4 files
mfilename count: 15 / 1 / 1 / 1
```

## Test plan

- [ ] Open each script in MATLAB and confirm `cd` resolves to the expected
      folder under the repo (no MATLAB Drive dependency).
- [ ] Run `MASTER_SCRIPT_ZTCF_ZVCF_PLOT_GENERATOR` end-to-end against a
      fresh checkout and confirm Tables/ and figures are generated under
      the model's `matlab/` directory.
- [ ] Confirm both `model_config()` returns sane absolute paths on Windows.