### PR TITLE
fix(drake): deepcopy _CANONICAL_SEGMENTS to avoid shared-state regression (closes #4217)

### DIFF
--- a/src/engines/physics_engines/drake/python/motion_matching/humanoid_urdf.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/humanoid_urdf.py
@@ -28,6 +28,7 @@ environments where ``pydrake`` is unavailable. Only the loader
 
 from __future__ import annotations
 
+import copy
 import xml.etree.ElementTree as ET  # noqa: N817
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -655,7 +656,7 @@ def load_humanoid_dimensions(
         hand_spacing_m=hand_spacing_m,
         total_mass_kg=total_mass_kg,
         total_height_m=total_height_m,
-        segments=_CANONICAL_SEGMENTS,
+        segments=copy.deepcopy(_CANONICAL_SEGMENTS),
         dimensions=dimensions,
         inertia=inertia_raw,
         topology=topo_raw,

--- a/tests/test_drake_urdf_generator.py
+++ b/tests/test_drake_urdf_generator.py
@@ -242,6 +242,29 @@ def test_aggregates_derived_from_canonical_yamls() -> None:
 
 
 @pytest.mark.unit
+def test_loader_returns_independent_segment_graph_each_call() -> None:
+    """Mutating one load's segments must not poison subsequent loads (#4217).
+
+    Regression: the previous implementation returned the module-level
+    ``_CANONICAL_SEGMENTS`` directly, so any caller mutating a segment
+    (test setup, custom post-processing) leaked into all later loads in
+    the same process.
+    """
+    dims_a = load_humanoid_dimensions()
+    dims_b = load_humanoid_dimensions()
+    # Different segment-list objects.
+    assert dims_a.segments is not dims_b.segments
+    # Different segment instances (and any nested mutables).
+    for seg_a, seg_b in zip(dims_a.segments, dims_b.segments, strict=True):
+        assert seg_a is not seg_b
+    # Mutating one must not affect the other.
+    original_name = dims_a.segments[0].name
+    object.__setattr__(dims_a.segments[0], "name", "MUTATED")
+    dims_c = load_humanoid_dimensions()
+    assert dims_c.segments[0].name == original_name
+
+
+@pytest.mark.unit
 def test_loader_raises_when_dimensions_yaml_empty(tmp_path: Path) -> None:
     """Empty dimensions YAML is a hard error with a descriptive message."""
     bad = tmp_path / "empty.yaml"


### PR DESCRIPTION
## Summary
- PR #4205 introduced a P2 regression: \`load_humanoid_dimensions()\` returned the module-level \`_CANONICAL_SEGMENTS\` directly, so any caller mutating a segment field leaked into subsequent loads in the same process.
- Restore the per-load fresh-graph invariant from the previous YAML-parsing path via \`copy.deepcopy\`.
- Adds a regression test asserting (a) different list/segment identities per load and (b) mutation of one load does not propagate to a fresh load.

Addresses P2 review feedback from PR #4205 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4205#discussion_r3198280081)).

Closes #4217.

## Test plan
- [x] \`test_loader_returns_independent_segment_graph_each_call\` added under \`@pytest.mark.unit\`
- [ ] CI runs full test suite