### PR TITLE
fix: Pass marker set in gui_source_panel _load_body() (#4509)

### DIFF
--- a/src/tools/starting_pose_matcher/gui_source_panel.py
+++ b/src/tools/starting_pose_matcher/gui_source_panel.py
@@ -386,6 +386,7 @@ class DataSourcesPanel(QGroupBox):
                 path,
                 opts=self.align_options(),
                 impact_source=self._club_target,
+                marker_set=self.combo_marker_set.currentText(),
             )
         except Exception as exc:  # noqa: BLE001
             QMessageBox.warning(


### PR DESCRIPTION
## Summary

Passed marker_set from combo into _safe_load_body_target (#4509)

## Related Issues

- Closes #4509

## Changes

```
src/tools/starting_pose_matcher/gui_source_panel.py | 1 +
 1 file changed, 1 insertion(+)
```

_Automated fix (run 3/10)_