### PR TITLE
fix(matlab/2d/ModelOutput): self-locating paths

### DIFF
--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_AllPlots.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_AllPlots.m
@@ -1,28 +1,23 @@
 %Master Script Plot:
 PauseTime=0;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_BaseData Scripts'/;
+scriptDir = fileparts(mfilename('fullpath'));
+cd(fullfile(scriptDir, '_BaseData Scripts'));
 MASTER_SCRIPT_BaseDataCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZTCF Scripts';
+cd(fullfile(scriptDir, '_ZTCF Scripts'));
 MASTER_SCRIPT_ZTCFCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_Delta Scripts';
+cd(fullfile(scriptDir, '_Delta Scripts'));
 MASTER_SCRIPT_DeltaCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_Comparison Scripts';
+cd(fullfile(scriptDir, '_Comparison Scripts'));
 MASTER_SCRIPT_ComparisonCharts;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/';
+cd(scriptDir);
 SCRIPT_ResultsFolderGeneration;
 
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 MASTER_SCRIPT_ZVCF_CHARTS;
 
 clear PauseTime;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_QTableTimeChange.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_QTableTimeChange.m
@@ -83,8 +83,7 @@ clear BASEQTime;
 clear DELTAQTime;
 clear ZTCFQTime;
 
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(fileparts(mfilename('fullpath'))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASEQ.mat',"BASEQ");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_ResultsFolderGeneration.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_ResultsFolderGeneration.m
@@ -1,32 +1,30 @@
 %Turn off the warning that a directory already exists when you create it.
 warning('off', 'MATLAB:MKDIR:DirectoryExists');
 
+% Project root is the grandparent of this script's parent directory
+% (script lives at Model Output/Scripts/, project root is matlab/).
+projectRoot = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+
 %Create a folder named results with organized plots and backup data to
 %rerun each trial is located:
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 mkdir 'Model Output';
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 cd 'Model Output';
 mkdir 'Scripts';
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 cd 'Model Output';
 mkdir 'Model and Parameters';
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 cd 'Model Output';
 mkdir 'Charts';
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 cd 'Model Output';
 mkdir 'Tables';
 
 %Write to the charts folder: How do I make these copy file from a location
 %specified in matlab drive using the matlab function?
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 copyfile 'Scripts/_BaseData Scripts/BaseData Charts' 'Model Output/Charts/';
 copyfile 'Scripts/_BaseData Scripts/BaseData Quiver Plots' 'Model Output/Charts/';
 copyfile 'Scripts/_ZTCF Scripts/ZTCF Charts' 'Model Output/Charts/';
@@ -40,21 +38,18 @@ copyfile 'Scripts/_ZVCF Scripts/ZVCF Quiver Plots' 'Model Output/Charts/';
 
 
 %Write to the Model and Parameters folder:
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 copyfile 'GolfSwing.slx' 'Model Output/Model and Parameters';
 copyfile 'ModelInputs.mat' 'Model Output/Model and Parameters';
 copyfile 'GolfSwingZVCF.slx' 'Model Output/Model and Parameters';
 copyfile 'ModelInputsZVCF.mat' 'Model Output/Model and Parameters';
 
 %Write to the Scripts folder:
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 copyfile 'Scripts/' 'Model Output/Scripts';
 
 %Write to the Tables folder on Model Output
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 copyfile 'Tables/BASE.mat' 'Model Output/Tables/';
 copyfile 'Tables/ZTCF.mat' 'Model Output/Tables/';
 copyfile 'Tables/DELTA.mat' 'Model Output/Tables/';
@@ -67,5 +62,4 @@ copyfile 'Tables/ClubQuiverAlphaReversal.mat' 'Model Output/Tables/';
 copyfile 'Tables/ClubQuiverMaxCHS.mat' 'Model Output/Tables/';
 copyfile 'Tables/SummaryTable.mat' 'Model Output/Tables/';
 
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_TotalWorkandPowerCalculation.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_TotalWorkandPowerCalculation.m
@@ -143,8 +143,7 @@ BASEQ.DELTAQLWFractionalPower=DELTAQ.TotalLWPower./BASEQ.TotalLWPower;
 BASEQ.DELTAQRWFractionalPower=DELTAQ.TotalRWPower./BASEQ.TotalRWPower;
 
 %Resave the Files to The Tables Folder in Model Output
-cd(matlabdrive)
-cd '2DModel';
+cd(fileparts(fileparts(mfilename('fullpath'))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASE.mat',"BASE");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_TransferStartPositionVelocityIntoModelFromMATFile.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_TransferStartPositionVelocityIntoModelFromMATFile.m
@@ -2,7 +2,7 @@
 % Read from model workspace the value in the starting position / velocity
 % from the impact optimized model
 
-cd(matlabdrive);
+cd(fileparts(mfilename('fullpath')));
 GolfSwing3D
 mdlWks=get_param('GolfSwing3D','ModelWorkspace');
 

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_ZVCF_GENERATOR.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_ZVCF_GENERATOR.m
@@ -18,8 +18,9 @@
 % applied as constant values and the joint interaction forces are
 % calculated at time zero and tabulated. 
 
-cd(matlabdrive);
-cd '2DModel';
+scriptDir = fileparts(mfilename('fullpath'));
+projectRoot = fileparts(scriptDir);
+cd(projectRoot);
 warning off Simulink:cgxe:LeakedJITEngine;
 
 % Copy the model inputs file that was used to generate the ZTCF and run the
@@ -30,26 +31,21 @@ cd 'Scripts/_ZVCF Scripts/';
 % Rename the file using the movefile function
 movefile 'ModelInputs.mat' 'ModelInputsZVCF.mat';
 % Move the file using the copyfile function
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 copyfile Scripts/'_ZVCF Scripts'/'ModelInputsZVCF.mat';
 
 % Delete the file that was copied into the ZVCF Scripts folder
-cd(matlabdrive);
-cd '2DModel/Scripts/';
-cd '_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 delete 'ModelInputsZVCF.mat';
 
 
 % Go back to the main folder. Open GolfSwingZVCF model. The model is set to
 % look for ModelInputsZVCF when it is opened.
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 GolfSwingZVCF
 
 % Load mdlWks for ZVCF Model from File
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 mdlWks=get_param('GolfSwingZVCF','ModelWorkspace');
 mdlWks.DataSource = 'MAT-File';
 mdlWks.FileName = 'ModelInputsZVCF.mat';
@@ -74,8 +70,7 @@ assignin(mdlWks,'StopTime',Simulink.Parameter(0.05));
 out=sim("GolfSwingZVCF");
 
 % Run Table Generation Script on "out"
-cd(matlabdrive);
-cd '2DModel/Scripts';
+cd(scriptDir);
 SCRIPT_TableGeneration;
 
 % Copy Data to ZTCF Table to Get Variable Names
@@ -204,11 +199,9 @@ ZVCFTable(:,:)=[]; %Delete All Data in ZTCF Table and Replace with Blanks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Generate the Q Table By Running Script
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+cd(fullfile(scriptDir, '_ZVCF Scripts'));
 SCRIPT_ZVCF_QTableGenerate;
-cd(matlabdrive);
-cd '2DModel';
+cd(projectRoot);
 
 
     

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_mdlWks_Generate.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/SCRIPT_mdlWks_Generate.m
@@ -1,9 +1,7 @@
 %SCRIPT_mdlWksGenerate.m;
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(fileparts(mfilename('fullpath'))));
 mdlWks=get_param('GolfSwing','ModelWorkspace');
 mdlWks.DataSource = 'MAT-File';
 mdlWks.FileName = 'ModelInputs.mat';
-cd(matlabdrive); 
-cd '2DModel'%added to see if it fixes things
+cd(fileparts(fileparts(mfilename('fullpath')))); %added to see if it fixes things
 mdlWks.reload;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_BaseData Scripts/MASTER_SCRIPT_BaseDataCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_BaseData Scripts/MASTER_SCRIPT_BaseDataCharts.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_BaseData Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 
 % PauseTime=0;
 

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Comparison Scripts/MASTER_SCRIPT_ComparisonCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Comparison Scripts/MASTER_SCRIPT_ComparisonCharts.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Comparison Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 % PauseTime=1;
 
 SCRIPT_701_QUIVER_Comparison_NetForceEquivalentCouple;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Data Scripts/MASTER_SCRIPT_DataCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Data Scripts/MASTER_SCRIPT_DataCharts.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Data Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 PauseTime=0;
 
 SCRIPT_TableGeneration;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Data Scripts/SCRIPT_QTableTimeChange.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Data Scripts/SCRIPT_QTableTimeChange.m
@@ -82,7 +82,7 @@ clear BASEQTime;
 clear DELTAQTime;
 clear ZTCFQTime;
 
-cd(matlabdrive);
+cd(fileparts(fileparts(fileparts(mfilename('fullpath')))));
 mkdir 'Tables';
 cd 'Tables/';
 save('BASEQ.mat',"BASEQ");

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Delta Scripts/MASTER_SCRIPT_DeltaCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_Delta Scripts/MASTER_SCRIPT_DeltaCharts.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_Delta Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 %PauseTime=0;
 
 SCRIPT_501_PLOT_DELTA_AngularWork;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZTCF Scripts/MASTER_SCRIPT_ZTCFCharts.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZTCF Scripts/MASTER_SCRIPT_ZTCFCharts.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZTCF Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 %PauseTime=0;
 
 SCRIPT_301_PLOT_ZTCF_AngularWork;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZVCF Scripts/MASTER_SCRIPT_ZVCF_CHARTS.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZVCF Scripts/MASTER_SCRIPT_ZVCF_CHARTS.m
@@ -1,5 +1,5 @@
-cd(matlabdrive);
-cd '2DModel/Scripts/_ZVCF Scripts';
+scriptDir = fileparts(mfilename('fullpath'));
+cd(scriptDir);
 % PauseTime=1;
 
 SCRIPT_ZVCF_QUIVER_LWRWForce;

--- a/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZVCF Scripts/SCRIPT_ZVCF_QTableGenerate.m
+++ b/src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/_ZVCF Scripts/SCRIPT_ZVCF_QTableGenerate.m
@@ -45,8 +45,7 @@ ZVCFTableQ.Time=ZVCFTableQTime;
 
 clear ZVCFTableQTime;
 
-cd(matlabdrive);
-cd '2DModel';
+cd(fileparts(fileparts(fileparts(mfilename('fullpath')))));
 mkdir 'Tables';
 cd 'Tables/';
 save('ZVCFTableQ.mat',"ZVCFTableQ");


### PR DESCRIPTION
## Summary

Fixes 15 MATLAB scripts under `src/engines/Simscape_Multibody_Models/2D_Golf_Model/matlab/Model Output/Scripts/` that used `cd(matlabdrive)` followed by hardcoded `2DModel/...` paths.

These scripts were copied from a MATLAB Drive layout where there was a single `2DModel` project at the drive root. In the cloned repo there is no `2DModel` folder, so every `cd '2DModel/...'` was broken. Replaced with `mfilename('fullpath')`-based self-locating navigation, using `fullfile()` for platform-independent path construction.

## Patterns applied

- MASTER_SCRIPTs in subdirs (`_BaseData Scripts/`, `_Comparison Scripts/`, etc.) navigate to their own location via `fileparts(mfilename('fullpath'))`.
- `SCRIPT_AllPlots.m` (in `Scripts/`) uses `fullfile(scriptDir, '_Foo Scripts')` for sibling subdirs.
- Scripts that originally did `cd '2DModel'` (project root) now use `fileparts(fileparts(mfilename('fullpath')))` to reach `Model Output/`, or `fileparts^3` to reach `matlab/` (the `2DModel`-equivalent project root) where appropriate.
- `SCRIPT_TransferStartPositionVelocityIntoModelFromMATFile.m` (bare `cd(matlabdrive)`) uses `cd(fileparts(mfilename('fullpath')))`.

## Test plan

- [ ] Run `MASTER_SCRIPT_BaseDataCharts` from any MATLAB working directory; confirm it cd's to its own folder.
- [ ] Run `SCRIPT_AllPlots` and confirm it walks all five subdirs without error.
- [ ] Run `SCRIPT_ResultsFolderGeneration` and confirm `Model Output/` tree is created at `matlab/` root.

Spec-exempt: pure MATLAB path-fix change, no Python/CI surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)