### PR TITLE
fix: simplify redundant validation checks in RL module

### DIFF
--- a/src/learning/rl/base_env.py
+++ b/src/learning/rl/base_env.py
@@ -163,9 +163,7 @@ class RoboticsGymEnv:
             Tuple of (observation, reward, terminated, truncated, info).
         """
         # Process action
-        if not (action is not None):
-            raise ValueError("action must be provided")
-        if not (action is not None):
+        if action is None:
             raise ValueError("action must be provided")
         processed_action = self.action_config.process_action(action, self._prev_action)
 

--- a/src/learning/rl/configs.py
+++ b/src/learning/rl/configs.py
@@ -75,9 +75,7 @@ class ObservationConfig:
         Returns:
             Total observation dimension.
         """
-        if not (n_joints is not None):
-            raise ValueError("n_joints must be provided")
-        if not (n_joints is not None):
+        if n_joints is None:
             raise ValueError("n_joints must be provided")
         dim = 0
         if self.include_joint_pos:
@@ -124,9 +122,7 @@ class ActionConfig:
             Processed action.
         """
         # Clip
-        if not (action is not None):
-            raise ValueError("action must be provided")
-        if not (action is not None):
+        if action is None:
             raise ValueError("action must be provided")
         action = np.clip(action, -self.action_clip, self.action_clip)
         # Scale
@@ -186,9 +182,7 @@ class RewardConfig:
         Returns:
             Smoothness penalty value.
         """
-        if not (action is not None):
-            raise ValueError("action must be provided")
-        if not (action is not None):
+        if action is None:
             raise ValueError("action must be provided")
         if prev_action is None:
             return 0.0


### PR DESCRIPTION
## Summary
This PR addresses code quality issues in the RL module by simplifying redundant validation checks:

- Replace 'if not (x is not None)' with 'if x is None'
- Remove duplicate validation statements

## Files Changed
- `src/learning/rl/configs.py`: Fixed 3 locations
- `src/learning/rl/base_env.py`: Fixed 1 location

## Testing
- No functional changes, code cleanup only
- Existing tests should pass