### PR TITLE
feat(motion-matching): per-timestep inverse-dynamics model on filtered data

### DIFF
--- a/src/shared/python/motion_matching/inverse_timestep/__init__.py
+++ b/src/shared/python/motion_matching/inverse_timestep/__init__.py
@@ -1,0 +1,59 @@
+"""Per-timestep inverse-dynamics model.
+
+A switch from full-trial inverse models (cVAE in :mod:`..inverse.cvae`,
+deterministic regressor in :mod:`..inverse.regressor`) — both of which
+plateau at the mean-prediction baseline on the random-sweep dataset
+because the trajectory -> 189-coefficient mapping is under-determined —
+to a per-timestep framing: each timestep is an independent sample of
+``(q, qd, qdd)`` -> ``tau``.
+
+Pipeline:
+    1. Load the compact dataset.
+    2. Filter timesteps by realistic clubhead speed (default 50-150 mph).
+    3. Train an MLP ``(q, qd, qdd) -> tau`` per timestep, masking joint
+       indices whose ``tau`` is NaN (joints not exposed by the dump).
+
+Public API:
+    realistic_speed_mask, filter_timesteps_by_speed,
+    TimestepInverseDynamics, TimestepInverseConfig,
+    train_timestep_inverse, TimestepTrainingResult,
+    TimestepEpochMetrics, predict_torques.
+"""
+
+from __future__ import annotations
+
+from .filter import (
+    filter_timesteps_by_speed,
+    realistic_speed_mask,
+)
+from .model import (
+    DEFAULT_HIDDEN,
+    DEFAULT_INPUT_DIM,
+    DEFAULT_N_BLOCKS,
+    DEFAULT_OUTPUT_DIM,
+    TimestepInverseConfig,
+    TimestepInverseDynamics,
+)
+from .predict import (
+    predict_torques,
+)
+from .training import (
+    TimestepEpochMetrics,
+    TimestepTrainingResult,
+    train_timestep_inverse,
+)
+
+__all__ = [
+    "DEFAULT_HIDDEN",
+    "DEFAULT_INPUT_DIM",
+    "DEFAULT_N_BLOCKS",
+    "DEFAULT_OUTPUT_DIM",
+    "TimestepEpochMetrics",
+    "TimestepInverseConfig",
+    "TimestepInverseDynamics",
+    "TimestepTrainingResult",
+    "filter_timesteps_by_speed",
+    "predict_torques",
+    "realistic_speed_mask",
+    "train_timestep_inverse",
+]

