### PR TITLE
fix(test): exclude requires_mocap_fixtures from default lanes (closes #4325)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -649,7 +649,7 @@ jobs:
                 -n 0 \
                 --timeout=60 \
                 --timeout-method=thread \
-                -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu" \
+                -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu and not requires_mocap_fixtures" \
                 --no-cov \
                 --tb=short \
                 -v
@@ -700,7 +700,7 @@ jobs:
             --ignore=tests/shared_contracts \
             --ignore=tests/heavy_integration \
             --ignore=tests/benchmarks \
-            -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu" \
+            -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu and not requires_mocap_fixtures" \
             --cov=src \
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
@@ -835,7 +835,7 @@ jobs:
               raise SystemExit(f"PostgreSQL did not accept SQL connections: {last_error!r}")
           PY
           python3 -m pytest -p pytest_timeout tests/integration/test_alembic_round_trip.py \
-            -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu" \
+            -m "not slow and not benchmark and not requires_gl and not requires_network and not requires_gpu and not requires_mocap_fixtures" \
             --timeout=180 \
             --timeout-method=thread \
             --durations=10 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,7 @@ pythonpath = [
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20 -m \"not live_simulation\""
+addopts = "-ra -q --strict-markers --strict-config --durations=20 -m \"not live_simulation and not requires_mocap_fixtures\""
 asyncio_mode = "auto"
 # Prevent ImportPathMismatchError from conftest.py files in engine subdirectories
 norecursedirs = [


### PR DESCRIPTION
## Summary
- PR #4323 added a Rajagopal2015 sentinel that fails loudly when mocap fixtures are absent (correct per #4296 AC1).
- But the \`requires_mocap_fixtures\` marker wasn't excluded from default lanes — root \`pyproject\` addopts only excluded \`live_simulation\`, and CI core-test steps filtered on \`not slow/benchmark/requires_gl/requires_network/requires_gpu\` without mocap.
- Result: default \`pytest\` and PR CI fail in environments without private mocap fixtures, breaking green-by-default for optional OpenSim paths.

Add \`requires_mocap_fixtures\` to both exclusion lists.

Addresses P1 review feedback from PR #4323 ([source comment](https://github.com/D-sorganization/UpstreamDrift/pull/4323#discussion_r3199740141)).

Closes #4325.

## Test plan
- [x] \`pytest tests/opensim/test_muscle_cmc.py\` (default): 17 passed, no failures
- [x] \`pytest tests/opensim/test_muscle_cmc.py -m requires_mocap_fixtures\`: still fails loudly with typed reason (acceptance criterion 1 preserved)