### PR TITLE
fix(ci): install defusedxml in drake URDF drift gate (closes #4206)

### DIFF
--- a/.github/workflows/ci-engine-models.yml
+++ b/.github/workflows/ci-engine-models.yml
@@ -54,10 +54,11 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          # The Drake URDF generator is pure-Python and only needs PyYAML
-          # plus numpy at parse time. Avoid pulling in pydrake / heavy
-          # extras so the gate stays under the 30 s budget (#4129 AC).
-          python -m pip install pyyaml numpy
+          # The Drake URDF generator is pure-Python and only needs PyYAML,
+          # numpy, and defusedxml (used by humanoid_urdf.py) at parse time.
+          # Avoid pulling in pydrake / heavy extras so the gate stays under
+          # the 30 s budget (#4129 AC).
+          python -m pip install pyyaml numpy defusedxml
 
       - name: Regenerate drake URDF and assert no drift
         shell: bash


### PR DESCRIPTION
## Summary
- The new `ci-engine-models.yml` workflow installed only `pyyaml` + `numpy`, but `humanoid_urdf.py` has a hard import of `defusedxml.minidom`.
- On runners without `defusedxml` preinstalled, the drift gate fails with `ModuleNotFoundError` before doing any drift comparison.
- This adds `defusedxml` to the install step so the gate is deterministic.

Addresses P1 review feedback from PR #4172 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4172#discussion_r3198211148)).

Closes #4206.

## Test plan
- [x] `git diff` confirms the install line now reads `pip install pyyaml numpy defusedxml`
- [x] Workflow paths trigger on this PR's `.github/workflows/` change so the gate self-validates