### PR TITLE
fix(docker): add WSL fallback for Docker build on Windows

### DIFF
--- a/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
+++ b/src/engines/physics_engines/mujoco/docker/gui/golf_gui_docker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -67,6 +68,14 @@ class DockerMixin:
     """
 
     @staticmethod
+    def _get_docker_cmd() -> list[str]:
+        if shutil.which("docker"):
+            return ["docker"]
+        if os.name == "nt" and shutil.which("wsl"):
+            return ["wsl", "docker"]
+        return ["docker"]
+
+    @staticmethod
     def _generate_update_dockerfile() -> str:
         """Generate a minimal Dockerfile to add missing dependencies."""
         return (
@@ -102,8 +111,7 @@ class DockerMixin:
     def _verify_docker_update(self) -> None:
         """Run a quick container test to verify defusedxml is available."""
         host = cast("DockerProtocol", self)
-        test_cmd = [
-            "docker",
+        test_cmd = self._get_docker_cmd() + [
             "run",
             "--rm",
             "upstream-drift:engine",
@@ -146,7 +154,7 @@ class DockerMixin:
                     with open(dockerfile_path, "w") as f:
                         f.write(dockerfile_content)
 
-                    cmd = ["docker", "build", "-t", "upstream-drift:engine", "."]
+                    cmd = self._get_docker_cmd() + ["build", "-t", "upstream-drift:engine", "."]
                     host.root.after(0, host.log, f"Running: {' '.join(cmd)}")
                     host.root.after(
                         0, host.log, "Adding defusedxml to upstream-drift..."

--- a/src/launchers/docker_manager.py
+++ b/src/launchers/docker_manager.py
@@ -7,8 +7,17 @@ orthogonality of the main launcher application.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+def get_docker_cmd() -> list[str]:
+    """Get the base docker command, using WSL fallback on Windows if needed."""
+    if shutil.which("docker"):
+        return ["docker"]
+    if os.name == "nt" and shutil.which("wsl"):
+        return ["wsl", "docker"]
+    return ["docker"]
 
 from PyQt6.QtCore import QThread, pyqtSignal
 
@@ -36,7 +45,7 @@ class DockerCheckThread(QThread):
         """Run docker check."""
         try:
             secure_run(
-                ["docker", "--version"],
+                get_docker_cmd() + ["--version"],
                 timeout=5.0,
                 check=True,
                 stdout=subprocess.DEVNULL,
@@ -77,8 +86,7 @@ class DockerBuildThread(QThread):
             )
             return
 
-        cmd = [
-            "docker",
+        cmd = get_docker_cmd() + [
             "build",
             "-t",
             self.image_name,
@@ -177,7 +185,7 @@ class DockerLauncher:
         """
         try:
             result = subprocess.run(
-                ["docker", "image", "inspect", self.image_name],
+                get_docker_cmd() + ["image", "inspect", self.image_name],
                 capture_output=True,
                 timeout=10,
             )
@@ -186,7 +194,7 @@ class DockerLauncher:
 
             for legacy_image in LEGACY_DOCKER_IMAGE_ALIASES:
                 legacy_result = subprocess.run(
-                    ["docker", "image", "inspect", legacy_image],
+                    get_docker_cmd() + ["image", "inspect", legacy_image],
                     capture_output=True,
                     timeout=10,
                 )
@@ -223,8 +231,7 @@ class DockerLauncher:
             raise ValueError("model_type must be provided")
         if not (model_type is not None):
             raise ValueError("model_type must be provided")
-        cmd = [
-            "docker",
+        cmd = get_docker_cmd() + [
             "run",
             "--rm",
             "-v",


### PR DESCRIPTION
This PR ensures that when Docker is not installed natively on Windows (but exists inside WSL), the UI correctly falls back to using wsl docker to build and run containers. Resolves FileNotFoundError when launching Docker commands from Windows hosts without Docker Desktop.