### PR TITLE
test(motion-pipeline): fail when required golden fixtures missing

### DIFF
--- a/tests/integration/motion_pipeline/test_end_to_end.py
+++ b/tests/integration/motion_pipeline/test_end_to_end.py
@@ -108,10 +108,17 @@ def load_golden_fixture(fixture_name: str, fmt: str) -> dict[str, Any]:
     
     Returns:
         Dictionary containing the golden data
+    
+    Raises:
+        FileNotFoundError: If the fixture file does not exist
     """
     fixture_path = DATA_DIR / f"{fixture_name}.{fmt}"
     if not fixture_path.exists():
-        pytest.skip(f"Golden fixture not present: {fixture_path}")
+        raise FileNotFoundError(
+            f"Required golden fixture not present: {fixture_path}. "
+            "These fixtures are required for regression testing. "
+            "See tests/data/motion_pipeline/golden/ for the fixture directory."
+        )
     
     if fmt == "json":
         return json.loads(fixture_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Fixes #4609.

## Summary

This PR fixes issue #4609 where skipping when a golden fixture file is absent makes the end-to-end suite pass with zero real coverage.

When the golden fixtures directory only contains .gitkeep, every parametrized case could be skipped instead of validating pipeline behavior. For regression protection, missing required fixtures now fail loudly.

## Changes

- Replace `pytest.skip()` with `FileNotFoundError` in `load_golden_fixture()`
- Add informative error message directing to fixture directory
- Update docstring to document the raises clause