### PR TITLE
[Mocap Pipeline fix] MediaPipe + HRNet adapters reject canonical exports (#4683)

### DIFF
--- a/src/shared/python/motion_pipeline/sources/hrnet_json_adapter.py
+++ b/src/shared/python/motion_pipeline/sources/hrnet_json_adapter.py
@@ -23,6 +23,54 @@ from src.shared.python.motion_pipeline.sources.base import (
 from src.shared.python.motion_pipeline.sources.registry import register_adapter
 
 
+def _parse_keypoints(data: object) -> list[Keypoint]:
+    """Parse HRNet keypoints from canonical export variants.
+
+    Accepts:
+      * Nested list of triplets: ``[[x, y, score], ...]`` (HRNet-mmpose form).
+      * Flat list: ``[x, y, score, x, y, score, ...]`` (AlphaPose / coco-eval form).
+      * Empty / non-list inputs yield an empty result.
+    """
+    if not isinstance(data, list) or not data:
+        return []
+    kps: list[Keypoint] = []
+    # Nested form when first element is itself a list/tuple.
+    if isinstance(data[0], (list, tuple)):
+        for triplet in data:
+            if not isinstance(triplet, (list, tuple)) or len(triplet) < 2:
+                continue
+            try:
+                x = float(triplet[0])
+                y = float(triplet[1])
+            except (TypeError, ValueError):
+                continue
+            if len(triplet) >= 3:
+                try:
+                    conf = max(0.0, min(1.0, float(triplet[2])))
+                except (TypeError, ValueError):
+                    conf = 1.0
+            else:
+                conf = 1.0
+            kps.append(Keypoint(x=x, y=y, confidence=conf))
+        return kps
+    # Flat form fallback.
+    for i in range(0, len(data), 3):
+        triplet = data[i : i + 3]
+        if len(triplet) < 3:
+            continue
+        try:
+            kps.append(
+                Keypoint(
+                    x=float(triplet[0]),
+                    y=float(triplet[1]),
+                    confidence=max(0.0, min(1.0, float(triplet[2]))),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return kps
+
+
 @register_adapter
 class HRNetJSONAdapter(MocapSourceAdapter):
     """HRNet JSON adapter."""
@@ -51,7 +99,10 @@ class HRNetJSONAdapter(MocapSourceAdapter):
         if isinstance(data, dict) and "frames" in data:
             frames = data["frames"]
             if isinstance(frames, list) and frames and isinstance(frames[0], dict):
-                return "keypoints" in frames[0] and "frame_index" in frames[0]
+                first = frames[0]
+                return "keypoints" in first and (
+                    "frame_index" in first or "frame" in first
+                )
         return False
 
     def _normalise(self, data: object) -> list[dict]:
@@ -87,30 +138,27 @@ class HRNetJSONAdapter(MocapSourceAdapter):
         if not raw:
             raise ValueError(f"HRNet JSON {p} has no frames")
 
+        def _frame_key(d: dict) -> int:
+            for k in ("frame_index", "frame", "image_id"):
+                v = d.get(k)
+                if isinstance(v, int):
+                    return v
+            return 0
+
         frames: list[KeypointFrame] = []
-        for idx, item in enumerate(sorted(raw, key=lambda d: d.get("frame_index", 0))):
-            flat = item.get("keypoints", [])
-            kps: list[Keypoint] = []
-            for i in range(0, len(flat), 3):
-                triplet = flat[i : i + 3]
-                if len(triplet) < 3:
-                    continue
-                kps.append(
-                    Keypoint(
-                        x=float(triplet[0]),
-                        y=float(triplet[1]),
-                        confidence=max(0.0, min(1.0, float(triplet[2]))),
-                    )
-                )
+        for idx, item in enumerate(sorted(raw, key=_frame_key)):
+            kp_data = item.get("keypoints", [])
+            kps = _parse_keypoints(kp_data)
             if not kps:
                 continue
             t = float(item.get("timestamp", idx / self.fps))
+            frame_idx_val = item.get("frame_index", item.get("frame", idx))
             frames.append(
                 KeypointFrame(
                     timestamp=t,
                     keypoints=kps,
                     schema_name=self.schema,  # type: ignore[arg-type]
-                    frame_index=int(item.get("frame_index", idx)),
+                    frame_index=int(frame_idx_val),
                 )
             )
         if not frames:

--- a/src/shared/python/motion_pipeline/sources/mediapipe_json_adapter.py
+++ b/src/shared/python/motion_pipeline/sources/mediapipe_json_adapter.py
@@ -31,6 +31,49 @@ from src.shared.python.motion_pipeline.sources.base import (
 from src.shared.python.motion_pipeline.sources.registry import register_adapter
 
 
+def _landmark_to_keypoint(lm: object) -> Keypoint | None:
+    """Convert a MediaPipe landmark in any canonical form to a Keypoint.
+
+    Accepts:
+      * dict form: ``{"x":..,"y":..,"z":..,"visibility":..}``
+      * list/tuple form: ``[x, y, z, visibility, presence?]`` (3 to 5 entries).
+
+    Returns ``None`` when the landmark cannot be parsed.
+    """
+    if isinstance(lm, dict):
+        try:
+            x = float(lm.get("x", 0.0))
+            y = float(lm.get("y", 0.0))
+        except (TypeError, ValueError):
+            return None
+        z_raw = lm.get("z")
+        z = float(z_raw) if z_raw is not None else None
+        vis = lm.get("visibility")
+        if vis is None:
+            vis = lm.get("presence", 1.0)
+        try:
+            confidence = max(0.0, min(1.0, float(vis)))
+        except (TypeError, ValueError):
+            confidence = 1.0
+        return Keypoint(x=x, y=y, z=z, confidence=confidence)
+    if isinstance(lm, (list, tuple)) and len(lm) >= 2:
+        try:
+            x = float(lm[0])
+            y = float(lm[1])
+        except (TypeError, ValueError):
+            return None
+        z = float(lm[2]) if len(lm) >= 3 and lm[2] is not None else None
+        if len(lm) >= 4:
+            try:
+                confidence = max(0.0, min(1.0, float(lm[3])))
+            except (TypeError, ValueError):
+                confidence = 1.0
+        else:
+            confidence = 1.0
+        return Keypoint(x=x, y=y, z=z, confidence=confidence)
+    return None
+
+
 @register_adapter
 class MediaPipeJSONAdapter(MocapSourceAdapter):
     """MediaPipe Pose JSON adapter."""
@@ -88,19 +131,17 @@ class MediaPipeJSONAdapter(MocapSourceAdapter):
         for idx, raw in enumerate(data["frames"]):
             if not isinstance(raw, dict):
                 continue
-            landmarks = raw.get("landmarks", [])
+            landmarks = (
+                raw.get("landmarks")
+                or raw.get("pose_landmarks")
+                or raw.get("pose_world_landmarks")
+                or []
+            )
             kps: list[Keypoint] = []
             for lm in landmarks:
-                if not isinstance(lm, dict):
-                    continue
-                kps.append(
-                    Keypoint(
-                        x=float(lm.get("x", 0.0)),
-                        y=float(lm.get("y", 0.0)),
-                        z=float(lm["z"]) if lm.get("z") is not None else None,
-                        confidence=max(0.0, min(1.0, float(lm.get("visibility", 1.0)))),
-                    )
-                )
+                kp = _landmark_to_keypoint(lm)
+                if kp is not None:
+                    kps.append(kp)
             if not kps:
                 continue
             t = float(raw.get("timestamp", idx / fps))

--- a/tests/integration/motion_pipeline/test_pipeline_invariants.py
+++ b/tests/integration/motion_pipeline/test_pipeline_invariants.py
@@ -137,8 +137,9 @@ def _golden_files() -> list[Path]:
 
 
 # Adapters known to raise on the current shipped golden fixtures - tracked
-# as #4683. Once that's fixed, drop the entries here.
-_BROKEN_ADAPTER_FIXTURES = frozenset({"mediapipe.json", "hrnet.json"})
+# as #4683. Fixed by mediapipe + hrnet adapter changes; set retained as a
+# hook in case future fixtures ship in a known-broken state.
+_BROKEN_ADAPTER_FIXTURES: frozenset[str] = frozenset()
 
 
 def _resolve_frames(payload: Any) -> list[Any] | None:

--- a/tests/unit/motion_pipeline/sources/test_hrnet_json_adapter_4683.py
+++ b/tests/unit/motion_pipeline/sources/test_hrnet_json_adapter_4683.py
@@ -1,0 +1,106 @@
+"""Regression tests for HRNet JSON adapter (#4683).
+
+The adapter previously crashed on canonical HRNet/mmpose exports where
+``keypoints`` is a nested list ``[[x, y, score], ...]`` rather than the
+flat AlphaPose-style triple. These tests pin both the shipped golden
+fixture and hand-built canonical samples covering both shapes.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.motion_pipeline.sources import load_any
+from src.shared.python.motion_pipeline.sources.hrnet_json_adapter import (
+    HRNetJSONAdapter,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GOLDEN = REPO_ROOT / "tests" / "data" / "motion_pipeline" / "golden" / "hrnet.json"
+
+
+def test_load_shipped_golden_fixture() -> None:
+    seq = load_any(GOLDEN)
+    assert len(seq.frames) == 30
+    assert all(f.schema_name == "COCO_17" for f in seq.frames)
+    assert all(len(f.keypoints) == 17 for f in seq.frames)
+    ts = [f.timestamp for f in seq.frames]
+    assert ts == sorted(ts)
+    for f in seq.frames:
+        for kp in f.keypoints:
+            assert math.isfinite(kp.x) and math.isfinite(kp.y)
+            assert 0.0 <= kp.confidence <= 1.0
+
+
+def test_canonical_nested_triplets(tmp_path: Path) -> None:
+    """COCO-17 nested ``[[x, y, score], ...]`` parses correctly."""
+    payload = {
+        "model": "hrnet_w32",
+        "schema": "COCO_17",
+        "fps": 60.0,
+        "frames": [
+            {"frame": i, "keypoints": [[1.0 * k, 2.0 * k, 0.9] for k in range(17)]}
+            for i in range(3)
+        ],
+    }
+    p = tmp_path / "hrnet.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = HRNetJSONAdapter().load(p)
+    assert len(seq.frames) == 3
+    assert all(len(f.keypoints) == 17 for f in seq.frames)
+    assert seq.frames[0].schema_name == "COCO_17"
+    assert seq.frames[0].keypoints[1].x == pytest.approx(1.0)
+    assert seq.frames[0].keypoints[1].confidence == pytest.approx(0.9)
+
+
+def test_flat_triplets_form(tmp_path: Path) -> None:
+    """Flat ``[x, y, c, x, y, c, ...]`` form (AlphaPose-style) still parses."""
+    flat: list[float] = []
+    for k in range(17):
+        flat.extend([float(k), float(2 * k), 0.8])
+    payload = {
+        "fps": 30.0,
+        "frames": [{"frame_index": 0, "keypoints": flat}],
+    }
+    p = tmp_path / "hrnet_flat.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = HRNetJSONAdapter().load(p)
+    assert len(seq.frames) == 1
+    assert len(seq.frames[0].keypoints) == 17
+    assert seq.frames[0].keypoints[0].confidence == pytest.approx(0.8)
+
+
+def test_frame_index_alias(tmp_path: Path) -> None:
+    """``frame`` is accepted as an alias for ``frame_index``."""
+    payload = {
+        "fps": 30.0,
+        "frames": [
+            {"frame": 2, "keypoints": [[0.0, 0.0, 1.0] for _ in range(17)]},
+            {"frame": 0, "keypoints": [[0.0, 0.0, 1.0] for _ in range(17)]},
+            {"frame": 1, "keypoints": [[0.0, 0.0, 1.0] for _ in range(17)]},
+        ],
+    }
+    p = tmp_path / "hrnet.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = HRNetJSONAdapter().load(p)
+    indices = [f.frame_index for f in seq.frames]
+    assert indices == [0, 1, 2]
+
+
+def test_rejects_no_frames(tmp_path: Path) -> None:
+    p = tmp_path / "hrnet.json"
+    p.write_text(json.dumps({"frames": []}), encoding="utf-8")
+    with pytest.raises(ValueError, match="no frames"):
+        HRNetJSONAdapter().load(p)
+
+
+def test_rejects_malformed_root(tmp_path: Path) -> None:
+    p = tmp_path / "hrnet.json"
+    p.write_text(json.dumps(42), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        HRNetJSONAdapter().load(p)

--- a/tests/unit/motion_pipeline/sources/test_mediapipe_json_adapter_4683.py
+++ b/tests/unit/motion_pipeline/sources/test_mediapipe_json_adapter_4683.py
@@ -1,0 +1,119 @@
+"""Regression tests for MediaPipe JSON adapter (#4683).
+
+The adapter previously rejected the canonical export form where each
+landmark is encoded as a list ``[x, y, z, visibility, presence]`` instead
+of a dict. These tests pin both the shipped golden fixture and a hand-built
+canonical sample.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.motion_pipeline.sources import load_any
+from src.shared.python.motion_pipeline.sources.mediapipe_json_adapter import (
+    MediaPipeJSONAdapter,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GOLDEN = REPO_ROOT / "tests" / "data" / "motion_pipeline" / "golden" / "mediapipe.json"
+
+
+def test_load_shipped_golden_fixture() -> None:
+    seq = load_any(GOLDEN)
+    assert len(seq.frames) == 30
+    assert all(f.schema_name == "MediaPipe_33" for f in seq.frames)
+    assert all(len(f.keypoints) == 33 for f in seq.frames)
+    # Monotonic timestamps and finite values.
+    ts = [f.timestamp for f in seq.frames]
+    assert ts == sorted(ts)
+    for f in seq.frames:
+        for kp in f.keypoints:
+            assert math.isfinite(kp.x) and math.isfinite(kp.y)
+            assert 0.0 <= kp.confidence <= 1.0
+
+
+def test_canonical_array_landmarks(tmp_path: Path) -> None:
+    """Hand-built canonical MediaPipe with [x,y,z,vis,presence] arrays."""
+    payload = {
+        "schema": "MediaPipe_33",
+        "fps": 30.0,
+        "frames": [
+            {
+                "frame_index": i,
+                "timestamp": i / 30.0,
+                "landmarks": [[0.5, 0.5, 0.0, 0.9, 0.95] for _ in range(33)],
+            }
+            for i in range(3)
+        ],
+    }
+    p = tmp_path / "mediapipe.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = MediaPipeJSONAdapter().load(p)
+    assert len(seq.frames) == 3
+    assert all(len(f.keypoints) == 33 for f in seq.frames)
+    assert seq.frames[0].schema_name == "MediaPipe_33"
+    assert seq.frames[0].keypoints[0].confidence == pytest.approx(0.9)
+
+
+def test_canonical_dict_landmarks(tmp_path: Path) -> None:
+    """Dict form ``{x,y,z,visibility}`` still parses (back-compat)."""
+    payload = {
+        "schema": "MediaPipe_33",
+        "fps": 60.0,
+        "frames": [
+            {
+                "frame_index": 0,
+                "timestamp": 0.0,
+                "landmarks": [
+                    {"x": 0.1, "y": 0.2, "z": 0.0, "visibility": 0.8} for _ in range(33)
+                ],
+            }
+        ],
+    }
+    p = tmp_path / "mediapipe.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = MediaPipeJSONAdapter().load(p)
+    assert seq.frames[0].keypoints[0].confidence == pytest.approx(0.8)
+
+
+def test_pose_landmarks_alias(tmp_path: Path) -> None:
+    """Some MediaPipe exports nest under ``pose_landmarks``."""
+    payload = {
+        "schema": "MediaPipe_33",
+        "fps": 30.0,
+        "frames": [
+            {
+                "frame_index": 0,
+                "timestamp": 0.0,
+                "pose_landmarks": [[0.0, 0.0, 0.0, 1.0] for _ in range(33)],
+            }
+        ],
+    }
+    p = tmp_path / "mp.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    seq = MediaPipeJSONAdapter().load(p)
+    assert len(seq.frames) == 1
+    assert len(seq.frames[0].keypoints) == 33
+
+
+def test_rejects_no_frames_key(tmp_path: Path) -> None:
+    p = tmp_path / "mediapipe.json"
+    p.write_text(json.dumps({"schema": "MediaPipe_33"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="frames"):
+        MediaPipeJSONAdapter().load(p)
+
+
+def test_rejects_empty_frames(tmp_path: Path) -> None:
+    p = tmp_path / "mediapipe.json"
+    p.write_text(
+        json.dumps({"schema": "MediaPipe_33", "frames": [{"landmarks": []}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="no usable frames"):
+        MediaPipeJSONAdapter().load(p)


### PR DESCRIPTION
## Summary

Closes #4683. The MediaPipe and HRNet JSON adapters rejected the shipped synthetic golden fixtures under `tests/data/motion_pipeline/golden/`:

```
mediapipe.json -> ValueError: MediaPipe JSON ... produced no usable frames
hrnet.json     -> TypeError: float() argument must be a string or a real number, not 'list'
```

Both errors traced to schema-shape mismatches between the generator (`tests/data/motion_pipeline/_generate.py`) and the parsers - the generator emits a valid canonical export form, the parsers were too narrow.

## Root cause per adapter

**MediaPipe** - `mediapipe_json_adapter.py` only handled the dict form (`{"x":..,"y":..,"z":..,"visibility":..}`) for each landmark. The fixture (and many real `mediapipe_estimator` exports) uses the equally canonical list form `[x, y, z, visibility, presence]`. Every landmark hit the `if not isinstance(lm, dict): continue` skip, leaving zero keypoints per frame, which tripped the "no usable frames" guard.

**HRNet** - `hrnet_json_adapter.py` assumed a flat `[x, y, c, x, y, c, ...]` array (AlphaPose-style). The fixture, and HRNet/mmpose dumps in the wild, ship a nested `[[x, y, score], ...]` array. The flat slicer pulled `triplet = [[x,y,c], [x,y,c], [x,y,c]]` and `float(triplet[0])` choked on the inner list. The fixture also uses `frame` rather than `frame_index`.

## Changes

- `mediapipe_json_adapter.py`: extracted `_landmark_to_keypoint()` accepting both dict and list forms (3-5 entries), plus `pose_landmarks` / `pose_world_landmarks` aliases.
- `hrnet_json_adapter.py`: extracted `_parse_keypoints()` that detects nested-vs-flat by inspecting the first element. Accepts `frame` as an alias for `frame_index`; sorting key checks both.
- `tests/integration/motion_pipeline/test_pipeline_invariants.py`: emptied `_BROKEN_ADAPTER_FIXTURES` so the previously xfailed-strict parametrized cases now assert real success on shipped fixtures.
- New unit tests `test_mediapipe_json_adapter_4683.py` / `test_hrnet_json_adapter_4683.py` (12 tests total).

Postconditions retained: monotonic timestamps, finite coordinates, schema match (MediaPipe_33 / COCO_17), `ValueError` on empty frames or missing root keys.

## Test plan

- [x] `pytest tests/unit/motion_pipeline/sources/test_mediapipe_json_adapter_4683.py tests/unit/motion_pipeline/sources/test_hrnet_json_adapter_4683.py -v` -> 12/12 pass
- [x] `pytest tests/integration/motion_pipeline -k "mediapipe or hrnet" -v` -> 4 pass, rest skip (missing optional engine deps)
- [x] `ruff check` + `ruff format --check` clean
- [x] `load_any()` smoke test on both shipped fixtures returns 30 frames with schema MediaPipe_33 / COCO_17 and 33 / 17 keypoints

Refs #4558, #4561, #4571

🤖 Generated with [Claude Code](https://claude.com/claude-code)