### PR TITLE
fix(ci): restrict docs-currency pattern to canonical files only

### DIFF
--- a/.github/workflows/docs-currency-warning.yml
+++ b/.github/workflows/docs-currency-warning.yml
@@ -45,7 +45,7 @@ jobs:
               *_test*.m|*tests/*.m|*/tests/*.py|*test_*.py|*_test.py) touches_tests=true ;;
             esac
             case "$f" in
-              *_SPEC.md|*_GUIDE.md|*_PLAYBOOK.md) touches_docs=true ;;
+              "src/engines/Simscape_Multibody_Models/3D_Golf_Model/PROJECT_SPEC.md"|"src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/MATLAB_GOLF_MODEL_GUIDE.md"|"src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/GRIP_FIT_PLAYBOOK.md") touches_docs=true ;;
             esac
           done <<< "$files"
 


### PR DESCRIPTION
## Summary
Restrict the docs-currency-warning.yml pattern match to only the three canonical spec files instead of matching any file ending with those suffixes.

## Changes
- Updated `.github/workflows/docs-currency-warning.yml` line 48 to match exact file paths:
  - `src/engines/Simscape_Multibody_Models/3D_Golf_Model/PROJECT_SPEC.md`
  - `src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/MATLAB_GOLF_MODEL_GUIDE.md`
  - `src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/GRIP_FIT_PLAYBOOK.md`

## Problem Solved
The previous pattern `*_SPEC.md|*_GUIDE.md|*_PLAYBOOK.md` was too broad and would match any file ending with these suffixes anywhere in the repo, causing false-positive warnings.

Closes #4088.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>