### PR TITLE
fix: correct repo-root path depth in legacy starting_pose_core shim (iteration 2)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
@@ -22,7 +22,9 @@ warnings.warn(
 # Re-export the new core's public surface unchanged.
 # Add repo-root fallback for legacy usage where repo root is not on sys.path
 # (e.g., `python -m starting_pose_matcher` from this directory)
-_repo_root = Path(__file__).resolve().parents[6]  # Motion Capture Plotter -> repo root
+# Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab ->
+#       3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root
+_repo_root = Path(__file__).resolve().parents[9]  # 9 levels to repo root
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 


### PR DESCRIPTION
Using parents[6] resolved to directory above repo root. The correct path depth is 9 levels to reach the repo root (UpstreamDrift).

Path: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo

Fixes review feedback in #4380 and #4381