### PR TITLE
test(lab/bio): C3D reader coverage >=90% (#4674)

### DIFF
--- a/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
@@ -1,0 +1,122 @@
+"""Synthetic ezc3d-shaped fixtures for unit tests.
+
+Returns dicts shaped like ``ezc3d.c3d(path)`` so tests can exercise the
+loader/parser code paths without committing real C3D files.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def _synthetic_c3d_dict(
+    n_frames: int = 10,
+    n_markers: int = 3,
+    marker_names: list[str] | None = None,
+    n_analog: int = 0,
+    analog_labels: list[str] | None = None,
+    analog_units: list[str] | None = None,
+    analog_rate: float = 1000.0,
+    frame_rate: float = 100.0,
+    units: str = "m",
+    with_events: bool = False,
+    event_labels: list[str] | None = None,
+    event_times: list[float] | None = None,
+    event_times_2d: bool = False,
+    event_times_missing: bool = False,
+    omit_analog_group: bool = False,
+    analog_subframes: int = 10,
+    point_data: np.ndarray | None = None,
+    analog_data: np.ndarray | None = None,
+) -> dict[str, Any]:
+    """Build a dict shaped like the result of ``ezc3d.c3d(path)``.
+
+    Args:
+        n_frames: Number of point frames.
+        n_markers: Number of markers.
+        marker_names: Optional explicit marker label list.
+        n_analog: Number of analog channels.
+        analog_labels: Optional explicit analog label list.
+        analog_units: Optional analog units list.
+        analog_rate: Analog sample rate (Hz).
+        frame_rate: Point frame rate (Hz).
+        units: Point units string.
+        with_events: Include EVENT group.
+        event_labels: Event labels.
+        event_times: Event times (seconds).
+        event_times_2d: If True, store TIMES as a 2-row array.
+        event_times_missing: If True, omit TIMES key entirely.
+        omit_analog_group: If True, omit the ANALOG parameter group.
+        analog_subframes: Analog subframes per point frame.
+        point_data: Override point data array (4, n_markers, n_frames).
+        analog_data: Override analog data array
+            (analog_subframes, n_analog, n_frames).
+    """
+    marker_names = (
+        marker_names
+        if marker_names is not None
+        else [f"M{i}" for i in range(n_markers)]
+    )
+    analog_labels = (
+        analog_labels
+        if analog_labels is not None
+        else [f"A{i}" for i in range(n_analog)]
+    )
+    analog_units = (
+        analog_units if analog_units is not None else [""] * len(analog_labels)
+    )
+
+    if point_data is None:
+        points = np.zeros((4, n_markers, n_frames), dtype=float)
+        # provide non-degenerate coordinates inside biomechanical range
+        for m in range(n_markers):
+            points[0, m, :] = 0.5 + 0.01 * m
+            points[1, m, :] = 0.4 + 0.01 * m
+            points[2, m, :] = 0.3 + 0.01 * m
+            points[3, m, :] = 0.0
+    else:
+        points = point_data
+
+    if analog_data is None:
+        analogs = np.zeros((analog_subframes, n_analog, n_frames), dtype=float)
+    else:
+        analogs = analog_data
+
+    parameters: dict[str, Any] = {
+        "POINT": {
+            "USED": {"value": np.array([n_markers])},
+            "RATE": {"value": np.array([frame_rate])},
+            "FRAMES": {"value": np.array([n_frames])},
+            "LABELS": {"value": list(marker_names)},
+            "UNITS": {"value": [units]},
+        },
+    }
+
+    if not omit_analog_group:
+        parameters["ANALOG"] = {
+            "USED": {"value": np.array([n_analog])},
+            "RATE": {"value": np.array([analog_rate])},
+            "LABELS": {"value": list(analog_labels)},
+            "UNITS": {"value": list(analog_units)},
+        }
+
+    if with_events:
+        labels = event_labels if event_labels is not None else ["FootStrike", "FootOff"]
+        times = event_times if event_times is not None else [0.1, 0.5]
+        event_group: dict[str, Any] = {"LABELS": {"value": labels}}
+        if not event_times_missing:
+            if event_times_2d:
+                arr = np.zeros((2, len(times)))
+                arr[1, :] = times
+                event_group["TIMES"] = {"value": arr}
+            else:
+                event_group["TIMES"] = {"value": np.asarray(times)}
+        parameters["EVENT"] = event_group
+
+    return {
+        "header": {},
+        "parameters": parameters,
+        "data": {"points": points, "analogs": analogs},
+    }

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_analog.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_analog.py
@@ -1,0 +1,387 @@
+"""Unit tests for ``_c3d_analog`` analog/force-plate processing."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_analog import (
+    build_analog_dataframe,
+    build_force_plate_dataframe,
+    build_plate_dataframe,
+    detect_force_plate_channels,
+    force_plate_columns,
+)
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_models import C3DMetadata
+
+ANALOG_LOGGER = "src.shared.python.upstream_drift_tools.lab.bio._c3d_analog"
+
+
+def _meta(
+    analog_labels: list[str],
+    analog_rate: float | None = 1000.0,
+) -> C3DMetadata:
+    return C3DMetadata(
+        marker_labels=["M1"],
+        frame_count=1,
+        frame_rate=100.0,
+        units="m",
+        analog_labels=analog_labels,
+        analog_units=[""] * len(analog_labels),
+        analog_rate=analog_rate,
+        events=[],
+    )
+
+
+# ----- build_analog_dataframe -----------------------------------------------
+
+
+def test_build_analog_dataframe_empty() -> None:
+    c3d_data = {"data": {"analogs": np.zeros((1, 0, 5))}}
+    md = _meta([])
+    df = build_analog_dataframe(c3d_data, md, include_time=True)
+    assert df.empty
+    assert list(df.columns) == ["sample", "time", "channel", "value"]
+
+
+def test_build_analog_dataframe_no_time() -> None:
+    c3d_data = {"data": {"analogs": np.zeros((1, 0, 5))}}
+    md = _meta([])
+    df = build_analog_dataframe(c3d_data, md, include_time=False)
+    assert list(df.columns) == ["sample", "channel", "value"]
+
+
+def test_build_analog_dataframe_synth_labels_when_unlabeled() -> None:
+    # 2 channels, 3 frames, 1 subframe each
+    arr = np.arange(6, dtype=float).reshape(1, 2, 3)
+    c3d_data = {"data": {"analogs": arr}}
+    md = _meta([], analog_rate=1000.0)
+    df = build_analog_dataframe(c3d_data, md, include_time=True)
+    assert set(df["channel"].unique()) == {"Analog_1", "Analog_2"}
+    assert "time" in df.columns
+    assert df.shape[0] == 6
+
+
+def test_build_analog_dataframe_no_rate_omits_time() -> None:
+    arr = np.arange(2, dtype=float).reshape(1, 1, 2)
+    c3d_data = {"data": {"analogs": arr}}
+    md = _meta(["A1"], analog_rate=None)
+    df = build_analog_dataframe(c3d_data, md, include_time=True)
+    assert "time" not in df.columns
+
+
+# ----- detect_force_plate_channels ------------------------------------------
+
+
+def test_detect_standard_channels() -> None:
+    labels = ["Fx1", "Fy1", "Fz1", "Mx1", "My1", "Mz1"]
+    plates = detect_force_plate_channels(labels)
+    assert set(plates.keys()) == {1}
+    assert plates[1] == {
+        "fx": "Fx1",
+        "fy": "Fy1",
+        "fz": "Fz1",
+        "mx": "Mx1",
+        "my": "My1",
+        "mz": "Mz1",
+    }
+
+
+def test_detect_force_dot_prefix() -> None:
+    labels = [
+        "Force.Fx1",
+        "Force.Fy1",
+        "Force.Fz1",
+        "Force.Mx1",
+        "Force.My1",
+        "Force.Mz1",
+    ]
+    plates = detect_force_plate_channels(labels)
+    assert plates[1]["fx"] == "Force.Fx1"
+
+
+def test_detect_vicon_style() -> None:
+    labels = ["FP2_Fx", "FP2_Fy", "FP2_Fz", "FP2_Mx", "FP2_My", "FP2_Mz"]
+    plates = detect_force_plate_channels(labels)
+    assert 2 in plates
+    assert plates[2]["fz"] == "FP2_Fz"
+
+
+def test_detect_two_plates() -> None:
+    labels = [
+        "Fx1",
+        "Fy1",
+        "Fz1",
+        "Mx1",
+        "My1",
+        "Mz1",
+        "Fx2",
+        "Fy2",
+        "Fz2",
+        "Mx2",
+        "My2",
+        "Mz2",
+    ]
+    plates = detect_force_plate_channels(labels)
+    assert set(plates.keys()) == {1, 2}
+
+
+def test_detect_ignores_unrelated_channels() -> None:
+    labels = ["EMG1", "BodyMass", "PowerSupply"]
+    assert detect_force_plate_channels(labels) == {}
+
+
+# ----- force_plate_columns --------------------------------------------------
+
+
+def test_force_plate_columns_all_options() -> None:
+    cols = force_plate_columns(include_time=True, compute_cop=True)
+    assert cols == [
+        "sample",
+        "time",
+        "plate",
+        "fx",
+        "fy",
+        "fz",
+        "mx",
+        "my",
+        "mz",
+        "cop_x",
+        "cop_y",
+        "cop_z",
+    ]
+
+
+def test_force_plate_columns_minimal() -> None:
+    assert force_plate_columns(False, False) == [
+        "sample",
+        "plate",
+        "fx",
+        "fy",
+        "fz",
+        "mx",
+        "my",
+        "mz",
+    ]
+
+
+# ----- build_plate_dataframe ------------------------------------------------
+
+
+def _wide(n: int = 4) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "sample": np.arange(n),
+            "Fx1": np.full(n, 1.0),
+            "Fy1": np.full(n, 2.0),
+            "Fz1": np.array([0.0, 0.0, 100.0, 100.0])[:n],
+            "Mx1": np.full(n, 5.0),
+            "My1": np.full(n, -10.0),
+            "Mz1": np.full(n, 0.5),
+        }
+    )
+
+
+def test_build_plate_dataframe_missing_channel_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    wide = _wide()
+    channels = {"fx": "Fx1", "fy": "Fy1", "fz": "Fz1", "mx": "Mx1", "my": "My1"}
+    with caplog.at_level(logging.WARNING, logger=ANALOG_LOGGER):
+        out = build_plate_dataframe(
+            1,
+            channels,
+            {"fx", "fy", "fz", "mx", "my", "mz"},
+            wide,
+            compute_cop=True,
+            ground_height=0.0,
+        )
+    assert out is None
+    assert any("missing channels" in r.getMessage() for r in caplog.records)
+
+
+def test_build_plate_dataframe_cop() -> None:
+    wide = _wide()
+    channels = {
+        "fx": "Fx1",
+        "fy": "Fy1",
+        "fz": "Fz1",
+        "mx": "Mx1",
+        "my": "My1",
+        "mz": "Mz1",
+    }
+    out = build_plate_dataframe(
+        1,
+        channels,
+        {"fx", "fy", "fz", "mx", "my", "mz"},
+        wide,
+        compute_cop=True,
+        ground_height=0.05,
+    )
+    assert out is not None
+    # First two rows: |fz|=0 < threshold -> NaN; last two rows: 100 N -> valid
+    assert np.isnan(out["cop_x"].iloc[0])
+    assert np.isnan(out["cop_z"].iloc[0])
+    assert out["cop_x"].iloc[2] == pytest.approx(10.0 / 100.0)
+    assert out["cop_y"].iloc[2] == pytest.approx(5.0 / 100.0)
+    assert out["cop_z"].iloc[2] == pytest.approx(0.05)
+
+
+def test_build_plate_dataframe_no_cop() -> None:
+    wide = _wide()
+    channels = {
+        "fx": "Fx1",
+        "fy": "Fy1",
+        "fz": "Fz1",
+        "mx": "Mx1",
+        "my": "My1",
+        "mz": "Mz1",
+    }
+    out = build_plate_dataframe(
+        1,
+        channels,
+        {"fx", "fy", "fz", "mx", "my", "mz"},
+        wide,
+        compute_cop=False,
+        ground_height=0.0,
+    )
+    assert out is not None
+    assert "cop_x" not in out.columns
+
+
+# ----- build_force_plate_dataframe ------------------------------------------
+
+
+def _analog_long_for_plate(samples: int = 4) -> pd.DataFrame:
+    """Build a long analog DataFrame for one plate's worth of channels."""
+    rows = []
+    fz_values = np.array([0.0, 0.0, 100.0, 100.0])[:samples]
+    channel_values = {
+        "Fx1": np.full(samples, 1.0),
+        "Fy1": np.full(samples, 2.0),
+        "Fz1": fz_values,
+        "Mx1": np.full(samples, 5.0),
+        "My1": np.full(samples, -10.0),
+        "Mz1": np.full(samples, 0.5),
+    }
+    for s in range(samples):
+        for ch, vals in channel_values.items():
+            rows.append({"sample": s, "channel": ch, "value": vals[s]})
+    return pd.DataFrame(rows)
+
+
+def test_build_force_plate_no_plates(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=ANALOG_LOGGER):
+        df = build_force_plate_dataframe(
+            {},
+            pd.DataFrame({"sample": [], "channel": [], "value": []}),
+            1000.0,
+            "x.c3d",
+            None,
+            True,
+            True,
+            0.0,
+        )
+    assert df.empty
+    assert any("No force plate channels" in r.getMessage() for r in caplog.records)
+
+
+def test_build_force_plate_unknown_plate_number() -> None:
+    plates = {
+        1: {
+            "fx": "Fx1",
+            "fy": "Fy1",
+            "fz": "Fz1",
+            "mx": "Mx1",
+            "my": "My1",
+            "mz": "Mz1",
+        }
+    }
+    long_df = _analog_long_for_plate()
+    with pytest.raises(ValueError, match="Force plate 5 not found"):
+        build_force_plate_dataframe(
+            plates, long_df, 1000.0, "x.c3d", 5, True, True, 0.0
+        )
+
+
+def test_build_force_plate_full_pipeline_with_time_and_cop() -> None:
+    plates = {
+        1: {
+            "fx": "Fx1",
+            "fy": "Fy1",
+            "fz": "Fz1",
+            "mx": "Mx1",
+            "my": "My1",
+            "mz": "Mz1",
+        }
+    }
+    long_df = _analog_long_for_plate()
+    df = build_force_plate_dataframe(
+        plates, long_df, 1000.0, "x.c3d", None, True, True, 0.05
+    )
+    assert "time" in df.columns
+    assert "cop_x" in df.columns
+    assert df["plate"].unique().tolist() == [1]
+    assert df.shape[0] == 4
+
+
+def test_build_force_plate_explicit_plate_filter() -> None:
+    plates = {
+        1: {
+            "fx": "Fx1",
+            "fy": "Fy1",
+            "fz": "Fz1",
+            "mx": "Mx1",
+            "my": "My1",
+            "mz": "Mz1",
+        },
+        2: {
+            "fx": "Fx1",
+            "fy": "Fy1",
+            "fz": "Fz1",
+            "mx": "Mx1",
+            "my": "My1",
+            "mz": "Mz1",
+        },  # share channels for test
+    }
+    long_df = _analog_long_for_plate()
+    df = build_force_plate_dataframe(
+        plates, long_df, 1000.0, "x.c3d", 2, False, False, 0.0
+    )
+    assert set(df["plate"].unique()) == {2}
+    assert "time" not in df.columns
+    assert "cop_x" not in df.columns
+
+
+def test_build_force_plate_all_skipped_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # plate channels missing required keys -> all skipped
+    plates = {1: {"fx": "Fx1"}}  # incomplete
+    long_df = _analog_long_for_plate()
+    with caplog.at_level(logging.WARNING, logger=ANALOG_LOGGER):
+        df = build_force_plate_dataframe(
+            plates, long_df, 1000.0, "x.c3d", None, True, True, 0.0
+        )
+    assert df.empty
+    assert list(df.columns) == force_plate_columns(True, True)
+
+
+def test_build_force_plate_no_rate_omits_time() -> None:
+    plates = {
+        1: {
+            "fx": "Fx1",
+            "fy": "Fy1",
+            "fz": "Fz1",
+            "mx": "Mx1",
+            "my": "My1",
+            "mz": "Mz1",
+        }
+    }
+    long_df = _analog_long_for_plate()
+    df = build_force_plate_dataframe(
+        plates, long_df, None, "x.c3d", None, True, False, 0.0
+    )
+    assert "time" not in df.columns

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_io.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_io.py
@@ -1,0 +1,373 @@
+"""Unit tests for ``_c3d_io`` parsers, unit-scale, sanitization, exports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.upstream_drift_tools.lab.bio import _c3d_io as io_mod
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_io import (
+    build_metadata,
+    export_dataframe,
+    get_analog_details,
+    get_analog_parameters,
+    get_events,
+    get_point_parameters,
+    load_c3d,
+    sanitize_for_csv,
+    unit_scale,
+    validate_export_path,
+    write_export,
+)
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_models import (
+    SCHEMA_VERSION,
+    C3DEvent,
+)
+from tests.unit.upstream_drift_tools.lab.bio._synthetic import _synthetic_c3d_dict
+
+
+# ----- load_c3d --------------------------------------------------------------
+
+
+def test_load_c3d_missing_file(tmp_path: Path) -> None:
+    bogus = tmp_path / "does_not_exist.c3d"
+    with pytest.raises(FileNotFoundError):
+        load_c3d(bogus)
+
+
+def test_load_c3d_no_ezc3d(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(io_mod, "ezc3d", None)
+    with pytest.raises(ImportError, match="ezc3d is required"):
+        load_c3d(tmp_path / "x.c3d")
+
+
+def test_load_c3d_real_file() -> None:
+    real = Path(__file__).resolve().parents[5] / "data" / "C3D_TA_Driver.c3d"
+    if not real.exists():
+        pytest.skip("real C3D fixture not present")
+    data = load_c3d(real)
+    assert "parameters" in data
+    assert "POINT" in data["parameters"]
+
+
+# ----- get_point_parameters / get_analog_parameters --------------------------
+
+
+def test_get_point_parameters() -> None:
+    data = _synthetic_c3d_dict()
+    pp = get_point_parameters(data, Path("foo.c3d"))
+    assert "LABELS" in pp
+
+
+def test_get_analog_parameters_present() -> None:
+    data = _synthetic_c3d_dict(n_analog=2)
+    ap = get_analog_parameters(data)
+    assert ap is not None
+    assert "LABELS" in ap
+
+
+def test_get_analog_parameters_missing() -> None:
+    data = _synthetic_c3d_dict(omit_analog_group=True)
+    assert get_analog_parameters(data) is None
+
+
+# ----- get_analog_details ----------------------------------------------------
+
+
+def test_analog_details_no_group() -> None:
+    data = _synthetic_c3d_dict(omit_analog_group=True)
+    labels, rate, units = get_analog_details(data)
+    assert labels == []
+    assert rate is None
+    assert units == []
+
+
+def test_analog_details_synth_labels_when_empty() -> None:
+    # Channel data exists but no labels — generated names
+    data = _synthetic_c3d_dict(n_analog=2, analog_labels=[], analog_units=[])
+    labels, rate, units = get_analog_details(data)
+    assert labels == ["Analog_1", "Analog_2"]
+    assert rate == 1000.0
+    # units padded
+    assert units == ["", ""]
+
+
+def test_analog_details_unit_truncation() -> None:
+    data = _synthetic_c3d_dict(
+        n_analog=1, analog_labels=["A1"], analog_units=["V", "extra"]
+    )
+    labels, _, units = get_analog_details(data)
+    assert labels == ["A1"]
+    assert units == ["V"]
+
+
+def test_analog_details_unit_padding() -> None:
+    data = _synthetic_c3d_dict(
+        n_analog=2, analog_labels=["A1", "A2"], analog_units=["V"]
+    )
+    _, _, units = get_analog_details(data)
+    assert units == ["V", ""]
+
+
+# ----- get_events ------------------------------------------------------------
+
+
+def test_get_events_none() -> None:
+    data = _synthetic_c3d_dict()
+    assert get_events(data) == []
+
+
+def test_get_events_simple() -> None:
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["A", "B"],
+        event_times=[0.1, 0.5],
+    )
+    events = get_events(data)
+    assert events == [C3DEvent("A", 0.1), C3DEvent("B", 0.5)]
+
+
+def test_get_events_2d_times() -> None:
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["A"],
+        event_times=[0.7],
+        event_times_2d=True,
+    )
+    events = get_events(data)
+    assert events == [C3DEvent("A", 0.7)]
+
+
+def test_get_events_missing_times() -> None:
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["A"],
+        event_times_missing=True,
+    )
+    assert get_events(data) == []
+
+
+def test_get_events_skips_non_finite_time() -> None:
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["good", "bad"],
+        event_times=[0.5, float("nan")],
+    )
+    events = get_events(data)
+    assert events == [C3DEvent("good", 0.5)]
+
+
+# ----- build_metadata --------------------------------------------------------
+
+
+def test_build_metadata_round_trip() -> None:
+    data = _synthetic_c3d_dict(
+        n_frames=5,
+        n_markers=2,
+        marker_names=["A", "B"],
+        n_analog=1,
+        analog_labels=["X"],
+        analog_units=["V"],
+        with_events=True,
+        event_labels=["evt"],
+        event_times=[0.01],
+    )
+    md = build_metadata(data, Path("dummy.c3d"))
+    assert md.marker_labels == ["A", "B"]
+    assert md.frame_count == 5
+    assert md.frame_rate == 100.0
+    assert md.units == "m"
+    assert md.analog_labels == ["X"]
+    assert md.analog_units == ["V"]
+    assert md.analog_rate == 1000.0
+    assert md.events == [C3DEvent("evt", 0.01)]
+
+
+# ----- unit_scale ------------------------------------------------------------
+
+
+def test_unit_scale_none() -> None:
+    assert unit_scale("m", None) == 1.0
+
+
+def test_unit_scale_same() -> None:
+    assert unit_scale("m", "m") == 1.0
+    assert unit_scale("MM", "mm") == 1.0
+
+
+@pytest.mark.parametrize(
+    "src,dst,expected",
+    [
+        ("m", "mm", 1000.0),
+        ("mm", "m", 0.001),
+        ("cm", "mm", 10.0),
+        ("in", "mm", 25.4),
+        ("ft", "m", 0.3048),
+    ],
+)
+def test_unit_scale_pairs(src: str, dst: str, expected: float) -> None:
+    assert unit_scale(src, dst) == pytest.approx(expected)
+
+
+def test_unit_scale_unsupported_source() -> None:
+    with pytest.raises(ValueError, match="Unsupported source unit"):
+        unit_scale("furlongs", "m")
+
+
+def test_unit_scale_unsupported_target() -> None:
+    with pytest.raises(ValueError, match="Unsupported target unit"):
+        unit_scale("m", "furlongs")
+
+
+# ----- sanitize_for_csv ------------------------------------------------------
+
+
+@pytest.mark.parametrize("prefix", ["=", "+", "-", "@"])
+def test_sanitize_for_csv_prefixes(prefix: str) -> None:
+    assert sanitize_for_csv(f"{prefix}cmd") == f"'{prefix}cmd"
+
+
+def test_sanitize_for_csv_safe_string() -> None:
+    assert sanitize_for_csv("plain") == "plain"
+
+
+def test_sanitize_for_csv_non_string() -> None:
+    assert sanitize_for_csv(42) == 42
+    assert sanitize_for_csv(None) is None
+
+
+# ----- validate_export_path --------------------------------------------------
+
+
+def test_validate_export_path_inside_test_env(tmp_path: Path) -> None:
+    # tmp_path strings include "pytest" so this is treated as test env
+    target = tmp_path / "out.csv"
+    validate_export_path(target)
+
+
+def test_validate_export_path_outside_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Patch Path.cwd to a clean string that doesn't contain "pytest"/"test",
+    # and target a clean path likewise. Otherwise the test-env heuristic
+    # short-circuits the security check.
+    fake_cwd = Path("C:/clean_root_xyz").resolve()
+    monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: fake_cwd))
+    other = Path("C:/").resolve() / "outside_clean_root" / "out.csv"
+    with pytest.raises(ValueError, match="Refusing to output"):
+        validate_export_path(other)
+
+
+# ----- write_export per format ----------------------------------------------
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "frame": [0, 1],
+            "marker": ["=danger", "safe"],
+            "x": [1.0, 2.0],
+        }
+    )
+
+
+def test_write_export_csv_sanitizes(tmp_path: Path) -> None:
+    df = _sample_df()
+    out = tmp_path / "p.csv"
+    write_export(out, "csv", df, {"k": "v"}, do_sanitize=True)
+    text = out.read_text()
+    assert "'=danger" in text
+    meta = json.loads((tmp_path / "p_meta.json").read_text())
+    assert meta == {"k": "v"}
+
+
+def test_write_export_csv_no_sanitize(tmp_path: Path) -> None:
+    df = _sample_df()
+    out = tmp_path / "p.csv"
+    write_export(out, "csv", df, {"k": "v"}, do_sanitize=False)
+    text = out.read_text()
+    assert "=danger" in text
+    assert "'=danger" not in text
+
+
+def test_write_export_json(tmp_path: Path) -> None:
+    df = _sample_df()
+    out = tmp_path / "p.json"
+    write_export(out, "json", df, {"src": "x"}, do_sanitize=False)
+    payload = json.loads(out.read_text())
+    assert payload["metadata"] == {"src": "x"}
+    assert len(payload["data"]) == 2
+
+
+def test_write_export_npz(tmp_path: Path) -> None:
+    df = _sample_df()
+    out = tmp_path / "p.npz"
+    write_export(out, "npz", df, {"src": "x"}, do_sanitize=False)
+    arr = np.load(out, allow_pickle=False)
+    assert "frame" in arr.files
+    assert "_metadata" in arr.files
+    assert json.loads(str(arr["_metadata"])) == {"src": "x"}
+
+
+def test_write_export_invalid_format(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        write_export(tmp_path / "p.xyz", "xyz", _sample_df(), {}, False)
+
+
+# ----- export_dataframe -----------------------------------------------------
+
+
+def test_export_dataframe_infers_format_from_suffix(tmp_path: Path) -> None:
+    df = _sample_df()
+    out = tmp_path / "auto.csv"
+    result = export_dataframe(df, out, None, "src.c3d", "m")
+    assert result.exists()
+    meta = json.loads((tmp_path / "auto_meta.json").read_text())
+    assert meta["schema_version"] == SCHEMA_VERSION
+    assert meta["source_file"] == "src.c3d"
+    assert meta["units"] == "m"
+    assert meta["row_count"] == 2
+
+
+def test_export_dataframe_no_suffix_no_format(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="File format could not be inferred"):
+        export_dataframe(_sample_df(), tmp_path / "noext", None, "x.c3d", "m")
+
+
+def test_export_dataframe_explicit_format(tmp_path: Path) -> None:
+    out = tmp_path / "explicit.bin"
+    result = export_dataframe(_sample_df(), out, "json", "src.c3d", "m")
+    assert result.exists()
+    payload = json.loads(out.read_text())
+    assert "metadata" in payload
+
+
+def test_export_dataframe_creates_parent(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deep" / "out.csv"
+    export_dataframe(_sample_df(), target, None, "x.c3d", "m")
+    assert target.exists()
+
+
+def test_export_dataframe_npz(tmp_path: Path) -> None:
+    out = tmp_path / "out.npz"
+    result = export_dataframe(_sample_df(), out, None, "x.c3d", "mm")
+    assert result.exists()
+    arr = np.load(result, allow_pickle=False)
+    meta = json.loads(str(arr["_metadata"]))
+    assert meta["units"] == "mm"
+
+
+# ----- patch-based load_c3d sanity ------------------------------------------
+
+
+def test_load_c3d_via_patch(tmp_path: Path) -> None:
+    real_path = tmp_path / "fake.c3d"
+    real_path.write_bytes(b"\x00")  # exists check
+    fake = _synthetic_c3d_dict()
+    with patch.object(io_mod.ezc3d, "c3d", return_value=fake):
+        loaded = load_c3d(real_path)
+    assert loaded is fake

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_markers.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_markers.py
@@ -19,8 +19,11 @@ import logging
 import numpy as np
 import pytest
 from src.shared.python.upstream_drift_tools.lab.bio._c3d_markers import (
+    build_points_dataframe,
     validate_marker_positions,
 )
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_models import C3DMetadata
+from tests.unit.upstream_drift_tools.lab.bio._synthetic import _synthetic_c3d_dict
 
 WARNING_LOGGER = "src.shared.python.upstream_drift_tools.lab.bio._c3d_markers"
 
@@ -81,3 +84,123 @@ def test_warning_message_encodes_under_cp1252(
         codecs.encode(formatted, "cp1252")
     except UnicodeEncodeError as exc:  # pragma: no cover - regression sentinel
         pytest.fail(f"warning message is not cp1252-safe: {exc}")
+
+
+# ----- additional validate_marker_positions edge cases ----------------------
+
+
+def test_validate_empty_array_short_circuits() -> None:
+    validate_marker_positions(np.array([]).reshape(0, 3), "m", "m")
+
+
+def test_validate_all_nan_warns_and_returns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coords = np.full((3, 3), np.nan)
+    with caplog.at_level(logging.WARNING, logger=WARNING_LOGGER):
+        validate_marker_positions(coords, "m", None)
+    assert any(
+        "All marker coordinates are NaN" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_validate_partial_nan_does_not_short_circuit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Partial NaN: nanmin/nanmax remain finite; should NOT trigger the
+    # all-NaN warning, and should not raise on healthy values.
+    coords = np.array([[0.5, np.nan, 0.5], [0.5, 0.5, np.nan]], dtype=float)
+    with caplog.at_level(logging.WARNING, logger=WARNING_LOGGER):
+        validate_marker_positions(coords, "m", None)
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("All marker coordinates are NaN" in m for m in msgs)
+
+
+def test_validate_max_position_raises() -> None:
+    coords = np.array([[15.0, 0.0, 0.0]], dtype=float)
+    with pytest.raises(ValueError, match="exceed"):
+        validate_marker_positions(coords, "m", None)
+
+
+# ----- build_points_dataframe ------------------------------------------------
+
+
+def _meta_for(
+    c3d: dict, frame_count: int = 5, marker_labels: list[str] | None = None
+) -> C3DMetadata:
+    return C3DMetadata(
+        marker_labels=marker_labels
+        or list(c3d["parameters"]["POINT"]["LABELS"]["value"]),
+        frame_count=frame_count,
+        frame_rate=100.0,
+        units="m",
+        analog_labels=[],
+        analog_units=[],
+        analog_rate=None,
+        events=[],
+    )
+
+
+def test_build_points_dataframe_basic() -> None:
+    c3d = _synthetic_c3d_dict(n_frames=5, n_markers=3, marker_names=["B", "A", "C"])
+    md = _meta_for(c3d, 5, ["B", "A", "C"])
+    df = build_points_dataframe(c3d, md, "x.c3d", 1.0, True, None, None, None)
+    # markers sorted alphabetically
+    assert list(df["marker"].iloc[:3]) == ["A", "B", "C"]
+    assert "time" in df.columns
+    assert df["time"].iloc[0] == 0.0
+    assert len(df) == 15
+
+
+def test_build_points_dataframe_marker_filter() -> None:
+    c3d = _synthetic_c3d_dict(n_frames=2, n_markers=3, marker_names=["A", "B", "C"])
+    md = _meta_for(c3d, 2, ["A", "B", "C"])
+    df = build_points_dataframe(c3d, md, "x.c3d", 1.0, False, ["A", "C"], None, None)
+    assert set(df["marker"].unique()) == {"A", "C"}
+    assert "time" not in df.columns
+
+
+def test_build_points_dataframe_residual_threshold() -> None:
+    c3d = _synthetic_c3d_dict(n_frames=2, n_markers=2, marker_names=["A", "B"])
+    # set residuals: marker A frame 0 -> 5, marker B frame 1 -> 0
+    c3d["data"]["points"][3, 0, 0] = 5.0
+    md = _meta_for(c3d, 2, ["A", "B"])
+    df = build_points_dataframe(c3d, md, "x.c3d", 1.0, False, None, 1.0, None)
+    # residuals > 1.0 should drive coords to NaN
+    a_frame0 = df[(df["marker"] == "A") & (df["frame"] == 0)].iloc[0]
+    assert np.isnan(a_frame0["x"])
+
+
+def test_build_points_dataframe_target_units_conversion() -> None:
+    # Use small native-units coordinates so scale=1000x stays within the
+    # biomechanical sanity range (<10 m).
+    pts = np.zeros((4, 1, 1), dtype=float)
+    pts[0, 0, 0] = 0.002  # 2 mm in native m
+    pts[1, 0, 0] = 0.001
+    pts[2, 0, 0] = 0.001
+    c3d = _synthetic_c3d_dict(
+        n_frames=1, n_markers=1, marker_names=["A"], point_data=pts
+    )
+    md = _meta_for(c3d, 1, ["A"])
+    df = build_points_dataframe(c3d, md, "x.c3d", 1000.0, False, None, None, "mm")
+    assert df["x"].iloc[0] == pytest.approx(2.0)
+
+
+def test_build_points_dataframe_zero_frame_rate_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    c3d = _synthetic_c3d_dict(n_frames=1, n_markers=1, marker_names=["A"])
+    md = C3DMetadata(
+        marker_labels=["A"],
+        frame_count=1,
+        frame_rate=0.0,
+        units="m",
+        analog_labels=[],
+        analog_units=[],
+        analog_rate=None,
+        events=[],
+    )
+    with caplog.at_level(logging.WARNING, logger=WARNING_LOGGER):
+        df = build_points_dataframe(c3d, md, "x.c3d", 1.0, True, None, None, None)
+    assert "time" not in df.columns
+    assert any("Frame rate is 0" in r.getMessage() for r in caplog.records)

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_models.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_models.py
@@ -1,0 +1,95 @@
+"""Unit tests for ``_c3d_models`` dataclass validation and constants."""
+
+from __future__ import annotations
+
+import pytest
+from src.shared.python.upstream_drift_tools.lab.bio._c3d_models import (
+    BIOMECHANICAL_MARKER_MAX_M,
+    BIOMECHANICAL_MARKER_MIN_M,
+    SCHEMA_VERSION,
+    C3DEvent,
+    C3DMetadata,
+)
+
+
+def test_schema_version_invariants() -> None:
+    assert SCHEMA_VERSION == "1.0"
+    assert isinstance(SCHEMA_VERSION, str)
+
+
+def test_biomechanical_constants() -> None:
+    assert BIOMECHANICAL_MARKER_MIN_M == 0.001
+    assert BIOMECHANICAL_MARKER_MAX_M == 10.0
+
+
+def test_c3d_event_valid() -> None:
+    event = C3DEvent(label="FootStrike", time=1.5)
+    assert event.label == "FootStrike"
+    assert event.time == 1.5
+
+
+def test_c3d_event_empty_label_rejected() -> None:
+    with pytest.raises(ValueError, match="Event label cannot be empty"):
+        C3DEvent(label="", time=0.0)
+
+
+def _valid_kwargs() -> dict:
+    return {
+        "marker_labels": ["M1", "M2"],
+        "frame_count": 10,
+        "frame_rate": 100.0,
+        "units": "m",
+        "analog_labels": ["A1"],
+        "analog_units": ["V"],
+        "analog_rate": 1000.0,
+        "events": [],
+    }
+
+
+def test_metadata_valid() -> None:
+    md = C3DMetadata(**_valid_kwargs())
+    assert md.marker_count == 2
+    assert md.analog_count == 1
+    assert md.duration == pytest.approx(10 / 100.0)
+
+
+def test_metadata_duration_zero_rate() -> None:
+    kw = _valid_kwargs()
+    kw["frame_rate"] = 0.0
+    md = C3DMetadata(**kw)
+    assert md.duration == 0.0
+
+
+def test_metadata_negative_frame_count() -> None:
+    kw = _valid_kwargs()
+    kw["frame_count"] = -1
+    with pytest.raises(ValueError, match="Frame count cannot be negative"):
+        C3DMetadata(**kw)
+
+
+def test_metadata_negative_frame_rate() -> None:
+    kw = _valid_kwargs()
+    kw["frame_rate"] = -1.0
+    with pytest.raises(ValueError, match="Frame rate cannot be negative"):
+        C3DMetadata(**kw)
+
+
+def test_metadata_negative_analog_rate() -> None:
+    kw = _valid_kwargs()
+    kw["analog_rate"] = -1.0
+    with pytest.raises(ValueError, match="Analog rate cannot be negative"):
+        C3DMetadata(**kw)
+
+
+def test_metadata_analog_rate_none_allowed() -> None:
+    kw = _valid_kwargs()
+    kw["analog_rate"] = None
+    md = C3DMetadata(**kw)
+    assert md.analog_rate is None
+
+
+def test_metadata_analog_units_label_mismatch() -> None:
+    kw = _valid_kwargs()
+    kw["analog_units"] = ["V", "V"]
+    with pytest.raises(ValueError, match="analog_units and analog_labels"):
+        C3DMetadata(**kw)

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_reader.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_reader.py
@@ -1,0 +1,249 @@
+"""Unit tests for ``C3DDataReader`` exercising every public method.
+
+Uses ``unittest.mock.patch`` to substitute a synthetic ezc3d-shaped dict for
+``ezc3d.c3d``, avoiding the need for a real C3D file in unit tests. A real
+file (``data/C3D_TA_Driver.c3d``) is exercised in a single sanity test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.upstream_drift_tools.lab.bio import _c3d_io as io_mod
+from src.shared.python.upstream_drift_tools.lab.bio.c3d_reader import C3DDataReader
+from tests.unit.upstream_drift_tools.lab.bio._synthetic import _synthetic_c3d_dict
+
+REAL_C3D = Path(__file__).resolve().parents[5] / "data" / "C3D_TA_Driver.c3d"
+
+
+def _force_plate_dict(n_frames: int = 4, n_subframes: int = 1) -> dict:
+    """Synthetic C3D dict with one fully-channeled force plate."""
+    labels = ["Fx1", "Fy1", "Fz1", "Mx1", "My1", "Mz1"]
+    n_analog = len(labels)
+    analog = np.zeros((n_subframes, n_analog, n_frames), dtype=float)
+    # set fz on plate 1 above the 10 N threshold for half the samples
+    fz_idx = labels.index("Fz1")
+    mx_idx = labels.index("Mx1")
+    my_idx = labels.index("My1")
+    analog[:, fz_idx, n_frames // 2 :] = 100.0
+    analog[:, mx_idx, :] = 5.0
+    analog[:, my_idx, :] = -10.0
+    return _synthetic_c3d_dict(
+        n_frames=n_frames,
+        n_markers=2,
+        marker_names=["A", "B"],
+        n_analog=n_analog,
+        analog_labels=labels,
+        analog_units=[""] * n_analog,
+        analog_rate=1000.0,
+        analog_subframes=n_subframes,
+        analog_data=analog,
+    )
+
+
+def _patched_reader(synthetic: dict, file_path: Path) -> C3DDataReader:
+    """Build a reader whose ``_load`` returns the supplied synthetic dict."""
+    file_path.write_bytes(b"\x00")
+    reader = C3DDataReader(file_path)
+    # Pre-populate cached load to skip ezc3d.c3d.
+    reader._c3d_data = synthetic  # noqa: SLF001
+    return reader
+
+
+# ----- get_metadata + caching -----------------------------------------------
+
+
+def test_get_metadata_caches(tmp_path: Path) -> None:
+    reader = _patched_reader(_synthetic_c3d_dict(), tmp_path / "x.c3d")
+    md1 = reader.get_metadata()
+    md2 = reader.get_metadata()
+    assert md1 is md2
+
+
+# ----- points_dataframe -----------------------------------------------------
+
+
+def test_points_dataframe_default(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(n_frames=3, n_markers=2, marker_names=["A", "B"]),
+        tmp_path / "x.c3d",
+    )
+    df = reader.points_dataframe()
+    assert {"frame", "marker", "x", "y", "z", "residual", "time"}.issubset(df.columns)
+
+
+def test_points_dataframe_filters_and_units(tmp_path: Path) -> None:
+    # Use small native-m coordinates so x1000 mm conversion stays under 10 m.
+    pts = np.zeros((4, 3, 2), dtype=float)
+    for m in range(3):
+        pts[0, m, :] = 0.001 * (m + 1)
+        pts[1, m, :] = 0.001
+        pts[2, m, :] = 0.001
+    reader = _patched_reader(
+        _synthetic_c3d_dict(
+            n_frames=2, n_markers=3, marker_names=["A", "B", "C"], point_data=pts
+        ),
+        tmp_path / "x.c3d",
+    )
+    df = reader.points_dataframe(
+        include_time=False,
+        markers=["A"],
+        residual_nan_threshold=0.5,
+        target_units="mm",
+    )
+    assert set(df["marker"].unique()) == {"A"}
+    assert "time" not in df.columns
+
+
+# ----- analog_dataframe -----------------------------------------------------
+
+
+def test_analog_dataframe(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(n_frames=2, n_markers=1, marker_names=["A"], n_analog=2),
+        tmp_path / "x.c3d",
+    )
+    df = reader.analog_dataframe(include_time=True)
+    assert "time" in df.columns
+    assert df.shape[0] > 0
+
+
+# ----- export_points / export_analog ----------------------------------------
+
+
+@pytest.mark.parametrize("ext", ["csv", "json", "npz"])
+def test_export_points_formats(tmp_path: Path, ext: str) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(n_frames=2, n_markers=1, marker_names=["A"]),
+        tmp_path / "x.c3d",
+    )
+    out = tmp_path / f"points.{ext}"
+    result = reader.export_points(out)
+    assert result.exists()
+    if ext == "csv":
+        text = out.read_text()
+        assert "marker" in text
+    elif ext == "json":
+        payload = json.loads(out.read_text())
+        assert "metadata" in payload
+    else:
+        arr = np.load(out, allow_pickle=False)
+        assert "marker" in arr.files
+
+
+def test_export_points_explicit_format(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(n_frames=1, n_markers=1, marker_names=["A"]),
+        tmp_path / "x.c3d",
+    )
+    out = tmp_path / "explicit.bin"
+    reader.export_points(out, file_format="json")
+    payload = json.loads(out.read_text())
+    assert "data" in payload
+
+
+def test_export_analog_csv(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(
+            n_frames=2,
+            n_markers=1,
+            marker_names=["A"],
+            n_analog=1,
+            analog_labels=["A1"],
+        ),
+        tmp_path / "x.c3d",
+    )
+    out = tmp_path / "analog.csv"
+    reader.export_analog(out)
+    assert out.exists()
+
+
+def test_export_analog_with_kwargs(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(
+            n_frames=2,
+            n_markers=1,
+            marker_names=["A"],
+            n_analog=1,
+            analog_labels=["A1"],
+        ),
+        tmp_path / "x.c3d",
+    )
+    out = tmp_path / "analog.json"
+    reader.export_analog(out, include_time=False, file_format="json")
+    payload = json.loads(out.read_text())
+    assert "data" in payload
+
+
+# ----- force-plate APIs -----------------------------------------------------
+
+
+def test_get_force_plate_count_zero(tmp_path: Path) -> None:
+    reader = _patched_reader(
+        _synthetic_c3d_dict(n_frames=2, n_markers=1, marker_names=["A"]),
+        tmp_path / "x.c3d",
+    )
+    assert reader.get_force_plate_count() == 0
+
+
+def test_force_plate_dataframe_synthetic(tmp_path: Path) -> None:
+    reader = _patched_reader(_force_plate_dict(n_frames=4), tmp_path / "x.c3d")
+    assert reader.get_force_plate_count() == 1
+    plate_channels = reader.get_force_plate_channels()
+    assert 1 in plate_channels
+    df = reader.force_plate_dataframe()
+    assert "fx" in df.columns and "cop_x" in df.columns
+    # The synthetic data has 4 frames * 1 subframe = 4 samples
+    assert df.shape[0] == 4
+
+
+def test_force_plate_dataframe_filter_and_no_cop(tmp_path: Path) -> None:
+    reader = _patched_reader(_force_plate_dict(n_frames=4), tmp_path / "x.c3d")
+    df = reader.force_plate_dataframe(
+        plate_number=1,
+        include_time=False,
+        compute_cop=False,
+        ground_height=0.1,
+    )
+    assert "time" not in df.columns
+    assert "cop_x" not in df.columns
+    assert df["plate"].unique().tolist() == [1]
+
+
+def test_force_plate_columns_static() -> None:
+    cols = C3DDataReader._force_plate_columns(True, True)
+    assert cols[0] == "sample"
+    assert "cop_x" in cols
+
+
+# ----- _load goes through ezc3d on first call -------------------------------
+
+
+def test_load_goes_through_ezc3d(tmp_path: Path) -> None:
+    fake = _synthetic_c3d_dict()
+    file_path = tmp_path / "x.c3d"
+    file_path.write_bytes(b"\x00")
+    reader = C3DDataReader(file_path)
+    with patch.object(io_mod.ezc3d, "c3d", return_value=fake) as m:
+        md = reader.get_metadata()
+    m.assert_called_once()
+    assert md.marker_count == 3
+
+
+# ----- real-file sanity (skip if absent) ------------------------------------
+
+
+def test_real_file_metadata() -> None:
+    if not REAL_C3D.exists():
+        pytest.skip("real C3D fixture not present")
+    reader = C3DDataReader(REAL_C3D)
+    md = reader.get_metadata()
+    assert md.marker_count > 0
+    df = reader.points_dataframe(include_time=True)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty


