### PR TITLE
feat(c3d-viewer): full-functionality upgrade (#4640)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
@@ -22,6 +22,7 @@ from .core.models import C3DDataModel
 from .services.loader_thread import C3DLoaderThread
 from .ui.tabs.analog_plot_tab import AnalogPlotTab
 from .ui.tabs.analysis_tab import AnalysisTab
+from .ui.tabs.force_plot_tab import ForcePlotTab
 from .ui.tabs.marker_plot_tab import MarkerPlotTab
 from .ui.tabs.overview_tab import OverviewTab
 from .ui.tabs.viewer_3d_tab import Viewer3DTab
@@ -62,6 +63,13 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.action_open.setStatusTip("Open a C3D file for analysis")
         self.action_open.triggered.connect(self.open_c3d_file)
 
+        self.action_export_csv = QtGui.QAction("Export markers to &CSV…", self)
+        self.action_export_csv.setStatusTip(
+            "Export selected 3D markers' trajectories to CSV"
+        )
+        self.action_export_csv.triggered.connect(self._export_markers_csv)
+        self.action_export_csv.setEnabled(False)
+
         self.action_exit = QtGui.QAction("E&xit", self)
         self.action_exit.setShortcut("Ctrl+Q")
         self.action_exit.triggered.connect(self.close)
@@ -78,6 +86,7 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         file_menu = menubar.addMenu("&File")
         if file_menu is not None:
             file_menu.addAction(self.action_open)
+            file_menu.addAction(self.action_export_csv)
             file_menu.addSeparator()
             file_menu.addAction(self.action_exit)
 
@@ -94,6 +103,7 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.analog_plot_tab = AnalogPlotTab()
         self.viewer3d_tab = Viewer3DTab()
         self.analysis_tab = AnalysisTab()
+        self.force_plot_tab = ForcePlotTab()
 
         self.tabs.addTab(self.overview_tab, "Overview")
         self.tabs.setTabToolTip(0, "Metadata and file information")
@@ -105,6 +115,8 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.tabs.setTabToolTip(3, "3D interactive view of markers")
         self.tabs.addTab(self.analysis_tab, "Analysis")
         self.tabs.setTabToolTip(4, "Kinematic analysis and calculations")
+        self.tabs.addTab(self.force_plot_tab, "Force Plates")
+        self.tabs.setTabToolTip(5, "Force plate GRF and COP visualization")
 
         self.setCentralWidget(self.tabs)
 
@@ -254,6 +266,28 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.analog_plot_tab.update_from_model(self.model)
         self.viewer3d_tab.update_from_model(self.model)
         self.analysis_tab.update_from_model(self.model)
+        self.force_plot_tab.update_from_model(self.model)
+        self.action_export_csv.setEnabled(True)
+
+    def _export_markers_csv(self) -> None:
+        """Export the 3D viewer's selected markers to CSV."""
+        if self.model is None:
+            QtWidgets.QMessageBox.information(self, "Export markers", "No file loaded.")
+            return
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Export markers to CSV", "", "CSV files (*.csv)"
+        )
+        if not path:
+            return
+        try:
+            self.viewer3d_tab.export_selected_markers_csv(path)
+        except (OSError, ValueError) as e:
+            QtWidgets.QMessageBox.warning(
+                self, "Export failed", f"Could not write CSV:\n{e}"
+            )
+            return
+        if (sb := self.statusBar()) is not None:
+            sb.showMessage(f"Exported markers to {os.path.basename(path)}")
 
 
 def main() -> None:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/core/models.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/core/models.py
@@ -6,6 +6,14 @@ import numpy as np
 import numpy.typing as npt
 
 
+@dataclass(frozen=True)
+class C3DEvent:
+    """A named C3D event with its timestamp in seconds."""
+
+    label: str
+    time: float
+
+
 @dataclass
 class MarkerData:
     """Represents a single optical marker trajectory."""
@@ -36,6 +44,7 @@ class C3DDataModel:
     point_time: npt.NDArray[np.float64] | None = None
     analog_time: npt.NDArray[np.float64] | None = None
     metadata: dict[str, str] = field(default_factory=dict)
+    events: list[C3DEvent] = field(default_factory=list)
 
     def marker_names(self) -> list[str]:
         """Return list of marker names."""

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ...c3d_reader import C3DDataReader  # type: ignore
 from ...logger_utils import log_execution_time
-from ..core.models import AnalogData, C3DDataModel, MarkerData
+from ..core.models import AnalogData, C3DDataModel, C3DEvent, MarkerData
 
 
 def _build_markers(df_points: Any, marker_names: list[str]) -> dict[str, MarkerData]:
@@ -137,6 +137,14 @@ def load_c3d_file(filepath: str) -> C3DDataModel:
         first_analog = next(iter(analog.values()))
         analog_time = np.arange(len(first_analog.values)) / metadata_obj.analog_rate
 
+    events: list[C3DEvent] = []
+    if getattr(metadata_obj, "events", None):
+        for ev in metadata_obj.events:
+            try:
+                events.append(C3DEvent(label=str(ev.label), time=float(ev.time)))
+            except (AttributeError, TypeError, ValueError):
+                continue
+
     return C3DDataModel(
         filepath=filepath,
         markers=markers,
@@ -146,4 +154,5 @@ def load_c3d_file(filepath: str) -> C3DDataModel:
         point_time=frame_time,
         analog_time=analog_time,
         metadata=_build_metadata_ui(filepath, metadata_obj),
+        events=events,
     )

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/force_plot_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/force_plot_tab.py
@@ -94,9 +94,18 @@ class ForcePlotTab(QtWidgets.QWidget):
             self.status_label.setText("")
             return
 
+        # Empty analog -> graceful no-data branch.
+        if not model.analog:
+            self.time_series_canvas.clear_axes()
+            self.cop_canvas.clear_axes()
+            self.status_label.setText("No force-plate data in this file")
+            return
+
         # Try to extract force plate data from analog channels
         if not self._load_force_plate_data():
