### PR TITLE
feat(launcher): dynamic tiles + view modes (#4626)

### DIFF
--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -258,7 +258,9 @@ class GolfLauncher(
             config_file=LAYOUT_CONFIG_FILE,
             available_models=self.available_models,
             get_model_func=self._get_model,
-            create_card_func=lambda model: DraggableModelCard(model, self),
+            create_card_func=lambda model, **kwargs: DraggableModelCard(
+                model, self, **kwargs
+            ),
             create_header_func=self._create_category_header,
         )
         self.model_cards = self.layout_manager.model_cards

--- a/src/launchers/launcher_constants.py
+++ b/src/launchers/launcher_constants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import subprocess
 import sys
+from enum import IntEnum
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,90 @@ REPOS_ROOT = Path(__file__).parent.parent.parent.resolve()
 CONFIG_DIR = REPOS_ROOT / ".kiro" / "launcher"
 LAYOUT_CONFIG_FILE = CONFIG_DIR / "layout.json"
 GRID_COLUMNS = 4  # Changed to 3x4 grid (12 tiles total)
+
+# Tile sizing constants for the resizable launcher tile system.
+# Reference (1.0x) values match the original hard-coded layout.
+TILE_SCALE_MIN = 0.25
+TILE_SCALE_MAX = 2.0
+TILE_SCALE_DEFAULT = 0.5
+TILE_BASE_IMAGE_PX = 200
+TILE_BASE_FONT_PT = 11
+TILE_BASE_PADDING_PX = 12
+# Floor for derived font sizes so chip/desc text stays legible at min scale.
+TILE_MIN_FONT_PT = 9
+
+
+class ViewMode(IntEnum):
+    """Launcher tile-grid layout modes.
+
+    Each mode maps to a (tile_scale, columns, show_description, is_list) tuple
+    via :func:`view_mode_settings`.
+    """
+
+    COMFORTABLE = 0
+    COMPACT = 1
+    DENSE = 2
+    LIST = 3
+
+
+# (tile_scale, columns, show_description, is_list)
+_VIEW_MODE_TABLE: dict[ViewMode, tuple[float, int, bool, bool]] = {
+    ViewMode.COMFORTABLE: (1.0, 4, True, False),
+    ViewMode.COMPACT: (0.5, 6, True, False),
+    ViewMode.DENSE: (0.35, 8, False, False),
+    ViewMode.LIST: (0.30, 1, True, True),
+}
+
+
+def view_mode_settings(mode: ViewMode) -> tuple[float, int, bool, bool]:
+    """Return the (tile_scale, columns, show_description, is_list) for a mode.
+
+    Raises:
+        TypeError: if ``mode`` is not a :class:`ViewMode`.
+        ValueError: if ``mode`` is not one of the known view modes.
+    """
+    if not isinstance(mode, ViewMode):
+        raise TypeError(f"mode must be a ViewMode IntEnum, got {type(mode).__name__}")
+    if mode not in _VIEW_MODE_TABLE:
+        raise ValueError(f"Unknown ViewMode: {mode!r}")
+    return _VIEW_MODE_TABLE[mode]
+
+
+def validate_tile_scale(scale: float) -> float:
+    """Validate and clamp a tile-scale value into [MIN, MAX].
+
+    Raises:
+        TypeError: if ``scale`` is not a real number.
+        ValueError: if ``scale`` is NaN or non-positive.
+    """
+    if isinstance(scale, bool) or not isinstance(scale, int | float):
+        raise TypeError(f"tile_scale must be a real number, got {type(scale).__name__}")
+    f = float(scale)
+    if f != f:  # NaN check
+        raise ValueError("tile_scale must not be NaN")
+    if f <= 0.0:
+        raise ValueError(f"tile_scale must be positive, got {f}")
+    if f < TILE_SCALE_MIN:
+        return TILE_SCALE_MIN
+    if f > TILE_SCALE_MAX:
+        return TILE_SCALE_MAX
+    return f
+
+
+def scaled_image_px(scale: float) -> int:
+    """Return the tile image size in pixels for a given tile_scale."""
+    return max(1, int(TILE_BASE_IMAGE_PX * validate_tile_scale(scale)))
+
+
+def scaled_font_pt(scale: float, base_pt: int = TILE_BASE_FONT_PT) -> int:
+    """Return a font point size for a given tile_scale, with a legibility floor."""
+    return max(TILE_MIN_FONT_PT, int(round(base_pt * validate_tile_scale(scale))))
+
+
+def scaled_padding_px(scale: float) -> int:
+    """Return padding/margin in pixels for a given tile_scale."""
+    return max(2, int(round(TILE_BASE_PADDING_PX * validate_tile_scale(scale))))
+
 
 DOCKER_STAGES: tuple[str, ...] = ("all", "mujoco", "pinocchio", "drake", "base")
 

--- a/src/launchers/launcher_layout_manager.py
+++ b/src/launchers/launcher_layout_manager.py
@@ -10,6 +10,12 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from src.launchers.launcher_constants import (
+    TILE_SCALE_DEFAULT,
+    ViewMode,
+    validate_tile_scale,
+    view_mode_settings,
+)
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -25,6 +31,17 @@ class LayoutConfig:
     DEFAULT_WINDOW_WIDTH = 1280
     DEFAULT_WINDOW_HEIGHT = 800
     MIN_WINDOW_Y = 50  # Ensure window title bar is visible
+
+
+def _view_mode_from_string(name: str | None) -> ViewMode:
+    """Parse a stored string into a :class:`ViewMode`, defaulting to COMPACT."""
+    if not name:
+        return ViewMode.COMPACT
+    try:
+        return ViewMode[str(name).strip().upper()]
+    except KeyError:
+        logger.warning("Unknown view_mode %r, falling back to COMPACT", name)
+        return ViewMode.COMPACT
 
 
 class LayoutManager:
@@ -69,6 +86,8 @@ class LayoutManager:
         self.model_cards: dict[str, Any] = {}
         self.edit_mode = False
         self.current_filter_text = ""
+        self.current_view_mode: ViewMode = ViewMode.COMPACT
+        self.tile_scale: float = TILE_SCALE_DEFAULT
 
     def initialize_model_order(self, default_ids: list[str] | None = None) -> None:
         """Set a sensible default grid ordering.
@@ -128,6 +147,8 @@ class LayoutManager:
                 "selected_model": window_state.get("selected_model"),
                 "window_geometry": window_state.get("geometry", {}),
                 "options": window_state.get("options", {}),
+                "view_mode": self.current_view_mode.name.lower(),
+                "tile_scale": float(self.tile_scale),
             }
 
             with open(self.config_file, "w", encoding="utf-8") as f:
@@ -162,6 +183,19 @@ class LayoutManager:
                 self.model_order = saved_order
                 logger.info("Model layout restored from saved configuration")
 
+            # View-mode + tile-scale are additive keys; missing ones use defaults.
+            self.current_view_mode = _view_mode_from_string(
+                layout_data.get("view_mode")
+            )
+            raw_scale = layout_data.get("tile_scale")
+            if raw_scale is not None:
+                try:
+                    self.tile_scale = validate_tile_scale(float(raw_scale))
+                except (TypeError, ValueError) as exc:
+                    logger.warning(
+                        "Invalid tile_scale %r in saved layout: %s", raw_scale, exc
+                    )
+
             return layout_data
 
         except (json.JSONDecodeError, OSError, KeyError) as e:
@@ -178,11 +212,17 @@ class LayoutManager:
                 widget.deleteLater()
 
         # Create cards for any newly added models
+        _scale, _cols, show_desc, is_list = view_mode_settings(self.current_view_mode)
         for model_id in self.model_order:
             if model_id not in self.model_cards:
                 model = self._get_model(model_id)
                 if model:
-                    self.model_cards[model_id] = self._create_card(model)
+                    self.model_cards[model_id] = self._build_card(
+                        model,
+                        tile_scale=self.tile_scale,
+                        show_description=show_desc,
+                        list_mode=is_list,
+                    )
 
     def apply_model_selection(self, selected_ids: list[str]) -> list[str]:
         """Apply a new set of selected models from the layout dialog.
@@ -295,16 +335,68 @@ class LayoutManager:
             return "Analysis Tools"
         return "Utilities"
 
+    def _build_card(self, model: Any, **kwargs: Any) -> Any:
+        """Invoke ``_create_card`` with optional keyword arguments.
+
+        Falls back to a positional-only call so legacy callbacks that accept
+        ``(model,)`` continue to work.
+        """
+        try:
+            return self._create_card(model, **kwargs)
+        except TypeError:
+            return self._create_card(model)
+
+    def set_view_mode(self, mode: ViewMode) -> None:
+        """Apply a new :class:`ViewMode` and propagate scaling to existing cards.
+
+        The actual grid is not rebuilt here — call :meth:`rebuild_grid` after.
+        """
+        if not isinstance(mode, ViewMode):
+            raise TypeError(f"mode must be a ViewMode, got {type(mode).__name__}")
+        scale, _cols, show_desc, is_list = view_mode_settings(mode)
+        self.current_view_mode = mode
+        self.tile_scale = scale
+        # When switching into/out of LIST mode the grid topology changes, so
+        # we drop existing cards and let rebuild_grid recreate them with the
+        # right list_mode flag. For grid->grid switches an in-place
+        # set_tile_scale is sufficient.
+        was_list = any(
+            getattr(c, "_list_mode", False) for c in self.model_cards.values()
+        )
+        if is_list != was_list:
+            for c in list(self.model_cards.values()):
+                c.setParent(None)
+                c.deleteLater()
+            self.model_cards.clear()
+        else:
+            for card in self.model_cards.values():
+                if hasattr(card, "set_tile_scale"):
+                    card.set_tile_scale(
+                        scale,
+                        show_description=show_desc,
+                        list_mode=is_list,
+                    )
+
+    def set_tile_scale(self, scale: float) -> None:
+        """Update tile_scale and resize all live cards in place."""
+        self.tile_scale = validate_tile_scale(scale)
+        _scale, _cols, show_desc, is_list = view_mode_settings(self.current_view_mode)
+        for card in self.model_cards.values():
+            if hasattr(card, "set_tile_scale"):
+                card.set_tile_scale(
+                    self.tile_scale,
+                    show_description=show_desc,
+                    list_mode=is_list,
+                )
+
     def rebuild_grid(self, grid_layout: QGridLayout) -> None:  # noqa: C901
-        """Rebuild the grid layout based on current model order.
+        """Rebuild the grid layout based on current model order and view mode.
 
         Args:
             grid_layout: The Qt grid layout to populate.
         """
         # Clean current layout
-        if not (grid_layout is not None):
-            raise ValueError("grid_layout must be provided")
-        if not (grid_layout is not None):
+        if grid_layout is None:
             raise ValueError("grid_layout must be provided")
         while grid_layout.count():
             item = grid_layout.takeAt(0)
@@ -313,11 +405,16 @@ class LayoutManager:
                 if widget:
                     widget.setParent(None)
 
+        scale, columns, show_desc, is_list = view_mode_settings(self.current_view_mode)
+        # Honour any explicit tile_scale set by the zoom slider, but fall
+        # back to the view-mode default if it matches the previous mode.
+        active_scale = self.tile_scale if self.tile_scale > 0 else scale
+
         # Get filtered model order
         filtered_order = self.get_filtered_order()
 
         # Group widgets by category maintaining order
-        categories = {
+        categories: dict[str, list[Any]] = {
             "Core Physics Engines": [],
             "Analysis Tools": [],
             "Matlab Simscape Models": [],
@@ -329,7 +426,21 @@ class LayoutManager:
             if model_id not in self.model_cards:
                 model = self._get_model(model_id)
                 if model:
-                    self.model_cards[model_id] = self._create_card(model)
+                    self.model_cards[model_id] = self._build_card(
+                        model,
+                        tile_scale=active_scale,
+                        show_description=show_desc,
+                        list_mode=is_list,
+                    )
+            else:
+                # Existing card — make sure it matches current scale/mode.
+                card = self.model_cards[model_id]
+                if hasattr(card, "set_tile_scale"):
+                    card.set_tile_scale(
+                        active_scale,
+                        show_description=show_desc,
+                        list_mode=is_list,
+                    )
 
             if model_id in self.model_cards:
                 model = self._get_model(model_id)
@@ -344,21 +455,26 @@ class LayoutManager:
             if not widgets:
                 continue
 
-            # Add section header
+            # Add section header spanning the active number of columns.
             if self._create_header:
                 header = self._create_header(cat_name)
-                grid_layout.addWidget(header, row, 0, 1, LayoutConfig.GRID_COLUMNS)
+                grid_layout.addWidget(header, row, 0, 1, columns)
             row += 1
 
             col = 0
             for widget in widgets:
-                grid_layout.addWidget(widget, row, col)
-                col += 1
-                if col >= LayoutConfig.GRID_COLUMNS:
-                    col = 0
+                if is_list:
+                    # Each card occupies a full row, one card per row.
+                    grid_layout.addWidget(widget, row, 0, 1, 1)
                     row += 1
+                else:
+                    grid_layout.addWidget(widget, row, col)
+                    col += 1
+                    if col >= columns:
+                        col = 0
+                        row += 1
 
-            if col > 0:
+            if not is_list and col > 0:
                 row += 1
 
     def set_edit_mode(self, enabled: bool) -> None:

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -19,6 +19,7 @@ from PyQt6.QtGui import (
 )
 from PyQt6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDockWidget,
     QFrame,
     QGridLayout,
@@ -28,11 +29,18 @@ from PyQt6.QtWidgets import (
     QPlainTextEdit,
     QPushButton,
     QScrollArea,
+    QSlider,
     QSplitter,
     QStyle,
     QToolButton,
     QVBoxLayout,
     QWidget,
+)
+
+from src.launchers.launcher_constants import (
+    TILE_SCALE_MAX,
+    TILE_SCALE_MIN,
+    ViewMode,
 )
 
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -566,11 +574,116 @@ class LauncherUISetupMixin:
             "engine_selection",
         )
 
+    # ---- View-mode + zoom controls --------------------------------------
+
+    _ZOOM_SLIDER_STEPS = 100  # slider integer range -> [MIN, MAX] tile_scale
+
+    def _slider_to_scale(self, value: int) -> float:
+        """Map a slider integer ``value`` to a tile_scale float."""
+        v = max(0, min(self._ZOOM_SLIDER_STEPS, int(value)))
+        frac = v / float(self._ZOOM_SLIDER_STEPS)
+        return TILE_SCALE_MIN + (TILE_SCALE_MAX - TILE_SCALE_MIN) * frac
+
+    def _scale_to_slider(self, scale: float) -> int:
+        """Map a tile_scale float back to slider integer steps."""
+        s = max(TILE_SCALE_MIN, min(TILE_SCALE_MAX, float(scale)))
+        frac = (s - TILE_SCALE_MIN) / (TILE_SCALE_MAX - TILE_SCALE_MIN)
+        return int(round(frac * self._ZOOM_SLIDER_STEPS))
+
+    def _setup_view_mode_and_zoom(self, top_bar: QHBoxLayout) -> None:
+        """Add view-mode combobox, zoom slider, and percent label to top bar."""
+        if top_bar is None:
+            raise ValueError("top_bar must be provided")
+
+        self.view_mode_combo = QComboBox()
+        self.view_mode_combo.addItem("Comfortable", ViewMode.COMFORTABLE)
+        self.view_mode_combo.addItem("Compact", ViewMode.COMPACT)
+        self.view_mode_combo.addItem("Dense", ViewMode.DENSE)
+        self.view_mode_combo.addItem("List", ViewMode.LIST)
+        self.view_mode_combo.setCurrentIndex(1)  # Compact default
+        self.view_mode_combo.setToolTip("Choose how the model tiles are arranged")
+        self.view_mode_combo.setAccessibleName("View mode")
+        self.view_mode_combo.currentIndexChanged.connect(self._on_view_mode_changed)
+        top_bar.addWidget(self.view_mode_combo)
+
+        self.zoom_slider = QSlider(Qt.Orientation.Horizontal)
+        self.zoom_slider.setRange(0, self._ZOOM_SLIDER_STEPS)
+        self.zoom_slider.setFixedWidth(140)
+        self.zoom_slider.setToolTip("Adjust the size of the model tiles")
+        self.zoom_slider.setAccessibleName("Tile zoom")
+
+        # Initial position from layout_manager if available, else compact 0.5.
+        from src.launchers.launcher_constants import TILE_SCALE_DEFAULT
+
+        initial_scale = TILE_SCALE_DEFAULT
+        lm = getattr(self, "layout_manager", None)
+        if lm is not None and hasattr(lm, "tile_scale"):
+            initial_scale = float(lm.tile_scale)
+        self.zoom_slider.setValue(self._scale_to_slider(initial_scale))
+        self.zoom_slider.valueChanged.connect(self._on_zoom_slider_changed)
+        top_bar.addWidget(self.zoom_slider)
+
+        self.lbl_zoom_pct = QLabel(f"{int(round(initial_scale * 100))}%")
+        self.lbl_zoom_pct.setToolTip("Current tile size as a percentage of base")
+        top_bar.addWidget(self.lbl_zoom_pct)
+
+        # Ctrl+= / Ctrl+- shortcuts adjust zoom by one step (~1.75% scale).
+        sc_in = QShortcut(QKeySequence("Ctrl+="), self)
+        sc_in.activated.connect(lambda: self._nudge_zoom(+5))
+        sc_in_alt = QShortcut(QKeySequence("Ctrl++"), self)
+        sc_in_alt.activated.connect(lambda: self._nudge_zoom(+5))
+        sc_out = QShortcut(QKeySequence("Ctrl+-"), self)
+        sc_out.activated.connect(lambda: self._nudge_zoom(-5))
+
+    def _nudge_zoom(self, delta_steps: int) -> None:
+        """Adjust the zoom slider by ``delta_steps`` integer ticks."""
+        slider = getattr(self, "zoom_slider", None)
+        if slider is None:
+            return
+        slider.setValue(slider.value() + delta_steps)
+
+    def _on_view_mode_changed(self, index: int) -> None:
+        """Apply the selected view mode to the layout manager + grid."""
+        combo = getattr(self, "view_mode_combo", None)
+        if combo is None:
+            return
+        mode = combo.itemData(index)
+        if not isinstance(mode, ViewMode):
+            return
+        lm = getattr(self, "layout_manager", None)
+        if lm is None:
+            return
+        lm.set_view_mode(mode)
+        # Update zoom slider/label to reflect the mode's default scale.
+        if hasattr(self, "zoom_slider"):
+            self.zoom_slider.blockSignals(True)
+            self.zoom_slider.setValue(self._scale_to_slider(lm.tile_scale))
+            self.zoom_slider.blockSignals(False)
+        if hasattr(self, "lbl_zoom_pct"):
+            self.lbl_zoom_pct.setText(f"{int(round(lm.tile_scale * 100))}%")
+        if hasattr(self, "grid_layout"):
+            lm.rebuild_grid(self.grid_layout)
+        if hasattr(self, "_save_layout"):
+            self._save_layout()
+
+    def _on_zoom_slider_changed(self, value: int) -> None:
+        """Live-resize all model cards to match the new slider position."""
+        lm = getattr(self, "layout_manager", None)
+        scale = self._slider_to_scale(value)
+        if hasattr(self, "lbl_zoom_pct"):
+            self.lbl_zoom_pct.setText(f"{int(round(scale * 100))}%")
+        if lm is None:
+            return
+        lm.set_tile_scale(scale)
+        if hasattr(self, "_save_layout"):
+            self._save_layout()
+
     def _setup_top_bar(self) -> QHBoxLayout:
         """Set up the top tool bar."""
         top_bar = QHBoxLayout()
 
         self._setup_top_bar_status_and_search(top_bar)
+        self._setup_view_mode_and_zoom(top_bar)
         self._setup_top_bar_config_checkboxes()
         self._setup_top_bar_action_buttons(top_bar)
 

--- a/src/launchers/model_card.py
+++ b/src/launchers/model_card.py
@@ -40,6 +40,13 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.theme.style_constants import Styles
 from src.shared.python.theme.typography import Weights, get_display_font, get_qfont
 
+from .launcher_constants import (
+    TILE_SCALE_DEFAULT,
+    scaled_font_pt,
+    scaled_image_px,
+    scaled_padding_px,
+    validate_tile_scale,
+)
 from .startup import ASSETS_DIR, _get_theme_colors
 
 if TYPE_CHECKING:
@@ -94,10 +101,21 @@ MODEL_IMAGES = {
 class DraggableModelCard(QFrame):
     """Draggable model card widget with reordering support."""
 
-    def __init__(self, model: Any, parent_launcher: Any) -> None:
+    def __init__(
+        self,
+        model: Any,
+        parent_launcher: Any,
+        tile_scale: float = TILE_SCALE_DEFAULT,
+        *,
+        show_description: bool = True,
+        list_mode: bool = False,
+    ) -> None:
         super().__init__(None)
         self.model = model
         self.parent_launcher = parent_launcher
+        self.tile_scale: float = validate_tile_scale(tile_scale)
+        self._show_description: bool = bool(show_description)
+        self._list_mode: bool = bool(list_mode)
 
         # Match initial drag-and-drop state to the parent's mode
         self.setAcceptDrops(bool(getattr(parent_launcher, "layout_edit_mode", False)))
@@ -154,7 +172,8 @@ class DraggableModelCard(QFrame):
         scale_factor = 1.0 + (value / 4.0) * 0.03
         if hasattr(self, "lbl_img") and hasattr(self, "base_pixmap"):  # noqa: SIM102
             if self.base_pixmap and not self.base_pixmap.isNull():
-                new_size = int(180 * scale_factor)
+                base_px = scaled_image_px(self.tile_scale)
+                new_size = max(1, int(base_px * 0.9 * scale_factor))
                 scaled = self.base_pixmap.scaled(
                     new_size,
                     new_size,
@@ -234,28 +253,31 @@ class DraggableModelCard(QFrame):
             return img_path
         return None
 
-    def _create_image_widget(self, layout: QVBoxLayout) -> None:
+    def _create_image_widget(self, layout: QVBoxLayout | QHBoxLayout) -> None:
         """Create and add the model image label to the layout."""
-        if not (layout is not None):
-            raise ValueError("layout must be provided")
-        if not (layout is not None):
+        if layout is None:
             raise ValueError("layout must be provided")
         img_name = self._resolve_image_name()
         img_path = self._find_image_path(img_name)
 
+        # In LIST mode the image is forced to a small (60x60) horizontal-row
+        # icon regardless of tile_scale. In other modes it scales from the
+        # 200px reference by ``tile_scale``.
+        img_size = 60 if self._list_mode else scaled_image_px(self.tile_scale)
+        pixmap_target = max(1, int(img_size * 0.9))
+
         self.lbl_img = QLabel()
         self.lbl_img.setObjectName("CardImage")
-        self.lbl_img.setFixedSize(200, 200)
+        self.lbl_img.setFixedSize(img_size, img_size)
         self.lbl_img.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.setAlignment(self.lbl_img, Qt.AlignmentFlag.AlignCenter)
         self.lbl_img.setStyleSheet(Styles.LABEL_TRANSPARENT)
         self.base_pixmap = None
 
         if img_path and img_path.exists():
             self.base_pixmap = QPixmap(str(img_path))
             pixmap = self.base_pixmap.scaled(
-                180,
-                180,
+                pixmap_target,
+                pixmap_target,
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
@@ -265,6 +287,12 @@ class DraggableModelCard(QFrame):
             self.lbl_img.setText("No Image")
             self.lbl_img.setStyleSheet(Styles.no_image_label(c.text_quaternary))
 
+        if self._list_mode:
+            # In list mode the icon sits to the left without centering frames.
+            layout.addWidget(self.lbl_img)
+            return
+
+        layout.setAlignment(self.lbl_img, Qt.AlignmentFlag.AlignCenter)
         img_container = QWidget()
         img_layout = QHBoxLayout(img_container)
         img_layout.setContentsMargins(0, 0, 0, 0)
@@ -273,19 +301,29 @@ class DraggableModelCard(QFrame):
         img_layout.addStretch()
         layout.addWidget(img_container)
 
-    def _create_status_chip(self, layout: QVBoxLayout) -> None:
-        """Create and add the status chip to the layout."""
-        if not (layout is not None):
-            raise ValueError("layout must be provided")
-        if not (layout is not None):
+    def _create_status_chip(
+        self, layout: QVBoxLayout | QHBoxLayout, *, embed_in_row: bool = False
+    ) -> None:
+        """Create and add the status chip to the layout.
+
+        When ``embed_in_row`` is True (LIST mode) the chip is added directly
+        to the supplied horizontal layout, on the right; otherwise it is
+        centred in its own horizontal sub-layout (grid modes).
+        """
+        if layout is None:
             raise ValueError("layout must be provided")
         status_text, status_color, text_color = self._get_status_info()
         lbl_status = QLabel(status_text)
         lbl_status.setObjectName("StatusChip")
-        lbl_status.setFont(get_qfont(size=8, weight=Weights.BOLD))
+        chip_pt = max(8, scaled_font_pt(self.tile_scale, base_pt=8))
+        lbl_status.setFont(get_qfont(size=chip_pt, weight=Weights.BOLD))
         lbl_status.setStyleSheet(Styles.status_chip(status_color, text_color))
         lbl_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         lbl_status.setMinimumWidth(80)
+
+        if embed_in_row:
+            layout.addWidget(lbl_status)
+            return
 
         chip_layout = QHBoxLayout()
         chip_layout.addStretch()
@@ -295,25 +333,12 @@ class DraggableModelCard(QFrame):
 
     def setup_ui(self) -> None:
         """Build the model card widget layout with image, labels, and status chip."""
-        layout = QVBoxLayout(self)
-        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        if self._list_mode:
+            self._setup_list_ui()
+        else:
+            self._setup_grid_ui()
 
-        self._create_image_widget(layout)
-
-        lbl_name = QLabel(self.model.name)
-        lbl_name.setFont(get_display_font(size=11, weight=Weights.BOLD))
-        lbl_name.setWordWrap(True)
-        lbl_name.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(lbl_name)
-
-        lbl_desc = QLabel(self.model.description)
-        lbl_desc.setFont(get_qfont(size=9))
-        lbl_desc.setObjectName("CardDescription")
-        lbl_desc.setWordWrap(True)
-        lbl_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(lbl_desc)
-
-        self._create_status_chip(layout)
+        self._apply_card_padding()
 
         # Tile-level help text.  Tooltip is a one-line preview; What's-this
         # shows the description and a usage hint.
@@ -329,6 +354,138 @@ class DraggableModelCard(QFrame):
             "Recommended when you want to inspect the tile's status chip "
             "before opening the simulator."
         )
+
+    def _setup_grid_ui(self) -> None:
+        """Build the vertical grid-mode layout (Comfortable/Compact/Dense)."""
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._create_image_widget(layout)
+
+        name_pt = scaled_font_pt(self.tile_scale)
+        self.lbl_name = QLabel(self.model.name)
+        self.lbl_name.setObjectName("CardName")
+        self.lbl_name.setFont(get_display_font(size=name_pt, weight=Weights.BOLD))
+        self.lbl_name.setWordWrap(True)
+        self.lbl_name.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.lbl_name)
+
+        desc_pt = max(scaled_font_pt(self.tile_scale, base_pt=9), 9)
+        self.lbl_desc = QLabel(self.model.description)
+        self.lbl_desc.setFont(get_qfont(size=desc_pt))
+        self.lbl_desc.setObjectName("CardDescription")
+        self.lbl_desc.setWordWrap(True)
+        self.lbl_desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.lbl_desc.setVisible(self._show_description)
+        layout.addWidget(self.lbl_desc)
+
+        self._create_status_chip(layout)
+
+    def _setup_list_ui(self) -> None:
+        """Build the horizontal LIST-mode layout (icon | name+desc | status)."""
+        outer = QHBoxLayout(self)
+        outer.setSpacing(12)
+
+        self._create_image_widget(outer)
+
+        text_box = QVBoxLayout()
+        text_box.setSpacing(2)
+        name_pt = max(scaled_font_pt(self.tile_scale, base_pt=12), 10)
+        self.lbl_name = QLabel(self.model.name)
+        self.lbl_name.setObjectName("CardName")
+        self.lbl_name.setFont(get_display_font(size=name_pt, weight=Weights.BOLD))
+        text_box.addWidget(self.lbl_name)
+
+        self.lbl_desc = QLabel(self.model.description)
+        self.lbl_desc.setObjectName("CardDescription")
+        self.lbl_desc.setFont(get_qfont(size=9))
+        self.lbl_desc.setVisible(self._show_description)
+        text_box.addWidget(self.lbl_desc)
+
+        outer.addLayout(text_box, 1)
+        self._create_status_chip(outer, embed_in_row=True)
+
+        # Force a row-strip footprint roughly matching the issue spec (~60 px).
+        self.setMinimumHeight(60)
+
+    def _apply_card_padding(self) -> None:
+        """Set contents margins on the active layout based on tile_scale."""
+        pad = scaled_padding_px(self.tile_scale)
+        active = self.layout()
+        if active is not None:
+            active.setContentsMargins(pad, pad, pad, pad)
+
+    def set_tile_scale(
+        self,
+        scale: float,
+        *,
+        show_description: bool | None = None,
+        list_mode: bool | None = None,
+    ) -> None:
+        """Resize this card in place using the supplied tile scale.
+
+        Existing labels/pixmap are reused — no disk reload — but the layout
+        is rebuilt when ``list_mode`` changes (vertical vs. horizontal).
+        """
+        scale = validate_tile_scale(scale)
+        if show_description is not None:
+            self._show_description = bool(show_description)
+        new_list_mode = self._list_mode if list_mode is None else bool(list_mode)
+        full_rebuild = new_list_mode != self._list_mode
+        self.tile_scale = scale
+        self._list_mode = new_list_mode
+
+        if full_rebuild:
+            # Clear children + layout, then rebuild from scratch.
+            old_layout = self.layout()
+            if old_layout is not None:
+                while old_layout.count():
+                    item = old_layout.takeAt(0)
+                    w = item.widget() if item else None
+                    if w is not None:
+                        w.setParent(None)
+                        w.deleteLater()
+                # PyQt6: detach the old layout by reparenting to a temp QWidget.
+                QWidget().setLayout(old_layout)
+            self.setup_ui()
+            return
+
+        # In-place update: image, fonts, padding, description visibility.
+        new_img = 60 if self._list_mode else scaled_image_px(self.tile_scale)
+        if hasattr(self, "lbl_img"):
+            self.lbl_img.setFixedSize(new_img, new_img)
+            if self.base_pixmap and not self.base_pixmap.isNull():
+                target = max(1, int(new_img * 0.9))
+                self.lbl_img.setPixmap(
+                    self.base_pixmap.scaled(
+                        target,
+                        target,
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
+                )
+        if hasattr(self, "lbl_name"):
+            base_pt = 12 if self._list_mode else 11
+            self.lbl_name.setFont(
+                get_display_font(
+                    size=scaled_font_pt(self.tile_scale, base_pt=base_pt),
+                    weight=Weights.BOLD,
+                )
+            )
+        if hasattr(self, "lbl_desc"):
+            self.lbl_desc.setVisible(self._show_description)
+            self.lbl_desc.setFont(
+                get_qfont(size=max(scaled_font_pt(self.tile_scale, base_pt=9), 9))
+            )
+        chip = self.findChild(QLabel, "StatusChip")
+        if chip is not None:
+            chip.setFont(
+                get_qfont(
+                    size=max(8, scaled_font_pt(self.tile_scale, base_pt=8)),
+                    weight=Weights.BOLD,
+                )
+            )
+        self._apply_card_padding()
 
     def _get_status_info(self) -> tuple[str, str, str]:
         c = _get_theme_colors()

--- a/tests/launchers/test_launcher_layout_manager.py
+++ b/tests/launchers/test_launcher_layout_manager.py
@@ -325,13 +325,17 @@ def test_rebuild_grid_multiple_columns(layout_manager, available_models) -> None
 
     grid_layout = MagicMock()
     grid_layout.count.return_value = 0
+    # Force COMFORTABLE (4 cols) so that 5 cards wrap to a second row.
+    from src.launchers.launcher_constants import ViewMode
+
+    layout_manager.set_view_mode(ViewMode.COMFORTABLE)
     layout_manager.model_order = ["model_1", "model_2", "model_3", "model_4", "model_5"]
     layout_manager.rebuild_grid(grid_layout)
 
     # Check that it wrapped around
     # 5 widgets + 1 header = 6 calls
     assert grid_layout.addWidget.call_count == 6
-    # The last call should be row=2, col=0 because GRID_COLUMNS=4 and row 0 is header
+    # The last call should be row=2, col=0 because columns=4 and row 0 is header
     last_call = grid_layout.addWidget.call_args_list[-1]
     assert last_call[0][1] == 2  # row
     assert last_call[0][2] == 0  # col

--- a/tests/launchers/test_layout_persistence.py
+++ b/tests/launchers/test_layout_persistence.py
@@ -1,0 +1,112 @@
+"""Tests for view-mode + tile-scale persistence in :class:`LayoutManager`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from src.launchers.launcher_constants import ViewMode
+from src.launchers.launcher_layout_manager import LayoutManager
+from src.launchers.model_registry import ModelSpec
+
+
+@pytest.fixture
+def available_models() -> dict[str, ModelSpec]:
+    return {
+        "model_1": ModelSpec(
+            id="model_1",
+            name="Model 1",
+            description="A",
+            type="managed",
+            path="p1",
+        ),
+    }
+
+
+@pytest.fixture
+def make_layout_manager(available_models, tmp_path: Path):
+    def _make(config_file: Path | None = None) -> LayoutManager:
+        cfg = config_file or (tmp_path / "launcher_layout.json")
+
+        def create_card(model, **kwargs):
+            card = MagicMock()
+            card.tile_scale = float(kwargs.get("tile_scale", 0.5))
+            card._list_mode = bool(kwargs.get("list_mode", False))
+            return card
+
+        return LayoutManager(
+            config_file=cfg,
+            available_models=available_models,
+            get_model_func=lambda mid: available_models.get(mid),
+            create_card_func=create_card,
+            create_header_func=lambda name: MagicMock(),
+        )
+
+    return _make
+
+
+def test_save_and_reload_view_mode_and_scale(make_layout_manager, tmp_path) -> None:
+    cfg = tmp_path / "launcher_layout.json"
+    lm = make_layout_manager(cfg)
+    lm.model_order = ["model_1"]
+    lm.set_view_mode(ViewMode.DENSE)  # sets tile_scale=0.35
+    lm.save_layout({"selected_model": "model_1", "geometry": {}})
+
+    payload = json.loads(cfg.read_text())
+    assert payload["view_mode"] == "dense"
+    assert payload["tile_scale"] == pytest.approx(0.35)
+
+    lm2 = make_layout_manager(cfg)
+    lm2.load_layout()
+    assert lm2.current_view_mode == ViewMode.DENSE
+    assert lm2.tile_scale == pytest.approx(0.35)
+
+
+def test_load_layout_missing_keys_uses_defaults(make_layout_manager, tmp_path) -> None:
+    cfg = tmp_path / "old_layout.json"
+    cfg.write_text(json.dumps({"model_order": ["model_1"]}))
+
+    lm = make_layout_manager(cfg)
+    lm.load_layout()
+    # Default view_mode is COMPACT; default tile_scale unchanged from init.
+    assert lm.current_view_mode == ViewMode.COMPACT
+    # tile_scale defaults to TILE_SCALE_DEFAULT (0.5) on the manager
+    assert lm.tile_scale == pytest.approx(0.5)
+
+
+def test_load_layout_invalid_view_mode_falls_back(
+    make_layout_manager, tmp_path
+) -> None:
+    cfg = tmp_path / "bad_mode.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "model_order": ["model_1"],
+                "view_mode": "BOGUS",
+                "tile_scale": 0.75,
+            }
+        )
+    )
+    lm = make_layout_manager(cfg)
+    lm.load_layout()
+    assert lm.current_view_mode == ViewMode.COMPACT
+    assert lm.tile_scale == pytest.approx(0.75)
+
+
+def test_load_layout_invalid_tile_scale_skipped(make_layout_manager, tmp_path) -> None:
+    cfg = tmp_path / "bad_scale.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "model_order": ["model_1"],
+                "view_mode": "compact",
+                "tile_scale": -2.0,
+            }
+        )
+    )
+    lm = make_layout_manager(cfg)
+    lm.load_layout()
+    # Invalid value rejected -> tile_scale remains at the constructor default.
+    assert lm.tile_scale == pytest.approx(0.5)

