### PR TITLE
feat(motion-matching): wire additional Wiffle xlsx test trials (closes #4081)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/CLUB_IK_SPEC.md
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/CLUB_IK_SPEC.md
@@ -4,6 +4,8 @@ The "club IK" is misnamed for Phase 1 — there is no actual joint-angle inverse
 
 When body markers come online, this same module gains a real IK stage that solves shoulder/elbow/wrist joint angles. Until then, only the club is observed.
 
+> **Test-trial inventory:** The canonical list of measured swings used by the test suite — sheet names, event markers, expected CHS_mph values, per-trial data-quality notes, and instructions for adding a new trial — lives in [TEST_TRIALS.md](TEST_TRIALS.md).
+
 ## Output schema (canonical `target` struct)
 
 ```matlab
@@ -59,7 +61,7 @@ class ClubTarget:
 - **Conversion:** cm → metres via `× 0.01`.
 - **Event markers:** row 1 of each sheet is `<trial> | A | <addr#> | T | <top#> | I | <impact#> | F | <finish#> | CHS | <mph>`.  The loader reads these into `target.events` and uses the documented `I_sample` for `impact_idx` (the speed-argmax heuristic is not authoritative — it can latch onto the wrong local maximum).
 - **Orientation:** the file stores 3×3 rotation matrices per frame; convert to unit quaternion with sign normalised so `q[0] >= 0` to suppress the `q ↔ -q` ambiguity at the source.
-- **Sheets:** `TW_wiffle`, `TW_ProV1`, `GW_wiffle`, `GW_ProV11`. Each is one swing.
+- **Sheets:** `TW_wiffle`, `TW_ProV1`, `GW_wiffle`, `GW_ProV11`. Each is one swing. See [TEST_TRIALS.md](TEST_TRIALS.md) for the canonical inventory of trials, their event markers, expected CHS values, and per-trial data-quality notes.
 
 ### 2. C3D (priority for Phase 1, validation)
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/TEST_TRIALS.md
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/TEST_TRIALS.md
@@ -1,0 +1,173 @@
+# Canonical Test-Trial Inventory
+
+This document is the authoritative inventory of measured swings wired into
+the motion-matching test suite. Each row is one trial and one expected
+failure mode; "a single trial is a single failure mode" — until we have
+≥ 5 trials we cannot distinguish signal from noise when comparing
+optimizer / cost-function options. See issue #4081 for context.
+
+> Cross-references: [CLUB_IK_SPEC.md](CLUB_IK_SPEC.md) defines the canonical
+> `target` schema; [DATASET_SCHEMA.md](DATASET_SCHEMA.md) defines the wider
+> dataset metadata. The loader entry point is
+> [`load_club_target_excel.m`](load_club_target_excel.m); regression tests
+> live in [`tests/test_load_club_target_excel.m`](tests/test_load_club_target_excel.m).
+
+## Source files
+
+| File | Subjects | Sheets | Native rate |
+|------|----------|--------|-------------|
+| `src/apps/golf_gui/Motion Capture Plotter/Wiffle_ProV1_club_3D_data.xlsx` | TW, GW | 4 | 240 Hz |
+
+## Trial summary
+
+All four trials below come from the same xlsx, parsed by
+`load_club_target_excel`. Each loads to **301 frames after NaN-filter**
+(≈ 1.25 s of motion at 240 Hz). Sample rate is 240 Hz native; the loader
+resamples onto the simulation timegrid via `align_to_simulation_grid`.
+
+| Sheet | Subject | Club | A_sample | T_sample | I_sample | F_sample | CHS_mph | Median shaft (m) |
+|-------|---------|------|----------|----------|----------|----------|---------|------------------|
+| `TW_ProV1`  | TW | ProV1   | 240 | 418 | 525 | 725 | 114.5 | 1.069 |
+| `TW_wiffle` | TW | Wiffle  | NaN | NaN | NaN | NaN | 114.5 | 1.069 |
+| `GW_wiffle` | GW | Wiffle  | 240 | 448 | 517 | 724 | 104.6 | 1.081 |
+| `GW_ProV11` | GW | ProV1.1 | 240 | 452 | 521 | 721 | 115.1 | 1.081 |
+
+Notes on the column meanings:
+
+- **A / T / I / F** are sample numbers in the **original** 1-indexed
+  recording (Address, Top of backswing, Impact, Finish). The loader
+  uses `I_sample` to set `target.impact_idx` when present, falling
+  back to the clubhead-speed argmax heuristic otherwise.
+- **CHS_mph** is the documented club-head speed at impact, in mph,
+  read straight from the row-1 header.
+- **Median shaft (m)** is `median(‖clubhead − grip‖)` after unit
+  conversion. The plausibility window for a real golf club is
+  0.7 – 1.4 m; values outside that window indicate a unit-conversion
+  bug or a malformed sheet.
+
+## Per-trial detail
+
+### `TW_ProV1` — Tiger / ProV1 (control, regression baseline)
+
+- The original "single trial" wired into the loader; serves as the
+  regression baseline for every change to `load_club_target_excel`.
+- Row-1 event header is fully populated and authoritative.
+- `impact_idx` lands at sample 258 in the post-NaN-filter, post-resample
+  timeline (`t ≈ 0.257 s`).
+- No documented data-quality issues.
+
+### `TW_wiffle` — Tiger / Wiffle (event-marker stripped)
+
+- Same subject and club geometry family as `TW_ProV1` (median shaft
+  1.069 m matches), different ball.
+- **Data-quality issue:** the row-1 header is missing the
+  A / T / I / F sample numbers — only `CHS = 114.5 mph` is populated.
+  The loader's `events.{A,T,I,F}_sample` come back NaN; `impact_idx`
+  is therefore derived from the clubhead-speed argmax heuristic, which
+  in practice lands at sample 254 (`t ≈ 0.253 s`).
+- The test asserts `events.CHS_mph` is finite but tolerates NaN sample
+  markers and only requires `impact_idx ∈ [1, N]`.
+
+### `GW_wiffle` — Generic Wiffle swing
+
+- Different subject (GW). Median shaft 1.081 m — about 12 mm longer
+  than the TW trials, consistent with a different physical club.
+- Row-1 header fully populated: A=240, T=448, I=517, F=724, CHS=104.6.
+  Note the slower CHS (104.6 vs 114.5 / 115.1) — useful for testing
+  cost-function speed sensitivity.
+- No documented data-quality issues.
+
+### `GW_ProV11` — Generic ProV1.1
+
+- Same subject and club geometry as `GW_wiffle` (median shaft
+  1.081 m). Different ball.
+- Row-1 header fully populated: A=240, T=452, I=521, F=721, CHS=115.1.
+- No documented data-quality issues.
+
+## Failure-mode taxonomy
+
+Each trial exercises a subtly different code path through the loader:
+
+| Failure mode | Exercised by |
+|--------------|--------------|
+| Fully-populated event header path | `TW_ProV1`, `GW_wiffle`, `GW_ProV11` |
+| Missing event-marker fallback to speed-argmax | `TW_wiffle` |
+| Two distinct subjects (different median shaft length) | TW vs GW |
+| Two ball types per subject | `*_ProV1` vs `*_wiffle` |
+| CHS sensitivity (104.6 mph low end vs 115.1 mph high end) | `GW_wiffle` vs `GW_ProV11` |
+
+If the cost function or alignment code starts treating any of these
+trials specially (e.g. branches on subject ID), the corresponding test
+should catch it.
+
+## Tests wired in
+
+`tests/test_load_club_target_excel.m` covers the four trials with one
+`test_loads_<sheet>_sheet` method per sheet plus the original schema /
+unit / quaternion / impact-index / provenance / missing-file tests.
+Each per-sheet test asserts:
+
+1. `load_club_target_excel(xlsx, sheet)` returns without error.
+2. All canonical fields are present (`time`, `grip`, `grip_quat`, `butt`,
+   `clubhead`, `club_quat`, `impact_idx`, `events`, `source`).
+3. Event markers parse into the `events` struct; finite where the
+   sheet's row-1 header populates them (i.e. all four for the
+   GW trials and TW_ProV1, only `CHS_mph` for TW_wiffle).
+4. Median shaft length sits in 0.7 – 1.4 m.
+
+Test runner:
+
+```bash
+matlab -batch "addpath(genpath('motion_matching/shared')); addpath(genpath('src')); runtests('motion_matching/shared/tests/test_load_club_target_excel.m')"
+```
+
+## Developer probe
+
+`scripts/probe_swing_sheets.m` walks all four sheets and prints per-trial
+diagnostics (frame count, event markers, shaft-length stats, first-frame
+and impact-frame raw values). Use it after adding a new trial or
+touching the loader to sanity-check unit conversion and event-header
+parsing without running the full test suite:
+
+```bash
+matlab -batch "addpath(genpath('motion_matching/shared')); probe_swing_sheets()"
+```
+
+## How to add a new trial
+
+1. **Drop the source file** under
+   `src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/`.
+   Prefer the existing xlsx layout (row 1 event header, row 2 group
+   labels, row 3 column names, data from row 4 — see the loader
+   header for the exact layout). Native frame rate should be 240 Hz
+   to match existing trials, but other rates work as long as the time
+   column is in seconds.
+2. **Whitelist the sheet name** in the `mustBeMember` clause of
+   [`load_club_target_excel.m`](load_club_target_excel.m). The loader
+   refuses unknown sheet names by design (`mustBeMember` is a
+   precondition gate, not a suggestion) — this forces every new trial
+   to be opted in deliberately rather than discovered ad-hoc.
+3. **Run the probe:**
+   `matlab -batch "addpath(genpath('motion_matching/shared')); probe_swing_sheets()"`.
+   Confirm the new sheet shows up with sensible frame count, event
+   markers, and median shaft in 0.7 – 1.4 m. If it doesn't, fix the
+   source data — do **not** weaken the loader to accept malformed data.
+4. **Document the trial in this file** — add a row to the summary
+   table and a per-trial subsection. Capture every data-quality issue
+   you noticed during the probe (missing columns, frame dropouts,
+   weird timing, etc.); future debugging starts here.
+5. **Add a test method** to
+   [`tests/test_load_club_target_excel.m`](tests/test_load_club_target_excel.m)
+   following the `test_loads_GW_wiffle_sheet` pattern: load the sheet,
+   verify canonical fields via the `verify_canonical_target_fields`
+   helper, assert event markers parse and the documented values match,
+   verify shaft length plausibility via the `verify_shaft_length_plausible`
+   helper.
+6. **If the sheet has a known limitation** (e.g. partial event header,
+   missing direction-cosine columns that the loader cannot
+   reconstruct), document the limitation in step 4 and use
+   `testCase.assumeFail("reason")` in the new test method, citing the
+   specific failure mode. Never weaken the loader to swallow malformed
+   data — the precondition gates exist to surface bad inputs early.
+7. **Run the full test suite** and confirm all per-trial tests still
+   pass. Open a PR that references the issue tracking the new trial.

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/scripts/probe_swing_sheets.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/scripts/probe_swing_sheets.m
@@ -1,0 +1,67 @@
+function probe_swing_sheets(xlsx_path)
+%PROBE_SWING_SHEETS  Inspect each sheet of a Wiffle-style xlsx mocap file.
+%
+%   PROBE_SWING_SHEETS(XLSX_PATH) iterates over the four canonical sheets
+%   ("TW_wiffle", "TW_ProV1", "GW_wiffle", "GW_ProV11") in XLSX_PATH and
+%   prints, for each:
+%     * Frames after NaN-filter
+%     * Event markers (A/T/I/F sample numbers + CHS_mph) from the row-1 header
+%     * Median mid-hands -> clubhead distance (sanity-check 0.7 - 1.4 m)
+%     * First-frame and impact-frame raw values (grip/clubhead positions)
+%
+%   No XLSX_PATH provided -> probes the canonical file under
+%   src/apps/golf_gui/Motion Capture Plotter/.
+%
+%   This script is a developer probe; it never asserts.  It catches loader
+%   errors and prints them so all four sheets get reported even if some fail.
+
+    if nargin < 1 || strlength(string(xlsx_path)) == 0
+        here = fileparts(mfilename("fullpath"));
+        xlsx_path = fullfile(here, "..", "..", "..", "src", "apps", ...
+            "golf_gui", "Motion Capture Plotter", ...
+            "Wiffle_ProV1_club_3D_data.xlsx");
+    end
+    xlsx_path = string(xlsx_path);
+
+    if exist(xlsx_path, "file") ~= 2
+        error("probe_swing_sheets:fileMissing", ...
+              "xlsx not found at %s", xlsx_path);
+    end
+
+    fprintf("=== probe_swing_sheets: %s ===\n", xlsx_path);
+
+    sheets = ["TW_wiffle", "TW_ProV1", "GW_wiffle", "GW_ProV11"];
+    for k = 1:numel(sheets)
+        sheet = sheets(k);
+        fprintf("\n--- Sheet: %s ---\n", sheet);
+        try
+            t = load_club_target_excel(xlsx_path, sheet);
+        catch ME
+            fprintf("  LOAD FAILED: %s\n", ME.message);
+            continue;
+        end
+        N = numel(t.time);
+        fprintf("  Frames (post NaN-filter): %d\n", N);
+        ev = t.events;
+        fprintf("  Events: A=%g  T=%g  I=%g  F=%g  CHS_mph=%g\n", ...
+            ev.A_sample, ev.T_sample, ev.I_sample, ev.F_sample, ev.CHS_mph);
+        shaft = vecnorm(t.clubhead - t.grip, 2, 2);
+        fprintf("  Shaft length (m): median=%.3f  min=%.3f  max=%.3f\n", ...
+            median(shaft), min(shaft), max(shaft));
+        ok = median(shaft) >= 0.7 && median(shaft) <= 1.4;
+        if ok
+            fprintf("    -> within 0.7-1.4 m (PLAUSIBLE)\n");
+        else
+            fprintf("    -> OUTSIDE 0.7-1.4 m (suspect)\n");
+        end
+        fprintf("  Frame[1]: grip=[%.3f %.3f %.3f]  clubhead=[%.3f %.3f %.3f]\n", ...
+            t.grip(1,1), t.grip(1,2), t.grip(1,3), ...
+            t.clubhead(1,1), t.clubhead(1,2), t.clubhead(1,3));
+        ii = t.impact_idx;
+        fprintf("  Frame[impact_idx=%d, t=%.3fs]: grip=[%.3f %.3f %.3f]  clubhead=[%.3f %.3f %.3f]\n", ...
+            ii, t.time(ii), ...
+            t.grip(ii,1), t.grip(ii,2), t.grip(ii,3), ...
+            t.clubhead(ii,1), t.clubhead(ii,2), t.clubhead(ii,3));
+    end
+    fprintf("\n=== probe complete ===\n");
+end

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/tests/test_load_club_target_excel.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/tests/test_load_club_target_excel.m
@@ -96,7 +96,89 @@ classdef test_load_club_target_excel < matlab.unittest.TestCase
                 @() load_club_target_excel("does_not_exist.xlsx", "TW_ProV1"), ...
                 ?MException);
         end
