### PR TITLE
feat(pinocchio): synthesize_target_from_coefficients + recovery harness (closes #4121)

### DIFF
--- a/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
@@ -16,6 +16,13 @@ Public API:
     load_robneal_target        -- ClubTarget adapter for Rob Neal *.mat (issue #4127).
     write_leaderboard_entry    -- leaderboard JSON writer (issue #4133).
     ClubTargetLike             -- protocol-style record for leaderboard inputs.
+    synthesize_target_from_coefficients -- SimOut -> ClubTarget oracle (issue #4121).
+    SynthesizeOptions          -- options for the synthesize oracle.
+    run_recovery_sweep         -- K random-theta recovery harness.
+    RecoveryHarnessOptions     -- knobs for the recovery sweep.
+    RecoverySummary            -- aggregate recovery statistics.
+    RecoveryTrial              -- per-sample recovery diagnostics.
+    sample_random_theta        -- helper to draw a random theta vector.
 
 Engine-local Rob Neal adapter is intentionally here until issue #4095
 (PARITY-LOADERS) lands a shared ``shared/python/motion_matching/loaders/``
@@ -36,6 +43,13 @@ from .fit_swing import (
     rotmat_to_quat_wxyz,
 )
 from .leaderboard_writer import write_leaderboard_entry
+from .recovery_harness import (
+    RecoveryHarnessOptions,
+    RecoverySummary,
+    RecoveryTrial,
+    run_recovery_sweep,
+    sample_random_theta,
+)
 from .simulate import (
     COEFFS_PER_JOINT,
     POLY_DEGREE,
@@ -44,6 +58,10 @@ from .simulate import (
     evaluate_polynomial_torque,
     simulate_with_coefficients,
 )
+from .synthesize import (
+    SynthesizeOptions,
+    synthesize_target_from_coefficients,
+)
 
 __all__ = [
     "COEFFS_PER_JOINT",
@@ -51,14 +69,21 @@ __all__ = [
     "FitOptions",
     "FitResult",
     "POLY_DEGREE",
+    "RecoveryHarnessOptions",
+    "RecoverySummary",
+    "RecoveryTrial",
     "SimOptions",
     "SimOut",
+    "SynthesizeOptions",
     "evaluate_polynomial_torque",
     "fit_swing_pinocchio",
     "load_robneal_target",
     "polynomial_basis",
     "polynomial_torque_chain_rule",
     "rotmat_to_quat_wxyz",
+    "run_recovery_sweep",
+    "sample_random_theta",
     "simulate_with_coefficients",
+    "synthesize_target_from_coefficients",
     "write_leaderboard_entry",
 ]

--- a/src/engines/physics_engines/pinocchio/python/motion_matching/recovery_harness.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/recovery_harness.py
@@ -1,0 +1,303 @@
+"""Recovery harness for the Pinocchio motion-matching oracle (issue #4121).
+
+This module builds the *executable* TDD acceptance gate: it generates K
+random ``theta`` vectors within the canonical bounds, synthesises a
+:class:`ClubTarget` via :func:`synthesize_target_from_coefficients`,
+hands the target to the optimiser ``fit_swing_pinocchio``, and asserts
+the recovered coefficient vector matches the ground truth within
+``||theta_recovered - theta_truth||_inf < 1e-3`` (per the parity spec).
+
+The harness is import-time decoupled from the optimiser: the
+``fit_swing`` callable is injected (defaulting to a lazy import of
+``fit_swing_pinocchio``). Until ``PIN-FIT-DRIVER`` lands, callers can
+pass a stub or simply skip the test that exercises the harness.
+
+CLAUDE.md gotcha (echoed): never call ``pin.computeTotalEnergy``. The
+upstream simulator handles energy correctly; this harness does not
+touch energy at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from src.shared.python.motion_matching.club_target import ClubTarget
+
+from .simulate import COEFFS_PER_JOINT
+from .synthesize import SynthesizeOptions, synthesize_target_from_coefficients
+
+logger = logging.getLogger(__name__)
+
+# Per-coefficient bounds matching ``generateRandomCoefficients.m`` (and
+# the MATLAB Simscape oracle): |A|,|B| <= 1000; |C|,|D| <= 500;
+# |E|,|F| <= 100; |G| <= 25. These cap the random sampling so the
+# resulting trajectories stay inside the simulator's well-posed regime.
+DEFAULT_THETA_BOUNDS: tuple[float, ...] = (
+    1000.0,
+    1000.0,
+    500.0,
+    500.0,
+    100.0,
+    100.0,
+    25.0,
+)
+
+# Default recovery tolerance, per PINOCCHIO_PARITY_SPEC.md sec 5.3.
+DEFAULT_RECOVERY_TOL: float = 1.0e-3
+
+# Default sample count -- small enough to keep heavy_integration runs
+# bounded, large enough to catch flake-y optimisers.
+DEFAULT_NUM_SAMPLES: int = 5
+
+# A ``fit_swing`` callable consumes a target + (optionally) opts and
+# returns ``(theta_recovered, info_dict)``. We keep the contract loose
+# so the harness can wrap any of the engine optimisers as they land.
+FitSwingFn = Callable[
+    [ClubTarget, dict[str, Any]],
+    tuple[npt.NDArray[np.float64], dict[str, Any]],
+]
+
+
+@dataclass(frozen=True)
+class RecoveryHarnessOptions:
+    """Knobs for the recovery sweep.
+
+    Attributes:
+        num_samples: K -- how many random theta vectors to fit.
+        n_joints: Number of actuated joints. ``None`` -> infer from the
+            URDF the first time the simulator is invoked.
+        seed: RNG seed for reproducibility. ``None`` -> non-deterministic
+            (``np.random.default_rng()`` with OS entropy).
+        bounds: Per-coefficient amplitude bounds (length 7).
+        bounds_scale: Multiplier applied to ``bounds`` before sampling.
+            Useful to shrink the test envelope so optimisers without
+            warm starts can still recover.
+        tolerance: Recovery tolerance on ``||theta_rec - theta_truth||_inf``.
+        synthesize_options: Forwarded to
+            :func:`synthesize_target_from_coefficients`.
+        fit_swing_kwargs: Extra kwargs forwarded to ``fit_swing``.
+    """
+
+    num_samples: int = DEFAULT_NUM_SAMPLES
+    n_joints: int | None = None
+    seed: int | None = 0
+    bounds: tuple[float, ...] = DEFAULT_THETA_BOUNDS
+    bounds_scale: float = 0.1
+    tolerance: float = DEFAULT_RECOVERY_TOL
+    synthesize_options: SynthesizeOptions = field(default_factory=SynthesizeOptions)
+    fit_swing_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.num_samples <= 0:
+            msg = f"num_samples must be > 0, got {self.num_samples!r}"
+            raise ValueError(msg)
+        if self.tolerance <= 0:
+            msg = f"tolerance must be > 0, got {self.tolerance!r}"
+            raise ValueError(msg)
+        if len(self.bounds) != COEFFS_PER_JOINT:
+            msg = (
+                f"bounds must have length {COEFFS_PER_JOINT}; got "
+                f"{len(self.bounds)} entries"
+            )
+            raise ValueError(msg)
+        if not (self.bounds_scale > 0):
+            msg = f"bounds_scale must be > 0, got {self.bounds_scale!r}"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class RecoveryTrial:
+    """Per-sample diagnostics for a single recovery attempt."""
+
+    index: int
+    theta_truth: npt.NDArray[np.float64]
+    theta_recovered: npt.NDArray[np.float64] | None
+    residual_inf: float
+    success: bool
+    wallclock_s: float
+    error: str | None
+
+
+@dataclass(frozen=True)
+class RecoverySummary:
+    """Aggregate recovery statistics over a sweep."""
+
+    num_samples: int
+    num_success: int
+    success_rate: float
+    median_residual_inf: float
+    max_residual_inf: float
+    wallclock_min_s: float
+    wallclock_median_s: float
+    wallclock_max_s: float
+    tolerance: float
+    trials: tuple[RecoveryTrial, ...]
+
+
+def _resolve_n_joints(opts: RecoveryHarnessOptions) -> int:
+    """Resolve ``n_joints`` from explicit override or by loading the URDF."""
+    if opts.n_joints is not None:
+        if opts.n_joints <= 0:
+            raise ValueError(f"n_joints must be > 0, got {opts.n_joints!r}")
+        return int(opts.n_joints)
+    # Defer to the simulator's lazy URDF cache so callers without
+    # pinocchio fail at the simulate call rather than at import.
+    from .simulate import (
+        _get_cached_model,  # noqa: PLC0415  -- private helper, lives next door
+        _resolve_urdf_path,  # noqa: PLC0415
+    )
+
+    sim_options = opts.synthesize_options.sim_options
+    urdf_override = sim_options.urdf_path if sim_options is not None else None
+    model = _get_cached_model(_resolve_urdf_path(urdf_override))
+    return int(model.nv)
+
+
+def sample_random_theta(
+    n_joints: int,
+    rng: np.random.Generator,
+    bounds: tuple[float, ...] = DEFAULT_THETA_BOUNDS,
+    scale: float = 0.1,
+) -> npt.NDArray[np.float64]:
+    """Draw a random ``theta`` vector inside ``scale * bounds``.
+
+    Returns a flat ``float64`` array of shape ``(n_joints * 7,)`` with
+    layout ``theta.reshape(n_joints, 7)[j, k] == a_{j, k}``.
+    """
+    if n_joints <= 0:
+        raise ValueError(f"n_joints must be > 0, got {n_joints!r}")
+    if len(bounds) != COEFFS_PER_JOINT:
+        msg = f"bounds must have length {COEFFS_PER_JOINT}; got {len(bounds)}"
+        raise ValueError(msg)
+    if scale <= 0:
+        raise ValueError(f"scale must be > 0, got {scale!r}")
+    bounds_arr = np.asarray(bounds, dtype=np.float64) * float(scale)
+    # Uniform in [-b, b] per coefficient, broadcast across joints.
+    raw = rng.uniform(-1.0, 1.0, size=(n_joints, COEFFS_PER_JOINT))
+    return (raw * bounds_arr[None, :]).reshape(-1)
+
+
+def _default_fit_swing() -> FitSwingFn:
+    """Lazily import the canonical ``fit_swing_pinocchio`` driver.
+
+    Raises ``NotImplementedError`` until ``PIN-FIT-DRIVER`` lands; this
+    keeps the harness usable as soon as the optimiser appears, with no
+    further wiring on the test side.
+    """
+    try:
+        from .fit_swing import (
+            fit_swing_pinocchio,  # type: ignore[attr-defined]  # noqa: PLC0415
+        )
+    except ImportError as exc:  # pragma: no cover - exercised once optimiser exists
+        msg = (
+            "fit_swing_pinocchio is not yet implemented (issue PIN-FIT-DRIVER). "
+            "Inject a custom ``fit_swing`` into ``run_recovery_sweep`` to "
+            "exercise the harness against a stub or experimental optimiser."
+        )
+        raise NotImplementedError(msg) from exc
+    return fit_swing_pinocchio  # type: ignore[no-any-return]
+
+
+def run_recovery_sweep(
+    options: RecoveryHarnessOptions | None = None,
+    fit_swing: FitSwingFn | None = None,
+) -> RecoverySummary:
+    """Run K synthesis -> fit -> verify trials and return aggregate stats.
+
+    Args:
+        options: Harness options. ``None`` -> defaults (K=5, seed=0,
+            10% of canonical bounds, 1e-3 tolerance).
+        fit_swing: Optimiser callable. ``None`` -> lazy import of
+            ``fit_swing_pinocchio`` (raises ``NotImplementedError``
+            until PIN-FIT-DRIVER lands).
+
+    Returns:
+        :class:`RecoverySummary` with success rate, residual statistics,
+        and per-trial diagnostics.
+    """
+    opts = options if options is not None else RecoveryHarnessOptions()
+    fit_fn = fit_swing if fit_swing is not None else _default_fit_swing()
+
+    rng = np.random.default_rng(opts.seed)
+    n_joints = _resolve_n_joints(opts)
+    trials: list[RecoveryTrial] = []
+
+    for i in range(opts.num_samples):
+        theta_truth = sample_random_theta(
+            n_joints, rng, bounds=opts.bounds, scale=opts.bounds_scale
+        )
+        wall_start = time.perf_counter()
+        try:
+            target = synthesize_target_from_coefficients(
+                theta_truth, options=opts.synthesize_options
+            )
+            theta_recovered, _info = fit_fn(target, dict(opts.fit_swing_kwargs))
+            recovered_arr = np.asarray(theta_recovered, dtype=np.float64).reshape(-1)
+            if recovered_arr.shape != theta_truth.shape:
+                msg = (
+                    f"fit_swing returned theta of shape {recovered_arr.shape}; "
+                    f"expected {theta_truth.shape}"
+                )
+                raise ValueError(msg)
+            residual_inf = float(np.max(np.abs(recovered_arr - theta_truth)))
+            success = residual_inf < opts.tolerance
+            err_msg: str | None = None
+        except Exception as exc:  # noqa: BLE001  -- harness reports any failure
+            recovered_arr = None
+            residual_inf = float("inf")
+            success = False
+            err_msg = f"{type(exc).__name__}: {exc}"
+            logger.warning("Recovery trial %d failed: %s", i, err_msg)
+        wall = time.perf_counter() - wall_start
+
+        trials.append(
+            RecoveryTrial(
+                index=i,
+                theta_truth=theta_truth,
+                theta_recovered=recovered_arr,
+                residual_inf=residual_inf,
+                success=success,
+                wallclock_s=wall,
+                error=err_msg,
+            )
+        )
+
+    residuals = [t.residual_inf for t in trials if np.isfinite(t.residual_inf)]
+    walls = [t.wallclock_s for t in trials]
+    n_success = sum(1 for t in trials if t.success)
+
+    return RecoverySummary(
+        num_samples=opts.num_samples,
+        num_success=n_success,
+        success_rate=n_success / opts.num_samples,
+        median_residual_inf=(
+            float(statistics.median(residuals)) if residuals else float("inf")
+        ),
+        max_residual_inf=float(max(residuals)) if residuals else float("inf"),
+        wallclock_min_s=float(min(walls)) if walls else 0.0,
+        wallclock_median_s=float(statistics.median(walls)) if walls else 0.0,
+        wallclock_max_s=float(max(walls)) if walls else 0.0,
+        tolerance=opts.tolerance,
+        trials=tuple(trials),
+    )
+
+
+__all__ = [
+    "DEFAULT_NUM_SAMPLES",
+    "DEFAULT_RECOVERY_TOL",
+    "DEFAULT_THETA_BOUNDS",
+    "FitSwingFn",
+    "RecoveryHarnessOptions",
+    "RecoverySummary",
+    "RecoveryTrial",
+    "run_recovery_sweep",
+    "sample_random_theta",
+]

--- a/src/engines/physics_engines/pinocchio/python/motion_matching/synthesize.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/synthesize.py
@@ -1,0 +1,239 @@
+"""TDD oracle for the Pinocchio motion-matching pipeline (issue #4121).
+
+This module implements ``synthesize_target_from_coefficients`` -- the
+canonical *forward* half of the optimiser oracle. Given a coefficient
+vector ``theta``, it runs ``simulate_with_coefficients`` and packages
+the result into a fully-validated :class:`ClubTarget` per
+``CLUB_IK_SPEC.md``.
+
+The schema mapping from the Pinocchio :class:`SimOut` to the canonical
+``ClubTarget`` is the single source of truth for the parity surface:
+
+* ``time``      <- ``SimOut.t``
+* ``butt``      <- ``SimOut.grip_position``     (mid-hands frame)
+* ``clubhead``  <- ``SimOut.clubhead_position`` (club-head frame)
+* ``club_quat`` <- quaternion of ``SimOut.clubhead_rotation`` (Shepperd)
+* ``impact_idx``<- 1-based ``argmax`` of clubhead linear speed (parity
+  with the Simscape MATLAB oracle's ``detect_clubhead_impact``)
+* ``source``    <- :class:`SourceProvenance` with ``format='synthetic'``,
+  ``filename='synthetic'``, ``trial_id`` derived from the theta hash
+
+CLAUDE.md gotcha (echoed): never call ``pin.computeTotalEnergy``. The
+upstream simulator already obeys this; this wrapper does not touch
+energy at all.
+
+See also:
+    * :mod:`...simulate` -- the forward simulator.
+    * ``src.shared.python.motion_matching.club_target`` -- the canonical
+      schema and validation rules.
+    * ``src.shared.python.motion_matching.loaders.synthetic`` -- the
+      shared dispatcher that delegates here when ``opts.engine ==
+      'pinocchio'``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from src.shared.python.motion_matching.club_target import (
+    AlignOptions,
+    ClubTarget,
+    SourceProvenance,
+)
+from src.shared.python.motion_matching.loaders._quaternion import rotmat_to_quat
+
+from .simulate import COEFFS_PER_JOINT, SimOptions, SimOut, simulate_with_coefficients
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SynthesizeOptions:
+    """Engine-specific options for :func:`synthesize_target_from_coefficients`.
+
+    The :class:`AlignOptions` sample-rate / simulation-time fields drive
+    the underlying :class:`SimOptions`; the remaining fields are
+    Pinocchio-specific.
+
+    Attributes:
+        sim_options: Forward-simulator options. ``None`` -> defaults
+            built from ``align``: ``dt = 1 / align.sample_rate_hz``,
+            ``t_final = align.simulation_time_s``.
+        align: ``AlignOptions`` for downstream resampling/provenance.
+        subject_id: Provenance subject id. Defaults to ``"synthetic"``.
+        trial_id: Provenance trial id. ``None`` -> ``f"theta_{sha[:8]}"``.
+        initial_pose: Optional initial state forwarded to the simulator.
+    """
+
+    sim_options: SimOptions | None = None
+    align: AlignOptions = AlignOptions()
+    subject_id: str = "synthetic"
+    trial_id: str | None = None
+    initial_pose: dict[str, Any] | None = None
+
+
+def _sim_options_from_align(align: AlignOptions) -> SimOptions:
+    """Build a :class:`SimOptions` consistent with the canonical timegrid."""
+    if align.sample_rate_hz <= 0:
+        msg = f"align.sample_rate_hz must be positive, got {align.sample_rate_hz!r}"
+        raise ValueError(msg)
+    if align.simulation_time_s <= 0:
+        msg = (
+            f"align.simulation_time_s must be positive, got {align.simulation_time_s!r}"
+        )
+        raise ValueError(msg)
+    return SimOptions(
+        t_final=float(align.simulation_time_s),
+        dt=1.0 / float(align.sample_rate_hz),
+    )
+
+
+def _theta_sha256(theta: npt.NDArray[np.float64]) -> str:
+    """Hex sha256 of the canonical ``theta`` byte representation.
+
+    Uses the ``float64`` byte image so the hash is reproducible across
+    interpreters. Distinct ``theta`` always produce distinct hashes
+    (collision probability negligible for our scale).
+    """
+    canonical = np.ascontiguousarray(theta, dtype=np.float64).tobytes()
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _impact_idx_from_clubhead(clubhead: npt.NDArray[np.float64]) -> int:
+    """1-based index of peak clubhead linear speed (parity with MATLAB).
+
+    Matches the postcondition in ``CLUB_IK_SPEC.md``: ``1 <= impact_idx
+    <= N``. The reference MATLAB implementation uses the discrete
+    derivative ``diff(clubhead, axis=0)`` and reports the speed
+    argmax + 1; we replicate that convention so the oracle is bit-for-
+    bit comparable across engines.
+    """
+    if clubhead.ndim != 2 or clubhead.shape[1] != 3:
+        msg = f"clubhead must have shape (N, 3); got {clubhead.shape}"
+        raise ValueError(msg)
+    if clubhead.shape[0] < 2:
+        msg = (
+            f"clubhead needs >= 2 samples for impact detection; got {clubhead.shape[0]}"
+        )
+        raise ValueError(msg)
+    diffs = np.diff(clubhead, axis=0)
+    speeds = np.linalg.norm(diffs, axis=1)
+    # ``np.argmax`` returns the first occurrence (0-based) into ``diffs``;
+    # the corresponding clubhead sample lies at index ``argmax + 1``.
+    # That happens to keep us in [1, N-1], i.e. strictly inside the
+    # open interval the schema requires.
+    return int(np.argmax(speeds)) + 1
+
+
+def _sim_out_to_club_target(
+    sim_out: SimOut,
+    theta: npt.NDArray[np.float64],
+    subject_id: str,
+    trial_id: str,
+) -> ClubTarget:
+    """Pure adapter from :class:`SimOut` to :class:`ClubTarget`.
+
+    Split out so the unit test can mock ``simulate_with_coefficients``
+    and exercise the schema mapping without importing pinocchio.
+    """
+    quat = rotmat_to_quat(sim_out.clubhead_rotation)
+    impact_idx = _impact_idx_from_clubhead(sim_out.clubhead_position)
+    sha = _theta_sha256(theta)
+    source = SourceProvenance(
+        filename="synthetic",
+        format="synthetic",
+        subject_id=subject_id,
+        trial_id=trial_id,
+        sha256=sha,
+    )
+    return ClubTarget(
+        time=np.asarray(sim_out.t, dtype=np.float64),
+        butt=np.asarray(sim_out.grip_position, dtype=np.float64),
+        clubhead=np.asarray(sim_out.clubhead_position, dtype=np.float64),
+        club_quat=quat,
+        impact_idx=int(impact_idx),
+        source=source,
+    )
+
+
+def synthesize_target_from_coefficients(
+    theta: npt.NDArray[np.float64],
+    options: SynthesizeOptions | None = None,
+) -> ClubTarget:
+    """Forward-synthesize a :class:`ClubTarget` from a known ``theta``.
+
+    This is the TDD oracle: any optimiser that cannot recover ``theta``
+    from ``synthesize_target_from_coefficients(theta)`` is broken.
+
+    Args:
+        theta: Flat coefficient vector of shape ``(n_joints * 7,)`` in
+            the same layout as :func:`simulate_with_coefficients`.
+        options: Engine-specific options. ``None`` uses the defaults
+            (1 kHz, 0.3 s, neutral initial pose, default gravity).
+
+    Returns:
+        Fully-validated :class:`ClubTarget`. The constructor enforces
+        every postcondition from ``CLUB_IK_SPEC.md``.
+
+    Raises:
+        ValueError: if ``theta`` is non-finite, or if the simulator's
+            output fails the ``ClubTarget`` validation rules (e.g. NaN
+            position, non-unit quaternion).
+        ImportError: if ``pinocchio`` is not installed (re-raised from
+            the lazy import inside the simulator).
+    """
+    opts = options if options is not None else SynthesizeOptions()
+    theta_arr = np.asarray(theta, dtype=np.float64).reshape(-1)
+    if theta_arr.size == 0:
+        raise ValueError("theta must be non-empty")
+    if theta_arr.size % COEFFS_PER_JOINT != 0:
+        msg = (
+            f"theta length {theta_arr.size} must be a multiple of "
+            f"{COEFFS_PER_JOINT} (n_joints * coeffs_per_joint)"
+        )
+        raise ValueError(msg)
+    if not np.all(np.isfinite(theta_arr)):
+        raise ValueError("theta contains non-finite entries")
+
+    sim_options = (
+        opts.sim_options
+        if opts.sim_options is not None
+        else _sim_options_from_align(opts.align)
+    )
+
+    sim_out = simulate_with_coefficients(
+        theta_arr,
+        options=sim_options,
+        initial_pose=opts.initial_pose,
+    )
+
+    sha = _theta_sha256(theta_arr)
+    trial_id = opts.trial_id if opts.trial_id is not None else f"theta_{sha[:8]}"
+
+    target = _sim_out_to_club_target(
+        sim_out,
+        theta=theta_arr,
+        subject_id=opts.subject_id,
+        trial_id=trial_id,
+    )
+    logger.debug(
+        "synthesize_target_from_coefficients: theta sha256=%s, n_joints=%d, "
+        "n_samples=%d, impact_idx=%d",
+        sha,
+        sim_out.meta.get("n_joints", -1),
+        target.time.shape[0],
+        target.impact_idx,
+    )
+    return target
+
+
+__all__ = [
+    "SynthesizeOptions",
+    "synthesize_target_from_coefficients",
+]

--- a/tests/heavy_integration/test_pinocchio_recovery.py
+++ b/tests/heavy_integration/test_pinocchio_recovery.py
@@ -1,0 +1,163 @@
+"""Heavy-integration tests for the Pinocchio recovery harness (issue #4121).
+
+These tests run the full ``synthesize_target -> fit_swing -> assert
+recovery`` loop against the real ``golfer.urdf`` + Pinocchio bindings.
+They are gated on ``pytest.mark.requires_pinocchio`` and skip cleanly
+when the optional engine is absent.
+
+The optimiser (``fit_swing_pinocchio``) is tracked under PIN-FIT-DRIVER
+and is expected to land in a follow-on PR. Until it does, the
+harness-level test xfails with a known reason: the harness itself runs
+end to end (synthesis succeeds, fit raises ``NotImplementedError``,
+``RecoverySummary`` records the failure cleanly), so the gate flips
+from ``xfail`` to ``pass`` the moment the optimiser appears.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytestmark = [
+    pytest.mark.requires_pinocchio,
+    pytest.mark.integration,
+    pytest.mark.slow,
+]
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fixtures: skip the whole module when pinocchio is absent.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def mm():
+    """Engine motion-matching module, skipping if pinocchio is missing."""
+    try:
+        import pinocchio  # noqa: F401
+    except ImportError:
+        pytest.skip("pinocchio not installed")
+    return importlib.import_module(
+        "src.engines.physics_engines.pinocchio.python.motion_matching"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Synthesize round-trip: theta -> ClubTarget passes the canonical schema.
+# --------------------------------------------------------------------------- #
+
+
+def test_synthesize_returns_validated_clubtarget(mm) -> None:
+    """One real synthesis trip with zero theta produces a valid target."""
+    n_joints = 25  # nominal; harness will resolve from URDF anyway
+    theta = np.zeros(n_joints * mm.COEFFS_PER_JOINT)
+    target = mm.synthesize_target_from_coefficients(theta)
+    # ClubTarget construction validates the canonical schema; reaching
+    # here means every postcondition held.
+    assert target.time.shape[0] >= 2
+    assert target.time[0] == 0.0
+    assert target.butt.shape[1] == 3
+    assert target.clubhead.shape[1] == 3
+    assert target.club_quat.shape[1] == 4
+    assert target.source.format == "synthetic"
+    # impact_idx is in [1, N]; with zero torque + neutral pose the
+    # discrete clubhead derivative is essentially zero so impact_idx
+    # ends up at the first samples_idx by argmax tie-break -- but in
+    # *any* case it lies inside the schema window.
+    assert 1 <= target.impact_idx <= target.time.shape[0]
+
+
+def test_synthesize_distinct_theta_distinct_sha(mm) -> None:
+    """Provenance hash discriminates different theta vectors."""
+    n = 25 * mm.COEFFS_PER_JOINT
+    theta_a = np.zeros(n)
+    theta_b = np.zeros(n)
+    theta_b[0] = 1e-3
+    a = mm.synthesize_target_from_coefficients(theta_a)
+    b = mm.synthesize_target_from_coefficients(theta_b)
+    assert a.source.sha256 != b.source.sha256
+
+
+# --------------------------------------------------------------------------- #
+# Recovery harness: K=5, with the optimiser stubbed when absent.
+# --------------------------------------------------------------------------- #
+
+
+def _identity_fit_swing(target, _kwargs):
+    """A perfect optimiser: returns ``theta_truth`` straight from provenance.
+
+    This stub demonstrates the harness wiring end-to-end without relying
+    on PIN-FIT-DRIVER. It is the *upper bound* of recovery quality --
+    any real optimiser should still land within tolerance.
+    """
+    # The TDD oracle stores theta_truth in the provenance hash, but that
+    # is one-way. We cheat by reading the tested theta out of a side
+    # channel: the test below calls the harness directly and sets up
+    # ``fit_swing_kwargs={'theta_truth': ...}`` for the stub to inspect.
+    theta = _kwargs["theta_truth"]
+    return theta, {"converged": True, "stub": True}
+
+
+def test_recovery_harness_runs_with_identity_stub(mm) -> None:
+    """Smoke: harness wires synthesize + fit + assert end-to-end.
+
+    Uses an identity optimiser (perfect recovery) so we exercise every
+    branch of the harness without depending on PIN-FIT-DRIVER.
+    """
+    n_joints = 25
+    rng = np.random.default_rng(0)
+
+    truths: list[np.ndarray] = []
+
+    def capturing_fit(target, _kwargs):
+        # Pop the next ground-truth theta from the queue.
+        return truths.pop(0), {"converged": True, "stub": True}
+
+    # Pre-seed truths so the stub can return them in order.
+    bounds = mm.RecoveryHarnessOptions().bounds
+    scale = 0.05  # very small so the simulator stays well-posed
+    for _ in range(5):
+        truths.append(mm.sample_random_theta(n_joints, rng, bounds=bounds, scale=scale))
+    # The harness uses its own RNG seeded identically -> reproduces
+    # exactly the same theta sequence.
+    summary = mm.run_recovery_sweep(
+        options=mm.RecoveryHarnessOptions(
+            num_samples=5,
+            n_joints=n_joints,
+            seed=0,
+            bounds_scale=scale,
+            tolerance=1e-9,
+        ),
+        fit_swing=capturing_fit,
+    )
+    assert summary.num_samples == 5
+    assert summary.num_success == 5
+    assert summary.success_rate == pytest.approx(1.0)
+    assert summary.median_residual_inf <= 1e-9
+    # All trials carry timing info.
+    for trial in summary.trials:
+        assert trial.wallclock_s >= 0.0
+        assert trial.error is None
+
+
+@pytest.mark.xfail(
+    reason="fit_swing_pinocchio not yet implemented (issue PIN-FIT-DRIVER); "
+    "the harness records the NotImplementedError per trial.",
+    strict=False,
+)
+def test_recovery_harness_default_optimiser(mm) -> None:
+    """Acceptance gate: K=5 random theta within tolerance.
+
+    Currently xfails because PIN-FIT-DRIVER has not landed. The moment
+    the optimiser appears under
+    ``...motion_matching.fit_swing.fit_swing_pinocchio`` this test
+    flips to ``pass``: the harness already calls it and asserts
+    ``residual_inf < 1e-3``.
+    """
+    summary = mm.run_recovery_sweep(
+        options=mm.RecoveryHarnessOptions(num_samples=5, seed=0, bounds_scale=0.05),
+    )
+    assert summary.success_rate >= 0.8, f"Recovery summary: {summary}"
+    assert summary.max_residual_inf < 1e-3

--- a/tests/unit/engines/pinocchio/test_synthesize_target.py
+++ b/tests/unit/engines/pinocchio/test_synthesize_target.py
@@ -1,0 +1,330 @@
+"""Unit tests for the Pinocchio synthesize oracle (issue #4121).
+
+These exercise the ``SimOut -> ClubTarget`` adapter and the surrounding
+contract -- with ``simulate_with_coefficients`` mocked -- so they run
+without requiring the optional ``pinocchio`` extra.
+
+The heavy round-trip path (real URDF + real ABA + recovery loop) lives
+in ``tests/heavy_integration/test_pinocchio_recovery.py`` under the
+``requires_pinocchio`` marker.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+simulate_mod = importlib.import_module(
+    "src.engines.physics_engines.pinocchio.python.motion_matching.simulate"
+)
+synthesize_mod = importlib.import_module(
+    "src.engines.physics_engines.pinocchio.python.motion_matching.synthesize"
+)
+SimOut = simulate_mod.SimOut
+COEFFS_PER_JOINT = simulate_mod.COEFFS_PER_JOINT
+synthesize_target_from_coefficients = synthesize_mod.synthesize_target_from_coefficients
+SynthesizeOptions = synthesize_mod.SynthesizeOptions
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Helpers: build a synthetic SimOut without touching pinocchio.
+# --------------------------------------------------------------------------- #
+
+
+def _identity_quat_track(n: int) -> np.ndarray:
+    """``(n, 3, 3)`` stack of identity rotation matrices."""
+    return np.broadcast_to(np.eye(3), (n, 3, 3)).copy()
+
+
+def _smooth_clubhead_track(
+    n: int, peak_idx: int = 50, dt: float = 1.0e-3
+) -> np.ndarray:
+    """``(n, 3)`` clubhead positions whose linear-speed argmax is ``peak_idx``.
+
+    A simple Gaussian-bump profile in the world-X channel: position is
+    cumulative trapezoidal of a velocity bump centred on ``peak_idx``,
+    so ``np.argmax(np.linalg.norm(diff, axis=1))`` lands on
+    ``peak_idx - 1`` and our 1-based ``impact_idx`` is ``peak_idx``.
+    """
+    t = np.arange(n)
+    sigma = max(2.0, n / 40.0)
+    velocity = np.exp(-0.5 * ((t - peak_idx) / sigma) ** 2)
+    pos_x = np.cumsum(velocity) * dt + 1.0  # offset so |r| > 0 but < 5
+    track = np.zeros((n, 3))
+    track[:, 0] = pos_x
+    track[:, 2] = 0.5  # clubhead a bit above the floor
+    return track
+
+
+def _make_sim_out(
+    n_samples: int = 101, n_joints: int = 25, dt: float = 1.0e-3
+) -> SimOut:
+    """Construct a minimal but schema-valid :class:`SimOut`."""
+    t = np.arange(n_samples, dtype=np.float64) * dt
+    nq = n_joints
+    q = np.zeros((n_samples, nq), dtype=np.float64)
+    qd = np.zeros((n_samples, n_joints), dtype=np.float64)
+    tau = np.zeros((n_samples, n_joints), dtype=np.float64)
+    grip_pos = np.tile(np.array([0.0, 0.0, 1.0]), (n_samples, 1))
+    grip_rot = _identity_quat_track(n_samples)
+    clubhead_pos = _smooth_clubhead_track(n_samples)
+    clubhead_rot = _identity_quat_track(n_samples)
+    return SimOut(
+        t=t,
+        q=q,
+        qd=qd,
+        tau=tau,
+        grip_position=grip_pos,
+        grip_rotation=grip_rot,
+        clubhead_position=clubhead_pos,
+        clubhead_rotation=clubhead_rot,
+        kinetic_energy=np.zeros(n_samples),
+        potential_energy=np.zeros(n_samples),
+        meta={"n_joints": n_joints, "model_nq": nq, "model_nv": n_joints},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# SimOut -> ClubTarget mapping (pure adapter, no simulator).
+# --------------------------------------------------------------------------- #
+
+
+class TestSimOutToClubTarget:
+    """Direct tests of ``_sim_out_to_club_target`` -- the schema mapping."""
+
+    def test_maps_time_grip_clubhead_arrays(self) -> None:
+        sim = _make_sim_out()
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        target = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta, subject_id="sub", trial_id="trial"
+        )
+        np.testing.assert_array_equal(target.time, sim.t)
+        np.testing.assert_array_equal(target.butt, sim.grip_position)
+        np.testing.assert_array_equal(target.clubhead, sim.clubhead_position)
+
+    def test_quaternion_unit_norm_and_w_nonneg(self) -> None:
+        sim = _make_sim_out()
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        target = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta, subject_id="sub", trial_id="trial"
+        )
+        norms = np.linalg.norm(target.club_quat, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-9)
+        # Identity rotation -> [1, 0, 0, 0]; w must be >= 0 by canonical sign.
+        assert np.all(target.club_quat[:, 0] >= 0.0)
+        np.testing.assert_allclose(target.club_quat[0], [1.0, 0.0, 0.0, 0.0])
+
+    def test_impact_idx_matches_speed_argmax(self) -> None:
+        peak = 47
+        sim = _make_sim_out()
+        # Re-synthesize with a known peak.
+        clubhead = _smooth_clubhead_track(sim.t.shape[0], peak_idx=peak)
+        sim2 = SimOut(
+            t=sim.t,
+            q=sim.q,
+            qd=sim.qd,
+            tau=sim.tau,
+            grip_position=sim.grip_position,
+            grip_rotation=sim.grip_rotation,
+            clubhead_position=clubhead,
+            clubhead_rotation=sim.clubhead_rotation,
+            kinetic_energy=sim.kinetic_energy,
+            potential_energy=sim.potential_energy,
+            meta=sim.meta,
+        )
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        target = synthesize_mod._sim_out_to_club_target(
+            sim2, theta=theta, subject_id="s", trial_id="t"
+        )
+        assert target.impact_idx == peak
+
+    def test_provenance_format_and_sha_reproducible(self) -> None:
+        sim = _make_sim_out()
+        theta = np.linspace(-1.0, 1.0, 25 * COEFFS_PER_JOINT)
+        t1 = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta, subject_id="sub", trial_id="trial"
+        )
+        t2 = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta.copy(), subject_id="sub", trial_id="trial"
+        )
+        assert t1.source.format == "synthetic"
+        assert t1.source.filename == "synthetic"
+        assert t1.source.subject_id == "sub"
+        assert t1.source.trial_id == "trial"
+        assert len(t1.source.sha256) == 64
+        assert t1.source.sha256 == t2.source.sha256
+
+    def test_distinct_theta_distinct_sha(self) -> None:
+        sim = _make_sim_out()
+        theta_a = np.zeros(25 * COEFFS_PER_JOINT)
+        theta_b = np.zeros(25 * COEFFS_PER_JOINT)
+        theta_b[0] = 1.0
+        ta = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta_a, subject_id="s", trial_id="t"
+        )
+        tb = synthesize_mod._sim_out_to_club_target(
+            sim, theta=theta_b, subject_id="s", trial_id="t"
+        )
+        assert ta.source.sha256 != tb.source.sha256
+
+
+# --------------------------------------------------------------------------- #
+# Public entrypoint, with the simulator mocked.
+# --------------------------------------------------------------------------- #
+
+
+class TestSynthesizeWithMockedSimulator:
+    """Ensures ``synthesize_target_from_coefficients`` only uses
+    documented :class:`SimOut` fields and produces a validated
+    :class:`ClubTarget` regardless of pinocchio availability."""
+
+    def _patched(self):
+        sim = _make_sim_out()
+
+        def fake_simulate(theta, options=None, initial_pose=None):
+            # Mirror the validation that ``simulate_with_coefficients``
+            # performs so we still cover the contract.
+            theta_arr = np.asarray(theta, dtype=np.float64)
+            assert theta_arr.shape == (25 * COEFFS_PER_JOINT,)
+            return sim
+
+        return patch.object(synthesize_mod, "simulate_with_coefficients", fake_simulate)
+
+    def test_returns_validated_clubtarget(self) -> None:
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        with self._patched():
+            target = synthesize_target_from_coefficients(theta)
+        # ``ClubTarget.__post_init__`` ran the schema check; reaching
+        # here means every postcondition held.
+        assert target.time.shape[0] == 101
+        assert target.butt.shape == (101, 3)
+        assert target.clubhead.shape == (101, 3)
+        assert target.club_quat.shape == (101, 4)
+        assert 1 <= target.impact_idx <= 101
+        assert target.source.format == "synthetic"
+
+    def test_round_trip_determinism(self) -> None:
+        theta = np.linspace(-0.1, 0.1, 25 * COEFFS_PER_JOINT)
+        with self._patched():
+            t1 = synthesize_target_from_coefficients(theta)
+            t2 = synthesize_target_from_coefficients(theta.copy())
+        np.testing.assert_array_equal(t1.time, t2.time)
+        np.testing.assert_array_equal(t1.butt, t2.butt)
+        np.testing.assert_array_equal(t1.clubhead, t2.clubhead)
+        np.testing.assert_array_equal(t1.club_quat, t2.club_quat)
+        assert t1.source.sha256 == t2.source.sha256
+        assert t1.impact_idx == t2.impact_idx
+
+    def test_default_trial_id_is_theta_hash_prefix(self) -> None:
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        with self._patched():
+            target = synthesize_target_from_coefficients(theta)
+        assert target.source.trial_id.startswith("theta_")
+        assert target.source.trial_id[len("theta_") :] == target.source.sha256[:8]
+
+    def test_custom_subject_and_trial_id(self) -> None:
+        theta = np.zeros(25 * COEFFS_PER_JOINT)
+        opts = SynthesizeOptions(subject_id="TW", trial_id="trial_42")
+        with self._patched():
+            target = synthesize_target_from_coefficients(theta, options=opts)
+        assert target.source.subject_id == "TW"
+        assert target.source.trial_id == "trial_42"
+
+    @pytest.mark.parametrize(
+        ("bad_theta", "match"),
+        [
+            (np.array([], dtype=np.float64), "non-empty"),
+            (np.ones(25 * COEFFS_PER_JOINT - 1), "multiple of"),
+            (np.full(25 * COEFFS_PER_JOINT, np.nan), "non-finite"),
+        ],
+    )
+    def test_rejects_malformed_theta(self, bad_theta: np.ndarray, match: str) -> None:
+        with self._patched(), pytest.raises(ValueError, match=match):
+            synthesize_target_from_coefficients(bad_theta)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers: impact detection and theta hashing.
+# --------------------------------------------------------------------------- #
+
+
+class TestImpactDetection:
+    def test_one_based_argmax_of_speed(self) -> None:
+        track = _smooth_clubhead_track(101, peak_idx=42)
+        idx = synthesize_mod._impact_idx_from_clubhead(track)
+        assert idx == 42  # 1-based
+
+    def test_rejects_short_tracks(self) -> None:
+        with pytest.raises(ValueError, match=">= 2 samples"):
+            synthesize_mod._impact_idx_from_clubhead(np.zeros((1, 3)))
+
+    def test_rejects_non_xyz_tracks(self) -> None:
+        with pytest.raises(ValueError, match=r"\(N, 3\)"):
+            synthesize_mod._impact_idx_from_clubhead(np.zeros((10, 4)))
+
+
+class TestThetaHash:
+    def test_sha_is_64_hex_chars(self) -> None:
+        sha = synthesize_mod._theta_sha256(np.arange(7, dtype=np.float64))
+        assert len(sha) == 64
+        int(sha, 16)  # parses as hex
+
+    def test_sha_independent_of_array_strides(self) -> None:
+        base = np.linspace(-1.0, 1.0, 100, dtype=np.float64)
+        sliced = base[::2].copy()
+        non_contig = np.ascontiguousarray(base)[::2]
+        assert synthesize_mod._theta_sha256(sliced) == synthesize_mod._theta_sha256(
+            non_contig
+        )
+
+
+# --------------------------------------------------------------------------- #
+# SynthesizeOptions / SimOptions wiring.
+# --------------------------------------------------------------------------- #
+
+
+class TestSimOptionsFromAlign:
+    def test_dt_is_inverse_sample_rate(self) -> None:
+        from src.shared.python.motion_matching.club_target import AlignOptions
+
+        sim_opts = synthesize_mod._sim_options_from_align(
+            AlignOptions(sample_rate_hz=500.0, simulation_time_s=0.2)
+        )
+        assert sim_opts.dt == pytest.approx(2e-3)
+        assert sim_opts.t_final == pytest.approx(0.2)
+        assert sim_opts.integrator == "rk4"
+
+    def test_rejects_non_positive_rate(self) -> None:
+        from src.shared.python.motion_matching.club_target import AlignOptions
+
+        with pytest.raises(ValueError, match="sample_rate_hz"):
+            synthesize_mod._sim_options_from_align(
+                AlignOptions(sample_rate_hz=0.0, simulation_time_s=0.2)
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Sanity: importing synthesize must not pull in pinocchio.
+# --------------------------------------------------------------------------- #
+
+
+def test_import_does_not_load_pinocchio() -> None:
+    # Cheap: if any test above accidentally imported pinocchio, we'd see
+    # it in sys.modules. The module should defer the import to call time.
+    assert "pinocchio" not in sys.modules or sys.modules["pinocchio"] is not None
+    # The check that matters: synthesize.py itself does not import pinocchio
+    # at module load. Re-import in a clean state to verify.
+    import importlib as _il
+
+    _il.reload(synthesize_mod)
+    # If pinocchio is not on the system, it must still not be required.
+    # Conversely, if it *is* installed, this assertion still holds: we
+    # only assert that the synthesize *module* did not import it.
+    assert "pinocchio" not in synthesize_mod.__dict__


### PR DESCRIPTION
## Summary

Lays the TDD oracle for the Pinocchio motion-matching pipeline so the optimiser issue **PIN-FIT-DRIVER** has its acceptance test ready before its implementation lands.

- `src/engines/physics_engines/pinocchio/python/motion_matching/synthesize.py::synthesize_target_from_coefficients(theta, options) -> ClubTarget` — calls `simulate_with_coefficients` (cherry-picked from #4168) and wraps the `SimOut` into a fully-validated `ClubTarget` per `CLUB_IK_SPEC.md`. Pure-numpy adapter, no pinocchio import at module scope.
- `src/engines/physics_engines/pinocchio/python/motion_matching/recovery_harness.py::run_recovery_sweep` — generates K random θ within canonical bounds (matching MATLAB's `generateRandomCoefficients`), runs synthesize → fit_swing per trial, and returns a `RecoverySummary` dataclass with success rate, median residual, and wall-clock distribution. The optimiser callable is injected (lazy default imports the unwritten `fit_swing_pinocchio` so tests already work and flip green the moment PIN-FIT-DRIVER lands).

### Schema mapping (SimOut → ClubTarget)

| ClubTarget field | Source |
|---|---|
| `time` | `SimOut.t` |
| `butt` | `SimOut.grip_position` (mid-hands frame) |
| `clubhead` | `SimOut.clubhead_position` (club-head frame) |
| `club_quat` | Shepperd quaternion of `SimOut.clubhead_rotation` |
| `impact_idx` | 1-based argmax of clubhead linear speed |
| `source` | `SourceProvenance(format='synthetic', sha256(theta))` |

### CLAUDE.md gotcha

Echoed: `synthesize.py` and `recovery_harness.py` never call `pin.computeTotalEnergy`. The upstream simulator already obeys this, and the new code does not touch energy at all.

### File sizes

239 / 303 / 61 / 330 / 163 LOC — all well inside the 1200-line budget.

## Closes

Closes #4121.

## Test plan

- [x] `pytest tests/unit/engines/pinocchio/test_synthesize_target.py` — 20/20 pass (no pinocchio required).
- [x] `pytest tests/unit/engines/pinocchio/` — 35/35 pass (with the simulate polynomial-torque tests).
- [x] `python3 -m ruff check` — clean on all touched files.
- [x] `python3 -m ruff format --check` — clean.
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget.
- [ ] `pytest -m requires_pinocchio tests/heavy_integration/test_pinocchio_recovery.py` — runs in CI image with the `pinocchio` extra. Covers the synthesize round-trip, provenance discrimination, and the harness end-to-end with an identity stub fit. The default-optimiser path is `xfail` until PIN-FIT-DRIVER lands.

## Notes

- This branch cherry-picks PR #4168 (`feat(pinocchio): simulate_with_coefficients with ABA + RK4`) so the synthesize oracle has its forward simulator on disk; that commit is unmodified and will collapse cleanly when #4168 merges.
- The recovery harness's `RecoveryHarnessOptions.bounds_scale` defaults to `0.1` (10 % of the canonical envelope) so the simulator stays well-posed; the heavy_integration smoke test uses `0.05` for extra margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)