### PR TITLE
fix: Clear cached targets in gui_source_panel restore() (#4510)

### DIFF
--- a/src/tools/starting_pose_matcher/gui_source_panel.py
+++ b/src/tools/starting_pose_matcher/gui_source_panel.py
@@ -297,6 +297,11 @@ class DataSourcesPanel(QGroupBox):
         side-effects when a session is loaded from a different machine
         whose paths no longer resolve.
         """
+        # Clear cached targets to prevent stale data when restoring a
+        # session with different (or no) source files.
+        self._club_target = None
+        self._body_target = None
+
         b = block or default_data_sources()
         self.cb_club.setChecked(b.club.enabled)
         self._club_path = b.club.file_path


### PR DESCRIPTION
## Summary

Clear cached club/body targets in restore() to prevent stale data (#4510)

## Related Issues

- Closes #4510

## Changes

```
src/tools/starting_pose_matcher/gui_source_panel.py | 5 +++++
 1 file changed, 5 insertions(+)
```

_Automated fix (run 2/10)_