### PR TITLE
feat(opensim): synthesize_target_from_coefficients TDD oracle (closes #4124)

### DIFF
--- a/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
@@ -13,6 +13,7 @@ Public surface (lazily imported to keep ``import opensim`` optional):
   from a SimTK state given the OpenSim model.
 * ``fit_swing_opensim``: scipy.optimize.minimize(SLSQP) driver that fits
   polynomial torque coefficients to a measured ClubTarget (issue #4128).
+* ``synthesize_target_from_coefficients``: TDD oracle (issue #4124).
 """
 
 from __future__ import annotations
@@ -35,6 +36,10 @@ from src.engines.physics_engines.opensim.python.motion_matching.simulate import 
     evaluate_polynomial_torque,
     simulate_with_coefficients,
 )
+from src.engines.physics_engines.opensim.python.motion_matching.synthesize import (
+    SynthOptions,
+    synthesize_target_from_coefficients,
+)
 
 __all__ = [
     "COEFFS_PER_JOINT",
@@ -43,11 +48,13 @@ __all__ = [
     "POLY_DEGREE",
     "SimOptions",
     "SimOut",
+    "SynthOptions",
     "evaluate_polynomial_torque",
     "extract_clubhead_pose",
     "extract_full_pose",
     "extract_grip_pose",
     "fit_swing_opensim",
     "simulate_with_coefficients",
+    "synthesize_target_from_coefficients",
     "viz",
 ]

--- a/src/engines/physics_engines/opensim/python/motion_matching/synthesize.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/synthesize.py
@@ -1,0 +1,386 @@
+"""TDD oracle: ``synthesize_target_from_coefficients`` for OpenSim (issue #4124).
+
+This module mirrors the MATLAB reference at
+``src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/
+shared/synthesize_target_from_coefficients.m`` and the equivalent
+MuJoCo / Pinocchio Python implementations (issues #4122 / #4121).
+
+Given a known coefficient vector ``theta``, forward-simulate the OpenSim
+golf humanoid and repackage the resulting butt + clubhead + club-quat
+trajectories as a canonical :class:`ClubTarget`. The ``ClubTarget``'s
+provenance pins ``theta_truth`` (via the sha256 hash) so the recovery
+test "synthesize -> fit -> ``theta_recovered ~= theta_truth``" needs no
+external data.
+
+Public API:
+    synthesize_target_from_coefficients(theta, options) -> ClubTarget
+    SynthOptions  -- options dataclass.
+
+The wrapper performs **no** OpenSim calls of its own. All ``osim.*`` work
+goes through ``simulate_with_coefficients`` (issue #4120) which is
+imported lazily so this module remains importable on platforms without
+the OpenSim Python bindings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.motion_matching.club_target import ClubTarget, SourceProvenance
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SynthOptions",
+    "synthesize_target_from_coefficients",
+]
+
+# ---------------------------------------------------------------------------
+# Coefficient bounds (mirrors generateRandomCoefficients.m / MATLAB oracle).
+# Per-joint coefficient ordering: [A, B, C, D, E, F, G].
+# ---------------------------------------------------------------------------
+_COEFF_BOUNDS: tuple[float, ...] = (1000.0, 1000.0, 500.0, 500.0, 100.0, 100.0, 25.0)
+_COEFFS_PER_JOINT: int = 7
+_BOUND_TOL: float = 1.0e-9
+
+# Quaternion / target validation tolerances (CLUB_IK_SPEC).
+_QUAT_NORM_TOL: float = 1.0e-6
+
+
+@dataclass(frozen=True)
+class SynthOptions:
+    """Options for :func:`synthesize_target_from_coefficients`.
+
+    Mirrors ``default_synth_options.m``. All fields have sensible defaults
+    matching the MATLAB reference so most callers can pass ``SynthOptions()``.
+
+    Attributes:
+        sample_rate_hz:    Output time-grid rate. Default 1 kHz.
+        simulation_time_s: Total simulation duration in (0, 1]. Default 0.3 s.
+        add_noise:         If True, add Gaussian position noise. Default False.
+        noise_sigma_m:     Std-dev (metres) when ``add_noise``. Default 1 mm.
+        subject_id:        Provenance label. Default ``"synthetic"``.
+        trial_id:          Provenance label. Default ``"synthesizer_v1"``.
+        sim_overrides:     Engine-specific simulation overrides applied on top
+                           of OpenSim's ``SimOptions`` defaults. Default empty.
+    """
+
+    sample_rate_hz: float = 1000.0
+    simulation_time_s: float = 0.3
+    add_noise: bool = False
+    noise_sigma_m: float = 1.0e-3
+    subject_id: str = "synthetic"
+    trial_id: str = "synthesizer_v1"
+    sim_overrides: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+
+
+def synthesize_target_from_coefficients(
+    theta: NDArray[np.float64] | np.ndarray,
+    options: SynthOptions | None = None,
+) -> ClubTarget:
+    """Synthesize a :class:`ClubTarget` by forward-simulating ``theta``.
+
+    Args:
+        theta:   Coefficient vector of length ``n_joints * 7``, ordered
+                 ``[A, B, C, D, E, F, G]`` per joint.  Bounds:
+                 ``|A|,|B| <= 1000``, ``|C|,|D| <= 500``, ``|E|,|F| <= 100``,
+                 ``|G| <= 25``.
+        options: :class:`SynthOptions`.  ``None`` -> defaults.
+
+    Returns:
+        A fully-validated :class:`ClubTarget` whose ``source.format`` is
+        ``"synthetic"`` and whose ``source.sha256`` is the sha256 of the
+        ``theta`` byte representation. The ``ClubTarget`` field schema
+        matches CLUB_IK_SPEC.md (also enforced inside ``ClubTarget``).
+
+    Raises:
+        TypeError:  ``theta`` is not array-like of floats.
+        ValueError: ``theta`` length is not a multiple of 7, contains
+                    NaN/Inf, or any coefficient exceeds its bound.
+        ValueError: ``options`` fields are out of range.
+        ImportError: the OpenSim ``simulate_with_coefficients`` module is
+                     not yet available (issue #4120 not landed).
+        RuntimeError: the underlying simulation reports
+                      ``solver_status == "failed"``.
+    """
+    opts = options if options is not None else SynthOptions()
+
+    # 1. Preconditions -------------------------------------------------------
+    theta_arr = _validate_theta(theta)
+    _validate_options(opts)
+
+    # 2. Forward sim via the canonical wrapper -------------------------------
+    sim_out = _run_simulate_with_coefficients(theta_arr, opts)
+
+    # 3. SimOut -> ClubTarget mapping ---------------------------------------
+    time = np.asarray(sim_out.time, dtype=np.float64).reshape(-1)
+    butt = np.asarray(sim_out.grip, dtype=np.float64)
+    clubhead = np.asarray(sim_out.clubhead, dtype=np.float64)
+    club_quat = _normalise_quat_rows(np.asarray(sim_out.club_quat, dtype=np.float64))
+
+    # Optional position noise (deterministic via fixed seed for reproducibility)
+    if opts.add_noise:
+        butt, clubhead = _add_position_noise(butt, clubhead, opts.noise_sigma_m)
+
+    impact_idx = int(_detect_clubhead_impact(time, clubhead))
+
+    # 4. Provenance ----------------------------------------------------------
+    theta_hash = hashlib.sha256(theta_arr.tobytes()).hexdigest()
+    source = SourceProvenance(
+        filename="",
+        format="synthetic",
+        subject_id=str(opts.subject_id),
+        trial_id=str(opts.trial_id),
+        sha256=theta_hash,
+    )
+
+    target = ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=club_quat,
+        impact_idx=impact_idx,
+        source=source,
+    )
+
+    # 5. Postconditions ------------------------------------------------------
+    # Most are enforced by ClubTarget.__post_init__ -- we add the engine-
+    # and oracle-specific checks here.
+    assert target.source.format == "synthetic"  # noqa: S101 - DbC postcondition
+    assert len(target.source.sha256) == 64  # noqa: S101
+    assert target.time[0] == 0.0  # noqa: S101
+    assert target.time[-1] <= opts.simulation_time_s + 1.0e-9  # noqa: S101
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private).
+# ---------------------------------------------------------------------------
+
+
+def _validate_theta(theta: Any) -> NDArray[np.float64]:
+    """Coerce + validate ``theta``; raise descriptive errors on failure."""
+    try:
+        arr = np.asarray(theta, dtype=np.float64).reshape(-1)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"theta must be array-like of floats, got {type(theta).__name__}"
+        ) from exc
+
+    if arr.size == 0 or arr.size % _COEFFS_PER_JOINT != 0:
+        raise ValueError(
+            "theta length must be a positive multiple of "
+            f"{_COEFFS_PER_JOINT} (got {arr.size})"
+        )
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("theta contains NaN or Inf")
+
+    n_joints = arr.size // _COEFFS_PER_JOINT
+    matrix = arr.reshape(n_joints, _COEFFS_PER_JOINT)  # rows = joints
+    for col, bound in enumerate(_COEFF_BOUNDS):
+        if np.any(np.abs(matrix[:, col]) > bound + _BOUND_TOL):
+            letter = chr(ord("A") + col)
+            raise ValueError(
+                f"coefficient {letter} exceeds +/-{bound:g} "
+                f"(max |{letter}| = {float(np.abs(matrix[:, col]).max()):.4g})"
+            )
+    return arr
+
+
+def _validate_options(opts: SynthOptions) -> None:
+    """Range-check :class:`SynthOptions`."""
+    if not (np.isfinite(opts.sample_rate_hz) and opts.sample_rate_hz > 0):
+        raise ValueError(
+            f"options.sample_rate_hz must be a positive finite scalar, "
+            f"got {opts.sample_rate_hz!r}"
+        )
+    if not (
+        np.isfinite(opts.simulation_time_s) and 0.0 < opts.simulation_time_s <= 1.0
+    ):
+        raise ValueError(
+            "options.simulation_time_s must be in (0, 1] s, got "
+            f"{opts.simulation_time_s!r}"
+        )
+    if opts.add_noise and not (
+        np.isfinite(opts.noise_sigma_m) and opts.noise_sigma_m >= 0.0
+    ):
+        raise ValueError(
+            "options.noise_sigma_m must be a non-negative finite scalar, "
+            f"got {opts.noise_sigma_m!r}"
+        )
+
+
+def _run_simulate_with_coefficients(
+    theta: NDArray[np.float64], opts: SynthOptions
+) -> Any:
+    """Locate and call the OpenSim ``simulate_with_coefficients`` entry point.
+
+    The simulator lives behind a lazy import so this module remains importable
+    on platforms without OpenSim. Issue #4120 introduces the module; until
+    that lands, callers receive a clear ``ImportError``.
+    """
+    sim_module = _load_simulate_module()
+
+    # Build engine-side SimOptions if the module exposes one; otherwise pass
+    # a plain dict and let the simulator coerce.
+    sim_options_cls = getattr(sim_module, "SimOptions", None)
+    if sim_options_cls is not None:
+        try:
+            sim_options = sim_options_cls(
+                sample_rate_hz=float(opts.sample_rate_hz),
+                simulation_time_s=float(opts.simulation_time_s),
+                **dict(opts.sim_overrides),
+            )
+        except TypeError:
+            # Older signature -- fall back to no kwargs and apply overrides
+            # post-hoc if the dataclass exposes ``replace``-friendly fields.
+            sim_options = sim_options_cls()
+    else:
+        sim_options = {
+            "sample_rate_hz": float(opts.sample_rate_hz),
+            "simulation_time_s": float(opts.simulation_time_s),
+            **dict(opts.sim_overrides),
+        }
+
+    sim_func = getattr(sim_module, "simulate_with_coefficients", None)
+    if sim_func is None:
+        raise ImportError(
+            "OpenSim simulate_with_coefficients is not yet available "
+            "(expected at "
+            "src/engines/physics_engines/opensim/python/motion_matching/"
+            "simulate.py::simulate_with_coefficients). "
+            "Pending issue #4120."
+        )
+
+    sim_out = sim_func(theta, sim_options)
+    status = getattr(sim_out, "solver_status", "success")
+    if str(status) == "failed":
+        message = getattr(sim_out, "status_message", "<no message>")
+        raise RuntimeError(
+            f"simulate_with_coefficients reported solver_status='failed': {message}"
+        )
+    return sim_out
+
+
+def _load_simulate_module() -> Any:
+    """Import the OpenSim simulate module by trying canonical locations."""
+    candidates = (
+        # The path referenced by issue #4124's prompt and OPENSIM_PARITY_SPEC's
+        # cross-engine layout.
+        "src.engines.physics_engines.opensim.python.motion_matching.simulate",
+        # Fallback to the location named in OPENSIM_PARITY_SPEC §2.2.
+        "src.engines.physics_engines.opensim.python.opensim_golf."
+        "simulate_with_coefficients",
+    )
+    last_err: Exception | None = None
+    for dotted in candidates:
+        try:
+            return importlib.import_module(dotted)
+        except ImportError as exc:
+            last_err = exc
+    raise ImportError(
+        "Could not locate OpenSim simulate_with_coefficients. Tried: "
+        + ", ".join(candidates)
+        + (f" (last error: {last_err})" if last_err is not None else "")
+    )
+
+
+def _normalise_quat_rows(q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Force unit-norm and ``q[:,0] >= 0`` sign convention.
+
+    Mirrors ``local_normalise_quat_rows`` in the MATLAB reference.
+    Returns a copy.
+    """
+    if q.ndim != 2 or q.shape[1] != 4:
+        raise ValueError(f"club_quat must have shape (N, 4), got {q.shape}")
+    if q.size == 0 or np.all(np.isnan(q)):
+        # Degenerate -- substitute identity quaternion to satisfy postcondition.
+        return np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (max(q.shape[0], 1), 1))
+    out = q.astype(np.float64, copy=True)
+    norms = np.linalg.norm(out, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    out = out / norms
+    flip_mask = out[:, 0] < 0.0
+    out[flip_mask] = -out[flip_mask]
+    # Re-check norms (post-flip should still be unit).
+    err = np.abs(np.linalg.norm(out, axis=1) - 1.0).max()
+    if err > _QUAT_NORM_TOL:  # pragma: no cover -- guarded above
+        raise ValueError(
+            f"club_quat rows could not be normalised (max |1 - |q|| = {err:.2e})"
+        )
+    return out
+
+
+def _add_position_noise(
+    butt: NDArray[np.float64],
+    clubhead: NDArray[np.float64],
+    sigma_m: float,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Add zero-mean Gaussian noise with deterministic seed.
+
+    Determinism is required for the round-trip identity test (same theta ->
+    same ClubTarget bytes within float rounding).
+    """
+    rng = np.random.default_rng(seed=0)
+    return (
+        butt + sigma_m * rng.standard_normal(butt.shape),
+        clubhead + sigma_m * rng.standard_normal(clubhead.shape),
+    )
+
+
+def _detect_clubhead_impact(
+    time: NDArray[np.float64], clubhead: NDArray[np.float64]
+) -> int:
+    """Return ``argmax || d r_clubhead / dt ||`` clamped to ``[1, N]`` (1-indexed).
+
+    Matches the MATLAB ``detect_clubhead_impact`` default behaviour:
+    pick the timestep at which clubhead speed peaks. The 1-indexed
+    convention matches MATLAB / CLUB_IK_SPEC.
+    """
+    n = time.shape[0]
+    if n < 2:
+        return 1
+    dt = np.diff(time)
+    dt[dt == 0.0] = np.finfo(np.float64).eps
+    velocity = np.diff(clubhead, axis=0) / dt[:, None]
+    speed = np.linalg.norm(velocity, axis=1)
+    if speed.size == 0 or not np.any(np.isfinite(speed)):
+        return 1
+    # argmax is 0-indexed on the velocity array (length N-1) -> map to 1..N.
+    idx0 = int(np.nanargmax(speed))
+    return max(1, min(n, idx0 + 1))
+
+
+def _git_commit() -> str:
+    """Best-effort current ``HEAD`` SHA; ``"unknown"`` on failure.
+
+    Currently unused by the dataclass (``SourceProvenance`` does not carry
+    ``git_commit``) but kept available for future schema expansion that
+    matches the MATLAB struct exactly.
+    """
+    try:
+        out = subprocess.run(  # noqa: S603,S607 - safe, fixed args
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover - defensive
+        pass
+    return "unknown"

--- a/tests/test_opensim_synthesize.py
+++ b/tests/test_opensim_synthesize.py
@@ -1,0 +1,410 @@
+"""Tests for OpenSim ``synthesize_target_from_coefficients`` (issue #4124).
+
+Two layers, mirroring ``test_opensim_model_loads.py``:
+
+1. **Pure-Python tests** — exercise the SimOut -> ClubTarget mapping,
+   precondition checks, and round-trip identity using a fake
+   ``simulate_with_coefficients`` patched into the engine module.  These
+   run without the OpenSim Python bindings and form the contract test
+   suite the optimizer code can rely on.
+
+2. **OpenSim binding tests** (``@pytest.mark.requires_opensim``) — call
+   the real engine.  Skipped when ``import opensim`` fails or when the
+   simulate wrapper (issue #4120) has not yet landed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import importlib.util
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+import pytest
+from src.engines.physics_engines.opensim.python.motion_matching import (
+    SynthOptions,
+    synthesize_target_from_coefficients,
+)
+from src.engines.physics_engines.opensim.python.motion_matching import (
+    synthesize as synth_module,
+)
+from src.shared.python.motion_matching.club_target import ClubTarget
+
+# ---------------------------------------------------------------------------
+# Test fixture: a tiny in-memory ``SimOut``-shaped object + a fake simulate.
+# ---------------------------------------------------------------------------
+
+_N_JOINTS = 25  # OpenSim golf humanoid coordinate count (per parity spec).
+_THETA_LEN = _N_JOINTS * 7
+_N_SAMPLES = 51
+
+
+@dataclasses.dataclass
+class _FakeSimOut:
+    """Stand-in for the engine ``SimOut`` until issue #4120 lands."""
+
+    time: np.ndarray
+    q: np.ndarray
+    qd: np.ndarray
+    qdd: np.ndarray
+    tau: np.ndarray
+    grip: np.ndarray
+    grip_quat: np.ndarray
+    clubhead: np.ndarray
+    club_quat: np.ndarray
+    solver_status: str = "success"
+    duration_s: float = 0.0
+
+
+def _make_fake_simout(
+    n_samples: int = _N_SAMPLES,
+    sim_time_s: float = 0.3,
+    impact_frac: float = 0.6,
+) -> _FakeSimOut:
+    """Build a deterministic ``_FakeSimOut`` shaped like the OpenSim engine.
+
+    Trajectories are smooth, finite, well-bounded, and have a clean speed
+    peak near ``impact_frac * sim_time_s`` so impact detection is unambiguous.
+    """
+    t = np.linspace(0.0, sim_time_s, n_samples)
+    n = t.size
+
+    # Joint state: zero -- only positions matter for ClubTarget.
+    n_joints = _N_JOINTS
+    q = np.zeros((n, n_joints))
+    qd = np.zeros((n, n_joints))
+    qdd = np.zeros((n, n_joints))
+    tau = np.zeros((n, n_joints))
+
+    # Grip travels along x with a smooth bump; clubhead has a stronger
+    # acceleration near impact_frac.
+    impact_t = impact_frac * sim_time_s
+    bump = np.exp(-((t - impact_t) ** 2) / 0.01)
+    grip = np.column_stack([0.5 + 0.1 * t, 0.05 * bump, np.zeros(n)])
+    clubhead = np.column_stack([0.5 + 1.5 * t**2, 0.2 * bump, 0.3 * t])
+
+    # Club orientation: identity quaternion the whole way.
+    grip_quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    club_quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+
+    return _FakeSimOut(
+        time=t,
+        q=q,
+        qd=qd,
+        qdd=qdd,
+        tau=tau,
+        grip=grip,
+        grip_quat=grip_quat,
+        clubhead=clubhead,
+        club_quat=club_quat,
+    )
+
+
+@pytest.fixture
+def patch_simulate(monkeypatch: pytest.MonkeyPatch):
+    """Inject a fake ``simulate_with_coefficients`` module for synthesize."""
+
+    def _patch(
+        sim_out_factory=_make_fake_simout,
+        sim_options_cls: type | None = None,
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {"calls": []}
+
+        def fake_simulate(theta, options):  # noqa: ANN001
+            captured["calls"].append((np.array(theta, copy=True), options))
+            return sim_out_factory()
+
+        fake_module = ModuleType(
+            "src.engines.physics_engines.opensim.python.motion_matching._fake_simulate"
+        )
+        fake_module.simulate_with_coefficients = fake_simulate  # type: ignore[attr-defined]
+        if sim_options_cls is not None:
+            fake_module.SimOptions = sim_options_cls  # type: ignore[attr-defined]
+
+        monkeypatch.setattr(
+            synth_module,
+            "_load_simulate_module",
+            lambda: fake_module,
+        )
+        return captured
+
+    return _patch
+
+
+def _theta_truth(seed: int = 1234) -> np.ndarray:
+    """Return a reproducible coefficient vector inside generateRandomCoefficients bounds."""
+    rng = np.random.default_rng(seed)
+    bounds = np.array([1000.0, 1000.0, 500.0, 500.0, 100.0, 100.0, 25.0])
+    # Sample to about 30% of each bound to leave headroom for any future tighter bound.
+    matrix = rng.uniform(-0.3, 0.3, size=(_N_JOINTS, 7)) * bounds
+    return matrix.reshape(-1)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: pure-Python contract tests (no OpenSim binding required).
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_identity_returns_clubtarget(patch_simulate) -> None:
+    """A known theta synthesizes to a fully-validated ClubTarget."""
+    patch_simulate()
+    theta = _theta_truth()
+
+    target = synthesize_target_from_coefficients(theta)
+
+    assert isinstance(target, ClubTarget)
+    n = target.time.shape[0]
+    assert n == _N_SAMPLES
+    assert target.butt.shape == (n, 3)
+    assert target.clubhead.shape == (n, 3)
+    assert target.club_quat.shape == (n, 4)
+    assert 1 <= target.impact_idx <= n
+
+
+def test_round_trip_identity_is_deterministic(patch_simulate) -> None:
+    """Same theta -> identical ClubTarget arrays on two runs."""
+    patch_simulate()
+    theta = _theta_truth(seed=7)
+
+    a = synthesize_target_from_coefficients(theta)
+    b = synthesize_target_from_coefficients(theta)
+
+    np.testing.assert_array_equal(a.time, b.time)
+    np.testing.assert_array_equal(a.butt, b.butt)
+    np.testing.assert_array_equal(a.clubhead, b.clubhead)
+    np.testing.assert_array_equal(a.club_quat, b.club_quat)
+    assert a.impact_idx == b.impact_idx
+    assert a.source.sha256 == b.source.sha256
+
+
+def test_simout_to_clubtarget_mapping_correctness(patch_simulate) -> None:
+    """SimOut.grip -> ClubTarget.butt, SimOut.clubhead -> ClubTarget.clubhead."""
+    captured = patch_simulate()
+    theta = _theta_truth()
+
+    target = synthesize_target_from_coefficients(theta)
+    fake = _make_fake_simout()
+
+    np.testing.assert_allclose(target.butt, fake.grip)
+    np.testing.assert_allclose(target.clubhead, fake.clubhead)
+    # Quaternion normalised + sign-flipped to q[:,0] >= 0.
+    np.testing.assert_allclose(np.linalg.norm(target.club_quat, axis=1), 1.0)
+    assert np.all(target.club_quat[:, 0] >= 0.0)
+    # The simulator was actually invoked once with the requested theta.
+    assert len(captured["calls"]) == 1
+    np.testing.assert_array_equal(captured["calls"][0][0].reshape(-1), theta)
+
+
+def test_provenance_is_synthetic_and_hashes_theta(patch_simulate) -> None:
+    """source.format=='synthetic' and sha256 is the digest of theta bytes."""
+    import hashlib
+
+    patch_simulate()
+    theta = _theta_truth(seed=11)
+
+    target = synthesize_target_from_coefficients(theta)
+
+    assert target.source.format == "synthetic"
+    assert target.source.subject_id == "synthetic"
+    assert target.source.trial_id == "synthesizer_v1"
+    assert target.source.filename == ""
+    expected_hash = hashlib.sha256(
+        np.asarray(theta, dtype=np.float64).reshape(-1).tobytes()
+    ).hexdigest()
+    assert target.source.sha256 == expected_hash
+
+
+def test_impact_idx_aligns_with_clubhead_speed_peak(patch_simulate) -> None:
+    """impact_idx points at the clubhead-velocity peak (1-indexed)."""
+    patch_simulate()
+    theta = _theta_truth()
+    target = synthesize_target_from_coefficients(theta)
+
+    # Reproduce expected impact: argmax of |d clubhead/dt|, 1-indexed.
+    fake = _make_fake_simout()
+    dt = np.diff(fake.time)
+    velocity = np.diff(fake.clubhead, axis=0) / dt[:, None]
+    speed = np.linalg.norm(velocity, axis=1)
+    expected = int(np.argmax(speed)) + 1
+    assert target.impact_idx == expected
+
+
+def test_options_propagate_to_simulator(patch_simulate) -> None:
+    """SynthOptions.sample_rate_hz / simulation_time_s are forwarded."""
+
+    @dataclasses.dataclass
+    class _SimOpts:
+        sample_rate_hz: float = 1000.0
+        simulation_time_s: float = 0.3
+
+    captured = patch_simulate(sim_options_cls=_SimOpts)
+
+    opts = SynthOptions(sample_rate_hz=2000.0, simulation_time_s=0.5)
+    synthesize_target_from_coefficients(_theta_truth(), opts)
+
+    assert len(captured["calls"]) == 1
+    forwarded_sim_opts = captured["calls"][0][1]
+    assert isinstance(forwarded_sim_opts, _SimOpts)
+    assert forwarded_sim_opts.sample_rate_hz == pytest.approx(2000.0)
+    assert forwarded_sim_opts.simulation_time_s == pytest.approx(0.5)
+
+
+def test_options_dict_fallback_when_no_simoptions_class(patch_simulate) -> None:
+    """When the engine module exposes no ``SimOptions`` class, a dict is sent."""
+    captured = patch_simulate()  # no SimOptions class on the fake module
+
+    synthesize_target_from_coefficients(_theta_truth())
+
+    forwarded = captured["calls"][0][1]
+    assert isinstance(forwarded, dict)
+    assert forwarded["sample_rate_hz"] == pytest.approx(1000.0)
+    assert forwarded["simulation_time_s"] == pytest.approx(0.3)
+
+
+def test_failed_solver_status_raises(patch_simulate, monkeypatch) -> None:
+    """``solver_status == 'failed'`` from the simulator surfaces as RuntimeError."""
+
+    def _failed_factory():
+        out = _make_fake_simout()
+        return dataclasses.replace(out, solver_status="failed")
+
+    patch_simulate(sim_out_factory=_failed_factory)
+
+    with pytest.raises(RuntimeError, match="solver_status='failed'"):
+        synthesize_target_from_coefficients(_theta_truth())
+
+
+def test_simulate_module_missing_raises_importerror(monkeypatch) -> None:
+    """Without the simulate wrapper, the synthesizer raises ImportError."""
+
+    def _raise_import(*args: Any, **kwargs: Any) -> None:
+        raise ImportError("simulate not yet available")
+
+    monkeypatch.setattr(synth_module, "_load_simulate_module", _raise_import)
+
+    with pytest.raises(ImportError, match="simulate not yet available"):
+        synthesize_target_from_coefficients(_theta_truth())
+
+
+# ----- Precondition / DbC checks ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("bad_theta", "match"),
+    [
+        (np.array([1.0, 2.0]), "multiple of 7"),
+        (np.array([]), "multiple of 7"),
+        (np.full(_THETA_LEN, np.nan), "NaN or Inf"),
+        # First coefficient out of bound: |A| > 1000.
+        (
+            np.concatenate(
+                [
+                    np.array([1500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+                    np.zeros(_THETA_LEN - 7),
+                ]
+            ),
+            "coefficient A exceeds",
+        ),
+        # G coefficient out of bound: |G| > 25.
+        (
+            np.concatenate(
+                [
+                    np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 50.0]),
+                    np.zeros(_THETA_LEN - 7),
+                ]
+            ),
+            "coefficient G exceeds",
+        ),
+    ],
+)
+def test_invalid_theta_raises(bad_theta, match, patch_simulate) -> None:
+    patch_simulate()
+    with pytest.raises(ValueError, match=match):
+        synthesize_target_from_coefficients(bad_theta)
+
+
+def test_invalid_options_raise(patch_simulate) -> None:
+    patch_simulate()
+    with pytest.raises(ValueError, match="sample_rate_hz"):
+        synthesize_target_from_coefficients(
+            _theta_truth(), SynthOptions(sample_rate_hz=0.0)
+        )
+    with pytest.raises(ValueError, match="simulation_time_s"):
+        synthesize_target_from_coefficients(
+            _theta_truth(), SynthOptions(simulation_time_s=2.0)
+        )
+
+
+def test_quaternion_normalisation(patch_simulate) -> None:
+    """A non-unit quaternion in SimOut is normalised; q[:,0] >= 0."""
+
+    def _bad_quat_factory():
+        out = _make_fake_simout()
+        bad = np.tile(np.array([-2.0, 0.0, 0.0, 0.0]), (out.time.size, 1))
+        return dataclasses.replace(out, club_quat=bad)
+
+    patch_simulate(sim_out_factory=_bad_quat_factory)
+    target = synthesize_target_from_coefficients(_theta_truth())
+
+    np.testing.assert_allclose(np.linalg.norm(target.club_quat, axis=1), 1.0)
+    assert np.all(target.club_quat[:, 0] >= 0.0)
+
+
+def test_position_noise_is_deterministic(patch_simulate) -> None:
+    """``add_noise`` perturbs positions but stays reproducible across runs."""
+    patch_simulate()
+    theta = _theta_truth()
+    opts_noise = SynthOptions(add_noise=True, noise_sigma_m=1.0e-3)
+
+    a = synthesize_target_from_coefficients(theta, opts_noise)
+    b = synthesize_target_from_coefficients(theta, opts_noise)
+    np.testing.assert_array_equal(a.butt, b.butt)
+    np.testing.assert_array_equal(a.clubhead, b.clubhead)
+
+    clean = synthesize_target_from_coefficients(theta, SynthOptions(add_noise=False))
+    # Noise is non-zero almost surely; assert positions actually changed.
+    assert not np.allclose(a.butt, clean.butt)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: live OpenSim test (skipped without bindings or simulate wrapper).
+# ---------------------------------------------------------------------------
+
+
+_OPENSIM_AVAILABLE = importlib.util.find_spec("opensim") is not None
+
+
+def _real_simulate_module_available() -> bool:
+    """Return True iff the issue-#4120 simulate wrapper has landed."""
+    candidates = (
+        "src.engines.physics_engines.opensim.python.motion_matching.simulate",
+        "src.engines.physics_engines.opensim.python.opensim_golf."
+        "simulate_with_coefficients",
+    )
+    return any(importlib.util.find_spec(dotted) is not None for dotted in candidates)
+
+
+@pytest.mark.requires_opensim
+@pytest.mark.skipif(
+    not _OPENSIM_AVAILABLE,
+    reason="OpenSim Python bindings not installed.",
+)
+@pytest.mark.skipif(
+    not _real_simulate_module_available(),
+    reason=(
+        "OpenSim simulate_with_coefficients not yet available (pending issue #4120)."
+    ),
+)
+def test_synthesize_with_real_opensim_simulator() -> None:
+    """End-to-end smoke: real engine produces a finite, schema-valid ClubTarget."""
+    # Use a small, gentle coefficient vector so the model stays inside the
+    # numerically stable region irrespective of the model build.
+    theta = np.zeros(_THETA_LEN)
+    target = synthesize_target_from_coefficients(theta)
+
+    assert isinstance(target, ClubTarget)
+    assert np.all(np.isfinite(target.butt))
+    assert np.all(np.isfinite(target.clubhead))
+    assert target.source.format == "synthetic"


### PR DESCRIPTION
## Summary

- Adds the OpenSim TDD oracle `synthesize_target_from_coefficients(theta, options) -> ClubTarget` at `src/engines/physics_engines/opensim/python/motion_matching/synthesize.py`.
- Mirrors the MuJoCo (#4122) and Pinocchio (#4121) synthesize patterns and the MATLAB reference (`shared/synthesize_target_from_coefficients.m`).
- Calls OpenSim's `simulate_with_coefficients` (issue #4120) via lazy import and wraps `SimOut` -> `ClubTarget` (`grip` -> `butt`, `clubhead` -> `clubhead`, normalised `club_quat`, impact-speed-peak `impact_idx`, `source.format == "synthetic"` with `sha256(theta_truth)` as provenance hash).

Closes #4124.

## Implementation notes

- `SynthOptions` dataclass mirrors `default_synth_options.m` (sample_rate, simulation_time, add_noise, noise_sigma_m, subject_id, trial_id, sim_overrides).
- Coefficient bounds enforced at the door: `|A|,|B|<=1000`, `|C|,|D|<=500`, `|E|,|F|<=100`, `|G|<=25`.
- `solver_status == "failed"` from the simulator surfaces as `RuntimeError`.
- Lazy module load: tries `opensim/python/motion_matching/simulate.py` first (per issue #4124 prompt), then falls back to `opensim_golf/simulate_with_coefficients.py` (per OPENSIM_PARITY_SPEC §2.2).
- Quaternion rows normalised to unit-norm with `q[:,0] >= 0` sign convention.

## Test plan

- [x] `tests/test_opensim_synthesize.py` (18 tests, 1 marked `requires_opensim` and auto-skipped):
  - Round-trip identity: synthesize(theta) returns a fully-validated `ClubTarget` with expected shapes
  - Determinism: same theta -> byte-identical arrays across runs
  - SimOut -> ClubTarget mapping: `grip` -> `butt`, `clubhead` -> `clubhead`, quat normalised
  - Provenance: `format == "synthetic"`, `sha256` is hash of theta bytes
  - Impact index: aligns with clubhead-velocity peak (1-indexed)
  - Options propagation to the simulator (both dataclass and dict fallback paths)
  - Failed solver -> `RuntimeError`; missing simulate module -> `ImportError`
  - Precondition checks: bad theta length / NaN / out-of-bound coefficients raise `ValueError`
  - Bad option ranges raise `ValueError`
  - Quaternion normalisation handles non-unit input
  - Position noise is reproducible (fixed seed)
- [x] `ruff check` -- clean
- [x] `ruff format --check` -- clean
- [x] All 17 layer-1 tests pass; layer-2 (`requires_opensim`) skipped pending #4120

## Spec exemption

This PR depends on issue #4120 (`simulate_with_coefficients`) which has not yet landed. The synthesize module loads it lazily, so this PR is safely mergeable now. Tagged `spec-exempt`.