### PR TITLE
fix: correct repo-root path depth in starting_pose_core.py (v2)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_core.py
@@ -22,7 +22,9 @@ warnings.warn(
 # Re-export the new core's public surface unchanged.
 # Add repo-root fallback for legacy usage where repo root is not on sys.path
 # (e.g., `python -m starting_pose_matcher` from this directory)
-_repo_root = Path(__file__).resolve().parents[6]  # Motion Capture Plotter -> repo root
+# Path depth: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model ->
+#             Simscape_Multibody_Models -> engines -> src -> repo root = 9 levels
+_repo_root = Path(__file__).resolve().parents[9]  # Motion Capture Plotter -> repo root
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 


### PR DESCRIPTION
Fixes #4447

- Change parents[6] to parents[9] to correctly resolve to repo root
- Path depth: Motion Capture Plotter -> golf_gui -> apps -> src -> matlab -> 3D_Golf_Model -> Simscape_Multibody_Models -> engines -> src -> repo root

This fixes the ModuleNotFoundError for legacy usage running from the Motion Capture Plotter directory.