### PR TITLE
fix(motion-matching): correct A_sample indexing in solve_starting_pose.m

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/solve_starting_pose.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/solve_starting_pose.m
@@ -109,16 +109,33 @@ function overrides = solve_starting_pose(target, base_input_mat, opts)
         "Precondition: target.events.A_sample must be finite");
 
     % Map A_sample (1-indexed sample number from the Wiffle row-1 header)
-    % onto an index into the aligned target arrays.  We pin to the first
-    % row when the sheet's A_sample falls before the aligned series, which
-    % is the dominant case (the alignment helper trims pre-address data).
+    % onto an index into the aligned target arrays.
+    %
+    % A_sample is a raw sheet sample number (e.g., 240 Hz frame count). The
+    % aligned target arrays (target.grip, target.grip_quat, etc.) are
+    % resampled onto the simulation grid via align_to_simulation_grid, which
+    % also trims pre-address data. Therefore, A_sample cannot be used
+    % directly as an index.
+    %
+    % DOMINANT CASE: The aligned series starts at or after the address frame,
+    % so address is at row 1 (target.time(1) == 0). We pin to index 1.
+    %
+    % FALLBACK: If the aligned series somehow starts before address (rare),
+    % clamp to the first row.
+    %
+    % TODO(#4091 resolution): If callers need arbitrary-frame addressing
+    % (e.g., top-of-backswing at a later time), the loader must capture a
+    % mapping from raw sample numbers to aligned indices, or A_sample must
+    % be documented as "the time of address in raw timegrid", not "sample #".
     n_rows = size(target.grip, 1);
-    addr_idx = max(1, min(n_rows, round(target.events.A_sample)));
-    if isfield(target, 'time') && ~isempty(target.time) && ...
-       isfield(target.events, 'A_sample')
-        % If the aligned series has a sane "address" it is row 1; clamp.
-        addr_idx = max(1, min(n_rows, addr_idx));
+    if isfield(target, 'time') && ~isempty(target.time)
+        % Aligned series with resampling: address is always row 1.
+        addr_idx = 1;
+    else
+        % No time field: raw (unaligned) arrays. Pin to first row (fallback).
+        addr_idx = 1;
     end
+    addr_idx = max(1, min(n_rows, addr_idx));  % Safety clamp.
 
     grip_target_xyz = target.grip(addr_idx, :);
     R_meas_grip     = local_quat_to_rotmat(target.grip_quat(addr_idx, :));


### PR DESCRIPTION
## Summary

**CRITICAL P1 BUG FIX** for issue #4091.

### The Bug
`target.events.A_sample` is a raw sheet sample number (e.g., 240 from a 240 Hz Wiffle Excel recording) read directly from the row-1 header. The code was using this value directly as an index into `target.grip`, but this is **categorically wrong**:

- The raw data goes through `align_to_simulation_grid`, which **resamples** the swing onto a simulation timegrid
- Pre-address frames are **trimmed** by the alignment helper  
- Therefore, A_sample (a raw frame #) has no relationship to the aligned array indices

**Impact:** Stage-1 optimizer was running against the *wrong measured grip frame*, producing invalid overrides.

### The Fix
- Always use index 1 for the address frame, since `align_to_simulation_grid` trims pre-address data and the aligned series starts at the address
- This is the dominant case per the CLUB_IK_SPEC alignment policy
- Added comprehensive comment explaining the mapping and noting that future callers needing arbitrary-frame addressing must use proper time-to-index mapping

### Validation
- Postcondition: `solve_starting_pose` now correctly selects `target.grip(1, :)` and `target.grip_quat(1, :)` as the address-frame anchor
- The fix aligns with CLUB_IK_SPEC §"Time alignment" which documents that address is at the start of the aligned series (row 1)

---

**Note:** Not yet ready to merge—flagged for review per issue #4091.