### PR TITLE
feat(c3d-viewer): segments + cylinders + export + metadata (#4661)

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
@@ -20,11 +20,13 @@ from PyQt6.QtCore import Qt
 
 from .core.models import C3DDataModel
 from .services.loader_thread import C3DLoaderThread
+from .services.marker_export import export_markers
 from .ui.tabs.analog_plot_tab import AnalogPlotTab
 from .ui.tabs.analysis_tab import AnalysisTab
 from .ui.tabs.force_plot_tab import ForcePlotTab
 from .ui.tabs.marker_plot_tab import MarkerPlotTab
 from .ui.tabs.overview_tab import OverviewTab
+from .ui.tabs.segments_tab import SegmentsTab
 from .ui.tabs.viewer_3d_tab import Viewer3DTab
 
 # ---------------------------------------------------------------------------
@@ -63,12 +65,14 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.action_open.setStatusTip("Open a C3D file for analysis")
         self.action_open.triggered.connect(self.open_c3d_file)
 
-        self.action_export_csv = QtGui.QAction("Export markers to &CSV…", self)
-        self.action_export_csv.setStatusTip(
-            "Export selected 3D markers' trajectories to CSV"
+        self.action_export_markers = QtGui.QAction("&Export markers…", self)
+        self.action_export_markers.setStatusTip(
+            "Export selected markers, components, and frame range to CSV/JSON/NPZ"
         )
-        self.action_export_csv.triggered.connect(self._export_markers_csv)
-        self.action_export_csv.setEnabled(False)
+        self.action_export_markers.triggered.connect(self._export_markers_dialog)
+        self.action_export_markers.setEnabled(False)
+        # Backwards-compatible alias for any existing test references.
+        self.action_export_csv = self.action_export_markers
 
         self.action_exit = QtGui.QAction("E&xit", self)
         self.action_exit.setShortcut("Ctrl+Q")
@@ -86,7 +90,7 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         file_menu = menubar.addMenu("&File")
         if file_menu is not None:
             file_menu.addAction(self.action_open)
-            file_menu.addAction(self.action_export_csv)
+            file_menu.addAction(self.action_export_markers)
             file_menu.addSeparator()
             file_menu.addAction(self.action_exit)
 
@@ -102,8 +106,11 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.marker_plot_tab = MarkerPlotTab()
         self.analog_plot_tab = AnalogPlotTab()
         self.viewer3d_tab = Viewer3DTab()
+        self.segments_tab = SegmentsTab()
         self.analysis_tab = AnalysisTab()
         self.force_plot_tab = ForcePlotTab()
+        # Plumb segment edits straight into the 3D viewer.
+        self.segments_tab.segments_changed.connect(self.viewer3d_tab.set_user_segments)
 
         self.tabs.addTab(self.overview_tab, "Overview")
         self.tabs.setTabToolTip(0, "Metadata and file information")
@@ -113,10 +120,12 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.tabs.setTabToolTip(2, "Analog data visualization")
         self.tabs.addTab(self.viewer3d_tab, "3D Viewer")
         self.tabs.setTabToolTip(3, "3D interactive view of markers")
+        self.tabs.addTab(self.segments_tab, "Segments")
+        self.tabs.setTabToolTip(4, "User-defined marker-pair segments")
         self.tabs.addTab(self.analysis_tab, "Analysis")
-        self.tabs.setTabToolTip(4, "Kinematic analysis and calculations")
+        self.tabs.setTabToolTip(5, "Kinematic analysis and calculations")
         self.tabs.addTab(self.force_plot_tab, "Force Plates")
-        self.tabs.setTabToolTip(5, "Force plate GRF and COP visualization")
+        self.tabs.setTabToolTip(6, "Force plate GRF and COP visualization")
 
         self.setCentralWidget(self.tabs)
 
@@ -265,29 +274,42 @@ class C3DViewerMainWindow(QtWidgets.QMainWindow):
         self.marker_plot_tab.update_from_model(self.model)
         self.analog_plot_tab.update_from_model(self.model)
         self.viewer3d_tab.update_from_model(self.model)
+        self.segments_tab.update_from_model(self.model)
         self.analysis_tab.update_from_model(self.model)
         self.force_plot_tab.update_from_model(self.model)
-        self.action_export_csv.setEnabled(True)
+        self.action_export_markers.setEnabled(True)
 
-    def _export_markers_csv(self) -> None:
-        """Export the 3D viewer's selected markers to CSV."""
+    def _export_markers_dialog(self) -> None:
+        """Open the selective marker-export dialog."""
         if self.model is None:
             QtWidgets.QMessageBox.information(self, "Export markers", "No file loaded.")
             return
-        path, _ = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Export markers to CSV", "", "CSV files (*.csv)"
-        )
-        if not path:
+        from .ui.dialogs.export_markers_dialog import ExportMarkersDialog
+
+        dlg = ExportMarkersDialog(self.model, self)
+        if dlg.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        params = dlg.export_params()
+        if params is None:
             return
         try:
-            self.viewer3d_tab.export_selected_markers_csv(path)
+            written = export_markers(
+                self.model,
+                params["marker_names"],
+                params["components"],
+                params["frame_range"],
+                params["fmt"],
+                params["path"],
+                include_time=params["include_time"],
+                include_residual=params["include_residual"],
+            )
         except (OSError, ValueError) as e:
             QtWidgets.QMessageBox.warning(
-                self, "Export failed", f"Could not write CSV:\n{e}"
+                self, "Export failed", f"Could not export markers:\n{e}"
             )
             return
         if (sb := self.statusBar()) is not None:
-            sb.showMessage(f"Exported markers to {os.path.basename(path)}")
+            sb.showMessage(f"Exported markers to {os.path.basename(str(written))}")
 
 
 def main() -> None:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/core/models.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/core/models.py
@@ -45,6 +45,7 @@ class C3DDataModel:
     analog_time: npt.NDArray[np.float64] | None = None
     metadata: dict[str, str] = field(default_factory=dict)
     events: list[C3DEvent] = field(default_factory=list)
+    raw_parameters: dict | None = None
 
     def marker_names(self) -> list[str]:
         """Return list of marker names."""

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/c3d_loader.py
@@ -120,6 +120,12 @@ def load_c3d_file(filepath: str) -> C3DDataModel:
         reader = C3DDataReader(filepath)
         metadata_obj = reader.get_metadata()
         df_points = reader.points_dataframe(include_time=False)
+        raw_params: dict | None = None
+        try:
+            c3d_data = reader._load()  # noqa: SLF001 — controlled internal use
+            raw_params = dict(c3d_data.get("parameters") or {})
+        except (KeyError, AttributeError, TypeError):
+            raw_params = None
 
     markers = _build_markers(df_points, metadata_obj.marker_labels)
 
@@ -155,4 +161,5 @@ def load_c3d_file(filepath: str) -> C3DDataModel:
         analog_time=analog_time,
         metadata=_build_metadata_ui(filepath, metadata_obj),
         events=events,
+        raw_parameters=raw_params,
     )

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/marker_export.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/marker_export.py
@@ -1,0 +1,330 @@
+"""Selective marker export to CSV / JSON / NPZ.
+
+Produces long-format CSV (one row per ``(frame, marker)``), a JSON object
+with a ``metadata`` block, or an NPZ archive (one array per marker plus a
+``_meta`` JSON-encoded string).
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ..core.models import C3DDataModel
+
+_VALID_FORMATS = ("csv", "json", "npz")
+_VALID_COMPONENTS = ("x", "y", "z")
+
+
+def _sanitize_csv_cell(value: Any) -> Any:
+    """Defang Excel-style formula injection in CSV cells."""
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@"):
+        return "'" + value
+    return value
+
+
+def _file_sha256(path: str) -> str | None:
+    if not path or not os.path.isfile(path):
+        return None
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _resolve_components(components: Sequence[str] | str) -> tuple[str, ...]:
+    if isinstance(components, str):
+        if components.lower() == "all":
+            return _VALID_COMPONENTS
+        components = (components,)
+    out: list[str] = []
+    for c in components:
+        c_low = str(c).lower()
+        if c_low not in _VALID_COMPONENTS:
+            raise ValueError(
+                f"component must be one of {_VALID_COMPONENTS} or 'all', got {c!r}"
+            )
+        if c_low not in out:
+            out.append(c_low)
+    if not out:
+        raise ValueError("at least one component must be selected")
+    return tuple(out)
+
+
+def _resolve_frame_range(
+    frame_range: tuple[int, int] | None, n_frames: int
+) -> tuple[int, int]:
+    if frame_range is None:
+        return (0, max(0, n_frames - 1))
+    if not isinstance(frame_range, tuple) or len(frame_range) != 2:
+        raise ValueError("frame_range must be a (start, end) tuple")
+    start, end = int(frame_range[0]), int(frame_range[1])
+    if start < 0 or end < start or end >= n_frames:
+        raise ValueError(
+            f"frame_range {frame_range!r} out of bounds [0, {n_frames - 1}]"
+        )
+    return (start, end)
+
+
+def _build_metadata_block(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str],
+    frame_range: tuple[int, int],
+    include_time: bool,
+    include_residual: bool,
+) -> dict[str, Any]:
+    return {
+        "file": os.path.basename(model.filepath) if model.filepath else None,
+        "sha256": _file_sha256(model.filepath),
+        "frame_range": list(frame_range),
+        "n_frames": frame_range[1] - frame_range[0] + 1,
+        "point_rate_hz": float(model.point_rate),
+        "markers": list(marker_names),
+        "components": list(components),
+        "include_time": include_time,
+        "include_residual": include_residual,
+        "units": model.metadata.get("Units (POINT)", ""),
+    }
+
+
+def _column_index_for(component: str) -> int:
+    return _VALID_COMPONENTS.index(component)
+
+
+def export_markers(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str] | str,
+    frame_range: tuple[int, int] | None,
+    fmt: str,
+    path: Path | str,
+    *,
+    include_time: bool = True,
+    include_residual: bool = False,
+) -> Path:
+    """Export the named markers to ``path`` in the requested format.
+
+    Args:
+        model: Loaded C3D model.
+        marker_names: Markers to export. Must all exist in ``model.markers``.
+        components: Subset of ``("x", "y", "z")`` or the literal string ``"all"``.
+        frame_range: ``(start, end)`` inclusive frame indices, or ``None`` for full.
+        fmt: One of ``"csv"``, ``"json"``, ``"npz"``.
+        path: Destination file.
+        include_time: Include a ``time_s`` column (CSV/JSON) — NPZ stores time
+            separately under ``_time``.
+        include_residual: Include the per-frame residual where available.
+    """
+    if model is None:
+        raise ValueError("model must be provided")
+    if not marker_names:
+        raise ValueError("at least one marker must be selected")
+    fmt_low = str(fmt).lower()
+    if fmt_low not in _VALID_FORMATS:
+        raise ValueError(f"fmt must be one of {_VALID_FORMATS}, got {fmt!r}")
+    missing = [n for n in marker_names if n not in model.markers]
+    if missing:
+        raise ValueError(f"unknown markers: {missing!r}")
+
+    comps = _resolve_components(components)
+    n_frames = (
+        len(model.point_time)
+        if model.point_time is not None
+        else max((m.position.shape[0] for m in model.markers.values()), default=0)
+    )
+    if n_frames <= 0:
+        raise ValueError("model has no frames to export")
+    fr_range = _resolve_frame_range(frame_range, n_frames)
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    metadata = _build_metadata_block(
+        model, marker_names, comps, fr_range, include_time, include_residual
+    )
+
+    if fmt_low == "csv":
+        return _write_csv(
+            model,
+            marker_names,
+            comps,
+            fr_range,
+            out_path,
+            include_time,
+            include_residual,
+        )
+    if fmt_low == "json":
+        return _write_json(
+            model,
+            marker_names,
+            comps,
+            fr_range,
+            out_path,
+            metadata,
+            include_time,
+            include_residual,
+        )
+    return _write_npz(
+        model,
+        marker_names,
+        comps,
+        fr_range,
+        out_path,
+        metadata,
+    )
+
+
+def _iter_rows(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str],
+    frame_range: tuple[int, int],
+    include_time: bool,
+    include_residual: bool,
+):
+    start, end = frame_range
+    time_arr = model.point_time
+    for fr in range(start, end + 1):
+        t = float(time_arr[fr]) if (time_arr is not None and fr < len(time_arr)) else ""
+        for name in marker_names:
+            m = model.markers[name]
+            if m.position.size == 0 or fr >= m.position.shape[0]:
+                vals: list[Any] = ["" for _ in components]
+                residual: Any = ""
+            else:
+                vals = [float(m.position[fr, _column_index_for(c)]) for c in components]
+                if (
+                    include_residual
+                    and m.residuals is not None
+                    and fr < len(m.residuals)
+                ):
+                    residual = float(m.residuals[fr])
+                else:
+                    residual = ""
+            row: list[Any] = [fr]
+            if include_time:
+                row.append(t)
+            row.append(name)
+            row.extend(vals)
+            if include_residual:
+                row.append(residual)
+            yield row
+
+
+def _write_csv(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str],
+    frame_range: tuple[int, int],
+    path: Path,
+    include_time: bool,
+    include_residual: bool,
+) -> Path:
+    header: list[str] = ["frame"]
+    if include_time:
+        header.append("time_s")
+    header.append("marker")
+    header.extend(components)
+    if include_residual:
+        header.append("residual")
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for row in _iter_rows(
+            model,
+            marker_names,
+            components,
+            frame_range,
+            include_time,
+            include_residual,
+        ):
+            writer.writerow([_sanitize_csv_cell(v) for v in row])
+    return path
+
+
+def _write_json(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str],
+    frame_range: tuple[int, int],
+    path: Path,
+    metadata: dict[str, Any],
+    include_time: bool,
+    include_residual: bool,
+) -> Path:
+    rows: list[dict[str, Any]] = []
+    start, end = frame_range
+    time_arr = model.point_time
+    for fr in range(start, end + 1):
+        t = (
+            float(time_arr[fr])
+            if (time_arr is not None and fr < len(time_arr))
+            else None
+        )
+        for name in marker_names:
+            m = model.markers[name]
+            entry: dict[str, Any] = {"frame": fr, "marker": name}
+            if include_time:
+                entry["time_s"] = t
+            if m.position.size == 0 or fr >= m.position.shape[0]:
+                for c in components:
+                    entry[c] = None
+            else:
+                for c in components:
+                    entry[c] = float(m.position[fr, _column_index_for(c)])
+            if include_residual:
+                if m.residuals is not None and fr < len(m.residuals):
+                    entry["residual"] = float(m.residuals[fr])
+                else:
+                    entry["residual"] = None
+            rows.append(entry)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump({"metadata": metadata, "data": rows}, f, indent=2)
+    return path
+
+
+def _write_npz(
+    model: C3DDataModel,
+    marker_names: Sequence[str],
+    components: Sequence[str],
+    frame_range: tuple[int, int],
+    path: Path,
+    metadata: dict[str, Any],
+) -> Path:
+    start, end = frame_range
+    n = end - start + 1
+    arrays: dict[str, np.ndarray] = {}
+    cols = [_column_index_for(c) for c in components]
+    for name in marker_names:
+        m = model.markers[name]
+        out = np.full((n, len(cols)), np.nan, dtype=float)
+        if m.position.size > 0:
+            up_to = min(end + 1, m.position.shape[0])
+            slice_n = max(0, up_to - start)
+            if slice_n > 0:
+                out[:slice_n, :] = m.position[start:up_to, cols]
+        arrays[name] = out
+    if model.point_time is not None:
+        time_arr = np.asarray(model.point_time, dtype=float)
+        end_t = min(end + 1, len(time_arr))
+        slice_n = max(0, end_t - start)
+        time_out = np.full(n, np.nan, dtype=float)
+        if slice_n > 0:
+            time_out[:slice_n] = time_arr[start:end_t]
+        arrays["_time"] = time_out
+    arrays["_meta"] = np.array(json.dumps(metadata))
+    np.savez(path, **arrays)
+    if path.suffix.lower() != ".npz":
+        return path.with_suffix(path.suffix + ".npz")
+    return path
+
+
+__all__ = ["export_markers"]

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/segment_set_io.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/services/segment_set_io.py
@@ -1,0 +1,166 @@
+"""Load and save user-defined segment sets as JSON.
+
+Schema v1::
+
+    {
+      "schema_version": 1,
+      "segments": [
+        {"a": "<marker_a>", "b": "<marker_b>",
+         "geometry": "line"|"cylinder",
+         "group": "<free-form>",
+         "visible": true,
+         "radius": 0.015}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_RADIUS_M = 0.015
+_VALID_GEOMETRIES = ("line", "cylinder")
+
+
+@dataclass(frozen=True)
+class SegmentSpec:
+    """A user-editable segment description."""
+
+    a: str
+    b: str
+    geometry: str = "line"
+    group: str = "auto"
+    visible: bool = True
+    radius: float = DEFAULT_RADIUS_M
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.a, str) or not self.a:
+            raise ValueError(
+                f"SegmentSpec.a must be a non-empty string, got {self.a!r}"
+            )
+        if not isinstance(self.b, str) or not self.b:
+            raise ValueError(
+                f"SegmentSpec.b must be a non-empty string, got {self.b!r}"
+            )
+        if self.a == self.b:
+            raise ValueError(
+                f"SegmentSpec endpoints must differ, got a == b == {self.a!r}"
+            )
+        if self.geometry not in _VALID_GEOMETRIES:
+            raise ValueError(
+                f"SegmentSpec.geometry must be one of {_VALID_GEOMETRIES}, "
+                f"got {self.geometry!r}"
+            )
+        if not isinstance(self.group, str) or not self.group:
+            raise ValueError(
+                f"SegmentSpec.group must be a non-empty string, got {self.group!r}"
+            )
+        if not isinstance(self.visible, bool):
+            raise TypeError(
+                f"SegmentSpec.visible must be bool, got {type(self.visible).__name__}"
+            )
+        if (
+            isinstance(self.radius, bool)
+            or not isinstance(self.radius, (int, float))
+            or self.radius <= 0.0
+        ):
+            raise ValueError(
+                f"SegmentSpec.radius must be a positive number, got {self.radius!r}"
+            )
+
+
+@dataclass
+class SegmentSet:
+    """A persisted set of user segments."""
+
+    segments: tuple[SegmentSpec, ...] = field(default_factory=tuple)
+    schema_version: int = SCHEMA_VERSION
+
+
+def default_segment_set_path() -> Path:
+    """Return the default JSON path for persisting user segments."""
+    return Path.home() / ".golf_modeling_suite" / "c3d_viewer_segments.json"
+
+
+def to_dict(segment_set: SegmentSet) -> dict[str, Any]:
+    """Serialise a ``SegmentSet`` to a JSON-ready dict."""
+    if not isinstance(segment_set, SegmentSet):
+        raise TypeError(
+            f"segment_set must be SegmentSet, got {type(segment_set).__name__}"
+        )
+    return {
+        "schema_version": segment_set.schema_version,
+        "segments": [asdict(s) for s in segment_set.segments],
+    }
+
+
+def from_dict(payload: dict[str, Any]) -> SegmentSet:
+    """Parse a dict (from ``json.load``) into a ``SegmentSet``."""
+    if not isinstance(payload, dict):
+        raise TypeError(f"payload must be dict, got {type(payload).__name__}")
+    version = int(payload.get("schema_version", SCHEMA_VERSION))
+    if version != SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported segment-set schema_version {version!r} "
+            f"(expected {SCHEMA_VERSION})"
+        )
+    raw_segments = payload.get("segments", [])
+    if not isinstance(raw_segments, list):
+        raise ValueError("'segments' must be a list")
+    parsed: list[SegmentSpec] = []
+    for entry in raw_segments:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"segment entry must be a dict, got {type(entry).__name__}"
+            )
+        parsed.append(
+            SegmentSpec(
+                a=str(entry["a"]),
+                b=str(entry["b"]),
+                geometry=str(entry.get("geometry", "line")),
+                group=str(entry.get("group", "auto")),
+                visible=bool(entry.get("visible", True)),
+                radius=float(entry.get("radius", DEFAULT_RADIUS_M)),
+            )
+        )
+    return SegmentSet(segments=tuple(parsed), schema_version=version)
+
+
+def save_segment_set(path: Path | str, segment_set: SegmentSet) -> Path:
+    """Write ``segment_set`` to ``path`` as JSON, creating parents as needed."""
+    if path is None:
+        raise ValueError("path must be provided")
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as f:
+        json.dump(to_dict(segment_set), f, indent=2, sort_keys=True)
+    return out
+
+
+def load_segment_set(path: Path | str) -> SegmentSet:
+    """Load a segment set from ``path``."""
+    if path is None:
+        raise ValueError("path must be provided")
+    src = Path(path)
+    if not src.is_file():
+        raise FileNotFoundError(f"segment-set file not found: {src}")
+    with src.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    return from_dict(payload)
+
+
+__all__ = [
+    "DEFAULT_RADIUS_M",
+    "SCHEMA_VERSION",
+    "SegmentSet",
+    "SegmentSpec",
+    "default_segment_set_path",
+    "from_dict",
+    "load_segment_set",
+    "save_segment_set",
+    "to_dict",
+]

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/dialogs/__init__.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""Modal dialogs for the C3D Viewer."""

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/dialogs/export_markers_dialog.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/dialogs/export_markers_dialog.py
@@ -1,0 +1,206 @@
+"""Dialog for selective marker export (CSV / JSON / NPZ)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from PyQt6 import QtWidgets
+
+from ...core.models import C3DDataModel
+
+_CLUB_MARKER_RE = re.compile(r"^Marker_\d+:\d+:", re.IGNORECASE)
+
+
+def _is_club_marker(name: str) -> bool:
+    return bool(_CLUB_MARKER_RE.match(name))
+
+
+class ExportMarkersDialog(QtWidgets.QDialog):
+    """Modal export-options picker."""
+
+    def __init__(
+        self, model: C3DDataModel, parent: QtWidgets.QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        if model is None:
+            raise ValueError("model must be provided")
+        self.model = model
+        self.setWindowTitle("Export markers")
+        self.resize(480, 540)
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Marker selection"))
+
+        select_row = QtWidgets.QHBoxLayout()
+        btn_all = QtWidgets.QPushButton("Select all")
+        btn_body = QtWidgets.QPushButton("Body")
+        btn_clear = QtWidgets.QPushButton("Clear")
+        btn_all.clicked.connect(lambda: self._set_selection(lambda _n: True))
+        btn_body.clicked.connect(self._select_body)
+        btn_clear.clicked.connect(lambda: self._set_selection(lambda _n: False))
+        for b in (btn_all, btn_body, btn_clear):
+            select_row.addWidget(b)
+        select_row.addStretch()
+        layout.addLayout(select_row)
+
+        self.list_markers = QtWidgets.QListWidget()
+        self.list_markers.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.MultiSelection
+        )
+        for name in self.model.marker_names():
+            self.list_markers.addItem(name)
+        self.list_markers.selectAll()
+        layout.addWidget(self.list_markers, 1)
+
+        # Components.
+        comp_box = QtWidgets.QGroupBox("Components")
+        comp_layout = QtWidgets.QHBoxLayout(comp_box)
+        self.radio_x = QtWidgets.QRadioButton("X")
+        self.radio_y = QtWidgets.QRadioButton("Y")
+        self.radio_z = QtWidgets.QRadioButton("Z")
+        self.radio_all = QtWidgets.QRadioButton("All (X, Y, Z)")
+        self.radio_all.setChecked(True)
+        for r in (self.radio_x, self.radio_y, self.radio_z, self.radio_all):
+            comp_layout.addWidget(r)
+        layout.addWidget(comp_box)
+
+        # Frame range.
+        n_frames = (
+            len(self.model.point_time) if self.model.point_time is not None else 0
+        )
+        range_box = QtWidgets.QGroupBox("Frame range")
+        range_layout = QtWidgets.QHBoxLayout(range_box)
+        self.spin_start = QtWidgets.QSpinBox()
+        self.spin_end = QtWidgets.QSpinBox()
+        self.spin_start.setRange(0, max(0, n_frames - 1))
+        self.spin_end.setRange(0, max(0, n_frames - 1))
+        self.spin_end.setValue(max(0, n_frames - 1))
+        range_layout.addWidget(QtWidgets.QLabel("Start"))
+        range_layout.addWidget(self.spin_start)
+        range_layout.addWidget(QtWidgets.QLabel("End"))
+        range_layout.addWidget(self.spin_end)
+        layout.addWidget(range_box)
+
+        # Format.
+        fmt_box = QtWidgets.QGroupBox("Format")
+        fmt_layout = QtWidgets.QHBoxLayout(fmt_box)
+        self.radio_csv = QtWidgets.QRadioButton("CSV")
+        self.radio_json = QtWidgets.QRadioButton("JSON")
+        self.radio_npz = QtWidgets.QRadioButton("NPZ")
+        self.radio_csv.setChecked(True)
+        for r in (self.radio_csv, self.radio_json, self.radio_npz):
+            fmt_layout.addWidget(r)
+        layout.addWidget(fmt_box)
+
+        # Options.
+        self.check_time = QtWidgets.QCheckBox("Include time column")
+        self.check_time.setChecked(True)
+        self.check_residual = QtWidgets.QCheckBox("Include residuals")
+        layout.addWidget(self.check_time)
+        layout.addWidget(self.check_residual)
+
+        # Buttons.
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        ok_btn = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if ok_btn is not None:
+            ok_btn.setText("Export…")
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self._chosen_path: str | None = None
+
+    # -------------------------------------------------------------- helpers
+
+    def _set_selection(self, predicate: Any) -> None:
+        self.list_markers.blockSignals(True)
+        try:
+            for i in range(self.list_markers.count()):
+                item = self.list_markers.item(i)
+                if item is None:
+                    continue
+                item.setSelected(bool(predicate(item.text())))
+        finally:
+            self.list_markers.blockSignals(False)
+
+    def _select_body(self) -> None:
+        try:
+            from src.shared.python.motion_matching.body_skeleton import (  # type: ignore
+                default_body_segments,
+            )
+        except ImportError:  # pragma: no cover
+            from shared.python.motion_matching.body_skeleton import (  # type: ignore
+                default_body_segments,
+            )
+        body = {
+            n
+            for s in default_body_segments(self.model.marker_names())
+            for n in (s.a, s.b)
+        }
+        self._set_selection(lambda n: n in body)
+
+    def _selected_markers(self) -> list[str]:
+        return [item.text() for item in self.list_markers.selectedItems()]
+
+    def _selected_format(self) -> str:
+        if self.radio_json.isChecked():
+            return "json"
+        if self.radio_npz.isChecked():
+            return "npz"
+        return "csv"
+
+    def _selected_components(self) -> tuple[str, ...]:
+        if self.radio_x.isChecked():
+            return ("x",)
+        if self.radio_y.isChecked():
+            return ("y",)
+        if self.radio_z.isChecked():
+            return ("z",)
+        return ("x", "y", "z")
+
+    def _default_extension(self) -> str:
+        return {"csv": "csv", "json": "json", "npz": "npz"}[self._selected_format()]
+
+    def _on_accept(self) -> None:
+        if not self._selected_markers():
+            QtWidgets.QMessageBox.information(
+                self, "Export markers", "Please select at least one marker."
+            )
+            return
+        ext = self._default_extension()
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export markers",
+            f"markers.{ext}",
+            f"{ext.upper()} files (*.{ext})",
+        )
+        if not path:
+            return
+        self._chosen_path = path
+        self.accept()
+
+    def export_params(self) -> dict[str, Any] | None:
+        """Return the user's chosen export parameters."""
+        if self._chosen_path is None:
+            return None
+        return {
+            "marker_names": self._selected_markers(),
+            "components": self._selected_components(),
+            "frame_range": (
+                int(self.spin_start.value()),
+                int(self.spin_end.value()),
+            ),
+            "fmt": self._selected_format(),
+            "path": self._chosen_path,
+            "include_time": bool(self.check_time.isChecked()),
+            "include_residual": bool(self.check_residual.isChecked()),
+        }
+
+
+__all__ = ["ExportMarkersDialog"]

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/overview_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/overview_tab.py
@@ -1,12 +1,128 @@
-"""Overview tab providing a summary view of the 3-D Golf Model simulation."""
+"""Overview tab — capture-metadata summary plus a full parameter tree."""
 
