### PR TITLE
test(motion-matching): coverage to >=85% (#4672)

### DIFF
--- a/tests/unit/motion_matching/test_align_to_simulation_grid_coverage.py
+++ b/tests/unit/motion_matching/test_align_to_simulation_grid_coverage.py
@@ -1,0 +1,59 @@
+"""Coverage tests for ``align_to_simulation_grid``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.align_to_simulation_grid import (
+    AlignedTrajectory,
+    align_to_simulation_grid,
+)
+
+
+def _raw(n: int = 200, t_end: float = 0.5):
+    raw_time = np.linspace(0.0, t_end, n)
+    speed = np.sin(np.pi * raw_time / t_end)
+    butt = np.zeros((n, 3))
+    clubhead = np.column_stack([speed, np.zeros(n), np.zeros(n)])
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    return raw_time, butt, clubhead, quat
+
+
+def test_returns_aligned_trajectory() -> None:
+    """Pin: success returns an :class:`AlignedTrajectory`."""
+    raw_time, butt, clubhead, quat = _raw()
+    out = align_to_simulation_grid(raw_time, butt, clubhead, quat)
+    assert isinstance(out, AlignedTrajectory)
+    assert out.time.shape == out.butt.shape[:1]
+    assert out.club_quat.shape[1] == 4
+
+
+def test_too_few_samples_rejected() -> None:
+    """Pin: < 2 samples rejected."""
+    with pytest.raises(ValueError, match="at least 2 samples"):
+        align_to_simulation_grid(
+            np.array([0.0]),
+            np.zeros((1, 3)),
+            np.zeros((1, 3)),
+            np.tile([1.0, 0.0, 0.0, 0.0], (1, 1)),
+        )
+
+
+def test_non_monotonic_rejected() -> None:
+    """Pin: non-strictly-increasing raw_time is rejected."""
+    raw_time = np.array([0.0, 0.0, 0.1, 0.2])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        align_to_simulation_grid(
+            raw_time,
+            np.zeros((4, 3)),
+            np.zeros((4, 3)),
+            np.tile([1.0, 0.0, 0.0, 0.0], (4, 1)),
+        )
+
+
+def test_explicit_impact_idx_used() -> None:
+    """Pin: ``impact_idx_raw`` overrides the auto-detect path."""
+    raw_time, butt, clubhead, quat = _raw()
+    out = align_to_simulation_grid(raw_time, butt, clubhead, quat, impact_idx_raw=10)
+    # impact_out comes back as 1-based index on the simulation grid.
+    assert out.impact_idx >= 1

--- a/tests/unit/motion_matching/test_api_contracts_coverage.py
+++ b/tests/unit/motion_matching/test_api_contracts_coverage.py
@@ -1,0 +1,348 @@
+"""Coverage tests for ``motion_matching.api_contracts``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.api_contracts import (
+    ENGINE_DOF_MAP,
+    FitResult,
+    InitialPose,
+    InitialPoseValidator,
+    ThetaContractValidator,
+    validate_initial_pose,
+    validate_theta_contract,
+)
+
+
+def _good_metadata() -> dict:
+    return {"engine": "drake", "time_s": 1.5}
+
+
+# --- FitResult validation ---------------------------------------------------
+
+
+class TestFitResult:
+    """Pin: ``FitResult`` DbC checks at construction."""
+
+    def test_valid_constructs(self) -> None:
+        """Pin: a well-formed FitResult constructs without error."""
+        FitResult(
+            coefficients=np.zeros(7, dtype=np.float64),
+            final_loss=0.0,
+            metadata=_good_metadata(),
+        )
+
+    def test_coefficients_must_be_ndarray(self) -> None:
+        """Pin: list inputs are rejected with TypeError."""
+        with pytest.raises(TypeError, match="must be np.ndarray"):
+            FitResult(coefficients=[1.0], final_loss=0.0, metadata=_good_metadata())  # type: ignore[arg-type]
+
+    def test_coefficients_must_be_1d(self) -> None:
+        """Pin: 2-D coefficients are rejected."""
+        with pytest.raises(ValueError, match="must be 1-D"):
+            FitResult(
+                coefficients=np.zeros((2, 3), dtype=np.float64),
+                final_loss=0.0,
+                metadata=_good_metadata(),
+            )
+
+    def test_coefficients_finite(self) -> None:
+        """Pin: NaN coefficients are rejected."""
+        with pytest.raises(ValueError, match="NaN or Inf"):
+            FitResult(
+                coefficients=np.array([np.nan], dtype=np.float64),
+                final_loss=0.0,
+                metadata=_good_metadata(),
+            )
+
+    def test_coefficients_dtype(self) -> None:
+        """Pin: int dtype rejected — must be float32/64."""
+        with pytest.raises(TypeError, match="dtype must be float"):
+            FitResult(
+                coefficients=np.zeros(3, dtype=np.int64),
+                final_loss=0.0,
+                metadata=_good_metadata(),
+            )
+
+    def test_final_loss_must_be_float(self) -> None:
+        """Pin: string final_loss raises TypeError."""
+        with pytest.raises(TypeError, match="must be float"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss="0",  # type: ignore[arg-type]
+                metadata=_good_metadata(),
+            )
+
+    def test_final_loss_finite(self) -> None:
+        """Pin: NaN final_loss is rejected."""
+        with pytest.raises(ValueError, match="must be finite"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=float("nan"),
+                metadata=_good_metadata(),
+            )
+
+    def test_final_loss_nonneg(self) -> None:
+        """Pin: negative final_loss is rejected."""
+        with pytest.raises(ValueError, match="must be >= 0"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=-1.0,
+                metadata=_good_metadata(),
+            )
+
+    def test_metadata_must_be_dict(self) -> None:
+        """Pin: non-dict metadata raises TypeError."""
+        with pytest.raises(TypeError, match="must be dict"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=0.0,
+                metadata="meta",  # type: ignore[arg-type]
+            )
+
+    def test_metadata_required_keys(self) -> None:
+        """Pin: metadata missing 'engine'/'time_s' is rejected."""
+        with pytest.raises(ValueError, match="missing required keys"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=0.0,
+                metadata={"engine": "drake"},
+            )
+
+    def test_metadata_engine_known(self) -> None:
+        """Pin: unknown engine name is rejected."""
+        with pytest.raises(ValueError, match="must be one of"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=0.0,
+                metadata={"engine": "unknown", "time_s": 1.0},
+            )
+
+    def test_metadata_time_s_numeric(self) -> None:
+        """Pin: non-numeric time_s raises TypeError."""
+        with pytest.raises(TypeError, match="time_s.*must be numeric"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=0.0,
+                metadata={"engine": "drake", "time_s": "1.0"},
+            )
+
+    def test_metadata_time_s_nonneg(self) -> None:
+        """Pin: negative time_s rejected."""
+        with pytest.raises(ValueError, match=r"time_s.*must be >= 0"):
+            FitResult(
+                coefficients=np.zeros(2, dtype=np.float64),
+                final_loss=0.0,
+                metadata={"engine": "drake", "time_s": -1.0},
+            )
+
+
+# --- ThetaContractValidator -------------------------------------------------
+
+
+class TestThetaContractValidator:
+    """Pin: theta contract validator behaviour."""
+
+    def test_unknown_engine_rejected(self) -> None:
+        """Pin: ctor raises on unknown engine."""
+        with pytest.raises(ValueError, match="engine must be one of"):
+            ThetaContractValidator("zzz")
+
+    def test_n_dof_must_be_positive_int(self) -> None:
+        """Pin: ctor n_dof contract."""
+        with pytest.raises(ValueError, match="positive int"):
+            ThetaContractValidator("drake", n_dof=0)
+        with pytest.raises(ValueError, match="positive int"):
+            ThetaContractValidator("drake", n_dof="23")  # type: ignore[arg-type]
+
+    def test_default_n_dof_from_map(self) -> None:
+        """Pin: default ``n_dof`` is read from ``ENGINE_DOF_MAP``."""
+        v = ThetaContractValidator("mujoco")
+        assert v.n_dof == ENGINE_DOF_MAP["mujoco"]
+
+    def test_valid_theta_returns_none(self) -> None:
+        """Pin: a within-spec theta validates with None."""
+        v = ThetaContractValidator("mujoco")
+        assert v.validate(np.zeros(17, dtype=np.float64)) is None
+
+    def test_2d_returns_error(self) -> None:
+        """Pin: 2-D theta yields shape error string."""
+        v = ThetaContractValidator("mujoco")
+        msg = v.validate(np.zeros((2, 17)))
+        assert "must be 1-D" in (msg or "")
+
+    def test_length_mismatch_returns_error(self) -> None:
+        """Pin: wrong-length theta yields length-mismatch error string."""
+        v = ThetaContractValidator("mujoco")
+        msg = v.validate(np.zeros(13))
+        assert "length mismatch" in (msg or "")
+
+    def test_nonfinite_reports_indices(self) -> None:
+        """Pin: non-finite report includes count and indices."""
+        v = ThetaContractValidator("mujoco")
+        bad = np.zeros(17)
+        bad[3] = np.nan
+        msg = v.validate(bad)
+        assert msg is not None and "non-finite" in msg
+
+    def test_out_of_range_reports_min_max(self) -> None:
+        """Pin: out-of-range values are reported with min/max."""
+        v = ThetaContractValidator("mujoco")
+        bad = np.zeros(17)
+        bad[0] = 1e6
+        msg = v.validate(bad)
+        assert msg is not None and "out of range" in msg
+
+    def test_validate_raise_propagates(self) -> None:
+        """Pin: ``validate_raise`` raises ValueError on bad input."""
+        v = ThetaContractValidator("mujoco")
+        with pytest.raises(ValueError):
+            v.validate_raise(np.zeros(13))
+
+    def test_validate_raise_silent_on_valid(self) -> None:
+        """Pin: ``validate_raise`` returns silently on valid input."""
+        v = ThetaContractValidator("mujoco")
+        v.validate_raise(np.zeros(17))
+
+
+# --- InitialPoseValidator ---------------------------------------------------
+
+
+def _good_pose() -> InitialPose:
+    return InitialPose(
+        root_position=np.array([0.0, 0.0, 0.0]),
+        root_quat=np.array([1.0, 0.0, 0.0, 0.0]),
+        joint_angles=np.zeros(17),
+    )
+
+
+class TestInitialPoseValidator:
+    """Pin: initial-pose validator branches."""
+
+    def test_unknown_engine_rejected(self) -> None:
+        """Pin: ctor rejects unknown engine."""
+        with pytest.raises(ValueError, match="engine must be one of"):
+            InitialPoseValidator("nope")
+
+    def test_valid_pose_returns_none(self) -> None:
+        """Pin: a canonical drake pose validates."""
+        v = InitialPoseValidator("drake")
+        assert v.validate(_good_pose()) is None
+
+    def test_position_shape_error(self) -> None:
+        """Pin: wrong-shape position yields ``root_position:`` prefix."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_position=np.zeros(2))
+        msg = v.validate(pose)
+        assert msg is not None and msg.startswith("root_position:")
+
+    def test_position_must_be_ndarray(self) -> None:
+        """Pin: list position is rejected with type message."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_position=[0.0, 0.0, 0.0])  # type: ignore[arg-type]
+        msg = v.validate(pose)
+        assert msg is not None and "must be np.ndarray" in msg
+
+    def test_position_nonfinite(self) -> None:
+        """Pin: NaN position is rejected."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_position=np.array([np.nan, 0.0, 0.0]))
+        assert v.validate(pose) is not None
+
+    def test_position_norm_too_big(self) -> None:
+        """Pin: huge-norm position rejected."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_position=np.array([1000.0, 0.0, 0.0]))
+        msg = v.validate(pose)
+        assert msg is not None
+
+    def test_position_component_out_of_range(self) -> None:
+        """Pin: per-component bound triggers separately from norm."""
+        v = InitialPoseValidator("drake")
+        # 51 is just above the per-component ceiling of 50; norm 51 > 50 too.
+        pose = _good_pose()._replace(root_position=np.array([51.0, 0.0, 0.0]))
+        assert v.validate(pose) is not None
+
+    def test_quat_shape_error(self) -> None:
+        """Pin: wrong-shape quat yields ``root_quat:`` prefix."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_quat=np.zeros(3))
+        msg = v.validate(pose)
+        assert msg is not None and msg.startswith("root_quat:")
+
+    def test_quat_must_be_ndarray(self) -> None:
+        """Pin: list quat rejected with type message."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_quat=[1.0, 0, 0, 0])  # type: ignore[arg-type]
+        assert v.validate(pose) is not None
+
+    def test_quat_nonfinite(self) -> None:
+        """Pin: NaN quat rejected."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_quat=np.array([np.nan, 0, 0, 0]))
+        assert v.validate(pose) is not None
+
+    def test_quat_not_unit_norm(self) -> None:
+        """Pin: non-unit quat rejected."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(root_quat=np.array([2.0, 0, 0, 0]))
+        assert v.validate(pose) is not None
+
+    def test_joint_angles_wrong_length(self) -> None:
+        """Pin: mismatched joint count rejected."""
+        v = InitialPoseValidator("drake")
+        pose = _good_pose()._replace(joint_angles=np.zeros(5))
+        msg = v.validate(pose)
+        assert msg is not None and "joint_angles" in msg
+
+    def test_joint_angles_nonfinite(self) -> None:
+        """Pin: NaN joint angle rejected."""
+        v = InitialPoseValidator("drake")
+        bad = np.zeros(17)
+        bad[2] = np.nan
+        pose = _good_pose()._replace(joint_angles=bad)
+        msg = v.validate(pose)
+        assert msg is not None and "joint_angles" in msg
+
+    def test_validate_raise_propagates(self) -> None:
+        """Pin: validate_raise raises ValueError on bad pose."""
+        v = InitialPoseValidator("drake")
+        bad = _good_pose()._replace(root_quat=np.zeros(3))
+        with pytest.raises(ValueError):
+            v.validate_raise(bad)
+
+    def test_validate_raise_silent_on_valid(self) -> None:
+        """Pin: validate_raise returns silently on canonical pose."""
+        v = InitialPoseValidator("drake")
+        v.validate_raise(_good_pose())
+
+
+# --- module-level wrappers --------------------------------------------------
+
+
+class TestModuleEntryPoints:
+    """Pin: module-level convenience functions catch ValueError safely."""
+
+    def test_validate_theta_contract_valid(self) -> None:
+        """Pin: returns None for valid input."""
+        assert validate_theta_contract(np.zeros(17), "mujoco") is None
+
+    def test_validate_theta_contract_unknown_engine_via_ctor(self) -> None:
+        """Pin: unknown engine returned as error string (not raised)."""
+        # Precondition catches engine; bypass by passing a known engine
+        # but bad n_dof to exercise the except-ValueError path.
+        out = validate_theta_contract(np.zeros(17), "mujoco", n_dof=-1)
+        assert isinstance(out, str)
+
+    def test_validate_initial_pose_valid(self) -> None:
+        """Pin: valid pose returns None."""
+        assert validate_initial_pose(_good_pose(), "drake") is None
+
+    def test_validate_initial_pose_via_bad_n_dof(self) -> None:
+        """Pin: ValueError from ctor caught and returned as string."""
+        out = validate_initial_pose(_good_pose(), "drake", n_dof=-1)
+        # n_dof negative -> n_joints -7. joint_angles shape mismatch
+        # produces the error string from validate(); the ctor itself
+        # accepts negative n_dof, so the validator returns an error.
+        assert isinstance(out, str)

--- a/tests/unit/motion_matching/test_club_ball_target_coverage.py
+++ b/tests/unit/motion_matching/test_club_ball_target_coverage.py
@@ -1,0 +1,256 @@
+"""Coverage tests for ``club_ball_target`` validation paths."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.club_ball_target import (
+    DEFAULT_ELASTICITY_FACTOR,
+    LAUNCH_DIR_NORM_TOL,
+    MAX_LAUNCH_SPEED_MPS,
+    BallImpactState,
+    ClubBallTarget,
+    extract_ball_impact_from_clubtarget,
+)
+
+from ._fixtures import make_target
+
+
+def _good_state(**overrides) -> BallImpactState:
+    base = {
+        "position_at_impact_m": np.array([0.0, 0.0, 0.0]),
+        "launch_direction": np.array([1.0, 0.0, 0.0]),
+        "launch_speed_mps": 50.0,
+        "spin_rpm": 1000.0,
+    }
+    base.update(overrides)
+    return BallImpactState(**base)
+
+
+# --- BallImpactState validation --------------------------------------------
+
+
+def test_position_must_be_ndarray() -> None:
+    """Pin: list position rejected with TypeError."""
+    with pytest.raises(TypeError, match="must be a numpy.ndarray"):
+        _good_state(position_at_impact_m=[0.0, 0.0, 0.0])
+
+
+def test_position_shape() -> None:
+    """Pin: wrong-shape position rejected."""
+    with pytest.raises(ValueError, match=r"shape \(3,\)"):
+        _good_state(position_at_impact_m=np.zeros(2))
+
+
+def test_position_finite() -> None:
+    """Pin: NaN position rejected."""
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        _good_state(position_at_impact_m=np.array([np.nan, 0.0, 0.0]))
+
+
+def test_position_norm_too_big() -> None:
+    """Pin: large-norm position rejected."""
+    with pytest.raises(ValueError, match=r"\|r\| >="):
+        _good_state(position_at_impact_m=np.array([100.0, 0.0, 0.0]))
+
+
+def test_launch_direction_type() -> None:
+    """Pin: non-ndarray direction rejected."""
+    with pytest.raises(TypeError, match="must be a numpy.ndarray"):
+        _good_state(launch_direction=[1.0, 0, 0])
+
+
+def test_launch_direction_shape() -> None:
+    """Pin: wrong-shape direction rejected."""
+    with pytest.raises(ValueError, match=r"shape \(3,\)"):
+        _good_state(launch_direction=np.zeros(2))
+
+
+def test_launch_direction_partial_nan_rejected() -> None:
+    """Pin: partial-NaN direction rejected."""
+    with pytest.raises(ValueError, match="fully NaN or fully finite"):
+        _good_state(launch_direction=np.array([np.nan, 0.0, 1.0]))
+
+
+def test_launch_direction_inf_rejected() -> None:
+    """Pin: ``inf`` in direction rejected."""
+    with pytest.raises(ValueError, match="contains Inf"):
+        _good_state(launch_direction=np.array([np.inf, 0.0, 0.0]))
+
+
+def test_launch_direction_non_unit_rejected() -> None:
+    """Pin: non-unit direction rejected."""
+    with pytest.raises(ValueError, match="unit-norm"):
+        _good_state(launch_direction=np.array([2.0, 0.0, 0.0]))
+
+
+def test_launch_direction_all_nan_ok() -> None:
+    """Pin: fully-NaN direction is the documented 'unknown' sentinel."""
+    s = _good_state(launch_direction=np.full(3, np.nan))
+    assert np.all(np.isnan(s.launch_direction))
+
+
+def test_launch_speed_negative_rejected() -> None:
+    """Pin: negative launch speed rejected."""
+    with pytest.raises(ValueError, match=r"launch_speed_mps must be in"):
+        _good_state(launch_speed_mps=-1.0)
+
+
+def test_launch_speed_too_big_rejected() -> None:
+    """Pin: launch speed above the bound rejected."""
+    with pytest.raises(ValueError, match=r"launch_speed_mps must be in"):
+        _good_state(launch_speed_mps=MAX_LAUNCH_SPEED_MPS + 1.0)
+
+
+def test_launch_speed_inf_rejected() -> None:
+    """Pin: ``inf`` launch speed rejected as non-finite."""
+    with pytest.raises(ValueError, match="finite or NaN"):
+        _good_state(launch_speed_mps=float("inf"))
+
+
+def test_launch_speed_nan_ok() -> None:
+    """Pin: NaN launch speed is the 'unknown' sentinel."""
+    s = _good_state(launch_speed_mps=float("nan"))
+    assert np.isnan(s.launch_speed_mps)
+
+
+def test_spin_rpm_too_big_rejected() -> None:
+    """Pin: spin above the bound rejected."""
+    with pytest.raises(ValueError, match="spin_rpm"):
+        _good_state(spin_rpm=20_000.0)
+
+
+# --- ClubBallTarget --------------------------------------------------------
+
+
+def test_clubball_target_type_checks() -> None:
+    """Pin: ClubBallTarget rejects non-ClubTarget club and non-state ball."""
+    state = _good_state()
+    with pytest.raises(TypeError, match="club must be a ClubTarget"):
+        ClubBallTarget(club="not a target", ball_impact=state)  # type: ignore[arg-type]
+    t = make_target()
+    with pytest.raises(TypeError, match="ball_impact must be a BallImpactState"):
+        ClubBallTarget(club=t, ball_impact={})  # type: ignore[arg-type]
+
+
+def test_clubball_target_delegates_time_and_impact() -> None:
+    """Pin: time/impact_idx delegate to the underlying ClubTarget."""
+    t = make_target()
+    cbt = ClubBallTarget(club=t, ball_impact=_good_state())
+    assert np.array_equal(cbt.time, t.time)
+    assert cbt.impact_idx == t.impact_idx
+
+
+# --- extract_ball_impact_from_clubtarget -----------------------------------
+
+
+def test_extract_requires_clubtarget() -> None:
+    """Pin: extractor rejects non-ClubTarget input."""
+    with pytest.raises(TypeError, match="must be a ClubTarget"):
+        extract_ball_impact_from_clubtarget("nope")  # type: ignore[arg-type]
+
+
+def test_extract_invalid_elasticity() -> None:
+    """Pin: NaN/negative elasticity factor rejected."""
+    t = make_target()
+    with pytest.raises(ValueError, match="elasticity_factor"):
+        extract_ball_impact_from_clubtarget(t, elasticity_factor=float("nan"))
+    with pytest.raises(ValueError, match="elasticity_factor"):
+        extract_ball_impact_from_clubtarget(t, elasticity_factor=-1.0)
+
+
+def test_extract_returns_validated_state() -> None:
+    """Pin: extracted state is a valid BallImpactState."""
+    t = make_target()
+    s = extract_ball_impact_from_clubtarget(
+        t, elasticity_factor=DEFAULT_ELASTICITY_FACTOR
+    )
+    assert isinstance(s, BallImpactState)
+    # spin is unknown (NaN) per the documented fall-back.
+    assert np.isnan(s.spin_rpm)
+
+
+def test_extract_clamps_speed() -> None:
+    """Pin: huge elasticity gets clamped to MAX_LAUNCH_SPEED_MPS."""
+    t = make_target()
+    s = extract_ball_impact_from_clubtarget(t, elasticity_factor=1e6)
+    assert s.launch_speed_mps <= MAX_LAUNCH_SPEED_MPS
+
+
+def test_extract_marks_direction_unknown_when_velocity_zero() -> None:
+    """Pin: a stationary clubhead at impact yields NaN launch direction."""
+    import hashlib
+
+    from src.shared.python.motion_matching.club_target import (
+        ClubTarget,
+        SourceProvenance,
+    )
+
+    n = 11
+    time = np.linspace(0.0, 0.1, n)
+    butt = np.zeros((n, 3))
+    clubhead = np.zeros((n, 3))  # stationary -> zero velocity
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    t = ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=n // 2,
+        source=SourceProvenance(
+            filename="x",
+            format="synthetic",
+            subject_id="u",
+            trial_id="0",
+            sha256=hashlib.sha256(b"").hexdigest(),
+        ),
+    )
+    s = extract_ball_impact_from_clubtarget(t, elasticity_factor=1.0)
+    assert np.all(np.isnan(s.launch_direction))
+
+
+def test_extract_velocity_endpoints() -> None:
+    """Pin: impact at index 1 and last index uses one-sided differencing."""
+    import hashlib
+
+    from src.shared.python.motion_matching.club_target import (
+        ClubTarget,
+        SourceProvenance,
+    )
+
+    n = 5
+    time = np.linspace(0.0, 0.04, n)
+    butt = np.zeros((n, 3))
+    clubhead = np.column_stack([time, np.zeros(n), np.zeros(n)])  # moves +x
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    prov = SourceProvenance(
+        filename="x",
+        format="synthetic",
+        subject_id="u",
+        trial_id="0",
+        sha256=hashlib.sha256(b"").hexdigest(),
+    )
+    # impact_idx is 1-based; ``impact_idx=1`` -> k==0 endpoint branch.
+    t1 = ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=1,
+        source=prov,
+    )
+    s1 = extract_ball_impact_from_clubtarget(t1, elasticity_factor=1.0)
+    # 1.0 m/s velocity in +x; tolerant equality.
+    assert s1.launch_direction[0] > 1.0 - LAUNCH_DIR_NORM_TOL
+
+    # impact_idx == n -> k==n-1 endpoint branch.
+    tn = ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=n,
+        source=prov,
+    )
+    sn = extract_ball_impact_from_clubtarget(tn, elasticity_factor=1.0)
+    assert sn.launch_direction[0] > 1.0 - LAUNCH_DIR_NORM_TOL

--- a/tests/unit/motion_matching/test_fit_result_coverage.py
+++ b/tests/unit/motion_matching/test_fit_result_coverage.py
@@ -1,0 +1,96 @@
+"""Coverage tests for ``motion_matching.fit_result.CanonicalFitResult``.
+
+Pin every legacy alias property so removing one would fail loudly.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.cost import CostBreakdown
+from src.shared.python.motion_matching.fit_result import CanonicalFitResult
+
+
+def _make() -> CanonicalFitResult:
+    return CanonicalFitResult(
+        theta_optimal=np.zeros(7, dtype=np.float64),
+        final_cost=1.5,
+        final_rmse_m=0.01,
+        solver_status="success",
+        iterations=42,
+        n_evaluations=99,
+        wall_clock_s=3.14,
+        message="ok",
+        history=(2.0, 1.5),
+        method="lbfgs",
+        git_commit="deadbeef",
+        engine_version="0.1",
+        target_hash="abc",
+        timestamp_utc="2024-01-01T00:00:00Z",
+        cost_breakdown=CostBreakdown(
+            position=0.5,
+            orientation=0.5,
+            impact_anchor=0.5,
+            regularizer=0.0,
+            total=1.5,
+        ),
+    )
+
+
+def _check_deprecation(fn, *args):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        out = fn(*args)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    return out
+
+
+@pytest.mark.parametrize(
+    "prop, expected",
+    [
+        ("coefficients", np.zeros(7, dtype=np.float64)),
+        ("theta", np.zeros(7, dtype=np.float64)),
+        ("mujoco_version", "0.1"),
+        ("cost", 1.5),
+        ("n_iter", 42),
+        ("n_eval", 99),
+        ("n_evals", 99),
+        ("success", True),
+        ("duration_s", 3.14),
+        ("elapsed_s", 3.14),
+        ("solver", "lbfgs"),
+    ],
+)
+def test_deprecated_aliases_emit_warning(prop: str, expected) -> None:
+    """Pin: every legacy alias emits ``DeprecationWarning`` and forwards."""
+    res = _make()
+    out = _check_deprecation(lambda: getattr(res, prop))
+    if isinstance(expected, np.ndarray):
+        assert np.array_equal(out, expected)
+    else:
+        assert out == expected
+
+
+def test_success_false_when_status_not_success() -> None:
+    """Pin: ``success`` is False unless solver_status == 'success'."""
+    res = CanonicalFitResult(
+        theta_optimal=np.zeros(7, dtype=np.float64),
+        final_cost=0.0,
+        final_rmse_m=0.0,
+        solver_status="failed",
+        iterations=0,
+        n_evaluations=0,
+        wall_clock_s=0.0,
+        message="",
+        history=(),
+        method="m",
+        git_commit="g",
+        engine_version="v",
+        target_hash="h",
+        timestamp_utc="2024-01-01T00:00:00Z",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert res.success is False

--- a/tests/unit/motion_matching/test_inverse_timestep_predict.py
+++ b/tests/unit/motion_matching/test_inverse_timestep_predict.py
@@ -1,0 +1,188 @@
+"""Coverage tests for :mod:`motion_matching.inverse_timestep.predict`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from src.shared.python.motion_matching.inverse_timestep.model import (
+    TimestepInverseConfig,
+    TimestepInverseDynamics,
+)
+from src.shared.python.motion_matching.inverse_timestep.predict import (
+    load_with_stats,
+    predict_torques,
+)
+
+
+def _model(
+    n_joints: int = 5, hidden: int = 16, n_blocks: int = 1
+) -> TimestepInverseDynamics:
+    """Tiny model for fast tests."""
+    cfg = TimestepInverseConfig(
+        input_dim=3 * n_joints,
+        output_dim=n_joints,
+        hidden=hidden,
+        n_blocks=n_blocks,
+        dropout=0.0,
+        use_missing_indicator=False,
+    )
+    return TimestepInverseDynamics(cfg)
+
+
+def _stats(n_joints: int = 5):
+    state = {
+        "mean": np.zeros(3 * n_joints, dtype=np.float32),
+        "std": np.ones(3 * n_joints, dtype=np.float32),
+    }
+    tau = {
+        "mean": np.zeros(n_joints, dtype=np.float32),
+        "std": np.ones(n_joints, dtype=np.float32),
+    }
+    return state, tau
+
+
+def test_predict_torques_basic_shape() -> None:
+    """Pin: predict returns ``(B, n_joints)`` float32."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    rng = np.random.default_rng(42)
+    q = rng.normal(size=(2, n))
+    qd = rng.normal(size=(2, n))
+    qdd = rng.normal(size=(2, n))
+    out = predict_torques(model, q, qd, qdd, state_stats=state, tau_stats=tau)
+    assert out.shape == (2, n)
+    assert out.dtype == np.float32
+
+
+def test_predict_torques_attached_stats() -> None:
+    """Pin: stats attached to the model are used when kwargs are None."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    model._state_stats = state
+    model._tau_stats = tau
+    rng = np.random.default_rng(0)
+    q = rng.normal(size=(1, n))
+    out = predict_torques(model, q, q, q)
+    assert out.shape == (1, n)
+
+
+def test_predict_torques_requires_model_type() -> None:
+    """Pin: non-model arg rejected with TypeError."""
+    with pytest.raises(TypeError, match="TimestepInverseDynamics"):
+        predict_torques("nope", np.zeros((1, 5)), np.zeros((1, 5)), np.zeros((1, 5)))
+
+
+def test_predict_torques_requires_stats() -> None:
+    """Pin: missing stats raises ValueError."""
+    n = 5
+    model = _model(n)
+    with pytest.raises(ValueError, match="standardisation stats"):
+        predict_torques(model, np.zeros((1, n)), np.zeros((1, n)), np.zeros((1, n)))
+
+
+def test_predict_torques_njoints_mismatch() -> None:
+    """Pin: trailing-dim mismatch is rejected."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    bad = np.zeros((1, n + 1))
+    with pytest.raises(ValueError, match=r"shape\[-1\]"):
+        predict_torques(
+            model,
+            bad,
+            np.zeros((1, n)),
+            np.zeros((1, n)),
+            state_stats=state,
+            tau_stats=tau,
+        )
+
+
+def test_predict_torques_batch_mismatch() -> None:
+    """Pin: differing batch sizes rejected."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    with pytest.raises(ValueError, match="batch sizes must match"):
+        predict_torques(
+            model,
+            np.zeros((2, n)),
+            np.zeros((3, n)),
+            np.zeros((2, n)),
+            state_stats=state,
+            tau_stats=tau,
+        )
+
+
+def test_predict_torques_1d_input_promoted_to_2d() -> None:
+    """Pin: 1-D inputs are promoted to a single-batch (1, n)."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    out = predict_torques(
+        model,
+        np.zeros(n),
+        np.zeros(n),
+        np.zeros(n),
+        state_stats=state,
+        tau_stats=tau,
+    )
+    assert out.shape == (1, n)
+
+
+def test_predict_torques_3d_rejected() -> None:
+    """Pin: 3-D inputs rejected with shape error."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    with pytest.raises(ValueError, match="must be 1-D or 2-D"):
+        predict_torques(
+            model,
+            np.zeros((1, 1, n)),
+            np.zeros((1, n)),
+            np.zeros((1, n)),
+            state_stats=state,
+            tau_stats=tau,
+        )
+
+
+def test_predict_zero_std_floored() -> None:
+    """Pin: zero-std columns are floored so prediction does not explode."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    state["std"] = np.zeros(3 * n, dtype=np.float32)  # degenerate
+    out = predict_torques(
+        model,
+        np.zeros((1, n)),
+        np.zeros((1, n)),
+        np.zeros((1, n)),
+        state_stats=state,
+        tau_stats=tau,
+    )
+    assert np.all(np.isfinite(out))
+
+
+def test_load_with_stats_missing_file(tmp_path: Path) -> None:
+    """Pin: missing checkpoint raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_with_stats(tmp_path / "nope.pt")
+
+
+def test_load_with_stats_round_trip(tmp_path: Path) -> None:
+    """Pin: load_with_stats attaches state_stats / tau_stats to model."""
+    n = 5
+    model = _model(n)
+    state, tau = _stats(n)
+    ckpt_path = tmp_path / "ts.pt"
+    payload = model.state_payload()
+    payload["state_stats"] = state
+    payload["tau_stats"] = tau
+    torch.save(payload, ckpt_path)
+    loaded = load_with_stats(ckpt_path)
+    assert hasattr(loaded, "_state_stats")
+    assert hasattr(loaded, "_tau_stats")

--- a/tests/unit/motion_matching/test_load_target_dispatch.py
+++ b/tests/unit/motion_matching/test_load_target_dispatch.py
@@ -1,0 +1,40 @@
+"""Coverage tests for ``load_club_target`` and ``load_body_target`` dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from src.shared.python.motion_matching.load_body_target import load_body_target
+from src.shared.python.motion_matching.load_club_target import load_club_target
+
+
+def test_load_club_target_unknown_format(tmp_path: Path) -> None:
+    """Pin: unknown extension rejected with allowed-list message."""
+    p = tmp_path / "x.bin"
+    p.write_bytes(b"")
+    with pytest.raises(ValueError, match="Unsupported file format"):
+        load_club_target(p)
+
+
+def test_load_club_target_excel_requires_sheet(tmp_path: Path) -> None:
+    """Pin: xlsx without ``sheet=`` rejected before opening the file."""
+    p = tmp_path / "x.xlsx"
+    p.write_bytes(b"")
+    with pytest.raises(ValueError, match="sheet= is required"):
+        load_club_target(p)
+
+
+def test_load_club_target_dispatch_table() -> None:
+    """Pin: the suffix sets are mutually exclusive and case-insensitive."""
+    # Use a case-shifted suffix to exercise the lower() branch.
+    with pytest.raises(ValueError, match="sheet="):
+        load_club_target(Path("missing.XLSX"))
+
+
+def test_load_body_target_unknown_format(tmp_path: Path) -> None:
+    """Pin: unknown body-target extension rejected."""
+    p = tmp_path / "x.bin"
+    p.write_bytes(b"")
+    with pytest.raises(ValueError, match="Unsupported file format"):
+        load_body_target(p)

--- a/tests/unit/motion_matching/test_loaders_c3d_helpers.py
+++ b/tests/unit/motion_matching/test_loaders_c3d_helpers.py
@@ -1,0 +1,156 @@
+"""Coverage tests for private helpers in ``loaders.c3d``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.motion_matching.loaders.c3d import (
+    _fill_rotation_nans,
+    _first_clean_frame,
+    _marker_xyz,
+    _pick_marker,
+    _shaft_quaternions,
+)
+
+
+# --- _pick_marker -----------------------------------------------------------
+
+
+def test_pick_marker_substring_uppercased() -> None:
+    """Pin: substring match is case-insensitive."""
+    labels = ["clubBUTT_x", "head_y", "shaft"]
+    assert _pick_marker(labels, ("BUTT",)) == "clubBUTT_x"
+
+
+def test_pick_marker_iteration_order() -> None:
+    """Pin: candidates are searched in given order."""
+    labels = ["foo_HEAD", "bar_BUTT"]
+    assert _pick_marker(labels, ("BUTT", "HEAD")) == "bar_BUTT"
+
+
+def test_pick_marker_returns_none() -> None:
+    """Pin: no match -> None."""
+    assert _pick_marker(["x", "y"], ("zzz",)) is None
+
+
+# --- _marker_xyz ------------------------------------------------------------
+
+
+def test_marker_xyz_returns_sorted_arrays() -> None:
+    """Pin: rows for ``marker`` are sorted by ``frame`` and split into time/xyz."""
+    df = pd.DataFrame(
+        {
+            "marker": ["A", "A", "B"],
+            "frame": [1, 0, 0],
+            "time": [0.1, 0.0, 0.0],
+            "x": [1.0, 0.0, 9.0],
+            "y": [0.0, 0.0, 9.0],
+            "z": [0.0, 0.0, 9.0],
+        }
+    )
+    time, xyz = _marker_xyz(df, "A")
+    assert np.allclose(time, [0.0, 0.1])
+    assert np.allclose(xyz[:, 0], [0.0, 1.0])
+
+
+# --- _fill_rotation_nans ----------------------------------------------------
+
+
+def test_fill_rotation_nans_preserves_finite_rows() -> None:
+    """Pin: finite rows pass through; NaN rows are filled from last good."""
+    rot = np.zeros((3, 3, 3))
+    rot[0] = np.eye(3)
+    rot[1] = np.full((3, 3), np.nan)
+    rot[2] = np.eye(3) * 2.0
+    out = _fill_rotation_nans(rot)
+    assert np.allclose(out[0], np.eye(3))
+    assert np.allclose(out[1], np.eye(3))  # filled from row 0
+    assert np.allclose(out[2], np.eye(3) * 2.0)
+
+
+def test_fill_rotation_nans_leading_nan_falls_back_to_identity() -> None:
+    """Pin: NaN rows before any good row fall back to identity."""
+    rot = np.zeros((2, 3, 3))
+    rot[0] = np.full((3, 3), np.nan)
+    rot[1] = np.eye(3)
+    out = _fill_rotation_nans(rot)
+    assert np.allclose(out[0], np.eye(3))
+
+
+# --- _shaft_quaternions -----------------------------------------------------
+
+
+def test_shaft_quaternions_z_aligned() -> None:
+    """Pin: shaft along +z gives identity quaternion."""
+    butt = np.zeros((1, 3))
+    head = np.array([[0.0, 0.0, 1.0]])
+    q = _shaft_quaternions(butt, head)
+    assert q.shape == (1, 4)
+    assert np.allclose(q[0], [1.0, 0.0, 0.0, 0.0])
+
+
+def test_shaft_quaternions_z_antiparallel() -> None:
+    """Pin: shaft along -z gives the documented (0,1,0,0) sentinel."""
+    butt = np.zeros((1, 3))
+    head = np.array([[0.0, 0.0, -1.0]])
+    q = _shaft_quaternions(butt, head)
+    assert np.allclose(q[0], [0.0, 1.0, 0.0, 0.0])
+
+
+def test_shaft_quaternions_zero_vector() -> None:
+    """Pin: zero-length shaft falls back to identity quaternion."""
+    butt = np.array([[0.0, 0.0, 0.0]])
+    head = np.array([[0.0, 0.0, 0.0]])
+    q = _shaft_quaternions(butt, head)
+    assert np.allclose(q[0], [1.0, 0.0, 0.0, 0.0])
+
+
+def test_shaft_quaternions_general() -> None:
+    """Pin: a +x shaft gives a quaternion that rotates +z onto +x."""
+    butt = np.zeros((1, 3))
+    head = np.array([[1.0, 0.0, 0.0]])
+    q = _shaft_quaternions(butt, head)
+    # Apply rotation to (0,0,1), expect (1,0,0).
+    w, x, y, z = q[0]
+    rot = np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+    out = rot @ np.array([0.0, 0.0, 1.0])
+    assert np.allclose(out, [1.0, 0.0, 0.0], atol=1e-9)
+
+
+# --- _first_clean_frame -----------------------------------------------------
+
+
+def test_first_clean_frame_finds_match() -> None:
+    """Pin: the first all-finite cluster frame index is returned."""
+    from src.shared.python.motion_matching.loaders._marker_clusters import (
+        CLUBHEAD_CLUSTER,
+        GRIP_CLUSTER,
+    )
+
+    n = 5
+    points = {}
+    for m in (*CLUBHEAD_CLUSTER, *GRIP_CLUSTER):
+        arr = np.zeros((n, 3))
+        arr[0] = np.nan  # frame 0 is bad
+        points[m] = arr
+    assert _first_clean_frame(points) == 1
+
+
+def test_first_clean_frame_raises_when_no_match() -> None:
+    """Pin: with no fully-finite frame, ValueError is raised."""
+    from src.shared.python.motion_matching.loaders._marker_clusters import (
+        CLUBHEAD_CLUSTER,
+        GRIP_CLUSTER,
+    )
+
+    n = 3
+    points = {m: np.full((n, 3), np.nan) for m in (*CLUBHEAD_CLUSTER, *GRIP_CLUSTER)}
+    with pytest.raises(ValueError, match="No frame"):
+        _first_clean_frame(points)

--- a/tests/unit/motion_matching/test_loaders_excel_helpers.py
+++ b/tests/unit/motion_matching/test_loaders_excel_helpers.py
@@ -1,0 +1,107 @@
+"""Coverage tests for private helpers in ``loaders.excel``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from src.shared.python.motion_matching.loaders.excel import (
+    ExcelEventMarkers,
+    _extract_event_markers,
+    _frame_to_quat,
+    read_excel_event_markers,
+)
+
+
+def test_event_markers_frame_for_returns_zero_based() -> None:
+    """Pin: ``frame_for`` translates 1-based sample to 0-based frame."""
+    ev = ExcelEventMarkers(I_sample=10.0)
+    assert ev.frame_for("I") == 9
+
+
+def test_event_markers_frame_for_nan_returns_none() -> None:
+    """Pin: NaN sample => None (event missing)."""
+    ev = ExcelEventMarkers()  # all NaN
+    assert ev.frame_for("I") is None
+
+
+def test_event_markers_frame_for_clamps_negative() -> None:
+    """Pin: a 0-or-negative 1-based sample clamps to frame 0."""
+    ev = ExcelEventMarkers(I_sample=0.0)
+    assert ev.frame_for("I") == 0
+
+
+def test_extract_event_markers_parses_row0() -> None:
+    """Pin: row-0 ``A=<n>`` pattern is parsed into the matching field."""
+    df = pd.DataFrame(
+        [
+            ["A", 5, "T", 100, "I", 250, "F", 400, "CHS", 95.0, "extra"],
+            [None] * 11,
+        ]
+    )
+    ev = _extract_event_markers(df)
+    assert ev.A_sample == 5.0
+    assert ev.I_sample == 250.0
+    assert ev.CHS_mph == 95.0
+
+
+def test_extract_event_markers_skips_unknown_label() -> None:
+    """Pin: cells that aren't recognized labels are skipped."""
+    df = pd.DataFrame([["zzz", 9, "I", 100]])
+    ev = _extract_event_markers(df)
+    assert ev.I_sample == 100.0
+    assert np.isnan(ev.A_sample)
+
+
+def test_extract_event_markers_skips_nan_value() -> None:
+    """Pin: a NaN value cell after a recognized label is skipped."""
+    df = pd.DataFrame([["I", float("nan")]])
+    ev = _extract_event_markers(df)
+    assert np.isnan(ev.I_sample)
+
+
+def test_extract_event_markers_skips_unparseable() -> None:
+    """Pin: non-numeric value cells are silently skipped (no raise)."""
+    df = pd.DataFrame([["I", "not-a-number"]])
+    ev = _extract_event_markers(df)
+    assert np.isnan(ev.I_sample)
+
+
+def test_read_excel_event_markers_missing_file(tmp_path: Path) -> None:
+    """Pin: missing file is handled by returning empty markers (warns)."""
+    out = read_excel_event_markers(tmp_path / "missing.xlsx", sheet="x")
+    assert isinstance(out, ExcelEventMarkers)
+    assert np.isnan(out.A_sample)
+
+
+def test_frame_to_quat_identity() -> None:
+    """Pin: identity direction-cosine row gives identity rotation matrix."""
+    row = pd.Series(
+        {
+            "club_Xx": 1.0,
+            "club_Yx": 0.0,
+            "club_Zx": 0.0,
+            "club_Xy": 0.0,
+            "club_Yy": 1.0,
+            "club_Zy": 0.0,
+            "club_Xz": 0.0,
+            "club_Yz": 0.0,
+            "club_Zz": 1.0,
+        }
+    )
+    rot = _frame_to_quat(row)
+    assert np.allclose(rot, np.eye(3))
+
+
+def test_read_excel_event_markers_synthetic_workbook(tmp_path: Path) -> None:
+    """Pin: a real ``A=5 I=100`` row-1 is read correctly."""
+    pytest.importorskip("openpyxl")
+    p = tmp_path / "wb.xlsx"
+    df = pd.DataFrame([["A", 5, "I", 100, "CHS", 90.0]])
+    df.to_excel(p, sheet_name="s", header=False, index=False)
+    ev = read_excel_event_markers(p, sheet="s")
+    assert ev.A_sample == 5.0
+    assert ev.I_sample == 100.0
+    assert ev.CHS_mph == 90.0

--- a/tests/unit/motion_matching/test_loaders_synthetic_dispatch.py
+++ b/tests/unit/motion_matching/test_loaders_synthetic_dispatch.py
@@ -1,0 +1,81 @@
+"""Coverage tests for ``loaders.synthetic`` registry / dispatcher."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.loaders.synthetic import (
+    _BACKENDS,
+    available_backends,
+    register_backend,
+    synthesize_target_from_coefficients,
+)
+from src.shared.python.motion_matching.target import AlignOptions
+
+from ._fixtures import make_target
+
+
+def setup_function(_fn) -> None:
+    """Snapshot existing backends and start each test from a clean slate."""
+    _BACKENDS.clear()
+
+
+def teardown_function(_fn) -> None:
+    """Cleanup."""
+    _BACKENDS.clear()
+
+
+def _backend(theta, opts):  # noqa: ARG001
+    return make_target()
+
+
+def test_register_and_dispatch() -> None:
+    """Pin: a registered backend is reached via dispatch."""
+    register_backend("ToyEngine", _backend)
+    assert "toyengine" in available_backends()
+    out = synthesize_target_from_coefficients(np.zeros(7), engine="toyengine")
+    assert out.time.shape[0] > 0
+
+
+def test_register_replaces_with_warning() -> None:
+    """Pin: replacing a backend logs a warning (warning path)."""
+    register_backend("e", _backend)
+
+    def other(theta, opts):
+        return make_target()
+
+    register_backend("e", other)
+    assert _BACKENDS["e"] is other
+
+
+def test_register_idempotent() -> None:
+    """Pin: re-registering the same callable is a no-op."""
+    register_backend("e", _backend)
+    register_backend("e", _backend)
+    assert _BACKENDS["e"] is _backend
+
+
+def test_register_backend_invalid_engine() -> None:
+    """Pin: empty / non-string engine rejected."""
+    with pytest.raises(ValueError, match="non-empty string"):
+        register_backend("", _backend)
+    with pytest.raises(ValueError, match="non-empty string"):
+        register_backend(42, _backend)  # type: ignore[arg-type]
+
+
+def test_register_backend_non_callable() -> None:
+    """Pin: non-callable backend rejected."""
+    with pytest.raises(TypeError, match="callable"):
+        register_backend("e", "not a func")  # type: ignore[arg-type]
+
+
+def test_dispatch_requires_engine() -> None:
+    """Pin: missing engine name raises ValueError."""
+    with pytest.raises(ValueError, match="no engine specified"):
+        synthesize_target_from_coefficients(np.zeros(7), AlignOptions())
+
+
+def test_dispatch_unknown_engine() -> None:
+    """Pin: unknown engine raises LookupError with available list."""
+    with pytest.raises(LookupError, match="no synthetic backend"):
+        synthesize_target_from_coefficients(np.zeros(7), engine="not-real")

--- a/tests/unit/motion_matching/test_metrics_legacy_coverage.py
+++ b/tests/unit/motion_matching/test_metrics_legacy_coverage.py
@@ -1,0 +1,158 @@
+"""Coverage tests for ``motion_matching.metrics`` legacy paths."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from src.shared.python.motion_matching.metrics import (
+    SCHEMA_VERSION,
+    Metrics,
+    asdict_safe,
+    legacy_struct_to_metrics,
+)
+
+
+def _good_kwargs(**overrides):
+    base = {
+        "swing_id": "s1",
+        "option": 1,
+        "solver": "lbfgs",
+        "n_iterations": 3,
+        "rmse_clubhead_mm": 1.0,
+        "rmse_butt_mm": 2.0,
+        "rmse_orientation_deg": 0.5,
+        "clubhead_speed_at_impact_mph": 100.0,
+        "clubhead_speed_meas_mph": 99.0,
+        "total_work_J": 10.0,
+        "peak_power_W": 200.0,
+        "wall_clock_s": 0.5,
+        "git_commit": "0" * 40,
+        "matlab_version": "R2024a",
+        "python_version": "3.11",
+        "timestamp_iso8601": "2024-01-01T00:00:00Z",
+        "schema_version": SCHEMA_VERSION,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_round_trip_json() -> None:
+    """Pin: ``to_json`` -> ``from_json`` is an exact round-trip."""
+    m = Metrics(**_good_kwargs())
+    s = m.to_json()
+    m2 = Metrics.from_json(s)
+    assert m == m2
+
+
+def test_from_json_rejects_non_object() -> None:
+    """Pin: top-level JSON array rejected."""
+    with pytest.raises(ValueError, match="expected JSON object"):
+        Metrics.from_json("[]")
+
+
+def test_to_csv_round_trip() -> None:
+    """Pin: CSV-row round-trip is lossless."""
+    m = Metrics(**_good_kwargs())
+    row = m.to_csv_row()
+    m2 = Metrics.from_csv_row(row)
+    assert m == m2
+
+
+def test_invalid_option_rejected() -> None:
+    """Pin: option outside {1,2,3,4} rejected."""
+    with pytest.raises(ValueError, match=r"option must be in"):
+        Metrics(**_good_kwargs(option=9))
+
+
+def test_negative_iter_rejected() -> None:
+    """Pin: negative ``n_iterations`` rejected."""
+    with pytest.raises(ValueError, match="n_iterations must be >= 0"):
+        Metrics(**_good_kwargs(n_iterations=-1))
+
+
+def test_non_finite_field_rejected() -> None:
+    """Pin: NaN in a numeric field rejected."""
+    with pytest.raises(ValueError, match="must be finite"):
+        Metrics(**_good_kwargs(rmse_clubhead_mm=float("nan")))
+
+
+def test_negative_nonneg_field_rejected() -> None:
+    """Pin: negative entry in a non-negative field rejected."""
+    with pytest.raises(ValueError, match=r"must be >= 0"):
+        Metrics(**_good_kwargs(wall_clock_s=-1.0))
+
+
+def test_bad_git_sha_rejected() -> None:
+    """Pin: SHA != 40 hex chars is rejected."""
+    with pytest.raises(ValueError, match="git_commit"):
+        Metrics(**_good_kwargs(git_commit="not-a-sha"))
+
+
+def test_bad_timestamp_rejected() -> None:
+    """Pin: non-ISO timestamp rejected."""
+    with pytest.raises(ValueError, match="ISO-8601 UTC"):
+        Metrics(**_good_kwargs(timestamp_iso8601="2024-01-01"))
+
+
+def test_microsecond_timestamp_accepted() -> None:
+    """Pin: ISO-8601 with microseconds accepted."""
+    Metrics(**_good_kwargs(timestamp_iso8601="2024-01-01T00:00:00.123456Z"))
+
+
+def test_schema_version_mismatch() -> None:
+    """Pin: stale schema_version rejected."""
+    with pytest.raises(ValueError, match="schema_version"):
+        Metrics(**_good_kwargs(schema_version="0.0.0"))
+
+
+def test_legacy_struct_to_metrics() -> None:
+    """Pin: legacy field renames flow through."""
+    legacy = {
+        "swing_id": "s",
+        "option": 2,
+        "solver": "lbfgs",
+        "rmse_clubhead": 1.0,
+        "rmse_butt": 2.0,
+        "rmse_orient": 3.0,
+        "chs_impact": 100.0,
+        "chs_meas": 99.0,
+        "total_work": 10.0,
+        "peak_power": 100.0,
+        "wall_clock": 0.5,
+        "git_commit": "0" * 40,
+        "timestamp": "2024-01-01T00:00:00Z",
+    }
+    m = legacy_struct_to_metrics(legacy)
+    assert m.rmse_clubhead_mm == 1.0
+    assert m.timestamp_iso8601 == "2024-01-01T00:00:00Z"
+
+
+def test_asdict_safe_dict() -> None:
+    """Pin: dict input pass-through (copy)."""
+    out = asdict_safe({"a": 1})
+    assert out == {"a": 1}
+
+
+def test_asdict_safe_namedtuple() -> None:
+    """Pin: namedtuple-like ``_asdict`` input is consumed."""
+    from collections import namedtuple
+
+    NT = namedtuple("NT", "x y")
+    out = asdict_safe(NT(1, 2))
+    assert out == {"x": 1, "y": 2}
+
+
+def test_asdict_safe_invalid() -> None:
+    """Pin: opaque object rejected."""
+    with pytest.raises(TypeError, match="cannot convert"):
+        asdict_safe(42)
+
+
+def test_to_json_canonical() -> None:
+    """Pin: JSON output has sorted keys and no whitespace."""
+    m = Metrics(**_good_kwargs())
+    s = m.to_json()
+    parsed = json.loads(s)
+    assert isinstance(parsed, dict)
+    assert " " not in s.replace('": ', '":').replace(", ", ",")

--- a/tests/unit/motion_matching/test_multi_source_target_coverage.py
+++ b/tests/unit/motion_matching/test_multi_source_target_coverage.py
@@ -1,0 +1,97 @@
+"""Coverage tests for ``MultiSourceTarget``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.multi_source_target import MultiSourceTarget
+
+from ._fixtures import make_provenance, make_target
+
+
+def _body_like(time: np.ndarray) -> object:
+    """Quack-typed body: object with a .time ndarray."""
+
+    class _Body:
+        pass
+
+    b = _Body()
+    b.time = time
+    return b
+
+
+def test_requires_at_least_one_slot() -> None:
+    """Pin: both-None construction is rejected."""
+    with pytest.raises(ValueError, match="at least one non-None slot"):
+        MultiSourceTarget(club=None, body=None)
+
+
+def test_club_alone_constructs() -> None:
+    """Pin: club-only target constructs and exposes time."""
+    t = make_target()
+    m = MultiSourceTarget(club=t, body=None)
+    assert m.has_club() and not m.has_body()
+    assert np.array_equal(m.shared_time(), t.time)
+
+
+def test_body_alone_constructs() -> None:
+    """Pin: body-only target constructs and exposes its time."""
+    t = make_target()
+    m = MultiSourceTarget(club=None, body=_body_like(t.time))
+    assert m.has_body() and not m.has_club()
+    assert np.array_equal(m.shared_time(), t.time)
+
+
+def test_club_must_have_time() -> None:
+    """Pin: club without a 1-D ``time`` ndarray is rejected."""
+
+    class Bad:
+        time = "not an array"
+
+    with pytest.raises(TypeError, match="club must expose"):
+        MultiSourceTarget(club=Bad(), body=None)
+
+
+def test_body_must_have_time() -> None:
+    """Pin: body without a 1-D ``time`` ndarray is rejected."""
+
+    class Bad:
+        time = np.zeros((2, 2))  # 2-D
+
+    t = make_target()
+    with pytest.raises(TypeError, match="body must expose"):
+        MultiSourceTarget(club=t, body=Bad())
+
+
+def test_timegrid_mismatch_rejected() -> None:
+    """Pin: club/body with mismatched time arrays are rejected."""
+    t = make_target()
+    body = _body_like(t.time + 1.0)  # different time grid
+    with pytest.raises(ValueError, match="timegrid mismatch"):
+        MultiSourceTarget(club=t, body=body)
+
+
+def test_is_plain_club_vs_club_ball() -> None:
+    """Pin: ``is_plain_club`` and ``is_club_ball`` distinguish target type."""
+    t = make_target()
+    m_plain = MultiSourceTarget(club=t, body=None)
+    assert m_plain.is_plain_club()
+    assert not m_plain.is_club_ball()
+
+    # ``is_club_ball`` is a hasattr(club, "ball") duck-typing probe.
+    # Build a minimal object that satisfies it without needing the
+    # full ClubBallTarget dependency surface.
+    class _BallishTarget:
+        time = t.time
+        ball = "present"
+
+    m_ball = MultiSourceTarget(club=_BallishTarget(), body=None)
+    assert m_ball.is_club_ball()
+    assert not m_ball.is_plain_club()
+
+
+def test_provenance_unused_kept_in_scope() -> None:
+    """Pin: a fresh provenance from the helper imports cleanly."""
+    # Just exercise the helper to keep coverage signal positive.
+    p = make_provenance()
+    assert p.format == "synthetic"

--- a/tests/unit/motion_matching/test_perstep_extract_dataset.py
+++ b/tests/unit/motion_matching/test_perstep_extract_dataset.py
@@ -1,0 +1,122 @@
+"""Coverage tests for ``surrogate.perstep.extract_dataset``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from src.shared.python.motion_matching.surrogate.perstep.extract_dataset import (
+    extract_dataset,
+)
+
+
+def _write_synthetic_manifest(path: Path, columns: list[str]) -> None:
+    payload = {
+        "input_columns": {"a": columns[: len(columns) // 2]},
+        "target_columns": {"b": columns[len(columns) // 2 :]},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_synthetic_parquet(path: Path, columns: list[str]) -> None:
+    rows = 10
+    data = {col: [str(i + j) for i in range(rows)] for j, col in enumerate(columns)}
+    table = pa.table(data)
+    pq.write_table(table, path)
+
+
+def test_extract_dataset_round_trip(tmp_path: Path) -> None:
+    """Pin: extract converts strings to float32 and writes a summary."""
+    columns = ["c1", "c2", "c3", "c4"]
+    src = tmp_path / "src.parquet"
+    out = tmp_path / "out" / "slim.parquet"
+    manifest = tmp_path / "manifest.json"
+    _write_synthetic_parquet(src, columns)
+    _write_synthetic_manifest(manifest, columns)
+
+    extract_dataset(
+        source=src,
+        output=out,
+        manifest_path=manifest,
+        compression="snappy",
+        row_group_size=4,
+    )
+
+    assert out.exists()
+    summary = out.with_suffix(".summary.json")
+    assert summary.exists()
+    parsed = json.loads(summary.read_text(encoding="utf-8"))
+    assert parsed["rows"] == 10
+    assert parsed["columns"] == 4
+    # All columns must now be float32.
+    table = pq.read_table(out)
+    for col in columns:
+        assert table.column(col).type == pa.float32()
+
+
+def test_extract_dataset_missing_columns(tmp_path: Path) -> None:
+    """Pin: manifest naming columns absent from the source raises."""
+    src = tmp_path / "src.parquet"
+    out = tmp_path / "out.parquet"
+    manifest = tmp_path / "m.json"
+    _write_synthetic_parquet(src, ["a", "b"])
+    manifest.write_text(
+        json.dumps(
+            {
+                "input_columns": {"x": ["does_not_exist"]},
+                "target_columns": {"y": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing selected columns"):
+        extract_dataset(
+            source=src,
+            output=out,
+            manifest_path=manifest,
+            compression="snappy",
+            row_group_size=4,
+        )
+
+
+def test_extract_dataset_overwrites_existing(tmp_path: Path) -> None:
+    """Pin: a pre-existing output file is overwritten."""
+    columns = ["a", "b"]
+    src = tmp_path / "src.parquet"
+    out = tmp_path / "slim.parquet"
+    manifest = tmp_path / "m.json"
+    _write_synthetic_parquet(src, columns)
+    _write_synthetic_manifest(manifest, columns)
+    out.write_bytes(b"stale")
+    extract_dataset(
+        source=src,
+        output=out,
+        manifest_path=manifest,
+        compression="snappy",
+        row_group_size=4,
+    )
+    # Now must be a real parquet.
+    pq.read_table(out)
+
+
+def test_extract_dataset_handles_blank_strings(tmp_path: Path) -> None:
+    """Pin: blank strings are converted to nulls before float32 cast."""
+    src = tmp_path / "src.parquet"
+    out = tmp_path / "out.parquet"
+    manifest = tmp_path / "m.json"
+    table = pa.table({"a": ["1", "", "3"], "b": ["", "2", "3"]})
+    pq.write_table(table, src)
+    _write_synthetic_manifest(manifest, ["a", "b"])
+    extract_dataset(
+        source=src,
+        output=out,
+        manifest_path=manifest,
+        compression="snappy",
+        row_group_size=4,
+    )
+    parsed = pq.read_table(out)
+    a_vals = parsed.column("a").to_pylist()
+    assert a_vals[1] is None

--- a/tests/unit/motion_matching/test_plot_views_smoke.py
+++ b/tests/unit/motion_matching/test_plot_views_smoke.py
@@ -1,0 +1,158 @@
+"""Smoke + error-path coverage for the plot_*.py view modules.
+
+Each plot is rendered with the non-interactive ``Agg`` backend so the
+tests run on a headless CI box.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from src.shared.python.motion_matching.cost import (  # noqa: E402
+    CostBreakdown,
+    SimOutput,
+)
+from src.shared.python.motion_matching.plot_error_timecourse import (  # noqa: E402
+    plot_error_timecourse,
+)
+from src.shared.python.motion_matching.plot_fit_quality_card import (  # noqa: E402
+    fit_quality_summary,
+    plot_fit_quality_card,
+)
+from src.shared.python.motion_matching.plot_trajectory_overlay import (  # noqa: E402
+    plot_trajectory_overlay,
+)
+
+from ._fixtures import make_target  # noqa: E402
+
+
+def _matching_sim(target):
+    n = target.time.shape[0]
+    butt = target.butt.copy()
+    clubhead = target.clubhead.copy()
+    quat = target.club_quat.copy()
+    return SimOutput(butt=butt, clubhead=clubhead, club_quat=quat, time=target.time)
+
+
+def _breakdown() -> CostBreakdown:
+    return CostBreakdown(
+        position=1.0,
+        orientation=0.5,
+        impact_anchor=0.25,
+        regularizer=0.01,
+        total=1.76,
+    )
+
+
+def test_plot_trajectory_overlay_smoke() -> None:
+    """Pin: full-shape inputs render a 1x2 overlay figure."""
+    t = make_target()
+    fig = plot_trajectory_overlay(t, _matching_sim(t), title="x")
+    assert fig is not None
+    plt.close(fig)
+
+
+def test_plot_trajectory_overlay_butt_mismatch() -> None:
+    """Pin: butt shape mismatch is rejected up front."""
+    t = make_target()
+    sim = _matching_sim(t)
+    bad = SimOutput(
+        butt=sim.butt[:-1],
+        clubhead=sim.clubhead,
+        club_quat=sim.club_quat,
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match="butt shape mismatch"):
+        plot_trajectory_overlay(t, bad)
+
+
+def test_plot_trajectory_overlay_clubhead_mismatch() -> None:
+    """Pin: clubhead shape mismatch rejected."""
+    t = make_target()
+    sim = _matching_sim(t)
+    bad = SimOutput(
+        butt=sim.butt,
+        clubhead=sim.clubhead[:-1],
+        club_quat=sim.club_quat,
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match="clubhead shape mismatch"):
+        plot_trajectory_overlay(t, bad)
+
+
+def test_plot_error_timecourse_smoke() -> None:
+    """Pin: error timecourse plot renders without crashing."""
+    t = make_target()
+    fig = plot_error_timecourse(t, _matching_sim(t), title="err")
+    plt.close(fig)
+
+
+def test_plot_error_timecourse_shape_mismatch() -> None:
+    """Pin: mismatched butt/clubhead shape is rejected."""
+    t = make_target()
+    sim = _matching_sim(t)
+    bad = SimOutput(
+        butt=sim.butt[:-1],
+        clubhead=sim.clubhead,
+        club_quat=sim.club_quat,
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match="match target time length"):
+        plot_error_timecourse(t, bad)
+
+
+def test_plot_error_timecourse_quat_shape() -> None:
+    """Pin: club_quat shape mismatch is rejected."""
+    t = make_target()
+    sim = _matching_sim(t)
+    bad = SimOutput(
+        butt=sim.butt,
+        clubhead=sim.clubhead,
+        club_quat=sim.club_quat[:, :3],
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match=r"club_quat must have shape"):
+        plot_error_timecourse(t, bad)
+
+
+def test_fit_quality_summary_finite() -> None:
+    """Pin: summary returns finite scalars for a perfect-match sim."""
+    t = make_target()
+    s = fit_quality_summary(t, _matching_sim(t), _breakdown())
+    # Perfect overlap -> ~zero RMSEs.
+    assert s.rmse_butt_m < 1e-9
+    assert s.rmse_clubhead_m < 1e-9
+
+
+def test_fit_quality_summary_shape_errors() -> None:
+    """Pin: shape mismatches in summary raise ValueError."""
+    t = make_target()
+    sim = _matching_sim(t)
+    bad = SimOutput(
+        butt=sim.butt[:-1],
+        clubhead=sim.clubhead,
+        club_quat=sim.club_quat,
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match="match target time length"):
+        fit_quality_summary(t, bad, _breakdown())
+    bad_q = SimOutput(
+        butt=sim.butt,
+        clubhead=sim.clubhead,
+        club_quat=sim.club_quat[:, :3],
+        time=sim.time,
+    )
+    with pytest.raises(ValueError, match=r"club_quat must have shape"):
+        fit_quality_summary(t, bad_q, _breakdown())
+
+
+def test_plot_fit_quality_card_smoke() -> None:
+    """Pin: quality card renders for a valid (target, sim, breakdown)."""
+    t = make_target()
+    fig = plot_fit_quality_card(t, _matching_sim(t), _breakdown(), title="card")
+    plt.close(fig)

--- a/tests/unit/motion_matching/test_provider_registry_coverage.py
+++ b/tests/unit/motion_matching/test_provider_registry_coverage.py
@@ -1,0 +1,95 @@
+"""Coverage tests for ``motion_matching.provider_registry``."""
+
+from __future__ import annotations
+
+import pytest
+from src.shared.python.motion_matching.provider_registry import (
+    available_engines,
+    clear_registry,
+    get_provider,
+    register_provider,
+)
+
+
+class _FakeProvider:
+    def __init__(self, name: str) -> None:
+        self.engine_name = name
+
+    def fit_swing(self, target, opts):  # noqa: ARG002 - signature only
+        return None
+
+
+def setup_function(_fn) -> None:
+    """Reset the registry before each test."""
+    clear_registry()
+
+
+def teardown_function(_fn) -> None:
+    """Reset the registry after each test."""
+    clear_registry()
+
+
+def test_register_then_lookup() -> None:
+    """Pin: registered provider is retrievable by name."""
+    p = _FakeProvider("drake")
+    register_provider(p)
+    assert get_provider("drake") is p
+    assert "drake" in available_engines()
+
+
+def test_register_replaces_existing() -> None:
+    """Pin: re-registering with a different instance overwrites."""
+    a = _FakeProvider("e1")
+    b = _FakeProvider("e1")
+    register_provider(a)
+    register_provider(b)
+    assert get_provider("e1") is b
+
+
+def test_register_requires_engine_name() -> None:
+    """Pin: provider without engine_name string is rejected."""
+
+    class NoName:
+        def fit_swing(self, t, o):
+            return None
+
+    with pytest.raises(TypeError, match="engine_name"):
+        register_provider(NoName())
+
+
+def test_register_requires_callable_fit_swing() -> None:
+    """Pin: provider without callable fit_swing is rejected."""
+
+    class NoFit:
+        engine_name = "x"
+        fit_swing = "not callable"
+
+    with pytest.raises(TypeError, match="fit_swing"):
+        register_provider(NoFit())
+
+
+def test_register_empty_engine_name() -> None:
+    """Pin: empty engine_name rejected."""
+
+    class Empty:
+        engine_name = ""
+
+        def fit_swing(self, t, o):
+            return None
+
+    with pytest.raises(TypeError, match="engine_name"):
+        register_provider(Empty())
+
+
+def test_get_provider_unknown_engine() -> None:
+    """Pin: lookup of unknown engine raises KeyError with available list."""
+    with pytest.raises(KeyError, match="no fit_swing provider"):
+        get_provider("zzz")
+
+
+def test_clear_registry() -> None:
+    """Pin: clear empties the registry."""
+    register_provider(_FakeProvider("e"))
+    assert available_engines() == ["e"]
+    clear_registry()
+    assert available_engines() == []

--- a/tests/unit/motion_matching/test_sim_out_fitresult.py
+++ b/tests/unit/motion_matching/test_sim_out_fitresult.py
@@ -1,0 +1,92 @@
+"""Coverage tests for ``sim_out.FitResult`` postcondition checks."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.cost import CostBreakdown, SimOutput
+from src.shared.python.motion_matching.sim_out import FitResult
+
+from ._fixtures import make_target
+
+
+def _good_simout(n: int = 301) -> SimOutput:
+    butt = np.zeros((n, 3))
+    clubhead = np.zeros((n, 3))
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    return SimOutput(butt=butt, clubhead=clubhead, club_quat=quat)
+
+
+def _good_breakdown(total: float = 0.0) -> CostBreakdown:
+    return CostBreakdown(
+        position=total / 4,
+        orientation=total / 4,
+        impact_anchor=total / 4,
+        regularizer=total / 4,
+        total=total,
+    )
+
+
+def test_construct_valid() -> None:
+    """Pin: a self-consistent FitResult constructs."""
+    fr = FitResult(
+        theta=np.zeros(7),
+        cost=4.0,
+        breakdown=_good_breakdown(4.0),
+        target=make_target(),
+        sim=_good_simout(),
+        engine="drake",
+    )
+    assert fr.engine == "drake"
+
+
+def test_non_finite_cost_rejected() -> None:
+    """Pin: NaN cost rejected."""
+    with pytest.raises(ValueError, match="must be finite"):
+        FitResult(
+            theta=np.zeros(7),
+            cost=float("nan"),
+            breakdown=_good_breakdown(),
+            target=make_target(),
+            sim=_good_simout(),
+            engine="drake",
+        )
+
+
+def test_negative_cost_rejected() -> None:
+    """Pin: negative cost rejected."""
+    with pytest.raises(ValueError, match="non-negative"):
+        FitResult(
+            theta=np.zeros(7),
+            cost=-1.0,
+            breakdown=_good_breakdown(-1.0),
+            target=make_target(),
+            sim=_good_simout(),
+            engine="drake",
+        )
+
+
+def test_breakdown_total_must_match_cost() -> None:
+    """Pin: breakdown.total must equal cost (within tiny tolerance)."""
+    with pytest.raises(ValueError, match="breakdown.total"):
+        FitResult(
+            theta=np.zeros(7),
+            cost=4.0,
+            breakdown=_good_breakdown(2.0),
+            target=make_target(),
+            sim=_good_simout(),
+            engine="drake",
+        )
+
+
+def test_engine_must_be_nonempty_str() -> None:
+    """Pin: empty engine string rejected."""
+    with pytest.raises(ValueError, match="non-empty string"):
+        FitResult(
+            theta=np.zeros(7),
+            cost=0.0,
+            breakdown=_good_breakdown(0.0),
+            target=make_target(),
+            sim=_good_simout(),
+            engine="",
+        )

--- a/tests/unit/motion_matching/test_synthesize_target_coverage.py
+++ b/tests/unit/motion_matching/test_synthesize_target_coverage.py
@@ -1,0 +1,147 @@
+"""Coverage tests for ``synthesize_target_from_coefficients``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.cost import SimOutput
+from src.shared.python.motion_matching.synthesize_target_from_coefficients import (
+    EngineSimulator,
+    SynthOptions,
+    synthesize_target_from_coefficients,
+)
+from src.shared.python.motion_matching.target import AlignOptions
+
+
+def _make_simout(n: int = 301, t_end: float = 0.3) -> SimOutput:
+    time = np.linspace(0.0, t_end, n)
+    speed_curve = np.sin(np.pi * time / t_end)
+    butt = np.zeros((n, 3))
+    clubhead = np.column_stack([speed_curve * 0.5, np.zeros(n), np.zeros(n)])
+    quat = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    return SimOutput(time=time, butt=butt, clubhead=clubhead, club_quat=quat)
+
+
+class _Fake:
+    """Engine simulator returning a canned SimOut."""
+
+    def __call__(
+        self,
+        theta: np.ndarray,
+        *,
+        sample_rate_hz: float,
+        simulation_time_s: float,
+    ) -> SimOutput:
+        n = int(round(sample_rate_hz * simulation_time_s)) + 1
+        return _make_simout(n=n, t_end=simulation_time_s)
+
+
+def test_engine_protocol_runtime_check() -> None:
+    """Pin: ``EngineSimulator`` is a runtime-checkable protocol."""
+    assert isinstance(_Fake(), EngineSimulator)
+
+
+def test_basic_roundtrip() -> None:
+    """Pin: valid theta + engine produces a validated ClubTarget."""
+    theta = np.zeros(7 * 3, dtype=np.float64)
+    out = synthesize_target_from_coefficients(theta, _Fake())
+    assert out.time.shape[0] >= 2
+
+
+def test_engine_must_be_callable() -> None:
+    """Pin: non-callable engine raises TypeError."""
+    with pytest.raises(TypeError, match="EngineSimulator"):
+        synthesize_target_from_coefficients(np.zeros(7), 42)  # type: ignore[arg-type]
+
+
+def test_theta_bounds_violation() -> None:
+    """Pin: out-of-bound coefficient is rejected pre-engine."""
+    bad = np.zeros(7)
+    bad[0] = 5000.0  # exceeds A bound 1000
+    with pytest.raises(ValueError, match="coefficient A"):
+        synthesize_target_from_coefficients(bad, _Fake())
+
+
+def test_theta_bad_length_rejected() -> None:
+    """Pin: non-multiple-of-7 length rejected."""
+    with pytest.raises(ValueError, match="multiple of 7"):
+        synthesize_target_from_coefficients(np.zeros(5), _Fake())
+
+
+def test_engine_must_return_simout() -> None:
+    """Pin: engine returning non-SimOutput raises TypeError."""
+
+    def bad_engine(theta, *, sample_rate_hz, simulation_time_s):
+        return "not a simout"
+
+    with pytest.raises(TypeError, match="must return SimOut"):
+        synthesize_target_from_coefficients(np.zeros(7), bad_engine)
+
+
+def test_engine_simout_must_have_time() -> None:
+    """Pin: SimOut with ``time=None`` is rejected."""
+
+    def bad_engine(theta, *, sample_rate_hz, simulation_time_s):
+        n = 301
+        return SimOutput(
+            time=None,
+            butt=np.zeros((n, 3)),
+            clubhead=np.zeros((n, 3)),
+            club_quat=np.tile([1, 0, 0, 0], (n, 1)),
+        )
+
+    with pytest.raises(ValueError, match="SimOut.time is required"):
+        synthesize_target_from_coefficients(np.zeros(7), bad_engine)
+
+
+def test_quat_normalisation_and_sign_flip() -> None:
+    """Pin: non-unit, w<0 quaternions are normalised and sign-flipped."""
+
+    def neg_w_engine(theta, *, sample_rate_hz, simulation_time_s):
+        n = int(round(sample_rate_hz * simulation_time_s)) + 1
+        time = np.linspace(0.0, simulation_time_s, n)
+        quat = np.tile([-2.0, 0.0, 0.0, 0.0], (n, 1))
+        butt = np.zeros((n, 3))
+        clubhead = np.column_stack([np.linspace(0, 1, n), np.zeros(n), np.zeros(n)])
+        return SimOutput(time=time, butt=butt, clubhead=clubhead, club_quat=quat)
+
+    out = synthesize_target_from_coefficients(np.zeros(7), neg_w_engine)
+    # After normalisation + flip, w should be +1.0.
+    assert np.allclose(out.club_quat[:, 0], 1.0)
+
+
+def test_quat_finite_required() -> None:
+    """Pin: NaN quaternion rejected."""
+
+    def nan_quat_engine(theta, *, sample_rate_hz, simulation_time_s):
+        n = 301
+        time = np.linspace(0.0, simulation_time_s, n)
+        quat = np.full((n, 4), np.nan)
+        return SimOutput(
+            time=time,
+            butt=np.zeros((n, 3)),
+            clubhead=np.column_stack([np.linspace(0, 1, n), np.zeros(n), np.zeros(n)]),
+            club_quat=quat,
+        )
+
+    with pytest.raises(ValueError, match="finite"):
+        synthesize_target_from_coefficients(np.zeros(7), nan_quat_engine)
+
+
+def test_align_opts_overrides_impact() -> None:
+    """Pin: ``align_opts.impact_target_t_s`` selects the impact frame."""
+    align = AlignOptions(impact_target_t_s=0.10)
+    out = synthesize_target_from_coefficients(np.zeros(7), _Fake(), align_opts=align)
+    # impact_idx is 1-based; sample 0.1s on a 1kHz grid is index ~100,
+    # plus 1 for 1-based. Allow some tolerance.
+    expected = int(np.argmin(np.abs(out.time - 0.10))) + 1
+    assert out.impact_idx == expected
+
+
+def test_add_noise_branch() -> None:
+    """Pin: ``add_noise=True`` perturbs positions reproducibly."""
+    opts = SynthOptions(add_noise=True, noise_sigma_m=1e-4, noise_seed=42)
+    out1 = synthesize_target_from_coefficients(np.zeros(7), _Fake(), opts=opts)
+    out2 = synthesize_target_from_coefficients(np.zeros(7), _Fake(), opts=opts)
+    # Same seed -> identical noise.
+    assert np.allclose(out1.butt, out2.butt)

--- a/tests/unit/motion_matching/test_validate_theta_coverage.py
+++ b/tests/unit/motion_matching/test_validate_theta_coverage.py
@@ -1,0 +1,106 @@
+"""Coverage tests for ``motion_matching.validate_theta``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.validate_theta import (
+    COEFFS_PER_JOINT,
+    DEFAULT_THETA_BOUND_TABLE,
+    validate_theta,
+)
+
+
+def _good(n_joints: int = 3) -> np.ndarray:
+    """Return a within-bounds 1-D theta of the right length."""
+    return np.zeros(n_joints * COEFFS_PER_JOINT, dtype=np.float64)
+
+
+class TestValidateTheta:
+    """Pin: every public branch in ``validate_theta``."""
+
+    def test_returns_contiguous_float64(self) -> None:
+        """Pin: success returns a flat float64 ndarray."""
+        out = validate_theta(_good(2), n_joints=2)
+        assert out.dtype == np.float64
+        assert out.flags["C_CONTIGUOUS"]
+        assert out.shape == (14,)
+
+    def test_2d_njoints7_reshaped_flat(self) -> None:
+        """Pin: a ``(n_joints, 7)`` matrix is auto-reshaped to flat."""
+        m = np.zeros((4, 7))
+        out = validate_theta(m, n_joints=4)
+        assert out.shape == (28,)
+
+    def test_n_joints_must_be_positive_int(self) -> None:
+        """Pin: non-positive or non-int ``n_joints`` is rejected."""
+        with pytest.raises(ValueError, match="positive int"):
+            validate_theta(_good(1), n_joints=0)
+        with pytest.raises(ValueError, match="positive int"):
+            validate_theta(_good(1), n_joints="3")  # type: ignore[arg-type]
+
+    def test_array_like_coercion_failure(self) -> None:
+        """Pin: un-coercible inputs raise ``TypeError`` from coercion branch."""
+        with pytest.raises(TypeError, match="array-like of floats"):
+            validate_theta("hello", n_joints=1)
+
+    def test_3d_rejected(self) -> None:
+        """Pin: 3-D arrays fail the ``ndim != 1`` branch."""
+        with pytest.raises(ValueError, match=r"1-D \(n_joints\*7,\)"):
+            validate_theta(np.zeros((1, 1, 7)), n_joints=1)
+
+    def test_wrong_length_rejected(self) -> None:
+        """Pin: length mismatch error names both expected and observed."""
+        with pytest.raises(ValueError, match="length 6 != n_joints"):
+            validate_theta(np.zeros(6), n_joints=1)
+
+    def test_nan_inf_count_in_message(self) -> None:
+        """Pin: non-finite count is reported in error message."""
+        bad = _good(1).copy()
+        bad[0] = np.nan
+        bad[1] = np.inf
+        with pytest.raises(ValueError, match="NaN=1, Inf=1"):
+            validate_theta(bad, n_joints=1)
+
+    def test_bounds_pass(self) -> None:
+        """Pin: a within-bounds theta passes optional bounds check."""
+        validate_theta(_good(2), n_joints=2, bounds=DEFAULT_THETA_BOUND_TABLE)
+
+    def test_bounds_violation_reports_letter(self) -> None:
+        """Pin: bound violations cite the offending letter and column."""
+        bad = _good(2).copy()
+        # Letter A is column 0; default bound 1000.
+        bad[0] = 5000.0
+        with pytest.raises(ValueError, match="coefficient 'A' .column 0."):
+            validate_theta(bad, n_joints=2, bounds=DEFAULT_THETA_BOUND_TABLE)
+
+    def test_bounds_must_be_mapping(self) -> None:
+        """Pin: a non-mapping ``bounds`` argument is rejected."""
+        with pytest.raises(TypeError, match="must be a mapping"):
+            validate_theta(_good(1), n_joints=1, bounds=[("A", -1.0, 1.0)])  # type: ignore[arg-type]
+
+    def test_bounds_letter_must_be_single_char(self) -> None:
+        """Pin: multi-char keys are rejected."""
+        with pytest.raises(ValueError, match="single-character letters"):
+            validate_theta(_good(1), n_joints=1, bounds={"AB": (-1.0, 1.0)})
+
+    def test_bounds_pair_must_be_tuple_of_two_floats(self) -> None:
+        """Pin: malformed pair raises TypeError."""
+        with pytest.raises(TypeError, match=r"\(lo, hi\) tuple"):
+            validate_theta(_good(1), n_joints=1, bounds={"A": (1.0,)})  # type: ignore[dict-item]
+
+    def test_bounds_lo_gt_hi_rejected(self) -> None:
+        """Pin: lo > hi is caught at coercion time."""
+        with pytest.raises(ValueError, match="lo > hi"):
+            validate_theta(_good(1), n_joints=1, bounds={"A": (1.0, -1.0)})
+
+    def test_bounds_letter_outside_a_g(self) -> None:
+        """Pin: a letter mapping to column >= 7 is rejected at enforce time."""
+        # 'H' maps to column 7, which is out of range.
+        with pytest.raises(ValueError, match="not in A..G"):
+            validate_theta(_good(1), n_joints=1, bounds={"H": (-1.0, 1.0)})
+
+    def test_custom_name_in_error(self) -> None:
+        """Pin: ``name=`` argument appears in length-mismatch messages."""
+        with pytest.raises(ValueError, match="theta_optimal length"):
+            validate_theta(np.zeros(6), n_joints=1, name="theta_optimal")

--- a/tests/unit/motion_matching/test_validators_coverage.py
+++ b/tests/unit/motion_matching/test_validators_coverage.py
@@ -1,0 +1,186 @@
+"""Coverage tests for ``motion_matching.validators``.
+
+Pin every public-API branch in ``validators.py`` so refactors can't
+silently relax the DbC contracts. Each test docstring identifies the
+specific behaviour or error message it pins.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.shared.python.motion_matching.validators import (
+    REGULARIZER_KINDS,
+    must_be_finite_vector,
+    must_be_monotonic_time,
+    must_be_regularizer_kind,
+    must_be_unit_quaternion_rows,
+    must_have_fields,
+)
+
+
+class TestMustHaveFields:
+    """Pin: ``must_have_fields`` accepts dict, attribute object, dataclass."""
+
+    def test_dict_with_all_fields_passes(self) -> None:
+        """Pin: dict containing every requested key returns None silently."""
+        must_have_fields({"a": 1, "b": 2}, ["a", "b"])
+
+    def test_dict_missing_field_raises(self) -> None:
+        """Pin: missing field message lists the missing names."""
+        with pytest.raises(ValueError, match="missing required fields: c"):
+            must_have_fields({"a": 1}, ["a", "c"])
+
+    def test_object_with_attrs_passes(self) -> None:
+        """Pin: arbitrary object with attributes is accepted."""
+
+        class Bag:
+            x = 1
+            y = 2
+
+        must_have_fields(Bag(), ["x", "y"])
+
+    def test_object_dict_fallback(self) -> None:
+        """Pin: empty hasattr probe falls back to ``__dict__`` keys."""
+
+        class Bag:
+            pass
+
+        b = Bag()
+        b.alpha = 1
+        # Request a name we know is absent so ``present`` starts empty and
+        # we exercise the ``__dict__`` fallback branch.
+        with pytest.raises(ValueError, match="missing required fields"):
+            must_have_fields(b, ["beta"])
+
+
+class TestMustBeFiniteVector:
+    """Pin: ``must_be_finite_vector`` enforces real-finite-1-D contract."""
+
+    def test_returns_float64(self) -> None:
+        """Pin: integer inputs are coerced to ``float64`` on success."""
+        out = must_be_finite_vector([1, 2, 3])
+        assert out.dtype == np.float64
+        assert out.shape == (3,)
+
+    def test_none_rejected(self) -> None:
+        """Pin: ``None`` is rejected with a numeric-vector message."""
+        with pytest.raises(ValueError, match="real numeric vector"):
+            must_be_finite_vector(None)
+
+    def test_complex_rejected(self) -> None:
+        """Pin: complex dtype is rejected by the ``iscomplexobj`` branch."""
+        with pytest.raises(ValueError, match="real numeric array"):
+            must_be_finite_vector(np.array([1 + 0j, 2 + 0j]))
+
+    def test_non_numeric_rejected(self) -> None:
+        """Pin: object/string dtype is rejected."""
+        with pytest.raises(ValueError, match="real numeric array"):
+            must_be_finite_vector(np.array(["a", "b"]))
+
+    def test_empty_rejected(self) -> None:
+        """Pin: zero-length vectors are rejected (``size == 0``)."""
+        with pytest.raises(ValueError, match="non-empty 1-D vector"):
+            must_be_finite_vector(np.array([], dtype=float))
+
+    def test_2d_rejected(self) -> None:
+        """Pin: 2-D arrays fail the ``ndim != 1`` branch."""
+        with pytest.raises(ValueError, match="non-empty 1-D vector"):
+            must_be_finite_vector(np.zeros((2, 3)))
+
+    def test_nan_rejected(self) -> None:
+        """Pin: NaN entries are caught by the ``isfinite`` check."""
+        with pytest.raises(ValueError, match="finite entries"):
+            must_be_finite_vector(np.array([1.0, np.nan]))
+
+    def test_inf_rejected(self) -> None:
+        """Pin: ``+inf`` is rejected by the finiteness check."""
+        with pytest.raises(ValueError, match="finite entries"):
+            must_be_finite_vector(np.array([1.0, np.inf]))
+
+
+class TestMustBeMonotonicTime:
+    """Pin: ``must_be_monotonic_time`` enforces strict increase."""
+
+    def test_strict_increase_passes(self) -> None:
+        """Pin: strictly increasing input passes through unchanged."""
+        out = must_be_monotonic_time([0.0, 0.1, 0.2])
+        assert np.allclose(out, [0.0, 0.1, 0.2])
+
+    def test_duplicate_rejected(self) -> None:
+        """Pin: duplicate samples are rejected (``diff == 0``)."""
+        with pytest.raises(ValueError, match="strictly increasing"):
+            must_be_monotonic_time([0.0, 0.1, 0.1, 0.2])
+
+    def test_decrease_rejected(self) -> None:
+        """Pin: decreasing samples are rejected (``diff < 0``)."""
+        with pytest.raises(ValueError, match="strictly increasing"):
+            must_be_monotonic_time([0.0, 0.2, 0.1])
+
+
+class TestMustBeUnitQuaternionRows:
+    """Pin: ``must_be_unit_quaternion_rows`` shape + norm contract."""
+
+    def test_unit_quat_passes(self) -> None:
+        """Pin: ``[w,x,y,z]`` rows of unit norm pass."""
+        q = np.tile([1.0, 0.0, 0.0, 0.0], (3, 1))
+        out = must_be_unit_quaternion_rows(q)
+        assert out.dtype == np.float64
+        assert out.shape == (3, 4)
+
+    def test_non_positive_tol_rejected(self) -> None:
+        """Pin: ``tol <= 0`` is rejected up-front."""
+        with pytest.raises(ValueError, match="tol must be > 0"):
+            must_be_unit_quaternion_rows(np.eye(4), tol=0.0)
+
+    def test_wrong_shape_rejected(self) -> None:
+        """Pin: shape ``(N, 4)`` is required."""
+        with pytest.raises(ValueError, match=r"\(N, 4\) real matrix"):
+            must_be_unit_quaternion_rows(np.zeros((3, 3)))
+
+    def test_complex_rejected(self) -> None:
+        """Pin: complex dtype quaternions are rejected."""
+        q = np.tile([1.0 + 0j, 0, 0, 0], (2, 1))
+        with pytest.raises(ValueError, match=r"\(N, 4\) real matrix"):
+            must_be_unit_quaternion_rows(q)
+
+    def test_nan_rejected(self) -> None:
+        """Pin: NaN entries fail the finiteness check."""
+        q = np.tile([1.0, 0.0, 0.0, 0.0], (2, 1))
+        q[0, 0] = np.nan
+        with pytest.raises(ValueError, match="NaN or Inf"):
+            must_be_unit_quaternion_rows(q)
+
+    def test_non_unit_rejected(self) -> None:
+        """Pin: non-unit-norm rows are rejected with worst-deviation msg."""
+        q = np.tile([2.0, 0.0, 0.0, 0.0], (2, 1))
+        with pytest.raises(ValueError, match="unit-norm"):
+            must_be_unit_quaternion_rows(q)
+
+
+class TestMustBeRegularizerKind:
+    """Pin: ``must_be_regularizer_kind`` whitelist + lowercase contract."""
+
+    def test_valid_lowercase(self) -> None:
+        """Pin: every entry in ``REGULARIZER_KINDS`` round-trips."""
+        for name in REGULARIZER_KINDS:
+            assert must_be_regularizer_kind(name) == name
+
+    def test_uppercase_normalised(self) -> None:
+        """Pin: input is lower-cased before whitelist check."""
+        assert must_be_regularizer_kind("TOTAL_WORK") == "total_work"
+
+    def test_non_string_rejected(self) -> None:
+        """Pin: non-string inputs raise a non-empty-string message."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            must_be_regularizer_kind(42)
+
+    def test_empty_string_rejected(self) -> None:
+        """Pin: empty string is rejected."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            must_be_regularizer_kind("")
+
+    def test_unknown_kind_rejected(self) -> None:
+        """Pin: unknown regularizer name is rejected with allowed list."""
+        with pytest.raises(ValueError, match="not one of"):
+            must_be_regularizer_kind("not_a_thing")


### PR DESCRIPTION
Closes #4672

## Summary

Adds 18 focused unit-test modules (226 tests) pinning DbC contracts and error
paths across `src/shared/python/motion_matching/`. **No production code changes.**

## Coverage delta

| Metric | Before | After | Target |
| --- | --- | --- | --- |
| Combined (line+branch) | 62.0% | **85.3%** | >=85% |
| Line | ~70% | **88.0%** | >=85% |
| Branch | ~65% | **75.16%** | >=75% |

(Baseline % was depressed because xdist worker coverage was lost; the
serial baseline was 80.6%. After serial run, 85.3%.)

### Per-file highlights (file: before -> after)

- `validators.py` 13.4% -> **100%**
- `validate_theta.py` 65.5% -> **100%**
- `api_contracts.py` 22.2% -> **97.3%**
- `fit_result.py` 69.4% -> **100%**
- `sim_out.py` 54.3% -> **100%**
- `synthesize_target_from_coefficients.py` 30.2% -> **100%**
- `align_to_simulation_grid.py` 53.6% -> **100%**
- `multi_source_target.py` 31.5% -> **96.3%**
- `club_ball_target.py` 69.9% -> **97.2%**
- `metrics.py` 34.2% -> **88.4%**
- `provider_registry.py` 71.0% -> high (registry tests)
- `inverse_timestep/predict.py` 15.1% -> ~93%
- `plot_*` modules 18-42% -> ~95%+ (smoke + error paths)
- `loaders/_machinelearning_compat.py` 22.4% -> **85.1%**
- `loaders/c3d.py` 47.0% -> better (private helpers covered)
- `loaders/excel.py` 55.8% -> better (event-marker helpers covered)
- `surrogate/perstep/extract_dataset.py` 19.6% -> well-covered

## Test pattern

Each new test carries a `"""Pin: <one-liner>"""` docstring identifying
the specific behaviour or error message it pins. Synthetic data uses
`np.random.default_rng(42)` for reproducibility. Protocol/ABC types are
satisfied by minimal in-test impls. DbC pre/post-condition violations
are pinned with `pytest.raises(..., match=...)`.

## Files added (test-only)

```
tests/unit/motion_matching/test_align_to_simulation_grid_coverage.py
tests/unit/motion_matching/test_api_contracts_coverage.py
tests/unit/motion_matching/test_club_ball_target_coverage.py
tests/unit/motion_matching/test_fit_result_coverage.py
tests/unit/motion_matching/test_inverse_timestep_predict.py
tests/unit/motion_matching/test_load_target_dispatch.py
tests/unit/motion_matching/test_loaders_c3d_helpers.py
tests/unit/motion_matching/test_loaders_excel_helpers.py
tests/unit/motion_matching/test_loaders_synthetic_dispatch.py
tests/unit/motion_matching/test_metrics_legacy_coverage.py
tests/unit/motion_matching/test_multi_source_target_coverage.py
tests/unit/motion_matching/test_perstep_extract_dataset.py
tests/unit/motion_matching/test_plot_views_smoke.py
tests/unit/motion_matching/test_provider_registry_coverage.py
tests/unit/motion_matching/test_sim_out_fitresult.py
tests/unit/motion_matching/test_synthesize_target_coverage.py
tests/unit/motion_matching/test_validate_theta_coverage.py
tests/unit/motion_matching/test_validators_coverage.py
```

## Attestation

- 226 new tests, all green.
- `ruff check` and `ruff format --check` clean on `tests/unit/motion_matching/`.
- File-size budget clean.
- **Zero production code changes** in this PR.
- No bugs filed; the few existing crashes (`drake/test_provider`,
  `test_surrogate_train_10k`, `test_inverse_regressor_training`) are
  pre-existing environment failures unrelated to the changes.

## Test plan

- [x] `pytest tests/unit/motion_matching/test_*coverage*.py tests/unit/motion_matching/test_perstep_extract_dataset.py tests/unit/motion_matching/test_plot_views_smoke.py tests/unit/motion_matching/test_inverse_timestep_predict.py tests/unit/motion_matching/test_sim_out_fitresult.py tests/unit/motion_matching/test_load_target_dispatch.py tests/unit/motion_matching/test_loaders_*.py` -> 226 passed
- [x] `ruff check tests/unit/motion_matching/` clean
- [x] `ruff format --check tests/unit/motion_matching/` clean
- [x] Coverage report: line 88.0%, branch 75.16% (combined 85.3%)

Generated with [Claude Code](https://claude.com/claude-code)