### PR TITLE
fix: provide file type when parsing Drake XML text

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -38,7 +38,8 @@
     "3205997874",
     "3206539605",
     "3206539607",
-    "3206539612"
+    "3206539612",
+    "3208032637"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -51,6 +52,7 @@
     "3205307354": "https://github.com/D-sorganization/UpstreamDrift/issues/4371",
     "3205307358": "https://github.com/D-sorganization/UpstreamDrift/issues/4372",
     "3205997871": "https://github.com/D-sorganization/UpstreamDrift/issues/4384",
-    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420"
+    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420",
+    "3208032637": "https://github.com/D-sorganization/UpstreamDrift/issues/4445"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,0 +1,21 @@
+# Review Comments Archive - 2026-05-08
+
+Generated: 2026-05-08T03:25:48.776505
+
+## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+
+### PR #4444: src/tools/starting_pose_matcher/providers/drake.py:112
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Detect SDF after XML declaration before selecting parser format**
+
+Handle SDF detection more robustly here: many valid SDF strings begin with an XML declaration (e.g., `<?xml ...?>`) or comments before the `<sdf>` root, so `model_xml.strip().startswith("<sdf")` evaluates false and forces `"urdf"`. In that case Drake will try to parse SDF content as URDF and reject the model, so `model_xml` inputs copied from ...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4444#discussion_r3208032637)
+
+---
+

--- a/src/tools/starting_pose_matcher/providers/drake.py
+++ b/src/tools/starting_pose_matcher/providers/drake.py
@@ -107,7 +107,12 @@ class DrakeSkeletonProvider:
         if model_xml is not None:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)
-            parser.AddModelFromString(model_xml)
+            # Drake requires file format hint for string parsing
+            # Determine format from content or default to URDF
+            if model_xml.strip().startswith("<sdf"):
+                parser.AddModelFromString(model_xml, "sdf")
+            else:
+                parser.AddModelFromString(model_xml, "urdf")
         else:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)

--- a/src/tools/starting_pose_matcher/providers/drake.py
+++ b/src/tools/starting_pose_matcher/providers/drake.py
@@ -108,8 +108,11 @@ class DrakeSkeletonProvider:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)
             # Drake requires file format hint for string parsing
-            # Determine format from content or default to URDF
-            if model_xml.strip().startswith("<sdf"):
+            # Determine format from content - search for <sdf> tag anywhere in content
+            # to handle XML declarations, comments, or whitespace before the root element
+            import re
+            # Check for SDF root element (may be preceded by XML declaration or comments)
+            if re.search(r'<sdf\s', model_xml):
                 parser.AddModelFromString(model_xml, "sdf")
             else:
                 parser.AddModelFromString(model_xml, "urdf")


### PR DESCRIPTION
Fixes #4418

This PR addresses the issue where Parser.AddModelFromString was called without the required file format hint.

Changes:
- Add format hint ('urdf' or 'sdf') to AddModelFromString calls
- Auto-detect format from XML content by checking if it starts with '<sdf'