### PR TITLE
feat(surrogate): Option-2 NN swing surrogate + MATLAB shim (closes #4075)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,6 +341,7 @@ markers = [
     "requires_mujoco: tests that require the mujoco Python bindings (skipped when `import mujoco` fails)",
     "requires_opensim: tests that require the OpenSim Python bindings (skipped when `import opensim` fails)",
     "requires_matlab_engine: tests that require matlab.engine importable (Option 4 bridge)",
+    "requires_torch: tests that require PyTorch importable (skipped via importorskip when missing)",
 ]
 filterwarnings = [
     # Suppress hppfcl→coal rename noise (third-party, not actionable in this repo)

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/fit_swing_surrogate.m
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/fit_swing_surrogate.m
@@ -1,0 +1,306 @@
+function result = fit_swing_surrogate(target, opts)
+%FIT_SWING_SURROGATE  Option-2 NN-surrogate-based swing fit (#4075).
+%
+%   RESULT = FIT_SWING_SURROGATE(TARGET, OPTS) optimises polynomial torque
+%   coefficients THETA against TARGET using a trained PyTorch surrogate as
+%   the forward model -- *not* a fresh Simscape simulation per fmincon
+%   evaluation. The surrogate maps a 189-vec of polynomial coefficients to
+%   the resulting clubhead/grip trajectory in milliseconds.
+%
+%   The function is a thin orchestrator:
+%     1. Resolves the surrogate-checkpoint path (OPTS.surrogate_checkpoint
+%        or the default ``output/surrogate/checkpoint_best.pt`` on the repo
+%        root).
+%     2. Builds an initial guess THETA0 from OPTS.initial_theta when given,
+%        otherwise zeros (the trained surrogate is most reliable inside its
+%        training distribution and the dataset is centred near zero after
+%        normalisation).
+%     3. Wraps a Python predictor in a MATLAB function handle via
+%        ``pyrunfile`` so each fmincon evaluation is a sub-millisecond NN
+%        forward pass.
+%     4. Runs fmincon('algorithm','sqp') against the surrogate's predicted
+%        clubhead/grip trajectory.
+%     5. Assembles the canonical RESULT struct used elsewhere in
+%        motion_matching/ -- same field set as the Option 1 fit, with
+%        ``solver = "swing_surrogate"``.
+%
+%   TARGET is the canonical struct from shared/CLUB_IK_SPEC.md.
+%   OPTS is a 1x1 struct with optional fields:
+%       surrogate_checkpoint  string  Path to the trained .pt checkpoint.
+%       initial_theta         double  (189,1) starting coefficients.
+%       n_joints              double  Defaults to 27 (compact-schema).
+%       coeffs_per_joint      double  Defaults to 7.
+%       max_iter              double  fmincon MaxIterations (default 200).
+%       grip_weight           double  Weight on grip-RMSE term (default 1.0).
+%       clubhead_weight       double  Weight on clubhead-RMSE term (default 1.0).
+%       impact_weight         double  Weight on clubhead-speed-at-impact (1.0).
+%       python_executable     string  Override for the python interpreter.
+%
+%   Preconditions (DbC, validated by `arguments`):
+%     - TARGET has the required fields {time, butt|r_grip, clubhead}.
+%     - OPTS is a 1x1 struct.
+%     - The Python surrogate package is importable in the active pyenv.
+%
+%   Postconditions:
+%     - result.solver == "swing_surrogate".
+%     - 0 <= result.final_rmse_m < Inf.
+%     - result.coefficients has the documented length (n_joints * 7).
+%
+%   GitHub issue: #4075.
+%
+%   See also: FIT_SWING_FMINCON, COMPUTE_COST,
+%             src/shared/python/motion_matching/surrogate/compact/
+
+    arguments
+        target (1,1) struct
+        opts (1,1) struct = struct()
+    end
+
+    t_start = tic;
+
+    opts = local_apply_defaults(opts);
+    surrogate_checkpoint = local_resolve_checkpoint(opts);
+    n_joints = opts.n_joints;
+    coeffs_per_joint = opts.coeffs_per_joint;
+    coeff_dim = n_joints * coeffs_per_joint;
+
+    % ---- 1. Initial guess --------------------------------------------------
+    theta0 = local_initial_theta(opts, coeff_dim);
+
+    % ---- 2. Build the Python predictor closure -----------------------------
+    %        Each call hits a cached SwingSurrogate inside the Python pyenv,
+    %        so the per-evaluation cost is dominated by the NN forward pass
+    %        (typically 2-5 ms on CPU).
+    predictor = local_make_python_predictor(surrogate_checkpoint, opts);
+
+    target_traj = local_extract_target_trajectory(target);
+
+    % ---- 3. fmincon options ------------------------------------------------
+    [lb, ub] = local_default_bounds(n_joints);
+    cost_fn = @(theta) local_surrogate_cost(theta, predictor, target_traj, opts);
+    fmincon_opts = optimoptions('fmincon', ...
+        'Algorithm', 'sqp', ...
+        'Display', 'none', ...
+        'MaxIterations', opts.max_iter, ...
+        'MaxFunctionEvaluations', 50 * coeff_dim, ...
+        'StepTolerance', 1e-8, ...
+        'OptimalityTolerance', 1e-6, ...
+        'SpecifyObjectiveGradient', false);
+
+    [theta_star, fval, exitflag, output] = fmincon( ...
+        cost_fn, theta0, [], [], [], [], lb, ub, [], fmincon_opts);
+
+    % ---- 4. Final eval + RMSE breakdown ------------------------------------
+    final_pred = predictor(theta_star);
+    rmse_grip = local_rmse(final_pred.r_grip, target_traj.r_grip);
+    rmse_ch   = local_rmse(final_pred.r_clubhead, target_traj.r_clubhead);
+    final_rmse_m = sqrt(rmse_grip^2 + rmse_ch^2);
+
+    % ---- 5. Assemble result struct -----------------------------------------
+    result = struct();
+    result.coefficients       = theta_star(:);
+    result.final_rmse_m       = final_rmse_m;
+    result.final_grip_rmse_m  = rmse_grip;
+    result.final_ch_rmse_m    = rmse_ch;
+    result.final_cost_terms   = struct( ...
+        'cost', double(fval), ...
+        'grip_rmse_m', rmse_grip, ...
+        'clubhead_rmse_m', rmse_ch);
+    result.final_total_work_J = NaN;  % Surrogate doesn't predict work.
+    result.solver             = "swing_surrogate";
+    result.solver_options     = fmincon_opts;
+    result.surrogate_checkpoint = string(surrogate_checkpoint);
+    result.target_hash        = local_hash_target(target);
+    result.git_commit         = local_safe_git_commit();
+    result.matlab_version     = string(version);
+    result.duration_s         = toc(t_start);
+    result.timestamp_utc      = string(datetime("now","TimeZone","UTC", ...
+                                  "Format","yyyy-MM-dd'T'HH:mm:ss'Z'"));
+    result.iter_history       = table();
+    result.exitflag           = exitflag;
+    result.output             = output;
+    result.start_points       = theta0(:);
+    result.start_costs        = double(cost_fn(theta0));
+    result.cache_hit          = false;
+    result.options            = opts;
+
+    assert(isfinite(result.final_rmse_m) && result.final_rmse_m >= 0, ...
+        "fit_swing_surrogate:badRmse", ...
+        "Postcondition: final_rmse_m must be finite and non-negative");
+end
+
+
+% ========================================================================= %
+% Helpers                                                                   %
+% ========================================================================= %
+
+
+function opts = local_apply_defaults(opts)
+    if ~isfield(opts, 'n_joints'),         opts.n_joints = 27;          end
+    if ~isfield(opts, 'coeffs_per_joint'), opts.coeffs_per_joint = 7;   end
+    if ~isfield(opts, 'max_iter'),         opts.max_iter = 200;         end
+    if ~isfield(opts, 'grip_weight'),      opts.grip_weight = 1.0;      end
+    if ~isfield(opts, 'clubhead_weight'),  opts.clubhead_weight = 1.0;  end
+    if ~isfield(opts, 'impact_weight'),    opts.impact_weight = 1.0;    end
+    if ~isfield(opts, 'python_executable'), opts.python_executable = ""; end
+end
+
+
+function path = local_resolve_checkpoint(opts)
+    if isfield(opts, 'surrogate_checkpoint') && ...
+            ~isempty(opts.surrogate_checkpoint) && ...
+            strlength(string(opts.surrogate_checkpoint)) > 0
+        path = char(opts.surrogate_checkpoint);
+    else
+        % Default: <repo_root>/output/surrogate/checkpoint_best.pt
+        here = fileparts(mfilename('fullpath'));
+        repo_root = fullfile(here, '..', '..', '..', '..', '..', '..', '..');
+        path = fullfile(repo_root, 'output', 'surrogate', 'checkpoint_best.pt');
+    end
+    assert(exist(path, 'file') == 2, ...
+        "fit_swing_surrogate:missingCheckpoint", ...
+        "Surrogate checkpoint not found: %s", path);
+end
+
+
+function theta0 = local_initial_theta(opts, coeff_dim)
+    if isfield(opts, 'initial_theta') && ~isempty(opts.initial_theta)
+        theta0 = double(opts.initial_theta(:));
+        assert(numel(theta0) == coeff_dim, ...
+            "fit_swing_surrogate:badInitial", ...
+            "initial_theta length %d != expected %d", ...
+            numel(theta0), coeff_dim);
+    else
+        theta0 = zeros(coeff_dim, 1);
+    end
+end
+
+
+function predictor = local_make_python_predictor(checkpoint_path, opts)
+%LOCAL_MAKE_PYTHON_PREDICTOR  Build a function handle that runs the surrogate.
+%
+%   The handle is ``predictor(theta)`` where THETA is a (D,1) double; the
+%   return value is a struct with fields {r_clubhead, v_clubhead, r_grip,
+%   clubhead_speed} as ``T x 3`` (or ``T x 1``) MATLAB doubles.
+    if strlength(string(opts.python_executable)) > 0
+        % Best-effort pyenv switch -- silently noop if already configured.
+        try
+            pyenv('Version', char(opts.python_executable));
+        catch
+            % pyenv is process-global; ignore failures.
+        end
+    end
+
+    % We use ``pyrun`` with persistent state so the surrogate stays in
+    % memory between fmincon iterations.
+    pyrun_setup = sprintf([ ...
+        "import torch\n", ...
+        "from src.shared.python.motion_matching.surrogate.compact import (\n", ...
+        "    SwingSurrogate, predict_trajectory)\n", ...
+        "_surrogate_model = SwingSurrogate.from_checkpoint(r'''%s''')\n"], ...
+        checkpoint_path);
+    pyrun(pyrun_setup);
+
+    predictor = @(theta) local_invoke_python(theta);
+end
+
+
+function out = local_invoke_python(theta)
+%LOCAL_INVOKE_PYTHON  Run the surrogate once for a single (D,1) coefficient vec.
+    theta_py = py.numpy.asarray(double(theta(:)).');
+    res = pyrun( ...
+        "result = predict_trajectory(_surrogate_model, theta)", ...
+        "result", ...
+        "theta", theta_py);
+    out = struct();
+    out.r_clubhead     = double(res{'r_clubhead'});
+    out.v_clubhead     = double(res{'v_clubhead'});
+    out.r_grip         = double(res{'r_grip'});
+    out.clubhead_speed = double(res{'clubhead_speed'});
+    if isfield(res, 'shaft_axis')
+        out.shaft_axis = double(res{'shaft_axis'});
+    end
+    % predict_trajectory returns (B=1, T, k); squeeze leading batch dim.
+    fns = fieldnames(out);
+    for ii = 1:numel(fns)
+        v = out.(fns{ii});
+        if size(v, 1) == 1 && ndims(v) >= 2
+            out.(fns{ii}) = squeeze(v);
+        end
+    end
+end
+
+
+function tgt = local_extract_target_trajectory(target)
+%LOCAL_EXTRACT_TARGET_TRAJECTORY  Pull the channels the surrogate predicts.
+    tgt = struct();
+    if isfield(target, 'r_grip')
+        tgt.r_grip = double(target.r_grip);
+    elseif isfield(target, 'butt')
+        tgt.r_grip = double(target.butt);  % butt-end is grip-equivalent.
+    else
+        error("fit_swing_surrogate:noGrip", ...
+              "TARGET must contain r_grip (or butt as fallback).");
+    end
+    if isfield(target, 'r_clubhead')
+        tgt.r_clubhead = double(target.r_clubhead);
+    elseif isfield(target, 'clubhead')
+        tgt.r_clubhead = double(target.clubhead);
+    else
+        error("fit_swing_surrogate:noCH", ...
+              "TARGET must contain clubhead (or r_clubhead).");
+    end
+end
+
+
+function cost = local_surrogate_cost(theta, predictor, tgt, opts)
+%LOCAL_SURROGATE_COST  Weighted RMSE on grip/clubhead + impact-speed term.
+    pred = predictor(theta);
+    grip_diff = pred.r_grip - tgt.r_grip;
+    ch_diff   = pred.r_clubhead - tgt.r_clubhead;
+    grip_rmse = sqrt(mean(grip_diff(:).^2));
+    ch_rmse   = sqrt(mean(ch_diff(:).^2));
+    cost = opts.grip_weight * grip_rmse^2 + opts.clubhead_weight * ch_rmse^2;
+    if isfield(tgt, 'clubhead_speed') && isfield(pred, 'clubhead_speed')
+        speed_diff = pred.clubhead_speed - tgt.clubhead_speed;
+        cost = cost + opts.impact_weight * mean(speed_diff(:).^2);
+    end
+end
+
+
+function [lb, ub] = local_default_bounds(n_joints)
+%LOCAL_DEFAULT_BOUNDS  Per-letter bounds from PROJECT_SPEC.md §4, tiled.
+    bounds_per_letter = [1000; 1000; 500; 500; 100; 100; 25];
+    ub = repmat(bounds_per_letter, n_joints, 1);
+    lb = -ub;
+end
+
+
+function rmse = local_rmse(a, b)
+    rmse = sqrt(mean((a(:) - b(:)).^2));
+end
+
+
+function h = local_hash_target(target)
+    try
+        h = string(matlab.lang.makeValidName( ...
+            sprintf('%g_%g', sum(target.r_grip(:), 'omitnan'), ...
+                    sum(target.r_clubhead(:), 'omitnan'))));
+    catch
+        h = "unknown";
+    end
+end
+
+
+function commit = local_safe_git_commit()
+    try
+        [status, out] = system('git rev-parse --short HEAD');
+        if status == 0
+            commit = strtrim(string(out));
+        else
+            commit = "unknown";
+        end
+    catch
+        commit = "unknown";
+    end
+end

--- a/src/shared/python/motion_matching/surrogate/compact/__init__.py
+++ b/src/shared/python/motion_matching/surrogate/compact/__init__.py
@@ -1,0 +1,38 @@
+"""Compact-schema Option-2 NN swing surrogate (issue #4075).
+
+This package implements the ``SwingSurrogate`` forward model that maps a
+189-dim polynomial-coefficient vector to the resulting hand-path
+trajectory described by ``COMPACT_DATASET_SCHEMA.md``. Once trained, it
+replaces the slow Simscape forward simulation with a millisecond-scale
+neural network during motion-matching fits.
+
+Public API:
+    SwingSurrogate    -- pure-PyTorch ``nn.Module`` (4-layer MLP w/ residual blocks).
+    SurrogateConfig   -- frozen dataclass of architectural hyperparameters.
+    CoeffNormalizer   -- normalises the 189-dim coefficient vector to ``[-1, 1]``.
+    train_surrogate   -- training entry-point returning a :class:`TrainingResult`.
+    TrainingResult    -- frozen dataclass returned by training.
+    predict_trajectory -- vectorised inference helper returning physical units.
+
+Sibling implementation:
+    The earlier FiLM-MLP variant (PR #4025) lives in
+    ``src/shared/python/motion_matching/surrogate/model.py`` and is preserved
+    untouched for backward compatibility. The compact-schema variant in this
+    subpackage follows the contract documented in #4075 — single 12-channel
+    output trajectory of length 31 plus a normalised 189-dim input.
+"""
+
+from __future__ import annotations
+
+from .model import CoeffNormalizer, SurrogateConfig, SwingSurrogate
+from .predict import predict_trajectory
+from .training import TrainingResult, train_surrogate
+
+__all__ = [
+    "CoeffNormalizer",
+    "SurrogateConfig",
+    "SwingSurrogate",
+    "TrainingResult",
+    "predict_trajectory",
+    "train_surrogate",
+]

--- a/src/shared/python/motion_matching/surrogate/compact/model.py
+++ b/src/shared/python/motion_matching/surrogate/compact/model.py
@@ -1,0 +1,417 @@
+"""Option-2 NN swing surrogate: forward map ``coeffs -> trajectory``.
+
+This module implements the compact-schema variant requested in issue
+#4075. It maps a 189-dimensional polynomial-coefficient vector to a
+``(T=31, 12)`` kinematic trajectory of the hand path. The 12 output
+channels are::
+
+    [r_clubhead(3), v_clubhead(3), r_grip(3), clubhead_speed(1), shaft_axis(2)]
+
+where ``shaft_axis = (r_clubhead - r_grip) / ||·||`` is reduced to
+``(azimuth, polar)`` for stability (the model never predicts a raw 3-vec
+that would have to be re-normalised at inference time).
+
+Architecture (~700k params at the documented defaults):
+
+* **Coefficient encoder.** A linear projection ``189 -> hidden`` followed
+  by three pre-norm residual MLP blocks of width ``hidden=256``. Each
+  residual block is ``LayerNorm -> Linear -> GELU -> Linear``. This is
+  the "4-layer MLP with residual blocks" from the spec — one input layer
+  plus three residual blocks gives four learnable layers along the
+  coefficient path while keeping gradient flow stable.
+* **Decoder.** A single linear projection from the encoded latent to
+  ``T * 12`` outputs, reshaped to ``(B, T, 12)``. The decoder is
+  intentionally cheap because the per-timestep dynamics is already
+  captured by the coefficient encoding — the trajectory is a smooth
+  function of the encoded latent.
+
+Why this rather than e.g. a transformer? Two reasons. (1) The input is
+a fixed-shape 189-vec with no sequence structure: attention adds no
+inductive bias. (2) Inversion via gradient descent through the surrogate
+(the next step in the motion-matching pipeline) is cheaper through a
+shallow MLP than a transformer; per #4075 the surrogate has to run in
+"millisecond-scale" and back-prop in tens of ms.
+
+The polynomial bounds from PROJECT_SPEC.md §4 are ``|A,B|<=1000``,
+``|C,D|<=500``, ``|E,F|<=100``, ``|G|<=25`` for letters ``[A..G]`` of
+each of the 27 joints. The :class:`CoeffNormalizer` rescales the raw
+189-vec to ``[-1, 1]`` and back.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+_LOGGER = logging.getLogger(__name__)
+
+# --- Physical constants (from PROJECT_SPEC.md §4 + COMPACT_DATASET_SCHEMA.md) ---
+
+#: Number of joints in the canonical compact-dataset ordering.
+N_JOINTS_DEFAULT: int = 27
+#: Polynomial coefficients per joint (letters A..G).
+COEFFS_PER_JOINT: int = 7
+#: Flattened coefficient-vector dimension.
+COEFF_DIM_DEFAULT: int = N_JOINTS_DEFAULT * COEFFS_PER_JOINT  # 189
+#: Number of timesteps in the compact dataset (≈ 0.30 s × 100 Hz + 1).
+SEQ_LEN_DEFAULT: int = 31
+#: Output channels: r_ch(3) + v_ch(3) + r_grip(3) + chs(1) + shaft_axis(2).
+OUT_CHANNELS: int = 12
+
+#: Per-letter coefficient bound (``|A|<=1000`` etc.) — letters A..G in order.
+COEFF_BOUNDS: tuple[float, ...] = (1000.0, 1000.0, 500.0, 500.0, 100.0, 100.0, 25.0)
+
+
+# --------------------------------------------------------------------------- #
+# Configuration                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class SurrogateConfig:
+    """Frozen architectural configuration for :class:`SwingSurrogate`.
+
+    Attributes:
+        n_joints: Number of joints (default 27 per the compact schema).
+        coeffs_per_joint: Polynomial coefficients per joint (default 7).
+        seq_len: Output trajectory length (default 31, matches compact data).
+        hidden_dim: Hidden width of the encoder (default 256).
+        n_residual_blocks: Number of pre-norm residual MLP blocks (default 3,
+            which combined with the input projection gives the "4-layer MLP"
+            from the spec).
+        decoder_hidden: Optional widening of the decoder MLP. ``None`` uses a
+            single ``Linear`` layer. Set e.g. ``512`` for a 2-layer decoder.
+        dropout: Dropout probability after each residual block (default 0.0).
+    """
+
+    n_joints: int = N_JOINTS_DEFAULT
+    coeffs_per_joint: int = COEFFS_PER_JOINT
+    seq_len: int = SEQ_LEN_DEFAULT
+    hidden_dim: int = 256
+    n_residual_blocks: int = 3
+    decoder_hidden: int | None = None
+    dropout: float = 0.0
+    coeff_bounds: tuple[float, ...] = field(default=COEFF_BOUNDS)
+
+    @property
+    def coeff_dim(self) -> int:
+        """Flat coefficient-vector dimension."""
+        return self.n_joints * self.coeffs_per_joint
+
+    @property
+    def out_channels(self) -> int:
+        """Number of output channels per timestep (=12)."""
+        return OUT_CHANNELS
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` for any field that breaks the architecture."""
+        if self.n_joints <= 0:
+            raise ValueError(f"n_joints must be positive, got {self.n_joints}")
+        if self.coeffs_per_joint <= 0:
+            raise ValueError(
+                f"coeffs_per_joint must be positive, got {self.coeffs_per_joint}"
+            )
+        if self.seq_len <= 1:
+            raise ValueError(f"seq_len must be > 1, got {self.seq_len}")
+        if self.hidden_dim <= 0:
+            raise ValueError(f"hidden_dim must be positive, got {self.hidden_dim}")
+        if self.n_residual_blocks < 1:
+            raise ValueError(
+                f"n_residual_blocks must be >= 1, got {self.n_residual_blocks}"
+            )
+        if not (0.0 <= self.dropout < 1.0):
+            raise ValueError(f"dropout must be in [0, 1), got {self.dropout}")
+        if self.decoder_hidden is not None and self.decoder_hidden <= 0:
+            raise ValueError(
+                f"decoder_hidden must be positive when set, got {self.decoder_hidden}"
+            )
+        if len(self.coeff_bounds) != self.coeffs_per_joint:
+            raise ValueError(
+                "coeff_bounds length must equal coeffs_per_joint "
+                f"({self.coeffs_per_joint}); got {len(self.coeff_bounds)}"
+            )
+        if any(b <= 0 for b in self.coeff_bounds):
+            raise ValueError("every coeff_bound must be strictly positive")
+
+
+# --------------------------------------------------------------------------- #
+# Coefficient normalisation                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class CoeffNormalizer:
+    """Maps the raw 189-vec to ``[-1, 1]`` and back, per PROJECT_SPEC.md §4.
+
+    Bounds are per-letter (``A..G``), tiled once per joint:
+        ``|A,B| <= 1000, |C,D| <= 500, |E,F| <= 100, |G| <= 25``.
+
+    The class is intentionally not an ``nn.Module`` — the bounds are
+    fixed physical constants, not learnable parameters.
+    """
+
+    def __init__(
+        self,
+        n_joints: int = N_JOINTS_DEFAULT,
+        coeff_bounds: Sequence[float] = COEFF_BOUNDS,
+    ) -> None:
+        if n_joints <= 0:
+            raise ValueError(f"n_joints must be positive, got {n_joints}")
+        if any(b <= 0 for b in coeff_bounds):
+            raise ValueError("every coeff_bound must be strictly positive")
+        self._n_joints = int(n_joints)
+        self._coeffs_per_joint = len(coeff_bounds)
+        # Repeat the per-letter bounds across joints — shape (n_joints*L,).
+        self._scale = torch.tensor(
+            list(coeff_bounds) * self._n_joints, dtype=torch.float32
+        )
+
+    @property
+    def coeff_dim(self) -> int:
+        """Total flat coefficient dimension."""
+        return self._n_joints * self._coeffs_per_joint
+
+    @property
+    def scale(self) -> torch.Tensor:
+        """Per-coefficient bound vector (shape ``(coeff_dim,)``)."""
+        return self._scale
+
+    def normalize(self, coeffs: torch.Tensor) -> torch.Tensor:
+        """Return ``coeffs / scale`` clamped to ``[-1, 1]``.
+
+        Args:
+            coeffs: ``(B, coeff_dim)`` raw polynomial coefficients in the
+                physical units of PROJECT_SPEC.md §4.
+
+        Returns:
+            ``(B, coeff_dim)`` tensor in ``[-1, 1]``.
+
+        Raises:
+            ValueError: If the trailing dim does not match ``coeff_dim``.
+        """
+        self._check_shape(coeffs)
+        scale = self._scale.to(coeffs.device).to(coeffs.dtype)
+        return torch.clamp(coeffs / scale, min=-1.0, max=1.0)
+
+    def denormalize(self, coeffs_norm: torch.Tensor) -> torch.Tensor:
+        """Inverse of :meth:`normalize` — returns physical-unit coefficients."""
+        self._check_shape(coeffs_norm)
+        scale = self._scale.to(coeffs_norm.device).to(coeffs_norm.dtype)
+        return coeffs_norm * scale
+
+    def _check_shape(self, coeffs: torch.Tensor) -> None:
+        if coeffs.ndim != 2:
+            raise ValueError(
+                f"coeffs must be 2-D (B, coeff_dim); got ndim={coeffs.ndim}"
+            )
+        if coeffs.shape[-1] != self.coeff_dim:
+            raise ValueError(
+                f"coeffs trailing dim {coeffs.shape[-1]} != expected {self.coeff_dim}"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Architecture                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class _ResidualBlock(nn.Module):
+    """Pre-norm residual MLP block: ``x + Linear(GELU(Linear(LayerNorm(x))))``."""
+
+    def __init__(self, hidden_dim: int, dropout: float) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_dim)
+        self.fc1 = nn.Linear(hidden_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.drop = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        h = self.norm(x)
+        h = self.fc1(h)
+        h = F.gelu(h)
+        h = self.fc2(h)
+        h = self.drop(h)
+        return residual + h
+
+
+class SwingSurrogate(nn.Module):
+    """Forward surrogate ``(B, 189) -> (B, 31, 12)``.
+
+    Input contract:
+        * ``coeffs.shape == (B, cfg.coeff_dim)``.
+        * ``coeffs.dtype == torch.float32``.
+        * ``coeffs`` already normalised to ``[-1, 1]`` (use
+          :class:`CoeffNormalizer` to enforce this).
+
+    Output contract:
+        * ``traj.shape == (B, cfg.seq_len, 12)``.
+        * Channel order ``[r_clubhead(3), v_clubhead(3), r_grip(3),
+          clubhead_speed(1), shaft_axis_az_pol(2)]``.
+        * ``traj.dtype == torch.float32``.
+    """
+
+    def __init__(self, cfg: SurrogateConfig | None = None) -> None:
+        super().__init__()
+        cfg = cfg if cfg is not None else SurrogateConfig()
+        cfg.validate()
+        self.cfg = cfg
+
+        self.input_proj = nn.Linear(cfg.coeff_dim, cfg.hidden_dim)
+        self.blocks = nn.ModuleList(
+            [
+                _ResidualBlock(cfg.hidden_dim, cfg.dropout)
+                for _ in range(cfg.n_residual_blocks)
+            ]
+        )
+        self.head_norm = nn.LayerNorm(cfg.hidden_dim)
+
+        out_dim = cfg.seq_len * cfg.out_channels
+        if cfg.decoder_hidden is None:
+            self.decoder: nn.Module = nn.Linear(cfg.hidden_dim, out_dim)
+        else:
+            self.decoder = nn.Sequential(
+                nn.Linear(cfg.hidden_dim, cfg.decoder_hidden),
+                nn.GELU(),
+                nn.Linear(cfg.decoder_hidden, out_dim),
+            )
+        self._init_weights()
+
+    # ----- public ----- #
+
+    def forward(self, coeffs: torch.Tensor) -> torch.Tensor:
+        """Map normalised polynomial coefficients to a hand-path trajectory.
+
+        Args:
+            coeffs: ``(B, coeff_dim)`` float32 tensor in ``[-1, 1]``. The
+                caller is responsible for normalisation — see
+                :class:`CoeffNormalizer`.
+
+        Returns:
+            ``(B, seq_len, 12)`` float32 trajectory tensor.
+
+        Raises:
+            TypeError: If ``coeffs`` is not a floating-point tensor.
+            ValueError: If shape, dtype, or value range is wrong.
+        """
+        self._validate_input(coeffs)
+        h = self.input_proj(coeffs)
+        for block in self.blocks:
+            h = block(h)
+        h = self.head_norm(h)
+        flat = self.decoder(h)
+        return flat.view(-1, self.cfg.seq_len, self.cfg.out_channels)
+
+    @torch.no_grad()
+    def parameter_count(self) -> int:
+        """Return the total number of learnable parameters."""
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+    # ----- private ----- #
+
+    def _validate_input(self, coeffs: torch.Tensor) -> None:
+        if not isinstance(coeffs, torch.Tensor):
+            raise TypeError(
+                f"coeffs must be a torch.Tensor, got {type(coeffs).__name__}"
+            )
+        if not coeffs.is_floating_point():
+            raise TypeError(
+                f"coeffs must be a floating-point tensor, got dtype={coeffs.dtype}"
+            )
+        if coeffs.dtype != torch.float32:
+            raise TypeError(
+                f"coeffs dtype must be torch.float32 per the contract, "
+                f"got {coeffs.dtype}"
+            )
+        if coeffs.ndim != 2:
+            raise ValueError(
+                f"coeffs must be 2-D (B, {self.cfg.coeff_dim}); "
+                f"got ndim={coeffs.ndim}, shape={tuple(coeffs.shape)}"
+            )
+        if coeffs.shape[-1] != self.cfg.coeff_dim:
+            raise ValueError(
+                f"coeffs trailing dim {coeffs.shape[-1]} != "
+                f"cfg.coeff_dim ({self.cfg.coeff_dim})"
+            )
+        # Normalisation contract: ``coeffs in [-1, 1]`` after CoeffNormalizer.
+        # We allow a small slack for fp jitter + downstream gradient steps
+        # that can briefly leave the unit cube during inversion.
+        if torch.is_grad_enabled() and coeffs.requires_grad:
+            return
+        with torch.no_grad():
+            max_abs = coeffs.abs().max().item() if coeffs.numel() else 0.0
+        if max_abs > 1.0 + 1e-3:
+            _LOGGER.debug(
+                "SwingSurrogate received coeffs with max-abs %.3f > 1; "
+                "did you forget to call CoeffNormalizer.normalize()?",
+                max_abs,
+            )
+
+    def _init_weights(self) -> None:
+        """Xavier-init linear layers; zero biases for stable training start."""
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.xavier_uniform_(module.weight, gain=1.0 / math.sqrt(2))
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+            elif isinstance(module, nn.LayerNorm):
+                nn.init.ones_(module.weight)
+                nn.init.zeros_(module.bias)
+
+
+# --------------------------------------------------------------------------- #
+# Channel-layout helpers                                                      #
+# --------------------------------------------------------------------------- #
+
+#: Output-channel slices (start, stop) — single source of truth.
+CHANNEL_SLICES: dict[str, tuple[int, int]] = {
+    "r_clubhead": (0, 3),
+    "v_clubhead": (3, 6),
+    "r_grip": (6, 9),
+    "clubhead_speed": (9, 10),
+    "shaft_axis_az_pol": (10, 12),
+}
+
+
+def shaft_axis_to_az_pol(shaft_axis_xyz: torch.Tensor) -> torch.Tensor:
+    """Convert a unit ``shaft_axis`` vector to ``(azimuth, polar)``.
+
+    Args:
+        shaft_axis_xyz: ``(..., 3)`` tensor; need not be unit-norm
+            (this function normalises it first).
+
+    Returns:
+        ``(..., 2)`` tensor of ``(azimuth, polar)`` angles in radians.
+        Azimuth is ``atan2(y, x)`` in ``[-pi, pi]``; polar is
+        ``acos(z / ||v||)`` in ``[0, pi]``.
+
+    Raises:
+        ValueError: If the trailing dim is not 3.
+    """
+    if shaft_axis_xyz.shape[-1] != 3:
+        raise ValueError(
+            f"shaft_axis_xyz must have trailing dim 3; got {shaft_axis_xyz.shape}"
+        )
+    norm = shaft_axis_xyz.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    unit = shaft_axis_xyz / norm
+    azimuth = torch.atan2(unit[..., 1], unit[..., 0])
+    polar = torch.acos(unit[..., 2].clamp(-1.0, 1.0))
+    return torch.stack([azimuth, polar], dim=-1)
+
+
+def az_pol_to_shaft_axis(az_pol: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`shaft_axis_to_az_pol` — back to a unit 3-vec."""
+    if az_pol.shape[-1] != 2:
+        raise ValueError(f"az_pol must have trailing dim 2; got {az_pol.shape}")
+    azimuth = az_pol[..., 0]
+    polar = az_pol[..., 1]
+    sin_p = torch.sin(polar)
+    x = sin_p * torch.cos(azimuth)
+    y = sin_p * torch.sin(azimuth)
+    z = torch.cos(polar)
+    return torch.stack([x, y, z], dim=-1)

--- a/src/shared/python/motion_matching/surrogate/compact/predict.py
+++ b/src/shared/python/motion_matching/surrogate/compact/predict.py
@@ -1,0 +1,207 @@
+"""Inference helpers for the compact-schema swing surrogate.
+
+Exposed surface:
+    SwingSurrogate.from_checkpoint(path)
+        Factory bound to :class:`SwingSurrogate` via ``__init_subclass__``-free
+        monkey-patching at import time.
+    predict_trajectory(model, theta) -> dict[str, np.ndarray]
+        Vectorised inference returning physical-unit channel arrays.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from .model import (
+    CHANNEL_SLICES,
+    CoeffNormalizer,
+    SurrogateConfig,
+    SwingSurrogate,
+    az_pol_to_shaft_axis,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_M_PER_MM = 1e-3
+_MS_PER_MPH = 1.0 / 2.2369362920544  # 1 mph -> m/s
+
+
+# --------------------------------------------------------------------------- #
+# Checkpoint factory                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _config_from_payload(payload: dict[str, Any]) -> SurrogateConfig:
+    """Reconstruct a :class:`SurrogateConfig` from the saved-payload dict."""
+    raw = dict(payload.get("config", {}))
+    if "coeff_bounds" in raw and raw["coeff_bounds"] is not None:
+        raw["coeff_bounds"] = tuple(raw["coeff_bounds"])
+    if "decoder_hidden" in raw and raw["decoder_hidden"] is not None:
+        raw["decoder_hidden"] = int(raw["decoder_hidden"])
+    return SurrogateConfig(**raw)
+
+
+def _from_checkpoint(
+    cls: type[SwingSurrogate],
+    path: str | Path,
+    *,
+    map_location: str | torch.device = "cpu",
+    strict: bool = True,
+) -> SwingSurrogate:
+    """Load a serialised :class:`SwingSurrogate` from ``path``.
+
+    Args:
+        cls: Always ``SwingSurrogate`` (bound by ``classmethod``).
+        path: Checkpoint file (typically ``checkpoint_best.pt``).
+        map_location: Torch device for the loaded weights.
+        strict: Pass-through to ``Module.load_state_dict``.
+
+    Returns:
+        A configured :class:`SwingSurrogate` with weights loaded and the
+        normaliser remembered as the ``coeff_normalizer`` attribute.
+
+    Raises:
+        FileNotFoundError: If the checkpoint does not exist.
+        ValueError: If the payload schema is unrecognised.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"checkpoint not found: {p}")
+    payload = torch.load(p, map_location=map_location, weights_only=False)
+    if "model_state_dict" not in payload:
+        raise ValueError(
+            f"checkpoint missing 'model_state_dict' key (got keys={list(payload)})"
+        )
+    cfg = _config_from_payload(payload)
+    model = cls(cfg)
+    model.load_state_dict(payload["model_state_dict"], strict=strict)
+    model.eval()
+    norm_meta = payload.get("normalizer", {})
+    bounds = norm_meta.get("coeff_bounds", cfg.coeff_bounds)
+    n_joints = norm_meta.get("n_joints", cfg.n_joints)
+    model.coeff_normalizer = CoeffNormalizer(  # type: ignore[attr-defined]
+        n_joints=n_joints, coeff_bounds=tuple(bounds)
+    )
+    return model
+
+
+# Bind ``from_checkpoint`` as a classmethod on SwingSurrogate at import time.
+# (Spec asks for ``SwingSurrogate.from_checkpoint(path)``.)
+SwingSurrogate.from_checkpoint = classmethod(_from_checkpoint)  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------- #
+# Vectorised prediction                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _coerce_theta(theta: Any) -> torch.Tensor:
+    """Accept numpy arrays / lists / tensors; return ``(B, D)`` float32 tensor."""
+    if isinstance(theta, torch.Tensor):
+        t = theta.to(dtype=torch.float32)
+    else:
+        t = torch.as_tensor(np.asarray(theta), dtype=torch.float32)
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    if t.ndim != 2:
+        raise ValueError(
+            f"theta must be 1-D (D,) or 2-D (B, D); got ndim={t.ndim}, "
+            f"shape={tuple(t.shape)}"
+        )
+    return t
+
+
+def predict_trajectory(
+    model: SwingSurrogate,
+    theta: np.ndarray | torch.Tensor | list[float],
+    *,
+    device: str | torch.device | None = None,
+) -> dict[str, np.ndarray]:
+    """Run the surrogate on raw (physical-unit) coefficients.
+
+    Args:
+        model: A trained :class:`SwingSurrogate` (loaded via
+            :meth:`SwingSurrogate.from_checkpoint` so ``coeff_normalizer``
+            is set, or constructed manually with one assigned).
+        theta: ``(D,)`` or ``(B, D)`` polynomial coefficients in physical
+            units (the bounds documented in PROJECT_SPEC.md §4).
+        device: Optional override; defaults to the device the model is on.
+
+    Returns:
+        Dict of numpy arrays in physical units::
+
+            r_clubhead:    (B, T, 3)  metres
+            v_clubhead:    (B, T, 3)  m/s
+            r_grip:        (B, T, 3)  metres
+            clubhead_speed:(B, T)     mph
+            shaft_axis:    (B, T, 3)  unit vector (denormalised from az/polar)
+
+    Raises:
+        AttributeError: If ``model.coeff_normalizer`` is missing.
+        ValueError: If ``theta`` shape doesn't match the model.
+    """
+    if not hasattr(model, "coeff_normalizer"):
+        raise AttributeError(
+            "model.coeff_normalizer is missing — load via "
+            "SwingSurrogate.from_checkpoint() or assign a CoeffNormalizer"
+        )
+    normalizer: CoeffNormalizer = model.coeff_normalizer  # type: ignore[attr-defined]
+    target_device = (
+        torch.device(device) if device is not None else next(model.parameters()).device
+    )
+    theta_t = _coerce_theta(theta).to(target_device)
+    if theta_t.shape[-1] != model.cfg.coeff_dim:
+        raise ValueError(
+            f"theta trailing dim {theta_t.shape[-1]} != model.cfg.coeff_dim "
+            f"({model.cfg.coeff_dim})"
+        )
+
+    model.eval()
+    with torch.no_grad():
+        coeffs_norm = normalizer.normalize(theta_t)
+        traj = model(coeffs_norm)
+    traj_np = traj.detach().cpu().numpy()
+    return _split_channels(traj_np)
+
+
+def _split_channels(traj: np.ndarray) -> dict[str, np.ndarray]:
+    """Slice a ``(B, T, 12)`` array into the documented physical-unit dict.
+
+    Conversion notes:
+        * ``r_*`` and ``v_*`` are already in metres / m/s — they pass through.
+        * ``clubhead_speed`` is in mph in the compact dataset, so it stays mph.
+        * ``shaft_axis`` is reconstructed from the (azimuth, polar) channels
+          back into a unit ``(x, y, z)`` 3-vec.
+    """
+    if traj.ndim != 3 or traj.shape[-1] != 12:
+        raise ValueError(f"expected (B, T, 12) trajectory, got shape={traj.shape}")
+    out: dict[str, np.ndarray] = {}
+    for name, (lo, hi) in CHANNEL_SLICES.items():
+        if name == "clubhead_speed":
+            out[name] = traj[..., lo:hi].squeeze(-1)
+        elif name == "shaft_axis_az_pol":
+            az_pol = torch.as_tensor(traj[..., lo:hi], dtype=torch.float32)
+            shaft = az_pol_to_shaft_axis(az_pol).numpy()
+            out["shaft_axis"] = shaft
+        else:
+            out[name] = traj[..., lo:hi]
+    return out
+
+
+def predict_clubhead_speed_ms(
+    model: SwingSurrogate,
+    theta: np.ndarray | torch.Tensor,
+) -> np.ndarray:
+    """Convenience wrapper: clubhead speed in metres/second.
+
+    The surrogate emits mph (matching the compact dataset's
+    ``clubhead_speed_mph`` column); this helper converts to SI for callers
+    that prefer metres.
+    """
+    out = predict_trajectory(model, theta)
+    return out["clubhead_speed"] * _MS_PER_MPH

--- a/src/shared/python/motion_matching/surrogate/compact/training.py
+++ b/src/shared/python/motion_matching/surrogate/compact/training.py
@@ -1,0 +1,689 @@
+"""Training loop for the compact-schema Option-2 NN swing surrogate.
+
+This module trains :class:`SwingSurrogate` against the compact swing
+parquet dataset documented in
+``src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/COMPACT_DATASET_SCHEMA.md``.
+
+The expected on-disk layout is::
+
+    <dataset_path>/
+        trials.parquet     # one row per simulation, includes 189-vec coefficients
+        timesteps.parquet  # one row per (trial_id, t) sample
+
+Public surface:
+    train_surrogate -- run the training loop and return a TrainingResult.
+    TrainingResult  -- frozen dataclass of artefacts produced by training.
+
+Loss design (as required by #4075):
+    * MSE per output channel.
+    * An additional weighted term on clubhead-speed-at-impact (the channel
+      everyone cares about most).
+
+Checkpointing:
+    Each epoch writes ``checkpoint_epoch_<N>.pt`` and an updated
+    ``metrics.json`` to ``output/surrogate/<timestamp>/`` (or to a
+    user-supplied directory).
+
+Early stopping:
+    Patience of 10 epochs on validation grip-RMSE (in mm).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import time
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset
+
+from .model import (
+    CHANNEL_SLICES,
+    CoeffNormalizer,
+    SurrogateConfig,
+    SwingSurrogate,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Conversion factors (dataset units -> training-loss units).
+_M_PER_MM = 1e-3
+_MPH_PER_MS = 2.2369362920544  # 1 m/s in mph
+
+
+# --------------------------------------------------------------------------- #
+# Result dataclass                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TrainingResult:
+    """Frozen snapshot of a training run.
+
+    Attributes:
+        output_dir: Directory containing checkpoints + ``metrics.json``.
+        best_checkpoint: Path to the best-val-grip-RMSE checkpoint.
+        last_checkpoint: Path to the final-epoch checkpoint.
+        best_epoch: 1-indexed epoch at which best val grip-RMSE was hit.
+        best_val_loss: Lowest val loss observed.
+        best_val_grip_rmse_mm: Lowest val grip-RMSE observed (mm).
+        history: Per-epoch metrics dict (lists of floats, plus epoch index).
+        config: Surrogate config that was trained.
+        total_seconds: Wall-clock duration of the run.
+        param_count: Trainable parameter count of the model.
+    """
+
+    output_dir: Path
+    best_checkpoint: Path
+    last_checkpoint: Path
+    best_epoch: int
+    best_val_loss: float
+    best_val_grip_rmse_mm: float
+    history: dict[str, list[float]] = field(default_factory=dict)
+    config: SurrogateConfig | None = None
+    total_seconds: float = 0.0
+    param_count: int = 0
+
+
+# --------------------------------------------------------------------------- #
+# Dataset                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class _CompactSwingTorchDataset(Dataset):
+    """In-memory PyTorch dataset built from a compact-schema parquet folder.
+
+    Each sample is ``(coeffs_norm, traj_target)`` where ``traj_target``
+    is the ``(seq_len, 12)`` ground-truth hand-path tensor assembled from
+    the compact-schema columns.
+    """
+
+    def __init__(
+        self,
+        coeffs: np.ndarray,
+        targets: np.ndarray,
+        trial_ids: np.ndarray,
+    ) -> None:
+        if coeffs.shape[0] != targets.shape[0] or coeffs.shape[0] != trial_ids.shape[0]:
+            raise ValueError(
+                "coeffs / targets / trial_ids must have matching first dim; "
+                f"got {coeffs.shape[0]}, {targets.shape[0]}, {trial_ids.shape[0]}"
+            )
+        if coeffs.ndim != 2 or targets.ndim != 3:
+            raise ValueError(
+                "coeffs must be 2-D, targets must be 3-D (N, T, 12); got "
+                f"{coeffs.shape}, {targets.shape}"
+            )
+        if targets.shape[-1] != 12:
+            raise ValueError(
+                f"targets trailing dim must be 12; got {targets.shape[-1]}"
+            )
+        self._coeffs = torch.as_tensor(coeffs, dtype=torch.float32)
+        self._targets = torch.as_tensor(targets, dtype=torch.float32)
+        self._trial_ids = np.asarray(trial_ids)
+
+    def __len__(self) -> int:
+        return self._coeffs.shape[0]
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self._coeffs[idx], self._targets[idx]
+
+    @property
+    def trial_ids(self) -> np.ndarray:
+        """Trial ids parallel to dataset rows (for split bookkeeping)."""
+        return self._trial_ids
+
+
+# --------------------------------------------------------------------------- #
+# Dataset loading                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _import_compact_loader() -> Callable[[Path], Any] | None:
+    """Try to import the canonical loader (#4074) — return ``None`` if absent."""
+    try:
+        # Documented import path per the task spec.
+        from src.shared.python.dataset_tools.load_compact import (  # type: ignore[import-not-found]
+            load_compact_swing_dataset,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return None
+    return load_compact_swing_dataset
+
+
+def _build_targets_from_compact(
+    trials_df: Any,
+    timesteps_df: Any,
+    seq_len: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Assemble ``(coeffs, targets, trial_ids)`` arrays from compact frames.
+
+    Targets follow the 12-channel layout documented in :mod:`.model`.
+
+    Args:
+        trials_df: DataFrame indexed/keyed by ``trial_id`` with a
+            ``coefficients`` ``list<float64>[189]`` column.
+        timesteps_df: DataFrame with ``trial_id`` + per-timestep arrays
+            (``r_clubhead``, ``v_clubhead``, ``r_grip``, ``clubhead_speed_mph``).
+        seq_len: Expected timesteps per trial.
+
+    Returns:
+        ``(coeffs[N, 189], targets[N, T, 12], trial_ids[N])`` numpy arrays.
+    """
+    import pandas as pd  # local import — pandas is heavy
+
+    if not isinstance(trials_df, pd.DataFrame):
+        trials_df = trials_df.collect().to_pandas()  # polars LazyFrame fallback
+    if not isinstance(timesteps_df, pd.DataFrame):
+        timesteps_df = timesteps_df.collect().to_pandas()
+
+    trial_ids = np.asarray(trials_df["trial_id"].to_numpy(), dtype=np.int64)
+    coeff_rows = [np.asarray(c, dtype=np.float32) for c in trials_df["coefficients"]]
+    coeffs = np.stack(coeff_rows, axis=0)
+    if coeffs.ndim != 2 or coeffs.shape[1] == 0:
+        raise ValueError(
+            f"unexpected coefficients shape {coeffs.shape}; "
+            "trials.coefficients must be list<float64>[D]"
+        )
+
+    targets = np.zeros((trial_ids.shape[0], seq_len, 12), dtype=np.float32)
+    grouped = timesteps_df.groupby("trial_id", sort=False)
+    for row_idx, tid in enumerate(trial_ids):
+        try:
+            block = grouped.get_group(tid)
+        except KeyError as exc:
+            raise ValueError(f"timesteps.parquet missing trial_id={tid}") from exc
+        if len(block) != seq_len:
+            raise ValueError(
+                f"trial_id={tid} has {len(block)} timesteps; expected {seq_len}"
+            )
+        block = block.sort_values("t")
+        r_ch = np.stack([np.asarray(v, dtype=np.float32) for v in block["r_clubhead"]])
+        v_ch = np.stack([np.asarray(v, dtype=np.float32) for v in block["v_clubhead"]])
+        r_gr = np.stack([np.asarray(v, dtype=np.float32) for v in block["r_grip"]])
+        chs = np.asarray(block["clubhead_speed_mph"], dtype=np.float32).reshape(-1, 1)
+        # shaft_axis -> az/polar
+        shaft = r_ch - r_gr
+        norm = np.linalg.norm(shaft, axis=-1, keepdims=True)
+        norm = np.maximum(norm, 1e-12)
+        unit = shaft / norm
+        azimuth = np.arctan2(unit[:, 1], unit[:, 0])
+        polar = np.arccos(np.clip(unit[:, 2], -1.0, 1.0))
+        az_pol = np.stack([azimuth, polar], axis=-1).astype(np.float32)
+        targets[row_idx] = np.concatenate([r_ch, v_ch, r_gr, chs, az_pol], axis=-1)
+    return coeffs, targets, trial_ids
+
+
+def _load_compact_dataset(
+    dataset_path: Path,
+    seq_len: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Load coeffs/targets/trial-ids from the compact parquet folder.
+
+    Falls back to a direct ``pyarrow`` read when the canonical loader
+    (``load_compact_swing_dataset``, owned by PR #4074) is unavailable —
+    so this trainer can still be exercised on a hand-built fixture.
+    """
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"dataset_path does not exist: {dataset_path}")
+    loader = _import_compact_loader()
+    if loader is not None:
+        ds = loader(dataset_path)
+        return _build_targets_from_compact(ds.trials, ds.timesteps, seq_len=seq_len)
+
+    # Fallback: direct parquet read.
+    import pandas as pd
+
+    trials_path = dataset_path / "trials.parquet"
+    timesteps_path = dataset_path / "timesteps.parquet"
+    if not (trials_path.exists() and timesteps_path.exists()):
+        raise FileNotFoundError(
+            "compact dataset must contain trials.parquet and timesteps.parquet"
+        )
+    trials_df = pd.read_parquet(trials_path)
+    timesteps_df = pd.read_parquet(timesteps_path)
+    return _build_targets_from_compact(trials_df, timesteps_df, seq_len=seq_len)
+
+
+# --------------------------------------------------------------------------- #
+# Loss + metrics                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def _channel_weighted_mse(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Vanilla MSE on the full ``(B, T, 12)`` tensor."""
+    return torch.mean((pred - target) ** 2)
+
+
+def _impact_speed_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Weighted MSE on the impact-time clubhead speed channel.
+
+    Impact is approximated as the timestep where ``target`` clubhead speed
+    is maximal. (For the documented 31-step compact dataset that's
+    typically the last few samples of the 0.30 s window.)
+    """
+    chs_lo, chs_hi = CHANNEL_SLICES["clubhead_speed"]
+    target_chs = target[..., chs_lo:chs_hi].squeeze(-1)
+    impact_idx = torch.argmax(target_chs, dim=-1)
+    batch_idx = torch.arange(target.shape[0], device=target.device)
+    pred_at_impact = pred[batch_idx, impact_idx, chs_lo:chs_hi].squeeze(-1)
+    target_at_impact = target_chs[batch_idx, impact_idx]
+    return torch.mean((pred_at_impact - target_at_impact) ** 2)
+
+
+def _grip_rmse_mm(pred: torch.Tensor, target: torch.Tensor) -> float:
+    """Validation metric: grip-position RMSE in millimetres."""
+    lo, hi = CHANNEL_SLICES["r_grip"]
+    diff = pred[..., lo:hi] - target[..., lo:hi]
+    rmse_m = torch.sqrt(torch.mean(diff**2)).item()
+    return rmse_m / _M_PER_MM  # m -> mm
+
+
+def _clubhead_speed_mae_mph(pred: torch.Tensor, target: torch.Tensor) -> float:
+    """Validation metric: clubhead-speed MAE in mph (channel already in mph)."""
+    lo, hi = CHANNEL_SLICES["clubhead_speed"]
+    diff = (pred[..., lo:hi] - target[..., lo:hi]).abs()
+    return float(diff.mean().item())
+
+
+# --------------------------------------------------------------------------- #
+# Training loop                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _split_indices_by_trial(
+    trial_ids: np.ndarray,
+    val_fraction: float,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """90/10 split by ``trial_id`` so no trial appears in both subsets."""
+    rng = np.random.default_rng(seed)
+    unique_ids = np.unique(trial_ids)
+    rng.shuffle(unique_ids)
+    n_val = max(1, int(round(len(unique_ids) * val_fraction)))
+    val_ids = set(unique_ids[:n_val].tolist())
+    val_mask = np.array([t in val_ids for t in trial_ids], dtype=bool)
+    val_idx = np.flatnonzero(val_mask)
+    train_idx = np.flatnonzero(~val_mask)
+    return train_idx, val_idx
+
+
+def _run_epoch(
+    model: SwingSurrogate,
+    loader: Iterable[tuple[torch.Tensor, torch.Tensor]],
+    *,
+    optimizer: torch.optim.Optimizer | None,
+    device: torch.device,
+    impact_weight: float,
+    normalizer: CoeffNormalizer,
+) -> dict[str, float]:
+    """Run one pass over ``loader``. ``optimizer is None`` means eval mode."""
+    is_train = optimizer is not None
+    model.train(is_train)
+    n = 0
+    total_loss = 0.0
+    total_mse = 0.0
+    total_impact = 0.0
+    grip_sq_sum = 0.0
+    chs_abs_sum = 0.0
+    chs_count = 0
+    for coeffs_raw, target in loader:
+        coeffs_raw = coeffs_raw.to(device, dtype=torch.float32)
+        target = target.to(device, dtype=torch.float32)
+        coeffs = normalizer.normalize(coeffs_raw)
+        if is_train:
+            optimizer.zero_grad(set_to_none=True)
+        with torch.set_grad_enabled(is_train):
+            pred = model(coeffs)
+            mse = _channel_weighted_mse(pred, target)
+            impact = _impact_speed_loss(pred, target)
+            loss = mse + impact_weight * impact
+        if is_train:
+            assert optimizer is not None  # narrow type
+            loss.backward()
+            optimizer.step()
+        bs = coeffs.shape[0]
+        n += bs
+        total_loss += float(loss.item()) * bs
+        total_mse += float(mse.item()) * bs
+        total_impact += float(impact.item()) * bs
+        # Per-batch validation metrics so we can report per-epoch averages.
+        with torch.no_grad():
+            lo, hi = CHANNEL_SLICES["r_grip"]
+            diff = pred[..., lo:hi] - target[..., lo:hi]
+            grip_sq_sum += float(torch.sum(diff**2).item())
+            chs_lo, chs_hi = CHANNEL_SLICES["clubhead_speed"]
+            chs_diff = (pred[..., chs_lo:chs_hi] - target[..., chs_lo:chs_hi]).abs()
+            chs_abs_sum += float(torch.sum(chs_diff).item())
+            chs_count += int(chs_diff.numel())
+    if n == 0:
+        return {
+            "loss": float("nan"),
+            "mse": float("nan"),
+            "impact_mse": float("nan"),
+            "grip_rmse_mm": float("nan"),
+            "clubhead_speed_mae_mph": float("nan"),
+        }
+    grip_rmse_m = math.sqrt(grip_sq_sum / max(n * 3 * model.cfg.seq_len, 1))
+    return {
+        "loss": total_loss / n,
+        "mse": total_mse / n,
+        "impact_mse": total_impact / n,
+        "grip_rmse_mm": grip_rmse_m / _M_PER_MM,
+        "clubhead_speed_mae_mph": chs_abs_sum / max(chs_count, 1),
+    }
+
+
+def _save_checkpoint(
+    path: Path,
+    *,
+    model: SwingSurrogate,
+    optimizer: torch.optim.Optimizer,
+    epoch: int,
+    metrics: dict[str, Any],
+    config: SurrogateConfig,
+    normalizer: CoeffNormalizer,
+) -> None:
+    """Persist a resumable checkpoint to ``path``."""
+    payload = {
+        "schema_version": "swing-surrogate-1.0",
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "epoch": int(epoch),
+        "metrics": metrics,
+        "config": asdict(config),
+        "normalizer": {
+            "n_joints": config.n_joints,
+            "coeff_bounds": list(config.coeff_bounds),
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(payload, path)
+
+
+def train_surrogate(
+    dataset_path: str | Path,
+    *,
+    epochs: int = 50,
+    batch_size: int = 64,
+    lr: float = 1e-3,
+    device: str | torch.device = "cpu",
+    seed: int = 0,
+    config: SurrogateConfig | None = None,
+    impact_weight: float = 1.0,
+    val_fraction: float = 0.1,
+    early_stopping_patience: int = 10,
+    output_dir: str | Path | None = None,
+    resume_from: str | Path | None = None,
+    progress_cb: Callable[[int, dict[str, float]], None] | None = None,
+) -> TrainingResult:
+    """Train :class:`SwingSurrogate` on a compact-schema parquet dataset.
+
+    Args:
+        dataset_path: Folder containing ``trials.parquet`` + ``timesteps.parquet``.
+        epochs: Maximum number of training epochs.
+        batch_size: Mini-batch size.
+        lr: Adam learning rate.
+        device: Torch device (string or ``torch.device``).
+        seed: RNG seed for the train/val split and weight init.
+        config: Surrogate config; defaults to :class:`SurrogateConfig()`.
+        impact_weight: Multiplier on the impact-speed loss term.
+        val_fraction: Fraction of trial_ids reserved for validation.
+        early_stopping_patience: Epochs without val grip-RMSE improvement
+            before training stops early.
+        output_dir: Where to write checkpoints. Defaults to
+            ``output/surrogate/<timestamp>``.
+        resume_from: Optional path to a checkpoint produced by a previous
+            run; loads model + optimizer state.
+        progress_cb: Optional callback ``(epoch, metrics_dict) -> None``;
+            called once per epoch for streaming UIs.
+
+    Returns:
+        A frozen :class:`TrainingResult`.
+
+    Raises:
+        ValueError: For invalid hyper-parameters or dataset shape.
+        FileNotFoundError: If ``dataset_path`` does not exist.
+    """
+    _check_train_args(epochs, batch_size, lr, val_fraction, early_stopping_patience)
+    cfg = config if config is not None else SurrogateConfig()
+    cfg.validate()
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    dev = torch.device(device)
+    out_path = _resolve_output_dir(output_dir)
+    _LOGGER.info("training surrogate -> %s", out_path)
+
+    coeffs_np, targets_np, trial_ids = _load_compact_dataset(
+        Path(dataset_path), seq_len=cfg.seq_len
+    )
+    if coeffs_np.shape[1] != cfg.coeff_dim:
+        raise ValueError(
+            f"dataset coeff dim {coeffs_np.shape[1]} != cfg.coeff_dim "
+            f"({cfg.coeff_dim}); check schema vs SurrogateConfig"
+        )
+    train_idx, val_idx = _split_indices_by_trial(trial_ids, val_fraction, seed=seed)
+    train_ds = _CompactSwingTorchDataset(
+        coeffs_np[train_idx], targets_np[train_idx], trial_ids[train_idx]
+    )
+    val_ds = _CompactSwingTorchDataset(
+        coeffs_np[val_idx], targets_np[val_idx], trial_ids[val_idx]
+    )
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, drop_last=False
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=batch_size, shuffle=False, drop_last=False
+    )
+
+    model = SwingSurrogate(cfg).to(dev)
+    optimizer: torch.optim.Optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    normalizer = CoeffNormalizer(n_joints=cfg.n_joints, coeff_bounds=cfg.coeff_bounds)
+    start_epoch = 0
+    if resume_from is not None:
+        start_epoch = _load_resume_state(
+            Path(resume_from), model=model, optimizer=optimizer
+        )
+        _LOGGER.info("resumed from %s at epoch %d", resume_from, start_epoch)
+
+    return _train_loop(
+        model=model,
+        optimizer=optimizer,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        cfg=cfg,
+        normalizer=normalizer,
+        device=dev,
+        epochs=epochs,
+        start_epoch=start_epoch,
+        impact_weight=impact_weight,
+        early_stopping_patience=early_stopping_patience,
+        out_path=out_path,
+        progress_cb=progress_cb,
+    )
+
+
+def _train_loop(
+    *,
+    model: SwingSurrogate,
+    optimizer: torch.optim.Optimizer,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    cfg: SurrogateConfig,
+    normalizer: CoeffNormalizer,
+    device: torch.device,
+    epochs: int,
+    start_epoch: int,
+    impact_weight: float,
+    early_stopping_patience: int,
+    out_path: Path,
+    progress_cb: Callable[[int, dict[str, float]], None] | None,
+) -> TrainingResult:
+    """The actual epoch loop, factored out so it can be unit-tested narrowly."""
+    history: dict[str, list[float]] = {
+        "epoch": [],
+        "train_loss": [],
+        "val_loss": [],
+        "val_grip_rmse_mm": [],
+        "val_clubhead_speed_mae_mph": [],
+    }
+    best_val_grip_rmse = float("inf")
+    best_val_loss = float("inf")
+    best_epoch = 0
+    last_ckpt: Path | None = None
+    best_ckpt: Path | None = None
+    no_improve = 0
+    t0 = time.perf_counter()
+    for epoch_idx in range(start_epoch, epochs):
+        epoch_human = epoch_idx + 1
+        train_metrics = _run_epoch(
+            model,
+            train_loader,
+            optimizer=optimizer,
+            device=device,
+            impact_weight=impact_weight,
+            normalizer=normalizer,
+        )
+        val_metrics = _run_epoch(
+            model,
+            val_loader,
+            optimizer=None,
+            device=device,
+            impact_weight=impact_weight,
+            normalizer=normalizer,
+        )
+        history["epoch"].append(float(epoch_human))
+        history["train_loss"].append(train_metrics["loss"])
+        history["val_loss"].append(val_metrics["loss"])
+        history["val_grip_rmse_mm"].append(val_metrics["grip_rmse_mm"])
+        history["val_clubhead_speed_mae_mph"].append(
+            val_metrics["clubhead_speed_mae_mph"]
+        )
+        ckpt_path = out_path / f"checkpoint_epoch_{epoch_human:03d}.pt"
+        _save_checkpoint(
+            ckpt_path,
+            model=model,
+            optimizer=optimizer,
+            epoch=epoch_human,
+            metrics={"train": train_metrics, "val": val_metrics},
+            config=cfg,
+            normalizer=normalizer,
+        )
+        last_ckpt = ckpt_path
+        _write_metrics_json(out_path, history)
+        _LOGGER.info(
+            "epoch %d/%d: train_loss=%.4g val_loss=%.4g grip_rmse=%.2f mm chs_mae=%.2f mph",
+            epoch_human,
+            epochs,
+            train_metrics["loss"],
+            val_metrics["loss"],
+            val_metrics["grip_rmse_mm"],
+            val_metrics["clubhead_speed_mae_mph"],
+        )
+        if progress_cb is not None:
+            progress_cb(epoch_human, val_metrics)
+        if val_metrics["grip_rmse_mm"] < best_val_grip_rmse - 1e-6:
+            best_val_grip_rmse = val_metrics["grip_rmse_mm"]
+            best_val_loss = val_metrics["loss"]
+            best_epoch = epoch_human
+            best_ckpt = out_path / "checkpoint_best.pt"
+            _save_checkpoint(
+                best_ckpt,
+                model=model,
+                optimizer=optimizer,
+                epoch=epoch_human,
+                metrics={"train": train_metrics, "val": val_metrics},
+                config=cfg,
+                normalizer=normalizer,
+            )
+            no_improve = 0
+        else:
+            no_improve += 1
+            if no_improve >= early_stopping_patience:
+                _LOGGER.info(
+                    "early stopping after %d epochs without improvement",
+                    early_stopping_patience,
+                )
+                break
+
+    elapsed = time.perf_counter() - t0
+    if last_ckpt is None:
+        raise RuntimeError("training produced no checkpoints (epochs == 0?)")
+    if best_ckpt is None:
+        best_ckpt = last_ckpt
+    return TrainingResult(
+        output_dir=out_path,
+        best_checkpoint=best_ckpt,
+        last_checkpoint=last_ckpt,
+        best_epoch=best_epoch,
+        best_val_loss=best_val_loss,
+        best_val_grip_rmse_mm=best_val_grip_rmse,
+        history=history,
+        config=cfg,
+        total_seconds=elapsed,
+        param_count=model.parameter_count(),
+    )
+
+
+def _check_train_args(
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    val_fraction: float,
+    early_stopping_patience: int,
+) -> None:
+    """Validate scalar hyper-parameters with descriptive error messages."""
+    if epochs <= 0:
+        raise ValueError(f"epochs must be positive, got {epochs}")
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if lr <= 0:
+        raise ValueError(f"lr must be positive, got {lr}")
+    if not (0.0 < val_fraction < 1.0):
+        raise ValueError(f"val_fraction must be in (0, 1), got {val_fraction}")
+    if early_stopping_patience <= 0:
+        raise ValueError(
+            f"early_stopping_patience must be positive, got {early_stopping_patience}"
+        )
+
+
+def _resolve_output_dir(output_dir: str | Path | None) -> Path:
+    """Pick / create the output directory. Defaults to ``output/surrogate/<ts>``."""
+    if output_dir is not None:
+        out_path = Path(output_dir)
+    else:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_path = Path("output") / "surrogate" / ts
+    out_path.mkdir(parents=True, exist_ok=True)
+    return out_path
+
+
+def _load_resume_state(
+    path: Path,
+    *,
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+) -> int:
+    """Load model + optimizer state from a previous checkpoint and return epoch."""
+    if not path.exists():
+        raise FileNotFoundError(f"resume_from checkpoint missing: {path}")
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    model.load_state_dict(payload["model_state_dict"])
+    optimizer.load_state_dict(payload["optimizer_state_dict"])
+    return int(payload.get("epoch", 0))
+
+
+def _write_metrics_json(out_path: Path, history: dict[str, Sequence[float]]) -> None:
+    """Persist the running per-epoch metrics dict to ``metrics.json``."""
+    metrics_path = out_path / "metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as fh:
+        json.dump({k: list(v) for k, v in history.items()}, fh, indent=2)

--- a/tests/unit/motion_matching/test_swing_surrogate_model.py
+++ b/tests/unit/motion_matching/test_swing_surrogate_model.py
@@ -1,0 +1,256 @@
+"""Tests for the compact-schema Option-2 SwingSurrogate model (#4075).
+
+Covers shape/dtype contract, deterministic forward, gradient flow, and
+the normalisation invariants on :class:`CoeffNormalizer`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.shared.python.motion_matching.surrogate.compact.model import (  # noqa: E402
+    CHANNEL_SLICES,
+    COEFF_BOUNDS,
+    CoeffNormalizer,
+    SurrogateConfig,
+    SwingSurrogate,
+    az_pol_to_shaft_axis,
+    shaft_axis_to_az_pol,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def cfg() -> SurrogateConfig:
+    """Default 27-joint compact-schema config (189 in, 31x12 out)."""
+    return SurrogateConfig()
+
+
+@pytest.fixture
+def small_cfg() -> SurrogateConfig:
+    """A trimmed config for fast unit tests (still uses real 12-channel head)."""
+    return SurrogateConfig(
+        n_joints=4,
+        coeffs_per_joint=7,
+        seq_len=8,
+        hidden_dim=32,
+        n_residual_blocks=2,
+    )
+
+
+@pytest.fixture
+def small_model(small_cfg: SurrogateConfig) -> SwingSurrogate:
+    """Deterministic small surrogate."""
+    torch.manual_seed(0)
+    return SwingSurrogate(small_cfg)
+
+
+# --------------------------------------------------------------------------- #
+# Config validation                                                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_default_config_is_189_in_31x12_out() -> None:
+    """The unparameterised default must match the issue #4075 contract."""
+    cfg = SurrogateConfig()
+    cfg.validate()
+    assert cfg.coeff_dim == 189
+    assert cfg.seq_len == 31
+    assert cfg.out_channels == 12
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_invalid_config_raises() -> None:
+    """Every malformed field surfaces as a ValueError with a useful message."""
+    with pytest.raises(ValueError, match="n_joints"):
+        SurrogateConfig(n_joints=0).validate()
+    with pytest.raises(ValueError, match="seq_len"):
+        SurrogateConfig(seq_len=1).validate()
+    with pytest.raises(ValueError, match="hidden_dim"):
+        SurrogateConfig(hidden_dim=0).validate()
+    with pytest.raises(ValueError, match="dropout"):
+        SurrogateConfig(dropout=1.5).validate()
+
+
+# --------------------------------------------------------------------------- #
+# Forward shape / dtype contract                                              #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_forward_shape_dtype_contract(
+    small_model: SwingSurrogate, small_cfg: SurrogateConfig
+) -> None:
+    """``forward`` must emit ``(B, T, 12)`` float32 trajectories."""
+    batch = 5
+    coeffs = torch.randn(batch, small_cfg.coeff_dim, dtype=torch.float32) * 0.5
+    out = small_model(coeffs)
+    assert out.shape == (batch, small_cfg.seq_len, 12)
+    assert out.dtype == torch.float32
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_default_model_real_input_shape() -> None:
+    """The default model accepts a real (B, 189) input and emits (B, 31, 12)."""
+    torch.manual_seed(0)
+    model = SwingSurrogate(SurrogateConfig())
+    coeffs = torch.zeros(2, 189, dtype=torch.float32)
+    out = model(coeffs)
+    assert out.shape == (2, 31, 12)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_forward_rejects_wrong_dtype(small_model: SwingSurrogate) -> None:
+    """Float64 input must raise TypeError per the documented contract."""
+    coeffs = torch.zeros(1, small_model.cfg.coeff_dim, dtype=torch.float64)
+    with pytest.raises(TypeError, match="float32"):
+        small_model(coeffs)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_forward_rejects_wrong_shape(small_model: SwingSurrogate) -> None:
+    """Wrong trailing dim raises ValueError; non-tensor raises TypeError."""
+    bad_dim = torch.zeros(1, small_model.cfg.coeff_dim + 1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="trailing dim"):
+        small_model(bad_dim)
+    one_d = torch.zeros(small_model.cfg.coeff_dim, dtype=torch.float32)
+    with pytest.raises(ValueError, match="2-D"):
+        small_model(one_d)
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        small_model([0.0] * small_model.cfg.coeff_dim)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic forward + gradient flow                                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_forward_is_deterministic_with_fixed_seed(
+    small_cfg: SurrogateConfig,
+) -> None:
+    """Same seed + same input -> bitwise-equal output."""
+    torch.manual_seed(0)
+    m1 = SwingSurrogate(small_cfg)
+    torch.manual_seed(0)
+    m2 = SwingSurrogate(small_cfg)
+    x = torch.randn(2, small_cfg.coeff_dim, dtype=torch.float32) * 0.5
+    out1 = m1(x)
+    out2 = m2(x)
+    torch.testing.assert_close(out1, out2, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_gradient_flow_to_input(
+    small_model: SwingSurrogate, small_cfg: SurrogateConfig
+) -> None:
+    """Gradients w.r.t. the coefficient input are finite and non-zero."""
+    coeffs = torch.randn(
+        1, small_cfg.coeff_dim, dtype=torch.float32, requires_grad=True
+    )
+    out = small_model(coeffs)
+    loss = (out**2).mean()
+    loss.backward()
+    assert coeffs.grad is not None
+    assert torch.isfinite(coeffs.grad).all().item()
+    assert coeffs.grad.abs().max().item() > 1e-12
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_parameter_count_within_documented_range(cfg: SurrogateConfig) -> None:
+    """Default config falls in the 500k-2M parameter band from the spec."""
+    torch.manual_seed(0)
+    model = SwingSurrogate(cfg)
+    n = model.parameter_count()
+    assert 500_000 <= n <= 2_000_000, f"unexpected param count: {n}"
+
+
+# --------------------------------------------------------------------------- #
+# Normalisation invariants                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_normalizer_round_trips_within_bounds() -> None:
+    """``denormalize(normalize(x)) == x`` when ``x`` is inside the bounds."""
+    norm = CoeffNormalizer()
+    rng = torch.Generator().manual_seed(0)
+    scale = torch.tensor(list(COEFF_BOUNDS) * 27)
+    raw = (torch.rand(4, 189, generator=rng) * 2 - 1) * scale
+    out = norm.denormalize(norm.normalize(raw))
+    torch.testing.assert_close(out, raw, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_normalizer_clamps_outside_bounds() -> None:
+    """Out-of-bounds raw coeffs land at exactly ``±1`` after normalize."""
+    norm = CoeffNormalizer()
+    raw = torch.full((1, 189), 1e6)
+    raw_neg = torch.full((1, 189), -1e6)
+    assert torch.all(norm.normalize(raw) == 1.0)
+    assert torch.all(norm.normalize(raw_neg) == -1.0)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_normalizer_rejects_bad_shape() -> None:
+    """Wrong-dim input raises ValueError with a descriptive message."""
+    norm = CoeffNormalizer()
+    with pytest.raises(ValueError, match="2-D"):
+        norm.normalize(torch.zeros(189))
+    with pytest.raises(ValueError, match="trailing dim"):
+        norm.normalize(torch.zeros(1, 100))
+
+
+# --------------------------------------------------------------------------- #
+# Channel layout helpers                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_channel_slices_cover_12_channels() -> None:
+    """The slice dict must partition the 12-channel output exactly."""
+    seen: set[int] = set()
+    for lo, hi in CHANNEL_SLICES.values():
+        seen.update(range(lo, hi))
+    assert seen == set(range(12))
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_shaft_axis_az_pol_round_trip() -> None:
+    """``az_pol_to_shaft_axis(shaft_axis_to_az_pol(v))`` ≈ unit(v)."""
+    rng = torch.Generator().manual_seed(0)
+    v = torch.randn(8, 3, generator=rng)
+    az_pol = shaft_axis_to_az_pol(v)
+    v_unit_back = az_pol_to_shaft_axis(az_pol)
+    v_unit = v / v.norm(dim=-1, keepdim=True)
+    torch.testing.assert_close(v_unit_back, v_unit, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_shaft_axis_helpers_reject_wrong_dim() -> None:
+    """Wrong-trailing-dim inputs raise ValueError."""
+    with pytest.raises(ValueError, match="trailing dim 3"):
+        shaft_axis_to_az_pol(torch.zeros(2, 4))
+    with pytest.raises(ValueError, match="trailing dim 2"):
+        az_pol_to_shaft_axis(torch.zeros(2, 3))

--- a/tests/unit/motion_matching/test_swing_surrogate_predict.py
+++ b/tests/unit/motion_matching/test_swing_surrogate_predict.py
@@ -1,0 +1,181 @@
+"""Inference tests for the compact-schema swing surrogate (#4075)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.shared.python.motion_matching.surrogate.compact import (  # noqa: E402
+    CoeffNormalizer,
+    SurrogateConfig,
+    SwingSurrogate,
+    predict_trajectory,
+)
+from src.shared.python.motion_matching.surrogate.compact.predict import (  # noqa: E402
+    predict_clubhead_speed_ms,
+)
+
+
+@pytest.fixture
+def trained_checkpoint(tmp_path: Path) -> Path:
+    """Manufacture a tiny ``checkpoint_best.pt`` so we can test the loader.
+
+    The "training" here is a single forward pass with random init, which
+    is sufficient for the round-trip and shape-contract tests.
+    """
+    cfg = SurrogateConfig(
+        n_joints=27,
+        coeffs_per_joint=7,
+        seq_len=31,
+        hidden_dim=32,
+        n_residual_blocks=2,
+    )
+    torch.manual_seed(0)
+    model = SwingSurrogate(cfg)
+    payload = {
+        "schema_version": "swing-surrogate-1.0",
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": {},
+        "epoch": 1,
+        "metrics": {},
+        "config": {
+            "n_joints": cfg.n_joints,
+            "coeffs_per_joint": cfg.coeffs_per_joint,
+            "seq_len": cfg.seq_len,
+            "hidden_dim": cfg.hidden_dim,
+            "n_residual_blocks": cfg.n_residual_blocks,
+            "decoder_hidden": cfg.decoder_hidden,
+            "dropout": cfg.dropout,
+            "coeff_bounds": list(cfg.coeff_bounds),
+        },
+        "normalizer": {
+            "n_joints": cfg.n_joints,
+            "coeff_bounds": list(cfg.coeff_bounds),
+        },
+    }
+    ckpt_path = tmp_path / "checkpoint_best.pt"
+    torch.save(payload, ckpt_path)
+    return ckpt_path
+
+
+# --------------------------------------------------------------------------- #
+# from_checkpoint                                                             #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_from_checkpoint_round_trip(trained_checkpoint: Path) -> None:
+    """``from_checkpoint`` reconstructs a model with matching weights/cfg."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    assert isinstance(model, SwingSurrogate)
+    assert model.cfg.coeff_dim == 189
+    assert hasattr(model, "coeff_normalizer")
+    assert isinstance(model.coeff_normalizer, CoeffNormalizer)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_from_checkpoint_missing_file_raises(tmp_path: Path) -> None:
+    """A nonexistent path must raise ``FileNotFoundError``."""
+    with pytest.raises(FileNotFoundError):
+        SwingSurrogate.from_checkpoint(tmp_path / "no.pt")
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_from_checkpoint_bad_payload_raises(tmp_path: Path) -> None:
+    """A payload missing ``model_state_dict`` raises ``ValueError``."""
+    bad = tmp_path / "bad.pt"
+    torch.save({"oops": True}, bad)
+    with pytest.raises(ValueError, match="model_state_dict"):
+        SwingSurrogate.from_checkpoint(bad)
+
+
+# --------------------------------------------------------------------------- #
+# predict_trajectory                                                          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_trajectory_returns_documented_keys(trained_checkpoint: Path) -> None:
+    """Output dict contains the documented physical-unit channel arrays."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    theta = np.zeros(model.cfg.coeff_dim, dtype=np.float64)
+    out = predict_trajectory(model, theta)
+    assert set(out) >= {
+        "r_clubhead",
+        "v_clubhead",
+        "r_grip",
+        "clubhead_speed",
+        "shaft_axis",
+    }
+    assert out["r_clubhead"].shape == (1, model.cfg.seq_len, 3)
+    assert out["v_clubhead"].shape == (1, model.cfg.seq_len, 3)
+    assert out["r_grip"].shape == (1, model.cfg.seq_len, 3)
+    assert out["clubhead_speed"].shape == (1, model.cfg.seq_len)
+    assert out["shaft_axis"].shape == (1, model.cfg.seq_len, 3)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_trajectory_batched(trained_checkpoint: Path) -> None:
+    """Batch inputs (B>1) propagate cleanly through to (B, T, ·) outputs."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    rng = np.random.default_rng(0)
+    bounds = np.tile([1000, 1000, 500, 500, 100, 100, 25.0], 27)
+    theta = (rng.uniform(-1.0, 1.0, size=(4, model.cfg.coeff_dim)) * bounds).astype(
+        np.float32
+    )
+    out = predict_trajectory(model, theta)
+    assert out["r_clubhead"].shape == (4, model.cfg.seq_len, 3)
+    assert out["clubhead_speed"].shape == (4, model.cfg.seq_len)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_trajectory_shaft_axis_is_unit_norm(
+    trained_checkpoint: Path,
+) -> None:
+    """Shaft-axis output is reconstructed as a unit 3-vec at every timestep."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    theta = np.zeros(model.cfg.coeff_dim, dtype=np.float32)
+    shaft = predict_trajectory(model, theta)["shaft_axis"]
+    norms = np.linalg.norm(shaft, axis=-1)
+    np.testing.assert_allclose(norms, np.ones_like(norms), atol=1e-5)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_trajectory_rejects_wrong_dim(trained_checkpoint: Path) -> None:
+    """Wrong trailing dim raises ``ValueError``."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    with pytest.raises(ValueError, match="trailing dim"):
+        predict_trajectory(model, np.zeros(model.cfg.coeff_dim - 1))
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_clubhead_speed_unit_conversion(trained_checkpoint: Path) -> None:
+    """``predict_clubhead_speed_ms`` returns mph * (1/2.2369...) m/s."""
+    model = SwingSurrogate.from_checkpoint(trained_checkpoint)
+    theta = np.zeros(model.cfg.coeff_dim, dtype=np.float32)
+    chs_mph = predict_trajectory(model, theta)["clubhead_speed"]
+    chs_ms = predict_clubhead_speed_ms(model, theta)
+    np.testing.assert_allclose(chs_ms, chs_mph / 2.2369362920544, rtol=1e-5)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_predict_trajectory_missing_normalizer_raises() -> None:
+    """A model built directly (no ``coeff_normalizer``) raises AttributeError."""
+    model = SwingSurrogate()
+    if hasattr(model, "coeff_normalizer"):
+        del model.coeff_normalizer
+    with pytest.raises(AttributeError, match="coeff_normalizer"):
+        predict_trajectory(model, np.zeros(model.cfg.coeff_dim))

--- a/tests/unit/motion_matching/test_swing_surrogate_training.py
+++ b/tests/unit/motion_matching/test_swing_surrogate_training.py
@@ -1,0 +1,248 @@
+"""Training-loop tests for the compact-schema swing surrogate (#4075)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pyarrow = pytest.importorskip("pyarrow")
+pd = pytest.importorskip("pandas")
+
+from src.shared.python.motion_matching.surrogate.compact import (  # noqa: E402
+    SurrogateConfig,
+    SwingSurrogate,
+    train_surrogate,
+)
+
+# --------------------------------------------------------------------------- #
+# Synthetic 8-trial fixture                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _build_synthetic_compact_dataset(out_dir: Path, n_trials: int = 8) -> Path:
+    """Write a tiny but contract-compliant compact parquet pair to ``out_dir``.
+
+    The targets are a smooth deterministic function of the coefficients so
+    that even a tiny model can learn to reduce val loss in 3 epochs.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(0)
+    n_joints = 27
+    coeffs_per_joint = 7
+    coeff_dim = n_joints * coeffs_per_joint
+    seq_len = 31
+    bounds = np.tile([1000, 1000, 500, 500, 100, 100, 25.0], n_joints).astype(
+        np.float64
+    )
+    trials_rows: list[dict[str, object]] = []
+    timesteps_rows: list[dict[str, object]] = []
+    for trial_id in range(n_trials):
+        coeffs = rng.uniform(-1.0, 1.0, size=coeff_dim) * bounds
+        # Deterministic smooth targets that depend on the coeffs.
+        weights = np.linspace(-0.1, 0.1, coeff_dim)
+        scalar = float(np.dot(coeffs / bounds, weights))
+        for t_idx in range(seq_len):
+            t = t_idx * 0.01
+            r_grip = np.array(
+                [0.5 + scalar * 0.05 + 0.1 * t, 0.0, 1.0 + 0.05 * np.sin(t)],
+                dtype=np.float64,
+            )
+            r_clubhead = r_grip + np.array(
+                [0.0, 0.0, -1.1 + 0.01 * scalar], dtype=np.float64
+            )
+            v_clubhead = np.array(
+                [10.0 + scalar, 0.0, 1.0 * np.cos(t)], dtype=np.float64
+            )
+            chs = float(np.linalg.norm(v_clubhead) * 2.236936)
+            timesteps_rows.append(
+                {
+                    "trial_id": np.uint32(trial_id),
+                    "t": t,
+                    "q": [0.0] * 27,
+                    "qd": [0.0] * 27,
+                    "qdd": [0.0] * 27,
+                    "tau": [0.0] * 27,
+                    "r_clubhead": r_clubhead.tolist(),
+                    "v_clubhead": v_clubhead.tolist(),
+                    "r_buttend": r_grip.tolist(),
+                    "r_lhand": r_grip.tolist(),
+                    "r_rhand": r_grip.tolist(),
+                    "r_grip": r_grip.tolist(),
+                    "clubhead_speed_mph": chs,
+                }
+            )
+        trials_rows.append(
+            {
+                "trial_id": np.uint32(trial_id),
+                "coefficients": coeffs.tolist(),
+                "joint_names": [f"j{i}" for i in range(n_joints)],
+                "coefficient_letters": ["A", "B", "C", "D", "E", "F", "G"],
+                "simulation_time_s": 0.30,
+                "sample_rate_hz": 100.0,
+                "clubhead_speed_max_mph": 100.0,
+                "total_work_J": 250.0,
+                "solver_status": "success",
+            }
+        )
+    pd.DataFrame(trials_rows).to_parquet(out_dir / "trials.parquet")
+    pd.DataFrame(timesteps_rows).to_parquet(out_dir / "timesteps.parquet")
+    return out_dir
+
+
+@pytest.fixture
+def synthetic_dataset(tmp_path: Path) -> Path:
+    """Build the 8-trial synthetic compact dataset once per test."""
+    return _build_synthetic_compact_dataset(tmp_path / "compact", n_trials=8)
+
+
+@pytest.fixture
+def small_config() -> SurrogateConfig:
+    """A trimmed config so 3 epochs run in well under 30 s on CPU."""
+    return SurrogateConfig(
+        n_joints=27,
+        coeffs_per_joint=7,
+        seq_len=31,
+        hidden_dim=32,
+        n_residual_blocks=2,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Training loop                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+@pytest.mark.slow
+def test_train_surrogate_reduces_val_loss(
+    synthetic_dataset: Path, small_config: SurrogateConfig, tmp_path: Path
+) -> None:
+    """3 epochs on the synthetic fixture must reduce val loss vs epoch 1."""
+    out_dir = tmp_path / "training_out"
+    result = train_surrogate(
+        synthetic_dataset,
+        epochs=3,
+        batch_size=4,
+        lr=1e-3,
+        seed=0,
+        config=small_config,
+        output_dir=out_dir,
+        early_stopping_patience=10,
+    )
+    assert result.output_dir == out_dir
+    val_losses = result.history["val_loss"]
+    assert len(val_losses) == 3, f"expected 3 epochs, got {len(val_losses)}"
+    assert val_losses[-1] < val_losses[0], f"val loss did not decrease: {val_losses}"
+    assert result.param_count > 0
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+@pytest.mark.slow
+def test_train_surrogate_writes_checkpoints_and_metrics(
+    synthetic_dataset: Path, small_config: SurrogateConfig, tmp_path: Path
+) -> None:
+    """Each epoch writes a checkpoint; ``metrics.json`` is valid JSON."""
+    out_dir = tmp_path / "training_out_ckpt"
+    result = train_surrogate(
+        synthetic_dataset,
+        epochs=3,
+        batch_size=4,
+        lr=1e-3,
+        seed=0,
+        config=small_config,
+        output_dir=out_dir,
+    )
+    epoch_files = sorted(out_dir.glob("checkpoint_epoch_*.pt"))
+    assert len(epoch_files) == 3
+    assert (out_dir / "checkpoint_best.pt").exists()
+    assert result.last_checkpoint.exists()
+    assert result.best_checkpoint.exists()
+    metrics = json.loads((out_dir / "metrics.json").read_text(encoding="utf-8"))
+    for key in (
+        "epoch",
+        "train_loss",
+        "val_loss",
+        "val_grip_rmse_mm",
+        "val_clubhead_speed_mae_mph",
+    ):
+        assert key in metrics
+        assert len(metrics[key]) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+@pytest.mark.slow
+def test_train_surrogate_resumes_from_checkpoint(
+    synthetic_dataset: Path, small_config: SurrogateConfig, tmp_path: Path
+) -> None:
+    """A second ``train_surrogate`` call resumes from the prior checkpoint."""
+    first_dir = tmp_path / "first"
+    train_surrogate(
+        synthetic_dataset,
+        epochs=2,
+        batch_size=4,
+        lr=1e-3,
+        seed=0,
+        config=small_config,
+        output_dir=first_dir,
+    )
+    last_ckpt = first_dir / "checkpoint_epoch_002.pt"
+    assert last_ckpt.exists()
+    second_dir = tmp_path / "second"
+    train_surrogate(
+        synthetic_dataset,
+        epochs=3,  # 1 more on top of the 2-epoch checkpoint
+        batch_size=4,
+        lr=1e-3,
+        seed=0,
+        config=small_config,
+        output_dir=second_dir,
+        resume_from=last_ckpt,
+    )
+    # Resuming from epoch 2 with epochs=3 yields one more epoch.
+    epoch_files = sorted(second_dir.glob("checkpoint_epoch_*.pt"))
+    assert len(epoch_files) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_train_surrogate_validates_args(tmp_path: Path) -> None:
+    """Bad scalar hyperparams must raise ``ValueError`` before training."""
+    with pytest.raises(ValueError, match="epochs"):
+        train_surrogate(tmp_path, epochs=0, batch_size=4, lr=1e-3)
+    with pytest.raises(ValueError, match="batch_size"):
+        train_surrogate(tmp_path, epochs=1, batch_size=0, lr=1e-3)
+    with pytest.raises(ValueError, match="lr"):
+        train_surrogate(tmp_path, epochs=1, batch_size=4, lr=0.0)
+    with pytest.raises(ValueError, match="val_fraction"):
+        train_surrogate(tmp_path, epochs=1, batch_size=4, lr=1e-3, val_fraction=1.0)
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_train_surrogate_missing_dataset_raises(tmp_path: Path) -> None:
+    """Pointing at a nonexistent path raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        train_surrogate(
+            tmp_path / "does-not-exist",
+            epochs=1,
+            batch_size=4,
+            lr=1e-3,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.requires_torch
+def test_swing_surrogate_modules_register_parameters() -> None:
+    """A freshly-built model has named parameters (sanity check for nn graph)."""
+    model = SwingSurrogate()
+    names = [n for n, _ in model.named_parameters()]
+    assert any("input_proj" in n for n in names)
+    assert any("blocks" in n for n in names)
+    assert any("decoder" in n for n in names)


### PR DESCRIPTION
## Summary
- Adds the Option-2 forward NN surrogate (PROJECT_SPEC.md §3) — maps polynomial coefficients to hand-path trajectory in milliseconds.
- MATLAB shim `fit_swing_surrogate.m` lets motion-matching fits use the surrogate instead of a fresh Simscape sim per evaluation.
- Closes #4075.
- Depends on PR #4074 (compact dataset loader) — coordinate the merge order. The trainer falls back to a direct parquet read when the loader is absent so this PR can land independently.

## Note on coexistence with #4227
Issue #4075 was previously closed by PR #4227, which trained the merged FiLM-MLP variant (`surrogate/model.py`) on the 10k dataset. That FiLM-MLP module emits a different output schema (separate butt/clubhead/quat/joint heads at `seq_len=300`) and is depended on by motion_matching/inverse, hybrid solver, and 6+ tests. To avoid clobbering it, the new compact-schema implementation lives at `surrogate/compact/` and exposes the exact API the issue spec calls for. Both surrogates can be trained/used in parallel.

## Test plan
- [x] Unit tests pass on synthetic 8-trial fixture (30 tests under `pytest -m unit -n auto --timeout=60`)
- [x] Training loop reduces val loss across 3 epochs (487.5 → 480.1 on the synthetic fixture)
- [x] Checkpoint round-trip works (`SwingSurrogate.from_checkpoint`)
- [x] Param count in spec'd 500k–2M range (default config: 541,044 params)
- [x] Ruff lint + format clean
- [ ] Manual training run on the real compact dataset (post-#4074 merge)

## Files
- `src/shared/python/motion_matching/surrogate/compact/{__init__,model,training,predict}.py`
- `src/engines/.../motion_matching/shared/fit_swing_surrogate.m`
- `tests/unit/motion_matching/test_swing_surrogate_{model,training,predict}.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)