### PR TITLE
fix(upstream-drift-tools): defensive import in utils/logging

### DIFF
--- a/src/shared/python/upstream_drift_tools/utils/logging.py
+++ b/src/shared/python/upstream_drift_tools/utils/logging.py
@@ -1,15 +1,15 @@
-"""Logging utilities for upstream_drift_tools.
-
-Uses shared logging configuration from utils.logging_utils.
-"""
+"""Logging utilities for upstream_drift_tools."""
 
 from __future__ import annotations
 
 import logging
 import sys
 
-# Import shared logging configuration
-from utils.logging_utils import DEFAULT_FORMAT
+# Default log format. Previously imported from a top-level ``utils.logging_utils``
+# module that does not exist in this repo, which raised ``ModuleNotFoundError``
+# in CI contexts where ``utils`` was not on ``sys.path``. Inlined here to make
+# the module self-contained.
+DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 
 def get_logger(


### PR DESCRIPTION
## Summary

`src/shared/python/upstream_drift_tools/utils/logging.py:12` had `from utils.logging_utils import DEFAULT_FORMAT`, referencing a top-level `utils` package that does not exist anywhere in this repo. This raised `ModuleNotFoundError: No module named 'utils'` in CI contexts where `utils` was not on `sys.path`.

`DEFAULT_FORMAT` is just a log-format string. Inlined it so the module is self-contained — no behavioral change.

Unblocks #4493's leaderboard regen.

## Test plan
- [x] `python -c "from src.shared.python.upstream_drift_tools.utils.logging import *; print('OK')"` succeeds
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Smoke `pytest -k "leaderboard or upstream_drift_tools"` — preexisting unrelated failures persist; no new failures from this change