--- a/tests/launchers/test_layout_view_modes.py
+++ b/tests/launchers/test_layout_view_modes.py
@@ -1,0 +1,158 @@
+"""Tests for the view-mode aware behaviour of :class:`LayoutManager`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from src.launchers.launcher_constants import ViewMode, view_mode_settings
+from src.launchers.launcher_layout_manager import LayoutManager
+from src.launchers.model_registry import ModelSpec
+
+
+@pytest.fixture
+def available_models() -> dict[str, ModelSpec]:
+    return {
+        f"model_{i}": ModelSpec(
+            id=f"model_{i}",
+            name=f"Model {i}",
+            description=f"Desc {i}",
+            type="managed",
+            path=f"path_{i}",
+        )
+        for i in range(1, 5)
+    }
+
+
+@pytest.fixture
+def get_model_func(available_models) -> Callable[[str], ModelSpec | None]:
+    return lambda mid: available_models.get(mid)
+
+
+@pytest.fixture
+def make_layout_manager(available_models, get_model_func):
+    def _make() -> LayoutManager:
+        # Cards are MagicMocks that record set_tile_scale + carry _list_mode.
+        def create_card(model, **kwargs):
+            card = MagicMock()
+            card.model_id = model.id
+            card._list_mode = bool(kwargs.get("list_mode", False))
+            card.tile_scale = float(kwargs.get("tile_scale", 0.5))
+            return card
+
+        return LayoutManager(
+            config_file=Path("/fake/cfg.json"),
+            available_models=available_models,
+            get_model_func=get_model_func,
+            create_card_func=create_card,
+            create_header_func=lambda name: MagicMock(),
+        )
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    "mode,expected_scale,expected_columns,expected_show_desc,expected_list",
+    [
+        (ViewMode.COMFORTABLE, 1.0, 4, True, False),
+        (ViewMode.COMPACT, 0.5, 6, True, False),
+        (ViewMode.DENSE, 0.35, 8, False, False),
+        (ViewMode.LIST, 0.30, 1, True, True),
+    ],
+)
+def test_view_mode_table_matches_spec(
+    mode: ViewMode,
+    expected_scale: float,
+    expected_columns: int,
+    expected_show_desc: bool,
+    expected_list: bool,
+) -> None:
+    scale, cols, show_desc, is_list = view_mode_settings(mode)
+    assert scale == expected_scale
+    assert cols == expected_columns
+    assert show_desc is expected_show_desc
+    assert is_list is expected_list
+
+
+@pytest.mark.parametrize(
+    "mode,expected_scale,expected_columns",
+    [
+        (ViewMode.COMFORTABLE, 1.0, 4),
+        (ViewMode.COMPACT, 0.5, 6),
+        (ViewMode.DENSE, 0.35, 8),
+        (ViewMode.LIST, 0.30, 1),
+    ],
+)
+def test_set_view_mode_updates_state(
+    make_layout_manager, mode, expected_scale, expected_columns
+) -> None:
+    lm = make_layout_manager()
+    lm.set_view_mode(mode)
+    assert lm.current_view_mode == mode
+    assert lm.tile_scale == expected_scale
+    # Columns are read from the table at rebuild time.
+    _scale, cols, _sd, _il = view_mode_settings(lm.current_view_mode)
+    assert cols == expected_columns
+
+
+def test_set_view_mode_rejects_non_enum(make_layout_manager) -> None:
+    lm = make_layout_manager()
+    with pytest.raises(TypeError):
+        lm.set_view_mode("compact")  # type: ignore[arg-type]
+
+
+def test_list_mode_yields_one_card_per_row(make_layout_manager) -> None:
+    lm = make_layout_manager()
+    lm.model_order = ["model_1", "model_2", "model_3", "model_4"]
+    lm.set_view_mode(ViewMode.LIST)
+
+    grid_layout = MagicMock()
+    grid_layout.count.return_value = 0
+
+    lm.rebuild_grid(grid_layout)
+
+    # In LIST mode each card is added as addWidget(widget, row, 0, 1, 1).
+    # The header is added as addWidget(header, row, 0, 1, 1) as well (LIST has
+    # column count 1). Distinguish by widget identity: cards are MagicMocks
+    # registered in lm.model_cards.
+    cards = {id(c) for c in lm.model_cards.values()}
+    rows_seen = set()
+    cols_seen = set()
+    for call in grid_layout.addWidget.call_args_list:
+        if len(call[0]) >= 5 and id(call[0][0]) in cards:
+            _w, row, col, _rs, _cs = call[0][:5]
+            rows_seen.add(row)
+            cols_seen.add(col)
+    # Four cards => four distinct rows, all at column 0
+    assert len(rows_seen) == 4
+    assert cols_seen == {0}
+
+
+def test_grid_mode_columns_drive_wrap(make_layout_manager) -> None:
+    lm = make_layout_manager()
+    # Use 8 cards to ensure wrap in COMFORTABLE (4 cols) -> 2 rows of cards.
+    for i in range(5, 9):
+        lm.available_models[f"model_{i}"] = ModelSpec(
+            id=f"model_{i}",
+            name=f"Model {i}",
+            description=f"Desc {i}",
+            type="managed",
+            path=f"path_{i}",
+        )
+    lm.model_order = [f"model_{i}" for i in range(1, 9)]
+    lm.set_view_mode(ViewMode.COMFORTABLE)
+
+    grid_layout = MagicMock()
+    grid_layout.count.return_value = 0
+    lm.rebuild_grid(grid_layout)
+
+    # COMFORTABLE => 4 columns; the last card (8th) should land at col == 3.
+    # Grid-mode cards are added as addWidget(widget, row, col) (3 args).
+    cards = {id(c) for c in lm.model_cards.values()}
+    cols_seen = set()
+    for call in grid_layout.addWidget.call_args_list:
+        if len(call[0]) == 3 and id(call[0][0]) in cards:
+            cols_seen.add(call[0][2])
+    assert max(cols_seen) == 3

--- a/tests/launchers/test_model_card_tile_scale.py
+++ b/tests/launchers/test_model_card_tile_scale.py
@@ -1,0 +1,110 @@
+"""Tests for the ``tile_scale`` parameter on :class:`DraggableModelCard`.
+
+These tests assert that the image size, font point size, and layout
+margins all scale linearly from the 1.0x reference values defined in
+``launcher_constants``.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+from src.launchers.launcher_constants import (
+    TILE_BASE_FONT_PT,
+    TILE_BASE_IMAGE_PX,
+    TILE_BASE_PADDING_PX,
+    TILE_MIN_FONT_PT,
+)
+from src.launchers.model_card import DraggableModelCard
+
+
+@pytest.fixture
+def parent_launcher() -> MagicMock:
+    launcher = MagicMock()
+    launcher.layout_edit_mode = False
+    return launcher
+
+
+@pytest.fixture
+def mock_model() -> MagicMock:
+    model = MagicMock()
+    model.id = "mujoco_unified"
+    model.name = "MuJoCo"
+    model.description = "Test description"
+    model.engine_type = "mujoco"
+    model.launcher = None
+    model.type = "custom_humanoid"
+    model.path = ""
+    return model
+
+
+@pytest.mark.parametrize("scale", [0.25, 0.5, 1.0, 2.0])
+def test_image_size_scales_linearly(
+    qapp,
+    mock_model: MagicMock,
+    parent_launcher: MagicMock,
+    scale: float,
+) -> None:
+    card = DraggableModelCard(mock_model, parent_launcher, tile_scale=scale)
+    expected = int(TILE_BASE_IMAGE_PX * scale)
+    assert card.lbl_img.size().width() == expected
+    assert card.lbl_img.size().height() == expected
+
+
+@pytest.mark.parametrize("scale", [0.25, 0.5, 1.0, 2.0])
+def test_name_font_scales_linearly(
+    qapp,
+    mock_model: MagicMock,
+    parent_launcher: MagicMock,
+    scale: float,
+) -> None:
+    card = DraggableModelCard(mock_model, parent_launcher, tile_scale=scale)
+    expected = max(TILE_MIN_FONT_PT, int(round(TILE_BASE_FONT_PT * scale)))
+    assert card.lbl_name.font().pointSize() == expected
+
+
+@pytest.mark.parametrize("scale", [0.25, 0.5, 1.0, 2.0])
+def test_padding_scales_linearly(
+    qapp,
+    mock_model: MagicMock,
+    parent_launcher: MagicMock,
+    scale: float,
+) -> None:
+    card = DraggableModelCard(mock_model, parent_launcher, tile_scale=scale)
+    margins = card.layout().contentsMargins()
+    expected = max(2, int(round(TILE_BASE_PADDING_PX * scale)))
+    # All four margins are equal — assert one of them.
+    assert margins.left() == expected
+
+
+def test_set_tile_scale_resizes_in_place(
+    qapp, mock_model: MagicMock, parent_launcher: MagicMock
+) -> None:
+    card = DraggableModelCard(mock_model, parent_launcher, tile_scale=0.5)
+    initial = card.lbl_img.size().width()
+    card.set_tile_scale(1.0)
+    assert card.lbl_img.size().width() == TILE_BASE_IMAGE_PX
+    assert card.lbl_img.size().width() != initial
+
+
+def test_invalid_scale_raises(
+    qapp, mock_model: MagicMock, parent_launcher: MagicMock
+) -> None:
+    with pytest.raises(ValueError):
+        DraggableModelCard(mock_model, parent_launcher, tile_scale=-1.0)
+    with pytest.raises(ValueError):
+        DraggableModelCard(mock_model, parent_launcher, tile_scale=float("nan"))
+    with pytest.raises(TypeError):
+        DraggableModelCard(mock_model, parent_launcher, tile_scale="big")  # type: ignore[arg-type]
+
+
+def test_font_floor_at_min_scale(
+    qapp, mock_model: MagicMock, parent_launcher: MagicMock
+) -> None:
+    card = DraggableModelCard(mock_model, parent_launcher, tile_scale=0.25)
+    # 11 * 0.25 = 2.75 -> would round to 3 without floor; we expect TILE_MIN_FONT_PT.
+    assert card.lbl_name.font().pointSize() >= TILE_MIN_FONT_PT
+    # And the floor is engaged for the chip (base 8 -> floor 8).
+    assert not math.isnan(float(card.lbl_name.font().pointSize()))


