### PR TITLE
feat(mujoco): synthesize_target_from_coefficients engine implementation (closes #4122)

### DIFF
--- a/src/engines/physics_engines/mujoco/python/motion_matching/synthesize.py
+++ b/src/engines/physics_engines/mujoco/python/motion_matching/synthesize.py
@@ -1,0 +1,289 @@
+"""MuJoCo backend for ``synthesize_target_from_coefficients``.
+
+Implements issue #4122 (PARITY-MUJOCO-SYNTH): the engine-specific oracle
+that runs the canonical MuJoCo forward-sim wrapper (``simulate.py``) with a
+known ``theta`` and packages the resulting trajectory into a canonical
+:class:`ClubTarget` per ``CLUB_IK_SPEC.md``.
+
+Per ``MUJOCO_PARITY_SPEC.md`` §2.2 the oracle MUST round-trip exactly
+through ``simulate_with_coefficients`` — this module provides a thin
+adapter that maps :class:`SimOut` fields to the :class:`ClubTarget`
+schema and never touches mujoco internals directly.
+
+This file is intentionally short. Heavy lifting lives in
+``simulate.py`` (issue #4113 / PR #4166).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.motion_matching.club_target import (
+    AlignOptions,
+    ClubTarget,
+    SourceProvenance,
+)
+
+from .simulate import SimOptions, SimOut, simulate_with_coefficients
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["synthesize_target_from_coefficients"]
+
+
+def _sim_options_from_align(opts: AlignOptions) -> SimOptions:
+    """Translate :class:`AlignOptions` into :class:`SimOptions`.
+
+    The cross-engine ``AlignOptions`` carries the simulation horizon and
+    sample rate; everything else falls back to the MuJoCo defaults
+    (full-body variant, polynomial torque, etc.). Engine-specific knobs
+    (variant, dt overrides) are not exposed through ``AlignOptions`` —
+    callers that need them must instantiate :class:`SimOptions` directly
+    via the lower-level entry point.
+
+    Args:
+        opts: Cross-engine align options.
+
+    Returns:
+        :class:`SimOptions` with ``T_s`` and ``output_rate_hz`` taken
+        from ``opts``; remaining fields default per :class:`SimOptions`.
+    """
+    return SimOptions(
+        T_s=float(opts.simulation_time_s),
+        output_rate_hz=float(opts.sample_rate_hz),
+    )
+
+
+def _detect_impact_index(
+    time: NDArray[np.float64], clubhead: NDArray[np.float64]
+) -> int:
+    """Return the 1-based index of peak clubhead speed.
+
+    Impact is conventionally identified as the frame at which
+    ``||d r_clubhead / dt||`` is maximal — this matches the MATLAB
+    oracle in ``synthesize_target_from_coefficients.m`` and the
+    cross-engine spec in ``CROSS_ENGINE_PARITY_SPEC.md``.
+
+    Args:
+        time:     ``(N,)`` strictly increasing time grid.
+        clubhead: ``(N, 3)`` clubhead position trajectory.
+
+    Returns:
+        ``int`` in ``[1, N]`` (1-based, to match :class:`ClubTarget`'s
+        validation rule).
+
+    Raises:
+        ValueError: if ``time`` and ``clubhead`` row counts disagree or
+            the trajectory has fewer than two samples (no derivative
+            defined).
+    """
+    if time.shape[0] != clubhead.shape[0]:
+        raise ValueError(
+            f"time and clubhead row count mismatch: "
+            f"{time.shape[0]} vs {clubhead.shape[0]}"
+        )
+    if time.shape[0] < 2:
+        raise ValueError("need at least two samples to detect impact")
+    # np.gradient gives a centred difference (forward/backward at the
+    # endpoints), which is more robust than np.diff for picking out the
+    # peak speed near the trajectory boundary.
+    velocity = np.gradient(clubhead, time, axis=0)
+    speed = np.linalg.norm(velocity, axis=1)
+    # +1 for the 1-based ClubTarget convention enforced by
+    # _validate_clubtarget.
+    return int(np.argmax(speed)) + 1
+
+
+def _theta_sha256(theta: NDArray[np.float64]) -> str:
+    """SHA-256 hex digest of ``theta``'s float64 byte representation.
+
+    Reproducible across calls for identical input vectors so the
+    provenance hash can be used as a cache key. Always cast through
+    ``float64`` first so callers passing in ``float32`` or python lists
+    get a stable hash.
+    """
+    canonical = np.ascontiguousarray(np.asarray(theta, dtype=np.float64).reshape(-1))
+    return hashlib.sha256(canonical.tobytes()).hexdigest()
+
+
+def _normalise_quaternions(quat: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Force unit-norm + non-negative w convention.
+
+    Mirrors the MATLAB ``local_normalise_quat_rows`` helper. Any zero-norm
+    rows (which would fail the postcondition in ``_validate_clubtarget``)
+    are replaced with the identity quaternion ``[1, 0, 0, 0]``.
+
+    Args:
+        quat: ``(N, 4)`` quaternion rows in ``[w, x, y, z]`` order.
+
+    Returns:
+        ``(N, 4)`` unit quaternions with ``w >= 0``.
+    """
+    if quat.shape[1] != 4:
+        raise ValueError(f"quat must have 4 columns, got {quat.shape}")
+    out = np.asarray(quat, dtype=np.float64).copy()
+    norms = np.linalg.norm(out, axis=1, keepdims=True)
+    # Identity fallback for any degenerate row.
+    bad = norms.reshape(-1) < 1.0e-12
+    out[bad] = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    norms = np.linalg.norm(out, axis=1, keepdims=True)
+    out = out / norms
+    flip = out[:, 0] < 0
+    out[flip] = -out[flip]
+    return out
+
+
+def _provenance(theta: NDArray[np.float64], opts: AlignOptions) -> SourceProvenance:
+    """Build the :class:`SourceProvenance` for a synthetic target.
+
+    The ``subject_id`` is derived from the theta hash so the same theta
+    always lands in the same logical bucket, and the ``trial_id`` carries
+    the alignment mode for traceability.
+    """
+    sha = _theta_sha256(theta)
+    return SourceProvenance(
+        filename="synthetic",
+        format="synthetic",
+        subject_id=f"theta_seed_{sha[:8]}",
+        trial_id=f"mujoco_align_{opts.time_alignment}",
+        sha256=sha,
+    )
+
+
+def synthesize_target_from_coefficients(
+    theta: NDArray[np.float64],
+    opts: AlignOptions | None = None,
+    *,
+    sim_options: SimOptions | None = None,
+) -> ClubTarget:
+    """Run the MuJoCo forward model with ``theta`` and return a ``ClubTarget``.
+
+    This is the engine-specific implementation registered behind the
+    shared dispatcher in ``shared/python/motion_matching/loaders/synthetic.py``
+    (see :func:`register_mujoco_backend`). The cross-engine spec
+    (CROSS_ENGINE_PARITY_SPEC.md §2.2) requires every backend to produce
+    the same :class:`ClubTarget` schema; this thin wrapper enforces that.
+
+    Args:
+        theta: ``(n_joints * 7,)`` flat coefficient vector. Layout per
+            joint is ``[A, B, C, D, E, F, G]`` matching the polynomial
+            torque driver in ``simulate.py``.
+        opts:  Cross-engine align options. ``None`` uses the
+            :class:`AlignOptions` defaults.
+        sim_options: Optional MuJoCo-specific overrides. When given, takes
+            precedence over the values derived from ``opts``. Useful for
+            picking the MJCF variant (``upper`` / ``full`` / ``advanced``)
+            without leaking that knob into the cross-engine signature.
+
+    Returns:
+        Validated :class:`ClubTarget` whose trajectory rows mirror the
+        underlying :class:`SimOut` (``butt = SimOut.grip``,
+        ``clubhead = SimOut.clubhead``, ``club_quat = SimOut.club_quat``).
+
+    Raises:
+        ValueError: if ``theta`` is malformed, or the underlying simulator
+            reports a non-finite trajectory.
+        RuntimeError: propagated from :func:`simulate_with_coefficients` if
+            the MJCF compilation or rollout fails.
+    """
+    if opts is None:
+        opts = AlignOptions()
+    if not isinstance(opts, AlignOptions):
+        raise TypeError(
+            f"opts must be an AlignOptions instance; got {type(opts).__name__}"
+        )
+
+    theta_arr = np.ascontiguousarray(np.asarray(theta, dtype=np.float64).reshape(-1))
+    if theta_arr.size == 0:
+        raise ValueError("theta must be non-empty")
+    if not np.all(np.isfinite(theta_arr)):
+        raise ValueError("theta must be finite (no NaN / Inf)")
+
+    base_sim_opts = _sim_options_from_align(opts)
+    if sim_options is not None:
+        if not isinstance(sim_options, SimOptions):
+            raise TypeError(
+                "sim_options must be a SimOptions instance; got "
+                f"{type(sim_options).__name__}"
+            )
+        # Caller override wins on every field.
+        merged_sim_opts = sim_options
+    else:
+        merged_sim_opts = base_sim_opts
+
+    logger.debug(
+        "synthesize_target_from_coefficients(mujoco): theta shape %s, "
+        "T_s=%s, output_rate_hz=%s",
+        theta_arr.shape,
+        merged_sim_opts.T_s,
+        merged_sim_opts.output_rate_hz,
+    )
+
+    sim_out: SimOut = simulate_with_coefficients(theta_arr, merged_sim_opts)
+
+    if sim_out.solver_status != "ok":
+        raise RuntimeError(
+            f"MuJoCo rollout did not converge: solver_status={sim_out.solver_status!r}"
+        )
+
+    return _build_target(sim_out, theta_arr, opts)
+
+
+def _build_target(
+    sim_out: SimOut,
+    theta: NDArray[np.float64],
+    opts: AlignOptions,
+) -> ClubTarget:
+    """Wrap a :class:`SimOut` into a validated :class:`ClubTarget`.
+
+    Field mapping (per the issue body):
+
+    * ``time``       <- ``SimOut.time``
+    * ``butt``       <- ``SimOut.grip``     (mid-hands anchor; CLUB_IK_SPEC)
+    * ``clubhead``   <- ``SimOut.clubhead``
+    * ``club_quat``  <- ``SimOut.club_quat`` (re-normalised to be safe)
+    * ``impact_idx`` <- argmax of clubhead speed
+    """
+    time = np.ascontiguousarray(np.asarray(sim_out.time, dtype=np.float64))
+    butt = np.ascontiguousarray(np.asarray(sim_out.grip, dtype=np.float64))
+    clubhead = np.ascontiguousarray(np.asarray(sim_out.clubhead, dtype=np.float64))
+    club_quat = _normalise_quaternions(np.asarray(sim_out.club_quat, dtype=np.float64))
+    impact_idx = _detect_impact_index(time, clubhead)
+    source = _provenance(theta, opts)
+
+    return ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=club_quat,
+        impact_idx=impact_idx,
+        source=source,
+    )
+
+
+def register_mujoco_backend() -> None:
+    """Register this implementation behind the shared synthetic dispatcher.
+
+    Importing this module is enough — the call is idempotent and lazy so
+    GUI surfaces that never need MuJoCo don't pull it in transitively.
+    """
+    # Local import to avoid a circular dependency at module load time
+    # (the shared dispatcher might in turn lazy-import this module).
+    from src.shared.python.motion_matching.loaders import synthetic as _shared
+
+    _shared.register_backend("mujoco", synthesize_target_from_coefficients)
+
+
+# Auto-register on import. Safe because ``synthetic.register_backend`` is
+# idempotent. The shared dispatcher uses ``opts.engine == "mujoco"`` to
+# pick this implementation.
+try:
+    register_mujoco_backend()
+except Exception:  # pragma: no cover - registration is best-effort
+    # Never fail import on registration errors; the dispatcher will raise
+    # a clear LookupError if the backend is needed but not registered.
+    logger.exception("failed to register mujoco synthetic backend")

