### PR TITLE
docs(motion-matching): ADR + user guide for multi-source motion targets (#4485)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,18 @@ the modules most often missed.
 `src/shared/python/motion_matching/`
 - `target.py`, `club_target.py`, `load_club_target.py`,
   `loaders/` — mocap target structures and loaders (xlsx / C3D / JSON).
+- `BodyTarget`, `ClubBallTarget`, `MultiSourceTarget` —
+  `src/shared/python/motion_matching/`.  Frozen dataclasses + an
+  aggregator covering club, ball-aware, and full-body capture
+  targets.  Cost-function code dispatches on `has_club()`,
+  `has_ball()`, `has_body()`.  See
+  [ADR 0006](docs/adr/0006-multi-source-motion-targets.md).
+- `load_body_target`, `load_club_target` — format-agnostic dispatcher
+  loaders in `src/shared/python/motion_matching/`.  Route on file
+  extension to the per-format loader under `loaders/`.
+- `default_body_segments` — helper returning the canonical full-body
+  segment label set; use it instead of hard-coding segment names in
+  cost terms or visualisations.
 - `align_to_simulation_grid.py` — re-time mocap onto a sim grid.
 - `cost.py`, `final_cost.py` — cost terms and aggregators.
 - `validators.py`, `validate_theta.py` — DbC checks for inputs.

--- a/docs/adr/0006-multi-source-motion-targets.md
+++ b/docs/adr/0006-multi-source-motion-targets.md
@@ -1,0 +1,182 @@
+# ADR 0006: Multi-Source Motion Targets
+
+- Status: Accepted
+- Date: 2026-05-08
+- Related issues: #4487
+
+## Context
+
+The motion-matching pipeline in `src/shared/python/motion_matching/` was
+originally built around a single frozen dataclass, `ClubTarget`, that
+captured the time-aligned six-degree-of-freedom trajectory of a club
+during a swing.  All cost terms, validators, alignment helpers, and
+visualisations consumed `ClubTarget` directly, and the Excel and C3D
+loaders both produced one.
+
+That design is no longer sufficient.  Two adjacent capture modalities
+are entering the pipeline:
+
+1. **Ball-aware club captures** — some sources record both the club
+   trajectory *and* the launch-frame ball state on the same clock
+   (impact-pinned).  Cost terms that score launch quality need both
+   tracks aligned to a shared time grid, but the ball track is
+   optional and not present in legacy xlsx workbooks.
+2. **Full-body motion capture** — C3D files from full-body marker sets
+   carry a heterogeneous bag of segment trajectories (pelvis, spine,
+   shoulders, elbows, wrists, hands, feet) that the pipeline wants to
+   match against forward-kinematic predictions from a physics engine.
+   These segments are independent of the club track and can come from
+   a separate file.
+
+Trying to bolt these onto `ClubTarget` creates a validation explosion:
+optional ball fields, optional segment dictionaries, optional segment
+labels, optional shared-clock metadata.  Every cost term then has to
+re-check which optional attributes are populated, and the post-init
+validator becomes a thicket of cross-field guards.
+
+The cost-function surface also needs to dispatch on what is actually
+available in a given run.  A "club only" run, a "club + ball" run, a
+"club + body" run, and a "club + ball + body" run share large amounts
+of code but score different terms.
+
+A separate forcing function is naming.  Several of the historical
+identifiers leaked source-specific terminology into otherwise generic
+code (the matcher tile is still labelled "Starting Pose Matcher", the
+xlsx variant carried a vendor-specific label).  Any restructuring is
+also an opportunity to clear those out so file-on-disk names can stay
+specific while everything in code, directories, and UI stays
+source-agnostic.
+
+## Decision
+
+Introduce three frozen dataclasses and one aggregator, plus a pair of
+format-agnostic dispatchers, and treat them as the canonical surface
+for downstream cost code:
+
+- `ClubTarget` — unchanged.  Six-DoF club trajectory on a sim timegrid.
+- `ClubBallTarget` — frozen dataclass adding launch-frame ball state on
+  the same impact-pinned clock as the club track.  Validates that ball
+  samples and club samples share the same time vector.
+- `BodyTarget` — frozen dataclass holding a labelled bag of segment
+  trajectories from a full-body capture.  Each segment carries its own
+  position (and where available, orientation) array on the shared time
+  vector.  A `default_body_segments` helper returns the canonical
+  segment labels for the supported marker set.
+- `MultiSourceTarget` — aggregator that holds at most one `ClubTarget`,
+  at most one `ClubBallTarget`, and at most one `BodyTarget`, plus the
+  shared time grid.  Exposes `has_club()`, `has_ball()`, and
+  `has_body()` accessors that cost-function code dispatches on.
+
+Loading is split into two format-agnostic dispatchers:
+
+- `load_club_target(path, ...)` — already present; routes on extension
+  (xlsx / xlsm / xls / c3d) to the per-format loader.
+- `load_body_target(path, ...)` — new dispatcher for full-body marker
+  sets.  Currently routes only `.c3d` to the C3D body-segment loader,
+  with the same dispatch shape as `load_club_target` so further
+  formats can plug in without changing call sites.
+
+A `MultiSourceTarget` is composed by the caller from one or more
+loader outputs; loaders themselves stay independent, so a script that
+only needs the club track does not pay the cost of opening a body
+file.
+
+### Generic-naming policy
+
+- File-on-disk names (vendor-specific xlsx workbooks, named C3D files)
+  remain whatever the source publishes them as.
+- Everything in code, directories, and UI stays source-agnostic:
+  `BodyTarget` not `MarkerSetTarget`, `load_body_target` not
+  `load_<vendor>_body`, `motion_target_preview` not
+  `<vendor>_starting_pose_matcher`.
+- This keeps the public surface stable when new vendors or capture
+  systems land — only the per-format loader inside `loaders/` changes.
+
+## Alternatives Considered
+
+### A. Single super-dataclass with optional fields
+
+Add ball, segment-bag, and shared-clock fields to `ClubTarget` itself
+and make them all `None`-able.
+
+Rejected.  The post-init validator becomes a combinatorial mess (ball
+implies club, body may or may not share a clock with club, segment
+labels must match a registered set when present, time vectors must
+agree across whichever subset is populated).  Cost-function code has
+to keep guarding on `is None` for every term it touches.  Worse, the
+"is this a body target?" question stops being answerable by type and
+becomes an attribute probe.
+
+### B. Abstract base class + Target subclasses
+
+Define a `Target` ABC and make `ClubTarget`, `ClubBallTarget`, and
+`BodyTarget` subclasses; have cost terms pattern-match on `isinstance`.
+
+Rejected.  Cost terms are not polymorphic over a single target — most
+of them want both a club track *and* a body track at once, so an ABC
+hierarchy implies dispatching N ways and re-assembling state on every
+call.  The flat frozen-dataclass + aggregator shape matches the actual
+data flow more honestly: cost terms receive one `MultiSourceTarget`
+and dispatch on `has_*()` for the terms they need.
+
+## Consequences
+
+### Positive
+
+- Cost-function code reads a single `MultiSourceTarget` and dispatches
+  on `has_club()`, `has_ball()`, `has_body()`.  No more `is None`
+  guards on optional attributes of the same dataclass.
+- Loaders stay independent and composable.  A caller that only needs
+  the club track does not pay the cost of opening a body file.
+- The dispatcher pattern (`load_club_target`, `load_body_target`)
+  scales: adding a new file format means adding one entry to the
+  routing table, not changing every call site.
+- Naming cleanup clears the source-revealing identifiers out of code
+  and UI without forcing renames on the underlying capture files.
+
+### Negative
+
+- One additional aggregation step at call sites that previously
+  consumed a `ClubTarget` directly.  A thin shim lets legacy code keep
+  passing a bare `ClubTarget` for one release while migrating.
+- Three dataclasses and one aggregator is more surface than one
+  dataclass.  The trade-off is paid back in cost-term clarity.
+
+## Validation Strategy
+
+- Every dataclass runs post-init validation:
+  - `ClubBallTarget` checks that ball samples share the club time
+    vector and that quaternions are unit-normalised within
+    `QUAT_NORM_TOL`.
+  - `BodyTarget` checks that every segment trajectory shares the
+    declared time vector and that segment labels come from the
+    registered set returned by `default_body_segments`.
+  - `MultiSourceTarget` checks that whatever subset of
+    `ClubTarget` / `ClubBallTarget` / `BodyTarget` it holds shares a
+    time grid (when the caller has declared `impact_source`).
+- Dispatchers refuse unsupported extensions with a `ValueError` that
+  lists the supported set, matching the existing `load_club_target`
+  error shape.
+- Cost terms that require a particular track call the matching
+  `has_*()` accessor and raise `ValueError` with a descriptive message
+  if the required track is absent.
+
+## Migration
+
+- Existing `load_club_target` callers continue to work unchanged.
+- Cost terms that consumed a bare `ClubTarget` accept either a
+  `ClubTarget` or a `MultiSourceTarget` for one release; the bare
+  form is wrapped internally and a `DeprecationWarning` points at the
+  new aggregator.
+- No on-disk format changes.  Existing xlsx / C3D files are still
+  loaded by the same per-format loaders.
+
+## References
+
+- `src/shared/python/motion_matching/club_target.py` — current
+  `ClubTarget` definition.
+- `src/shared/python/motion_matching/load_club_target.py` — existing
+  dispatcher whose shape `load_body_target` mirrors.
+- `src/shared/python/motion_matching/loaders/` — per-format loaders.
+- `docs/user_guide/motion_matching/loading_targets.md` — companion
+  user-guide for the new surface.

--- a/docs/motion_matching/README.md
+++ b/docs/motion_matching/README.md
@@ -1,0 +1,37 @@
+# Motion Matching Documentation
+
+Entry point for documentation covering UpstreamDrift's motion-matching
+pipeline: target loading, cost terms, validation, and the desktop
+preview tool.
+
+## Contents
+
+### Architecture decisions
+
+- [ADR 0006 — Multi-Source Motion Targets](../adr/0006-multi-source-motion-targets.md)
+  Decision record for the `ClubTarget` / `ClubBallTarget` / `BodyTarget`
+  + `MultiSourceTarget` aggregator surface and the format-agnostic
+  loader dispatchers.
+
+### Specifications
+
+- [CLUB_IK_SPEC](../../src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/motion_matching/shared/CLUB_IK_SPEC.md)
+  Inverse-kinematics specification for the club chain shared between
+  the MATLAB and Python loaders.
+
+### Tools
+
+- [Starting-Pose Matcher README](../../src/tools/starting_pose_matcher/README.md)
+  PyQt6 desktop tool for previewing motion targets and aligning
+  starting poses before optimisation.
+
+### User guides
+
+- [Loading Motion Targets](../user_guide/motion_matching/loading_targets.md)
+  How to load club, ball-aware, and full-body targets from xlsx,
+  `.mat`, and `.c3d` sources, including a worked example.
+
+### Related guides
+
+- [Surrogate Training Guide](SURROGATE_TRAINING_GUIDE.md)
+  Training the surrogate model that the matcher consumes.

--- a/docs/user_guide/motion_matching/loading_targets.md
+++ b/docs/user_guide/motion_matching/loading_targets.md
@@ -1,0 +1,162 @@
+# Loading Motion Targets
+
+This guide walks through loading club, ball-aware, and full-body motion
+targets and assembling them into a `MultiSourceTarget` for the
+motion-matching pipeline.  See
+[ADR 0006](../../adr/0006-multi-source-motion-targets.md) for the
+design rationale.
+
+## Source formats at a glance
+
+| Source                     | Loader              | Returns           |
+| -------------------------- | ------------------- | ----------------- |
+| Wiffle-style xlsx workbook | `load_club_target`  | `ClubTarget`      |
+| C3D club capture           | `load_club_target`  | `ClubTarget`      |
+| MAT club capture           | `load_club_target`  | `ClubTarget`      |
+| C3D full-body marker set   | `load_body_target`  | `BodyTarget`      |
+
+Both dispatchers route on file extension, so call sites do not need to
+special-case the source format.
+
+## Loading a club track
+
+```python
+from pathlib import Path
+
+from src.shared.python.motion_matching import load_club_target
+from src.shared.python.motion_matching.target import AlignOptions
+
+# xlsx workbook -- a sheet name is required.
+club = load_club_target(
+    Path("data/Club_Data.xlsx"),
+    sheet="Driver",
+    opts=AlignOptions(),
+)
+
+# C3D capture -- no sheet argument; impact alignment is read from the
+# event channel.
+club = load_club_target(Path("data/C3D_TA_Driver.c3d"))
+
+# MAT capture -- routed the same way.
+club = load_club_target(Path("data/some_capture.mat"))
+```
+
+The returned `ClubTarget` carries a unit-normalised quaternion track,
+position samples on the simulation timegrid, and impact-pinned
+indices.  Validation runs in `__post_init__`; an invalid file raises
+`ValueError`.
+
+## Loading a body track
+
+```python
+from src.shared.python.motion_matching import load_body_target
+
+body = load_body_target(Path("data/C3D_TA_Driver.c3d"))
+```
+
+`load_body_target` returns a `BodyTarget` containing a labelled
+mapping of segment trajectories.  The default segment set is exposed
+by the `default_body_segments` helper for callers that want to
+restrict cost terms to a known subset:
+
+```python
+from src.shared.python.motion_matching import default_body_segments
+
+segments = default_body_segments()
+# ('pelvis', 'spine', 'torso', 'left_shoulder', 'right_shoulder',
+#  'left_elbow', 'right_elbow', 'left_wrist', 'right_wrist',
+#  'left_hand', 'right_hand', ...)
+```
+
+Unsupported extensions raise `ValueError` with the supported set listed
+in the message, matching the `load_club_target` behaviour.
+
+## Sharing a clock between body and club
+
+When the body capture and the club capture come from the same session
+and share an impact event, pass `impact_source` so the aggregator
+re-times both onto the same grid:
+
+```python
+from src.shared.python.motion_matching import MultiSourceTarget
+
+target = MultiSourceTarget(
+    club=club,
+    body=body,
+    impact_source="club",   # club track defines t=0 at impact
+)
+```
+
+`impact_source` accepts `"club"`, `"body"`, or `"explicit"`.  If the
+two tracks already agree on time, `MultiSourceTarget` validates that
+their time vectors are equal within `TIME_EPS`.  If not, the body
+track is re-aligned to the chosen impact source and re-validated.
+
+## Worked example: a representative full-body mocap capture
+
+The repository ships with a small representative full-body mocap
+capture, `data/C3D_TA_Driver.c3d`, that contains both a club track and
+a body marker set on the same clock.  This example walks through
+loading both, assembling a `MultiSourceTarget`, and querying the
+aggregator from cost-function code.
+
+```python
+from pathlib import Path
+
+from src.shared.python.motion_matching import (
+    MultiSourceTarget,
+    load_body_target,
+    load_club_target,
+)
+
+capture_path = Path("data/C3D_TA_Driver.c3d")
+
+# 1.  Load the club track.  AlignOptions defaults to a 1 kHz sim grid
+#     pinned at impact.
+club = load_club_target(capture_path)
+
+# 2.  Load the body markers from the same file.  The body loader
+#     reads the same impact event, so both tracks land on the same
+#     clock.
+body = load_body_target(capture_path)
+
+# 3.  Assemble a MultiSourceTarget.  impact_source="club" pins the
+#     shared clock to the club's impact frame.
+target = MultiSourceTarget(
+    club=club,
+    body=body,
+    impact_source="club",
+)
+
+assert target.has_club()
+assert target.has_body()
+assert not target.has_ball()  # this capture has no launch ball state
+```
+
+A cost-function call site then dispatches on the `has_*()` accessors:
+
+```python
+def total_cost(target: MultiSourceTarget, prediction) -> float:
+    cost = 0.0
+    if target.has_club():
+        cost += club_pose_cost(target.club, prediction.club)
+    if target.has_body():
+        cost += body_segment_cost(target.body, prediction.body)
+    if target.has_ball():
+        cost += launch_state_cost(target.ball, prediction.launch)
+    return cost
+```
+
+Because the dispatcher / accessor pattern is uniform, adding a new
+track type later (for example, a force-plate channel) is a matter of
+adding one accessor and one dataclass — call sites that do not need
+the new track do not change.
+
+## Naming conventions
+
+File-on-disk names follow whatever the capture system publishes; this
+guide uses the literal filenames present in `data/`.  Everything
+above the loader boundary uses source-agnostic names: `BodyTarget`
+not `MarkerSetTarget`, `load_body_target` not the per-vendor variant.
+The motivation is documented in
+[ADR 0006](../../adr/0006-multi-source-motion-targets.md).


### PR DESCRIPTION
Closes #4485

## Summary

Adds documentation for the multi-source motion-target surface
(`ClubTarget` / `ClubBallTarget` / `BodyTarget` + `MultiSourceTarget`
aggregator with format-agnostic `load_club_target` / `load_body_target`
dispatchers).

## Files added / changed

- New: `docs/adr/0006-multi-source-motion-targets.md` — ADR (Accepted)
  covering context, decision, alternatives considered, consequences,
  validation strategy, and the generic-naming policy.
- New: `docs/user_guide/motion_matching/loading_targets.md` — user
  guide walking through xlsx / `.mat` / `.c3d` loading, sharing a
  clock between body and club via `impact_source`, and a worked
  example using a representative full-body mocap capture, including
  a `MultiSourceTarget` construction snippet.
- New: `docs/motion_matching/README.md` — index linking to the new
  ADR, `CLUB_IK_SPEC.md`, the matcher README, the new user guide,
  and the surrogate training guide.
- Updated: `AGENTS.md` — adds `BodyTarget`, `ClubBallTarget`,
  `MultiSourceTarget`, the `load_body_target` / `load_club_target`
  dispatchers, and `default_body_segments` to the shared-infrastructure
  directory.

## Generic naming

Code, directories, and UI references stay source-agnostic. The
worked example uses the literal filename `data/C3D_TA_Driver.c3d`
present in the repo, framed in prose as "a representative full-body
mocap capture".

## Test plan

- [x] `python3 -m ruff check .` — no new violations introduced (pre-existing failures unchanged; no Python changes in this PR)
- [x] Visual inspection of all four markdown files (no `.markdownlint.json` present in the repo)
- [ ] Reviewer confirms ADR style mirrors `docs/adr/0004-launcher-provider-migration.md`