### PR TITLE
feat(motion-matching): body-skeleton segments (#4483)

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -40,7 +40,8 @@
     "3206539607",
     "3206539612",
     "3208650036",
-    "3210255790"
+    "3210255790",
+    "3210197994"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -2,7 +2,7 @@
 
 Generated: 2026-05-08T10:29:35.487192
 
-## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+## Reviewer (chatgpt-codex-connector[bot]) (2 comments)
 
 ### PR #4504: src/shared/python/motion_matching/loaders/c3d_body.py:393
 
@@ -16,6 +16,21 @@ Even in the `impact_source is not None` branch, the loader still calls `_detect_
 ```
 
 [View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4504#discussion_r3210255790)
+
+---
+
+### PR #4496: tests/unit/motion_matching/test_body_skeleton.py:7
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Guard optional matplotlib import in unit test**
+
+Importing `matplotlib` at module scope makes this test file fail during collection when the optional GUI dependency is not installed (e.g., minimal CI/dev environments), so the suite errors out instead of skipping cleanly. The repo’s root `AGENTS.md` explicitly requires matplotlib/PyQt-dependent tests to wrap imports and call `pytest.skip(...)` on `ImportError`...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4496#discussion_r3210197994)
 
 ---
 

--- a/src/shared/python/motion_matching/__init__.py
+++ b/src/shared/python/motion_matching/__init__.py
@@ -48,6 +48,11 @@ from .align_to_simulation_grid import (
     align_to_simulation_grid,
     detect_impact_index,
 )
+from .body_skeleton import (
+    BodySegment,
+    BodySegmentGroup,
+    default_body_segments,
+)
 from .compute_total_work import compute_total_work
 from .cost import (
     CostBreakdown,
@@ -111,6 +116,8 @@ __all__ = [
     "AlignedTrajectory",
     "BODY_TARGET_SCHEMA_VERSION",
     "BodyEvent",
+    "BodySegment",
+    "BodySegmentGroup",
     "BodyTarget",
     "COEFFS_PER_JOINT",
     "CanonicalFitResult",
@@ -131,6 +138,7 @@ __all__ = [
     "align_to_simulation_grid",
     "compute_cost",
     "compute_total_work",
+    "default_body_segments",
     "detect_impact_index",
     "fit_quality_summary",
     "load_body_target",

--- a/src/shared/python/motion_matching/body_skeleton.py
+++ b/src/shared/python/motion_matching/body_skeleton.py
@@ -1,0 +1,128 @@
+"""Body-skeleton segment connectivity for full-body marker targets.
+
+Defines the canonical pair-of-marker segments that turn a marker cloud
+into a stick figure. The connectivity is data-driven — it targets the
+"anatomical 28" marker subset used by the full-body C3D loader (a
+Plug-in-Gait subset: pelvis / back / head / shoulder / elbow / wrist /
+knee / ankle / toe).
+
+The default segment table is filtered at runtime to those segments whose
+endpoints are actually present in the supplied marker name list, so the
+helpers are always safe to call with a partial marker set.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, get_args
+
+BodySegmentGroup = Literal[
+    "torso",
+    "head",
+    "left_arm",
+    "right_arm",
+    "left_leg",
+    "right_leg",
+    "pelvis",
+]
+
+_VALID_GROUPS: frozenset[str] = frozenset(get_args(BodySegmentGroup))
+
+
+@dataclass(frozen=True)
+class BodySegment:
+    """A directed pair of marker names connected by a single bone-like line.
+
+    ``a`` and ``b`` are marker names (non-empty, distinct strings). ``group``
+    is one of the seven anatomical body-region literals.
+    """
+
+    a: str
+    b: str
+    group: BodySegmentGroup
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.a, str) or not self.a:
+            raise ValueError(
+                f"BodySegment.a must be a non-empty string, got {self.a!r}"
+            )
+        if not isinstance(self.b, str) or not self.b:
+            raise ValueError(
+                f"BodySegment.b must be a non-empty string, got {self.b!r}"
+            )
+        if self.a == self.b:
+            raise ValueError(
+                f"BodySegment.a and BodySegment.b must differ, got {self.a!r}"
+            )
+        if self.group not in _VALID_GROUPS:
+            raise ValueError(
+                f"BodySegment.group must be one of {sorted(_VALID_GROUPS)}, "
+                f"got {self.group!r}"
+            )
+
+
+# Canonical 26-segment table for the anatomical 28-marker subset.
+# Tuples are (a, b, group). Ordering is anatomically grouped for readability;
+# downstream consumers must not depend on iteration order.
+_CANONICAL_SEGMENTS: tuple[tuple[str, str, BodySegmentGroup], ...] = (
+    # pelvis (4)
+    ("WaistLeft", "WaistRight", "pelvis"),
+    ("WaistLeft", "WaistLBack", "pelvis"),
+    ("WaistRight", "WaistRBack", "pelvis"),
+    ("WaistLBack", "WaistRBack", "pelvis"),
+    # torso (4) — BackTop acts as upper-spine proxy
+    ("BackTop", "BackLeft", "torso"),
+    ("BackTop", "BackRight", "torso"),
+    ("BackTop", "WaistLBack", "torso"),
+    ("BackTop", "WaistRBack", "torso"),
+    # head (2)
+    ("HeadTop", "HeadFront", "head"),
+    ("HeadTop", "HeadSide", "head"),
+    # left arm (4)
+    ("LShoulderTop", "LShoulderBack", "left_arm"),
+    ("LShoulderTop", "LUArmHigh", "left_arm"),
+    ("LUArmHigh", "LElbowOut", "left_arm"),
+    ("LElbowOut", "LWristTop", "left_arm"),
+    # right arm (4)
+    ("RShoulderTop", "RShoulderBack", "right_arm"),
+    ("RShoulderTop", "RUArmHigh", "right_arm"),
+    ("RUArmHigh", "RElbowOut", "right_arm"),
+    ("RElbowOut", "RWristTop", "right_arm"),
+    # left leg (4)
+    ("WaistLeft", "LKneeOut", "left_leg"),
+    ("LKneeOut", "LAnkleOut", "left_leg"),
+    ("LAnkleOut", "LToeIn", "left_leg"),
+    ("LToeIn", "LToeOut", "left_leg"),
+    # right leg (4)
+    ("WaistRight", "RKneeOut", "right_leg"),
+    ("RKneeOut", "RAnkleOut", "right_leg"),
+    ("RAnkleOut", "RToeIn", "right_leg"),
+    ("RToeIn", "RToeOut", "right_leg"),
+)
+
+
+def default_body_segments(
+    marker_names: Sequence[str],
+) -> tuple[BodySegment, ...]:
+    """Return the canonical segment list filtered to present markers.
+
+    Only segments whose BOTH endpoints appear in ``marker_names`` are
+    returned. Always safe — a missing marker just drops the segments that
+    reference it, leaving the remainder of the figure intact.
+    """
+    if marker_names is None:
+        raise TypeError("marker_names must be a sequence of strings, got None")
+    available = frozenset(marker_names)
+    return tuple(
+        BodySegment(a=a, b=b, group=group)
+        for (a, b, group) in _CANONICAL_SEGMENTS
+        if a in available and b in available
+    )
+
+
+__all__ = [
+    "BodySegment",
+    "BodySegmentGroup",
+    "default_body_segments",
+]

--- a/src/shared/python/motion_matching/diagnostics/_skeleton_render.py
+++ b/src/shared/python/motion_matching/diagnostics/_skeleton_render.py
@@ -8,9 +8,29 @@ each diagnostic doesn't reinvent the same matplotlib boilerplate.
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from typing import Protocol
 
 import numpy as np
 from matplotlib.axes import Axes
+
+from ..body_skeleton import BodySegment, default_body_segments
+
+_DEFAULT_BODY_COLOR_MAP: dict[str, str] = {
+    "torso": "#444444",
+    "head": "#666666",
+    "left_arm": "#1f77b4",
+    "right_arm": "#ff7f0e",
+    "left_leg": "#2ca02c",
+    "right_leg": "#d62728",
+    "pelvis": "#9467bd",
+}
+
+
+class _BodyTargetLike(Protocol):
+    """Structural protocol for the subset of ``BodyTarget`` the renderer needs."""
+
+    marker_xyz: np.ndarray  # (N, M, 3)
+    marker_names: tuple[str, ...]
 
 
 def draw_segments(
@@ -94,3 +114,82 @@ def equalize_3d_axes(ax: Axes, points: np.ndarray) -> None:
     ax.set_xlim(centers[0] - half, centers[0] + half)
     ax.set_ylim(centers[1] - half, centers[1] + half)
     ax.set_zlim(centers[2] - half, centers[2] + half)  # type: ignore[attr-defined]
+
+
+def draw_body_target_frame(
+    ax: Axes,
+    target: _BodyTargetLike,
+    frame_idx: int,
+    *,
+    segment_groups: Sequence[str] | None = None,
+    color_map: dict[str, str] | None = None,
+    linewidth: float = 1.5,
+) -> None:
+    """Render one frame of a full-body marker target as a stick figure.
+
+    Draws each segment from :func:`default_body_segments` (filtered to
+    markers present on ``target``) as a coloured line on ``ax``. Segments
+    whose endpoints contain any NaN coordinate at this frame are silently
+    skipped, so missing/occluded markers degrade gracefully.
+
+    Parameters
+    ----------
+    ax
+        A matplotlib 3D axis (``projection='3d'``).
+    target
+        Anything exposing ``marker_xyz`` (shape ``(N, M, 3)``, metres) and
+        ``marker_names`` (length-``M`` tuple of strings) — typically a
+        ``BodyTarget`` instance.
+    frame_idx
+        Frame index into ``target.marker_xyz``.
+    segment_groups
+        Optional iterable of group names; only segments in these groups
+        are drawn. ``None`` (default) draws every group.
+    color_map
+        Optional override mapping ``group -> matplotlib colour``. Missing
+        keys fall back to the default colour map.
+    linewidth
+        Stroke width for every drawn segment.
+    """
+    xyz = np.asarray(target.marker_xyz)
+    names = tuple(target.marker_names)
+    if xyz.ndim != 3 or xyz.shape[2] != 3:
+        raise ValueError(
+            f"target.marker_xyz must have shape (N, M, 3); got {xyz.shape!r}"
+        )
+    if xyz.shape[1] != len(names):
+        raise ValueError(
+            "target.marker_names length must equal marker_xyz.shape[1]; "
+            f"got {len(names)} vs {xyz.shape[1]}"
+        )
+    n_frames = xyz.shape[0]
+    if not (0 <= frame_idx < n_frames):
+        raise ValueError(f"frame_idx {frame_idx} out of range [0, {n_frames})")
+
+    groups_filter: frozenset[str] | None = (
+        frozenset(segment_groups) if segment_groups is not None else None
+    )
+    colours = dict(_DEFAULT_BODY_COLOR_MAP)
+    if color_map is not None:
+        colours.update(color_map)
+
+    name_to_idx = {n: i for i, n in enumerate(names)}
+    segments: tuple[BodySegment, ...] = default_body_segments(names)
+    frame = xyz[frame_idx]
+
+    for seg in segments:
+        if groups_filter is not None and seg.group not in groups_filter:
+            continue
+        ia = name_to_idx[seg.a]
+        ib = name_to_idx[seg.b]
+        pa = frame[ia]
+        pb = frame[ib]
+        if not (np.all(np.isfinite(pa)) and np.all(np.isfinite(pb))):
+            continue
+        ax.plot(
+            [pa[0], pb[0]],
+            [pa[1], pb[1]],
+            [pa[2], pb[2]],
+            color=colours.get(seg.group, "#888888"),
+            linewidth=linewidth,
+        )

--- a/tests/unit/motion_matching/test_body_skeleton.py
+++ b/tests/unit/motion_matching/test_body_skeleton.py
@@ -1,0 +1,175 @@
+"""Unit tests for the body-skeleton segment table and matplotlib renderer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from mpl_toolkits.mplot3d import Axes3D  # noqa: E402,F401  # registers 3d projection
+
+from src.shared.python.motion_matching.body_skeleton import (  # noqa: E402
+    BodySegment,
+    default_body_segments,
+)
+from src.shared.python.motion_matching.diagnostics._skeleton_render import (  # noqa: E402
+    draw_body_target_frame,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Canonical 28-marker anatomical subset (Plug-in-Gait subset).
+FULL_28_MARKERS: tuple[str, ...] = (
+    "WaistLeft",
+    "WaistRight",
+    "WaistLBack",
+    "WaistRBack",
+    "BackTop",
+    "BackLeft",
+    "BackRight",
+    "HeadTop",
+    "HeadFront",
+    "HeadSide",
+    "LShoulderTop",
+    "LShoulderBack",
+    "LUArmHigh",
+    "LElbowOut",
+    "LWristTop",
+    "RShoulderTop",
+    "RShoulderBack",
+    "RUArmHigh",
+    "RElbowOut",
+    "RWristTop",
+    "LKneeOut",
+    "LAnkleOut",
+    "LToeIn",
+    "LToeOut",
+    "RKneeOut",
+    "RAnkleOut",
+    "RToeIn",
+    "RToeOut",
+)
+
+
+def test_default_body_segments_full_set_returns_canonical_count() -> None:
+    segs = default_body_segments(FULL_28_MARKERS)
+    assert len(segs) == 26
+    # Every group is represented.
+    groups = {s.group for s in segs}
+    assert groups == {
+        "torso",
+        "head",
+        "left_arm",
+        "right_arm",
+        "left_leg",
+        "right_leg",
+        "pelvis",
+    }
+
+
+def test_default_body_segments_filters_missing_markers() -> None:
+    # Drop the right shoulder cluster — every right-arm segment must vanish.
+    partial = tuple(
+        m for m in FULL_28_MARKERS if m not in {"RShoulderTop", "RShoulderBack"}
+    )
+    segs = default_body_segments(partial)
+    assert all("RShoulder" not in s.a and "RShoulder" not in s.b for s in segs)
+    # Other groups are unaffected.
+    left_arm_segs = [s for s in segs if s.group == "left_arm"]
+    assert len(left_arm_segs) == 4
+
+
+def test_default_body_segments_empty_marker_list_returns_empty() -> None:
+    assert default_body_segments(()) == ()
+    assert default_body_segments([]) == ()
+
+
+def test_body_segment_validation_rules() -> None:
+    # Happy path
+    BodySegment(a="HeadTop", b="HeadFront", group="head")
+
+    # Empty endpoint
+    with pytest.raises(ValueError, match="non-empty"):
+        BodySegment(a="", b="HeadFront", group="head")
+    with pytest.raises(ValueError, match="non-empty"):
+        BodySegment(a="HeadTop", b="", group="head")
+
+    # Same endpoint
+    with pytest.raises(ValueError, match="must differ"):
+        BodySegment(a="HeadTop", b="HeadTop", group="head")
+
+    # Bad group literal
+    with pytest.raises(ValueError, match="group must be one of"):
+        BodySegment(a="HeadTop", b="HeadFront", group="not-a-group")  # type: ignore[arg-type]
+
+
+def test_body_segment_is_frozen() -> None:
+    seg = BodySegment(a="HeadTop", b="HeadFront", group="head")
+    with pytest.raises(AttributeError):  # FrozenInstanceError subclasses AttributeError
+        seg.a = "Other"  # type: ignore[misc]
+
+
+@dataclass
+class _BodyTargetStub:
+    """Minimal structural stand-in for ``BodyTarget`` used in renderer tests."""
+
+    marker_xyz: np.ndarray
+    marker_names: tuple[str, ...]
+
+
+def _make_synthetic_target(*, with_nan: bool = False) -> _BodyTargetStub:
+    rng = np.random.default_rng(0)
+    n_frames = 4
+    n_markers = len(FULL_28_MARKERS)
+    xyz = rng.standard_normal((n_frames, n_markers, 3)) * 0.3
+    if with_nan:
+        # Occlude an entire arm at frame 0.
+        idx = FULL_28_MARKERS.index("RWristTop")
+        xyz[0, idx, :] = np.nan
+    return _BodyTargetStub(marker_xyz=xyz, marker_names=FULL_28_MARKERS)
+
+
+def test_draw_body_target_frame_smoke() -> None:
+    target = _make_synthetic_target()
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    initial_lines = len(ax.lines)
+    draw_body_target_frame(ax, target, frame_idx=2)
+    assert len(ax.lines) - initial_lines >= 1
+    plt.close(fig)
+
+
+def test_draw_body_target_frame_skips_nan_endpoints() -> None:
+    target = _make_synthetic_target(with_nan=True)
+    fig = plt.figure()
+    ax_full = fig.add_subplot(121, projection="3d")
+    ax_nan = fig.add_subplot(122, projection="3d")
+    draw_body_target_frame(ax_full, target, frame_idx=1)  # no NaN frame
+    draw_body_target_frame(ax_nan, target, frame_idx=0)  # has NaN
+    # NaN frame must drop at least one segment vs. the clean frame.
+    assert len(ax_nan.lines) < len(ax_full.lines)
+    plt.close(fig)
+
+
+def test_draw_body_target_frame_group_filter() -> None:
+    target = _make_synthetic_target()
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    draw_body_target_frame(ax, target, frame_idx=0, segment_groups=["head"])
+    # Only the 2 head segments should be drawn.
+    assert len(ax.lines) == 2
+    plt.close(fig)
+
+
+def test_draw_body_target_frame_rejects_bad_frame_idx() -> None:
+    target = _make_synthetic_target()
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    with pytest.raises(ValueError, match="out of range"):
+        draw_body_target_frame(ax, target, frame_idx=99)
+    plt.close(fig)


### PR DESCRIPTION
Closes #4483

## Summary
- New `src/shared/python/motion_matching/body_skeleton.py` with `BodySegment` dataclass and `default_body_segments(marker_names)` returning the canonical 26-segment list (across 7 anatomical groups: pelvis, torso, head, left/right arm, left/right leg) for the anatomical 28-marker subset. Segments whose endpoints aren't present in the supplied marker list are silently filtered out.
- Extended `diagnostics/_skeleton_render.py` with `draw_body_target_frame(ax, target, frame_idx, ...)` — renders one frame as a coloured stick figure on a 3D matplotlib axis. Accepts a structural `BodyTarget`-like protocol (so it doesn't hard-couple to a specific class) and skips any segment whose endpoint contains NaN at this frame, so occluded markers degrade gracefully. Default colour map gives one colour per group; group filter and colour overrides are supported.
- Public re-exports: `BodySegment`, `BodySegmentGroup`, `default_body_segments` added to package `__init__.py`/`__all__`.
- 9 unit tests in `tests/unit/motion_matching/test_body_skeleton.py` covering: full-set canonical count (26), partial-marker filtering, empty input, dataclass validation rules (empty/duplicate endpoints, bad group literal), frozen-instance enforcement, and the renderer (smoke, NaN-skip, group filter, frame-index range check).

## Test plan
- [x] `python3 -m ruff check` on touched files — clean
- [x] `python3 -m ruff format --check` on touched files — clean
- [x] `python3 -m pytest tests/unit/motion_matching/test_body_skeleton.py -n auto --timeout=60` — 9 passed
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>