### PR TITLE
fix(motion-matching): resolve final_cost alias, hybrid attrs, leaderboard CLI, surrogate invert

### DIFF
--- a/src/shared/python/motion_matching/final_cost.py
+++ b/src/shared/python/motion_matching/final_cost.py
@@ -1,0 +1,18 @@
+"""Backward-compat alias: final_cost -> cost."""
+
+from src.shared.python.motion_matching.cost import *  # noqa: F401,F403
+from src.shared.python.motion_matching.cost import (
+    CostBreakdown,
+    CostOptions,
+    SimOutput,
+    compute_cost,
+    compute_total_work,
+)
+
+__all__ = [
+    "CostBreakdown",
+    "CostOptions",
+    "SimOutput",
+    "compute_cost",
+    "compute_total_work",
+]

--- a/src/shared/python/motion_matching/hybrid.py
+++ b/src/shared/python/motion_matching/hybrid.py
@@ -115,6 +115,16 @@ class HybridFitResult:
     polish_phase: dict[str, Any] | None
     duration_s: float
 
+    @property
+    def method(self) -> str:
+        """Alias for ``solver`` matching the canonical FitResult schema."""
+        return self.solver
+
+    @property
+    def theta_optimal(self) -> np.ndarray:
+        """Alias for ``coefficients`` matching the canonical FitResult schema."""
+        return self.coefficients
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers

--- a/src/shared/python/motion_matching/surrogate/invert.py
+++ b/src/shared/python/motion_matching/surrogate/invert.py
@@ -114,6 +114,11 @@ class FitResult:
     all_starts: list[np.ndarray]
     surrogate_pred: ClubTrajectory = field(repr=False)
 
+    @property
+    def theta_optimal(self) -> np.ndarray:
+        """Alias for ``coefficients`` matching the canonical FitResult schema."""
+        return self.coefficients
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers

--- a/tests/unit/motion_matching/test_leaderboard_cli.py
+++ b/tests/unit/motion_matching/test_leaderboard_cli.py
@@ -11,10 +11,18 @@ Issue #4248: Cross-engine leaderboard infrastructure
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
+
+# Root of the UpstreamDrift repository (two levels above tests/unit/).
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+
+# Subprocess environment with PYTHONPATH set so src.shared is importable
+# regardless of the working directory used by each test.
+_SUBPROCESS_ENV = {**os.environ, "PYTHONPATH": _REPO_ROOT}
 
 
 def _write_fit_result(trial_dir: Path, engine: str, data: dict | None = None) -> Path:
@@ -86,7 +94,7 @@ def test_leaderboard_cli_generates_report(tmp_path: Path) -> None:
         "--output",
         str(output_file),
     ]
-    result = subprocess.run(cmd, cwd="/home/dieterolson/Repositories-WSL/UpstreamDrift")
+    result = subprocess.run(cmd, cwd=_REPO_ROOT, env=_SUBPROCESS_ENV)
 
     # Verify success
     assert result.returncode == 0
@@ -101,8 +109,8 @@ def test_leaderboard_cli_generates_report(tmp_path: Path) -> None:
     assert "drake" in content
     # Results should be sorted by grip_rmse_mm ascending
     lines = content.split("\n")
-    pinocchio_line = next((l for l in lines if "pinocchio" in l), None)
-    mujoco_line = next((l for l in lines if "mujoco" in l), None)
+    pinocchio_line = next((ln for ln in lines if "pinocchio" in ln), None)
+    mujoco_line = next((ln for ln in lines if "mujoco" in ln), None)
     if pinocchio_line and mujoco_line:
         # pinocchio should come first (lower rmse = 1.5 vs 2.5)
         assert lines.index(pinocchio_line) < lines.index(mujoco_line)
@@ -129,6 +137,7 @@ def test_leaderboard_cli_default_output_path(tmp_path: Path) -> None:
     result = subprocess.run(
         cmd,
         cwd=str(tmp_path),
+        env=_SUBPROCESS_ENV,
     )
 
     # Default should create LEADERBOARD.md in cwd
@@ -152,7 +161,7 @@ def test_leaderboard_cli_nonexistent_dir_fails(tmp_path: Path) -> None:
         "--output",
         str(tmp_path / "output.md"),
     ]
-    result = subprocess.run(cmd, cwd="/home/dieterolson/Repositories-WSL/UpstreamDrift")
+    result = subprocess.run(cmd, cwd=_REPO_ROOT, env=_SUBPROCESS_ENV)
 
     # Should fail with exit code 1
     assert result.returncode == 1


### PR DESCRIPTION
## Summary
- Creates `final_cost.py` backward-compat shim re-exporting from `cost.py` (3 collection errors fixed)
- Adds `method` and `theta_optimal` property aliases to `HybridFitResult` and `FitResult` (4 test failures fixed)
- Fixes leaderboard CLI subprocess on Windows: dynamic `_REPO_ROOT` + `PYTHONPATH` env injection (3 test failures fixed)
- Adds `theta_optimal` alias to surrogate `FitResult` (1 test failure fixed)

## Test plan
- [x] `python3 -m pytest tests/unit/motion_matching/ --timeout=60 -q --continue-on-collection-errors` → 400 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)