### PR TITLE
[Mocap Pipeline 1/10] Canonical Intermediate Representation (CIR) — Pydantic contracts

### DIFF
--- a/src/learning/retargeting/retargeter.py
+++ b/src/learning/retargeting/retargeter.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+    from src.shared.python.motion_pipeline import SkeletonRig
 
 
 def _squared_euclidean_error(
@@ -52,6 +55,12 @@ class SkeletonConfig:
 
     def __post_init__(self) -> None:
         """Validate skeleton configuration."""
+        warnings.warn(
+            "SkeletonConfig is deprecated; use "
+            "src.shared.python.motion_pipeline.SkeletonRig instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         n_joints = len(self.joint_names)
 
         if len(self.parent_indices) != n_joints:
@@ -128,6 +137,68 @@ class SkeletonConfig:
             idx = self.parent_indices[idx]
 
         return chain
+
+    def to_skeleton_rig(self) -> SkeletonRig:
+        """Build the canonical motion-pipeline ``SkeletonRig`` from this config.
+
+        Adapter for incremental migration to
+        ``src.shared.python.motion_pipeline.SkeletonRig``. Defaults are
+        applied for axes / limits if absent (z-axis, +/- pi).
+        """
+        # Lazy import avoids a circular dependency at module load.
+        import math
+
+        from src.shared.python.motion_pipeline import (
+            JointAxis,
+            JointLimit,
+            SkeletonRig as _SkeletonRig,
+        )
+
+        n = len(self.joint_names)
+        offsets = [
+            (
+                float(self.joint_offsets[i, 0]),
+                float(self.joint_offsets[i, 1]),
+                float(self.joint_offsets[i, 2]),
+            )
+            for i in range(n)
+        ]
+        if self.joint_axes is None:
+            axes = [JointAxis.from_cardinal("Z") for _ in range(n)]
+        else:
+            axes = []
+            for i in range(n):
+                vec = (
+                    float(self.joint_axes[i, 0]),
+                    float(self.joint_axes[i, 1]),
+                    float(self.joint_axes[i, 2]),
+                )
+                norm = math.sqrt(sum(c * c for c in vec))
+                if norm == 0.0:
+                    axes.append(JointAxis.from_cardinal("Z"))
+                else:
+                    axes.append(
+                        JointAxis(vector=(vec[0] / norm, vec[1] / norm, vec[2] / norm))
+                    )
+        if self.joint_limits is None:
+            limits = [JointLimit(lo=-math.pi, hi=math.pi) for _ in range(n)]
+        else:
+            limits = [
+                JointLimit(
+                    lo=float(self.joint_limits[i, 0]),
+                    hi=float(self.joint_limits[i, 1]),
+                )
+                for i in range(n)
+            ]
+        return _SkeletonRig(
+            joint_names=list(self.joint_names),
+            parents=list(self.parent_indices),
+            tpose_offsets=offsets,
+            axes=axes,
+            limits=limits,
+            semantic_labels=dict(self.semantic_labels),
+            end_effectors=list(self.end_effectors),
+        )
 
     @classmethod
     def create_humanoid(cls) -> SkeletonConfig:

--- a/src/shared/python/motion_pipeline/__init__.py
+++ b/src/shared/python/motion_pipeline/__init__.py
@@ -1,0 +1,60 @@
+"""Motion pipeline canonical intermediate representation (CIR).
+
+Pydantic v2 contracts for the markerless mocap to motion-matching
+pipeline. This package is the foundation of epic #4558 -- every later
+stage depends on these types. It must not import from engines, api,
+learning, apps, tools, or deployment (Law of Demeter at the package
+level).
+"""
+
+from src.shared.python.motion_pipeline.contracts import (
+    Calibration,
+    CostWeights,
+    EngineType,
+    JointAxis,
+    JointLimit,
+    JointStateFrame,
+    JointTrajectory,
+    KeypointFrame,
+    KeypointSchema,
+    KeypointSequence,
+    MarkerFrame,
+    MarkerSample,
+    MarkerTrajectory,
+    MotionMatchingRequest,
+    MotionMatchingResult,
+    MotionTrajectory,
+    MuscleActivationTrajectory,
+    Provenance,
+    ResidualReport,
+    SkeletonRig,
+    TorqueTrajectory,
+    UnitSystem,
+    WorldUp,
+)
+
+__all__ = [
+    "Calibration",
+    "CostWeights",
+    "EngineType",
+    "JointAxis",
+    "JointLimit",
+    "JointStateFrame",
+    "JointTrajectory",
+    "KeypointFrame",
+    "KeypointSchema",
+    "KeypointSequence",
+    "MarkerFrame",
+    "MarkerSample",
+    "MarkerTrajectory",
+    "MotionMatchingRequest",
+    "MotionMatchingResult",
+    "MotionTrajectory",
+    "MuscleActivationTrajectory",
+    "Provenance",
+    "ResidualReport",
+    "SkeletonRig",
+    "TorqueTrajectory",
+    "UnitSystem",
+    "WorldUp",
+]

--- a/src/shared/python/motion_pipeline/contracts.py
+++ b/src/shared/python/motion_pipeline/contracts.py
@@ -1,733 +1,661 @@
-"""
-Canonical Intermediate Representation (CIR) for Motion Capture Pipeline.
+"""Canonical Intermediate Representation (CIR) for the motion pipeline.
 
-This module defines the Pydantic v2 contracts that every pipeline stage reads/writes.
-It unifies engine-specific dataclasses and API models into a single canonical representation.
+Pydantic v2 contracts shared by every stage of the markerless mocap to
+motion-matching pipeline (epic #4558). Validators enforce DbC-style
+invariants (monotonic timestamps, finite values, dimensional
+consistency, acyclic parent indices, etc.).
 
-Models:
-- Calibration: Camera intrinsics/extrinsics, unit system, source FPS, world-up axis
-- KeypointFrame: 2D or 3D keypoints with confidences
-- KeypointSequence: Timestamped sequence of KeypointFrame
-- MarkerFrame / MarkerTrajectory: Labeled 3D markers
-- SkeletonRig: Joints, parents, T-pose offsets, axes, limits
-- JointStateFrame / JointTrajectory: q, qdot, qddot, time
-- MotionTrajectory: Skeleton + joint trajectory + metadata
-- MotionMatchingRequest / MotionMatchingResult: Solver inputs/outputs
+This module has zero dependencies on engine, api, learning, apps,
+tools, or deployment packages -- enforced by
+``tests/unit/motion_pipeline/test_lod.py``.
 """
 
 from __future__ import annotations
 
-import json
-from datetime import datetime
-from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+import math
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
 
-import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from pydantic.functional_validators import AfterValidator
-from typing_extensions import Annotated
 
-from src.shared.python.contracts import invariant
-
-
-# =============================================================================
-# Type Aliases
-# =============================================================================
-
-ArrayLike = Union[List[float], np.ndarray]
-SchemaName = Literal["BODY_25", "MediaPipe_33", "COCO_17", "OpenPose_25", "custom"]
-Axis = Literal["X", "Y", "Z", "+X", "-X", "+Y", "-Y", "+Z", "-Z"]
-UpAxis = Literal["+Y", "+Z", "+X", "-Y", "-Z", "-X"]
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
 
 
-# =============================================================================
+class UnitSystem(str, Enum):
+    """Length unit system."""
+
+    MILLIMETERS = "mm"
+    METERS = "m"
+
+
+class WorldUp(str, Enum):
+    """World up-axis convention."""
+
+    Y_UP = "Y_UP"
+    Z_UP = "Z_UP"
+
+
+class KeypointSchema(str, Enum):
+    """Recognised 2D/3D keypoint topologies."""
+
+    BODY_25 = "BODY_25"
+    MEDIAPIPE_33 = "MEDIAPIPE_33"
+    COCO_17 = "COCO_17"
+    CUSTOM = "CUSTOM"
+
+
+class EngineType(str, Enum):
+    """Physics engines targetable by the motion pipeline.
+
+    Lowercase string values match the convention used elsewhere in the
+    codebase (see ``EngineManager``).
+    """
+
+    MUJOCO = "mujoco"
+    OPENSIM = "opensim"
+    DRAKE = "drake"
+    PINOCCHIO = "pinocchio"
+    MYOSUITE = "myosuite"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _all_finite(values: Any) -> bool:
+    """Return True iff every scalar in ``values`` is finite."""
+    if isinstance(values, bool):
+        return True
+    if isinstance(values, (int, float)):
+        return math.isfinite(float(values))
+    try:
+        iterator = iter(values)
+    except TypeError:
+        return True
+    return all(_all_finite(item) for item in iterator)
+
+
+def _is_monotonic(timestamps: list[float]) -> bool:
+    """Return True iff ``timestamps`` is non-decreasing."""
+    return all(timestamps[i] <= timestamps[i + 1] for i in range(len(timestamps) - 1))
+
+
+_FROZEN = ConfigDict(frozen=True, arbitrary_types_allowed=False)
+
+
+# ---------------------------------------------------------------------------
 # Calibration
-# =============================================================================
-
-
-class CameraIntrinsics(BaseModel):
-    """Camera intrinsic parameters."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    fx: float = Field(..., description="Focal length x (pixels)", gt=0)
-    fy: float = Field(..., description="Focal length y (pixels)", gt=0)
-    cx: float = Field(..., description="Principal point x (pixels)")
-    cy: float = Field(..., description="Principal point y (pixels)")
-    k1: float = Field(default=0.0, description="Radial distortion coefficient 1")
-    k2: float = Field(default=0.0, description="Radial distortion coefficient 2")
-    p1: float = Field(default=0.0, description="Tangential distortion coefficient 1")
-    p2: float = Field(default=0.0, description="Tangential distortion coefficient 2")
-
-    @field_validator("fx", "fy", "cx", "cy")
-    @classmethod
-    def check_finite(cls, v: float) -> float:
-        if not np.isfinite(v):
-            raise ValueError("Value must be finite")
-        return v
-
-
-class CameraExtrinsics(BaseModel):
-    """Camera extrinsic parameters (world-to-camera transform)."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    rotation: List[List[float]] = Field(
-        default_factory=lambda: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-        description="3x3 rotation matrix (world-to-camera)",
-    )
-    translation: List[float] = Field(
-        default_factory=lambda: [0.0, 0.0, 0.0],
-        description="Translation vector (world-to-camera, meters)",
-    )
-
-    @field_validator("rotation")
-    @classmethod
-    def check_rotation_shape(cls, v: List[List[float]]) -> List[List[float]]:
-        if len(v) != 3 or any(len(row) != 3 for row in v):
-            raise ValueError("Rotation must be 3x3 matrix")
-        return v
-
-    @field_validator("translation")
-    @classmethod
-    def check_translation_shape(cls, v: List[float]) -> List[float]:
-        if len(v) != 3:
-            raise ValueError("Translation must be length 3")
-        return v
+# ---------------------------------------------------------------------------
 
 
 class Calibration(BaseModel):
-    """Multi-camera calibration data."""
+    """Single-camera calibration.
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    Multi-camera setups are represented as ``list[Calibration]`` by
+    callers; each element is one camera with its own intrinsics /
+    extrinsics. Intrinsics and extrinsics are optional so that purely
+    monocular pipelines (without explicit calibration) can still flow
+    through the CIR.
+    """
 
-    id: str = Field(..., description="Unique calibration identifier")
-    cameras: Dict[str, Dict[str, Any]] = Field(
-        default_factory=dict,
-        description="Camera ID -> {intrinsics, extrinsics}",
-    )
-    unit_system: Literal["meters", "millimeters", "pixels"] = Field(
-        default="meters", description="Unit system for 3D coordinates"
-    )
-    source_fps: float = Field(..., description="Source capture frame rate (Hz)", gt=0)
-    world_up_axis: UpAxis = Field(
-        default="+Y", description="World coordinate system up axis"
-    )
-    calibrated_at: datetime = Field(
-        default_factory=datetime.now, description="Calibration timestamp"
-    )
+    model_config = _FROZEN
 
-    @field_validator("source_fps")
+    camera_id: str = Field(..., min_length=1)
+    intrinsics: list[list[float]] | None = None
+    extrinsics: list[list[float]] | None = None
+    source_fps: float = Field(..., gt=0.0)
+    unit_system: UnitSystem
+    world_up: WorldUp
+
+    @field_validator("intrinsics")
     @classmethod
-    def check_fps_finite(cls, v: float) -> float:
-        if not np.isfinite(v):
-            raise ValueError("FPS must be finite")
+    def _check_intrinsics(cls, v: list[list[float]] | None) -> list[list[float]] | None:
+        if v is None:
+            return v
+        if len(v) != 3 or any(len(row) != 3 for row in v):
+            raise ValueError("intrinsics must be a 3x3 matrix")
+        if not _all_finite(v):
+            raise ValueError("intrinsics entries must be finite")
         return v
 
-    @model_validator(mode="after")
-    def check_cameras_have_intrinsics(self) -> "Calibration":
-        for cam_id, cam_data in self.cameras.items():
-            if "intrinsics" not in cam_data:
-                raise ValueError(f"Camera {cam_id} missing intrinsics")
-        return self
-
-
-# =============================================================================
-# Keypoint Data
-# =============================================================================
-
-
-class Keypoint(BaseModel):
-    """Single keypoint with optional confidence."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    x: float = Field(..., description="X coordinate (pixels or normalized)")
-    y: float = Field(..., description="Y coordinate (pixels or normalized)")
-    z: Optional[float] = Field(default=None, description="Z coordinate (if 3D)")
-    confidence: float = Field(
-        default=1.0, description="Confidence score [0, 1]", ge=0, le=1
-    )
-    name: Optional[str] = Field(default=None, description="Keypoint name (e.g., 'nose')")
-
-    @field_validator("x", "y", "z")
+    @field_validator("extrinsics")
     @classmethod
-    def check_finite(cls, v: Optional[float]) -> Optional[float]:
-        if v is not None and not np.isfinite(v):
-            raise ValueError("Coordinate must be finite")
+    def _check_extrinsics(cls, v: list[list[float]] | None) -> list[list[float]] | None:
+        if v is None:
+            return v
+        if len(v) != 4 or any(len(row) != 4 for row in v):
+            raise ValueError("extrinsics must be a 4x4 matrix")
+        if not _all_finite(v):
+            raise ValueError("extrinsics entries must be finite")
         return v
+
+
+# ---------------------------------------------------------------------------
+# Keypoints
+# ---------------------------------------------------------------------------
+
+PointTuple = tuple[float, float] | tuple[float, float, float]
 
 
 class KeypointFrame(BaseModel):
-    """Single frame of keypoints (2D or 3D)."""
+    """Single frame of 2D or 3D keypoints with confidences."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    timestamp: float = Field(..., description="Frame timestamp (seconds)", ge=0)
-    keypoints: List[Keypoint] = Field(
-        ..., description="List of keypoints", min_length=1
-    )
-    schema_name: SchemaName = Field(..., description="Keypoint schema used")
-    frame_index: Optional[int] = Field(default=None, description="Frame index in sequence")
+    points: list[PointTuple]
+    confidences: list[float]
+    keypoint_schema: KeypointSchema = Field(..., alias="schema")
+    timestamp: float
 
     @field_validator("timestamp")
     @classmethod
-    def check_timestamp_finite(cls, v: float) -> float:
-        if not np.isfinite(v):
-            raise ValueError("Timestamp must be finite")
+    def _finite_ts(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("timestamp must be finite")
         return v
 
-    @invariant("keypoints_have_consistent_depth")
-    def check_keypoint_depth_consistency(self) -> bool:
-        """All keypoints should be either 2D or 3D."""
-        has_z = [kp.z is not None for kp in self.keypoints]
-        return all(has_z) or not any(has_z)
+    @field_validator("points")
+    @classmethod
+    def _check_points(cls, v: list[PointTuple]) -> list[PointTuple]:
+        if not v:
+            raise ValueError("points must be non-empty")
+        dim = len(v[0])
+        if dim not in (2, 3):
+            raise ValueError("points must be 2D or 3D")
+        for row in v:
+            if len(row) != dim:
+                raise ValueError("all keypoints must have the same dimensionality")
+        if not _all_finite(v):
+            raise ValueError("keypoint coordinates must be finite")
+        return v
+
+    @field_validator("confidences")
+    @classmethod
+    def _check_confidences(cls, v: list[float]) -> list[float]:
+        if not _all_finite(v):
+            raise ValueError("confidences must be finite")
+        if any(c < 0.0 or c > 1.0 for c in v):
+            raise ValueError("confidences must lie in [0, 1]")
+        return v
+
+    @model_validator(mode="after")
+    def _consistency(self) -> KeypointFrame:
+        if len(self.confidences) != len(self.points):
+            raise ValueError("confidences length must equal number of points")
+        return self
 
 
 class KeypointSequence(BaseModel):
-    """Timestamped sequence of keypoint frames."""
+    """Time-ordered keypoint frames sharing a single schema."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    id: str = Field(..., description="Unique sequence identifier")
-    frames: List[KeypointFrame] = Field(
-        ..., description="Sequence of keypoint frames", min_length=1
-    )
-    calibration: Optional[Calibration] = Field(
-        default=None, description="Associated calibration data"
-    )
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    frames: list[KeypointFrame] = Field(..., min_length=1)
+    calibration: Calibration
 
     @model_validator(mode="after")
-    def check_monotonic_timestamps(self) -> "KeypointSequence":
+    def _check(self) -> KeypointSequence:
         timestamps = [f.timestamp for f in self.frames]
-        if timestamps != sorted(timestamps):
-            raise ValueError("Timestamps must be monotonically increasing")
+        if not _is_monotonic(timestamps):
+            raise ValueError("frame timestamps must be monotonic non-decreasing")
+        schemas = {f.keypoint_schema for f in self.frames}
+        if len(schemas) != 1:
+            raise ValueError("all frames must share the same schema")
+        n_points = {len(f.points) for f in self.frames}
+        if len(n_points) != 1:
+            raise ValueError("all frames must have the same number of keypoints")
         return self
+
+
+# ---------------------------------------------------------------------------
+# Markers
+# ---------------------------------------------------------------------------
+
+
+class MarkerSample(BaseModel):
+    """A single labelled 3D marker observation."""
+
+    model_config = _FROZEN
+
+    xyz: tuple[float, float, float]
+    occluded: bool = False
 
     @model_validator(mode="after")
-    def check_consistent_schema(self) -> "KeypointSequence":
-        schemas = {f.schema_name for f in self.frames}
-        if len(schemas) > 1:
-            raise ValueError(f"Inconsistent schemas: {schemas}")
+    def _check(self) -> MarkerSample:
+        if not self.occluded and not _all_finite(self.xyz):
+            raise ValueError("xyz must be finite unless the marker is marked occluded")
         return self
-
-    @property
-    def num_frames(self) -> int:
-        return len(self.frames)
-
-    @property
-    def num_keypoints(self) -> int:
-        return len(self.frames[0].keypoints) if self.frames else 0
-
-    @property
-    def duration(self) -> float:
-        if len(self.frames) < 2:
-            return 0.0
-        return self.frames[-1].timestamp - self.frames[0].timestamp
-
-
-# =============================================================================
-# Marker Data
-# =============================================================================
-
-
-class Marker(BaseModel):
-    """Single 3D marker with label and confidence."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    name: str = Field(..., description="Marker name/label")
-    x: float = Field(..., description="X position (meters)")
-    y: float = Field(..., description="Y position (meters)")
-    z: float = Field(..., description="Z position (meters)")
-    residual: Optional[float] = Field(
-        default=None, description="Residual error (mm)", ge=0
-    )
-    occluded: bool = Field(default=False, description="Marker is occluded")
-
-    @field_validator("x", "y", "z", "residual")
-    @classmethod
-    def check_finite(cls, v: Optional[float]) -> Optional[float]:
-        if v is not None and not np.isfinite(v):
-            raise ValueError("Value must be finite")
-        return v
 
 
 class MarkerFrame(BaseModel):
-    """Single frame of 3D markers."""
+    """One timestamped frame of labelled markers."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    timestamp: float = Field(..., description="Frame timestamp (seconds)", ge=0)
-    markers: Dict[str, Marker] = Field(
-        default_factory=dict, description="Marker name -> Marker data"
-    )
-    frame_index: Optional[int] = Field(default=None, description="Frame index in sequence")
+    samples: dict[str, MarkerSample]
+    timestamp: float
 
     @field_validator("timestamp")
     @classmethod
-    def check_timestamp_finite(cls, v: float) -> float:
-        if not np.isfinite(v):
-            raise ValueError("Timestamp must be finite")
+    def _finite_ts(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("timestamp must be finite")
         return v
 
-    @property
-    def marker_names(self) -> List[str]:
-        return list(self.markers.keys())
-
-    @property
-    def num_markers(self) -> int:
-        return len(self.markers)
+    @field_validator("samples")
+    @classmethod
+    def _non_empty(cls, v: dict[str, MarkerSample]) -> dict[str, MarkerSample]:
+        if not v:
+            raise ValueError("samples must be non-empty")
+        return v
 
 
 class MarkerTrajectory(BaseModel):
-    """Time series of marker frames."""
+    """Time-ordered marker frames with a shared label set."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    id: str = Field(..., description="Unique trajectory identifier")
-    frames: List[MarkerFrame] = Field(
-        ..., description="Sequence of marker frames", min_length=1
-    )
-    calibration: Optional[Calibration] = Field(
-        default=None, description="Associated calibration data"
-    )
-    subject_id: Optional[str] = Field(default=None, description="Subject identifier")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    frames: list[MarkerFrame] = Field(..., min_length=1)
+    unit_system: UnitSystem
+    marker_set_name: str | None = None
 
     @model_validator(mode="after")
-    def check_monotonic_timestamps(self) -> "MarkerTrajectory":
+    def _check(self) -> MarkerTrajectory:
         timestamps = [f.timestamp for f in self.frames]
-        if timestamps != sorted(timestamps):
-            raise ValueError("Timestamps must be monotonically increasing")
+        if not _is_monotonic(timestamps):
+            raise ValueError("frame timestamps must be monotonic non-decreasing")
+        ref_labels = set(self.frames[0].samples.keys())
+        for i, f in enumerate(self.frames[1:], start=1):
+            if set(f.samples.keys()) != ref_labels:
+                raise ValueError(f"frame {i} marker label set differs from frame 0")
         return self
 
-    @model_validator(mode="after")
-    def check_consistent_markers(self) -> "MarkerTrajectory":
-        """All frames should have the same marker set."""
-        if len(self.frames) < 2:
-            return self
-        reference_markers = set(self.frames[0].marker_names)
-        for i, frame in enumerate(self.frames[1:], 1):
-            frame_markers = set(frame.marker_names)
-            if frame_markers != reference_markers:
-                # Allow for occlusions, but names should be consistent
-                pass  # Relaxing this constraint for practical use
-        return self
 
-    @property
-    def num_frames(self) -> int:
-        return len(self.frames)
-
-    @property
-    def marker_names(self) -> List[str]:
-        return self.frames[0].marker_names if self.frames else []
-
-    @property
-    def duration(self) -> float:
-        if len(self.frames) < 2:
-            return 0.0
-        return self.frames[-1].timestamp - self.frames[0].timestamp
+# ---------------------------------------------------------------------------
+# Skeleton rig
+# ---------------------------------------------------------------------------
 
 
-# =============================================================================
-# Skeleton Rig
-# =============================================================================
+class JointAxis(BaseModel):
+    """Rotation axis for a 1-DoF joint, stored as a unit 3-vector.
+
+    For cardinal axes use ``JointAxis.from_cardinal("X" | "Y" | "Z")``.
+    """
+
+    model_config = _FROZEN
+
+    vector: tuple[float, float, float]
+
+    @field_validator("vector")
+    @classmethod
+    def _check_vector(cls, v: tuple[float, float, float]) -> tuple[float, float, float]:
+        if not _all_finite(v):
+            raise ValueError("axis vector components must be finite")
+        norm = math.sqrt(sum(c * c for c in v))
+        if norm == 0.0:
+            raise ValueError("axis vector must be non-zero")
+        if not math.isclose(norm, 1.0, abs_tol=1e-6):
+            raise ValueError("axis vector must have unit norm")
+        return v
+
+    @classmethod
+    def from_cardinal(cls, axis: Literal["X", "Y", "Z"]) -> JointAxis:
+        """Construct a JointAxis aligned with a cardinal axis."""
+        if axis == "X":
+            return cls(vector=(1.0, 0.0, 0.0))
+        if axis == "Y":
+            return cls(vector=(0.0, 1.0, 0.0))
+        if axis == "Z":
+            return cls(vector=(0.0, 0.0, 1.0))
+        raise ValueError(f"unknown cardinal axis: {axis}")
 
 
 class JointLimit(BaseModel):
-    """Joint limit specification."""
+    """Inclusive [lo, hi] joint angle limit (radians)."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    lower: Optional[float] = Field(default=None, description="Lower limit (radians)")
-    upper: Optional[float] = Field(default=None, description="Upper limit (radians)")
-    soft_lower: Optional[float] = Field(default=None, description="Soft lower limit")
-    soft_upper: Optional[float] = Field(default=None, description="Soft upper limit")
-
-    @field_validator("lower", "upper", "soft_lower", "soft_upper")
-    @classmethod
-    def check_finite(cls, v: Optional[float]) -> Optional[float]:
-        if v is not None and not np.isfinite(v):
-            raise ValueError("Limit must be finite")
-        return v
+    lo: float
+    hi: float
 
     @model_validator(mode="after")
-    def check_limit_order(self) -> "JointLimit":
-        if self.lower is not None and self.upper is not None:
-            if self.lower > self.upper:
-                raise ValueError("Lower limit must be <= upper limit")
+    def _check(self) -> JointLimit:
+        if not (math.isfinite(self.lo) and math.isfinite(self.hi)):
+            raise ValueError("joint limit bounds must be finite")
+        if self.lo > self.hi:
+            raise ValueError("lo must be <= hi")
         return self
-
-
-class JointDef(BaseModel):
-    """Joint definition in skeleton rig."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    name: str = Field(..., description="Joint name")
-    parent: Optional[str] = Field(default=None, description="Parent joint name")
-    children: List[str] = Field(
-        default_factory=list, description="Child joint names"
-    )
-    tpose_offset: List[float] = Field(
-        default_factory=lambda: [0.0, 0.0, 0.0],
-        description="T-pose offset from parent (meters)",
-    )
-    axes: List[Axis] = Field(
-        default_factory=lambda: ["X", "Y", "Z"],
-        description="Joint rotation axes",
-    )
-    limits: List[JointLimit] = Field(
-        default_factory=list,
-        description="Joint limits (one per DOF)",
-    )
-    semantic_label: Optional[str] = Field(
-        default=None, description="Semantic label (e.g., 'right_knee')"
-    )
-
-    @field_validator("tpose_offset")
-    @classmethod
-    def check_offset_shape(cls, v: List[float]) -> List[float]:
-        if len(v) != 3:
-            raise ValueError("T-pose offset must be length 3")
-        return v
-
-    @invariant("axes_match_limits")
-    def check_axes_limits_consistency(self) -> bool:
-        """Number of axes should match number of limits (if limits provided)."""
-        if self.limits:
-            return len(self.axes) == len(self.limits)
-        return True
 
 
 class SkeletonRig(BaseModel):
-    """Skeleton rig definition."""
+    """Kinematic skeleton: joints, parents, T-pose offsets, axes, limits."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    id: str = Field(..., description="Unique rig identifier")
-    joints: Dict[str, JointDef] = Field(
-        ..., description="Joint name -> Joint definition", min_length=1
-    )
-    root_joint: str = Field(..., description="Root joint name")
-    up_axis: UpAxis = Field(default="+Y", description="Skeleton up axis")
-    scale: float = Field(default=1.0, description="Global scale factor", gt=0)
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
-
-    @model_validator(mode="after")
-    def check_root_exists(self) -> "SkeletonRig":
-        if self.root_joint not in self.joints:
-            raise ValueError(f"Root joint '{self.root_joint}' not found in joints")
-        return self
-
-    @model_validator(mode="after")
-    def check_parent_child_consistency(self) -> "SkeletonRig":
-        """Verify parent-child relationships are consistent."""
-        for joint_name, joint in self.joints.items():
-            # Check children reference valid joints
-            for child in joint.children:
-                if child not in self.joints:
-                    raise ValueError(f"Joint {joint_name} has invalid child {child}")
-            # Check parent references valid joint
-            if joint.parent is not None and joint.parent not in self.joints:
-                raise ValueError(f"Joint {joint_name} has invalid parent {joint.parent}")
-        return self
+    joint_names: list[str] = Field(..., min_length=1)
+    parents: list[int]
+    tpose_offsets: list[tuple[float, float, float]]
+    axes: list[JointAxis]
+    limits: list[JointLimit]
+    semantic_labels: dict[str, str] = Field(default_factory=dict)
+    end_effectors: list[str] = Field(default_factory=list)
 
     @property
-    def num_joints(self) -> int:
-        return len(self.joints)
+    def n_joints(self) -> int:
+        return len(self.joint_names)
 
-    @property
-    def num_dofs(self) -> int:
-        return sum(len(j.axes) for j in self.joints.values())
+    @field_validator("joint_names")
+    @classmethod
+    def _unique_names(cls, v: list[str]) -> list[str]:
+        if any(not name for name in v):
+            raise ValueError("joint names must be non-empty strings")
+        if len(set(v)) != len(v):
+            raise ValueError("joint_names must be unique")
+        return v
 
-    def get_joint_chain(self, joint_name: str) -> List[str]:
-        """Get the chain of joints from root to specified joint."""
-        if joint_name not in self.joints:
-            raise ValueError(f"Joint {joint_name} not found")
-        chain = [joint_name]
-        current = self.joints[joint_name].parent
-        while current is not None:
-            chain.insert(0, current)
-            current = self.joints[current].parent
-        return chain
+    @model_validator(mode="after")
+    def _check_topology(self) -> SkeletonRig:
+        n = self.n_joints
+        for length, label in (
+            (len(self.parents), "parents"),
+            (len(self.tpose_offsets), "tpose_offsets"),
+            (len(self.axes), "axes"),
+            (len(self.limits), "limits"),
+        ):
+            if length != n:
+                raise ValueError(f"{label} length must equal n_joints ({n})")
+
+        for offset in self.tpose_offsets:
+            if not _all_finite(offset):
+                raise ValueError("tpose_offsets must be finite")
+
+        # Validate parent indices and detect cycles via DFS to root.
+        for i, p in enumerate(self.parents):
+            if p == i:
+                raise ValueError(f"joint {i} cannot be its own parent")
+            if not (-1 <= p < n):
+                raise ValueError(
+                    f"parent index {p} for joint {i} out of range [-1, {n - 1}]"
+                )
+
+        for start in range(n):
+            seen: set[int] = set()
+            cur = start
+            while cur != -1:
+                if cur in seen:
+                    raise ValueError(f"cycle detected in parent chain at joint {cur}")
+                seen.add(cur)
+                cur = self.parents[cur]
+
+        names = set(self.joint_names)
+        for label, target in self.semantic_labels.items():
+            if target not in names:
+                raise ValueError(
+                    f"semantic_labels['{label}']='{target}' not in joint_names"
+                )
+        for ee in self.end_effectors:
+            if ee not in names:
+                raise ValueError(f"end_effector '{ee}' not in joint_names")
+        return self
 
 
-# =============================================================================
-# Joint States
-# =============================================================================
+# ---------------------------------------------------------------------------
+# Joint trajectories
+# ---------------------------------------------------------------------------
 
 
 class JointStateFrame(BaseModel):
-    """Single frame of joint states."""
+    """Generalised coordinates (and optional derivatives) at one timestamp."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    timestamp: float = Field(..., description="Frame timestamp (seconds)", ge=0)
-    q: List[float] = Field(..., description="Joint positions", min_length=1)
-    qdot: Optional[List[float]] = Field(
-        default=None, description="Joint velocities"
-    )
-    qddot: Optional[List[float]] = Field(
-        default=None, description="Joint accelerations"
-    )
-    frame_index: Optional[int] = Field(default=None, description="Frame index")
+    q: list[float]
+    qdot: list[float] | None = None
+    qddot: list[float] | None = None
+    timestamp: float
 
     @field_validator("timestamp")
     @classmethod
-    def check_timestamp_finite(cls, v: float) -> float:
-        if not np.isfinite(v):
-            raise ValueError("Timestamp must be finite")
+    def _finite_ts(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("timestamp must be finite")
         return v
 
-    @field_validator("q", "qdot", "qddot")
+    @field_validator("q")
     @classmethod
-    def check_finite_values(cls, v: Optional[List[float]]) -> Optional[List[float]]:
-        if v is not None:
-            if not all(np.isfinite(x) for x in v):
-                raise ValueError("All values must be finite")
+    def _check_q(cls, v: list[float]) -> list[float]:
+        if not v:
+            raise ValueError("q must be non-empty")
+        if not _all_finite(v):
+            raise ValueError("q values must be finite")
         return v
 
-    @invariant("matching_dimensions")
-    def check_dimensions(self) -> bool:
-        """q, qdot, qddot should have same length if all present."""
-        lengths = [len(self.q)]
+    @model_validator(mode="after")
+    def _consistent_derivs(self) -> JointStateFrame:
+        n = len(self.q)
         if self.qdot is not None:
-            lengths.append(len(self.qdot))
+            if len(self.qdot) != n:
+                raise ValueError("qdot length must match q")
+            if not _all_finite(self.qdot):
+                raise ValueError("qdot values must be finite")
         if self.qddot is not None:
-            lengths.append(len(self.qddot))
-        return len(set(lengths)) == 1
-
-    @property
-    def num_dofs(self) -> int:
-        return len(self.q)
+            if len(self.qddot) != n:
+                raise ValueError("qddot length must match q")
+            if not _all_finite(self.qddot):
+                raise ValueError("qddot values must be finite")
+        return self
 
 
 class JointTrajectory(BaseModel):
-    """Time series of joint states."""
+    """Time-ordered joint states bound to a rig (1-DoF per joint)."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    id: str = Field(..., description="Unique trajectory identifier")
-    skeleton: SkeletonRig = Field(..., description="Associated skeleton rig")
-    frames: List[JointStateFrame] = Field(
-        ..., description="Sequence of joint states", min_length=1
-    )
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    frames: list[JointStateFrame] = Field(..., min_length=1)
+    rig: SkeletonRig
 
     @model_validator(mode="after")
-    def check_monotonic_timestamps(self) -> "JointTrajectory":
+    def _check(self) -> JointTrajectory:
         timestamps = [f.timestamp for f in self.frames]
-        if timestamps != sorted(timestamps):
-            raise ValueError("Timestamps must be monotonically increasing")
-        return self
-
-    @model_validator(mode="after")
-    def check_dof_consistency(self) -> "JointTrajectory":
-        """All frames should have same DOF count as skeleton."""
-        expected_dofs = self.skeleton.num_dofs
-        for frame in self.frames:
-            if frame.num_dofs != expected_dofs:
+        if not _is_monotonic(timestamps):
+            raise ValueError("frame timestamps must be monotonic non-decreasing")
+        n = self.rig.n_joints
+        for i, f in enumerate(self.frames):
+            if len(f.q) != n:
                 raise ValueError(
-                    f"Frame has {frame.num_dofs} DOFs, expected {expected_dofs}"
+                    f"frame {i}: q has {len(f.q)} entries, rig has {n} joints"
                 )
         return self
 
-    @property
-    def num_frames(self) -> int:
-        return len(self.frames)
 
-    @property
-    def duration(self) -> float:
-        if len(self.frames) < 2:
-            return 0.0
-        return self.frames[-1].timestamp - self.frames[0].timestamp
+# ---------------------------------------------------------------------------
+# Provenance + headline CIR
+# ---------------------------------------------------------------------------
 
 
-# =============================================================================
-# Motion Trajectory (High-level CIR)
-# =============================================================================
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class Provenance(BaseModel):
+    """Capture / source provenance for a motion artefact."""
+
+    model_config = _FROZEN
+
+    subject_id: str | None = None
+    sport: str | None = "golf"
+    club: str | None = None
+    source_path_hash: str | None = None
+    software_version: str
+    created_at: datetime = Field(default_factory=_utc_now)
 
 
 class MotionTrajectory(BaseModel):
-    """High-level motion representation combining skeleton, trajectory, and metadata."""
+    """Headline canonical intermediate representation."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = _FROZEN
 
-    id: str = Field(..., description="Unique motion identifier")
-    skeleton: SkeletonRig = Field(..., description="Skeleton rig")
-    trajectory: JointTrajectory = Field(..., description="Joint trajectory")
-    marker_reference: Optional[MarkerTrajectory] = Field(
-        default=None, description="Optional reference marker trajectory"
-    )
-    subject: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Subject metadata (height, mass, age, etc.)",
-    )
-    sport: Optional[str] = Field(default=None, description="Sport type (e.g., 'golf')")
-    club: Optional[str] = Field(default=None, description="Club/equipment used")
-    source_provenance: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Source data provenance (file paths, capture system, etc.)",
-    )
-    created_at: datetime = Field(
-        default_factory=datetime.now, description="Creation timestamp"
-    )
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    rig: SkeletonRig
+    joint_trajectory: JointTrajectory
+    markers: MarkerTrajectory | None = None
+    provenance: Provenance
 
     @model_validator(mode="after")
-    def check_trajectory_skeleton_match(self) -> "MotionTrajectory":
-        """Trajectory skeleton should match main skeleton."""
-        if self.trajectory.skeleton.id != self.skeleton.id:
-            raise ValueError("Trajectory skeleton does not match main skeleton")
-        return self
-
-    @property
-    def duration(self) -> float:
-        return self.trajectory.duration
-
-    @property
-    def num_frames(self) -> int:
-        return self.trajectory.num_frames
-
-
-# =============================================================================
-# Motion Matching
-# =============================================================================
-
-
-class MotionMatchingRequest(BaseModel):
-    """Motion matching solver request."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    id: str = Field(..., description="Unique request identifier")
-    target_trajectory: Optional[MotionTrajectory] = Field(
-        default=None, description="Target trajectory to match"
-    )
-    target_markers: Optional[MarkerTrajectory] = Field(
-        default=None, description="Target marker trajectory"
-    )
-    target_keypoints: Optional[KeypointSequence] = Field(
-        default=None, description="Target keypoint sequence"
-    )
-    skeleton: SkeletonRig = Field(..., description="Skeleton to use for matching")
-    constraints: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Matching constraints (weights, tolerances, etc.)",
-    )
-    solver_config: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Solver-specific configuration",
-    )
-
-    @model_validator(mode="after")
-    def check_has_target(self) -> "MotionMatchingRequest":
-        """Must have at least one target specification."""
-        has_target = (
-            self.target_trajectory is not None
-            or self.target_markers is not None
-            or self.target_keypoints is not None
-        )
-        if not has_target:
-            raise ValueError("Must specify at least one target (trajectory, markers, or keypoints)")
+    def _rigs_match(self) -> MotionTrajectory:
+        if self.joint_trajectory.rig.joint_names != self.rig.joint_names:
+            raise ValueError(
+                "joint_trajectory.rig.joint_names must equal rig.joint_names"
+            )
         return self
 
 
-class MotionMatchingResult(BaseModel):
-    """Motion matching solver result."""
+# ---------------------------------------------------------------------------
+# Motion matching request / result
+# ---------------------------------------------------------------------------
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    request_id: str = Field(..., description="Associated request identifier")
-    success: bool = Field(..., description="Whether matching succeeded")
-    matched_trajectory: Optional[MotionTrajectory] = Field(
-        default=None, description="Matched joint trajectory"
-    )
-    error_metrics: Dict[str, float] = Field(
-        default_factory=dict,
-        description="Error metrics (RMSE, max error, etc.)",
-    )
-    iterations: Optional[int] = Field(default=None, description="Solver iterations")
-    solve_time: Optional[float] = Field(
-        default=None, description="Solve time (seconds)", ge=0
-    )
-    message: Optional[str] = Field(default=None, description="Status message")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+class CostWeights(BaseModel):
+    """Non-negative weights for arbitrary cost terms."""
 
-    @field_validator("solve_time")
+    model_config = _FROZEN
+
+    weights: dict[str, float] = Field(default_factory=dict)
+
+    @field_validator("weights")
     @classmethod
-    def check_solve_time_finite(cls, v: Optional[float]) -> Optional[float]:
-        if v is not None and not np.isfinite(v):
-            raise ValueError("Solve time must be finite")
+    def _non_negative(cls, v: dict[str, float]) -> dict[str, float]:
+        for k, val in v.items():
+            if not math.isfinite(val):
+                raise ValueError(f"weight '{k}' must be finite")
+            if val < 0.0:
+                raise ValueError(f"weight '{k}' must be >= 0")
         return v
 
 
-# =============================================================================
-# Serialization Helpers
-# =============================================================================
+class MotionMatchingRequest(BaseModel):
+    """Inputs to the motion-matching solver."""
+
+    model_config = _FROZEN
+
+    reference: MotionTrajectory
+    cost_weights: CostWeights
+    constraints: dict[str, Any] = Field(default_factory=dict)
+    time_horizon: float | None = None
+    integrator: dict[str, Any] = Field(default_factory=dict)
+    engine: EngineType
+
+    @field_validator("time_horizon")
+    @classmethod
+    def _positive_horizon(cls, v: float | None) -> float | None:
+        if v is not None:
+            if not math.isfinite(v):
+                raise ValueError("time_horizon must be finite")
+            if v <= 0.0:
+                raise ValueError("time_horizon must be > 0 if given")
+        return v
 
 
-def serialize_model(model: BaseModel) -> str:
-    """Serialize a Pydantic model to JSON string."""
-    return model.model_dump_json(indent=2)
+class TorqueTrajectory(BaseModel):
+    """Joint-torque control trajectory."""
+
+    model_config = _FROZEN
+
+    frames: list[tuple[float, list[float]]] = Field(..., min_length=1)
+    rig_joint_names: list[str] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def _check(self) -> TorqueTrajectory:
+        ts = [t for t, _ in self.frames]
+        if not _is_monotonic(ts):
+            raise ValueError("torque frame timestamps must be monotonic")
+        n = len(self.rig_joint_names)
+        for i, (t, vec) in enumerate(self.frames):
+            if not math.isfinite(t):
+                raise ValueError(f"torque frame {i}: timestamp not finite")
+            if len(vec) != n:
+                raise ValueError(
+                    f"torque frame {i}: expected {n} entries, got {len(vec)}"
+                )
+            if not _all_finite(vec):
+                raise ValueError(f"torque frame {i}: values not finite")
+        return self
 
 
-def deserialize_model(json_str: str, model_class: type) -> BaseModel:
-    """Deserialize a JSON string to a Pydantic model."""
-    return model_class.model_validate_json(json_str)
+class MuscleActivationTrajectory(BaseModel):
+    """Muscle-activation control trajectory (activations in [0, 1])."""
+
+    model_config = _FROZEN
+
+    frames: list[tuple[float, list[float]]] = Field(..., min_length=1)
+    muscle_names: list[str] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def _check(self) -> MuscleActivationTrajectory:
+        if len(set(self.muscle_names)) != len(self.muscle_names):
+            raise ValueError("muscle_names must be unique")
+        ts = [t for t, _ in self.frames]
+        if not _is_monotonic(ts):
+            raise ValueError("muscle frame timestamps must be monotonic")
+        n = len(self.muscle_names)
+        for i, (t, vec) in enumerate(self.frames):
+            if not math.isfinite(t):
+                raise ValueError(f"muscle frame {i}: timestamp not finite")
+            if len(vec) != n:
+                raise ValueError(
+                    f"muscle frame {i}: expected {n} activations, got {len(vec)}"
+                )
+            if not _all_finite(vec):
+                raise ValueError(f"muscle frame {i}: values not finite")
+            if any(a < 0.0 or a > 1.0 for a in vec):
+                raise ValueError(f"muscle frame {i}: activations must lie in [0, 1]")
+        return self
 
 
-def save_model(model: BaseModel, path: Union[str, Path]) -> None:
-    """Save a Pydantic model to a JSON file."""
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        f.write(serialize_model(model))
+class ResidualReport(BaseModel):
+    """Residual / fit summary."""
+
+    model_config = _FROZEN
+
+    per_joint_rmse: dict[str, float] = Field(default_factory=dict)
+    aggregate_rmse: float = Field(..., ge=0.0)
+    notes: str = ""
+
+    @field_validator("per_joint_rmse")
+    @classmethod
+    def _non_neg_finite(cls, v: dict[str, float]) -> dict[str, float]:
+        for k, val in v.items():
+            if not math.isfinite(val) or val < 0.0:
+                raise ValueError(f"per_joint_rmse['{k}']={val} must be finite and >= 0")
+        return v
+
+    @field_validator("aggregate_rmse")
+    @classmethod
+    def _finite_agg(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("aggregate_rmse must be finite")
+        return v
 
 
-def load_model(json_path: Union[str, Path], model_class: type) -> BaseModel:
-    """Load a Pydantic model from a JSON file."""
-    with open(json_path, "r") as f:
-        return deserialize_model(f.read(), model_class)
+class MotionMatchingResult(BaseModel):
+    """Outputs of the motion-matching solver."""
 
+    model_config = _FROZEN
 
-# =============================================================================
-# Backward Compatibility Shims (Deprecated)
-# =============================================================================
-# These re-exports provide backward compatibility with existing code.
-# New code should import directly from this module.
+    tracked: JointTrajectory
+    torques: TorqueTrajectory | None = None
+    activations: MuscleActivationTrajectory | None = None
+    residuals: ResidualReport
+    fit_metrics: dict[str, float] = Field(default_factory=dict)
+    provenance: Provenance
 
-
-__all__ = [
-    # Core types
-    "Calibration",
-    "CameraIntrinsics",
-    "CameraExtrinsics",
-    # Keypoint types
-    "Keypoint",
-    "KeypointFrame",
-    "KeypointSequence",
-    # Marker types
-    "Marker",
-    "MarkerFrame",
-    "MarkerTrajectory",
-    # Skeleton types
-    "JointDef",
-    "JointLimit",
-    "SkeletonRig",
-    # Joint state types
-    "JointStateFrame",
-    "JointTrajectory",
-    # High-level types
-    "MotionTrajectory",
-    "MotionMatchingRequest",
-    "MotionMatchingResult",
-    # Serialization
-    "serialize_model",
-    "deserialize_model",
-    "save_model",
-    "load_model",
-]
+    @model_validator(mode="after")
+    def _at_least_one_control(self) -> MotionMatchingResult:
+        if self.torques is None and self.activations is None:
+            raise ValueError(
+                "MotionMatchingResult requires at least one of torques / activations"
+            )
+        return self

--- a/tests/unit/motion_pipeline/_fixtures.py
+++ b/tests/unit/motion_pipeline/_fixtures.py
@@ -1,0 +1,174 @@
+"""Synthetic fixture builders for motion-pipeline contract tests.
+
+These helpers are reused by downstream waves of epic #4558 -- keep them
+side-effect-free, deterministic, and minimal.
+"""
+
+from __future__ import annotations
+
+import math
+
+from src.shared.python.motion_pipeline import (
+    Calibration,
+    JointAxis,
+    JointLimit,
+    JointStateFrame,
+    JointTrajectory,
+    KeypointFrame,
+    KeypointSchema,
+    KeypointSequence,
+    MarkerFrame,
+    MarkerSample,
+    MarkerTrajectory,
+    MotionTrajectory,
+    Provenance,
+    SkeletonRig,
+    UnitSystem,
+    WorldUp,
+)
+
+
+def make_calibration(
+    camera_id: str = "cam0",
+    fps: float = 60.0,
+    unit_system: UnitSystem = UnitSystem.METERS,
+    world_up: WorldUp = WorldUp.Y_UP,
+) -> Calibration:
+    return Calibration(
+        camera_id=camera_id,
+        intrinsics=[[1000.0, 0.0, 640.0], [0.0, 1000.0, 360.0], [0.0, 0.0, 1.0]],
+        extrinsics=[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        source_fps=fps,
+        unit_system=unit_system,
+        world_up=world_up,
+    )
+
+
+def make_keypoint_sequence(
+    n_frames: int = 10,
+    n_points: int = 33,
+    schema: KeypointSchema = KeypointSchema.MEDIAPIPE_33,
+    fps: float = 60.0,
+) -> KeypointSequence:
+    dt = 1.0 / fps
+    frames = []
+    for f in range(n_frames):
+        points: list[tuple[float, float, float]] = [
+            (
+                math.cos(0.1 * (f + p)),
+                math.sin(0.1 * (f + p)),
+                0.5 * p / max(n_points, 1),
+            )
+            for p in range(n_points)
+        ]
+        confidences = [0.9 for _ in range(n_points)]
+        frames.append(
+            KeypointFrame(
+                points=points,
+                confidences=confidences,
+                schema=schema,
+                timestamp=f * dt,
+            )
+        )
+    return KeypointSequence(frames=frames, calibration=make_calibration(fps=fps))
+
+
+def make_marker_trajectory(
+    n_frames: int = 10,
+    marker_names: tuple[str, ...] = (
+        "LSHO",
+        "RSHO",
+        "LASI",
+        "RASI",
+        "LKNE",
+        "LANK",
+    ),
+    fps: float = 240.0,
+    unit_system: UnitSystem = UnitSystem.METERS,
+) -> MarkerTrajectory:
+    dt = 1.0 / fps
+    frames = []
+    for f in range(n_frames):
+        samples = {
+            name: MarkerSample(
+                xyz=(0.1 * i + 0.001 * f, 0.2 * i, 0.3 * i),
+                occluded=False,
+            )
+            for i, name in enumerate(marker_names)
+        }
+        frames.append(MarkerFrame(samples=samples, timestamp=f * dt))
+    return MarkerTrajectory(
+        frames=frames,
+        unit_system=unit_system,
+        marker_set_name="synthetic",
+    )
+
+
+def make_skeleton_rig(n_joints: int = 6) -> SkeletonRig:
+    if n_joints < 1:
+        raise ValueError("n_joints must be >= 1")
+    joint_names = [f"joint_{i}" for i in range(n_joints)]
+    parents = [-1] + list(range(n_joints - 1))  # simple chain
+    tpose_offsets = [(0.0, float(i) * 0.1, 0.0) for i in range(n_joints)]
+    axes = [JointAxis.from_cardinal("Z") for _ in range(n_joints)]
+    limits = [JointLimit(lo=-math.pi, hi=math.pi) for _ in range(n_joints)]
+    semantic_labels = {"root": joint_names[0]}
+    end_effectors = [joint_names[-1]]
+    return SkeletonRig(
+        joint_names=joint_names,
+        parents=parents,
+        tpose_offsets=tpose_offsets,
+        axes=axes,
+        limits=limits,
+        semantic_labels=semantic_labels,
+        end_effectors=end_effectors,
+    )
+
+
+def make_joint_trajectory(
+    rig: SkeletonRig,
+    n_frames: int = 10,
+    fps: float = 240.0,
+) -> JointTrajectory:
+    dt = 1.0 / fps
+    frames = [
+        JointStateFrame(
+            q=[0.01 * (i + f) for i in range(rig.n_joints)],
+            qdot=[0.0 for _ in range(rig.n_joints)],
+            qddot=None,
+            timestamp=f * dt,
+        )
+        for f in range(n_frames)
+    ]
+    return JointTrajectory(frames=frames, rig=rig)
+
+
+def make_provenance(software_version: str = "0.1.0") -> Provenance:
+    return Provenance(
+        subject_id="subject_001",
+        sport="golf",
+        club="7iron",
+        source_path_hash="deadbeef",
+        software_version=software_version,
+    )
+
+
+def make_motion_trajectory(
+    n_joints: int = 6,
+    n_frames: int = 10,
+) -> MotionTrajectory:
+    rig = make_skeleton_rig(n_joints=n_joints)
+    jt = make_joint_trajectory(rig, n_frames=n_frames)
+    mt = make_marker_trajectory(n_frames=n_frames)
+    prov = make_provenance()
+    return MotionTrajectory(
+        rig=rig,
+        joint_trajectory=jt,
+        markers=mt,
+        provenance=prov,
+    )

--- a/tests/unit/motion_pipeline/test_contracts.py
+++ b/tests/unit/motion_pipeline/test_contracts.py
@@ -1,757 +1,816 @@
-"""
-Unit tests for motion pipeline contracts (CIR).
+"""Unit tests for the motion pipeline canonical intermediate representation.
 
-Tests cover:
-- Pydantic v2 validation
-- Invariants via @invariant decorator
-- Round-trip serialization (JSON)
-- Edge cases and error handling
+Targets >=95% coverage of ``src/shared/python/motion_pipeline/contracts.py``.
 """
 
-import json
-import tempfile
-from datetime import datetime
-from pathlib import Path
+from __future__ import annotations
 
-import numpy as np
+import math
+
 import pytest
+from pydantic import ValidationError
 
-from src.shared.python.motion_pipeline.contracts import (
+from src.shared.python.motion_pipeline import (
     Calibration,
-    CameraExtrinsics,
-    CameraIntrinsics,
-    JointDef,
+    CostWeights,
+    EngineType,
+    JointAxis,
     JointLimit,
     JointStateFrame,
     JointTrajectory,
-    Keypoint,
     KeypointFrame,
+    KeypointSchema,
     KeypointSequence,
-    Marker,
     MarkerFrame,
+    MarkerSample,
     MarkerTrajectory,
     MotionMatchingRequest,
     MotionMatchingResult,
     MotionTrajectory,
+    MuscleActivationTrajectory,
+    Provenance,
+    ResidualReport,
     SkeletonRig,
-    UpAxis,
-    deserialize_model,
-    load_model,
-    save_model,
-    serialize_model,
+    TorqueTrajectory,
+    UnitSystem,
+    WorldUp,
+)
+from tests.unit.motion_pipeline._fixtures import (
+    make_calibration,
+    make_joint_trajectory,
+    make_keypoint_sequence,
+    make_marker_trajectory,
+    make_motion_trajectory,
+    make_provenance,
+    make_skeleton_rig,
 )
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
+# ---------------------------------------------------------------------------
+# Enums + simple sanity
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def sample_intrinsics() -> CameraIntrinsics:
-    """Create a sample camera intrinsics."""
-    return CameraIntrinsics(fx=800.0, fy=800.0, cx=640.0, cy=480.0)
+def test_engine_type_lowercase_string_values() -> None:
+    assert EngineType.MUJOCO.value == "mujoco"
+    assert EngineType.OPENSIM.value == "opensim"
+    assert EngineType.DRAKE.value == "drake"
+    assert EngineType.PINOCCHIO.value == "pinocchio"
+    assert EngineType.MYOSUITE.value == "myosuite"
 
 
-@pytest.fixture
-def sample_extrinsics() -> CameraExtrinsics:
-    """Create a sample camera extrinsics."""
-    return CameraExtrinsics(
-        rotation=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-        translation=[0.0, 0.0, 0.0],
-    )
+def test_unit_system_world_up_keypoint_schema_values() -> None:
+    assert UnitSystem.MILLIMETERS.value == "mm"
+    assert UnitSystem.METERS.value == "m"
+    assert WorldUp.Y_UP.value == "Y_UP"
+    assert WorldUp.Z_UP.value == "Z_UP"
+    assert KeypointSchema.MEDIAPIPE_33.value == "MEDIAPIPE_33"
 
 
-@pytest.fixture
-def sample_calibration() -> Calibration:
-    """Create a sample calibration."""
-    return Calibration(
-        id="calib_001",
-        cameras={
-            "cam_0": {
-                "intrinsics": {"fx": 800.0, "fy": 800.0, "cx": 640.0, "cy": 480.0},
-                "extrinsics": {"rotation": [[1, 0, 0], [0, 1, 0], [0, 0, 1]], "translation": [0, 0, 0]},
-            }
-        },
-        unit_system="meters",
+# ---------------------------------------------------------------------------
+# Calibration
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_valid() -> None:
+    c = make_calibration()
+    assert c.source_fps == 60.0
+    assert c.unit_system == UnitSystem.METERS
+
+
+def test_calibration_minimal_no_optional_matrices() -> None:
+    c = Calibration(
+        camera_id="cam0",
         source_fps=30.0,
-        world_up_axis="+Y",
+        unit_system=UnitSystem.MILLIMETERS,
+        world_up=WorldUp.Z_UP,
     )
+    assert c.intrinsics is None
+    assert c.extrinsics is None
 
 
-@pytest.fixture
-def sample_keypoint_frame() -> KeypointFrame:
-    """Create a sample keypoint frame."""
-    return KeypointFrame(
+@pytest.mark.parametrize("bad", [[[1.0, 0.0]], [[1.0, 0.0, 0.0], [0.0]]])
+def test_calibration_rejects_bad_intrinsics_shape(
+    bad: list[list[float]],
+) -> None:
+    with pytest.raises(ValidationError):
+        Calibration(
+            camera_id="cam0",
+            intrinsics=bad,
+            source_fps=30.0,
+            unit_system=UnitSystem.METERS,
+            world_up=WorldUp.Y_UP,
+        )
+
+
+def test_calibration_rejects_non_finite_intrinsics() -> None:
+    with pytest.raises(ValidationError):
+        Calibration(
+            camera_id="cam0",
+            intrinsics=[
+                [math.nan, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            source_fps=30.0,
+            unit_system=UnitSystem.METERS,
+            world_up=WorldUp.Y_UP,
+        )
+
+
+def test_calibration_rejects_bad_extrinsics_shape() -> None:
+    with pytest.raises(ValidationError):
+        Calibration(
+            camera_id="cam0",
+            extrinsics=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            source_fps=30.0,
+            unit_system=UnitSystem.METERS,
+            world_up=WorldUp.Y_UP,
+        )
+
+
+def test_calibration_rejects_zero_or_negative_fps() -> None:
+    with pytest.raises(ValidationError):
+        Calibration(
+            camera_id="cam0",
+            source_fps=0.0,
+            unit_system=UnitSystem.METERS,
+            world_up=WorldUp.Y_UP,
+        )
+
+
+# ---------------------------------------------------------------------------
+# KeypointFrame / KeypointSequence
+# ---------------------------------------------------------------------------
+
+
+def test_keypoint_frame_valid_2d_and_3d() -> None:
+    f2 = KeypointFrame(
+        points=[(0.0, 0.0), (1.0, 1.0)],
+        confidences=[0.5, 0.9],
+        schema=KeypointSchema.CUSTOM,
         timestamp=0.0,
-        keypoints=[
-            Keypoint(x=100.0, y=200.0, z=0.5, confidence=0.95, name="nose"),
-            Keypoint(x=110.0, y=210.0, z=0.6, confidence=0.90, name="left_eye"),
-        ],
-        schema_name="BODY_25",
-        frame_index=0,
     )
-
-
-@pytest.fixture
-def sample_skeleton() -> SkeletonRig:
-    """Create a sample skeleton rig."""
-    return SkeletonRig(
-        id="skeleton_001",
-        joints={
-            "pelvis": JointDef(name="pelvis", parent=None, children=["spine"], tpose_offset=[0, 0, 0]),
-            "spine": JointDef(name="spine", parent="pelvis", children=["neck"], tpose_offset=[0, 0.1, 0]),
-            "neck": JointDef(name="neck", parent="spine", children=[], tpose_offset=[0, 0.15, 0]),
-        },
-        root_joint="pelvis",
-        up_axis="+Y",
+    assert len(f2.points) == 2
+    f3 = KeypointFrame(
+        points=[(0.0, 0.0, 0.0)],
+        confidences=[0.7],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=0.0,
     )
+    assert len(f3.points[0]) == 3
 
 
-@pytest.fixture
-def sample_joint_trajectory(sample_skeleton: SkeletonRig) -> JointTrajectory:
-    """Create a sample joint trajectory."""
-    frames = [
-        JointStateFrame(timestamp=0.0, q=[0.0] * sample_skeleton.num_dofs, frame_index=0),
-        JointStateFrame(timestamp=0.033, q=[0.1] * sample_skeleton.num_dofs, frame_index=1),
-        JointStateFrame(timestamp=0.066, q=[0.2] * sample_skeleton.num_dofs, frame_index=2),
-    ]
-    return JointTrajectory(id="traj_001", skeleton=sample_skeleton, frames=frames)
+def test_keypoint_frame_rejects_confidence_length_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        KeypointFrame(
+            points=[(0.0, 0.0), (1.0, 1.0)],
+            confidences=[0.5],
+            schema=KeypointSchema.CUSTOM,
+            timestamp=0.0,
+        )
 
 
-@pytest.fixture
-def sample_motion_trajectory(sample_skeleton: SkeletonRig, sample_joint_trajectory: JointTrajectory) -> MotionTrajectory:
-    """Create a sample motion trajectory."""
-    return MotionTrajectory(
-        id="motion_001",
-        skeleton=sample_skeleton,
-        trajectory=sample_joint_trajectory,
-        subject={"height_m": 1.75, "mass_kg": 70.0, "age": 25},
-        sport="golf",
-        club="driver",
+@pytest.mark.parametrize("bad", [-0.01, 1.5, math.inf, math.nan])
+def test_keypoint_frame_rejects_invalid_confidence(bad: float) -> None:
+    with pytest.raises(ValidationError):
+        KeypointFrame(
+            points=[(0.0, 0.0)],
+            confidences=[bad],
+            schema=KeypointSchema.CUSTOM,
+            timestamp=0.0,
+        )
+
+
+def test_keypoint_frame_rejects_non_finite_points() -> None:
+    with pytest.raises(ValidationError):
+        KeypointFrame(
+            points=[(math.inf, 0.0)],
+            confidences=[1.0],
+            schema=KeypointSchema.CUSTOM,
+            timestamp=0.0,
+        )
+
+
+def test_keypoint_frame_rejects_mixed_dimensionality() -> None:
+    with pytest.raises(ValidationError):
+        KeypointFrame(
+            points=[(0.0, 0.0), (1.0, 1.0, 1.0)],  # type: ignore[list-item]
+            confidences=[1.0, 1.0],
+            schema=KeypointSchema.CUSTOM,
+            timestamp=0.0,
+        )
+
+
+def test_keypoint_sequence_valid() -> None:
+    seq = make_keypoint_sequence(n_frames=4, n_points=5, schema=KeypointSchema.CUSTOM)
+    assert len(seq.frames) == 4
+
+
+def test_keypoint_sequence_rejects_non_monotonic_timestamps() -> None:
+    cal = make_calibration()
+    f0 = KeypointFrame(
+        points=[(0.0, 0.0)],
+        confidences=[1.0],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=1.0,
     )
+    f1 = KeypointFrame(
+        points=[(0.0, 0.0)],
+        confidences=[1.0],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=0.0,
+    )
+    with pytest.raises(ValidationError):
+        KeypointSequence(frames=[f0, f1], calibration=cal)
 
 
-# =============================================================================
-# Calibration Tests
-# =============================================================================
+def test_keypoint_sequence_rejects_schema_mismatch() -> None:
+    cal = make_calibration()
+    f0 = KeypointFrame(
+        points=[(0.0, 0.0)],
+        confidences=[1.0],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=0.0,
+    )
+    f1 = KeypointFrame(
+        points=[(0.0, 0.0)],
+        confidences=[1.0],
+        schema=KeypointSchema.COCO_17,
+        timestamp=1.0,
+    )
+    with pytest.raises(ValidationError):
+        KeypointSequence(frames=[f0, f1], calibration=cal)
 
 
-class TestCameraIntrinsics:
-    """Tests for CameraIntrinsics model."""
-
-    def test_valid_intrinsics(self, sample_intrinsics: CameraIntrinsics):
-        """Test valid intrinsics creation."""
-        assert sample_intrinsics.fx == 800.0
-        assert sample_intrinsics.fy == 800.0
-        assert sample_intrinsics.cx == 640.0
-        assert sample_intrinsics.cy == 480.0
-
-    def test_invalid_focal_length_zero(self):
-        """Test that zero focal length raises error."""
-        with pytest.raises(ValueError, match="greater than 0"):
-            CameraIntrinsics(fx=0.0, fy=800.0, cx=640.0, cy=480.0)
-
-    def test_invalid_focal_length_negative(self):
-        """Test that negative focal length raises error."""
-        with pytest.raises(ValueError, match="greater than 0"):
-            CameraIntrinsics(fx=-800.0, fy=800.0, cx=640.0, cy=480.0)
-
-    def test_nan_focal_length(self):
-        """Test that NaN focal length raises error."""
-        with pytest.raises(ValueError, match="finite"):
-            CameraIntrinsics(fx=float("nan"), fy=800.0, cx=640.0, cy=480.0)
-
-    def test_inf_focal_length(self):
-        """Test that infinite focal length raises error."""
-        with pytest.raises(ValueError, match="finite"):
-            CameraIntrinsics(fx=float("inf"), fy=800.0, cx=640.0, cy=480.0)
-
-    def test_default_distortion(self):
-        """Test default distortion coefficients."""
-        intrinsics = CameraIntrinsics(fx=800.0, fy=800.0, cx=640.0, cy=480.0)
-        assert intrinsics.k1 == 0.0
-        assert intrinsics.k2 == 0.0
-        assert intrinsics.p1 == 0.0
-        assert intrinsics.p2 == 0.0
+def test_keypoint_sequence_rejects_inconsistent_point_count() -> None:
+    cal = make_calibration()
+    f0 = KeypointFrame(
+        points=[(0.0, 0.0)],
+        confidences=[1.0],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=0.0,
+    )
+    f1 = KeypointFrame(
+        points=[(0.0, 0.0), (1.0, 1.0)],
+        confidences=[1.0, 1.0],
+        schema=KeypointSchema.CUSTOM,
+        timestamp=1.0,
+    )
+    with pytest.raises(ValidationError):
+        KeypointSequence(frames=[f0, f1], calibration=cal)
 
 
-class TestCameraExtrinsics:
-    """Tests for CameraExtrinsics model."""
-
-    def test_valid_extrinsics(self, sample_extrinsics: CameraExtrinsics):
-        """Test valid extrinsics creation."""
-        assert len(sample_extrinsics.rotation) == 3
-        assert len(sample_extrinsics.translation) == 3
-
-    def test_default_rotation_identity(self):
-        """Test default rotation is identity."""
-        extrinsics = CameraExtrinsics()
-        assert extrinsics.rotation == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-
-    def test_default_translation_zero(self):
-        """Test default translation is zero."""
-        extrinsics = CameraExtrinsics()
-        assert extrinsics.translation == [0.0, 0.0, 0.0]
-
-    def test_invalid_rotation_shape(self):
-        """Test that invalid rotation shape raises error."""
-        with pytest.raises(ValueError, match="3x3"):
-            CameraExtrinsics(rotation=[[1, 0], [0, 1]], translation=[0, 0, 0])
-
-    def test_invalid_translation_shape(self):
-        """Test that invalid translation shape raises error."""
-        with pytest.raises(ValueError, match="length 3"):
-            CameraExtrinsics(rotation=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], translation=[0, 0])
+# ---------------------------------------------------------------------------
+# MarkerSample / MarkerFrame / MarkerTrajectory
+# ---------------------------------------------------------------------------
 
 
-class TestCalibration:
-    """Tests for Calibration model."""
-
-    def test_valid_calibration(self, sample_calibration: Calibration):
-        """Test valid calibration creation."""
-        assert sample_calibration.id == "calib_001"
-        assert sample_calibration.unit_system == "meters"
-        assert sample_calibration.source_fps == 30.0
-        assert sample_calibration.world_up_axis == "+Y"
-
-    def test_invalid_fps_zero(self):
-        """Test that zero FPS raises error."""
-        with pytest.raises(ValueError, match="greater than 0"):
-            Calibration(
-                id="calib_001",
-                cameras={"cam_0": {"intrinsics": {"fx": 800.0, "fy": 800.0, "cx": 640.0, "cy": 480.0}}},
-                source_fps=0.0,
-            )
-
-    def test_missing_intrinsics(self):
-        """Test that missing intrinsics raises error."""
-        with pytest.raises(ValueError, match="missing intrinsics"):
-            Calibration(
-                id="calib_001",
-                cameras={"cam_0": {"extrinsics": {"rotation": [[1, 0, 0], [0, 1, 0], [0, 0, 1]], "translation": [0, 0, 0]}}},
-                source_fps=30.0,
-            )
-
-    def test_invalid_unit_system(self):
-        """Test that invalid unit system raises error."""
-        with pytest.raises(ValueError):
-            Calibration(
-                id="calib_001",
-                cameras={"cam_0": {"intrinsics": {"fx": 800.0, "fy": 800.0, "cx": 640.0, "cy": 480.0}}},
-                unit_system="invalid",  # type: ignore
-                source_fps=30.0,
-            )
-
-    def test_invalid_up_axis(self):
-        """Test that invalid up axis raises error."""
-        with pytest.raises(ValueError):
-            Calibration(
-                id="calib_001",
-                cameras={"cam_0": {"intrinsics": {"fx": 800.0, "fy": 800.0, "cx": 640.0, "cy": 480.0}}},
-                source_fps=30.0,
-                world_up_axis="invalid",  # type: ignore
-            )
+def test_marker_sample_valid() -> None:
+    s = MarkerSample(xyz=(0.0, 1.0, 2.0))
+    assert s.occluded is False
 
 
-# =============================================================================
-# Keypoint Tests
-# =============================================================================
+def test_marker_sample_occluded_allows_nan() -> None:
+    s = MarkerSample(xyz=(math.nan, math.nan, math.nan), occluded=True)
+    assert s.occluded
 
 
-class TestKeypoint:
-    """Tests for Keypoint model."""
-
-    def test_valid_3d_keypoint(self):
-        """Test valid 3D keypoint creation."""
-        kp = Keypoint(x=100.0, y=200.0, z=0.5, confidence=0.95, name="nose")
-        assert kp.x == 100.0
-        assert kp.y == 200.0
-        assert kp.z == 0.5
-        assert kp.confidence == 0.95
-
-    def test_valid_2d_keypoint(self):
-        """Test valid 2D keypoint creation."""
-        kp = Keypoint(x=100.0, y=200.0, confidence=0.95)
-        assert kp.x == 100.0
-        assert kp.y == 200.0
-        assert kp.z is None
-
-    def test_confidence_bounds_zero(self):
-        """Test confidence at lower bound."""
-        kp = Keypoint(x=100.0, y=200.0, confidence=0.0)
-        assert kp.confidence == 0.0
-
-    def test_confidence_bounds_one(self):
-        """Test confidence at upper bound."""
-        kp = Keypoint(x=100.0, y=200.0, confidence=1.0)
-        assert kp.confidence == 1.0
-
-    def test_confidence_negative(self):
-        """Test that negative confidence raises error."""
-        with pytest.raises(ValueError, match="greater than or equal to 0"):
-            Keypoint(x=100.0, y=200.0, confidence=-0.1)
-
-    def test_confidence_over_one(self):
-        """Test that confidence over 1 raises error."""
-        with pytest.raises(ValueError, match="less than or equal to 1"):
-            Keypoint(x=100.0, y=200.0, confidence=1.1)
-
-    def test_nan_coordinate(self):
-        """Test that NaN coordinate raises error."""
-        with pytest.raises(ValueError, match="finite"):
-            Keypoint(x=float("nan"), y=200.0)
+def test_marker_sample_rejects_non_finite_when_visible() -> None:
+    with pytest.raises(ValidationError):
+        MarkerSample(xyz=(math.nan, 0.0, 0.0), occluded=False)
 
 
-class TestKeypointFrame:
-    """Tests for KeypointFrame model."""
+def test_marker_frame_rejects_empty_samples() -> None:
+    with pytest.raises(ValidationError):
+        MarkerFrame(samples={}, timestamp=0.0)
 
-    def test_valid_frame(self, sample_keypoint_frame: KeypointFrame):
-        """Test valid keypoint frame creation."""
-        assert sample_keypoint_frame.timestamp == 0.0
-        assert len(sample_keypoint_frame.keypoints) == 2
-        assert sample_keypoint_frame.schema_name == "BODY_25"
 
-    def test_empty_keypoints(self):
-        """Test that empty keypoints raises error."""
-        with pytest.raises(ValueError, match="at least 1"):
-            KeypointFrame(timestamp=0.0, keypoints=[], schema_name="BODY_25")
+def test_marker_trajectory_valid() -> None:
+    t = make_marker_trajectory()
+    assert len(t.frames) == 10
 
-    def test_negative_timestamp(self):
-        """Test that negative timestamp raises error."""
-        with pytest.raises(ValueError, match="greater than or equal to 0"):
-            KeypointFrame(
-                timestamp=-1.0,
-                keypoints=[Keypoint(x=100.0, y=200.0)],
-                schema_name="BODY_25",
-            )
 
-    def test_depth_consistency_3d(self):
-        """Test 3D keypoints pass depth consistency check."""
-        frame = KeypointFrame(
-            timestamp=0.0,
-            keypoints=[
-                Keypoint(x=100.0, y=200.0, z=0.5),
-                Keypoint(x=110.0, y=210.0, z=0.6),
-            ],
-            schema_name="BODY_25",
+def test_marker_trajectory_rejects_inconsistent_label_set() -> None:
+    f0 = MarkerFrame(samples={"A": MarkerSample(xyz=(0, 0, 0))}, timestamp=0.0)
+    f1 = MarkerFrame(samples={"B": MarkerSample(xyz=(0, 0, 0))}, timestamp=1.0)
+    with pytest.raises(ValidationError):
+        MarkerTrajectory(frames=[f0, f1], unit_system=UnitSystem.METERS)
+
+
+def test_marker_trajectory_rejects_non_monotonic_timestamps() -> None:
+    f0 = MarkerFrame(samples={"A": MarkerSample(xyz=(0, 0, 0))}, timestamp=1.0)
+    f1 = MarkerFrame(samples={"A": MarkerSample(xyz=(0, 0, 0))}, timestamp=0.0)
+    with pytest.raises(ValidationError):
+        MarkerTrajectory(frames=[f0, f1], unit_system=UnitSystem.METERS)
+
+
+# ---------------------------------------------------------------------------
+# JointAxis / JointLimit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axis", ["X", "Y", "Z"])
+def test_joint_axis_from_cardinal(axis: str) -> None:
+    a = JointAxis.from_cardinal(axis)  # type: ignore[arg-type]
+    assert math.isclose(sum(c * c for c in a.vector), 1.0)
+
+
+def test_joint_axis_from_cardinal_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        JointAxis.from_cardinal("W")  # type: ignore[arg-type]
+
+
+def test_joint_axis_rejects_non_unit_vector() -> None:
+    with pytest.raises(ValidationError):
+        JointAxis(vector=(2.0, 0.0, 0.0))
+
+
+def test_joint_axis_rejects_zero_vector() -> None:
+    with pytest.raises(ValidationError):
+        JointAxis(vector=(0.0, 0.0, 0.0))
+
+
+def test_joint_axis_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        JointAxis(vector=(math.nan, 0.0, 0.0))
+
+
+def test_joint_limit_valid() -> None:
+    lim = JointLimit(lo=-1.0, hi=1.0)
+    assert lim.lo < lim.hi
+
+
+def test_joint_limit_lo_equal_hi_allowed() -> None:
+    lim = JointLimit(lo=0.0, hi=0.0)
+    assert lim.lo == lim.hi
+
+
+def test_joint_limit_rejects_lo_gt_hi() -> None:
+    with pytest.raises(ValidationError):
+        JointLimit(lo=2.0, hi=1.0)
+
+
+def test_joint_limit_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        JointLimit(lo=math.nan, hi=1.0)
+
+
+# ---------------------------------------------------------------------------
+# SkeletonRig
+# ---------------------------------------------------------------------------
+
+
+def test_skeleton_rig_valid() -> None:
+    rig = make_skeleton_rig(n_joints=4)
+    assert rig.n_joints == 4
+
+
+def test_skeleton_rig_rejects_duplicate_joint_names() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a", "a"],
+            parents=[-1, 0],
+            tpose_offsets=[(0, 0, 0), (0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z"), JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1), JointLimit(lo=-1, hi=1)],
         )
-        assert frame.check_keypoint_depth_consistency()
 
-    def test_depth_consistency_2d(self):
-        """Test 2D keypoints pass depth consistency check."""
-        frame = KeypointFrame(
-            timestamp=0.0,
-            keypoints=[
-                Keypoint(x=100.0, y=200.0),
-                Keypoint(x=110.0, y=210.0),
-            ],
-            schema_name="BODY_25",
+
+def test_skeleton_rig_rejects_empty_joint_name() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=[""],
+            parents=[-1],
+            tpose_offsets=[(0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1)],
         )
-        assert frame.check_keypoint_depth_consistency()
 
-    def test_depth_inconsistency_mixed(self):
-        """Test mixed 2D/3D keypoints fail depth consistency check."""
-        frame = KeypointFrame(
-            timestamp=0.0,
-            keypoints=[
-                Keypoint(x=100.0, y=200.0, z=0.5),
-                Keypoint(x=110.0, y=210.0),
-            ],
-            schema_name="BODY_25",
+
+def test_skeleton_rig_rejects_length_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a", "b"],
+            parents=[-1],
+            tpose_offsets=[(0, 0, 0), (0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z"), JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1), JointLimit(lo=-1, hi=1)],
         )
-        assert not frame.check_keypoint_depth_consistency()
 
 
-class TestKeypointSequence:
-    """Tests for KeypointSequence model."""
-
-    def test_valid_sequence(self, sample_keypoint_frame: KeypointFrame):
-        """Test valid keypoint sequence creation."""
-        seq = KeypointSequence(id="seq_001", frames=[sample_keypoint_frame])
-        assert seq.id == "seq_001"
-        assert seq.num_frames == 1
-        assert seq.num_keypoints == 2
-
-    def test_monotonic_timestamps(self, sample_keypoint_frame: KeypointFrame):
-        """Test monotonically increasing timestamps."""
-        frame2 = KeypointFrame(
-            timestamp=0.033,
-            keypoints=[Keypoint(x=105.0, y=205.0)],
-            schema_name="BODY_25",
+def test_skeleton_rig_rejects_self_parent() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a"],
+            parents=[0],
+            tpose_offsets=[(0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1)],
         )
-        seq = KeypointSequence(id="seq_001", frames=[sample_keypoint_frame, frame2])
-        assert seq.duration == 0.033
 
-    def test_non_monotonic_timestamps(self, sample_keypoint_frame: KeypointFrame):
-        """Test that non-monotonic timestamps raise error."""
-        frame2 = KeypointFrame(
-            timestamp=-0.01,
-            keypoints=[Keypoint(x=105.0, y=205.0)],
-            schema_name="BODY_25",
+
+def test_skeleton_rig_rejects_out_of_range_parent() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a", "b"],
+            parents=[-1, 5],
+            tpose_offsets=[(0, 0, 0), (0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z"), JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1), JointLimit(lo=-1, hi=1)],
         )
-        with pytest.raises(ValueError, match="monotonically increasing"):
-            KeypointSequence(id="seq_001", frames=[sample_keypoint_frame, frame2])
 
-    def test_consistent_schema(self, sample_keypoint_frame: KeypointFrame):
-        """Test consistent schema across frames."""
-        frame2 = KeypointFrame(
-            timestamp=0.033,
-            keypoints=[Keypoint(x=105.0, y=205.0)],
-            schema_name="BODY_25",
+
+def test_skeleton_rig_rejects_cycle() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a", "b", "c"],
+            parents=[1, 2, 0],  # cycle a->b->c->a
+            tpose_offsets=[(0, 0, 0)] * 3,
+            axes=[JointAxis.from_cardinal("Z")] * 3,
+            limits=[JointLimit(lo=-1, hi=1)] * 3,
         )
-        seq = KeypointSequence(id="seq_001", frames=[sample_keypoint_frame, frame2])
-        assert seq.check_consistent_schema()
 
-    def test_inconsistent_schema(self, sample_keypoint_frame: KeypointFrame):
-        """Test that inconsistent schema raises error."""
-        frame2 = KeypointFrame(
-            timestamp=0.033,
-            keypoints=[Keypoint(x=105.0, y=205.0)],
-            schema_name="COCO_17",
+
+def test_skeleton_rig_rejects_non_finite_offset() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a"],
+            parents=[-1],
+            tpose_offsets=[(math.nan, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1)],
         )
-        with pytest.raises(ValueError, match="Inconsistent schemas"):
-            KeypointSequence(id="seq_001", frames=[sample_keypoint_frame, frame2])
 
 
-# =============================================================================
-# Skeleton Tests
-# =============================================================================
-
-
-class TestSkeletonRig:
-    """Tests for SkeletonRig model."""
-
-    def test_valid_skeleton(self, sample_skeleton: SkeletonRig):
-        """Test valid skeleton creation."""
-        assert sample_skeleton.id == "skeleton_001"
-        assert sample_skeleton.root_joint == "pelvis"
-        assert sample_skeleton.num_joints == 3
-
-    def test_root_not_exists(self):
-        """Test that non-existent root raises error."""
-        with pytest.raises(ValueError, match="not found"):
-            SkeletonRig(
-                id="skeleton_001",
-                joints={"pelvis": JointDef(name="pelvis")},
-                root_joint="nonexistent",
-            )
-
-    def test_invalid_child(self):
-        """Test that invalid child reference raises error."""
-        with pytest.raises(ValueError, match="invalid child"):
-            SkeletonRig(
-                id="skeleton_001",
-                joints={
-                    "pelvis": JointDef(name="pelvis", children=["nonexistent"]),
-                },
-                root_joint="pelvis",
-            )
-
-    def test_invalid_parent(self):
-        """Test that invalid parent reference raises error."""
-        with pytest.raises(ValueError, match="invalid parent"):
-            SkeletonRig(
-                id="skeleton_001",
-                joints={
-                    "pelvis": JointDef(name="pelvis", parent="nonexistent"),
-                },
-                root_joint="pelvis",
-            )
-
-    def test_joint_chain(self, sample_skeleton: SkeletonRig):
-        """Test joint chain retrieval."""
-        chain = sample_skeleton.get_joint_chain("neck")
-        assert chain == ["pelvis", "spine", "neck"]
-
-    def test_num_dofs(self):
-        """Test DOF calculation."""
-        skeleton = SkeletonRig(
-            id="skeleton_001",
-            joints={
-                "pelvis": JointDef(name="pelvis", axes=["X", "Y", "Z"]),
-                "spine": JointDef(name="spine", axes=["X", "Y", "Z"]),
-            },
-            root_joint="pelvis",
+def test_skeleton_rig_rejects_unknown_semantic_label() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a"],
+            parents=[-1],
+            tpose_offsets=[(0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1)],
+            semantic_labels={"root": "missing"},
         )
-        assert skeleton.num_dofs == 6
 
 
-class TestJointLimit:
-    """Tests for JointLimit model."""
-
-    def test_valid_limit(self):
-        """Test valid joint limit creation."""
-        limit = JointLimit(lower=-0.5, upper=0.5)
-        assert limit.lower == -0.5
-        assert limit.upper == 0.5
-
-    def test_limit_order_valid(self):
-        """Test valid limit order."""
-        limit = JointLimit(lower=-0.5, upper=0.5)
-        assert limit.check_limit_order()
-
-    def test_limit_order_invalid(self):
-        """Test that invalid limit order raises error."""
-        with pytest.raises(ValueError, match="Lower limit must be"):
-            JointLimit(lower=0.5, upper=-0.5)
-
-    def test_optional_limits(self):
-        """Test optional limits."""
-        limit = JointLimit()
-        assert limit.lower is None
-        assert limit.upper is None
-
-
-# =============================================================================
-# Joint Trajectory Tests
-# =============================================================================
-
-
-class TestJointStateFrame:
-    """Tests for JointStateFrame model."""
-
-    def test_valid_frame(self):
-        """Test valid joint state frame creation."""
-        frame = JointStateFrame(timestamp=0.0, q=[0.0, 0.1, 0.2])
-        assert frame.num_dofs == 3
-
-    def test_frame_with_velocities(self):
-        """Test frame with velocities."""
-        frame = JointStateFrame(
-            timestamp=0.0,
-            q=[0.0, 0.1, 0.2],
-            qdot=[0.01, 0.02, 0.03],
+def test_skeleton_rig_rejects_unknown_end_effector() -> None:
+    with pytest.raises(ValidationError):
+        SkeletonRig(
+            joint_names=["a"],
+            parents=[-1],
+            tpose_offsets=[(0, 0, 0)],
+            axes=[JointAxis.from_cardinal("Z")],
+            limits=[JointLimit(lo=-1, hi=1)],
+            end_effectors=["missing"],
         )
-        assert frame.qdot == [0.01, 0.02, 0.03]
 
-    def test_frame_with_accelerations(self):
-        """Test frame with accelerations."""
-        frame = JointStateFrame(
-            timestamp=0.0,
-            q=[0.0, 0.1, 0.2],
-            qdot=[0.01, 0.02, 0.03],
-            qddot=[0.001, 0.002, 0.003],
+
+# ---------------------------------------------------------------------------
+# JointStateFrame / JointTrajectory
+# ---------------------------------------------------------------------------
+
+
+def test_joint_state_frame_optional_derivs() -> None:
+    f = JointStateFrame(q=[0.0, 0.0], timestamp=0.0)
+    assert f.qdot is None and f.qddot is None
+
+
+def test_joint_state_frame_rejects_qdot_length_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[0.0, 0.0], qdot=[0.0], timestamp=0.0)
+
+
+def test_joint_state_frame_rejects_qddot_length_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[0.0, 0.0], qddot=[0.0], timestamp=0.0)
+
+
+def test_joint_state_frame_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[math.nan], timestamp=0.0)
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[0.0], qdot=[math.inf], timestamp=0.0)
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[0.0], qddot=[math.inf], timestamp=0.0)
+
+
+def test_joint_state_frame_rejects_empty_q() -> None:
+    with pytest.raises(ValidationError):
+        JointStateFrame(q=[], timestamp=0.0)
+
+
+def test_joint_trajectory_valid() -> None:
+    rig = make_skeleton_rig(n_joints=3)
+    jt = make_joint_trajectory(rig, n_frames=5)
+    assert len(jt.frames) == 5
+
+
+def test_joint_trajectory_rejects_dof_mismatch() -> None:
+    rig = make_skeleton_rig(n_joints=3)
+    bad_frame = JointStateFrame(q=[0.0, 0.0], timestamp=0.0)
+    with pytest.raises(ValidationError):
+        JointTrajectory(frames=[bad_frame], rig=rig)
+
+
+def test_joint_trajectory_rejects_non_monotonic() -> None:
+    rig = make_skeleton_rig(n_joints=2)
+    f0 = JointStateFrame(q=[0.0, 0.0], timestamp=1.0)
+    f1 = JointStateFrame(q=[0.0, 0.0], timestamp=0.0)
+    with pytest.raises(ValidationError):
+        JointTrajectory(frames=[f0, f1], rig=rig)
+
+
+# ---------------------------------------------------------------------------
+# MotionTrajectory
+# ---------------------------------------------------------------------------
+
+
+def test_motion_trajectory_valid() -> None:
+    mt = make_motion_trajectory()
+    assert mt.markers is not None
+    assert mt.rig.n_joints == 6
+
+
+def test_motion_trajectory_rejects_rig_mismatch() -> None:
+    rig_a = make_skeleton_rig(n_joints=3)
+    rig_b = make_skeleton_rig(n_joints=4)
+    jt = make_joint_trajectory(rig_b, n_frames=2)
+    prov = make_provenance()
+    with pytest.raises(ValidationError):
+        MotionTrajectory(rig=rig_a, joint_trajectory=jt, provenance=prov)
+
+
+# ---------------------------------------------------------------------------
+# CostWeights
+# ---------------------------------------------------------------------------
+
+
+def test_cost_weights_default_empty() -> None:
+    cw = CostWeights()
+    assert cw.weights == {}
+
+
+def test_cost_weights_valid() -> None:
+    cw = CostWeights(weights={"track": 1.5, "smooth": 0.0})
+    assert cw.weights["track"] == 1.5
+
+
+def test_cost_weights_rejects_negative() -> None:
+    with pytest.raises(ValidationError):
+        CostWeights(weights={"x": -0.1})
+
+
+def test_cost_weights_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        CostWeights(weights={"x": math.inf})
+
+
+# ---------------------------------------------------------------------------
+# MotionMatchingRequest
+# ---------------------------------------------------------------------------
+
+
+def test_motion_matching_request_valid() -> None:
+    req = MotionMatchingRequest(
+        reference=make_motion_trajectory(),
+        cost_weights=CostWeights(weights={"track": 1.0}),
+        time_horizon=1.5,
+        engine=EngineType.MUJOCO,
+    )
+    assert req.engine == EngineType.MUJOCO
+
+
+def test_motion_matching_request_optional_horizon() -> None:
+    req = MotionMatchingRequest(
+        reference=make_motion_trajectory(),
+        cost_weights=CostWeights(),
+        engine=EngineType.DRAKE,
+    )
+    assert req.time_horizon is None
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, math.inf, math.nan])
+def test_motion_matching_request_rejects_bad_horizon(bad: float) -> None:
+    with pytest.raises(ValidationError):
+        MotionMatchingRequest(
+            reference=make_motion_trajectory(),
+            cost_weights=CostWeights(),
+            time_horizon=bad,
+            engine=EngineType.PINOCCHIO,
         )
-        assert frame.qddot == [0.001, 0.002, 0.003]
-
-    def test_dimension_mismatch(self):
-        """Test that dimension mismatch raises error."""
-        with pytest.raises(ValueError, match="matching_dimensions"):
-            JointStateFrame(
-                timestamp=0.0,
-                q=[0.0, 0.1, 0.2],
-                qdot=[0.01, 0.02],  # Different length
-            )
-
-    def test_nan_values(self):
-        """Test that NaN values raise error."""
-        with pytest.raises(ValueError, match="finite"):
-            JointStateFrame(timestamp=0.0, q=[float("nan"), 0.1, 0.2])
 
 
-class TestJointTrajectory:
-    """Tests for JointTrajectory model."""
-
-    def test_valid_trajectory(self, sample_joint_trajectory: JointTrajectory):
-        """Test valid joint trajectory creation."""
-        assert sample_joint_trajectory.id == "traj_001"
-        assert sample_joint_trajectory.num_frames == 3
-        assert sample_joint_trajectory.duration > 0
-
-    def test_dof_consistency(self, sample_skeleton: SkeletonRig):
-        """Test DOF consistency validation."""
-        frames = [
-            JointStateFrame(timestamp=0.0, q=[0.0] * sample_skeleton.num_dofs),
-            JointStateFrame(timestamp=0.033, q=[0.0] * (sample_skeleton.num_dofs + 1)),  # Wrong DOF
-        ]
-        with pytest.raises(ValueError, match="DOFs"):
-            JointTrajectory(id="traj_001", skeleton=sample_skeleton, frames=frames)
+# ---------------------------------------------------------------------------
+# TorqueTrajectory / MuscleActivationTrajectory
+# ---------------------------------------------------------------------------
 
 
-# =============================================================================
-# Motion Trajectory Tests
-# =============================================================================
+def test_torque_trajectory_valid() -> None:
+    tt = TorqueTrajectory(
+        frames=[(0.0, [0.0, 0.0]), (0.1, [1.0, -1.0])],
+        rig_joint_names=["a", "b"],
+    )
+    assert len(tt.frames) == 2
 
 
-class TestMotionTrajectory:
-    """Tests for MotionTrajectory model."""
-
-    def test_valid_motion(self, sample_motion_trajectory: MotionTrajectory):
-        """Test valid motion trajectory creation."""
-        assert sample_motion_trajectory.id == "motion_001"
-        assert sample_motion_trajectory.sport == "golf"
-        assert sample_motion_trajectory.club == "driver"
-
-    def test_skeleton_mismatch(self, sample_skeleton: SkeletonRig, sample_joint_trajectory: JointTrajectory):
-        """Test that skeleton mismatch raises error."""
-        other_skeleton = SkeletonRig(
-            id="other_skeleton",
-            joints={"pelvis": JointDef(name="pelvis")},
-            root_joint="pelvis",
+def test_torque_trajectory_rejects_dim_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        TorqueTrajectory(
+            frames=[(0.0, [0.0])],
+            rig_joint_names=["a", "b"],
         )
-        with pytest.raises(ValueError, match="does not match"):
-            MotionTrajectory(
-                id="motion_001",
-                skeleton=other_skeleton,
-                trajectory=sample_joint_trajectory,
-            )
 
 
-# =============================================================================
-# Motion Matching Tests
-# =============================================================================
-
-
-class TestMotionMatchingRequest:
-    """Tests for MotionMatchingRequest model."""
-
-    def test_request_with_trajectory(self, sample_motion_trajectory: MotionTrajectory):
-        """Test request with trajectory target."""
-        request = MotionMatchingRequest(
-            id="request_001",
-            target_trajectory=sample_motion_trajectory,
-            skeleton=sample_motion_trajectory.skeleton,
+def test_torque_trajectory_rejects_non_monotonic() -> None:
+    with pytest.raises(ValidationError):
+        TorqueTrajectory(
+            frames=[(1.0, [0.0]), (0.0, [0.0])],
+            rig_joint_names=["a"],
         )
-        assert request.id == "request_001"
-
-    def test_request_without_target(self, sample_skeleton: SkeletonRig):
-        """Test that missing target raises error."""
-        with pytest.raises(ValueError, match="at least one target"):
-            MotionMatchingRequest(id="request_001", skeleton=sample_skeleton)
 
 
-class TestMotionMatchingResult:
-    """Tests for MotionMatchingResult model."""
-
-    def test_successful_result(self):
-        """Test successful result creation."""
-        result = MotionMatchingResult(
-            request_id="request_001",
-            success=True,
-            error_metrics={"rmse": 0.05, "max_error": 0.1},
-            iterations=10,
-            solve_time=0.5,
+def test_torque_trajectory_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        TorqueTrajectory(
+            frames=[(0.0, [math.inf])],
+            rig_joint_names=["a"],
         )
-        assert result.success
-        assert result.iterations == 10
 
-    def test_failed_result(self):
-        """Test failed result creation."""
-        result = MotionMatchingResult(
-            request_id="request_001",
-            success=False,
-            message="Solver did not converge",
+
+def test_muscle_activation_valid() -> None:
+    m = MuscleActivationTrajectory(
+        frames=[(0.0, [0.0, 1.0]), (0.1, [0.5, 0.5])],
+        muscle_names=["m1", "m2"],
+    )
+    assert m.muscle_names[0] == "m1"
+
+
+def test_muscle_activation_rejects_out_of_range() -> None:
+    with pytest.raises(ValidationError):
+        MuscleActivationTrajectory(
+            frames=[(0.0, [1.5])],
+            muscle_names=["m1"],
         )
-        assert not result.success
-        assert "not converge" in result.message
-
-    def test_negative_solve_time(self):
-        """Test that negative solve time raises error."""
-        with pytest.raises(ValueError, match="greater than or equal to 0"):
-            MotionMatchingResult(request_id="request_001", success=True, solve_time=-1.0)
 
 
-# =============================================================================
-# Serialization Tests
-# =============================================================================
-
-
-class TestSerialization:
-    """Tests for serialization/deserialization."""
-
-    def test_serialize_calibration(self, sample_calibration: Calibration):
-        """Test calibration serialization."""
-        json_str = serialize_model(sample_calibration)
-        assert isinstance(json_str, str)
-        data = json.loads(json_str)
-        assert data["id"] == "calib_001"
-
-    def test_roundtrip_calibration(self, sample_calibration: Calibration):
-        """Test calibration round-trip."""
-        json_str = serialize_model(sample_calibration)
-        restored = deserialize_model(json_str, Calibration)
-        assert restored.id == sample_calibration.id
-        assert restored.source_fps == sample_calibration.source_fps
-
-    def test_serialize_motion(self, sample_motion_trajectory: MotionTrajectory):
-        """Test motion trajectory serialization."""
-        json_str = serialize_model(sample_motion_trajectory)
-        data = json.loads(json_str)
-        assert data["id"] == "motion_001"
-        assert data["sport"] == "golf"
-
-    def test_save_load_file(self, sample_calibration: Calibration):
-        """Test save/load to file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir) / "calibration.json"
-            save_model(sample_calibration, path)
-            assert path.exists()
-            restored = load_model(path, Calibration)
-            assert restored.id == sample_calibration.id
-
-
-# =============================================================================
-# Marker Tests
-# =============================================================================
-
-
-class TestMarker:
-    """Tests for Marker model."""
-
-    def test_valid_marker(self):
-        """Test valid marker creation."""
-        marker = Marker(name="LASI", x=0.1, y=0.2, z=0.3)
-        assert marker.name == "LASI"
-        assert marker.x == 0.1
-
-    def test_marker_with_residual(self):
-        """Test marker with residual."""
-        marker = Marker(name="LASI", x=0.1, y=0.2, z=0.3, residual=0.5)
-        assert marker.residual == 0.5
-
-    def test_negative_residual(self):
-        """Test that negative residual raises error."""
-        with pytest.raises(ValueError, match="greater than or equal to 0"):
-            Marker(name="LASI", x=0.1, y=0.2, z=0.3, residual=-0.1)
-
-
-class TestMarkerFrame:
-    """Tests for MarkerFrame model."""
-
-    def test_valid_frame(self):
-        """Test valid marker frame creation."""
-        frame = MarkerFrame(
-            timestamp=0.0,
-            markers={
-                "LASI": Marker(name="LASI", x=0.1, y=0.2, z=0.3),
-                "RASI": Marker(name="RASI", x=0.2, y=0.2, z=0.3),
-            },
+def test_muscle_activation_rejects_duplicate_names() -> None:
+    with pytest.raises(ValidationError):
+        MuscleActivationTrajectory(
+            frames=[(0.0, [0.0, 0.0])],
+            muscle_names=["m1", "m1"],
         )
-        assert frame.num_markers == 2
 
-    def test_marker_names(self):
-        """Test marker names property."""
-        frame = MarkerFrame(
-            timestamp=0.0,
-            markers={"LASI": Marker(name="LASI", x=0.1, y=0.2, z=0.3)},
+
+def test_muscle_activation_rejects_dim_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        MuscleActivationTrajectory(
+            frames=[(0.0, [0.0])],
+            muscle_names=["m1", "m2"],
         )
-        assert "LASI" in frame.marker_names
 
 
-class TestMarkerTrajectory:
-    """Tests for MarkerTrajectory model."""
-
-    def test_valid_trajectory(self):
-        """Test valid marker trajectory creation."""
-        frames = [
-            MarkerFrame(timestamp=0.0, markers={"LASI": Marker(name="LASI", x=0.1, y=0.2, z=0.3)}),
-            MarkerFrame(timestamp=0.033, markers={"LASI": Marker(name="LASI", x=0.11, y=0.21, z=0.31)}),
-        ]
-        traj = MarkerTrajectory(id="traj_001", frames=frames)
-        assert traj.num_frames == 2
-        assert traj.duration > 0
+def test_muscle_activation_rejects_non_monotonic() -> None:
+    with pytest.raises(ValidationError):
+        MuscleActivationTrajectory(
+            frames=[(1.0, [0.0]), (0.0, [0.0])],
+            muscle_names=["m1"],
+        )
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+# ---------------------------------------------------------------------------
+# ResidualReport / MotionMatchingResult
+# ---------------------------------------------------------------------------
+
+
+def test_residual_report_valid() -> None:
+    r = ResidualReport(
+        per_joint_rmse={"a": 0.1, "b": 0.2},
+        aggregate_rmse=0.15,
+        notes="ok",
+    )
+    assert r.aggregate_rmse == 0.15
+
+
+def test_residual_report_rejects_negative_per_joint() -> None:
+    with pytest.raises(ValidationError):
+        ResidualReport(per_joint_rmse={"a": -1.0}, aggregate_rmse=0.0)
+
+
+def test_residual_report_rejects_non_finite_aggregate() -> None:
+    with pytest.raises(ValidationError):
+        ResidualReport(per_joint_rmse={}, aggregate_rmse=math.nan)
+
+
+def test_residual_report_rejects_negative_aggregate() -> None:
+    with pytest.raises(ValidationError):
+        ResidualReport(per_joint_rmse={}, aggregate_rmse=-1.0)
+
+
+def test_motion_matching_result_requires_at_least_one_control() -> None:
+    rig = make_skeleton_rig(n_joints=2)
+    jt = make_joint_trajectory(rig, n_frames=2)
+    with pytest.raises(ValidationError):
+        MotionMatchingResult(
+            tracked=jt,
+            torques=None,
+            activations=None,
+            residuals=ResidualReport(per_joint_rmse={}, aggregate_rmse=0.0),
+            provenance=make_provenance(),
+        )
+
+
+def test_motion_matching_result_with_torques() -> None:
+    rig = make_skeleton_rig(n_joints=2)
+    jt = make_joint_trajectory(rig, n_frames=2)
+    tt = TorqueTrajectory(
+        frames=[(0.0, [0.0, 0.0])],
+        rig_joint_names=rig.joint_names,
+    )
+    res = MotionMatchingResult(
+        tracked=jt,
+        torques=tt,
+        residuals=ResidualReport(per_joint_rmse={}, aggregate_rmse=0.0),
+        provenance=make_provenance(),
+    )
+    assert res.torques is not None and res.activations is None
+
+
+def test_motion_matching_result_with_activations() -> None:
+    rig = make_skeleton_rig(n_joints=2)
+    jt = make_joint_trajectory(rig, n_frames=2)
+    act = MuscleActivationTrajectory(
+        frames=[(0.0, [0.5])],
+        muscle_names=["biceps"],
+    )
+    res = MotionMatchingResult(
+        tracked=jt,
+        activations=act,
+        residuals=ResidualReport(per_joint_rmse={}, aggregate_rmse=0.0),
+        provenance=make_provenance(),
+    )
+    assert res.activations is not None
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_default_factory_created_at() -> None:
+    p = Provenance(software_version="0.1.0")
+    assert p.created_at is not None
+    assert p.sport == "golf"
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        make_calibration(),
+        make_keypoint_sequence(n_frames=3, n_points=4, schema=KeypointSchema.CUSTOM),
+        make_marker_trajectory(n_frames=3),
+        make_skeleton_rig(n_joints=4),
+        make_motion_trajectory(),
+        CostWeights(weights={"a": 1.0, "b": 0.0}),
+        ResidualReport(per_joint_rmse={"a": 0.1}, aggregate_rmse=0.1),
+        Provenance(software_version="1.2.3"),
+        TorqueTrajectory(frames=[(0.0, [0.0])], rig_joint_names=["x"]),
+        MuscleActivationTrajectory(frames=[(0.0, [0.0])], muscle_names=["m1"]),
+    ],
+)
+def test_json_round_trip(obj: object) -> None:
+    cls = type(obj)
+    raw = obj.model_dump_json()  # type: ignore[attr-defined]
+    restored = cls.model_validate_json(raw)  # type: ignore[attr-defined]
+    assert restored == obj
+
+
+def test_motion_matching_request_round_trip() -> None:
+    req = MotionMatchingRequest(
+        reference=make_motion_trajectory(),
+        cost_weights=CostWeights(weights={"track": 1.0}),
+        time_horizon=1.0,
+        engine=EngineType.MUJOCO,
+    )
+    raw = req.model_dump_json()
+    assert MotionMatchingRequest.model_validate_json(raw) == req
+
+
+def test_motion_matching_result_round_trip() -> None:
+    rig = make_skeleton_rig(n_joints=2)
+    jt = make_joint_trajectory(rig, n_frames=2)
+    tt = TorqueTrajectory(frames=[(0.0, [0.0, 0.0])], rig_joint_names=rig.joint_names)
+    res = MotionMatchingResult(
+        tracked=jt,
+        torques=tt,
+        residuals=ResidualReport(per_joint_rmse={}, aggregate_rmse=0.0),
+        provenance=make_provenance(),
+    )
+    raw = res.model_dump_json()
+    assert MotionMatchingResult.model_validate_json(raw) == res

--- a/tests/unit/motion_pipeline/test_lod.py
+++ b/tests/unit/motion_pipeline/test_lod.py
@@ -1,0 +1,73 @@
+"""Law-of-Demeter import-graph test for the motion pipeline contracts.
+
+The motion pipeline CIR sits at the bottom of the dependency tree; it
+must not import from engines, api, learning, apps, tools, or
+deployment. This test parses ``contracts.py`` via ``ast`` and asserts
+the rule.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+CONTRACTS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "shared"
+    / "python"
+    / "motion_pipeline"
+    / "contracts.py"
+)
+
+FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "src.engines",
+    "src.api",
+    "src.learning",
+    "src.apps",
+    "src.tools",
+    "src.deployment",
+    "engines.",
+    "api.",
+    "learning.",
+    "apps.",
+    "tools.",
+    "deployment.",
+)
+
+
+def _collect_imported_modules(source: str) -> list[str]:
+    tree = ast.parse(source)
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.append(node.module)
+    return modules
+
+
+def test_contracts_file_exists() -> None:
+    assert CONTRACTS_PATH.is_file(), f"{CONTRACTS_PATH} not found"
+
+
+def test_contracts_imports_respect_lod() -> None:
+    source = CONTRACTS_PATH.read_text(encoding="utf-8")
+    modules = _collect_imported_modules(source)
+    violations = [
+        m for m in modules if any(m.startswith(p) for p in FORBIDDEN_PREFIXES)
+    ]
+    assert not violations, (
+        f"contracts.py must not import from forbidden layers; found: {violations}"
+    )
+
+
+@pytest.mark.parametrize("forbidden", FORBIDDEN_PREFIXES)
+def test_no_specific_forbidden_prefix_imported(forbidden: str) -> None:
+    source = CONTRACTS_PATH.read_text(encoding="utf-8")
+    modules = _collect_imported_modules(source)
+    bad = [m for m in modules if m.startswith(forbidden)]
+    assert not bad, f"forbidden import prefix '{forbidden}' present: {bad}"


### PR DESCRIPTION
Wave 1 of epic #4558 — closes #4560.

## Summary
Defines the **canonical intermediate representation** every downstream stage of the markerless-mocap → motion-matching pipeline reads/writes. Today engine-specific dataclasses (`MotionCaptureFrame`/`MarkerSet` in `_mocap_data.py`, `SkeletonConfig` in `retargeter.py`) and scattered API models duplicate the same concepts. This PR introduces the shared package they will collapse into.

## Files added/modified
- `src/shared/python/motion_pipeline/__init__.py` — re-exports
- `src/shared/python/motion_pipeline/contracts.py` — Pydantic v2 models + validators (Calibration, KeypointFrame/Sequence, MarkerSample/Frame/Trajectory, JointAxis/Limit, SkeletonRig, JointStateFrame/Trajectory, Provenance, MotionTrajectory, EngineType, CostWeights, MotionMatchingRequest, TorqueTrajectory, MuscleActivationTrajectory, ResidualReport, MotionMatchingResult)
- `tests/unit/motion_pipeline/_fixtures.py` — synthetic builders (`make_keypoint_sequence`, `make_marker_trajectory`, `make_skeleton_rig`, `make_joint_trajectory`, `make_motion_trajectory`)
- `tests/unit/motion_pipeline/test_contracts.py` — 80 unit tests, every invariant + JSON round-trip via `model_dump_json` / `model_validate_json`
- `tests/unit/motion_pipeline/test_lod.py` — `ast`-based import-graph test, parametrized over forbidden prefixes
- `src/learning/retargeting/retargeter.py` — added `SkeletonConfig.to_skeleton_rig()` adapter + `DeprecationWarning` on instantiation (lazy import to avoid cycle; nothing removed)

## Posture
- **TDD**: contracts tested at construction, every invariant violation, and round-trip
- **DbC**: validators enforce monotonic timestamps, finite values, dim consistency, acyclic parent forest, unique joint names, end-effectors ⊆ joint names, cost weights ≥ 0, `lo ≤ hi`, `MotionTrajectory.rig == joint_trajectory.rig`, etc.
- **DRY**: this is the single source of truth that retargeter / mocap_data / api routes will collapse into in later waves
- **LoD**: `contracts.py` imports only stdlib + pydantic; enforced by `test_lod.py` walking `ast.Import`/`ast.ImportFrom`

## Test plan
- [x] `ruff check --fix` clean on the new package + retargeter shim
- [x] `ruff format` clean
- [x] 80/80 contract tests pass (verified via direct module exec — see note below)
- [x] All LoD assertions pass (no engine/api/learning/apps/tools/deployment imports)
- [x] Retargeter shim emits `DeprecationWarning` and `to_skeleton_rig()` produces a valid `SkeletonRig`
- [ ] CI green (watching)

**Local pytest note**: pytest-cov + pytest-xdist + the heavy global `tests/conftest.py` cause `pytest` to hang on this Windows box (a pre-existing environment issue, not caused by this PR). Tests were verified by importing the test modules directly via `importlib` and invoking each `test_*` function (incl. parametrized cases). All 80 contract tests + LoD parametrized cases pass. CI will be the authoritative run.

## Constraints honoured
- No edits to `.github/workflows/`
- Pydantic v2 only
- No new top-level dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)