### PR TITLE
fix(opensim): reject empty 2-D theta in prescribed-controller (closes #4322)

### DIFF
--- a/src/engines/physics_engines/opensim/python/motion_matching/prescribed_controller.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/prescribed_controller.py
@@ -109,6 +109,9 @@ def _coerce_coeffs(theta: npt.ArrayLike) -> npt.NDArray[np.float64]:
             raise ValueError(msg)
         coeffs = theta_arr.reshape(-1, COEFFS_PER_JOINT)
     elif theta_arr.ndim == 2:
+        if theta_arr.shape[0] == 0:
+            msg = "theta must contain at least one actuator coefficient row"
+            raise ValueError(msg)
         if theta_arr.shape[1] != COEFFS_PER_JOINT:
             msg = f"theta coefficient matrix must have {COEFFS_PER_JOINT} coefficients"
             raise ValueError(msg)

--- a/tests/unit/engines/opensim/test_prescribed_controller.py
+++ b/tests/unit/engines/opensim/test_prescribed_controller.py
@@ -70,6 +70,12 @@ def test_plan_rejects_invalid_time_grid(time_grid: np.ndarray, match: str) -> No
             np.array([0.0, np.inf] + [0.0] * 12, dtype=np.float64),
             "theta must be finite",
         ),
+        # Empty 2-D theta must be rejected for parity with the 1-D branch
+        # (issue #4322 — codex review on PR #4320 caught this asymmetry).
+        (
+            np.zeros((0, COEFFS_PER_JOINT), dtype=np.float64),
+            "at least one actuator coefficient row",
+        ),
     ],
 )
 def test_plan_rejects_invalid_theta_shape_or_values(


### PR DESCRIPTION
## Summary
- The 2-D theta path in \`_coerce_coeffs\` accepted shape \`(0, 7)\`, letting \`build_prescribed_polynomial_torque_plan\` produce a plan with zero actuators and a \`(N, 0)\` torque matrix.
- The 1-D branch already rejects empty theta. Add a \`shape[0]==0\` check to the 2-D branch for parity.

Addresses P2 review feedback from PR #4320 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4320#discussion_r3199678992)).

Closes #4322.

## Test plan
- [x] New parametrized case: \`(np.zeros((0, 7)), \"at least one actuator coefficient row\")\`
- [x] All 14 existing prescribed-controller unit tests still pass
- [x] \`ruff check\` + \`ruff format --check\` clean