+
+        % --- Additional swing trials wired in for issue #4081 -----------
+        % Each trial gets the same plausibility battery: load succeeds,
+        % required fields present, event markers parse and (if present)
+        % are finite, shaft length within 0.7-1.4 m.  See TEST_TRIALS.md
+        % for the canonical inventory of trials and known data-quality
+        % issues per trial.
+
+        function test_loads_TW_wiffle_sheet(testCase)
+            % TW_wiffle: row-1 header omits A/T/I/F sample numbers in
+            % this trial (only CHS_mph is populated).  We therefore
+            % verify CHS_mph is finite but tolerate NaN sample markers
+            % and require impact_idx still landed in-bounds via the
+            % clubhead-speed argmax fallback.
+            xlsx = locate_xlsx(testCase);
+            target = load_club_target_excel(xlsx, "TW_wiffle");
+            verify_canonical_target_fields(testCase, target);
+            ev = target.events;
+            testCase.verifyTrue(isfinite(ev.CHS_mph));
+            testCase.verifyEqual(ev.CHS_mph, 114.5, "AbsTol", 0.1);
+            verify_shaft_length_plausible(testCase, target);
+        end
+
+        function test_loads_GW_wiffle_sheet(testCase)
+            % GW_wiffle: A=240, T=448, I=517, F=724, CHS=104.6 mph.
+            xlsx = locate_xlsx(testCase);
+            target = load_club_target_excel(xlsx, "GW_wiffle");
+            verify_canonical_target_fields(testCase, target);
+            ev = target.events;
+            for f = ["A_sample","T_sample","I_sample","F_sample","CHS_mph"]
+                testCase.verifyTrue(isfinite(ev.(f)), ...
+                    sprintf("GW_wiffle event marker %s should be finite", f));
+            end
+            testCase.verifyEqual(ev.A_sample, 240);
+            testCase.verifyEqual(ev.I_sample, 517);
+            testCase.verifyEqual(ev.CHS_mph, 104.6, "AbsTol", 0.1);
+            verify_shaft_length_plausible(testCase, target);
+        end
+
+        function test_loads_GW_ProV11_sheet(testCase)
+            % GW_ProV11: A=240, T=452, I=521, F=721, CHS=115.1 mph.
+            xlsx = locate_xlsx(testCase);
+            target = load_club_target_excel(xlsx, "GW_ProV11");
+            verify_canonical_target_fields(testCase, target);
+            ev = target.events;
+            for f = ["A_sample","T_sample","I_sample","F_sample","CHS_mph"]
+                testCase.verifyTrue(isfinite(ev.(f)), ...
+                    sprintf("GW_ProV11 event marker %s should be finite", f));
+            end
+            testCase.verifyEqual(ev.A_sample, 240);
+            testCase.verifyEqual(ev.I_sample, 521);
+            testCase.verifyEqual(ev.CHS_mph, 115.1, "AbsTol", 0.1);
+            verify_shaft_length_plausible(testCase, target);
+        end
     end
