### PR TITLE
fix(review): batch resolve codex review-feedback issues 4301-4315

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/PROJECT_SPEC.md
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/PROJECT_SPEC.md
@@ -163,6 +163,17 @@ leaderboard helper).
 
 - Production checkpoint: `data/training/surrogate_v4/checkpoint_production.pt`
   (~541 k parameters; clubhead-speed MAE 0.04 mph; grip RMSE ~43 mm).
+  > **Note (codex review feedback, issue #4312):** the
+  > `data/training/surrogate_v4/` directory is **not committed to this
+  > repository** — checkpoints are produced by a local training run and live
+  > outside version control. The shipped MATLAB entry point
+  > (`matlab/motion_matching/shared/fit_swing_surrogate.m`,
+  > `local_resolve_checkpoint`) currently defaults to
+  > `<repo_root>/output/surrogate/checkpoint_best.pt`; pass
+  > `opts.surrogate_checkpoint` (or stage your trained
+  > `checkpoint_production.pt` at that path) to consume the production
+  > artifact described below. A future PR will align the MATLAB default
+  > with this guidance and provide a download/cache helper.
 - **Always load `checkpoint_production.pt`, not `checkpoint_best.pt`.** The
   current early-stop criterion is single-objective on grip RMSE and selects
   an unconverged epoch (e.g. epoch 2) before the model has learned to predict

--- a/tests/motion_matching/mujoco_mjcf/test_synthesize.py
+++ b/tests/motion_matching/mujoco_mjcf/test_synthesize.py
@@ -17,7 +17,7 @@ All tests are marked ``requires_mujoco``; the entire module is skipped if
 
 from __future__ import annotations
 
-from pathlib import Path
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -85,13 +85,66 @@ def test_round_trip_returns_validated_clubtarget() -> None:
     assert np.all(np.abs(qnorms - 1.0) < 1.0e-6)
 
 
-def test_accepts_canonical_success_solver_status() -> None:
-    """``solver_status='success'`` is the canonical successful rollout status."""
-    source = mj_synthesize.__file__ and Path(mj_synthesize.__file__).read_text(
-        encoding="utf-8"
+def test_accepts_canonical_success_solver_status(monkeypatch) -> None:
+    """``solver_status='success'`` must NOT raise from the synthesizer.
+
+    Behavioural guard for codex review feedback (issue #4304): the previous
+    revision only string-searched the source for ``{"ok", "success"}``, which
+    would stay green if the runtime check regressed (e.g. an inverted
+    condition with the literal in dead code). Stub
+    ``simulate_with_coefficients`` so we can deterministically assert the
+    function tolerates the canonical ``"success"`` status without hitting
+    real MuJoCo time.
+    """
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
     )
 
-    assert '{"ok", "success"}' in source
+    real_sim_out = simulate_with_coefficients(theta, sim_opts)
+    success_sim_out = replace(real_sim_out, solver_status="success")
+
+    captured: dict[str, object] = {}
+
+    def _stub(theta_arr, opts):
+        captured["called"] = True
+        return success_sim_out
+
+    monkeypatch.setattr(mj_synthesize, "simulate_with_coefficients", _stub)
+
+    target = mj_synthesize.synthesize_target_from_coefficients(
+        theta, align, sim_options=sim_opts
+    )
+
+    assert captured.get("called") is True
+    assert isinstance(target, ClubTarget)
+
+
+def test_rejects_failed_solver_status(monkeypatch) -> None:
+    """A non-canonical ``solver_status`` must raise ``RuntimeError``.
+
+    Pairs with the ``success``-acceptance test above: validates that the
+    runtime gate still rejects divergent rollouts. Without this companion
+    test, an inverted condition could let everything through.
+    """
+    theta, sim_opts = _theta_zero_full()
+    align = AlignOptions(
+        simulation_time_s=sim_opts.T_s, sample_rate_hz=sim_opts.output_rate_hz
+    )
+
+    real_sim_out = simulate_with_coefficients(theta, sim_opts)
+    failed_sim_out = replace(real_sim_out, solver_status="failed")
+
+    monkeypatch.setattr(
+        mj_synthesize,
+        "simulate_with_coefficients",
+        lambda theta_arr, opts: failed_sim_out,
+    )
+
+    with pytest.raises(RuntimeError, match="solver_status"):
+        mj_synthesize.synthesize_target_from_coefficients(
+            theta, align, sim_options=sim_opts
+        )
 
 
 def test_round_trip_matches_simulate_clubhead_exactly() -> None:

--- a/tests/motion_matching/test_cross_engine_equivalence.py
+++ b/tests/motion_matching/test_cross_engine_equivalence.py
@@ -56,8 +56,24 @@ def _create_zero_polynomial_theta(n_joints: int = 19) -> np.ndarray:
 
 
 def _create_mujoco_zero_polynomial_theta() -> np.ndarray:
-    """Create a zero-torque polynomial matching the active MuJoCo model."""
-    return _create_zero_polynomial_theta(n_joints=15)
+    """Create a zero-torque polynomial matching the active MuJoCo model.
+
+    Per codex review feedback (issue #4305) we derive ``nu`` from the
+    actual MJCF model so a future actuator-count drift fails fast at the
+    fixture site instead of silently passing on a hardcoded ``15``.
+    Falls back to ``15`` only if MuJoCo isn't available, in which case
+    the equivalence tests are gated by ``requires_mujoco`` anyway.
+    """
+    try:
+        import mujoco
+        from src.engines.physics_engines.mujoco._golf_swing_full_body_xml import (
+            FULL_BODY_GOLF_SWING_XML,
+        )
+
+        nu = int(mujoco.MjModel.from_xml_string(FULL_BODY_GOLF_SWING_XML).nu)
+    except Exception:  # noqa: BLE001 - keep contract test runnable headless
+        nu = 15
+    return _create_zero_polynomial_theta(n_joints=nu)
 
 
 def _compute_grip_rmse(simulated_grip: np.ndarray, reference_grip: np.ndarray) -> float:
@@ -85,8 +101,27 @@ def _compute_grip_rmse(simulated_grip: np.ndarray, reference_grip: np.ndarray) -
 
 
 def test_mujoco_theta_fixture_matches_active_model_actuators() -> None:
-    """MuJoCo parity inputs must match the model's 15 actuators."""
-    assert _create_mujoco_zero_polynomial_theta().shape == (105,)
+    """MuJoCo parity fixture length must equal ``nu * 7`` for the live model.
+
+    Codex review feedback (issue #4305): the prior assertion only checked
+    the literal ``(105,)`` shape, which made it tautological with the
+    hardcoded ``n_joints=15`` helper. Drive both ends from
+    ``MjModel.nu`` so an actuator-count drift fails this test loudly.
+    """
+    try:
+        import mujoco
+        from src.engines.physics_engines.mujoco._golf_swing_full_body_xml import (
+            FULL_BODY_GOLF_SWING_XML,
+        )
+    except ImportError:
+        pytest.skip("MuJoCo not installed; cannot validate fixture against model.")
+
+    nu = int(mujoco.MjModel.from_xml_string(FULL_BODY_GOLF_SWING_XML).nu)
+    theta = _create_mujoco_zero_polynomial_theta()
+    assert theta.shape == (nu * 7,), (
+        f"Fixture length {theta.shape[0]} != nu*7 ({nu * 7}); "
+        "MuJoCo actuator count drifted from helper."
+    )
 
 
 @pytest.mark.requires_mujoco


### PR DESCRIPTION
## Summary
Batched resolution of 9 codex-bot review-feedback issues. Three (#4301, #4303, #4315) were already addressed on main before this branch landed; the remaining six are closed by this PR.

| Issue | Disposition | What changed |
|---|---|---|
| #4301 | already-fixed | Resolved on main (PR #4310): `git fetch --depth=10` and a fallback to direct `origin/<base>` diff in `.github/workflows/ci-standard.yml` so a missing merge-base no longer silently `exit 0`s the PR-scoped lane. |
| #4303 | already-fixed | Resolved on main (PR #4311): `pytest` exit code 5 now falls through to the full default core lane instead of being treated as success. |
| #4304 | fix | `tests/motion_matching/mujoco_mjcf/test_synthesize.py` — replaced the string-search `assert '{"ok", "success"}' in source` with a behavioural test that stubs `simulate_with_coefficients` to return `solver_status="success"` and asserts no `RuntimeError`. Added a companion `test_rejects_failed_solver_status` so an inverted runtime check would fail loudly. (Codex: "Verify solver-status acceptance by behavior, not source text".) |
| #4305 | fix | `tests/motion_matching/test_cross_engine_equivalence.py` — `_create_mujoco_zero_polynomial_theta` now reads `nu` from `MjModel.from_xml_string(FULL_BODY_GOLF_SWING_XML)` and the assertion compares fixture length to `nu * 7`, eliminating the hardcoded 15/105 tautology. (Codex: "Validate MuJoCo theta fixture against model actuator count".) |
| #4306 | duplicate of #4304 | Same source PR / line as #4304; closed by the same fix. |
| #4307 | duplicate of #4305 | Same source PR / line as #4305; closed by the same fix. |
| #4309 | already-fixed | `CanonicalFitResult.theta` deprecated alias is already implemented at `src/shared/python/motion_matching/fit_result.py` lines 53-68 (returns `self.theta_optimal` and emits `DeprecationWarning`). (Codex: "Add deprecated `theta` alias to CanonicalFitResult".) |
| #4312 | fix | `src/engines/Simscape_Multibody_Models/3D_Golf_Model/PROJECT_SPEC.md` — added a callout that `data/training/surrogate_v4/` is uncommitted/external and that the MATLAB entry point currently resolves `output/surrogate/checkpoint_best.pt` by default; users must either pass `opts.surrogate_checkpoint` or stage a trained `checkpoint_production.pt` at the documented path. (Codex: "Point docs to an existing surrogate checkpoint".) |
| #4315 | already-fixed | Resolved on main by PR #4316 (`fix(inverse): avoid timestep artifact collisions`) which makes timestep-inverse training output dirs collision-safe. |

## Quoted feedback (verbatim from each issue)
- #4304/#4306: *"This check only searches for the string `{\"ok\", \"success\"}` in the file, so it can pass even if `synthesize_target_from_coefficients` regresses and still rejects `solver_status=\"success\"` at runtime ... it should exercise the function behavior directly (e.g., stub `simulate_with_coefficients` and assert no `RuntimeError` for `success`)."*
- #4305/#4307: *"This test is effectively tautological: the helper is hardcoded to 15 joints and the assertion only checks for `(105,)` ... it should derive `nu` from the model and compare the fixture length to `nu * 7`."*
- #4309: *"`CanonicalFitResult` adds aliases like `coefficients`/`cost`, but it does not expose the legacy `theta` attribute that OpenSim/Pinocchio callers still use."*
- #4312: *"The new Option 2 guidance tells users to load `data/training/surrogate_v4/checkpoint_production.pt`, but that file is not present in this repo and the shipped MATLAB entry point still resolves a different default (`output/surrogate/checkpoint_best.pt`...). Following this spec now leads to a missing-file failure ..."*

## Test plan
- [x] Existing unit tests pass — failures observed in `tests/unit/` are pre-existing on main (verified by `git stash` baseline).
- [x] Per-fix regression tests added: `test_accepts_canonical_success_solver_status` (behaviour), `test_rejects_failed_solver_status` (companion), `test_mujoco_theta_fixture_matches_active_model_actuators` rewritten to derive `nu` from the live model.
- [x] `python3 -m ruff check` and `python3 -m ruff format --check` clean for changed Python files.
- [x] File-size budget: all touched files under 320 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)