### PR TITLE
fix(motion-matching): three real-data bugs found by end-to-end testing

### DIFF
--- a/src/shared/python/motion_matching/loaders/c3d_body.py
+++ b/src/shared/python/motion_matching/loaders/c3d_body.py
@@ -382,16 +382,19 @@ def load_body_target_c3d(
     # --- Determine impact + grid ------------------------------------------
     if impact_source is not None:
         sim_time = np.asarray(impact_source.time, dtype=np.float64).copy()
-        # Use the same impact target time as the club target lands on; this
-        # keeps the two clocks identical without re-running impact detection.
+        # Reuse the club's resampled-grid impact index directly so the two
+        # clocks land on the same sample. ``impact_idx`` is 0-based on the
+        # resampled grid (see ClubTarget contract). Re-deriving it via argmin
+        # would introduce a 1-sample drift when the chosen impact_target_t_s
+        # falls between grid samples.
+        impact_idx_out = int(impact_source.impact_idx)
         impact_target_t_s = (
-            float(sim_time[int(impact_source.impact_idx) - 1])
-            if 1 <= int(impact_source.impact_idx) <= sim_time.size
+            float(sim_time[impact_idx_out])
+            if 0 <= impact_idx_out < sim_time.size
             else float(opts.impact_target_t_s)
         )
         impact_raw = _detect_impact_via_wrist(raw_time, z_up)
         time_offset = float(raw_time[impact_raw]) - impact_target_t_s
-        impact_idx_out = int(np.argmin(np.abs(sim_time - impact_target_t_s)))
     else:
         sim_time = _build_sim_grid(opts)
         impact_raw = _detect_impact_via_wrist(raw_time, z_up)

--- a/src/shared/python/upstream_drift_tools/lab/bio/_c3d_markers.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/_c3d_markers.py
@@ -40,14 +40,20 @@ def validate_marker_positions(
         )
         return
 
-    if min_pos < BIOMECHANICAL_MARKER_MIN_M:
+    # Heuristic: only flag suspiciously small positive coordinates. Negative
+    # values up to ~2 m are normal for swing data when the world origin is
+    # placed at the target (clubs and body sweep behind the player on the
+    # backswing). Filtering on |min_pos| < 1mm AND min_pos >= 0 avoids the
+    # false positive seen on Tour-average driver/iron files where
+    # min_pos ~= -1.97 m.
+    if 0.0 <= min_pos < BIOMECHANICAL_MARKER_MIN_M:
         logger.warning(
-            "\u26a0\ufe0f Suspiciously small marker positions detected (< 1mm). "
-            f"Min position: {min_pos:.6f}m. "
-            f"Source units: {source_units}, target: "
-            f"{target_units or 'unchanged'}. "
-            "Guideline P1: Verify unit conversion is correct to "
-            "avoid 1000x errors."
+            "Suspiciously small marker positions detected (< 1mm). "
+            "Min position: %.6f m. Source units: %s, target: %s. "
+            "Guideline P1: Verify unit conversion is correct to avoid 1000x errors.",
+            min_pos,
+            source_units,
+            target_units or "unchanged",
         )
 
     if max_pos > BIOMECHANICAL_MARKER_MAX_M:

--- a/src/tools/starting_pose_matcher/live_view_controller.py
+++ b/src/tools/starting_pose_matcher/live_view_controller.py
@@ -53,20 +53,32 @@ def _default_body_segments_safe(marker_names: tuple[str, ...]) -> list[tuple[int
     """Return body-skeleton segment index pairs.
 
     Tries to import ``default_body_segments`` from the body-skeleton
-    module first (PR #4496). Falls back to a minimal heuristic — pairs
-    of consecutive markers — if the module is not yet on this branch.
-    The fallback keeps the live view working even if the upstream PR
-    has not merged yet; the test does not depend on the exact pairing.
+    module first. That helper returns ``BodySegment`` dataclasses keyed
+    on marker NAMES — we map back to integer indices into
+    ``marker_names`` here so :func:`precompute_segments_from_pairs`
+    receives the ``(int, int)`` pairs it expects. Falls back to a minimal
+    heuristic (pairs of consecutive markers) when the helper is absent
+    or any segment endpoint is missing from ``marker_names``.
     """
     try:
-        from motion_matching.body_skeleton import (  # type: ignore[import-not-found]
+        from src.shared.python.motion_matching.body_skeleton import (
             default_body_segments,
         )
 
-        return list(default_body_segments(marker_names))
+        name_to_idx = {n: i for i, n in enumerate(marker_names)}
+        pairs: list[tuple[int, int]] = []
+        for seg in default_body_segments(marker_names):
+            ia = name_to_idx.get(getattr(seg, "a", None))
+            ib = name_to_idx.get(getattr(seg, "b", None))
+            if ia is not None and ib is not None:
+                pairs.append((ia, ib))
+        if pairs:
+            return pairs
+        # Empty result -> fall through to consecutive-pairs fallback
     except Exception:  # pragma: no cover - branch-dependent import
-        m = len(marker_names)
-        return [(i, i + 1) for i in range(m - 1)]
+        pass
+    m = len(marker_names)
+    return [(i, i + 1) for i in range(m - 1)]
 
 
 class LiveViewController:
@@ -222,7 +234,7 @@ class LiveViewController:
         # load lands a properly framed view (acceptance criterion).
         if fit_points and not self._auto_fit_done:
             try:
-                from motion_matching.diagnostics._skeleton_render import (
+                from src.shared.python.motion_matching.diagnostics._skeleton_render import (  # noqa: E501
                     equalize_3d_axes,
                 )
 


### PR DESCRIPTION
End-to-end smoke test against `data/C3D_TA_Driver.c3d` and `data/C3D_TA_Iron.c3d` surfaced three real bugs that unit tests against synthetic data did not catch.

## Fixes

1. **`live_view_controller.py` import paths** — `equalize_3d_axes` and `default_body_segments` were imported from bare `motion_matching.*` paths that don't resolve at runtime. Switched to canonical `src.shared.python.motion_matching.*` paths.

2. **Segment-pairs type mismatch** — `default_body_segments` returns `BodySegment` dataclasses keyed on marker NAME strings, but `precompute_segments_from_pairs` expects `(int, int)` index pairs. Added a `marker_names`→index map step before passing through.

3. **Body-target `impact_idx` off-by-one** — when `impact_source=club_target` is supplied, the body loader was re-deriving `impact_idx_out` via `argmin(|sim_time - target_t|)`, drifting one sample off the club's true impact (250 vs 251). Now reuses `impact_source.impact_idx` directly so body and club share the resampled grid clock exactly.

4. **Windows cp1252 logging crash** — the "<1mm coords" validation warning included a `⚠️` emoji that broke Windows logging. Stripped the emoji. Also tightened the heuristic to only fire for non-negative coords; the previous version false-positived on every swing-data file because marker `x` ranges legitimately include negative values.

## Test results

All 76 motion-matching unit + integration + UI tests pass against the real C3D fixtures:

```
76 passed, 16 skipped, 2 warnings
```

(The 16 skips are `.mat` data fixtures not committed to the repo.)

## End-to-end smoke (real data)

- BodyTarget loads 27 anatomical markers, 301 samples, impact at frame 250
- ClubTarget loads, **clubhead speed at impact = 51.03 m/s = 114.2 mph (Tour-average driver)**
- ClubBallTarget extractor produces ball state
- MultiSourceTarget composes both with shared timegrid
- LiveViewController scrubs through frames 0/100/250/300 without crash

## Test plan

- [x] `python3 -m pytest tests/ui/test_live_view_controller.py tests/integration/test_c3d_body_pipeline.py tests/integration/test_multi_source_pipeline.py tests/unit/motion_matching/ -n auto --timeout=60` — all green
- [x] End-to-end smoke against `data/C3D_TA_Driver.c3d` confirms Tour-average impact speed
- [x] Ruff check + format clean on touched files