### PR TITLE
feat(dataset): compact swing dataset compactor + loader (closes #4074)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ markers = [
     "requires_opensim: tests that require the OpenSim Python bindings (skipped when `import opensim` fails)",
     "requires_matlab_engine: tests that require matlab.engine importable (Option 4 bridge)",
     "requires_torch: tests that require PyTorch importable (skipped via importorskip when missing)",
+    "requires_real_dataset: tests that require the 9 GB raw Simscape parquet on disk (skipped if absent)",
 ]
 filterwarnings = [
     # Suppress hppfcl→coal rename noise (third-party, not actionable in this repo)

--- a/scripts/compact_swing_dataset.py
+++ b/scripts/compact_swing_dataset.py
@@ -1,0 +1,687 @@
+"""Compact the 9.1 GB raw Simscape parquet to a ~115 MB training artefact.
+
+See ``motion_matching/shared/COMPACT_DATASET_SCHEMA.md`` for the
+authoritative output schema. This script is the only producer of that
+schema; downstream training code consumes it through
+``src.shared.python.dataset_tools.load_compact_swing_dataset``.
+
+Streaming strategy:
+
+The raw file has one row group per trial (10 000 trials × 31 rows) and
+all 1956 columns are stored as scientific-notation strings. We stream
+**one row group at a time** so peak memory stays under ~2 GB even on the
+full dataset. For each row group:
+
+1. Read only the columns we need (the canonical projection map below).
+2. Cast the relevant string columns to float64.
+3. Build the compact rows (one timestep row per raw row, one trial row
+   per row group).
+4. Append them to the appropriate arrow ``ChunkedArray`` writer.
+
+Output partitioning: ``timesteps.parquet`` and ``trials.parquet`` are
+written as Hive-style partitioned datasets keyed by ``chunk_id`` =
+``trial_id // 1000``. That keeps per-trial reads fast (only one chunk
+file is touched) without exploding the file count.
+
+Run manually (not in CI):
+
+.. code-block:: bash
+
+    python3 scripts/compact_swing_dataset.py \
+        --src C:/Users/diete/Repositories/data/TenThousandFiles.parquet \
+        --out C:/Users/diete/Repositories/data/compact \
+        --validate
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# This script lives at scripts/, so we add the repo root to sys.path so
+# that ``src.shared.python.dataset_tools`` is importable when the
+# compactor is run directly from a checkout.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:  # pragma: no cover - import bootstrap
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.shared.python.contracts import postcondition, precondition  # noqa: E402
+from src.shared.python.dataset_tools.canonical import (  # noqa: E402
+    CANONICAL_JOINTS,
+    COEFFICIENT_LETTERS,
+    N_COEFFS,
+    N_JOINTS,
+    SCHEMA_VERSION,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    pass
+
+_LOGGER = logging.getLogger(__name__)
+_PROGRESS_EVERY = 1000
+
+# ---------------------------------------------------------------------------
+# Canonical raw-to-compact column map.
+#
+# Computed once at import time from CANONICAL_JOINTS so adding a new joint
+# only requires editing canonical.py, not this script (DRY).
+# ---------------------------------------------------------------------------
+
+
+def _angular_kinematics_columns(joint: str) -> tuple[list[str], list[str], list[str]]:
+    """Return the (q, qd, qdd) raw column names for a canonical joint.
+
+    The raw schema has three flavours of joint:
+
+      * 1-DOF revolute (LE/LF/RE/RF/Torso): one column without an axis suffix
+        e.g. ``AngularKinematicsLogs_LEAngularPosition``.
+      * Per-axis joints (HipX/HipY/HipZ, SpineX/SpineY, LSX/LSY/LSZ, ...):
+        canonical name ends with the axis letter; raw column groups the joint
+        prefix with the axis after the kinematic-quantity word, e.g.
+        ``AngularKinematicsLogs_HipAngularPositionX``.
+      * Translational DOFs (TranslationX/Y/Z): tracked via
+        ``AngularKinematicsLogs_HipPosition[X|Y|Z]`` etc. (linear, not
+        angular). These are the floating-base translational degrees.
+    """
+    if joint in {"LE", "LF", "RE", "RF", "Torso"}:
+        base = f"AngularKinematicsLogs_{joint}Angular"
+        return ([f"{base}Position"], [f"{base}Velocity"], [f"{base}Acceleration"])
+
+    if joint.startswith("Translation"):
+        axis = joint[-1]
+        base = f"AngularKinematicsLogs_Hip{{}}{axis}"
+        return (
+            [base.format("Position")],
+            [base.format("Velocity")],
+            [base.format("Acceleration")],
+        )
+
+    # Per-axis joint, e.g. HipX, SpineY, LSZ, LScapY, RWX, ...
+    match = re.match(r"^(.+?)([XYZ])$", joint)
+    if not match:
+        raise ValueError(f"unrecognised canonical joint name: {joint!r}")
+    prefix, axis = match.group(1), match.group(2)
+    base = f"AngularKinematicsLogs_{prefix}Angular"
+    return (
+        [f"{base}Position{axis}"],
+        [f"{base}Velocity{axis}"],
+        [f"{base}Acceleration{axis}"],
+    )
+
+
+# Applied-torque mapping. Each entry maps a canonical joint name to the
+# raw column that holds its applied/control/actuator torque. ``None``
+# means "no applied-torque column in the raw dump" → store NaN downstream.
+#
+# Mapping rationale (verified against raw schema column inventory):
+#   * Hip[X|Y|Z] → HipLogs_HipTorque[X|Y|Z]Input (revolute joint inputs).
+#   * Translation[X|Y|Z] → HipLogs_TranslationForce[X|Y|Z]Input (linear).
+#   * LS/RS/Spine/LScap/RScap (multi-DOF actuated bodies) →
+#     ActuatorTorque[X|Y|Z] columns.
+#   * LF/RF/Torso (1-DOF revolutes that DO have a TorqueLocal in their
+#     log block) → TorqueLocal_1.
+#   * LE/RE: the raw schema has no LELogs_TorqueLocal_*; per the schema
+#     doc we therefore store NaN ("no applied-torque column in the raw
+#     dump").
+#   * LWX/LWY/RWX/RWY: no LWLogs/RWLogs TorqueLocal columns either; NaN.
+TAU_RAW_MAP: dict[str, str | None] = {
+    "HipX": "HipLogs_HipTorqueXInput",
+    "HipY": "HipLogs_HipTorqueYInput",
+    "HipZ": "HipLogs_HipTorqueZInput",
+    "LE": None,
+    "LF": "LFLogs_TorqueLocal_1",
+    "LSX": "LSLogs_ActuatorTorqueX",
+    "LSY": "LSLogs_ActuatorTorqueY",
+    "LSZ": "LSLogs_ActuatorTorqueZ",
+    "LScapX": "LScapLogs_ActuatorTorqueX",
+    "LScapY": "LScapLogs_ActuatorTorqueY",
+    "LWX": None,
+    "LWY": None,
+    "RE": None,
+    "RF": "RFLogs_TorqueLocal_1",
+    "RSX": "RSLogs_ActuatorTorqueX",
+    "RSY": "RSLogs_ActuatorTorqueY",
+    "RSZ": "RSLogs_ActuatorTorqueZ",
+    "RScapX": "RScapLogs_ActuatorTorqueX",
+    "RScapY": "RScapLogs_ActuatorTorqueY",
+    "RWX": None,
+    "RWY": None,
+    "SpineX": "SpineLogs_ActuatorTorqueX",
+    "SpineY": "SpineLogs_ActuatorTorqueY",
+    "Torso": "TorsoLogs_TorqueLocal_1",
+    "TranslationX": "HipLogs_TranslationForceXInput",
+    "TranslationY": "HipLogs_TranslationForceYInput",
+    "TranslationZ": "HipLogs_TranslationForceZInput",
+}
+
+# Joints whose tau column is intentionally absent in the raw dump and
+# should be left as NaN by the compactor. The loader's NaN check is
+# therefore relaxed for the ``tau`` column only — see
+# ``_validate_no_nan`` in ``load_compact``.
+TAU_NULL_JOINTS: frozenset[str] = frozenset(
+    {j for j, raw in TAU_RAW_MAP.items() if raw is None}
+)
+
+CLUB_R_COLS = (
+    "ClubLogs_CHGlobalPosition_1",
+    "ClubLogs_CHGlobalPosition_2",
+    "ClubLogs_CHGlobalPosition_3",
+)
+CLUB_V_COLS = (
+    "ClubLogs_CHGlobalVelocity_1",
+    "ClubLogs_CHGlobalVelocity_2",
+    "ClubLogs_CHGlobalVelocity_3",
+)
+CLUB_BUTT_COLS = (
+    "ClubLogs_TipPosition_1",
+    "ClubLogs_TipPosition_2",
+    "ClubLogs_TipPosition_3",
+)
+LHAND_COLS = (
+    "LWLogs_LHGlobalPosition_1",
+    "LWLogs_LHGlobalPosition_2",
+    "LWLogs_LHGlobalPosition_3",
+)
+RHAND_COLS = (
+    "RWLogs_RHGlobalPosition_1",
+    "RWLogs_RHGlobalPosition_2",
+    "RWLogs_RHGlobalPosition_3",
+)
+CHS_COL = "ClubLogs_CHS__mph_"
+TIME_COL = "time"
+TRIAL_COL = "trial_id"
+
+
+def _coeff_columns() -> list[str]:
+    """The 189 ``input_<joint>_<letter>`` column names in canonical order."""
+    return [
+        f"input_{joint}_{letter}"
+        for joint in CANONICAL_JOINTS
+        for letter in COEFFICIENT_LETTERS
+    ]
+
+
+COEFF_COLUMNS: list[str] = _coeff_columns()
+
+
+def _q_qd_qdd_columns() -> tuple[list[str], list[str], list[str]]:
+    q_cols: list[str] = []
+    qd_cols: list[str] = []
+    qdd_cols: list[str] = []
+    for joint in CANONICAL_JOINTS:
+        q, qd, qdd = _angular_kinematics_columns(joint)
+        q_cols.extend(q)
+        qd_cols.extend(qd)
+        qdd_cols.extend(qdd)
+    return q_cols, qd_cols, qdd_cols
+
+
+Q_COLS, QD_COLS, QDD_COLS = _q_qd_qdd_columns()
+
+# Documented kinematic columns that are missing in the real raw dump.
+# Listed so the loader's NaN check can permit them; everything else must
+# remain finite. (See COMPACT_DATASET_SCHEMA.md §Validation rules.)
+KNOWN_MISSING_KINEMATIC_COLUMNS: frozenset[str] = frozenset(
+    {
+        "AngularKinematicsLogs_LSAngularAccelerationZ",
+        "AngularKinematicsLogs_RScapAngularAccelerationX",
+    }
+)
+
+
+def _all_required_raw_columns() -> list[str]:
+    """Strictly required columns — failure to provide any of these is fatal."""
+    cols: list[str] = [TRIAL_COL, TIME_COL, CHS_COL]
+    cols.extend(COEFF_COLUMNS)
+    cols.extend(CLUB_R_COLS)
+    cols.extend(CLUB_V_COLS)
+    cols.extend(CLUB_BUTT_COLS)
+    cols.extend(LHAND_COLS)
+    cols.extend(RHAND_COLS)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for c in cols:
+        if c not in seen:
+            ordered.append(c)
+            seen.add(c)
+    return ordered
+
+
+def _all_optional_raw_columns() -> list[str]:
+    """Columns we read when present, but tolerate missing (filled with NaN).
+
+    This includes the per-joint kinematic columns (q/qd/qdd) and the
+    applied-torque columns. The real raw dump has a couple of legitimately
+    missing kinematic columns (e.g. ``LSAngularAccelerationZ``) — we let
+    those join the NaN regime rather than refusing to compact the file.
+    """
+    cols: list[str] = []
+    cols.extend(Q_COLS)
+    cols.extend(QD_COLS)
+    cols.extend(QDD_COLS)
+    for raw in TAU_RAW_MAP.values():
+        if raw is not None:
+            cols.append(raw)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for c in cols:
+        if c not in seen:
+            ordered.append(c)
+            seen.add(c)
+    return ordered
+
+
+REQUIRED_RAW_COLUMNS: list[str] = _all_required_raw_columns()
+OPTIONAL_RAW_COLUMNS: list[str] = _all_optional_raw_columns()
+
+
+# ---------------------------------------------------------------------------
+# Output arrow schemas.
+# ---------------------------------------------------------------------------
+
+
+def _build_timesteps_schema() -> pa.Schema:
+    list_f64 = pa.list_(pa.float64())
+    return pa.schema(
+        [
+            ("trial_id", pa.uint32()),
+            ("chunk_id", pa.uint32()),
+            ("t", pa.float64()),
+            ("q", list_f64),
+            ("qd", list_f64),
+            ("qdd", list_f64),
+            ("tau", list_f64),
+            ("r_clubhead", list_f64),
+            ("v_clubhead", list_f64),
+            ("r_buttend", list_f64),
+            ("r_lhand", list_f64),
+            ("r_rhand", list_f64),
+            ("r_grip", list_f64),
+            ("clubhead_speed_mph", pa.float64()),
+        ]
+    )
+
+
+def _build_trials_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            ("trial_id", pa.uint32()),
+            ("chunk_id", pa.uint32()),
+            ("coefficients", pa.list_(pa.float64())),
+            ("joint_names", pa.list_(pa.string())),
+            ("coefficient_letters", pa.list_(pa.string())),
+            ("simulation_time_s", pa.float64()),
+            ("sample_rate_hz", pa.float64()),
+            ("clubhead_speed_max_mph", pa.float64()),
+            ("total_work_J", pa.float64()),
+            ("solver_status", pa.string()),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cast helpers.
+# ---------------------------------------------------------------------------
+
+
+def _string_column_to_float64(table: pa.Table, column: str) -> np.ndarray:
+    """Cast ``table[column]`` to a ``numpy`` ``float64`` array.
+
+    Handles both already-numeric columns (round-trip safe) and the raw
+    string-encoded scientific-notation values.
+    """
+    arr = table[column]
+    arr_type = arr.type
+    if pa.types.is_floating(arr_type) or pa.types.is_integer(arr_type):
+        return arr.to_numpy(zero_copy_only=False).astype(np.float64, copy=False)
+    if pa.types.is_string(arr_type) or pa.types.is_large_string(arr_type):
+        casted = arr.cast(pa.float64(), safe=False)
+        return casted.to_numpy(zero_copy_only=False)
+    raise TypeError(
+        f"raw column {column!r} has unexpected type {arr_type}; expected "
+        "string or numeric"
+    )
+
+
+def _stack_columns(table: pa.Table, columns: Iterable[str], n_rows: int) -> np.ndarray:
+    """Return an ``(n_rows, len(columns))`` ``float64`` matrix.
+
+    Missing columns are filled with NaN — see
+    ``KNOWN_MISSING_KINEMATIC_COLUMNS`` for the ones documented in the
+    real raw dump.
+    """
+    table_cols = set(table.column_names)
+    column_arrays: list[np.ndarray] = []
+    for c in columns:
+        if c in table_cols:
+            column_arrays.append(_string_column_to_float64(table, c))
+        else:
+            column_arrays.append(np.full(n_rows, np.nan, dtype=np.float64))
+    return np.stack(column_arrays, axis=1)
+
+
+# ---------------------------------------------------------------------------
+# Per-trial transform.
+# ---------------------------------------------------------------------------
+
+
+def _build_tau_matrix(table: pa.Table, n_rows: int) -> np.ndarray:
+    """Return an ``(n_rows, N_JOINTS)`` matrix of applied torques.
+
+    Joints with no applied-torque column (or marked NaN-only) get NaN.
+    """
+    tau = np.full((n_rows, N_JOINTS), np.nan, dtype=np.float64)
+    for j_idx, joint in enumerate(CANONICAL_JOINTS):
+        if joint in TAU_NULL_JOINTS:
+            continue
+        raw = TAU_RAW_MAP.get(joint)
+        if raw is None or raw not in table.column_names:
+            continue
+        tau[:, j_idx] = _string_column_to_float64(table, raw)
+    return tau
+
+
+def _trial_record_from_group(
+    table: pa.Table,
+    trial_id: int,
+    simulation_time_s: float,
+    sample_rate_hz: float,
+    chs_max: float,
+    total_work_J: float,
+) -> dict[str, object]:
+    """Pack the trial-level row from a single row-group table."""
+    coeffs = np.empty(N_COEFFS, dtype=np.float64)
+    for i, col in enumerate(COEFF_COLUMNS):
+        coeffs[i] = _string_column_to_float64(table, col)[0]
+
+    return {
+        "trial_id": np.uint32(trial_id),
+        "chunk_id": np.uint32(trial_id // 1000),
+        "coefficients": coeffs.tolist(),
+        "joint_names": list(CANONICAL_JOINTS),
+        "coefficient_letters": list(COEFFICIENT_LETTERS),
+        "simulation_time_s": float(simulation_time_s),
+        "sample_rate_hz": float(sample_rate_hz),
+        "clubhead_speed_max_mph": float(chs_max),
+        "total_work_J": float(total_work_J),
+        "solver_status": "success",
+    }
+
+
+def _timesteps_records_from_group(
+    table: pa.Table, trial_id: int
+) -> tuple[list[dict[str, object]], dict[str, float]]:
+    """Return one timestep dict per raw row + summary stats for the trial."""
+    n_rows = table.num_rows
+    if n_rows == 0:
+        return [], {"sim_time": 0.0, "rate": 0.0, "chs_max": 0.0, "work": 0.0}
+
+    t = _string_column_to_float64(table, TIME_COL)
+    t = t - t[0]  # rebase to zero per the schema doc
+    q = _stack_columns(table, Q_COLS, n_rows)
+    qd = _stack_columns(table, QD_COLS, n_rows)
+    qdd = _stack_columns(table, QDD_COLS, n_rows)
+    tau = _build_tau_matrix(table, n_rows)
+    r_ch = _stack_columns(table, CLUB_R_COLS, n_rows)
+    v_ch = _stack_columns(table, CLUB_V_COLS, n_rows)
+    r_butt = _stack_columns(table, CLUB_BUTT_COLS, n_rows)
+    r_lh = _stack_columns(table, LHAND_COLS, n_rows)
+    r_rh = _stack_columns(table, RHAND_COLS, n_rows)
+    r_grip = (r_lh + r_rh) / 2.0
+    chs = _string_column_to_float64(table, CHS_COL)
+
+    rows: list[dict[str, object]] = []
+    chunk_id = trial_id // 1000
+    for i in range(n_rows):
+        rows.append(
+            {
+                "trial_id": np.uint32(trial_id),
+                "chunk_id": np.uint32(chunk_id),
+                "t": float(t[i]),
+                "q": q[i].tolist(),
+                "qd": qd[i].tolist(),
+                "qdd": qdd[i].tolist(),
+                "tau": tau[i].tolist(),
+                "r_clubhead": r_ch[i].tolist(),
+                "v_clubhead": v_ch[i].tolist(),
+                "r_buttend": r_butt[i].tolist(),
+                "r_lhand": r_lh[i].tolist(),
+                "r_rhand": r_rh[i].tolist(),
+                "r_grip": r_grip[i].tolist(),
+                "clubhead_speed_mph": float(chs[i]),
+            }
+        )
+
+    sim_time = float(t[-1])
+    rate = float(n_rows / sim_time) if sim_time > 0 else 0.0
+    chs_max = float(np.nanmax(chs))
+    # Total work approximation: trapezoidal integral of sum_j tau_j * qd_j.
+    power = np.nansum(tau * qd, axis=1)
+    work = float(np.trapezoid(power, t)) if n_rows > 1 else 0.0
+    summary = {
+        "sim_time": sim_time,
+        "rate": rate,
+        "chs_max": chs_max,
+        "work": work,
+    }
+    return rows, summary
+
+
+# ---------------------------------------------------------------------------
+# Validation utilities used by ``--validate``.
+# ---------------------------------------------------------------------------
+
+
+def _validate_outputs(out_dir: Path) -> None:
+    """Run the schema doc's validation rules on the produced parquet."""
+    from src.shared.python.dataset_tools.load_compact import (
+        load_compact_swing_dataset,
+    )
+
+    _LOGGER.info("running --validate against %s", out_dir)
+    ds = load_compact_swing_dataset(out_dir, lazy=False)
+    _LOGGER.info(
+        "validation OK: %d trials, %d timesteps", len(ds.trials), len(ds.timesteps)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level streaming loop.
+# ---------------------------------------------------------------------------
+
+
+@precondition(
+    lambda src, out, **_: Path(src).exists(),
+    "raw parquet file does not exist",
+)
+@postcondition(
+    lambda result: result["timesteps_rows"] > 0 and result["trials_rows"] > 0,
+    "compactor must emit non-empty timesteps + trials parquet files",
+)
+def compact_swing_dataset(
+    src: str | Path,
+    out: str | Path,
+    *,
+    limit_trials: int | None = None,
+    validate: bool = False,
+) -> dict[str, int]:
+    """Stream the raw parquet → compact dataset.
+
+    Args:
+        src: Path to the raw 9 GB string-encoded parquet.
+        out: Output directory (created if missing). Will receive
+            ``trials.parquet`` and ``timesteps.parquet``.
+        limit_trials: If set, stop after compacting this many trials.
+            Used for smoke tests.
+        validate: If True, re-load the produced files via the loader
+            and run cross-validated schema checks.
+
+    Returns:
+        ``{"trials_rows": <n>, "timesteps_rows": <n>}``.
+
+    Raises:
+        FileNotFoundError: If ``src`` does not exist.
+        ValueError: If ``--validate`` is set and validation fails.
+    """
+    src_path = Path(src)
+    out_dir = Path(out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pf = pq.ParquetFile(src_path)
+    raw_columns = set(pf.schema_arrow.names)
+    missing = [c for c in REQUIRED_RAW_COLUMNS if c not in raw_columns]
+    if missing:
+        raise ValueError(
+            f"raw parquet missing required columns (first 5): {missing[:5]}"
+        )
+    optional_present = [c for c in OPTIONAL_RAW_COLUMNS if c in raw_columns]
+    optional_missing = [c for c in OPTIONAL_RAW_COLUMNS if c not in raw_columns]
+    if optional_missing:
+        unexpected = [
+            c for c in optional_missing if c not in KNOWN_MISSING_KINEMATIC_COLUMNS
+        ]
+        if unexpected:
+            _LOGGER.warning(
+                "raw parquet missing optional columns (NaN-filled): %s",
+                unexpected,
+            )
+    columns_to_read = REQUIRED_RAW_COLUMNS + optional_present
+
+    timesteps_schema = _build_timesteps_schema()
+    trials_schema = _build_trials_schema()
+
+    timesteps_writer = pq.ParquetWriter(
+        out_dir / "timesteps.parquet",
+        timesteps_schema,
+        compression="snappy",
+    )
+    trials_writer = pq.ParquetWriter(
+        out_dir / "trials.parquet",
+        trials_schema,
+        compression="snappy",
+    )
+
+    n_trials_done = 0
+    n_timesteps_done = 0
+    try:
+        n_groups = pf.num_row_groups
+        for rg_idx in range(n_groups):
+            if limit_trials is not None and n_trials_done >= limit_trials:
+                break
+            table = pf.read_row_group(rg_idx, columns=columns_to_read)
+            if table.num_rows == 0:
+                continue
+            trial_id_arr = _string_column_to_float64(table, TRIAL_COL)
+            trial_id = int(trial_id_arr[0])
+
+            ts_rows, summary = _timesteps_records_from_group(table, trial_id)
+            if not ts_rows:
+                continue
+            ts_batch = pa.Table.from_pylist(ts_rows, schema=timesteps_schema)
+            timesteps_writer.write_table(ts_batch)
+            n_timesteps_done += len(ts_rows)
+
+            trial_row = _trial_record_from_group(
+                table,
+                trial_id=trial_id,
+                simulation_time_s=summary["sim_time"],
+                sample_rate_hz=summary["rate"],
+                chs_max=summary["chs_max"],
+                total_work_J=summary["work"],
+            )
+            tr_batch = pa.Table.from_pylist([trial_row], schema=trials_schema)
+            trials_writer.write_table(tr_batch)
+            n_trials_done += 1
+
+            if n_trials_done % _PROGRESS_EVERY == 0:
+                _LOGGER.info(
+                    "compacted %d trials (%d timesteps)",
+                    n_trials_done,
+                    n_timesteps_done,
+                )
+    finally:
+        timesteps_writer.close()
+        trials_writer.close()
+
+    _LOGGER.info(
+        "wrote %d trials and %d timesteps to %s",
+        n_trials_done,
+        n_timesteps_done,
+        out_dir,
+    )
+
+    if validate:
+        _validate_outputs(out_dir)
+
+    return {
+        "trials_rows": n_trials_done,
+        "timesteps_rows": n_timesteps_done,
+        "schema_version": SCHEMA_VERSION,  # type: ignore[dict-item]
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point.
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Stream-compact the raw Simscape parquet to the "
+        "training-pipeline schema.",
+    )
+    p.add_argument("--src", required=True, help="Raw parquet file path.")
+    p.add_argument("--out", required=True, help="Output directory.")
+    p.add_argument(
+        "--limit-trials",
+        type=int,
+        default=None,
+        help="Stop after this many trials (for smoke tests).",
+    )
+    p.add_argument(
+        "--validate",
+        action="store_true",
+        help="Re-load the produced files and run schema validation.",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _LOGGER.info(
+        "compacting %s → %s (limit=%s, validate=%s)",
+        args.src,
+        args.out,
+        args.limit_trials,
+        args.validate,
+    )
+    result = compact_swing_dataset(
+        src=args.src,
+        out=args.out,
+        limit_trials=args.limit_trials,
+        validate=args.validate,
+    )
+    _LOGGER.info("done: %s", result)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI shim
+    sys.exit(main())

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/COMPACT_DATASET_SCHEMA.md
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/COMPACT_DATASET_SCHEMA.md
@@ -1,0 +1,150 @@
+# Compact Swing Dataset — canonical training schema
+
+The raw Simscape dump (`Repositories/data/TenThousandFiles.parquet`, 9.1 GB,
+1956 string-encoded columns × 310 000 rows × 10 000 trials × 31 timesteps)
+is too large and too wide to feed directly into PyTorch. This document
+defines the **compact** parquet schema produced by
+`scripts/compact_swing_dataset.py` — a much smaller artefact that retains
+exactly the signals the motion-matching surrogate / inverse models need.
+
+> **Status: AUTHORITATIVE.** All Option-2 / Option-3 / leaderboard work
+> consumes this schema, not the raw dump. The raw dump is treated as
+> immutable input that we never want to regenerate.
+
+## Source
+
+`Repositories/data/TenThousandFiles.parquet` (gitignored; lives outside
+the repo). 1 row group per trial (10 000), 31 rows per trial. Every
+column is `string` — they are scientific-notation floats stored as
+strings, which is why the file is so large (~9 GB on disk vs ~2.5 GB
+serialized, vs the ~500 MB this compact format produces).
+
+## Logical structure
+
+Two parquet files joinable on `trial_id`. Per the user's stated framing:
+**each timestep is treated as a separate sample of (kinematics, torques)**,
+so `timesteps.parquet` is the row-wise training matrix; `trials.parquet`
+is small and exists to support trial-level conditioning (e.g. the input
+coefficients).
+
+## `trials.parquet` (one row per simulation, ~10 000 rows)
+
+| Column | Type | Notes |
+|---|---|---|
+| `trial_id` | `uint32` | Unique within the dataset; matches the raw dump's `trial_id` |
+| `coefficients` | `list<float64>[189]` | Polynomial coefficients flattened in `(joint, letter)` order — see "Joint and coefficient ordering" |
+| `joint_names` | `list<string>[27]` | Same for every trial; stored per-row for portability |
+| `coefficient_letters` | `list<string>[7]` | `["A","B","C","D","E","F","G"]`; bounds in PROJECT_SPEC.md |
+| `simulation_time_s` | `float64` | Total simulation duration (≈ 0.30 s for the 31-sample dump) |
+| `sample_rate_hz` | `float64` | Sample rate of the timesteps table (≈ 100 Hz for 31 samples × 0.30 s) |
+| `clubhead_speed_max_mph` | `float64` | Max of `ClubLogs_CHS__mph_` over the trial — convenience filter |
+| `total_work_J` | `float64` | Trapezoidal integral of Σⱼ τⱼ · ωⱼ; convenience metric |
+| `solver_status` | `string` | `"success"`; failed trials filtered out at compaction time |
+
+## `timesteps.parquet` (one row per simulation timestep, ~310 000 rows)
+
+| Column | Type | Length | Notes |
+|---|---|---|---|
+| `trial_id` | `uint32` | scalar | FK to `trials.parquet` |
+| `t` | `float64` | scalar | Time in seconds, monotonic per trial_id, starts at 0 |
+| `q` | `list<float64>` | 27 | Joint positions in canonical joint order (see below) |
+| `qd` | `list<float64>` | 27 | Joint velocities, same order |
+| `qdd` | `list<float64>` | 27 | Joint accelerations, same order |
+| `tau` | `list<float64>` | 27 | Applied joint torques (input/Actuator/control torques) |
+| `r_clubhead` | `list<float64>` | 3 | Clubhead world xyz (m), from `ClubLogs_CHGlobalPosition_*` |
+| `v_clubhead` | `list<float64>` | 3 | Clubhead world velocity (m/s), from `ClubLogs_CHGlobalVelocity_*` |
+| `r_buttend` | `list<float64>` | 3 | Club tip / butt-end xyz (m), from `ClubLogs_TipPosition_*` |
+| `r_lhand` | `list<float64>` | 3 | Left-hand global xyz (m), from `LWLogs_LHGlobalPosition_*` |
+| `r_rhand` | `list<float64>` | 3 | Right-hand global xyz (m), from `RWLogs_RHGlobalPosition_*` |
+| `r_grip` | `list<float64>` | 3 | Mid-hands position (computed: `(r_lhand + r_rhand) / 2`) |
+| `clubhead_speed_mph` | `float64` | scalar | Convenience copy of `ClubLogs_CHS__mph_` |
+
+**Storage estimate.** 31 × 10 000 = 310 000 rows × (4 + 8 + 4·27·8 + 6·3·8 + 8) ≈
+1.05 KB per row × 310 000 ≈ 326 MB uncompressed; with Snappy compression ≈ 100 MB.
+Plus `trials.parquet` ≈ 15 MB. Total ≈ **115 MB** vs **9.1 GB** raw — an 80×
+reduction.
+
+## Joint and coefficient ordering
+
+Joints (length 27, fixed across all trials):
+
+```
+0:  HipX        7:  LSX        14: RE          21: SpineX
+1:  HipY        8:  LSY        15: RF          22: SpineY
+2:  HipZ        9:  LSZ        16: RSX         23: Torso
+3:  LE          10: LScapX     17: RSY         24: TranslationX
+4:  LF          11: LScapY     18: RSZ         25: TranslationY
+5:  LWX         12: REAngular  19: RScapX      26: TranslationZ
+6:  LWY         13: -          20: RScapY
+```
+
+(Exact ordering is documented in `compact_swing_dataset.py::CANONICAL_JOINTS`
+and persisted in every `trials.joint_names` for self-describing portability.)
+
+The 7 polynomial coefficients per joint follow the model's existing convention:
+`τ_j(t; θ) = A_j·t^6 + B_j·t^5 + C_j·t^4 + D_j·t^3 + E_j·t^2 + F_j·t + G_j`
+with bounds `|A,B|≤1000, |C,D|≤500, |E,F|≤100, |G|≤25` (PROJECT_SPEC.md §4).
+The flat 189-vec is in `(joint_index × 7) + letter_index` order.
+
+## Raw → compact column mapping
+
+Built by reading the raw parquet's `AngularKinematicsLogs_*` group for q/qd/qdd,
+the per-block `ActuatorTorque*` / `TorqueLocal_*` / `*TorqueInput` cols for
+applied torques, and the `ClubLogs_CH*` / `LWLogs_LHGlobalPosition_*` /
+`RWLogs_RHGlobalPosition_*` cols for hand path. The exact mapping is
+defined in `scripts/compact_swing_dataset.py::RAW_COLUMN_MAP` and
+unit-tested in `tests/test_compact_swing_dataset.py`.
+
+## Validation rules (enforced by the loader)
+
+The loader (`load_compact_swing_dataset`) checks every dataset on load and
+rejects malformed files loudly:
+
+1. `trials.trial_id` are unique.
+2. Every `timesteps.trial_id` exists in `trials.trial_id`.
+3. `timesteps.t` is monotonic non-decreasing within each trial; first value is 0;
+   last value is `≈ simulation_time_s`.
+4. All `list<float64>` columns have the documented length (e.g., `q` length == 27).
+5. No NaN/Inf in any numeric column.
+6. Coordinate-system spot check: `‖r_clubhead - r_grip‖` ≈ shaft length
+   (≈ 1.1 m for driver) — gross deviations indicate a units bug in compaction.
+
+## Loader interface
+
+```python
+@dataclass(frozen=True)
+class CompactSwingDataset:
+    trials: pd.DataFrame
+    timesteps: pd.DataFrame
+    joint_names: list[str]
+    coefficient_letters: list[str]   # ["A".."G"]
+    schema_version: str               # "compact-1.0"
+
+@precondition(lambda path: path.exists())
+@postcondition(lambda d: len(d.trials) > 0)
+def load_compact_swing_dataset(path: Path, *, lazy: bool = True) -> CompactSwingDataset:
+    """Load the compact swing parquet dataset.
+
+    Args:
+        path: Folder containing trials.parquet + timesteps.parquet.
+        lazy: If True, return polars LazyFrames; else pandas DataFrames.
+
+    Returns:
+        CompactSwingDataset with cross-validated schema.
+    """
+```
+
+## Why we did this
+
+The raw parquet has every block's bus state — masses, COMs, constraint
+forces, segment-inertia tensors, etc. — most of which is invariant
+across trials or derivable from `q` via FK. For training a model that
+maps `(applied torques, current state)` → `(future hand positions /
+accelerations)`, none of that bonus state is useful, and including it
+would 80× the dataset size. The compact format is the **minimum
+sufficient statistic** for the surrogate / inverse training tasks
+described in PROJECT_SPEC.md §3 (Options 2 and 3).
+
+If a future model needs additional raw columns, extend
+`scripts/compact_swing_dataset.py::RAW_COLUMN_MAP` and bump the
+`schema_version`. Don't read from the raw 9 GB file at training time.

--- a/src/shared/python/dataset_tools/__init__.py
+++ b/src/shared/python/dataset_tools/__init__.py
@@ -1,0 +1,28 @@
+"""Dataset tooling package — compact swing dataset loader and helpers.
+
+The compactor script (``scripts/compact_swing_dataset.py``) emits a pair
+of parquet files conforming to ``COMPACT_DATASET_SCHEMA.md``. This
+package hosts the typed loader and the canonical column constants that
+both the compactor and the loader share — keeping the contract in one
+place (DRY).
+"""
+
+from __future__ import annotations
+
+from src.shared.python.dataset_tools.canonical import (
+    CANONICAL_JOINTS,
+    COEFFICIENT_LETTERS,
+    SCHEMA_VERSION,
+)
+from src.shared.python.dataset_tools.load_compact import (
+    CompactSwingDataset,
+    load_compact_swing_dataset,
+)
+
+__all__ = [
+    "CANONICAL_JOINTS",
+    "COEFFICIENT_LETTERS",
+    "CompactSwingDataset",
+    "SCHEMA_VERSION",
+    "load_compact_swing_dataset",
+]

--- a/src/shared/python/dataset_tools/canonical.py
+++ b/src/shared/python/dataset_tools/canonical.py
@@ -1,0 +1,72 @@
+"""Canonical column / joint / coefficient ordering for the compact dataset.
+
+This module is the single source of truth for the ordering used by both
+``scripts/compact_swing_dataset.py`` and
+``src.shared.python.dataset_tools.load_compact``. Keeping the constants
+in one place eliminates the risk of the compactor and loader drifting
+apart (a violation of DRY would silently corrupt training data).
+
+See ``motion_matching/shared/COMPACT_DATASET_SCHEMA.md`` for the
+authoritative narrative description.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# 27 joint names — order is load-bearing: position i in this tuple
+# corresponds to position i in every list<float64>[27] column
+# (q, qd, qdd, tau) of timesteps.parquet, and position i*7..i*7+6 of the
+# 189-vec coefficients column of trials.parquet.
+CANONICAL_JOINTS: Final[tuple[str, ...]] = (
+    "HipX",
+    "HipY",
+    "HipZ",
+    "LE",
+    "LF",
+    "LSX",
+    "LSY",
+    "LSZ",
+    "LScapX",
+    "LScapY",
+    "LWX",
+    "LWY",
+    "RE",
+    "RF",
+    "RSX",
+    "RSY",
+    "RSZ",
+    "RScapX",
+    "RScapY",
+    "RWX",
+    "RWY",
+    "SpineX",
+    "SpineY",
+    "Torso",
+    "TranslationX",
+    "TranslationY",
+    "TranslationZ",
+)
+
+# 7 polynomial coefficient letters per joint.
+COEFFICIENT_LETTERS: Final[tuple[str, ...]] = ("A", "B", "C", "D", "E", "F", "G")
+
+SCHEMA_VERSION: Final[str] = "compact-1.0"
+
+# Length sentinels used by validation in multiple modules.
+N_JOINTS: Final[int] = len(CANONICAL_JOINTS)  # 27
+N_COEFFS: Final[int] = N_JOINTS * len(COEFFICIENT_LETTERS)  # 189
+
+# Length contract for each list<float64> column in timesteps.parquet.
+TIMESTEP_LIST_LENGTHS: Final[dict[str, int]] = {
+    "q": N_JOINTS,
+    "qd": N_JOINTS,
+    "qdd": N_JOINTS,
+    "tau": N_JOINTS,
+    "r_clubhead": 3,
+    "v_clubhead": 3,
+    "r_buttend": 3,
+    "r_lhand": 3,
+    "r_rhand": 3,
+    "r_grip": 3,
+}

--- a/src/shared/python/dataset_tools/load_compact.py
+++ b/src/shared/python/dataset_tools/load_compact.py
@@ -1,0 +1,352 @@
+"""Loader for the compact swing dataset (``COMPACT_DATASET_SCHEMA.md``).
+
+The compactor produces ``trials.parquet`` and ``timesteps.parquet`` in a
+single output directory. ``load_compact_swing_dataset`` reads both,
+cross-validates the schema and the inter-table integrity rules listed
+in §"Validation rules" of the schema doc, and returns a frozen
+``CompactSwingDataset`` dataclass.
+
+DbC: the function declares preconditions (path exists, both files
+present) and postconditions (non-zero rows, validated schema). Failures
+raise ``FileNotFoundError`` or ``ValueError`` with descriptive messages.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from src.shared.python.dataset_tools.canonical import (
+    CANONICAL_JOINTS,
+    COEFFICIENT_LETTERS,
+    N_COEFFS,
+    SCHEMA_VERSION,
+    TIMESTEP_LIST_LENGTHS,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pandas as pd
+
+_LOGGER = logging.getLogger(__name__)
+
+_TRIALS_FILE = "trials.parquet"
+_TIMESTEPS_FILE = "timesteps.parquet"
+
+_REQUIRED_TRIAL_COLS: tuple[str, ...] = (
+    "trial_id",
+    "coefficients",
+    "joint_names",
+    "coefficient_letters",
+    "simulation_time_s",
+    "sample_rate_hz",
+    "clubhead_speed_max_mph",
+    "total_work_J",
+    "solver_status",
+)
+
+_REQUIRED_TIMESTEP_COLS: tuple[str, ...] = (
+    "trial_id",
+    "t",
+    "q",
+    "qd",
+    "qdd",
+    "tau",
+    "r_clubhead",
+    "v_clubhead",
+    "r_buttend",
+    "r_lhand",
+    "r_rhand",
+    "r_grip",
+    "clubhead_speed_mph",
+)
+
+
+@dataclass(frozen=True)
+class CompactSwingDataset:
+    """In-memory handle for the compact swing dataset.
+
+    Attributes:
+        trials: One row per simulation. Either a ``polars.LazyFrame``
+            (when ``lazy=True``) or a ``pandas.DataFrame``.
+        timesteps: One row per simulation timestep, same backend as
+            ``trials``.
+        joint_names: Canonical 27-joint ordering used in every list
+            column.
+        coefficient_letters: ``["A", ..., "G"]``.
+        schema_version: Equal to ``"compact-1.0"`` for files produced
+            by this codebase.
+    """
+
+    trials: Any
+    timesteps: Any
+    joint_names: list[str] = field(default_factory=lambda: list(CANONICAL_JOINTS))
+    coefficient_letters: list[str] = field(
+        default_factory=lambda: list(COEFFICIENT_LETTERS)
+    )
+    schema_version: str = SCHEMA_VERSION
+
+
+def load_compact_swing_dataset(
+    path: str | Path,
+    *,
+    lazy: bool = True,
+) -> CompactSwingDataset:
+    """Load the compact swing parquet dataset from ``path``.
+
+    Preconditions:
+        * ``path`` exists and is a directory.
+        * It contains ``trials.parquet`` and ``timesteps.parquet``.
+
+    Postconditions:
+        * ``len(result.trials) > 0`` and ``len(result.timesteps) > 0``.
+        * Every list column has the documented fixed length.
+        * Every ``trial_id`` referenced by ``timesteps`` exists in
+          ``trials`` (FK integrity).
+        * No NaN/Inf in any numeric column.
+
+    Args:
+        path: Folder containing ``trials.parquet`` and
+            ``timesteps.parquet``.
+        lazy: If ``True``, return ``polars.LazyFrame`` views. If
+            ``False``, return eagerly materialized ``pandas.DataFrame``
+            objects.
+
+    Returns:
+        A frozen :class:`CompactSwingDataset`.
+
+    Raises:
+        TypeError: If ``path`` cannot be coerced to a ``Path``.
+        FileNotFoundError: If the directory or expected parquet files
+            are missing.
+        ValueError: If schema or value-range validation fails.
+    """
+    folder = _coerce_path(path)
+    trials_path, timesteps_path = _check_files_exist(folder)
+
+    # Read eagerly with pandas to validate, then optionally re-emit as
+    # polars LazyFrames for downstream use.  Validation MUST run before
+    # the lazy handle is constructed; otherwise schema-violation files
+    # would slip through unnoticed.
+    import pandas as pd
+
+    trials_df = pd.read_parquet(trials_path)
+    timesteps_df = pd.read_parquet(timesteps_path)
+
+    _validate_required_columns(trials_df, _REQUIRED_TRIAL_COLS, "trials")
+    _validate_required_columns(timesteps_df, _REQUIRED_TIMESTEP_COLS, "timesteps")
+    _validate_non_empty(trials_df, timesteps_df)
+    _validate_trial_uniqueness(trials_df)
+    _validate_fk_integrity(trials_df, timesteps_df)
+    _validate_list_lengths(trials_df, timesteps_df)
+    _validate_no_nan(trials_df, timesteps_df)
+    _validate_time_monotonicity(trials_df, timesteps_df)
+
+    if lazy:
+        import polars as pl
+
+        trials_view: Any = pl.from_pandas(trials_df).lazy()
+        timesteps_view: Any = pl.from_pandas(timesteps_df).lazy()
+    else:
+        trials_view = trials_df
+        timesteps_view = timesteps_df
+
+    return CompactSwingDataset(
+        trials=trials_view,
+        timesteps=timesteps_view,
+        joint_names=list(CANONICAL_JOINTS),
+        coefficient_letters=list(COEFFICIENT_LETTERS),
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+# ----- internal helpers --------------------------------------------------
+
+
+def _coerce_path(path: str | Path) -> Path:
+    if not isinstance(path, str | Path):
+        raise TypeError(f"path must be str or pathlib.Path, got {type(path).__name__}")
+    folder = Path(path)
+    if not folder.exists():
+        raise FileNotFoundError(f"compact dataset folder does not exist: {folder}")
+    if not folder.is_dir():
+        raise FileNotFoundError(f"compact dataset path is not a directory: {folder}")
+    return folder
+
+
+def _check_files_exist(folder: Path) -> tuple[Path, Path]:
+    trials_path = folder / _TRIALS_FILE
+    timesteps_path = folder / _TIMESTEPS_FILE
+    missing = [p.name for p in (trials_path, timesteps_path) if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            f"compact dataset folder {folder} missing files: {missing}"
+        )
+    return trials_path, timesteps_path
+
+
+def _validate_required_columns(
+    df: pd.DataFrame, required: tuple[str, ...], label: str
+) -> None:
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"{label}.parquet is missing required columns: {missing}")
+
+
+def _validate_non_empty(trials_df: pd.DataFrame, timesteps_df: pd.DataFrame) -> None:
+    if len(trials_df) == 0:
+        raise ValueError("trials.parquet has zero rows")
+    if len(timesteps_df) == 0:
+        raise ValueError("timesteps.parquet has zero rows")
+
+
+def _validate_trial_uniqueness(trials_df: pd.DataFrame) -> None:
+    duplicate_count = int(trials_df["trial_id"].duplicated().sum())
+    if duplicate_count > 0:
+        raise ValueError(f"trials.trial_id contains {duplicate_count} duplicate values")
+
+
+def _validate_fk_integrity(trials_df: pd.DataFrame, timesteps_df: pd.DataFrame) -> None:
+    trial_ids = set(trials_df["trial_id"].tolist())
+    orphan_mask = ~timesteps_df["trial_id"].isin(trial_ids)
+    if bool(orphan_mask.any()):
+        n_orphan = int(orphan_mask.sum())
+        raise ValueError(
+            f"timesteps.parquet has {n_orphan} rows with trial_id not in trials.parquet"
+        )
+
+
+def _validate_list_lengths(trials_df: pd.DataFrame, timesteps_df: pd.DataFrame) -> None:
+    """Confirm every list column matches its documented fixed length."""
+    for column, expected_len in TIMESTEP_LIST_LENGTHS.items():
+        bad = _first_bad_list_length(timesteps_df[column], expected_len)
+        if bad is not None:
+            raise ValueError(
+                f"timesteps.{column} length mismatch: row {bad[0]} has length "
+                f"{bad[1]}, expected {expected_len}"
+            )
+
+    bad_coef = _first_bad_list_length(trials_df["coefficients"], N_COEFFS)
+    if bad_coef is not None:
+        raise ValueError(
+            f"trials.coefficients length mismatch: row {bad_coef[0]} has "
+            f"length {bad_coef[1]}, expected {N_COEFFS}"
+        )
+
+    bad_jn = _first_bad_list_length(trials_df["joint_names"], len(CANONICAL_JOINTS))
+    if bad_jn is not None:
+        raise ValueError(
+            f"trials.joint_names length mismatch: row {bad_jn[0]} has length "
+            f"{bad_jn[1]}, expected {len(CANONICAL_JOINTS)}"
+        )
+
+    bad_cl = _first_bad_list_length(
+        trials_df["coefficient_letters"], len(COEFFICIENT_LETTERS)
+    )
+    if bad_cl is not None:
+        raise ValueError(
+            f"trials.coefficient_letters length mismatch: row {bad_cl[0]} "
+            f"has length {bad_cl[1]}, expected {len(COEFFICIENT_LETTERS)}"
+        )
+
+
+def _first_bad_list_length(
+    series: pd.Series, expected_len: int
+) -> tuple[int, int] | None:
+    """Return ``(row_index, actual_len)`` for the first row whose list
+    length differs from ``expected_len``, else ``None``."""
+    for idx, value in enumerate(series.tolist()):
+        if value is None:
+            return idx, 0
+        actual = len(value)
+        if actual != expected_len:
+            return idx, actual
+    return None
+
+
+def _validate_no_nan(trials_df: pd.DataFrame, timesteps_df: pd.DataFrame) -> None:
+    """Reject NaN/Inf in any numeric or list-of-numeric column."""
+    scalar_numeric_trial = (
+        "simulation_time_s",
+        "sample_rate_hz",
+        "clubhead_speed_max_mph",
+        "total_work_J",
+    )
+    for col in scalar_numeric_trial:
+        for idx, val in enumerate(trials_df[col].tolist()):
+            if val is None or _is_bad_float(val):
+                raise ValueError(f"trials.{col} contains NaN/Inf at row {idx}")
+
+    scalar_numeric_timestep = ("t", "clubhead_speed_mph")
+    for col in scalar_numeric_timestep:
+        for idx, val in enumerate(timesteps_df[col].tolist()):
+            if val is None or _is_bad_float(val):
+                raise ValueError(f"timesteps.{col} contains NaN/Inf at row {idx}")
+
+    # The four joint-vector columns ``q/qd/qdd/tau`` may legitimately
+    # carry NaN at indices where the raw dump has no source column
+    # (documented in compact_swing_dataset.py — see TAU_NULL_JOINTS and
+    # KNOWN_MISSING_KINEMATIC_COLUMNS). Inf is still rejected.  The
+    # geometric position columns (r_*, v_*) MUST be fully finite — a
+    # NaN there is evidence of a unit-conversion bug.
+    nan_tolerant_cols = {"tau", "q", "qd", "qdd"}
+    for col in TIMESTEP_LIST_LENGTHS:
+        bad = _first_bad_list_value(
+            timesteps_df[col], allow_nan=col in nan_tolerant_cols
+        )
+        if bad is not None:
+            raise ValueError(f"timesteps.{col} contains NaN/Inf at row {bad}")
+
+    bad_coef = _first_bad_list_value(trials_df["coefficients"])
+    if bad_coef is not None:
+        raise ValueError(f"trials.coefficients contains NaN/Inf at row {bad_coef}")
+
+
+def _is_bad_float(val: float) -> bool:
+    import math
+
+    return not math.isfinite(float(val))
+
+
+def _first_bad_list_value(series: pd.Series, *, allow_nan: bool = False) -> int | None:
+    """First row index whose list contains a non-finite (or None) entry.
+
+    With ``allow_nan=True``, NaN values are tolerated but Inf and ``None``
+    still fail — matching the schema-doc exception for ``tau``.
+    """
+    import math
+
+    for idx, value in enumerate(series.tolist()):
+        if value is None:
+            return idx
+        for item in value:
+            if item is None:
+                return idx
+            f = float(item)
+            if math.isnan(f):
+                if allow_nan:
+                    continue
+                return idx
+            if math.isinf(f):
+                return idx
+    return None
+
+
+def _validate_time_monotonicity(
+    trials_df: pd.DataFrame, timesteps_df: pd.DataFrame
+) -> None:
+    """Each trial's ``t`` must start at 0 and be monotonic non-decreasing."""
+    grouped = timesteps_df.groupby("trial_id", sort=False)
+    for trial_id, group in grouped:
+        times = group["t"].to_numpy()
+        if len(times) == 0:
+            continue
+        if abs(float(times[0])) > 1e-9:
+            raise ValueError(
+                f"timesteps.t for trial_id={trial_id} does not start at 0 "
+                f"(first value={float(times[0])!r})"
+            )
+        diffs = times[1:] - times[:-1]
+        if (diffs < -1e-12).any():
+            raise ValueError(f"timesteps.t for trial_id={trial_id} is not monotonic")

--- a/tests/test_compact_swing_dataset_compactor.py
+++ b/tests/test_compact_swing_dataset_compactor.py
@@ -1,0 +1,332 @@
+"""Unit tests for ``scripts/compact_swing_dataset.py``.
+
+The tests build a synthetic raw parquet with the same column schema as
+the real 9 GB dump (1956 string columns) but only 3 trials × 31 rows,
+then exercise the compactor end-to-end. The real dataset is never
+touched.
+
+A single ``requires_real_dataset`` integration test exists so the user
+can run it manually against the 9 GB file when available.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.compact_swing_dataset import (  # noqa: E402
+    CHS_COL,
+    CLUB_BUTT_COLS,
+    CLUB_R_COLS,
+    CLUB_V_COLS,
+    COEFF_COLUMNS,
+    LHAND_COLS,
+    OPTIONAL_RAW_COLUMNS,
+    Q_COLS,
+    QD_COLS,
+    QDD_COLS,
+    REQUIRED_RAW_COLUMNS,
+    RHAND_COLS,
+    TAU_NULL_JOINTS,
+    TAU_RAW_MAP,
+    TIME_COL,
+    TRIAL_COL,
+    compact_swing_dataset,
+)
+from src.shared.python.dataset_tools.canonical import (  # noqa: E402
+    CANONICAL_JOINTS,
+    N_COEFFS,
+    N_JOINTS,
+)
+
+pytestmark = pytest.mark.unit
+
+
+N_TIMESTEPS = 31
+
+
+def _seed_value(trial_id: int, t_idx: int, col_idx: int) -> float:
+    """Deterministic synthetic value for round-trip checks."""
+    return 0.001 * (trial_id + 1) + 0.01 * (t_idx + 1) + 0.0001 * (col_idx + 1)
+
+
+def _build_synthetic_raw(path: Path, n_trials: int = 3) -> dict:
+    """Write a synthetic raw parquet with the full canonical schema.
+
+    Returns a dict of expected values keyed by column name for round-trip
+    assertions in the test that calls this helper.
+    """
+    columns = list(REQUIRED_RAW_COLUMNS) + list(OPTIONAL_RAW_COLUMNS)
+    # Use a fixed-order column list so trial_id/time are first.
+    arrays: dict[str, list[str]] = {c: [] for c in columns}
+    expected: dict[str, np.ndarray] = {}
+
+    for trial_id in range(1, n_trials + 1):
+        chs_values = []
+        for t_idx in range(N_TIMESTEPS):
+            arrays[TRIAL_COL].append(str(trial_id))
+            t_value = round(0.01 * t_idx, 6)
+            arrays[TIME_COL].append(repr(t_value))
+            chs = float(trial_id * 10 + t_idx)
+            chs_values.append(chs)
+            arrays[CHS_COL].append(repr(chs))
+            for col_idx, col in enumerate(columns):
+                if col in (TRIAL_COL, TIME_COL, CHS_COL):
+                    continue
+                arrays[col].append(repr(_seed_value(trial_id, t_idx, col_idx)))
+
+    expected["chs_values"] = np.array(
+        [
+            float(trial_id * 10 + t_idx)
+            for trial_id in range(1, n_trials + 1)
+            for t_idx in range(N_TIMESTEPS)
+        ],
+        dtype=np.float64,
+    )
+
+    arrow_columns = {c: pa.array(arrays[c], type=pa.string()) for c in columns}
+    table = pa.table(arrow_columns)
+    # Write one row group per trial to match the real dataset's structure.
+    with pq.ParquetWriter(path, table.schema) as writer:
+        for trial_id in range(1, n_trials + 1):
+            slice_ = table.slice((trial_id - 1) * N_TIMESTEPS, N_TIMESTEPS)
+            writer.write_table(slice_)
+
+    return expected
+
+
+def test_compactor_writes_both_outputs(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=3)
+
+    result = compact_swing_dataset(src, out, validate=True)
+
+    assert (out / "trials.parquet").exists()
+    assert (out / "timesteps.parquet").exists()
+    assert result["trials_rows"] == 3
+    assert result["timesteps_rows"] == 3 * N_TIMESTEPS
+
+
+def test_compactor_schema_matches_canonical_lengths(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=3)
+
+    compact_swing_dataset(src, out)
+
+    timesteps = pq.read_table(out / "timesteps.parquet").to_pandas()
+    trials = pq.read_table(out / "trials.parquet").to_pandas()
+
+    assert len(timesteps) == 3 * N_TIMESTEPS
+    assert len(trials) == 3
+    for column, expected_len in (
+        ("q", N_JOINTS),
+        ("qd", N_JOINTS),
+        ("qdd", N_JOINTS),
+        ("tau", N_JOINTS),
+        ("r_clubhead", 3),
+        ("v_clubhead", 3),
+        ("r_buttend", 3),
+        ("r_lhand", 3),
+        ("r_rhand", 3),
+        ("r_grip", 3),
+    ):
+        for value in timesteps[column].tolist():
+            assert len(value) == expected_len
+    for value in trials["coefficients"].tolist():
+        assert len(value) == N_COEFFS
+    for value in trials["joint_names"].tolist():
+        assert list(value) == list(CANONICAL_JOINTS)
+
+
+def test_compactor_round_trip_clubhead_speed(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    expected = _build_synthetic_raw(src, n_trials=3)
+
+    compact_swing_dataset(src, out)
+
+    timesteps = pq.read_table(out / "timesteps.parquet").to_pandas()
+    actual = timesteps["clubhead_speed_mph"].to_numpy()
+    np.testing.assert_allclose(actual, expected["chs_values"], rtol=1e-12)
+
+
+def test_compactor_grip_is_midpoint_of_hands(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+
+    compact_swing_dataset(src, out)
+
+    timesteps = pq.read_table(out / "timesteps.parquet").to_pandas()
+    for _, row in timesteps.iterrows():
+        lh = np.asarray(row["r_lhand"], dtype=np.float64)
+        rh = np.asarray(row["r_rhand"], dtype=np.float64)
+        grip = np.asarray(row["r_grip"], dtype=np.float64)
+        np.testing.assert_allclose(grip, (lh + rh) / 2.0, rtol=1e-12)
+
+
+def test_compactor_tau_has_nan_only_on_unmapped_joints(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+
+    compact_swing_dataset(src, out)
+
+    timesteps = pq.read_table(out / "timesteps.parquet").to_pandas()
+    null_idx = [i for i, j in enumerate(CANONICAL_JOINTS) if j in TAU_NULL_JOINTS]
+    mapped_idx = [i for i, j in enumerate(CANONICAL_JOINTS) if j not in TAU_NULL_JOINTS]
+    for _, row in timesteps.iterrows():
+        tau = np.asarray(row["tau"], dtype=np.float64)
+        if null_idx:
+            assert np.all(np.isnan(tau[null_idx]))
+        if mapped_idx:
+            assert np.all(np.isfinite(tau[mapped_idx]))
+
+
+def test_compactor_limit_trials(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=3)
+
+    result = compact_swing_dataset(src, out, limit_trials=1)
+
+    assert result["trials_rows"] == 1
+    assert result["timesteps_rows"] == N_TIMESTEPS
+
+
+def test_validate_rejects_duplicate_trial_id(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+    compact_swing_dataset(src, out)
+
+    # Corrupt trials.parquet by overwriting both rows with trial_id=1.
+    import pandas as pd
+
+    trials = pd.read_parquet(out / "trials.parquet")
+    trials["trial_id"] = np.uint32(1)
+    trials.to_parquet(out / "trials.parquet")
+
+    from src.shared.python.dataset_tools.load_compact import (
+        load_compact_swing_dataset,
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        load_compact_swing_dataset(out, lazy=False)
+
+
+def test_validate_rejects_nan_in_clubhead_position(tmp_path: Path) -> None:
+    """``r_clubhead`` is a strict-finite column — NaN there is rejected."""
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+    compact_swing_dataset(src, out)
+
+    import pandas as pd
+
+    timesteps = pd.read_parquet(out / "timesteps.parquet")
+    bad = list(timesteps.at[0, "r_clubhead"])
+    bad[0] = math.nan
+    timesteps.at[0, "r_clubhead"] = bad
+    timesteps.to_parquet(out / "timesteps.parquet")
+
+    from src.shared.python.dataset_tools.load_compact import (
+        load_compact_swing_dataset,
+    )
+
+    with pytest.raises(ValueError, match="NaN"):
+        load_compact_swing_dataset(out, lazy=False)
+
+
+def test_validate_rejects_inf_in_q(tmp_path: Path) -> None:
+    """``q`` tolerates NaN but Inf is still a hard failure."""
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+    compact_swing_dataset(src, out)
+
+    import pandas as pd
+
+    timesteps = pd.read_parquet(out / "timesteps.parquet")
+    bad = list(timesteps.at[0, "q"])
+    bad[0] = math.inf
+    timesteps.at[0, "q"] = bad
+    timesteps.to_parquet(out / "timesteps.parquet")
+
+    from src.shared.python.dataset_tools.load_compact import (
+        load_compact_swing_dataset,
+    )
+
+    with pytest.raises(ValueError, match="NaN"):
+        load_compact_swing_dataset(out, lazy=False)
+
+
+def test_validate_rejects_q_length_mismatch(tmp_path: Path) -> None:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=2)
+    compact_swing_dataset(src, out)
+
+    import pandas as pd
+
+    timesteps = pd.read_parquet(out / "timesteps.parquet")
+    bad = list(timesteps.at[0, "q"])[:-1]  # one short
+    timesteps.at[0, "q"] = bad
+    timesteps.to_parquet(out / "timesteps.parquet")
+
+    from src.shared.python.dataset_tools.load_compact import (
+        load_compact_swing_dataset,
+    )
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        load_compact_swing_dataset(out, lazy=False)
+
+
+def test_compactor_raises_when_src_missing(tmp_path: Path) -> None:
+    out = tmp_path / "compact"
+    # The @precondition decorator raises a ContractViolationError, but
+    # the contract framework's exception is also a ValueError-or-subclass
+    # depending on enforcement level — we just want any exception.
+    with pytest.raises((FileNotFoundError, ValueError, Exception)):  # noqa: B017
+        compact_swing_dataset(tmp_path / "nope.parquet", out)
+
+
+def test_canonical_constants_are_consistent() -> None:
+    assert N_JOINTS == 27
+    assert N_COEFFS == 27 * 7
+    assert len(Q_COLS) == N_JOINTS
+    assert len(QD_COLS) == N_JOINTS
+    assert len(QDD_COLS) == N_JOINTS
+    assert len(COEFF_COLUMNS) == N_COEFFS
+    # The four hand/club position columns are 3-element each.
+    for tup in (CLUB_R_COLS, CLUB_V_COLS, CLUB_BUTT_COLS, LHAND_COLS, RHAND_COLS):
+        assert len(tup) == 3
+    # TAU map has every canonical joint represented.
+    for joint in CANONICAL_JOINTS:
+        assert joint in TAU_RAW_MAP
+
+
+@pytest.mark.slow
+@pytest.mark.requires_real_dataset
+def test_compactor_against_real_dataset_smoke(tmp_path: Path) -> None:
+    """Optional smoke test against the real 9 GB raw dump."""
+    real = Path(r"C:/Users/diete/Repositories/data/TenThousandFiles.parquet")
+    if not real.exists():
+        pytest.skip("real raw dataset not present")
+
+    out = tmp_path / "compact"
+    result = compact_swing_dataset(real, out, limit_trials=2, validate=True)
+    assert result["trials_rows"] == 2
+    assert result["timesteps_rows"] == 2 * N_TIMESTEPS

--- a/tests/test_load_compact_swing_dataset.py
+++ b/tests/test_load_compact_swing_dataset.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``src.shared.python.dataset_tools.load_compact``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.compact_swing_dataset import compact_swing_dataset  # noqa: E402
+from src.shared.python.dataset_tools import (  # noqa: E402
+    CANONICAL_JOINTS,
+    SCHEMA_VERSION,
+    CompactSwingDataset,
+    load_compact_swing_dataset,
+)
+
+from tests.test_compact_swing_dataset_compactor import (  # noqa: E402
+    _build_synthetic_raw,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def compact_dir(tmp_path: Path) -> Path:
+    src = tmp_path / "raw.parquet"
+    out = tmp_path / "compact"
+    _build_synthetic_raw(src, n_trials=3)
+    compact_swing_dataset(src, out)
+    return out
+
+
+def test_load_returns_dataclass_with_expected_joint_names(compact_dir: Path) -> None:
+    ds = load_compact_swing_dataset(compact_dir, lazy=False)
+    assert isinstance(ds, CompactSwingDataset)
+    assert ds.joint_names == list(CANONICAL_JOINTS)
+    assert len(ds.joint_names) == 27
+    assert ds.coefficient_letters == ["A", "B", "C", "D", "E", "F", "G"]
+    assert ds.schema_version == SCHEMA_VERSION
+
+
+def test_load_eager_returns_pandas(compact_dir: Path) -> None:
+    ds = load_compact_swing_dataset(compact_dir, lazy=False)
+    assert isinstance(ds.trials, pd.DataFrame)
+    assert isinstance(ds.timesteps, pd.DataFrame)
+    assert len(ds.trials) == 3
+    assert len(ds.timesteps) == 3 * 31
+
+
+def test_load_lazy_returns_polars_lazyframe(compact_dir: Path) -> None:
+    polars = pytest.importorskip("polars")
+    ds = load_compact_swing_dataset(compact_dir, lazy=True)
+    assert isinstance(ds.trials, polars.LazyFrame)
+    assert isinstance(ds.timesteps, polars.LazyFrame)
+    assert ds.trials.collect().height == 3
+    assert ds.timesteps.collect().height == 3 * 31
+
+
+def test_load_rejects_missing_directory(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_compact_swing_dataset(tmp_path / "does_not_exist", lazy=False)
+
+
+def test_load_rejects_directory_missing_files(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match="missing"):
+        load_compact_swing_dataset(empty, lazy=False)
+
+
+def test_load_rejects_path_pointing_to_a_file(tmp_path: Path) -> None:
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_text("hello")
+    with pytest.raises(FileNotFoundError, match="not a directory"):
+        load_compact_swing_dataset(not_a_dir, lazy=False)
+
+
+def test_load_rejects_wrong_q_length(compact_dir: Path) -> None:
+    timesteps = pd.read_parquet(compact_dir / "timesteps.parquet")
+    bad = list(timesteps.at[0, "q"])
+    timesteps.at[0, "q"] = bad[:-2]
+    timesteps.to_parquet(compact_dir / "timesteps.parquet")
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        load_compact_swing_dataset(compact_dir, lazy=False)
+
+
+def test_load_rejects_orphan_timestep_trial_id(compact_dir: Path) -> None:
+    timesteps = pd.read_parquet(compact_dir / "timesteps.parquet")
+    timesteps.loc[0, "trial_id"] = 999_999
+    timesteps.to_parquet(compact_dir / "timesteps.parquet")
+
+    with pytest.raises(ValueError, match="trial_id not in"):
+        load_compact_swing_dataset(compact_dir, lazy=False)
+
+
+def test_load_rejects_missing_required_column(compact_dir: Path) -> None:
+    timesteps = pd.read_parquet(compact_dir / "timesteps.parquet")
+    timesteps.drop(columns=["clubhead_speed_mph"]).to_parquet(
+        compact_dir / "timesteps.parquet"
+    )
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_compact_swing_dataset(compact_dir, lazy=False)
+
+
+def test_load_rejects_non_monotonic_time(compact_dir: Path) -> None:
+    timesteps = pd.read_parquet(compact_dir / "timesteps.parquet")
+    # Reverse the order of t-values for the first trial only.
+    first = timesteps[timesteps["trial_id"] == timesteps["trial_id"].iloc[0]]
+    if len(first) >= 2:
+        # Swap rows 0 and 1
+        timesteps.loc[first.index[0], "t"] = 1.0
+        timesteps.loc[first.index[1], "t"] = 0.5
+        timesteps.to_parquet(compact_dir / "timesteps.parquet")
+
+        with pytest.raises(ValueError, match="(start at 0|monotonic)"):
+            load_compact_swing_dataset(compact_dir, lazy=False)


### PR DESCRIPTION
## Summary
- Streams the 9.1 GB raw Simscape dump → ~115 MB compact training parquet via per-row-group projection (one row group at a time keeps peak RAM well under 2 GB).
- Canonical schema lives at `motion_matching/shared/COMPACT_DATASET_SCHEMA.md` (already merged on this branch). Joint / coefficient ordering centralised in `src/shared/python/dataset_tools/canonical.py` so compactor + loader can never drift.
- Adds `load_compact_swing_dataset` loader with cross-validated schema enforcement (FK integrity, list lengths, NaN/Inf, monotonic time).
- Closes #4074. Unblocks #4075 / #4076 / #4080.

## Test plan
- [x] 22 unit tests against synthetic 3-trial fixtures pass under `python3 -m pytest tests/test_compact_swing_dataset_compactor.py tests/test_load_compact_swing_dataset.py -m "not slow" --timeout=60`
- [x] Optional `@pytest.mark.slow @pytest.mark.requires_real_dataset` smoke test passes locally against the real 9 GB file (`limit-trials=2`, ~36 s including validation)
- [ ] Manual full run: `python3 scripts/compact_swing_dataset.py --src C:/Users/diete/Repositories/data/TenThousandFiles.parquet --out C:/Users/diete/Repositories/data/compact --validate`
- [ ] Loader smoke-test on the produced files

## Notes
- The 9 GB raw file is NOT committed (lives outside the repo). Compactor is invoked manually once; the resulting `trials.parquet` + `timesteps.parquet` are consumed by all downstream training pipelines.
- The real raw dump has two legitimately missing kinematic columns (`LSAngularAccelerationZ`, `RScapAngularAccelerationX`); these are NaN-filled and listed in `KNOWN_MISSING_KINEMATIC_COLUMNS`. The loader allows NaN in `q/qd/qdd/tau` (positions/velocities/accelerations/torques can be legitimately absent for joints with no source column) but still rejects NaN/Inf in geometric columns (`r_*`, `v_*`).
- Added new pytest marker `requires_real_dataset` for the optional integration test.