+end
+
+
+function verify_canonical_target_fields(testCase, target)
+%VERIFY_CANONICAL_TARGET_FIELDS  Common shape/field assertions per CLUB_IK_SPEC.
+    testCase.verifyTrue(isstruct(target));
+    for f = ["time","grip","grip_quat","butt","clubhead","club_quat", ...
+             "impact_idx","events","source"]
+        testCase.verifyTrue(isfield(target, f), ...
+            sprintf("Missing field: %s", f));
+    end
+    N = numel(target.time);
+    testCase.verifyGreaterThan(N, 0);
+    testCase.verifyEqual(size(target.grip,      2), 3);
+    testCase.verifyEqual(size(target.grip_quat, 2), 4);
+    testCase.verifyEqual(size(target.clubhead,  2), 3);
+    testCase.verifyEqual(size(target.club_quat, 2), 4);
+    testCase.verifyEqual(target.butt, target.grip);
+    testCase.verifyGreaterThanOrEqual(target.impact_idx, 1);
+    testCase.verifyLessThanOrEqual(target.impact_idx, N);
+end
+
+
+function verify_shaft_length_plausible(testCase, target)
+%VERIFY_SHAFT_LENGTH_PLAUSIBLE  Median mid-hands -> clubhead in 0.7-1.4 m.
+    shaft = vecnorm(target.clubhead - target.grip, 2, 2);
+    testCase.verifyGreaterThan(median(shaft), 0.7);
+    testCase.verifyLessThan(median(shaft), 1.4);
 end
 
 


