### PR TITLE
feat(matlab): fit_swing_full_pipeline.m single-call M1 driver (closes #4083)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/fit_swing_full_pipeline.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/fit_swing_full_pipeline.m
@@ -1,0 +1,659 @@
+function result = fit_swing_full_pipeline(target_or_xlsx, opts)
+%FIT_SWING_FULL_PIPELINE  One-call grip-primary swing fit (Stage-1 + Stage-2).
+%
+%   RESULT = FIT_SWING_FULL_PIPELINE(TARGET_OR_XLSX, OPTS) codifies the
+%   GRIP_FIT_PLAYBOOK.md §6.4 copy-paste recipe as a reusable function:
+%
+%     1. Resolve the target (load Wiffle xlsx if a path is given, else
+%        accept a pre-loaded canonical target struct).
+%     2. Run SOLVE_STARTING_POSE (Stage-1) to compute the small set of
+%        ``*StartPosition*`` / ``*StartVelocity*`` overrides that put the
+%        body at the address pose.
+%     3. Inject those overrides into ``opts.stage2_opts.sim.input_overrides``.
+%     4. Dispatch the requested optimizer
+%        (FIT_SWING_FMINCON / FIT_SWING_MULTISTART / FIT_SWING_SURROGATEOPT
+%        / FIT_SWING_HYBRID).
+%     5. Render the canonical figures
+%        (PLOT_TRAJECTORY_OVERLAY, PLOT_ERROR_TIMECOURSE,
+%        PLOT_FIT_QUALITY_CARD) with `Visible='off'` and save them as PNGs.
+%     6. Optionally render the swing animation.
+%     7. Save the result struct + a plain-text human-readable report.
+%     8. Return the augmented RESULT struct.
+%
+%   Inputs
+%   ------
+%   TARGET_OR_XLSX
+%       Either a string/char path to a Wiffle xlsx file (the sheet name
+%       comes from OPTS.sheet, default "TW_ProV1") OR a pre-loaded
+%       canonical target struct (must satisfy CLUB_IK_SPEC.md — fields
+%       time, grip, grip_quat, butt, clubhead, club_quat, impact_idx,
+%       events, source).
+%
+%   OPTS  (1,1) struct.  Optional fields with defaults:
+%     .sheet            "TW_ProV1"
+%     .option           "fmincon" (default) | "multistart" | "surrogate"
+%                       | "surrogateopt" | "hybrid"
+%     .save_dir         default = output/fits/<yyyyMMdd_HHmmss>
+%     .render_figures   default true
+%     .save_animation   default false
+%     .input_mat        default 3DModelInputs_Impact.mat (path resolved
+%                       relative to the engine root if found, else used
+%                       as-is)
+%     .stage1_opts      passed straight to solve_starting_pose
+%     .stage2_opts      seeded from default_option1_options(), then
+%                       deep-merged with caller overrides; the Stage-1
+%                       overrides are written into
+%                       opts.stage2_opts.sim.input_overrides before
+%                       dispatch.
+%     .viz_opts         passed to the figure renderers (defaults from
+%                       default_viz_options() with .visible="off").
+%     .skip_stage1      logical; if true, Stage-1 is skipped and the
+%                       returned overrides struct is empty.  Useful for
+%                       smoke tests.
+%     .verbose          default true
+%
+%   Output
+%   ------
+%   RESULT
+%       The canonical fit-result struct returned by the dispatched
+%       optimizer (see option1_direct_optimization/INTERFACES.md "Result
+%       struct contract"), augmented with:
+%         .stage1_overrides   struct of *StartPosition* / *StartVelocity*
+%                             overrides from solve_starting_pose
+%         .figure_paths       cell array of saved figure paths (PNG)
+%         .report_path        full path to a plain-text summary report
+%         .save_dir           save directory used
+%         .target             the resolved canonical target (also nested
+%                             inside the inner solver result)
+%
+%   Preconditions (DbC)
+%   -------------------
+%     * TARGET_OR_XLSX is a string/char path that exists, OR a 1x1 struct
+%       with the required canonical fields.
+%     * OPTS, when supplied, is a 1x1 struct.
+%     * OPTS.option (when set) names a known optimizer dispatch.
+%
+%   Postconditions
+%   --------------
+%     * RESULT contains the fields .stage1_overrides, .figure_paths,
+%       .report_path, .save_dir; figure_paths is a cellstr (possibly
+%       empty when render_figures=false), and report_path is a non-empty
+%       string pointing at an existing file.
+%     * RESULT.solver matches the dispatched optimizer name.
+%     * The save directory exists.
+%
+%   See also: SOLVE_STARTING_POSE, LOAD_CLUB_TARGET_EXCEL,
+%             FIT_SWING_FMINCON, FIT_SWING_MULTISTART, FIT_SWING_SURROGATEOPT,
+%             FIT_SWING_HYBRID, PLOT_TRAJECTORY_OVERLAY,
+%             PLOT_ERROR_TIMECOURSE, PLOT_FIT_QUALITY_CARD,
+%             ANIMATE_TRAJECTORY_OVERLAY, GRIP_FIT_PLAYBOOK.
+
+    arguments
+        target_or_xlsx
+        opts (1,1) struct = struct()
+    end
+
+    % ---- 1. Fill option defaults --------------------------------------
+    opts = local_fill_defaults(opts);
+
+    if opts.verbose
+        fprintf("[fit_swing_full_pipeline] option=%s sheet=%s save_dir=%s\n", ...
+                opts.option, opts.sheet, opts.save_dir);
+    end
+
+    pipeline_t0 = tic;
+
+    % ---- 2. Resolve target --------------------------------------------
+    target = local_resolve_target(target_or_xlsx, opts);
+
+    % ---- 3. Stage-1: starting pose ------------------------------------
+    if opts.skip_stage1
+        if opts.verbose
+            fprintf("[fit_swing_full_pipeline] Stage-1 skipped (opts.skip_stage1=true)\n");
+        end
+        stage1_overrides = struct();
+        stage1_duration_s = 0.0;
+    else
+        stage1_t0 = tic;
+        stage1_overrides = solve_starting_pose(target, ...
+                                               string(opts.input_mat), ...
+                                               opts.stage1_opts);
+        stage1_duration_s = toc(stage1_t0);
+        if opts.verbose
+            fprintf("[fit_swing_full_pipeline] Stage-1 done in %.2fs\n", ...
+                    stage1_duration_s);
+        end
+    end
+
+    % ---- 4. Inject overrides into Stage-2 sim opts --------------------
+    stage2_opts = opts.stage2_opts;
+    if ~isfield(stage2_opts, "sim") || ~isstruct(stage2_opts.sim)
+        stage2_opts.sim = default_sim_options();
+    end
+    stage2_opts.sim.input_overrides = local_merge_overrides( ...
+        local_get_field(stage2_opts.sim, "input_overrides", struct()), ...
+        stage1_overrides);
+
+    % ---- 5. Stage-2: dispatch the optimizer ---------------------------
+    [solver_fn, solver_name] = local_dispatch(opts.option);
+    if opts.verbose
+        fprintf("[fit_swing_full_pipeline] dispatching Stage-2 -> %s\n", ...
+                solver_name);
+    end
+    stage2_t0 = tic;
+    inner_result = solver_fn(target, stage2_opts);
+    stage2_duration_s = toc(stage2_t0);
+    if opts.verbose
+        fprintf("[fit_swing_full_pipeline] Stage-2 done in %.2fs\n", ...
+                stage2_duration_s);
+    end
+
+    % ---- 6. Ensure save dir exists ------------------------------------
+    if ~isfolder(opts.save_dir)
+        mkdir(opts.save_dir);
+    end
+
+    % ---- 7. Augment result --------------------------------------------
+    result = inner_result;
+    result.stage1_overrides   = stage1_overrides;
+    result.save_dir           = string(opts.save_dir);
+    result.target             = target;
+    result.stage1_duration_s  = stage1_duration_s;
+    result.stage2_duration_s  = stage2_duration_s;
+    result.pipeline_duration_s = toc(pipeline_t0);
+
+    % ---- 8. Render and save figures -----------------------------------
+    fig_paths = cell(0, 1);
+    if opts.render_figures
+        fig_paths = local_render_figures(result, target, opts);
+    end
+    result.figure_paths = fig_paths;
+
+    % ---- 9. Optional animation ----------------------------------------
+    if opts.save_animation && opts.render_figures
+        anim_path = local_render_animation(result, target, opts);
+        if strlength(string(anim_path)) > 0
+            result.animation_path = anim_path;
+        end
+    end
+
+    % ---- 10. Write report ---------------------------------------------
+    report_path = local_write_report(result, target, opts, solver_name);
+    result.report_path = string(report_path);
+
+    % ---- 11. Save the result struct -----------------------------------
+    result_mat = fullfile(opts.save_dir, "result.mat");
+    try
+        save(char(result_mat), "result", "-v7");
+    catch ME
+        if opts.verbose
+            fprintf("[fit_swing_full_pipeline] WARNING: could not save result.mat: %s\n", ...
+                    ME.message);
+        end
+    end
+
+    % ---- 12. Postconditions -------------------------------------------
+    assert(isfield(result, "stage1_overrides"), ...
+        "fit_swing_full_pipeline:postOverrides", ...
+        "Postcondition: result must have .stage1_overrides");
+    assert(isfield(result, "figure_paths") && iscell(result.figure_paths), ...
+        "fit_swing_full_pipeline:postFigPaths", ...
+        "Postcondition: result.figure_paths must be a cell array");
+    assert(isfield(result, "report_path") && ...
+           strlength(string(result.report_path)) > 0, ...
+        "fit_swing_full_pipeline:postReport", ...
+        "Postcondition: result.report_path must be a non-empty string");
+    assert(isfile(char(result.report_path)), ...
+        "fit_swing_full_pipeline:postReportFile", ...
+        "Postcondition: result.report_path must point at an existing file");
+    assert(isfolder(char(result.save_dir)), ...
+        "fit_swing_full_pipeline:postSaveDir", ...
+        "Postcondition: result.save_dir must exist");
+    assert(string(result.solver) == solver_name, ...
+        "fit_swing_full_pipeline:postSolver", ...
+        "Postcondition: result.solver must equal dispatched solver name");
+
+    if opts.verbose
+        fprintf("[fit_swing_full_pipeline] all done in %.2fs (RMSE=%.2f mm)\n", ...
+                result.pipeline_duration_s, ...
+                1000 * local_get_field(result, "final_rmse_m", NaN));
+    end
+end
+
+
+%% =====================================================================
+function opts = local_fill_defaults(opts)
+%LOCAL_FILL_DEFAULTS  Apply default values for unset OPTS fields.
+
+    if ~isfield(opts, "sheet"),           opts.sheet           = "TW_ProV1";    end
+    if ~isfield(opts, "option"),          opts.option          = "fmincon";     end
+    if ~isfield(opts, "render_figures"),  opts.render_figures  = true;          end
+    if ~isfield(opts, "save_animation"),  opts.save_animation  = false;         end
+    if ~isfield(opts, "skip_stage1"),     opts.skip_stage1     = false;         end
+    if ~isfield(opts, "verbose"),         opts.verbose         = true;          end
+
+    if ~isfield(opts, "save_dir") || strlength(string(opts.save_dir)) == 0
+        ts = char(datetime("now", "Format", "yyyyMMdd_HHmmss"));
+        opts.save_dir = fullfile("output", "fits", ts);
+    end
+    opts.save_dir = char(opts.save_dir);
+
+    if ~isfield(opts, "input_mat") || strlength(string(opts.input_mat)) == 0
+        opts.input_mat = local_default_input_mat();
+    end
+    opts.input_mat = char(opts.input_mat);
+
+    if ~isfield(opts, "stage1_opts"), opts.stage1_opts = struct(); end
+    if ~isstruct(opts.stage1_opts)
+        error("fit_swing_full_pipeline:badStage1Opts", ...
+              "Precondition: opts.stage1_opts must be a struct");
+    end
+    if ~isfield(opts.stage1_opts, "verbose")
+        opts.stage1_opts.verbose = opts.verbose;
+    end
+
+    if ~isfield(opts, "stage2_opts"), opts.stage2_opts = struct(); end
+    if ~isstruct(opts.stage2_opts)
+        error("fit_swing_full_pipeline:badStage2Opts", ...
+              "Precondition: opts.stage2_opts must be a struct");
+    end
+    % Seed Stage-2 from default_option1_options where available, then
+    % overlay caller-supplied fields (caller wins).
+    try
+        base_stage2 = default_option1_options();
+    catch
+        base_stage2 = struct();
+    end
+    opts.stage2_opts = local_merge_structs(base_stage2, opts.stage2_opts);
+    % Apply the grip-primary cost weights from the playbook (caller can
+    % override any of these by setting opts.stage2_opts.cost.<field>).
+    opts.stage2_opts.cost = local_apply_grip_primary_cost( ...
+        local_get_field(opts.stage2_opts, "cost", struct()));
+
+    if ~isfield(opts, "viz_opts") || ~isstruct(opts.viz_opts)
+        opts.viz_opts = default_viz_options();
+    else
+        opts.viz_opts = local_merge_structs(default_viz_options(), opts.viz_opts);
+    end
+    % Force headless rendering by default for batch / CI use; the caller
+    % can flip this back to "on" by setting opts.viz_opts.visible="on".
+    if ~isfield(opts.viz_opts, "visible") || ...
+            strlength(string(opts.viz_opts.visible)) == 0
+        opts.viz_opts.visible = "off";
+    end
+
+    % Validate dispatch name early so we fail fast.
+    local_validate_option(opts.option);
+end
+
+
+%% =====================================================================
+function cost = local_apply_grip_primary_cost(cost)
+%LOCAL_APPLY_GRIP_PRIMARY_COST  Seed grip-primary defaults; do not clobber
+%   any field the caller has already set.
+    try
+        base = default_cost_options();
+    catch
+        base = struct();
+    end
+    cost = local_merge_structs(base, cost);
+    if ~isfield(cost, "w_position_grip"),     cost.w_position_grip     = 1.0;          end
+    if ~isfield(cost, "w_orientation_grip"),  cost.w_orientation_grip  = 0.5;          end
+    if ~isfield(cost, "w_position_clubhead"), cost.w_position_clubhead = 0.0;          end
+    if ~isfield(cost, "w_orientation_club"),  cost.w_orientation_club  = 0.0;          end
+    if ~isfield(cost, "w_anchor_impact"),     cost.w_anchor_impact     = 10.0;         end
+    if ~isfield(cost, "lambda"),              cost.lambda              = 1e-4;         end
+    if ~isfield(cost, "regularizer"),         cost.regularizer         = "total_work"; end
+end
+
+
+%% =====================================================================
+function p = local_default_input_mat()
+%LOCAL_DEFAULT_INPUT_MAT  Best-effort path to 3DModelInputs_Impact.mat.
+%   Resolves relative to this .m file when running inside the repo; falls
+%   back to the bare filename so MATLAB's path search can find it.
+    here = fileparts(mfilename("fullpath"));
+    % shared/ -> motion_matching/ -> matlab/ -> 3D_Golf_Model/
+    engine_root = fileparts(fileparts(fileparts(here)));
+    candidate   = fullfile(engine_root, "src", "model", "inputs", ...
+                           "3DModelInputs_Impact.mat");
+    if isfile(candidate)
+        p = char(candidate);
+    else
+        p = "3DModelInputs_Impact.mat";
+    end
+end
+
+
+%% =====================================================================
+function local_validate_option(name)
+%LOCAL_VALIDATE_OPTION  Reject unknown optimizer names with a clear error.
+    allowed = ["fmincon", "multistart", "surrogate", "surrogateopt", "hybrid"];
+    if ~ismember(string(name), allowed)
+        error("fit_swing_full_pipeline:unknownOption", ...
+              "Unknown optimizer '%s'. Allowed: %s", ...
+              string(name), strjoin(allowed, ", "));
+    end
+end
+
+
+%% =====================================================================
+function [fn, name] = local_dispatch(option)
+%LOCAL_DISPATCH  Map option name -> {handle, canonical solver string}.
+    switch lower(string(option))
+        case "fmincon"
+            fn   = @fit_swing_fmincon;
+            name = "fmincon";
+        case "multistart"
+            fn   = @fit_swing_multistart;
+            name = "multistart";
+        case {"surrogate", "surrogateopt"}
+            fn   = @fit_swing_surrogateopt;
+            name = "surrogateopt";
+        case "hybrid"
+            fn   = @fit_swing_hybrid;
+            name = "hybrid";
+        otherwise
+            % Caught earlier by local_validate_option, but defensive.
+            error("fit_swing_full_pipeline:unknownOption", ...
+                  "Unknown optimizer '%s'", string(option));
+    end
+end
+
+
+%% =====================================================================
+function target = local_resolve_target(target_or_xlsx, opts)
+%LOCAL_RESOLVE_TARGET  Accept either an xlsx path or a pre-loaded struct.
+    if isstruct(target_or_xlsx)
+        target = target_or_xlsx;
+        required = ["time", "grip", "grip_quat", "butt", "clubhead", ...
+                    "club_quat", "impact_idx", "events"];
+        missing = setdiff(required, string(fieldnames(target)));
+        if ~isempty(missing)
+            error("fit_swing_full_pipeline:badTarget", ...
+                  "Precondition: target struct missing fields: %s", ...
+                  strjoin(missing, ", "));
+        end
+        return;
+    end
+    if ~(ischar(target_or_xlsx) || isstring(target_or_xlsx))
+        error("fit_swing_full_pipeline:badTarget", ...
+              "Precondition: target_or_xlsx must be a path or a struct");
+    end
+    xlsx_path = string(target_or_xlsx);
+    if ~isfile(xlsx_path)
+        error("fit_swing_full_pipeline:targetNotFound", ...
+              "Precondition: xlsx file not found: %s", xlsx_path);
+    end
+    target = load_club_target_excel(xlsx_path, string(opts.sheet));
+end
+
+
+%% =====================================================================
+function paths = local_render_figures(result, target, opts)
+%LOCAL_RENDER_FIGURES  Render the three canonical views and save as PNG.
+    paths = cell(0, 1);
+    save_dir = opts.save_dir;
+    viz = opts.viz_opts;
+
+    % Each renderer is wrapped in a try so a single crash doesn't abort
+    % the whole pipeline (useful when running before the model is fully
+    % wired but Stage-1/2 already ran).
+    paths = local_try_render(paths, save_dir, "trajectory_overlay.png", ...
+        @() plot_trajectory_overlay(result, target, viz), opts.verbose);
+    paths = local_try_render(paths, save_dir, "error_timecourse.png", ...
+        @() plot_error_timecourse(result, target, viz), opts.verbose);
+    paths = local_try_render(paths, save_dir, "fit_quality_card.png", ...
+        @() plot_fit_quality_card(result, target, viz), opts.verbose);
+end
+
+
+%% =====================================================================
+function paths = local_try_render(paths, save_dir, filename, render_fn, verbose)
+%LOCAL_TRY_RENDER  Best-effort render+save; never aborts the pipeline.
+    full_path = fullfile(save_dir, filename);
+    fig = [];
+    try
+        fig = render_fn();
+        if ~isempty(fig) && isgraphics(fig)
+            try
+                exportgraphics(fig, char(full_path), "Resolution", 200);
+            catch
+                saveas(fig, char(full_path));
+            end
+            paths{end + 1, 1} = char(full_path); %#ok<AGROW>
+        end
+    catch ME
+        if verbose
+            fprintf("[fit_swing_full_pipeline] WARNING: %s render failed: %s\n", ...
+                    filename, ME.message);
+        end
+    end
+    if ~isempty(fig) && isgraphics(fig)
+        try, close(fig); catch, end %#ok<NOCOM>
+    end
+end
+
+
+%% =====================================================================
+function anim_path = local_render_animation(result, target, opts)
+%LOCAL_RENDER_ANIMATION  Best-effort animation render.
+    anim_path = "";
+    out_path = fullfile(opts.save_dir, "trajectory_animation.mp4");
+    viz = opts.viz_opts;
+    viz.save_path = out_path;
+    try
+        animate_trajectory_overlay(result, target, viz);
+        anim_path = string(out_path);
+    catch ME
+        if opts.verbose
+            fprintf("[fit_swing_full_pipeline] WARNING: animation render failed: %s\n", ...
+                    ME.message);
+        end
+    end
+end
+
+
+%% =====================================================================
+function report_path = local_write_report(result, target, opts, solver_name)
+%LOCAL_WRITE_REPORT  Emit a plain-text human-readable summary.
+    report_path = fullfile(opts.save_dir, "report.txt");
+
+    rmse_mm = 1000 * local_get_field(result, "final_rmse_m", NaN);
+    work_J  = local_get_field(result, "final_total_work_J", NaN);
+    pipeline_s = local_get_field(result, "pipeline_duration_s", NaN);
+    stage1_s   = local_get_field(result, "stage1_duration_s", NaN);
+    stage2_s   = local_get_field(result, "stage2_duration_s", NaN);
+    target_hash = string(local_get_field(result, "target_hash", ""));
+    git_commit  = string(local_get_field(result, "git_commit", ""));
+    timestamp   = string(local_get_field(result, "timestamp_utc", ""));
+    exitflag    = local_get_field(result, "exitflag", NaN);
+
+    % Provenance for the target.
+    src = local_get_field(target, "source", struct());
+    src_filename = string(local_get_field(src, "filename", ""));
+    src_format   = string(local_get_field(src, "format", ""));
+    src_subject  = string(local_get_field(src, "subject_id", ""));
+    src_trial    = string(local_get_field(src, "trial_id", ""));
+    src_sha      = string(local_get_field(src, "sha256", ""));
+
+    % Solver options summary.
+    solver_opts = local_get_field(result, "solver_options", struct());
+    max_iter = local_get_field(solver_opts, "MaxIterations", ...
+                local_get_field(opts.stage2_opts, "max_iter", NaN));
+    if ~isnumeric(max_iter); max_iter = double(max_iter); end
+
+    % Cost breakdown.
+    terms = local_get_field(result, "final_cost_terms", struct());
+
+    % Stage-1 overrides table.
+    s1 = local_get_field(result, "stage1_overrides", struct());
+    s1_lines = local_format_overrides(s1);
+
+    fid = fopen(char(report_path), "w");
+    if fid < 0
+        error("fit_swing_full_pipeline:reportOpen", ...
+              "Could not open report file for writing: %s", report_path);
+    end
+    cleanup_fid = onCleanup(@() fclose(fid));
+
+    fprintf(fid, "Grip-Primary Swing Fit Report\n");
+    fprintf(fid, "================================\n\n");
+    fprintf(fid, "Timestamp (UTC) : %s\n", timestamp);
+    fprintf(fid, "Git commit      : %s\n", git_commit);
+    fprintf(fid, "Save dir        : %s\n", string(opts.save_dir));
+    fprintf(fid, "Sheet           : %s\n", string(opts.sheet));
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Target source\n");
+    fprintf(fid, "-------------\n");
+    fprintf(fid, "  filename   : %s\n", src_filename);
+    fprintf(fid, "  format     : %s\n", src_format);
+    fprintf(fid, "  subject_id : %s\n", src_subject);
+    fprintf(fid, "  trial_id   : %s\n", src_trial);
+    fprintf(fid, "  sha256     : %s\n", src_sha);
+    fprintf(fid, "  hash       : %s\n", target_hash);
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Pipeline timing\n");
+    fprintf(fid, "---------------\n");
+    fprintf(fid, "  total      : %s\n", local_fmt_seconds(pipeline_s));
+    fprintf(fid, "  Stage-1    : %s\n", local_fmt_seconds(stage1_s));
+    fprintf(fid, "  Stage-2    : %s\n", local_fmt_seconds(stage2_s));
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Stage-2 optimizer\n");
+    fprintf(fid, "-----------------\n");
+    fprintf(fid, "  name           : %s\n", solver_name);
+    fprintf(fid, "  MaxIterations  : %s\n", local_fmt_num(max_iter));
+    fprintf(fid, "  exitflag       : %s\n", local_fmt_num(exitflag));
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Fit quality\n");
+    fprintf(fid, "-----------\n");
+    fprintf(fid, "  grip RMSE      : %s mm\n", local_fmt_num(rmse_mm));
+    fprintf(fid, "  total work     : %s J\n", local_fmt_num(work_J));
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Terminal cost breakdown\n");
+    fprintf(fid, "-----------------------\n");
+    if isstruct(terms)
+        f = fieldnames(terms);
+        if isempty(f)
+            fprintf(fid, "  (no cost terms recorded)\n");
+        end
+        for k = 1:numel(f)
+            v = terms.(f{k});
+            if isnumeric(v) && isscalar(v)
+                fprintf(fid, "  %-15s: %s\n", f{k}, local_fmt_num(double(v)));
+            end
+        end
+    else
+        fprintf(fid, "  (cost-terms struct unavailable)\n");
+    end
+    fprintf(fid, "\n");
+
+    fprintf(fid, "Stage-1 overrides\n");
+    fprintf(fid, "-----------------\n");
+    if isempty(s1_lines)
+        fprintf(fid, "  (none — Stage-1 skipped or returned empty)\n");
+    else
+        for k = 1:numel(s1_lines)
+            fprintf(fid, "  %s\n", s1_lines{k});
+        end
+    end
+    fprintf(fid, "\n");
+
+    figs = local_get_field(result, "figure_paths", {});
+    fprintf(fid, "Figures\n");
+    fprintf(fid, "-------\n");
+    if isempty(figs)
+        fprintf(fid, "  (none rendered)\n");
+    else
+        for k = 1:numel(figs)
+            fprintf(fid, "  %s\n", figs{k});
+        end
+    end
+
+    clear cleanup_fid; %#ok<CLEAR>
+
+    if ~isfile(char(report_path))
+        error("fit_swing_full_pipeline:reportMissing", ...
+              "Postcondition: report file was not created at %s", report_path);
+    end
+end
+
+
+%% =====================================================================
+function lines = local_format_overrides(s)
+%LOCAL_FORMAT_OVERRIDES  Pretty-print an overrides struct as a cell of lines.
+    lines = {};
+    if ~isstruct(s); return; end
+    f = fieldnames(s);
+    for k = 1:numel(f)
+        v = s.(f{k});
+        if isnumeric(v) && isscalar(v)
+            lines{end + 1, 1} = sprintf("%-32s = %+.6f", f{k}, double(v)); %#ok<AGROW>
+        end
+    end
+end
+
+
+%% =====================================================================
+function s_out = local_merge_structs(base, overlay)
+%LOCAL_MERGE_STRUCTS  Shallow-merge: overlay fields win over base fields.
+    s_out = base;
+    if ~isstruct(overlay); return; end
+    f = fieldnames(overlay);
+    for k = 1:numel(f)
+        s_out.(f{k}) = overlay.(f{k});
+    end
+end
+
+
+%% =====================================================================
+function s_out = local_merge_overrides(base_overrides, stage1)
+%LOCAL_MERGE_OVERRIDES  Stage-1 fields are layered on top of any caller-
+%   supplied input_overrides.  Stage-1 wins on collisions.
+    s_out = base_overrides;
+    if ~isstruct(s_out); s_out = struct(); end
+    if ~isstruct(stage1); return; end
+    f = fieldnames(stage1);
+    for k = 1:numel(f)
+        s_out.(f{k}) = stage1.(f{k});
+    end
+end
+
+
+%% =====================================================================
+function v = local_get_field(s, name, default)
+    if isstruct(s) && isfield(s, name)
+        v = s.(name);
+    else
+        v = default;
+    end
+end
+
+
+%% =====================================================================
+function s = local_fmt_num(x)
+    if isnumeric(x) && isscalar(x) && isfinite(x)
+        if abs(x) >= 1e6 || (abs(x) > 0 && abs(x) < 1e-3)
+            s = sprintf("%.4e", double(x));
+        else
+            s = sprintf("%.4f", double(x));
+        end
+    else
+        s = "n/a";
+    end
+end
+
+
+%% =====================================================================
+function s = local_fmt_seconds(x)
+    if isnumeric(x) && isscalar(x) && isfinite(x) && x >= 0
+        s = sprintf("%.2fs", double(x));
+    else
+        s = "n/a";
+    end
+end

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/tests/test_fit_swing_full_pipeline.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/tests/test_fit_swing_full_pipeline.m
@@ -1,0 +1,247 @@
+classdef test_fit_swing_full_pipeline < matlab.unittest.TestCase
+%TEST_FIT_SWING_FULL_PIPELINE  Tests for the single-call M1 driver.
+%
+%   Mirrors the gating pattern from test_load_club_target_excel.m: tests
+%   that need MATLAB's Simulink toolbox or the Wiffle xlsx call
+%   testCase.assumeFail when those resources are absent so unit-only CI
+%   keeps passing.
+%
+%   GitHub issue: #4083.
+
+    properties
+        save_root  char
+    end
+
+    methods (TestClassSetup)
+        function add_paths(testCase)
+            here = fileparts(mfilename('fullpath'));
+            shared_dir = fileparts(here);
+            engine_root = fileparts(fileparts(shared_dir));
+            addpath(shared_dir);
+            addpath(genpath(fullfile(engine_root, 'motion_matching', ...
+                                     'option1_direct_optimization')));
+            testCase.addTeardown(@() rmpath(shared_dir));
+
+            % Tests scribble into a unique tempdir so we don't pollute
+            % the repo's output/ tree.
+            testCase.save_root = tempname;
+            mkdir(testCase.save_root);
+            testCase.addTeardown(@() local_safe_rmdir(testCase.save_root));
+        end
+    end
+
+    methods (Test)
+
+        %% ---------- Pure unit tests (no Simulink required) ------------
+
+        function test_unknown_optimizer_rejected(testCase)
+            target = local_make_stub_target();
+            opts = struct('option', 'totally_made_up_solver', ...
+                          'render_figures', false, ...
+                          'skip_stage1', true, ...
+                          'verbose', false, ...
+                          'save_dir', fullfile(testCase.save_root, "unknown"));
+            testCase.verifyError( ...
+                @() fit_swing_full_pipeline(target, opts), ...
+                "fit_swing_full_pipeline:unknownOption");
+        end
+
+        function test_target_struct_missing_required_fields(testCase)
+            % Strip 'grip_quat' from a stub; resolver should raise.
+            bad_target = local_make_stub_target();
+            bad_target = rmfield(bad_target, 'grip_quat');
+            opts = struct('render_figures', false, ...
+                          'skip_stage1', true, ...
+                          'verbose', false, ...
+                          'save_dir', fullfile(testCase.save_root, "missing_field"));
+            testCase.verifyError( ...
+                @() fit_swing_full_pipeline(bad_target, opts), ...
+                "fit_swing_full_pipeline:badTarget");
+        end
+
+        function test_xlsx_path_must_exist(testCase)
+            opts = struct('render_figures', false, ...
+                          'skip_stage1', true, ...
+                          'verbose', false, ...
+                          'save_dir', fullfile(testCase.save_root, "no_xlsx"));
+            testCase.verifyError( ...
+                @() fit_swing_full_pipeline("nonexistent_file.xlsx", opts), ...
+                "fit_swing_full_pipeline:targetNotFound");
+        end
+
+        function test_stage1_opts_must_be_struct(testCase)
+            target = local_make_stub_target();
+            opts = struct('stage1_opts', 'not a struct', ...
+                          'render_figures', false, ...
+                          'skip_stage1', true, ...
+                          'verbose', false, ...
+                          'save_dir', fullfile(testCase.save_root, "bad_stage1"));
+            testCase.verifyError( ...
+                @() fit_swing_full_pipeline(target, opts), ...
+                "fit_swing_full_pipeline:badStage1Opts");
+        end
+
+        function test_dispatch_uses_named_optimizer(testCase)
+            % Inject a fake fit_swing_<option> via opts trick: we can't
+            % easily monkeypatch in MATLAB, so this test verifies that
+            % the dispatcher accepts each documented option name without
+            % rejecting it during precondition validation.  The actual
+            % dispatched function will then attempt to run; we stop
+            % before that by setting skip_stage1=true and intercepting
+            % via verifyError on the *first* expected failure (Simulink
+            % missing) — but unit-only CI doesn't have that, so we
+            % verify the precondition gate accepts the names.
+            for option = ["fmincon", "multistart", "surrogate", ...
+                          "surrogateopt", "hybrid"]
+                target = local_make_stub_target();
+                opts = struct('option', option, ...
+                              'render_figures', false, ...
+                              'skip_stage1', true, ...
+                              'verbose', false, ...
+                              'save_dir', fullfile(testCase.save_root, ...
+                                                   "dispatch_" + option));
+                % We expect the dispatch *itself* to succeed (i.e., not
+                % error out with unknownOption). Whatever happens
+                % downstream — Simulink missing, etc. — is not an
+                % unknownOption error.
+                err = local_capture_error(@() ...
+                    fit_swing_full_pipeline(target, opts));
+                if ~isempty(err)
+                    testCase.verifyNotEqual(string(err.identifier), ...
+                        "fit_swing_full_pipeline:unknownOption", ...
+                        sprintf("Option '%s' unexpectedly hit unknownOption", option));
+                end
+            end
+        end
+
+        %% ---------- Live tests (require Simulink + model) -------------
+
+        function test_returns_augmented_result_struct(testCase)
+            % End-to-end: target -> Stage-1 -> Stage-2 -> figures ->
+            % report.  Verifies the augmented result struct contract.
+            testCase.assumeSimulinkAvailable();
+            xlsx = locate_xlsx_or_skip(testCase);
+            input_mat = locate_input_mat_or_skip(testCase);
+
+            save_dir = fullfile(testCase.save_root, "e2e");
+            opts = struct( ...
+                'sheet',          "TW_ProV1", ...
+                'option',         "fmincon", ...
+                'save_dir',       save_dir, ...
+                'render_figures', true, ...
+                'save_animation', false, ...
+                'input_mat',      input_mat, ...
+                'verbose',        false, ...
+                'stage1_opts',    struct('max_iters', 4, 'verbose', false), ...
+                'stage2_opts',    struct('max_iter',  uint32(2), ...
+                                         'max_function_evals', uint32(8), ...
+                                         'display', "off"));
+
+            result = fit_swing_full_pipeline(xlsx, opts);
+
+            for f = ["stage1_overrides", "figure_paths", "report_path", ...
+                     "save_dir", "target", "solver", "final_rmse_m"]
+                testCase.verifyTrue(isfield(result, f), ...
+                    sprintf("result missing field: %s", f));
+            end
+            testCase.verifyTrue(iscell(result.figure_paths));
+            testCase.verifyTrue(isstruct(result.stage1_overrides));
+            testCase.verifyTrue(isfile(char(result.report_path)));
+            testCase.verifyEqual(string(result.solver), "fmincon");
+            testCase.verifyTrue(isfolder(char(result.save_dir)));
+        end
+    end
+
+    %% --------------------- Helpers ------------------------------------
+    methods (Access = private)
+        function assumeSimulinkAvailable(testCase)
+            try
+                v = ver('simulink'); %#ok<VERMATLAB>
+            catch
+                v = [];
+            end
+            if isempty(v)
+                testCase.assumeFail("Simulink toolbox not installed");
+            end
+            if exist('GolfSwing3D_Kinetic', 'file') == 0 && ...
+               exist('GolfSwing3D_Kinetic.slx', 'file') == 0
+                testCase.assumeFail("GolfSwing3D_Kinetic.slx not on path");
+            end
+        end
+    end
+end
+
+
+%% =====================================================================
+function err = local_capture_error(fn)
+%LOCAL_CAPTURE_ERROR  Run fn(); return the MException it threw, or [] if
+%   it didn't throw.
+    err = [];
+    try
+        fn();
+    catch ME
+        err = ME;
+    end
+end
+
+
+%% =====================================================================
+function target = local_make_stub_target()
+%LOCAL_MAKE_STUB_TARGET  Minimal canonical target struct for unit tests.
+    N = 5;
+    target = struct( ...
+        'time',      (0:N-1).' / 240, ...
+        'grip',      repmat([0.10 0.20 0.95], N, 1), ...
+        'grip_quat', repmat([1 0 0 0], N, 1), ...
+        'butt',      repmat([0.10 0.20 0.95], N, 1), ...
+        'clubhead',  repmat([0.10 0.20 0.05], N, 1), ...
+        'club_quat', repmat([1 0 0 0], N, 1), ...
+        'impact_idx', 3, ...
+        'events',    struct('A_sample', 1, 'T_sample', 2, ...
+                            'I_sample', 3, 'F_sample', 4, 'CHS_mph', 100), ...
+        'source',    struct('filename', "stub.xlsx", 'format', "stub", ...
+                            'subject_id', "stub", 'trial_id', "stub", ...
+                            'sha256', repmat('0', 1, 64)));
+end
+
+
+%% =====================================================================
+function xlsx = locate_xlsx_or_skip(testCase)
+    here = fileparts(mfilename("fullpath"));
+    candidate = fullfile(here, ...
+        "..", "..", "..", "src", "apps", "golf_gui", ...
+        "Motion Capture Plotter", "Wiffle_ProV1_club_3D_data.xlsx");
+    if exist(candidate, "file") ~= 2
+        testCase.assumeFail( ...
+            "skipped — Wiffle_ProV1_club_3D_data.xlsx not present at " + ...
+            string(candidate));
+    end
+    xlsx = string(candidate);
+end
+
+
+%% =====================================================================
+function p = locate_input_mat_or_skip(testCase)
+    here = fileparts(mfilename("fullpath"));
+    shared_dir = fileparts(here);
+    engine_root = fileparts(fileparts(shared_dir));
+    candidate = fullfile(engine_root, "src", "model", "inputs", ...
+                         "3DModelInputs_Impact.mat");
+    if ~isfile(candidate)
+        testCase.assumeFail( ...
+            "skipped — 3DModelInputs_Impact.mat not present at " + ...
+            string(candidate));
+    end
+    p = char(candidate);
+end
+
+
+%% =====================================================================
+function local_safe_rmdir(p)
+    try
+        if isfolder(p)
+            rmdir(p, 's');
+        end
+    catch
+    end
+end


### PR DESCRIPTION
## Summary
- Codifies the GRIP_FIT_PLAYBOOK §6.4 copy-paste recipe as a reusable function: target -> Stage-1 starting pose -> Stage-2 dispatch -> figures -> save.
- Single entry point `fit_swing_full_pipeline(target_or_xlsx, opts)` accepts either an xlsx path (sheet via `opts.sheet`, default `TW_ProV1`) or a pre-loaded canonical target struct.
- Dispatches to `fit_swing_fmincon` (default), `fit_swing_multistart`, `fit_swing_surrogateopt`, or `fit_swing_hybrid` per `opts.option`. Unknown names raise a clear `fit_swing_full_pipeline:unknownOption` error.
- Renders `plot_trajectory_overlay`, `plot_error_timecourse`, `plot_fit_quality_card` (each best-effort, headless `Visible="off"` by default), saves them as PNGs, and writes a plain-text `report.txt` summarizing timing, grip RMSE in mm, target source provenance, optimizer name, MaxIterations, and the terminal cost breakdown.
- Default save dir is `output/fits/<yyyyMMdd_HHmmss>/`, auto-created. The engine's `output/.gitignore` already excludes everything under `output/`.
- Closes #4083.

## Notes
- Issue #4073 (CI smoke fit) can now be a one-line invocation of this function, e.g. `result = fit_swing_full_pipeline(xlsx, opts)`. Filed as follow-up; intentionally not in scope here.
- Stage-1 overrides are merged on top of any caller-supplied `opts.stage2_opts.sim.input_overrides` (Stage-1 wins on collision) before the Stage-2 dispatch.
- Grip-primary cost weights from the playbook are applied as defaults but never clobber a caller-supplied `opts.stage2_opts.cost.<field>`.
- The driver itself is a thin orchestrator: 659 lines total including the docstring, well under the 1200-line budget.

## Test plan
- [x] `motion_matching/shared/tests/test_fit_swing_full_pipeline.m` added covering: augmented `result` struct contract (figure_paths, report_path, stage1_overrides), optimizer dispatch for all five names, unknown-optimizer rejection, target-struct field validation, missing-xlsx error, bad `stage1_opts` rejection. The end-to-end test `assumeFail`s when the Wiffle xlsx, Impact MAT, or Simulink toolbox are missing — same gating pattern as `test_load_club_target_excel.m`.
- [ ] CI runs pre-existing pytest suite (MATLAB tests gated; live Stage-1/2 only runs locally with the model + xlsx present).