### PR TITLE
feat(motion-matching): add BodyTarget canonical contract (#4479)

### DIFF
--- a/src/shared/python/motion_matching/__init__.py
+++ b/src/shared/python/motion_matching/__init__.py
@@ -43,6 +43,12 @@ See ``src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching
 shared/CLUB_IK_SPEC.md`` for the canonical schema.
 """
 
+from .body_target import (
+    BODY_TARGET_SCHEMA_VERSION,
+    MAX_BODY_POSITION_NORM_M,
+    BodyEvent,
+    BodyTarget,
+)
 from .align_to_simulation_grid import (
     AlignedTrajectory,
     align_to_simulation_grid,
@@ -99,6 +105,9 @@ __all__ = [
     "ALLOWED_SHEETS",
     "AlignOptions",
     "AlignedTrajectory",
+    "BODY_TARGET_SCHEMA_VERSION",
+    "BodyEvent",
+    "BodyTarget",
     "COEFFS_PER_JOINT",
     "CanonicalFitResult",
     "ClubTarget",
@@ -108,6 +117,7 @@ __all__ = [
     "EngineSimulator",
     "FitQualityScalars",
     "FitResult",
+    "MAX_BODY_POSITION_NORM_M",
     "REGULARIZER_KINDS",
     "SimOut",
     "SimOutput",

--- a/src/shared/python/motion_matching/body_target.py
+++ b/src/shared/python/motion_matching/body_target.py
@@ -1,0 +1,198 @@
+"""Canonical ``BodyTarget`` dataclass and validation.
+
+A first-class, validated, immutable target dataclass for full-body marker
+trajectories — parallel to :class:`ClubTarget`. Loaders and downstream cost
+functions, visualisers, and exporters can rely on the validated artifact
+without re-parsing raw motion-capture files.
+
+The dataclass and its validation are source-agnostic: nothing here references
+a specific motion-capture vendor, study, lab, or person. Provenance lives in
+the free-form :class:`SourceProvenance` ``format`` field set by the loader.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .club_target import TIME_EPS, SourceProvenance
+
+# Schema-version constant (bump on any breaking field/semantics change).
+BODY_TARGET_SCHEMA_VERSION = 1
+
+# Per-marker position-norm sanity bound for human-scale motion (metres).
+MAX_BODY_POSITION_NORM_M = 3.0
+
+# Minimum fraction of markers that must be finite in at least one frame.
+_MIN_FINITE_MARKER_FRACTION = 0.5
+
+BodyCoordinateFrame = Literal["z_up_right_handed"]
+
+
+@dataclass(frozen=True)
+class BodyEvent:
+    """Named event on the resampled body-marker timegrid.
+
+    Attributes:
+        label:  Free-form non-empty event label (e.g. ``"address"``,
+                ``"top"``, ``"impact"``).
+        frame:  Frame index on the resampled grid; must lie in ``[0, N)``.
+        time_s: Wall-clock seconds since the first sample (``time[0] == 0``).
+    """
+
+    label: str
+    frame: int
+    time_s: float
+
+
+@dataclass(frozen=True)
+class BodyTarget:
+    """Canonical full-body marker trajectory.
+
+    Validated at construction; any violation of the validation rules raises
+    :class:`ValueError` (or :class:`TypeError` for the source-type check).
+    Frozen so loaders are forced to produce a fully-formed, validated artifact
+    rather than mutating one in place.
+
+    Attributes:
+        time:         ``(N,)`` seconds, strictly increasing, ``time[0] == 0``.
+        marker_xyz:   ``(N, M, 3)`` metres; NaN allowed for occluded samples.
+        marker_names: Length-``M`` tuple of unique non-empty marker names.
+        impact_idx:   Frame index of impact on the resampled grid; ``[0, N)``.
+        events:       Named events with frame indices on the resampled grid.
+        source:       File-level provenance metadata.
+        coordinate_frame: World-frame convention; only ``"z_up_right_handed"``
+                          is currently supported.
+    """
+
+    time: np.ndarray
+    marker_xyz: np.ndarray
+    marker_names: tuple[str, ...]
+    impact_idx: int
+    events: tuple[BodyEvent, ...]
+    source: SourceProvenance
+    coordinate_frame: BodyCoordinateFrame = "z_up_right_handed"
+
+    def __post_init__(self) -> None:
+        """Run all postcondition checks at construction."""
+        _validate_bodytarget(self)
+
+
+def _validate_time(time: np.ndarray) -> int:
+    """Check the time vector and return its length ``N``."""
+    if not isinstance(time, np.ndarray) or time.ndim != 1:
+        raise ValueError(
+            f"time must be a 1-D ndarray, got shape "
+            f"{getattr(time, 'shape', type(time).__name__)!r}"
+        )
+    n = int(time.shape[0])
+    if n < 2:
+        raise ValueError(f"time must have at least 2 samples (got {n})")
+    if abs(float(time[0])) > TIME_EPS:
+        raise ValueError(f"time[0] must be 0 within {TIME_EPS}, got {time[0]!r}")
+    if not np.all(np.diff(time) > 0):
+        raise ValueError("time must be strictly increasing")
+    return n
+
+
+def _validate_marker_names(marker_names: tuple[str, ...]) -> int:
+    """Check marker_names; return its length ``M``."""
+    if not isinstance(marker_names, tuple):
+        raise ValueError(
+            f"marker_names must be a tuple, got {type(marker_names).__name__}"
+        )
+    m = len(marker_names)
+    for i, name in enumerate(marker_names):
+        if not isinstance(name, str):
+            raise ValueError(
+                f"marker_names[{i}] must be a string, got {type(name).__name__}"
+            )
+        if name == "":
+            raise ValueError(f"marker_names[{i}] must be non-empty")
+    if len(set(marker_names)) != m:
+        raise ValueError("marker_names must be unique")
+    return m
+
+
+def _validate_marker_xyz_shape(marker_xyz: np.ndarray, n: int, m: int) -> None:
+    """Check that ``marker_xyz`` has the expected ``(N, M, 3)`` shape."""
+    if not isinstance(marker_xyz, np.ndarray):
+        raise ValueError(
+            f"marker_xyz must be an ndarray, got {type(marker_xyz).__name__}"
+        )
+    if m < 3:
+        raise ValueError(f"marker count M must be >= 3, got {m}")
+    if marker_xyz.shape != (n, m, 3):
+        raise ValueError(
+            f"marker_xyz must have shape ({n}, {m}, 3), got {marker_xyz.shape}"
+        )
+
+
+def _validate_marker_norms(marker_xyz: np.ndarray) -> None:
+    """Reject finite samples whose per-marker position norm is implausible."""
+    finite_mask = np.all(np.isfinite(marker_xyz), axis=2)
+    if not np.any(finite_mask):
+        return
+    # Compute norms only on finite samples to avoid NaN propagation.
+    safe_xyz = np.where(finite_mask[..., None], marker_xyz, 0.0)
+    norms = np.linalg.norm(safe_xyz, axis=2)
+    # Mask out non-finite frames so they do not register as violations.
+    masked_norms = np.where(finite_mask, norms, 0.0)
+    if np.any(masked_norms >= MAX_BODY_POSITION_NORM_M):
+        max_norm = float(masked_norms.max())
+        raise ValueError(
+            f"marker_xyz has |r| >= {MAX_BODY_POSITION_NORM_M} m on a finite "
+            f"sample (max {max_norm:.3f})"
+        )
+
+
+def _validate_finite_coverage(marker_xyz: np.ndarray, m: int) -> None:
+    """At least one frame must be finite for >= 50% of markers."""
+    finite_per_frame = np.all(np.isfinite(marker_xyz), axis=2).sum(axis=1)
+    threshold = _MIN_FINITE_MARKER_FRACTION * m
+    if not np.any(finite_per_frame >= threshold):
+        raise ValueError(
+            "no frame has at least "
+            f"{int(np.ceil(threshold))} of {m} markers finite "
+            f"(>= {_MIN_FINITE_MARKER_FRACTION:.0%} coverage required); "
+            "loader must crop leading/trailing all-NaN windows"
+        )
+
+
+def _validate_events(events: tuple[BodyEvent, ...], n: int) -> None:
+    """Check events tuple: types, frame range, non-empty unique labels."""
+    if not isinstance(events, tuple):
+        raise ValueError(f"events must be a tuple, got {type(events).__name__}")
+    seen: set[str] = set()
+    for i, event in enumerate(events):
+        if not isinstance(event, BodyEvent):
+            raise ValueError(
+                f"events[{i}] must be a BodyEvent, got {type(event).__name__}"
+            )
+        if not isinstance(event.label, str) or event.label == "":
+            raise ValueError(f"events[{i}].label must be a non-empty string")
+        if event.label in seen:
+            raise ValueError(
+                f"events labels must be unique (duplicate {event.label!r})"
+            )
+        seen.add(event.label)
+        if not (0 <= int(event.frame) < n):
+            raise ValueError(
+                f"events[{i}].frame must be in [0, {n}), got {event.frame}"
+            )
+
+
+def _validate_bodytarget(t: BodyTarget) -> None:
+    """Enforce the BodyTarget validation rules (see issue spec)."""
+    n = _validate_time(t.time)
+    m = _validate_marker_names(t.marker_names)
+    _validate_marker_xyz_shape(t.marker_xyz, n, m)
+    _validate_marker_norms(t.marker_xyz)
+    _validate_finite_coverage(t.marker_xyz, m)
+    if not (0 <= int(t.impact_idx) < n):
+        raise ValueError(f"impact_idx must be in [0, {n}), got {t.impact_idx}")
+    _validate_events(t.events, n)
+    if not isinstance(t.source, SourceProvenance):
+        raise TypeError("source must be a SourceProvenance instance")

--- a/src/shared/python/motion_matching/target.py
+++ b/src/shared/python/motion_matching/target.py
@@ -13,6 +13,12 @@ Public API:
 
 from __future__ import annotations
 
+from .body_target import (
+    BODY_TARGET_SCHEMA_VERSION,
+    MAX_BODY_POSITION_NORM_M,
+    BodyEvent,
+    BodyTarget,
+)
 from .club_target import (
     QUAT_NORM_TOL,
     TIME_EPS,
@@ -24,7 +30,11 @@ from .club_target import (
 
 __all__ = [
     "AlignOptions",
+    "BODY_TARGET_SCHEMA_VERSION",
+    "BodyEvent",
+    "BodyTarget",
     "ClubTarget",
+    "MAX_BODY_POSITION_NORM_M",
     "QUAT_NORM_TOL",
     "SourceProvenance",
     "TIME_EPS",

--- a/tests/unit/motion_matching/test_body_target.py
+++ b/tests/unit/motion_matching/test_body_target.py
@@ -1,0 +1,242 @@
+"""Unit tests for the ``BodyTarget`` dataclass and validation rules.
+
+Each validation rule has one happy-path test (covered by the shared
+``_make_body_target`` helper plus :func:`test_body_target_happy_path`) and one
+failure case using ``pytest.raises(ValueError, match=...)`` to pin the error
+message.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.body_target import (
+    BODY_TARGET_SCHEMA_VERSION,
+    MAX_BODY_POSITION_NORM_M,
+    BodyEvent,
+    BodyTarget,
+)
+from src.shared.python.motion_matching.club_target import SourceProvenance
+
+
+def _make_provenance() -> SourceProvenance:
+    return SourceProvenance(
+        filename="trial.c3d",
+        format="c3d",
+        subject_id="S01",
+        trial_id="T01",
+        sha256="0" * 64,
+    )
+
+
+def _make_body_target(
+    *,
+    n: int = 8,
+    m: int = 4,
+    time: np.ndarray | None = None,
+    marker_xyz: np.ndarray | None = None,
+    marker_names: tuple[str, ...] | None = None,
+    impact_idx: int = 4,
+    events: tuple[BodyEvent, ...] | None = None,
+    source: SourceProvenance | None = None,
+) -> BodyTarget:
+    if time is None:
+        time = np.linspace(0.0, 0.1, n)
+    if marker_xyz is None:
+        # Small finite values well under MAX_BODY_POSITION_NORM_M.
+        marker_xyz = np.zeros((n, m, 3))
+        marker_xyz[..., 2] = 1.0
+    if marker_names is None:
+        marker_names = tuple(f"M{i}" for i in range(m))
+    if events is None:
+        time_s = float(time.flat[impact_idx]) if time.size > impact_idx else 0.0
+        events = (BodyEvent(label="impact", frame=impact_idx, time_s=time_s),)
+    if source is None:
+        source = _make_provenance()
+    return BodyTarget(
+        time=time,
+        marker_xyz=marker_xyz,
+        marker_names=marker_names,
+        impact_idx=impact_idx,
+        events=events,
+        source=source,
+    )
+
+
+def test_constants_exposed() -> None:
+    assert BODY_TARGET_SCHEMA_VERSION == 1
+    assert MAX_BODY_POSITION_NORM_M == 3.0
+
+
+def test_body_target_happy_path() -> None:
+    target = _make_body_target()
+    assert target.coordinate_frame == "z_up_right_handed"
+    assert target.marker_xyz.shape == (8, 4, 3)
+    assert len(target.marker_names) == 4
+    assert target.impact_idx == 4
+
+
+def test_body_target_immutable() -> None:
+    target = _make_body_target()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        target.impact_idx = 99  # type: ignore[misc]
+
+
+def test_validation_rejects_non_monotonic_time() -> None:
+    bad_time = np.linspace(0.0, 0.1, 8)
+    bad_time[5] = bad_time[4]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _make_body_target(time=bad_time)
+
+
+def test_validation_rejects_non_zero_start_time() -> None:
+    time = np.linspace(0.05, 0.15, 8)
+    with pytest.raises(ValueError, match=r"time\[0\] must be 0"):
+        _make_body_target(time=time)
+
+
+def test_validation_rejects_non_1d_time() -> None:
+    bad_time = np.zeros((8, 1))
+    with pytest.raises(ValueError, match="time must be a 1-D ndarray"):
+        _make_body_target(time=bad_time)
+
+
+def test_validation_rejects_too_short_time() -> None:
+    with pytest.raises(ValueError, match="at least 2 samples"):
+        _make_body_target(
+            n=1,
+            time=np.array([0.0]),
+            marker_xyz=np.zeros((1, 4, 3)),
+            impact_idx=0,
+            events=(BodyEvent(label="impact", frame=0, time_s=0.0),),
+        )
+
+
+def test_validation_rejects_marker_xyz_shape_mismatch() -> None:
+    bad_xyz = np.zeros((8, 5, 3))  # M==5 but names give M==4
+    with pytest.raises(ValueError, match=r"marker_xyz must have shape \(8, 4, 3\)"):
+        _make_body_target(marker_xyz=bad_xyz)
+
+
+def test_validation_rejects_too_few_markers() -> None:
+    # M=2 < 3 minimum.
+    with pytest.raises(ValueError, match="marker count M must be >= 3"):
+        _make_body_target(
+            m=2,
+            marker_xyz=np.zeros((8, 2, 3)),
+            marker_names=("A", "B"),
+        )
+
+
+def test_validation_rejects_duplicate_marker_names() -> None:
+    with pytest.raises(ValueError, match="marker_names must be unique"):
+        _make_body_target(marker_names=("A", "B", "C", "A"))
+
+
+def test_validation_rejects_empty_marker_name() -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        _make_body_target(marker_names=("A", "B", "C", ""))
+
+
+def test_validation_rejects_non_string_marker_name() -> None:
+    with pytest.raises(ValueError, match="must be a string"):
+        _make_body_target(marker_names=("A", "B", "C", 1))  # type: ignore[arg-type]
+
+
+def test_validation_rejects_marker_names_not_tuple() -> None:
+    with pytest.raises(ValueError, match="marker_names must be a tuple"):
+        _make_body_target(marker_names=["A", "B", "C", "D"])  # type: ignore[arg-type]
+
+
+def test_validation_rejects_excessive_position_norm() -> None:
+    n, m = 8, 4
+    xyz = np.zeros((n, m, 3))
+    xyz[..., 2] = 1.0
+    xyz[3, 1, 0] = MAX_BODY_POSITION_NORM_M + 0.5
+    with pytest.raises(ValueError, match=r"\|r\| >="):
+        _make_body_target(marker_xyz=xyz)
+
+
+def test_validation_allows_nan_for_occluded_samples() -> None:
+    # Occluded samples are permitted; a finite frame for >=50% markers exists.
+    n, m = 8, 4
+    xyz = np.zeros((n, m, 3))
+    xyz[..., 2] = 1.0
+    xyz[2, 0, :] = np.nan  # one occluded sample
+    target = _make_body_target(marker_xyz=xyz)
+    assert np.isnan(target.marker_xyz[2, 0, 0])
+
+
+def test_validation_rejects_insufficient_finite_coverage() -> None:
+    n, m = 8, 4
+    # Only 1 of 4 markers ever finite => 25% coverage < 50%.
+    xyz = np.full((n, m, 3), np.nan)
+    xyz[:, 0, :] = 0.0
+    with pytest.raises(ValueError, match="finite"):
+        _make_body_target(marker_xyz=xyz)
+
+
+def test_validation_rejects_impact_idx_out_of_range() -> None:
+    with pytest.raises(ValueError, match=r"impact_idx must be in \[0, 8\)"):
+        _make_body_target(
+            impact_idx=8,
+            events=(BodyEvent(label="impact", frame=0, time_s=0.0),),
+        )
+
+
+def test_validation_rejects_negative_impact_idx() -> None:
+    with pytest.raises(ValueError, match=r"impact_idx must be in \[0, 8\)"):
+        _make_body_target(
+            impact_idx=-1,
+            events=(BodyEvent(label="impact", frame=0, time_s=0.0),),
+        )
+
+
+def test_validation_rejects_event_frame_out_of_range() -> None:
+    with pytest.raises(ValueError, match=r"events\[0\].frame must be in \[0, 8\)"):
+        _make_body_target(
+            events=(BodyEvent(label="impact", frame=99, time_s=0.05),),
+        )
+
+
+def test_validation_rejects_empty_event_label() -> None:
+    with pytest.raises(ValueError, match="label must be a non-empty string"):
+        _make_body_target(
+            events=(BodyEvent(label="", frame=4, time_s=0.05),),
+        )
+
+
+def test_validation_rejects_duplicate_event_labels() -> None:
+    with pytest.raises(ValueError, match="events labels must be unique"):
+        _make_body_target(
+            events=(
+                BodyEvent(label="impact", frame=4, time_s=0.05),
+                BodyEvent(label="impact", frame=5, time_s=0.06),
+            ),
+        )
+
+
+def test_validation_rejects_non_bodyevent_in_events() -> None:
+    with pytest.raises(ValueError, match="must be a BodyEvent"):
+        _make_body_target(events=("not-an-event",))  # type: ignore[arg-type]
+
+
+def test_validation_rejects_non_tuple_events() -> None:
+    with pytest.raises(ValueError, match="events must be a tuple"):
+        _make_body_target(
+            events=[BodyEvent(label="impact", frame=4, time_s=0.05)],  # type: ignore[arg-type]
+        )
+
+
+def test_validation_rejects_bad_source_type() -> None:
+    with pytest.raises(TypeError, match="source must be a SourceProvenance"):
+        BodyTarget(
+            time=np.linspace(0.0, 0.1, 8),
+            marker_xyz=np.zeros((8, 4, 3)),
+            marker_names=("A", "B", "C", "D"),
+            impact_idx=4,
+            events=(BodyEvent(label="impact", frame=4, time_s=0.05),),
+            source="not-a-provenance",  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Closes #4479

Adds the canonical `BodyTarget` dataclass for full-body marker trajectories
(NxMx3 array of marker positions over time) — distinct from `ClubBallTarget`
(issue #4476), which targets club kinematics + ball impact boundary state.

## What's added

- `src/shared/python/motion_matching/body_target.py`:
  - `BodyTarget` frozen dataclass (`time`, `marker_xyz`, `marker_names`,
    `impact_idx`, `events`, `source`, `coordinate_frame`).
  - `BodyEvent` companion frozen dataclass.
  - `BODY_TARGET_SCHEMA_VERSION = 1`, `MAX_BODY_POSITION_NORM_M = 3.0`.
  - `_validate_bodytarget` enforcing all 8 rules from the issue spec
    (time monotonicity, shape consistency, unique non-empty marker names,
    per-marker norm bound, >=50%-finite-coverage, impact_idx range,
    events frame range and unique non-empty labels, source type).
  - Reuses `SourceProvenance` from `club_target.py`.
- Re-exports from `target.py` and `__init__.py`.
- `tests/unit/motion_matching/test_body_target.py` with one happy path plus
  one failure case per validation rule, using
  `pytest.raises(ValueError, match=...)` to pin error messages (24 tests).

## Test plan
- [x] `python3 -m pytest tests/unit/motion_matching/test_body_target.py -n auto --timeout=60` — 24 passed
- [x] `python3 -m ruff check` on touched files — clean
- [x] `python3 -m ruff format --check` on touched files — clean
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget