### PR TITLE
fix(motion-pipeline): fix mediapipe and hrnet adapters for golden fixtures

### DIFF
--- a/src/shared/python/motion_pipeline/sources/hrnet_json_adapter.py
+++ b/src/shared/python/motion_pipeline/sources/hrnet_json_adapter.py
@@ -51,7 +51,7 @@ class HRNetJSONAdapter(MocapSourceAdapter):
         if isinstance(data, dict) and "frames" in data:
             frames = data["frames"]
             if isinstance(frames, list) and frames and isinstance(frames[0], dict):
-                return "keypoints" in frames[0] and "frame_index" in frames[0]
+                return "keypoints" in frames[0] and ("frame_index" in frames[0] or "frame" in frames[0])
         return False
 
     def _normalise(self, data: object) -> list[dict]:
@@ -62,6 +62,14 @@ class HRNetJSONAdapter(MocapSourceAdapter):
         if isinstance(data, list):
             return [f for f in data if isinstance(f, dict)]
         raise ValueError("HRNet JSON must be a list or {'frames': [...]} object")
+
+    def _get_frame_index(self, item: dict, default: int) -> int:
+        """Get frame index from item, supporting both 'frame' and 'frame_index' keys."""
+        if "frame_index" in item:
+            return int(item["frame_index"])
+        if "frame" in item:
+            return int(item["frame"])
+        return default
 
     def metadata(self, path: Path) -> SourceMetadata:
         p = Path(path)
@@ -88,7 +96,7 @@ class HRNetJSONAdapter(MocapSourceAdapter):
             raise ValueError(f"HRNet JSON {p} has no frames")
 
         frames: list[KeypointFrame] = []
-        for idx, item in enumerate(sorted(raw, key=lambda d: d.get("frame_index", 0))):
+        for idx, item in enumerate(sorted(raw, key=lambda d: self._get_frame_index(d, 0))):
             flat = item.get("keypoints", [])
             kps: list[Keypoint] = []
             for i in range(0, len(flat), 3):
@@ -110,7 +118,7 @@ class HRNetJSONAdapter(MocapSourceAdapter):
                     timestamp=t,
                     keypoints=kps,
                     schema_name=self.schema,  # type: ignore[arg-type]
-                    frame_index=int(item.get("frame_index", idx)),
+                    frame_index=self._get_frame_index(item, idx),
                 )
             )
         if not frames:

--- a/src/shared/python/motion_pipeline/sources/mediapipe_json_adapter.py
+++ b/src/shared/python/motion_pipeline/sources/mediapipe_json_adapter.py
@@ -91,16 +91,27 @@ class MediaPipeJSONAdapter(MocapSourceAdapter):
             landmarks = raw.get("landmarks", [])
             kps: list[Keypoint] = []
             for lm in landmarks:
-                if not isinstance(lm, dict):
-                    continue
-                kps.append(
-                    Keypoint(
-                        x=float(lm.get("x", 0.0)),
-                        y=float(lm.get("y", 0.0)),
-                        z=float(lm["z"]) if lm.get("z") is not None else None,
-                        confidence=max(0.0, min(1.0, float(lm.get("visibility", 1.0)))),
+                # Support both dict format {"x": ..., "y": ..., "z": ...}
+                # and array format [x, y, z, visibility, confidence]
+                if isinstance(lm, dict):
+                    kps.append(
+                        Keypoint(
+                            x=float(lm.get("x", 0.0)),
+                            y=float(lm.get("y", 0.0)),
+                            z=float(lm["z"]) if lm.get("z") is not None else None,
+                            confidence=max(0.0, min(1.0, float(lm.get("visibility", 1.0)))),
+                        )
                     )
-                )
+                elif isinstance(lm, (list, tuple)) and len(lm) >= 4:
+                    # Array format: [x, y, z, visibility, confidence?]
+                    kps.append(
+                        Keypoint(
+                            x=float(lm[0]),
+                            y=float(lm[1]),
+                            z=float(lm[2]) if lm[2] is not None else None,
+                            confidence=max(0.0, min(1.0, float(lm[3]))),
+                        )
+                    )
             if not kps:
                 continue
             t = float(raw.get("timestamp", idx / fps))


### PR DESCRIPTION
Fixes #4683.

## Summary

This PR fixes bugs in the MediaPipe and HRNet JSON adapters that prevented them from loading the shipped golden fixtures.

## Changes

### MediaPipe adapter
- Support array format `[x, y, z, visibility]` in addition to dict format
- The golden fixture uses array format which was not being parsed

### HRNet adapter
- Support `frame` key in addition to `frame_index` key
- The golden fixture uses `frame` key which was not being recognized
- Add `_get_frame_index()` helper method for unified handling

## Testing

Both adapters now correctly parse their respective golden fixtures in `tests/data/motion_pipeline/golden/`.