### PR TITLE
fix: keep list-mode hover scaling consistent with fixed icon size

### DIFF
--- a/src/launchers/model_card.py
+++ b/src/launchers/model_card.py
@@ -172,7 +172,13 @@ class DraggableModelCard(QFrame):
         scale_factor = 1.0 + (value / 4.0) * 0.03
         if hasattr(self, "lbl_img") and hasattr(self, "base_pixmap"):  # noqa: SIM102
             if self.base_pixmap and not self.base_pixmap.isNull():
-                base_px = scaled_image_px(self.tile_scale)
+                # In list mode, icon is fixed at 60x60 regardless of tile_scale.
+                # Hover animation must use the same fixed base size to avoid
+                # clipping/jitter when zoom is adjusted.
+                if self._list_mode:
+                    base_px = 60  # Fixed icon size in list mode
+                else:
+                    base_px = scaled_image_px(self.tile_scale)
                 new_size = max(1, int(base_px * 0.9 * scale_factor))
                 scaled = self.base_pixmap.scaled(
                     new_size,


### PR DESCRIPTION
## Summary
This PR addresses review feedback from PR #4633 (issue #4636) by fixing the hover animation in list mode.

## Changes
- **src/launchers/model_card.py**: In list mode, use fixed 60px base size for hover animation instead of scaled size

## Why
In list mode, the icon is fixed at 60x60 regardless of tile_scale, but the hover animation was deriving its base size from scaled_image_px(tile_scale). This caused visible clipping/jitter when zoom was adjusted in list mode.