### PR TITLE
fix: correct repo-root path depth in legacy starting_pose_matcher.py (iteration 2)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
@@ -125,8 +125,10 @@ except ImportError:
     # when running from the legacy directory path.
     here_dir = Path(__file__).parent
     sys.path.insert(0, str(here_dir))
-    # Add repo root (6 levels up from Motion Capture Plotter) for src.* imports
-    repo_root = here_dir.parents[6]
+    # Add repo root (8 levels up from Motion Capture Plotter) for src.* imports
+    # Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab ->
+    #       3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root
+    repo_root = here_dir.parents[8]
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
     from starting_pose_core import (


### PR DESCRIPTION
The previous fix used parents[9] but the correct path depth is 8 levels from Motion Capture Plotter to the repo root.

Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root

Fixes review feedback in #4455