-from PyQt6 import QtWidgets
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from ...core.models import C3DDataModel
 
+_ELEVATED_GROUPS_PRIORITY = (
+    "POINT",
+    "ANALOG",
+    "FORCE_PLATFORM",
+    "TRIAL",
+    "MANUFACTURER",
+)
+_PROVENANCE_PATTERNS = (
+    "CAPTURE_ID",
+    "EXPORTED_AT",
+    "PLAYER_ID",
+    "SUB_TYPE",
+    "CREATED_AT",
+)
+
+
+def _is_metadata_internal_key(key: str) -> bool:
+    return key.startswith("__") and key.endswith("__")
+
+
+def _scalar_value(node: Any) -> Any:
+    """Extract the user-facing value from an ezc3d-style ``{"value": ...}``."""
+    if isinstance(node, dict) and "value" in node:
+        node = node["value"]
+    if isinstance(node, np.ndarray):
+        if node.ndim == 0:
+            return node.item()
+        if node.size == 1:
+            return node.flat[0]
+        return node
+    if isinstance(node, list) and len(node) == 1:
+        return node[0]
+    return node
+
+
+def _format_value(node: Any) -> str:
+    val = _scalar_value(node)
+    if isinstance(val, np.ndarray):
+        flat = val.ravel()
+        head = ", ".join(repr(x) for x in flat[:5].tolist())
+        suffix = ", …" if flat.size > 5 else ""
+        return f"shape={val.shape} [{head}{suffix}]"
+    if isinstance(val, list):
+        if len(val) > 5:
+            head = ", ".join(repr(x) for x in val[:5])
+            return f"len={len(val)} [{head}, …]"
+        return repr(val)
+    if isinstance(val, (bytes, bytearray)):
+        return val.decode("latin-1", errors="replace")
+    if isinstance(val, str):
+        return val
+    return repr(val)
+
+
+def _summarize_capture(model: C3DDataModel) -> list[tuple[str, str]]:
+    """Build the elevated capture-metadata summary rows."""
+    out: list[tuple[str, str]] = []
+    out.append(("File", os.path.basename(model.filepath) if model.filepath else ""))
+    out.append(("Point rate (Hz)", f"{model.point_rate:.3f}"))
+    out.append(
+        ("Analog rate (Hz)", f"{model.analog_rate:.3f}" if model.analog_rate else "N/A")
+    )
+    n_frames = len(model.point_time) if model.point_time is not None else 0
+    out.append(("Frames", str(n_frames)))
+    duration = (n_frames / model.point_rate) if model.point_rate > 0 else 0.0
+    out.append(("Duration", f"{duration:.3f} s"))
+    raw = model.raw_parameters or {}
+    point = raw.get("POINT", {}) if isinstance(raw, dict) else {}
+    units = _scalar_value(point.get("UNITS")) if isinstance(point, dict) else None
+    if units:
+        out.append(("Units (POINT)", str(units)))
+    if isinstance(point, dict) and "X_SCREEN" in point and "Y_SCREEN" in point:
+        out.append(
+            (
+                "Axis convention",
+                f"X={_scalar_value(point.get('X_SCREEN'))!s}  "
+                f"Y={_scalar_value(point.get('Y_SCREEN'))!s}",
+            )
+        )
+    fp = raw.get("FORCE_PLATFORM", {}) if isinstance(raw, dict) else {}
+    if isinstance(fp, dict) and "USED" in fp:
+        out.append(("Force-plate count", f"{_scalar_value(fp.get('USED'))!s}"))
+    analog = raw.get("ANALOG", {}) if isinstance(raw, dict) else {}
+    if isinstance(analog, dict) and "USED" in analog:
+        out.append(("Analog channels", f"{_scalar_value(analog.get('USED'))!s}"))
+    mfg = raw.get("MANUFACTURER", {}) if isinstance(raw, dict) else {}
+    if isinstance(mfg, dict):
+        sw = _scalar_value(mfg.get("SOFTWARE")) if "SOFTWARE" in mfg else None
+        ver = _scalar_value(mfg.get("VERSION")) if "VERSION" in mfg else None
+        if sw or ver:
+            out.append(("Software", f"{sw or ''} {ver or ''}".strip()))
+    return out
+
+
+def _collect_provenance(model: C3DDataModel) -> list[tuple[str, str]]:
+    """Walk the param tree gathering provenance-pattern keys."""
+    raw = model.raw_parameters or {}
+    if not isinstance(raw, dict):
+        return []
+    rows: list[tuple[str, str]] = []
+    for group_name, group in raw.items():
+        if not isinstance(group, dict):
+            continue
+        for key, node in group.items():
+            if _is_metadata_internal_key(key):
+                continue
+            if any(p in key.upper() for p in _PROVENANCE_PATTERNS):
+                rows.append((f"{group_name}.{key}", _format_value(node)))
+    return rows
+
 
 class OverviewTab(QtWidgets.QWidget):
