### PR TITLE
feat(launcher): modern info-icon help button (#4627)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Motion Capture Plotter/starting_pose_matcher.py
@@ -435,20 +435,20 @@ _HELP_TEXT: dict[str, str] = {
 
 
 def _help_button(section_title: str, parent: QWidget | None = None) -> QToolButton:
-    """Make a small ``?`` button that pops up the help text for a section."""
-    btn = QToolButton(parent)
-    btn.setText("?")
-    btn.setToolTip(f"Help: {section_title}")
-    btn.setObjectName("help")
-    btn.setAutoRaise(True)
-    btn.setCursor(Qt.CursorShape.WhatsThisCursor)
-    btn.setFixedSize(20, 20)
+    """Make a small info-icon button that pops up the help text for a section."""
+    from src.shared.python.ui.info_button import make_info_button
 
     def _show() -> None:
         text = _HELP_TEXT.get(section_title, "(no help text registered)")
         QMessageBox.information(parent, f"Help — {section_title}", text)
 
-    btn.clicked.connect(_show)
+    btn = make_info_button(
+        parent,
+        tooltip=f"Help: {section_title}",
+        accessible_name=f"Help: {section_title}",
+        on_click=_show,
+    )
+    btn.setObjectName("help")
     return btn
 
 

--- a/src/launchers/runtime_mode_help.py
+++ b/src/launchers/runtime_mode_help.py
@@ -96,16 +96,14 @@ def make_runtime_mode_help_button(parent: QWidget | None = None) -> QToolButton:
     Returns:
         Configured QToolButton; click it to show :func:`show_runtime_mode_help`.
     """
-    btn = QToolButton(parent)
-    btn.setText("?")
-    btn.setAutoRaise(True)
-    btn.setCursor(Qt.CursorShape.WhatsThisCursor)
-    btn.setAccessibleName("Engine runtime help")
-    btn.setToolTip("What's the difference between Native, Docker, and WSL2 runtimes?")
-    # Keep it compact — fixed width so it doesn't expand in the top bar.
-    btn.setFixedWidth(22)
-    btn.clicked.connect(lambda: show_runtime_mode_help(parent))
-    return btn
+    from src.shared.python.ui.info_button import make_info_button
+
+    return make_info_button(
+        parent,
+        tooltip=("What's the difference between Native, Docker, and WSL2 runtimes?"),
+        accessible_name="Engine runtime help",
+        on_click=lambda: show_runtime_mode_help(parent),
+    )
 
 
 __all__ = [

--- a/src/shared/python/ui/info_button.py
+++ b/src/shared/python/ui/info_button.py
@@ -1,0 +1,64 @@
+"""Compact, flat info-icon button for inline help affordances.
+
+Uses the platform's standard ``SP_MessageBoxInformation`` icon so the
+button looks native on Windows / macOS / Linux instead of rendering as
+a literal "?" text glyph.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from PyQt6.QtCore import QSize, Qt
+from PyQt6.QtWidgets import QStyle, QToolButton
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QWidget
+
+
+def make_info_button(
+    parent: QWidget | None = None,
+    *,
+    tooltip: str = "More information",
+    accessible_name: str = "More information",
+    on_click: Callable[[], None] | None = None,
+    icon_size_px: int = 16,
+) -> QToolButton:
+    """Build a small, flat info button using the platform's info icon.
+
+    The button uses :attr:`QStyle.StandardPixmap.SP_MessageBoxInformation`
+    so it picks up the host platform's native "circle-i" glyph rather
+    than rendering a literal ``?`` text character.
+
+    Args:
+        parent: Optional parent widget; the button is added to its
+            layout by the caller.
+        tooltip: Tooltip displayed on hover. Should describe what
+            the click reveals (e.g. "What's the difference between X
+            and Y?") rather than a generic phrase.
+        accessible_name: Name exposed to assistive technology / screen
+            readers.
+        on_click: Optional zero-argument callable connected to the
+            ``clicked`` signal.
+        icon_size_px: Edge length, in pixels, of the rendered icon.
+            Defaults to 16 — small enough to sit flush with a label.
+
+    Returns:
+        A configured :class:`QToolButton` ready to be inserted into a
+        layout.
+    """
+    btn = QToolButton(parent)
+    style = btn.style()
+    btn.setIcon(style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxInformation))
+    btn.setIconSize(QSize(icon_size_px, icon_size_px))
+    btn.setAutoRaise(True)
+    btn.setCursor(Qt.CursorShape.WhatsThisCursor)
+    btn.setToolTip(tooltip)
+    btn.setAccessibleName(accessible_name)
+    if on_click is not None:
+        btn.clicked.connect(on_click)
+    return btn
+
+
+__all__ = ["make_info_button"]

--- a/src/tools/starting_pose_matcher/gui.py
+++ b/src/tools/starting_pose_matcher/gui.py
@@ -387,20 +387,20 @@ _HELP_TEXT: dict[str, str] = {
 
 
 def _help_button(section_title: str, parent: QWidget | None = None) -> QToolButton:
-    """Make a small ``?`` button that pops up the help text for a section."""
-    btn = QToolButton(parent)
-    btn.setText("?")
-    btn.setToolTip(f"Help: {section_title}")
-    btn.setObjectName("help")
-    btn.setAutoRaise(True)
-    btn.setCursor(Qt.CursorShape.WhatsThisCursor)
-    btn.setFixedSize(20, 20)
+    """Make a small info-icon button that pops up the help text for a section."""
+    from src.shared.python.ui.info_button import make_info_button
 
     def _show() -> None:
         text = _HELP_TEXT.get(section_title, "(no help text registered)")
         QMessageBox.information(parent, f"Help — {section_title}", text)
 
-    btn.clicked.connect(_show)
+    btn = make_info_button(
+        parent,
+        tooltip=f"Help: {section_title}",
+        accessible_name=f"Help: {section_title}",
+        on_click=_show,
+    )
+    btn.setObjectName("help")
     return btn
 
 

--- a/tests/launchers/test_runtime_mode_help.py
+++ b/tests/launchers/test_runtime_mode_help.py
@@ -1,0 +1,70 @@
+"""Tests for the runtime-mode help button (issue #4627)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def test_runtime_mode_help_button_uses_icon_not_text(qt_app) -> None:
+    from src.launchers.runtime_mode_help import make_runtime_mode_help_button
+
+    btn = make_runtime_mode_help_button()
+
+    assert btn.text() == "", "runtime-mode help button must not use a literal '?'"
+    assert not btn.icon().isNull(), "runtime-mode help button must carry an icon"
+
+
+def test_runtime_mode_help_button_tooltip_is_specific(qt_app) -> None:
+    from src.launchers.runtime_mode_help import make_runtime_mode_help_button
+
+    btn = make_runtime_mode_help_button()
+    tooltip = btn.toolTip()
+
+    assert tooltip, "tooltip must be non-empty"
+    # Tooltip should specifically mention the runtimes it explains, not be
+    # a generic phrase like "More information".
+    lower = tooltip.lower()
+    assert "runtime" in lower or "native" in lower or "docker" in lower
+
+
+def test_runtime_mode_help_button_accessible_name(qt_app) -> None:
+    from src.launchers.runtime_mode_help import make_runtime_mode_help_button
+
+    btn = make_runtime_mode_help_button()
+    assert "runtime" in btn.accessibleName().lower()
+
+
+def test_runtime_mode_help_button_click_opens_dialog(qt_app) -> None:
+    from src.launchers.runtime_mode_help import make_runtime_mode_help_button
+
+    with patch("src.launchers.runtime_mode_help.QMessageBox") as mock_msgbox_cls:
+        instance = mock_msgbox_cls.return_value
+        btn = make_runtime_mode_help_button()
+        btn.click()
+
+        assert mock_msgbox_cls.called, (
+            "clicking the button must construct a QMessageBox"
+        )
+        # Find the title set on the message box.
+        title_calls = [
+            call_args.args[0] for call_args in instance.setWindowTitle.call_args_list
+        ]
+        assert any("Engine Runtime" in t for t in title_calls), (
+            f"expected 'Engine Runtime' in dialog title; got {title_calls!r}"
+        )

--- a/tests/unit/ui/test_info_button.py
+++ b/tests/unit/ui/test_info_button.py
@@ -1,0 +1,74 @@
+"""Unit tests for the shared info-icon button helper."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def test_info_button_has_icon_and_no_question_mark_text(qt_app) -> None:
+    from PyQt6.QtCore import QSize
+
+    from src.shared.python.ui.info_button import make_info_button
+
+    btn = make_info_button(tooltip="Specific help text", accessible_name="Help A")
+
+    assert not btn.icon().isNull(), "info button should carry a non-null icon"
+    assert btn.iconSize() == QSize(16, 16)
+    assert btn.text() == "", "info button must NOT use a literal '?' text glyph"
+
+
+def test_info_button_invokes_callback(qt_app) -> None:
+    from src.shared.python.ui.info_button import make_info_button
+
+    calls: list[int] = []
+
+    def _cb() -> None:
+        calls.append(1)
+
+    btn = make_info_button(on_click=_cb, tooltip="X", accessible_name="X")
+    btn.click()
+
+    assert calls == [1]
+
+
+def test_info_button_accessible_name(qt_app) -> None:
+    from src.shared.python.ui.info_button import make_info_button
+
+    btn = make_info_button(
+        tooltip="Adjust the size of the model tiles",
+        accessible_name="Tile scale help",
+    )
+
+    assert btn.accessibleName() == "Tile scale help"
+    assert btn.toolTip() == "Adjust the size of the model tiles"
+
+
+def test_info_button_custom_icon_size(qt_app) -> None:
+    from PyQt6.QtCore import QSize
+
+    from src.shared.python.ui.info_button import make_info_button
+
+    btn = make_info_button(icon_size_px=24, tooltip="X", accessible_name="X")
+    assert btn.iconSize() == QSize(24, 24)
+
+
+def test_info_button_is_auto_raise(qt_app) -> None:
+    from src.shared.python.ui.info_button import make_info_button
+
+    btn = make_info_button(tooltip="X", accessible_name="X")
+    assert btn.autoRaise() is True


### PR DESCRIPTION
Closes #4627

## Summary

- Adds `src/shared/python/ui/info_button.py` — `make_info_button(...)` factory that uses the platform's standard `SP_MessageBoxInformation` icon (native circle-i on Windows / macOS / Linux) instead of a literal `?` text glyph.
- Refactors `src/launchers/runtime_mode_help.py` to call `make_info_button` (drops `setText("?")` + `setFixedWidth(22)`).
- Replaces 2 other literal `?` help buttons that pop a dialog: `src/tools/starting_pose_matcher/gui.py` and the parallel `src/engines/Simscape_Multibody_Models/.../starting_pose_matcher.py`. Each retains its specific tooltip ("Help: <section>").
- Leaves `src/shared/python/gui_pkg/help_system.py` alone — it intentionally renders a styled circular `?` badge (custom CSS background / border-radius), a different visual pattern that's out of scope for this issue.

Total literal-`?` help buttons replaced: **3** (runtime-mode + 2 starting-pose-matcher).

`git grep -nE '\.setText\(\s*"\?"\s*\)' src/launchers/` returns zero hits.

## Test plan

- [x] `ruff check` and `ruff format --check` pass on touched files.
- [x] `scripts/ci/check_file_size_budget.py` passes.
- [x] New `tests/unit/ui/test_info_button.py` covers icon presence, no `?` text, icon size, callback wiring, accessible name, auto-raise.
- [x] New `tests/launchers/test_runtime_mode_help.py` covers icon-not-text, specific tooltip, accessible name, click → `QMessageBox` with "Engine Runtime" title.
- [x] Manual smoke run (offscreen Qt) confirmed: `btn.text() == ""`, icon non-null, `iconSize == 16x16`, callback fires on `click()`, runtime-mode helper composes correctly.
- [ ] Visual verification on Windows 11 (native info icon vs old `?` glyph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)