### PR TITLE
feat(opensim): forward-kinematics for grip + clubhead (closes #4116)

### DIFF
--- a/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
@@ -9,10 +9,17 @@ Public surface (lazily imported to keep ``import opensim`` optional):
 * ``SimOptions`` / ``SimOut`` frozen dataclasses
 * ``PolynomialTorqueController`` (only when ``opensim`` is installed)
 * ``evaluate_polynomial_torque`` (pure-numpy, always importable)
+* ``forward_kinematics``: extract canonical landmarks (grip, clubhead, ...)
+  from a SimTK state given the OpenSim model.
 """
 
 from __future__ import annotations
 
+from src.engines.physics_engines.opensim.python.motion_matching.forward_kinematics import (
+    extract_clubhead_pose,
+    extract_full_pose,
+    extract_grip_pose,
+)
 from src.engines.physics_engines.opensim.python.motion_matching.simulate import (
     COEFFS_PER_JOINT,
     POLY_DEGREE,
@@ -28,6 +35,9 @@ __all__ = [
     "SimOptions",
     "SimOut",
     "evaluate_polynomial_torque",
+    "extract_clubhead_pose",
+    "extract_full_pose",
+    "extract_grip_pose",
     "simulate_with_coefficients",
     "viz",
 ]

--- a/src/engines/physics_engines/opensim/python/motion_matching/forward_kinematics.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/forward_kinematics.py
@@ -1,0 +1,297 @@
+"""Forward-kinematics extraction for the OpenSim golf humanoid.
+
+This module provides the boundary between OpenSim's internal ``SimTK::State``
+and the canonical cross-engine ``SimOut`` schema. It pulls grip, clubhead,
+and other anatomical landmark poses out of a realised state in the
+canonical world frame.
+
+Canonical conventions (per
+``src/engines/CROSS_ENGINE_PARITY_SPEC.md`` and
+``OPENSIM_PARITY_SPEC.md`` §3.3):
+
+* Position: 3-vector ``[x, y, z]`` in metres, world frame.
+* Quaternion: 4-vector ``[w, x, y, z]``, unit norm.
+
+OpenSim itself returns rotation matrices and Eigen-style quaternions
+``[x, y, z, w]``. All conversion to canonical form happens here so callers
+never see the OpenSim convention.
+
+The MVP model ships two landmark frames as ``PhysicalOffsetFrame`` objects:
+
+* ``/bodyset/Club/club_grip_offset`` -> grip
+* ``/bodyset/Club/club_head_offset`` -> clubhead
+
+If a future model adds extra frames (e.g. butt, mid-hands, lead-shoulder)
+they can be added to :data:`CANONICAL_LANDMARKS` and will surface in
+:func:`extract_full_pose` automatically.
+
+This module is the OpenSim-side counterpart of the Simscape
+``compute_skeleton_fk.m`` helper. The output schema matches the canonical
+``SimOut`` fields read by ``src/shared/python/motion_matching/cost.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.engines.physics_engines.opensim.python.opensim_golf.core import (
+    OpenSimNotInstalledError,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    pass
+
+
+# --- Canonical landmark catalogue ----------------------------------------
+#
+# Maps a canonical landmark name to the OpenSim frame component path. The
+# frames live on the ``Club`` body (rigidly welded to the right hand in the
+# MVP model). If a downstream model needs more landmarks, extend this dict;
+# every consumer of :func:`extract_full_pose` will pick them up.
+
+CANONICAL_LANDMARKS: dict[str, str] = {
+    "grip": "/bodyset/Club/club_grip_offset",
+    "clubhead": "/bodyset/Club/club_head_offset",
+}
+
+
+# --- Quaternion conversion -----------------------------------------------
+
+
+def _rotation_matrix_to_quat_wxyz(
+    rot: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Convert a 3x3 rotation matrix to a unit quaternion ``[w, x, y, z]``.
+
+    Uses Shepperd's numerically-stable branch selection: pick the largest
+    diagonal-related quantity to avoid divide-by-near-zero. Pure-Python /
+    NumPy so it can be unit tested without OpenSim installed.
+
+    Args:
+        rot: ``(3, 3)`` rotation matrix. Must be orthonormal.
+
+    Returns:
+        ``(4,)`` unit quaternion in canonical ``[w, x, y, z]`` order with
+        ``w >= 0`` (sign-canonicalised so the scalar component is
+        non-negative — there are two equivalent quaternions for every
+        rotation).
+
+    Raises:
+        ValueError: If ``rot`` is not a ``(3, 3)`` array.
+    """
+    rot = np.asarray(rot, dtype=np.float64)
+    if rot.shape != (3, 3):
+        raise ValueError(f"rot must be (3, 3); got {rot.shape}")
+
+    trace = rot[0, 0] + rot[1, 1] + rot[2, 2]
+    if trace > 0.0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (rot[2, 1] - rot[1, 2]) * s
+        y = (rot[0, 2] - rot[2, 0]) * s
+        z = (rot[1, 0] - rot[0, 1]) * s
+    elif rot[0, 0] > rot[1, 1] and rot[0, 0] > rot[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + rot[0, 0] - rot[1, 1] - rot[2, 2])
+        w = (rot[2, 1] - rot[1, 2]) / s
+        x = 0.25 * s
+        y = (rot[0, 1] + rot[1, 0]) / s
+        z = (rot[0, 2] + rot[2, 0]) / s
+    elif rot[1, 1] > rot[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + rot[1, 1] - rot[0, 0] - rot[2, 2])
+        w = (rot[0, 2] - rot[2, 0]) / s
+        x = (rot[0, 1] + rot[1, 0]) / s
+        y = 0.25 * s
+        z = (rot[1, 2] + rot[2, 1]) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + rot[2, 2] - rot[0, 0] - rot[1, 1])
+        w = (rot[1, 0] - rot[0, 1]) / s
+        x = (rot[0, 2] + rot[2, 0]) / s
+        y = (rot[1, 2] + rot[2, 1]) / s
+        z = 0.25 * s
+
+    quat = np.array([w, x, y, z], dtype=np.float64)
+    # Sign-canonicalise so w >= 0 (q and -q represent the same rotation).
+    if quat[0] < 0.0:
+        quat = -quat
+    # Renormalise to absorb numerical drift.
+    norm = float(np.linalg.norm(quat))
+    if norm == 0.0:
+        raise ValueError("Degenerate rotation produced zero-norm quaternion")
+    return quat / norm
+
+
+# --- OpenSim helpers (LOD <= 2) ------------------------------------------
+
+
+def _ensure_position_realised(model: Any, state: Any) -> None:
+    """Realise the model to Position stage so frame transforms are valid.
+
+    OpenSim raises if you query a frame's location-in-ground when the
+    state has not been realised at least to ``Position``. This helper is
+    idempotent (re-realising a realised state is cheap) and isolates the
+    SWIG call from callers.
+    """
+    try:
+        model.realizePosition(state)
+    except Exception as exc:  # noqa: BLE001 — surface OpenSim errors uniformly
+        raise RuntimeError(
+            f"OpenSim realizePosition failed: {exc}. "
+            "Verify the state was produced by this model's initSystem()."
+        ) from exc
+
+
+def _frame_pose_in_ground(
+    model: Any, state: Any, frame_path: str
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return ``(pos_xyz, quat_wxyz)`` for a named frame in world frame.
+
+    Resolves ``frame_path`` via ``model.getComponent``, queries
+    ``getTransformInGround(state)``, and converts to canonical NumPy types.
+
+    Args:
+        model: An ``opensim.Model`` whose system has been initialised.
+        state: A realised ``simbody::State`` (Position stage or higher).
+        frame_path: Component path, e.g. ``"/bodyset/Club/club_grip_offset"``.
+
+    Returns:
+        ``(pos, quat)`` where ``pos`` is ``(3,) float64`` in metres and
+        ``quat`` is ``(4,) float64`` ``[w, x, y, z]`` unit quaternion.
+    """
+    try:
+        frame = model.getComponent(frame_path)
+    except Exception as exc:  # noqa: BLE001 — OpenSim raises generic errors
+        raise KeyError(
+            f"Frame {frame_path!r} not found in model. "
+            f"Check the model exposes this PhysicalOffsetFrame."
+        ) from exc
+
+    # getTransformInGround returns a SimTK::Transform with .R() (Rotation)
+    # and .p() (Vec3 translation).
+    transform = frame.getTransformInGround(state)
+    p = transform.p()
+    pos = np.array([p.get(0), p.get(1), p.get(2)], dtype=np.float64)
+
+    rotation = transform.R()
+    rot_mat = np.empty((3, 3), dtype=np.float64)
+    for i in range(3):
+        for j in range(3):
+            rot_mat[i, j] = rotation.get(i, j)
+    quat = _rotation_matrix_to_quat_wxyz(rot_mat)
+    return pos, quat
+
+
+def _require_opensim() -> None:
+    """Raise :class:`OpenSimNotInstalledError` if the SWIG bindings are missing.
+
+    All public extraction functions are usable only inside the OpenSim
+    Python environment because they consume a live ``simbody::State``. This
+    helper runs the import probe so the error message is consistent.
+    """
+    try:
+        import opensim  # type: ignore[import-untyped]  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised in env without opensim
+        raise OpenSimNotInstalledError(
+            "OpenSim Python bindings are required for forward-kinematics "
+            "extraction. Install via 'conda install -c opensim-org opensim' "
+            "or 'pip install opensim'."
+        ) from exc
+
+
+# --- Public API -----------------------------------------------------------
+
+
+def extract_grip_pose(
+    state: Any, model: Any
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return ``(grip_position_xyz, grip_quaternion_wxyz)`` in world frame.
+
+    Args:
+        state: A ``simbody::State`` produced by ``model.initSystem()`` (or
+            equivalent) that has been realised to at least Position stage.
+            This helper will realise it if needed.
+        model: The ``opensim.Model`` whose ``Club`` body carries the
+            ``club_grip_offset`` frame.
+
+    Returns:
+        ``(pos, quat)`` with ``pos`` shape ``(3,)`` in metres and ``quat``
+        shape ``(4,)`` in canonical ``[w, x, y, z]`` order.
+
+    Raises:
+        OpenSimNotInstalledError: If the OpenSim Python bindings are missing.
+        KeyError: If the model does not expose ``club_grip_offset``.
+        ValueError: If preconditions fail.
+    """
+    if state is None or model is None:
+        raise ValueError("state and model are both required")
+    _require_opensim()
+    _ensure_position_realised(model, state)
+    return _frame_pose_in_ground(model, state, CANONICAL_LANDMARKS["grip"])
+
+
+def extract_clubhead_pose(
+    state: Any, model: Any
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return ``(clubhead_position_xyz, clubhead_quaternion_wxyz)``.
+
+    Args:
+        state: Realised ``simbody::State``.
+        model: ``opensim.Model`` carrying the ``club_head_offset`` frame.
+
+    Returns:
+        ``(pos, quat)`` — see :func:`extract_grip_pose`.
+
+    Raises:
+        OpenSimNotInstalledError: If the OpenSim Python bindings are missing.
+        KeyError: If the model does not expose ``club_head_offset``.
+        ValueError: If preconditions fail.
+    """
+    if state is None or model is None:
+        raise ValueError("state and model are both required")
+    _require_opensim()
+    _ensure_position_realised(model, state)
+    return _frame_pose_in_ground(model, state, CANONICAL_LANDMARKS["clubhead"])
+
+
+def extract_full_pose(state: Any, model: Any) -> dict[str, NDArray[np.float64]]:
+    """Extract every canonical landmark in one realisation pass.
+
+    Returns a dict shaped to match the cross-engine ``SimOut`` (per-step)
+    schema, with two flat keys per landmark:
+
+    * ``"<landmark>_pos"`` -> ``(3,) float64`` position in world frame
+    * ``"<landmark>_quat"`` -> ``(4,) float64`` quaternion ``[w, x, y, z]``
+
+    For the MVP model that yields:
+
+    * ``grip_pos``, ``grip_quat``
+    * ``clubhead_pos``, ``clubhead_quat``
+
+    The single-pass form avoids redundant ``realizePosition`` calls when
+    populating a per-step ``SimOut`` row inside an integration loop.
+
+    Args:
+        state: Realised ``simbody::State``.
+        model: An ``opensim.Model`` exposing the canonical landmark frames.
+
+    Returns:
+        Dict from canonical key to NumPy array.
+
+    Raises:
+        OpenSimNotInstalledError: If the OpenSim Python bindings are missing.
+        KeyError: If a canonical landmark frame is missing from the model.
+        ValueError: If preconditions fail.
+    """
+    if state is None or model is None:
+        raise ValueError("state and model are both required")
+    _require_opensim()
+    _ensure_position_realised(model, state)
+
+    out: dict[str, NDArray[np.float64]] = {}
+    for landmark, path in CANONICAL_LANDMARKS.items():
+        pos, quat = _frame_pose_in_ground(model, state, path)
+        out[f"{landmark}_pos"] = pos
+        out[f"{landmark}_quat"] = quat
+    return out

--- a/tests/test_opensim_fk.py
+++ b/tests/test_opensim_fk.py
@@ -1,0 +1,335 @@
+"""Tests for OpenSim forward-kinematics extraction (issue #4116).
+
+The pure-NumPy quaternion conversion is exercised without the OpenSim
+wheel installed. The end-to-end FK tests load the shipped
+``golf_humanoid.osim`` and are gated behind ``@pytest.mark.requires_opensim``
+so default CI passes on hosts without the OpenSim bindings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from src.engines.physics_engines.opensim.python.motion_matching.forward_kinematics import (
+    CANONICAL_LANDMARKS,
+    _rotation_matrix_to_quat_wxyz,
+    extract_clubhead_pose,
+    extract_full_pose,
+    extract_grip_pose,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-NumPy unit tests (run on every CI; no OpenSim required).
+# ---------------------------------------------------------------------------
+
+
+class TestRotationToQuat:
+    """Unit tests for ``_rotation_matrix_to_quat_wxyz``."""
+
+    def test_identity_returns_unit_w(self) -> None:
+        q = _rotation_matrix_to_quat_wxyz(np.eye(3))
+        np.testing.assert_allclose(q, [1.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_180_about_x_returns_x_unit(self) -> None:
+        # Rotation 180 deg about X: diag(1, -1, -1)
+        rot = np.diag([1.0, -1.0, -1.0])
+        q = _rotation_matrix_to_quat_wxyz(rot)
+        # 180 about x -> q = (0, 1, 0, 0); sign-canonicalised w >= 0.
+        # When w == 0 either sign is valid; just assert magnitude.
+        assert abs(q[0]) < 1e-12
+        np.testing.assert_allclose(np.abs(q[1:]), [1.0, 0.0, 0.0], atol=1e-12)
+
+    def test_90_about_z_correct(self) -> None:
+        # 90 deg about Z: cos=0, sin=1
+        rot = np.array(
+            [
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        q = _rotation_matrix_to_quat_wxyz(rot)
+        expected = np.array([np.sqrt(0.5), 0.0, 0.0, np.sqrt(0.5)])
+        np.testing.assert_allclose(q, expected, atol=1e-12)
+
+    def test_unit_norm(self) -> None:
+        # Random small rotation
+        rng = np.random.default_rng(42)
+        for _ in range(10):
+            axis = rng.normal(size=3)
+            axis /= np.linalg.norm(axis)
+            angle = rng.uniform(-np.pi, np.pi)
+            # Rodrigues
+            k = np.array(
+                [
+                    [0.0, -axis[2], axis[1]],
+                    [axis[2], 0.0, -axis[0]],
+                    [-axis[1], axis[0], 0.0],
+                ]
+            )
+            rot = np.eye(3) + np.sin(angle) * k + (1.0 - np.cos(angle)) * (k @ k)
+            q = _rotation_matrix_to_quat_wxyz(rot)
+            assert abs(np.linalg.norm(q) - 1.0) < 1e-12
+            assert q[0] >= 0.0  # w sign-canonicalised
+
+    def test_bad_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match="rot must be"):
+            _rotation_matrix_to_quat_wxyz(np.eye(4))
+
+
+class TestExtractWithMockModel:
+    """Verify extraction logic with a mocked OpenSim model.
+
+    These tests do not need the OpenSim wheel because we replace the
+    SWIG calls with ``MagicMock`` instances that return scripted values.
+    They confirm the canonical-frame contract (shape, dtype, ordering).
+    """
+
+    @staticmethod
+    def _make_mock_model(
+        translations: dict[str, tuple[float, float, float]],
+    ) -> MagicMock:
+        """Build a model whose components return scripted positions.
+
+        Each frame returns identity rotation and the supplied translation,
+        so we can sanity-check that pos/quat plumbing maps frames -> output
+        keys correctly.
+        """
+        model = MagicMock()
+
+        def get_component(path: str) -> MagicMock:
+            xyz = translations[path]
+            transform = MagicMock()
+
+            p_vec = MagicMock()
+            p_vec.get.side_effect = lambda i, _xyz=xyz: _xyz[i]
+            transform.p.return_value = p_vec
+
+            rot = MagicMock()
+            rot.get.side_effect = lambda i, j: 1.0 if i == j else 0.0
+            transform.R.return_value = rot
+
+            frame = MagicMock()
+            frame.getTransformInGround.return_value = transform
+            return frame
+
+        model.getComponent.side_effect = get_component
+        return model
+
+    def test_extract_grip_pose_returns_canonical_shapes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bypass the opensim import probe.
+        monkeypatch.setattr(
+            "src.engines.physics_engines.opensim.python.motion_matching."
+            "forward_kinematics._require_opensim",
+            lambda: None,
+        )
+        translations = {
+            CANONICAL_LANDMARKS["grip"]: (0.10, 1.20, -0.05),
+            CANONICAL_LANDMARKS["clubhead"]: (0.30, 0.10, -0.04),
+        }
+        model = self._make_mock_model(translations)
+        state = MagicMock()
+
+        pos, quat = extract_grip_pose(state, model)
+
+        assert pos.shape == (3,)
+        assert quat.shape == (4,)
+        assert pos.dtype == np.float64
+        assert quat.dtype == np.float64
+        np.testing.assert_allclose(pos, [0.10, 1.20, -0.05], atol=1e-12)
+        # Identity rotation -> quat = (1, 0, 0, 0).
+        np.testing.assert_allclose(quat, [1.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_extract_clubhead_pose_uses_correct_frame(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "src.engines.physics_engines.opensim.python.motion_matching."
+            "forward_kinematics._require_opensim",
+            lambda: None,
+        )
+        translations = {
+            CANONICAL_LANDMARKS["grip"]: (0.10, 1.20, -0.05),
+            CANONICAL_LANDMARKS["clubhead"]: (0.30, 0.10, -0.04),
+        }
+        model = self._make_mock_model(translations)
+        state = MagicMock()
+
+        pos, quat = extract_clubhead_pose(state, model)
+        np.testing.assert_allclose(pos, [0.30, 0.10, -0.04], atol=1e-12)
+        np.testing.assert_allclose(quat, [1.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_extract_full_pose_returns_all_landmarks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "src.engines.physics_engines.opensim.python.motion_matching."
+            "forward_kinematics._require_opensim",
+            lambda: None,
+        )
+        translations = {
+            CANONICAL_LANDMARKS["grip"]: (0.10, 1.20, -0.05),
+            CANONICAL_LANDMARKS["clubhead"]: (0.30, 0.10, -0.04),
+        }
+        model = self._make_mock_model(translations)
+        state = MagicMock()
+
+        full = extract_full_pose(state, model)
+        # Each landmark must produce two keys: <name>_pos, <name>_quat.
+        for landmark in CANONICAL_LANDMARKS:
+            assert f"{landmark}_pos" in full
+            assert f"{landmark}_quat" in full
+            assert full[f"{landmark}_pos"].shape == (3,)
+            assert full[f"{landmark}_quat"].shape == (4,)
+        np.testing.assert_allclose(full["grip_pos"], [0.10, 1.20, -0.05], atol=1e-12)
+        np.testing.assert_allclose(
+            full["clubhead_pos"], [0.30, 0.10, -0.04], atol=1e-12
+        )
+
+    def test_none_inputs_raise_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            extract_grip_pose(None, MagicMock())
+        with pytest.raises(ValueError):
+            extract_clubhead_pose(MagicMock(), None)
+        with pytest.raises(ValueError):
+            extract_full_pose(None, None)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests against the shipped golf_humanoid.osim.
+# Skipped on hosts without the OpenSim Python bindings.
+# ---------------------------------------------------------------------------
+
+
+_MODEL_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "engines"
+    / "physics_engines"
+    / "opensim"
+    / "models"
+    / "golf_humanoid.osim"
+)
+
+
+@pytest.fixture(scope="module")
+def opensim_module() -> object:
+    """Import opensim or skip the module if unavailable."""
+    pytest.importorskip("opensim", reason="OpenSim Python bindings not installed")
+    import opensim  # type: ignore[import-untyped]
+
+    return opensim
+
+
+@pytest.fixture(scope="module")
+def golf_humanoid(opensim_module: object) -> tuple[object, object]:
+    """Load the MVP golf-humanoid model and a freshly-realised state."""
+    if not _MODEL_PATH.exists():
+        pytest.skip(f"Model file missing: {_MODEL_PATH}")
+    model = opensim_module.Model(str(_MODEL_PATH))  # type: ignore[attr-defined]
+    state = model.initSystem()
+    return model, state
+
+
+@pytest.mark.requires_opensim
+class TestForwardKinematicsLive:
+    """End-to-end FK extraction against the shipped .osim model."""
+
+    def test_neutral_pose_grip_is_finite_and_plausible(
+        self, golf_humanoid: tuple[object, object]
+    ) -> None:
+        """Neutral pose: grip is finite, non-zero, within a plausible range."""
+        model, state = golf_humanoid
+        pos, quat = extract_grip_pose(state, model)
+        assert pos.shape == (3,) and quat.shape == (4,)
+        assert np.all(np.isfinite(pos))
+        assert np.all(np.isfinite(quat))
+        # Non-zero: at least one component above 1 cm magnitude.
+        assert np.linalg.norm(pos) > 1e-2
+        # Plausibility: a ~1.8 m human's grip cannot be more than 3 m
+        # from origin in any direction.
+        assert np.all(np.abs(pos) < 3.0)
+        # Unit quaternion.
+        assert abs(np.linalg.norm(quat) - 1.0) < 1e-9
+        assert quat[0] >= 0.0
+
+    def test_neutral_pose_clubhead_is_finite_and_plausible(
+        self, golf_humanoid: tuple[object, object]
+    ) -> None:
+        """Neutral pose: clubhead is finite, non-zero, within plausible range."""
+        model, state = golf_humanoid
+        pos, quat = extract_clubhead_pose(state, model)
+        assert np.all(np.isfinite(pos))
+        assert np.all(np.isfinite(quat))
+        assert np.linalg.norm(pos) > 1e-2
+        assert np.all(np.abs(pos) < 3.5)
+        assert abs(np.linalg.norm(quat) - 1.0) < 1e-9
+
+    def test_clubhead_below_grip_in_world(
+        self, golf_humanoid: tuple[object, object]
+    ) -> None:
+        """In the neutral hanging pose the clubhead sits below the grip.
+
+        OpenSim is Y-up; ``club_head_offset`` is at ``Club + (0, -1.14, 0)``
+        so the clubhead Y-coord must be lower than the grip Y-coord.
+        """
+        model, state = golf_humanoid
+        grip_pos, _ = extract_grip_pose(state, model)
+        head_pos, _ = extract_clubhead_pose(state, model)
+        assert head_pos[1] < grip_pos[1], (
+            f"Expected clubhead Y < grip Y; got grip={grip_pos}, clubhead={head_pos}"
+        )
+
+    def test_extract_full_pose_contains_all_landmarks(
+        self, golf_humanoid: tuple[object, object]
+    ) -> None:
+        model, state = golf_humanoid
+        full = extract_full_pose(state, model)
+        for landmark in CANONICAL_LANDMARKS:
+            assert f"{landmark}_pos" in full
+            assert f"{landmark}_quat" in full
+            assert np.all(np.isfinite(full[f"{landmark}_pos"]))
+            assert np.all(np.isfinite(full[f"{landmark}_quat"]))
+
+    def test_round_trip_set_q_recover_grip(
+        self,
+        opensim_module: object,
+        golf_humanoid: tuple[object, object],
+    ) -> None:
+        """Round-trip: set ``q`` via the model's coordinate handles,
+        re-realise position, and confirm extraction returns a different
+        (but still finite) grip pose than the neutral one.
+
+        This is the FK side of the coord_map round-trip described in
+        issue #4114; the actual coord_map module is tracked separately.
+        """
+        model, state = golf_humanoid
+        neutral_grip, _ = extract_grip_pose(state, model)
+
+        # Perturb every coordinate by a small angle (1 deg = 0.0174 rad).
+        coord_set = model.getCoordinateSet()
+        n_coords = coord_set.getSize()
+        assert n_coords > 0, "Model must have at least one coordinate"
+
+        for i in range(n_coords):
+            coord = coord_set.get(i)
+            try:
+                value = coord.getValue(state)
+                coord.setValue(state, value + 0.0174)
+            except Exception:  # noqa: BLE001 — locked coords raise; skip them
+                continue
+
+        moved_grip, moved_quat = extract_grip_pose(state, model)
+        assert np.all(np.isfinite(moved_grip))
+        assert np.all(np.isfinite(moved_quat))
+        # The grip should have moved at least 1 mm somewhere.
+        delta = float(np.linalg.norm(moved_grip - neutral_grip))
+        assert delta > 1e-3, (
+            f"Grip did not move after perturbing every coordinate; "
+            f"neutral={neutral_grip}, moved={moved_grip}"
+        )


### PR DESCRIPTION
## Summary

- New OpenSim FK extraction module at `src/engines/physics_engines/opensim/python/motion_matching/forward_kinematics.py` exposing `extract_grip_pose`, `extract_clubhead_pose`, and `extract_full_pose` against the canonical landmark frames (`club_grip_offset`, `club_head_offset`) shipped in #4110 / PR #4149.
- Returns positions in metres (XYZ) and unit quaternions in canonical `[w, x, y, z]` ordering, converted from OpenSim's rotation-matrix output via a numerically-stable Shepperd branch selection (sign-canonicalised so `w >= 0`).
- `extract_full_pose` returns a flat dict (`grip_pos`, `grip_quat`, `clubhead_pos`, `clubhead_quat`, ...) in a single `realizePosition` pass; the canonical landmark catalogue is data-driven so adding new frames does not require editing the extraction loop.
- Tests at `tests/test_opensim_fk.py` cover the pure-NumPy quaternion conversion, the extraction plumbing under a mocked OpenSim model, and end-to-end FK on the shipped `golf_humanoid.osim` (gated behind the existing `requires_opensim` marker; sanity + neutral-pose plausibility + round-trip after perturbing every coordinate).

## Why this is `spec-exempt`

Issue #4116 specified `python/opensim_golf/fk.py` with `compute_grip` / `compute_clubhead` / `compute_skeleton_fk`; PRs #4158 and #4160 already landed that path on main. This PR delivers the alternate placement requested in the parent task (`motion_matching/forward_kinematics.py` with `extract_grip_pose` / `extract_clubhead_pose` / `extract_full_pose`) — same boundary, complementary entry-points, no overlap with the merged file. Hence `spec-exempt`.

## Test plan

- [x] `python3 -m pytest tests/test_opensim_fk.py -v` — 9 passed, 5 skipped on a host without OpenSim
- [x] `python3 -m ruff check src/engines/physics_engines/opensim/python/motion_matching/ tests/test_opensim_fk.py`
- [x] `python3 -m ruff format --check src/engines/physics_engines/opensim/python/motion_matching/ tests/test_opensim_fk.py`
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [ ] CI passes on a host with the OpenSim wheel installed (live FK tests run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)