--- a/src/shared/python/motion_matching/inverse_timestep/filter.py
+++ b/src/shared/python/motion_matching/inverse_timestep/filter.py
@@ -1,0 +1,151 @@
+"""Speed-mask helpers for the per-timestep inverse-dynamics pipeline.
+
+The compact dataset's per-timestep clubhead-speed distribution is highly
+skewed (p25=103 mph, p50=165 mph, p99=2984 mph). The model trains on the
+realistic-swing slice ``||v_clubhead|| in [50, 150] mph``, which keeps
+~29% of the timesteps and spreads broadly across trials (5-9 timesteps
+per trial out of 31).
+
+This module is pure-python (numpy + pandas) and does not import torch,
+so it can be used in lightweight contexts.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pandas as pd
+
+    from src.shared.python.dataset_tools.load_compact import CompactSwingDataset
+
+logger = logging.getLogger(__name__)
+
+
+def realistic_speed_mask(
+    speeds_mph: np.ndarray,
+    lo: float = 50.0,
+    hi: float = 150.0,
+) -> np.ndarray:
+    """Return a boolean mask for clubhead speeds in ``[lo, hi]`` mph.
+
+    Preconditions:
+        * ``0 <= lo < hi``.
+        * ``speeds_mph`` is a 1-D finite numpy array of floats.
+
+    Postconditions:
+        * Output is a 1-D ``np.bool_`` array of the same length as
+          ``speeds_mph``; ``out[i] == (lo <= speeds_mph[i] <= hi)``.
+
+    Args:
+        speeds_mph: 1-D array of clubhead speeds in mph.
+        lo: Lower bound of the realistic speed window (inclusive).
+        hi: Upper bound of the realistic speed window (inclusive).
+
+    Returns:
+        Boolean mask array.
+
+    Raises:
+        TypeError: If ``speeds_mph`` is not a numpy array.
+        ValueError: If preconditions are violated.
+    """
+    if not isinstance(speeds_mph, np.ndarray):
+        raise TypeError(
+            f"speeds_mph must be np.ndarray, got {type(speeds_mph).__name__}"
+        )
+    if speeds_mph.ndim != 1:
+        raise ValueError(f"speeds_mph must be 1-D, got shape {tuple(speeds_mph.shape)}")
+    if not np.isfinite(speeds_mph).all():
+        raise ValueError("speeds_mph contains non-finite values (NaN/Inf)")
+    _validate_bounds(lo, hi)
+    return (speeds_mph >= lo) & (speeds_mph <= hi)
+
+
+def filter_timesteps_by_speed(
+    dataset: CompactSwingDataset,
+    *,
+    lo: float = 50.0,
+    hi: float = 150.0,
+) -> CompactSwingDataset:
+    """Return ``dataset`` with timesteps filtered to ``[lo, hi]`` mph.
+
+    Operates on an eagerly materialised pandas DataFrame, replacing the
+    ``timesteps`` field of the dataclass via :func:`dataclasses.replace`.
+    The ``trials`` field is unchanged so callers can still cross-reference.
+
+    Preconditions:
+        * ``dataset.timesteps`` is a pandas DataFrame with a finite
+          ``clubhead_speed_mph`` column.
+        * ``0 <= lo < hi``.
+
+    Postconditions:
+        * Resulting timesteps DataFrame has length <= original length.
+        * Every retained row has ``lo <= clubhead_speed_mph <= hi``.
+
+    Args:
+        dataset: Compact dataset handle (see :class:`CompactSwingDataset`).
+        lo: Lower bound on clubhead speed in mph (inclusive).
+        hi: Upper bound on clubhead speed in mph (inclusive).
+
+    Returns:
+        New :class:`CompactSwingDataset` with the timesteps frame filtered.
+
+    Raises:
+        TypeError: If the timesteps backend is not a pandas DataFrame.
+        ValueError: If preconditions are violated.
+    """
+    timesteps_obj = dataset.timesteps
+    timesteps_df = _require_pandas(timesteps_obj)
+    _validate_bounds(lo, hi)
+    if "clubhead_speed_mph" not in timesteps_df.columns:
+        raise ValueError("timesteps DataFrame missing 'clubhead_speed_mph' column")
+    speeds = timesteps_df["clubhead_speed_mph"].to_numpy(dtype=np.float64)
+    mask = realistic_speed_mask(speeds, lo=lo, hi=hi)
+    filtered = timesteps_df.loc[mask].reset_index(drop=True)
+    n_before = len(timesteps_df)
+    n_after = len(filtered)
+    logger.info(
+        "filter_timesteps_by_speed: %d -> %d rows (%.1f%%) at lo=%.1f hi=%.1f mph",
+        n_before,
+        n_after,
+        100.0 * n_after / max(1, n_before),
+        lo,
+        hi,
+    )
+    return replace(dataset, timesteps=filtered)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _validate_bounds(lo: float, hi: float) -> None:
+    if not isinstance(lo, int | float):
+        raise TypeError(f"lo must be a number, got {type(lo).__name__}")
+    if not isinstance(hi, int | float):
+        raise TypeError(f"hi must be a number, got {type(hi).__name__}")
+    lo_f = float(lo)
+    hi_f = float(hi)
+    if not np.isfinite(lo_f) or not np.isfinite(hi_f):
+        raise ValueError(f"lo/hi must be finite; got lo={lo_f}, hi={hi_f}")
+    if lo_f < 0:
+        raise ValueError(f"lo must be >= 0, got {lo_f}")
+    if not lo_f < hi_f:
+        raise ValueError(f"must have lo < hi; got lo={lo_f}, hi={hi_f}")
+
+
+def _require_pandas(obj: Any) -> pd.DataFrame:
+    import pandas as pd
+
+    if not isinstance(obj, pd.DataFrame):
+        raise TypeError(
+            "filter_timesteps_by_speed requires an eagerly materialised "
+            "pandas DataFrame for `timesteps` (load with lazy=False); "
+            f"got {type(obj).__name__}"
+        )
+    return obj

--- a/src/shared/python/motion_matching/inverse_timestep/model.py
+++ b/src/shared/python/motion_matching/inverse_timestep/model.py
@@ -1,0 +1,247 @@
+"""Per-timestep inverse-dynamics MLP: ``(q, qd, qdd) -> tau``.
+
+Each timestep is treated as an independent sample. State vector is
+``concat(q, qd, qdd)`` of size 3*27 = 81. Output is the 27-dim torque
+vector. NaN inputs (e.g. unmapped DOFs like ``LSAngularAccelerationZ``)
+are zero-filled with a per-DOF "missing" indicator channel appended,
+yielding ``81 + 81 = 162`` effective input features.
+
+Architecture mirrors the surrogate's ``_ResidualBlock`` style: a
+LayerNorm-input projection followed by ``n_blocks`` pre-norm residual
+blocks of width ``hidden``, then a final norm + linear head to 27 dims.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+DEFAULT_INPUT_DIM = 81  # 3 * 27 (q, qd, qdd)
+DEFAULT_OUTPUT_DIM = 27
+DEFAULT_HIDDEN = 256
+DEFAULT_N_BLOCKS = 4
+DEFAULT_DROPOUT = 0.1
+
+
+@dataclass(frozen=True)
+class TimestepInverseConfig:
+    """Architectural hyperparameters for :class:`TimestepInverseDynamics`.
+
+    Defaults yield ~280k parameters with a 162-feature effective input
+    (81 raw + 81 missing-indicator) and ``hidden=256``, ``n_blocks=4``.
+    """
+
+    input_dim: int = DEFAULT_INPUT_DIM
+    output_dim: int = DEFAULT_OUTPUT_DIM
+    hidden: int = DEFAULT_HIDDEN
+    n_blocks: int = DEFAULT_N_BLOCKS
+    dropout: float = DEFAULT_DROPOUT
+    use_missing_indicator: bool = True
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` for any field that breaks the architecture."""
+        if self.input_dim <= 0:
+            raise ValueError(f"input_dim must be positive, got {self.input_dim}")
+        if self.output_dim <= 0:
+            raise ValueError(f"output_dim must be positive, got {self.output_dim}")
+        if self.hidden <= 0:
+            raise ValueError(f"hidden must be positive, got {self.hidden}")
+        if self.n_blocks < 1:
+            raise ValueError(f"n_blocks must be >= 1, got {self.n_blocks}")
+        if not (0.0 <= self.dropout < 1.0):
+            raise ValueError(f"dropout must be in [0, 1), got {self.dropout}")
+
+    @property
+    def effective_input_dim(self) -> int:
+        if self.use_missing_indicator:
+            return self.input_dim * 2
+        return self.input_dim
+
+
+class _ResidualBlock(nn.Module):
+    """Pre-norm residual MLP block: ``x + Linear(GELU(Linear(LayerNorm(x))))``."""
+
+    def __init__(self, hidden_dim: int, dropout: float) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_dim)
+        self.fc1 = nn.Linear(hidden_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.drop = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        residual = x
+        h = self.norm(x)
+        h = self.fc1(h)
+        h = F.gelu(h)
+        h = self.fc2(h)
+        h = self.drop(h)
+        return residual + h
+
+
+class TimestepInverseDynamics(nn.Module):
+    """MLP mapping per-timestep ``(q, qd, qdd)`` to applied torque.
+
+    Input contract (``state``):
+        * ``state.shape == (B, cfg.input_dim)`` (default 81).
+        * ``state.dtype == torch.float32``.
+        * NaN entries are tolerated and replaced with 0.0; if
+          ``cfg.use_missing_indicator`` is True (default), a per-DOF
+          binary indicator channel is appended internally so the MLP can
+          distinguish "value 0.0" from "missing".
+
+    Output contract:
+        * ``out.shape == (B, cfg.output_dim)`` (default 27).
+        * ``out.dtype == torch.float32``.
+        * In the standardised space the model is trained on; callers must
+          de-standardise using the per-DOF stats stored in the checkpoint
+          payload to recover Newton-metres.
+    """
+
+    SCHEMA_VERSION: ClassVar[str] = "1.0"
+
+    def __init__(self, cfg: TimestepInverseConfig | None = None) -> None:
+        super().__init__()
+        cfg = cfg if cfg is not None else TimestepInverseConfig()
+        cfg.validate()
+        self.cfg = cfg
+
+        eff_in = cfg.effective_input_dim
+        self.input_proj = nn.Linear(eff_in, cfg.hidden)
+        self.input_norm = nn.LayerNorm(cfg.hidden)
+        self.blocks = nn.ModuleList(
+            [_ResidualBlock(cfg.hidden, cfg.dropout) for _ in range(cfg.n_blocks)]
+        )
+        self.head_norm = nn.LayerNorm(cfg.hidden)
+        self.head = nn.Linear(cfg.hidden, cfg.output_dim)
+
+    # ----- public ----- #
+
+    def forward(self, state: Tensor) -> Tensor:
+        """Predict the standardised torque vector for a batch of states.
+
+        Args:
+            state: ``(B, cfg.input_dim)`` float32 tensor of standardised
+                ``concat(q, qd, qdd)`` values, possibly containing NaN
+                for unmapped DOFs.
+
+        Returns:
+            ``(B, cfg.output_dim)`` float32 tensor of standardised torques.
+
+        Raises:
+            TypeError: If ``state`` is not a float32 tensor.
+            ValueError: If the shape/rank is wrong or values are non-finite
+                (Inf rejected; NaN tolerated and zero-filled).
+        """
+        self._validate_input(state)
+        x = self._apply_missing_indicator(state)
+        h = self.input_proj(x)
+        h = self.input_norm(h)
+        for block in self.blocks:
+            h = block(h)
+        h = self.head_norm(h)
+        return self.head(h)
+
+    def state_payload(self) -> dict:
+        """Return a checkpoint-ready dict bundling weights and config."""
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "config": _config_to_dict(self.cfg),
+            "state_dict": self.state_dict(),
+        }
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        path: str | Path,
+        *,
+        map_location: str | torch.device | None = None,
+    ) -> TimestepInverseDynamics:
+        """Re-instantiate a model from a payload produced by ``state_payload``.
+
+        The returned model is in eval mode and has its weights loaded.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            ValueError: If the payload is missing required keys.
+        """
+        ckpt_path = Path(path)
+        if not ckpt_path.exists():
+            raise FileNotFoundError(f"checkpoint not found: {ckpt_path}")
+        payload = torch.load(ckpt_path, map_location=map_location, weights_only=False)
+        if not isinstance(payload, dict) or "state_dict" not in payload:
+            raise ValueError(
+                f"checkpoint at {ckpt_path} is not a TimestepInverseDynamics payload"
+            )
+        cfg_dict = payload.get("config")
+        if cfg_dict is None:
+            raise ValueError("checkpoint missing 'config' entry")
+        cfg = _config_from_dict(cfg_dict)
+        model = cls(cfg)
+        model.load_state_dict(payload["state_dict"])
+        model.eval()
+        return model
+
+    # ----- private ----- #
+
+    def _apply_missing_indicator(self, state: Tensor) -> Tensor:
+        """Replace NaN with 0 and (optionally) append a missing-mask channel."""
+        nan_mask = torch.isnan(state)
+        clean = torch.where(
+            nan_mask,
+            torch.zeros_like(state),
+            state,
+        )
+        if not self.cfg.use_missing_indicator:
+            return clean
+        indicator = nan_mask.to(state.dtype)
+        return torch.cat([clean, indicator], dim=-1)
+
+    def _validate_input(self, state: Tensor) -> None:
+        if not isinstance(state, Tensor):
+            raise TypeError(f"state must be torch.Tensor, got {type(state).__name__}")
+        if state.dim() != 2:
+            raise ValueError(
+                f"state must be 2-D (B, input_dim); got shape {tuple(state.shape)}"
+            )
+        if state.shape[-1] != self.cfg.input_dim:
+            raise ValueError(
+                f"state last-dim must be {self.cfg.input_dim}; got {state.shape[-1]}"
+            )
+        if state.dtype != torch.float32:
+            raise TypeError(f"state must be float32; got {state.dtype}")
+        # Inf is always rejected (a real numerical bug). NaN is tolerated
+        # because unmapped DOFs legitimately carry NaN per the schema.
+        if torch.isinf(state).any():
+            raise ValueError("state contains Inf values (NaN is tolerated)")
+
+
+# ---------------------------------------------------------------------------
+# Config (de)serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _config_to_dict(cfg: TimestepInverseConfig) -> dict:
+    return {
+        "input_dim": cfg.input_dim,
+        "output_dim": cfg.output_dim,
+        "hidden": cfg.hidden,
+        "n_blocks": cfg.n_blocks,
+        "dropout": cfg.dropout,
+        "use_missing_indicator": cfg.use_missing_indicator,
+    }
+
+
+def _config_from_dict(d: dict) -> TimestepInverseConfig:
+    return TimestepInverseConfig(
+        input_dim=int(d.get("input_dim", DEFAULT_INPUT_DIM)),
+        output_dim=int(d.get("output_dim", DEFAULT_OUTPUT_DIM)),
+        hidden=int(d.get("hidden", DEFAULT_HIDDEN)),
+        n_blocks=int(d.get("n_blocks", DEFAULT_N_BLOCKS)),
+        dropout=float(d.get("dropout", DEFAULT_DROPOUT)),
+        use_missing_indicator=bool(d.get("use_missing_indicator", True)),
+    )

--- a/src/shared/python/motion_matching/inverse_timestep/predict.py
+++ b/src/shared/python/motion_matching/inverse_timestep/predict.py
@@ -1,0 +1,165 @@
+"""Inference surface for :class:`TimestepInverseDynamics`.
+
+Loads a checkpoint payload, de-standardises the predicted torques using
+the stats persisted at training time, and returns physical-unit (Nm)
+torques.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import torch
+from numpy.typing import ArrayLike, NDArray
+
+from .model import TimestepInverseDynamics
+
+logger = logging.getLogger(__name__)
+
+
+def predict_torques(
+    model: TimestepInverseDynamics,
+    q: ArrayLike,
+    qd: ArrayLike,
+    qdd: ArrayLike,
+    *,
+    state_stats: dict | None = None,
+    tau_stats: dict | None = None,
+) -> NDArray[np.float32]:
+    """Predict per-timestep torques in physical units (Nm).
+
+    The standardisation stats may be supplied directly via the keyword
+    arguments or attached to the model as ``model._state_stats`` /
+    ``model._tau_stats`` (the loaders below set those attributes).
+
+    Parameters
+    ----------
+    model
+        Trained :class:`TimestepInverseDynamics`.
+    q, qd, qdd
+        ``(B, 27)`` arrays of generalised coordinates/velocities/accelerations,
+        in physical units. NaN entries (unmapped DOFs) are tolerated.
+    state_stats
+        ``{"mean": (81,), "std": (81,)}`` for input standardisation.
+    tau_stats
+        ``{"mean": (27,), "std": (27,)}`` for output de-standardisation.
+
+    Returns
+    -------
+    np.ndarray
+        ``(B, 27)`` float32 torques in Newton-metres.
+
+    Raises
+    ------
+    TypeError, ValueError
+        For shape/dtype contract violations or missing standardisation stats.
+    """
+    if not isinstance(model, TimestepInverseDynamics):
+        raise TypeError(
+            f"model must be TimestepInverseDynamics, got {type(model).__name__}"
+        )
+    state_stats = (
+        state_stats
+        if state_stats is not None
+        else _attached_stats(model, "_state_stats")
+    )
+    tau_stats = (
+        tau_stats if tau_stats is not None else _attached_stats(model, "_tau_stats")
+    )
+    if state_stats is None or tau_stats is None:
+        raise ValueError(
+            "predict_torques requires standardisation stats (state_stats and "
+            "tau_stats); attach them to the model or pass them explicitly"
+        )
+
+    q_arr = _as_2d(q, name="q")
+    qd_arr = _as_2d(qd, name="qd")
+    qdd_arr = _as_2d(qdd, name="qdd")
+    n_joints = model.cfg.output_dim
+    for arr, name in ((q_arr, "q"), (qd_arr, "qd"), (qdd_arr, "qdd")):
+        if arr.shape[-1] != n_joints:
+            raise ValueError(
+                f"{name}.shape[-1] must equal n_joints={n_joints}; got {arr.shape[-1]}"
+            )
+        if arr.shape[0] != q_arr.shape[0]:
+            raise ValueError(
+                f"batch sizes must match; got {arr.shape[0]} vs {q_arr.shape[0]}"
+            )
+
+    raw_state = np.concatenate([q_arr, qd_arr, qdd_arr], axis=-1).astype(
+        np.float32, copy=False
+    )
+    state_mean = np.asarray(state_stats["mean"], dtype=np.float32)
+    state_std = np.asarray(state_stats["std"], dtype=np.float32)
+    tau_mean = np.asarray(tau_stats["mean"], dtype=np.float32)
+    tau_std = np.asarray(tau_stats["std"], dtype=np.float32)
+    standardised = _standardise(raw_state, state_mean, state_std)
+    state_t = torch.from_numpy(standardised)
+    try:
+        device = next(model.parameters()).device
+    except StopIteration:
+        device = torch.device("cpu")
+    state_t = state_t.to(device)
+
+    model.eval()
+    with torch.no_grad():
+        pred_std = model(state_t)
+    pred_std_np = pred_std.detach().cpu().numpy().astype(np.float32)
+    return (pred_std_np * tau_std + tau_mean).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _attached_stats(model: TimestepInverseDynamics, attr: str) -> dict | None:
+    return getattr(model, attr, None)
+
+
+def _as_2d(arr: ArrayLike, *, name: str) -> np.ndarray:
+    a = np.asarray(arr, dtype=np.float64)
+    if a.ndim == 1:
+        a = a.reshape(1, -1)
+    if a.ndim != 2:
+        raise ValueError(f"{name} must be 1-D or 2-D, got shape {tuple(a.shape)}")
+    return a
+
+
+def _standardise(raw: np.ndarray, mean: np.ndarray, std: np.ndarray) -> np.ndarray:
+    """``(raw - mean) / std`` with NaN preserved and divide-by-zero guarded.
+
+    Standard deviations <= 1e-8 are floored to 1.0 so a constant column
+    (e.g. an unmapped DOF with all-NaN entries) does not explode.
+    """
+    safe_std = np.where(std > 1e-8, std, np.float32(1.0)).astype(np.float32)
+    return ((raw - mean) / safe_std).astype(np.float32)
+
+
+def load_with_stats(
+    checkpoint_path: str | Path,
+    *,
+    map_location: str | torch.device | None = None,
+) -> TimestepInverseDynamics:
+    """Load a checkpoint and attach the standardisation stats to the model.
+
+    Convenience wrapper that mirrors the cVAE / regressor loaders. The
+    returned model has ``_state_stats`` and ``_tau_stats`` attributes
+    suitable for :func:`predict_torques`.
+    """
+    ckpt_path = Path(checkpoint_path)
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"checkpoint not found: {ckpt_path}")
+    payload = torch.load(ckpt_path, map_location=map_location, weights_only=False)
+    model = TimestepInverseDynamics.from_checkpoint(
+        ckpt_path, map_location=map_location
+    )
+    state_stats = payload.get("state_stats")
+    tau_stats = payload.get("tau_stats")
+    if state_stats is not None:
+        model._state_stats = state_stats  # noqa: SLF001 - intentional sidecar
+    if tau_stats is not None:
+        model._tau_stats = tau_stats  # noqa: SLF001 - intentional sidecar
+    return model

--- a/src/shared/python/motion_matching/inverse_timestep/training.py
+++ b/src/shared/python/motion_matching/inverse_timestep/training.py
@@ -1,0 +1,651 @@
+"""Training loop for :class:`TimestepInverseDynamics` on the realistic-speed
+filtered subset of the compact dataset.
+
+Pipeline:
+    1. Load compact dataset (eager pandas DataFrames).
+    2. Split *by trial_id* (90/10) so val timesteps come from unseen trials.
+    3. Filter both splits to ``||v_clubhead|| in [lo, hi]`` mph.
+    4. Compute per-DOF (mean, std) from the train split (NaN-aware).
+    5. Standardise inputs/targets, train an MLP with masked MSE on the
+       standardised tau (mask zeros out gradients on NaN-target DOFs).
+    6. Report per-epoch ``train_loss``, ``val_loss``, and ``val_tau_mae_nm``
+       (de-standardised, masked, in physical Nm).
+    7. Persist best checkpoint + ``metrics.json``.
+
+Loss baseline: standardised MSE of the mean-prediction baseline is 1.0.
+A working model should be < 0.1.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import warnings
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, Dataset
+
+from src.shared.python.dataset_tools.load_compact import (
+    CompactSwingDataset,
+    load_compact_swing_dataset,
+)
+
+from .filter import filter_timesteps_by_speed
+from .model import (
+    TimestepInverseConfig,
+    TimestepInverseDynamics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_OUTPUT_ROOT = Path("output/timestep_inverse")
+DEFAULT_PATIENCE = 15
+DEFAULT_SEED = 0xC0FFEE
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimestepEpochMetrics:
+    """Per-epoch metrics for the timestep inverse-dynamics trainer.
+
+    Attributes:
+        epoch: 0-based epoch index.
+        train_loss: Mean masked MSE on standardised tau over train batches.
+        val_loss: Mean masked MSE on standardised tau over val batches.
+        val_tau_mae_nm: Mean absolute error in physical Nm over the val
+            split, masked on NaN-target DOFs.
+        duration_s: Wall-clock seconds for this epoch.
+    """
+
+    epoch: int
+    train_loss: float
+    val_loss: float
+    val_tau_mae_nm: float
+    duration_s: float
+
+
+@dataclass(frozen=True)
+class TimestepTrainingResult:
+    """Outcome of :func:`train_timestep_inverse`."""
+
+    history: tuple[TimestepEpochMetrics, ...]
+    best_epoch: int
+    best_val_loss: float
+    final_epoch: int
+    checkpoint_path: Path
+    output_dir: Path
+    n_train_trials: int
+    n_val_trials: int
+    n_train_timesteps: int
+    n_val_timesteps: int
+    parameter_count: int
+    config: TimestepInverseConfig
+    speed_lo_mph: float
+    speed_hi_mph: float
+
+    def to_summary(self) -> dict:
+        """JSON-serialisable summary for ``metrics.json``."""
+        return {
+            "history": [asdict(h) for h in self.history],
+            "best_epoch": self.best_epoch,
+            "best_val_loss": self.best_val_loss,
+            "final_epoch": self.final_epoch,
+            "checkpoint_path": str(self.checkpoint_path),
+            "output_dir": str(self.output_dir),
+            "n_train_trials": self.n_train_trials,
+            "n_val_trials": self.n_val_trials,
+            "n_train_timesteps": self.n_train_timesteps,
+            "n_val_timesteps": self.n_val_timesteps,
+            "parameter_count": self.parameter_count,
+            "speed_lo_mph": self.speed_lo_mph,
+            "speed_hi_mph": self.speed_hi_mph,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Dataset adapter
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PreparedTimestepBatch:
+    state: torch.Tensor  # (N, input_dim)
+    tau: torch.Tensor  # (N, output_dim)
+    tau_mask: torch.Tensor  # (N, output_dim) float32 in {0, 1}
+
+
+class _TimestepTensorDataset(Dataset[dict[str, torch.Tensor]]):
+    def __init__(
+        self,
+        state: torch.Tensor,
+        tau: torch.Tensor,
+        tau_mask: torch.Tensor,
+    ) -> None:
+        if state.shape[0] != tau.shape[0] or tau.shape != tau_mask.shape:
+            raise ValueError("state/tau/tau_mask first-dim mismatch")
+        self._state = state
+        self._tau = tau
+        self._tau_mask = tau_mask
+
+    def __len__(self) -> int:
+        return int(self._state.shape[0])
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        return {
+            "state": self._state[idx],
+            "tau": self._tau[idx],
+            "tau_mask": self._tau_mask[idx],
+        }
+
+
+def _collate(items: Iterable[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+    items_list = list(items)
+    state = torch.stack([it["state"] for it in items_list], dim=0)
+    tau = torch.stack([it["tau"] for it in items_list], dim=0)
+    tau_mask = torch.stack([it["tau_mask"] for it in items_list], dim=0)
+    return {"state": state, "tau": tau, "tau_mask": tau_mask}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def train_timestep_inverse(
+    dataset_path: str | Path,
+    *,
+    speed_lo_mph: float = 50.0,
+    speed_hi_mph: float = 150.0,
+    epochs: int = 80,
+    batch_size: int = 512,
+    lr: float = 1e-3,
+    weight_decay: float = 1e-5,
+    device: str | torch.device = "auto",
+    seed: int = DEFAULT_SEED,
+    patience: int = DEFAULT_PATIENCE,
+    val_fraction: float = 0.1,
+    output_root: str | Path = DEFAULT_OUTPUT_ROOT,
+    grad_clip: float = 1.0,
+    config: TimestepInverseConfig | None = None,
+    dataset_loader: Any = None,
+) -> TimestepTrainingResult:
+    """Train a per-timestep inverse-dynamics MLP end-to-end.
+
+    Parameters
+    ----------
+    dataset_path
+        Folder containing ``trials.parquet`` and ``timesteps.parquet``.
+    speed_lo_mph, speed_hi_mph
+        Realistic clubhead-speed window (inclusive). Default 50-150 mph.
+    epochs
+        Maximum number of training epochs (must be > 0).
+    batch_size
+        DataLoader batch size (must be > 0).
+    lr
+        AdamW learning rate (must be > 0).
+    device
+        Torch device or ``"auto"`` (CUDA if available else CPU).
+    seed
+        Random seed for split + torch RNG.
+    patience
+        Early-stop after ``patience`` epochs without val_loss improvement.
+    val_fraction
+        Fraction of trials assigned to validation (0 < f < 1).
+    output_root
+        Root directory under which a timestamped output folder is created.
+    config
+        Optional :class:`TimestepInverseConfig`.
+    dataset_loader
+        Optional callable ``(path) -> CompactSwingDataset`` for testing.
+
+    Returns
+    -------
+    TimestepTrainingResult
+        History, best-epoch index, output directory, parameter count.
+
+    Raises
+    ------
+    ValueError
+        If any precondition is violated.
+    """
+    _validate_train_args(
+        epochs=epochs,
+        batch_size=batch_size,
+        lr=lr,
+        val_fraction=val_fraction,
+        patience=patience,
+        speed_lo_mph=speed_lo_mph,
+        speed_hi_mph=speed_hi_mph,
+    )
+    loader_fn = dataset_loader or _default_compact_loader
+    dataset = loader_fn(Path(dataset_path))
+
+    rng = np.random.default_rng(seed)
+    train_ids, val_ids = _split_trial_ids(dataset, val_fraction, rng)
+
+    train_ts = _select_trials(dataset, train_ids)
+    val_ts = _select_trials(dataset, val_ids)
+    train_ts = _filter_speed(train_ts, speed_lo_mph, speed_hi_mph)
+    val_ts = _filter_speed(val_ts, speed_lo_mph, speed_hi_mph)
+    if len(train_ts) == 0:
+        raise ValueError("train split has 0 timesteps after speed filter")
+    if len(val_ts) == 0:
+        raise ValueError("val split has 0 timesteps after speed filter")
+
+    cfg = config or TimestepInverseConfig()
+    state_train, tau_train, mask_train = _materialise_arrays(train_ts, cfg)
+    state_val, tau_val, mask_val = _materialise_arrays(val_ts, cfg)
+    state_stats = _compute_stats(state_train)
+    tau_stats = _compute_stats_with_mask(tau_train, mask_train)
+
+    state_train_std = _standardise(state_train, state_stats)
+    state_val_std = _standardise(state_val, state_stats)
+    tau_train_std = _standardise(tau_train, tau_stats)
+    tau_val_std = _standardise(tau_val, tau_stats)
+
+    train_ds = _TimestepTensorDataset(
+        torch.from_numpy(state_train_std),
+        torch.from_numpy(tau_train_std),
+        torch.from_numpy(mask_train),
+    )
+    val_ds = _TimestepTensorDataset(
+        torch.from_numpy(state_val_std),
+        torch.from_numpy(tau_val_std),
+        torch.from_numpy(mask_val),
+    )
+
+    torch.manual_seed(seed)
+    selected_device = _resolve_device(device)
+    model = TimestepInverseDynamics(cfg).to(selected_device)
+    opt = AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        collate_fn=_collate,
+        drop_last=False,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=_collate,
+    )
+
+    output_dir = _make_output_dir(Path(output_root))
+    history: list[TimestepEpochMetrics] = []
+    best_val_loss = float("inf")
+    best_epoch = 0
+    best_path = output_dir / "checkpoint_best.pt"
+    plateau = 0
+    tau_std_t = torch.from_numpy(np.asarray(tau_stats["std"], dtype=np.float32)).to(
+        selected_device
+    )
+
+    for epoch in range(epochs):
+        t0 = time.time()
+        train_loss = _run_epoch(
+            model,
+            train_loader,
+            selected_device,
+            opt,
+            train=True,
+            grad_clip=grad_clip,
+        )
+        val_loss, val_tau_mae_nm = _eval_epoch(
+            model,
+            val_loader,
+            selected_device,
+            tau_std_t,
+        )
+        duration = time.time() - t0
+
+        metrics = TimestepEpochMetrics(
+            epoch=epoch,
+            train_loss=train_loss,
+            val_loss=val_loss,
+            val_tau_mae_nm=val_tau_mae_nm,
+            duration_s=duration,
+        )
+        history.append(metrics)
+        logger.info(
+            "epoch=%d train_loss=%.4g val_loss=%.4g val_tau_mae_nm=%.4g dt=%.2fs",
+            epoch,
+            train_loss,
+            val_loss,
+            val_tau_mae_nm,
+            duration,
+        )
+
+        payload = _build_payload(
+            model, state_stats, tau_stats, speed_lo_mph, speed_hi_mph
+        )
+        if val_loss < best_val_loss - 1e-6:
+            best_val_loss = val_loss
+            best_epoch = epoch
+            plateau = 0
+            torch.save(payload, best_path)
+        else:
+            plateau += 1
+            if plateau >= patience:
+                logger.info("early stop: val_loss plateau at epoch %d", epoch)
+                break
+
+    final_epoch = history[-1].epoch
+    n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    result = TimestepTrainingResult(
+        history=tuple(history),
+        best_epoch=best_epoch,
+        best_val_loss=best_val_loss,
+        final_epoch=final_epoch,
+        checkpoint_path=best_path,
+        output_dir=output_dir,
+        n_train_trials=len(train_ids),
+        n_val_trials=len(val_ids),
+        n_train_timesteps=int(state_train.shape[0]),
+        n_val_timesteps=int(state_val.shape[0]),
+        parameter_count=n_params,
+        config=cfg,
+        speed_lo_mph=float(speed_lo_mph),
+        speed_hi_mph=float(speed_hi_mph),
+    )
+    summary_path = output_dir / "metrics.json"
+    summary_path.write_text(json.dumps(result.to_summary(), indent=2))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _validate_train_args(
+    *,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    val_fraction: float,
+    patience: int,
+    speed_lo_mph: float,
+    speed_hi_mph: float,
+) -> None:
+    if epochs <= 0:
+        raise ValueError(f"epochs must be positive, got {epochs}")
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if lr <= 0:
+        raise ValueError(f"lr must be positive, got {lr}")
+    if not 0.0 < val_fraction < 1.0:
+        raise ValueError(f"val_fraction must be in (0, 1), got {val_fraction}")
+    if patience < 1:
+        raise ValueError(f"patience must be >= 1, got {patience}")
+    if speed_lo_mph < 0:
+        raise ValueError(f"speed_lo_mph must be >= 0, got {speed_lo_mph}")
+    if not speed_lo_mph < speed_hi_mph:
+        raise ValueError(
+            "must have speed_lo_mph < speed_hi_mph; got "
+            f"lo={speed_lo_mph}, hi={speed_hi_mph}"
+        )
+
+
+def _resolve_device(device: str | torch.device) -> torch.device:
+    if isinstance(device, torch.device):
+        return device
+    if device == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device)
+
+
+def _make_output_dir(root: Path) -> Path:
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    out = root / stamp
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _split_trial_ids(
+    dataset: CompactSwingDataset,
+    val_fraction: float,
+    rng: np.random.Generator,
+) -> tuple[set[int], set[int]]:
+    trials_df = _require_pandas(dataset.trials, "trials")
+    trial_ids = np.asarray(
+        trials_df["trial_id"].to_numpy(dtype=np.int64), dtype=np.int64
+    )
+    if trial_ids.size < 2:
+        raise ValueError(f"need at least 2 trials to split; got {int(trial_ids.size)}")
+    perm = rng.permutation(trial_ids)
+    n_val = max(1, int(round(val_fraction * len(perm))))
+    val = {int(t) for t in perm[:n_val]}
+    train = {int(t) for t in perm[n_val:]}
+    if not train:
+        raise ValueError("split produced empty train set; reduce val_fraction")
+    return train, val
+
+
+def _select_trials(
+    dataset: CompactSwingDataset,
+    trial_ids: set[int],
+) -> pd.DataFrame:
+    timesteps_df = _require_pandas(dataset.timesteps, "timesteps")
+    if not trial_ids:
+        return timesteps_df.iloc[0:0].copy()
+    mask = timesteps_df["trial_id"].isin(trial_ids)
+    return timesteps_df.loc[mask].reset_index(drop=True)
+
+
+def _filter_speed(timesteps_df: pd.DataFrame, lo: float, hi: float) -> pd.DataFrame:
+    speeds = timesteps_df["clubhead_speed_mph"].to_numpy(dtype=np.float64)
+    keep = (speeds >= lo) & (speeds <= hi)
+    return timesteps_df.loc[keep].reset_index(drop=True)
+
+
+def _materialise_arrays(
+    timesteps_df: pd.DataFrame, cfg: TimestepInverseConfig
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Stack list-columns into ``(N, 27)`` arrays for each of ``q, qd, qdd, tau``.
+
+    Returns ``(state[N, 81], tau[N, 27], mask[N, 27])`` where ``state`` is
+    ``concat(q, qd, qdd)``, ``tau`` has NaN replaced with 0.0, and
+    ``mask`` is 1.0 where the original ``tau`` was finite, else 0.0.
+    """
+    n = len(timesteps_df)
+    if n == 0:
+        return (
+            np.zeros((0, cfg.input_dim), dtype=np.float32),
+            np.zeros((0, cfg.output_dim), dtype=np.float32),
+            np.zeros((0, cfg.output_dim), dtype=np.float32),
+        )
+    q = _stack_list_col(timesteps_df["q"])
+    qd = _stack_list_col(timesteps_df["qd"])
+    qdd = _stack_list_col(timesteps_df["qdd"])
+    tau = _stack_list_col(timesteps_df["tau"])
+    state = np.concatenate([q, qd, qdd], axis=-1).astype(np.float32, copy=False)
+    if state.shape[-1] != cfg.input_dim:
+        raise ValueError(
+            f"state input_dim mismatch: got {state.shape[-1]}, expected {cfg.input_dim}"
+        )
+    if tau.shape[-1] != cfg.output_dim:
+        raise ValueError(
+            f"tau output_dim mismatch: got {tau.shape[-1]}, expected {cfg.output_dim}"
+        )
+    mask = np.isfinite(tau).astype(np.float32)
+    tau_clean = np.where(mask > 0, tau, np.float32(0.0)).astype(np.float32)
+    return state.astype(np.float32, copy=False), tau_clean, mask
+
+
+def _stack_list_col(series: pd.Series) -> np.ndarray:
+    return np.stack([np.asarray(v, dtype=np.float32) for v in series], axis=0)
+
+
+def _compute_stats(arr: np.ndarray) -> dict[str, np.ndarray]:
+    """Compute per-column NaN-aware mean/std (NaN propagated via nanmean/nanstd).
+
+    Std is floored at 1e-8 then any near-zero entries are replaced by 1.0
+    so divide is safe and constant columns are not amplified.
+    """
+    mean = np.nanmean(arr, axis=0).astype(np.float32)
+    std = np.nanstd(arr, axis=0).astype(np.float32)
+    mean = np.nan_to_num(mean, nan=0.0).astype(np.float32)
+    std = np.nan_to_num(std, nan=1.0).astype(np.float32)
+    safe = np.where(std > 1e-8, std, np.float32(1.0)).astype(np.float32)
+    return {"mean": mean, "std": safe}
+
+
+def _compute_stats_with_mask(
+    arr: np.ndarray, mask: np.ndarray
+) -> dict[str, np.ndarray]:
+    """Mean/std over only the masked-finite entries (per column).
+
+    Columns with zero finite entries (e.g. an always-NaN tau index in this
+    split) get mean=0, std=1.
+    """
+    masked = np.where(mask > 0, arr, np.nan)
+    n_finite = mask.sum(axis=0)
+    # nanmean/nanstd warn for all-NaN columns; we explicitly substitute
+    # safe defaults via ``np.where`` after the call, so the warning is
+    # uninteresting noise.
+    with np.errstate(invalid="ignore"), warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        raw_mean = np.nanmean(masked, axis=0)
+        raw_std = np.nanstd(masked, axis=0)
+    mean = np.where(n_finite > 0, raw_mean, 0.0).astype(np.float32)
+    std = np.where(n_finite > 1, raw_std, 1.0).astype(np.float32)
+    safe = np.where(std > 1e-8, std, np.float32(1.0)).astype(np.float32)
+    return {"mean": mean, "std": safe}
+
+
+def _standardise(arr: np.ndarray, stats: dict[str, np.ndarray]) -> np.ndarray:
+    return ((arr - stats["mean"]) / stats["std"]).astype(np.float32)
+
+
+def _build_payload(
+    model: TimestepInverseDynamics,
+    state_stats: dict[str, np.ndarray],
+    tau_stats: dict[str, np.ndarray],
+    speed_lo_mph: float,
+    speed_hi_mph: float,
+) -> dict:
+    base = model.state_payload()
+    base["state_stats"] = {
+        "mean": state_stats["mean"].tolist(),
+        "std": state_stats["std"].tolist(),
+    }
+    base["tau_stats"] = {
+        "mean": tau_stats["mean"].tolist(),
+        "std": tau_stats["std"].tolist(),
+    }
+    base["speed_window_mph"] = [float(speed_lo_mph), float(speed_hi_mph)]
+    return base
+
+
+def _run_epoch(
+    model: TimestepInverseDynamics,
+    loader: DataLoader,
+    device: torch.device,
+    opt: AdamW,
+    *,
+    train: bool,
+    grad_clip: float,
+) -> float:
+    """One pass over ``loader``. Returns the masked-mean standardised MSE."""
+    if train:
+        model.train()
+    else:
+        model.eval()
+    total_loss = 0.0
+    total_count = 0.0
+    with torch.set_grad_enabled(train):
+        for batch in loader:
+            state = batch["state"].to(device, non_blocking=True)
+            tau = batch["tau"].to(device, non_blocking=True)
+            mask = batch["tau_mask"].to(device, non_blocking=True)
+            pred = model(state)
+            sq_err = (pred - tau) ** 2
+            masked = sq_err * mask
+            count = mask.sum()
+            if float(count.detach().cpu()) <= 0:
+                continue
+            loss = masked.sum() / count.clamp_min(1.0)
+            if train:
+                opt.zero_grad(set_to_none=True)
+                loss.backward()
+                if grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+                opt.step()
+            total_loss += float(masked.sum().detach().cpu())
+            total_count += float(count.detach().cpu())
+    if total_count <= 0:
+        return 0.0
+    return total_loss / total_count
+
+
+def _eval_epoch(
+    model: TimestepInverseDynamics,
+    loader: DataLoader,
+    device: torch.device,
+    tau_std_t: torch.Tensor,
+) -> tuple[float, float]:
+    """Eval pass; returns ``(masked_mse_std, mae_physical_nm)``."""
+    model.eval()
+    total_sq = 0.0
+    total_abs = 0.0
+    total_count = 0.0
+    with torch.no_grad():
+        for batch in loader:
+            state = batch["state"].to(device, non_blocking=True)
+            tau = batch["tau"].to(device, non_blocking=True)
+            mask = batch["tau_mask"].to(device, non_blocking=True)
+            pred = model(state)
+            sq_err = (pred - tau) ** 2
+            masked_sq = sq_err * mask
+            # MAE in physical units: undo standardisation by multiplying by
+            # tau_std (broadcast over batch). Since pred and tau live in
+            # standardised space, |pred - tau| * std == |pred_phys - tau_phys|.
+            abs_err = (pred - tau).abs() * tau_std_t
+            masked_abs = abs_err * mask
+            total_sq += float(masked_sq.sum().detach().cpu())
+            total_abs += float(masked_abs.sum().detach().cpu())
+            total_count += float(mask.sum().detach().cpu())
+    if total_count <= 0:
+        return 0.0, 0.0
+    return total_sq / total_count, total_abs / total_count
+
+
+def _require_pandas(obj: Any, label: str) -> pd.DataFrame:
+    if not isinstance(obj, pd.DataFrame):
+        raise TypeError(
+            f"timestep training requires eager pandas DataFrame for `{label}`; "
+            f"got {type(obj).__name__} (load with lazy=False)"
+        )
+    return obj
+
+
+def _default_compact_loader(path: Path) -> CompactSwingDataset:
+    return load_compact_swing_dataset(path, lazy=False)
+
+
+# Re-export for convenience.
+__all__ = [
+    "DEFAULT_OUTPUT_ROOT",
+    "DEFAULT_PATIENCE",
+    "DEFAULT_SEED",
+    "TimestepEpochMetrics",
+    "TimestepTrainingResult",
+    "filter_timesteps_by_speed",
+    "train_timestep_inverse",
+]

--- a/tests/unit/motion_matching/test_timestep_filter.py
+++ b/tests/unit/motion_matching/test_timestep_filter.py
@@ -1,0 +1,147 @@
+"""Unit tests for the realistic-speed mask + timestep filter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.motion_matching.inverse_timestep.filter import (
+    filter_timesteps_by_speed,
+    realistic_speed_mask,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# realistic_speed_mask
+# ---------------------------------------------------------------------------
+
+
+def test_realistic_speed_mask_inclusive_bounds() -> None:
+    speeds = np.array([49.9, 50.0, 100.0, 150.0, 150.1, 0.0, 200.0])
+    mask = realistic_speed_mask(speeds, lo=50.0, hi=150.0)
+    expected = np.array([False, True, True, True, False, False, False])
+    np.testing.assert_array_equal(mask, expected)
+
+
+def test_realistic_speed_mask_default_window() -> None:
+    speeds = np.array([10.0, 50.0, 100.0, 150.0, 200.0])
+    mask = realistic_speed_mask(speeds)
+    np.testing.assert_array_equal(mask, [False, True, True, True, False])
+
+
+def test_realistic_speed_mask_custom_window() -> None:
+    speeds = np.array([60.0, 80.0, 100.0])
+    mask = realistic_speed_mask(speeds, lo=70.0, hi=90.0)
+    np.testing.assert_array_equal(mask, [False, True, False])
+
+
+def test_realistic_speed_mask_rejects_non_array() -> None:
+    with pytest.raises(TypeError, match="np.ndarray"):
+        realistic_speed_mask([50.0, 100.0], lo=50.0, hi=150.0)  # type: ignore[arg-type]
+
+
+def test_realistic_speed_mask_rejects_2d_array() -> None:
+    with pytest.raises(ValueError, match="1-D"):
+        realistic_speed_mask(np.zeros((2, 2)), lo=50.0, hi=150.0)
+
+
+def test_realistic_speed_mask_rejects_nan() -> None:
+    speeds = np.array([50.0, np.nan, 100.0])
+    with pytest.raises(ValueError, match="non-finite"):
+        realistic_speed_mask(speeds)
+
+
+def test_realistic_speed_mask_rejects_inf() -> None:
+    speeds = np.array([50.0, np.inf, 100.0])
+    with pytest.raises(ValueError, match="non-finite"):
+        realistic_speed_mask(speeds)
+
+
+def test_realistic_speed_mask_rejects_negative_lo() -> None:
+    speeds = np.array([10.0])
+    with pytest.raises(ValueError, match="lo must be >= 0"):
+        realistic_speed_mask(speeds, lo=-1.0, hi=10.0)
+
+
+def test_realistic_speed_mask_rejects_lo_eq_hi() -> None:
+    speeds = np.array([10.0])
+    with pytest.raises(ValueError, match="lo < hi"):
+        realistic_speed_mask(speeds, lo=10.0, hi=10.0)
+
+
+def test_realistic_speed_mask_rejects_lo_gt_hi() -> None:
+    speeds = np.array([10.0])
+    with pytest.raises(ValueError, match="lo < hi"):
+        realistic_speed_mask(speeds, lo=200.0, hi=100.0)
+
+
+# ---------------------------------------------------------------------------
+# filter_timesteps_by_speed
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeDataset:
+    trials: Any
+    timesteps: Any
+    joint_names: tuple = ()
+    coefficient_letters: tuple = ("A", "B", "C", "D", "E", "F", "G")
+    schema_version: str = "compact-1.0"
+
+
+def _make_dataset(speeds: list[float]) -> _FakeDataset:
+    timesteps = pd.DataFrame(
+        {
+            "trial_id": [0] * len(speeds),
+            "clubhead_speed_mph": speeds,
+            "extra": list(range(len(speeds))),
+        }
+    )
+    trials = pd.DataFrame({"trial_id": [0]})
+    return _FakeDataset(trials=trials, timesteps=timesteps)
+
+
+def test_filter_timesteps_basic() -> None:
+    ds = _make_dataset([10.0, 60.0, 120.0, 200.0, 80.0])
+    out = filter_timesteps_by_speed(ds, lo=50.0, hi=150.0)
+    assert len(out.timesteps) == 3
+    speeds = out.timesteps["clubhead_speed_mph"].tolist()
+    assert speeds == [60.0, 120.0, 80.0]
+    assert out.timesteps["extra"].tolist() == [1, 2, 4]
+
+
+def test_filter_timesteps_preserves_trials_field() -> None:
+    ds = _make_dataset([10.0, 60.0])
+    out = filter_timesteps_by_speed(ds)
+    assert out.trials is ds.trials
+    assert out.schema_version == ds.schema_version
+
+
+def test_filter_timesteps_empty_window_yields_zero_rows() -> None:
+    ds = _make_dataset([200.0, 300.0, 400.0])
+    out = filter_timesteps_by_speed(ds, lo=50.0, hi=150.0)
+    assert len(out.timesteps) == 0
+
+
+def test_filter_timesteps_requires_pandas() -> None:
+    ds = _FakeDataset(trials=None, timesteps={"clubhead_speed_mph": [50.0]})
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        filter_timesteps_by_speed(ds)
+
+
+def test_filter_timesteps_requires_speed_column() -> None:
+    ts = pd.DataFrame({"trial_id": [0], "other": [1.0]})
+    ds = _FakeDataset(trials=pd.DataFrame({"trial_id": [0]}), timesteps=ts)
+    with pytest.raises(ValueError, match="clubhead_speed_mph"):
+        filter_timesteps_by_speed(ds)
+
+
+def test_filter_timesteps_validates_bounds() -> None:
+    ds = _make_dataset([60.0])
+    with pytest.raises(ValueError, match="lo < hi"):
+        filter_timesteps_by_speed(ds, lo=100.0, hi=50.0)

--- a/tests/unit/motion_matching/test_timestep_inverse_model.py
+++ b/tests/unit/motion_matching/test_timestep_inverse_model.py
@@ -1,0 +1,159 @@
+"""Unit tests for :class:`TimestepInverseDynamics`."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.shared.python.motion_matching.inverse_timestep.model import (  # noqa: E402
+    DEFAULT_INPUT_DIM,
+    DEFAULT_OUTPUT_DIM,
+    TimestepInverseConfig,
+    TimestepInverseDynamics,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.requires_torch]
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults() -> None:
+    cfg = TimestepInverseConfig()
+    cfg.validate()
+    assert cfg.input_dim == DEFAULT_INPUT_DIM == 81
+    assert cfg.output_dim == DEFAULT_OUTPUT_DIM == 27
+    assert cfg.use_missing_indicator is True
+    assert cfg.effective_input_dim == 162
+
+
+def test_config_rejects_zero_input_dim() -> None:
+    with pytest.raises(ValueError, match="input_dim"):
+        TimestepInverseConfig(input_dim=0).validate()
+
+
+def test_config_rejects_negative_n_blocks() -> None:
+    with pytest.raises(ValueError, match="n_blocks"):
+        TimestepInverseConfig(n_blocks=0).validate()
+
+
+def test_config_rejects_dropout_one() -> None:
+    with pytest.raises(ValueError, match="dropout"):
+        TimestepInverseConfig(dropout=1.0).validate()
+
+
+def test_config_no_indicator_input_doubled_off() -> None:
+    cfg = TimestepInverseConfig(use_missing_indicator=False)
+    cfg.validate()
+    assert cfg.effective_input_dim == cfg.input_dim
+
+
+# ---------------------------------------------------------------------------
+# Forward shape / dtype
+# ---------------------------------------------------------------------------
+
+
+def _make_state(n: int = 4, dim: int = DEFAULT_INPUT_DIM) -> torch.Tensor:
+    return torch.zeros(n, dim, dtype=torch.float32)
+
+
+def test_forward_returns_correct_shape_and_dtype() -> None:
+    model = TimestepInverseDynamics()
+    state = _make_state(8)
+    out = model(state)
+    assert out.shape == (8, DEFAULT_OUTPUT_DIM)
+    assert out.dtype == torch.float32
+
+
+def test_forward_with_small_config() -> None:
+    cfg = TimestepInverseConfig(hidden=32, n_blocks=2, dropout=0.0)
+    model = TimestepInverseDynamics(cfg)
+    state = torch.randn(3, cfg.input_dim, dtype=torch.float32)
+    out = model(state)
+    assert out.shape == (3, cfg.output_dim)
+
+
+def test_forward_deterministic_in_eval() -> None:
+    cfg = TimestepInverseConfig(hidden=32, n_blocks=2, dropout=0.0)
+    model = TimestepInverseDynamics(cfg)
+    model.eval()
+    state = torch.randn(2, cfg.input_dim, dtype=torch.float32)
+    with torch.no_grad():
+        a = model(state)
+        b = model(state)
+    torch.testing.assert_close(a, b)
+
+
+def test_forward_gradient_flow() -> None:
+    cfg = TimestepInverseConfig(hidden=32, n_blocks=2, dropout=0.0)
+    model = TimestepInverseDynamics(cfg)
+    state = torch.randn(4, cfg.input_dim, dtype=torch.float32)
+    target = torch.randn(4, cfg.output_dim, dtype=torch.float32)
+    pred = model(state)
+    loss = ((pred - target) ** 2).mean()
+    loss.backward()
+    grads = [p.grad for p in model.parameters() if p.requires_grad]
+    assert all(g is not None for g in grads)
+    assert any((g.abs().sum() > 0).item() for g in grads if g is not None)
+
+
+# ---------------------------------------------------------------------------
+# Input validation (DbC)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_rejects_non_tensor() -> None:
+    model = TimestepInverseDynamics()
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        model([0.0] * DEFAULT_INPUT_DIM)  # type: ignore[arg-type]
+
+
+def test_forward_rejects_wrong_rank() -> None:
+    model = TimestepInverseDynamics()
+    with pytest.raises(ValueError, match="2-D"):
+        model(torch.zeros(DEFAULT_INPUT_DIM, dtype=torch.float32))
+
+
+def test_forward_rejects_wrong_last_dim() -> None:
+    model = TimestepInverseDynamics()
+    with pytest.raises(ValueError, match="last-dim"):
+        model(torch.zeros(2, DEFAULT_INPUT_DIM - 1, dtype=torch.float32))
+
+
+def test_forward_rejects_non_float32() -> None:
+    model = TimestepInverseDynamics()
+    with pytest.raises(TypeError, match="float32"):
+        model(torch.zeros(2, DEFAULT_INPUT_DIM, dtype=torch.float64))
+
+
+def test_forward_rejects_inf_input() -> None:
+    model = TimestepInverseDynamics()
+    bad = torch.zeros(2, DEFAULT_INPUT_DIM, dtype=torch.float32)
+    bad[0, 0] = float("inf")
+    with pytest.raises(ValueError, match="Inf"):
+        model(bad)
+
+
+def test_forward_tolerates_nan_input_when_indicator_on() -> None:
+    cfg = TimestepInverseConfig(hidden=32, n_blocks=2, dropout=0.0)
+    model = TimestepInverseDynamics(cfg)
+    state = torch.randn(2, cfg.input_dim, dtype=torch.float32)
+    state[0, 0] = float("nan")
+    state[1, 5] = float("nan")
+    out = model(state)
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()
+
+
+def test_forward_tolerates_nan_when_indicator_off() -> None:
+    cfg = TimestepInverseConfig(
+        hidden=32, n_blocks=2, dropout=0.0, use_missing_indicator=False
+    )
+    model = TimestepInverseDynamics(cfg)
+    state = torch.randn(2, cfg.input_dim, dtype=torch.float32)
+    state[0, 0] = float("nan")
+    out = model(state)
+    assert not torch.isnan(out).any()

--- a/tests/unit/motion_matching/test_timestep_inverse_training.py
+++ b/tests/unit/motion_matching/test_timestep_inverse_training.py
@@ -1,0 +1,199 @@
+"""Training-loop tests for :func:`train_timestep_inverse`.
+
+Uses an in-memory synthetic 8-trial fixture (no parquet IO) by injecting a
+custom ``dataset_loader``. Verifies a few epochs reduce val loss by >=10%
+and that the checkpoint round-trips via ``from_checkpoint``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.shared.python.motion_matching.inverse_timestep import (  # noqa: E402
+    TimestepInverseConfig,
+    TimestepInverseDynamics,
+    train_timestep_inverse,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.requires_torch]
+
+
+# ---------------------------------------------------------------------------
+# Synthetic 8-trial fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeCompactDataset:
+    trials: pd.DataFrame
+    timesteps: pd.DataFrame
+    joint_names: tuple = ()
+    coefficient_letters: tuple = ("A", "B", "C", "D", "E", "F", "G")
+    schema_version: str = "compact-1.0"
+
+
+def _build_synthetic_dataset(
+    n_trials: int = 8, n_timesteps: int = 31
+) -> _FakeCompactDataset:
+    """Build a fixture with strong (q, qd, qdd) -> tau coupling.
+
+    tau is a fixed linear function of the state plus a small noise term,
+    so a 2-block MLP can fit it in a few epochs and val_loss should fall
+    well below the standardised baseline of 1.0.
+    """
+    rng = np.random.default_rng(0)
+    n_joints = 27
+    state_dim = 3 * n_joints
+    weight = rng.normal(0, 0.1, size=(state_dim, n_joints)).astype(np.float32)
+    bias = rng.normal(0, 0.1, size=(n_joints,)).astype(np.float32)
+    speed_uniform = rng.uniform(60.0, 140.0, size=(n_trials, n_timesteps)).astype(
+        np.float32
+    )
+
+    trial_rows: list[dict[str, Any]] = []
+    ts_rows: list[dict[str, Any]] = []
+    for trial_id in range(n_trials):
+        trial_rows.append({"trial_id": trial_id})
+        ts = np.linspace(0.0, 0.3, n_timesteps)
+        for j, t in enumerate(ts):
+            q = rng.normal(0, 0.5, size=(n_joints,)).astype(np.float32)
+            qd = rng.normal(0, 0.5, size=(n_joints,)).astype(np.float32)
+            qdd = rng.normal(0, 0.5, size=(n_joints,)).astype(np.float32)
+            state = np.concatenate([q, qd, qdd])
+            tau = state @ weight + bias
+            tau += rng.normal(0, 0.01, size=(n_joints,)).astype(np.float32)
+            # Mark a couple of joint indices as unmapped (NaN) to exercise
+            # the masked-loss path.
+            tau[3] = np.nan
+            tau[7] = np.nan
+            ts_rows.append(
+                {
+                    "trial_id": trial_id,
+                    "t": float(t),
+                    "q": q.tolist(),
+                    "qd": qd.tolist(),
+                    "qdd": qdd.tolist(),
+                    "tau": tau.tolist(),
+                    "clubhead_speed_mph": float(speed_uniform[trial_id, j]),
+                }
+            )
+    return _FakeCompactDataset(
+        trials=pd.DataFrame(trial_rows),
+        timesteps=pd.DataFrame(ts_rows),
+    )
+
+
+def _loader_factory():
+    dataset = _build_synthetic_dataset()
+    return lambda _path: dataset
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_three_epoch_run_reduces_val_loss(tmp_path: Path) -> None:
+    cfg = TimestepInverseConfig(hidden=64, n_blocks=2, dropout=0.0)
+    result = train_timestep_inverse(
+        tmp_path,
+        speed_lo_mph=50.0,
+        speed_hi_mph=150.0,
+        epochs=10,
+        batch_size=32,
+        lr=5e-3,
+        seed=42,
+        device="cpu",
+        patience=20,
+        output_root=tmp_path / "out",
+        config=cfg,
+        dataset_loader=_loader_factory(),
+    )
+
+    assert len(result.history) == 10
+    first = result.history[0].val_loss
+    last = result.history[-1].val_loss
+    assert last < first * 0.9, (
+        f"val_loss did not reduce by >=10%: {first:.4g} -> {last:.4g}"
+    )
+    assert result.checkpoint_path.exists()
+    metrics_file = result.output_dir / "metrics.json"
+    assert metrics_file.exists()
+    assert result.parameter_count > 0
+    assert result.n_train_trials >= 1
+    assert result.n_val_trials >= 1
+    assert result.n_train_timesteps > 0
+    assert result.n_val_timesteps > 0
+    assert all(m.val_tau_mae_nm >= 0 for m in result.history)
+
+
+def test_checkpoint_round_trip(tmp_path: Path) -> None:
+    cfg = TimestepInverseConfig(hidden=32, n_blocks=2, dropout=0.0)
+    result = train_timestep_inverse(
+        tmp_path,
+        speed_lo_mph=50.0,
+        speed_hi_mph=150.0,
+        epochs=2,
+        batch_size=32,
+        lr=1e-3,
+        seed=0,
+        device="cpu",
+        patience=5,
+        output_root=tmp_path / "out",
+        config=cfg,
+        dataset_loader=_loader_factory(),
+    )
+    restored = TimestepInverseDynamics.from_checkpoint(result.checkpoint_path)
+    assert isinstance(restored, TimestepInverseDynamics)
+    assert restored.cfg == cfg
+
+    restored.eval()
+    state = torch.zeros(1, cfg.input_dim, dtype=torch.float32)
+    with torch.no_grad():
+        out_a = restored(state)
+        out_b = restored(state)
+    torch.testing.assert_close(out_a, out_b)
+
+
+def test_invalid_epochs_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="epochs"):
+        train_timestep_inverse(
+            tmp_path,
+            epochs=0,
+            device="cpu",
+            output_root=tmp_path / "out",
+            dataset_loader=_loader_factory(),
+        )
+
+
+def test_invalid_val_fraction_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="val_fraction"):
+        train_timestep_inverse(
+            tmp_path,
+            epochs=1,
+            val_fraction=1.5,
+            device="cpu",
+            output_root=tmp_path / "out",
+            dataset_loader=_loader_factory(),
+        )
+
+
+def test_invalid_speed_window_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="speed"):
+        train_timestep_inverse(
+            tmp_path,
+            speed_lo_mph=200.0,
+            speed_hi_mph=100.0,
+            epochs=1,
+            device="cpu",
+            output_root=tmp_path / "out",
+            dataset_loader=_loader_factory(),
+        )


### PR DESCRIPTION
## Summary
- The full-trial cVAE (#4240) and regressor (#4267) plateau at the mean-prediction baseline on the random-sweep dataset (under-determined inverse problem).
- This switches to the user's preferred framing: each timestep is an independent (kinematics, torques) sample.
- Filters compact dataset to `||v_clubhead|| in [50, 150] mph` (~90 k of 310 k timesteps) - only the realistic-speed slice.
- Trains a per-timestep MLP `(q, qd, qdd) -> tau` with masked loss for unmapped joints.

## Architecture
- New sub-package `src/shared/python/motion_matching/inverse_timestep/`:
  - `filter.py` - `realistic_speed_mask` + `filter_timesteps_by_speed` (DbC-validated).
  - `model.py` - `TimestepInverseDynamics`: 4 pre-norm residual blocks, hidden=256, NaN -> 0 with per-DOF missing-indicator channel (162 effective input features).
  - `training.py` - splits by `trial_id` (90/10), filters by speed window, standardises (q, qd, qdd, tau) per-coordinate from train-split stats, masked MSE on standardised tau, early-stopping, JSON metrics + checkpoint payload (stats persisted alongside weights).
  - `predict.py` - `predict_torques` returns physical-unit Nm by de-standardising; loader attaches stats to the model.

## Real-data results (on `C:/Users/diete/Repositories/data/compact`, 80 epochs max, patience=15, CPU)
| metric | value |
|---|---|
| best_epoch | 59 |
| val_loss (standardised) | 4.10e-7 (baseline 1.0 = mean prediction; ~2.4M x lower) |
| val_tau_mae_nm @ best (physical) | 0.23 Nm |
| val_tau_mae_nm @ final (physical) | 0.60 Nm |
| param_count | 578,075 |
| filtered timesteps (train / val) | 81,000 / 9,000 |
| train / val trials | 9,000 / 1,000 |
| early-stop epoch | 74 |
| epoch wall time (CPU) | ~4.3 s |

## Test plan
- [x] `tests/unit/motion_matching/test_timestep_filter.py` - speed-mask boundary cases, NaN handling, DbC violations.
- [x] `tests/unit/motion_matching/test_timestep_inverse_model.py` - shape/dtype, deterministic forward, gradient flow, NaN tolerated, Inf rejected.
- [x] `tests/unit/motion_matching/test_timestep_inverse_training.py` - synthetic 8-trial fixture, multi-epoch run reduces val_loss by >=10%, checkpoint round-trip via `from_checkpoint`.
- [x] All 37 new tests pass; existing `tests/unit/motion_matching/` suite unaffected (3 pre-existing failures in `test_leaderboard_cli.py` are unrelated).
- [x] `ruff check` + `ruff format --check` clean on the new files.
- [x] Real-data training run reported above.