-    """Overview tab showing file metadata."""
+    """Overview tab with elevated summary and full C3D parameter tree."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -15,38 +131,184 @@ class OverviewTab(QtWidgets.QWidget):
     def _init_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
 
-        # File info
         self.label_file = QtWidgets.QLabel("No file loaded")
         self.label_file.setWordWrap(True)
         self.label_file.setStyleSheet("font-weight: bold;")
         layout.addWidget(self.label_file)
 
-        # Basic info table
-        self.table_metadata = QtWidgets.QTableWidget()
-        self.table_metadata.setColumnCount(2)
-        self.table_metadata.setHorizontalHeaderLabels(["Field", "Value"])
-        header = self.table_metadata.horizontalHeader()
-        if header is not None:
-            header.setSectionResizeMode(
-                0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
-            )  # noqa: E501
-            header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
-        layout.addWidget(self.table_metadata)
+        # Capture metadata summary (top, always visible).
+        summary_group = QtWidgets.QGroupBox("Capture metadata")
+        summary_layout = QtWidgets.QFormLayout(summary_group)
+        self._summary_rows: dict[str, QtWidgets.QLabel] = {}
+        self._summary_form = summary_layout
+        self._summary_group = summary_group
+        layout.addWidget(summary_group)
+
+        # Provenance subsection.
+        self._prov_group = QtWidgets.QGroupBox("Provenance")
+        self._prov_form = QtWidgets.QFormLayout(self._prov_group)
+        layout.addWidget(self._prov_group)
+        self._prov_group.setVisible(False)
+
+        # Full parameter tree.
+        layout.addWidget(QtWidgets.QLabel("Full parameter tree:"))
+        self.tree = QtWidgets.QTreeView()
+        self.tree.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+        self.tree.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tree.customContextMenuRequested.connect(self._on_context_menu)
+        self._tree_model = QtGui.QStandardItemModel()
+        self._tree_model.setHorizontalHeaderLabels(["Key", "Value"])
+        self.tree.setModel(self._tree_model)
+        layout.addWidget(self.tree, 1)
+
+    # ----------------------------------------------------------- Public API
 
     def update_from_model(self, model: C3DDataModel | None) -> None:
         """Update UI with data from the model."""
+        # Reset summary form.
+        while self._summary_form.rowCount() > 0:
+            self._summary_form.removeRow(0)
+        # Reset provenance form.
+        while self._prov_form.rowCount() > 0:
+            self._prov_form.removeRow(0)
+        self._tree_model.removeRows(0, self._tree_model.rowCount())
+
         if model is None:
             self.label_file.setText("No file loaded")
-            self.table_metadata.setRowCount(0)
+            self._prov_group.setVisible(False)
             return
 
         self.label_file.setText(f"Loaded file: {model.filepath}")
 
-        self.table_metadata.setRowCount(0)
-        for key, value in model.metadata.items():
-            row = self.table_metadata.rowCount()
-            self.table_metadata.insertRow(row)
-            item_key = QtWidgets.QTableWidgetItem(key)
-            item_value = QtWidgets.QTableWidgetItem(str(value))
-            self.table_metadata.setItem(row, 0, item_key)
-            self.table_metadata.setItem(row, 1, item_value)
+        for key, value in _summarize_capture(model):
+            label = QtWidgets.QLabel(value)
+            label.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._summary_form.addRow(QtWidgets.QLabel(key + ":"), label)
+
+        prov = _collect_provenance(model)
+        if prov:
+            for key, value in prov:
+                label = QtWidgets.QLabel(value)
+                label.setTextInteractionFlags(
+                    QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+                )
+                self._prov_form.addRow(QtWidgets.QLabel(key + ":"), label)
+            self._prov_group.setVisible(True)
+        else:
+            label = QtWidgets.QLabel("no provenance available")
+            label.setStyleSheet("color: gray; font-style: italic;")
+            self._prov_form.addRow(label)
+            self._prov_group.setVisible(True)
+
+        self._populate_tree(model)
+
+    @property
+    def tree_node_count(self) -> int:
+        """Total number of nodes (groups + their children) in the tree."""
+        count = 0
+
+        def _walk(parent: QtGui.QStandardItem) -> None:
+            nonlocal count
+            for r in range(parent.rowCount()):
+                count += 1
+                _walk(parent.child(r))
+
+        _walk(self._tree_model.invisibleRootItem())
+        return count
+
+    @property
+    def tree_group_count(self) -> int:
+        """Number of top-level group nodes in the tree."""
+        return self._tree_model.invisibleRootItem().rowCount()
+
+    # -------------------------------------------------------------- Internal
+
+    def _populate_tree(self, model: C3DDataModel) -> None:
+        raw = model.raw_parameters
+        # Fall back to the flat metadata dict if raw parameters are absent.
+        if not isinstance(raw, dict) or not raw:
+            for key, value in model.metadata.items():
+                row = [QtGui.QStandardItem(str(key)), QtGui.QStandardItem(str(value))]
+                for item in row:
+                    item.setEditable(False)
+                self._tree_model.invisibleRootItem().appendRow(row)
+            return
+
+        # Elevated groups first, then everything else alphabetically.
+        priority = list(_ELEVATED_GROUPS_PRIORITY)
+        ordered = [g for g in priority if g in raw]
+        ordered += sorted(g for g in raw if g not in priority)
+
+        for group_name in ordered:
+            group = raw.get(group_name)
+            if not isinstance(group, dict):
+                continue
+            group_item = QtGui.QStandardItem(str(group_name))
+            group_item.setEditable(False)
+            group_value = QtGui.QStandardItem("")
+            group_value.setEditable(False)
+            self._tree_model.invisibleRootItem().appendRow([group_item, group_value])
+            for key in sorted(group.keys()):
+                if _is_metadata_internal_key(key):
+                    continue
+                node = group[key]
+                key_item = QtGui.QStandardItem(str(key))
+                val_item = QtGui.QStandardItem(_format_value(node))
+                key_item.setEditable(False)
+                val_item.setEditable(False)
+                # If the value is a list with multiple items, attach children.
+                raw_val = _scalar_value(node)
+                if isinstance(raw_val, np.ndarray) and raw_val.ndim >= 1:
+                    flat = raw_val.ravel().tolist()
+                    for i, v in enumerate(flat):
+                        ck = QtGui.QStandardItem(f"[{i}]")
+                        cv = QtGui.QStandardItem(repr(v))
+                        ck.setEditable(False)
+                        cv.setEditable(False)
+                        key_item.appendRow([ck, cv])
+                elif isinstance(raw_val, list) and len(raw_val) > 1:
+                    for i, v in enumerate(raw_val):
+                        ck = QtGui.QStandardItem(f"[{i}]")
+                        cv = QtGui.QStandardItem(repr(v))
+                        ck.setEditable(False)
+                        cv.setEditable(False)
+                        key_item.appendRow([ck, cv])
+                group_item.appendRow([key_item, val_item])
+
+    # -------------------------------------------------------- Context menu
+
+    def _on_context_menu(self, point: QtCore.QPoint) -> None:
+        index = self.tree.indexAt(point)
+        if not index.isValid():
+            return
+        row = index.row()
+        parent = index.parent()
+        key_item = self._tree_model.itemFromIndex(
+            self._tree_model.index(row, 0, parent)
+        )
+        val_item = self._tree_model.itemFromIndex(
+            self._tree_model.index(row, 1, parent)
+        )
+        key = key_item.text() if key_item is not None else ""
+        value = val_item.text() if val_item is not None else ""
+        menu = QtWidgets.QMenu(self.tree)
+        act_value = menu.addAction("Copy value")
+        act_pair = menu.addAction("Copy key=value")
+        viewport = self.tree.viewport()
+        if viewport is None:
+            return
+        chosen = menu.exec(viewport.mapToGlobal(point))
+        clipboard = QtWidgets.QApplication.clipboard()
+        if clipboard is None or chosen is None:
+            return
+        if chosen is act_value:
+            clipboard.setText(value)
+        elif chosen is act_pair:
+            clipboard.setText(f"{key}={value}")
+
+
+__all__ = ["OverviewTab"]

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/segments_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/segments_tab.py
@@ -1,0 +1,389 @@
+"""Segments tab — interactively edit user-defined marker-pair segments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from PyQt6 import QtCore, QtWidgets
+
+from ...core.models import C3DDataModel
+from ...services.segment_set_io import (
+    DEFAULT_RADIUS_M,
+    SegmentSet,
+    SegmentSpec,
+    default_segment_set_path,
+    load_segment_set,
+    save_segment_set,
+)
+
+try:
+    from src.shared.python.motion_matching.body_skeleton import (
+        default_body_segments,
+    )
+except ImportError:  # pragma: no cover
+    from shared.python.motion_matching.body_skeleton import (  # type: ignore
+        default_body_segments,
+    )
+
+_GEOMETRIES = ("line", "cylinder")
+_COL_VISIBLE = 0
+_COL_A = 1
+_COL_B = 2
+_COL_GEOMETRY = 3
+_COL_GROUP = 4
+_COL_DELETE = 5
+
+
+class _AddSegmentDialog(QtWidgets.QDialog):
+    """Modal dialog to add a new segment."""
+
+    def __init__(
+        self,
+        marker_names: list[str],
+        last_group: str,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add segment")
+        layout = QtWidgets.QFormLayout(self)
+        self.combo_a = QtWidgets.QComboBox()
+        self.combo_b = QtWidgets.QComboBox()
+        self.combo_a.addItems(marker_names)
+        self.combo_b.addItems(marker_names)
+        if len(marker_names) >= 2:
+            self.combo_b.setCurrentIndex(1)
+        self.combo_geometry = QtWidgets.QComboBox()
+        self.combo_geometry.addItems(_GEOMETRIES)
+        self.edit_group = QtWidgets.QLineEdit(last_group or "auto")
+        layout.addRow("Marker A", self.combo_a)
+        layout.addRow("Marker B", self.combo_b)
+        layout.addRow("Geometry", self.combo_geometry)
+        layout.addRow("Group", self.edit_group)
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    def selected_spec(self) -> SegmentSpec | None:
+        a = self.combo_a.currentText()
+        b = self.combo_b.currentText()
+        if not a or not b or a == b:
+            return None
+        return SegmentSpec(
+            a=a,
+            b=b,
+            geometry=self.combo_geometry.currentText(),
+            group=self.edit_group.text().strip() or "auto",
+            visible=True,
+            radius=DEFAULT_RADIUS_M,
+        )
+
+
+class SegmentsTab(QtWidgets.QWidget):
+    """Editor for user-defined segments overlaid on the 3D scene."""
+
+    segments_changed = QtCore.pyqtSignal(tuple)  # tuple[SegmentSpec, ...]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model: C3DDataModel | None = None
+        self._marker_names: list[str] = []
+        self._segments: list[SegmentSpec] = []
+        self._last_group: str = "auto"
+        self._suspend_signals: bool = False
+        self._init_ui()
+
+    # -------------------------------------------------------------------- UI
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+
+        top_row = QtWidgets.QHBoxLayout()
+        self.btn_add = QtWidgets.QPushButton("+ Add segment")
+        self.btn_reset = QtWidgets.QPushButton("Reset to default")
+        self.btn_add.clicked.connect(self._on_add_clicked)
+        self.btn_reset.clicked.connect(self._on_reset_clicked)
+        top_row.addWidget(self.btn_add)
+        top_row.addWidget(self.btn_reset)
+        top_row.addStretch()
+        layout.addLayout(top_row)
+
+        self.table = QtWidgets.QTableWidget()
+        self.table.setColumnCount(6)
+        self.table.setHorizontalHeaderLabels(
+            ["Visible", "Marker A", "Marker B", "Geometry", "Group", ""]
+        )
+        header = self.table.horizontalHeader()
+        if header is not None:
+            header.setSectionResizeMode(
+                _COL_GROUP, QtWidgets.QHeaderView.ResizeMode.Stretch
+            )
+        layout.addWidget(self.table)
+
+        bottom_row = QtWidgets.QHBoxLayout()
+        self.btn_save = QtWidgets.QPushButton("Save segment set…")
+        self.btn_load = QtWidgets.QPushButton("Load segment set…")
+        self.btn_export = QtWidgets.QPushButton("Export to JSON")
+        self.btn_save.clicked.connect(self._on_save_clicked)
+        self.btn_load.clicked.connect(self._on_load_clicked)
+        self.btn_export.clicked.connect(self._on_export_clicked)
+        bottom_row.addWidget(self.btn_save)
+        bottom_row.addWidget(self.btn_load)
+        bottom_row.addWidget(self.btn_export)
+        bottom_row.addStretch()
+        layout.addLayout(bottom_row)
+
+    # ------------------------------------------------------------- Public API
+
+    def update_from_model(self, model: C3DDataModel | None) -> None:
+        """Repopulate when a new model is loaded."""
+        self.model = model
+        self._marker_names = list(model.marker_names()) if model is not None else []
+        if model is None:
+            self._set_segments([])
+            return
+        defaults = tuple(
+            SegmentSpec(a=s.a, b=s.b, geometry="line", group=s.group)
+            for s in default_body_segments(self._marker_names)
+        )
+        self._set_segments(list(defaults))
+
+    @property
+    def segments(self) -> tuple[SegmentSpec, ...]:
+        """Current user segment list."""
+        return tuple(self._segments)
+
+    def add_segment(self, spec: SegmentSpec) -> None:
+        """Programmatically append a segment (test-friendly)."""
+        if not isinstance(spec, SegmentSpec):
+            raise TypeError(f"spec must be SegmentSpec, got {type(spec).__name__}")
+        self._segments.append(spec)
+        self._last_group = spec.group
+        self._rebuild_table()
+        self._emit_changed()
+
+    def set_segment_geometry(self, index: int, geometry: str) -> None:
+        """Programmatically swap the geometry of segment ``index``."""
+        if not 0 <= index < len(self._segments):
+            raise ValueError(f"index {index} out of range [0, {len(self._segments)})")
+        if geometry not in _GEOMETRIES:
+            raise ValueError(f"geometry must be one of {_GEOMETRIES}, got {geometry!r}")
+        old = self._segments[index]
+        self._segments[index] = SegmentSpec(
+            a=old.a,
+            b=old.b,
+            geometry=geometry,
+            group=old.group,
+            visible=old.visible,
+            radius=old.radius,
+        )
+        self._rebuild_table()
+        self._emit_changed()
+
+    def set_segment_visibility(self, index: int, visible: bool) -> None:
+        """Programmatically toggle visibility of segment ``index``."""
+        if not 0 <= index < len(self._segments):
+            raise ValueError(f"index {index} out of range [0, {len(self._segments)})")
+        old = self._segments[index]
+        self._segments[index] = SegmentSpec(
+            a=old.a,
+            b=old.b,
+            geometry=old.geometry,
+            group=old.group,
+            visible=bool(visible),
+            radius=old.radius,
+        )
+        self._rebuild_table()
+        self._emit_changed()
+
+    # -------------------------------------------------------------- Internal
+
+    def _set_segments(self, segments: list[SegmentSpec]) -> None:
+        self._segments = list(segments)
+        self._rebuild_table()
+        self._emit_changed()
+
+    def _emit_changed(self) -> None:
+        if self._suspend_signals:
+            return
+        self.segments_changed.emit(tuple(self._segments))
+
+    def _rebuild_table(self) -> None:
+        self._suspend_signals = True
+        try:
+            self.table.blockSignals(True)
+            self.table.setRowCount(0)
+            for row, spec in enumerate(self._segments):
+                self.table.insertRow(row)
+                self._populate_row(row, spec)
+        finally:
+            self.table.blockSignals(False)
+            self._suspend_signals = False
+
+    def _populate_row(self, row: int, spec: SegmentSpec) -> None:
+        # Visible checkbox
+        chk = QtWidgets.QCheckBox()
+        chk.setChecked(spec.visible)
+        chk.toggled.connect(lambda v, r=row: self._on_visible_toggled(r, v))
+        wrapper = QtWidgets.QWidget()
+        lay = QtWidgets.QHBoxLayout(wrapper)
+        lay.setContentsMargins(4, 0, 4, 0)
+        lay.addWidget(chk)
+        self.table.setCellWidget(row, _COL_VISIBLE, wrapper)
+
+        combo_a = QtWidgets.QComboBox()
+        combo_b = QtWidgets.QComboBox()
+        for combo, current in ((combo_a, spec.a), (combo_b, spec.b)):
+            combo.addItems(self._marker_names)
+            if current in self._marker_names:
+                combo.setCurrentText(current)
+            else:
+                combo.insertItem(0, current)
+                combo.setCurrentIndex(0)
+        combo_a.currentTextChanged.connect(
+            lambda val, r=row: self._on_endpoint_changed(r, "a", val)
+        )
+        combo_b.currentTextChanged.connect(
+            lambda val, r=row: self._on_endpoint_changed(r, "b", val)
+        )
+        self.table.setCellWidget(row, _COL_A, combo_a)
+        self.table.setCellWidget(row, _COL_B, combo_b)
+
+        combo_geom = QtWidgets.QComboBox()
+        combo_geom.addItems(_GEOMETRIES)
+        combo_geom.setCurrentText(spec.geometry)
+        combo_geom.currentTextChanged.connect(
+            lambda val, r=row: self._on_geometry_changed(r, val)
+        )
+        self.table.setCellWidget(row, _COL_GEOMETRY, combo_geom)
+
+        edit_group = QtWidgets.QLineEdit(spec.group)
+        edit_group.editingFinished.connect(
+            lambda r=row, w=edit_group: self._on_group_changed(r, w.text())
+        )
+        self.table.setCellWidget(row, _COL_GROUP, edit_group)
+
+        btn_del = QtWidgets.QPushButton("×")
+        btn_del.setMaximumWidth(28)
+        btn_del.clicked.connect(lambda _checked=False, r=row: self._delete_row(r))
+        self.table.setCellWidget(row, _COL_DELETE, btn_del)
+
+    # ---------------------------------------------------------- Row callbacks
+
+    def _replace(self, index: int, **kwargs: Any) -> None:
+        old = self._segments[index]
+        merged = {
+            "a": kwargs.get("a", old.a),
+            "b": kwargs.get("b", old.b),
+            "geometry": kwargs.get("geometry", old.geometry),
+            "group": kwargs.get("group", old.group),
+            "visible": kwargs.get("visible", old.visible),
+            "radius": kwargs.get("radius", old.radius),
+        }
+        try:
+            self._segments[index] = SegmentSpec(**merged)
+        except ValueError:
+            # Reject the change silently — table will rebuild from old state.
+            self._rebuild_table()
+            return
+        self._emit_changed()
+
+    def _on_visible_toggled(self, row: int, value: bool) -> None:
+        if self._suspend_signals or not 0 <= row < len(self._segments):
+            return
+        self._replace(row, visible=value)
+
+    def _on_endpoint_changed(self, row: int, which: str, value: str) -> None:
+        if self._suspend_signals or not 0 <= row < len(self._segments):
+            return
+        self._replace(row, **{which: value})
+
+    def _on_geometry_changed(self, row: int, value: str) -> None:
+        if self._suspend_signals or not 0 <= row < len(self._segments):
+            return
+        self._replace(row, geometry=value)
+
+    def _on_group_changed(self, row: int, value: str) -> None:
+        if self._suspend_signals or not 0 <= row < len(self._segments):
+            return
+        text = value.strip() or "auto"
+        self._last_group = text
+        self._replace(row, group=text)
+
+    def _delete_row(self, row: int) -> None:
+        if not 0 <= row < len(self._segments):
+            return
+        del self._segments[row]
+        self._rebuild_table()
+        self._emit_changed()
+
+    # ---------------------------------------------------------- Top buttons
+
+    def _on_add_clicked(self) -> None:
+        if not self._marker_names:
+            QtWidgets.QMessageBox.information(
+                self, "Add segment", "No markers available. Load a C3D file first."
+            )
+            return
+        dlg = _AddSegmentDialog(self._marker_names, self._last_group, self)
+        if dlg.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            spec = dlg.selected_spec()
+            if spec is None:
+                QtWidgets.QMessageBox.warning(
+                    self, "Add segment", "Marker A and Marker B must differ."
+                )
+                return
+            self.add_segment(spec)
+
+    def _on_reset_clicked(self) -> None:
+        if self.model is None:
+            return
+        defaults = [
+            SegmentSpec(a=s.a, b=s.b, geometry="line", group=s.group)
+            for s in default_body_segments(self._marker_names)
+        ]
+        self._set_segments(defaults)
+
+    # ----------------------------------------------------------- Save / Load
+
+    def _on_save_clicked(self) -> None:
+        default = default_segment_set_path()
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save segment set", str(default), "JSON files (*.json)"
+        )
+        if path:
+            save_segment_set(path, SegmentSet(segments=tuple(self._segments)))
+
+    def _on_load_clicked(self) -> None:
+        default = default_segment_set_path()
+        start_dir = str(default.parent) if default.parent.exists() else str(Path.home())
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Load segment set", start_dir, "JSON files (*.json)"
+        )
+        if path:
+            try:
+                segset = load_segment_set(path)
+            except (OSError, ValueError) as e:
+                QtWidgets.QMessageBox.warning(
+                    self, "Load segment set", f"Could not load:\n{e}"
+                )
+                return
+            self._set_segments(list(segset.segments))
+
+    def _on_export_clicked(self) -> None:
+        # Same as save, but force a clear default filename.
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export segment set to JSON",
+            "segments.json",
+            "JSON files (*.json)",
+        )
+        if path:
+            save_segment_set(path, SegmentSet(segments=tuple(self._segments)))
+
+
+__all__ = ["SegmentsTab"]

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
@@ -17,14 +17,75 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colors as mcolors
-from mpl_toolkits.mplot3d.art3d import Line3DCollection
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
 from PyQt6 import QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QTimer
 
 from src.shared.python.qt_utils.wheel_event_filter import suppress_wheel_on_widgets
 
 from ...core.models import C3DDataModel
