### PR TITLE
feat(parity): cross-engine leaderboard + report (closes #4097)

### DIFF
--- a/.github/workflows/cross-engine-leaderboard.yml
+++ b/.github/workflows/cross-engine-leaderboard.yml
@@ -1,0 +1,93 @@
+# Cross-engine leaderboard regenerator (issue #4097, PARITY-LEADERBOARD).
+#
+# Runs `scripts/run_cross_engine_leaderboard.py` whenever a PR touches
+# `src/engines/` or one of the leaderboard scripts itself, so reviewers
+# can see at a glance how each engine's grip/clubhead RMSE / wall-clock
+# changes. Engines whose deps aren't installed are honestly skipped by
+# the orchestrator (NotImplementedError / ImportError -> "skip" cell);
+# the leaderboard still renders for the engines that did run.
+#
+# This workflow runs the **report-only** flow on hosted runners (no MATLAB,
+# no proprietary engine deps), since the canonical fits are produced on
+# the self-hosted fleet and committed under `motion_matching/results/`.
+# That way every PR sees the most-recent committed fits even when the
+# triggering change can't actually rerun them.
+
+name: cross-engine-leaderboard
+
+on:
+  pull_request:
+    paths:
+      - "src/engines/**"
+      - "scripts/run_cross_engine_leaderboard.py"
+      - "src/shared/python/motion_matching/leaderboard.py"
+      - "tests/unit/motion_matching/test_leaderboard.py"
+      - ".github/workflows/cross-engine-leaderboard.yml"
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the job if any engine raises (default false = honest-skip)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cross-engine-leaderboard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: regenerate cross-engine leaderboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+
+      - name: Install minimal deps
+        # Only what the leaderboard report code itself needs - we skip the
+        # heavy engine extras intentionally so this job stays fast and
+        # green even when drake / pinocchio / opensim aren't installed.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run leaderboard tests (table-generation logic only)
+        run: |
+          pytest tests/unit/motion_matching/test_leaderboard.py -v --timeout=60
+
+      - name: Regenerate leaderboard from existing committed FitResults
+        env:
+          GIT_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          python3 scripts/run_cross_engine_leaderboard.py --skip-fits
+
+      - name: Show diff against committed leaderboard
+        if: always()
+        run: |
+          if git diff --quiet -- motion_matching/results/CROSS_ENGINE_LEADERBOARD.md; then
+            echo "No changes to CROSS_ENGINE_LEADERBOARD.md"
+          else
+            echo "## Cross-engine leaderboard diff" >> "$GITHUB_STEP_SUMMARY"
+            echo '```diff' >> "$GITHUB_STEP_SUMMARY"
+            git diff -- motion_matching/results/CROSS_ENGINE_LEADERBOARD.md >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload leaderboard artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cross-engine-leaderboard
+          path: motion_matching/results/CROSS_ENGINE_LEADERBOARD.md

--- a/motion_matching/results/CROSS_ENGINE_LEADERBOARD.md
+++ b/motion_matching/results/CROSS_ENGINE_LEADERBOARD.md
@@ -1,0 +1,3 @@
+# Cross-engine leaderboard
+
+_No FitResult JSON files found. Engines that have not yet implemented `fit_swing_<engine>` are honestly skipped._

--- a/scripts/run_cross_engine_leaderboard.py
+++ b/scripts/run_cross_engine_leaderboard.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Run every engine's ``fit_swing_<engine>`` on every canonical test trial
+and emit the cross-engine leaderboard.
+
+Per :doc:`CROSS_ENGINE_PARITY_SPEC.md` §2.8 (issue #4097).
+
+Layout produced::
+
+    motion_matching/
+        results/
+            TW_ProV1/
+                simscape.json
+                mujoco.json
+                drake.json
+                pinocchio.json
+                opensim.json
+            TW_wiffle/...
+            GW_wiffle/...
+            GW_ProV11/...
+            CROSS_ENGINE_LEADERBOARD.md
+
+Engines whose Python deps aren't installed (``drake``, ``pinocchio``,
+``opensim``) or whose ``fit_swing_*`` driver hasn't landed yet are
+**honestly skipped**: a stub JSON is *not* written; the engine simply
+fails to appear in that trial's row set. Acceptance criterion in
+issue #4097: "Leaderboard populated for at least 1 trial × 5 engines (or
+honestly skipped for missing deps)".
+
+Usage::
+
+    python3 scripts/run_cross_engine_leaderboard.py
+    python3 scripts/run_cross_engine_leaderboard.py --trial TW_ProV1
+    python3 scripts/run_cross_engine_leaderboard.py --skip-fits  # report only
+
+Exit codes:
+    0  success (leaderboard written, even if empty / partially skipped)
+    2  CLI / configuration error
+    3  fatal error inside a fit (only when --strict)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import traceback
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- Repo-relative paths -----------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = REPO_ROOT / "motion_matching" / "results"
+LEADERBOARD_MD = RESULTS_DIR / "CROSS_ENGINE_LEADERBOARD.md"
+WIFFLE_XLSX = (
+    REPO_ROOT
+    / "src"
+    / "engines"
+    / "Simscape_Multibody_Models"
+    / "3D_Golf_Model"
+    / "matlab"
+    / "src"
+    / "apps"
+    / "golf_gui"
+    / "Motion Capture Plotter"
+    / "Wiffle_ProV1_club_3D_data.xlsx"
+)
+
+# Canonical test trial set; same four sheets wired by #4081 / #4086.
+CANONICAL_TRIALS: tuple[str, ...] = ("TW_ProV1", "TW_wiffle", "GW_wiffle", "GW_ProV11")
+
+# Per #4097, every engine in the parity matrix gets a row attempt.
+CANONICAL_ENGINES: tuple[str, ...] = (
+    "simscape",
+    "mujoco",
+    "drake",
+    "pinocchio",
+    "opensim",
+)
+
+# Where each engine's `fit_swing_<engine>` lives (or is expected to live).
+# When the import fails the orchestrator skips the engine honestly rather
+# than synthesising a misleading row.
+_FIT_DRIVER_MODULES: dict[str, tuple[str, str]] = {
+    "simscape": (
+        "src.engines.physics_engines.simscape.fit_swing_simscape",
+        "fit_swing_simscape",
+    ),
+    "mujoco": (
+        "src.engines.physics_engines.mujoco.fit_swing_mujoco",
+        "fit_swing_mujoco",
+    ),
+    "drake": ("src.engines.physics_engines.drake.fit_swing_drake", "fit_swing_drake"),
+    "pinocchio": (
+        "src.engines.physics_engines.pinocchio.fit_swing_pinocchio",
+        "fit_swing_pinocchio",
+    ),
+    "opensim": (
+        "src.engines.physics_engines.opensim.fit_swing_opensim",
+        "fit_swing_opensim",
+    ),
+}
+
+LOGGER = logging.getLogger("run_cross_engine_leaderboard")
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    )
+    p.add_argument(
+        "--results-dir",
+        type=Path,
+        default=RESULTS_DIR,
+        help="Where per-engine FitResult JSON files are written.",
+    )
+    p.add_argument(
+        "--leaderboard-path",
+        type=Path,
+        default=LEADERBOARD_MD,
+        help="Output path for the rendered Markdown table.",
+    )
+    p.add_argument(
+        "--trial",
+        action="append",
+        default=None,
+        help="Limit to one or more trials by name. Repeatable. Default: all canonical trials.",
+    )
+    p.add_argument(
+        "--engine",
+        action="append",
+        default=None,
+        help="Limit to one or more engines by name. Repeatable. Default: all 5 engines.",
+    )
+    p.add_argument(
+        "--skip-fits",
+        action="store_true",
+        help="Don't run any engine; just regenerate the Markdown from existing JSONs.",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat per-engine failures as fatal (default: warn and continue).",
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose logging.",
+    )
+    return p.parse_args(argv)
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _git_commit() -> str:
+    """Short git SHA of HEAD; falls back to the env var GIT_COMMIT or a
+    hard-coded ``unknown`` if neither resolves. Always 7-40 lowercase hex.
+    """
+    env = os.environ.get("GIT_COMMIT", "").strip().lower()
+    if env and 7 <= len(env) <= 40 and all(c in "0123456789abcdef" for c in env):
+        return env
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(REPO_ROOT),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        sha = out.stdout.strip().lower()
+        if 7 <= len(sha) <= 40 and all(c in "0123456789abcdef" for c in sha):
+            return sha
+    except (subprocess.SubprocessError, OSError, FileNotFoundError):
+        pass
+    return "0000000"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_target(trial: str) -> Any:
+    """Load the canonical ``ClubTarget`` for ``trial`` from the Wiffle xlsx.
+
+    Raises ``ImportError`` or ``FileNotFoundError`` if the loader / data
+    aren't available; the caller treats those as honest skips.
+    """
+    if not WIFFLE_XLSX.exists():
+        raise FileNotFoundError(f"canonical Wiffle xlsx not found: {WIFFLE_XLSX}")
+    # Late import: avoid forcing pandas / openpyxl install on report-only runs.
+    from src.shared.python.motion_matching import load_club_target_excel
+
+    return load_club_target_excel(WIFFLE_XLSX, sheet=trial)
+
+
+def _load_fit_driver(engine: str):
+    """Import ``fit_swing_<engine>`` and return the callable, or ``None`` if
+    the engine is not installed / not yet implemented.
+    """
+    module_path, attr = _FIT_DRIVER_MODULES[engine]
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError as exc:
+        LOGGER.info("engine %s: fit driver not importable (%s) - skipping", engine, exc)
+        return None
+    fn = getattr(mod, attr, None)
+    if fn is None:
+        LOGGER.info("engine %s: module loaded but %s missing - skipping", engine, attr)
+        return None
+    return fn
+
+
+def _coerce_to_dict(fit_result: Any) -> dict[str, Any]:
+    """Normalise a per-engine ``FitResult`` into a plain dict.
+
+    Accepts (a) a dict, (b) a frozen dataclass, (c) any object with the
+    canonical attributes — in that order. Whatever the engine returns, we
+    only persist the leaderboard columns + a few diagnostic extras.
+    """
+    if isinstance(fit_result, dict):
+        return dict(fit_result)
+    if hasattr(fit_result, "__dataclass_fields__"):
+        return asdict(fit_result)
+    if hasattr(fit_result, "_asdict"):
+        return dict(fit_result._asdict())
+    # Fallback: read attributes by name.
+    attrs = (
+        "engine",
+        "solver",
+        "trial",
+        "grip_rmse_mm",
+        "clubhead_rmse_mm",
+        "total_work_J",
+        "wall_clock_s",
+        "commit",
+        "run_at",
+    )
+    out: dict[str, Any] = {}
+    for name in attrs:
+        if hasattr(fit_result, name):
+            out[name] = getattr(fit_result, name)
+    return out
+
+
+def _write_engine_json(
+    results_dir: Path,
+    trial: str,
+    engine: str,
+    payload: dict[str, Any],
+) -> Path:
+    """Persist ``payload`` to ``<results_dir>/<trial>/<engine>.json``.
+
+    Required leaderboard fields are filled with the orchestrator's own
+    metadata if the engine didn't name them, so engines can return
+    partial dicts during early implementation.
+    """
+    payload.setdefault("trial", trial)
+    payload.setdefault("engine", engine)
+    payload.setdefault("commit", _git_commit())
+    payload.setdefault("run_at", _now_iso())
+    out_dir = results_dir / trial
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{engine}.json"
+    out_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
+
+
+# --- Run loop ----------------------------------------------------------------
+
+
+def run_one_engine(
+    trial: str,
+    engine: str,
+    target: Any,
+    results_dir: Path,
+    strict: bool,
+) -> str:
+    """Run a single (trial, engine) cell. Returns one of ``ok``, ``skip``,
+    ``error``.
+    """
+    fit_fn = _load_fit_driver(engine)
+    if fit_fn is None:
+        return "skip"
+    t0 = time.perf_counter()
+    try:
+        result = fit_fn(target)
+    except NotImplementedError as exc:
+        LOGGER.info(
+            "engine %s for trial %s: not implemented yet (%s) - skipping",
+            engine,
+            trial,
+            exc,
+        )
+        return "skip"
+    except Exception:  # noqa: BLE001 - we want a clean honest skip message
+        LOGGER.error(
+            "engine %s for trial %s: fit driver crashed:\n%s",
+            engine,
+            trial,
+            traceback.format_exc(),
+        )
+        if strict:
+            raise
+        return "error"
+    elapsed = time.perf_counter() - t0
+
+    payload = _coerce_to_dict(result)
+    # Some drivers report wall clock themselves; if absent, use ours.
+    payload.setdefault("wall_clock_s", float(elapsed))
+    _write_engine_json(results_dir, trial, engine, payload)
+    LOGGER.info("engine %s for trial %s: ok (%.3fs)", engine, trial, elapsed)
+    return "ok"
+
+
+def run_all(args: argparse.Namespace) -> dict[str, dict[str, str]]:
+    """Drive every (trial, engine) cell. Returns a status grid suitable
+    for printing a summary at the end.
+    """
+    trials = tuple(args.trial) if args.trial else CANONICAL_TRIALS
+    engines = tuple(args.engine) if args.engine else CANONICAL_ENGINES
+    grid: dict[str, dict[str, str]] = {
+        t: dict.fromkeys(engines, "skip") for t in trials
+    }
+
+    if args.skip_fits:
+        LOGGER.info("--skip-fits: not running any fit driver, regenerating report only")
+        return grid
+
+    for trial in trials:
+        try:
+            target = _load_target(trial)
+        except (ImportError, FileNotFoundError, KeyError, ValueError) as exc:
+            LOGGER.warning(
+                "trial %s: target unavailable (%s) - skipping all engines", trial, exc
+            )
+            continue
+        for engine in engines:
+            grid[trial][engine] = run_one_engine(
+                trial, engine, target, args.results_dir, args.strict
+            )
+    return grid
+
+
+# --- Main --------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not args.results_dir.exists():
+        args.results_dir.mkdir(parents=True, exist_ok=True)
+
+    grid = run_all(args)
+
+    # Lazy import so `--help` works even without the package on sys.path.
+    sys.path.insert(0, str(REPO_ROOT))
+    from src.shared.python.motion_matching.leaderboard import generate_report
+
+    out = generate_report(args.results_dir, args.leaderboard_path)
+    LOGGER.info("leaderboard written: %s", out)
+
+    # Print a small status grid so reviewers can see at a glance which
+    # engines were skipped honestly.
+    if grid:
+        header_engines = sorted({e for engines in grid.values() for e in engines})
+        sys.stdout.write("\nstatus grid (rows = trials, cols = engines):\n")
+        sys.stdout.write("trial".ljust(14))
+        for e in header_engines:
+            sys.stdout.write(e.ljust(12))
+        sys.stdout.write("\n")
+        for trial in sorted(grid):
+            sys.stdout.write(trial.ljust(14))
+            for e in header_engines:
+                sys.stdout.write(grid[trial].get(e, "-").ljust(12))
+            sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/src/shared/python/motion_matching/leaderboard.py
+++ b/src/shared/python/motion_matching/leaderboard.py
@@ -1,0 +1,330 @@
+"""Cross-engine motion-matching leaderboard.
+
+Aggregates per-engine ``FitResult`` JSON files emitted by
+``fit_swing_<engine>(target)`` drivers into a single Markdown comparison
+table per :doc:`VISUALIZATION_SPEC.md` "Comparison across options".
+
+The on-disk layout consumed by :func:`generate_report` is:
+
+    <results_dir>/
+        <trial>/
+            <engine>.json       -- one FitResult per (trial, engine)
+
+A ``FitResult`` JSON document is the canonical schema described in
+``CROSS_ENGINE_PARITY_SPEC.md`` §2.4 / §2.8 with at minimum these fields:
+
+    {
+        "engine":            str,    # "simscape" | "mujoco" | "drake"
+                                     # | "pinocchio" | "opensim"
+        "solver":            str,    # e.g. "fmincon-sqp+ms8", "ipopt", "lm"
+        "trial":             str,    # e.g. "TW_ProV1"
+        "grip_rmse_mm":      float,  # >= 0
+        "clubhead_rmse_mm":  float,  # >= 0
+        "total_work_J":      float,  # >= 0 (regularised effort, summed)
+        "wall_clock_s":      float,  # >= 0
+        "commit":            str,    # 7-40 hex chars; short or full git SHA
+        "run_at":            str,    # ISO-8601 UTC, "...Z"
+    }
+
+Additional fields are tolerated and ignored — engines emit richer payloads
+(``coefficients``, ``solver_options``, ``n_iterations`` ...) but only the
+columns above show up in the leaderboard.
+
+Public API
+----------
+    FitResult           -- frozen dataclass; the leaderboard row schema.
+    LeaderboardError    -- raised on schema violations or unreadable input.
+    load_results        -- read every ``<trial>/<engine>.json`` under a dir.
+    render_markdown     -- format a list of FitResults as a Markdown table.
+    generate_report     -- end-to-end: read directory -> write ``.md`` file.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, fields
+from datetime import datetime
+from pathlib import Path
+
+__all__ = [
+    "FitResult",
+    "LeaderboardError",
+    "load_results",
+    "render_markdown",
+    "generate_report",
+]
+
+# --- Schema ------------------------------------------------------------------
+
+_VALID_ENGINES: frozenset[str] = frozenset(
+    {"simscape", "mujoco", "drake", "pinocchio", "opensim"}
+)
+_COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_ISO8601_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+# Canonical column order for the Markdown table (matches issue #4097 spec).
+_COLUMNS: tuple[str, ...] = (
+    "engine",
+    "solver",
+    "grip_rmse_mm",
+    "clubhead_rmse_mm",
+    "total_work_J",
+    "wall_clock_s",
+    "commit",
+    "run_at",
+)
+_REQUIRED_FIELDS: tuple[str, ...] = ("trial", *_COLUMNS)
+_NONNEG_FIELDS: tuple[str, ...] = (
+    "grip_rmse_mm",
+    "clubhead_rmse_mm",
+    "total_work_J",
+    "wall_clock_s",
+)
+
+
+class LeaderboardError(ValueError):
+    """Raised when a ``FitResult`` JSON file is malformed or the directory
+    layout does not match ``<trial>/<engine>.json``.
+    """
+
+
+def _validate_strings(record: FitResult) -> None:
+    """Trial / engine / solver string fields must be present and recognised."""
+    if not isinstance(record.trial, str) or not record.trial:
+        raise LeaderboardError(
+            f"trial must be a non-empty string, got {record.trial!r}"
+        )
+    if record.engine not in _VALID_ENGINES:
+        raise LeaderboardError(
+            f"engine must be one of {sorted(_VALID_ENGINES)}, got {record.engine!r}"
+        )
+    if not isinstance(record.solver, str) or not record.solver:
+        raise LeaderboardError(
+            f"solver must be a non-empty string, got {record.solver!r}"
+        )
+
+
+def _validate_numbers(record: FitResult) -> None:
+    """Numeric fields must be finite and non-negative."""
+    for name in _NONNEG_FIELDS:
+        value = getattr(record, name)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise LeaderboardError(f"{name} must be a number, got {value!r}")
+        if value < 0:
+            raise LeaderboardError(f"{name} must be >= 0, got {value!r}")
+
+
+def _validate_commit(commit: str) -> None:
+    if not _COMMIT_RE.match(commit):
+        raise LeaderboardError(
+            f"commit must be 7-40 lowercase hex chars, got {commit!r}"
+        )
+
+
+def _validate_timestamp(run_at: str) -> None:
+    if not _ISO8601_RE.match(run_at):
+        raise LeaderboardError(
+            f"run_at must be ISO-8601 UTC ending in 'Z', got {run_at!r}"
+        )
+    # Cheap final sanity check: parse the timestamp.
+    try:
+        datetime.strptime(run_at, "%Y-%m-%dT%H:%M:%SZ")
+        return
+    except ValueError:
+        pass
+    try:
+        datetime.strptime(run_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise LeaderboardError(f"run_at unparseable as ISO-8601: {run_at!r}") from exc
+
+
+@dataclass(frozen=True)
+class FitResult:
+    """Cross-engine leaderboard row.
+
+    Mirrors the per-engine ``fit_swing_<engine>`` JSON contract from
+    CROSS_ENGINE_PARITY_SPEC.md §2.8. All fields are required and validated
+    in :meth:`__post_init__`.
+    """
+
+    trial: str
+    engine: str
+    solver: str
+    grip_rmse_mm: float
+    clubhead_rmse_mm: float
+    total_work_J: float
+    wall_clock_s: float
+    commit: str
+    run_at: str
+
+    def __post_init__(self) -> None:
+        _validate_strings(self)
+        _validate_numbers(self)
+        _validate_commit(self.commit)
+        _validate_timestamp(self.run_at)
+
+    @classmethod
+    def from_dict(cls, data: dict, trial: str) -> FitResult:
+        """Build a FitResult from a parsed JSON dict.
+
+        ``trial`` is supplied separately because most fit drivers know
+        which trial they ran without re-stating it; if the JSON does name
+        ``trial`` and it disagrees with the directory name, that is a
+        :class:`LeaderboardError`.
+        """
+        if not isinstance(data, dict):
+            raise LeaderboardError(f"expected JSON object, got {type(data).__name__}")
+        if "trial" in data and data["trial"] != trial:
+            raise LeaderboardError(
+                f"trial mismatch: directory says {trial!r}, payload says {data['trial']!r}"
+            )
+        kwargs = {name: data.get(name) for name in _REQUIRED_FIELDS}
+        kwargs["trial"] = trial
+        missing = [name for name, v in kwargs.items() if v is None]
+        if missing:
+            raise LeaderboardError(
+                f"missing required field(s) {sorted(missing)} in FitResult JSON"
+            )
+        return cls(**kwargs)  # type: ignore[arg-type]
+
+    def as_row(self) -> dict[str, str]:
+        """Return a stringly-typed mapping for the Markdown row."""
+        out: dict[str, str] = {}
+        for name in _COLUMNS:
+            value = getattr(self, name)
+            if isinstance(value, float):
+                out[name] = f"{value:.3f}"
+            else:
+                out[name] = str(value)
+        return out
+
+
+# --- I/O ---------------------------------------------------------------------
+
+
+def load_results(results_dir: Path) -> dict[str, list[FitResult]]:
+    """Read every ``<trial>/<engine>.json`` under ``results_dir``.
+
+    Returns a mapping ``trial -> [FitResult, ...]``. Files whose basename
+    is not a recognised engine are skipped silently — the leaderboard does
+    not police that subdirectory for unrelated artefacts. JSON parse errors
+    or schema violations raise :class:`LeaderboardError` so callers see the
+    failure rather than a silently-incomplete table.
+    """
+    if not isinstance(results_dir, Path):
+        raise TypeError(f"results_dir must be a Path, got {type(results_dir).__name__}")
+    out: dict[str, list[FitResult]] = {}
+    if not results_dir.exists():
+        return out
+    if not results_dir.is_dir():
+        raise LeaderboardError(f"{results_dir} is not a directory")
+
+    for trial_dir in sorted(results_dir.iterdir()):
+        if not trial_dir.is_dir():
+            continue
+        rows = _load_trial_dir(trial_dir)
+        if rows:
+            out[trial_dir.name] = rows
+    return out
+
+
+def _load_trial_dir(trial_dir: Path) -> list[FitResult]:
+    """Read every recognised ``<engine>.json`` under one trial directory."""
+    trial = trial_dir.name
+    rows: list[FitResult] = []
+    for engine_file in sorted(trial_dir.glob("*.json")):
+        engine = engine_file.stem
+        if engine not in _VALID_ENGINES:
+            # Tolerate sibling artefacts; the layout is conventional, not
+            # exclusive.
+            continue
+        try:
+            payload = json.loads(engine_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise LeaderboardError(f"could not parse {engine_file}: {exc}") from exc
+        # Inject the engine if the JSON does not name itself; this lets
+        # writers be lazy.
+        if isinstance(payload, dict):
+            payload.setdefault("engine", engine)
+        rows.append(FitResult.from_dict(payload, trial=trial))
+    return rows
+
+
+# --- Rendering ---------------------------------------------------------------
+
+
+def _format_table(rows: list[dict[str, str]], columns: tuple[str, ...]) -> list[str]:
+    """Format a Markdown table with column-width alignment."""
+    widths = {col: len(col) for col in columns}
+    for row in rows:
+        for col in columns:
+            widths[col] = max(widths[col], len(row[col]))
+    header = "| " + " | ".join(col.ljust(widths[col]) for col in columns) + " |"
+    sep = "| " + " | ".join("-" * widths[col] for col in columns) + " |"
+    body = [
+        "| " + " | ".join(row[col].ljust(widths[col]) for col in columns) + " |"
+        for row in rows
+    ]
+    return [header, sep, *body]
+
+
+def render_markdown(results: dict[str, list[FitResult]]) -> str:
+    """Render the full leaderboard Markdown.
+
+    Sections are sorted by trial name (alphabetical). Within a trial, rows
+    are sorted by ``grip_rmse_mm`` ascending so the most accurate engine
+    appears first. The output is deterministic — same input, same bytes —
+    so the file is safe to commit and diff across PRs.
+    """
+    lines: list[str] = ["# Cross-engine leaderboard", ""]
+    if not results:
+        lines.append(
+            "_No FitResult JSON files found. Engines that have not yet "
+            "implemented `fit_swing_<engine>` are honestly skipped._"
+        )
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append(
+        "Sorted by `grip_rmse_mm` ascending within each trial; lower is better."
+    )
+    lines.append("")
+
+    for trial in sorted(results.keys()):
+        rows = sorted(results[trial], key=lambda r: r.grip_rmse_mm)
+        lines.append(f"## {trial}")
+        lines.append("")
+        lines.extend(_format_table([r.as_row() for r in rows], _COLUMNS))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def generate_report(results_dir: Path, output_path: Path) -> Path:
+    """Read every FitResult under ``results_dir`` and write a Markdown
+    leaderboard to ``output_path``.
+
+    Returns the absolute path of the written file. The parent directory of
+    ``output_path`` is created if it does not exist. The output is
+    deterministic — same inputs always produce the same bytes — so the
+    leaderboard file is safe to commit.
+    """
+    if not isinstance(results_dir, Path):
+        raise TypeError(f"results_dir must be a Path, got {type(results_dir).__name__}")
+    if not isinstance(output_path, Path):
+        raise TypeError(f"output_path must be a Path, got {type(output_path).__name__}")
+    results = load_results(results_dir)
+    text = render_markdown(results)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        text + ("" if text.endswith("\n") else "\n"), encoding="utf-8"
+    )
+    return output_path.resolve()
+
+
+# --- Module-level metadata ---------------------------------------------------
+
+# Re-export for documentation / introspection.
+COLUMNS: tuple[str, ...] = _COLUMNS
+SUPPORTED_ENGINES: frozenset[str] = _VALID_ENGINES
+SCHEMA_FIELDS: tuple[str, ...] = tuple(f.name for f in fields(FitResult))

--- a/tests/unit/motion_matching/test_leaderboard.py
+++ b/tests/unit/motion_matching/test_leaderboard.py
@@ -1,0 +1,338 @@
+"""Unit tests for the cross-engine leaderboard helper.
+
+Mirrors issue #4097 acceptance: empty-results case, single-engine case,
+multi-engine sorting, schema validation. No physics-engine dependencies
+are required - the table-generation logic is pure Python.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from src.shared.python.motion_matching.leaderboard import (
+    COLUMNS,
+    SCHEMA_FIELDS,
+    SUPPORTED_ENGINES,
+    FitResult,
+    LeaderboardError,
+    generate_report,
+    load_results,
+    render_markdown,
+)
+
+# --- Fixtures ----------------------------------------------------------------
+
+
+def _good_payload(**overrides) -> dict:
+    base = {
+        "engine": "simscape",
+        "solver": "fmincon-sqp+ms8",
+        "trial": "TW_ProV1",
+        "grip_rmse_mm": 1.85,
+        "clubhead_rmse_mm": 2.31,
+        "total_work_J": 284.0,
+        "wall_clock_s": 252.4,
+        "commit": "7a3f1c2",
+        "run_at": "2026-05-05T17:34:21Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --- Schema --------------------------------------------------------------
+
+
+class TestFitResultSchema:
+    def test_constructs_with_valid_fields(self) -> None:
+        r = FitResult(**_good_payload())
+        assert r.engine == "simscape"
+        assert r.trial == "TW_ProV1"
+        assert r.grip_rmse_mm == pytest.approx(1.85)
+
+    def test_rejects_unknown_engine(self) -> None:
+        with pytest.raises(LeaderboardError, match="engine must be one of"):
+            FitResult(**_good_payload(engine="bullet"))
+
+    def test_rejects_negative_rmse(self) -> None:
+        with pytest.raises(LeaderboardError, match="grip_rmse_mm"):
+            FitResult(**_good_payload(grip_rmse_mm=-1.0))
+
+    def test_rejects_negative_wall_clock(self) -> None:
+        with pytest.raises(LeaderboardError, match="wall_clock_s"):
+            FitResult(**_good_payload(wall_clock_s=-0.001))
+
+    def test_rejects_non_hex_commit(self) -> None:
+        with pytest.raises(LeaderboardError, match="commit"):
+            FitResult(**_good_payload(commit="not-a-sha"))
+
+    def test_rejects_too_short_commit(self) -> None:
+        with pytest.raises(LeaderboardError, match="commit"):
+            FitResult(**_good_payload(commit="abc"))
+
+    def test_rejects_non_iso8601_timestamp(self) -> None:
+        with pytest.raises(LeaderboardError, match="run_at"):
+            FitResult(**_good_payload(run_at="yesterday"))
+
+    def test_rejects_naive_iso8601_timestamp(self) -> None:
+        with pytest.raises(LeaderboardError, match="run_at"):
+            FitResult(**_good_payload(run_at="2026-05-05T17:34:21"))  # missing Z
+
+    def test_accepts_iso8601_with_microseconds(self) -> None:
+        r = FitResult(**_good_payload(run_at="2026-05-05T17:34:21.123456Z"))
+        assert r.run_at.endswith("Z")
+
+    def test_rejects_empty_solver(self) -> None:
+        with pytest.raises(LeaderboardError, match="solver"):
+            FitResult(**_good_payload(solver=""))
+
+    def test_rejects_empty_trial(self) -> None:
+        with pytest.raises(LeaderboardError, match="trial"):
+            FitResult(**_good_payload(trial=""))
+
+    def test_frozen(self) -> None:
+        import dataclasses
+
+        r = FitResult(**_good_payload())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.engine = "mujoco"  # type: ignore[misc]
+
+    def test_supported_engines_set(self) -> None:
+        assert (
+            frozenset({"simscape", "mujoco", "drake", "pinocchio", "opensim"})
+            == SUPPORTED_ENGINES
+        )
+
+    def test_columns_match_issue_spec(self) -> None:
+        # Per #4097: engine, solver, grip_rmse_mm, clubhead_rmse_mm,
+        # total_work_J, wall_clock_s, commit, run_at.
+        assert COLUMNS == (
+            "engine",
+            "solver",
+            "grip_rmse_mm",
+            "clubhead_rmse_mm",
+            "total_work_J",
+            "wall_clock_s",
+            "commit",
+            "run_at",
+        )
+
+    def test_schema_fields_documented(self) -> None:
+        # SCHEMA_FIELDS exposes the dataclass field names; useful for
+        # downstream introspection and stable for tests.
+        assert "trial" in SCHEMA_FIELDS
+        for col in COLUMNS:
+            assert col in SCHEMA_FIELDS
+
+
+class TestFitResultFromDict:
+    def test_from_dict_roundtrip(self) -> None:
+        r = FitResult.from_dict(_good_payload(), trial="TW_ProV1")
+        assert r.engine == "simscape"
+
+    def test_from_dict_trial_mismatch_raises(self) -> None:
+        with pytest.raises(LeaderboardError, match="trial mismatch"):
+            FitResult.from_dict(_good_payload(trial="TW_ProV1"), trial="GW_wiffle")
+
+    def test_from_dict_missing_field_raises(self) -> None:
+        payload = _good_payload()
+        del payload["solver"]
+        with pytest.raises(LeaderboardError, match="missing required field"):
+            FitResult.from_dict(payload, trial="TW_ProV1")
+
+    def test_from_dict_extra_fields_ignored(self) -> None:
+        payload = _good_payload(coefficients=[[1, 2, 3]], n_iterations=42)
+        r = FitResult.from_dict(payload, trial="TW_ProV1")
+        assert r.engine == "simscape"
+
+    def test_from_dict_rejects_non_object(self) -> None:
+        with pytest.raises(LeaderboardError, match="expected JSON object"):
+            FitResult.from_dict([1, 2, 3], trial="TW_ProV1")  # type: ignore[arg-type]
+
+
+# --- load_results ------------------------------------------------------------
+
+
+class TestLoadResults:
+    def test_empty_results_dir_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert load_results(tmp_path) == {}
+
+    def test_nonexistent_dir_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert load_results(tmp_path / "missing") == {}
+
+    def test_path_to_file_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "f.txt"
+        f.write_text("hi")
+        with pytest.raises(LeaderboardError, match="not a directory"):
+            load_results(f)
+
+    def test_single_engine_single_trial(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "TW_ProV1" / "simscape.json", _good_payload())
+        results = load_results(tmp_path)
+        assert set(results) == {"TW_ProV1"}
+        assert len(results["TW_ProV1"]) == 1
+        assert results["TW_ProV1"][0].engine == "simscape"
+
+    def test_multi_engine_multi_trial(self, tmp_path: Path) -> None:
+        _write_json(
+            tmp_path / "TW_ProV1" / "simscape.json",
+            _good_payload(engine="simscape", grip_rmse_mm=2.3),
+        )
+        _write_json(
+            tmp_path / "TW_ProV1" / "mujoco.json",
+            _good_payload(engine="mujoco", grip_rmse_mm=3.7, solver="cma-es"),
+        )
+        _write_json(
+            tmp_path / "GW_wiffle" / "drake.json",
+            _good_payload(
+                engine="drake",
+                trial="GW_wiffle",
+                grip_rmse_mm=2.4,
+                solver="ipopt",
+            ),
+        )
+        results = load_results(tmp_path)
+        assert set(results) == {"TW_ProV1", "GW_wiffle"}
+        assert {r.engine for r in results["TW_ProV1"]} == {"simscape", "mujoco"}
+        assert {r.engine for r in results["GW_wiffle"]} == {"drake"}
+
+    def test_unrecognised_filename_skipped(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "TW_ProV1" / "simscape.json", _good_payload())
+        # Stray sibling file: not a recognised engine, ignored.
+        (tmp_path / "TW_ProV1" / "notes.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "TW_ProV1" / "bullet.json").write_text("{}", encoding="utf-8")
+        results = load_results(tmp_path)
+        assert len(results["TW_ProV1"]) == 1
+
+    def test_missing_engine_field_filled_from_filename(self, tmp_path: Path) -> None:
+        # Engines may be lazy and not include their own name; the loader
+        # injects it from the file stem.
+        payload = _good_payload()
+        del payload["engine"]
+        _write_json(tmp_path / "TW_ProV1" / "mujoco.json", payload)
+        results = load_results(tmp_path)
+        assert results["TW_ProV1"][0].engine == "mujoco"
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "TW_ProV1" / "simscape.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(LeaderboardError, match="could not parse"):
+            load_results(tmp_path)
+
+    def test_non_path_raises_typeerror(self) -> None:
+        with pytest.raises(TypeError, match="results_dir"):
+            load_results("some/path")  # type: ignore[arg-type]
+
+
+# --- render_markdown ---------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def test_empty_renders_skip_message(self) -> None:
+        md = render_markdown({})
+        assert "No FitResult JSON files found" in md
+        assert "honestly skipped" in md
+
+    def test_single_engine_renders_table(self) -> None:
+        rows = {"TW_ProV1": [FitResult(**_good_payload())]}
+        md = render_markdown(rows)
+        # Header + columns + at least one row.
+        assert "## TW_ProV1" in md
+        assert "engine" in md and "solver" in md and "grip_rmse_mm" in md
+        assert "simscape" in md
+        # 1.85 mm should round-trip with 3 decimals.
+        assert "1.850" in md
+
+    def test_multi_engine_sorted_by_grip_rmse_ascending(self) -> None:
+        rows = {
+            "TW_ProV1": [
+                FitResult(**_good_payload(engine="simscape", grip_rmse_mm=2.3)),
+                FitResult(**_good_payload(engine="mujoco", grip_rmse_mm=1.1)),
+                FitResult(**_good_payload(engine="drake", grip_rmse_mm=3.7)),
+            ]
+        }
+        md = render_markdown(rows)
+        # The most accurate engine should appear first within the trial.
+        body = md.split("## TW_ProV1", 1)[1]
+        idx_mujoco = body.index("mujoco")
+        idx_simscape = body.index("simscape")
+        idx_drake = body.index("drake")
+        assert idx_mujoco < idx_simscape < idx_drake
+
+    def test_multi_trial_sorted_alphabetically(self) -> None:
+        rows = {
+            "TW_ProV1": [FitResult(**_good_payload(engine="simscape"))],
+            "GW_wiffle": [
+                FitResult(**_good_payload(engine="drake", trial="GW_wiffle"))
+            ],
+        }
+        md = render_markdown(rows)
+        idx_gw = md.index("## GW_wiffle")
+        idx_tw = md.index("## TW_ProV1")
+        assert idx_gw < idx_tw
+
+    def test_render_is_deterministic(self) -> None:
+        rows = {
+            "TW_ProV1": [
+                FitResult(**_good_payload(engine="mujoco", grip_rmse_mm=1.1)),
+                FitResult(**_good_payload(engine="simscape", grip_rmse_mm=2.3)),
+            ]
+        }
+        # Same input must produce byte-identical output across calls.
+        assert render_markdown(rows) == render_markdown(rows)
+
+    def test_columns_appear_in_canonical_order(self) -> None:
+        rows = {"TW_ProV1": [FitResult(**_good_payload())]}
+        md = render_markdown(rows)
+        header_line = next(
+            line for line in md.splitlines() if "engine" in line and "solver" in line
+        )
+        positions = [header_line.index(col) for col in COLUMNS]
+        assert positions == sorted(positions)
+
+
+# --- generate_report end-to-end ---------------------------------------------
+
+
+class TestGenerateReport:
+    def test_writes_file_for_empty_dir(self, tmp_path: Path) -> None:
+        out = tmp_path / "out" / "LB.md"
+        result = generate_report(tmp_path / "results", out)
+        assert result == out.resolve()
+        assert out.exists()
+        assert "No FitResult JSON files found" in out.read_text(encoding="utf-8")
+
+    def test_writes_file_for_populated_dir(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        _write_json(
+            results_dir / "TW_ProV1" / "simscape.json",
+            _good_payload(engine="simscape", grip_rmse_mm=2.3),
+        )
+        _write_json(
+            results_dir / "TW_ProV1" / "pinocchio.json",
+            _good_payload(engine="pinocchio", grip_rmse_mm=1.7, solver="lm"),
+        )
+        out = tmp_path / "LB.md"
+        generate_report(results_dir, out)
+        text = out.read_text(encoding="utf-8")
+        assert "## TW_ProV1" in text
+        assert "simscape" in text and "pinocchio" in text
+        assert text.endswith("\n")
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        out = tmp_path / "deeply" / "nested" / "missing" / "LB.md"
+        generate_report(tmp_path / "results", out)
+        assert out.exists()
+
+    def test_non_path_args_raise_typeerror(self, tmp_path: Path) -> None:
+        with pytest.raises(TypeError):
+            generate_report("results", tmp_path / "out.md")  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            generate_report(tmp_path, "out.md")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Implements **PARITY-LEADERBOARD** per [`CROSS_ENGINE_PARITY_SPEC.md`](../tree/main/src/engines/CROSS_ENGINE_PARITY_SPEC.md) §2.8 (issue #4097).

Three deliverables, all in this PR:

1. **Shared library** — `src/shared/python/motion_matching/leaderboard.py`
   - Frozen `FitResult` dataclass (engine, solver, trial, grip_rmse_mm, clubhead_rmse_mm, total_work_J, wall_clock_s, commit, run_at), with strict per-field validation.
   - `generate_report(results_dir, output_path)` reads every `<trial>/<engine>.json`, sorts by `grip_rmse_mm` ascending within each trial, and writes a deterministic Markdown table (safe to commit and diff across PRs).
   - Per-engine writers from #4133 (Pinocchio) and the upcoming Drake / MuJoCo / OpenSim drivers can produce richer payloads — extra fields are tolerated and ignored.
2. **Orchestrator** — `scripts/run_cross_engine_leaderboard.py`
   - Iterates the four canonical Wiffle xlsx trials (`TW_ProV1`, `TW_wiffle`, `GW_wiffle`, `GW_ProV11`, wired by #4081 / #4086) × 5 engines.
   - For each cell, dynamically imports `fit_swing_<engine>`, runs it on the loaded `ClubTarget`, and writes the `FitResult` to `motion_matching/results/<trial>/<engine>.json`.
   - **Honestly skips** engines whose fit driver isn't yet importable / hasn't landed (the acceptance criterion in #4097).
   - Calls `generate_report` to render `motion_matching/results/CROSS_ENGINE_LEADERBOARD.md`.
   - `--skip-fits` flag re-renders from existing JSONs without rerunning anything (used by CI).
3. **CI** — `.github/workflows/cross-engine-leaderboard.yml`
   - Triggers on PRs touching `src/engines/` or the leaderboard scripts themselves.
   - Runs the 39 unit tests, regenerates the report from committed JSONs in `--skip-fits` mode, posts the diff to the workflow summary, and uploads the leaderboard as an artifact.
   - Pinned actions (matches repo convention).

Initial committed leaderboard: `motion_matching/results/CROSS_ENGINE_LEADERBOARD.md` — currently empty / honest-skip because no `fit_swing_<engine>` driver has landed yet (per-engine PRs are in flight). The first engine to merge populates a row; the cross-engine grip-RMSE clustering becomes verifiable as soon as ≥ 2 engines fit on the same trial.

## Test plan

- [x] `python3 -m pytest tests/unit/motion_matching/test_leaderboard.py -v` — 39/39 passed (empty, single-engine, multi-engine sorting, schema validation)
- [x] `python3 -m ruff check` on touched files — clean
- [x] `python3 -m ruff format --check` on touched files — clean
- [x] `python3 scripts/run_cross_engine_leaderboard.py --skip-fits` — generates initial honest-skip report
- [x] Smoke test with two synthetic FitResult JSONs (Simscape + Pinocchio) — Markdown table renders correctly with column alignment, sorted ascending by grip_rmse_mm
- [x] `python3 scripts/check_github_actions_pinned.py` — clean
- [x] `python3 scripts/ci/check_file_size_budget.py` — clean (largest new file 400 lines, well under the 1200-line cap)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cross-engine-leaderboard.yml'))"` — valid

[no-docs-needed]

🤖 Generated with [Claude Code](https://claude.com/claude-code)