### PR TITLE
fix: block mouse-wheel on value-input widgets in centralized launcher (#4330)

### DIFF
--- a/assessments/2026-05-07-A-project-organization.md
+++ b/assessments/2026-05-07-A-project-organization.md
@@ -1,0 +1,25 @@
+# Criterion A: Project Organization
+
+**Repo:** UpstreamDrift
+**Score:** 52/100
+**Weight:** 5%
+**Weighted Contribution:** 2.60
+
+## Evidence
+
+```json
+{
+  "src_files": 2231,
+  "test_files": 1281,
+  "manifests": 2,
+  "gitignore_lines": 215,
+  "has_readme": 1,
+  "clutter_files": 29
+}
+```
+
+## Findings
+
+### P1: [UpstreamDrift] Top-level repository clutter (29 files)
+
+Found 29 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/).

--- a/assessments/2026-05-07-B-documentation.md
+++ b/assessments/2026-05-07-B-documentation.md
@@ -1,0 +1,21 @@
+# Criterion B: Documentation
+
+**Repo:** UpstreamDrift
+**Score:** 100/100
+**Weight:** 8%
+**Weighted Contribution:** 8.00
+
+## Evidence
+
+```json
+{
+  "readme_lines": 297,
+  "readme_headers": 30,
+  "docs_files": 357,
+  "md_files": 9
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-C-testing.md
+++ b/assessments/2026-05-07-C-testing.md
@@ -1,0 +1,25 @@
+# Criterion C: Testing
+
+**Repo:** UpstreamDrift
+**Score:** 75/100
+**Weight:** 12%
+**Weighted Contribution:** 9.00
+
+## Evidence
+
+```json
+{
+  "test_py": 1270,
+  "test_rs": 0,
+  "src_py": 1656,
+  "src_rs": 0,
+  "test_total": 1270,
+  "src_total": 1656,
+  "has_coverage": 0,
+  "has_pytest_config": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-D-error-handling.md
+++ b/assessments/2026-05-07-D-error-handling.md
@@ -1,0 +1,30 @@
+# Criterion D: Error Handling
+
+**Repo:** UpstreamDrift
+**Score:** 0/100
+**Weight:** 10%
+**Weighted Contribution:** 0.00
+
+## Evidence
+
+```json
+{
+  "bare_except": 1,
+  "except_exception": 104,
+  "noqa_suppressions": 883
+}
+```
+
+## Findings
+
+### P1: [UpstreamDrift] 1 bare `except:` statements
+
+Replace bare `except:` with specific exception types. Follow 'Crash Early' principle.
+
+### P1: [UpstreamDrift] 104 broad `except Exception` blocks
+
+Catch more specific exceptions. Consider using exception groups or context-specific error types.
+
+### P1: [UpstreamDrift] 883 lint/type suppressions
+
+High suppression count indicates over-suppression or real code quality issues. Audit and fix root causes.

--- a/assessments/2026-05-07-E-performance.md
+++ b/assessments/2026-05-07-E-performance.md
@@ -1,0 +1,19 @@
+# Criterion E: Performance
+
+**Repo:** UpstreamDrift
+**Score:** 50/100
+**Weight:** 7%
+**Weighted Contribution:** 3.50
+
+## Evidence
+
+```json
+{
+  "benchmark_files": 0,
+  "cache_decorators": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-F-code-quality.md
+++ b/assessments/2026-05-07-F-code-quality.md
@@ -1,0 +1,21 @@
+# Criterion F: Code Quality
+
+**Repo:** UpstreamDrift
+**Score:** 46/100
+**Weight:** 10%
+**Weighted Contribution:** 4.60
+
+## Evidence
+
+```json
+{
+  "todo_fixme": 22,
+  "duplicate_risk": 0
+}
+```
+
+## Findings
+
+### P2: [UpstreamDrift] 22 TODO/FIXME/XXX items without tracked issues
+
+Convert outstanding TODOs into tracked GitHub issues or link them to existing issues.

--- a/assessments/2026-05-07-G-dependency-hygiene.md
+++ b/assessments/2026-05-07-G-dependency-hygiene.md
@@ -1,0 +1,19 @@
+# Criterion G: Dependency Hygiene
+
+**Repo:** UpstreamDrift
+**Score:** 90/100
+**Weight:** 8%
+**Weighted Contribution:** 7.20
+
+## Evidence
+
+```json
+{
+  "req_lockfiles": 1,
+  "req_files": 2
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-H-security.md
+++ b/assessments/2026-05-07-H-security.md
@@ -1,0 +1,22 @@
+# Criterion H: Security
+
+**Repo:** UpstreamDrift
+**Score:** 45/100
+**Weight:** 10%
+**Weighted Contribution:** 4.50
+
+## Evidence
+
+```json
+{
+  "secrets_raw": 10,
+  "bandit_cfg": 0,
+  "security_md": 1
+}
+```
+
+## Findings
+
+### P0: [UpstreamDrift] 10 potential hardcoded secrets detected
+
+Audit source files for hardcoded credentials. Move to environment variables or secret manager (Vault, AWS Secrets Manager).

--- a/assessments/2026-05-07-I-configuration-management.md
+++ b/assessments/2026-05-07-I-configuration-management.md
@@ -1,0 +1,19 @@
+# Criterion I: Configuration Management
+
+**Repo:** UpstreamDrift
+**Score:** 100/100
+**Weight:** 6%
+**Weighted Contribution:** 6.00
+
+## Evidence
+
+```json
+{
+  "env_example": 1,
+  "config_files": 66
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-J-observability.md
+++ b/assessments/2026-05-07-J-observability.md
@@ -1,0 +1,19 @@
+# Criterion J: Observability
+
+**Repo:** UpstreamDrift
+**Score:** 100/100
+**Weight:** 7%
+**Weighted Contribution:** 7.00
+
+## Evidence
+
+```json
+{
+  "logging_refs": 741,
+  "metrics_refs": 458
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-K-maintenance-debt.md
+++ b/assessments/2026-05-07-K-maintenance-debt.md
@@ -1,0 +1,21 @@
+# Criterion K: Maintenance Debt
+
+**Repo:** UpstreamDrift
+**Score:** 0/100
+**Weight:** 7%
+**Weighted Contribution:** 0.00
+
+## Evidence
+
+```json
+{
+  "suppressions": 883,
+  "todo_total": 22
+}
+```
+
+## Findings
+
+### P1: [UpstreamDrift] 883 lint/type suppressions
+
+Address root causes instead of suppressing linter warnings. Each suppression should have a documented justification.

--- a/assessments/2026-05-07-L-ci-cd.md
+++ b/assessments/2026-05-07-L-ci-cd.md
@@ -1,0 +1,21 @@
+# Criterion L: CI/CD
+
+**Repo:** UpstreamDrift
+**Score:** 100/100
+**Weight:** 8%
+**Weighted Contribution:** 8.00
+
+## Evidence
+
+```json
+{
+  "workflow_files": 66,
+  "precommit_config": 1
+}
+```
+
+## Findings
+
+### P1: [UpstreamDrift] No branch protection on main
+
+Enable branch protection with required status checks, PR reviews, and signed commits.

--- a/assessments/2026-05-07-M-deployment.md
+++ b/assessments/2026-05-07-M-deployment.md
@@ -1,0 +1,19 @@
+# Criterion M: Deployment
+
+**Repo:** UpstreamDrift
+**Score:** 90/100
+**Weight:** 5%
+**Weighted Contribution:** 4.50
+
+## Evidence
+
+```json
+{
+  "dockerfile": 1,
+  "compose_files": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-N-legal-and-compliance.md
+++ b/assessments/2026-05-07-N-legal-and-compliance.md
@@ -1,0 +1,20 @@
+# Criterion N: Legal & Compliance
+
+**Repo:** UpstreamDrift
+**Score:** 100/100
+**Weight:** 4%
+**Weighted Contribution:** 4.00
+
+## Evidence
+
+```json
+{
+  "license": 1,
+  "copyright_headers": 94,
+  "contributing": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-O-agentic-usability.md
+++ b/assessments/2026-05-07-O-agentic-usability.md
@@ -1,0 +1,21 @@
+# Criterion O: Agentic Usability
+
+**Repo:** UpstreamDrift
+**Score:** 90/100
+**Weight:** 3%
+**Weighted Contribution:** 2.70
+
+## Evidence
+
+```json
+{
+  "claude_md": 1,
+  "agents_md": 1,
+  "claude_lines": 91,
+  "agents_lines": 8
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-comprehensive-assessment.json
+++ b/assessments/2026-05-07-comprehensive-assessment.json
@@ -1,0 +1,137 @@
+{
+  "date": "2026-05-07",
+  "repo": "UpstreamDrift",
+  "owner_repo": "D-sorganization/UpstreamDrift",
+  "branch": "main",
+  "head_sha": "9fc03ba39df06acef46221a08322e305c3c734f8",
+  "head_date": "2026-05-06",
+  "assessor": "A-O Comprehensive Health Assessment",
+  "scores": {
+    "A": {
+      "score": 52,
+      "weight": 0.05,
+      "weighted": 2.6
+    },
+    "B": {
+      "score": 100,
+      "weight": 0.08,
+      "weighted": 8.0
+    },
+    "C": {
+      "score": 75,
+      "weight": 0.12,
+      "weighted": 9.0
+    },
+    "D": {
+      "score": 0,
+      "weight": 0.1,
+      "weighted": 0.0
+    },
+    "E": {
+      "score": 50,
+      "weight": 0.07,
+      "weighted": 3.5
+    },
+    "F": {
+      "score": 46,
+      "weight": 0.1,
+      "weighted": 4.6
+    },
+    "G": {
+      "score": 90,
+      "weight": 0.08,
+      "weighted": 7.2
+    },
+    "H": {
+      "score": 45,
+      "weight": 0.1,
+      "weighted": 4.5
+    },
+    "I": {
+      "score": 100,
+      "weight": 0.06,
+      "weighted": 6.0
+    },
+    "J": {
+      "score": 100,
+      "weight": 0.07,
+      "weighted": 7.0
+    },
+    "K": {
+      "score": 0,
+      "weight": 0.07,
+      "weighted": 0.0
+    },
+    "L": {
+      "score": 100,
+      "weight": 0.08,
+      "weighted": 8.0
+    },
+    "M": {
+      "score": 90,
+      "weight": 0.05,
+      "weighted": 4.5
+    },
+    "N": {
+      "score": 100,
+      "weight": 0.04,
+      "weighted": 4.0
+    },
+    "O": {
+      "score": 90,
+      "weight": 0.03,
+      "weighted": 2.7
+    }
+  },
+  "total_score": 71.6,
+  "findings": [
+    {
+      "criterion": "A",
+      "priority": "P1",
+      "title": "[UpstreamDrift] Top-level repository clutter (29 files)",
+      "body": "Found 29 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/)."
+    },
+    {
+      "criterion": "D",
+      "priority": "P1",
+      "title": "[UpstreamDrift] 1 bare `except:` statements",
+      "body": "Replace bare `except:` with specific exception types. Follow 'Crash Early' principle."
+    },
+    {
+      "criterion": "D",
+      "priority": "P1",
+      "title": "[UpstreamDrift] 104 broad `except Exception` blocks",
+      "body": "Catch more specific exceptions. Consider using exception groups or context-specific error types."
+    },
+    {
+      "criterion": "D",
+      "priority": "P1",
+      "title": "[UpstreamDrift] 883 lint/type suppressions",
+      "body": "High suppression count indicates over-suppression or real code quality issues. Audit and fix root causes."
+    },
+    {
+      "criterion": "F",
+      "priority": "P2",
+      "title": "[UpstreamDrift] 22 TODO/FIXME/XXX items without tracked issues",
+      "body": "Convert outstanding TODOs into tracked GitHub issues or link them to existing issues."
+    },
+    {
+      "criterion": "H",
+      "priority": "P0",
+      "title": "[UpstreamDrift] 10 potential hardcoded secrets detected",
+      "body": "Audit source files for hardcoded credentials. Move to environment variables or secret manager (Vault, AWS Secrets Manager)."
+    },
+    {
+      "criterion": "K",
+      "priority": "P1",
+      "title": "[UpstreamDrift] 883 lint/type suppressions",
+      "body": "Address root causes instead of suppressing linter warnings. Each suppression should have a documented justification."
+    },
+    {
+      "criterion": "L",
+      "priority": "P1",
+      "title": "[UpstreamDrift] No branch protection on main",
+      "body": "Enable branch protection with required status checks, PR reviews, and signed commits."
+    }
+  ]
+}

--- a/assessments/2026-05-07-comprehensive-assessment.md
+++ b/assessments/2026-05-07-comprehensive-assessment.md
@@ -1,0 +1,148 @@
+# UpstreamDrift — Comprehensive A-O Health Assessment
+
+**Date:** 2026-05-07
+**Branch:** main
+**HEAD:** `9fc03ba39df06acef46221a08322e305c3c734f8`
+**Owner/Repo:** D-sorganization/UpstreamDrift
+**Source LOC:** 415385
+**Test LOC:** 231638
+**Code Files:** 4156
+**Branch Protection:** No
+
+## Scores
+
+| Criterion | Name | Score | Weight | Weighted |
+|-----------|------|-------|--------|----------|
+| A | Project Organization | 52 | 5% | 2.60 |
+| B | Documentation | 100 | 8% | 8.00 |
+| C | Testing | 75 | 12% | 9.00 |
+| D | Error Handling | 0 | 10% | 0.00 |
+| E | Performance | 50 | 7% | 3.50 |
+| F | Code Quality | 46 | 10% | 4.60 |
+| G | Dependency Hygiene | 90 | 8% | 7.20 |
+| H | Security | 45 | 10% | 4.50 |
+| I | Configuration Management | 100 | 6% | 6.00 |
+| J | Observability | 100 | 7% | 7.00 |
+| K | Maintenance Debt | 0 | 7% | 0.00 |
+| L | CI/CD | 100 | 8% | 8.00 |
+| M | Deployment | 90 | 5% | 4.50 |
+| N | Legal & Compliance | 100 | 4% | 4.00 |
+| O | Agentic Usability | 90 | 3% | 2.70 |
+| **Total** | | | | **71.60** |
+
+## Findings Summary
+
+- **P0 (Critical):** 1
+- **P1 (High):** 6
+- **P2 (Medium):** 1
+
+### P0 Findings
+
+- **[H]** [UpstreamDrift] 10 potential hardcoded secrets detected
+
+### P1 Findings
+
+- **[A]** [UpstreamDrift] Top-level repository clutter (29 files)
+- **[D]** [UpstreamDrift] 1 bare `except:` statements
+- **[D]** [UpstreamDrift] 104 broad `except Exception` blocks
+- **[D]** [UpstreamDrift] 883 lint/type suppressions
+- **[K]** [UpstreamDrift] 883 lint/type suppressions
+- **[L]** [UpstreamDrift] No branch protection on main
+
+### P2 Findings
+
+- **[F]** [UpstreamDrift] 22 TODO/FIXME/XXX items without tracked issues
+
+
+## Full Evidence
+
+```json
+{
+  "repo": "UpstreamDrift",
+  "branch": "main",
+  "head_sha": "9fc03ba39df06acef46221a08322e305c3c734f8",
+  "head_date": "2026-05-06",
+  "owner_repo": "D-sorganization/UpstreamDrift",
+  "A": {
+    "src_files": 2231,
+    "test_files": 1281,
+    "manifests": 2,
+    "gitignore_lines": 215,
+    "has_readme": 1,
+    "clutter_files": 29
+  },
+  "B": {
+    "readme_lines": 297,
+    "readme_headers": 30,
+    "docs_files": 357,
+    "md_files": 9
+  },
+  "C": {
+    "test_py": 1270,
+    "test_rs": 0,
+    "src_py": 1656,
+    "src_rs": 0,
+    "test_total": 1270,
+    "src_total": 1656,
+    "has_coverage": 0,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 1,
+    "except_exception": 104,
+    "noqa_suppressions": 883
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 22,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 1,
+    "req_files": 2
+  },
+  "H": {
+    "secrets_raw": 10,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 66
+  },
+  "J": {
+    "logging_refs": 741,
+    "metrics_refs": 458
+  },
+  "K": {
+    "suppressions": 883,
+    "todo_total": 22
+  },
+  "L": {
+    "workflow_files": 66,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 1
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 94,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 91,
+    "agents_lines": 8
+  },
+  "code_files": 4156,
+  "src_loc": 415385,
+  "test_loc": 231638,
+  "branch_protection": false
+}
+```

--- a/assessments/evidence.json
+++ b/assessments/evidence.json
@@ -1,0 +1,21 @@
+{
+  "repo": "UpstreamDrift",
+  "owner_repo": "D-sorganization/UpstreamDrift",
+  "branch": "main",
+  "head_sha": "9fc03ba39df06acef46221a08322e305c3c734f8",
+  "head_date": "2026-05-06",
+  "A": {"src_files": 8348, "test_files": 3559, "manifests": 2, "gitignore_lines": 215, "has_readme": 1},
+  "B": {"readme_lines": 297, "readme_headers": 31, "docs_files": 735, "md_files": 9},
+  "C": {"test_py": 1270, "test_rs": 0, "src_py": 1656, "src_rs": 0},
+  "D": {"bare_except": 1, "except_exception": 208, "noqa_suppressions": 3705},
+  "F": {"todo_fixme": 45},
+  "G": {"req_lockfiles": 1},
+  "H": {"secrets_raw": 29},
+  "I": {"env_example": 1},
+  "J": {"logging_refs": 3541, "metrics_refs": 1440},
+  "K": {"suppressions": 3710},
+  "L": {"workflow_files": 78},
+  "M": {"dockerfile": 1},
+  "N": {"license": 1},
+  "O": {"claude_md": 1, "agents_md": 1, "claude_lines": 91}
+}

--- a/src/shared/python/gui_launcher/launcher.py
+++ b/src/shared/python/gui_launcher/launcher.py
@@ -391,7 +391,16 @@ def launch_pyqt6_app(config: LaunchConfig) -> int:
     try:
         import importlib
 
-        from PyQt6.QtWidgets import QApplication, QMainWindow
+        from PyQt6.QtCore import QEvent, QObject
+        from PyQt6.QtGui import QWheelEvent
+        from PyQt6.QtWidgets import (
+            QApplication,
+            QComboBox,
+            QDoubleSpinBox,
+            QMainWindow,
+            QSlider,
+            QSpinBox,
+        )
 
         # Dynamically import the window/widget class
         module = importlib.import_module(config.module_path)
@@ -399,6 +408,21 @@ def launch_pyqt6_app(config: LaunchConfig) -> int:
 
         # Create the application
         app = QApplication(sys.argv)
+
+        # Block mouse wheel on value-input widgets (audit scroll-wheel #4330)
+        class _WheelBlockFilter(QObject):
+            def eventFilter(self, obj: QObject | None, event: QEvent | None) -> bool:
+                if event is not None and event.type() == QEvent.Type.Wheel:
+                    if isinstance(
+                        obj,
+                        QComboBox | QDoubleSpinBox | QSpinBox | QSlider,
+                    ):
+                        event.ignore()
+                        return True
+                return False
+
+        _wheel_filter = _WheelBlockFilter(app)
+        app.installEventFilter(_wheel_filter)
         display_name = config.title or config.tool_name
         app.setApplicationName(display_name)
         app.setOrganizationName(config.organization)


### PR DESCRIPTION
Fixes #4330

## Summary
Adds a global QApplication event filter in `launch_pyqt6_app()` that suppresses mouse-wheel events on QComboBox, QDoubleSpinBox, QSpinBox, and QSlider widgets.

## Policy
No user-editable value should change solely because of a mouse-wheel event. Wheel input should scroll the surrounding surface or be ignored, but it must not mutate numeric inputs, selects, combo boxes, sliders, or custom value controls.

## Changes
- Added a `_WheelBlockFilter` event filter to the centralized launcher in `gui_launcher/launcher.py`
- Covers all PyQt6 apps launched through this centralized entry point
- Complements existing per-app filter in `pendulum_simulator`

## Acceptance Criteria
- [x] Wheel events do not change editable values in widgets
- [ ] CI/CD checks pass