### PR TITLE
fix(launcher): preferences dialog crashed on get_available_fleet_themes (#4491)

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -39,7 +39,8 @@
     "3206539605",
     "3206539607",
     "3206539612",
-    "3208650036"
+    "3208650036",
+    "3210175668"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,21 +1,21 @@
 # Review Comments Archive - 2026-05-08
 
-Generated: 2026-05-08T05:31:38.799024
+Generated: 2026-05-08T10:09:19.309955
 
 ## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
 
-### PR #4462: src/tools/starting_pose_matcher/providers/drake.py:121
+### PR #4495: tests/unit/ui/test_preferences_dialog.py:9
 
 Actionable: No
 Has Suggestion: No
 
 ```
-**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Drop unsupported `Parser.SetPackageMapAutoMerge` calls**
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Handle PyQt DLL-load failures as test skips**
 
-`Parser` in the supported Drake range (`drake>=1.22.0` in `pyproject.toml`) does not expose `SetPackageMapAutoMerge`, so this line raises `AttributeError` as soon as a `DrakeSkeletonProvider` is created. Because the same call is now in both the `model_xml` and `model_path` branches, all Drake provider initialization paths fail at runtime before any mod...
+Replace module-level `pytest.importorskip("PyQt6.QtWidgets")` with an explicit import guard that also catches `OSError`; `importorskip` only skips `ImportError`, so environments where PyQt6 is installed but fails to load native DLLs (a known Windows/user-site case in this repo) will raise at collection time and fail the suite instead of skipping this optional GUI...
 ```
 
-[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4462#discussion_r3208650036)
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4495#discussion_r3210175668)
 
 ---
 

--- a/src/shared/python/ui/preferences_dialog.py
+++ b/src/shared/python/ui/preferences_dialog.py
@@ -181,7 +181,7 @@ class PreferencesDialog(QDialog):
         try:
             from src.shared.python.theme import ThemeManager
 
-            fleet = ThemeManager.instance().get_available_fleet_themes()
+            fleet = ThemeManager.instance().get_available_themes()
             for name in fleet:
                 if name not in theme_items:
                     theme_items.append(name)

--- a/tests/unit/ui/test_preferences_dialog.py
+++ b/tests/unit/ui/test_preferences_dialog.py
@@ -1,0 +1,26 @@
+"""Headless smoke test for the launcher Preferences dialog (#4491)."""
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+@pytest.fixture
+def app():
+    from PyQt6.QtWidgets import QApplication
+
+    a = QApplication.instance() or QApplication([])
+    yield a
+
+
+def test_preferences_dialog_opens_without_attribute_error(app):
+    from src.shared.python.ui.preferences_dialog import PreferencesDialog
+
+    dlg = PreferencesDialog(parent=None)
+    # appearance tab built without crash
+    assert dlg.theme_combo.count() >= 3, "expected at least Dark/Light/HighContrast"
+    # The bug was in the appearance-tab path; just instantiating proves the fix.


### PR DESCRIPTION
Closes #4491

## Summary
- Replace stale `ThemeManager.instance().get_available_fleet_themes()` call at `src/shared/python/ui/preferences_dialog.py:184` with the real method `get_available_themes()` (Option A from the issue).
- Add headless smoke test `tests/unit/ui/test_preferences_dialog.py` that instantiates `PreferencesDialog` under `QT_QPA_PLATFORM=offscreen` and asserts `theme_combo.count() >= 3`.

## Test plan
- [x] `python3 -m ruff check .` on touched files (clean)
- [x] `python3 -m ruff format --check .` on touched files (clean)
- [x] `python3 scripts/ci/check_file_size_budget.py` (within budget)
- [ ] CI green on PyQt6 environment (PyQt6 not loadable on local Py 3.14, smoke test skips locally)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>