### PR DESCRIPTION
## Summary

Wires the three previously-unused sheets in `Wiffle_ProV1_club_3D_data.xlsx`
(`TW_wiffle`, `GW_wiffle`, `GW_ProV11`) into the loader regression suite so
we now have four measured trials covered instead of one.

A single trial is a single failure mode; until we have at least four wired
in we cannot distinguish loader signal from per-recording noise when
comparing optimizer / cost-function options.

Closes #4081.

## Changes

- `motion_matching/shared/scripts/probe_swing_sheets.m` — developer probe
  that walks all four sheets and prints frame count, event markers, median
  shaft length, and first / impact-frame raw values.
- `motion_matching/shared/tests/test_load_club_target_excel.m` — three new
  test methods (`test_loads_TW_wiffle_sheet`, `test_loads_GW_wiffle_sheet`,
  `test_loads_GW_ProV11_sheet`) plus shared `verify_canonical_target_fields`
  and `verify_shaft_length_plausible` helpers.
- `motion_matching/shared/TEST_TRIALS.md` — new file documenting the
  canonical trial inventory, expected CHS_mph values, per-trial data-quality
  issues, and a "How to add a new trial" section at the bottom.
- `motion_matching/shared/CLUB_IK_SPEC.md` — cross-references TEST_TRIALS.md
  from the top-of-file overview and from the Excel source-format section.

## Trial summary

| Sheet | Subject | Club | A | T | I | F | CHS_mph | Median shaft (m) |
|-------|---------|------|---|---|---|---|---------|------------------|
| `TW_ProV1`  | TW | ProV1   | 240 | 418 | 525 | 725 | 114.5 | 1.069 |
| `TW_wiffle` | TW | Wiffle  | NaN | NaN | NaN | NaN | 114.5 | 1.069 |
| `GW_wiffle` | GW | Wiffle  | 240 | 448 | 517 | 724 | 104.6 | 1.081 |
| `GW_ProV11` | GW | ProV1.1 | 240 | 452 | 521 | 721 | 115.1 | 1.081 |

All four trials load to 301 frames after NaN-filter at 240 Hz native rate.

## Documented data-quality issue

`TW_wiffle` ships with the row-1 A / T / I / F sample-number cells empty
(only `CHS = 114.5` is populated). The loader gracefully falls back to the
clubhead-speed argmax for `impact_idx`; the new test asserts `CHS_mph` is
finite and tolerates NaN sample markers, citing the failure mode in the
test docstring and in TEST_TRIALS.md. The loader was **not** weakened —
the `mustBeMember` precondition gate and the postcondition asserts in
`load_club_target_excel.m` are unchanged.

## Test plan

- [x] `runtests('motion_matching/shared/tests/test_load_club_target_excel.m')`
      — 10/10 pass locally (R2025b)
- [x] `probe_swing_sheets()` — all four sheets report plausible
      shaft length (0.7 - 1.4 m) and finite frame counts
- [ ] CI matrix passes

## Test command

```bash
matlab -batch "addpath(genpath('motion_matching/shared')); addpath(genpath('src')); runtests('motion_matching/shared/tests/test_load_club_target_excel.m')"
```