+from ...services.segment_set_io import SegmentSpec
 from ..widgets.mpl_canvas import MplCanvas
+
+# Anatomical-region colour map (generic, source-agnostic).
+_GROUP_COLORS: dict[str, tuple[float, float, float, float]] = {
+    "pelvis": (0.20, 0.55, 0.85, 1.0),
+    "torso": (0.45, 0.30, 0.75, 1.0),
+    "head": (0.85, 0.60, 0.20, 1.0),
+    "left_arm": (0.30, 0.75, 0.40, 1.0),
+    "right_arm": (0.20, 0.50, 0.30, 1.0),
+    "left_leg": (0.85, 0.30, 0.30, 1.0),
+    "right_leg": (0.65, 0.20, 0.20, 1.0),
+    "auto": (0.30, 0.30, 0.30, 1.0),
+}
+
+
+def _color_for_group(group: str) -> tuple[float, float, float, float]:
+    return _GROUP_COLORS.get(group, _GROUP_COLORS["auto"])
+
+
+def _build_cylinder_verts(
+    pa: np.ndarray,
+    pb: np.ndarray,
+    radius: float,
+    n_facets: int,
+) -> list[list[tuple[float, float, float]]]:
+    """Return Poly3DCollection vertex lists for a closed cylinder.
+
+    Yields ``n_facets`` side quads plus two end-cap polygons. Endpoints with
+    zero length collapse to a single degenerate facet so the artist update is
+    side-effect free even at frames where markers coincide or are missing.
+    """
+    direction = pb - pa
+    length = float(np.linalg.norm(direction))
+    if not np.isfinite(length) or length <= 1e-9:
+        return [[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0)]]
+    axis = direction / length
+    # Build orthonormal basis.
+    helper = np.array([1.0, 0.0, 0.0])
+    if abs(float(axis @ helper)) > 0.95:
+        helper = np.array([0.0, 1.0, 0.0])
+    u = np.cross(axis, helper)
+    u /= max(np.linalg.norm(u), 1e-12)
+    v = np.cross(axis, u)
+    angles = np.linspace(0.0, 2.0 * np.pi, n_facets, endpoint=False)
+    ring_a = np.array([pa + radius * (np.cos(a) * u + np.sin(a) * v) for a in angles])
+    ring_b = np.array([pb + radius * (np.cos(a) * u + np.sin(a) * v) for a in angles])
+    polys: list[list[tuple[float, float, float]]] = []
+    for i in range(n_facets):
+        j = (i + 1) % n_facets
+        polys.append(
+            [
+                (float(ring_a[i, 0]), float(ring_a[i, 1]), float(ring_a[i, 2])),
+                (float(ring_a[j, 0]), float(ring_a[j, 1]), float(ring_a[j, 2])),
+                (float(ring_b[j, 0]), float(ring_b[j, 1]), float(ring_b[j, 2])),
+                (float(ring_b[i, 0]), float(ring_b[i, 1]), float(ring_b[i, 2])),
+            ]
+        )
+    polys.append([(float(p[0]), float(p[1]), float(p[2])) for p in ring_a])
+    polys.append([(float(p[0]), float(p[1]), float(p[2])) for p in ring_b])
+    return polys
+
 
 try:
     from src.shared.python.motion_matching.body_skeleton import (
@@ -108,6 +169,13 @@ class Viewer3DTab(QtWidgets.QWidget):
         self._skeleton_collection: Line3DCollection | None = None
         self._skeleton_segments: tuple[tuple[str, str], ...] = ()
         self._event_buttons: list[QtWidgets.QToolButton] = []
+
+        # User-defined segments (Segments tab -> here).
+        self._user_segments: tuple[SegmentSpec, ...] = ()
+        self._user_line_collection: Line3DCollection | None = None
+        self._user_cylinder_artists: list[Poly3DCollection] = []
+        self._cylinder_facets: int = 8
+        self._user_line_render_count: int = 0
 
         # Playback timer.
         self._timer = QTimer(self)
@@ -598,6 +666,8 @@ class Viewer3DTab(QtWidgets.QWidget):
         if len(selected) <= 12:
             ax.legend(loc="upper right", fontsize=8)
 
+        self._rebuild_user_segment_artists()
+
         self.canvas_3d.fig.tight_layout()
         self._render_current_frame()
 
@@ -607,7 +677,148 @@ class Viewer3DTab(QtWidgets.QWidget):
         self._label_texts = []
         self._skeleton_collection = None
         self._skeleton_segments = ()
+        self._user_line_collection = None
+        self._user_cylinder_artists = []
         self._ax = None
+
+    # ---------------------------------------------------- User segments API
+
+    def set_user_segments(self, segments: tuple[SegmentSpec, ...]) -> None:
+        """Receive a new user-defined segment set from the Segments tab."""
+        if segments is None:
+            raise ValueError("segments must be provided (use () for an empty set)")
+        self._user_segments = tuple(segments)
+        if self._ax is not None:
+            self._rebuild_user_segment_artists()
+            self._render_current_frame()
+
+    @property
+    def user_cylinder_count(self) -> int:
+        """Number of cylinder artists currently allocated (test helper)."""
+        return len(self._user_cylinder_artists)
+
+    @property
+    def user_line_segment_count(self) -> int:
+        """Number of line-geometry user segments currently rendered."""
+        return self._user_line_render_count
+
+    def _rebuild_user_segment_artists(self) -> None:
+        ax = self._ax
+        if ax is None:
+            return
+        # Drop old artists.
+        if self._user_line_collection is not None:
+            try:
+                self._user_line_collection.remove()
+            except (ValueError, AttributeError):
+                pass
+            self._user_line_collection = None
+        for art in self._user_cylinder_artists:
+            try:
+                art.remove()
+            except (ValueError, AttributeError):
+                pass
+        self._user_cylinder_artists = []
+
+        line_specs = [s for s in self._user_segments if s.geometry == "line"]
+        cyl_specs = [s for s in self._user_segments if s.geometry == "cylinder"]
+
+        if line_specs:
+            self._user_line_collection = Line3DCollection(
+                [[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
+                colors=[_color_for_group(s.group) for s in line_specs],
+                linewidths=2.0,
+                alpha=0.9,
+            )
+            ax.add_collection3d(self._user_line_collection)
+            self._user_line_collection.set_segments([])
+
+        for spec in cyl_specs:
+            poly = Poly3DCollection(
+                [[(0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
+                facecolors=[_color_for_group(spec.group)],
+                edgecolors=[_color_for_group(spec.group)],
+                alpha=0.85,
+            )
+            ax.add_collection3d(poly)
+            self._user_cylinder_artists.append(poly)
+
+    def _update_user_segment_artists(self) -> None:
+        if (
+            self._ax is None
+            or not self._user_segments
+            or self.model is None
+            or self._n_frames <= 0
+        ):
+            if self._user_line_collection is not None:
+                self._user_line_collection.set_segments([])
+            for art in self._user_cylinder_artists:
+                art.set_verts([])
+            self._user_line_render_count = 0
+            return
+        frame = self.slider_frame.value()
+        markers = self.model.markers
+        line_specs = [s for s in self._user_segments if s.geometry == "line"]
+        cyl_specs = [s for s in self._user_segments if s.geometry == "cylinder"]
+
+        line_segments: list[list[tuple[float, float, float]]] = []
+        for spec in line_specs:
+            if not spec.visible:
+                continue
+            ma = markers.get(spec.a)
+            mb = markers.get(spec.b)
+            if (
+                ma is None
+                or mb is None
+                or ma.position.size == 0
+                or mb.position.size == 0
+            ):
+                continue
+            if frame >= ma.position.shape[0] or frame >= mb.position.shape[0]:
+                continue
+            pa = ma.position[frame]
+            pb = mb.position[frame]
+            if not (np.isfinite(pa).all() and np.isfinite(pb).all()):
+                continue
+            line_segments.append(
+                [
+                    (float(pa[0]), float(pa[1]), float(pa[2])),
+                    (float(pb[0]), float(pb[1]), float(pb[2])),
+                ]
+            )
+        if self._user_line_collection is not None:
+            self._user_line_collection.set_segments(line_segments)
+        self._user_line_render_count = len(line_segments)
+
+        for art, spec in zip(self._user_cylinder_artists, cyl_specs, strict=False):
+            if not spec.visible:
+                art.set_verts([])
+                continue
+            ma = markers.get(spec.a)
+            mb = markers.get(spec.b)
+            if (
+                ma is None
+                or mb is None
+                or ma.position.size == 0
+                or mb.position.size == 0
+            ):
+                art.set_verts([])
+                continue
+            if frame >= ma.position.shape[0] or frame >= mb.position.shape[0]:
+                art.set_verts([])
+                continue
+            pa = ma.position[frame]
+            pb = mb.position[frame]
+            if not (np.isfinite(pa).all() and np.isfinite(pb).all()):
+                art.set_verts([])
+                continue
+            verts = _build_cylinder_verts(
+                np.asarray(pa, dtype=float),
+                np.asarray(pb, dtype=float),
+                float(spec.radius),
+                self._cylinder_facets,
+            )
+            art.set_verts(verts)
 
     # -------------------------------------------------- Per-frame render
 
@@ -648,6 +859,9 @@ class Viewer3DTab(QtWidgets.QWidget):
 
         # Update skeleton segments.
         self._update_skeleton_segments()
+
+        # Update user-defined segments / cylinders.
+        self._update_user_segment_artists()
 
         self.canvas_3d.draw_idle()
 

--- a/tests/unit/engines/simscape/three_d_gui/test_marker_export.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_marker_export.py
@@ -1,0 +1,118 @@
+"""Tests for selective marker export (CSV / JSON / NPZ)."""
+
+from __future__ import annotations
+
+import csv
+import json
+
+import numpy as np
+import pytest
+
+
+def _make_model(n_frames: int = 100):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+
+    rng = np.random.default_rng(42)
+    names = ["WaistLeft", "WaistRight", "LKneeOut", "RKneeOut", "Marker_1:1:Club"]
+    markers = {}
+    for i, n in enumerate(names):
+        pos = rng.normal(size=(n_frames, 3)) + i
+        markers[n] = MarkerData(name=n, position=pos)
+    return C3DDataModel(
+        filepath="synthetic.c3d",
+        markers=markers,
+        analog={},
+        point_rate=100.0,
+        analog_rate=0.0,
+        point_time=np.arange(n_frames) / 100.0,
+        analog_time=None,
+        metadata={"Units (POINT)": "m"},
+        events=[],
+    )
+
+
+def test_csv_x_only_subset_frame_range(tmp_path) -> None:
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = _make_model(100)
+    out = tmp_path / "out.csv"
+    export_markers(
+        model,
+        marker_names=["WaistLeft", "WaistRight"],
+        components=("x",),
+        frame_range=(10, 20),
+        fmt="csv",
+        path=out,
+        include_time=True,
+        include_residual=False,
+    )
+    with out.open("r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    header = rows[0]
+    assert header == ["frame", "time_s", "marker", "x"]
+    # 11 frames * 2 markers = 22 data rows.
+    assert len(rows) == 1 + 22
+    # Confirm a value matches the source.
+    sample = [r for r in rows[1:] if r[0] == "10" and r[2] == "WaistLeft"][0]
+    assert pytest.approx(float(sample[3]), rel=1e-6) == float(
+        model.markers["WaistLeft"].position[10, 0]
+    )
+
+
+def test_json_metadata_block(tmp_path) -> None:
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = _make_model(50)
+    out = tmp_path / "out.json"
+    export_markers(
+        model,
+        marker_names=["WaistLeft"],
+        components="all",
+        frame_range=None,
+        fmt="json",
+        path=out,
+    )
+    with out.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    assert "metadata" in payload and "data" in payload
+    assert payload["metadata"]["point_rate_hz"] == pytest.approx(100.0)
+    assert payload["metadata"]["frame_range"] == [0, 49]
+    assert payload["metadata"]["markers"] == ["WaistLeft"]
+    # Synthetic model points to a non-existent file so sha256 should be None.
+    assert payload["metadata"]["sha256"] is None
+    assert len(payload["data"]) == 50
+
+
+def test_npz_round_trip(tmp_path) -> None:
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = _make_model(30)
+    out = tmp_path / "out.npz"
+    export_markers(
+        model,
+        marker_names=["WaistLeft", "LKneeOut"],
+        components="all",
+        frame_range=(5, 15),
+        fmt="npz",
+        path=out,
+    )
+    with np.load(out, allow_pickle=False) as arr:
+        assert "WaistLeft" in arr.files
+        assert "LKneeOut" in arr.files
+        assert arr["WaistLeft"].shape == (11, 3)
+        meta = json.loads(str(arr["_meta"]))
+        assert meta["frame_range"] == [5, 15]
+
+
+def test_invalid_inputs() -> None:
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = _make_model(10)
+    with pytest.raises(ValueError):
+        export_markers(model, [], "all", None, "csv", "/tmp/x.csv")
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "all", None, "txt", "/tmp/x.txt")
+    with pytest.raises(ValueError):
+        export_markers(model, ["NopeMarker"], "all", None, "csv", "/tmp/x.csv")
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "all", (0, 999), "csv", "/tmp/x.csv")

--- a/tests/unit/engines/simscape/three_d_gui/test_metadata_panel.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_metadata_panel.py
@@ -1,0 +1,94 @@
+"""Tests for the Overview-tab metadata tree + provenance summary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ._viewer_test_helpers import make_synthetic_model
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def _wrap(value):
+    """Wrap a Python value in the ezc3d-style ``{"value": ...}`` envelope."""
+    return {"value": np.asarray(value)}
+
+
+def test_metadata_tree_with_synthetic_params(qt_app) -> None:
+    from src.apps.ui.tabs.overview_tab import OverviewTab  # type: ignore
+
+    model = make_synthetic_model(["WaistLeft", "WaistRight"], n_frames=10)
+    model.raw_parameters = {
+        "POINT": {
+            "USED": _wrap([2]),
+            "FRAMES": _wrap([10]),
+            "RATE": _wrap([100.0]),
+            "UNITS": _wrap(["m"]),
+            "X_SCREEN": _wrap(["+X"]),
+            "Y_SCREEN": _wrap(["+Z"]),
+            "LABELS": _wrap(["WaistLeft", "WaistRight"]),
+        },
+        "ANALOG": {"USED": _wrap([0]), "RATE": _wrap([1000.0])},
+        "FORCE_PLATFORM": {"USED": _wrap([2])},
+        "TRIAL": {"ACTUAL_START_FIELD": _wrap([1])},
+        "MANUFACTURER": {
+            "SOFTWARE": _wrap(["GenericMocap"]),
+            "VERSION": _wrap(["1.0"]),
+        },
+        "VENDOR_X": {
+            "CAPTURE_ID": _wrap(["abc-123"]),
+            "SUB_TYPE": _wrap(["full_swing"]),
+            "PLAYER_ID": _wrap(["P-001"]),
+        },
+    }
+    tab = OverviewTab()
+    tab.update_from_model(model)
+    # 5 elevated groups + VENDOR_X.
+    assert tab.tree_group_count >= 5
+
+
+def test_no_provenance_placeholder(qt_app) -> None:
+    from src.apps.ui.tabs.overview_tab import OverviewTab  # type: ignore
+
+    model = make_synthetic_model(["WaistLeft", "WaistRight"], n_frames=5)
+    model.raw_parameters = {
+        "POINT": {
+            "FRAMES": _wrap([5]),
+            "RATE": _wrap([100.0]),
+            "UNITS": _wrap(["m"]),
+        },
+    }
+    tab = OverviewTab()
+    tab.update_from_model(model)
+    assert tab.tree_group_count >= 1
+
+
+def test_real_capture_file_when_available(qt_app) -> None:
+    """Smoke against the canonical sample C3D when present."""
+    here = Path(__file__).resolve()
+    repo_root = here.parents[5]
+    sample = repo_root / "data" / "C3D_TA_Driver.c3d"
+    if not sample.is_file():
+        pytest.skip("sample C3D not present in this checkout")
+    from src.apps.services.c3d_loader import load_c3d_file  # type: ignore
+    from src.apps.ui.tabs.overview_tab import OverviewTab  # type: ignore
+
+    model = load_c3d_file(str(sample))
+    tab = OverviewTab()
+    tab.update_from_model(model)
+    # ezc3d guarantees POINT and ANALOG groups; real captures include several
+    # vendor-specific groups too.
+    assert tab.tree_group_count >= 5
+    assert tab.tree_node_count > 50

--- a/tests/unit/engines/simscape/three_d_gui/test_segment_editor.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_segment_editor.py
@@ -1,0 +1,133 @@
+"""Tests for the user-defined segment editor + 3D viewer plumbing."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from ._viewer_test_helpers import ANATOMICAL_28, make_synthetic_model
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+def test_reset_to_default_populates_canonical_set(qt_app, tmp_path) -> None:
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=20)
+    tab = SegmentsTab()
+    tab.update_from_model(model)
+
+    # 26 canonical segments for the 28-marker subset.
+    assert len(tab.segments) == 26
+
+
+def test_add_segment_emits_signal_and_renders_line(qt_app) -> None:
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=20)
+    seg_tab = SegmentsTab()
+    viewer = Viewer3DTab()
+    seg_tab.segments_changed.connect(viewer.set_user_segments)
+
+    seg_tab.update_from_model(model)
+    viewer.update_from_model(model)
+    viewer.select_body_markers()
+
+    spec = SegmentSpec(a="WaistLeft", b="LKneeOut", geometry="line", group="left_leg")
+    seg_tab.add_segment(spec)
+    assert any(s.a == "WaistLeft" and s.b == "LKneeOut" for s in seg_tab.segments)
+    # Line collection allocated; some line segments rendered.
+    assert viewer.user_line_segment_count >= 1
+
+
+def test_geometry_switch_swaps_artist_kind(qt_app) -> None:
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=20)
+    seg_tab = SegmentsTab()
+    viewer = Viewer3DTab()
+    seg_tab.segments_changed.connect(viewer.set_user_segments)
+    seg_tab.update_from_model(model)
+    viewer.update_from_model(model)
+    viewer.select_body_markers()
+
+    seg_tab.add_segment(
+        SegmentSpec(a="WaistLeft", b="LKneeOut", geometry="line", group="left_leg")
+    )
+    last = len(seg_tab.segments) - 1
+    seg_tab.set_segment_geometry(last, "cylinder")
+    assert seg_tab.segments[last].geometry == "cylinder"
+    assert viewer.user_cylinder_count >= 1
+
+
+def test_visibility_toggle(qt_app) -> None:
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+
+    model = make_synthetic_model(list(ANATOMICAL_28), n_frames=20)
+    tab = SegmentsTab()
+    tab.update_from_model(model)
+    tab.add_segment(
+        SegmentSpec(a="WaistLeft", b="LKneeOut", geometry="line", group="left_leg")
+    )
+    last = len(tab.segments) - 1
+    tab.set_segment_visibility(last, False)
+    assert tab.segments[last].visible is False
+
+
+def test_save_load_round_trip(qt_app, tmp_path) -> None:
+    from src.apps.services.segment_set_io import (  # type: ignore
+        SegmentSet,
+        SegmentSpec,
+        load_segment_set,
+        save_segment_set,
+    )
+
+    seg_set = SegmentSet(
+        segments=(
+            SegmentSpec(
+                a="WaistLeft",
+                b="WaistRight",
+                geometry="line",
+                group="pelvis",
+                visible=True,
+                radius=0.02,
+            ),
+            SegmentSpec(
+                a="WaistLeft",
+                b="LKneeOut",
+                geometry="cylinder",
+                group="left_leg",
+                visible=False,
+                radius=0.018,
+            ),
+        )
+    )
+    out = tmp_path / "segments.json"
+    save_segment_set(out, seg_set)
+    loaded = load_segment_set(out)
+    assert loaded.segments == seg_set.segments
+
+
+def test_invalid_segment_spec_raises() -> None:
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+
+    with pytest.raises(ValueError):
+        SegmentSpec(a="A", b="A")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="A", b="B", geometry="bezier")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="A", b="B", radius=-1.0)


