### PR TITLE
test(starting-pose-matcher): coverage to ≥85% (#4673)

### DIFF
--- a/tests/unit/tools/starting_pose_matcher/test_core_math_and_loaders.py
+++ b/tests/unit/tools/starting_pose_matcher/test_core_math_and_loaders.py
@@ -1,0 +1,549 @@
+"""Coverage tests for ``starting_pose_matcher.core``.
+
+Pure math + loader paths. Covers fallback skeleton building, RigidTransform
+math, phase label utilities, the Simscape trajectory CSV loader and the
+shaft-snap solver. Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.tools.starting_pose_matcher.core import (
+    CM_TO_M,
+    DEFAULT_EVENT_PRESET,
+    DEFAULT_PHASE,
+    EVENT_KEYS,
+    EVENT_LABEL_PRESETS,
+    FALLBACK_SEGMENTS,
+    PHASE_BOUNDS,
+    PHASE_KEYS,
+    MocapEvents,
+    PoseSlot,
+    RigidTransform,
+    SESSION_SCHEMA_VERSION,
+    Skeleton,
+    SkeletonTrajectory,
+    _xyz_columns_for,
+    clubtarget_from_multi,
+    dispatch_cost_inputs,
+    fallback_skeleton,
+    load_simscape_trajectory_csv,
+    load_skeleton,
+    phase_display_label,
+    phase_key_from_label,
+    solve_shaft_rz_deg,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Module-level constants                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_constants_have_expected_shape():
+    assert CM_TO_M == 0.01
+    assert SESSION_SCHEMA_VERSION >= 4
+    assert EVENT_KEYS == ("A", "T", "I", "F")
+    assert DEFAULT_EVENT_PRESET in EVENT_LABEL_PRESETS
+    assert DEFAULT_PHASE in PHASE_KEYS
+    for key in PHASE_KEYS:
+        assert key in PHASE_BOUNDS
+    # Fallback segment chain is non-empty and references compact joint names.
+    assert ("hip", "spine") in FALLBACK_SEGMENTS
+
+
+# --------------------------------------------------------------------------- #
+# MocapEvents                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_mocap_events_frame_for_returns_zero_indexed():
+    ev = MocapEvents(A_sample=1, T_sample=10, I_sample=20, F_sample=30, CHS_mph=85.0)
+    assert ev.frame_for("A") == 0
+    assert ev.frame_for("T") == 9
+    assert ev.frame_for("I") == 19
+    assert ev.frame_for("F") == 29
+
+
+def test_mocap_events_frame_for_nan_returns_none():
+    ev = MocapEvents()  # all NaN
+    assert ev.frame_for("A") is None
+    assert ev.frame_for("T") is None
+    assert ev.frame_for("F") is None
+
+
+def test_mocap_events_frame_for_clamps_to_zero():
+    ev = MocapEvents(A_sample=0)  # 0 -> int(0) - 1 = -1, clamps to 0
+    assert ev.frame_for("A") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Phase label helpers                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_phase_display_label_known_keys_use_event_labels():
+    labels = {"A": "Address", "T": "Top", "I": "Impact", "F": "Finish"}
+    assert phase_display_label("backswing", labels) == "Backswing (Address to Top)"
+    assert phase_display_label("downswing", labels) == "Downswing (Top to Impact)"
+    assert (
+        phase_display_label("follow_through", labels)
+        == "Follow-through (Impact to Finish)"
+    )
+    assert phase_display_label("full_swing", labels) == "Full swing (Address to Finish)"
+    assert phase_display_label("manual", labels) == "Manual frame range"
+    assert phase_display_label("none", labels).startswith("None")
+
+
+def test_phase_display_label_uses_default_when_event_label_missing():
+    # Empty dict -> falls back to canonical defaults.
+    out = phase_display_label("backswing", {})
+    assert "Address" in out and "Top of Backswing" in out
+
+
+def test_phase_display_label_unknown_key_returned_verbatim():
+    assert phase_display_label("zzz", {}) == "zzz"
+
+
+def test_phase_key_from_label_legacy_and_current():
+    assert phase_key_from_label("Backswing (A → T)") == "backswing"
+    assert phase_key_from_label("backswing") == "backswing"
+    # Leading-prefix lookup.
+    assert phase_key_from_label("Backswing - whatever") == "backswing"
+    assert phase_key_from_label("Manual:") == "manual"
+
+
+def test_phase_key_from_label_unknown_returns_none():
+    assert phase_key_from_label("xyzzy whatever") is None
+
+
+# --------------------------------------------------------------------------- #
+# RigidTransform                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_rigid_transform_identity_is_no_op():
+    rt = RigidTransform()
+    pts = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    out = rt.apply(pts)
+    np.testing.assert_allclose(out, pts)
+
+
+def test_rigid_transform_pure_translation():
+    rt = RigidTransform(tx=1.0, ty=2.0, tz=-3.0)
+    pts = np.array([[0.0, 0.0, 0.0]])
+    out = rt.apply(pts)
+    np.testing.assert_allclose(out, [[1.0, 2.0, -3.0]])
+
+
+def test_rigid_transform_rotation_z_90():
+    rt = RigidTransform(rz=90.0)
+    pts = np.array([[1.0, 0.0, 0.0]])
+    out = rt.apply(pts)
+    np.testing.assert_allclose(out, [[0.0, 1.0, 0.0]], atol=1e-12)
+
+
+def test_rigid_transform_scale_with_pivot():
+    rt = RigidTransform(scale=2.0, pivot=(1.0, 1.0, 0.0))
+    pts = np.array([[2.0, 1.0, 0.0]])  # offset 1.0 in x from pivot
+    out = rt.apply(pts)
+    # 2*(2-1, 1-1, 0-0) + (1,1,0) + (0,0,0) = (3, 1, 0)
+    np.testing.assert_allclose(out, [[3.0, 1.0, 0.0]])
+
+
+def test_rigid_transform_matrix_returns_R_and_t():
+    rt = RigidTransform(tx=5.0, scale=3.0)
+    R, t = rt.matrix()
+    assert R.shape == (3, 3)
+    np.testing.assert_allclose(t, [5.0, 0.0, 0.0])
+    # scale embedded in R
+    np.testing.assert_allclose(R, np.eye(3) * 3.0)
+
+
+# --------------------------------------------------------------------------- #
+# SkeletonTrajectory + Skeleton                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_skeleton_trajectory_len_and_frame_at_time():
+    times = np.array([0.0, 0.1, 0.2, 0.3])
+    frames = [Skeleton(name=f"f{i}") for i in range(4)]
+    traj = SkeletonTrajectory(times=times, frames=frames)
+    assert len(traj) == 4
+    assert traj.frame_at_time(0.0) == 0
+    assert traj.frame_at_time(0.11) == 1
+    # Out-of-range clamps.
+    assert traj.frame_at_time(99.0) == 3
+    assert traj.frame_at_time(-1.0) == 0
+
+
+def test_skeleton_trajectory_empty_returns_zero():
+    traj = SkeletonTrajectory()
+    assert len(traj) == 0
+    assert traj.frame_at_time(1.0) == 0
+
+
+def test_pose_slot_dataclass_round_trip():
+    skel = Skeleton(name="x")
+    slot = PoseSlot(
+        name="a",
+        skeleton=skel,
+        color="#fff",
+        mocap_color="#000",
+        target_event="A",
+    )
+    assert slot.visible is True
+    assert slot.trajectory is None
+    assert slot.trajectory_frame_index == 0
+
+
+# --------------------------------------------------------------------------- #
+# Fallback skeleton                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_fallback_skeleton_address_has_required_joints():
+    skel = fallback_skeleton("Impact")
+    for name in ("hip", "spine", "torso", "hub", "ls", "rs"):
+        assert name in skel.joints, f"missing {name}"
+    assert skel.segments == FALLBACK_SEGMENTS
+
+
+def test_fallback_skeleton_top_of_backswing_has_butt_alias():
+    skel = fallback_skeleton("TopofBackswing")
+    assert skel.name == "TopofBackswing"
+    assert "butt" in skel.joints
+    assert "mp" in skel.joints
+    np.testing.assert_allclose(skel.joints["butt"], skel.joints["mp"])
+
+
+def test_fallback_skeleton_top_case_insensitive():
+    a = fallback_skeleton("top_of_thing")
+    b = fallback_skeleton("Top")
+    # both branch into TOB builder
+    assert a.name == "TopofBackswing"
+    assert b.name == "TopofBackswing"
+
+
+# --------------------------------------------------------------------------- #
+# load_skeleton                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_load_skeleton_missing_file_falls_back(tmp_path: Path):
+    skel = load_skeleton(tmp_path / "nope.json", fallback_pose="Impact")
+    # FK-derived fallback returns a skeleton named "Impact".
+    assert "hip" in skel.joints
+
+
+def test_load_skeleton_reads_json_file(tmp_path: Path):
+    blob = {
+        "pose": "MyPose",
+        "joints": {
+            "hip": [0.0, 0.0, 0.0],
+            "ch": [0.5, 0.0, 1.0],
+        },
+        "segments": [["hip", "ch"]],
+    }
+    path = tmp_path / "simscape_skeleton_MyPose.json"
+    path.write_text(json.dumps(blob))
+    skel = load_skeleton(path)
+    assert skel.name == "MyPose"
+    assert "hip" in skel.joints
+    np.testing.assert_allclose(skel.joints["ch"], [0.5, 0.0, 1.0])
+    assert skel.segments == [("hip", "ch")]
+
+
+def test_load_skeleton_missing_segments_uses_fallback_segments(tmp_path: Path):
+    blob = {"pose": "X", "joints": {"hip": [0.0, 0.0, 0.0]}}
+    path = tmp_path / "skel.json"
+    path.write_text(json.dumps(blob))
+    skel = load_skeleton(path)
+    assert skel.segments == FALLBACK_SEGMENTS
+
+
+def test_load_skeleton_drops_malformed_segment_entries(tmp_path: Path):
+    blob = {
+        "pose": "X",
+        "joints": {"hip": [0.0, 0.0, 0.0]},
+        "segments": [["hip", "ch"], "not-a-list", ["only-one"]],
+    }
+    path = tmp_path / "skel.json"
+    path.write_text(json.dumps(blob))
+    skel = load_skeleton(path)
+    assert skel.segments == [("hip", "ch")]
+
+
+# --------------------------------------------------------------------------- #
+# CSV column resolution                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_xyz_columns_for_short_form():
+    cols = ["club_head_X", "club_head_Y", "club_head_Z", "other"]
+    assert _xyz_columns_for(cols, "club_head_X") == [
+        "club_head_X",
+        "club_head_Y",
+        "club_head_Z",
+    ]
+
+
+def test_xyz_columns_for_lower_short():
+    cols = ["club_head_x", "club_head_y", "club_head_z"]
+    assert _xyz_columns_for(cols, "club_head_x") == [
+        "club_head_x",
+        "club_head_y",
+        "club_head_z",
+    ]
+
+
+def test_xyz_columns_for_long_form():
+    cols = [
+        "ClubLogs_CHGlobalPosition_1",
+        "ClubLogs_CHGlobalPosition_2",
+        "ClubLogs_CHGlobalPosition_3",
+    ]
+    assert _xyz_columns_for(cols, "ClubLogs_CHGlobalPosition_1") == cols
+
+
+def test_xyz_columns_for_dim_long_form():
+    cols = [
+        "HipLogs_HipGlobalPosition_dim1",
+        "HipLogs_HipGlobalPosition_dim2",
+        "HipLogs_HipGlobalPosition_dim3",
+    ]
+    assert _xyz_columns_for(cols, "HipLogs_HipGlobalPosition_dim1") == cols
+
+
+def test_xyz_columns_for_unknown_pattern_returns_none():
+    assert _xyz_columns_for(["a", "b"], "nope") is None
+
+
+def test_xyz_columns_for_missing_y_returns_none():
+    assert _xyz_columns_for(["club_X", "club_Z"], "club_X") is None
+
+
+# --------------------------------------------------------------------------- #
+# load_simscape_trajectory_csv                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _write_short_form_csv(path: Path, n: int = 4) -> None:
+    t = np.linspace(0.0, 0.3, n)
+    df = pd.DataFrame(
+        {
+            "time": t,
+            "left_hand_X": np.linspace(0.0, 0.1, n),
+            "left_hand_Y": np.zeros(n),
+            "left_hand_Z": np.zeros(n),
+            "right_hand_X": np.linspace(0.0, -0.1, n),
+            "right_hand_Y": np.zeros(n),
+            "right_hand_Z": np.zeros(n),
+            "club_head_X": np.linspace(0.0, 0.5, n),
+            "club_head_Y": np.zeros(n),
+            "club_head_Z": np.linspace(0.0, 0.2, n),
+            "spine_X": np.zeros(n),
+            "spine_Y": np.zeros(n),
+            "spine_Z": np.full(n, 0.4),
+            "hub_X": np.zeros(n),
+            "hub_Y": np.zeros(n),
+            "hub_Z": np.full(n, 0.6),
+            "hip_X": np.zeros(n),
+            "hip_Y": np.zeros(n),
+            "hip_Z": np.zeros(n),
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+def test_load_simscape_trajectory_csv_short_form(tmp_path: Path):
+    p = tmp_path / "traj.csv"
+    _write_short_form_csv(p, n=5)
+    traj = load_simscape_trajectory_csv(p)
+    assert len(traj) == 5
+    assert traj.source_path == str(p)
+    # mp synthesised from lw + rw
+    assert "mp" in traj.frames[0].joints
+    np.testing.assert_allclose(traj.frames[0].joints["mp"], [0.0, 0.0, 0.0])
+    # torso synthesised from spine + hub
+    assert "torso" in traj.frames[0].joints
+    expected_torso_z = 0.4 + 0.2 * (0.6 - 0.4)
+    np.testing.assert_allclose(traj.frames[0].joints["torso"][2], expected_torso_z)
+
+
+def test_load_simscape_trajectory_csv_long_form(tmp_path: Path):
+    n = 3
+    df = pd.DataFrame(
+        {
+            "time": np.linspace(0.0, 0.2, n),
+            "ClubLogs_CHGlobalPosition_1": np.zeros(n),
+            "ClubLogs_CHGlobalPosition_2": np.zeros(n),
+            "ClubLogs_CHGlobalPosition_3": np.zeros(n),
+            "LWLogs_LHGlobalPosition_1": np.zeros(n),
+            "LWLogs_LHGlobalPosition_2": np.zeros(n),
+            "LWLogs_LHGlobalPosition_3": np.zeros(n),
+            "RWLogs_RHGlobalPosition_1": np.zeros(n),
+            "RWLogs_RHGlobalPosition_2": np.zeros(n),
+            "RWLogs_RHGlobalPosition_3": np.zeros(n),
+        }
+    )
+    p = tmp_path / "traj.csv"
+    df.to_csv(p, index=False)
+    traj = load_simscape_trajectory_csv(p)
+    assert len(traj) == n
+    assert "ch" in traj.frames[0].joints
+
+
+def test_load_simscape_trajectory_csv_no_time_column_raises(tmp_path: Path):
+    p = tmp_path / "bad.csv"
+    pd.DataFrame({"foo": [1, 2]}).to_csv(p, index=False)
+    with pytest.raises(ValueError, match="time"):
+        load_simscape_trajectory_csv(p)
+
+
+def test_load_simscape_trajectory_csv_no_joints_raises(tmp_path: Path):
+    p = tmp_path / "bad.csv"
+    pd.DataFrame({"time": [0.0, 0.1], "irrelevant": [1, 2]}).to_csv(p, index=False)
+    with pytest.raises(ValueError, match="recognised joint columns"):
+        load_simscape_trajectory_csv(p)
+
+
+def test_load_simscape_trajectory_csv_drops_non_finite_rows(tmp_path: Path):
+    p = tmp_path / "traj.csv"
+    df = pd.DataFrame(
+        {
+            "time": [0.0, 0.1],
+            "club_head_X": [0.0, np.nan],
+            "club_head_Y": [0.0, 0.0],
+            "club_head_Z": [0.0, 0.0],
+        }
+    )
+    df.to_csv(p, index=False)
+    traj = load_simscape_trajectory_csv(p)
+    assert "ch" in traj.frames[0].joints
+    assert "ch" not in traj.frames[1].joints  # NaN row excluded
+
+
+# --------------------------------------------------------------------------- #
+# solve_shaft_rz_deg                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_solve_shaft_rz_zero_rotation():
+    mp = np.zeros(3)
+    ch = np.array([1.0, 0.0, 0.5])
+    rz = solve_shaft_rz_deg(mp, ch, mp, ch)
+    assert abs(rz) < 1e-9
+
+
+def test_solve_shaft_rz_90_degrees():
+    mp = np.zeros(3)
+    ch_target = np.array([0.0, 1.0, 0.0])
+    ch_skel = np.array([1.0, 0.0, 0.0])
+    rz = solve_shaft_rz_deg(mp, ch_target, mp, ch_skel)
+    assert abs(rz - 90.0) < 1e-9
+
+
+def test_solve_shaft_rz_zero_magnitude_target_returns_zero():
+    mp = np.zeros(3)
+    ch = np.array([0.0, 0.0, 1.0])  # all magnitude on Z, projected XY is zero
+    rz = solve_shaft_rz_deg(mp, ch, mp, np.array([1.0, 0.0, 0.0]))
+    assert rz == 0.0
+
+
+def test_solve_shaft_rz_zero_magnitude_skel_returns_zero():
+    mp = np.zeros(3)
+    rz = solve_shaft_rz_deg(mp, np.array([1.0, 0.0, 0.0]), mp, mp)
+    assert rz == 0.0
+
+
+def test_solve_shaft_rz_wraps_to_signed_range():
+    mp = np.zeros(3)
+    rz = solve_shaft_rz_deg(
+        np.zeros(3),
+        np.array([-1.0, 0.0, 0.0]),
+        np.zeros(3),
+        np.array([1.0, 0.0, 0.0]),
+    )
+    # 180 or -180 are both valid (wrapped to (-180, 180]).
+    assert abs(abs(rz) - 180.0) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Multi-source dispatch helpers                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _make_multi_target(*, club=None, body=None, ball=None, time=None):
+    """Build a duck-typed MultiSourceTarget for unit tests."""
+    obj = SimpleNamespace()
+    obj.club = club
+    obj.body = body
+    obj.ball = ball
+    obj.has_club = lambda: club is not None
+    obj.has_body = lambda: body is not None
+    obj.is_club_ball = lambda: ball is not None
+    obj.shared_time = lambda: (time if time is not None else np.array([]))
+    return obj
+
+
+def test_dispatch_cost_inputs_with_only_body():
+    body = SimpleNamespace(time=np.array([0.0, 0.1]))
+    target = _make_multi_target(body=body, time=np.array([0.0, 0.1]))
+    out = dispatch_cost_inputs(target)
+    assert "time" in out
+    assert "club" not in out
+    assert out["body"] is body
+
+
+def _make_clubtarget(n: int):
+    from src.shared.python.motion_matching.target import ClubTarget, SourceProvenance
+
+    src = SourceProvenance(
+        filename="x", format="xlsx", subject_id="s", trial_id="t", sha256="0" * 64
+    )
+    return ClubTarget(
+        time=np.linspace(0.0, 0.3, n),
+        butt=np.zeros((n, 3)),
+        clubhead=np.ones((n, 3)),
+        club_quat=np.tile([1.0, 0.0, 0.0, 0.0], (n, 1)),
+        impact_idx=min(n - 1, 2),
+        source=src,
+    )
+
+
+def test_dispatch_cost_inputs_with_club_and_ball_flags():
+    club = _make_clubtarget(4)
+    target = _make_multi_target(club=club, ball=object(), time=club.time)
+    out = dispatch_cost_inputs(target)
+    assert "club" in out
+    assert out["has_ball"] is True
+
+
+def test_clubtarget_from_multi_no_club_returns_none():
+    target = _make_multi_target(time=np.array([0.0, 0.1]))
+    assert clubtarget_from_multi(target) is None
+
+
+def test_clubtarget_from_multi_returns_inner_clubtarget():
+    club = _make_clubtarget(3)
+    # Wrap the ClubTarget so .club exposes the inner one.
+    wrapper = SimpleNamespace(club=club, time=club.time)
+    target = _make_multi_target(club=wrapper, time=club.time)
+    assert clubtarget_from_multi(target) is club
+
+
+def test_clubtarget_from_multi_returns_clubtarget_directly():
+    club = _make_clubtarget(3)
+    target = _make_multi_target(club=club, time=club.time)
+    assert clubtarget_from_multi(target) is club

--- a/tests/unit/tools/starting_pose_matcher/test_core_xlsx_adapters.py
+++ b/tests/unit/tools/starting_pose_matcher/test_core_xlsx_adapters.py
@@ -1,0 +1,132 @@
+"""Cover ``core.py`` xlsx loaders + adapters.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.tools.starting_pose_matcher import core
+from src.tools.starting_pose_matcher.core import (
+    MocapEvents,
+    _clubtarget_to_dataframe,
+    _safe,
+    load_mocap_xlsx,
+    read_event_header,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _build_clubtarget(n: int = 8, *, scale: float = 1.0):
+    """Build a synthetic ClubTarget for the dataframe adapter.
+
+    Uses ``scale`` to push the shaft length above 1.4 (which triggers
+    the cm/inches re-scaling branch) or below it.
+    """
+    from src.shared.python.motion_matching.target import ClubTarget, SourceProvenance
+
+    src = SourceProvenance(
+        filename="x", format="xlsx", subject_id="s", trial_id="t", sha256="0" * 64
+    )
+    return ClubTarget(
+        time=np.linspace(0.0, 0.3, n),
+        butt=np.zeros((n, 3)),
+        clubhead=np.tile([scale, 0.0, 0.0], (n, 1)),
+        club_quat=np.tile([1.0, 0.0, 0.0, 0.0], (n, 1)),
+        impact_idx=min(n - 1, n // 2),
+        source=src,
+    )
+
+
+def test_clubtarget_to_dataframe_columns_present():
+    df = _clubtarget_to_dataframe(_build_clubtarget(n=4))
+    for col in (
+        "time",
+        "mid_X",
+        "mid_Y",
+        "mid_Z",
+        "club_X",
+        "club_Y",
+        "club_Z",
+        "club_Xx",
+        "club_Yy",
+        "club_Zz",
+    ):
+        assert col in df.columns
+
+
+def test_clubtarget_to_dataframe_rotation_identity():
+    df = _clubtarget_to_dataframe(_build_clubtarget(n=3))
+    # Identity quaternion -> identity rotation.
+    np.testing.assert_allclose(
+        df[["club_Xx", "club_Yy", "club_Zz"]].iloc[0].to_numpy(), [1.0, 1.0, 1.0]
+    )
+
+
+def test_clubtarget_to_dataframe_scaling_branch():
+    """When the median shaft length is > 1.4 m the adapter re-scales by
+    ``CM_TO_M / inches_factor``."""
+    target = _build_clubtarget(n=4, scale=2.0)  # shaft length 2.0 m > 1.4
+    df = _clubtarget_to_dataframe(target)
+    # After re-scaling, club_X is much smaller than the raw 2.0.
+    assert abs(float(df["club_X"].iloc[0])) < 1.0
+
+
+def test_clubtarget_to_dataframe_no_scaling_when_short():
+    target = _build_clubtarget(n=4, scale=0.9)  # shaft 0.9 m < 1.4
+    df = _clubtarget_to_dataframe(target)
+    # No rescaling — value is preserved.
+    assert float(df["club_X"].iloc[0]) == pytest.approx(0.9)
+
+
+def test_safe_handles_index_and_keyerror():
+    s = pd.Series([1.0, 2.0, 3.0])
+    assert _safe(s, 0) == 1.0
+    # Out-of-range -> default.
+    assert _safe(s, 99, default=-1.0) == -1.0
+
+
+def test_safe_handles_nan_and_returns_default():
+    s = pd.Series([np.nan, 1.0])
+    assert _safe(s, 0, default=42.0) == 42.0
+
+
+def test_safe_handles_non_numeric_and_returns_default():
+    s = pd.Series(["abc", 2.0])
+    assert _safe(s, 0, default=7.0) == 7.0
+
+
+def test_safe_returns_float():
+    s = pd.Series([2])
+    out = _safe(s, 0)
+    assert isinstance(out, float)
+
+
+def test_load_mocap_xlsx_delegates_to_clubtarget_loader():
+    """Patch the canonical loader so we don't need a real xlsx file."""
+    target = _build_clubtarget(n=5, scale=0.5)
+    with patch.object(core, "load_club_target", return_value=target) as mock_loader:
+        df = load_mocap_xlsx("/fake/path.xlsx", "Sheet1")
+    mock_loader.assert_called_once()
+    assert "time" in df.columns
+    assert len(df) == 5
+
+
+def test_read_event_header_passes_through():
+    """Patch the shared loader and verify the header values land."""
+    fake = SimpleNamespace(
+        A_sample=1.0, T_sample=10.0, I_sample=20.0, F_sample=30.0, CHS_mph=85.0
+    )
+    with patch.object(core, "read_excel_event_markers", return_value=fake):
+        ev = read_event_header("/fake/path.xlsx", "Sheet1")
+    assert isinstance(ev, MocapEvents)
+    assert ev.A_sample == 1.0
+    assert ev.CHS_mph == 85.0

--- a/tests/unit/tools/starting_pose_matcher/test_data_sources_panel.py
+++ b/tests/unit/tools/starting_pose_matcher/test_data_sources_panel.py
@@ -1,0 +1,270 @@
+"""Coverage tests for ``starting_pose_matcher.gui_source_panel``.
+
+Avoids ``pytest.importorskip("PyQt6.QtWidgets", ...)`` which crashes the
+Windows / Python 3.14 PyQt6 build at pytest collection time
+(``Windows fatal exception 0xc0000139`` on re-import). Instead we
+import PyQt6 directly inside a try/except and skip the module if the
+import fails for any reason.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Headless GUI BEFORE any Qt import.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+# pytest-qt loads PySide6 at startup on this Windows / Python 3.14 install,
+# which prevents subsequent PyQt6 DLL loading. When we detect the conflict
+# we skip cleanly. CI Linux uses PyQt6 only and runs every test below.
+if "PySide6" in sys.modules:
+    pytest.skip(
+        "PySide6 already loaded — PyQt6 DLLs unavailable", allow_module_level=True
+    )
+
+try:
+    from PyQt6.QtWidgets import QApplication  # noqa: F401  (used in fixture)
+
+    _HAVE_QT = True
+except Exception:  # noqa: BLE001 — DLL load can raise OSError or worse
+    _HAVE_QT = False
+
+if not _HAVE_QT:  # pragma: no cover - environment-dependent
+    pytest.skip("PyQt6.QtWidgets unavailable", allow_module_level=True)
+
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from src.tools.starting_pose_matcher.gui_source_panel import (  # noqa: E402
+    BODY_FILE_FILTER,
+    CLUB_FILE_FILTER,
+    DataSourcesPanel,
+    _try_clamp_signed_int,
+    shared_timegrid_ok,
+)
+from src.tools.starting_pose_matcher.session_schema import (  # noqa: E402
+    DEFAULT_BODY_MARKER_SET,
+    AlignOptionsBlock,
+    BodySourceBlock,
+    ClubSourceBlock,
+    DataSourcesBlock,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no Qt instance needed)                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_clamp_signed_int_in_bounds():
+    assert _try_clamp_signed_int(5, 0, 10) == 5
+
+
+def test_clamp_signed_int_below_lower():
+    assert _try_clamp_signed_int(-3, 0, 10) == 0
+
+
+def test_clamp_signed_int_above_upper():
+    assert _try_clamp_signed_int(99, 0, 10) == 10
+
+
+def test_shared_timegrid_ok_equal_arrays():
+    from types import SimpleNamespace
+
+    a = SimpleNamespace(time=np.array([0.0, 0.1, 0.2]))
+    b = SimpleNamespace(time=np.array([0.0, 0.1, 0.2]))
+    assert shared_timegrid_ok(a, b) is True
+
+
+def test_shared_timegrid_ok_unequal_arrays():
+    from types import SimpleNamespace
+
+    a = SimpleNamespace(time=np.array([0.0, 0.1, 0.2]))
+    b = SimpleNamespace(time=np.array([0.0, 0.1, 0.3]))
+    assert shared_timegrid_ok(a, b) is False
+
+
+def test_shared_timegrid_ok_different_shapes():
+    from types import SimpleNamespace
+
+    a = SimpleNamespace(time=np.array([0.0, 0.1]))
+    b = SimpleNamespace(time=np.array([0.0, 0.1, 0.2]))
+    assert shared_timegrid_ok(a, b) is False
+
+
+def test_shared_timegrid_ok_none_inputs():
+    assert shared_timegrid_ok(None, None) is False
+    from types import SimpleNamespace
+
+    a = SimpleNamespace(time=None)
+    b = SimpleNamespace(time=np.zeros(3))
+    assert shared_timegrid_ok(a, b) is False
+
+
+def test_filters_are_generic():
+    for token in ("Wiffle", "ProV1", "TW_", "GW_"):
+        assert token not in CLUB_FILE_FILTER
+        assert token not in BODY_FILE_FILTER
+    assert ".xlsx" in CLUB_FILE_FILTER
+    assert ".c3d" in BODY_FILE_FILTER
+
+
+# --------------------------------------------------------------------------- #
+# Panel construction + state round-trips (Qt-light)                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_panel_builds_with_default_state(qapp):
+    panel = DataSourcesPanel()
+    assert panel.title() == "Data sources"
+    # Default state.
+    assert panel.cb_club.isChecked() is False
+    assert panel.cb_body.isChecked() is False
+    assert panel.rb_club_only.isChecked() is True
+    assert panel.rb_align_impact.isChecked() is True
+    assert panel.combo_marker_set.currentText() == DEFAULT_BODY_MARKER_SET
+
+
+def test_panel_widgets_have_object_names(qapp):
+    panel = DataSourcesPanel()
+    for name in (
+        "cb_club",
+        "cb_body",
+        "btn_club_browse",
+        "btn_body_browse",
+        "rb_club_only",
+        "rb_club_ball",
+        "lbl_club_path",
+        "lbl_body_path",
+        "combo_marker_set",
+        "rb_align_impact",
+        "rb_align_address",
+        "spin_sample_rate",
+        "spin_duration",
+    ):
+        assert panel.findChild(object, name) is not None, f"missing widget: {name}"
+
+
+def test_align_options_returns_live_values(qapp):
+    panel = DataSourcesPanel()
+    panel.spin_sample_rate.setValue(1500)
+    panel.spin_duration.setValue(0.500)
+    panel.rb_align_address.setChecked(True)
+    opts = panel.align_options()
+    assert opts.sample_rate_hz == pytest.approx(1500.0)
+    assert opts.simulation_time_s == pytest.approx(0.5)
+    assert opts.time_alignment == "address"
+
+
+def test_snapshot_round_trip(qapp):
+    panel = DataSourcesPanel()
+    panel.cb_club.setChecked(True)
+    panel.rb_club_ball.setChecked(True)
+    panel.cb_body.setChecked(True)
+    panel.combo_marker_set.setCurrentText("All markers")
+    panel.spin_sample_rate.setValue(800)
+    panel.spin_duration.setValue(0.250)
+    block = panel.snapshot()
+    assert block.club.enabled is True
+    assert block.club.include_ball is True
+    assert block.body.enabled is True
+    assert block.body.marker_set == "All markers"
+    assert block.align.sample_rate_hz == pytest.approx(800.0)
+    assert block.align.time_alignment == "impact"
+
+
+def test_restore_with_none_uses_default(qapp):
+    panel = DataSourcesPanel()
+    panel.cb_club.setChecked(True)
+    panel.restore(None)
+    assert panel.cb_club.isChecked() is False
+    assert panel.combo_marker_set.currentText() == DEFAULT_BODY_MARKER_SET
+
+
+def test_restore_full_block(qapp):
+    panel = DataSourcesPanel()
+    block = DataSourcesBlock(
+        club=ClubSourceBlock(
+            enabled=True, file_path="/tmp/foo.xlsx", include_ball=True
+        ),
+        body=BodySourceBlock(
+            enabled=True, file_path="/tmp/body.c3d", marker_set="Lower body only"
+        ),
+        align=AlignOptionsBlock(
+            sample_rate_hz=2000.0, simulation_time_s=0.45, time_alignment="address"
+        ),
+    )
+    panel.restore(block)
+    assert panel.cb_club.isChecked() is True
+    assert panel.rb_club_ball.isChecked() is True
+    assert panel.cb_body.isChecked() is True
+    assert panel.combo_marker_set.currentText() == "Lower body only"
+    assert panel.spin_sample_rate.value() == 2000
+    assert panel.spin_duration.value() == pytest.approx(0.45)
+    assert panel.rb_align_address.isChecked() is True
+    # snapshot round-trips back.
+    block2 = panel.snapshot()
+    assert block2 == block
+
+
+def test_restore_unknown_marker_set_keeps_combo_intact(qapp):
+    panel = DataSourcesPanel()
+    block = DataSourcesBlock(body=BodySourceBlock(marker_set="not-a-real-set"))
+    panel.restore(block)
+    # Combo wasn't changed (findText returned -1).
+    assert panel.combo_marker_set.currentText() == DEFAULT_BODY_MARKER_SET
+
+
+def test_restore_no_file_paths_shows_placeholder(qapp):
+    panel = DataSourcesPanel()
+    panel.restore(DataSourcesBlock())
+    assert panel.lbl_club_path.text() == "(no file)"
+    assert panel.lbl_body_path.text() == "(no file)"
+
+
+def test_emit_targets_with_no_slots_emits_none(qapp):
+    panel = DataSourcesPanel()
+    received: list = []
+    panel.targets_changed.connect(received.append)
+    # Toggling a checkbox with nothing loaded -> emits None.
+    panel.cb_club.setChecked(True)
+    panel.cb_club.setChecked(False)
+    assert received[-1] is None
+
+
+def test_current_targets_initially_none(qapp):
+    panel = DataSourcesPanel()
+    assert panel.current_targets() is None
+
+
+def test_force_set_body_target_without_club(qapp):
+    panel = DataSourcesPanel()
+    received: list = []
+    panel.targets_changed.connect(received.append)
+    from types import SimpleNamespace
+
+    body = SimpleNamespace(
+        time=np.array([0.0, 0.1, 0.2]), marker_xyz=np.zeros((3, 1, 3))
+    )
+    panel._force_set_body_target(body, "/tmp/body.c3d")
+    # body-only is allowed by MultiSourceTarget; latest target should be set.
+    # Even if it isn't (e.g. validator rejects), no crash.
+    assert panel.lbl_body_path.text() == "body.c3d"

--- a/tests/unit/tools/starting_pose_matcher/test_live_view_controller.py
+++ b/tests/unit/tools/starting_pose_matcher/test_live_view_controller.py
@@ -1,0 +1,284 @@
+"""Coverage tests for ``starting_pose_matcher.live_view_controller``.
+
+Edge cases: NaN markers, club-only, ball-only, body-only, layer toggling.
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+# Headless GUI/drawing stack BEFORE matplotlib is imported.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from src.tools.starting_pose_matcher.live_view_controller import (
+    LiveViewController,
+    _default_body_segments_safe,
+    _finite_rows,
+    _maybe_xyz,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def axes_canvas():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    yield ax, fig.canvas
+    plt.close(fig)
+
+
+def _body(n_frames=8, n_markers=4, names=None, marker_xyz=None):
+    if marker_xyz is None:
+        marker_xyz = np.linspace(0.0, 1.0, n_frames * n_markers * 3).reshape(
+            n_frames, n_markers, 3
+        )
+    if names is None:
+        names = tuple(f"m{i}" for i in range(marker_xyz.shape[1]))
+    return SimpleNamespace(marker_xyz=marker_xyz, marker_names=names)
+
+
+def _club(n=8):
+    return SimpleNamespace(
+        mid_hands=np.linspace(0.0, 1.0, n * 3).reshape(n, 3),
+        clubhead=np.linspace(0.5, 1.5, n * 3).reshape(n, 3),
+        clubface_triad=np.broadcast_to(np.eye(3), (n, 3, 3)).copy(),
+    )
+
+
+def _ball(pos=(0.0, 0.0, 0.0)):
+    return SimpleNamespace(position=np.array(pos, dtype=float))
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_maybe_xyz_returns_first_present():
+    obj = SimpleNamespace(a=None, b=np.array([[1.0, 2.0, 3.0]]))
+    out = _maybe_xyz(obj, ("a", "b"))
+    np.testing.assert_array_equal(out, [[1.0, 2.0, 3.0]])
+
+
+def test_maybe_xyz_returns_none_when_all_missing():
+    obj = SimpleNamespace()
+    assert _maybe_xyz(obj, ("a", "b")) is None
+
+
+def test_maybe_xyz_skips_empty_arrays():
+    obj = SimpleNamespace(a=np.array([]), b=np.array([[0.0, 0.0, 0.0]]))
+    out = _maybe_xyz(obj, ("a", "b"))
+    np.testing.assert_array_equal(out, [[0.0, 0.0, 0.0]])
+
+
+def test_finite_rows_filters_nans():
+    arr = np.array([[1.0, 2.0, 3.0], [np.nan, 0.0, 0.0], [4.0, 5.0, 6.0]])
+    out = _finite_rows(arr)
+    assert out.shape == (2, 3)
+
+
+def test_finite_rows_all_nan_returns_empty():
+    arr = np.full((3, 3), np.nan)
+    out = _finite_rows(arr)
+    assert out.shape == (0, 3)
+
+
+def test_finite_rows_wrong_shape_reshapes():
+    arr = np.zeros(6)  # shape (6,)
+    out = _finite_rows(arr)
+    assert out.shape == (2, 3)
+
+
+def test_default_body_segments_safe_returns_pairs():
+    # Use names unlikely to be in the shared body segment table — falls
+    # back to the consecutive-pairs heuristic.
+    pairs = _default_body_segments_safe(("p0", "p1", "p2"))
+    assert isinstance(pairs, list)
+    assert pairs  # not empty
+    # All entries are 2-tuples of ints.
+    for pair in pairs:
+        assert len(pair) == 2
+        assert all(isinstance(p, int) for p in pair)
+
+
+# --------------------------------------------------------------------------- #
+# Controller behaviour                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_controller_initial_state(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    assert ctrl.n_frames == 0
+    assert ctrl.current_frame == 0
+    assert ctrl.layers() == {}
+    assert ctrl.has_layer("body_markers") is False
+
+
+def test_controller_set_target_body_only(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    body = _body(n_frames=10, n_markers=5)
+    ctrl.set_target(body=body)
+    assert ctrl.n_frames == 10
+    assert ctrl.has_layer("body_markers")
+    assert ctrl.has_layer("body_skeleton")
+    assert ctrl.has_layer("body_trail")
+    assert not ctrl.has_layer("clubface_trace")
+    assert not ctrl.has_layer("ball_impact")
+
+
+def test_controller_set_target_club_only(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    club = _club(n=6)
+    ctrl.set_target(club=club)
+    assert ctrl.n_frames == 6
+    assert ctrl.has_layer("club_midhands_trace")
+    assert ctrl.has_layer("clubface_trace")
+    assert ctrl.has_layer("clubface_triad")
+    assert not ctrl.has_layer("body_markers")
+
+
+def test_controller_set_target_ball_only(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ball = _ball((0.1, 0.2, 0.3))
+    ctrl.set_target(ball=ball)
+    assert ctrl.has_layer("ball_impact")
+    assert ctrl.n_frames == 0  # ball alone doesn't drive frames
+
+
+def test_controller_set_target_ball_with_bad_shape_skipped(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    bad = SimpleNamespace(position=np.array([1.0, 2.0]))  # not (3,)
+    ctrl.set_target(ball=bad)
+    assert not ctrl.has_layer("ball_impact")
+
+
+def test_controller_set_target_ball_position_none_skipped(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(ball=SimpleNamespace(position=None))
+    assert not ctrl.has_layer("ball_impact")
+
+
+def test_controller_set_target_full_combo(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=6), club=_club(n=10), ball=_ball())
+    # Maximum frame count from the slots.
+    assert ctrl.n_frames == 10
+    assert ctrl.has_layer("body_markers")
+    assert ctrl.has_layer("clubface_triad")
+    assert ctrl.has_layer("ball_impact")
+
+
+def test_controller_body_shape_validation(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    bad = SimpleNamespace(marker_xyz=np.zeros((3, 3)), marker_names=("a", "b", "c"))
+    with pytest.raises(ValueError, match="must have shape"):
+        ctrl.set_target(body=bad)
+
+
+def test_controller_body_with_nan_markers_no_fit_crash(axes_canvas):
+    """Body with all-NaN markers must not crash auto-fit (covers the
+    'finite.any() is False' branch)."""
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    marker_xyz = np.full((4, 3, 3), np.nan)
+    body = SimpleNamespace(marker_xyz=marker_xyz, marker_names=("a", "b", "c"))
+    ctrl.set_target(body=body)
+    assert ctrl.n_frames == 4
+
+
+def test_controller_set_frame_clamps(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=5))
+    ctrl.set_frame(2)
+    assert ctrl.current_frame == 2
+    ctrl.set_frame(99)
+    assert ctrl.current_frame == 4
+    ctrl.set_frame(-1)
+    assert ctrl.current_frame == 0
+
+
+def test_controller_set_frame_with_no_target_is_noop(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_frame(5)
+    assert ctrl.current_frame == 0
+
+
+def test_controller_clear_drops_layers(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=4))
+    assert ctrl.layers()
+    ctrl.clear()
+    assert ctrl.layers() == {}
+    assert ctrl.n_frames == 0
+    assert ctrl.current_frame == 0
+
+
+def test_controller_set_layer_visible_body_markers_also_toggles_trail(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=4))
+    ctrl.set_layer_visible("body_markers", False)
+    # Both body_markers and body_trail should now be invisible (we only
+    # assert no exception was raised; gui_playback layers handle the
+    # visibility internally).
+    assert ctrl.has_layer("body_markers")
+
+
+def test_controller_set_layer_visible_unknown_key_is_noop(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=4))
+    # Should not raise.
+    ctrl.set_layer_visible("does_not_exist", False)
+
+
+def test_controller_set_target_replaces_old_layers(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    ctrl.set_target(body=_body(n_frames=4))
+    keys_v1 = set(ctrl.layers().keys())
+    ctrl.set_target(club=_club(n=3))
+    keys_v2 = set(ctrl.layers().keys())
+    assert "body_markers" in keys_v1
+    assert "body_markers" not in keys_v2
+    assert "clubface_trace" in keys_v2
+
+
+def test_controller_club_without_triad(axes_canvas):
+    ax, canvas = axes_canvas
+    ctrl = LiveViewController(ax=ax, canvas=canvas)
+    club = SimpleNamespace(
+        mid_hands=np.zeros((3, 3)),
+        clubhead=np.ones((3, 3)),
+    )
+    ctrl.set_target(club=club)
+    assert ctrl.has_layer("clubface_trace")
+    assert not ctrl.has_layer("clubface_triad")

--- a/tests/unit/tools/starting_pose_matcher/test_observed_input_edge_cases.py
+++ b/tests/unit/tools/starting_pose_matcher/test_observed_input_edge_cases.py
@@ -1,0 +1,162 @@
+"""Edge-case coverage for OpenPose / MediaPipe providers.
+
+Targets the missing branches reported by ``coverage.py``:
+out-of-range frame index, hip-only-one-side, low-confidence variants.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tools.starting_pose_matcher.providers.mediapipe import (
+    MediaPipeProvider,
+    MediaPipeProviderError,
+)
+from src.tools.starting_pose_matcher.providers.openpose import (
+    OpenPoseProvider,
+    OpenPoseProviderError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# OpenPose                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _openpose_fixture(*, conf=0.9):
+    """18 keypoints * (x, y, conf) values.  Low conf to stress the
+    is_observed=False branches when desired."""
+    flat = []
+    for i in range(18):
+        flat.extend([float(100 + i), float(100 + i), conf])
+    return {"people": [{"pose_keypoints_2d": flat}]}
+
+
+def test_openpose_loads_from_file(tmp_path: Path):
+    import json
+
+    fix = _openpose_fixture()
+    p = tmp_path / "kp.json"
+    p.write_text(json.dumps(fix))
+    provider = OpenPoseProvider(json_path=str(p))
+    assert len(provider.frames) == 1
+
+
+def test_openpose_get_skeleton_out_of_range_raises():
+    provider = OpenPoseProvider(json_data=_openpose_fixture())
+    with pytest.raises(OpenPoseProviderError, match="out of range"):
+        provider.get_skeleton(frame_index=99)
+
+
+def test_openpose_confidence_map_out_of_range_raises():
+    provider = OpenPoseProvider(json_data=_openpose_fixture())
+    with pytest.raises(OpenPoseProviderError, match="out of range"):
+        provider.get_confidence_map(frame_index=99)
+
+
+def test_openpose_skips_person_with_no_keypoints():
+    fix = {
+        "people": [
+            {"pose_keypoints_2d": []},
+            {
+                "pose_keypoints_2d": _openpose_fixture()["people"][0][
+                    "pose_keypoints_2d"
+                ]
+            },
+        ]
+    }
+    provider = OpenPoseProvider(json_data=fix)
+    # Empty person was skipped; only the second is recorded.
+    assert len(provider.frames) == 1
+
+
+def test_openpose_only_left_hip_observed():
+    """Right-hip absent (low conf) -> left-hip alone is used as the hip."""
+    flat = []
+    for i in range(18):
+        # OpenPose index 8 = right_hip, 11 = left_hip
+        if i == 8:
+            flat.extend([0.0, 0.0, 0.0])  # right_hip is low conf
+        else:
+            flat.extend([float(100 + i), float(100 + i), 0.9])
+    fix = {"people": [{"pose_keypoints_2d": flat}]}
+    provider = OpenPoseProvider(json_data=fix)
+    skel = provider.get_skeleton()
+    assert "hip" in skel  # left-hip-only path
+
+
+def test_openpose_only_right_hip_observed():
+    """Left-hip absent -> right_hip falls through to the unprocessed-side
+    branch (skipped because we 'continue' when both not present)."""
+    flat = []
+    for i in range(18):
+        if i == 11:  # left_hip
+            flat.extend([0.0, 0.0, 0.0])
+        else:
+            flat.extend([float(100 + i), float(100 + i), 0.9])
+    fix = {"people": [{"pose_keypoints_2d": flat}]}
+    provider = OpenPoseProvider(json_data=fix)
+    skel = provider.get_skeleton()
+    # Right-hip falls through and assigns hip from itself.
+    assert "hip" in skel
+
+
+# --------------------------------------------------------------------------- #
+# MediaPipe                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class _MockLandmark:
+    def __init__(self, x=0.0, y=0.0, z=0.0, visibility=0.9, presence=0.9):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.visibility = visibility
+        self.presence = presence
+
+
+def test_mediapipe_get_skeleton_out_of_range_raises():
+    landmarks = [_MockLandmark() for _ in range(33)]
+    p = MediaPipeProvider(landmarks_data=[landmarks])
+    with pytest.raises(MediaPipeProviderError, match="out of range"):
+        p.get_skeleton(frame_index=99)
+
+
+def test_mediapipe_visibility_map_out_of_range_raises():
+    landmarks = [_MockLandmark() for _ in range(33)]
+    p = MediaPipeProvider(landmarks_data=[landmarks])
+    with pytest.raises(MediaPipeProviderError, match="out of range"):
+        p.get_visibility_map(frame_index=99)
+
+
+def test_mediapipe_only_left_hip_observed():
+    landmarks = [_MockLandmark() for _ in range(33)]
+    # Index 24 = right_hip
+    landmarks[24] = _MockLandmark(visibility=0.0, presence=0.0)
+    p = MediaPipeProvider(landmarks_data=[landmarks])
+    skel = p.get_skeleton()
+    assert "hip" in skel
+
+
+def test_mediapipe_only_right_hip_observed():
+    landmarks = [_MockLandmark() for _ in range(33)]
+    # Index 23 = left_hip
+    landmarks[23] = _MockLandmark(visibility=0.0, presence=0.0)
+    p = MediaPipeProvider(landmarks_data=[landmarks])
+    skel = p.get_skeleton()
+    assert "hip" in skel  # right-hip path
+
+
+def test_mediapipe_skipped_landmark_index_outside_table():
+    """Landmark indices above 32 don't appear in MEDIAPIPE_POSE_LANDMARKS;
+    the parser silently skips them."""
+    extras = [_MockLandmark() for _ in range(40)]  # 7 extras with no name
+    p = MediaPipeProvider(landmarks_data=[extras])
+    assert len(p.frames[0].landmarks) == 33  # only the named ones survive

--- a/tests/unit/tools/starting_pose_matcher/test_provider_error_paths.py
+++ b/tests/unit/tools/starting_pose_matcher/test_provider_error_paths.py
@@ -1,0 +1,190 @@
+"""Error / availability paths for physics-engine providers.
+
+Each provider's import fails to a clean ``*NotAvailableError`` when the
+engine wheel isn't installed; ``*ProviderError`` is raised on missing
+or invalid configuration. These tests do not need the real engine
+because the conftest replaces them with ``MagicMock``.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Drake                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_drake_constants_and_classes_importable():
+    from src.tools.starting_pose_matcher.providers import drake
+
+    assert hasattr(drake, "DRAKE_TO_MATCHER_VOCAB")
+    assert hasattr(drake, "MATCHER_TO_DRAKE")
+    assert "ch" in drake.MATCHER_TO_DRAKE
+    assert drake.MATCHER_TO_DRAKE["ch"] == "clubhead"
+
+
+def test_drake_provider_with_neither_raises_provider_error():
+    from src.tools.starting_pose_matcher.providers.drake import (
+        DrakeNotAvailableError,
+        DrakeProviderError,
+        DrakeSkeletonProvider,
+    )
+
+    # Either DrakeNotAvailableError (real Drake missing) or the
+    # DrakeProviderError (our explicit "neither path nor xml" message).
+    with pytest.raises((DrakeNotAvailableError, DrakeProviderError)):
+        DrakeSkeletonProvider(model_path=None, model_xml=None)
+
+
+def test_drake_create_provider_factory():
+    from src.tools.starting_pose_matcher.providers import drake
+
+    # The factory is a thin wrapper — ensure it forwards to the constructor.
+    with pytest.raises((drake.DrakeNotAvailableError, drake.DrakeProviderError)):
+        drake.create_provider(model_path=None, model_xml=None)
+
+
+# --------------------------------------------------------------------------- #
+# OpenSim                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_opensim_constants_and_classes_importable():
+    from src.tools.starting_pose_matcher.providers import opensim
+
+    assert hasattr(opensim, "OPENSIM_TO_MATCHER_VOCAB")
+    assert opensim.MATCHER_TO_OPENSIM["ls"] == "left_shoulder"
+
+
+def test_opensim_provider_with_neither_raises():
+    from src.tools.starting_pose_matcher.providers.opensim import (
+        OpenSimNotAvailableError,
+        OpenSimProviderError,
+        OpenSimSkeletonProvider,
+    )
+
+    with pytest.raises((OpenSimNotAvailableError, OpenSimProviderError)):
+        OpenSimSkeletonProvider(model_path=None, model_xml=None)
+
+
+def test_opensim_create_provider_factory():
+    from src.tools.starting_pose_matcher.providers import opensim
+
+    with pytest.raises(
+        (opensim.OpenSimNotAvailableError, opensim.OpenSimProviderError)
+    ):
+        opensim.create_provider(model_path=None, model_xml=None)
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_mujoco_constants_and_classes_importable():
+    from src.tools.starting_pose_matcher.providers import mujoco
+
+    assert hasattr(mujoco, "MUJOCO_TO_MATCHER_VOCAB")
+    # "hip" in matcher vocab maps to either "hip" or "pelvis" in MuJoCo —
+    # both are accepted by MUJOCO_TO_MATCHER_VOCAB.
+    assert mujoco.MATCHER_TO_MUJOCO["hip"] in ("hip", "pelvis")
+
+
+def test_mujoco_provider_with_neither_raises():
+    from src.tools.starting_pose_matcher.providers.mujoco import (
+        MuJoCoNotAvailableError,
+        MuJoCoProviderError,
+        MuJoCoSkeletonProvider,
+    )
+
+    with pytest.raises((MuJoCoNotAvailableError, MuJoCoProviderError)):
+        MuJoCoSkeletonProvider(model_path=None, model_xml=None)
+
+
+def test_mujoco_create_provider_factory():
+    from src.tools.starting_pose_matcher.providers import mujoco
+
+    with pytest.raises((mujoco.MuJoCoNotAvailableError, mujoco.MuJoCoProviderError)):
+        mujoco.create_provider(model_path=None, model_xml=None)
+
+
+# --------------------------------------------------------------------------- #
+# Pinocchio                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_pinocchio_constants_and_classes_importable():
+    from src.tools.starting_pose_matcher.providers import pinocchio
+
+    assert hasattr(pinocchio, "PINOCCHIO_TO_MATCHER_VOCAB")
+    assert pinocchio.MATCHER_TO_PINOCCHIO["mp"] == "midpoint"
+
+
+def test_pinocchio_provider_without_path_raises():
+    from src.tools.starting_pose_matcher.providers.pinocchio import (
+        PinocchioNotAvailableError,
+        PinocchioProviderError,
+        PinocchioSkeletonProvider,
+    )
+
+    with pytest.raises((PinocchioNotAvailableError, PinocchioProviderError)):
+        PinocchioSkeletonProvider(urdf_path=None)
+
+
+def test_pinocchio_create_provider_factory_with_no_path():
+    from src.tools.starting_pose_matcher.providers import pinocchio
+
+    with pytest.raises(
+        (pinocchio.PinocchioNotAvailableError, pinocchio.PinocchioProviderError)
+    ):
+        pinocchio.create_provider(urdf_path=None)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Vocabulary completeness — every required short name maps somewhere.        #
+# --------------------------------------------------------------------------- #
+
+
+REQUIRED_VOCAB = [
+    "hip",
+    "spine",
+    "torso",
+    "hub",
+    "ls",
+    "rs",
+    "le",
+    "re",
+    "lw",
+    "rw",
+    "mp",
+    "ch",
+]
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "src.tools.starting_pose_matcher.providers.drake",
+        "src.tools.starting_pose_matcher.providers.mujoco",
+        "src.tools.starting_pose_matcher.providers.opensim",
+        "src.tools.starting_pose_matcher.providers.pinocchio",
+    ],
+)
+def test_provider_vocabulary_is_complete(module_name: str):
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    matcher_to_engine = next(
+        getattr(mod, name) for name in dir(mod) if name.startswith("MATCHER_TO_")
+    )
+    for vocab in REQUIRED_VOCAB:
+        assert vocab in matcher_to_engine, (
+            f"{module_name}: missing vocabulary mapping for {vocab}"
+        )

--- a/tests/unit/tools/starting_pose_matcher/test_session_schema.py
+++ b/tests/unit/tools/starting_pose_matcher/test_session_schema.py
@@ -1,0 +1,215 @@
+"""Coverage tests for ``starting_pose_matcher.session_schema``.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools.starting_pose_matcher.session_schema import (
+    ALLOWED_SPEEDS,
+    DEFAULT_BODY_MARKER_SET,
+    DEFAULT_BODY_MARKER_SETS,
+    DEFAULT_TIME_ALIGNMENT,
+    DEFAULT_TRAIL_FRAMES,
+    SESSION_SCHEMA_VERSION,
+    AlignOptionsBlock,
+    BodySourceBlock,
+    ClubSourceBlock,
+    DataSourcesBlock,
+    PlaybackState,
+    default_data_sources,
+    parse_data_sources,
+    serialize_data_sources,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# PlaybackState                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_playback_state_defaults():
+    s = PlaybackState()
+    assert s.current_frame == 0
+    assert s.speed == 1.0
+    assert s.loop is True
+    assert s.trail_frames == DEFAULT_TRAIL_FRAMES
+
+
+@pytest.mark.parametrize(
+    "kwargs,err",
+    [
+        ({"current_frame": -1}, "current_frame must be >= 0"),
+        ({"speed": 0}, "speed must be > 0"),
+        ({"speed": -2.0}, "speed must be > 0"),
+        ({"trail_frames": -5}, "trail_frames must be >= 0"),
+    ],
+)
+def test_playback_state_validation_raises(kwargs, err):
+    with pytest.raises(ValueError, match=err):
+        PlaybackState(**kwargs)
+
+
+def test_playback_state_from_dict_none_returns_defaults():
+    s = PlaybackState.from_dict(None)
+    assert s == PlaybackState()
+    s = PlaybackState.from_dict({})
+    assert s == PlaybackState()
+
+
+def test_playback_state_from_dict_full():
+    s = PlaybackState.from_dict(
+        {"current_frame": 7, "speed": 2.0, "loop": False, "trail_frames": 12}
+    )
+    assert s.current_frame == 7
+    assert s.speed == 2.0
+    assert s.loop is False
+    assert s.trail_frames == 12
+
+
+def test_playback_state_from_dict_partial_uses_defaults():
+    s = PlaybackState.from_dict({"speed": 0.5})
+    assert s.speed == 0.5
+    assert s.current_frame == 0
+    assert s.loop is True
+
+
+def test_playback_state_from_dict_ignores_unknown_keys():
+    s = PlaybackState.from_dict({"speed": 0.25, "future_field": "ignored"})
+    assert s.speed == 0.25
+
+
+def test_playback_state_to_dict_round_trip():
+    s = PlaybackState(current_frame=3, speed=2.0, loop=False, trail_frames=10)
+    d = s.to_dict()
+    assert d == {
+        "current_frame": 3,
+        "speed": 2.0,
+        "loop": False,
+        "trail_frames": 10,
+    }
+    assert PlaybackState.from_dict(d) == s
+
+
+def test_playback_state_snap_speed_to_allowed_picks_closest():
+    s = PlaybackState(speed=0.31)
+    assert s.snap_speed_to_allowed() == 0.25
+    s = PlaybackState(speed=3.0)
+    # closest of 2.0 vs 4.0 — tie-broken to 2.0 (first in iteration with smallest diff)
+    snapped = s.snap_speed_to_allowed()
+    assert snapped in (2.0, 4.0)
+    s = PlaybackState(speed=1.0)
+    assert s.snap_speed_to_allowed() == 1.0
+
+
+def test_allowed_speeds_constants():
+    # API guarantee: tuple of positive multipliers including 1.0
+    assert 1.0 in ALLOWED_SPEEDS
+    assert all(v > 0 for v in ALLOWED_SPEEDS)
+
+
+# --------------------------------------------------------------------------- #
+# DataSourcesBlock                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_session_schema_version_at_least_4():
+    assert SESSION_SCHEMA_VERSION >= 4
+
+
+def test_default_body_marker_sets_includes_default():
+    assert DEFAULT_BODY_MARKER_SET in DEFAULT_BODY_MARKER_SETS
+
+
+def test_default_data_sources_returns_empty_block():
+    d = default_data_sources()
+    assert d == DataSourcesBlock()
+    assert d.club.enabled is False
+    assert d.body.enabled is False
+    assert d.align.time_alignment == DEFAULT_TIME_ALIGNMENT
+
+
+def test_serialize_data_sources_returns_dict():
+    block = DataSourcesBlock(
+        club=ClubSourceBlock(enabled=True, file_path="/tmp/x.xlsx", include_ball=True),
+        body=BodySourceBlock(
+            enabled=True, file_path="/tmp/y.c3d", marker_set="All markers"
+        ),
+        align=AlignOptionsBlock(
+            sample_rate_hz=500.0, simulation_time_s=0.4, time_alignment="address"
+        ),
+    )
+    blob = serialize_data_sources(block)
+    assert isinstance(blob, dict)
+    assert blob["club"]["enabled"] is True
+    assert blob["club"]["include_ball"] is True
+    assert blob["body"]["marker_set"] == "All markers"
+    assert blob["align"]["time_alignment"] == "address"
+
+
+def test_parse_data_sources_round_trip():
+    src = DataSourcesBlock(
+        club=ClubSourceBlock(enabled=True, file_path="/p", include_ball=False),
+        body=BodySourceBlock(
+            enabled=False, file_path=None, marker_set="Upper body only"
+        ),
+        align=AlignOptionsBlock(sample_rate_hz=2000.0, simulation_time_s=0.5),
+    )
+    assert parse_data_sources(serialize_data_sources(src)) == src
+
+
+def test_parse_data_sources_none_and_empty():
+    assert parse_data_sources(None) == default_data_sources()
+    assert parse_data_sources({}) == default_data_sources()
+
+
+def test_parse_data_sources_invalid_time_alignment_falls_back():
+    block = parse_data_sources({"align": {"time_alignment": "garbage"}})
+    assert block.align.time_alignment == DEFAULT_TIME_ALIGNMENT
+
+
+def test_parse_data_sources_none_time_alignment_falls_back():
+    block = parse_data_sources({"align": {"time_alignment": None}})
+    assert block.align.time_alignment == DEFAULT_TIME_ALIGNMENT
+
+
+def test_parse_data_sources_partial_blocks_use_defaults():
+    block = parse_data_sources({"club": {"enabled": True}})
+    assert block.club.enabled is True
+    assert block.club.file_path is None
+    assert block.body == BodySourceBlock()
+    assert block.align == AlignOptionsBlock()
+
+
+def test_parse_data_sources_string_coercion_for_file_path():
+    block = parse_data_sources({"body": {"file_path": 12345}})
+    # _coerce_str_or_none stringifies non-None
+    assert block.body.file_path == "12345"
+
+
+def test_parse_data_sources_none_subblocks_treated_as_empty():
+    block = parse_data_sources({"club": None, "body": None, "align": None})
+    assert block == default_data_sources()
+
+
+def test_parse_data_sources_unknown_keys_are_ignored():
+    block = parse_data_sources(
+        {
+            "club": {"enabled": True, "future_field": "ignored"},
+            "extra_top_level": 42,
+        }
+    )
+    assert block.club.enabled is True
+
+
+def test_dataclass_blocks_are_frozen_and_hashable():
+    a = ClubSourceBlock(enabled=True)
+    b = ClubSourceBlock(enabled=True)
+    assert a == b
+    # frozen=True implies hashable by default
+    assert hash(a) == hash(b)

--- a/tests/unit/tools/starting_pose_matcher/test_skeleton_provider.py
+++ b/tests/unit/tools/starting_pose_matcher/test_skeleton_provider.py
@@ -1,0 +1,80 @@
+"""Coverage tests for ``starting_pose_matcher.skeleton_provider``.
+
+Test-only; no production code changes (issue #4673).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.tools.starting_pose_matcher.core import Skeleton, fallback_skeleton
+from src.tools.starting_pose_matcher.skeleton_provider import (
+    JsonSkeletonProvider,
+    SkeletonProvider,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_skeleton_provider_is_abstract():
+    with pytest.raises(TypeError):
+        SkeletonProvider()  # type: ignore[abstract]
+
+
+def test_json_provider_default_poses(tmp_path: Path):
+    provider = JsonSkeletonProvider(json_dir=tmp_path)
+    assert provider.list_poses() == ["TopofBackswing", "Impact"]
+
+
+def test_json_provider_custom_poses(tmp_path: Path):
+    provider = JsonSkeletonProvider(json_dir=tmp_path, poses=("A", "B", "C"))
+    assert provider.list_poses() == ["A", "B", "C"]
+
+
+def test_json_provider_get_skeleton_loads_existing_json(tmp_path: Path):
+    blob = {
+        "pose": "Impact",
+        "joints": {"hip": [0.0, 0.0, 0.0]},
+        "segments": [],
+    }
+    (tmp_path / "simscape_skeleton_Impact.json").write_text(json.dumps(blob))
+    provider = JsonSkeletonProvider(json_dir=tmp_path)
+    skel = provider.get_skeleton("Impact")
+    assert isinstance(skel, Skeleton)
+    assert skel.name == "Impact"
+    assert "hip" in skel.joints
+
+
+def test_json_provider_get_skeleton_falls_back_when_file_missing(tmp_path: Path):
+    provider = JsonSkeletonProvider(json_dir=tmp_path)
+    skel = provider.get_skeleton("Impact")
+    # Falls back to FK-derived skeleton.
+    assert isinstance(skel, Skeleton)
+    fb = fallback_skeleton("Impact")
+    assert set(skel.joints.keys()) == set(fb.joints.keys())
+
+
+def test_json_provider_accepts_str_path(tmp_path: Path):
+    provider = JsonSkeletonProvider(json_dir=str(tmp_path))
+    skel = provider.get_skeleton("TopofBackswing")
+    assert isinstance(skel, Skeleton)
+
+
+class _ConcreteProvider(SkeletonProvider):
+    def list_poses(self) -> list[str]:
+        return ["only"]
+
+    def get_skeleton(self, pose_name: str) -> Skeleton:
+        return Skeleton(name=pose_name, joints={"hip": np.zeros(3)})
+
+
+def test_skeleton_provider_subclass_works():
+    p = _ConcreteProvider()
+    assert p.list_poses() == ["only"]
+    skel = p.get_skeleton("foo")
+    assert skel.name == "foo"


### PR DESCRIPTION
Closes #4673

## Summary

Adds 8 unit-test modules under `tests/unit/tools/starting_pose_matcher/` raising line + branch coverage of every non-Qt module to near-100% and adding the missing edge-case coverage for the Qt-offscreen modules that already had partial coverage.

## Per-file coverage delta

| Module | Before | After (line / branch) |
| --- | --- | --- |
| `core.py` | 25.3% | **98.8%** / 95% |
| `session_schema.py` | 73.1% | **100.0%** / 100% |
| `skeleton_provider.py` | 0.0% | **100.0%** / 100% |
| `live_view_controller.py` | 0.0% | **92.7%** / 88% |
| `providers/openpose.py` | 88.0% | **95.2%** |
| `providers/mediapipe.py` | 88.9% | **95.7%** |
| `providers/drake.py` | 18.9% | 20.0% (engine-blocked; error paths added) |
| `providers/mujoco.py` | 53.7% | 55.2% (engine-blocked; error paths added) |
| `providers/opensim.py` | 18.4% | 19.4% (engine-blocked; error paths added) |
| `providers/pinocchio.py` | 53.4% | 54.5% (engine-blocked; error paths added) |

Drake / OpenSim / MuJoCo / Pinocchio remain engine-gated — their happy paths exercise on CI workers that have the wheel installed and skip cleanly elsewhere. The new tests add the no-config error path, the factory wrapper, and the vocabulary-completeness invariant that runs on every box.

`gui.py` (1545 stmts) and `gui_source_panel.py` (267 stmts) remain Qt-driven. On Linux CI these are exercised by the existing `test_source_toggle.py` plus the new `test_data_sources_panel.py`. They skip cleanly on hosts where pytest-qt has loaded PySide6 ahead of PyQt6 (Windows / Python 3.14 dev box).

## What was added

- **test_session_schema.py** — full coverage of `PlaybackState`, `DataSourcesBlock`, `parse_data_sources` (None / empty / partial / bad-type / unknown-key paths), `_coerce_str_or_none`, `_coerce_time_alignment`.
- **test_core_math_and_loaders.py** — `RigidTransform` (identity / translation / rotation / scale-with-pivot / matrix accessor), `SkeletonTrajectory` frame_at_time edges, `fallback_skeleton` both branches (TopofBackswing / Address), `load_skeleton` (existing / missing / malformed-segments), `load_simscape_trajectory_csv` (short / long / dim / no-time-col / no-joints / NaN-row), `solve_shaft_rz_deg` zero-magnitude and 180-wrap, `clubtarget_from_multi` / `dispatch_cost_inputs`.
- **test_core_xlsx_adapters.py** — `_clubtarget_to_dataframe` rotation + cm/inches rescale branch, `_safe` IndexError / KeyError / NaN / non-numeric, `load_mocap_xlsx` + `read_event_header` via patched canonical loaders.
- **test_skeleton_provider.py** — ABC enforcement, JsonSkeletonProvider with default + custom poses, file-load and fallback paths, str-path support.
- **test_live_view_controller.py** — body-only / club-only / ball-only / full combo, body shape validation, NaN-marker no-fit-crash branch, set_frame clamp, layer toggling (including `body_markers` -> `body_trail` cascade), target replacement teardown.
- **test_data_sources_panel.py** — DataSourcesPanel construction, snapshot/restore round-trip, align_options live read, no-slot None emission. Module-level `pytest.skip` when PySide6 has captured the Qt namespace before PyQt6 can load (CI Linux runs every test).
- **test_observed_input_edge_cases.py** — out-of-range frame raises, one-side-hip variants for both providers, file-path load path, drop-empty-person path.
- **test_provider_error_paths.py** — every provider's NotAvailableError + ProviderError + factory wrapper + vocabulary completeness invariant.

## Test plan

- [x] `python -m ruff check tests/unit/tools/starting_pose_matcher/` — clean
- [x] `python -m ruff format --check tests/unit/tools/starting_pose_matcher/` — clean
- [x] All new tests pass under `QT_QPA_PLATFORM=offscreen`
- [ ] CI: ≥85% line, ≥75% branch (depends on PyQt6 working in CI workers)

## No production-code changes

This PR touches only files under `tests/unit/tools/starting_pose_matcher/`. No file under `src/` was modified. Verified via `git diff --stat origin/main...HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)