### PR TITLE
feat(motion-matching): add ClubBallTarget for ball boundary condition

### DIFF
--- a/src/shared/python/motion_matching/__init__.py
+++ b/src/shared/python/motion_matching/__init__.py
@@ -93,8 +93,11 @@ from .synthesize_target_from_coefficients import (
 )
 from .target import (
     AlignOptions,
+    BallImpactState,
+    ClubBallTarget,
     ClubTarget,
     SourceProvenance,
+    extract_ball_impact_from_clubtarget,
 )
 from .validate_theta import (
     COEFFS_PER_JOINT,
@@ -115,12 +118,14 @@ __all__ = [
     "AlignOptions",
     "AlignedTrajectory",
     "BODY_TARGET_SCHEMA_VERSION",
+    "BallImpactState",
     "BodyEvent",
     "BodySegment",
     "BodySegmentGroup",
     "BodyTarget",
     "COEFFS_PER_JOINT",
     "CanonicalFitResult",
+    "ClubBallTarget",
     "ClubTarget",
     "CostBreakdown",
     "CostOptions",
@@ -140,6 +145,7 @@ __all__ = [
     "compute_total_work",
     "default_body_segments",
     "detect_impact_index",
+    "extract_ball_impact_from_clubtarget",
     "fit_quality_summary",
     "load_body_target",
     "load_body_target_c3d",

--- a/src/shared/python/motion_matching/club_ball_target.py
+++ b/src/shared/python/motion_matching/club_ball_target.py
@@ -1,0 +1,255 @@
+"""Canonical ``ClubBallTarget`` dataclass and ball-impact boundary state.
+
+Mirrors the style of :mod:`club_target`: frozen dataclasses, validated at
+construction, descriptive ``ValueError``/``TypeError`` raised on contract
+violation. The ball-impact boundary condition lets motion matching score
+fits not just by club kinematics but also by alignment with the ball at
+impact (position, launch direction, launch speed).
+
+The default extractor :func:`extract_ball_impact_from_clubtarget`
+approximates the ball state from the club state alone — adequate for
+visualisation and as a stand-in until a real launch-monitor feed is wired
+in by a separate loader path. The approximations are documented in the
+extractor docstring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .club_target import MAX_POSITION_NORM_M, ClubTarget
+
+# --- Validation tolerances and bounds -------------------------------------
+
+# Unit-norm tolerance for the launch-direction vector. Loose enough for
+# float32-then-cast inputs; tight enough to catch un-normalised data.
+LAUNCH_DIR_NORM_TOL = 1.0e-6
+
+# Plausible upper bound on launch speed (m/s) for any human-driven club.
+MAX_LAUNCH_SPEED_MPS = 100.0
+
+# Plausible upper bound on ball spin (rpm). 15k covers extreme wedge spin.
+MAX_SPIN_RPM = 15_000.0
+
+# Elasticity factor used by the default extractor to estimate launch speed
+# from clubhead speed. Documented as a stand-in pending real launch-monitor
+# data; clamped to ``MAX_LAUNCH_SPEED_MPS``.
+DEFAULT_ELASTICITY_FACTOR = 1.5
+
+# Schema version for forward-compatible serialisation.
+CLUB_BALL_TARGET_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class BallImpactState:
+    """Ball state at the moment of impact (boundary condition).
+
+    Attributes:
+        position_at_impact_m: World-frame Z-up position (3,) in metres.
+            All components must be finite and ``|r| < MAX_POSITION_NORM_M``.
+        launch_direction:     Unit vector (3,) in the world frame. Either
+            fully finite (and unit-norm to ``LAUNCH_DIR_NORM_TOL``) or
+            fully NaN (unknown). Partial unknowns are rejected.
+        launch_speed_mps:     Launch speed in m/s. Either NaN (unknown) or
+            finite in ``[0, MAX_LAUNCH_SPEED_MPS]``.
+        spin_rpm:             Ball spin in rpm. Either NaN (unknown) or
+            finite in ``[0, MAX_SPIN_RPM]``.
+    """
+
+    position_at_impact_m: np.ndarray
+    launch_direction: np.ndarray
+    launch_speed_mps: float
+    spin_rpm: float
+
+    def __post_init__(self) -> None:
+        """Validate the boundary state at construction."""
+        _validate_ball_impact_state(self)
+
+
+@dataclass(frozen=True)
+class ClubBallTarget:
+    """Composite target combining a ``ClubTarget`` with a ball boundary state.
+
+    Used by motion matching when the user wants the ball impact state to
+    contribute to the cost (e.g. clubface aligned with launch direction at
+    impact). The ``time`` and ``impact_idx`` properties delegate to the
+    underlying club target so callers can treat a ``ClubBallTarget`` as a
+    drop-in for ``ClubTarget`` in code that only needs those fields.
+    """
+
+    club: ClubTarget
+    ball_impact: BallImpactState
+
+    def __post_init__(self) -> None:
+        """Type-check the wrapped components."""
+        if not isinstance(self.club, ClubTarget):
+            raise TypeError("club must be a ClubTarget instance")
+        if not isinstance(self.ball_impact, BallImpactState):
+            raise TypeError("ball_impact must be a BallImpactState instance")
+
+    @property
+    def time(self) -> np.ndarray:
+        """Delegate: the resampled time grid from the club target."""
+        return self.club.time
+
+    @property
+    def impact_idx(self) -> int:
+        """Delegate: the impact index (1-based) from the club target."""
+        return self.club.impact_idx
+
+
+# --- Validation helpers ---------------------------------------------------
+
+
+def _validate_position(pos: np.ndarray) -> None:
+    """Reject malformed, NaN/Inf, or implausibly large impact positions."""
+    if not isinstance(pos, np.ndarray):
+        raise TypeError("position_at_impact_m must be a numpy.ndarray")
+    if pos.shape != (3,):
+        raise ValueError(f"position_at_impact_m must have shape (3,), got {pos.shape}")
+    if not np.all(np.isfinite(pos)):
+        raise ValueError("position_at_impact_m contains NaN or Inf")
+    norm = float(np.linalg.norm(pos))
+    if norm >= MAX_POSITION_NORM_M:
+        raise ValueError(
+            f"position_at_impact_m has |r| >= {MAX_POSITION_NORM_M} m (got {norm:.3f})"
+        )
+
+
+def _validate_launch_direction(direction: np.ndarray) -> None:
+    """Allow either fully-NaN or fully-finite unit-norm launch directions."""
+    if not isinstance(direction, np.ndarray):
+        raise TypeError("launch_direction must be a numpy.ndarray")
+    if direction.shape != (3,):
+        raise ValueError(
+            f"launch_direction must have shape (3,), got {direction.shape}"
+        )
+    nan_mask = np.isnan(direction)
+    if np.any(nan_mask) and not np.all(nan_mask):
+        raise ValueError(
+            "launch_direction must be fully NaN or fully finite (no partial unknowns)"
+        )
+    if np.all(nan_mask):
+        return
+    if not np.all(np.isfinite(direction)):
+        raise ValueError("launch_direction contains Inf")
+    norm = float(np.linalg.norm(direction))
+    if abs(norm - 1.0) > LAUNCH_DIR_NORM_TOL:
+        raise ValueError(
+            "launch_direction must be unit-norm to within "
+            f"{LAUNCH_DIR_NORM_TOL} (got {norm:.6f})"
+        )
+
+
+def _validate_scalar_in_range(value: float, name: str, lo: float, hi: float) -> None:
+    """Validate a finite-or-NaN scalar against ``[lo, hi]`` when finite."""
+    fv = float(value)
+    if np.isnan(fv):
+        return
+    if not np.isfinite(fv):
+        raise ValueError(f"{name} must be finite or NaN (got {fv!r})")
+    if not (lo <= fv <= hi):
+        raise ValueError(f"{name} must be in [{lo}, {hi}] (got {fv})")
+
+
+def _validate_ball_impact_state(s: BallImpactState) -> None:
+    """Enforce the ``BallImpactState`` validation rules."""
+    _validate_position(s.position_at_impact_m)
+    _validate_launch_direction(s.launch_direction)
+    _validate_scalar_in_range(
+        s.launch_speed_mps, "launch_speed_mps", 0.0, MAX_LAUNCH_SPEED_MPS
+    )
+    _validate_scalar_in_range(s.spin_rpm, "spin_rpm", 0.0, MAX_SPIN_RPM)
+
+
+# --- Default extractor ----------------------------------------------------
+
+
+def _clubhead_velocity_at_impact(target: ClubTarget) -> np.ndarray:
+    """Numerical clubhead velocity at the impact frame (1-based ``impact_idx``).
+
+    Uses a centred difference where possible, falling back to one-sided
+    differences at the array endpoints. Returns a (3,) vector in m/s.
+    """
+    k = int(target.impact_idx) - 1  # 1-based -> 0-based array index
+    n = target.time.shape[0]
+    if not 0 <= k < n:
+        raise ValueError(f"impact_idx {target.impact_idx} maps outside range for N={n}")
+    if n < 2:
+        raise ValueError("ClubTarget must have at least 2 samples for velocity")
+    if k == 0:
+        dt = float(target.time[1] - target.time[0])
+        return (target.clubhead[1] - target.clubhead[0]) / dt
+    if k == n - 1:
+        dt = float(target.time[k] - target.time[k - 1])
+        return (target.clubhead[k] - target.clubhead[k - 1]) / dt
+    dt = float(target.time[k + 1] - target.time[k - 1])
+    return (target.clubhead[k + 1] - target.clubhead[k - 1]) / dt
+
+
+def extract_ball_impact_from_clubtarget(
+    target: ClubTarget,
+    *,
+    elasticity_factor: float = DEFAULT_ELASTICITY_FACTOR,
+) -> BallImpactState:
+    """Approximate a :class:`BallImpactState` from a :class:`ClubTarget`.
+
+    This is a stand-in for a real launch-monitor feed and is intended for
+    visualisation and for the ball-aware cost term in the absence of
+    measured ball data. The approximations are:
+
+    * ``position_at_impact_m`` := clubhead position at the impact frame.
+      Strictly speaking the ball is offset by the clubhead radius and the
+      impact location on the face; using the clubhead centre is good
+      enough for visual overlay and within the validation envelope.
+    * ``launch_direction`` := unit vector of the centred-difference
+      clubhead velocity at impact. If the velocity is degenerate
+      (norm below numerical noise) the direction is reported as NaN to
+      signal "unknown" rather than fabricate a value.
+    * ``launch_speed_mps`` := ``|v_clubhead at impact| * elasticity_factor``,
+      clamped to ``MAX_LAUNCH_SPEED_MPS``. The default factor of 1.5 is a
+      stand-in pending real launch-monitor data.
+    * ``spin_rpm`` := ``NaN`` (no acceptable approximation from club state).
+
+    A real launch-monitor loader can construct a :class:`BallImpactState`
+    directly without going through this extractor.
+
+    Args:
+        target: A validated :class:`ClubTarget`.
+        elasticity_factor: Stand-in factor relating clubhead speed at
+            impact to ball launch speed. Must be finite and >= 0.
+
+    Returns:
+        A validated :class:`BallImpactState`.
+
+    Raises:
+        TypeError:  If ``target`` is not a :class:`ClubTarget`.
+        ValueError: If ``elasticity_factor`` is non-finite or negative.
+    """
+    if not isinstance(target, ClubTarget):
+        raise TypeError("target must be a ClubTarget instance")
+    if not np.isfinite(elasticity_factor) or elasticity_factor < 0.0:
+        raise ValueError(
+            f"elasticity_factor must be finite and >= 0 (got {elasticity_factor!r})"
+        )
+
+    k = int(target.impact_idx) - 1
+    position = np.asarray(target.clubhead[k], dtype=float).copy()
+
+    velocity = _clubhead_velocity_at_impact(target)
+    speed = float(np.linalg.norm(velocity))
+    if speed > LAUNCH_DIR_NORM_TOL:
+        direction = (velocity / speed).astype(float)
+    else:
+        direction = np.full(3, np.nan, dtype=float)
+
+    launch_speed = min(speed * float(elasticity_factor), MAX_LAUNCH_SPEED_MPS)
+
+    return BallImpactState(
+        position_at_impact_m=position,
+        launch_direction=direction,
+        launch_speed_mps=float(launch_speed),
+        spin_rpm=float("nan"),
+    )

--- a/src/shared/python/motion_matching/target.py
+++ b/src/shared/python/motion_matching/target.py
@@ -1,4 +1,4 @@
-"""Public re-export of the ``ClubTarget`` dataclass.
+"""Public re-export of the ``ClubTarget`` and ``ClubBallTarget`` dataclasses.
 
 Issue #4095 promotes the loader/oracle/cost surface to a top-level package.
 ``target`` is the canonical module name (matching ``target.m`` in MATLAB
@@ -9,6 +9,9 @@ Public API:
     ClubTarget       -- frozen dataclass for a measured club swing.
     AlignOptions     -- resampling and impact-alignment options.
     SourceProvenance -- file-level provenance metadata.
+    BallImpactState  -- ball boundary condition at impact.
+    ClubBallTarget   -- club + ball composite target.
+    extract_ball_impact_from_clubtarget -- club-state-only extractor.
 """
 
 from __future__ import annotations
@@ -18,6 +21,16 @@ from .body_target import (
     MAX_BODY_POSITION_NORM_M,
     BodyEvent,
     BodyTarget,
+)
+from .club_ball_target import (
+    CLUB_BALL_TARGET_SCHEMA_VERSION,
+    DEFAULT_ELASTICITY_FACTOR,
+    LAUNCH_DIR_NORM_TOL,
+    MAX_LAUNCH_SPEED_MPS,
+    MAX_SPIN_RPM,
+    BallImpactState,
+    ClubBallTarget,
+    extract_ball_impact_from_clubtarget,
 )
 from .club_target import (
     QUAT_NORM_TOL,
@@ -31,12 +44,20 @@ from .club_target import (
 __all__ = [
     "AlignOptions",
     "BODY_TARGET_SCHEMA_VERSION",
+    "BallImpactState",
     "BodyEvent",
     "BodyTarget",
+    "CLUB_BALL_TARGET_SCHEMA_VERSION",
+    "ClubBallTarget",
     "ClubTarget",
+    "DEFAULT_ELASTICITY_FACTOR",
+    "LAUNCH_DIR_NORM_TOL",
     "MAX_BODY_POSITION_NORM_M",
+    "MAX_LAUNCH_SPEED_MPS",
+    "MAX_SPIN_RPM",
     "QUAT_NORM_TOL",
     "SourceProvenance",
     "TIME_EPS",
     "ValidAlignment",
+    "extract_ball_impact_from_clubtarget",
 ]

--- a/tests/unit/motion_matching/test_club_ball_target.py
+++ b/tests/unit/motion_matching/test_club_ball_target.py
@@ -1,0 +1,308 @@
+"""Unit tests for ``ClubBallTarget`` and the default ball-impact extractor."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.club_ball_target import (
+    DEFAULT_ELASTICITY_FACTOR,
+    MAX_LAUNCH_SPEED_MPS,
+    MAX_SPIN_RPM,
+    BallImpactState,
+    ClubBallTarget,
+    extract_ball_impact_from_clubtarget,
+)
+from src.shared.python.motion_matching.club_target import (
+    MAX_POSITION_NORM_M,
+    ClubTarget,
+)
+
+from ._fixtures import make_provenance, make_target
+
+
+# --- BallImpactState happy path ------------------------------------------
+
+
+def _good_ball_impact_state(**overrides: object) -> BallImpactState:
+    """Build a valid ``BallImpactState`` with optional field overrides."""
+    kwargs: dict[str, object] = {
+        "position_at_impact_m": np.array([0.0, 0.5, 0.05]),
+        "launch_direction": np.array([1.0, 0.0, 0.0]),
+        "launch_speed_mps": 60.0,
+        "spin_rpm": 2500.0,
+    }
+    kwargs.update(overrides)
+    return BallImpactState(**kwargs)  # type: ignore[arg-type]
+
+
+def test_ball_impact_state_happy_path() -> None:
+    state = _good_ball_impact_state()
+    assert state.launch_speed_mps == 60.0
+    assert np.isclose(np.linalg.norm(state.launch_direction), 1.0)
+
+
+def test_ball_impact_state_is_frozen() -> None:
+    state = _good_ball_impact_state()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        state.launch_speed_mps = 70.0  # type: ignore[misc]
+
+
+def test_ball_impact_state_allows_all_unknown_optional_fields() -> None:
+    state = _good_ball_impact_state(
+        launch_direction=np.full(3, np.nan),
+        launch_speed_mps=float("nan"),
+        spin_rpm=float("nan"),
+    )
+    assert np.all(np.isnan(state.launch_direction))
+    assert np.isnan(state.launch_speed_mps)
+    assert np.isnan(state.spin_rpm)
+
+
+# --- BallImpactState validation rules ------------------------------------
+
+
+def test_position_wrong_shape_rejected() -> None:
+    with pytest.raises(ValueError, match="shape \\(3,\\)"):
+        _good_ball_impact_state(position_at_impact_m=np.zeros(4))
+
+
+def test_position_nan_rejected() -> None:
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        _good_ball_impact_state(position_at_impact_m=np.array([np.nan, 0.0, 0.0]))
+
+
+def test_position_implausible_radius_rejected() -> None:
+    big = np.array([MAX_POSITION_NORM_M + 1.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="\\|r\\| >="):
+        _good_ball_impact_state(position_at_impact_m=big)
+
+
+def test_launch_direction_wrong_shape_rejected() -> None:
+    with pytest.raises(ValueError, match="shape \\(3,\\)"):
+        _good_ball_impact_state(launch_direction=np.zeros(4))
+
+
+def test_launch_direction_partial_nan_rejected() -> None:
+    bad = np.array([np.nan, 0.0, 1.0])
+    with pytest.raises(ValueError, match="fully NaN or fully finite"):
+        _good_ball_impact_state(launch_direction=bad)
+
+
+def test_launch_direction_non_unit_rejected() -> None:
+    with pytest.raises(ValueError, match="unit-norm"):
+        _good_ball_impact_state(launch_direction=np.array([2.0, 0.0, 0.0]))
+
+
+def test_launch_direction_inf_rejected() -> None:
+    bad = np.array([np.inf, 0.0, 0.0])
+    with pytest.raises(ValueError, match="Inf"):
+        _good_ball_impact_state(launch_direction=bad)
+
+
+def test_launch_speed_negative_rejected() -> None:
+    with pytest.raises(ValueError, match="launch_speed_mps"):
+        _good_ball_impact_state(launch_speed_mps=-1.0)
+
+
+def test_launch_speed_too_large_rejected() -> None:
+    with pytest.raises(ValueError, match="launch_speed_mps"):
+        _good_ball_impact_state(launch_speed_mps=MAX_LAUNCH_SPEED_MPS + 1.0)
+
+
+def test_launch_speed_inf_rejected() -> None:
+    with pytest.raises(ValueError, match="launch_speed_mps"):
+        _good_ball_impact_state(launch_speed_mps=float("inf"))
+
+
+def test_spin_negative_rejected() -> None:
+    with pytest.raises(ValueError, match="spin_rpm"):
+        _good_ball_impact_state(spin_rpm=-10.0)
+
+
+def test_spin_too_large_rejected() -> None:
+    with pytest.raises(ValueError, match="spin_rpm"):
+        _good_ball_impact_state(spin_rpm=MAX_SPIN_RPM + 1.0)
+
+
+# --- ClubBallTarget composite -------------------------------------------
+
+
+def test_club_ball_target_happy_path() -> None:
+    club = make_target()
+    state = _good_ball_impact_state()
+    composite = ClubBallTarget(club=club, ball_impact=state)
+    # Delegating properties.
+    assert composite.impact_idx == club.impact_idx
+    assert composite.time is club.time
+
+
+def test_club_ball_target_is_frozen() -> None:
+    composite = ClubBallTarget(
+        club=make_target(), ball_impact=_good_ball_impact_state()
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        composite.club = make_target()  # type: ignore[misc]
+
+
+def test_club_ball_target_rejects_wrong_club_type() -> None:
+    with pytest.raises(TypeError, match="ClubTarget"):
+        ClubBallTarget(  # type: ignore[arg-type]
+            club="not a club target",
+            ball_impact=_good_ball_impact_state(),
+        )
+
+
+def test_club_ball_target_rejects_wrong_ball_type() -> None:
+    with pytest.raises(TypeError, match="BallImpactState"):
+        ClubBallTarget(  # type: ignore[arg-type]
+            club=make_target(), ball_impact={"not": "a state"}
+        )
+
+
+# --- Default extractor ---------------------------------------------------
+
+
+def _linear_clubhead_target(
+    velocity: np.ndarray, *, n: int = 51, impact_idx: int = 25
+) -> ClubTarget:
+    """Synthetic ClubTarget whose clubhead moves at constant ``velocity``."""
+    time = np.linspace(0.0, 0.3, n)
+    butt = np.zeros((n, 3))
+    clubhead = np.array([0.0, 0.0, 1.0])[None, :] + velocity[None, :] * time[:, None]
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    return ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=impact_idx,
+        source=make_provenance(),
+    )
+
+
+def test_extractor_position_matches_clubhead_at_impact() -> None:
+    target = _linear_clubhead_target(np.array([10.0, 0.0, 0.0]))
+    state = extract_ball_impact_from_clubtarget(target)
+    expected = target.clubhead[target.impact_idx - 1]
+    assert np.allclose(state.position_at_impact_m, expected)
+
+
+def test_extractor_launch_direction_matches_velocity_unit() -> None:
+    velocity = np.array([8.0, 6.0, 0.0])  # |v| = 10
+    target = _linear_clubhead_target(velocity)
+    state = extract_ball_impact_from_clubtarget(target)
+    expected_dir = velocity / np.linalg.norm(velocity)
+    assert np.allclose(state.launch_direction, expected_dir, atol=1e-10)
+
+
+def test_extractor_launch_speed_uses_elasticity_factor() -> None:
+    velocity = np.array([10.0, 0.0, 0.0])
+    target = _linear_clubhead_target(velocity)
+    state = extract_ball_impact_from_clubtarget(target)
+    expected = 10.0 * DEFAULT_ELASTICITY_FACTOR
+    assert state.launch_speed_mps == pytest.approx(expected, rel=1e-9)
+
+
+def test_extractor_launch_speed_clamped_to_max() -> None:
+    # Build a tiny linear-motion target so |position| stays inside the
+    # ClubTarget envelope while clubhead speed is comfortably above
+    # MAX_LAUNCH_SPEED_MPS / DEFAULT_ELASTICITY_FACTOR.
+    n = 3
+    time = np.linspace(0.0, 1.0e-3, n)  # 1 ms window
+    velocity = np.array([80.0, 0.0, 0.0])  # 80 m/s -> 120 m/s ball
+    clubhead = np.array([0.0, 0.0, 1.0])[None, :] + velocity[None, :] * time[:, None]
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    target = ClubTarget(
+        time=time,
+        butt=np.zeros((n, 3)),
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=2,
+        source=make_provenance(),
+    )
+    state = extract_ball_impact_from_clubtarget(target)
+    assert state.launch_speed_mps == pytest.approx(MAX_LAUNCH_SPEED_MPS)
+
+
+def test_extractor_spin_is_nan() -> None:
+    target = _linear_clubhead_target(np.array([10.0, 0.0, 0.0]))
+    state = extract_ball_impact_from_clubtarget(target)
+    assert np.isnan(state.spin_rpm)
+
+
+def test_extractor_zero_velocity_yields_nan_direction() -> None:
+    n = 51
+    time = np.linspace(0.0, 0.3, n)
+    clubhead = np.tile(np.array([0.0, 0.0, 1.0]), (n, 1))
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    target = ClubTarget(
+        time=time,
+        butt=np.zeros((n, 3)),
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=25,
+        source=make_provenance(),
+    )
+    state = extract_ball_impact_from_clubtarget(target)
+    assert np.all(np.isnan(state.launch_direction))
+    assert state.launch_speed_mps == pytest.approx(0.0)
+
+
+def test_extractor_works_at_first_frame() -> None:
+    target = _linear_clubhead_target(np.array([1.0, 0.0, 0.0]), impact_idx=1)
+    state = extract_ball_impact_from_clubtarget(target)
+    assert np.allclose(state.launch_direction, [1.0, 0.0, 0.0])
+
+
+def test_extractor_works_at_last_frame() -> None:
+    n = 51
+    target = _linear_clubhead_target(np.array([1.0, 0.0, 0.0]), n=n, impact_idx=n)
+    state = extract_ball_impact_from_clubtarget(target)
+    assert np.allclose(state.launch_direction, [1.0, 0.0, 0.0])
+
+
+def test_extractor_rejects_wrong_target_type() -> None:
+    with pytest.raises(TypeError, match="ClubTarget"):
+        extract_ball_impact_from_clubtarget("not a target")  # type: ignore[arg-type]
+
+
+def test_extractor_rejects_negative_elasticity() -> None:
+    target = _linear_clubhead_target(np.array([1.0, 0.0, 0.0]))
+    with pytest.raises(ValueError, match="elasticity_factor"):
+        extract_ball_impact_from_clubtarget(target, elasticity_factor=-0.1)
+
+
+def test_extractor_rejects_non_finite_elasticity() -> None:
+    target = _linear_clubhead_target(np.array([1.0, 0.0, 0.0]))
+    with pytest.raises(ValueError, match="elasticity_factor"):
+        extract_ball_impact_from_clubtarget(target, elasticity_factor=float("nan"))
+
+
+def test_extractor_zero_elasticity_yields_zero_speed() -> None:
+    target = _linear_clubhead_target(np.array([10.0, 0.0, 0.0]))
+    state = extract_ball_impact_from_clubtarget(target, elasticity_factor=0.0)
+    assert state.launch_speed_mps == pytest.approx(0.0)
+
+
+# --- Re-exports through target.py and the package root -------------------
+
+
+def test_re_exported_from_target_module() -> None:
+    from src.shared.python.motion_matching import target as target_mod
+
+    assert target_mod.BallImpactState is BallImpactState
+    assert target_mod.ClubBallTarget is ClubBallTarget
+    assert (
+        target_mod.extract_ball_impact_from_clubtarget
+        is extract_ball_impact_from_clubtarget
+    )
+
+
+def test_re_exported_from_package_root() -> None:
+    import src.shared.python.motion_matching as mm
+
+    assert mm.BallImpactState is BallImpactState
+    assert mm.ClubBallTarget is ClubBallTarget
+    assert mm.extract_ball_impact_from_clubtarget is extract_ball_impact_from_clubtarget


### PR DESCRIPTION
Closes #4476

## Summary

- Adds `BallImpactState` and `ClubBallTarget` frozen, validated dataclasses in `src/shared/python/motion_matching/club_ball_target.py`.
- Adds `extract_ball_impact_from_clubtarget(target)` — documented approximation of ball state from club kinematics alone (clubhead position at impact, centred-difference velocity for launch direction, `e=1.5` factor for launch speed clamped to 100 m/s, NaN spin until a real launch-monitor loader lands).
- Re-exports through `target.py` and the package `__init__.py`.
- 33 unit tests in `tests/unit/motion_matching/test_club_ball_target.py` pin every validation rule (happy + fail) and exercise the extractor at the first frame, last frame, zero velocity, the speed clamp, custom elasticity factor, and bad inputs.

## Validation rules pinned

- `position_at_impact_m` shape (3,), all finite, `|r| < MAX_POSITION_NORM_M = 5.0`
- `launch_direction` fully NaN (unknown) or fully finite unit-norm to 1e-6 — partial NaN rejected
- `launch_speed_mps` finite-or-NaN, `[0, 100]` when finite
- `spin_rpm` finite-or-NaN, `[0, 15_000]` when finite
- `ClubBallTarget.club` is `ClubTarget`, `ClubBallTarget.ball_impact` is `BallImpactState`

## Generic naming

No vendor / brand / launch-monitor names anywhere in code, docstrings, or error messages — the extractor is described as a stand-in pending a real launch-monitor feed via a sibling loader path.

## Test plan

- [x] `python3 -m ruff check` on changed files clean
- [x] `python3 -m ruff format --check` on changed files clean
- [x] `python3 -m pytest tests/unit/motion_matching/test_club_ball_target.py -n auto --timeout=60` — 33 passed
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget

---

**Note**: the `Closes #` reference was briefly retargeted to #4479 in error during a number-mapping mixup, then restored. The real ClubBallTarget issue is #4476.