### PR TITLE
fix(starting-pose-matcher): import missing load_skeleton in gui.py

### DIFF
--- a/src/tools/starting_pose_matcher/gui.py
+++ b/src/tools/starting_pose_matcher/gui.py
@@ -35,7 +35,6 @@ Or, from the GolfLauncher tile (registered in ``src/config/models.yaml``).
 """
 
 from __future__ import annotations
-from src.tools.starting_pose_matcher.utils import load_skeleton
 
 from contextlib import suppress
 import json
@@ -99,6 +98,7 @@ from src.tools.starting_pose_matcher.core import (
     SkeletonTrajectory,
     load_mocap_xlsx,
     load_simscape_trajectory_csv,
+    load_skeleton,
     phase_display_label as _phase_display_label,
     phase_key_from_label as _phase_key_from_label,
     read_event_header,


### PR DESCRIPTION
## Summary

The import `from src.tools.starting_pose_matcher.utils import load_skeleton` referenced a non-existent `utils` module, producing F821 in CI and a `ModuleNotFoundError` at import time. The function actually lives in `core.py`. Moved it into the existing `core` import block.

This was preexisting on `main` and was blocking #4500 via the repo-level lint baseline.

Unblocks #4500.

## Test plan
- [x] `python3 -m ruff check src/tools/starting_pose_matcher/gui.py` clean
- [x] `python3 -m ruff format --check` clean
- [x] `python -c "from src.tools.starting_pose_matcher import gui"` imports cleanly
- [x] Matcher unit tests still pass (preexisting unrelated mujoco/pinocchio provider failures persist on main)