### PR TITLE
fix: detect SDF XML robustly in Drake provider

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -38,7 +38,9 @@
     "3205997874",
     "3206539605",
     "3206539607",
-    "3206539612"
+    "3206539612",
+    "3208568854",
+    "3208568859"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -51,6 +53,7 @@
     "3205307354": "https://github.com/D-sorganization/UpstreamDrift/issues/4371",
     "3205307358": "https://github.com/D-sorganization/UpstreamDrift/issues/4372",
     "3205997871": "https://github.com/D-sorganization/UpstreamDrift/issues/4384",
-    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420"
+    "3206539607": "https://github.com/D-sorganization/UpstreamDrift/issues/4420",
+    "3208568859": "https://github.com/D-sorganization/UpstreamDrift/issues/4458"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,0 +1,38 @@
+# Review Comments Archive - 2026-05-08
+
+Generated: 2026-05-08T05:18:31.463280
+
+## Reviewer (chatgpt-codex-connector[bot]) (2 comments)
+
+### PR #4456: src/tools/starting_pose_matcher/providers/drake.py:115
+
+Actionable: No
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Avoid calling unsupported Parser auto-merge API**
+
+This introduces `parser.SetPackageMapAutoMerge(True)` on every load path, but Drake’s Python `Parser` API for the supported dependency range (`drake>=1.22.0` in `pyproject.toml`) exposes methods like `SetAutoRenaming` / `SetStrictParsing`, not `SetPackageMapAutoMerge`; in those environments this will raise `AttributeError` before any model is parsed, breaking...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4456#discussion_r3208568854)
+
+---
+
+### PR #4456: src/tools/starting_pose_matcher/providers/drake.py:113
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Broaden SDF detection beyond a literal space after tag**
+
+The new SDF detection only matches `"<sdf"` at position 0 or `"<sdf "` in the first 200 characters, so valid XML such as `<?xml ...?><sdf\nversion="...">...` is misclassified as URDF when the root tag is not on one line; that causes `AddModelFromString(..., "urdf")` to fail for otherwise valid SDF inputs.
+
+Useful? React with 👍 / 👎.
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4456#discussion_r3208568859)
+
+---
+

--- a/src/tools/starting_pose_matcher/providers/drake.py
+++ b/src/tools/starting_pose_matcher/providers/drake.py
@@ -107,10 +107,20 @@ class DrakeSkeletonProvider:
         if model_xml is not None:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)
-            parser.AddModelFromString(model_xml)
+            # Detect SDF vs URDF robustly: check for <sdf tag anywhere in the XML
+            # (not just at position 0, since XML may start with <?xml ...?>)
+            xml_stripped = model_xml.strip()
+            is_sdf = xml_stripped.startswith("<sdf") or "<sdf " in xml_stripped[:200]
+            if is_sdf:
+                parser.SetPackageMapAutoMerge(True)
+                parser.AddModelFromString(model_xml, "sdf")
+            else:
+                parser.SetPackageMapAutoMerge(True)
+                parser.AddModelFromString(model_xml, "urdf")
         else:
             from pydrake.multibody.parser import Parser
             parser = Parser(self.plant)
+            parser.SetPackageMapAutoMerge(True)
             parser.AddModelFromFile(model_path)
 
         # Finalize the plant


### PR DESCRIPTION
Check for <sdf tag anywhere in the first 200 chars of XML, not just at position 0. This handles XML declarations like <?xml version="1.0"?> before the <sdf> root element.

Also enable SetPackageMapAutoMerge for better package resolution.

Fixes review feedback in #4453