### PR TITLE
refactor(pinocchio): break LOD violations (>2-deep method chains) (closes #4139)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -88,6 +88,7 @@ guardrails until the active workflow count reaches the 25-workflow target:
 | Nightly-Doc-Organizer.yml | schedule/workflow_dispatch | @docs | contents/pull-requests: write | MERGE: nightly docs cleanup. | docs-ci.yml |
 | pdf-size-guard.yml | pull_request | @docs | contents: read | KEEP: PDF size guard. | n/a |
 | pr-auto-labeler.yml | pull_request | @triage | pull-requests: write | KEEP: PR labeling. | n/a |
+| quality-gate.yml | pull_request/workflow_dispatch | @core | contents: read | KEEP: advisory engine-specific quality lints (e.g. pinocchio LOD). | n/a |
 | PR-Comment-Responder.yml | issue_comment/workflow_dispatch | @triage | issues/pull-requests: write | KEEP: canonical PR comment responder. | n/a |
 | release.yml | push/workflow_dispatch | @release | contents: write | KEEP: build and publish releases. | n/a |
 | security-osv-monitor.yml | schedule/workflow_dispatch | @security | contents/issues/security-events: write | KEEP: scheduled OSV vulnerability triage SLA monitor. | n/a |

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,47 @@
+name: Quality Gate
+
+# Advisory quality checks for engine-specific coding standards.
+# Currently runs the LOD (Law of Demeter) lint over the pinocchio Python
+# package; the check is **advisory** (it prints warnings and never fails the
+# build) until issue #4139 is fully landed and we want to start blocking
+# regressions.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "src/engines/physics_engines/pinocchio/python/**"
+      - "scripts/ci/check_lod.py"
+      - ".github/workflows/quality-gate.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lod-pinocchio:
+    name: LOD lint (pinocchio python) — advisory
+    runs-on: d-sorg-fleet
+    timeout-minutes: 5
+    steps:
+      - name: Enable long Git paths
+        run: git config --global core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+
+      - name: Run LOD lint (advisory)
+        shell: bash
+        run: |
+          python3 scripts/ci/check_lod.py \
+            src/engines/physics_engines/pinocchio/python \
+            --advisory

--- a/scripts/ci/check_lod.py
+++ b/scripts/ci/check_lod.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""LOD (Law of Demeter) lint check for the pinocchio Python package.
+
+Flags attribute-access chains deeper than 2 levels (i.e. `a.b.c.d` and longer)
+that are likely to be genuine LOD violations.
+
+A chain is considered "deep" when more than 2 ``ast.Attribute`` nodes are
+stacked on top of an underlying ``ast.Name`` receiver (so ``a.b.c`` is fine
+but ``a.b.c.d`` is not). This matches the standard LOD interpretation used
+in the project's CODING_STANDARDS.md.
+
+Allow-list rationale (these are library API patterns, not LOD violations):
+- Qt signal/slot wiring: ``self.btn.clicked.connect(...)`` — fixed call shape
+  imposed by PyQt's signal API. Refactoring would just hide the wiring.
+- numpy / scipy / pandas method chains where the second-to-last segment is a
+  method that returns a new array (``.copy()``, ``.tolist()``, ``.reshape()``,
+  ``.astype()``, ``.flatten()``, ``.T``, ``.add_subplot()``, ``.fig.clear()``).
+  These are method chains on library return values, not object-graph
+  navigation.
+- Logging: ``self.logger.info.something`` style does not actually appear; the
+  logger calls in the codebase are well-behaved.
+
+The script exits with code 0 if no violations are found, code 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+# Final attribute / method names that indicate a library API chain rather
+# than navigation through application state.
+LIBRARY_API_LEAVES: frozenset[str] = frozenset(
+    {
+        # Qt signal/slot wiring
+        "connect",
+        "disconnect",
+        "emit",
+        # numpy / pandas tail operations
+        "tolist",
+        "copy",
+        "reshape",
+        "astype",
+        "flatten",
+        "ravel",
+        "squeeze",
+        "transpose",
+        "T",
+        "item",
+        "all",
+        "any",
+        "sum",
+        "mean",
+        "max",
+        "min",
+        "argmax",
+        "argmin",
+        # matplotlib/figure helpers commonly chained on canvas.fig
+        "add_subplot",
+        "clear",
+        "tight_layout",
+        "savefig",
+        "draw",
+        "draw_idle",
+    }
+)
+
+# Intermediate segments that indicate this chain reaches into a library
+# object (so the *next* call is library API, not object navigation).
+LIBRARY_API_INTERMEDIATES: frozenset[str] = frozenset(
+    {
+        # PyQt signals
+        "clicked",
+        "toggled",
+        "currentTextChanged",
+        "currentIndexChanged",
+        "valueChanged",
+        "textChanged",
+        "timeout",
+        "returnPressed",
+        "stateChanged",
+        "triggered",
+        "activated",
+        "released",
+        "pressed",
+        "editingFinished",
+        # Custom Qt-style signals defined in the codebase
+        "gravity_changed",
+        "pose_loaded",
+        "interpolation_requested",
+        # Matplotlib canvas
+        "fig",
+        "figure",
+        "axes",
+        "canvas",
+    }
+)
+
+
+def _attr_chain(node: ast.AST) -> list[str] | None:
+    """Return the dotted-attribute chain for an Attribute/Name expression.
+
+    Returns ``None`` if the chain bottoms out in something other than a Name
+    (e.g. a Call, Subscript, or literal) — those cases are filtered separately.
+    """
+    parts: list[str] = []
+    current: ast.AST = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        parts.reverse()
+        return parts
+    return None
+
+
+def _is_library_chain(chain: list[str]) -> bool:
+    """Heuristically classify a chain as library-API rather than navigation."""
+    if not chain:
+        return True
+    if chain[-1] in LIBRARY_API_LEAVES:
+        return True
+    if any(seg in LIBRARY_API_INTERMEDIATES for seg in chain):
+        return True
+    # Static enum / module access — e.g. QtCore.Qt.Orientation.Horizontal,
+    # pin.GeometryType.VISUAL, np.linalg.norm. These are namespaced constants
+    # or qualified function references, not object navigation.
+    return chain[0] in {
+        "QtCore",
+        "QtGui",
+        "QtWidgets",
+        "Qt",
+        "pin",
+        "pinocchio",
+        "np",
+        "numpy",
+    }
+
+
+class LODVisitor(ast.NodeVisitor):
+    """Collect deep attribute chains rooted at a Name node."""
+
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+        # Only consider the *outermost* Attribute of a chain. We detect that by
+        # the parent-tracking established in ``check_file``.
+        parent = getattr(node, "_parent", None)
+        if isinstance(parent, ast.Attribute):
+            self.generic_visit(node)
+            return
+
+        chain = _attr_chain(node)
+        if chain is None:
+            self.generic_visit(node)
+            return
+
+        # Chain length: the number of attribute hops past the receiver.
+        # `a.b` -> chain == ["a","b"] -> 1 hop. `a.b.c.d` -> 3 hops.
+        hops = len(chain) - 1
+        if hops <= 2:
+            self.generic_visit(node)
+            return
+
+        if _is_library_chain(chain):
+            self.generic_visit(node)
+            return
+
+        self.violations.append((node.lineno, ".".join(chain)))
+        self.generic_visit(node)
+
+
+def _annotate_parents(tree: ast.AST) -> None:
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            child._parent = parent  # type: ignore[attr-defined]
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    _annotate_parents(tree)
+    visitor = LODVisitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def iter_python_files(root: Path) -> list[Path]:
+    return [
+        p
+        for p in root.rglob("*.py")
+        if "tests" not in p.parts and "examples" not in p.parts
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="src/engines/physics_engines/pinocchio/python",
+        help="Root directory to scan.",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="Print violations but exit 0 (warning mode).",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if not root.exists():
+        print(f"check_lod: root path does not exist: {root}", file=sys.stderr)
+        return 2
+
+    files = iter_python_files(root)
+    total = 0
+    for path in sorted(files):
+        violations = check_file(path)
+        if not violations:
+            continue
+        rel = path.relative_to(root.parent) if root.parent in path.parents else path
+        for lineno, chain in violations:
+            print(f"{rel}:{lineno}: LOD chain >2 deep: {chain}")
+            total += 1
+
+    if total == 0:
+        print(f"check_lod: clean ({len(files)} files scanned under {root})")
+        return 0
+
+    print(f"check_lod: found {total} LOD violation(s)", file=sys.stderr)
+    return 0 if args.advisory else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/engines/physics_engines/pinocchio/python/dtack/viz/geppetto_viewer.py
+++ b/src/engines/physics_engines/pinocchio/python/dtack/viz/geppetto_viewer.py
@@ -47,7 +47,10 @@ class GeppettoViewer:
 
         try:
             self.client = gepetto.corbaserver.Client()
-            self.client.gui.createWindow("golfer_viewer")
+            # Bind the GUI handle locally so call sites stay within LOD bounds
+            # (avoid ``self.client.gui.createWindow(...)`` chains).
+            gui = self.client.gui
+            gui.createWindow("golfer_viewer")
             logger.info("Geppetto viewer initialized")
         except (RuntimeError, ValueError, OSError) as e:
             logger.warning("Failed to connect to Geppetto server: %s", e)

--- a/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/club_trajectory_parser.py
@@ -92,6 +92,34 @@ class ClubTrajectory:
         """Return Nx3 array of club face positions."""
         return np.array([f.club_face_position for f in self.frames])
 
+    # --- Delegating accessors for SwingEventMarkers (LOD: keep callers from
+    # reaching through ``self.events`` for routine logging / export). ---
+
+    @property
+    def address_frame(self) -> int:
+        """Frame index of the address (setup) event."""
+        return self.events.address
+
+    @property
+    def top_frame(self) -> int:
+        """Frame index of the top-of-backswing event."""
+        return self.events.top
+
+    @property
+    def impact_frame(self) -> int:
+        """Frame index of the ball-impact event."""
+        return self.events.impact
+
+    @property
+    def finish_frame(self) -> int:
+        """Frame index of the finish (end of follow-through) event."""
+        return self.events.finish
+
+    @property
+    def club_head_speed_mph(self) -> float:
+        """Club-head speed at impact, in miles per hour."""
+        return self.events.club_head_speed
+
     def get_frame_at_time(self, t: float) -> ClubFrame:
         """Interpolate to get frame at specific time."""
         if not (t is not None):

--- a/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/dual_hand_ik_solver.py
@@ -88,6 +88,12 @@ class TrajectoryIKResult:
         """Return NxQ array of joint configurations."""
         return np.array(self.configurations)
 
+    @property
+    def q_dim(self) -> int:
+        """Return the per-frame joint-configuration dimension (Q)."""
+        traj = self.q_trajectory
+        return int(traj.shape[1]) if traj.ndim == 2 else 0
+
 
 class DualHandIKSolver:
     """Inverse kinematics solver for dual-hand golf swing tracking.
@@ -152,6 +158,16 @@ class DualHandIKSolver:
 
         # Reference configuration (neutral pose)
         self.q_ref = pin.neutral(self.model)
+
+    @property
+    def nq(self) -> int:
+        """Configuration-space dimension of the underlying Pinocchio model."""
+        return int(self.model.nq)
+
+    @property
+    def nv(self) -> int:
+        """Tangent-space (velocity) dimension of the underlying model."""
+        return int(self.model.nv)
 
     def _setup_tasks(self) -> None:
         """Setup Pink IK tasks."""

--- a/src/engines/physics_engines/pinocchio/python/motion_training/training_pipeline.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/training_pipeline.py
@@ -123,10 +123,10 @@ class MotionTrainingPipeline:
         logger.debug(f"      Loaded {self.trajectory.num_frames} frames")
         logger.info(f"      Duration: {self.trajectory.duration:.3f} seconds")
         logger.info(
-            f"      Events: A={self.trajectory.events.address}, "
-            f"T={self.trajectory.events.top}, "
-            f"I={self.trajectory.events.impact}, "
-            f"F={self.trajectory.events.finish}"
+            f"      Events: A={self.trajectory.address_frame}, "
+            f"T={self.trajectory.top_frame}, "
+            f"I={self.trajectory.impact_frame}, "
+            f"F={self.trajectory.finish_frame}"
         )
 
         # Step 2: Initialize IK solver
@@ -135,7 +135,7 @@ class MotionTrainingPipeline:
         logger.info(f"      Model: {self.config.golfer_urdf}")
         if not (self.ik_solver is not None):
             raise ValueError("DbC Blocked: Precondition failed.")
-        logger.info(f"      DOF: {self.ik_solver.model.nq}")
+        logger.info(f"      DOF: {self.ik_solver.nq}")
 
         # Step 3: Solve IK
         logger.info("\n[3/4] Solving inverse kinematics...")
@@ -232,9 +232,7 @@ class MotionTrainingPipeline:
 
         with open(output_dir / "joint_trajectory.csv", "w", newline="") as f:
             writer = csv.writer(f)
-            header = ["time"] + [
-                f"q{i}" for i in range(self.ik_result.q_trajectory.shape[1])
-            ]  # noqa: E501
+            header = ["time"] + [f"q{i}" for i in range(self.ik_result.q_dim)]  # noqa: E501
             writer.writerow(header)
             for i, t in enumerate(self.ik_result.times):
                 row = [t] + list(self.ik_result.q_trajectory[i])

--- a/src/engines/physics_engines/pinocchio/python/motion_training/trajectory_exporter.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_training/trajectory_exporter.py
@@ -171,11 +171,11 @@ class TrajectoryExporter:
                 "grip_positions": self.trajectory.grip_positions.tolist(),
                 "club_face_positions": self.trajectory.club_face_positions.tolist(),
                 "events": {
-                    "address": self.trajectory.events.address,
-                    "top": self.trajectory.events.top,
-                    "impact": self.trajectory.events.impact,
-                    "finish": self.trajectory.events.finish,
-                    "club_head_speed_mph": self.trajectory.events.club_head_speed,
+                    "address": self.trajectory.address_frame,
+                    "top": self.trajectory.top_frame,
+                    "impact": self.trajectory.impact_frame,
+                    "finish": self.trajectory.finish_frame,
+                    "club_head_speed_mph": self.trajectory.club_head_speed_mph,
                 },
             }
 

--- a/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
+++ b/src/engines/physics_engines/pinocchio/python/pinocchio_golf/pose_editor_tab.py
@@ -334,10 +334,10 @@ class PinocchioPoseEditor(BasePoseEditor):
 
         try:
             if enabled:
-                self._model.gravity.linear = self._original_gravity
+                self._set_model_gravity(self._original_gravity)
                 logger.info("Gravity enabled: %s", self._original_gravity)
             else:
-                self._model.gravity.linear = np.zeros(3)
+                self._set_model_gravity(np.zeros(3))
                 logger.info("Gravity disabled")
 
             self._state.gravity_enabled = enabled
@@ -350,11 +350,25 @@ class PinocchioPoseEditor(BasePoseEditor):
         """Check if gravity is enabled."""
         return self._state.gravity_enabled
 
+    def _get_model_gravity(self) -> np.ndarray:
+        """Read the linear-gravity vector from the underlying Pinocchio model.
+
+        Encapsulates ``pin.Model.gravity.linear`` so call sites don't reach
+        through the third-party object graph (LOD).
+        """
+        gravity = self._model.gravity
+        return gravity.linear
+
+    def _set_model_gravity(self, vec: np.ndarray) -> None:
+        """Write the linear-gravity vector on the underlying Pinocchio model."""
+        gravity = self._model.gravity
+        gravity.linear = vec
+
     def _get_gravity_magnitude(self) -> float:
         """Get current gravity magnitude."""
         if self._model is None:
             return GRAVITY
-        return float(np.linalg.norm(self._model.gravity.linear))
+        return float(np.linalg.norm(self._get_model_gravity()))
 
     def update_visualization(self) -> None:
         """Update visualization to reflect current pose."""

--- a/tests/unit/engines/pinocchio/motion_training/test_lod_delegations.py
+++ b/tests/unit/engines/pinocchio/motion_training/test_lod_delegations.py
@@ -1,0 +1,69 @@
+"""Tests for the LOD-driven delegating accessors added under issue #4139.
+
+These tests pin down the new `ClubTrajectory` and `TrajectoryIKResult`
+properties so future changes can't silently regress the LOD refactor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.unit
+def test_club_trajectory_delegates_event_markers() -> None:
+    """ClubTrajectory exposes flat accessors for SwingEventMarkers fields."""
+    try:
+        from src.engines.physics_engines.pinocchio.python.motion_training.club_trajectory_parser import (  # noqa: E501
+            ClubTrajectory,
+            SwingEventMarkers,
+        )
+    except ImportError as e:  # pragma: no cover - dependency-gated
+        pytest.skip(f"motion_training package not importable: {e}")
+
+    events = SwingEventMarkers(
+        address=10,
+        top=50,
+        impact=80,
+        finish=120,
+        club_head_speed=95.5,
+    )
+    traj = ClubTrajectory(events=events)
+
+    assert traj.address_frame == 10
+    assert traj.top_frame == 50
+    assert traj.impact_frame == 80
+    assert traj.finish_frame == 120
+    assert traj.club_head_speed_mph == pytest.approx(95.5)
+
+
+@pytest.mark.unit
+def test_trajectory_ik_result_q_dim() -> None:
+    """TrajectoryIKResult.q_dim returns the per-frame configuration size."""
+    try:
+        from src.engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver import (  # noqa: E501
+            TrajectoryIKResult,
+        )
+    except ImportError as e:  # pragma: no cover - dependency-gated
+        pytest.skip(f"dual_hand_ik_solver not importable: {e}")
+
+    cfg = [np.zeros(7), np.ones(7), np.zeros(7)]
+    result = TrajectoryIKResult(configurations=cfg)
+
+    assert result.q_dim == 7
+    assert result.q_trajectory.shape == (3, 7)
+
+
+@pytest.mark.unit
+def test_trajectory_ik_result_q_dim_empty() -> None:
+    """An empty result reports q_dim == 0 rather than raising."""
+    try:
+        from src.engines.physics_engines.pinocchio.python.motion_training.dual_hand_ik_solver import (  # noqa: E501
+            TrajectoryIKResult,
+        )
+    except ImportError as e:  # pragma: no cover - dependency-gated
+        pytest.skip(f"dual_hand_ik_solver not importable: {e}")
+
+    result = TrajectoryIKResult()
+
+    assert result.q_dim == 0


### PR DESCRIPTION
## Summary

Audit fixed 15 genuine LOD (Law of Demeter) violations across 4 files in
`src/engines/physics_engines/pinocchio/python/`. Method chains deeper than 2
hops (`a.b.c.d`) are refactored via delegating accessors or local-bind
helpers, in line with the project's CODING_STANDARDS.md and the issue brief.

A new advisory CI lint (`scripts/ci/check_lod.py`) flags future regressions
and is wired into a new `quality-gate.yml` workflow (advisory-warn).

Closes #4139.

## Refactors (before / after)

### `motion_training/club_trajectory_parser.py`
Added delegating properties on `ClubTrajectory` for `SwingEventMarkers` fields:
`address_frame`, `top_frame`, `impact_frame`, `finish_frame`, `club_head_speed_mph`.

### `motion_training/dual_hand_ik_solver.py`
- Added `nq` / `nv` delegating properties on `DualHandIKSolver`.
- Added `q_dim` property on `TrajectoryIKResult`.

### `motion_training/training_pipeline.py`
| Before | After |
|---|---|
| `self.trajectory.events.address` (and `top`/`impact`/`finish`) | `self.trajectory.address_frame` (and friends) |
| `self.ik_solver.model.nq` | `self.ik_solver.nq` |
| `self.ik_result.q_trajectory.shape[1]` | `self.ik_result.q_dim` |

### `motion_training/trajectory_exporter.py`
| Before | After |
|---|---|
| `self.trajectory.events.address` | `self.trajectory.address_frame` |
| `self.trajectory.events.top` | `self.trajectory.top_frame` |
| `self.trajectory.events.impact` | `self.trajectory.impact_frame` |
| `self.trajectory.events.finish` | `self.trajectory.finish_frame` |
| `self.trajectory.events.club_head_speed` | `self.trajectory.club_head_speed_mph` |

### `pinocchio_golf/pose_editor_tab.py`
| Before | After |
|---|---|
| `self._model.gravity.linear = self._original_gravity` | `self._set_model_gravity(self._original_gravity)` |
| `self._model.gravity.linear = np.zeros(3)` | `self._set_model_gravity(np.zeros(3))` |
| `np.linalg.norm(self._model.gravity.linear)` | `np.linalg.norm(self._get_model_gravity())` |

The new `_get_model_gravity` / `_set_model_gravity` helpers contain a single
1-hop intermediate (`gravity = self._model.gravity`) to encapsulate the
third-party `pin.Model.gravity.linear` access at the LOD boundary, since
`pin.Model` is a third-party class we can't add delegators to directly.

### `dtack/viz/geppetto_viewer.py`
| Before | After |
|---|---|
| `self.client.gui.createWindow("golfer_viewer")` | `gui = self.client.gui; gui.createWindow("golfer_viewer")` |

(Local-bind because `gepetto.corbaserver.Client` is also a third-party API.)

## CI / Lint

- **`scripts/ci/check_lod.py`** — AST-based LOD checker for the pinocchio
  python package. Skips library-API patterns: Qt signal/slot wiring
  (`.clicked.connect`, `.toggled.connect`, ...), numpy tail operations
  (`.tolist()`, `.copy()`, `.reshape()`, ...), and namespaced enum/module
  access (`QtCore.Qt.Orientation.Horizontal`, `pin.GeometryType.VISUAL`,
  `np.linalg.norm`, ...). Run locally with:
  ```
  python3 scripts/ci/check_lod.py
  ```
- **`.github/workflows/quality-gate.yml`** — advisory-warn workflow that
  runs the LOD check on PRs touching the pinocchio python tree
  (`--advisory` flag → exit 0 even on violations, for now).
- **`.github/WORKFLOWS.md`** — new workflow registered per inventory policy.

## Tests

- `tests/unit/engines/pinocchio/motion_training/test_lod_delegations.py`
  pins down the new delegating accessors. The `ClubTrajectory` test runs
  green; the `TrajectoryIKResult` tests skip cleanly in environments
  where the sibling-import path of `dual_hand_ik_solver` can't resolve
  (pre-existing packaging quirk, not introduced by this PR).

## Test plan

- [x] `python3 scripts/ci/check_lod.py` reports clean (0 violations across
  58 files).
- [x] `python3 -m ruff check` passes on all touched files.
- [x] `python3 -m ruff format --check` passes on all touched files.
- [x] `python3 -m pytest tests/unit/engines/pinocchio/motion_training/`
  passes (2 passed, 6 skipped — skips are pre-existing dependency-gated
  smoke tests, unchanged by this PR).
- [x] All Python files in the pinocchio package compile (`py_compile`
  loop).

## Notes for reviewer

- The PR is labelled `spec-exempt`: it is a pure refactor with no public
  API changes outside the pinocchio package and no behavioural delta.
- The active-workflow inventory cap is exceeded on `main` already (60/59);
  this PR adds 1 (61/59), still over the same pre-existing cap. The new
  workflow is registered in `.github/WORKFLOWS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)