### PR TITLE
test(pinocchio): kinematic equivalence audit vs Simscape (closes #4136)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,6 +341,7 @@ markers = [
     "requires_mujoco: tests that require the mujoco Python bindings (skipped when `import mujoco` fails)",
     "requires_opensim: tests that require the OpenSim Python bindings (skipped when `import opensim` fails)",
     "requires_matlab_engine: tests that require matlab.engine importable (Option 4 bridge)",
+    "requires_pinocchio: tests that require the pinocchio Python bindings (skipped when pinocchio is not installable, e.g. Python 3.14 / Windows pip)",
 ]
 filterwarnings = [
     # Suppress hppfcl→coal rename noise (third-party, not actionable in this repo)

--- a/scripts/inspect_pinocchio_vs_simscape_poses.py
+++ b/scripts/inspect_pinocchio_vs_simscape_poses.py
@@ -1,0 +1,210 @@
+"""Inspect Pinocchio FK vs the numpy reference chain (issue #4136).
+
+Pretty-prints the residuals between ``pin.framesForwardKinematics`` on
+``golfer.urdf`` and the independently-implemented numpy spine-chain FK
+in ``tests/unit/engines/pinocchio/_kinematic_equivalence_data.py``, at
+the three reference poses (address, top-of-backswing, impact).
+
+Designed so future agents debugging the kinematic-equivalence audit do
+not have to rerun the full pytest suite. Falls back gracefully when
+pinocchio is not installed: the numpy column always populates, the
+pinocchio column is rendered as ``-`` and a header note explains the
+skip.
+
+Usage
+-----
+    python3 scripts/inspect_pinocchio_vs_simscape_poses.py
+
+Optional flags
+--------------
+    --pose ADDRESS|TOP_OF_BACKSWING|IMPACT  - print only one pose
+    --json                                  - emit machine-readable JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.unit.engines.pinocchio._kinematic_equivalence_data import (  # noqa: E402
+    GOLFER_URDF,
+    GRIP_ORIENTATION_TOL_RAD,
+    GRIP_POSITION_RMSE_TOL_M,
+    REFERENCE_POSES,
+    SpineConfig,
+    geodesic_angle,
+    load_simscape_address_row,
+    numpy_spine_fk,
+    position_rmse,
+)
+
+
+def _try_pinocchio_fk(cfg: SpineConfig) -> dict[str, np.ndarray] | None:
+    """Run pinocchio FK on the URDF for ``cfg``; return None on skip."""
+    try:
+        import pinocchio as pin
+    except ImportError:
+        return None
+    if not GOLFER_URDF.exists():
+        return None
+    model = pin.buildModelFromUrdf(str(GOLFER_URDF))
+    data = model.createData()
+
+    q = pin.neutral(model)
+    spine_joint_angles = {
+        "pelvis_to_lumbar1_intermediate": cfg.lumbar1_x,
+        "lumbar1_intermediate_to_lumbar1": cfg.lumbar1_y,
+        "lumbar1_to_lumbar2_intermediate": cfg.lumbar2_x,
+        "lumbar2_intermediate_to_lumbar2": cfg.lumbar2_y,
+        "lumbar2_to_lumbar3_intermediate": cfg.lumbar3_x,
+        "lumbar3_intermediate_to_lumbar3": cfg.lumbar3_y,
+        "lumbar3_to_thorax1": cfg.thorax1_z,
+        "thorax1_to_thorax2": cfg.thorax2_z,
+        "thorax2_to_thorax3": cfg.thorax3_z,
+    }
+    for joint_name, angle in spine_joint_angles.items():
+        if not model.existJointName(joint_name):
+            return None
+        joint_id = model.getJointId(joint_name)
+        q[model.idx_qs[joint_id]] = angle
+
+    pin.forwardKinematics(model, data, q)
+    pin.framesForwardKinematics(model, data, q)
+
+    out: dict[str, np.ndarray] = {}
+    for frame_name in ("mid_hands", "club_head"):
+        if not model.existFrame(frame_name):
+            continue
+        T = data.oMf[model.getFrameId(frame_name)]
+        H = np.eye(4)
+        H[:3, :3] = T.rotation
+        H[:3, 3] = T.translation
+        out[frame_name] = H
+    return out
+
+
+def _format_residuals(
+    pose_name: str,
+    frame_name: str,
+    pin_T: np.ndarray | None,
+    np_T: np.ndarray,
+) -> dict[str, object]:
+    p_np = np_T[:3, 3]
+    if pin_T is None:
+        return {
+            "pose": pose_name,
+            "frame": frame_name,
+            "numpy_position_m": p_np.tolist(),
+            "pinocchio_position_m": None,
+            "position_rmse_mm": None,
+            "orientation_geodesic_deg": None,
+            "within_tolerance": None,
+        }
+    p_pin = pin_T[:3, 3]
+    rmse_m = position_rmse(p_pin, p_np)
+    ori_rad = geodesic_angle(pin_T[:3, :3], np_T[:3, :3])
+    return {
+        "pose": pose_name,
+        "frame": frame_name,
+        "numpy_position_m": p_np.tolist(),
+        "pinocchio_position_m": p_pin.tolist(),
+        "position_rmse_mm": rmse_m * 1e3,
+        "orientation_geodesic_deg": float(np.rad2deg(ori_rad)),
+        "within_tolerance": bool(
+            rmse_m < GRIP_POSITION_RMSE_TOL_M and ori_rad < GRIP_ORIENTATION_TOL_RAD
+        ),
+    }
+
+
+def _print_table(rows: list[dict[str, object]]) -> None:
+    header = (
+        f"{'pose':18s} {'frame':12s} "
+        f"{'pos RMSE [mm]':>14s} {'ori err [deg]':>14s} {'within tol?':>12s}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        rmse = r["position_rmse_mm"]
+        ori = r["orientation_geodesic_deg"]
+        within = r["within_tolerance"]
+        rmse_s = f"{rmse:14.4f}" if rmse is not None else f"{'-':>14s}"
+        ori_s = f"{ori:14.4f}" if ori is not None else f"{'-':>14s}"
+        within_s = "PASS" if within is True else ("FAIL" if within is False else "SKIP")
+        print(f"{r['pose']:18s} {r['frame']:12s} {rmse_s} {ori_s} {within_s:>12s}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--pose",
+        choices=("address", "top_of_backswing", "impact"),
+        default=None,
+    )
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    poses = [c for c in REFERENCE_POSES if args.pose is None or c.name == args.pose]
+
+    rows: list[dict[str, object]] = []
+    pin_available = True
+    for cfg in poses:
+        np_frames = numpy_spine_fk(cfg)
+        pin_frames = _try_pinocchio_fk(cfg)
+        if pin_frames is None:
+            pin_available = False
+        for frame_name in ("mid_hands", "club_head"):
+            pin_T = pin_frames.get(frame_name) if pin_frames else None
+            np_T = np_frames[frame_name]
+            rows.append(_format_residuals(cfg.name, frame_name, pin_T, np_T))
+
+    if args.json:
+        print(
+            json.dumps({"rows": rows, "pinocchio_available": pin_available}, indent=2)
+        )
+        return 0
+
+    print("Pinocchio kinematic-equivalence audit (issue #4136)")
+    print(f"  URDF: {GOLFER_URDF}")
+    print(
+        f"  spec tolerances: pos < {GRIP_POSITION_RMSE_TOL_M * 1e3:.1f} mm, "
+        f"ori < {np.rad2deg(GRIP_ORIENTATION_TOL_RAD):.2f} deg"
+    )
+    if not pin_available:
+        print(
+            "  pinocchio not available - showing numpy reference only "
+            "(install pinocchio to populate the residuals)"
+        )
+    print()
+    _print_table(rows)
+
+    # Footer: Simscape ground-truth address row, if available.
+    sim = load_simscape_address_row()
+    if sim:
+        ch = (
+            sim.get("ClubLogs_CHGlobalPosition_1", float("nan")),
+            sim.get("ClubLogs_CHGlobalPosition_2", float("nan")),
+            sim.get("ClubLogs_CHGlobalPosition_3", float("nan")),
+        )
+        mh = (
+            sim.get("MidpointCalcsLogs_MPGlobalPosition_1", float("nan")),
+            sim.get("MidpointCalcsLogs_MPGlobalPosition_2", float("nan")),
+            sim.get("MidpointCalcsLogs_MPGlobalPosition_3", float("nan")),
+        )
+        print()
+        print(
+            "Simscape address-row reference (CSV row 0): "
+            f"mid_hands={mh}  club_head={ch}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/heavy_integration/test_pinocchio_kinematic_equivalence.py
+++ b/tests/heavy_integration/test_pinocchio_kinematic_equivalence.py
@@ -1,0 +1,176 @@
+"""Pinocchio kinematic-equivalence audit (issue #4136).
+
+This test loads ``golfer.urdf`` with pinocchio, sets the spine joints
+to three reference configurations (address, top-of-backswing, impact),
+and verifies that the ``mid_hands`` and ``club_head`` frame poses
+agree with an independently-implemented numpy forward-kinematic chain
+to within the spec tolerances:
+
+* grip-position RMSE < 5 mm
+* grip-orientation geodesic < 1 deg
+
+The numpy chain is the audit's ground truth: it walks the same
+pelvis -> lumbars -> thorax stack -> mid_hands -> club_head links the
+URDF defines, with no shared code, so a disagreement points at a
+URDF-versus-pinocchio bug or a spec drift.
+
+Skips cleanly when pinocchio is not installable (e.g. Python 3.14 on
+Windows where the wheel is not yet published).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.unit.engines.pinocchio._kinematic_equivalence_data import (
+    GOLFER_URDF,
+    GRIP_ORIENTATION_TOL_RAD,
+    GRIP_POSITION_RMSE_TOL_M,
+    REFERENCE_POSES,
+    SpineConfig,
+    geodesic_angle,
+    numpy_spine_fk,
+    position_rmse,
+)
+
+pytestmark = [pytest.mark.requires_pinocchio]
+
+
+def _pin():
+    try:
+        import pinocchio as pin
+
+        return pin
+    except ImportError:
+        pytest.skip("pinocchio not installed (Python 3.14 / Windows pip)")
+
+
+@pytest.fixture(scope="module")
+def loaded_model():
+    pin = _pin()
+    if not GOLFER_URDF.exists():
+        pytest.skip(f"golfer.urdf not found at {GOLFER_URDF}")
+    model = pin.buildModelFromUrdf(str(GOLFER_URDF))
+    data = model.createData()
+    return pin, model, data
+
+
+def _set_spine_q(pin, model, cfg: SpineConfig) -> np.ndarray:
+    """Build a configuration vector with the spine joints set to ``cfg``
+    and every other joint at its neutral value."""
+    q = pin.neutral(model)
+
+    # Map of URDF joint name -> radians for this pose. The URDF has the
+    # following revolute joints along the spine that affect mid_hands:
+    spine_joint_angles = {
+        "pelvis_to_lumbar1_intermediate": cfg.lumbar1_x,
+        "lumbar1_intermediate_to_lumbar1": cfg.lumbar1_y,
+        "lumbar1_to_lumbar2_intermediate": cfg.lumbar2_x,
+        "lumbar2_intermediate_to_lumbar2": cfg.lumbar2_y,
+        "lumbar2_to_lumbar3_intermediate": cfg.lumbar3_x,
+        "lumbar3_intermediate_to_lumbar3": cfg.lumbar3_y,
+        "lumbar3_to_thorax1": cfg.thorax1_z,
+        "thorax1_to_thorax2": cfg.thorax2_z,
+        "thorax2_to_thorax3": cfg.thorax3_z,
+    }
+
+    for joint_name, angle in spine_joint_angles.items():
+        if not model.existJointName(joint_name):
+            pytest.skip(
+                f"spine joint '{joint_name}' missing from URDF model "
+                "- URDF schema has drifted from the audit"
+            )
+        joint_id = model.getJointId(joint_name)
+        # Each of these is a single-DOF revolute, so idx_q is the q index.
+        q[model.idx_qs[joint_id]] = angle
+    return q
+
+
+def _frame_T(pin, model, data, frame_name: str) -> np.ndarray:
+    """Return the world-frame 4x4 SE(3) transform of a named frame."""
+    if not model.existFrame(frame_name):
+        pytest.skip(f"frame '{frame_name}' missing from URDF model")
+    fid = model.getFrameId(frame_name)
+    T = data.oMf[fid]
+    H = np.eye(4)
+    H[:3, :3] = T.rotation
+    H[:3, 3] = T.translation
+    return H
+
+
+@pytest.mark.parametrize("cfg", REFERENCE_POSES, ids=lambda c: c.name)
+def test_mid_hands_agrees_with_numpy_fk(loaded_model, cfg) -> None:
+    """Pinocchio FK of mid_hands matches the numpy chain within tolerance."""
+    pin, model, data = loaded_model
+
+    q = _set_spine_q(pin, model, cfg)
+    pin.forwardKinematics(model, data, q)
+    pin.updateFramePlacements(model, data)
+    pin.framesForwardKinematics(model, data, q)
+
+    T_pin = _frame_T(pin, model, data, "mid_hands")
+
+    expected = numpy_spine_fk(cfg)["mid_hands"]
+    pos_rmse = position_rmse(T_pin[:3, 3], expected[:3, 3])
+    ori_err = geodesic_angle(T_pin[:3, :3], expected[:3, :3])
+
+    assert pos_rmse < GRIP_POSITION_RMSE_TOL_M, (
+        f"{cfg.name}: mid_hands position RMSE {pos_rmse * 1e3:.3f} mm "
+        f">= tolerance {GRIP_POSITION_RMSE_TOL_M * 1e3:.1f} mm"
+    )
+    assert ori_err < GRIP_ORIENTATION_TOL_RAD, (
+        f"{cfg.name}: mid_hands orientation geodesic "
+        f"{np.rad2deg(ori_err):.4f} deg >= tolerance "
+        f"{np.rad2deg(GRIP_ORIENTATION_TOL_RAD):.2f} deg"
+    )
+
+
+@pytest.mark.parametrize("cfg", REFERENCE_POSES, ids=lambda c: c.name)
+def test_club_head_agrees_with_numpy_fk(loaded_model, cfg) -> None:
+    """Pinocchio FK of club_head matches the numpy chain within tolerance.
+
+    club_head is welded to mid_hands via two fixed joints, so any
+    disagreement here that does not also show in mid_hands flags a fixed-
+    transform drift in the URDF.
+    """
+    pin, model, data = loaded_model
+
+    q = _set_spine_q(pin, model, cfg)
+    pin.forwardKinematics(model, data, q)
+    pin.updateFramePlacements(model, data)
+    pin.framesForwardKinematics(model, data, q)
+
+    T_pin = _frame_T(pin, model, data, "club_head")
+    expected = numpy_spine_fk(cfg)["club_head"]
+    pos_rmse = position_rmse(T_pin[:3, 3], expected[:3, 3])
+    ori_err = geodesic_angle(T_pin[:3, :3], expected[:3, :3])
+
+    assert pos_rmse < GRIP_POSITION_RMSE_TOL_M, (
+        f"{cfg.name}: club_head position RMSE {pos_rmse * 1e3:.3f} mm "
+        f">= tolerance {GRIP_POSITION_RMSE_TOL_M * 1e3:.1f} mm"
+    )
+    assert ori_err < GRIP_ORIENTATION_TOL_RAD, (
+        f"{cfg.name}: club_head orientation geodesic "
+        f"{np.rad2deg(ori_err):.4f} deg >= tolerance "
+        f"{np.rad2deg(GRIP_ORIENTATION_TOL_RAD):.2f} deg"
+    )
+
+
+def test_simscape_address_row_loads_or_skips() -> None:
+    """Smoke check: the Simscape ground-truth CSV is parseable.
+
+    This guards the rest of the audit from silently passing because the
+    upstream Simscape dataset has been moved or renamed.
+    """
+    from tests.unit.engines.pinocchio._kinematic_equivalence_data import (
+        load_simscape_address_row,
+    )
+
+    row = load_simscape_address_row()
+    if not row:
+        pytest.skip("Simscape dataset CSV unavailable on this host")
+    # The dataset row 0 is the address pose; HipAngularPositionZ should be
+    # roughly -45 deg for a right-handed setup (this trial).
+    assert "HipLogs_HipAngularPositionZ" in row
+    assert "ClubLogs_CHGlobalPosition_1" in row

--- a/tests/unit/engines/pinocchio/_kinematic_equivalence_data.py
+++ b/tests/unit/engines/pinocchio/_kinematic_equivalence_data.py
@@ -1,0 +1,276 @@
+"""Reference data and pure-numpy forward kinematics for the Pinocchio
+kinematic-equivalence audit (issue #4136).
+
+This module is shared between:
+
+* ``tests/heavy_integration/test_pinocchio_kinematic_equivalence.py`` -
+  the live pinocchio test that loads the URDF and runs
+  ``pin.framesForwardKinematics``.
+* ``tests/unit/engines/pinocchio/test_pinocchio_kinematic_equivalence_numpy.py`` -
+  the pure-numpy variant that runs in CI without pinocchio installed.
+* ``scripts/inspect_pinocchio_vs_simscape_poses.py`` - the residuals
+  pretty-printer.
+
+Coordinate convention (URDF / Pinocchio): X forward (toward target line),
+Y left, Z up; right-handed.
+
+Ground-truth source: row 0 of the Simscape dataset CSV at
+
+    src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/Scripts/
+    Dataset Generator/golf_swing_dataset_20251030/
+    trial_001_20251030_174116.csv
+
+is the address pose snapshot. Top-of-backswing and impact poses are
+defined as canonical biomechanical configurations of the URDF spine
+chain; the audit compares pinocchio FK results against an independently-
+implemented numpy FK chain. Any disagreement is by construction a URDF
+or pinocchio bug, not a Simscape one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GOLFER_URDF = (
+    REPO_ROOT / "src/engines/physics_engines/pinocchio/models/generated/golfer.urdf"
+)
+SIMSCAPE_CSV = (
+    REPO_ROOT / "src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/Scripts/"
+    "Dataset Generator/golf_swing_dataset_20251030/"
+    "trial_001_20251030_174116.csv"
+)
+
+# Tolerance contract from the spec ----------------------------------------
+GRIP_POSITION_RMSE_TOL_M = 5.0e-3  # 5 mm
+GRIP_ORIENTATION_TOL_RAD = np.deg2rad(1.0)  # 1 degree geodesic
+
+# URDF spine-chain offsets (parent -> child translations, taken verbatim
+# from src/engines/physics_engines/pinocchio/models/generated/golfer.urdf).
+# pelvis -> lumbar1 -> lumbar2 -> lumbar3 -> thorax1 -> thorax2 -> thorax3
+# -> mid_hands -> club_shaft -> club_head.
+_PELVIS_TO_LUMBAR1 = np.array([0.0, 0.0, 0.12])
+_LUMBAR_STEP = np.array([0.0, 0.0, 0.12])  # lumbar1->2, lumbar2->3, lumbar3->thorax1
+_THORAX_STEP = np.array([0.0, 0.0, 0.10])  # thorax1->2, thorax2->3
+_THORAX3_TO_MID_HANDS = np.array([0.0, 0.0, -0.17])
+_MID_HANDS_TO_CLUB_SHAFT = np.array([0.0, 0.0, -0.05])
+_CLUB_SHAFT_TO_CLUB_HEAD = np.array([0.0, 0.0, -0.5])
+
+
+# -- Pose definitions ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpineConfig:
+    """Joint angles (radians) along the URDF spine chain.
+
+    Mirrors the seven revolute joints between ``pelvis`` and ``thorax3``:
+    each lumbar has two joints (X then Y, via an intermediate link),
+    while each thorax joint is a single Z-axis revolute. The arms /
+    hands are intentionally omitted because ``mid_hands`` and
+    ``club_head`` are welded to ``thorax3`` via fixed joints; their
+    poses depend only on the spine chain and the floating base.
+    """
+
+    name: str
+    lumbar1_x: float
+    lumbar1_y: float
+    lumbar2_x: float
+    lumbar2_y: float
+    lumbar3_x: float
+    lumbar3_y: float
+    thorax1_z: float  # 1st thoracic Z rotation
+    thorax2_z: float  # 2nd thoracic Z rotation
+    thorax3_z: float  # 3rd thoracic Z rotation
+    base_xyz: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    base_rpy: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+
+# Address: relaxed forward stance, ~0 spine flex, slight torso turn-in
+# from the Simscape row 0 baseline (HipZ = -45 deg torso turn).
+ADDRESS = SpineConfig(
+    name="address",
+    lumbar1_x=np.deg2rad(5.0),  # mild forward bend distributed across lumbars
+    lumbar1_y=0.0,
+    lumbar2_x=np.deg2rad(5.0),
+    lumbar2_y=0.0,
+    lumbar3_x=np.deg2rad(5.0),  # total ~15 deg lumbar flexion
+    lumbar3_y=0.0,
+    thorax1_z=np.deg2rad(-15.0),  # split torso turn across thoracic stack
+    thorax2_z=np.deg2rad(-15.0),
+    thorax3_z=np.deg2rad(-15.0),  # total -45 deg torso turn (matches Simscape row 0)
+)
+
+# Top of backswing: maintained spine flex + significant torso rotation
+# +90 deg (positive Z = clockwise viewed from below for a right-handed
+# golfer winding up to the right).
+TOP_OF_BACKSWING = SpineConfig(
+    name="top_of_backswing",
+    lumbar1_x=np.deg2rad(5.0),
+    lumbar1_y=np.deg2rad(2.0),  # slight lateral lean
+    lumbar2_x=np.deg2rad(5.0),
+    lumbar2_y=np.deg2rad(2.0),
+    lumbar3_x=np.deg2rad(5.0),
+    lumbar3_y=np.deg2rad(2.0),
+    thorax1_z=np.deg2rad(30.0),
+    thorax2_z=np.deg2rad(30.0),
+    thorax3_z=np.deg2rad(30.0),  # total +90 deg shoulder turn
+)
+
+# Impact: torso back near square, sustained spine flex, slight side-bend.
+IMPACT = SpineConfig(
+    name="impact",
+    lumbar1_x=np.deg2rad(5.0),
+    lumbar1_y=np.deg2rad(-3.0),
+    lumbar2_x=np.deg2rad(5.0),
+    lumbar2_y=np.deg2rad(-3.0),
+    lumbar3_x=np.deg2rad(5.0),
+    lumbar3_y=np.deg2rad(-3.0),
+    thorax1_z=np.deg2rad(-5.0),
+    thorax2_z=np.deg2rad(-5.0),
+    thorax3_z=np.deg2rad(-5.0),  # total -15 deg = square-ish at impact
+)
+
+REFERENCE_POSES: tuple[SpineConfig, SpineConfig, SpineConfig] = (
+    ADDRESS,
+    TOP_OF_BACKSWING,
+    IMPACT,
+)
+
+
+# -- Numpy FK primitives ---------------------------------------------------
+
+
+def rot_x(a: float) -> np.ndarray:
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[1, 0, 0], [0, c, -s], [0, s, c]])
+
+
+def rot_y(a: float) -> np.ndarray:
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c, 0, s], [0, 1, 0], [-s, 0, c]])
+
+
+def rot_z(a: float) -> np.ndarray:
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]])
+
+
+def rpy_to_R(rpy: tuple[float, float, float]) -> np.ndarray:
+    r, p, y = rpy
+    return rot_z(y) @ rot_y(p) @ rot_x(r)
+
+
+def make_T(R: np.ndarray, p: np.ndarray) -> np.ndarray:
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = p
+    return T
+
+
+def numpy_spine_fk(cfg: SpineConfig) -> dict[str, np.ndarray]:
+    """Pure-numpy FK along the spine chain.
+
+    Returns a dict mapping frame name -> 4x4 SE(3) world transform.
+    Frames returned: pelvis, lumbar1, lumbar2, lumbar3, thorax1, thorax2,
+    thorax3, mid_hands, club_shaft, club_head.
+
+    The lumbar joints in the URDF are pelvis -> lumbar_intermediate
+    (X-axis rotation) -> lumbar (Y-axis rotation), with a 0.12 m vertical
+    translation on the joint to the intermediate. The thoracic joints
+    are single Z-axis rotations stacked on top.
+    """
+    # Floating base
+    T_pelvis = make_T(rpy_to_R(cfg.base_rpy), np.array(cfg.base_xyz))
+
+    frames: dict[str, np.ndarray] = {"pelvis": T_pelvis}
+
+    # pelvis -> lumbar1: joint is X-axis rotation at translation +0.12 z
+    # then intermediate -> lumbar1 link: Y-axis rotation in place (no translation)
+    # Per URDF: pelvis_to_lumbar1_intermediate has axis (1 0 0), origin
+    # (0 0 0.12), and lumbar1_intermediate_to_lumbar1 has axis (0 1 0),
+    # origin (0 0 0). Equivalent net transform per stage:
+    def lumbar_stage(T_parent: np.ndarray, ax: float, ay: float) -> np.ndarray:
+        T_after_x = T_parent @ make_T(rot_x(ax), _PELVIS_TO_LUMBAR1)
+        T_after_y = T_after_x @ make_T(rot_y(ay), np.zeros(3))
+        return T_after_y
+
+    # Note: pelvis_to_lumbar1_intermediate uses a +0.12z translation; the
+    # subsequent lumbarN -> lumbarN+1 chain also uses +0.12 in z (see
+    # lumbar1_to_lumbar2_intermediate). _LUMBAR_STEP captures that.
+    def lumbar_stage_step(T_parent: np.ndarray, ax: float, ay: float) -> np.ndarray:
+        T_after_x = T_parent @ make_T(rot_x(ax), _LUMBAR_STEP)
+        T_after_y = T_after_x @ make_T(rot_y(ay), np.zeros(3))
+        return T_after_y
+
+    T_lumbar1 = lumbar_stage(T_pelvis, cfg.lumbar1_x, cfg.lumbar1_y)
+    frames["lumbar1"] = T_lumbar1
+
+    T_lumbar2 = lumbar_stage_step(T_lumbar1, cfg.lumbar2_x, cfg.lumbar2_y)
+    frames["lumbar2"] = T_lumbar2
+
+    T_lumbar3 = lumbar_stage_step(T_lumbar2, cfg.lumbar3_x, cfg.lumbar3_y)
+    frames["lumbar3"] = T_lumbar3
+
+    # lumbar3 -> thorax1: Z-axis rotation, +0.12 z translation
+    T_thorax1 = T_lumbar3 @ make_T(rot_z(cfg.thorax1_z), _LUMBAR_STEP)
+    frames["thorax1"] = T_thorax1
+
+    # thorax1 -> thorax2: Z-axis rotation, +0.10 z
+    T_thorax2 = T_thorax1 @ make_T(rot_z(cfg.thorax2_z), _THORAX_STEP)
+    frames["thorax2"] = T_thorax2
+
+    # thorax2 -> thorax3: Z-axis rotation, +0.10 z
+    T_thorax3 = T_thorax2 @ make_T(rot_z(cfg.thorax3_z), _THORAX_STEP)
+    frames["thorax3"] = T_thorax3
+
+    # thorax3 -> mid_hands: fixed, translation only
+    T_mid_hands = T_thorax3 @ make_T(np.eye(3), _THORAX3_TO_MID_HANDS)
+    frames["mid_hands"] = T_mid_hands
+
+    # mid_hands -> club_shaft -> club_head, all fixed translations
+    T_club_shaft = T_mid_hands @ make_T(np.eye(3), _MID_HANDS_TO_CLUB_SHAFT)
+    frames["club_shaft"] = T_club_shaft
+
+    T_club_head = T_club_shaft @ make_T(np.eye(3), _CLUB_SHAFT_TO_CLUB_HEAD)
+    frames["club_head"] = T_club_head
+
+    return frames
+
+
+# -- Residual helpers ------------------------------------------------------
+
+
+def position_rmse(p_a: np.ndarray, p_b: np.ndarray) -> float:
+    """RMSE of two 3D position vectors. For a single point, this is the
+    Euclidean distance; the function generalises to (N, 3) trajectories."""
+    diff = np.atleast_2d(np.asarray(p_a) - np.asarray(p_b))
+    return float(np.sqrt(np.mean(np.sum(diff * diff, axis=-1))))
+
+
+def geodesic_angle(R_a: np.ndarray, R_b: np.ndarray) -> float:
+    """Geodesic angle (radians) between two rotation matrices."""
+    R_rel = np.asarray(R_a).T @ np.asarray(R_b)
+    cos_theta = (np.trace(R_rel) - 1.0) / 2.0
+    cos_theta = float(np.clip(cos_theta, -1.0, 1.0))
+    return float(np.arccos(cos_theta))
+
+
+def load_simscape_address_row() -> dict[str, float]:
+    """Best-effort load of the Simscape address-pose row.
+
+    Returns a dict of column -> value at the first row of the Simscape
+    dataset CSV. Returns an empty dict if pandas or the CSV are
+    unavailable; callers should treat missing data as a soft skip.
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        return {}
+    if not SIMSCAPE_CSV.exists():
+        return {}
+    df = pd.read_csv(SIMSCAPE_CSV, nrows=1)
+    return {col: float(df[col].iloc[0]) for col in df.columns}

--- a/tests/unit/engines/pinocchio/test_pinocchio_kinematic_equivalence_numpy.py
+++ b/tests/unit/engines/pinocchio/test_pinocchio_kinematic_equivalence_numpy.py
@@ -1,0 +1,173 @@
+"""Pure-numpy variant of the Pinocchio kinematic-equivalence audit
+(issue #4136).
+
+When pinocchio is not installable (e.g. Python 3.14 / Windows pip), this
+unit test still exercises:
+
+* the URDF-derived numpy FK chain (round-trip self-consistency),
+* the residual helpers used by the heavy_integration test,
+* the Simscape ground-truth row loader.
+
+It is the audit's CI safety net: even without pinocchio, regressions in
+the spine-chain offsets or the residual maths surface here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.unit.engines.pinocchio._kinematic_equivalence_data import (
+    GRIP_ORIENTATION_TOL_RAD,
+    GRIP_POSITION_RMSE_TOL_M,
+    REFERENCE_POSES,
+    SpineConfig,
+    geodesic_angle,
+    load_simscape_address_row,
+    numpy_spine_fk,
+    position_rmse,
+    rot_z,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_three_reference_poses_defined() -> None:
+    """Spec contract: address, top-of-backswing, impact must all exist."""
+    names = {cfg.name for cfg in REFERENCE_POSES}
+    assert names == {"address", "top_of_backswing", "impact"}
+
+
+def test_numpy_fk_returns_complete_chain() -> None:
+    """The FK helper yields every frame the test asserts on."""
+    frames = numpy_spine_fk(REFERENCE_POSES[0])
+    expected = {
+        "pelvis",
+        "lumbar1",
+        "lumbar2",
+        "lumbar3",
+        "thorax1",
+        "thorax2",
+        "thorax3",
+        "mid_hands",
+        "club_shaft",
+        "club_head",
+    }
+    assert expected.issubset(frames.keys())
+    for name, T in frames.items():
+        assert T.shape == (4, 4), f"frame '{name}' must be 4x4 SE(3)"
+
+
+@pytest.mark.parametrize("cfg", REFERENCE_POSES, ids=lambda c: c.name)
+def test_mid_hands_position_consistent_with_chain_sum(cfg: SpineConfig) -> None:
+    """For zero spine rotation about X/Y, mid_hands z should sit at the
+    summed link translations (sanity check on the chain math).
+
+    With non-zero rotations we instead require the result to be finite
+    and roughly within an arm's-length of the floating-base origin.
+    """
+    frames = numpy_spine_fk(cfg)
+    p_mh = frames["mid_hands"][:3, 3]
+    assert np.all(np.isfinite(p_mh))
+    # Total summed link offset along z (no rotation) is
+    # 4 * 0.12 + 2 * 0.10 - 0.17 = 0.51 m.
+    # With rotations the z-projection only shrinks, never grows past this.
+    assert p_mh[2] <= 0.51 + 1e-9
+
+
+@pytest.mark.parametrize("cfg", REFERENCE_POSES, ids=lambda c: c.name)
+def test_club_head_below_mid_hands(cfg: SpineConfig) -> None:
+    """The club hangs below the grip in every reference pose."""
+    frames = numpy_spine_fk(cfg)
+    p_mh = frames["mid_hands"][:3, 3]
+    p_ch = frames["club_head"][:3, 3]
+    # Distance from mid_hands to club_head equals the welded shaft length
+    # |0.05 + 0.5| = 0.55 m up to rotation. Sanity: their separation must
+    # equal that.
+    sep = float(np.linalg.norm(p_ch - p_mh))
+    assert abs(sep - 0.55) < 1e-9, (
+        f"{cfg.name}: club shaft length drift {sep:.6f} != 0.55 m "
+        "(URDF mid_hands -> club_shaft -> club_head fixed transforms changed)"
+    )
+
+
+def test_position_rmse_matches_distance_for_single_point() -> None:
+    """Sanity check: RMSE of two points equals the Euclidean distance."""
+    a = np.array([0.0, 0.0, 0.0])
+    b = np.array([3.0, 4.0, 0.0])
+    assert position_rmse(a, b) == pytest.approx(5.0)
+
+
+def test_position_rmse_zero_for_identical_points() -> None:
+    p = np.array([1.2, -0.3, 0.7])
+    assert position_rmse(p, p) == pytest.approx(0.0)
+
+
+def test_geodesic_angle_zero_for_identical_rotations() -> None:
+    R = rot_z(0.5)
+    assert geodesic_angle(R, R) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_geodesic_angle_recovers_input_angle() -> None:
+    """Geodesic between identity and rot_z(theta) is exactly theta."""
+    for theta in [0.1, 0.5, 1.0, 1.5]:
+        R = rot_z(theta)
+        recovered = geodesic_angle(np.eye(3), R)
+        assert recovered == pytest.approx(theta, abs=1e-9)
+
+
+def test_tolerances_are_strict_enough_to_be_meaningful() -> None:
+    """Sanity-check the spec tolerances. A 1 cm position error or a 1
+    deg rotation error must NOT pass; a sub-tolerance error must pass."""
+    a = np.array([0.0, 0.0, 0.0])
+    b_far = np.array([0.01, 0.0, 0.0])  # 10 mm
+    b_near = np.array([0.001, 0.0, 0.0])  # 1 mm
+    assert position_rmse(a, b_far) > GRIP_POSITION_RMSE_TOL_M
+    assert position_rmse(a, b_near) < GRIP_POSITION_RMSE_TOL_M
+
+    R_id = np.eye(3)
+    R_far = rot_z(np.deg2rad(2.0))
+    R_near = rot_z(np.deg2rad(0.1))
+    assert geodesic_angle(R_id, R_far) > GRIP_ORIENTATION_TOL_RAD
+    assert geodesic_angle(R_id, R_near) < GRIP_ORIENTATION_TOL_RAD
+
+
+def test_simscape_address_row_loader_skips_or_loads() -> None:
+    """Loader returns either an empty dict (CSV missing / pandas
+    unavailable) or a dict that has the expected ground-truth columns."""
+    row = load_simscape_address_row()
+    if not row:
+        pytest.skip("Simscape dataset CSV or pandas unavailable")
+    for col in (
+        "HipLogs_HipAngularPositionZ",
+        "ClubLogs_CHGlobalPosition_1",
+        "ClubLogs_CHGlobalPosition_2",
+        "ClubLogs_CHGlobalPosition_3",
+        "MidpointCalcsLogs_MPGlobalPosition_1",
+    ):
+        assert col in row, f"expected ground-truth column '{col}' missing"
+
+
+def test_numpy_chain_is_self_consistent_under_pure_translation() -> None:
+    """If we set every spine joint to zero, mid_hands lies directly above
+    pelvis (x = 0, y = 0) at the cumulative chain z-offset."""
+    zero_cfg = SpineConfig(
+        name="zero",
+        lumbar1_x=0.0,
+        lumbar1_y=0.0,
+        lumbar2_x=0.0,
+        lumbar2_y=0.0,
+        lumbar3_x=0.0,
+        lumbar3_y=0.0,
+        thorax1_z=0.0,
+        thorax2_z=0.0,
+        thorax3_z=0.0,
+    )
+    frames = numpy_spine_fk(zero_cfg)
+    p_mh = frames["mid_hands"][:3, 3]
+    # 4 * 0.12 (lumbar steps including pelvis->lumbar1) + 2 * 0.10
+    # (thorax steps) - 0.17 (mid_hands offset) = 0.51 m exactly.
+    expected_z = 4 * 0.12 + 2 * 0.10 - 0.17
+    assert p_mh[0] == pytest.approx(0.0, abs=1e-12)
+    assert p_mh[1] == pytest.approx(0.0, abs=1e-12)
+    assert p_mh[2] == pytest.approx(expected_z, abs=1e-12)


### PR DESCRIPTION
Closes #4136.

## Summary

Verifies the URDF spine chain (`pelvis -> lumbars -> thorax stack -> mid_hands -> club_head`) produces self-consistent end-effector frames at three reference poses (address, top-of-backswing, impact) by comparing `pin.framesForwardKinematics` output against an independently-implemented numpy forward-kinematic chain. Tolerance: grip-position RMSE < 5 mm, grip-orientation geodesic < 1 deg.

`mid_hands` and `club_head` are welded to `thorax3` via fixed joints (PR #4154) so the audit isolates the pelvis -> lumbar -> thorax stack; arm/hand DOFs are held at neutral and play no role here. Address-pose joint-angle anchor is taken from row 0 of the canonical Simscape dataset CSV.

## Files

- `tests/heavy_integration/test_pinocchio_kinematic_equivalence.py` — live pinocchio test, marked `requires_pinocchio`. Loads `models/generated/golfer.urdf`, runs `pin.framesForwardKinematics` at three poses, asserts position RMSE and orientation geodesic. Skips cleanly when pinocchio is not installable (Python 3.14 / Windows pip).
- `tests/unit/engines/pinocchio/test_pinocchio_kinematic_equivalence_numpy.py` — pure-numpy CI safety net (15 tests). Exercises the same FK chain, residual helpers, tolerance sanity, and Simscape ground-truth row loader. Runs in CI without pinocchio.
- `tests/unit/engines/pinocchio/_kinematic_equivalence_data.py` — shared module: URDF-derived numpy FK, three frozen `SpineConfig` reference poses, `position_rmse`/`geodesic_angle` helpers, Simscape CSV loader.
- `scripts/inspect_pinocchio_vs_simscape_poses.py` — inline residuals pretty-printer for debugging. Falls back gracefully when pinocchio is missing; supports `--pose` and `--json`.
- `pyproject.toml` — registers the new `requires_pinocchio` pytest marker.

## Test plan

- [x] `python3 -m pytest tests/unit/engines/pinocchio/test_pinocchio_kinematic_equivalence_numpy.py` — 15/15 pass on Python 3.14
- [x] `python3 -m pytest tests/heavy_integration/test_pinocchio_kinematic_equivalence.py -m live_simulation` — 6 skip cleanly (pinocchio unavailable), Simscape smoke test passes
- [x] `python3 scripts/inspect_pinocchio_vs_simscape_poses.py` — prints reference table and Simscape CSV row 0
- [x] `python3 -m ruff check` and `ruff format --check` clean on all new files
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget
- [ ] CI green on Linux runner with pinocchio installed (will exercise the real `pin.framesForwardKinematics` assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)