### PR TITLE
fix: Re-export SMPLX_AVAILABLE/TRIMESH_AVAILABLE from mesh_generator (#4528)

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
@@ -15,6 +15,19 @@ from ._mesh_smplx import (
     _trimesh_module,  # type: ignore[attr-defined]
 )
 from ._mesh_types import (
+# Re-export capability flags for test compatibility (#4528)
+try:
+    from humanoid_character_builder.generators._mesh_smplx import SMPLX_AVAILABLE
+except ImportError:
+    SMPLX_AVAILABLE = False
+try:
+    from humanoid_character_builder.generators._mesh_smplx import TRIMESH_AVAILABLE
+except ImportError:
+    TRIMESH_AVAILABLE = False
+try:
+    from humanoid_character_builder.generators._mesh_smplx import _trimesh_module
+except ImportError:
+    _trimesh_module = None
     GeneratedMeshResult,
     MeshGeneratorBackend,
     MeshGeneratorInterface,


### PR DESCRIPTION
## Summary

Re-exported SMPLX_AVAILABLE, TRIMESH_AVAILABLE, _trimesh_module (#4528)

## Related Issues

- Closes #4528

## Changes

```
.../humanoid_character_builder/generators/mesh_generator.py | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```

_Automated fix (run 6/10)_