### PR DESCRIPTION
Closes #4661

## Summary

Phase-2 viewer features in four mostly-isolated areas:

- **A. User-defined segments tab** — `QTableWidget` editor with visibility, marker A/B comboboxes, geometry (line/cylinder), group label, delete. "+ Add segment" modal, "Reset to default" (calls `default_body_segments`), and Save/Load/Export JSON. Default path is `~/.golf_modeling_suite/c3d_viewer_segments.json`. Schema-v1 `SegmentSet`/`SegmentSpec` dataclasses round-trip with full DbC validation.
- **B. Cylinder rendering** — `Poly3DCollection`-based path in `viewer_3d_tab.py`, preallocated artists per segment, `set_verts` per frame from a numpy buffer. Default 0.015 m radius, 8 facets, configurable in JSON. Offscreen perf test: ~160 fps for 30 cylinders x 8 facets (target: >= 30 fps).
- **C. Selective marker export** — File -> Export markers... dialog (per-marker selection with Select-all/Body/Clear, X/Y/Z/All, frame range, CSV/JSON/NPZ, time + residual toggles). Backed by a new `marker_export` service: long-format CSV, JSON with a `metadata` block including SHA-256, NPZ with one array per marker plus `_meta`/`_time` companion entries.
- **D. Metadata tree** — Overview tab now has a "Capture metadata" summary box (file, point/analog rate, frames, duration, units, axis convention, force-plate count, software), a "Provenance" subsection (auto-collects keys matching `CAPTURE_ID`/`SUB_TYPE`/`PLAYER_ID`/`EXPORTED_AT`/`CREATED_AT`), and a full `QTreeView` over the raw C3D parameter tree. Right-click -> "Copy value" / "Copy key=value". `C3DDataModel` gains a `raw_parameters` field that the loader plumbs through.

For `data/C3D_TA_Driver.c3d`: 6 top-level parameter groups (POINT, ANALOG, FORCE_PLATFORM, GEARS, MANUFACTURER, TRIAL), 132 total nodes.

The canonical `C3DDataReader.export_points` only supports per-marker filtering, not per-component slicing or per-format options matching the issue spec, so the new `marker_export` service composes directly on top of `model.markers[name].position` instead.

## Test plan

- [x] `python3 -m pytest tests/unit/engines/simscape/three_d_gui/test_segment_editor.py tests/unit/engines/simscape/three_d_gui/test_marker_export.py tests/unit/engines/simscape/three_d_gui/test_metadata_panel.py` — 13 new tests pass
- [x] Existing playback + skeleton tests pass (26 in scope)
- [x] `python3 -m ruff check` — clean on all modified/new files
- [x] `python3 -m ruff format --check` — clean on all modified/new files
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>