### PR TITLE
fix(motion-matching): rewrite train_option3_example to canonical TrainingConfig API (closes #4241)

### DIFF
--- a/motion_matching/train_option3_example.py
+++ b/motion_matching/train_option3_example.py
@@ -1,87 +1,113 @@
 #!/usr/bin/env python3
-"""Example script for training Option-3 inverse cVAE on 10k parquet dataset.
+"""Example script for training Option-3 inverse cVAE on the compact dataset.
 
-This script demonstrates the complete workflow:
-1. Load dataset from parquet files
-2. Train the cVAE with ELBO + work regularization
-3. Evaluate on held-out test set (coverage, reconstruction, diversity)
-4. Save trained model and metrics
+This script demonstrates the workflow:
+1. Load a compact swing dataset (per ``COMPACT_DATASET_SCHEMA.md``).
+2. Train the cVAE end-to-end with beta-annealed ELBO.
+3. Save the trained model + ``metrics.json`` under ``output/inverse_cvae/<timestamp>/``.
 
-Usage (synthetic data):
+Usage::
+
     cd /path/to/UpstreamDrift
-    python3 motion_matching/train_option3_example.py
+    python3 motion_matching/train_option3_example.py \\
+        --dataset C:/Users/diete/Repositories/data/compact \\
+        --epochs 50 \\
+        --batch-size 32
 
-Usage (real dataset):
-    python3 motion_matching/train_option3_example.py \
-        --dataset /path/to/10k_dataset \
-        --output ./results/option3_cvae
+GH issue #4076: M3 — Train Option-3 inverse cVAE on the compact 10k dataset.
 
-Issue #4076: M3: Train Option-3 inverse cVAE on 10k parquet
+Note: the legacy public API (``Option3TrainConfig``, ``TrainInverseConfig``,
+``train_option3_inverse_cvae``) was replaced by the canonical
+``TrainingConfig`` + ``train_inverse_cvae`` surface in PR #4240. This
+example consumes the new API.
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 from pathlib import Path
 
-import torch
-
-# Add project root to path
+# Add project root to path so the ``src`` package resolves when run as a script.
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.shared.python.logging_pkg.logging_config import (  # noqa: E402
     get_logger,
 )
-from src.shared.python.motion_matching.dataset.synthetic import (  # noqa: E402
-    make_synthetic_sweep,
-)
 from src.shared.python.motion_matching.inverse import (  # noqa: E402
     CVAEConfig,
-    Option3TrainConfig,
-    TrainInverseConfig,
-    train_option3_inverse_cvae,
+    TrainingConfig,
+    train_inverse_cvae,
 )
 
 logger = get_logger(__name__)
 
 
+def _resolve_device(arg: str) -> str:
+    if arg != "auto":
+        return arg
+    try:
+        import torch
+
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except ImportError:
+        return "cpu"
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="Train Option-3 inverse cVAE on 10k parquet dataset."
+        description="Train Option-3 inverse cVAE on the compact swing dataset."
     )
     parser.add_argument(
         "--dataset",
-        type=str,
-        default=None,
-        help="Path to dataset folder (trials.parquet + timesteps.parquet). "
-        "If None, generates synthetic data for demo.",
+        type=Path,
+        required=True,
+        help="Path to compact dataset folder (trials.parquet + timesteps.parquet).",
     )
     parser.add_argument(
-        "--output",
-        type=str,
-        default="./motion_matching/results/option3_cvae_trained",
-        help="Output directory for model, metrics, and plots.",
-    )
-    parser.add_argument(
-        "--n-epochs",
+        "--epochs",
         type=int,
-        default=5,
+        default=TrainingConfig.epochs,
         help="Number of training epochs.",
     )
     parser.add_argument(
         "--batch-size",
         type=int,
-        default=32,
+        default=TrainingConfig.batch_size,
         help="Training batch size.",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=TrainingConfig.lr,
+        help="AdamW learning rate.",
     )
     parser.add_argument(
         "--latent-dim",
         type=int,
-        default=16,
+        default=CVAEConfig.latent_dim,
         help="Latent space dimensionality.",
+    )
+    parser.add_argument(
+        "--kl-anneal-epochs",
+        type=int,
+        default=TrainingConfig.kl_anneal_epochs,
+        help="Number of epochs over which to anneal KL beta from 0 to max.",
+    )
+    parser.add_argument(
+        "--max-beta",
+        type=float,
+        default=TrainingConfig.max_beta,
+        help="Maximum KL weight after annealing.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("output/inverse_cvae"),
+        help="Root output directory; a timestamped subdir is created inside it.",
     )
     parser.add_argument(
         "--device",
@@ -93,145 +119,81 @@ def main() -> int:
     parser.add_argument(
         "--seed",
         type=int,
-        default=0xC0FFEE,
+        default=TrainingConfig.seed,
         help="RNG seed.",
-    )
-    parser.add_argument(
-        "--skip-synthetic",
-        action="store_true",
-        help="Do not generate synthetic data if dataset path is None.",
     )
 
     args = parser.parse_args()
-    output_dir = Path(args.output)
 
-    # Resolve dataset
-    dataset_path = args.dataset
-    if dataset_path is None:
-        if args.skip_synthetic:
-            logger.error("No dataset provided and --skip-synthetic is set.")
-            return 1
-        # Generate synthetic data for demonstration
-        logger.info("No dataset provided; generating synthetic data for demo.")
-        synthetic_path = output_dir.parent / "synthetic_dataset"
-        dataset_path = make_synthetic_sweep(
-            synthetic_path,
-            n_trials=100,  # Small for demo; real = 10000
-            n_joints=14,
-            n_timesteps=300,
-            seed=args.seed,
-        )
-        logger.info("Generated synthetic dataset: %s", dataset_path)
-    else:
-        dataset_path = Path(dataset_path)
-
-    # Ensure dataset exists
-    if not dataset_path.exists():
-        logger.error("Dataset path does not exist: %s", dataset_path)
+    if not args.dataset.exists():
+        logger.error("Dataset path does not exist: %s", args.dataset)
         return 1
 
-    # Resolve device
-    if args.device == "auto":
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-    else:
-        device = args.device
+    device = _resolve_device(args.device)
     logger.info("Using device: %s", device)
 
-    # Build configs
-    cvae_config = CVAEConfig(
-        n_joints=14,
-        n_timesteps=300,
-        n_kinematic_channels=12,
-        latent_dim=args.latent_dim,
-        encoder_layers=4,
-        encoder_heads=4,
-        encoder_dim=128,
-        decoder_hidden=256,
-        dropout=0.1,
-    )
-
-    train_config = TrainInverseConfig(
-        n_epochs=args.n_epochs,
-        batch_size=args.batch_size,
-        lr=1e-3,
-        weight_decay=1e-5,
-        grad_clip=1.0,
-        lambda_recon=1.0,
-        lambda_work=1e-3,
-        max_beta=1.0,
-        kl_warmup_epochs=None,  # auto = 20% of n_epochs
-        val_fraction=0.1,
-        test_fraction=0.1,
-        seed=args.seed,
-        device=device,
-    )
-
-    option3_config = Option3TrainConfig(
-        dataset_path=dataset_path,
-        output_dir=output_dir,
-        cvae_config=cvae_config,
-        train_config=train_config,
-        n_test_samples=50,
-        coverage_threshold_m=0.05,
-        latent_projection_method="umap",
-        latent_projection_seed=args.seed,
-    )
+    cvae_config = CVAEConfig(latent_dim=args.latent_dim)
 
     logger.info(
-        "Option-3 cVAE Training Config:\n"
-        "  Dataset: %s (%d trials)\n"
+        "Option-3 cVAE training:\n"
+        "  Dataset: %s\n"
         "  Latent dim: %d\n"
         "  Epochs: %d\n"
         "  Batch size: %d\n"
+        "  Learning rate: %.2e\n"
+        "  KL anneal epochs: %d (max beta %.3f)\n"
         "  Device: %s\n"
-        "  Output: %s",
-        dataset_path,
-        "?",  # Will be printed during load
+        "  Output root: %s",
+        args.dataset,
         args.latent_dim,
-        args.n_epochs,
+        args.epochs,
         args.batch_size,
+        args.lr,
+        args.kl_anneal_epochs,
+        args.max_beta,
         device,
-        output_dir,
+        args.output_root,
     )
 
-    # Train
     try:
-        result = train_option3_inverse_cvae(option3_config)
-        logger.info(
-            "\n" + "=" * 70 + "\nOption-3 cVAE Training Complete\n" + "=" * 70
+        result = train_inverse_cvae(
+            dataset_path=args.dataset,
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            device=device,
+            seed=args.seed,
+            kl_anneal_epochs=args.kl_anneal_epochs,
+            max_beta=args.max_beta,
+            output_root=args.output_root,
+            cvae_config=cvae_config,
         )
-        logger.info("Model saved to: %s", result.model_path)
-        logger.info("Config saved to: %s", result.config_path)
-        logger.info("Metrics saved to: %s", result.metrics_path)
-        logger.info("Evaluation plots: %s", result.evaluation_plot_dir)
-
-        # Print key metrics
-        logger.info("\nKey Evaluation Metrics:")
-        logger.info("  Final train loss: %.4f", result.metrics.get("final_train_loss"))
-        logger.info("  Final val loss: %.4f", result.metrics.get("final_val_loss"))
-        logger.info(
-            "  Coverage mean RMSE (m): %.4f",
-            result.metrics.get("coverage_mean_rmse_m", float("nan")),
-        )
-        logger.info(
-            "  Diversity mean pairwise L2: %.4f",
-            result.metrics.get("diversity_mean_pairwise_l2", float("nan")),
-        )
-        logger.info(
-            "  Inference latency (ms): %.3f",
-            result.metrics.get("inference_latency_ms", float("nan")),
-        )
-        logger.info(
-            "  Latent spread: %.4f", result.metrics.get("latent_spread", float("nan"))
-        )
-
-        logger.info("\nTraining curves saved (train_loss, val_loss, KL, etc.)")
-        return 0
-
-    except Exception as e:
-        logger.exception("Training failed: %s", e)
+    except (ValueError, FileNotFoundError) as exc:
+        logger.error("Training rejected by precondition: %s", exc)
         return 1
+    except Exception:
+        logger.exception("Training failed")
+        return 1
+
+    logger.info("=" * 70)
+    logger.info("Option-3 cVAE training complete")
+    logger.info("=" * 70)
+    logger.info("Output directory: %s", result.output_dir)
+    logger.info("Best epoch: %d", result.best_epoch)
+    logger.info("Total parameters: %d", result.parameter_count)
+
+    last = result.history[-1]
+    logger.info(
+        "Final epoch %d: train_loss=%.4f val_recon=%.4f val_kl=%.4f",
+        last.epoch,
+        last.train_loss,
+        last.val_recon,
+        last.val_kl,
+    )
+
+    return 0
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s: %(message)s")
     sys.exit(main())


### PR DESCRIPTION
## Summary
- PR #4240 replaced \`Option3TrainConfig\` / \`TrainInverseConfig\` / \`train_option3_inverse_cvae\` with the new canonical \`TrainingConfig\` + \`train_inverse_cvae\` surface.
- \`motion_matching/train_option3_example.py\` still imported the removed symbols and would fail at module import time.
- Rewrite the example to use the new API. The script now takes a required \`--dataset\` arg pointing at a compact swing dataset (\`trials.parquet\` + \`timesteps.parquet\`) per \`COMPACT_DATASET_SCHEMA.md\`.

Addresses P2 review feedback from PR #4240 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4240#discussion_r3198663915)).

Closes #4241.

## Test plan
- [x] \`python3 motion_matching/train_option3_example.py --help\` prints the new CLI cleanly
- [x] Module imports resolve via \`from src.shared.python.motion_matching.inverse import CVAEConfig, TrainingConfig, train_inverse_cvae\`
- [x] \`ruff check\` + \`ruff format --check\` clean