### PR DESCRIPTION
Closes #4674

## Summary

Brings `src/shared/python/upstream_drift_tools/lab/bio/` (the canonical C3D reader powering every loader and viewer) from 41.5% line / 16.1% branch coverage to **99.0% line / 99.2% branch** with 100 new unit tests.

## Per-file coverage

| File | Before | After |
|---|---|---|
| `__init__.py` | 100.0% | 100.0% |
| `_c3d_analog.py` | 9.8% | **100.0%** |
| `_c3d_io.py` | 35.6% | **97.4%** |
| `_c3d_markers.py` | 72.7% | **100.0%** |
| `_c3d_models.py` | 64.8% | **100.0%** |
| `c3d_reader.py` | 77.4% | **100.0%** |
| **TOTAL** | **41.5%** | **99.0%** |

Branch coverage on the package: **99.2%** (1 partial out of 124 branches).

## Test surface added

- `_synthetic.py` — `_synthetic_c3d_dict()` helper returning a dict shaped like `ezc3d.c3d(path)`. Unlocks unit tests against every code path without committing fixture C3D files.
- `test_c3d_models.py` — `C3DEvent` / `C3DMetadata` validation, `SCHEMA_VERSION` invariants, biomechanical constants, every `__post_init__` branch.
- `test_c3d_io.py` — `load_c3d` (missing file, missing ezc3d, real file, mocked), every parser (`get_point_parameters`, `get_analog_parameters`, `get_analog_details` incl. label synthesis, unit padding, unit truncation), every `get_events` branch (none, simple, 2D times, missing times, non-finite skip), `build_metadata`, every `unit_scale` pair (m/mm/cm/in/ft) plus invalid src/dst, every `sanitize_for_csv` prefix, `validate_export_path` inside-test-env and outside-rejected, `write_export` per format (csv with sanitization, csv without, json, npz, invalid format), `export_dataframe` (suffix inference, missing suffix, explicit format, parent creation, npz).
- `test_c3d_analog.py` — `build_analog_dataframe` (empty, no-time, label synthesis, no-rate omits time), `detect_force_plate_channels` (standard / `Force.` prefix / Vicon-style / two plates / unrelated rejected), `force_plate_columns` both options, `build_plate_dataframe` (missing channel skip, COP with valid + below-threshold rows, no-COP), `build_force_plate_dataframe` (no plates, unknown plate number, full pipeline with time + COP, explicit plate filter, all-skipped fallback, no-rate omits time).
- `test_c3d_markers.py` — extended with empty array, all-NaN warns-and-returns, partial NaN, max-position raises, full `build_points_dataframe` (basic, marker filter, residual threshold, target_units conversion, zero frame rate warning).
- `test_c3d_reader.py` — `C3DDataReader` covering metadata caching, `points_dataframe` defaults + filters, `analog_dataframe`, `export_points` per format (csv/json/npz) + explicit format override, `export_analog`, force-plate APIs (`get_force_plate_channels`, `get_force_plate_count`, `force_plate_dataframe` with COP and with explicit plate filter / no-COP / no-time), `_force_plate_columns` static helper, `_load` going through `ezc3d.c3d` once, plus a real-file sanity test.

## No production changes

This is a **TEST-ONLY** PR. No files outside `tests/unit/upstream_drift_tools/lab/bio/` are modified.

## Test plan

- [x] `python3 -m pytest tests/unit/upstream_drift_tools/lab/bio/` — 103 passed
- [x] `python3 -m ruff check tests/unit/upstream_drift_tools/lab/bio/` — clean
- [x] `python3 -m ruff format --check tests/unit/upstream_drift_tools/lab/bio/` — clean
- [x] Coverage on `src/shared/python/upstream_drift_tools/lab/bio/` >=90% line, >=80% branch

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>