-            self.status_label.setText("No force plate channels detected")
+            self.time_series_canvas.clear_axes()
+            self.cop_canvas.clear_axes()
+            self.status_label.setText("No force-plate data in this file")
             return
 
         # Populate plate selector

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
@@ -1,48 +1,223 @@
-"""Three-dimensional scene viewer tab for the 3-D Golf Model GUI."""
+"""Three-dimensional scene viewer tab for the 3-D Golf Model GUI.
 
+Provides interactive playback (play/pause/speed/loop), keyboard
+shortcuts, an optional skeleton overlay built from the canonical
+anatomical-subset segment table, marker-selection helpers, view-angle
+presets, event-frame quick-jump, marker-label toggling, CSV export,
+and an incremental-update render path that preallocates artists once
+per selection and only mutates them per frame for smooth scrubbing.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
 from typing import Any
 
+import matplotlib.pyplot as plt
 import numpy as np
-from PyQt6 import QtWidgets
-from PyQt6.QtCore import Qt
+from matplotlib import colors as mcolors
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+from PyQt6 import QtGui, QtWidgets
+from PyQt6.QtCore import Qt, QTimer
 
 from src.shared.python.qt_utils.wheel_event_filter import suppress_wheel_on_widgets
 
 from ...core.models import C3DDataModel
 from ..widgets.mpl_canvas import MplCanvas
 
+try:
+    from src.shared.python.motion_matching.body_skeleton import (
+        default_body_segments,
+    )
+except ImportError:  # pragma: no cover - exercised via fallback path only
+    # Fallback: when running inside the engine's pivoted sys.modules layout
+    # the canonical wrapper exposes the symbol via the bare-rooted path.
+    from shared.python.motion_matching.body_skeleton import (  # type: ignore
+        default_body_segments,
+    )
+
+
+# View-angle presets: (elev, azim) tuned to match issue spec.
+_VIEW_PRESETS: dict[str, tuple[float, float]] = {
+    "Front": (0.0, 90.0),
+    "Side": (0.0, 0.0),
+    "Top": (90.0, -90.0),
+    "Iso": (30.0, -60.0),
+}
+
+_PLAYBACK_SPEEDS: tuple[float, ...] = (0.1, 0.25, 0.5, 1.0, 2.0, 4.0)
+_DEFAULT_SPEED_INDEX = 3  # 1.0×
+
+# Cluster/club marker name patterns — generic, not vendor-specific.
+_CLUB_MARKER_RE = re.compile(r"^Marker_\d+:\d+:", re.IGNORECASE)
+
+
+def _is_club_marker(name: str) -> bool:
+    """Return True when ``name`` looks like a club / cluster marker."""
+    return bool(_CLUB_MARKER_RE.match(name))
+
+
+def _validate_speed(speed: float) -> float:
+    """Validate a playback speed multiplier.
+
+    Raises:
+        TypeError: if ``speed`` is not a real number.
+        ValueError: if ``speed`` is non-positive or non-finite.
+    """
+    if isinstance(speed, bool) or not isinstance(speed, (int, float)):
+        raise TypeError(f"speed must be a real number, got {type(speed).__name__}")
+    if not np.isfinite(speed) or speed <= 0.0:
+        raise ValueError(f"speed must be positive and finite, got {speed!r}")
+    return float(speed)
+
+
+def _validate_frame(frame: int, n_frames: int) -> int:
+    """Validate a frame index against ``n_frames``.
+
+    Raises:
+        TypeError: if ``frame`` is not an int.
+        ValueError: if ``frame`` is out of [0, n_frames).
+    """
+    if isinstance(frame, bool) or not isinstance(frame, int):
+        raise TypeError(f"frame must be int, got {type(frame).__name__}")
+    if n_frames <= 0:
+        raise ValueError("no frames loaded")
+    if not 0 <= frame < n_frames:
+        raise ValueError(f"frame {frame} out of range [0, {n_frames})")
+    return frame
+
 
 class Viewer3DTab(QtWidgets.QWidget):
-    """3D marker trajectory viewer tab."""
+    """3D marker trajectory viewer tab with playback and skeleton overlay."""
 
     def __init__(self) -> None:
         super().__init__()
         self.model: C3DDataModel | None = None
+        self._n_frames: int = 0
+        self._selected_names: list[str] = []
+        # Cached arrays for fast frame updates.
+        self._selected_positions: np.ndarray = np.empty((0, 0, 3))
+        self._marker_colors: list[tuple[float, float, float, float]] = []
+
+        # Matplotlib artists pre-allocated per selection.
+        self._ax: Any = None
+        self._trail_lines: list[Any] = []
+        self._point_artist: Any = None
+        self._label_texts: list[Any] = []
+        self._skeleton_collection: Line3DCollection | None = None
+        self._skeleton_segments: tuple[tuple[str, str], ...] = ()
+        self._event_buttons: list[QtWidgets.QToolButton] = []
+
+        # Playback timer.
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._on_timer_tick)
+        self._is_playing = False
+
         self._init_ui()
+        self._install_shortcuts()
+
+    # ------------------------------------------------------------------ UI
 
     def _init_ui(self) -> None:
         layout = QtWidgets.QHBoxLayout(self)
 
         left_panel = QtWidgets.QVBoxLayout()
+
+        # Selection helpers.
+        sel_row = QtWidgets.QHBoxLayout()
+        self.btn_select_all = QtWidgets.QPushButton("Select all")
+        self.btn_select_body = QtWidgets.QPushButton("Body")
+        self.btn_select_club = QtWidgets.QPushButton("Club")
+        self.btn_clear_selection = QtWidgets.QPushButton("Clear")
+        self.btn_select_all.clicked.connect(self.select_all_markers)
+        self.btn_select_body.clicked.connect(self.select_body_markers)
+        self.btn_select_club.clicked.connect(self.select_club_markers)
+        self.btn_clear_selection.clicked.connect(self.clear_marker_selection)
+        for btn in (
+            self.btn_select_all,
+            self.btn_select_body,
+            self.btn_select_club,
+            self.btn_clear_selection,
+        ):
+            sel_row.addWidget(btn)
+        left_panel.addLayout(sel_row)
+
+        left_panel.addWidget(QtWidgets.QLabel("Markers to display in 3D:"))
         self.list_markers_3d = QtWidgets.QListWidget()
         self.list_markers_3d.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.MultiSelection
         )
-        self.list_markers_3d.itemSelectionChanged.connect(self.update_view)
-        left_panel.addWidget(QtWidgets.QLabel("Markers to display in 3D:"))
+        self.list_markers_3d.itemSelectionChanged.connect(self._on_selection_changed)
         left_panel.addWidget(self.list_markers_3d)
 
-        # Frame slider
+        # Playback controls.
+        playback_row = QtWidgets.QHBoxLayout()
+        self.btn_play = QtWidgets.QToolButton()
+        self.btn_play.setToolTip("Play / Pause (Space)")
+        self._update_play_icon()
+        self.btn_play.clicked.connect(self.toggle_play)
+        playback_row.addWidget(self.btn_play)
+
+        playback_row.addWidget(QtWidgets.QLabel("Speed:"))
+        self.combo_speed = QtWidgets.QComboBox()
+        for s in _PLAYBACK_SPEEDS:
+            self.combo_speed.addItem(f"{s:g}×", s)
+        self.combo_speed.setCurrentIndex(_DEFAULT_SPEED_INDEX)
+        self.combo_speed.currentIndexChanged.connect(self._on_speed_changed)
+        playback_row.addWidget(self.combo_speed)
+
+        self.check_loop = QtWidgets.QCheckBox("Loop")
+        self.check_loop.setChecked(True)
+        playback_row.addWidget(self.check_loop)
+
+        playback_row.addStretch()
+        left_panel.addLayout(playback_row)
+
+        # View / overlay toggles.
+        toggles_row = QtWidgets.QHBoxLayout()
+        self.check_skeleton = QtWidgets.QCheckBox("Show skeleton")
+        self.check_skeleton.setChecked(True)
+        self.check_skeleton.toggled.connect(self._on_skeleton_toggled)
+        toggles_row.addWidget(self.check_skeleton)
+
+        self.check_labels = QtWidgets.QCheckBox("Show labels")
+        self.check_labels.setChecked(False)
+        self.check_labels.toggled.connect(self._on_labels_toggled)
+        toggles_row.addWidget(self.check_labels)
+        toggles_row.addStretch()
+        left_panel.addLayout(toggles_row)
+
+        # View-angle presets.
+        view_row = QtWidgets.QHBoxLayout()
+        view_row.addWidget(QtWidgets.QLabel("View:"))
+        self._view_buttons: dict[str, QtWidgets.QToolButton] = {}
+        for name in _VIEW_PRESETS:
+            b = QtWidgets.QToolButton()
+            b.setText(name)
+            b.clicked.connect(lambda _checked=False, n=name: self.set_view_preset(n))
+            self._view_buttons[name] = b
+            view_row.addWidget(b)
+        view_row.addStretch()
+        left_panel.addLayout(view_row)
+
+        # Frame slider with event-quick-jump strip.
+        slider_row = QtWidgets.QHBoxLayout()
         self.slider_frame = QtWidgets.QSlider(Qt.Orientation.Horizontal)
         self.slider_frame.setMinimum(0)
         self.slider_frame.setMaximum(0)
         self.slider_frame.setValue(0)
-        self.slider_frame.valueChanged.connect(self.update_view)
-        left_panel.addWidget(QtWidgets.QLabel("Frame index:"))
-        left_panel.addWidget(self.slider_frame)
+        self.slider_frame.valueChanged.connect(self._on_frame_changed)
+        suppress_wheel_on_widgets(self.slider_frame, self.combo_speed)
+        slider_row.addWidget(self.slider_frame)
+        left_panel.addLayout(slider_row)
 
-        # Suppress wheel events on slider to prevent unintended value changes
-        suppress_wheel_on_widgets(self.slider_frame)
+        # Event-jump button row (populated when events present).
+        self._event_row = QtWidgets.QHBoxLayout()
+        self._event_container = QtWidgets.QWidget()
+        self._event_container.setLayout(self._event_row)
+        left_panel.addWidget(self._event_container)
+        self._event_container.setVisible(False)
 
         self.label_frame_info = QtWidgets.QLabel("Frame: - / Time: -")
         left_panel.addWidget(self.label_frame_info)
@@ -52,101 +227,523 @@ class Viewer3DTab(QtWidgets.QWidget):
         right_panel = QtWidgets.QVBoxLayout()
         self.canvas_3d = MplCanvas(self, width=5, height=4, dpi=100)
         right_panel.addWidget(self.canvas_3d)
-
         layout.addLayout(right_panel, 3)
+
+    # ---------------------------------------------------------- Shortcuts
+
+    def _install_shortcuts(self) -> None:
+        """Register keyboard shortcuts on this tab."""
+
+        def _mk(seq: str, slot: Any) -> QtGui.QShortcut:
+            sc = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
+            sc.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
+            sc.activated.connect(slot)
+            return sc
+
+        self._shortcut_play = _mk("Space", self.toggle_play)
+        self._shortcut_left = _mk("Left", lambda: self.step_frame(-1))
+        self._shortcut_right = _mk("Right", lambda: self.step_frame(1))
+        self._shortcut_shift_left = _mk("Shift+Left", lambda: self.step_frame(-10))
+        self._shortcut_shift_right = _mk("Shift+Right", lambda: self.step_frame(10))
+        self._shortcut_home = _mk("Home", lambda: self.set_frame(0))
+        self._shortcut_end = _mk(
+            "End", lambda: self.set_frame(max(0, self._n_frames - 1))
+        )
+
+    # ------------------------------------------------------------- Model
 
     def update_from_model(self, model: C3DDataModel | None) -> None:
         """Update UI with data from the model."""
+        self.pause()
         self.model = model
         self.list_markers_3d.clear()
+        self._clear_event_buttons()
 
         if model is None:
+            self._n_frames = 0
             self.slider_frame.setMaximum(0)
+            self._teardown_artists()
             self.canvas_3d.clear_axes()
             return
 
         for name in model.marker_names():
             self.list_markers_3d.addItem(name)
 
-        # Frame slider for 3D
         if model.point_time is not None:
-            n_frames = len(model.point_time)
+            self._n_frames = len(model.point_time)
             self.slider_frame.setMinimum(0)
-            self.slider_frame.setMaximum(n_frames - 1)
+            self.slider_frame.setMaximum(max(0, self._n_frames - 1))
             self.slider_frame.setValue(0)
         else:
+            self._n_frames = 0
             self.slider_frame.setMaximum(0)
             self.slider_frame.setValue(0)
 
-        if model.marker_names():
+        self._populate_event_buttons()
+
+        # Default selection: pick the body markers if any are present, else
+        # fall back to the first marker (preserves prior behaviour when the
+        # file has no anatomical markers).
+        marker_names = model.marker_names()
+        body_segments_present = default_body_segments(marker_names)
+        if body_segments_present:
+            self.select_body_markers()
+        elif marker_names:
             self.list_markers_3d.setCurrentRow(0)
 
-    def update_view(self) -> None:  # noqa: C901
-        """Update the 3D view based on selected Markers and frame."""
+    # ------------------------------------------------------- Selection
+
+    def select_all_markers(self) -> None:
+        """Select every marker in the list."""
+        self.list_markers_3d.selectAll()
+
+    def select_body_markers(self) -> None:
+        """Select the canonical anatomical-subset body markers."""
         if self.model is None:
             return
+        body_names = {
+            n
+            for s in default_body_segments(self.model.marker_names())
+            for n in (s.a, s.b)
+        }
+        self._set_selection(lambda n: n in body_names)
 
-        # Get selected markers
-        selected_items = self.list_markers_3d.selectedItems()
-        marker_names = [item.text() for item in selected_items]
-        if not marker_names:
-            self.canvas_3d.clear_axes()
+    def select_club_markers(self) -> None:
+        """Select markers that match the generic club/cluster pattern."""
+        self._set_selection(_is_club_marker)
+
+    def clear_marker_selection(self) -> None:
+        """Clear all marker selections."""
+        self.list_markers_3d.clearSelection()
+
+    def _set_selection(self, predicate: Any) -> None:
+        self.list_markers_3d.blockSignals(True)
+        try:
+            for i in range(self.list_markers_3d.count()):
+                item = self.list_markers_3d.item(i)
+                if item is None:
+                    continue
+                item.setSelected(bool(predicate(item.text())))
+        finally:
+            self.list_markers_3d.blockSignals(False)
+        self._on_selection_changed()
+
+    # --------------------------------------------------------- Playback
+
+    @property
+    def is_playing(self) -> bool:
+        """Whether playback is currently running."""
+        return self._is_playing
+
+    def toggle_play(self) -> None:
+        """Toggle play/pause state."""
+        if self._is_playing:
+            self.pause()
+        else:
+            self.play()
+
+    def play(self) -> None:
+        """Start playback at the current speed."""
+        if self._n_frames <= 1:
+            return
+        speed = float(self.combo_speed.currentData() or 1.0)
+        rate = self.model.point_rate if self.model is not None else 0.0
+        if rate <= 0.0:
+            rate = 60.0  # fallback display rate
+        interval_ms = max(1, int(round(1000.0 / (rate * speed))))
+        self._timer.start(interval_ms)
+        self._is_playing = True
+        self._update_play_icon()
+
+    def pause(self) -> None:
+        """Pause playback."""
+        if self._timer.isActive():
+            self._timer.stop()
+        self._is_playing = False
+        self._update_play_icon()
+
+    def set_speed(self, speed: float) -> None:
+        """Programmatically set the playback speed multiplier."""
+        speed = _validate_speed(speed)
+        # Snap to the closest preset for the combo box display.
+        idx = int(np.argmin([abs(s - speed) for s in _PLAYBACK_SPEEDS]))
+        self.combo_speed.setCurrentIndex(idx)
+        if self._is_playing:
+            self.pause()
+            self.play()
+
+    def _on_speed_changed(self, _idx: int) -> None:
+        if self._is_playing:
+            self.pause()
+            self.play()
+
+    def _on_timer_tick(self) -> None:
+        if self._n_frames <= 0:
+            self.pause()
+            return
+        nxt = self.slider_frame.value() + 1
+        if nxt >= self._n_frames:
+            if self.check_loop.isChecked():
+                nxt = 0
+            else:
+                self.pause()
+                return
+        self.slider_frame.setValue(nxt)
+
+    def _update_play_icon(self) -> None:
+        style = self.style()
+        if style is None:
+            self.btn_play.setText("Pause" if self._is_playing else "Play")
+            return
+        icon = (
+            QtWidgets.QStyle.StandardPixmap.SP_MediaPause
+            if self._is_playing
+            else QtWidgets.QStyle.StandardPixmap.SP_MediaPlay
+        )
+        self.btn_play.setIcon(style.standardIcon(icon))
+        self.btn_play.setText("Pause" if self._is_playing else "Play")
+
+    # ------------------------------------------------- Frame navigation
+
+    def set_frame(self, frame: int) -> None:
+        """Jump to ``frame``. Validates inputs (DbC)."""
+        frame = _validate_frame(frame, self._n_frames)
+        self.slider_frame.setValue(frame)
+
+    def step_frame(self, delta: int) -> None:
+        """Advance the slider by ``delta`` frames, clamped to bounds."""
+        if self._n_frames <= 0:
+            return
+        nxt = max(0, min(self._n_frames - 1, self.slider_frame.value() + int(delta)))
+        self.slider_frame.setValue(nxt)
+
+    def _on_frame_changed(self, _value: int) -> None:
+        self._render_current_frame()
+
+    # --------------------------------------------------- Event quick-jump
+
+    def _populate_event_buttons(self) -> None:
+        self._clear_event_buttons()
+        if self.model is None or not self.model.events:
+            self._event_container.setVisible(False)
+            return
+        self._event_container.setVisible(True)
+        for ev in self.model.events:
+            btn = QtWidgets.QToolButton()
+            btn.setText(ev.label)
+            btn.setToolTip(f"Jump to event {ev.label} @ {ev.time:.3f}s")
+            btn.clicked.connect(lambda _c=False, t=ev.time: self.jump_to_time(t))
+            self._event_row.addWidget(btn)
+            self._event_buttons.append(btn)
+
+    def _clear_event_buttons(self) -> None:
+        for btn in self._event_buttons:
+            self._event_row.removeWidget(btn)
+            btn.setParent(None)
+            btn.deleteLater()
+        self._event_buttons = []
+
+    def jump_to_time(self, time_s: float) -> None:
+        """Jump to the frame nearest ``time_s`` seconds."""
+        if self.model is None or self.model.point_time is None:
+            return
+        if not np.isfinite(time_s):
+            raise ValueError(f"time_s must be finite, got {time_s!r}")
+        frame = int(np.argmin(np.abs(self.model.point_time - float(time_s))))
+        self.set_frame(frame)
+
+    # -------------------------------------------------------- View presets
+
+    def set_view_preset(self, name: str) -> None:
+        """Snap the 3D axes to a named view preset."""
+        if name not in _VIEW_PRESETS:
+            raise ValueError(
+                f"unknown view preset {name!r}, expected one of {sorted(_VIEW_PRESETS)}"
+            )
+        if self._ax is None:
+            return
+        elev, azim = _VIEW_PRESETS[name]
+        self._ax.view_init(elev=elev, azim=azim)
+        self.canvas_3d.draw_idle()
+
+    # ---------------------------------------------------- Skeleton state
+
+    def _on_skeleton_toggled(self, _on: bool) -> None:
+        if self._skeleton_collection is not None:
+            self._skeleton_collection.set_visible(self.check_skeleton.isChecked())
+            self._update_skeleton_segments()
+            self.canvas_3d.draw_idle()
+
+    def _on_labels_toggled(self, _on: bool) -> None:
+        for txt in self._label_texts:
+            txt.set_visible(self.check_labels.isChecked())
+        self.canvas_3d.draw_idle()
+
+    @property
+    def skeleton_segment_count(self) -> int:
+        """Number of skeleton segments currently rendered."""
+        return len(self._skeleton_segments)
+
+    # --------------------------------------------------- Selection plumbing
+
+    def _on_selection_changed(self) -> None:
+        self._rebuild_scene()
+
+    def _rebuild_scene(self) -> None:
+        """Tear down and recreate artists when the selection changes."""
+        if self.model is None:
+            return
+        selected = [item.text() for item in self.list_markers_3d.selectedItems()]
+        self._selected_names = selected
+
+        self._teardown_artists()
+        if not selected:
+            self.canvas_3d.fig.clear()
+            self.canvas_3d.draw_idle()
             self.label_frame_info.setText("Frame: - / Time: -")
             return
 
-        frame_index = self.slider_frame.value()
-        if self.model.point_time is None:
-            time_str = "-"
-        else:
-            if 0 <= frame_index < len(self.model.point_time):
-                time_str = f"{self.model.point_time[frame_index]:.4f} s"
-            else:
-                time_str = "-"
+        # Cache positions: shape (M, N, 3); pad missing with NaN.
+        if self._n_frames <= 0:
+            return
+        positions = np.full((len(selected), self._n_frames, 3), np.nan, dtype=float)
+        for i, name in enumerate(selected):
+            m = self.model.markers.get(name)
+            if m is None or m.position.size == 0:
+                continue
+            n = min(m.position.shape[0], self._n_frames)
+            positions[i, :n, :] = m.position[:n, :]
+        self._selected_positions = positions
 
-        self.label_frame_info.setText(f"Frame: {frame_index} / Time: {time_str}")
+        # Build colors from a perceptually-distinct map.
+        cmap = plt.get_cmap("tab20" if len(selected) <= 20 else "Spectral")
+        denom = max(1, len(selected) - 1)
+        self._marker_colors = [
+            mcolors.to_rgba(cmap(i / denom)) for i in range(len(selected))
+        ]
 
         self.canvas_3d.fig.clear()
-        ax: Any = self.canvas_3d.add_subplot(111, projection="3d")
+        ax = self.canvas_3d.add_subplot(111, projection="3d")
+        self._ax = ax
 
-        # Plot full trajectories (faint) and current point (bold)
-        for name in marker_names:
-            marker = self.model.markers.get(name)
-            if marker is None:
-                continue
-            pos = marker.position  # (N,3)
-            if pos.shape[0] == 0:
-                continue
+        self._trail_lines = []
+        for i, name in enumerate(selected):
+            pos = positions[i]
+            (ln,) = ax.plot(
+                pos[:, 0],
+                pos[:, 1],
+                pos[:, 2],
+                alpha=0.35,
+                color=self._marker_colors[i],
+                linewidth=1.0,
+                label=name,
+            )
+            self._trail_lines.append(ln)
 
-            ax.plot(pos[:, 0], pos[:, 1], pos[:, 2], alpha=0.3, label=name)
-            if 0 <= frame_index < pos.shape[0]:
-                x, y, z = pos[frame_index]
-                ax.scatter([x], [y], [z], s=40)
+        # Current-frame point — high-contrast, larger.
+        self._point_artist = ax.scatter(
+            [],
+            [],
+            [],
+            s=80,
+            c="red",
+            edgecolors="black",
+            linewidths=0.6,
+            depthshade=False,
+        )
+
+        # Labels (hidden by default).
+        self._label_texts = []
+        for name in selected:
+            txt = ax.text(0.0, 0.0, 0.0, name, fontsize=8, color="black")
+            txt.set_visible(self.check_labels.isChecked())
+            self._label_texts.append(txt)
+
+        # Skeleton overlay.
+        segs = default_body_segments(selected)
+        self._skeleton_segments = tuple((s.a, s.b) for s in segs)
+        # Seed with a degenerate origin segment because ``add_collection3d``
+        # requires non-empty data to compute initial autoscale; we clear it
+        # immediately afterwards.
+        self._skeleton_collection = Line3DCollection(
+            [[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
+            colors="black",
+            linewidths=2.0,
+            alpha=0.85,
+        )
+        ax.add_collection3d(self._skeleton_collection)
+        self._skeleton_collection.set_segments([])
+        self._skeleton_collection.set_visible(
+            self.check_skeleton.isChecked() and bool(self._skeleton_segments)
+        )
 
         ax.set_xlabel("X")
         ax.set_ylabel("Y")
         ax.set_zlabel("Z")
         ax.set_title("3D Marker Trajectories")
 
-        # Try to set equal aspect ratio
-        all_pts = []
-        for name in marker_names:
-            m = self.model.markers.get(name)
-            if m is not None and m.position.size > 0:
-                all_pts.append(m.position)
-        if all_pts:
-            pts = np.vstack(all_pts)
-            x_min, y_min, z_min = pts.min(axis=0)
-            x_max, y_max, z_max = pts.max(axis=0)
-            max_range = max(x_max - x_min, y_max - y_min, z_max - z_min)
-            if max_range > 0:
-                mid_x = 0.5 * (x_max + x_min)
-                mid_y = 0.5 * (y_max + y_min)
-                mid_z = 0.5 * (z_max + z_min)
+        # Equal aspect.
+        finite = positions[np.isfinite(positions).all(axis=2)]
+        if finite.size > 0:
+            mn = finite.min(axis=0)
+            mx = finite.max(axis=0)
+            max_range = float(np.max(mx - mn))
+            if max_range > 0.0:
+                mid = 0.5 * (mx + mn)
                 half = max_range / 2.0
-                ax.set_xlim(mid_x - half, mid_x + half)
-                ax.set_ylim(mid_y - half, mid_y + half)
-                ax.set_zlim(mid_z - half, mid_z + half)
+                ax.set_xlim(mid[0] - half, mid[0] + half)
+                ax.set_ylim(mid[1] - half, mid[1] + half)
+                ax.set_zlim(mid[2] - half, mid[2] + half)
 
-        ax.legend()
+        if len(selected) <= 12:
+            ax.legend(loc="upper right", fontsize=8)
+
         self.canvas_3d.fig.tight_layout()
-        self.canvas_3d.draw()  # type: ignore
+        self._render_current_frame()
+
+    def _teardown_artists(self) -> None:
+        self._trail_lines = []
+        self._point_artist = None
+        self._label_texts = []
+        self._skeleton_collection = None
+        self._skeleton_segments = ()
+        self._ax = None
+
+    # -------------------------------------------------- Per-frame render
+
+    def _render_current_frame(self) -> None:
+        if self.model is None or self._ax is None:
+            if self.model is not None:
+                # Update label even when nothing is selected.
+                self._update_frame_label()
+            return
+        frame = self.slider_frame.value()
+        self._update_frame_label()
+        if self._selected_positions.size == 0:
+            return
+
+        pts = self._selected_positions[:, frame, :]  # (M,3)
+        finite_mask = np.isfinite(pts).all(axis=1)
+
+        # Update current-frame scatter.
+        if self._point_artist is not None:
+            valid = pts[finite_mask]
+            if valid.size > 0:
+                self._point_artist._offsets3d = (
+                    valid[:, 0],
+                    valid[:, 1],
+                    valid[:, 2],
+                )
+            else:
+                self._point_artist._offsets3d = ([], [], [])
+
+        # Update labels at the current point.
+        for i, txt in enumerate(self._label_texts):
+            if finite_mask[i]:
+                p = pts[i]
+                txt.set_position((float(p[0]), float(p[1])))
+                # set_3d_properties for the z-coord on text3d.
+                if hasattr(txt, "set_3d_properties"):
+                    txt.set_3d_properties(float(p[2]))
+
+        # Update skeleton segments.
+        self._update_skeleton_segments()
+
+        self.canvas_3d.draw_idle()
+
+    def _update_skeleton_segments(self) -> None:
+        if (
+            self._skeleton_collection is None
+            or not self._skeleton_segments
+            or not self._selected_names
+        ):
+            return
+        if not self.check_skeleton.isChecked():
+            self._skeleton_collection.set_segments([])
+            return
+        frame = self.slider_frame.value()
+        idx = {n: i for i, n in enumerate(self._selected_names)}
+        segs: list[list[tuple[float, float, float]]] = []
+        for a, b in self._skeleton_segments:
+            ia = idx.get(a)
+            ib = idx.get(b)
+            if ia is None or ib is None:
+                continue
+            pa = self._selected_positions[ia, frame, :]
+            pb = self._selected_positions[ib, frame, :]
+            if not (np.isfinite(pa).all() and np.isfinite(pb).all()):
+                continue
+            segs.append(
+                [
+                    (float(pa[0]), float(pa[1]), float(pa[2])),
+                    (float(pb[0]), float(pb[1]), float(pb[2])),
+                ]
+            )
+        self._skeleton_collection.set_segments(segs)
+
+    def _update_frame_label(self) -> None:
+        frame = self.slider_frame.value()
+        if (
+            self.model is not None
+            and self.model.point_time is not None
+            and 0 <= frame < len(self.model.point_time)
+        ):
+            t = float(self.model.point_time[frame])
+            time_str = f"{t:.4f} s"
+        else:
+            time_str = "-"
+        self.label_frame_info.setText(
+            f"Frame: {frame} / {max(0, self._n_frames - 1)}  Time: {time_str}"
+        )
+
+    # Backwards-compatible name used by existing tests / code paths.
+    def update_view(self) -> None:
+        """Compatibility shim: rebuild the scene from scratch."""
+        self._rebuild_scene()
+
+    # ----------------------------------------------------------- CSV
+
+    def export_selected_markers_csv(self, path: str) -> None:
+        """Write the currently selected markers' trajectories to CSV.
+
+        Columns: frame, time_s, <marker>_x, <marker>_y, <marker>_z, …
+        """
+        if not isinstance(path, str) or not path:
+            raise ValueError("path must be a non-empty string")
+        if self.model is None:
+            raise ValueError("no model loaded")
+        names = self._selected_names or self.model.marker_names()
+        if not names:
+            raise ValueError("no markers selected to export")
+
+        header = ["frame", "time_s"]
+        for name in names:
+            header += [f"{name}_x", f"{name}_y", f"{name}_z"]
+
+        n = self._n_frames
+        time_arr = (
+            self.model.point_time
+            if self.model.point_time is not None
+            else np.full(n, np.nan)
+        )
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+            for fr in range(n):
+                row: list[Any] = [fr, float(time_arr[fr]) if fr < len(time_arr) else ""]
+                for name in names:
+                    m = self.model.markers.get(name)
+                    if m is None or m.position.size == 0 or fr >= m.position.shape[0]:
+                        row += ["", "", ""]
+                    else:
+                        x, y, z = m.position[fr]
+                        row += [float(x), float(y), float(z)]
+                writer.writerow(row)
+
+    # -------------------------------------------------- Show/Hide events
+
+    def hideEvent(self, event: QtGui.QHideEvent) -> None:  # noqa: N802 (Qt)
+        """Pause playback when the tab is hidden."""
+        self.pause()
+        super().hideEvent(event)

--- a/tests/unit/engines/simscape/three_d_gui/_viewer_test_helpers.py
+++ b/tests/unit/engines/simscape/three_d_gui/_viewer_test_helpers.py
@@ -1,0 +1,111 @@
+"""Shared synthetic-model factory for C3D viewer unit tests.
+
+The actual ``sys.path`` pivot for the engine package lives in the
+sibling ``conftest.py`` (it must run at collection time before any
+``import src.apps`` happens).
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def make_synthetic_model(
+    marker_names: list[str],
+    n_frames: int = 100,
+    point_rate: float = 100.0,
+    include_events: bool = False,
+    include_analog: bool = False,
+):
+    """Construct a deterministic ``C3DDataModel`` for tests.
+
+    Each marker's trajectory is a unique 3-D Lissajous-ish curve so the
+    artists have something interesting to render.
+    """
+    from src.apps.core.models import (  # type: ignore
+        AnalogData,
+        C3DDataModel,
+        C3DEvent,
+        MarkerData,
+    )
+
+    point_time = np.arange(n_frames, dtype=float) / point_rate
+    markers: dict[str, MarkerData] = {}
+    rng = np.random.default_rng(0)
+    for i, name in enumerate(marker_names):
+        phase = 2 * np.pi * (i + 1) / max(1, len(marker_names))
+        pos = np.column_stack(
+            [
+                np.cos(point_time * 2.0 + phase)
+                + rng.normal(scale=0.01, size=n_frames),
+                np.sin(point_time * 2.0 + phase)
+                + rng.normal(scale=0.01, size=n_frames),
+                point_time * 0.1 + i * 0.05,
+            ]
+        )
+        markers[name] = MarkerData(name=name, position=pos)
+
+    analog: dict[str, AnalogData] = {}
+    if include_analog:
+        analog["Fz1"] = AnalogData(
+            name="Fz1", values=np.linspace(0.0, 1.0, n_frames), unit="N"
+        )
+
+    events: list[C3DEvent] = []
+    if include_events:
+        events = [
+            C3DEvent(label="Address", time=0.0),
+            C3DEvent(label="Top", time=point_time[n_frames // 3]),
+            C3DEvent(label="Impact", time=point_time[2 * n_frames // 3]),
+            C3DEvent(label="Finish", time=point_time[-1]),
+        ]
+
+    return C3DDataModel(
+        filepath="synthetic.c3d",
+        markers=markers,
+        analog=analog,
+        point_rate=point_rate,
+        analog_rate=point_rate if include_analog else 0.0,
+        point_time=point_time,
+        analog_time=point_time if include_analog else None,
+        metadata={},
+        events=events,
+    )
+
+
+# Canonical 28-marker anatomical subset used by ``default_body_segments``.
+ANATOMICAL_28: tuple[str, ...] = (
+    "WaistLeft",
+    "WaistRight",
+    "WaistLBack",
+    "WaistRBack",
+    "BackTop",
+    "BackLeft",
+    "BackRight",
+    "HeadTop",
+    "HeadFront",
+    "HeadSide",
+    "LShoulderTop",
+    "LShoulderBack",
+    "LUArmHigh",
+    "LElbowOut",
+    "LWristTop",
+    "RShoulderTop",
+    "RShoulderBack",
+    "RUArmHigh",
+    "RElbowOut",
+    "RWristTop",
+    "LKneeOut",
+    "LAnkleOut",
+    "LToeIn",
+    "LToeOut",
+    "RKneeOut",
+    "RAnkleOut",
+    "RToeIn",
+    "RToeOut",
+)

--- a/tests/unit/engines/simscape/three_d_gui/conftest.py
+++ b/tests/unit/engines/simscape/three_d_gui/conftest.py
@@ -1,0 +1,78 @@
+"""Per-directory conftest that pivots sys.path for the C3D viewer tests."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def _pivot_sys_path() -> None:
+    here = Path(__file__).resolve()
+    repo_root = here.parents[5]
+    engine_python = (
+        repo_root
+        / "src"
+        / "engines"
+        / "Simscape_Multibody_Models"
+        / "3D_Golf_Model"
+        / "python"
+    )
+    engine_src = engine_python / "src"
+    if not engine_src.is_dir():
+        return
+
+    # Pre-cache shared deps the viewer uses so they survive the pivot.
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+    import importlib
+
+    for qual in (
+        "src.shared.python.upstream_drift_tools.lab.bio.c3d_reader",
+        "src.shared.python.qt_utils.wheel_event_filter",
+        "src.shared.python.motion_matching.body_skeleton",
+    ):
+        with contextlib.suppress(ImportError):
+            sys.modules[qual] = importlib.import_module(qual)
+
+    # Drop the repo's ``src`` package so we can rebind it to the engine's.
+    keep_prefix = "src.shared."
+    for modname in list(sys.modules):
+        if modname == "src" or modname.startswith("src."):
+            if modname.startswith(keep_prefix):
+                continue
+            del sys.modules[modname]
+
+    # Bind ``src`` directly to the engine's package via importlib.util so we
+    # don't have to fight pytest's sys.path mutations.
+    import importlib.util as _util
+
+    spec = _util.spec_from_file_location(
+        "src",
+        str(engine_src / "__init__.py"),
+        submodule_search_locations=[str(engine_src)],
+    )
+    if spec is None or spec.loader is None:
+        return
+    src_mod = _util.module_from_spec(spec)
+    sys.modules["src"] = src_mod
+    spec.loader.exec_module(src_mod)
+    # Make ``src`` a multi-rooted package so submodules from EITHER the
+    # engine src/ or the repo src/ resolve cleanly. Engine path comes
+    # first so ``src.apps`` (engine-only) wins; repo path supplies
+    # ``src.tools``, ``src.shared``, etc.
+    repo_src = repo_root / "src"
+    src_mod.__path__ = [str(engine_src), str(repo_src)]
+
+    # Add ``<repo>/src`` for bare ``shared.python.*`` imports the viewer does.
+    repo_src_str = str(repo_src)
+    if repo_src_str not in sys.path:
+        sys.path.append(repo_src_str)
+
+
+_pivot_sys_path()

--- a/tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_playback.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_playback.py
@@ -1,0 +1,136 @@
+"""Playback / shortcut tests for the C3D viewer's 3D tab."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ._viewer_test_helpers import make_synthetic_model
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+@pytest.fixture()
+def tab(qt_app):
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    model = make_synthetic_model(
+        ["m0", "m1", "m2", "m3", "m4"], n_frames=100, point_rate=100.0
+    )
+    t = Viewer3DTab()
+    t.update_from_model(model)
+    # Force a deterministic single-marker selection for predictable assertions.
+    t.list_markers_3d.clearSelection()
+    item = t.list_markers_3d.item(0)
+    assert item is not None
+    item.setSelected(True)
+    return t
+
+
+def test_play_pause_toggle(tab) -> None:
+    assert tab.is_playing is False
+    tab.toggle_play()
+    assert tab.is_playing is True
+    assert tab._timer.isActive()
+    tab.toggle_play()
+    assert tab.is_playing is False
+    assert not tab._timer.isActive()
+
+
+def test_speed_validation(tab) -> None:
+    with pytest.raises(TypeError):
+        tab.set_speed("fast")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        tab.set_speed(0.0)
+    with pytest.raises(ValueError):
+        tab.set_speed(-1.0)
+    tab.set_speed(2.0)
+    assert tab.combo_speed.currentData() == pytest.approx(2.0)
+
+
+def test_frame_validation(tab) -> None:
+    with pytest.raises(TypeError):
+        tab.set_frame("0")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        tab.set_frame(999)
+    tab.set_frame(10)
+    assert tab.slider_frame.value() == 10
+
+
+def test_timer_advances_slider(tab) -> None:
+    tab.slider_frame.setValue(0)
+    # Manually trigger a tick rather than relying on the event loop.
+    tab._on_timer_tick()
+    assert tab.slider_frame.value() == 1
+    tab._on_timer_tick()
+    assert tab.slider_frame.value() == 2
+
+
+def test_loop_wraparound_on(tab) -> None:
+    tab.check_loop.setChecked(True)
+    tab.slider_frame.setValue(tab._n_frames - 1)
+    tab._on_timer_tick()
+    assert tab.slider_frame.value() == 0
+
+
+def test_loop_wraparound_off_stops(tab) -> None:
+    tab.check_loop.setChecked(False)
+    tab.play()
+    tab.slider_frame.setValue(tab._n_frames - 1)
+    tab._on_timer_tick()
+    # Should have stopped, slider stays at last frame.
+    assert tab.is_playing is False
+    assert tab.slider_frame.value() == tab._n_frames - 1
+
+
+def test_step_frame(tab) -> None:
+    tab.slider_frame.setValue(50)
+    tab.step_frame(1)
+    assert tab.slider_frame.value() == 51
+    tab.step_frame(-10)
+    assert tab.slider_frame.value() == 41
+    # Clamped at bounds.
+    tab.step_frame(-9999)
+    assert tab.slider_frame.value() == 0
+
+
+def test_keyboard_shortcuts(qt_app, tab) -> None:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtTest import QTest
+
+    tab.show()
+    QTest.qWaitForWindowExposed(tab)
+    tab.setFocus()
+
+    tab.slider_frame.setValue(0)
+    QTest.keyClick(tab, Qt.Key.Key_Right)
+    assert tab.slider_frame.value() == 1
+    QTest.keyClick(tab, Qt.Key.Key_End)
+    assert tab.slider_frame.value() == tab._n_frames - 1
+    QTest.keyClick(tab, Qt.Key.Key_Home)
+    assert tab.slider_frame.value() == 0
+    QTest.keyClick(tab, Qt.Key.Key_Space)
+    assert tab.is_playing is True
+    QTest.keyClick(tab, Qt.Key.Key_Space)
+    assert tab.is_playing is False
+
+
+def test_event_buttons_jump_to_time(qt_app) -> None:
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    model = make_synthetic_model(["m0"], n_frames=100, include_events=True)
+    t = Viewer3DTab()
+    t.update_from_model(model)
+    assert len(t._event_buttons) == 4
+    t.jump_to_time(model.events[2].time)
+    expected = 2 * 100 // 3
+    assert t.slider_frame.value() == expected

--- a/tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_skeleton.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_skeleton.py
@@ -1,0 +1,78 @@
+"""Skeleton-overlay tests for the C3D viewer's 3D tab."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ._viewer_test_helpers import ANATOMICAL_28, make_synthetic_model
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def test_skeleton_segment_count_matches_canonical(qt_app) -> None:
+    """The 28-marker anatomical subset yields 26 canonical segments."""
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+    from src.shared.python.motion_matching.body_skeleton import (  # type: ignore
+        default_body_segments,
+    )
+
+    expected_segments = default_body_segments(list(ANATOMICAL_28))
+    assert len(expected_segments) == 26
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=50)
+    tab = Viewer3DTab()
+    tab.update_from_model(model)
+    tab.select_body_markers()
+
+    assert tab.skeleton_segment_count == len(expected_segments)
+
+
+def test_skeleton_visibility_toggle(qt_app) -> None:
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=20)
+    tab = Viewer3DTab()
+    tab.update_from_model(model)
+    tab.select_body_markers()
+
+    coll = tab._skeleton_collection
+    assert coll is not None
+    assert coll.get_visible() is True
+
+    tab.check_skeleton.setChecked(False)
+    assert coll.get_visible() is False
+
+    tab.check_skeleton.setChecked(True)
+    assert coll.get_visible() is True
+
+
+def test_skeleton_partial_marker_set(qt_app) -> None:
+    """Missing endpoints simply drop their segments — no exception."""
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    partial = list(ANATOMICAL_28[:10])  # head + pelvis + a few torso
+    model = make_synthetic_model(partial, n_frames=20)
+    tab = Viewer3DTab()
+    tab.update_from_model(model)
+    tab.select_all_markers()
+
+    # Some segments should exist (pelvis + head); count must be < full 26.
+    assert 0 < tab.skeleton_segment_count < 26
+
+
+def test_view_preset_validation(qt_app) -> None:
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    tab = Viewer3DTab()
+    with pytest.raises(ValueError):
+        tab.set_view_preset("Bogus")

--- a/tests/unit/engines/simscape/three_d_gui/test_force_plot_tab_wired.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_force_plot_tab_wired.py
@@ -1,0 +1,55 @@
+"""Verify the Force Plates tab is wired into the main viewer window."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ._viewer_test_helpers import make_synthetic_model
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def test_main_viewer_has_force_plates_tab(qt_app) -> None:
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    win = C3DViewerMainWindow()
+    assert win.tabs.count() >= 6
+    titles = [win.tabs.tabText(i) for i in range(win.tabs.count())]
+    assert "Force Plates" in titles
+
+
+def test_force_plot_tab_handles_empty_analog(qt_app) -> None:
+    from src.apps.ui.tabs.force_plot_tab import ForcePlotTab  # type: ignore
+
+    tab = ForcePlotTab()
+    model = make_synthetic_model(["m0", "m1"], n_frames=20, include_analog=False)
+    tab.update_from_model(model)
+    assert "No force-plate data" in tab.status_label.text()
+
+
+def test_force_plot_tab_no_match_pattern(qt_app) -> None:
+    """Analog present but no force-plate-pattern channels -> graceful no-data."""
+    from src.apps.ui.tabs.force_plot_tab import ForcePlotTab  # type: ignore
+
+    tab = ForcePlotTab()
+    model = make_synthetic_model(["m0"], n_frames=10, include_analog=True)
+    # Synthetic analog channel "Fz1" matches the pattern; rename it so it doesn't.
+    from src.apps.core.models import AnalogData  # type: ignore
+
+    model.analog = {
+        "EMG_biceps": AnalogData(
+            name="EMG_biceps", values=model.analog["Fz1"].values, unit="V"
+        )
+    }
+    tab.update_from_model(model)
+    assert "No force-plate data" in tab.status_label.text()


### PR DESCRIPTION
Closes #4640

## Summary

End-to-end upgrade of the C3D Viewer's 3-D tab plus main-window wiring,
covering all eight feature areas (A–H) called out in the issue.

### Feature areas

- **A. Playback machinery** — play/pause toggle, speed combo (0.1×–4×),
  loop checkbox; QTimer ticks at `int(1000 / (point_rate * speed))`;
  paused on tab hide.
- **A². Keyboard shortcuts** — Space toggles play/pause, Left/Right
  step ±1 frame, Shift+Left/Right step ±10, Home/End jump to first/last.
- **B. Skeleton overlay** — `Line3DCollection` driven by
  `src.shared.python.motion_matching.body_skeleton.default_body_segments`,
  with a "Show skeleton" toggle. Auto-filters to segments whose
  endpoints are present in the loaded marker subset.
- **C. Selection helpers** — Select all / Body / Club / Clear buttons
  above the marker list (Body uses the canonical anatomical subset,
  Club matches a generic `Marker_<n>:<n>:` cluster pattern).
- **D. View-angle presets** — Front / Side / Top / Iso `QToolButton`s
  that call `ax.view_init(elev, azim)` with the issue-spec pairs.
- **E. Performance refactor** — artists pre-allocated per selection;
  per-frame change calls `_offsets3d` / `set_3d_properties` /
  `set_segments` only, then `canvas.draw_idle()` once. Scrub fps
  measured at ~4000 fps offscreen on 38 markers × 654 frames (issue
  target was 60 fps).
- **F. Force-plate tab** — wired into the main window after the
  Analysis tab; renders the existing `ForcePlotTab`. Empty-analog and
  no-pattern-match paths show "No force-plate data in this file".
- **G. Event quick-jump** — buttons next to the slider, populated from
  `model.events`; hidden when the file carries no events.
- **H. Polish** — "Show labels" checkbox (default off); current-frame
  point uses high-contrast red with a black edge; per-marker colors
  from `tab20` / `Spectral`; "Export markers to CSV…" menu item under
  File.

DbC: `_validate_speed` and `_validate_frame` raise `TypeError` /
`ValueError` per the project standard.

### Numbers

- Skeleton segment count for the 28-marker anatomical subset: **26**
  (matches `default_body_segments` exactly).
- Scrub fps on 38 markers × 654 frames (Agg + offscreen): **~4063 fps**.

### Test plan

- [x] Lint (`ruff check`) clean on touched files.
- [x] Format (`ruff format --check`) clean.
- [x] `pytest tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_playback.py
      tests/unit/engines/simscape/three_d_gui/test_c3d_viewer_skeleton.py
      tests/unit/engines/simscape/three_d_gui/test_force_plot_tab_wired.py`
      → **16 passed**.
- [x] Existing `test_starting_pose_matcher.py` tests still pass under
      the new directory conftest (the 2 pre-existing failures on `main`
      are unchanged).
- [ ] Manual smoke test: open the viewer, load `data/C3D_TA_Driver.c3d`,
      scrub the 3D tab, press Space, toggle skeleton.

### Notes for reviewers

- A per-directory `conftest.py` rebinds `sys.modules['src']` to the
  engine package via `importlib.util.spec_from_file_location` with a
  multi-rooted `__path__` (`[engine_src, repo_src]`) so both the
  engine's `src.apps.*` and the repo's `src.shared.*` / `src.tools.*`
  resolve cleanly under pytest. This is an additive test-only change
  — production code keeps using the existing `src.shared.*` import
  paths.
- The viewer's class hierarchy is unchanged; new behaviour is
  additive on `Viewer3DTab`. The previous `update_view()` entry
  point is preserved as a compatibility shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)