### PR TITLE
ci(urdf): layering CI gate + mesh-types consolidation (closes #4602, #4603)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -58,6 +58,15 @@ jobs:
         shell: bash
         run: python3 scripts/check_workflow_inventory.py
 
+  urdf-layering:
+    name: Enforce URDF subsystem layering (ADR 0007)
+    runs-on: d-sorg-fleet
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Run URDF layering guard
+        shell: bash
+        run: python3 scripts/ci/check_urdf_layering.py
+
   # -- Dispatcher: route to self-hosted if available --------------------------
   pick-runner:
     runs-on: d-sorg-fleet

--- a/scripts/ci/check_urdf_layering.py
+++ b/scripts/ci/check_urdf_layering.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""CI gate: enforce the layered URDF subsystem boundary from ADR 0007.
+
+Per the layered architecture decision (issue #4521 / ADR 0007):
+
+- ``model_generation`` is the low-level URDF / mesh / inertia toolkit.
+- ``humanoid_character_builder`` is the anthropometric-domain layer that
+  composes the toolkit.
+
+This script enforces three rules statically (no execution required):
+
+1. ``humanoid_character_builder/`` MUST NOT contain its own URDF XML
+   writer. Files matching that pattern must delegate to
+   ``model_generation/builders/urdf_writer.py``.
+2. ``humanoid_character_builder/mesh/`` files MUST delegate to
+   ``model_generation/inertia/`` for primitive inertia computation.
+3. Source files in ``model_generation/`` MUST NOT import from
+   ``humanoid_character_builder/`` (the toolkit layer cannot depend on
+   the domain layer).
+
+Exits 0 if all rules pass, 1 if any violation is detected.
+
+Usage::
+
+    python3 scripts/ci/check_urdf_layering.py
+
+Output is suitable for GitHub Actions step summaries.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HCB = REPO_ROOT / "src" / "shared" / "python" / "humanoid_character_builder"
+MG = REPO_ROOT / "src" / "shared" / "python" / "model_generation"
+
+# Import patterns that signal a layering violation.
+HCB_OWNED_URDF_WRITER_HINTS: tuple[str, ...] = (
+    "<robot",
+    "ET.SubElement",
+    "ET.Element(",
+    "DefusedET.parse",
+)
+
+# Files in humanoid_character_builder that *are allowed* to construct
+# URDF XML directly (the existing emitter, until #4601 lands).
+# Once #4601 ships these will be removed from this allowlist.
+HCB_URDF_WRITER_ALLOWLIST: set[Path] = {
+    HCB / "generators" / "urdf_xml_builder.py",
+    HCB / "generators" / "_urdf_xml_writer.py",
+    HCB / "generators" / "urdf_generator.py",
+    # The canonical adapter explicitly composes model_generation's URDFWriter
+    # — that's its whole purpose. The static check's heuristic flags it
+    # because the file mentions <robot> in its docstring and calls .write(),
+    # but it's the OPPOSITE of a violation: it's the bridge to the canonical
+    # writer.
+    HCB / "generators" / "_canonical_adapter.py",
+}
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    return [p for p in root.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+# Files in model_generation that are explicitly *allowed* to import from
+# humanoid_character_builder. These are intentional domain-aware shims
+# that re-export the domain types under the toolkit's namespace for
+# convenience. Per ADR 0007 §"Consequences": "Some integrations may need
+# updating (any caller currently importing from
+# humanoid_character_builder.mesh.primitive_inertia would now get a
+# re-export from model_generation.inertia)."
+MG_SHIM_ALLOWLIST: set[Path] = {
+    MG / "humanoid" / "__init__.py",
+    MG / "mesh" / "__init__.py",
+}
+
+
+def check_no_reverse_imports() -> list[str]:
+    """Rule 3: model_generation must not import from humanoid_character_builder.
+
+    Shim modules are allowlisted (see ``MG_SHIM_ALLOWLIST``).
+    """
+    violations: list[str] = []
+    for path in _iter_python_files(MG):
+        if path in MG_SHIM_ALLOWLIST:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "humanoid_character_builder" in line and (
+                "import " in line or "from " in line
+            ):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(
+                    f"{rel}:{lineno}: model_generation cannot import "
+                    f"from humanoid_character_builder (toolkit layer cannot "
+                    f"depend on domain layer). If this is an intentional "
+                    f"shim, add it to MG_SHIM_ALLOWLIST in this script."
+                )
+    return violations
+
+
+def check_inertia_delegation() -> list[str]:
+    """Rule 2: hcb.mesh primitive inertia files must import from model_generation.inertia."""
+    violations: list[str] = []
+    target = HCB / "mesh" / "primitive_inertia.py"
+    if not target.exists():
+        return violations
+    text = target.read_text(encoding="utf-8")
+    if "from model_generation.inertia" not in text:
+        rel = target.relative_to(REPO_ROOT)
+        violations.append(
+            f"{rel}: missing `from model_generation.inertia.primitives import ...`. "
+            f"Per ADR 0007, primitive inertia must delegate to model_generation."
+        )
+    return violations
+
+
+def check_urdf_writer_layer() -> list[str]:
+    """Rule 1 (advisory until #4601 lands): non-allowlisted hcb files must not emit URDF XML directly."""
+    violations: list[str] = []
+    for path in _iter_python_files(HCB):
+        if path in HCB_URDF_WRITER_ALLOWLIST:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        # Check whether the file constructs URDF root XML elements directly.
+        # We're looking for any signs of low-level XML emission outside the
+        # allowlist; the file should compose model_generation.builders.urdf_writer
+        # if it needs to produce URDF XML.
+        if "<robot" in text and "import " in text and ".write(" in text:
+            rel = path.relative_to(REPO_ROOT)
+            violations.append(
+                f"{rel}: appears to construct URDF XML directly outside the "
+                f"allowlist. Use model_generation.builders.urdf_writer.URDFWriter "
+                f"(see ADR 0007 / #4601)."
+            )
+    return violations
+
+
+def main() -> int:
+    all_violations: list[str] = []
+    all_violations += check_no_reverse_imports()
+    all_violations += check_inertia_delegation()
+    all_violations += check_urdf_writer_layer()
+
+    if not all_violations:
+        print("OK: URDF layering rules satisfied (ADR 0007).")
+        return 0
+
+    print("URDF layering violations detected:\n")
+    for v in all_violations:
+        print(f"  {v}")
+    print("\nSee docs/adr/0007-canonical-urdf-subsystem.md for the rules.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator_models.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator_models.py
@@ -1,103 +1,30 @@
-"""Shared mesh-generator data models and interfaces."""
+"""Shared mesh-generator data models and interfaces.
+
+This module is now a thin re-export of :mod:`._mesh_types`, the canonical
+home for mesh-generator types in this subsystem. Kept for backward
+compatibility with the legacy ``mesh_generator_models`` import path used
+by ``mesh_generator_factory``, ``mesh_generator_makehuman``,
+``mesh_generator_primitive``, and ``mesh_generator_smplx``.
+
+See issue #4602 (URDF Hardening Campaign / arch-B/3): the two duplicate
+``GeneratedMeshResult`` / ``MeshGeneratorBackend`` / ``MeshGeneratorInterface``
+definitions in this directory were collapsed onto ``_mesh_types`` so
+identity comparisons (``MeshGeneratorBackend.SMPLX is X``) work across
+both legacy import paths.
+"""
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from enum import Enum
-from pathlib import Path
-from typing import Any
+from humanoid_character_builder.generators._mesh_types import (
+    GeneratedMeshResult,
+    MeshGeneratorBackend,
+    MeshGeneratorInterface,
+    segment_mesh_by_range,
+)
 
-from humanoid_character_builder.core.body_parameters import BodyParameters
-
-
-class MeshGeneratorBackend(Enum):
-    """Available mesh generation backends."""
-
-    PRIMITIVE = "primitive"  # Generate primitive shapes (built-in)
-    MAKEHUMAN = "makehuman"  # MakeHuman integration
-    SMPLX = "smplx"  # SMPL-X body model
-    CUSTOM = "custom"  # Custom mesh provider
-
-
-@dataclass
-class GeneratedMeshResult:
-    """Result of mesh generation."""
-
-    # Whether generation was successful
-    success: bool
-
-    # Canonical status string ("success", "failure", "partial").
-    # See issue #4522 for the unified BuildResult contract.
-    solver_status: str = "success"
-
-    # Path to generated mesh files (segment name -> path)
-    mesh_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Path to collision mesh files
-    collision_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Path to texture files
-    texture_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Vertex group mapping (for segmentation)
-    vertex_groups: dict[str, list[int]] = field(default_factory=dict)
-
-    # Error message if failed
-    error_message: str | None = None
-
-    # Additional metadata
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        # If caller passed success=False but didn't override solver_status,
-        # derive solver_status from success. Keeps backward compatibility
-        # with code that only sets success.
-        if not self.success and self.solver_status == "success":
-            self.solver_status = "failure"
-
-
-class MeshGeneratorInterface(ABC):
-    """
-    Abstract interface for mesh generation backends.
-
-    Implement this interface to add new mesh generation sources
-    (MakeHuman, SMPL, etc.).
-    """
-
-    @property
-    @abstractmethod
-    def backend_name(self) -> str:
-        """Return the backend name."""
-        ...
-
-    @property
-    @abstractmethod
-    def is_available(self) -> bool:
-        """Check if the backend is available (installed, configured)."""
-        ...
-
-    @abstractmethod
-    def generate(
-        self,
-        params: BodyParameters,
-        output_dir: Path,
-        **kwargs: Any,
-    ) -> GeneratedMeshResult:
-        """
-        Generate meshes for the given body parameters.
-
-        Args:
-            params: Body parameters
-            output_dir: Directory to write mesh files
-            **kwargs: Backend-specific options
-
-        Returns:
-            GeneratedMeshResult with paths to generated files
-        """
-        ...
-
-    @abstractmethod
-    def get_supported_segments(self) -> list[str]:
-        """Return list of segment names this backend can generate."""
-        ...
+__all__ = [
+    "GeneratedMeshResult",
+    "MeshGeneratorBackend",
+    "MeshGeneratorInterface",
+    "segment_mesh_by_range",
+]


### PR DESCRIPTION
## Summary

Closes the last two open issues from the URDF Hardening Campaign:

- **#4603** — URDF layering CI gate (`scripts/ci/check_urdf_layering.py` + `urdf-layering` job in `ci-standard.yml`)
- **#4602** — `mesh_generator_models.py` consolidated to a thin re-export of `_mesh_types.py`

## Changes

### `scripts/ci/check_urdf_layering.py` (new, 174 LOC)

Static check enforcing ADR 0007's three layering rules:
1. `humanoid_character_builder/` may not write URDF XML directly outside the explicit allowlist (existing emitters + canonical adapter from #4665).
2. `humanoid_character_builder.mesh.primitive_inertia` must delegate to `model_generation.inertia.primitives`.
3. `model_generation/` may not import from `humanoid_character_builder/` (with explicit allowlist for the two intentional shims).

### `.github/workflows/ci-standard.yml`

Adds the `urdf-layering` job that runs the new check on every PR.

### `src/shared/python/humanoid_character_builder/generators/mesh_generator_models.py`

Now a thin re-export of `_mesh_types.py`. Previously two parallel definitions of `GeneratedMeshResult`, `MeshGeneratorBackend`, and `MeshGeneratorInterface` existed in this directory. Identity comparisons (`A.SMPLX is B.SMPLX`) silently failed because the imports resolved to *different* enum classes. Consolidating fixes that.

Verified post-change:

```
>>> from humanoid_character_builder.generators._mesh_types import MeshGeneratorBackend as A
>>> from humanoid_character_builder.generators.mesh_generator_models import MeshGeneratorBackend as B
>>> A.SMPLX is B.SMPLX
True
```

## Test plan

- [x] `python3 scripts/ci/check_urdf_layering.py` → `OK: URDF layering rules satisfied (ADR 0007).`
- [x] `pytest tests/unit/tools/humanoid_character_builder/ tests/unit/tools/model_generation/` → 748 pass, 0 fail
- [x] `ruff check` on changed files — clean
- [x] Identity comparison post-#4602 returns True
- [ ] CI green (the new `urdf-layering` job will run on this PR)

## History

These were originally part of [PR #4617](https://github.com/D-sorganization/UpstreamDrift/pull/4617), which I closed after most of its other contents (inertia migration, solver_status fixes) had landed via parallel-agent work. But the layering gate and the mesh-types consolidation hadn't actually merged anywhere, so they're reapplied here as a focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)