### PR TITLE
fix(inverse): limit even-kernel rejection to flatten aggregation only (closes #4294)

### DIFF
--- a/src/shared/python/motion_matching/inverse/regressor.py
+++ b/src/shared/python/motion_matching/inverse/regressor.py
@@ -155,20 +155,17 @@ class RegressorConfig:
             )
         # ``_ConvStem`` uses ``padding = kernel // 2`` for SAME padding,
         # which only preserves the time-axis length when the kernel is
-        # odd. With ``flatten`` / ``flatten_raw`` aggregations,
-        # ``input_proj`` is sized for ``seq_len * embed_dim`` and would
-        # crash at the first forward pass if the conv produced ``T+1``
-        # samples. Reject even kernels for these aggregations up-front
-        # rather than letting a seemingly valid config blow up at
-        # runtime.
-        if self.temporal_aggregation in ("flatten", "flatten_raw") and (
-            self.conv_kernel % 2 == 0
-        ):
+        # odd. The ``flatten`` aggregation routes through ``_ConvStem``
+        # and then sizes ``input_proj`` for ``seq_len * embed_dim``, so
+        # an even kernel would crash at the first forward pass. Reject
+        # even kernels for ``flatten`` up-front. ``flatten_raw`` skips
+        # the conv stem entirely (see issue #4294 — codex review on PR
+        # #4292) so kernel parity has no effect there.
+        if self.temporal_aggregation == "flatten" and (self.conv_kernel % 2 == 0):
             raise ValueError(
                 "conv_kernel must be odd when temporal_aggregation is "
-                f"{self.temporal_aggregation!r} (SAME padding requires an "
-                f"odd kernel to preserve seq_len); got conv_kernel="
-                f"{self.conv_kernel}"
+                "'flatten' (SAME padding requires an odd kernel to "
+                f"preserve seq_len); got conv_kernel={self.conv_kernel}"
             )
 
 

--- a/tests/unit/motion_matching/test_inverse_regressor_model.py
+++ b/tests/unit/motion_matching/test_inverse_regressor_model.py
@@ -230,7 +230,7 @@ def test_invalid_config_rejected() -> None:
 
 
 def test_even_conv_kernel_rejected_for_flatten() -> None:
-    """Even ``conv_kernel`` blows up the flatten path (issue #4269).
+    """Even ``conv_kernel`` blows up the ``flatten`` path (issue #4269).
 
     With ``padding = kernel // 2`` SAME padding only preserves
     sequence length for odd kernels; an even kernel under
@@ -240,10 +240,12 @@ def test_even_conv_kernel_rejected_for_flatten() -> None:
     """
     with pytest.raises(ValueError, match="conv_kernel must be odd"):
         InverseRegressor(RegressorConfig(temporal_aggregation="flatten", conv_kernel=4))
-    with pytest.raises(ValueError, match="conv_kernel must be odd"):
-        InverseRegressor(
-            RegressorConfig(temporal_aggregation="flatten_raw", conv_kernel=2)
-        )
+    # ``flatten_raw`` skips the conv stem entirely (forward path reshapes
+    # raw input directly), so kernel parity is irrelevant there. Even
+    # kernels must be accepted (issue #4294 — codex review on PR #4292
+    # caught the over-broad rejection in the original #4269 fix).
+    InverseRegressor(RegressorConfig(temporal_aggregation="flatten_raw", conv_kernel=2))
+    InverseRegressor(RegressorConfig(temporal_aggregation="flatten_raw", conv_kernel=4))
     # ``meanmax`` is unaffected because aggregation collapses the time
     # axis before the linear projection, so an even kernel is still OK.
     InverseRegressor(RegressorConfig(temporal_aggregation="meanmax", conv_kernel=4))


### PR DESCRIPTION
## Summary
- PR #4292's #4269 fix over-broadly rejected even \`conv_kernel\` for both \`flatten\` and \`flatten_raw\` aggregations.
- \`flatten_raw\` bypasses \`_ConvStem\` entirely (forward path reshapes raw input directly), so kernel parity is irrelevant there.
- The over-broad rejection blocked previously valid configs and broke checkpoint reload for models trained with even kernels in \`flatten_raw\` mode.
- Limit the rejection to \`flatten\` only.

Addresses P1 review feedback from PR #4292 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4292#discussion_r3199128255)).

Closes #4294.

## Test plan
- [x] \`test_even_conv_kernel_rejected_for_flatten\` updated: \`flatten_raw + conv_kernel=2\` and \`conv_kernel=4\` now both succeed
- [x] \`flatten + conv_kernel=4\` still rejected as before
- [x] \`ruff check\` + \`ruff format --check\` clean