### PR TITLE
fix(c3d-viewer): resolve crash when loading file via Open dialog

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/run_c3d_viewer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/run_c3d_viewer.py
@@ -54,6 +54,14 @@ for _modname in list(sys.modules):
 
 sys.path.insert(0, str(_PYTHON_DIR))
 
+# Step 3: also add ``<repo>/src/`` so bare top-level imports done by the
+# viewer code (``from shared.python.security...``) resolve. The engine's
+# local ``src/`` does not contain a ``shared/`` subpackage, so adding the
+# repo's ``src/`` directory does not conflict with the engine package.
+_REPO_SRC = _REPO_ROOT / "src"
+if _REPO_SRC.is_dir():
+    sys.path.insert(0, str(_REPO_SRC))
+
 from src.apps.c3d_viewer import main  # noqa: E402  (post-sys.path pivot)
 
 


### PR DESCRIPTION
## Symptom

Clicking the **C3D Viewer** tile, then **File → Open** and selecting a `.c3d` file crashes the viewer subprocess.

## Root cause

\`src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py:170\` does:

\`\`\`python
from shared.python.security.security_utils import validate_path
\`\`\`

This is a **bare top-level import** — \`shared\` must be findable as a directory on \`sys.path\`. The wrapper script (\`run_c3d_viewer.py\`) carefully pivots \`sys.path\` and \`sys.modules['src']\` to point at the engine's local \`src/\` package so the viewer's relative imports resolve. But the pivot did NOT extend \`sys.path\` with \`<repo>/src/\`, so when the viewer code later does the bare \`shared.python...\` lookup, Python finds no top-level \`shared\` directory and raises \`ModuleNotFoundError\`.

## Fix

Add \`<repo>/src/\` to \`sys.path\` in the wrapper. The engine's local \`src/\` does NOT have a \`shared/\` subdirectory, so adding the repo's \`src/\` is safe and does not conflict with the engine's \`src.apps.c3d_viewer\` import.

## Verification

Reproduced the crash by calling \`load_c3d_file_from_path()\` directly:

\`\`\`
ModuleNotFoundError: No module named 'shared.python.security'
\`\`\`

After the fix, the same call succeeds:

\`\`\`
OK: model loaded -> C3DDataModel
     markers=38, frames=654
\`\`\`

## Test plan

- [x] Reproduce: bare import of \`shared.python.security.security_utils\` post-pivot raises ModuleNotFoundError
- [x] Verify: post-fix, import resolves and \`load_c3d_file_from_path\` succeeds
- [x] No regression: existing wrapper smoke (Qt window opens cleanly) still passes