### PR TITLE
fix: correct repo-root path depth in legacy starting_pose_matcher.py

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -38,7 +38,8 @@
     "3205997874",
     "3206539605",
     "3206539607",
-    "3206539612"
+    "3206539612",
+    "3208533260"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -51,6 +52,7 @@
     "3205307354": "https://github.com/D-sorganization/UpstreamDrift/issues/4371",
     "3205307358": "https://github.com/D-sorganization/UpstreamDrift/issues/4372",
     "3205997871": "https://github.com/D-sorganization/UpstreamDrift/issues/4384",
-    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420"
+    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420",
+    "3208533260": "https://github.com/D-sorganization/UpstreamDrift/issues/4455"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,0 +1,21 @@
+# Review Comments Archive - 2026-05-08
+
+Generated: 2026-05-08T05:09:20.352691
+
+## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+
+### PR #4454: src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py:131
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Fix off-by-one when deriving repo root**
+
+When this fallback branch runs (`python -m starting_pose_matcher` from the legacy directory), `here_dir` is already the `Motion Capture Plotter` directory, so `here_dir.parents[9]` resolves to `/workspace` instead of the repository root (`/workspace/UpstreamDrift`). That leaves `src.tools.starting_pose_matcher` unresolved (no `/workspace/src`), so the intended legacy ...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4454#discussion_r3208533260)
+
+---
+

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
@@ -125,8 +125,10 @@ except ImportError:
     # when running from the legacy directory path.
     here_dir = Path(__file__).parent
     sys.path.insert(0, str(here_dir))
-    # Add repo root (6 levels up from Motion Capture Plotter) for src.* imports
-    repo_root = here_dir.parents[6]
+    # Add repo root (9 levels up from Motion Capture Plotter) for src.* imports
+    # Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab ->
+    #       3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root
+    repo_root = here_dir.parents[9]
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
     from starting_pose_core import (


### PR DESCRIPTION
Using parents[6] resolved to directory above repo root. The correct path depth is 9 levels to reach the repo root (UpstreamDrift).

Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo

Fixes review feedback in #4380 and #4381