### PR TITLE
fix(motion_pipeline): Use Form() annotation for FastAPI parameters

### DIFF
--- a/src/shared/python/motion_pipeline/api.py
+++ b/src/shared/python/motion_pipeline/api.py
@@ -17,7 +17,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, File, HTTPException, UploadFile, status
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
 from .contracts import MotionMatchingResult
@@ -191,9 +191,9 @@ Returns MotionMatchingResult with matched trajectory and error metrics.
     )
     async def run_pipeline(
         file: UploadFile = File(..., description="Motion capture file"),
-        source_format: str = Field(..., description="Source format"),
-        ik_backend: str = Field(default="mujoco", description="IK backend"),
-        matching_backend: str = Field(default="mujoco", description="Matching backend"),
+        source_format: str = Form(..., description="Source format"),
+        ik_backend: str = Form(default="mujoco", description="IK backend"),
+        matching_backend: str = Form(default="mujoco", description="Matching backend"),
     ) -> PipelineResponse:
         """
         Run motion pipeline on uploaded file.


### PR DESCRIPTION
## Summary

This PR fixes issue #4722 by correcting the FastAPI parameter annotations in the API endpoint.

## Problem

The `source_format`, `ik_backend`, and `matching_backend` parameters were using `Field()` instead of `Form()`, causing an AssertionError at import time:

```
AssertionError: non-body parameters must be in path, query, header or cookie: source_format
```

## Solution

- Import `Form` from fastapi
- Change `source_format` from `Field()` to `Form(...)`
- Change `ik_backend` and `matching_backend` to use `Form()` as well

This makes the endpoint work correctly with multipart form data (file uploads).

## Testing

The API can now be imported without errors:
```python
from motion_pipeline.api import create_app
app = create_app()  # No longer crashes
```

Fixes #4722