### PR TITLE
feat(motion-matching): add ClubBallTarget canonical contract (#4476)

### DIFF
--- a/src/shared/python/motion_matching/__init__.py
+++ b/src/shared/python/motion_matching/__init__.py
@@ -78,8 +78,11 @@ from .synthesize_target_from_coefficients import (
 )
 from .target import (
     AlignOptions,
+    BallImpactState,
+    ClubBallTarget,
     ClubTarget,
     SourceProvenance,
+    extract_ball_impact_from_clubtarget,
 )
 from .validate_theta import (
     COEFFS_PER_JOINT,
@@ -99,8 +102,10 @@ __all__ = [
     "ALLOWED_SHEETS",
     "AlignOptions",
     "AlignedTrajectory",
+    "BallImpactState",
     "COEFFS_PER_JOINT",
     "CanonicalFitResult",
+    "ClubBallTarget",
     "ClubTarget",
     "CostBreakdown",
     "CostOptions",
@@ -118,6 +123,7 @@ __all__ = [
     "compute_cost",
     "compute_total_work",
     "detect_impact_index",
+    "extract_ball_impact_from_clubtarget",
     "fit_quality_summary",
     "load_club_target",
     "load_club_target_c3d",

--- a/src/shared/python/motion_matching/club_ball_target.py
+++ b/src/shared/python/motion_matching/club_ball_target.py
@@ -1,0 +1,220 @@
+"""Canonical ``ClubBallTarget`` dataclass and ball-impact extraction.
+
+Extends :class:`ClubTarget` with a ball boundary condition (position at
+impact, launch direction, launch speed, spin). Frozen and validated at
+construction so loaders are forced to produce a fully-formed artifact.
+
+Public API:
+    BallImpactState                       -- frozen dataclass for ball state
+                                              at impact.
+    ClubBallTarget                        -- composite ``ClubTarget`` +
+                                              ``BallImpactState``.
+    extract_ball_impact_from_clubtarget   -- approximate ball-impact extractor
+                                              from clubhead kinematics.
+
+The naming policy is source-agnostic: no reference to specific launch
+monitors, brand names, ball makes, or studies anywhere in this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .club_target import MAX_POSITION_NORM_M, ClubTarget
+
+# Validation bounds (frozen here; documented in the issue rationale).
+LAUNCH_SPEED_MAX_MPS = 100.0
+SPIN_RPM_MAX = 15000.0
+UNIT_NORM_TOL = 1.0e-6
+
+# Default elasticity stand-in used when approximating ball launch speed
+# from clubhead speed in the absence of a real launch-monitor feed.
+DEFAULT_ELASTICITY_FACTOR = 1.5
+
+
+@dataclass(frozen=True)
+class BallImpactState:
+    """Ball state at the moment of impact (boundary condition).
+
+    Attributes:
+        position_at_impact_m: World-frame Z-up ball position at impact, in
+            metres. Shape ``(3,)``. All components must be finite.
+        launch_direction: Unit vector giving the launch direction in the
+            world frame. Shape ``(3,)``. If unknown, all three components
+            must be NaN (no partial unknowns are allowed).
+        launch_speed_mps: Ball launch speed in metres per second. NaN if
+            unknown; if finite, must lie in ``[0, 100]``.
+        spin_rpm: Total spin rate in revolutions per minute. NaN if unknown;
+            if finite, must lie in ``[0, 15000]``.
+    """
+
+    position_at_impact_m: np.ndarray
+    launch_direction: np.ndarray
+    launch_speed_mps: float
+    spin_rpm: float
+
+
+@dataclass(frozen=True)
+class ClubBallTarget:
+    """Composite target combining a :class:`ClubTarget` with a ball boundary.
+
+    Validated at construction; any rule violation raises ``ValueError`` or
+    ``TypeError`` with a descriptive message.
+    """
+
+    club: ClubTarget
+    ball_impact: BallImpactState
+
+    def __post_init__(self) -> None:
+        """Run all postcondition checks at construction."""
+        _validate_club_ball_target(self)
+
+    @property
+    def time(self) -> np.ndarray:
+        """Delegate to the wrapped ``ClubTarget.time``."""
+        return self.club.time
+
+    @property
+    def impact_idx(self) -> int:
+        """Delegate to the wrapped ``ClubTarget.impact_idx``."""
+        return self.club.impact_idx
+
+
+def _validate_position_at_impact(position: np.ndarray) -> None:
+    """Check ``position_at_impact_m`` shape, finiteness, and norm bound."""
+    if not isinstance(position, np.ndarray):
+        raise TypeError(
+            "position_at_impact_m must be a numpy ndarray, "
+            f"got {type(position).__name__}"
+        )
+    if position.shape != (3,):
+        raise ValueError(
+            f"position_at_impact_m must have shape (3,), got {position.shape}"
+        )
+    if not np.all(np.isfinite(position)):
+        raise ValueError("position_at_impact_m contains NaN or Inf")
+    norm = float(np.linalg.norm(position))
+    if norm >= MAX_POSITION_NORM_M:
+        raise ValueError(
+            f"position_at_impact_m has |r| >= {MAX_POSITION_NORM_M} m (got {norm:.3f})"
+        )
+
+
+def _validate_launch_direction(direction: np.ndarray) -> None:
+    """Check ``launch_direction`` shape and unit-norm-or-all-NaN rule."""
+    if not isinstance(direction, np.ndarray):
+        raise TypeError(
+            f"launch_direction must be a numpy ndarray, got {type(direction).__name__}"
+        )
+    if direction.shape != (3,):
+        raise ValueError(
+            f"launch_direction must have shape (3,), got {direction.shape}"
+        )
+    nan_mask = np.isnan(direction)
+    if np.any(nan_mask):
+        if not np.all(nan_mask):
+            raise ValueError(
+                "launch_direction must be either fully finite or all-NaN; "
+                "partial NaN components are not allowed"
+            )
+        return
+    if not np.all(np.isfinite(direction)):
+        raise ValueError("launch_direction contains Inf")
+    norm = float(np.linalg.norm(direction))
+    if abs(norm - 1.0) > UNIT_NORM_TOL:
+        raise ValueError(
+            "launch_direction must be unit-norm to within "
+            f"{UNIT_NORM_TOL} (got |v|={norm:.6f})"
+        )
+
+
+def _validate_finite_or_nan_in_range(
+    value: float, name: str, lo: float, hi: float
+) -> None:
+    """Validate a scalar that may be NaN, else must lie in ``[lo, hi]``."""
+    fvalue = float(value)
+    if np.isnan(fvalue):
+        return
+    if not np.isfinite(fvalue):
+        raise ValueError(f"{name} must be finite or NaN, got {fvalue!r}")
+    if not (lo <= fvalue <= hi):
+        raise ValueError(f"{name} must be in [{lo}, {hi}], got {fvalue!r}")
+
+
+def _validate_club_ball_target(t: ClubBallTarget) -> None:
+    """Enforce the ``ClubBallTarget`` validation rules."""
+    if not isinstance(t.club, ClubTarget):
+        raise TypeError(
+            f"club must be a ClubTarget instance, got {type(t.club).__name__}"
+        )
+    if not isinstance(t.ball_impact, BallImpactState):
+        raise TypeError(
+            "ball_impact must be a BallImpactState instance, "
+            f"got {type(t.ball_impact).__name__}"
+        )
+    bi = t.ball_impact
+    _validate_position_at_impact(bi.position_at_impact_m)
+    _validate_launch_direction(bi.launch_direction)
+    _validate_finite_or_nan_in_range(
+        bi.launch_speed_mps, "launch_speed_mps", 0.0, LAUNCH_SPEED_MAX_MPS
+    )
+    _validate_finite_or_nan_in_range(bi.spin_rpm, "spin_rpm", 0.0, SPIN_RPM_MAX)
+
+
+def extract_ball_impact_from_clubtarget(target: ClubTarget) -> BallImpactState:
+    """Approximate a :class:`BallImpactState` from a :class:`ClubTarget`.
+
+    This is a stand-in extractor for use when a real launch-monitor feed is
+    unavailable. The approximation collapses the ball position to the
+    clubhead position at impact (within a ball radius, fine for visual
+    overlays) and derives launch direction and speed from the numerical
+    clubhead-velocity gradient at the impact frame.
+
+    Approximation details:
+        * ``position_at_impact_m`` := ``target.clubhead[impact_idx_0]``,
+          where ``impact_idx_0`` is the 0-based index. The MATLAB-style
+          ``ClubTarget.impact_idx`` is 1-based, so we subtract one.
+        * ``launch_direction`` := unit vector of the clubhead velocity at
+          impact, computed via ``np.gradient`` on the resampled grid. If
+          the clubhead is stationary at impact (zero velocity), the
+          direction collapses to all-NaN.
+        * ``launch_speed_mps`` := ``|v_clubhead at impact|`` multiplied by
+          :data:`DEFAULT_ELASTICITY_FACTOR`, clamped to
+          :data:`LAUNCH_SPEED_MAX_MPS`. This is a documented stand-in
+          pending real launch-monitor data.
+        * ``spin_rpm`` := ``NaN`` (no kinematic estimator implemented).
+
+    Args:
+        target: A validated :class:`ClubTarget`.
+
+    Returns:
+        A validated :class:`BallImpactState`.
+
+    Raises:
+        TypeError: If ``target`` is not a :class:`ClubTarget`.
+    """
+    if not isinstance(target, ClubTarget):
+        raise TypeError(
+            f"target must be a ClubTarget instance, got {type(target).__name__}"
+        )
+    impact_idx_0 = int(target.impact_idx) - 1
+    n = target.time.shape[0]
+    if not (0 <= impact_idx_0 < n):
+        raise ValueError(
+            f"impact_idx {target.impact_idx} maps to out-of-range "
+            f"0-based index {impact_idx_0} for time length {n}"
+        )
+    position = np.asarray(target.clubhead[impact_idx_0], dtype=float).copy()
+    velocity = np.gradient(target.clubhead, target.time, axis=0)
+    v_impact = np.asarray(velocity[impact_idx_0], dtype=float)
+    speed = float(np.linalg.norm(v_impact))
+    direction = v_impact / speed if speed > 0.0 else np.full(3, np.nan, dtype=float)
+    launch_speed = min(speed * DEFAULT_ELASTICITY_FACTOR, LAUNCH_SPEED_MAX_MPS)
+    return BallImpactState(
+        position_at_impact_m=position,
+        launch_direction=direction,
+        launch_speed_mps=launch_speed,
+        spin_rpm=float("nan"),
+    )

--- a/src/shared/python/motion_matching/target.py
+++ b/src/shared/python/motion_matching/target.py
@@ -1,4 +1,4 @@
-"""Public re-export of the ``ClubTarget`` dataclass.
+"""Public re-export of the ``ClubTarget`` and ``ClubBallTarget`` dataclasses.
 
 Issue #4095 promotes the loader/oracle/cost surface to a top-level package.
 ``target`` is the canonical module name (matching ``target.m`` in MATLAB
@@ -9,10 +9,18 @@ Public API:
     ClubTarget       -- frozen dataclass for a measured club swing.
     AlignOptions     -- resampling and impact-alignment options.
     SourceProvenance -- file-level provenance metadata.
+    BallImpactState  -- frozen dataclass for ball state at impact.
+    ClubBallTarget   -- composite ``ClubTarget`` + ``BallImpactState``.
+    extract_ball_impact_from_clubtarget -- approximate ball-impact extractor.
 """
 
 from __future__ import annotations
 
+from .club_ball_target import (
+    BallImpactState,
+    ClubBallTarget,
+    extract_ball_impact_from_clubtarget,
+)
 from .club_target import (
     QUAT_NORM_TOL,
     TIME_EPS,
@@ -24,9 +32,12 @@ from .club_target import (
 
 __all__ = [
     "AlignOptions",
+    "BallImpactState",
+    "ClubBallTarget",
     "ClubTarget",
     "QUAT_NORM_TOL",
     "SourceProvenance",
     "TIME_EPS",
     "ValidAlignment",
+    "extract_ball_impact_from_clubtarget",
 ]

--- a/tests/unit/motion_matching/test_club_ball_target.py
+++ b/tests/unit/motion_matching/test_club_ball_target.py
@@ -1,0 +1,315 @@
+"""Unit tests for the ``ClubBallTarget`` dataclass and validation rules."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.club_ball_target import (
+    DEFAULT_ELASTICITY_FACTOR,
+    LAUNCH_SPEED_MAX_MPS,
+    BallImpactState,
+    ClubBallTarget,
+    extract_ball_impact_from_clubtarget,
+)
+
+from ._fixtures import make_provenance, make_target
+
+
+def _good_ball_impact() -> BallImpactState:
+    """A valid BallImpactState for use in unit tests."""
+    return BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=60.0,
+        spin_rpm=3000.0,
+    )
+
+
+def test_club_ball_target_happy_path() -> None:
+    cbt = ClubBallTarget(club=make_target(), ball_impact=_good_ball_impact())
+    assert isinstance(cbt.club.time, np.ndarray)
+    # Property delegates.
+    np.testing.assert_array_equal(cbt.time, cbt.club.time)
+    assert cbt.impact_idx == cbt.club.impact_idx
+
+
+def test_club_ball_target_immutable() -> None:
+    cbt = ClubBallTarget(club=make_target(), ball_impact=_good_ball_impact())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cbt.ball_impact = _good_ball_impact()  # type: ignore[misc]
+
+
+def test_ball_impact_state_immutable() -> None:
+    bi = _good_ball_impact()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        bi.launch_speed_mps = 50.0  # type: ignore[misc]
+
+
+def test_validation_rejects_non_clubtarget_club() -> None:
+    with pytest.raises(TypeError, match="ClubTarget"):
+        ClubBallTarget(
+            club="not-a-target",  # type: ignore[arg-type]
+            ball_impact=_good_ball_impact(),
+        )
+
+
+def test_validation_rejects_non_ballimpactstate_ball_impact() -> None:
+    with pytest.raises(TypeError, match="BallImpactState"):
+        ClubBallTarget(
+            club=make_target(),
+            ball_impact="not-a-ball-state",  # type: ignore[arg-type]
+        )
+
+
+def test_validation_rejects_position_wrong_shape() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.zeros((3, 1)),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="position_at_impact_m must have shape"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_position_with_nan() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([np.nan, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_position_too_large() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([99.0, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match=">="):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_position_non_ndarray() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=[0.5, 0.0, 0.0],  # type: ignore[arg-type]
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(TypeError, match="position_at_impact_m must be a numpy"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_launch_direction_wrong_shape() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="launch_direction must have shape"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_partial_nan_launch_direction() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([np.nan, 0.0, 1.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="fully finite or all-NaN"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_non_unit_launch_direction() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([2.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="unit-norm"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_accepts_all_nan_launch_direction() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.full(3, np.nan),
+        launch_speed_mps=float("nan"),
+        spin_rpm=float("nan"),
+    )
+    cbt = ClubBallTarget(club=make_target(), ball_impact=bi)
+    assert np.all(np.isnan(cbt.ball_impact.launch_direction))
+
+
+def test_validation_rejects_inf_launch_direction() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([np.inf, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="Inf"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_launch_speed_negative() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=-1.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="launch_speed_mps must be in"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_launch_speed_too_large() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=LAUNCH_SPEED_MAX_MPS + 1.0,
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="launch_speed_mps must be in"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_launch_speed_inf() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=float("inf"),
+        spin_rpm=float("nan"),
+    )
+    with pytest.raises(ValueError, match="launch_speed_mps must be finite or NaN"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_accepts_nan_launch_speed() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=float("nan"),
+        spin_rpm=float("nan"),
+    )
+    cbt = ClubBallTarget(club=make_target(), ball_impact=bi)
+    assert np.isnan(cbt.ball_impact.launch_speed_mps)
+
+
+def test_validation_rejects_spin_negative() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=-1.0,
+    )
+    with pytest.raises(ValueError, match="spin_rpm must be in"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_spin_too_large() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=99999.0,
+    )
+    with pytest.raises(ValueError, match="spin_rpm must be in"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_validation_rejects_spin_inf() -> None:
+    bi = BallImpactState(
+        position_at_impact_m=np.array([0.5, 0.0, 0.0]),
+        launch_direction=np.array([1.0, 0.0, 0.0]),
+        launch_speed_mps=10.0,
+        spin_rpm=float("inf"),
+    )
+    with pytest.raises(ValueError, match="spin_rpm must be finite or NaN"):
+        ClubBallTarget(club=make_target(), ball_impact=bi)
+
+
+def test_extract_ball_impact_from_clubtarget_happy_path() -> None:
+    target = make_target()
+    bi = extract_ball_impact_from_clubtarget(target)
+    assert isinstance(bi, BallImpactState)
+    # Position lives at the clubhead's impact-frame location (1-based -> 0-based).
+    expected_pos = target.clubhead[target.impact_idx - 1]
+    np.testing.assert_allclose(bi.position_at_impact_m, expected_pos)
+    # Direction is unit-norm because the synthetic clubhead has a non-zero v.
+    assert np.all(np.isfinite(bi.launch_direction))
+    np.testing.assert_allclose(np.linalg.norm(bi.launch_direction), 1.0, atol=1e-9)
+    # Speed is finite, in [0, 100], and equal to elasticity * |v_impact|
+    # (or clamped).
+    assert 0.0 <= bi.launch_speed_mps <= LAUNCH_SPEED_MAX_MPS
+    assert np.isnan(bi.spin_rpm)
+    # Verify the resulting state is acceptable to ClubBallTarget validation.
+    ClubBallTarget(club=target, ball_impact=bi)
+
+
+def test_extract_ball_impact_clamps_launch_speed() -> None:
+    target = make_target(n=5)
+    # Build a degenerate target with huge clubhead velocity (>> 100/elasticity).
+    huge_speed = LAUNCH_SPEED_MAX_MPS * 10.0  # m/s
+    bi = extract_ball_impact_from_clubtarget(_target_with_constant_velocity(huge_speed))
+    assert bi.launch_speed_mps == LAUNCH_SPEED_MAX_MPS
+    assert target.time.shape[0] == 5  # sanity: didn't mutate fixture target
+
+
+def test_extract_ball_impact_zero_velocity_yields_nan_direction() -> None:
+    target = _target_with_constant_velocity(0.0)
+    bi = extract_ball_impact_from_clubtarget(target)
+    assert np.all(np.isnan(bi.launch_direction))
+    assert bi.launch_speed_mps == 0.0
+
+
+def test_extract_ball_impact_uses_elasticity_factor() -> None:
+    speed_mps = 10.0
+    target = _target_with_constant_velocity(speed_mps)
+    bi = extract_ball_impact_from_clubtarget(target)
+    expected = speed_mps * DEFAULT_ELASTICITY_FACTOR
+    assert bi.launch_speed_mps == pytest.approx(expected)
+
+
+def test_extract_ball_impact_rejects_non_clubtarget() -> None:
+    with pytest.raises(TypeError, match="ClubTarget"):
+        extract_ball_impact_from_clubtarget("not-a-target")  # type: ignore[arg-type]
+
+
+def _target_with_constant_velocity(speed_mps: float):
+    """A small ClubTarget whose clubhead moves at constant +x velocity.
+
+    Centered around t = 0 so positions stay within the ``MAX_POSITION_NORM_M``
+    bound regardless of the requested speed (the bound is 5 m and the time
+    span used here is short enough that position remains bounded).
+    """
+    from src.shared.python.motion_matching.club_target import ClubTarget
+
+    n = 11
+    # 1 ms keeps |x| <= speed * 0.5 ms strictly < 5 m for the tested speeds
+    # (max speed in tests is 1000 m/s -> max |x| = 0.5 m).
+    duration = 0.001
+    time = np.linspace(0.0, duration, n)
+    centered = time - duration / 2.0
+    butt = np.zeros((n, 3))
+    butt[:, 0] = speed_mps * centered
+    clubhead = butt + np.array([0.0, 0.0, 1.0])
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1))
+    return ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=n // 2,
+        source=make_provenance(),
+    )


### PR DESCRIPTION
Closes #4476

## Summary

- Adds `BallImpactState` and `ClubBallTarget` frozen dataclasses in `src/shared/python/motion_matching/club_ball_target.py`. Both validate at construction and reuse `SourceProvenance` from the existing `club_target` module.
- Adds `extract_ball_impact_from_clubtarget`, a documented stand-in extractor that approximates ball position, launch direction, and launch speed from clubhead kinematics (with `spin_rpm := NaN`) until a real launch-monitor feed is wired up.
- Re-exports the new public symbols from `motion_matching/target.py` and the package `__init__.py`.
- Adds comprehensive unit tests in `tests/unit/motion_matching/test_club_ball_target.py`: one happy path plus one failure case for every validation rule, plus extractor tests that pin clamping, zero-velocity NaN behaviour, and elasticity factor.

## Test plan

- [x] unit tests pass (`pytest tests/unit/motion_matching/test_club_ball_target.py -n auto --timeout=60` -> 26 passed)
- [x] ruff check + ruff format --check clean for the touched files
- [x] file size budget OK