### PR TITLE
feat(pinocchio): ClubTarget adapter for Rob Neal *.mat targets (closes #4127)

### DIFF
--- a/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
@@ -1,15 +1,11 @@
-"""Pinocchio motion-matching forward simulation + LM fit utilities.
-
-Implements the canonical engine-agnostic ``simulate_with_coefficients``
-forward-sim wrapper (issue #4118) and the ``fit_swing_pinocchio`` LM
-optimiser with analytical Jacobians (issue #4132 — the killer feature).
+"""Pinocchio motion-matching forward simulation, LM fit, and target adapters.
 
 Public API:
-    simulate_with_coefficients -- RK4 + ABA forward simulator.
+    simulate_with_coefficients -- RK4 + ABA forward simulator (issue #4118).
     SimOptions                 -- frozen dataclass of integrator options.
     SimOut                     -- frozen dataclass of trajectory + diagnostics.
     evaluate_polynomial_torque -- pure-numpy polynomial torque evaluation.
-    fit_swing_pinocchio        -- LM + analytical-Jacobian swing fit.
+    fit_swing_pinocchio        -- LM + analytical-Jacobian swing fit (issue #4132).
     FitOptions, FitResult      -- canonical fit configuration / result.
     polynomial_basis,
     polynomial_torque_chain_rule,
@@ -17,10 +13,17 @@ Public API:
                                   without pinocchio).
     POLY_DEGREE                -- canonical polynomial degree (6).
     COEFFS_PER_JOINT           -- canonical coeffs-per-joint count (7).
+    load_robneal_target        -- ClubTarget adapter for Rob Neal *.mat (issue #4127).
+
+Engine-local Rob Neal adapter is intentionally here until issue #4095
+(PARITY-LOADERS) lands a shared ``shared/python/motion_matching/loaders/``
+package. At that point ``load_robneal_target`` should be promoted upstream
+and this module should re-export it for backward compatibility.
 """
 
 from __future__ import annotations
 
+from .club_target_adapter import load_robneal_target
 from .fit_swing import (
     FitOptions,
     FitResult,
@@ -47,6 +50,7 @@ __all__ = [
     "SimOut",
     "evaluate_polynomial_torque",
     "fit_swing_pinocchio",
+    "load_robneal_target",
     "polynomial_basis",
     "polynomial_torque_chain_rule",
     "rotmat_to_quat_wxyz",

--- a/src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py
@@ -1,0 +1,496 @@
+"""Rob Neal ``*.mat`` -> canonical :class:`ClubTarget` adapter.
+
+The Rob Neal mocap dataset ships as paired MATLAB files:
+
+* ``<name>.mat``                  -- raw fields (``data.time``, ``data.midhands_xyz``,
+  ``data.midhands_dircos``, ``data.clubface_xyz``, ``data.clubface_dircos``) plus
+  ``params`` with event indices (``Address``, ``TopOfBackswing``, ``Impact``,
+  ``Finish``, ``impact_frame``).
+* ``<name>_targetKinematics.mat`` -- resampled / cleaned version with fields
+  ``Time``, ``MH`` (mid-hands xyz), ``MH_R`` (3x3xN rotation stack).
+
+This adapter reads both, prefers the ``_targetKinematics`` arrays for the
+canonical fields, but pulls event indices from the raw ``params`` struct and
+keeps the clubface trajectory from the raw file (the resampled artifact does
+not include it).
+
+The output is the canonical ``ClubTarget`` from
+``src/shared/python/motion_matching/club_target.py`` (frozen dataclass with a
+``__post_init__`` validator). If that module is unavailable for any reason a
+local stub is used and a warning is logged. See issue #4095 (PARITY-LOADERS)
+for the planned promotion of this loader to
+``shared/python/motion_matching/loaders/rob_neal.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import scipy.io as _sio
+
+logger = logging.getLogger(__name__)
+
+# Validation tolerances mirror the canonical ``ClubTarget`` defaults so the
+# stub fallback below stays consistent with the upstream schema.
+_QUAT_NORM_TOL = 1.0e-6
+_MAX_POSITION_NORM_M = 5.0
+_TIME_EPS = 1.0e-9
+
+
+# ---------------------------------------------------------------------------
+# ClubTarget import w/ stub fallback (TODO: drop once #4095 PARITY-LOADERS
+# guarantees the shared module is always importable from every engine path).
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - exercised by both branches via tests
+    from src.shared.python.motion_matching.club_target import (  # type: ignore[import-not-found]
+        ClubTarget,
+        SourceProvenance,
+    )
+
+    _USING_STUB = False
+except ImportError:  # pragma: no cover - fallback for stripped-down checkouts
+    logger.warning(
+        "src.shared.python.motion_matching.club_target unavailable; using "
+        "local stub. TODO(#4095 PARITY-LOADERS): remove this fallback once "
+        "the shared package is guaranteed importable."
+    )
+
+    @dataclass(frozen=True)
+    class SourceProvenance:  # type: ignore[no-redef]
+        """Local stub mirroring the canonical ``SourceProvenance``."""
+
+        filename: str
+        format: str
+        subject_id: str
+        trial_id: str
+        sha256: str
+
+    @dataclass(frozen=True)
+    class ClubTarget:  # type: ignore[no-redef]
+        """Local stub mirroring the canonical ``ClubTarget``.
+
+        Validation rules match ``CLUB_IK_SPEC.md`` so the stub round-trips
+        with the upstream type whenever both are available.
+        """
+
+        time: np.ndarray
+        butt: np.ndarray
+        clubhead: np.ndarray
+        club_quat: np.ndarray
+        impact_idx: int
+        source: SourceProvenance
+
+        def __post_init__(self) -> None:
+            _validate_stub_target(self)
+
+    _USING_STUB = True
+
+
+# ---------------------------------------------------------------------------
+# Stub validation helpers (only used when the canonical type isn't available).
+# ---------------------------------------------------------------------------
+
+
+def _validate_stub_target(t: ClubTarget) -> None:
+    """Replicate the canonical validation rules for the local stub."""
+    time = np.asarray(t.time)
+    if time.ndim != 1:
+        raise ValueError(f"time must be 1-D, got shape {time.shape}")
+    n = time.shape[0]
+    if n < 2:
+        raise ValueError(f"time must have at least 2 samples (got {n})")
+    if abs(float(time[0])) > _TIME_EPS:
+        raise ValueError(f"time[0] must be 0, got {time[0]!r}")
+    if not np.all(np.diff(time) > 0):
+        raise ValueError("time must be strictly increasing")
+    for name, arr, cols in (
+        ("butt", t.butt, 3),
+        ("clubhead", t.clubhead, 3),
+        ("club_quat", t.club_quat, 4),
+    ):
+        if np.asarray(arr).shape != (n, cols):
+            raise ValueError(
+                f"{name} must have shape ({n}, {cols}), got {np.asarray(arr).shape}"
+            )
+    for name, arr in (("butt", t.butt), ("clubhead", t.clubhead)):
+        if not np.all(np.isfinite(arr)):
+            raise ValueError(f"{name} contains NaN or Inf")
+        norms = np.linalg.norm(arr, axis=1)
+        if np.any(norms >= _MAX_POSITION_NORM_M):
+            raise ValueError(
+                f"{name} has |r| >= {_MAX_POSITION_NORM_M} m "
+                f"(max {float(norms.max()):.3f})"
+            )
+    qnorms = np.linalg.norm(t.club_quat, axis=1)
+    if np.any(np.abs(qnorms - 1.0) > _QUAT_NORM_TOL):
+        max_dev = float(np.abs(qnorms - 1.0).max())
+        raise ValueError(
+            "club_quat rows must be unit-norm to within "
+            f"{_QUAT_NORM_TOL} (max deviation {max_dev:.2e})"
+        )
+    if not (1 <= int(t.impact_idx) <= n):
+        raise ValueError(f"impact_idx must be in [1, {n}], got {t.impact_idx}")
+    if not isinstance(t.source, SourceProvenance):
+        raise TypeError("source must be a SourceProvenance instance")
+
+
+# ---------------------------------------------------------------------------
+# .mat helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pair(path: Path) -> tuple[Path, Path]:
+    """Return ``(raw_path, resampled_path)`` regardless of which one was given.
+
+    Accepts either ``<name>.mat`` or ``<name>_targetKinematics.mat`` and locates
+    the missing partner alongside it. Raises ``FileNotFoundError`` if either
+    half of the pair is missing.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"File not found: {p}")
+    if p.suffix.lower() != ".mat":
+        raise ValueError(f"Expected a .mat file, got {p.name}")
+
+    name = p.name
+    if name.lower().endswith("_targetkinematics.mat"):
+        resampled = p
+        raw_name = re.sub(
+            r"_targetkinematics\.mat$",
+            ".mat",
+            name,
+            flags=re.IGNORECASE,
+        )
+        raw = p.with_name(raw_name)
+    else:
+        raw = p
+        resampled = p.with_name(p.stem + "_targetKinematics.mat")
+
+    if not raw.exists():
+        raise FileNotFoundError(f"Raw .mat partner not found: {raw}")
+    if not resampled.exists():
+        raise FileNotFoundError(f"Resampled .mat partner not found: {resampled}")
+    return raw, resampled
+
+
+def _sha256_of(path: Path) -> str:
+    """Return the hex sha256 digest of ``path``'s bytes."""
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_mat(path: Path) -> dict[str, Any]:
+    """``scipy.io.loadmat`` with squeezing and struct unwrapping enabled."""
+    return _sio.loadmat(str(path), struct_as_record=False, squeeze_me=True)
+
+
+def _struct_field(obj: Any, *names: str) -> Any:
+    """Return the first present attribute among ``names`` on a MATLAB struct.
+
+    Raises ``KeyError`` if none of ``names`` are present.
+    """
+    for n in names:
+        if hasattr(obj, n):
+            return getattr(obj, n)
+    raise KeyError(f"None of fields {names!r} found on struct")
+
+
+def _dircos_to_rotmat(dircos: np.ndarray) -> np.ndarray:
+    """Reshape an ``(N, 9)`` direction-cosine table into ``(N, 3, 3)``.
+
+    The Rob Neal convention is row-major: each row is
+    ``[Xx, Xy, Xz, Yx, Yy, Yz, Zx, Zy, Zz]`` where ``X`` / ``Y`` / ``Z`` are
+    the columns of the rotation matrix expressed in world coordinates.
+    """
+    arr = np.asarray(dircos, dtype=np.float64)
+    if arr.ndim != 2 or arr.shape[1] != 9:
+        raise ValueError(
+            f"direction-cosine table must be (N, 9); got shape {arr.shape}"
+        )
+    n = arr.shape[0]
+    out = np.empty((n, 3, 3), dtype=np.float64)
+    out[:, 0, 0] = arr[:, 0]  # Xx
+    out[:, 1, 0] = arr[:, 1]  # Xy
+    out[:, 2, 0] = arr[:, 2]  # Xz
+    out[:, 0, 1] = arr[:, 3]  # Yx
+    out[:, 1, 1] = arr[:, 4]  # Yy
+    out[:, 2, 1] = arr[:, 5]  # Yz
+    out[:, 0, 2] = arr[:, 6]  # Zx
+    out[:, 1, 2] = arr[:, 7]  # Zy
+    out[:, 2, 2] = arr[:, 8]  # Zz
+    return out
+
+
+def _rotmat_stack_to_quat(rotmats: np.ndarray) -> np.ndarray:
+    """Convert an ``(N, 3, 3)`` rotation stack to ``(N, 4)`` ``[w,x,y,z]``.
+
+    Defers to the shared loader helper when available (single source of truth)
+    and otherwise uses an inlined Shepperd's method so this adapter remains
+    importable in stripped-down checkouts.
+    """
+    try:
+        from src.shared.python.motion_matching.loaders._quaternion import (  # type: ignore[import-not-found]
+            rotmat_to_quat,
+        )
+
+        return rotmat_to_quat(rotmats)
+    except ImportError:  # pragma: no cover - exercised when shared is absent
+        return _rotmat_to_quat_local(rotmats)
+
+
+def _rotmat_to_quat_local(rotmats: np.ndarray) -> np.ndarray:
+    """Fallback Shepperd's-method conversion (matches the shared helper)."""
+    arr = np.asarray(rotmats, dtype=np.float64)
+    if arr.ndim != 3 or arr.shape[1:] != (3, 3):
+        raise ValueError(f"Expected (N, 3, 3); got {arr.shape}")
+    n = arr.shape[0]
+    out = np.empty((n, 4), dtype=np.float64)
+    for i in range(n):
+        r = arr[i]
+        m00, m01, m02 = r[0, 0], r[0, 1], r[0, 2]
+        m10, m11, m12 = r[1, 0], r[1, 1], r[1, 2]
+        m20, m21, m22 = r[2, 0], r[2, 1], r[2, 2]
+        trace = m00 + m11 + m22
+        if trace > 0.0:
+            s = 0.5 / np.sqrt(trace + 1.0)
+            w = 0.25 / s
+            x = (m21 - m12) * s
+            y = (m02 - m20) * s
+            z = (m10 - m01) * s
+        elif (m00 > m11) and (m00 > m22):
+            s = 2.0 * np.sqrt(1.0 + m00 - m11 - m22)
+            w = (m21 - m12) / s
+            x = 0.25 * s
+            y = (m01 + m10) / s
+            z = (m02 + m20) / s
+        elif m11 > m22:
+            s = 2.0 * np.sqrt(1.0 + m11 - m00 - m22)
+            w = (m02 - m20) / s
+            x = (m01 + m10) / s
+            y = 0.25 * s
+            z = (m12 + m21) / s
+        else:
+            s = 2.0 * np.sqrt(1.0 + m22 - m00 - m11)
+            w = (m10 - m01) / s
+            x = (m02 + m20) / s
+            y = (m12 + m21) / s
+            z = 0.25 * s
+        q = np.array([w, x, y, z], dtype=np.float64)
+        norm = np.linalg.norm(q)
+        out[i] = q / norm if norm > 0.0 else np.array([1.0, 0.0, 0.0, 0.0])
+    flips = out[:, 0] < 0.0
+    if np.any(flips):
+        out[flips] = -out[flips]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_robneal_target(path: Path | str) -> ClubTarget:
+    """Load a Rob Neal mocap pair into a canonical :class:`ClubTarget`.
+
+    Args:
+        path: Either the raw ``<name>.mat`` or the resampled
+              ``<name>_targetKinematics.mat``. The partner file is auto-located
+              alongside.
+
+    Returns:
+        A validated :class:`ClubTarget` whose ``source.format`` is
+        ``"rob_neal_mat"`` and whose ``source.filename`` is the *raw* file's
+        basename (the resampled partner is recorded in ``trial_id``).
+
+    Raises:
+        FileNotFoundError: if either half of the pair is missing.
+        ValueError: if the .mat structure is malformed, contains NaN/Inf
+            frames, or otherwise fails ``ClubTarget`` validation.
+        KeyError: if expected MATLAB struct fields are missing.
+
+    Notes:
+        * Time is rebased so ``time[0] == 0``.
+        * Frames containing any NaN/Inf in mid-hands xyz, clubface xyz, or
+          either direction-cosine table are dropped before validation. If the
+          drop removes the impact frame the next surviving frame is used.
+        * ``impact_idx`` is **1-based** to match the canonical schema.
+    """
+    raw_path, resampled_path = _resolve_pair(Path(path))
+
+    raw = _load_mat(raw_path)
+    resampled = _load_mat(resampled_path)
+
+    if "data" not in raw or "params" not in raw:
+        raise ValueError(
+            f"{raw_path.name}: expected top-level 'data' and 'params' structs"
+        )
+    data = raw["data"]
+    params = raw["params"]
+
+    raw_time = np.asarray(_struct_field(data, "time"), dtype=np.float64).ravel()
+    butt_xyz = np.asarray(_struct_field(data, "midhands_xyz"), dtype=np.float64)
+    butt_dircos = np.asarray(_struct_field(data, "midhands_dircos"), dtype=np.float64)
+    head_xyz = np.asarray(_struct_field(data, "clubface_xyz"), dtype=np.float64)
+    head_dircos = np.asarray(_struct_field(data, "clubface_dircos"), dtype=np.float64)
+
+    n_raw = raw_time.shape[0]
+    for name, arr, cols in (
+        ("midhands_xyz", butt_xyz, 3),
+        ("clubface_xyz", head_xyz, 3),
+        ("midhands_dircos", butt_dircos, 9),
+        ("clubface_dircos", head_dircos, 9),
+    ):
+        if arr.shape != (n_raw, cols):
+            raise ValueError(
+                f"{raw_path.name}: {name} has shape {arr.shape}, "
+                f"expected ({n_raw}, {cols})"
+            )
+
+    # Prefer the resampled mid-hands trajectory + rotation when shapes line up.
+    use_resampled = False
+    if "Time" in resampled and "MH" in resampled and "MH_R" in resampled:
+        rs_time = np.asarray(resampled["Time"], dtype=np.float64).ravel()
+        rs_mh = np.asarray(resampled["MH"], dtype=np.float64)
+        rs_mh_r = np.asarray(resampled["MH_R"], dtype=np.float64)
+        # MH_R is stored as (3, 3, N) in MATLAB; rearrange to (N, 3, 3).
+        if rs_mh_r.ndim == 3 and rs_mh_r.shape[:2] == (3, 3):
+            rs_mh_r = np.moveaxis(rs_mh_r, 2, 0)
+        if (
+            rs_time.shape[0] == n_raw
+            and rs_mh.shape == (n_raw, 3)
+            and rs_mh_r.shape == (n_raw, 3, 3)
+        ):
+            use_resampled = True
+            base_time = rs_time
+            butt_xyz = rs_mh
+            butt_rotmats = rs_mh_r
+            logger.debug(
+                "%s: using resampled MH/MH_R from %s",
+                raw_path.name,
+                resampled_path.name,
+            )
+        else:
+            logger.debug(
+                "%s: resampled shapes %s/%s/%s incompatible with raw N=%d; "
+                "falling back to raw arrays",
+                raw_path.name,
+                rs_time.shape,
+                rs_mh.shape,
+                rs_mh_r.shape,
+                n_raw,
+            )
+    if not use_resampled:
+        base_time = raw_time
+        butt_rotmats = _dircos_to_rotmat(butt_dircos)
+    head_rotmats = _dircos_to_rotmat(head_dircos)
+
+    # Drop frames with any non-finite values across all source arrays.
+    finite_mask = (
+        np.all(np.isfinite(base_time[:, None]), axis=1)
+        & np.all(np.isfinite(butt_xyz), axis=1)
+        & np.all(np.isfinite(head_xyz), axis=1)
+        & np.all(np.isfinite(butt_rotmats.reshape(n_raw, -1)), axis=1)
+        & np.all(np.isfinite(head_rotmats.reshape(n_raw, -1)), axis=1)
+    )
+    if not np.any(finite_mask):
+        raise ValueError(f"{raw_path.name}: no finite frames after NaN/Inf filter")
+    n_dropped = int(n_raw - finite_mask.sum())
+    if n_dropped > 0:
+        logger.info(
+            "%s: dropped %d non-finite frames out of %d",
+            raw_path.name,
+            n_dropped,
+            n_raw,
+        )
+
+    keep_idx = np.flatnonzero(finite_mask)
+    time = base_time[keep_idx].astype(np.float64)
+    butt = butt_xyz[keep_idx].astype(np.float64)
+    clubhead = head_xyz[keep_idx].astype(np.float64)
+    butt_rotmats = butt_rotmats[keep_idx]
+    # We expose the *clubhead* (a.k.a. clubface) orientation via club_quat
+    # because that is what downstream IK consumes; the butt rotation is
+    # available as raw data only and used here for impact-frame fallback.
+    club_quat = _rotmat_stack_to_quat(head_rotmats[keep_idx])
+
+    # Rebase time to start at 0 and confirm strict monotonicity (resampled
+    # arrays are already monotonic; raw mocap occasionally has duplicate
+    # frames at the boundaries which would fail validation downstream).
+    time = time - float(time[0])
+    if not np.all(np.diff(time) > 0):
+        # Drop duplicate timestamps (keep the first).
+        unique_mask = np.concatenate(([True], np.diff(time) > 0))
+        if unique_mask.sum() < 2:
+            raise ValueError(
+                f"{raw_path.name}: fewer than 2 strictly increasing samples"
+            )
+        time = time[unique_mask]
+        butt = butt[unique_mask]
+        clubhead = clubhead[unique_mask]
+        club_quat = club_quat[unique_mask]
+        keep_idx = keep_idx[unique_mask]
+        logger.info(
+            "%s: dropped %d duplicate-timestamp frames",
+            raw_path.name,
+            int((~unique_mask).sum()),
+        )
+
+    # Resolve the impact frame: prefer ``params.Impact``, fall back to
+    # ``params.impact_frame``. Map the original 1-based MATLAB index back
+    # through the keep mask.
+    raw_impact_1b = int(_struct_field(params, "Impact", "impact_frame"))
+    if raw_impact_1b < 1 or raw_impact_1b > n_raw:
+        raise ValueError(
+            f"{raw_path.name}: impact index {raw_impact_1b} out of range [1, {n_raw}]"
+        )
+    raw_impact_0b = raw_impact_1b - 1
+    surviving = np.flatnonzero(keep_idx >= raw_impact_0b)
+    if surviving.size == 0:
+        raise ValueError(
+            f"{raw_path.name}: impact frame {raw_impact_1b} dropped and no "
+            "later surviving frame is available"
+        )
+    impact_idx_0b = int(surviving[0])
+    impact_idx = impact_idx_0b + 1  # 1-based per CLUB_IK_SPEC
+
+    subject_id = raw_path.stem.split("_")[0] or "unknown"
+    source = SourceProvenance(
+        filename=raw_path.name,
+        format="rob_neal_mat",
+        subject_id=subject_id,
+        trial_id=raw_path.stem,
+        sha256=_sha256_of(raw_path),
+    )
+    logger.info(
+        "Loaded ClubTarget from %s (+ %s): %d samples, impact_idx=%d, subject=%s",
+        raw_path.name,
+        resampled_path.name,
+        time.shape[0],
+        impact_idx,
+        subject_id,
+    )
+    return ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=club_quat,
+        impact_idx=int(impact_idx),
+        source=source,
+    )
+
+
+__all__ = [
+    "ClubTarget",
+    "SourceProvenance",
+    "load_robneal_target",
+]

--- a/tests/test_pinocchio_club_target_adapter.py
+++ b/tests/test_pinocchio_club_target_adapter.py
@@ -1,0 +1,334 @@
+"""Tests for the Pinocchio Rob Neal -> ``ClubTarget`` adapter.
+
+Covers:
+
+* schema validation through ``ClubTarget.__post_init__``,
+* round-trip on a synthetic fixture (always runnable),
+* round-trip on each real Rob Neal trial under
+  ``src/engines/physics_engines/pinocchio/data/rob_neal/`` when present
+  (skipped otherwise so this file is portable),
+* edge cases: NaN frames, missing partner file, unknown path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.io as sio
+from src.engines.physics_engines.pinocchio.python.motion_matching.club_target_adapter import (  # noqa: E501
+    ClubTarget,
+    SourceProvenance,
+    load_robneal_target,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _identity_dircos(n: int) -> np.ndarray:
+    """Return ``(N, 9)`` row-major identity-rotation direction-cosine table."""
+    row = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    return np.tile(row, (n, 1))
+
+
+def _write_synthetic_pair(
+    tmp_path: Path,
+    *,
+    name: str = "SYN_test",
+    n: int = 50,
+    impact_one_based: int = 25,
+    inject_nan_frames: tuple[int, ...] = (),
+    monotonic_time: bool = True,
+) -> Path:
+    """Write a synthetic raw + resampled .mat pair under ``tmp_path``.
+
+    Returns the *raw* file path. The structure mirrors the Rob Neal layout
+    observed at ``src/engines/physics_engines/pinocchio/data/rob_neal/`` (see
+    issue #4127):
+
+    * raw file: ``data.{time, midhands_xyz, midhands_dircos, clubface_xyz,
+      clubface_dircos}`` and ``params.{Impact, impact_frame, ...}``.
+    * resampled: ``Time``, ``MH``, ``MH_R`` (with ``MH_R`` shaped ``(3, 3, N)``).
+    """
+    if monotonic_time:
+        time = np.linspace(0.0, 1.0, n, dtype=np.float64)
+    else:
+        time = np.linspace(0.0, 1.0, n, dtype=np.float64)
+        time[5] = time[4]  # break monotonicity
+
+    butt_xyz = np.column_stack(
+        [
+            0.4 * np.cos(2 * np.pi * time),
+            0.4 * np.sin(2 * np.pi * time),
+            np.full_like(time, 1.0),
+        ]
+    ).astype(np.float64)
+    head_xyz = butt_xyz + np.array([0.0, 0.0, -1.0])
+    butt_dircos = _identity_dircos(n)
+    head_dircos = _identity_dircos(n)
+
+    if inject_nan_frames:
+        butt_xyz = butt_xyz.copy()
+        for idx in inject_nan_frames:
+            butt_xyz[idx, 0] = np.nan
+
+    raw_data = {
+        "time": time,
+        "midhands_xyz": butt_xyz,
+        "midhands_dircos": butt_dircos,
+        "clubface_xyz": head_xyz,
+        "clubface_dircos": head_dircos,
+    }
+    raw_params = {
+        "Impact": impact_one_based,
+        "impact_frame": impact_one_based,
+        "Address": 1,
+        "TopOfBackswing": max(1, impact_one_based // 2),
+        "Finish": n,
+        "backswing_start": 1,
+        "swing_start": 1,
+    }
+    raw_path = tmp_path / f"{name}.mat"
+    sio.savemat(
+        str(raw_path), {"data": raw_data, "params": raw_params}, oned_as="column"
+    )
+
+    # Resampled file: identical time/positions/identity rotations stack.
+    mh_r_stack = np.tile(np.eye(3, dtype=np.float64)[:, :, None], (1, 1, n))
+    resampled = {
+        "Time": time,
+        "MH": butt_xyz,
+        "MH_R": mh_r_stack,
+    }
+    resampled_path = tmp_path / f"{name}_targetKinematics.mat"
+    sio.savemat(str(resampled_path), resampled, oned_as="column")
+    return raw_path
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-fixture tests (always runnable)
+# ---------------------------------------------------------------------------
+
+
+def test_load_synthetic_round_trip(tmp_path: Path) -> None:
+    """Synthetic fixture loads and produces a valid ``ClubTarget``."""
+    raw = _write_synthetic_pair(tmp_path, n=100, impact_one_based=42)
+    target = load_robneal_target(raw)
+
+    assert isinstance(target, ClubTarget)
+    assert isinstance(target.source, SourceProvenance)
+    assert target.source.format == "rob_neal_mat"
+    assert target.source.filename == raw.name
+    assert target.source.subject_id == "SYN"
+    assert target.time.shape == (100,)
+    assert target.butt.shape == (100, 3)
+    assert target.clubhead.shape == (100, 3)
+    assert target.club_quat.shape == (100, 4)
+    # Time is rebased to start at 0.
+    assert target.time[0] == pytest.approx(0.0)
+    # Identity rotations -> [1, 0, 0, 0] quaternions.
+    np.testing.assert_allclose(target.club_quat[0], [1.0, 0.0, 0.0, 0.0])
+    qnorms = np.linalg.norm(target.club_quat, axis=1)
+    np.testing.assert_allclose(qnorms, 1.0, atol=1.0e-9)
+    assert target.impact_idx == 42  # 1-based, matches raw params.Impact
+
+
+def test_load_accepts_resampled_path(tmp_path: Path) -> None:
+    """Passing the ``_targetKinematics.mat`` path also resolves the pair."""
+    raw = _write_synthetic_pair(tmp_path, n=20, impact_one_based=10)
+    resampled = raw.with_name(raw.stem + "_targetKinematics.mat")
+    target_from_raw = load_robneal_target(raw)
+    target_from_resampled = load_robneal_target(resampled)
+    np.testing.assert_array_equal(target_from_raw.time, target_from_resampled.time)
+    np.testing.assert_array_equal(target_from_raw.butt, target_from_resampled.butt)
+    assert target_from_raw.impact_idx == target_from_resampled.impact_idx
+    assert target_from_raw.source.filename == target_from_resampled.source.filename
+
+
+def test_drops_nan_frames(tmp_path: Path) -> None:
+    """Frames with NaNs are dropped; impact_idx is remapped to a survivor."""
+    raw = _write_synthetic_pair(
+        tmp_path,
+        n=30,
+        impact_one_based=15,
+        inject_nan_frames=(2, 7),
+    )
+    target = load_robneal_target(raw)
+    assert target.time.shape == (28,)
+    assert np.all(np.isfinite(target.butt))
+    assert np.all(np.isfinite(target.clubhead))
+    # Impact (raw 1-based 15 -> 0-based 14) survives the drop, but the
+    # 0-based index in the kept array shifts by 2 (frames 2 and 7 dropped).
+    assert target.impact_idx == 15 - 2  # 13 (1-based)
+
+
+def test_dropped_impact_frame_uses_next_survivor(tmp_path: Path) -> None:
+    """If the impact frame itself is NaN we fall through to the next frame."""
+    raw = _write_synthetic_pair(
+        tmp_path,
+        n=20,
+        impact_one_based=10,
+        inject_nan_frames=(9,),  # 0-based 9 == 1-based 10 (the impact)
+    )
+    target = load_robneal_target(raw)
+    # Original impact frame (1-based 10, 0-based 9) was dropped. The next
+    # surviving raw frame is 0-based 10 -> in the kept array, that's 0-based 9
+    # -> 1-based 10.
+    assert target.impact_idx == 10
+    assert target.time.shape == (19,)
+
+
+def test_missing_partner_raises(tmp_path: Path) -> None:
+    """Deleting either half of the pair triggers a ``FileNotFoundError``."""
+    raw = _write_synthetic_pair(tmp_path, n=10, impact_one_based=5)
+    raw.with_name(raw.stem + "_targetKinematics.mat").unlink()
+    with pytest.raises(FileNotFoundError, match="Resampled .mat partner"):
+        load_robneal_target(raw)
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    """A non-existent path is rejected up front."""
+    with pytest.raises(FileNotFoundError):
+        load_robneal_target(tmp_path / "does_not_exist.mat")
+
+
+def test_non_mat_extension_rejected(tmp_path: Path) -> None:
+    """Paths without the ``.mat`` extension are rejected."""
+    bogus = tmp_path / "trial.txt"
+    bogus.write_text("hello")
+    with pytest.raises(ValueError, match="Expected a .mat file"):
+        load_robneal_target(bogus)
+
+
+def test_validation_rejects_out_of_range_impact(tmp_path: Path) -> None:
+    """Out-of-range ``params.Impact`` raises ``ValueError``."""
+    # Hand-craft a bad raw with Impact > N.
+    bad_raw = tmp_path / "BAD_test.mat"
+    sio.savemat(
+        str(bad_raw),
+        {
+            "data": {
+                "time": np.linspace(0.0, 1.0, 5),
+                "midhands_xyz": np.zeros((5, 3)),
+                "midhands_dircos": _identity_dircos(5),
+                "clubface_xyz": np.zeros((5, 3)) + np.array([0, 0, -1.0]),
+                "clubface_dircos": _identity_dircos(5),
+            },
+            "params": {"Impact": 99, "impact_frame": 99},
+        },
+        oned_as="column",
+    )
+    # Resampled partner with matching N.
+    sio.savemat(
+        str(tmp_path / "BAD_test_targetKinematics.mat"),
+        {
+            "Time": np.linspace(0.0, 1.0, 5),
+            "MH": np.zeros((5, 3)),
+            "MH_R": np.tile(np.eye(3)[:, :, None], (1, 1, 5)),
+        },
+        oned_as="column",
+    )
+    with pytest.raises(ValueError, match="impact index"):
+        load_robneal_target(bad_raw)
+
+
+def test_quaternions_are_unit_norm_for_random_rotations(
+    tmp_path: Path,
+) -> None:
+    """Non-identity rotations still yield unit-norm quaternions."""
+    n = 40
+    time = np.linspace(0.0, 1.0, n)
+    butt_xyz = np.zeros((n, 3))
+    butt_xyz[:, 2] = 1.0
+    head_xyz = butt_xyz - np.array([0.0, 0.0, 1.0])
+    # Build a smoothly-rotating clubface frame (yaw about +Z).
+    head_dircos = np.zeros((n, 9))
+    for i in range(n):
+        a = 2.0 * np.pi * i / (n - 1) * 0.25
+        ca, sa = np.cos(a), np.sin(a)
+        # Row order [Xx, Xy, Xz, Yx, Yy, Yz, Zx, Zy, Zz].
+        head_dircos[i] = [ca, sa, 0.0, -sa, ca, 0.0, 0.0, 0.0, 1.0]
+    butt_dircos = _identity_dircos(n)
+
+    raw = tmp_path / "ROT_trial.mat"
+    sio.savemat(
+        str(raw),
+        {
+            "data": {
+                "time": time,
+                "midhands_xyz": butt_xyz,
+                "midhands_dircos": butt_dircos,
+                "clubface_xyz": head_xyz,
+                "clubface_dircos": head_dircos,
+            },
+            "params": {"Impact": n // 2, "impact_frame": n // 2},
+        },
+        oned_as="column",
+    )
+    sio.savemat(
+        str(tmp_path / "ROT_trial_targetKinematics.mat"),
+        {
+            "Time": time,
+            "MH": butt_xyz,
+            "MH_R": np.tile(np.eye(3)[:, :, None], (1, 1, n)),
+        },
+        oned_as="column",
+    )
+
+    target = load_robneal_target(raw)
+    qnorms = np.linalg.norm(target.club_quat, axis=1)
+    np.testing.assert_allclose(qnorms, 1.0, atol=1.0e-9)
+    # The first quaternion is identity rotation.
+    np.testing.assert_allclose(target.club_quat[0], [1, 0, 0, 0], atol=1.0e-9)
+    # Quaternions should not all be identical (the clubface is rotating).
+    assert np.linalg.norm(target.club_quat[-1] - target.club_quat[0]) > 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Real-fixture tests (skipped when data/ is unavailable)
+# ---------------------------------------------------------------------------
+
+
+def _repo_root_from_here() -> Path:
+    """Walk up to find the repo root (directory with ``pyproject.toml``)."""
+    p = Path(__file__).resolve()
+    for parent in p.parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise RuntimeError("could not locate repo root from test file")
+
+
+_ROB_NEAL_DIR = (
+    _repo_root_from_here()
+    / "src"
+    / "engines"
+    / "physics_engines"
+    / "pinocchio"
+    / "data"
+    / "rob_neal"
+)
+_REAL_TRIALS = ("TW_ProV1", "TW_wiffle", "GW_ProV1", "GW_wiffle")
+
+
+@pytest.mark.parametrize("trial", _REAL_TRIALS)
+def test_real_robneal_trials_load(trial: str) -> None:
+    """Each shipped Rob Neal trial loads into a valid ``ClubTarget``."""
+    raw = _ROB_NEAL_DIR / f"{trial}.mat"
+    resampled = _ROB_NEAL_DIR / f"{trial}_targetKinematics.mat"
+    if not raw.is_file() or not resampled.is_file():
+        pytest.skip(f"Rob Neal fixture not available: {raw}")
+
+    target = load_robneal_target(raw)
+    assert isinstance(target, ClubTarget)
+    assert target.source.filename == raw.name
+    assert target.source.subject_id == trial.split("_")[0]
+    assert target.time.shape[0] >= 2
+    assert target.butt.shape == (target.time.shape[0], 3)
+    assert target.clubhead.shape == (target.time.shape[0], 3)
+    assert target.club_quat.shape == (target.time.shape[0], 4)
+    assert 1 <= target.impact_idx <= target.time.shape[0]
+    qnorms = np.linalg.norm(target.club_quat, axis=1)
+    np.testing.assert_allclose(qnorms, 1.0, atol=1.0e-6)


### PR DESCRIPTION
## Summary
- Adds `load_robneal_target(path) -> ClubTarget` under `src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py`. Reads paired raw `<name>.mat` + resampled `<name>_targetKinematics.mat` Rob Neal mocap files via `scipy.io.loadmat`.
- Returns the canonical `ClubTarget` from `src/shared/python/motion_matching/club_target.py` (fields `time`, `butt`, `clubhead`, `club_quat`, `impact_idx`, `source`). Prefers the resampled `MH`/`MH_R` arrays for mid-hands trajectory; clubface trajectory + orientation come from the raw `clubface_xyz`/`clubface_dircos`. Validates via the dataclass `__post_init__`.
- Drops NaN/Inf and duplicate-timestamp frames; remaps `impact_idx` (1-based) to the next surviving frame when the raw impact gets filtered out.
- Provides a local `ClubTarget` stub fallback for stripped-down checkouts, with a TODO referencing #4095 (PARITY-LOADERS) for promotion to `shared/python/motion_matching/loaders/rob_neal.py`.

## Test plan
- [x] `python3 -m pytest tests/test_pinocchio_club_target_adapter.py` — 13 passed including round-trip on all four shipped trials (TW_ProV1, TW_wiffle, GW_ProV1, GW_wiffle).
- [x] `python3 -m ruff check` — clean on new files.
- [x] `python3 -m ruff format --check` — clean on new files.
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget (496 / 334 lines).

Closes #4127.

Note: `spec-exempt` requested because this PR is scoped to a Pinocchio engine-local adapter; the canonical `ClubTarget` schema was already authored in #4067 and this change does not modify cross-engine spec content.