### PR DESCRIPTION
Closes #4626

## Summary

- Adds a user-resizable tile system to the launcher: `tile_scale` defaults to 0.5 (100x100 image, ~quarter of the original 200x200 footprint), with bounds [0.25, 2.0].
- Introduces four view-layout modes selectable from a top-bar combobox:
  - **Comfortable** - tile_scale 1.0, 4 columns, image + name + description
  - **Compact** (default) - tile_scale 0.5, 6 columns, image + name + one-line description
  - **Dense** - tile_scale 0.35, 8 columns, image + name (description hidden)
  - **List** - tile_scale 0.30, 1 column, horizontal strips (icon | name+desc | status chip), full row width
- Adds a horizontal zoom QSlider (mapped to [TILE_SCALE_MIN, TILE_SCALE_MAX]) with a live percentage label, plus `Ctrl+=` / `Ctrl++` / `Ctrl+-` keyboard shortcuts.
- Persists `view_mode` (string) and `tile_scale` (float) into the existing layout JSON; missing keys load with defaults so old configs do not crash.
- Shared scaling helpers (`scaled_image_px`, `scaled_font_pt`, `scaled_padding_px`, `validate_tile_scale`) live in `launcher_constants.py` so `model_card.py` and `launcher_layout_manager.py` agree on the math (DRY).
- Font/chip sizes have a 9 pt floor so text stays legible at minimum scale.

## Test plan

- [x] `python3 -m ruff check src/launchers tests/launchers` clean
- [x] `python3 -m ruff format --check` clean for the touched files
- [x] `python3 -m pytest tests/launchers/test_model_card_tile_scale.py tests/launchers/test_layout_view_modes.py tests/launchers/test_layout_persistence.py tests/launchers/test_launcher_layout_manager.py` - 37 new + adjusted tests pass
- [x] `python3 scripts/ci/check_file_size_budget.py` clean (no file >1200 lines)
- [x] Existing `test_model_card.py`, `test_launcher_constants.py`, `test_launcher_ui_setup.py` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)