### PR TITLE
feat(drake): visualisation (Meshcat + 2D) (closes #4126)

### DIFF
--- a/src/engines/physics_engines/drake/python/motion_matching/viz/__init__.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/viz/__init__.py
@@ -1,0 +1,39 @@
+"""Drake motion-matching visualization parity package (issue #4126).
+
+Three views per VISUALIZATION_SPEC.md (cross-engine §2.5):
+
+* :mod:`render_trajectory_overlay` -- Meshcat 3D side-by-side overlay
+  of the measured club trajectory and the simulated club trajectory
+  produced by ``simulate_with_coefficients``. Saves an HTML scene file
+  plus a screenshot PNG fallback.
+* :mod:`render_error_timecourse` -- 2D matplotlib stacked plots of
+  position / orientation / clubhead-speed / joint-torque errors versus
+  simulation time.
+* :mod:`render_fit_quality_card` -- 2D matplotlib summary card with the
+  headline RMSE metrics, suitable for dropping into a PR or status
+  update.
+
+The 2D plotters are deliberately engine-agnostic (they accept the
+generic ``DrakeFitResult`` + canonical ``ClubTarget`` only) so other
+parity engines can reuse them via ``from src.engines.physics_engines.drake
+.python.motion_matching.viz import render_error_timecourse`` until a
+formal ``shared/python/motion_matching/plot_*.py`` package is split out.
+"""
+
+from __future__ import annotations
+
+from .render_error_timecourse import render_error_timecourse
+from .render_fit_quality_card import render_fit_quality_card
+from .render_trajectory_overlay import (
+    DrakeFitResult,
+    OverlayArtifacts,
+    render_trajectory_overlay,
+)
+
+__all__ = [
+    "DrakeFitResult",
+    "OverlayArtifacts",
+    "render_error_timecourse",
+    "render_fit_quality_card",
+    "render_trajectory_overlay",
+]

--- a/src/engines/physics_engines/drake/python/motion_matching/viz/render_error_timecourse.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/viz/render_error_timecourse.py
@@ -1,0 +1,217 @@
+"""Error timecourse stack (View 2 of VISUALIZATION_SPEC.md).
+
+Stacked 2D matplotlib panels versus simulation time:
+
+1. Position error (mm) -- butt (blue) and clubhead (orange).
+2. Orientation error (deg) -- geodesic distance between the simulated
+   and measured club quaternions.
+3. Clubhead speed (mph) -- measured (solid) vs simulated (dashed).
+4. Joint torques (N*m) -- one trace per actuated joint, only drawn if
+   the simulated ``tau`` field is populated.
+
+A vertical guide is drawn across all panels at the impact frame
+recorded on the canonical ``ClubTarget``.
+
+The implementation is engine-agnostic: it reads only the documented
+fields of :class:`DrakeFitResult` and :class:`ClubTarget`, so any
+physics engine that adopts the same ``FitResult``-shape can reuse this
+module verbatim until the formal cross-engine ``shared/python/
+motion_matching/plot_*.py`` package is split out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from matplotlib.figure import Figure
+
+    from src.shared.python.motion_matching.club_target import ClubTarget
+
+    from .render_trajectory_overlay import DrakeFitResult
+
+
+# Conversions used by the plot.
+M_TO_MM = 1000.0
+MS_TO_MPH = 2.23694  # 1 m/s = 2.23694 mph
+
+# Palette (mirrors VISUALIZATION_SPEC.md).
+COLOR_BUTT = "#1f77b4"
+COLOR_CLUBHEAD = "#ff7f0e"
+COLOR_MEASURED = "#1f77b4"
+COLOR_SIMULATED = "#d62728"
+COLOR_IMPACT_GUIDE = "#7f7f7f"
+
+
+__all__ = ["render_error_timecourse"]
+
+
+def render_error_timecourse(
+    fit: DrakeFitResult,
+    target: ClubTarget,
+    out_dir: Path,
+    *,
+    title: str | None = None,
+) -> Path:
+    """Render the error timecourse panel stack.
+
+    Args:
+        fit: :class:`DrakeFitResult` from the optimiser.
+        target: Canonical :class:`ClubTarget` consumed by the fit.
+        out_dir: Directory to write into. Created if missing.
+        title: Optional figure title; defaults to ``fit.swing_id``.
+
+    Returns:
+        The :class:`pathlib.Path` of the PNG written.
+
+    Raises:
+        ValueError: if the ``fit`` and ``target`` timegrids disagree.
+    """
+    if fit.time.shape[0] != target.time.shape[0]:
+        msg = (
+            "fit and target must share the canonical timegrid; got "
+            f"{fit.time.shape[0]} vs {target.time.shape[0]} samples"
+        )
+        raise ValueError(msg)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Local imports keep matplotlib optional at module-import time.
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    import matplotlib.figure as _mfig
+
+    n_panels = 4 if fit.tau is not None else 3
+    fig: Figure = _mfig.Figure(figsize=(8.5, 2.0 * n_panels + 0.6), dpi=150)
+    axes = [fig.add_subplot(n_panels, 1, k + 1) for k in range(n_panels)]
+
+    t = np.asarray(fit.time, dtype=float)
+
+    _draw_position_error_panel(axes[0], t, fit, target)
+    _draw_orientation_error_panel(axes[1], t, fit, target)
+    _draw_clubhead_speed_panel(axes[2], t, fit, target)
+    if fit.tau is not None:
+        _draw_torque_panel(axes[3], t, fit.tau)
+
+    # Impact guide on every panel.
+    impact_idx = max(0, min(int(target.impact_idx) - 1, t.shape[0] - 1))
+    impact_t = float(t[impact_idx])
+    for ax in axes:
+        ax.axvline(impact_t, color=COLOR_IMPACT_GUIDE, linestyle="--", linewidth=0.8)
+
+    axes[-1].set_xlabel("time (s)")
+    fig.suptitle(title or fit.swing_id or "Error timecourse", fontsize=13)
+    fig.tight_layout()
+
+    png_path = out_dir / "error_timecourse.png"
+    fig.savefig(png_path, dpi=200, bbox_inches="tight")
+    return png_path
+
+
+# ---------------------------------------------------------------------------
+# Panel renderers
+# ---------------------------------------------------------------------------
+
+
+def _draw_position_error_panel(
+    ax,  # type: ignore[no-untyped-def]
+    t: NDArray[np.float64],
+    fit: DrakeFitResult,
+    target: ClubTarget,
+) -> None:
+    """Top panel: butt and clubhead position error in millimetres."""
+    butt_err = (
+        np.linalg.norm(np.asarray(fit.grip) - np.asarray(target.butt), axis=1) * M_TO_MM
+    )
+    head_err = (
+        np.linalg.norm(np.asarray(fit.clubhead) - np.asarray(target.clubhead), axis=1)
+        * M_TO_MM
+    )
+    ax.plot(t, butt_err, color=COLOR_BUTT, linewidth=1.4, label="butt")
+    ax.plot(t, head_err, color=COLOR_CLUBHEAD, linewidth=1.4, label="clubhead")
+    ax.set_ylabel("position error (mm)")
+    ax.legend(loc="upper right", fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+
+def _draw_orientation_error_panel(
+    ax,  # type: ignore[no-untyped-def]
+    t: NDArray[np.float64],
+    fit: DrakeFitResult,
+    target: ClubTarget,
+) -> None:
+    """Geodesic quaternion distance, expressed in degrees."""
+    q_sim = _to_unit_quat(np.asarray(fit.club_quat, dtype=float))
+    q_meas = _to_unit_quat(np.asarray(target.club_quat, dtype=float))
+    # Quaternion dot, clipped for numerical safety; double-cover -> abs.
+    dot = np.abs(np.sum(q_sim * q_meas, axis=1))
+    dot = np.clip(dot, -1.0, 1.0)
+    err_rad = 2.0 * np.arccos(dot)
+    err_deg = np.degrees(err_rad)
+    ax.plot(t, err_deg, color=COLOR_SIMULATED, linewidth=1.4)
+    ax.set_ylabel("orientation err (deg)")
+    ax.grid(True, alpha=0.3)
+
+
+def _draw_clubhead_speed_panel(
+    ax,  # type: ignore[no-untyped-def]
+    t: NDArray[np.float64],
+    fit: DrakeFitResult,
+    target: ClubTarget,
+) -> None:
+    """Clubhead linear speed in mph -- measured solid, simulated dashed."""
+    v_meas = _path_speed(np.asarray(target.clubhead, dtype=float), t) * MS_TO_MPH
+    v_sim = _path_speed(np.asarray(fit.clubhead, dtype=float), t) * MS_TO_MPH
+    ax.plot(t, v_meas, color=COLOR_MEASURED, linewidth=1.4, label="measured")
+    ax.plot(
+        t,
+        v_sim,
+        color=COLOR_SIMULATED,
+        linewidth=1.4,
+        linestyle="--",
+        label="simulated",
+    )
+    ax.set_ylabel("clubhead speed (mph)")
+    ax.legend(loc="upper left", fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+
+def _draw_torque_panel(
+    ax,  # type: ignore[no-untyped-def]
+    t: NDArray[np.float64],
+    tau: NDArray[np.float64],
+) -> None:
+    """Bottom panel: one trace per joint torque (N*m)."""
+    n_joints = tau.shape[1]
+    for j in range(n_joints):
+        ax.plot(t, tau[:, j], linewidth=0.8, alpha=0.8)
+    ax.set_ylabel("joint torque (N*m)")
+    ax.grid(True, alpha=0.3)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_unit_quat(q: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Renormalise per-row quaternions; tolerant of small drift."""
+    norms = np.linalg.norm(q, axis=1, keepdims=True)
+    return q / np.maximum(norms, 1.0e-12)
+
+
+def _path_speed(p: NDArray[np.float64], t: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Centred-difference speed (m/s) along the (N, 3) path ``p``.
+
+    Endpoints use forward / backward differences so the output has the
+    same length as ``p``.
+    """
+    if p.shape[0] < 2:
+        return np.zeros(p.shape[0], dtype=float)
+    v = np.gradient(p, t, axis=0)
+    return np.linalg.norm(v, axis=1)

--- a/src/engines/physics_engines/drake/python/motion_matching/viz/render_fit_quality_card.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/viz/render_fit_quality_card.py
@@ -1,0 +1,247 @@
+"""Fit quality summary card (View 3 of VISUALIZATION_SPEC.md).
+
+A single 2D matplotlib figure with the headline RMSE metrics laid out
+as a card -- safe to drop into a PR or a status update without further
+formatting. The card mirrors the ASCII mock in VISUALIZATION_SPEC.md:
+
+* swing id / solver / iteration count / wall clock,
+* clubhead RMSE, butt RMSE, mean orientation error,
+* impact-frame clubhead speed (sim vs measured),
+* commit hash + branch footer.
+
+The card is engine-agnostic: it consumes the same
+:class:`DrakeFitResult` + canonical :class:`ClubTarget` as the other
+two views, so any parity engine can adopt it once it produces a
+``FitResult``-shaped bundle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from src.shared.python.motion_matching.club_target import ClubTarget
+
+    from .render_trajectory_overlay import DrakeFitResult
+
+
+M_TO_MM = 1000.0
+MS_TO_MPH = 2.23694
+
+
+__all__ = [
+    "FitQualityMetrics",
+    "compute_fit_quality_metrics",
+    "render_fit_quality_card",
+]
+
+
+@dataclass(frozen=True)
+class FitQualityMetrics:
+    """Headline metrics rendered onto the summary card.
+
+    Attributes:
+        clubhead_rmse_mm: RMS clubhead position error (mm).
+        butt_rmse_mm:     RMS butt position error (mm).
+        mean_orient_err_deg: Mean geodesic orientation error (deg).
+        impact_speed_sim_mph: Simulated clubhead speed at impact (mph).
+        impact_speed_meas_mph: Measured clubhead speed at impact (mph).
+    """
+
+    clubhead_rmse_mm: float
+    butt_rmse_mm: float
+    mean_orient_err_deg: float
+    impact_speed_sim_mph: float
+    impact_speed_meas_mph: float
+
+
+def compute_fit_quality_metrics(
+    fit: DrakeFitResult, target: ClubTarget
+) -> FitQualityMetrics:
+    """Compute the headline metrics rendered on the summary card.
+
+    Public so the same numbers can be logged or written to JSON without
+    re-rendering the matplotlib card.
+    """
+    if fit.time.shape[0] != target.time.shape[0]:
+        msg = (
+            "fit and target must share the canonical timegrid; got "
+            f"{fit.time.shape[0]} vs {target.time.shape[0]} samples"
+        )
+        raise ValueError(msg)
+    head_err_m = np.linalg.norm(
+        np.asarray(fit.clubhead, dtype=float)
+        - np.asarray(target.clubhead, dtype=float),
+        axis=1,
+    )
+    butt_err_m = np.linalg.norm(
+        np.asarray(fit.grip, dtype=float) - np.asarray(target.butt, dtype=float),
+        axis=1,
+    )
+    orient_err_deg = _orientation_error_deg(
+        np.asarray(fit.club_quat, dtype=float),
+        np.asarray(target.club_quat, dtype=float),
+    )
+    impact_idx = max(0, min(int(target.impact_idx) - 1, fit.time.shape[0] - 1))
+    sim_speed_mph = _impact_speed_mph(
+        np.asarray(fit.clubhead, dtype=float), fit.time, impact_idx
+    )
+    meas_speed_mph = _impact_speed_mph(
+        np.asarray(target.clubhead, dtype=float), fit.time, impact_idx
+    )
+    return FitQualityMetrics(
+        clubhead_rmse_mm=float(np.sqrt(np.mean(head_err_m**2)) * M_TO_MM),
+        butt_rmse_mm=float(np.sqrt(np.mean(butt_err_m**2)) * M_TO_MM),
+        mean_orient_err_deg=float(np.mean(orient_err_deg)),
+        impact_speed_sim_mph=float(sim_speed_mph),
+        impact_speed_meas_mph=float(meas_speed_mph),
+    )
+
+
+def render_fit_quality_card(
+    fit: DrakeFitResult,
+    target: ClubTarget,
+    out_dir: Path,
+    *,
+    title: str | None = None,
+) -> Path:
+    """Render the fit quality summary card.
+
+    Args:
+        fit: :class:`DrakeFitResult` from the optimiser.
+        target: Canonical :class:`ClubTarget` consumed by the fit.
+        out_dir: Directory to write into. Created if missing.
+        title: Optional override; defaults to ``fit.swing_id``.
+
+    Returns:
+        :class:`pathlib.Path` of the PNG written.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    metrics = compute_fit_quality_metrics(fit, target)
+
+    # Local imports keep matplotlib optional at module-import time.
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    import matplotlib.figure as _mfig
+
+    fig = _mfig.Figure(figsize=(7.5, 5.0), dpi=150)
+    ax = fig.add_subplot(111)
+    ax.set_axis_off()
+
+    header = title or fit.swing_id or "Fit quality summary"
+    solver_line = (
+        f"Solver: drake float-pathway   Iterations: {fit.n_iterations}   "
+        f"Wall clock: {fit.wall_clock_s:.1f}s"
+    )
+
+    body_lines = [
+        f"Final RMSE - clubhead position : {metrics.clubhead_rmse_mm:6.2f} mm",
+        f"Final RMSE - butt position     : {metrics.butt_rmse_mm:6.2f} mm",
+        f"Final mean orientation error   : {metrics.mean_orient_err_deg:6.3f} deg",
+        (
+            f"Clubhead speed at impact       : "
+            f"{metrics.impact_speed_sim_mph:6.1f} mph "
+            f"(meas: {metrics.impact_speed_meas_mph:.1f})"
+        ),
+        f"Final loss                     : {fit.final_loss:.6e}",
+        f"Solver status                  : {fit.solver_status}",
+    ]
+    footer = f"Hash: {fit.commit_hash or '-'}     Branch: {fit.branch or '-'}"
+
+    # Stack the lines vertically; explicit y coordinates keep the layout
+    # deterministic across matplotlib versions.
+    ax.text(
+        0.02,
+        0.95,
+        header,
+        fontsize=14,
+        fontweight="bold",
+        transform=ax.transAxes,
+        verticalalignment="top",
+    )
+    ax.text(
+        0.02,
+        0.86,
+        solver_line,
+        fontsize=10,
+        transform=ax.transAxes,
+        verticalalignment="top",
+    )
+    y = 0.74
+    for line in body_lines:
+        ax.text(
+            0.04,
+            y,
+            line,
+            fontsize=11,
+            family="monospace",
+            transform=ax.transAxes,
+            verticalalignment="top",
+        )
+        y -= 0.08
+    ax.text(
+        0.02,
+        0.05,
+        footer,
+        fontsize=9,
+        color="#555555",
+        transform=ax.transAxes,
+        verticalalignment="bottom",
+    )
+
+    # Card border for the at-a-glance look.
+    ax.add_patch(_card_border())
+
+    png_path = out_dir / "fit_quality_card.png"
+    fig.savefig(png_path, dpi=200, bbox_inches="tight")
+    return png_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _card_border():  # type: ignore[no-untyped-def]
+    """Return a matplotlib ``Rectangle`` patch for the card border."""
+    from matplotlib.patches import Rectangle
+
+    return Rectangle(
+        (0.005, 0.005),
+        0.99,
+        0.99,
+        transform=None,
+        fill=False,
+        linewidth=1.0,
+        edgecolor="#cccccc",
+    )
+
+
+def _orientation_error_deg(
+    q_sim: NDArray[np.float64], q_meas: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Per-frame geodesic orientation error in degrees."""
+    n_sim = np.linalg.norm(q_sim, axis=1, keepdims=True)
+    n_meas = np.linalg.norm(q_meas, axis=1, keepdims=True)
+    a = q_sim / np.maximum(n_sim, 1.0e-12)
+    b = q_meas / np.maximum(n_meas, 1.0e-12)
+    dot = np.abs(np.sum(a * b, axis=1))
+    dot = np.clip(dot, -1.0, 1.0)
+    return np.degrees(2.0 * np.arccos(dot))
+
+
+def _impact_speed_mph(
+    path: NDArray[np.float64], t: NDArray[np.float64], impact_idx: int
+) -> float:
+    """Linear speed (mph) at ``impact_idx`` of a (N, 3) path."""
+    if path.shape[0] < 2:
+        return 0.0
+    v = np.gradient(path, t, axis=0)
+    return float(np.linalg.norm(v[impact_idx]) * MS_TO_MPH)

--- a/src/engines/physics_engines/drake/python/motion_matching/viz/render_trajectory_overlay.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/viz/render_trajectory_overlay.py
@@ -1,0 +1,456 @@
+"""Meshcat 3D trajectory overlay (View 1 of VISUALIZATION_SPEC.md).
+
+The overlay shows the canonical humanoid skeleton plus *both* the
+measured grip path (blue, ``#1f77b4``) and the simulated grip path
+(red, ``#d62728``) on the same Meshcat scene. A third grey trace draws
+the per-frame error vector from simulated -> measured clubhead so you
+can see *where* the fit is failing without flipping between two
+viewports.
+
+Two artefacts are written:
+
+1. ``<out_dir>/trajectory_overlay.html`` -- a static, self-contained
+   Meshcat scene (saved via ``Meshcat.StaticHtml``). Open in any
+   browser; no Drake or server needed.
+2. ``<out_dir>/trajectory_overlay.png`` -- a matplotlib screenshot
+   fallback rendered with the ``Agg`` backend so the file is produced
+   even on headless CI nodes that cannot run Meshcat. The PNG is
+   *always* produced; the HTML is produced only when ``pydrake`` is
+   importable.
+
+Per CLAUDE.md, all ``pydrake`` imports are explicit
+``from pydrake.X import Y`` and live inside the function so the module
+imports cleanly on systems without ``pydrake`` (e.g. the standard CI
+runner without the Drake extras).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from src.shared.python.motion_matching.club_target import ClubTarget
+
+
+# Shared palette -- mirrors VISUALIZATION_SPEC.md "Styling".
+COLOR_MEASURED = "#1f77b4"
+COLOR_SIMULATED = "#d62728"
+COLOR_ERROR = "#7f7f7f"
+
+
+__all__ = [
+    "DrakeFitResult",
+    "OverlayArtifacts",
+    "render_trajectory_overlay",
+]
+
+
+# ---------------------------------------------------------------------------
+# Drake-side FitResult bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DrakeFitResult:
+    """Drake-engine bundle consumed by every viz entry point.
+
+    A thin, frozen wrapper around the float-pathway ``SimOut`` plus the
+    minimum metadata needed to render the three views without re-running
+    the simulator. Constructed by callers (e.g. the optimiser, the CLI
+    ``visualize_fit`` entry point of a future issue) from the canonical
+    ``simulate_with_coefficients`` output.
+
+    Attributes:
+        time:        ``(N,)`` simulation time grid in seconds. Strictly
+                     increasing.
+        grip:        ``(N, 3)`` simulated grip path (m). Mirrors
+                     ``SimOut.grip``.
+        clubhead:    ``(N, 3)`` simulated clubhead path (m).
+        club_quat:   ``(N, 4)`` simulated club quaternions ``[w, x, y, z]``.
+        tau:         ``(N, n_joints)`` simulated joint torques (N*m).
+                     Optional; if ``None`` the joint-torque panel is
+                     skipped.
+        coefficients: ``(n_joints*7,)`` polynomial coefficient vector
+                     reported by the optimiser.
+        final_loss:  Final scalar loss from the optimiser.
+        solver_status: ``"success"`` / ``"warning"`` / ``"failed"``.
+        wall_clock_s: Optimiser wall-clock seconds, for the summary card.
+        n_iterations: Optimiser iteration count, for the summary card.
+        swing_id:    Free-form trial identifier (e.g. ``"TW_ProV1"``).
+        commit_hash: Optional 7-character git commit hash.
+        branch:      Optional branch name.
+    """
+
+    time: NDArray[np.float64]
+    grip: NDArray[np.float64]
+    clubhead: NDArray[np.float64]
+    club_quat: NDArray[np.float64]
+    coefficients: NDArray[np.float64]
+    final_loss: float
+    tau: NDArray[np.float64] | None = None
+    solver_status: str = "success"
+    wall_clock_s: float = 0.0
+    n_iterations: int = 0
+    swing_id: str = ""
+    commit_hash: str = ""
+    branch: str = ""
+
+    def __post_init__(self) -> None:
+        # DbC: shape parity with ClubTarget so downstream maths just works.
+        if self.time.ndim != 1:
+            msg = f"time must be 1-D; got shape {self.time.shape}"
+            raise ValueError(msg)
+        n = self.time.shape[0]
+        if n < 2:
+            msg = f"time must have at least 2 samples; got {n}"
+            raise ValueError(msg)
+        for name, arr, cols in (
+            ("grip", self.grip, 3),
+            ("clubhead", self.clubhead, 3),
+            ("club_quat", self.club_quat, 4),
+        ):
+            if arr.shape != (n, cols):
+                msg = f"{name} must have shape ({n}, {cols}); got {arr.shape}"
+                raise ValueError(msg)
+        if self.tau is not None:
+            if self.tau.ndim != 2 or self.tau.shape[0] != n:
+                msg = (
+                    "tau must have shape (N, n_joints) matching time length "
+                    f"N={n}; got {self.tau.shape}"
+                )
+                raise ValueError(msg)
+        if self.solver_status not in {"success", "warning", "failed"}:
+            msg = (
+                "solver_status must be 'success' / 'warning' / 'failed'; "
+                f"got {self.solver_status!r}"
+            )
+            raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Output artefacts bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OverlayArtifacts:
+    """Paths to the artefacts produced by :func:`render_trajectory_overlay`.
+
+    ``html_path`` is ``None`` when the Drake/Meshcat path could not run
+    (e.g. ``pydrake`` not importable on the host); ``png_path`` is
+    always produced because matplotlib with the ``Agg`` backend works
+    on every CI node.
+    """
+
+    png_path: Path
+    html_path: Path | None = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def render_trajectory_overlay(
+    fit: DrakeFitResult,
+    target: ClubTarget,
+    out_dir: Path,
+    *,
+    title: str | None = None,
+) -> OverlayArtifacts:
+    """Render the side-by-side trajectory overlay (View 1).
+
+    The function *always* writes the PNG fallback so headless CI gets a
+    stable artefact, and *additionally* writes a static Meshcat HTML
+    scene when ``pydrake`` is importable on the host.
+
+    Args:
+        fit:    :class:`DrakeFitResult` from the optimiser.
+        target: Canonical :class:`ClubTarget` consumed by the fit.
+        out_dir: Directory to write artefacts into. Created if missing.
+        title:  Optional figure title. Defaults to ``fit.swing_id`` or
+                ``"Trajectory overlay"``.
+
+    Returns:
+        :class:`OverlayArtifacts` with paths to every artefact actually
+        written.
+
+    Raises:
+        ValueError: if ``fit`` and ``target`` do not have the same
+            number of samples (the loader/sim contract guarantees they
+            do, so this is a hard fail rather than a resample).
+    """
+    if fit.time.shape[0] != target.time.shape[0]:
+        msg = (
+            "fit and target must share the canonical timegrid; got "
+            f"{fit.time.shape[0]} vs {target.time.shape[0]} samples"
+        )
+        raise ValueError(msg)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    resolved_title = title or fit.swing_id or "Trajectory overlay"
+
+    png_path = _render_png_fallback(fit, target, out_dir, resolved_title)
+    html_path = _try_render_meshcat_html(fit, target, out_dir, resolved_title)
+
+    return OverlayArtifacts(
+        png_path=png_path,
+        html_path=html_path,
+        meta={
+            "title": resolved_title,
+            "n_samples": int(fit.time.shape[0]),
+            "solver_status": fit.solver_status,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matplotlib fallback (always runs)
+# ---------------------------------------------------------------------------
+
+
+def _render_png_fallback(
+    fit: DrakeFitResult,
+    target: ClubTarget,
+    out_dir: Path,
+    title: str,
+) -> Path:
+    """Render the PNG screenshot fallback.
+
+    Two side-by-side 3D axes -- left is the measured trajectory, right
+    the simulated -- with the same camera limits so visual drift is
+    obvious. The grey error vectors connect simulated -> measured at a
+    handful of evenly spaced frames.
+
+    Returns the path of the PNG written.
+    """
+    # Local imports keep matplotlib optional at module-import time.
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    import matplotlib.figure as _mfig
+    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3d projection)
+
+    fig = _mfig.Figure(figsize=(12.0, 5.5), dpi=150)
+    ax_left = fig.add_subplot(1, 2, 1, projection="3d")
+    ax_right = fig.add_subplot(1, 2, 2, projection="3d")
+
+    _draw_club_skeleton_panel(
+        ax_left,
+        butt=target.butt,
+        clubhead=target.clubhead,
+        color=COLOR_MEASURED,
+        title="Measured",
+    )
+    _draw_club_skeleton_panel(
+        ax_right,
+        butt=fit.grip,
+        clubhead=fit.clubhead,
+        color=COLOR_SIMULATED,
+        title="Simulated",
+    )
+
+    # Error vectors -- draw on the right panel at ~10 evenly spaced frames.
+    n = fit.time.shape[0]
+    indices = np.linspace(0, n - 1, num=min(10, n), dtype=int)
+    for k in indices:
+        ax_right.plot(
+            [fit.clubhead[k, 0], target.clubhead[k, 0]],
+            [fit.clubhead[k, 1], target.clubhead[k, 1]],
+            [fit.clubhead[k, 2], target.clubhead[k, 2]],
+            color=COLOR_ERROR,
+            linewidth=0.8,
+            alpha=0.6,
+        )
+
+    # Tie the camera limits across both panels so drift is legible.
+    _share_axis_limits(ax_left, ax_right, fit, target)
+
+    fig.suptitle(title, fontsize=13)
+    fig.tight_layout()
+    png_path = out_dir / "trajectory_overlay.png"
+    fig.savefig(png_path, dpi=200, bbox_inches="tight")
+    return png_path
+
+
+def _draw_club_skeleton_panel(
+    ax: Any,
+    *,
+    butt: NDArray[np.float64],
+    clubhead: NDArray[np.float64],
+    color: str,
+    title: str,
+) -> None:
+    """Draw a single 3D panel of the club skeleton + clubhead trace."""
+    ax.plot(
+        clubhead[:, 0],
+        clubhead[:, 1],
+        clubhead[:, 2],
+        color=color,
+        linewidth=1.4,
+        label="clubhead path",
+    )
+    # Faint butt path, since it's the slow end of the skeleton.
+    ax.plot(
+        butt[:, 0],
+        butt[:, 1],
+        butt[:, 2],
+        color=color,
+        linewidth=0.8,
+        alpha=0.4,
+        label="butt path",
+    )
+    # Skeleton at impact-ish (mid-frame) so the figure isn't just two curves.
+    mid = butt.shape[0] // 2
+    ax.plot(
+        [butt[mid, 0], clubhead[mid, 0]],
+        [butt[mid, 1], clubhead[mid, 1]],
+        [butt[mid, 2], clubhead[mid, 2]],
+        color=color,
+        linewidth=2.5,
+    )
+    ax.set_title(title, fontsize=11)
+    ax.set_xlabel("x (m)")
+    ax.set_ylabel("y (m)")
+    ax.set_zlabel("z (m)")
+    ax.legend(loc="upper right", fontsize=8)
+
+
+def _share_axis_limits(
+    ax_left: Any,
+    ax_right: Any,
+    fit: DrakeFitResult,
+    target: ClubTarget,
+) -> None:
+    """Pin both 3D axes to the union bounding box of all four traces."""
+    pts = np.concatenate(
+        [
+            np.asarray(target.butt, dtype=float),
+            np.asarray(target.clubhead, dtype=float),
+            np.asarray(fit.grip, dtype=float),
+            np.asarray(fit.clubhead, dtype=float),
+        ],
+        axis=0,
+    )
+    lo = pts.min(axis=0)
+    hi = pts.max(axis=0)
+    pad = 0.05 * np.maximum(hi - lo, 1.0e-3)
+    for ax in (ax_left, ax_right):
+        ax.set_xlim(float(lo[0] - pad[0]), float(hi[0] + pad[0]))
+        ax.set_ylim(float(lo[1] - pad[1]), float(hi[1] + pad[1]))
+        ax.set_zlim(float(lo[2] - pad[2]), float(hi[2] + pad[2]))
+
+
+# ---------------------------------------------------------------------------
+# Optional Meshcat HTML (skipped on hosts without pydrake)
+# ---------------------------------------------------------------------------
+
+
+def _try_render_meshcat_html(
+    fit: DrakeFitResult,
+    target: ClubTarget,
+    out_dir: Path,
+    title: str,
+) -> Path | None:
+    """Attempt to write a static Meshcat HTML scene.
+
+    Returns the path on success and ``None`` on any importable-or-runtime
+    failure (e.g. ``pydrake`` not installed). The PNG fallback ensures
+    callers always get a usable artefact.
+    """
+    try:  # pragma: no cover - exercised only when pydrake is installed
+        # Explicit imports per CLAUDE.md.
+        from pydrake.geometry import Meshcat, Rgba, Sphere
+        from pydrake.math import RigidTransform
+    except Exception:
+        return None
+
+    try:  # pragma: no cover - same gating
+        meshcat = Meshcat()
+        # Path prefix so all this issue's geometry is removable in one go.
+        prefix = "trajectory_overlay"
+        meshcat.Delete(prefix)
+
+        _publish_path_as_spheres(
+            meshcat,
+            f"{prefix}/measured/clubhead",
+            target.clubhead,
+            color=Rgba(0.122, 0.467, 0.706, 1.0),  # COLOR_MEASURED
+            radius=0.012,
+            sphere_cls=Sphere,
+            transform_cls=RigidTransform,
+        )
+        _publish_path_as_spheres(
+            meshcat,
+            f"{prefix}/measured/butt",
+            target.butt,
+            color=Rgba(0.122, 0.467, 0.706, 0.5),
+            radius=0.010,
+            sphere_cls=Sphere,
+            transform_cls=RigidTransform,
+        )
+        _publish_path_as_spheres(
+            meshcat,
+            f"{prefix}/simulated/clubhead",
+            fit.clubhead,
+            color=Rgba(0.839, 0.153, 0.157, 1.0),  # COLOR_SIMULATED
+            radius=0.012,
+            sphere_cls=Sphere,
+            transform_cls=RigidTransform,
+        )
+        _publish_path_as_spheres(
+            meshcat,
+            f"{prefix}/simulated/grip",
+            fit.grip,
+            color=Rgba(0.839, 0.153, 0.157, 0.5),
+            radius=0.010,
+            sphere_cls=Sphere,
+            transform_cls=RigidTransform,
+        )
+
+        html = meshcat.StaticHtml()
+        html_path = out_dir / "trajectory_overlay.html"
+        html_path.write_text(html, encoding="utf-8")
+        # Bake the title into the HTML so the artefact is self-describing.
+        html_path.write_text(
+            f"<!-- {title} -->\n" + html_path.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return html_path
+    except Exception:
+        return None
+
+
+def _publish_path_as_spheres(
+    meshcat: Any,
+    path: str,
+    points: NDArray[np.float64],
+    *,
+    color: Any,
+    radius: float,
+    sphere_cls: Any,
+    transform_cls: Any,
+) -> None:  # pragma: no cover - only runs with pydrake
+    """Publish a polyline as a chain of small spheres on the Meshcat tree.
+
+    Meshcat's ``SetLine`` API exists in newer wheels but is awkward to
+    feature-detect across versions; small spheres render identically
+    everywhere and double as time markers in the static HTML.
+    """
+    n = points.shape[0]
+    # Subsample so we don't render 1k+ spheres into the static HTML.
+    step = max(1, n // 80)
+    for k in range(0, n, step):
+        meshcat.SetObject(f"{path}/{k}", sphere_cls(radius), color)
+        p = [
+            float(points[k, 0]),
+            float(points[k, 1]),
+            float(points[k, 2]),
+        ]
+        meshcat.SetTransform(f"{path}/{k}", transform_cls(p=p))

--- a/tests/test_drake_viz.py
+++ b/tests/test_drake_viz.py
@@ -1,0 +1,265 @@
+"""Smoke tests for the Drake visualisation parity package (issue #4126).
+
+The viz modules are deliberately engine-agnostic at the Python level
+(they only consume the documented :class:`DrakeFitResult` and
+:class:`ClubTarget` fields) so these tests run on every CI node --
+``pydrake`` is not required for the matplotlib + dataclass paths.
+
+Tests that exercise the live Meshcat HTML pathway are additionally
+gated on ``requires_drake`` so they are skipped on the standard CI
+runner.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+from src.engines.physics_engines.drake.python.motion_matching.viz import (
+    DrakeFitResult,
+    OverlayArtifacts,
+    render_error_timecourse,
+    render_fit_quality_card,
+    render_trajectory_overlay,
+)
+from src.engines.physics_engines.drake.python.motion_matching.viz.render_fit_quality_card import (
+    compute_fit_quality_metrics,
+)
+from src.shared.python.motion_matching.club_target import (
+    ClubTarget,
+    SourceProvenance,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_target(n: int = 32) -> ClubTarget:
+    """A short, smooth synthetic ``ClubTarget`` good enough for smoke tests.
+
+    The trajectory is a small circular arc traced out by the clubhead
+    around the butt; the orientation is held identity for the duration
+    so the orientation-error panel renders a flat zero line.
+    """
+    t = np.linspace(0.0, 0.3, n, dtype=float)
+    butt = np.zeros((n, 3), dtype=float)
+    radius = 0.5
+    omega = 2.0 * np.pi * 1.5  # ~1.5 Hz
+    head = np.stack(
+        [
+            radius * np.cos(omega * t),
+            radius * np.sin(omega * t),
+            0.5 + 0.05 * t,
+        ],
+        axis=1,
+    )
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    return ClubTarget(
+        time=t,
+        butt=butt,
+        clubhead=head,
+        club_quat=quat,
+        impact_idx=n // 2 + 1,  # 1-based per CLUB_IK_SPEC
+        source=SourceProvenance(
+            filename="synthetic.csv",
+            format="synthetic",
+            subject_id="UNIT",
+            trial_id="VIZ",
+            sha256="0" * 64,
+        ),
+    )
+
+
+def _synthetic_fit(target: ClubTarget, *, with_tau: bool = True) -> DrakeFitResult:
+    """A synthetic ``DrakeFitResult`` whose paths drift slightly from target.
+
+    A small constant offset on the clubhead and a low-amplitude wobble
+    on the grip exercise the position-error and orientation-error
+    panels without violating the validators.
+    """
+    grip = np.asarray(target.butt) + np.array([0.005, 0.0, 0.0])
+    head = np.asarray(target.clubhead) + np.array([0.0, 0.005, 0.002])
+    quat = np.asarray(target.club_quat).copy()
+    # Tiny rotation around z for a non-zero orientation error.
+    half = 1.0e-3 / 2.0
+    quat[:, 0] = np.cos(half)
+    quat[:, 3] = np.sin(half)
+    norms = np.linalg.norm(quat, axis=1, keepdims=True)
+    quat = quat / np.maximum(norms, 1.0e-12)
+    n_joints = 5
+    tau = (
+        0.1
+        * np.sin(
+            2.0
+            * np.pi
+            * np.arange(n_joints).reshape(1, -1)
+            * target.time.reshape(-1, 1)
+        )
+        if with_tau
+        else None
+    )
+    coeffs = np.zeros(n_joints * 7, dtype=float)
+    return DrakeFitResult(
+        time=target.time.copy(),
+        grip=grip,
+        clubhead=head,
+        club_quat=quat,
+        coefficients=coeffs,
+        final_loss=1.234e-3,
+        tau=tau,
+        solver_status="success",
+        wall_clock_s=2.5,
+        n_iterations=42,
+        swing_id="SYNTHETIC_TW",
+        commit_hash="abcdef0",
+        branch="feat/issue-4126",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataclass validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_drake_fit_result_rejects_mismatched_shapes() -> None:
+    """``DrakeFitResult.__post_init__`` is the DbC line-of-defence."""
+    with pytest.raises(ValueError, match="grip"):
+        DrakeFitResult(
+            time=np.linspace(0.0, 0.3, 8),
+            grip=np.zeros((4, 3)),  # wrong N
+            clubhead=np.zeros((8, 3)),
+            club_quat=np.tile([1.0, 0.0, 0.0, 0.0], (8, 1)),
+            coefficients=np.zeros(7),
+            final_loss=0.0,
+        )
+
+
+@pytest.mark.unit
+def test_drake_fit_result_rejects_bad_solver_status() -> None:
+    """Only ``success`` / ``warning`` / ``failed`` survive validation."""
+    with pytest.raises(ValueError, match="solver_status"):
+        DrakeFitResult(
+            time=np.linspace(0.0, 0.3, 8),
+            grip=np.zeros((8, 3)),
+            clubhead=np.zeros((8, 3)),
+            club_quat=np.tile([1.0, 0.0, 0.0, 0.0], (8, 1)),
+            coefficients=np.zeros(7),
+            final_loss=0.0,
+            solver_status="weird",
+        )
+
+
+# ---------------------------------------------------------------------------
+# View 1 -- trajectory overlay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_render_trajectory_overlay_writes_png(tmp_path: Path) -> None:
+    """The PNG fallback is *always* produced, even without pydrake.
+
+    The mark is ``requires_drake`` per the issue acceptance criteria;
+    the body itself only relies on matplotlib so the test is also
+    valid as a smoke test on a Drake-equipped runner.
+    """
+    target = _synthetic_target()
+    fit = _synthetic_fit(target)
+
+    artefacts = render_trajectory_overlay(fit, target, tmp_path, title="UnitTest")
+
+    assert isinstance(artefacts, OverlayArtifacts)
+    assert artefacts.png_path.exists()
+    assert artefacts.png_path.stat().st_size > 0
+    # HTML is best-effort: present iff pydrake imported successfully.
+    if artefacts.html_path is not None:
+        assert artefacts.html_path.exists()
+        assert artefacts.html_path.stat().st_size > 0
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_render_trajectory_overlay_rejects_mismatched_grids(tmp_path: Path) -> None:
+    """Mismatched timegrids are a hard fail (loaders/sim guarantee parity)."""
+    target = _synthetic_target(n=32)
+    fit = _synthetic_fit(_synthetic_target(n=16))
+    with pytest.raises(ValueError, match="timegrid"):
+        render_trajectory_overlay(fit, target, tmp_path)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_overlay_html_rendered_when_pydrake_available(tmp_path: Path) -> None:
+    """If ``pydrake`` is on the path, the HTML scene is also produced."""
+    if importlib.util.find_spec("pydrake") is None:
+        pytest.skip("pydrake not installed on this runner")
+    target = _synthetic_target()
+    fit = _synthetic_fit(target)
+    artefacts = render_trajectory_overlay(fit, target, tmp_path)
+    # Drake's Meshcat occasionally fails to bind a port in CI; treat the
+    # HTML as best-effort even when pydrake imports.
+    if artefacts.html_path is not None:
+        assert artefacts.html_path.suffix == ".html"
+
+
+# ---------------------------------------------------------------------------
+# View 2 -- error timecourse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_render_error_timecourse_writes_png(tmp_path: Path) -> None:
+    """The 2D matplotlib timecourse is produced and non-empty."""
+    target = _synthetic_target()
+    fit = _synthetic_fit(target)
+    out = render_error_timecourse(fit, target, tmp_path)
+    assert out.exists()
+    assert out.suffix == ".png"
+    assert out.stat().st_size > 0
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_render_error_timecourse_works_without_torque(tmp_path: Path) -> None:
+    """If ``tau`` is ``None`` the joint-torque panel is skipped (no crash)."""
+    target = _synthetic_target()
+    fit = _synthetic_fit(target, with_tau=False)
+    out = render_error_timecourse(fit, target, tmp_path)
+    assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# View 3 -- fit quality summary card
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_render_fit_quality_card_writes_png(tmp_path: Path) -> None:
+    """The summary card writes a PNG of non-zero size."""
+    target = _synthetic_target()
+    fit = _synthetic_fit(target)
+    out = render_fit_quality_card(fit, target, tmp_path, title="Smoke")
+    assert out.exists()
+    assert out.suffix == ".png"
+    assert out.stat().st_size > 0
+
+
+@pytest.mark.unit
+@pytest.mark.requires_drake
+def test_compute_fit_quality_metrics_round_trip() -> None:
+    """The headline metrics are real, finite, and shape-stable."""
+    target = _synthetic_target()
+    fit = _synthetic_fit(target)
+    metrics = compute_fit_quality_metrics(fit, target)
+    assert metrics.clubhead_rmse_mm >= 0.0
+    assert metrics.butt_rmse_mm >= 0.0
+    assert 0.0 <= metrics.mean_orient_err_deg < 360.0
+    # Synthetic offsets were tiny but non-zero -> RMS error is positive.
+    assert metrics.clubhead_rmse_mm > 0.0
+    assert metrics.butt_rmse_mm > 0.0


### PR DESCRIPTION
## Summary

Implements issue #4126 — Drake visualisation parity per VISUALIZATION_SPEC.md / cross-engine spec section 2.5.

- `src/engines/physics_engines/drake/python/motion_matching/viz/render_trajectory_overlay.py` — side-by-side 3D Meshcat HTML scene + always-on matplotlib PNG fallback.
- `src/engines/physics_engines/drake/python/motion_matching/viz/render_error_timecourse.py` — 2D stack: position / orientation / clubhead-speed / joint-torque vs time, with impact-frame guide.
- `src/engines/physics_engines/drake/python/motion_matching/viz/render_fit_quality_card.py` — single-figure summary card with headline RMSE metrics.
- New frozen `DrakeFitResult` dataclass wraps the float-pathway `SimOut` for viz consumption (engine-agnostic plotters can be lifted to `shared/python/motion_matching/plot_*.py` later).

CLAUDE.md compliance: all `pydrake` imports are explicit `from pydrake.X import Y` and stay inside functions so the modules import cleanly on hosts without pydrake.

## Test plan

- [x] `python3 -m pytest tests/test_drake_viz.py` — 8 passed, 1 skipped (pydrake not on local runner)
- [x] `python3 -m ruff check` and `python3 -m ruff format --check` — clean on all changed files
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)