--- a/src/shared/python/motion_matching/loaders/synthetic.py
+++ b/src/shared/python/motion_matching/loaders/synthetic.py
@@ -1,39 +1,145 @@
-"""Synthetic-target stub.
+"""Synthetic-target dispatcher.
 
-The full implementation depends on issues #014 (Simscape callback wiring) and
-#018 (``simulate_with_coefficients``). This stub keeps the public signature
-stable so callers can already target it; it raises ``NotImplementedError`` so
-nobody accidentally relies on a no-op result.
+Engine-specific implementations register themselves by calling
+:func:`register_backend`. The cross-engine entry point
+:func:`synthesize_target_from_coefficients` looks up the backend by name
+and forwards the call.
+
+The dispatcher itself does NOT import any engine package — that would
+defeat the lazy-import policy that keeps the GUI from pulling MuJoCo /
+Drake / Pinocchio transitively. Callers must import the desired backend
+module first (e.g. ``from src.engines.physics_engines.mujoco.python.motion_matching
+import synthesize``) which will register itself on import. After that,
+calling ``synthesize_target_from_coefficients(theta, opts, engine="mujoco")``
+dispatches to the registered implementation.
+
+Issue history: stub originally raised ``NotImplementedError`` (#014/#018);
+MuJoCo backend lands in #4122; Simscape and Drake backends to follow.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from typing import Protocol
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..club_target import AlignOptions, ClubTarget
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "SyntheticBackend",
+    "available_backends",
+    "register_backend",
+    "synthesize_target_from_coefficients",
+]
 
