### PR TITLE
fix(deps): add lxml to dev dependencies for URDF schema tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ dev = [
     # Type stubs for untyped third-party packages (GH2034)
     "types-PyYAML>=6.0",
     "scipy-stubs>=1.13.0",
+    # Required for URDF schema validation tests (issue #4597)
+    "lxml>=5.0.0",
 ]
 
 # GUI testing (requires PyQt6)


### PR DESCRIPTION
Fixes #4597.

## Summary

This PR adds lxml to the dev dependencies to fix issue #4597 where test_urdf_schema.py imports lxml but pyproject.toml did not declare it.

This caused pytest to fail during collection with ModuleNotFoundError in environments that install only the project's declared test deps.

The test file already uses `pytest.importorskip()` correctly, but adding lxml to dev dependencies ensures the schema validation tests run in standard dev environments.

## Changes

- Add `lxml>=5.0.0` to `[project.optional-dependencies]` dev section