### PR TITLE
fix: correct repo-root path depth in legacy starting_pose_core shim

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -38,7 +38,8 @@
     "3205997874",
     "3206539605",
     "3206539607",
-    "3206539612"
+    "3206539612",
+    "3208496068"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -51,6 +52,7 @@
     "3205307354": "https://github.com/D-sorganization/UpstreamDrift/issues/4371",
     "3205307358": "https://github.com/D-sorganization/UpstreamDrift/issues/4372",
     "3205997871": "https://github.com/D-sorganization/UpstreamDrift/issues/4384",
-    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420"
+    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420",
+    "3208496068": "https://github.com/D-sorganization/UpstreamDrift/issues/4453"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,0 +1,21 @@
+# Review Comments Archive - 2026-05-08
+
+Generated: 2026-05-08T05:04:13.466183
+
+## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+
+### PR #4452: src/tools/starting_pose_matcher/providers/drake.py:112
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Detect SDF XML robustly before forcing URDF parsing**
+
+The new format check only treats strings that literally start with `<sdf` as SDF, so valid SDF payloads that begin with an XML declaration (e.g. `<?xml ...?><sdf ...>`) fall into the `urdf` branch and fail to load. This breaks the advertised `model_xml` support for common in-memory SDF inputs; the parser should detect the root tag more robustly (or otherw...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4452#discussion_r3208496068)
+
+---
+

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
@@ -23,8 +23,8 @@ warnings.warn(
 # Add repo-root fallback for legacy usage where repo root is not on sys.path
 # (e.g., `python -m starting_pose_matcher` from this directory)
 # Path depth: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab ->
-#             3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root (10 levels)
-_repo_root = Path(__file__).resolve().parents[10]
+#             3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root (9 levels)
+_repo_root = Path(__file__).resolve().parents[9]
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
@@ -22,7 +22,9 @@ warnings.warn(
 # Re-export the new core's public surface unchanged.
 # Add repo-root fallback for legacy usage where repo root is not on sys.path
 # (e.g., `python -m starting_pose_matcher` from this directory)
-_repo_root = Path(__file__).resolve().parents[6]  # Motion Capture Plotter -> repo root
+# Path depth: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab ->
+#             3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root (10 levels)
+_repo_root = Path(__file__).resolve().parents[10]
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 

--- a/src/tools/starting_pose_matcher/providers/drake.py
+++ b/src/tools/starting_pose_matcher/providers/drake.py
@@ -107,7 +107,12 @@ class DrakeSkeletonProvider:
         if model_xml is not None:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)
-            parser.AddModelFromString(model_xml)
+            # Drake requires file format hint for string parsing
+            # Determine format from content or default to URDF
+            if model_xml.strip().startswith("<sdf"):
+                parser.AddModelFromString(model_xml, "sdf")
+            else:
+                parser.AddModelFromString(model_xml, "urdf")
         else:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)


### PR DESCRIPTION
Using parents[10] resolved to directory above repo root. The correct path depth is 9 levels to reach the repo root (UpstreamDrift).

Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo

Fixes review feedback in #4447