-def synthesize_target_from_coefficients(
-    theta: np.ndarray, opts: AlignOptions
-) -> ClubTarget:
-    """Build a ``ClubTarget`` from a known coefficient vector ``theta``.
 
-    Pending issues #014 and #018. The function signature matches
-    ``CLUB_IK_SPEC.md`` so optimizer code can already type-check against it.
+class SyntheticBackend(Protocol):
+    """Engine-specific implementation contract.
+
+    Every backend takes the same ``(theta, opts)`` pair the cross-engine
+    entry point accepts and returns a fully-validated :class:`ClubTarget`.
+    """
+
+    def __call__(
+        self, theta: NDArray[np.float64], opts: AlignOptions
+    ) -> ClubTarget: ...
+
+
+# Module-level registry. Keys are engine names (``"mujoco"``, ``"simscape"``,
+# ``"drake"``, ...). Values are backend callables.
+_BACKENDS: dict[str, Callable[[NDArray[np.float64], AlignOptions], ClubTarget]] = {}
+
+
+def register_backend(
+    engine: str,
+    backend: Callable[[NDArray[np.float64], AlignOptions], ClubTarget],
+) -> None:
+    """Register ``backend`` as the implementation for ``engine``.
+
+    Idempotent: re-registering the same callable for the same engine is a
+    no-op; replacing with a different callable logs a warning so accidental
+    overrides are visible.
+
+    Args:
+        engine:  Engine identifier, e.g. ``"mujoco"``. Case-insensitive.
+        backend: Callable matching :class:`SyntheticBackend`.
 
     Raises:
