### PR TITLE
fix: add precheck requiring 2+ importable engines for URDF equivalence gate

### DIFF
--- a/.github/workflows/urdf-cross-engine-equivalence.yml
+++ b/.github/workflows/urdf-cross-engine-equivalence.yml
@@ -84,6 +84,29 @@ jobs:
           pip install "pinocchio>=2.6.0" || echo "::warning::pinocchio install failed"
           pip install "opensim>=4.4.0" || echo "::warning::opensim install failed"
 
+      - name: Precheck — verify at least 2 engines are importable
+        # This gate enforces cross-engine parity, so it must fail if fewer than
+        # 2 engines can be imported. Without this check, the job could succeed
+        # with all equivalence tests skipped (via pytest.importorskip) and no
+        # actual comparison performed.
+        shell: bash
+        run: |
+          set -euo pipefail
+          count=0
+          for engine in mujoco pydrake pinocchio opensim; do
+            if python3 -c "import $engine" 2>/dev/null; then
+              count=$((count + 1))
+              echo "✓ $engine importable"
+            else
+              echo "✗ $engine not importable"
+            fi
+          done
+          echo "Importable engines: $count / 4"
+          if [ "$count" -lt 2 ]; then
+            echo "::error::Cross-engine equivalence gate requires ≥2 importable engines; only $count available. Failing."
+            exit 1
+          fi
+
       - name: Run URDF cross-engine forward-sim equivalence test
         env:
           UPSTREAM_DRIFT_OUTPUT_ROOT: ${{ github.workspace }}/output


### PR DESCRIPTION
## Summary
This PR addresses review feedback from PR #4641 (issue #4644) by adding a precheck step to the URDF cross-engine equivalence workflow.

## Changes
- **.github/workflows/urdf-cross-engine-equivalence.yml**: Added new step 'Precheck — verify at least 2 engines are importable' that runs before the equivalence test

## Why
The workflow suppresses install failures for optional engines (|| echo ...), while tests skip missing backends via importorskip. Without this check, the job could succeed with all equivalence tests skipped and no actual cross-engine comparison performed. This precheck ensures the gate fails if fewer than 2 engines can be imported.