### PR TITLE
fix: guard Qt app fixture imports against OSError

### DIFF
--- a/tests/launchers/test_runtime_mode_help.py
+++ b/tests/launchers/test_runtime_mode_help.py
@@ -15,7 +15,10 @@ pytest.importorskip("PyQt6")
 
 @pytest.fixture(scope="module")
 def qt_app():
-    from PyQt6.QtWidgets import QApplication
+    try:
+        from PyQt6.QtWidgets import QApplication
+    except (ImportError, OSError) as e:  # noqa: F841
+        pytest.skip(f"PyQt6 runtime unavailable (import/runtime error): {e}")
 
     app = QApplication.instance() or QApplication(sys.argv[:1])
     yield app

--- a/tests/unit/ui/test_info_button.py
+++ b/tests/unit/ui/test_info_button.py
@@ -14,7 +14,10 @@ pytest.importorskip("PyQt6")
 
 @pytest.fixture(scope="module")
 def qt_app():
-    from PyQt6.QtWidgets import QApplication
+    try:
+        from PyQt6.QtWidgets import QApplication
+    except (ImportError, OSError) as e:  # noqa: F841
+        pytest.skip(f"PyQt6 runtime unavailable (import/runtime error): {e}")
 
     app = QApplication.instance() or QApplication(sys.argv[:1])
     yield app


### PR DESCRIPTION
## Summary
This PR addresses review feedback from PR #4630 (issues #4635 and #4632) by adding proper error handling for Qt runtime failures in test fixtures.

## Changes
- **tests/unit/ui/test_info_button.py**: Wrap PyQt6.QtWidgets import in qt_app fixture with try/except (ImportError, OSError) and pytest.skip() on failure
- **tests/launchers/test_runtime_mode_help.py**: Same fix for the qt_app fixture

## Why
The existing pytest.importorskip("PyQt6") at module scope does not protect against later submodule load/runtime errors. Environments with a broken PyQt6 runtime (e.g., DLL load failures on Windows) would raise OSError and fail the suite instead of skipping gracefully.

## Testing
- Changes are to test infrastructure only
- Tests will now properly skip on Qt runtime failures instead of failing