### PR TITLE
test(c3d-viewer): coverage to >=85% (#4675)

### DIFF
--- a/tests/unit/engines/simscape/three_d_gui/_apps_coverage_helpers.py
+++ b/tests/unit/engines/simscape/three_d_gui/_apps_coverage_helpers.py
@@ -1,0 +1,99 @@
+"""Shared helpers for the issue #4675 apps/ coverage tests."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def make_model(
+    n_frames: int = 60,
+    point_rate: float = 100.0,
+    include_analog: bool = True,
+    include_force_plate: bool = True,
+    include_events: bool = True,
+    include_raw_params: bool = True,
+):
+    """Build a synthetic C3DDataModel with optional force-plate channels."""
+    from src.apps.core.models import (  # type: ignore
+        AnalogData,
+        C3DDataModel,
+        C3DEvent,
+        MarkerData,
+    )
+
+    rng = np.random.default_rng(7)
+    names = ["WaistLeft", "WaistRight", "LKneeOut", "RKneeOut"]
+    markers = {}
+    for i, name in enumerate(names):
+        pos = rng.normal(size=(n_frames, 3)) + i
+        residuals = rng.uniform(0.0, 0.01, size=n_frames)
+        markers[name] = MarkerData(name=name, position=pos, residuals=residuals)
+
+    analog = {}
+    if include_analog:
+        analog["EMG1"] = AnalogData(
+            name="EMG1", values=np.linspace(-1.0, 1.0, n_frames), unit="V"
+        )
+    if include_force_plate:
+        for plate in (1, 2):
+            for axis, base in zip("xyz", (10.0, 20.0, 100.0), strict=True):
+                analog[f"F{axis}{plate}"] = AnalogData(
+                    name=f"F{axis}{plate}",
+                    values=base + np.sin(np.arange(n_frames) * 0.1),
+                    unit="N",
+                )
+                analog[f"M{axis}{plate}"] = AnalogData(
+                    name=f"M{axis}{plate}",
+                    values=np.cos(np.arange(n_frames) * 0.1),
+                    unit="N.m",
+                )
+
+    events = []
+    if include_events:
+        events = [
+            C3DEvent(label="Address", time=0.0),
+            C3DEvent(label="Impact", time=0.3),
+        ]
+
+    raw_params = None
+    if include_raw_params:
+        raw_params = {
+            "POINT": {
+                "UNITS": {"value": ["m"]},
+                "X_SCREEN": {"value": ["+X"]},
+                "Y_SCREEN": {"value": ["+Z"]},
+                "RATE": {"value": [point_rate]},
+                "LABELS": {"value": names},
+                "__internal__": {"value": "skip"},
+            },
+            "ANALOG": {"USED": {"value": [len(analog)]}},
+            "FORCE_PLATFORM": {"USED": {"value": [2 if include_force_plate else 0]}},
+            "MANUFACTURER": {
+                "SOFTWARE": {"value": ["Vicon Nexus"]},
+                "VERSION": {"value": ["2.0"]},
+            },
+            "TRIAL": {
+                "CAPTURE_ID": {"value": ["abc-123"]},
+                "EXPORTED_AT": {"value": ["2026-01-01"]},
+                "PLAYER_ID": {"value": ["P0001"]},
+            },
+            "EXTRA": {"NUMERIC": {"value": np.array([[1.0, 2.0], [3.0, 4.0]])}},
+        }
+
+    return C3DDataModel(
+        filepath="/tmp/synthetic.c3d",
+        markers=markers,
+        analog=analog,
+        point_rate=point_rate,
+        analog_rate=point_rate if analog else 0.0,
+        point_time=np.arange(n_frames, dtype=float) / point_rate,
+        analog_time=(np.arange(n_frames, dtype=float) / point_rate if analog else None),
+        metadata={"File": "synthetic.c3d", "Units (POINT)": "m"},
+        events=events,
+        raw_parameters=raw_params,
+    )

--- a/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675.py
@@ -1,0 +1,795 @@
+"""Coverage tests for apps/ui/* and apps/c3d_viewer.py (issue #4675).
+
+Test-only — no production code changes. Qt-offscreen tab smoke tests
+plus the C3DViewerMainWindow drag/drop and dialog plumbing. Pure-data
+service tests live in test_apps_coverage_4675_services.py.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from ._apps_coverage_helpers import make_model
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+# --------------------------------------------------------------------------
+# ui/widgets/mpl_canvas.py
+# --------------------------------------------------------------------------
+
+
+def test_mpl_canvas_basic(qapp):
+    from src.apps.ui.widgets.mpl_canvas import MplCanvas  # type: ignore
+
+    c = MplCanvas(None, width=4, height=3, dpi=80)
+    ax = c.add_subplot(111)
+    ax.plot([0, 1], [0, 1])
+    c.clear_axes()
+    assert len(c.fig.axes) == 0
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/analog_plot_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_analog_plot_tab(qapp):
+    from src.apps.ui.tabs.analog_plot_tab import AnalogPlotTab  # type: ignore
+
+    tab = AnalogPlotTab()
+    tab.update_from_model(None)
+    tab.update_plot()
+
+    model = make_model(40)
+    tab.update_from_model(model)
+    assert tab.list_analog.count() > 0
+    tab.update_plot()
+    tab.list_analog.clearSelection()
+    tab.update_plot()
+
+
+def test_analog_plot_tab_missing_time(qapp):
+    """analog_time=None branch."""
+    from src.apps.core.models import AnalogData, C3DDataModel  # type: ignore
+    from src.apps.ui.tabs.analog_plot_tab import AnalogPlotTab  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={},
+        analog={"E": AnalogData(name="E", values=np.zeros(5), unit="V")},
+        point_rate=100.0,
+        analog_rate=100.0,
+        point_time=None,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    tab = AnalogPlotTab()
+    tab.update_from_model(model)
+    tab.list_analog.setCurrentRow(0)
+    tab.update_plot()
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/marker_plot_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_marker_plot_tab_components(qapp):
+    from src.apps.ui.tabs.marker_plot_tab import MarkerPlotTab  # type: ignore
+
+    tab = MarkerPlotTab()
+    tab.update_from_model(None)
+    tab.update_plot()
+
+    model = make_model(40)
+    tab.update_from_model(model)
+    assert tab.list_markers.count() > 0
+    for idx in range(5):
+        tab.combo_component.setCurrentIndex(idx)
+        tab.update_plot()
+
+    tab.list_markers.clearSelection()
+    tab.update_plot()
+
+
+def test_marker_plot_tab_missing_time(qapp):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.ui.tabs.marker_plot_tab import MarkerPlotTab  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"M": MarkerData(name="M", position=np.zeros((5, 3)))},
+        analog={},
+        point_rate=100.0,
+        analog_rate=0.0,
+        point_time=None,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    tab = MarkerPlotTab()
+    tab.update_from_model(model)
+    tab.list_markers.setCurrentRow(0)
+    tab.update_plot()
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/analysis_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_analysis_tab(qapp):
+    from src.apps.ui.tabs.analysis_tab import AnalysisTab  # type: ignore
+
+    tab = AnalysisTab()
+    tab.update_from_model(None)
+    tab.update_panel()
+
+    model = make_model(30)
+    tab.update_from_model(model)
+    assert tab.combo_marker_analysis.count() > 0
+    tab.button_recompute_stats.click()
+    text = tab.text_analysis.toPlainText()
+    assert "Marker:" in text
+
+
+def test_analysis_tab_single_frame(qapp):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.ui.tabs.analysis_tab import AnalysisTab  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"M": MarkerData(name="M", position=np.zeros((1, 3)))},
+        analog={},
+        point_rate=100.0,
+        analog_rate=0.0,
+        point_time=np.array([0.0]),
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    tab = AnalysisTab()
+    tab.update_from_model(model)
+    tab.update_panel()
+
+
+def test_analysis_tab_no_time(qapp):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.ui.tabs.analysis_tab import AnalysisTab  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"M": MarkerData(name="M", position=np.zeros((5, 3)))},
+        analog={},
+        point_rate=100.0,
+        analog_rate=0.0,
+        point_time=None,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    tab = AnalysisTab()
+    tab.update_from_model(model)
+    tab.update_panel()
+    assert "No marker" in tab.text_analysis.toPlainText()
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/force_plot_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_force_plot_tab_full_flow(qapp):
+    from src.apps.ui.tabs.force_plot_tab import ForcePlotTab  # type: ignore
+
+    tab = ForcePlotTab()
+    tab.update_from_model(None)
+
+    empty = make_model(20, include_analog=False, include_force_plate=False)
+    tab.update_from_model(empty)
+    assert "No force-plate" in tab.status_label.text()
+
+    model = make_model(40, include_analog=True, include_force_plate=True)
+    tab.update_from_model(model)
+    assert tab.plate_combo.count() > 0
+    for i in range(tab.component_combo.count()):
+        tab.component_combo.setCurrentIndex(i)
+    tab.show_cop_checkbox.setChecked(False)
+    tab.show_cop_checkbox.setChecked(True)
+
+
+def test_force_plot_tab_no_force_plate_channels(qapp):
+    from src.apps.core.models import AnalogData, C3DDataModel  # type: ignore
+    from src.apps.ui.tabs.force_plot_tab import ForcePlotTab  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={},
+        analog={"EMG1": AnalogData(name="EMG1", values=np.zeros(5), unit="V")},
+        point_rate=100.0,
+        analog_rate=100.0,
+        point_time=np.zeros(5),
+        analog_time=np.zeros(5),
+        metadata={},
+        events=[],
+    )
+    tab = ForcePlotTab()
+    tab.update_from_model(model)
+    assert "No force-plate" in tab.status_label.text()
+
+
+def test_force_plot_tab_cop_no_time(qapp):
+    """Force plate data with analog_time=None goes through plot-line branch."""
+    from src.apps.core.models import AnalogData, C3DDataModel  # type: ignore
+    from src.apps.ui.tabs.force_plot_tab import ForcePlotTab  # type: ignore
+
+    n = 20
+    analog = {}
+    for axis, base in zip("xyz", (10.0, 20.0, 100.0), strict=True):
+        analog[f"F{axis}1"] = AnalogData(
+            name=f"F{axis}1",
+            values=base + np.arange(n) * 0.1,
+            unit="N",
+        )
+        analog[f"M{axis}1"] = AnalogData(
+            name=f"M{axis}1",
+            values=np.arange(n) * 0.05,
+            unit="N.m",
+        )
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={},
+        analog=analog,
+        point_rate=100.0,
+        analog_rate=100.0,
+        point_time=np.arange(n) / 100.0,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    tab = ForcePlotTab()
+    tab.update_from_model(model)
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/overview_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_overview_tab_full(qapp):
+    from src.apps.ui.tabs.overview_tab import OverviewTab  # type: ignore
+
+    tab = OverviewTab()
+    tab.update_from_model(None)
+    assert tab.label_file.text() == "No file loaded"
+
+    model = make_model(50)
+    tab.update_from_model(model)
+    assert "Loaded file" in tab.label_file.text()
+    assert tab.tree_group_count >= 1
+    assert tab.tree_node_count > tab.tree_group_count
+
+
+def test_overview_tab_no_raw_params_fallback(qapp):
+    from src.apps.ui.tabs.overview_tab import OverviewTab  # type: ignore
+
+    model = make_model(10, include_raw_params=False)
+    object.__setattr__(model, "metadata", {"k1": "v1", "k2": "v2"})
+    tab = OverviewTab()
+    tab.update_from_model(model)
+    assert tab._prov_form.rowCount() >= 1
+
+
+def test_overview_helpers_format_value():
+    from src.apps.ui.tabs.overview_tab import (  # type: ignore
+        _format_value,
+        _is_metadata_internal_key,
+        _scalar_value,
+    )
+
+    assert _is_metadata_internal_key("__type__")
+    assert not _is_metadata_internal_key("UNITS")
+    assert _scalar_value({"value": 3}) == 3
+    assert _scalar_value(np.array(7)) == 7
+    arr_one = np.array([5])
+    assert _scalar_value(arr_one) == 5
+    assert _scalar_value(np.array([1, 2, 3])).shape == (3,)
+    assert _scalar_value([42]) == 42
+
+    assert "shape=" in _format_value(np.arange(20))
+    s = _format_value(list(range(10)))
+    assert "len=" in s
+    assert _format_value([1, 2]) == "[1, 2]"
+    assert _format_value(b"hi") == "hi"
+    assert _format_value("plain") == "plain"
+    assert _format_value(42) == "42"
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/segments_tab.py
+# --------------------------------------------------------------------------
+
+
+def test_segments_tab_basic(qapp):
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+
+    tab = SegmentsTab()
+    tab.update_from_model(None)
+
+    model = make_model(20)
+    tab.update_from_model(model)
+    n0 = len(tab.segments)
+
+    tab.add_segment(SegmentSpec(a="WaistLeft", b="WaistRight", group="custom"))
+    assert len(tab.segments) == n0 + 1
+
+    tab.set_segment_visibility(0, False)
+    assert tab.segments[0].visible is False
+    tab.set_segment_geometry(0, "cylinder")
+    assert tab.segments[0].geometry == "cylinder"
+
+    with pytest.raises(ValueError):
+        tab.set_segment_geometry(999, "line")
+    with pytest.raises(ValueError):
+        tab.set_segment_visibility(-1, True)
+    with pytest.raises(ValueError):
+        tab.set_segment_geometry(0, "bogus")
+    with pytest.raises(TypeError):
+        tab.add_segment("not-a-spec")  # type: ignore[arg-type]
+
+    tab._on_reset_clicked()
+    tab._delete_row(0)
+    tab._delete_row(999)
+
+    tab._on_visible_toggled(999, True)
+    tab._on_endpoint_changed(999, "a", "x")
+    tab._on_geometry_changed(999, "line")
+    tab._on_group_changed(999, "g")
+
+    tab._on_endpoint_changed(0, "a", "WaistRight")
+    tab._on_geometry_changed(0, "cylinder")
+    tab._on_group_changed(0, "   ")
+    assert tab.segments[0].group == "auto"
+
+    tab._on_endpoint_changed(0, "b", tab.segments[0].a)
+
+
+def test_segments_tab_save_load(qapp, tmp_path, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    from src.apps.ui.tabs.segments_tab import SegmentsTab  # type: ignore
+
+    tab = SegmentsTab()
+    model = make_model(20)
+    tab.update_from_model(model)
+
+    save_path = tmp_path / "segs.json"
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: (str(save_path), ""),
+    )
+    tab._on_save_clicked()
+    assert save_path.is_file()
+    tab._on_export_clicked()
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (str(save_path), ""),
+    )
+    tab._on_load_clicked()
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: ("", ""),
+    )
+    tab._on_load_clicked()
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: ("", ""),
+    )
+    tab._on_save_clicked()
+    tab._on_export_clicked()
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: (str(bad), ""),
+    )
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: None)
+    tab._on_load_clicked()
+
+
+def test_segments_tab_add_dialog(qapp, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    from src.apps.ui.tabs import segments_tab as st  # type: ignore
+
+    tab = st.SegmentsTab()
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    tab._on_add_clicked()
+
+    model = make_model(20)
+    tab.update_from_model(model)
+
+    class _FakeDlg:
+        def __init__(self, *a, **k):
+            pass
+
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+        def selected_spec(self):
+            from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+
+            return SegmentSpec(a="WaistLeft", b="WaistRight", group="ok")
+
+    monkeypatch.setattr(st, "_AddSegmentDialog", _FakeDlg)
+    n0 = len(tab.segments)
+    tab._on_add_clicked()
+    assert len(tab.segments) == n0 + 1
+
+    class _FakeDlgNone(_FakeDlg):
+        def selected_spec(self):
+            return None
+
+    monkeypatch.setattr(st, "_AddSegmentDialog", _FakeDlgNone)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: None)
+    tab._on_add_clicked()
+
+    class _FakeDlgReject(_FakeDlg):
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Rejected
+
+    monkeypatch.setattr(st, "_AddSegmentDialog", _FakeDlgReject)
+    tab._on_add_clicked()
+
+
+def test_add_segment_dialog_selected_spec(qapp):
+    from src.apps.ui.tabs.segments_tab import _AddSegmentDialog  # type: ignore
+
+    dlg = _AddSegmentDialog(["A", "B", "C"], "myGroup")
+    spec = dlg.selected_spec()
+    assert spec is not None
+    assert spec.a == "A" and spec.b == "B"
+
+    dlg2 = _AddSegmentDialog(["A"], "")
+    assert dlg2.selected_spec() is None
+
+
+# --------------------------------------------------------------------------
+# ui/dialogs/export_markers_dialog.py
+# --------------------------------------------------------------------------
+
+
+def test_export_markers_dialog(qapp, monkeypatch, tmp_path):
+    from PyQt6 import QtWidgets
+
+    from src.apps.ui.dialogs.export_markers_dialog import (  # type: ignore
+        ExportMarkersDialog,
+        _is_club_marker,
+    )
+
+    assert _is_club_marker("Marker_1:2:Club")
+    assert not _is_club_marker("WaistLeft")
+
+    with pytest.raises(ValueError):
+        ExportMarkersDialog(None)  # type: ignore[arg-type]
+
+    model = make_model(20)
+    dlg = ExportMarkersDialog(model)
+    assert dlg.list_markers.count() == len(model.marker_names())
+
+    dlg.radio_x.setChecked(True)
+    assert dlg._selected_components() == ("x",)
+    dlg.radio_y.setChecked(True)
+    assert dlg._selected_components() == ("y",)
+    dlg.radio_z.setChecked(True)
+    assert dlg._selected_components() == ("z",)
+    dlg.radio_all.setChecked(True)
+    assert dlg._selected_components() == ("x", "y", "z")
+
+    dlg.radio_csv.setChecked(True)
+    assert dlg._selected_format() == "csv"
+    assert dlg._default_extension() == "csv"
+    dlg.radio_json.setChecked(True)
+    assert dlg._selected_format() == "json"
+    dlg.radio_npz.setChecked(True)
+    assert dlg._selected_format() == "npz"
+
+    dlg._set_selection(lambda _n: True)
+    assert all(
+        dlg.list_markers.item(i).isSelected() for i in range(dlg.list_markers.count())
+    )
+    dlg._set_selection(lambda _n: False)
+    assert dlg._selected_markers() == []
+
+    dlg._select_body()
+
+    dlg._set_selection(lambda _n: False)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    dlg._on_accept()
+    assert dlg._chosen_path is None
+
+    dlg._set_selection(lambda _n: True)
+    out = tmp_path / "x.csv"
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: (str(out), ""),
+    )
+    dlg._on_accept()
+    assert dlg._chosen_path == str(out)
+
+    params = dlg.export_params()
+    assert params is not None
+    assert params["path"] == str(out)
+    assert params["fmt"] in {"csv", "json", "npz"}
+
+    dlg2 = ExportMarkersDialog(model)
+    dlg2._set_selection(lambda _n: True)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: ("", ""),
+    )
+    dlg2._on_accept()
+    assert dlg2.export_params() is None
+
+
+def test_export_markers_dialog_no_point_time(qapp):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.ui.dialogs.export_markers_dialog import (  # type: ignore
+        ExportMarkersDialog,
+    )
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"M": MarkerData(name="M", position=np.zeros((3, 3)))},
+        analog={},
+        point_rate=0.0,
+        analog_rate=0.0,
+        point_time=None,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    dlg = ExportMarkersDialog(model)
+    assert dlg.spin_end.maximum() == 0
+
+
+# --------------------------------------------------------------------------
+# c3d_viewer.py — main window
+# --------------------------------------------------------------------------
+
+
+def test_c3d_viewer_main_window_basic(qapp, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "critical", lambda *a, **k: None)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "about", lambda *a, **k: None)
+    win = C3DViewerMainWindow()
+    assert win.windowTitle() == "C3D Motion Analysis Viewer"
+    assert win.tabs.count() == 7
+
+    with pytest.raises(ValueError):
+        win._update_ui_state(None)  # type: ignore[arg-type]
+
+    win._update_ui_state(True)
+    assert win.tabs.isEnabled()
+    win._update_ui_state(False)
+
+    model = make_model(20)
+    win.model = model
+    win._populate_ui_with_model()
+    assert win.action_export_markers.isEnabled()
+
+    win._on_load_success(model)
+    with pytest.raises(ValueError):
+        win._on_load_success(None)  # type: ignore[arg-type]
+
+    win._on_load_failure("oops")
+    with pytest.raises(ValueError):
+        win._on_load_failure(None)  # type: ignore[arg-type]
+
+    win._on_load_finished()
+
+
+def test_c3d_viewer_about_and_drag(qapp, monkeypatch):
+    from PyQt6 import QtCore, QtGui, QtWidgets
+
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    win = C3DViewerMainWindow()
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "about", lambda *a, **k: None)
+    win.show_about_dialog()
+
+    with pytest.raises(ValueError):
+        win.dragEnterEvent(None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        win.dropEvent(None)  # type: ignore[arg-type]
+
+    mime = QtCore.QMimeData()
+    mime.setUrls([QtCore.QUrl.fromLocalFile("/tmp/x.c3d")])
+    drag_event = QtGui.QDragEnterEvent(
+        QtCore.QPoint(0, 0),
+        QtCore.Qt.DropAction.CopyAction,
+        mime,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    win.dragEnterEvent(drag_event)
+
+    mime2 = QtCore.QMimeData()
+    mime2.setUrls([QtCore.QUrl.fromLocalFile("/tmp/x.txt")])
+    drag_event2 = QtGui.QDragEnterEvent(
+        QtCore.QPoint(0, 0),
+        QtCore.Qt.DropAction.CopyAction,
+        mime2,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    win.dragEnterEvent(drag_event2)
+
+    mime3 = QtCore.QMimeData()
+    drag_event3 = QtGui.QDragEnterEvent(
+        QtCore.QPoint(0, 0),
+        QtCore.Qt.DropAction.CopyAction,
+        mime3,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    win.dragEnterEvent(drag_event3)
+
+
+def test_c3d_viewer_load_path_security_blocked(qapp, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    win = C3DViewerMainWindow()
+
+    with pytest.raises(ValueError):
+        win.load_c3d_file_from_path(None)  # type: ignore[arg-type]
+
+    import shared.python.security.security_utils as sec  # type: ignore
+
+    def _bad(*a, **k):
+        raise ValueError("denied")
+
+    monkeypatch.setattr(sec, "validate_path", _bad)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: None)
+    win.load_c3d_file_from_path("/etc/shadow")
+
+
+def test_c3d_viewer_open_file_cancel(qapp, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    win = C3DViewerMainWindow()
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: ("", "")
+    )
+    win.open_c3d_file()
+
+
+def test_c3d_viewer_export_markers_dialog(qapp, monkeypatch, tmp_path):
+    from PyQt6 import QtWidgets
+
+    from src.apps.c3d_viewer import C3DViewerMainWindow  # type: ignore
+
+    win = C3DViewerMainWindow()
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    win._export_markers_dialog()
+
+    model = make_model(20)
+    win.model = model
+
+    out_path = tmp_path / "x.csv"
+
+    class _FakeDlg:
+        def __init__(self, *a, **k):
+            pass
+
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+        def export_params(self):
+            return {
+                "marker_names": ["WaistLeft"],
+                "components": "all",
+                "frame_range": None,
+                "fmt": "csv",
+                "path": str(out_path),
+                "include_time": True,
+                "include_residual": False,
+            }
+
+    from src.apps.ui.dialogs import export_markers_dialog as emd  # type: ignore
+
+    monkeypatch.setattr(emd, "ExportMarkersDialog", _FakeDlg)
+    win._export_markers_dialog()
+    assert out_path.is_file()
+
+    class _RejDlg(_FakeDlg):
+        def exec(self):
+            return QtWidgets.QDialog.DialogCode.Rejected
+
+    monkeypatch.setattr(emd, "ExportMarkersDialog", _RejDlg)
+    win._export_markers_dialog()
+
+    class _NoneDlg(_FakeDlg):
+        def export_params(self):
+            return None
+
+    monkeypatch.setattr(emd, "ExportMarkersDialog", _NoneDlg)
+    win._export_markers_dialog()
+
+    class _RaisingDlg(_FakeDlg):
+        def export_params(self):
+            return {
+                "marker_names": ["NotAMarker"],
+                "components": "all",
+                "frame_range": None,
+                "fmt": "csv",
+                "path": str(out_path),
+                "include_time": True,
+                "include_residual": False,
+            }
+
+    monkeypatch.setattr(emd, "ExportMarkersDialog", _RaisingDlg)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: None)
+    win._export_markers_dialog()
+
+
+# --------------------------------------------------------------------------
+# ui/tabs/viewer_3d_tab.py — additional CSV export branch
+# --------------------------------------------------------------------------
+
+
+def test_viewer_3d_tab_export_selected_markers_csv(qapp, tmp_path):
+    from src.apps.ui.tabs.viewer_3d_tab import Viewer3DTab  # type: ignore
+
+    tab = Viewer3DTab()
+
+    with pytest.raises(ValueError):
+        tab.export_selected_markers_csv(str(tmp_path / "x.csv"))
+    with pytest.raises(ValueError):
+        tab.export_selected_markers_csv("")
+
+    model = make_model(15)
+    tab.update_from_model(model)
+    out = tmp_path / "trajs.csv"
+    tab.export_selected_markers_csv(str(out))
+    assert out.is_file()
+    text = out.read_text(encoding="utf-8")
+    assert "frame,time_s" in text

--- a/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675_services.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675_services.py
@@ -1,0 +1,561 @@
+"""Coverage tests for apps/services and apps/core (issue #4675).
+
+Test-only — no production code changes. Pure-data services and core
+dataclasses; no Qt widgets except the loader-thread tests, which need
+QApplication for QThread signal delivery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from ._apps_coverage_helpers import make_model
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+# --------------------------------------------------------------------------
+# core/models.py
+# --------------------------------------------------------------------------
+
+
+def test_models_dataclasses_round_trip():
+    from src.apps.core.models import (  # type: ignore
+        AnalogData,
+        C3DDataModel,
+        C3DEvent,
+        MarkerData,
+    )
+
+    pos = np.zeros((3, 3))
+    md = MarkerData(name="m", position=pos, residuals=np.zeros(3))
+    assert md.name == "m"
+    assert md.position.shape == (3, 3)
+
+    ad = AnalogData(name="a", values=np.zeros(3), unit="V")
+    assert ad.unit == "V"
+
+    ev = C3DEvent(label="L", time=0.5)
+    assert ev.label == "L"
+    assert ev.time == 0.5
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"m": md},
+        analog={"a": ad},
+        events=[ev],
+        raw_parameters={"X": 1},
+    )
+    assert model.marker_names() == ["m"]
+    assert model.analog_names() == ["a"]
+    assert model.raw_parameters == {"X": 1}
+
+
+# --------------------------------------------------------------------------
+# services/analysis.py
+# --------------------------------------------------------------------------
+
+
+def test_analysis_compute_marker_statistics_basic():
+    from src.apps.services.analysis import compute_marker_statistics  # type: ignore
+
+    t = np.linspace(0, 1, 11)
+    pos = np.column_stack([t, np.zeros(11), np.zeros(11)])
+    stats = compute_marker_statistics(t, pos)
+    assert pytest.approx(stats["path_length"], rel=1e-6) == 1.0
+    assert stats["max_speed"] > 0
+    assert stats["mean_speed"] > 0
+
+
+def test_analysis_too_few_frames_returns_nans():
+    from src.apps.services.analysis import compute_marker_statistics  # type: ignore
+
+    stats = compute_marker_statistics(np.array([0.0]), np.zeros((1, 3)))
+    assert np.isnan(stats["path_length"])
+    assert np.isnan(stats["max_speed"])
+    assert np.isnan(stats["mean_speed"])
+
+
+def test_analysis_no_time_returns_nans():
+    from src.apps.services.analysis import compute_marker_statistics  # type: ignore
+
+    stats = compute_marker_statistics(None, np.zeros((5, 3)))
+    assert np.isnan(stats["path_length"])
+
+
+def test_analysis_zero_dt_yields_nan_speed():
+    from src.apps.services.analysis import compute_marker_statistics  # type: ignore
+
+    t = np.array([0.0, 0.0, 0.0, 0.0])
+    pos = np.zeros((4, 3))
+    stats = compute_marker_statistics(t, pos)
+    assert np.isnan(stats["max_speed"])
+    assert np.isnan(stats["mean_speed"])
+
+
+# --------------------------------------------------------------------------
+# services/c3d_loader.py
+# --------------------------------------------------------------------------
+
+
+def test_c3d_loader_file_not_found():
+    from src.apps.services.c3d_loader import load_c3d_file  # type: ignore
+
+    with pytest.raises(FileNotFoundError):
+        load_c3d_file("/nonexistent/path/foo.c3d")
+
+
+def test_c3d_loader_build_helpers(monkeypatch, tmp_path):
+    """Drive load_c3d_file with a stubbed C3DDataReader."""
+    import pandas as pd
+
+    from src.apps.services import c3d_loader  # type: ignore
+
+    fake_path = tmp_path / "fake.c3d"
+    fake_path.write_bytes(b"\x00")
+
+    class _Meta:
+        frame_rate = 100.0
+        analog_rate = 1000.0
+        frame_count = 5
+        marker_count = 2
+        units = "m"
+        marker_labels = ["A", "B", "C"]  # C is missing -> empty branch
+        analog_labels = ["EMG"]
+        analog_units = ["V"]
+
+        class _Ev:
+            label = "Top"
+            time = 0.1
+
+        events = [_Ev()]
+
+    class _Reader:
+        def __init__(self, _path):
+            pass
+
+        def get_metadata(self):
+            return _Meta()
+
+        def points_dataframe(self, include_time=False):
+            return pd.DataFrame(
+                {
+                    "marker": ["A", "A", "B", "B"],
+                    "x": [0.0, 1.0, 0.0, 1.0],
+                    "y": [0.0, 0.0, 0.0, 0.0],
+                    "z": [0.0, 0.0, 0.0, 0.0],
+                    "residual": [0.0, 0.0, 0.0, 0.0],
+                }
+            )
+
+        def analog_dataframe(self, include_time=False):
+            return pd.DataFrame(
+                {
+                    "channel": ["EMG", "EMG"],
+                    "value": [0.1, 0.2],
+                }
+            )
+
+        def _load(self):
+            return {"parameters": {"POINT": {"UNITS": "m"}}}
+
+    monkeypatch.setattr(c3d_loader, "C3DDataReader", _Reader)
+    model = c3d_loader.load_c3d_file(str(fake_path))
+    assert "A" in model.markers
+    assert "C" in model.markers  # missing-label branch
+    assert model.markers["C"].position.shape == (0, 3)
+    assert model.analog["EMG"].unit == "V"
+    assert model.point_rate == 100.0
+    assert model.events[0].label == "Top"
+    assert model.raw_parameters == {"POINT": {"UNITS": "m"}}
+
+
+def test_c3d_loader_raw_params_failure_branch(monkeypatch, tmp_path):
+    import pandas as pd
+
+    from src.apps.services import c3d_loader  # type: ignore
+
+    fake_path = tmp_path / "fake.c3d"
+    fake_path.write_bytes(b"\x00")
+
+    class _Meta:
+        frame_rate = 0.0  # exercise frame_time None branch
+        analog_rate = 0.0
+        frame_count = 0
+        marker_count = 0
+        units = ""
+        marker_labels = []
+        analog_labels = []
+        analog_units = []
+        events = None  # falsy -> skip events loop
+
+    class _Reader:
+        def __init__(self, _path):
+            pass
+
+        def get_metadata(self):
+            return _Meta()
+
+        def points_dataframe(self, include_time=False):
+            return pd.DataFrame(
+                {"marker": [], "x": [], "y": [], "z": [], "residual": []}
+            )
+
+        def analog_dataframe(self, include_time=False):
+            return pd.DataFrame()
+
+        def _load(self):
+            raise KeyError("parameters")
+
+    monkeypatch.setattr(c3d_loader, "C3DDataReader", _Reader)
+    model = c3d_loader.load_c3d_file(str(fake_path))
+    assert model.raw_parameters is None
+    assert model.point_time is None
+    assert model.analog == {}
+
+
+def test_c3d_loader_build_markers_validation():
+    from src.apps.services.c3d_loader import _build_markers  # type: ignore
+
+    with pytest.raises(ValueError):
+        _build_markers(None, [])
+
+
+def test_c3d_loader_build_analog_validation():
+    from src.apps.services.c3d_loader import _build_analog  # type: ignore
+
+    with pytest.raises(ValueError):
+        _build_analog(None, MagicMock())
+
+
+def test_c3d_loader_build_metadata_ui_validation():
+    from src.apps.services.c3d_loader import _build_metadata_ui  # type: ignore
+
+    with pytest.raises(ValueError):
+        _build_metadata_ui(None, MagicMock())
+
+
+def test_c3d_loader_build_metadata_ui_with_events():
+    from src.apps.services.c3d_loader import _build_metadata_ui  # type: ignore
+
+    class _Ev:
+        label = "Top"
+        time = 0.5
+
+    class _Meta:
+        frame_rate = 100.0
+        analog_rate = 1000.0
+        frame_count = 10
+        marker_count = 5
+        units = "m"
+        events = [_Ev()]
+
+    md = _build_metadata_ui("/path/to/file.c3d", _Meta())
+    assert md["File"] == "file.c3d"
+    assert "Events" in md
+    assert "Top" in md["Events"]
+
+
+# --------------------------------------------------------------------------
+# services/loader_thread.py
+# --------------------------------------------------------------------------
+
+
+def test_loader_thread_validates_filepath():
+    from src.apps.services.loader_thread import C3DLoaderThread  # type: ignore
+
+    with pytest.raises(ValueError):
+        C3DLoaderThread(None)  # type: ignore[arg-type]
+
+
+def test_loader_thread_emits_failed_for_missing_file(qapp):
+    from PyQt6.QtCore import QEventLoop, QTimer
+
+    from src.apps.services.loader_thread import C3DLoaderThread  # type: ignore
+
+    th = C3DLoaderThread("/no/such/file.c3d")
+    received = {}
+
+    def on_fail(msg):
+        received["msg"] = msg
+
+    th.failed.connect(on_fail)
+
+    loop = QEventLoop()
+    th.failed.connect(lambda _: loop.quit())
+    th.loaded.connect(lambda _: loop.quit())
+    QTimer.singleShot(5000, loop.quit)
+    th.start()
+    loop.exec()
+    th.wait(2000)
+    assert "File not found" in received.get("msg", "")
+
+
+def test_loader_thread_emits_loaded(qapp, monkeypatch, tmp_path):
+    from PyQt6.QtCore import QEventLoop, QTimer
+
+    from src.apps.services import loader_thread as lt  # type: ignore
+
+    fake = tmp_path / "ok.c3d"
+    fake.write_bytes(b"\x00")
+    sentinel = MagicMock(name="model")
+
+    monkeypatch.setattr(lt, "load_c3d_file", lambda _p: sentinel)
+    th = lt.C3DLoaderThread(str(fake))
+    seen = {}
+    th.loaded.connect(lambda m: seen.setdefault("m", m))
+    loop = QEventLoop()
+    th.loaded.connect(lambda _: loop.quit())
+    th.failed.connect(lambda _: loop.quit())
+    QTimer.singleShot(5000, loop.quit)
+    th.start()
+    loop.exec()
+    th.wait(2000)
+    assert seen.get("m") is sentinel
+
+
+def test_loader_thread_emits_failed_for_various_exceptions(qapp, monkeypatch, tmp_path):
+    from PyQt6.QtCore import QEventLoop, QTimer
+
+    from src.apps.services import loader_thread as lt  # type: ignore
+
+    fake = tmp_path / "ok.c3d"
+    fake.write_bytes(b"\x00")
+
+    for exc, fragment in (
+        (ImportError("ezc3d"), "Missing dependency"),
+        (KeyError("POINT"), "Corrupted"),
+        (ValueError("bad data"), "Data inconsistency"),
+        (RuntimeError("boom"), "Unexpected error"),
+    ):
+        captured = {}
+
+        def _raise(_p, e=exc):
+            raise e
+
+        monkeypatch.setattr(lt, "load_c3d_file", _raise)
+        th = lt.C3DLoaderThread(str(fake))
+        th.failed.connect(lambda msg, c=captured: c.setdefault("m", msg))
+        loop = QEventLoop()
+        th.failed.connect(lambda _, _l=loop: _l.quit())
+        QTimer.singleShot(5000, loop.quit)
+        th.start()
+        loop.exec()
+        th.wait(2000)
+        assert fragment in captured.get("m", ""), (fragment, captured)
+
+
+# --------------------------------------------------------------------------
+# services/segment_set_io.py
+# --------------------------------------------------------------------------
+
+
+def test_segment_spec_validation_errors():
+    from src.apps.services.segment_set_io import SegmentSpec  # type: ignore
+
+    with pytest.raises(ValueError):
+        SegmentSpec(a="", b="x")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="x")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="y", geometry="bogus")
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="y", group="")
+    with pytest.raises(TypeError):
+        SegmentSpec(a="x", b="y", visible="yes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="y", radius=0)
+    with pytest.raises(ValueError):
+        SegmentSpec(a="x", b="y", radius=True)
+
+
+def test_segment_set_round_trip(tmp_path):
+    from src.apps.services.segment_set_io import (  # type: ignore
+        SegmentSet,
+        SegmentSpec,
+        default_segment_set_path,
+        from_dict,
+        load_segment_set,
+        save_segment_set,
+        to_dict,
+    )
+
+    segset = SegmentSet(
+        segments=(
+            SegmentSpec(a="A", b="B", geometry="line", group="g1"),
+            SegmentSpec(a="C", b="D", geometry="cylinder", group="g2"),
+        )
+    )
+    out = tmp_path / "sub" / "segs.json"
+    save_segment_set(out, segset)
+    assert out.is_file()
+
+    reloaded = load_segment_set(out)
+    assert reloaded.segments == segset.segments
+
+    payload = to_dict(segset)
+    assert payload["schema_version"] == 1
+    assert from_dict(payload).segments == segset.segments
+
+    p = default_segment_set_path()
+    assert isinstance(p, Path)
+
+
+def test_segment_set_io_error_paths(tmp_path):
+    from src.apps.services.segment_set_io import (  # type: ignore
+        from_dict,
+        load_segment_set,
+        save_segment_set,
+        to_dict,
+    )
+
+    with pytest.raises(TypeError):
+        to_dict({"segments": []})  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        from_dict("not a dict")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        from_dict({"schema_version": 999, "segments": []})
+    with pytest.raises(ValueError):
+        from_dict({"schema_version": 1, "segments": "not-a-list"})
+    with pytest.raises(ValueError):
+        from_dict({"schema_version": 1, "segments": ["bad-entry"]})
+    with pytest.raises(ValueError):
+        save_segment_set(None, MagicMock())  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        load_segment_set(None)  # type: ignore[arg-type]
+    with pytest.raises(FileNotFoundError):
+        load_segment_set(tmp_path / "missing.json")
+
+
+# --------------------------------------------------------------------------
+# services/marker_export.py
+# --------------------------------------------------------------------------
+
+
+def test_marker_export_validation_errors(tmp_path):
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = make_model(20)
+    out = tmp_path / "x.csv"
+
+    with pytest.raises(ValueError):
+        export_markers(None, ["WaistLeft"], "x", None, "csv", out)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        export_markers(model, [], "x", None, "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "x", None, "bogus", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["NotAMarker"], "x", None, "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "q", None, "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], [], None, "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "x", (5, 100), "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "x", (5, 4), "csv", out)
+    with pytest.raises(ValueError):
+        export_markers(model, ["WaistLeft"], "x", (1, 2, 3), "csv", out)  # type: ignore[arg-type]
+
+
+def test_marker_export_csv_sanitizes_formula(tmp_path):
+    """Export a marker whose name starts with '=' to confirm sanitisation."""
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    danger_name = "=DANGER"
+    pos = np.arange(30, dtype=float).reshape(10, 3)
+    model = C3DDataModel(
+        filepath="syn.c3d",
+        markers={danger_name: MarkerData(name=danger_name, position=pos)},
+        analog={},
+        point_rate=100.0,
+        analog_rate=0.0,
+        point_time=np.arange(10) / 100.0,
+        analog_time=None,
+        metadata={"Units (POINT)": "m"},
+        events=[],
+    )
+    out = tmp_path / "danger.csv"
+    export_markers(model, [danger_name], "all", None, "csv", out)
+    text = out.read_text(encoding="utf-8")
+    assert "'=DANGER" in text
+
+
+def test_marker_export_json_npz(tmp_path):
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = make_model(30, include_force_plate=False, include_analog=False)
+    out_json = tmp_path / "m.json"
+    export_markers(
+        model,
+        ["WaistLeft", "WaistRight"],
+        "all",
+        None,
+        "json",
+        out_json,
+        include_residual=True,
+    )
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert "metadata" in payload and "data" in payload
+    assert payload["metadata"]["units"] == "m"
+
+    out_npz = tmp_path / "m.npz"
+    export_markers(
+        model,
+        ["WaistLeft"],
+        ("x", "y"),
+        (5, 10),
+        "npz",
+        out_npz,
+        include_residual=False,
+    )
+    with np.load(out_npz, allow_pickle=False) as data:
+        assert "WaistLeft" in data.files
+        assert data["WaistLeft"].shape == (6, 2)
+
+
+def test_marker_export_default_frame_range(tmp_path):
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = make_model(15, include_force_plate=False, include_analog=False)
+    out = tmp_path / "m.csv"
+    export_markers(model, ["WaistLeft"], "all", None, "csv", out)
+    rows = out.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 16
+
+
+def test_marker_export_no_frames_raises(tmp_path):
+    from src.apps.core.models import C3DDataModel, MarkerData  # type: ignore
+    from src.apps.services.marker_export import export_markers  # type: ignore
+
+    model = C3DDataModel(
+        filepath="x.c3d",
+        markers={"M": MarkerData(name="M", position=np.empty((0, 3)))},
+        analog={},
+        point_rate=0.0,
+        analog_rate=0.0,
+        point_time=None,
+        analog_time=None,
+        metadata={},
+        events=[],
+    )
+    with pytest.raises(ValueError):
+        export_markers(model, ["M"], "all", None, "csv", tmp_path / "z.csv")


### PR DESCRIPTION
Closes #4675

## Summary

Brings the C3D Viewer (`apps/`) subtree to **>=85% line, >=75% branch** coverage. Test-only — no production code changes.

## Coverage delta

| File | Before | After |
|---|---|---|
| `core/models.py` | 100.0% | 100.0% |
| `services/analysis.py` | 9.7% | 87.1% |
| `services/c3d_loader.py` | 62.4% | 92.7% |
| `services/loader_thread.py` | 25.8% | 93.5% |
| `services/marker_export.py` | 79.0% | 86.3% |
| `services/segment_set_io.py` | 76.4% | 100.0% |
| `ui/dialogs/export_markers_dialog.py` | 0.0% | 98.1% |
| `ui/tabs/analog_plot_tab.py` | 33.8% | 98.5% |
| `ui/tabs/analysis_tab.py` | 37.8% | 98.8% |
| `ui/tabs/force_plot_tab.py` | 34.8% | 95.2% |
| `ui/tabs/marker_plot_tab.py` | 32.0% | 99.0% |
| `ui/tabs/overview_tab.py` | 79.1% | 87.1% |
| `ui/tabs/segments_tab.py` | 55.2% | 96.5% |
| `ui/tabs/viewer_3d_tab.py` | 78.3% | 83.3% |
| `ui/widgets/mpl_canvas.py` | 83.3% | 83.3% |
| `c3d_viewer.py` | 41.4% | 80.9% |
| **TOTAL** | **58.5%** | **88.5% line / 83.6% branch** |

## Files added

- `tests/unit/engines/simscape/three_d_gui/_apps_coverage_helpers.py` — shared synthetic-model factory.
- `tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675_services.py` — pure-data + Qt-thread service tests.
- `tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675.py` — Qt-offscreen UI tab + dialog + main-window tests.

## No production changes

`src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/` is untouched.

## Test plan

- [x] `python3 -m pytest tests/unit/engines/simscape/three_d_gui/ --cov=...apps --cov-branch` reports >=85% line, >=75% branch
- [x] `python3 -m ruff check tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675*.py _apps_coverage_helpers.py`
- [x] `python3 -m ruff format --check ...`
- [x] All new tests pass; no production code modified

Two pre-existing `test_starting_pose_matcher.py` failures (`test_phase_window_switch`, `test_session_round_trip`) are unrelated to this PR — they fail on `main` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)