### PR TITLE
fix(tests): skip leaderboard freshness assert in shallow clones (closes #4243)

### DIFF
--- a/tests/unit/motion_matching/test_leaderboard_freshness.py
+++ b/tests/unit/motion_matching/test_leaderboard_freshness.py
@@ -60,11 +60,29 @@ def test_leaderboard_meta_schema():
     )
 
 
+def _is_shallow_repo() -> bool:
+    """Return True when the working tree is a shallow git clone."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-shallow-repository"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+
 @pytest.mark.unit
 def test_leaderboard_meta_git_head_resolves():
     """git_head must point at a commit that actually exists in the repo.
 
-    Skipped when the test runs outside a git checkout (e.g. tarball install).
+    Skipped when the test runs outside a git checkout (e.g. tarball install)
+    or in a shallow clone where the recorded sha may have been pruned. CI
+    that wants to enforce this check should run with `actions/checkout`
+    `fetch-depth: 0` (the leaderboard workflow already does so).
     """
     meta = json.loads(META_PATH.read_text(encoding="utf-8"))
     sha = meta["git_head"]
@@ -77,8 +95,14 @@ def test_leaderboard_meta_git_head_resolves():
         )
     except FileNotFoundError:
         pytest.skip("git binary not available")
-    if result.returncode != 0 and not (REPO_ROOT / ".git").exists():
-        pytest.skip("not a git checkout")
+    if result.returncode != 0:
+        if not (REPO_ROOT / ".git").exists():
+            pytest.skip("not a git checkout")
+        if _is_shallow_repo():
+            pytest.skip(
+                "shallow git clone — recorded git_head may have been pruned; "
+                "re-run with fetch-depth: 0 to enforce this check"
+            )
     assert result.returncode == 0, (
         f"git_head {sha} in {META_PATH} does not resolve to a real commit. "
         "Re-run scripts/run_leaderboard.m and commit the refreshed sidecar."


### PR DESCRIPTION
## Summary
- \`test_leaderboard_meta_git_head_resolves\` resolved \`meta.git_head\` via \`git cat-file -e\`. In shallow clones (\`actions/checkout\`'s default \`fetch-depth: 1\`) older SHAs may not be present even when the sidecar is correct, producing spurious failures.
- Add a \`_is_shallow_repo()\` helper and skip with a clear message when the lookup fails specifically because of shallow truncation. The leaderboard workflow itself already pins \`fetch-depth: 0\`, so the freshness gate is still enforced where it matters.

Addresses P1 review feedback from PR #4242 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4242#discussion_r3198687612)).

Closes #4243.

## Test plan
- [x] \`pytest tests/unit/motion_matching/test_leaderboard_freshness.py\` — 3 passed locally
- [x] \`ruff check\` + \`ruff format --check\` clean