### PR TITLE
[Mocap Pipeline] Distinct TorqueTrajectory + MuscleActivationTrajectory types (#4667)

### DIFF
--- a/src/shared/python/motion_pipeline/__init__.py
+++ b/src/shared/python/motion_pipeline/__init__.py
@@ -24,7 +24,11 @@ from src.shared.python.motion_pipeline.contracts import (
     MotionMatchingRequest,
     MotionMatchingResult,
     MotionTrajectory,
+    MuscleActivationFrame,
+    MuscleActivationTrajectory,
     SkeletonRig,
+    TorqueFrame,
+    TorqueTrajectory,
 )
 
 __all__ = [
@@ -44,5 +48,9 @@ __all__ = [
     "MotionMatchingRequest",
     "MotionMatchingResult",
     "MotionTrajectory",
+    "MuscleActivationFrame",
+    "MuscleActivationTrajectory",
     "SkeletonRig",
+    "TorqueFrame",
+    "TorqueTrajectory",
 ]

--- a/src/shared/python/motion_pipeline/contracts.py
+++ b/src/shared/python/motion_pipeline/contracts.py
@@ -651,6 +651,142 @@ class MotionMatchingRequest(BaseModel):
         return self
 
 
+class TorqueFrame(BaseModel):
+    """Single frame of generalized joint torques."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    timestamp: float = Field(..., description="Frame timestamp (seconds)")
+    tau: list[float] = Field(..., description="Generalized joint torques (N*m)")
+
+    @field_validator("timestamp")
+    @classmethod
+    def _timestamp_finite(cls, v: float) -> float:
+        if not np.isfinite(v):
+            raise ValueError("timestamp must be finite")
+        return v
+
+    @field_validator("tau")
+    @classmethod
+    def _tau_finite(cls, v: list[float]) -> list[float]:
+        if not all(np.isfinite(x) for x in v):
+            raise ValueError("tau values must be finite")
+        return v
+
+
+class TorqueTrajectory(BaseModel):
+    """Time series of generalized joint torques.
+
+    Distinct from :class:`JointTrajectory`: torques have different
+    invariants (any sign, no q/qdot/qddot semantics) and align with
+    a rig's joint name list rather than its DOF list.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    frames: list[TorqueFrame] = Field(..., description="Per-frame torques")
+    rig_joint_names: list[str] = Field(
+        ..., description="Joint names corresponding to tau entries"
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Additional metadata"
+    )
+
+    @model_validator(mode="after")
+    def _invariant_consistent(self) -> TorqueTrajectory:
+        if not self.frames:
+            raise ValueError("TorqueTrajectory must have at least one frame")
+        n = len(self.rig_joint_names)
+        for i, f in enumerate(self.frames):
+            if len(f.tau) != n:
+                raise ValueError(
+                    f"frame {i} tau length {len(f.tau)} != rig_joint_names length {n}"
+                )
+        ts = [f.timestamp for f in self.frames]
+        if any(b <= a for a, b in zip(ts, ts[1:])):
+            raise ValueError("timestamps must be strictly monotonic")
+        return self
+
+    @property
+    def num_frames(self) -> int:
+        return len(self.frames)
+
+    @property
+    def duration(self) -> float:
+        if len(self.frames) < 2:
+            return 0.0
+        return self.frames[-1].timestamp - self.frames[0].timestamp
+
+
+class MuscleActivationFrame(BaseModel):
+    """Single frame of muscle activations in [0, 1]."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    timestamp: float = Field(..., description="Frame timestamp (seconds)")
+    activations: list[float] = Field(..., description="Muscle activations [0, 1]")
+
+    @field_validator("timestamp")
+    @classmethod
+    def _timestamp_finite(cls, v: float) -> float:
+        if not np.isfinite(v):
+            raise ValueError("timestamp must be finite")
+        return v
+
+    @field_validator("activations")
+    @classmethod
+    def _activations_in_unit_interval(cls, v: list[float]) -> list[float]:
+        if not all(np.isfinite(a) and 0.0 <= a <= 1.0 for a in v):
+            raise ValueError("activations must lie in [0, 1] and be finite")
+        return v
+
+
+class MuscleActivationTrajectory(BaseModel):
+    """Time series of muscle activations.
+
+    Distinct from :class:`JointTrajectory`: activation values are bounded
+    to [0, 1] and align with muscle names, not DOFs.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    frames: list[MuscleActivationFrame] = Field(
+        ..., description="Per-frame activations"
+    )
+    muscle_names: list[str] = Field(
+        ..., description="Muscle names corresponding to activation entries"
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Additional metadata"
+    )
+
+    @model_validator(mode="after")
+    def _invariant_consistent(self) -> MuscleActivationTrajectory:
+        if not self.frames:
+            raise ValueError("MuscleActivationTrajectory must have at least one frame")
+        n = len(self.muscle_names)
+        for i, f in enumerate(self.frames):
+            if len(f.activations) != n:
+                raise ValueError(
+                    f"frame {i} activation length {len(f.activations)} != "
+                    f"muscle_names length {n}"
+                )
+        ts = [f.timestamp for f in self.frames]
+        if any(b <= a for a, b in zip(ts, ts[1:])):
+            raise ValueError("timestamps must be strictly monotonic")
+        return self
+
+    @property
+    def num_frames(self) -> int:
+        return len(self.frames)
+
+    @property
+    def duration(self) -> float:
+        if len(self.frames) < 2:
+            return 0.0
+        return self.frames[-1].timestamp - self.frames[0].timestamp
+
+
 class MotionMatchingResult(BaseModel):
     """Motion matching solver result."""
 
@@ -660,6 +796,14 @@ class MotionMatchingResult(BaseModel):
     success: bool = Field(..., description="Whether matching succeeded")
     matched_trajectory: MotionTrajectory | None = Field(
         default=None, description="Matched joint trajectory"
+    )
+    torques: TorqueTrajectory | None = Field(
+        default=None,
+        description="Generalized joint torques (distinct from JointTrajectory)",
+    )
+    activations: MuscleActivationTrajectory | None = Field(
+        default=None,
+        description="Muscle activations in [0, 1] (distinct from JointTrajectory)",
     )
     error_metrics: dict[str, float] = Field(
         default_factory=dict,
@@ -680,6 +824,28 @@ class MotionMatchingResult(BaseModel):
         if v is not None and not np.isfinite(v):
             raise ValueError("Solve time must be finite")
         return v
+
+    @model_validator(mode="after")
+    def _invariant_has_payload_when_successful(self) -> MotionMatchingResult:
+        """Successful results must carry at least one payload.
+
+        A successful match must produce at least one of: matched
+        trajectory, torques, or muscle activations. Failed results may
+        carry only a message. Either ``torques`` or ``activations`` is
+        sufficient — the two are not interchangeable.
+        """
+        if self.success:
+            has_payload = (
+                self.matched_trajectory is not None
+                or self.torques is not None
+                or self.activations is not None
+            )
+            if not has_payload:
+                raise ValueError(
+                    "Successful MotionMatchingResult must include at least one "
+                    "of: matched_trajectory, torques, activations"
+                )
+        return self
 
 
 # =============================================================================
@@ -738,6 +904,11 @@ __all__ = [
     # Joint state types
     "JointStateFrame",
     "JointTrajectory",
+    # Torque + muscle-activation types
+    "TorqueFrame",
+    "TorqueTrajectory",
+    "MuscleActivationFrame",
+    "MuscleActivationTrajectory",
     # High-level types
     "MotionTrajectory",
     "MotionMatchingRequest",

--- a/src/shared/python/motion_pipeline/contracts.py
+++ b/src/shared/python/motion_pipeline/contracts.py
@@ -20,18 +20,17 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.functional_validators import AfterValidator
-from typing import Annotated
 
 # =============================================================================
 # Type Aliases
 # =============================================================================
 
-ArrayLike = Union[list[float], np.ndarray]
+ArrayLike = list[float] | np.ndarray
 SchemaName = Literal["BODY_25", "MediaPipe_33", "COCO_17", "OpenPose_25", "custom"]
 Axis = Literal["X", "Y", "Z", "+X", "-X", "+Y", "-Y", "+Z", "-Z"]
 UpAxis = Literal["+Y", "+Z", "+X", "-Y", "-Z", "-X"]
@@ -314,7 +313,7 @@ class MarkerTrajectory(BaseModel):
         if len(self.frames) < 2:
             return self
         reference_markers = set(self.frames[0].marker_names)
-        for i, frame in enumerate(self.frames[1:], 1):
+        for _i, frame in enumerate(self.frames[1:], 1):
             frame_markers = set(frame.marker_names)
             if frame_markers != reference_markers:
                 # Allow for occlusions, but names should be consistent
@@ -360,9 +359,12 @@ class JointLimit(BaseModel):
 
     @model_validator(mode="after")
     def check_limit_order(self) -> JointLimit:
-        if self.lower is not None and self.upper is not None:
-            if self.lower > self.upper:
-                raise ValueError("Lower limit must be <= upper limit")
+        if (
+            self.lower is not None
+            and self.upper is not None
+            and self.lower > self.upper
+        ):
+            raise ValueError("Lower limit must be <= upper limit")
         return self
 
 
@@ -490,9 +492,8 @@ class JointStateFrame(BaseModel):
     @field_validator("q", "qdot", "qddot")
     @classmethod
     def check_finite_values(cls, v: list[float] | None) -> list[float] | None:
-        if v is not None:
-            if not all(np.isfinite(x) for x in v):
-                raise ValueError("All values must be finite")
+        if v is not None and not all(np.isfinite(x) for x in v):
+            raise ValueError("All values must be finite")
         return v
 
     @model_validator(mode="after")
@@ -703,7 +704,7 @@ class TorqueTrajectory(BaseModel):
                     f"frame {i} tau length {len(f.tau)} != rig_joint_names length {n}"
                 )
         ts = [f.timestamp for f in self.frames]
-        if any(b <= a for a, b in zip(ts, ts[1:])):
+        if any(b <= a for a, b in zip(ts, ts[1:], strict=False)):
             raise ValueError("timestamps must be strictly monotonic")
         return self
 
@@ -772,7 +773,7 @@ class MuscleActivationTrajectory(BaseModel):
                     f"muscle_names length {n}"
                 )
         ts = [f.timestamp for f in self.frames]
-        if any(b <= a for a, b in zip(ts, ts[1:])):
+        if any(b <= a for a, b in zip(ts, ts[1:], strict=False)):
             raise ValueError("timestamps must be strictly monotonic")
         return self
 

--- a/src/shared/python/motion_pipeline/matching/base.py
+++ b/src/shared/python/motion_pipeline/matching/base.py
@@ -17,13 +17,15 @@ from ..contracts import (
     JointTrajectory,
     MotionMatchingRequest as ContractMotionMatchingRequest,
     MotionMatchingResult as ContractMotionMatchingResult,
+    MuscleActivationTrajectory,
     SkeletonRig,
+    TorqueTrajectory,
 )
 
 
 class MatchingBackendType(str, Enum):
     """Available motion matching backend types."""
-    
+
     CMC = "cmc"  # Computed Muscle Control (OpenSim)
     RRA = "rra"  # Residual Reduction Algorithm (OpenSim)
     TRAJOPT_DRAKE = "drake_trajopt"  # Drake trajectory optimization
@@ -35,7 +37,7 @@ class MatchingBackendType(str, Enum):
 class CostWeights:
     """
     Cost function weights for motion matching.
-    
+
     Attributes:
         joint_tracking: Weight for joint position tracking
         marker_tracking: Weight for marker position tracking
@@ -44,7 +46,7 @@ class CostWeights:
         contact: Weight for contact force regularization
         residual: Weight for residual force reduction
     """
-    
+
     joint_tracking: float = field(default=1.0)
     marker_tracking: float = field(default=0.5)
     smoothness: float = field(default=0.1)
@@ -57,7 +59,7 @@ class CostWeights:
 class MotionMatchingRequest:
     """
     Request for motion matching solver.
-    
+
     Attributes:
         id: Unique request identifier
         reference: Reference joint trajectory to track
@@ -69,7 +71,7 @@ class MotionMatchingRequest:
         use_residuals: Whether to use residual forces
         use_contacts: Whether to include contact forces
     """
-    
+
     id: str
     reference: JointTrajectory
     rig: SkeletonRig
@@ -79,7 +81,7 @@ class MotionMatchingRequest:
     max_iterations: int = field(default=100)
     use_residuals: bool = field(default=True)
     use_contacts: bool = field(default=False)
-    
+
     def __post_init__(self):
         if self.time_horizon is None:
             self.time_horizon = self.reference.duration
@@ -89,7 +91,7 @@ class MotionMatchingRequest:
 class MotionMatchingResult:
     """
     Result from motion matching solver.
-    
+
     Attributes:
         request_id: Associated request identifier
         success: Whether matching succeeded
@@ -101,37 +103,45 @@ class MotionMatchingResult:
         message: Status message
         metadata: Additional metadata
     """
-    
+
     request_id: str
     success: bool
     tracked_trajectory: JointTrajectory | None = None
-    torque_trajectory: JointTrajectory | None = None
+    torque_trajectory: TorqueTrajectory | None = None
+    activation_trajectory: MuscleActivationTrajectory | None = None
     residual_report: dict | None = None
     fit_metrics: dict | None = None
     solve_time: float | None = None
     message: str | None = None
     metadata: dict = field(default_factory=dict)
-    
+
     def to_contract(self) -> ContractMotionMatchingResult:
-        """Convert to contract MotionMatchingResult."""
+        """Convert to contract MotionMatchingResult.
+
+        ``tracked_trajectory`` is a ``JointTrajectory`` here; the contract
+        ``matched_trajectory`` is a ``MotionTrajectory``, so the conversion
+        only sets the ``torques``/``activations`` payloads and lets the
+        caller construct a ``MotionTrajectory`` if they need one.
+        """
         return ContractMotionMatchingResult(
             request_id=self.request_id,
             success=self.success,
-            matched_trajectory=self.tracked_trajectory,
+            torques=self.torque_trajectory,
+            activations=self.activation_trajectory,
             error_metrics=self.fit_metrics or {},
             message=self.message,
-            metadata=self.metadata
+            metadata=self.metadata,
         )
 
 
 class MotionMatchingSolver(Protocol):
     """
     Protocol for Motion Matching solvers.
-    
+
     Converts a kinematic JointTrajectory into a dynamically
     consistent, torque-driven trajectory.
     """
-    
+
     def match(
         self,
         reference: JointTrajectory,
@@ -140,15 +150,15 @@ class MotionMatchingSolver(Protocol):
     ) -> MotionMatchingResult:
         """
         Solve motion matching for a reference trajectory.
-        
+
         Args:
             reference: Reference joint trajectory to track
             rig: Scaled skeleton rig
             request: Optional matching request with configuration
-        
+
         Returns:
             MotionMatchingResult with tracked trajectory and metrics
-        
+
         Raises:
             ValueError: If reference/rig are invalid
             RuntimeError: If solver fails to converge
@@ -159,20 +169,20 @@ class MotionMatchingSolver(Protocol):
 class BaseMotionMatchingSolver(ABC):
     """
     Abstract base class for motion matching solvers.
-    
+
     Provides common functionality for cost computation,
     residual reporting, and validation.
     """
-    
+
     def __init__(self, cost_weights: CostWeights | None = None):
         """
         Initialize motion matching solver.
-        
+
         Args:
             cost_weights: Cost function weights
         """
         self.cost_weights = cost_weights or CostWeights()
-    
+
     @abstractmethod
     def match(
         self,
@@ -181,7 +191,7 @@ class BaseMotionMatchingSolver(ABC):
         request: MotionMatchingRequest | None = None,
     ) -> MotionMatchingResult:
         """Solve motion matching for a reference trajectory."""
-    
+
     def _compute_rmse(
         self,
         reference: JointTrajectory,
@@ -189,11 +199,11 @@ class BaseMotionMatchingSolver(ABC):
     ) -> float:
         """
         Compute RMSE between reference and tracked trajectories.
-        
+
         Args:
             reference: Reference trajectory
             tracked: Tracked trajectory
-        
+
         Returns:
             RMSE in radians
         """
@@ -201,9 +211,9 @@ class BaseMotionMatchingSolver(ABC):
         for ref_frame, track_frame in zip(reference.frames, tracked.frames):
             for ref_q, track_q in zip(ref_frame.q, track_frame.q):
                 errors.append((ref_q - track_q) ** 2)
-        
+
         return float(np.sqrt(np.mean(errors)))
-    
+
     def _compute_residual_report(
         self,
         reference: JointTrajectory,
@@ -211,11 +221,11 @@ class BaseMotionMatchingSolver(ABC):
     ) -> dict:
         """
         Compute residual force report.
-        
+
         Args:
             reference: Reference trajectory
             tracked: Tracked trajectory
-        
+
         Returns:
             Dict with residual statistics
         """
@@ -224,21 +234,21 @@ class BaseMotionMatchingSolver(ABC):
         for ref_frame, track_frame in zip(reference.frames, tracked.frames):
             for ref_q, track_q in zip(ref_frame.q, track_frame.q):
                 residuals.append(abs(ref_q - track_q))
-        
+
         return {
             "mean_residual": float(np.mean(residuals)),
             "max_residual": float(np.max(residuals)),
             "std_residual": float(np.std(residuals)),
             "num_frames": len(reference.frames),
         }
-    
+
     def _validate_result(
         self,
         trajectory: JointTrajectory,
     ) -> bool:
         """
         Validate motion matching result satisfies DbC postconditions.
-        
+
         Postconditions:
         - Torque/activation finite
         - Time grid matches reference
@@ -247,7 +257,7 @@ class BaseMotionMatchingSolver(ABC):
         for frame in trajectory.frames:
             if any(not np.isfinite(v) for v in frame.q):
                 return False
-        
+
         return True
 
 
@@ -257,39 +267,44 @@ def make_matching_solver(
 ) -> MotionMatchingSolver:
     """
     Factory function to create a motion matching solver for the specified backend.
-    
+
     Args:
         backend: Backend type (cmc, rra, drake_trajopt, mujoco_torque, pinocchio_inverse_dyn)
         cost_weights: Optional cost weights
-    
+
     Returns:
         MotionMatchingSolver instance
-    
+
     Raises:
         ImportError: If backend not available
         ValueError: If backend not recognized
     """
     if isinstance(backend, str):
         backend = MatchingBackendType(backend.lower())
-    
+
     if backend == MatchingBackendType.CMC:
         from .cmc import CMCMatchingSolver
+
         return CMCMatchingSolver(cost_weights)
-    
+
     if backend == MatchingBackendType.RRA:
         from .rra import RRAMatchingSolver
+
         return RRAMatchingSolver(cost_weights)
-    
+
     if backend == MatchingBackendType.TRAJOPT_DRAKE:
         from .trajopt_drake import DrakeTrajoptMatchingSolver
+
         return DrakeTrajoptMatchingSolver(cost_weights)
-    
+
     if backend == MatchingBackendType.TORQUE_MUJOCO:
         from .torque_mujoco import MuJoCoTorqueMatchingSolver
+
         return MuJoCoTorqueMatchingSolver(cost_weights)
-    
+
     if backend == MatchingBackendType.INVERSE_DYN_PINOCCHIO:
         from .inverse_dyn_pinocchio import PinocchioInverseDynMatchingSolver
+
         return PinocchioInverseDynMatchingSolver(cost_weights)
-    
+
     raise ValueError(f"Unknown motion matching backend: {backend}")

--- a/src/shared/python/motion_pipeline/matching/base.py
+++ b/src/shared/python/motion_pipeline/matching/base.py
@@ -208,8 +208,10 @@ class BaseMotionMatchingSolver(ABC):
             RMSE in radians
         """
         errors = []
-        for ref_frame, track_frame in zip(reference.frames, tracked.frames):
-            for ref_q, track_q in zip(ref_frame.q, track_frame.q):
+        for ref_frame, track_frame in zip(
+            reference.frames, tracked.frames, strict=False
+        ):
+            for ref_q, track_q in zip(ref_frame.q, track_frame.q, strict=False):
                 errors.append((ref_q - track_q) ** 2)
 
         return float(np.sqrt(np.mean(errors)))
@@ -231,8 +233,10 @@ class BaseMotionMatchingSolver(ABC):
         """
         # Compute residual as difference in joint angles
         residuals = []
-        for ref_frame, track_frame in zip(reference.frames, tracked.frames):
-            for ref_q, track_q in zip(ref_frame.q, track_frame.q):
+        for ref_frame, track_frame in zip(
+            reference.frames, tracked.frames, strict=False
+        ):
+            for ref_q, track_q in zip(ref_frame.q, track_frame.q, strict=False):
                 residuals.append(abs(ref_q - track_q))
 
         return {

--- a/src/shared/python/motion_pipeline/matching/cmc.py
+++ b/src/shared/python/motion_pipeline/matching/cmc.py
@@ -23,20 +23,20 @@ logger = logging.getLogger(__name__)
 class CMCMatchingSolver(BaseMotionMatchingSolver):
     """
     Computed Muscle Control (CMC) motion matching solver.
-    
+
     Uses OpenSim's CMC algorithm to compute muscle activations
     that track a reference joint trajectory.
     """
-    
+
     def __init__(self, cost_weights: CostWeights | None = None):
         """
         Initialize CMC solver.
-        
+
         Args:
             cost_weights: Cost function weights
         """
         super().__init__(cost_weights)
-    
+
     def match(
         self,
         reference: JointTrajectory,
@@ -45,12 +45,12 @@ class CMCMatchingSolver(BaseMotionMatchingSolver):
     ) -> MotionMatchingResult:
         """
         Solve motion matching using Computed Muscle Control.
-        
+
         Args:
             reference: Reference joint trajectory to track
             rig: Scaled skeleton rig
             request: Optional matching request with configuration
-        
+
         Returns:
             MotionMatchingResult with tracked trajectory and muscle activations
         """
@@ -59,13 +59,13 @@ class CMCMatchingSolver(BaseMotionMatchingSolver):
         # 1. Write OpenSim setup files (TRC, MOT, XML)
         # 2. Run CMC tool
         # 3. Parse output muscle activations and states
-        
+
         request_id = request.id if request else f"cmc-{reference.id}"
-        
+
         # Return placeholder result
         return MotionMatchingResult(
             request_id=request_id,
             success=False,
             message="CMC solver not yet implemented - OpenSim integration pending",
-            metadata={"backend": "cmc", "status": "placeholder"}
+            metadata={"backend": "cmc", "status": "placeholder"},
         )

--- a/src/shared/python/motion_pipeline/matching/costs.py
+++ b/src/shared/python/motion_pipeline/matching/costs.py
@@ -17,6 +17,7 @@ from ..contracts import (
     JointTrajectory,
     MarkerFrame,
     MarkerTrajectory,
+    TorqueTrajectory,
 )
 from .base import CostWeights
 
@@ -24,13 +25,11 @@ logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
-# Lightweight typing aliases — full Pydantic counterparts may not exist yet.
+# Lightweight typing aliases for non-CIR shapes.
 # -----------------------------------------------------------------------------
 
-# A torque trajectory is structurally identical to a JointTrajectory whose
-# `q` slot carries generalized forces. We keep the alias for readability; the
-# spec text refers to ``TorqueTrajectory`` and ``ResidualReport``.
-TorqueTrajectory = JointTrajectory
+# ``TorqueTrajectory`` is now a distinct Pydantic model imported from
+# ``contracts``; it is no longer aliased to ``JointTrajectory``. See #4667.
 ResidualReport = Mapping[str, Any]
 
 
@@ -221,14 +220,14 @@ def effort_cost(torques: TorqueTrajectory) -> float:
     Integral of squared torque (rectangle rule).
 
     Args:
-        torques: Torque trajectory (uses ``q`` slot for tau).
+        torques: Torque trajectory whose frames carry per-DOF ``tau``.
 
     Returns:
         Non-negative finite scalar.
     """
     if torques is None or not torques.frames:
         raise ValueError("Torque trajectory must have at least one frame")
-    tau = _q_matrix(torques)
+    tau = np.asarray([list(f.tau) for f in torques.frames], dtype=float)
     times = np.asarray([f.timestamp for f in torques.frames], dtype=float)
 
     if len(times) == 1:

--- a/src/shared/python/motion_pipeline/matching/inverse_dyn_pinocchio.py
+++ b/src/shared/python/motion_pipeline/matching/inverse_dyn_pinocchio.py
@@ -20,6 +20,8 @@ from ..contracts import (
     JointStateFrame,
     JointTrajectory,
     SkeletonRig,
+    TorqueFrame,
+    TorqueTrajectory,
 )
 from .base import (
     BaseMotionMatchingSolver,
@@ -198,7 +200,7 @@ class PinocchioInverseDynMatchingSolver(BaseMotionMatchingSolver):
                 f"trajectory DOFs={n_dof_traj}"
             )
 
-        torque_frames: list[JointStateFrame] = []
+        torque_frames: list[TorqueFrame] = []
         for i, t in enumerate(times):
             q = q_all[i]
             v = qdot_all[i]
@@ -208,18 +210,23 @@ class PinocchioInverseDynMatchingSolver(BaseMotionMatchingSolver):
             if not np.all(np.isfinite(tau_arr)):
                 raise RuntimeError(f"RNEA produced non-finite torques at frame {i}")
             torque_frames.append(
-                JointStateFrame(
+                TorqueFrame(
                     timestamp=float(t),
-                    q=tau_arr.tolist(),
-                    frame_index=i,
+                    tau=tau_arr.tolist(),
                 )
             )
 
-        torque_traj = JointTrajectory(
-            id=f"{reference.id}-torques",
-            skeleton=rig,
+        # Build per-DOF joint-name list (one entry per axis) so the torque
+        # trajectory's invariant matches the per-frame tau length.
+        rig_joint_names: list[str] = []
+        for jname, jdef in rig.joints.items():
+            for _ in jdef.axes:
+                rig_joint_names.append(jname)
+
+        torque_traj = TorqueTrajectory(
             frames=torque_frames,
-            metadata={"semantics": "torques"},
+            rig_joint_names=rig_joint_names,
+            metadata={"semantics": "torques", "source_id": f"{reference.id}-torques"},
         )
 
         residual_report = self._compute_residual_report(reference, reference)

--- a/src/shared/python/motion_pipeline/matching/rra.py
+++ b/src/shared/python/motion_pipeline/matching/rra.py
@@ -23,20 +23,20 @@ logger = logging.getLogger(__name__)
 class RRAMatchingSolver(BaseMotionMatchingSolver):
     """
     Residual Reduction Algorithm (RRA) motion matching solver.
-    
+
     Uses OpenSim's RRA to reduce residual forces and correct
     kinematic inconsistencies.
     """
-    
+
     def __init__(self, cost_weights: CostWeights | None = None):
         """
         Initialize RRA solver.
-        
+
         Args:
             cost_weights: Cost function weights
         """
         super().__init__(cost_weights)
-    
+
     def match(
         self,
         reference: JointTrajectory,
@@ -45,12 +45,12 @@ class RRAMatchingSolver(BaseMotionMatchingSolver):
     ) -> MotionMatchingResult:
         """
         Solve motion matching using Residual Reduction Algorithm.
-        
+
         Args:
             reference: Reference joint trajectory to track
             rig: Scaled skeleton rig
             request: Optional matching request with configuration
-        
+
         Returns:
             MotionMatchingResult with corrected trajectory and residual report
         """
@@ -59,13 +59,13 @@ class RRAMatchingSolver(BaseMotionMatchingSolver):
         # 1. Write OpenSim RRA setup files
         # 2. Run RRA tool
         # 3. Parse corrected kinematics and residual forces
-        
+
         request_id = request.id if request else f"rra-{reference.id}"
-        
+
         # Return placeholder result
         return MotionMatchingResult(
             request_id=request_id,
             success=False,
             message="RRA solver not yet implemented - OpenSim integration pending",
-            metadata={"backend": "rra", "status": "placeholder"}
+            metadata={"backend": "rra", "status": "placeholder"},
         )

--- a/src/shared/python/motion_pipeline/matching/torque_mujoco.py
+++ b/src/shared/python/motion_pipeline/matching/torque_mujoco.py
@@ -23,20 +23,20 @@ logger = logging.getLogger(__name__)
 class MuJoCoTorqueMatchingSolver(BaseMotionMatchingSolver):
     """
     MuJoCo torque tracking motion matching solver.
-    
+
     Uses MuJoCo's physics engine for torque-based PD tracking
     with residual force logging.
     """
-    
+
     def __init__(self, cost_weights: CostWeights | None = None):
         """
         Initialize MuJoCo torque tracking solver.
-        
+
         Args:
             cost_weights: Cost function weights
         """
         super().__init__(cost_weights)
-    
+
     def match(
         self,
         reference: JointTrajectory,
@@ -45,12 +45,12 @@ class MuJoCoTorqueMatchingSolver(BaseMotionMatchingSolver):
     ) -> MotionMatchingResult:
         """
         Solve motion matching using MuJoCo torque tracking.
-        
+
         Args:
             reference: Reference joint trajectory to track
             rig: Scaled skeleton rig
             request: Optional matching request with configuration
-        
+
         Returns:
             MotionMatchingResult with tracked trajectory and torque data
         """
@@ -60,12 +60,12 @@ class MuJoCoTorqueMatchingSolver(BaseMotionMatchingSolver):
         # 2. Set up PD controller with reference trajectory
         # 3. Run forward dynamics simulation
         # 4. Extract joint angles and torques
-        
+
         request_id = request.id if request else f"mujoco-torque-{reference.id}"
-        
+
         # Compute residual report for placeholder
         residual_report = self._compute_residual_report(reference, reference)
-        
+
         # Return reference trajectory as tracked (placeholder)
         return MotionMatchingResult(
             request_id=request_id,
@@ -76,5 +76,5 @@ class MuJoCoTorqueMatchingSolver(BaseMotionMatchingSolver):
             fit_metrics={"rmse": 0.0, "max_error": 0.0},
             solve_time=0.0,
             message="MuJoCo torque tracking solver - placeholder implementation",
-            metadata={"backend": "mujoco_torque", "status": "placeholder"}
+            metadata={"backend": "mujoco_torque", "status": "placeholder"},
         )

--- a/src/shared/python/motion_pipeline/matching/trajopt_drake.py
+++ b/src/shared/python/motion_pipeline/matching/trajopt_drake.py
@@ -23,20 +23,20 @@ logger = logging.getLogger(__name__)
 class DrakeTrajoptMatchingSolver(BaseMotionMatchingSolver):
     """
     Drake trajectory optimization motion matching solver.
-    
+
     Uses Drake's direct-collocation and contact-implicit
     trajectory optimization for dynamically consistent motion.
     """
-    
+
     def __init__(self, cost_weights: CostWeights | None = None):
         """
         Initialize Drake trajectory optimization solver.
-        
+
         Args:
             cost_weights: Cost function weights
         """
         super().__init__(cost_weights)
-    
+
     def match(
         self,
         reference: JointTrajectory,
@@ -45,12 +45,12 @@ class DrakeTrajoptMatchingSolver(BaseMotionMatchingSolver):
     ) -> MotionMatchingResult:
         """
         Solve motion matching using Drake trajectory optimization.
-        
+
         Args:
             reference: Reference joint trajectory to track
             rig: Scaled skeleton rig
             request: Optional matching request with configuration
-        
+
         Returns:
             MotionMatchingResult with optimized trajectory
         """
@@ -61,13 +61,13 @@ class DrakeTrajoptMatchingSolver(BaseMotionMatchingSolver):
         # 3. Add running costs (tracking, effort, smoothness)
         # 4. Add contact constraints if enabled
         # 5. Solve with SNOPT or IPOPT
-        
+
         request_id = request.id if request else f"drake-trajopt-{reference.id}"
-        
+
         # Return placeholder result
         return MotionMatchingResult(
             request_id=request_id,
             success=False,
             message="Drake trajectory optimization solver not yet implemented",
-            metadata={"backend": "drake_trajopt", "status": "placeholder"}
+            metadata={"backend": "drake_trajopt", "status": "placeholder"},
         )

--- a/tests/unit/motion_pipeline/matching_completeness/test_costs.py
+++ b/tests/unit/motion_pipeline/matching_completeness/test_costs.py
@@ -13,6 +13,8 @@ from src.shared.python.motion_pipeline.contracts import (
     MarkerFrame,
     MarkerTrajectory,
     SkeletonRig,
+    TorqueFrame,
+    TorqueTrajectory,
 )
 from src.shared.python.motion_pipeline.matching.base import CostWeights
 from src.shared.python.motion_pipeline.matching.costs import (
@@ -120,16 +122,19 @@ def test_smoothness_cost_positive_for_jerky():
     assert smoothness_cost(traj) > 0.0
 
 
+def _make_torque_traj(taus: list[list[float]], dt: float = 0.01) -> TorqueTrajectory:
+    frames = [TorqueFrame(timestamp=i * dt, tau=tau) for i, tau in enumerate(taus)]
+    return TorqueTrajectory(frames=frames, rig_joint_names=["root", "seg"])
+
+
 def test_effort_cost_zero_for_zero_torque():
-    rig = _make_rig()
-    traj = _make_traj(rig, [[0.0, 0.0], [0.0, 0.0]])
+    traj = _make_torque_traj([[0.0, 0.0], [0.0, 0.0]])
     assert effort_cost(traj) == pytest.approx(0.0)
 
 
 def test_effort_cost_scales_with_torque():
-    rig = _make_rig()
-    small = _make_traj(rig, [[1.0, 0.0], [1.0, 0.0]])
-    big = _make_traj(rig, [[10.0, 0.0], [10.0, 0.0]])
+    small = _make_torque_traj([[1.0, 0.0], [1.0, 0.0]])
+    big = _make_torque_traj([[10.0, 0.0], [10.0, 0.0]])
     assert effort_cost(big) > effort_cost(small)
 
 

--- a/tests/unit/motion_pipeline/matching_completeness/test_inverse_dyn_pinocchio.py
+++ b/tests/unit/motion_pipeline/matching_completeness/test_inverse_dyn_pinocchio.py
@@ -59,7 +59,7 @@ def test_match_returns_finite_torques_for_static_pose():
     assert result.torque_trajectory is not None
     assert result.torque_trajectory.num_frames == traj.num_frames
     for f in result.torque_trajectory.frames:
-        assert all(np.isfinite(v) for v in f.q)
+        assert all(np.isfinite(v) for v in f.tau)
 
 
 def test_match_postconditions():

--- a/tests/unit/motion_pipeline/test_contracts.py
+++ b/tests/unit/motion_pipeline/test_contracts.py
@@ -686,15 +686,29 @@ class TestMotionMatchingResult:
 
     def test_successful_result(self):
         """Test successful result creation."""
+        from src.shared.python.motion_pipeline.contracts import (
+            TorqueFrame,
+            TorqueTrajectory,
+        )
+
+        torques = TorqueTrajectory(
+            frames=[
+                TorqueFrame(timestamp=0.0, tau=[0.0]),
+                TorqueFrame(timestamp=0.01, tau=[0.1]),
+            ],
+            rig_joint_names=["j0"],
+        )
         result = MotionMatchingResult(
             request_id="request_001",
             success=True,
+            torques=torques,
             error_metrics={"rmse": 0.05, "max_error": 0.1},
             iterations=10,
             solve_time=0.5,
         )
         assert result.success
         assert result.iterations == 10
+        assert result.torques is torques
 
     def test_failed_result(self):
         """Test failed result creation."""
@@ -707,10 +721,29 @@ class TestMotionMatchingResult:
         assert "not converge" in result.message
 
     def test_negative_solve_time(self):
-        """Test that negative solve time raises error."""
+        """Test that negative solve time raises error.
+
+        Provides torques to satisfy the success-payload invariant so that
+        the solve_time validator is the one that triggers.
+        """
+        from src.shared.python.motion_pipeline.contracts import (
+            TorqueFrame,
+            TorqueTrajectory,
+        )
+
+        torques = TorqueTrajectory(
+            frames=[
+                TorqueFrame(timestamp=0.0, tau=[0.0]),
+                TorqueFrame(timestamp=0.01, tau=[0.1]),
+            ],
+            rig_joint_names=["j0"],
+        )
         with pytest.raises(ValueError, match="greater than or equal to 0"):
             MotionMatchingResult(
-                request_id="request_001", success=True, solve_time=-1.0
+                request_id="request_001",
+                success=True,
+                torques=torques,
+                solve_time=-1.0,
             )
 
 

--- a/tests/unit/motion_pipeline/test_torque_activation_trajectories.py
+++ b/tests/unit/motion_pipeline/test_torque_activation_trajectories.py
@@ -1,0 +1,226 @@
+"""Tests for distinct TorqueTrajectory and MuscleActivationTrajectory types.
+
+Issue #4667. Validates that torque and muscle-activation trajectories are
+distinct Pydantic models with their own invariants — and that
+``MotionMatchingResult`` accepts them as alternatives to a matched joint
+trajectory.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.shared.python.motion_pipeline.contracts import (
+    MotionMatchingResult,
+    MuscleActivationFrame,
+    MuscleActivationTrajectory,
+    TorqueFrame,
+    TorqueTrajectory,
+)
+
+
+# -----------------------------------------------------------------------------
+# TorqueTrajectory
+# -----------------------------------------------------------------------------
+
+
+def _make_torque_traj(
+    taus: list[list[float]],
+    times: list[float] | None = None,
+    rig_joint_names: list[str] | None = None,
+) -> TorqueTrajectory:
+    if times is None:
+        times = [float(i) * 0.01 for i in range(len(taus))]
+    if rig_joint_names is None:
+        rig_joint_names = ["j0", "j1"] if taus and len(taus[0]) == 2 else ["j0"]
+    frames = [
+        TorqueFrame(timestamp=t, tau=tau) for t, tau in zip(times, taus, strict=True)
+    ]
+    return TorqueTrajectory(frames=frames, rig_joint_names=rig_joint_names)
+
+
+def test_torque_trajectory_valid_construction():
+    traj = _make_torque_traj([[0.1, -0.2], [0.3, 0.4], [-1.0, 1.5]])
+    assert traj.num_frames == 3
+    assert traj.duration == pytest.approx(0.02)
+    assert traj.rig_joint_names == ["j0", "j1"]
+
+
+def test_torque_trajectory_rejects_nan_tau():
+    with pytest.raises(ValueError, match="finite"):
+        TorqueFrame(timestamp=0.0, tau=[float("nan"), 0.0])
+
+
+def test_torque_trajectory_rejects_inf_tau():
+    with pytest.raises(ValueError, match="finite"):
+        TorqueFrame(timestamp=0.0, tau=[math.inf, 0.0])
+
+
+def test_torque_trajectory_rejects_dim_mismatch():
+    frames = [
+        TorqueFrame(timestamp=0.0, tau=[0.1, 0.2]),
+        TorqueFrame(timestamp=0.01, tau=[0.3]),  # length 1 != joint_names len 2
+    ]
+    with pytest.raises(ValueError, match="length"):
+        TorqueTrajectory(frames=frames, rig_joint_names=["j0", "j1"])
+
+
+def test_torque_trajectory_rejects_non_monotonic_time():
+    with pytest.raises(ValueError, match="monotonic"):
+        _make_torque_traj([[0.0, 0.0], [0.1, 0.1]], times=[0.01, 0.0])
+
+
+def test_torque_trajectory_rejects_equal_timestamps():
+    with pytest.raises(ValueError, match="monotonic"):
+        _make_torque_traj([[0.0, 0.0], [0.1, 0.1]], times=[0.0, 0.0])
+
+
+def test_torque_trajectory_rejects_empty_frames():
+    with pytest.raises(ValueError, match="at least one frame"):
+        TorqueTrajectory(frames=[], rig_joint_names=["j0"])
+
+
+# -----------------------------------------------------------------------------
+# MuscleActivationTrajectory
+# -----------------------------------------------------------------------------
+
+
+def _make_activation_traj(
+    activations: list[list[float]],
+    times: list[float] | None = None,
+    muscle_names: list[str] | None = None,
+) -> MuscleActivationTrajectory:
+    if times is None:
+        times = [float(i) * 0.01 for i in range(len(activations))]
+    if muscle_names is None:
+        muscle_names = (
+            ["m0", "m1"] if activations and len(activations[0]) == 2 else ["m0"]
+        )
+    frames = [
+        MuscleActivationFrame(timestamp=t, activations=a)
+        for t, a in zip(times, activations, strict=True)
+    ]
+    return MuscleActivationTrajectory(frames=frames, muscle_names=muscle_names)
+
+
+def test_muscle_activation_trajectory_valid_construction():
+    traj = _make_activation_traj([[0.0, 0.5], [1.0, 0.25], [0.7, 0.1]])
+    assert traj.num_frames == 3
+    assert traj.muscle_names == ["m0", "m1"]
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [-0.1, 1.1, float("nan"), math.inf, -math.inf],
+)
+def test_muscle_activation_trajectory_rejects_out_of_range(bad_value: float):
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        MuscleActivationFrame(timestamp=0.0, activations=[bad_value, 0.5])
+
+
+def test_muscle_activation_trajectory_rejects_dim_mismatch():
+    frames = [
+        MuscleActivationFrame(timestamp=0.0, activations=[0.1, 0.2]),
+        MuscleActivationFrame(timestamp=0.01, activations=[0.3]),
+    ]
+    with pytest.raises(ValueError, match="length"):
+        MuscleActivationTrajectory(frames=frames, muscle_names=["m0", "m1"])
+
+
+def test_muscle_activation_trajectory_rejects_non_monotonic_time():
+    with pytest.raises(ValueError, match="monotonic"):
+        _make_activation_traj([[0.5, 0.5], [0.5, 0.5]], times=[0.01, 0.0])
+
+
+def test_muscle_activation_trajectory_rejects_empty_frames():
+    with pytest.raises(ValueError, match="at least one frame"):
+        MuscleActivationTrajectory(frames=[], muscle_names=["m0"])
+
+
+def test_muscle_activation_trajectory_accepts_boundary_values():
+    traj = _make_activation_traj([[0.0, 1.0], [1.0, 0.0]])
+    assert traj.num_frames == 2
+
+
+# -----------------------------------------------------------------------------
+# MotionMatchingResult — accepts torques OR activations
+# -----------------------------------------------------------------------------
+
+
+def test_motion_matching_result_accepts_torque_only():
+    torques = _make_torque_traj([[0.1, 0.2], [0.3, 0.4]])
+    res = MotionMatchingResult(
+        request_id="r1",
+        success=True,
+        torques=torques,
+    )
+    assert res.torques is torques
+    assert res.activations is None
+
+
+def test_motion_matching_result_accepts_activation_only():
+    acts = _make_activation_traj([[0.1, 0.5], [0.2, 0.6]])
+    res = MotionMatchingResult(
+        request_id="r2",
+        success=True,
+        activations=acts,
+    )
+    assert res.activations is acts
+    assert res.torques is None
+
+
+def test_motion_matching_result_accepts_both():
+    torques = _make_torque_traj([[0.1, 0.2], [0.3, 0.4]])
+    acts = _make_activation_traj([[0.1, 0.5], [0.2, 0.6]])
+    res = MotionMatchingResult(
+        request_id="r3",
+        success=True,
+        torques=torques,
+        activations=acts,
+    )
+    assert res.torques is torques
+    assert res.activations is acts
+
+
+def test_motion_matching_result_rejects_when_successful_but_no_payload():
+    """A success=True result with no matched_trajectory, torques, or
+    activations is invalid."""
+    with pytest.raises(ValueError, match="at least one"):
+        MotionMatchingResult(request_id="r4", success=True)
+
+
+def test_motion_matching_result_failed_no_payload_ok():
+    """A failed result without payload is allowed (carries only message)."""
+    res = MotionMatchingResult(request_id="r5", success=False, message="solver failed")
+    assert res.success is False
+    assert res.torques is None
+    assert res.activations is None
+
+
+# -----------------------------------------------------------------------------
+# JSON round-trip
+# -----------------------------------------------------------------------------
+
+
+def test_torque_trajectory_json_round_trip():
+    original = _make_torque_traj([[0.1, -0.2], [0.3, 0.4]])
+    json_str = original.model_dump_json()
+    restored = TorqueTrajectory.model_validate_json(json_str)
+    assert restored.num_frames == original.num_frames
+    assert restored.rig_joint_names == original.rig_joint_names
+    for a, b in zip(original.frames, restored.frames, strict=True):
+        assert a.timestamp == b.timestamp
+        assert a.tau == b.tau
+
+
+def test_muscle_activation_trajectory_json_round_trip():
+    original = _make_activation_traj([[0.1, 0.5], [0.2, 0.6]])
+    json_str = original.model_dump_json()
+    restored = MuscleActivationTrajectory.model_validate_json(json_str)
+    assert restored.num_frames == original.num_frames
+    assert restored.muscle_names == original.muscle_names
+    for a, b in zip(original.frames, restored.frames, strict=True):
+        assert a.timestamp == b.timestamp
+        assert a.activations == b.activations


### PR DESCRIPTION
## Summary

Closes #4667. The CIR previously aliased ``TorqueTrajectory = JointTrajectory`` (in ``matching/costs.py``) and silently re-used the joint-trajectory shape for muscle activations. That collapsed three semantically distinct concepts (joint angles, generalized torques, muscle activations) into one type, removing every per-type invariant and forcing every consumer to remember the convention "``q`` here means tau."

This PR introduces distinct Pydantic models, each with its own invariants enforced by Pydantic validators rather than convention.

## New types (in ``src/shared/python/motion_pipeline/contracts.py``)

- ``TorqueFrame`` / ``TorqueTrajectory`` — generalized joint torques. Frames carry ``tau`` (any finite sign), the trajectory aligns with ``rig_joint_names``, timestamps are strictly monotonic.
- ``MuscleActivationFrame`` / ``MuscleActivationTrajectory`` — muscle activations bounded to ``[0, 1]``, aligned with ``muscle_names``, strictly monotonic time.
- All four models are ``frozen=True`` for value-object semantics.

## ``MotionMatchingResult`` updates

- New optional ``torques`` and ``activations`` fields on the contract model.
- New ``model_validator`` requires successful results to carry at least one payload (``matched_trajectory``, ``torques``, or ``activations``). Failed results may still carry only a message.

## Backends updated

- ``matching/costs.py`` — alias removed; ``TorqueTrajectory`` imported directly from ``contracts``; ``effort_cost`` reads ``f.tau`` instead of ``f.q``.
- ``matching/base.py`` — local dataclass ``MotionMatchingResult`` retyped.
- ``matching/inverse_dyn_pinocchio.py`` — produces a real ``TorqueTrajectory``.
- ``cmc.py``, ``rra.py``, ``torque_mujoco.py``, ``trajopt_drake.py`` — placeholders, formatter-only diffs.

## Test plan

- [x] 24 new unit tests in ``test_torque_activation_trajectories.py``
- [x] Existing ``test_costs.py`` ``effort_cost`` tests migrated to ``TorqueTrajectory``
- [x] Existing ``test_inverse_dyn_pinocchio.py`` reads ``f.tau``
- [x] Existing ``TestMotionMatchingResult`` updated to provide a torque payload
- [x] ``ruff check`` and ``ruff format --check`` clean on every touched file
- [x] Regression: only pre-existing failures remain (pinocchio mocked-import, etc.)

Refs #4558

🤖 Generated with [Claude Code](https://claude.com/claude-code)