-        NotImplementedError: always, until #014/#018 land.
+        TypeError: if ``backend`` is not callable.
+        ValueError: if ``engine`` is not a non-empty string.
     """
-    _ = (np.asarray(theta), opts)
+    if not isinstance(engine, str) or not engine:
+        raise ValueError("engine must be a non-empty string")
+    if not callable(backend):
+        raise TypeError(f"backend must be callable; got {type(backend).__name__}")
+    key = engine.lower()
+    existing = _BACKENDS.get(key)
+    if existing is not None and existing is not backend:
+        logger.warning("replacing existing %r backend with %r", engine, backend)
+    _BACKENDS[key] = backend
+
+
+def available_backends() -> tuple[str, ...]:
+    """Return a sorted tuple of registered engine names."""
+    return tuple(sorted(_BACKENDS))
+
+
+def synthesize_target_from_coefficients(
+    theta: NDArray[np.float64],
+    opts: AlignOptions | None = None,
+    *,
+    engine: str | None = None,
+) -> ClubTarget:
+    """Dispatch to the registered backend for ``engine``.
+
+    Args:
+        theta: ``(n,)`` flat coefficient vector. Each backend imposes its
+            own layout / bounds; this dispatcher does not validate.
+        opts:  :class:`AlignOptions`; defaults to ``AlignOptions()``.
+        engine: Engine name. ``None`` defers to ``opts.engine`` if that
+            attribute exists, otherwise raises ``ValueError``.
+
+    Returns:
+        Validated :class:`ClubTarget` from the backend.
+
+    Raises:
+        ValueError: if no engine is specified.
+        LookupError: if no backend is registered for the requested engine.
+            The error message lists the registered backends so the caller
+            can tell whether they need to import the engine module first.
+    """
+    if opts is None:
+        opts = AlignOptions()
+
+    # Allow callers to pass the engine via opts (forward compatibility for
+    # if/when AlignOptions grows an explicit ``engine`` field).
+    engine_name = engine or getattr(opts, "engine", None)
+    if not engine_name:
+        raise ValueError(
+            "no engine specified. Pass engine= explicitly or set opts.engine. "
+            f"Available backends: {available_backends()}"
+        )
+    key = str(engine_name).lower()
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        raise LookupError(
+            f"no synthetic backend registered for engine {engine_name!r}. "
+            f"Available: {available_backends()}. "
+            "Make sure you've imported the engine's synthesize module "
+            "(e.g. ``from src.engines.physics_engines.mujoco.python."
+            "motion_matching import synthesize``)."
+        )
+
+    theta_arr = np.ascontiguousarray(np.asarray(theta, dtype=np.float64).reshape(-1))
     logger.debug(
-        "synthesize_target_from_coefficients called with theta of shape %s",
-        np.asarray(theta).shape,
+        "dispatching synthesize_target_from_coefficients to %r backend "
+        "(theta shape %s)",
+        key,
+        theta_arr.shape,
     )
-    raise NotImplementedError(
-        "synthesize_target_from_coefficients depends on #014 (Simscape "
-        "callback) and #018 (simulate_with_coefficients). Stub only."
-    )
+    return backend(theta_arr, opts)

--- a/tests/motion_matching/mujoco_mjcf/test_synthesize.py
+++ b/tests/motion_matching/mujoco_mjcf/test_synthesize.py
@@ -1,0 +1,203 @@
+"""Tests for the MuJoCo backend of ``synthesize_target_from_coefficients``.
+
+Implements the acceptance criteria of issue #4122:
+
+- Round-trip identity: ``synthesize(theta_known)`` produces a validated
+  :class:`ClubTarget` whose shape and trajectory mirror the underlying
+  :class:`SimOut`.
+- Cross-engine SimOut -> ClubTarget mapping correctness: every documented
+  field maps as advertised (``grip -> butt``, ``clubhead -> clubhead``,
+  ``club_quat -> club_quat``).
+- Dispatcher hookup: the shared ``loaders.synthetic`` dispatcher routes
+  to the MuJoCo backend when ``engine="mujoco"``.
+
+All tests are marked ``requires_mujoco``; the entire module is skipped if
+``import mujoco`` fails (see ``conftest.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# Importing the engine module triggers ``register_mujoco_backend`` so the
+# shared dispatcher knows about us.
+from src.engines.physics_engines.mujoco.python.motion_matching import (  # noqa: E402
+    synthesize as mj_synthesize,
+)
+from src.engines.physics_engines.mujoco.python.motion_matching.simulate import (  # noqa: E402
+    SimOptions,
+    simulate_with_coefficients,
+)
+from src.shared.python.motion_matching.club_target import (  # noqa: E402
+    AlignOptions,
+    ClubTarget,
+    SourceProvenance,
+)
+from src.shared.python.motion_matching.loaders import (
+    synthetic as shared_synth,  # noqa: E402
+)
+
+pytestmark = [pytest.mark.requires_mujoco, pytest.mark.unit]
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _theta_zero_full() -> tuple[np.ndarray, SimOptions]:
+    """Build a zero-torque coefficient vector matching the full-body model."""
+    import mujoco
+    from src.engines.physics_engines.mujoco._golf_swing_full_body_xml import (
+        FULL_BODY_GOLF_SWING_XML,
+    )
+
+    nu = mujoco.MjModel.from_xml_string(FULL_BODY_GOLF_SWING_XML).nu
+    theta = np.zeros(nu * 7, dtype=np.float64)
+    sim_opts = SimOptions(variant="full", T_s=0.2, output_rate_hz=500.0)
+    return theta, sim_opts
+
+
+# --- Round-trip identity ----------------------------------------------------
+
+
+def test_round_trip_returns_validated_clubtarget() -> None:
+    """``synthesize(theta_known)`` returns a fully-validated ``ClubTarget``."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+
+    assert isinstance(target, ClubTarget)
+    n_expected = int(round(sim_opts.T_s * sim_opts.output_rate_hz)) + 1
+    assert target.time.shape == (n_expected,)
+    assert target.butt.shape == (n_expected, 3)
+    assert target.clubhead.shape == (n_expected, 3)
+    assert target.club_quat.shape == (n_expected, 4)
+    assert 1 <= int(target.impact_idx) <= n_expected
+    # Quaternions are unit-norm to within ClubTarget's tolerance (1e-6).
+    qnorms = np.linalg.norm(target.club_quat, axis=1)
+    assert np.all(np.abs(qnorms - 1.0) < 1.0e-6)
+
+
+def test_round_trip_matches_simulate_clubhead_exactly() -> None:
+    """``synthesize.clubhead`` equals ``simulate.clubhead`` byte-for-byte.
+
+    The cross-engine spec promises the synthesize wrapper makes a single
+    deterministic call to the underlying simulator and copies the result
+    through verbatim. Use ``assert_array_equal`` (not approx) so any
+    accidental smoothing or alignment regresses loudly.
+    """
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+
+    sim_out = simulate_with_coefficients(theta, sim_opts)
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+
+    np.testing.assert_array_equal(target.clubhead, sim_out.clubhead)
+    np.testing.assert_array_equal(target.time, sim_out.time)
+
+
+# --- Cross-engine mapping correctness ---------------------------------------
+
+
+def test_grip_maps_to_butt() -> None:
+    """``SimOut.grip`` populates ``ClubTarget.butt`` (mid-hands anchor)."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+    sim_out = simulate_with_coefficients(theta, sim_opts)
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+    np.testing.assert_array_equal(target.butt, sim_out.grip)
+
+
+def test_club_quat_is_unit_norm_after_renormalisation() -> None:
+    """The synthesizer's renormalisation guards against tiny drift in SimOut."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+    norms = np.linalg.norm(target.club_quat, axis=1)
+    assert np.allclose(norms, 1.0, atol=1.0e-9)
+    # Sign convention: w >= 0 across every row.
+    assert np.all(target.club_quat[:, 0] >= 0.0)
+
+
+def test_impact_idx_is_argmax_clubhead_speed() -> None:
+    """``impact_idx`` should equal ``argmax(||d clubhead/dt||) + 1``."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+    velocity = np.gradient(target.clubhead, target.time, axis=0)
+    speed = np.linalg.norm(velocity, axis=1)
+    expected = int(np.argmax(speed)) + 1  # ClubTarget uses 1-based indexing.
+    assert int(target.impact_idx) == expected
+
+
+def test_provenance_sha_reproducible() -> None:
+    """Same theta -> same provenance.sha256."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+    a = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+    b = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+    assert isinstance(a.source, SourceProvenance)
+    assert a.source.sha256 == b.source.sha256
+    assert len(a.source.sha256) == 64  # full sha256 hex digest
+    assert a.source.format == "synthetic"
+
+
+# --- Dispatcher hookup ------------------------------------------------------
+
+
+def test_dispatcher_routes_to_mujoco() -> None:
+    """``shared.synthetic.synthesize_target_from_coefficients`` dispatches us."""
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+
+    # Sanity: registration happened on import of the engine module.
+    assert "mujoco" in shared_synth.available_backends()
+
+    # Direct vs dispatched results must match for the same inputs. The
+    # dispatcher uses the AlignOptions-derived SimOptions so we apply the
+    # same here for an apples-to-apples comparison.
+    direct = mj_synthesize.synthesize_target_from_coefficients(theta, align)
+    via_dispatch = shared_synth.synthesize_target_from_coefficients(
+        theta, align, engine="mujoco"
+    )
+    np.testing.assert_array_equal(direct.clubhead, via_dispatch.clubhead)
+    np.testing.assert_array_equal(direct.butt, via_dispatch.butt)
+    assert direct.source.sha256 == via_dispatch.source.sha256
+
+
+def test_dispatcher_unknown_engine_raises() -> None:
+    """Asking for an unregistered engine should raise ``LookupError``."""
+    theta = np.zeros(7, dtype=np.float64)
+    with pytest.raises(LookupError, match="no synthetic backend"):
+        shared_synth.synthesize_target_from_coefficients(
+            theta, AlignOptions(), engine="not_a_real_engine"
+        )

--- a/tests/unit/motion_matching/test_loaders_c3d.py
+++ b/tests/unit/motion_matching/test_loaders_c3d.py
@@ -33,8 +33,10 @@ def test_c3d_rejects_missing_file() -> None:
 
     with pytest.raises((FileNotFoundError, ValueError, PreconditionError)):
         load_club_target_c3d("does/not/exist.c3d", AlignOptions())
-    # Synthetic stub raises NotImplementedError
-    with pytest.raises(NotImplementedError):
+    # Synthetic dispatcher requires an explicit engine name and raises
+    # ValueError when none is provided (replaced the original
+    # NotImplementedError stub once #4122 / #4166 landed engine backends).
+    with pytest.raises(ValueError, match="no engine specified"):
         synthesize_target_from_coefficients(np.zeros(3), AlignOptions())
 
 


### PR DESCRIPTION
## Summary

Implements ISSUE-MUJOCO-SYNTH (issue #4122): the MuJoCo-specific oracle that runs the canonical forward-sim wrapper from PR #4166 with a known `theta` and packages the resulting trajectory into a validated `ClubTarget` per `CLUB_IK_SPEC.md`.

- **`src/engines/physics_engines/mujoco/python/motion_matching/synthesize.py`** — thin engine adapter that calls `simulate_with_coefficients(theta, options)` and maps `SimOut` fields onto `ClubTarget` per the issue body:
  - `time` <- `SimOut.time`
  - `butt` <- `SimOut.grip` (mid-hands anchor; CLUB_IK_SPEC "grip-primary")
  - `clubhead` <- `SimOut.clubhead`
  - `club_quat` <- `SimOut.club_quat` (re-normalised + `w >= 0` sign convention)
  - `impact_idx` <- `argmax(||d clubhead/dt||) + 1` (1-based, ClubTarget convention)
  - `source` populated with `SourceProvenance(format="synthetic", sha256=sha256(theta.bytes))`
- **`src/shared/python/motion_matching/loaders/synthetic.py`** — replaces the `NotImplementedError` stub with a tiny backend registry and dispatcher. The dispatcher imports no engine packages so GUI surfaces don't pull MuJoCo / Drake / Pinocchio transitively. Engine modules call `register_backend("mujoco", ...)` at import time; the cross-engine entry point now accepts `engine="mujoco"` and routes to the registered implementation.
- **Tests** (`tests/motion_matching/mujoco_mjcf/test_synthesize.py`) — 8 tests, all `requires_mujoco`:
  - Round-trip identity: `synthesize(theta_known)` produces a `ClubTarget` that passes `_validate_clubtarget`, with the expected `(N, 3)` / `(N, 4)` shapes.
  - Round-trip exactness: `synthesize(theta).clubhead` and `.time` match `simulate_with_coefficients(theta).clubhead` / `.time` byte-for-byte.
  - Cross-engine field mapping: `grip -> butt`, quaternion unit-norm + `w >= 0`, `impact_idx == argmax(speed) + 1`.
  - Provenance: same `theta` -> same `sha256`, length 64, `format == "synthetic"`.
  - Dispatcher: `shared.synthetic.synthesize_target_from_coefficients(..., engine="mujoco")` produces identical results to the direct call; unknown engine raises `LookupError`.

Updates the legacy `NotImplementedError` assertion in `test_loaders_c3d.py` to expect the new `ValueError` raised when no engine is specified.

Marked `spec-exempt` per the issue body — depends on PR #4166 (#4113) which is currently the base of this stack; the engine is wired through the pre-registered shared dispatcher.

Closes #4122.

## Test plan

- [x] `python3 -m ruff check src/engines/physics_engines/mujoco/python/motion_matching/ src/shared/python/motion_matching/loaders/ tests/motion_matching/mujoco_mjcf/ tests/unit/motion_matching/`
- [x] `python3 -m ruff format --check ...` clean
- [x] `python3 -m pytest tests/motion_matching/mujoco_mjcf/test_synthesize.py` -> 8 passed
- [x] `python3 -m pytest tests/motion_matching/ tests/unit/motion_matching/` -> 268 passed, 2 skipped
- [x] `python3 scripts/ci/check_file_size_budget.py` clean