### PR TITLE
feat(c3d): FORCE_PLATFORM group parsing (#4711)

### DIFF
--- a/src/shared/python/upstream_drift_tools/lab/bio/_c3d_analog.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/_c3d_analog.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from ...utils.logging import get_logger
-from ._c3d_models import C3DMetadata
+from ._c3d_models import C3DMetadata, ForcePlateCalibration
 
 logger = get_logger(__name__)
 
@@ -141,6 +141,204 @@ def build_plate_dataframe(
         plate_df["cop_z"] = np.where(valid_contact, ground_height, np.nan)
 
     return plate_df
+
+
+def _plate_channel_samples(
+    analog_array: np.ndarray, channel_indices: tuple[int, int]
+) -> np.ndarray:
+    """Return analog samples for a plate as ``(n_samples, n_channels)``.
+
+    ``analog_array`` is the raw ezc3d ``data['analogs']`` array shaped
+    ``(subframes, channels, frames)``; we flatten to one row per analog sample.
+    """
+    start, end = channel_indices
+    if end <= start:
+        return np.zeros((0, 0))
+    subframes, _, frame_count = analog_array.shape
+    plate_slice = analog_array[:, start:end, :]
+    # (subframes, n_channels, frames) -> (frames, subframes, n_channels)
+    samples = plate_slice.transpose(2, 0, 1).reshape(
+        frame_count * subframes, end - start
+    )
+    return samples
+
+
+def _apply_calibration(
+    raw: np.ndarray, cal_matrix: np.ndarray | None, plate_type: int
+) -> np.ndarray:
+    """Convert raw voltages to forces/moments via the cal matrix when needed.
+
+    Type 1 plates report calibrated forces/moments directly. Type 2/3/4 plates
+    require multiplication by the calibration matrix. Returns an
+    ``(n_samples, 6)`` array of ``(fx, fy, fz, mx, my, mz)``.
+    """
+    n_samples, n_channels = raw.shape
+    if plate_type == 1 or cal_matrix is None:
+        if n_channels < 6:
+            padded = np.zeros((n_samples, 6))
+            padded[:, :n_channels] = raw
+            return padded
+        return raw[:, :6].copy()
+
+    # cal_matrix shape is (6, n_channels). Multiply per sample.
+    if cal_matrix.shape[0] != 6 or cal_matrix.shape[1] != n_channels:
+        logger.warning(
+            "Calibration matrix shape %s incompatible with %d analog channels; "
+            "returning uncalibrated channels.",
+            cal_matrix.shape,
+            n_channels,
+        )
+        if n_channels < 6:
+            padded = np.zeros((n_samples, 6))
+            padded[:, :n_channels] = raw
+            return padded
+        return raw[:, :6].copy()
+
+    # (n_samples, n_channels) @ (n_channels, 6) -> (n_samples, 6)
+    return raw @ cal_matrix.T
+
+
+def _cop_local_to_lab(
+    fx: np.ndarray,
+    fy: np.ndarray,
+    fz: np.ndarray,
+    mx: np.ndarray,
+    my: np.ndarray,
+    calibration: ForcePlateCalibration,
+    ground_height: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute centre of pressure in lab frame using corners + origin.
+
+    Plate-local CoP from forces/moments at the plate origin:
+        cop_x_local = (-my - fx * z0) / fz
+        cop_y_local = ( mx - fy * z0) / fz
+    where ``z0`` is the z component of the plate origin (typically negative,
+    measured from plate top surface to sensor centre).
+
+    The plate-local frame is rebuilt from the four corners:
+        +x axis: midpoint(c1, c4) - midpoint(c2, c3) (corners are +x+y, -x+y,
+                  -x-y, +x-y in C3D order)
+        +y axis: midpoint(c1, c2) - midpoint(c3, c4)
+        +z axis: x_axis x y_axis
+        origin: mean of the four corners (plate top surface centre)
+    """
+    z0 = float(calibration.origin[2])
+    safe_fz = np.where(np.abs(fz) > 1e-9, fz, np.nan)
+    cop_local_x = (-my - fx * z0) / safe_fz
+    cop_local_y = (mx - fy * z0) / safe_fz
+    cop_local_z = np.zeros_like(cop_local_x)
+
+    corners = calibration.corners  # (4, 3) in metres
+    centre = corners.mean(axis=0)
+    x_axis = ((corners[0] + corners[3]) / 2.0) - ((corners[1] + corners[2]) / 2.0)
+    y_axis = ((corners[0] + corners[1]) / 2.0) - ((corners[2] + corners[3]) / 2.0)
+    x_norm = np.linalg.norm(x_axis)
+    y_norm = np.linalg.norm(y_axis)
+    if x_norm > 0:
+        x_axis = x_axis / x_norm
+    if y_norm > 0:
+        y_axis = y_axis / y_norm
+    z_axis = np.cross(x_axis, y_axis)
+    z_norm = np.linalg.norm(z_axis)
+    if z_norm > 0:
+        z_axis = z_axis / z_norm
+
+    rotation = np.column_stack([x_axis, y_axis, z_axis])  # (3, 3)
+    local = np.column_stack([cop_local_x, cop_local_y, cop_local_z])  # (n, 3)
+    lab = local @ rotation.T + centre
+
+    cop_x = lab[:, 0]
+    cop_y = lab[:, 1]
+    cop_z = np.where(np.isfinite(cop_x), np.full_like(cop_x, ground_height), np.nan)
+    # Preserve NaN where fz was too low.
+    cop_x = np.where(np.isfinite(cop_local_x), cop_x, np.nan)
+    cop_y = np.where(np.isfinite(cop_local_y), cop_y, np.nan)
+    return cop_x, cop_y, cop_z
+
+
+def build_force_plate_dataframe_from_calibration(
+    analog_array: np.ndarray,
+    calibrations: tuple[ForcePlateCalibration, ...],
+    analog_rate: float | None,
+    file_name: str,
+    plate_number: int | None,
+    include_time: bool,
+    compute_cop: bool,
+    ground_height: float,
+) -> pd.DataFrame:
+    """Build a force-plate dataframe using FORCE_PLATFORM calibration metadata.
+
+    Honours plate type (1: pre-calibrated; 2/3/4: cal_matrix applied) and
+    transforms CoP from plate-local to lab frame using corners + origin.
+    """
+    if not calibrations:
+        return pd.DataFrame(columns=force_plate_columns(include_time, compute_cop))
+
+    selected: list[tuple[int, ForcePlateCalibration]]
+    if plate_number is not None:
+        if plate_number < 1 or plate_number > len(calibrations):
+            raise ValueError(
+                f"Force plate {plate_number} not found. "
+                f"Available plates: {list(range(1, len(calibrations) + 1))}"
+            )
+        selected = [(plate_number, calibrations[plate_number - 1])]
+    else:
+        selected = [(i + 1, cal) for i, cal in enumerate(calibrations)]
+
+    frames: list[pd.DataFrame] = []
+    for plate_num, calibration in selected:
+        raw = _plate_channel_samples(analog_array, calibration.channel_indices)
+        if raw.size == 0:
+            logger.warning(
+                "Force plate %d has no analog samples in channels %s; skipping.",
+                plate_num,
+                calibration.channel_indices,
+            )
+            continue
+        wrench = _apply_calibration(raw, calibration.cal_matrix, calibration.plate_type)
+        n_samples = wrench.shape[0]
+        fx, fy, fz = wrench[:, 0], wrench[:, 1], wrench[:, 2]
+        mx, my, mz = wrench[:, 3], wrench[:, 4], wrench[:, 5]
+
+        plate_df = pd.DataFrame(
+            {
+                "sample": np.arange(n_samples),
+                "plate": plate_num,
+                "fx": fx,
+                "fy": fy,
+                "fz": fz,
+                "mx": mx,
+                "my": my,
+                "mz": mz,
+            }
+        )
+
+        if compute_cop:
+            cop_x, cop_y, cop_z = _cop_local_to_lab(
+                fx, fy, fz, mx, my, calibration, ground_height
+            )
+            plate_df["cop_x"] = cop_x
+            plate_df["cop_y"] = cop_y
+            plate_df["cop_z"] = cop_z
+
+        frames.append(plate_df)
+
+    if not frames:
+        return pd.DataFrame(columns=force_plate_columns(include_time, compute_cop))
+
+    result = pd.concat(frames, ignore_index=True)
+    if include_time and analog_rate:
+        result.insert(1, "time", result["sample"] / analog_rate)
+
+    logger.info(
+        "Extracted force plate data via FORCE_PLATFORM group for %d plates, "
+        "%d samples from %s",
+        len(selected),
+        len(result),
+        file_name,
+    )
+
+    return result
 
 
 def build_force_plate_dataframe(

--- a/src/shared/python/upstream_drift_tools/lab/bio/_c3d_io.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/_c3d_io.py
@@ -15,7 +15,12 @@ import numpy as np
 import pandas as pd
 
 from ...utils.logging import get_logger, log_execution_time
-from ._c3d_models import SCHEMA_VERSION, C3DEvent, C3DMetadata
+from ._c3d_models import (
+    SCHEMA_VERSION,
+    C3DEvent,
+    C3DMetadata,
+    ForcePlateCalibration,
+)
 
 logger = get_logger(__name__)
 
@@ -109,6 +114,211 @@ def get_events(c3d_data: C3DMapping) -> list[C3DEvent]:
     return events
 
 
+def _as_array(value: Any) -> np.ndarray:
+    """Coerce an ezc3d parameter value into a numpy array."""
+    return np.asarray(value)
+
+
+def _scalar_int(value: Any, default: int = 0) -> int:
+    """Read the first scalar from an ezc3d parameter value as int."""
+    arr = _as_array(value).ravel()
+    if arr.size == 0:
+        return default
+    return int(arr[0])
+
+
+def get_force_platforms(
+    c3d_data: C3DMapping, analog_label_count: int
+) -> tuple[ForcePlateCalibration, ...]:
+    """Build a tuple of ForcePlateCalibration from the FORCE_PLATFORM group.
+
+    Returns an empty tuple when the group is absent, USED is zero, or any of
+    the required CORNERS/ORIGIN/TYPE entries are missing.
+    """
+    fp_params = c3d_data["parameters"].get("FORCE_PLATFORM")
+    if fp_params is None:
+        return ()
+
+    used_value = fp_params.get("USED", {}).get("value")
+    if used_value is None:
+        return ()
+    n_used = _scalar_int(used_value)
+    if n_used <= 0:
+        return ()
+
+    type_value = fp_params.get("TYPE", {}).get("value")
+    corners_value = fp_params.get("CORNERS", {}).get("value")
+    origin_value = fp_params.get("ORIGIN", {}).get("value")
+    if type_value is None or corners_value is None or origin_value is None:
+        logger.warning(
+            "FORCE_PLATFORM group present but missing TYPE/CORNERS/ORIGIN; "
+            "skipping force-plate metadata."
+        )
+        return ()
+
+    types_arr = _as_array(type_value).ravel().astype(int)
+    corners_arr = _as_array(corners_value).astype(float)
+    origin_arr = _as_array(origin_value).astype(float)
+    cal_matrix_value = fp_params.get("CAL_MATRIX", {}).get("value")
+    cal_matrix_arr = (
+        _as_array(cal_matrix_value).astype(float)
+        if cal_matrix_value is not None
+        else None
+    )
+    channel_value = fp_params.get("CHANNEL", {}).get("value")
+    channel_arr = (
+        _as_array(channel_value).astype(int) if channel_value is not None else None
+    )
+
+    plates: list[ForcePlateCalibration] = []
+    fallback_cursor = 0
+    for plate_idx in range(n_used):
+        plate_type = int(types_arr[plate_idx]) if plate_idx < types_arr.size else 1
+
+        corners_plate = _extract_plate_corners(corners_arr, plate_idx, n_used)
+        if corners_plate is None:
+            logger.warning(
+                "FORCE_PLATFORM CORNERS for plate %d has unexpected shape %s; "
+                "skipping plate.",
+                plate_idx + 1,
+                corners_arr.shape,
+            )
+            continue
+        # ezc3d reports CORNERS in millimetres per the C3D spec.
+        corners_plate = corners_plate * 0.001
+
+        origin_plate = _extract_plate_origin(origin_arr, plate_idx, n_used)
+        if origin_plate is None:
+            logger.warning(
+                "FORCE_PLATFORM ORIGIN for plate %d has unexpected shape %s; "
+                "skipping plate.",
+                plate_idx + 1,
+                origin_arr.shape,
+            )
+            continue
+        origin_plate = origin_plate * 0.001
+
+        cal_matrix_plate = _extract_plate_cal_matrix(
+            cal_matrix_arr, plate_idx, n_used, plate_type
+        )
+
+        start, end = _extract_plate_channels(
+            channel_arr,
+            plate_idx,
+            n_used,
+            plate_type,
+            fallback_cursor,
+            analog_label_count,
+        )
+        fallback_cursor = end
+
+        if plate_type not in (1, 2, 3, 4):
+            logger.warning(
+                "FORCE_PLATFORM plate %d has unsupported type %d; "
+                "treating as type 1 (pre-calibrated).",
+                plate_idx + 1,
+                plate_type,
+            )
+            plate_type = 1
+
+        plates.append(
+            ForcePlateCalibration(
+                corners=corners_plate,
+                origin=origin_plate,
+                cal_matrix=cal_matrix_plate,
+                plate_type=plate_type,
+                channel_indices=(start, end),
+            )
+        )
+
+    return tuple(plates)
+
+
+def _extract_plate_corners(
+    corners_arr: np.ndarray, plate_idx: int, n_plates: int
+) -> np.ndarray | None:
+    """Slice a single plate's corners (returns 4x3 array) from a flexible layout."""
+    # ezc3d typically returns (3, 4, n_plates).
+    if corners_arr.ndim == 3 and corners_arr.shape[:2] == (3, 4):
+        if plate_idx >= corners_arr.shape[2]:
+            return None
+        return corners_arr[:, :, plate_idx].T.copy()
+    if corners_arr.ndim == 3 and corners_arr.shape[:2] == (4, 3):
+        if plate_idx >= corners_arr.shape[2]:
+            return None
+        return corners_arr[:, :, plate_idx].copy()
+    if corners_arr.ndim == 2 and n_plates == 1 and corners_arr.shape == (3, 4):
+        return corners_arr.T.copy()
+    if corners_arr.ndim == 2 and n_plates == 1 and corners_arr.shape == (4, 3):
+        return corners_arr.copy()
+    if corners_arr.size == 12 * n_plates:
+        reshaped = corners_arr.reshape(3, 4, n_plates)
+        return reshaped[:, :, plate_idx].T.copy()
+    return None
+
+
+def _extract_plate_origin(
+    origin_arr: np.ndarray, plate_idx: int, n_plates: int
+) -> np.ndarray | None:
+    """Slice a single plate's origin (returns shape (3,))."""
+    if origin_arr.ndim == 2 and origin_arr.shape[0] == 3:
+        if plate_idx >= origin_arr.shape[1]:
+            return None
+        return origin_arr[:, plate_idx].copy()
+    if origin_arr.ndim == 1 and n_plates == 1 and origin_arr.size == 3:
+        return origin_arr.copy()
+    if origin_arr.size == 3 * n_plates:
+        return origin_arr.reshape(3, n_plates)[:, plate_idx].copy()
+    return None
+
+
+def _extract_plate_cal_matrix(
+    cal_matrix_arr: np.ndarray | None,
+    plate_idx: int,
+    n_plates: int,
+    plate_type: int,
+) -> np.ndarray | None:
+    """Slice a single plate's calibration matrix, or None when not applicable."""
+    if cal_matrix_arr is None or cal_matrix_arr.size == 0 or plate_type == 1:
+        return None
+    if cal_matrix_arr.ndim == 3:
+        if plate_idx >= cal_matrix_arr.shape[-1]:
+            return None
+        return cal_matrix_arr[..., plate_idx].copy()
+    if cal_matrix_arr.ndim == 2 and n_plates == 1:
+        return cal_matrix_arr.copy()
+    return None
+
+
+def _extract_plate_channels(
+    channel_arr: np.ndarray | None,
+    plate_idx: int,
+    n_plates: int,
+    plate_type: int,
+    fallback_cursor: int,
+    analog_label_count: int,
+) -> tuple[int, int]:
+    """Return ``(start, end)`` analog indices for the plate (zero-based, end-exclusive)."""
+    expected = 6 if plate_type in (1, 2, 3) else 8 if plate_type == 4 else 6
+    if channel_arr is not None and channel_arr.size:
+        # CHANNEL is typically (n_channels, n_plates) of 1-based indices.
+        if channel_arr.ndim == 2:
+            if plate_idx < channel_arr.shape[1]:
+                col = channel_arr[:, plate_idx]
+                col = col[col > 0]
+                if col.size:
+                    start = int(col.min()) - 1
+                    end = int(col.max())
+                    return start, end
+        elif channel_arr.ndim == 1 and n_plates == 1:
+            col = channel_arr[channel_arr > 0]
+            if col.size:
+                return int(col.min()) - 1, int(col.max())
+
+    end = min(fallback_cursor + expected, analog_label_count)
+    return fallback_cursor, end
+
+
 def build_metadata(c3d_data: C3DMapping, file_path: Path) -> C3DMetadata:
     """Build a C3DMetadata object from loaded C3D data."""
     point_parameters = get_point_parameters(c3d_data, file_path)
@@ -118,6 +328,7 @@ def build_metadata(c3d_data: C3DMapping, file_path: Path) -> C3DMetadata:
     units = str(point_parameters["UNITS"]["value"][0])
     analog_labels, analog_rate, analog_units = get_analog_details(c3d_data)
     events = get_events(c3d_data)
+    force_plates = get_force_platforms(c3d_data, len(analog_labels))
     return C3DMetadata(
         marker_labels=marker_labels,
         frame_count=frame_count,
@@ -127,6 +338,7 @@ def build_metadata(c3d_data: C3DMapping, file_path: Path) -> C3DMetadata:
         analog_units=analog_units,
         analog_rate=analog_rate,
         events=events,
+        force_plates=force_plates,
     )
 
 

--- a/src/shared/python/upstream_drift_tools/lab/bio/_c3d_models.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/_c3d_models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+import numpy as np
 
 SCHEMA_VERSION = "1.0"
 
@@ -22,6 +24,50 @@ class C3DEvent:
 
 
 @dataclass(frozen=True)
+class ForcePlateCalibration:
+    """Calibration data for a single force plate from the C3D FORCE_PLATFORM group.
+
+    Attributes:
+        corners: Plate corners in lab frame, shape ``(4, 3)`` in metres. Order is
+            +x+y, -x+y, -x-y, +x-y as defined by the C3D specification.
+        origin: Origin of the plate measurement coordinate system, expressed as
+            an offset from the plate centre. Shape ``(3,)`` in metres.
+        cal_matrix: Calibration matrix relating raw analog voltages to
+            forces/moments. Shape varies by plate type (None for type 1, where
+            channels are pre-calibrated). Type 2/3: 6x6. Type 4: 6x6 typical.
+            Type 7/11/12: larger.
+        plate_type: C3D plate type code (1-4 supported in this reader). 1 means
+            channels already report forces/moments in plate frame; 2/3/4 require
+            ``cal_matrix`` to be applied to raw voltages.
+        channel_indices: ``(start, end)`` indices into the analog channel array
+            (inclusive start, exclusive end) that belong to this plate.
+    """
+
+    corners: np.ndarray
+    origin: np.ndarray
+    cal_matrix: np.ndarray | None
+    plate_type: int
+    channel_indices: tuple[int, int]
+
+    def __post_init__(self) -> None:
+        """Validate calibration shapes."""
+        if self.corners.shape != (4, 3):
+            raise ValueError(
+                f"corners must have shape (4, 3); got {self.corners.shape}"
+            )
+        if self.origin.shape != (3,):
+            raise ValueError(f"origin must have shape (3,); got {self.origin.shape}")
+        if self.plate_type not in (1, 2, 3, 4):
+            raise ValueError(f"plate_type must be one of 1-4; got {self.plate_type}")
+        start, end = self.channel_indices
+        if start < 0 or end < start:
+            raise ValueError(
+                f"channel_indices must be (start, end) with 0 <= start <= end; "
+                f"got {self.channel_indices}"
+            )
+
+
+@dataclass(frozen=True)
 class C3DMetadata:
     """Describes key properties of a C3D motion-capture recording."""
 
@@ -33,6 +79,7 @@ class C3DMetadata:
     analog_units: list[str]
     analog_rate: float | None
     events: list[C3DEvent]
+    force_plates: tuple[ForcePlateCalibration, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         """Validate metadata fields."""

--- a/src/shared/python/upstream_drift_tools/lab/bio/c3d_reader.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/c3d_reader.py
@@ -18,6 +18,7 @@ from ...utils.logging import get_logger
 from ._c3d_analog import (
     build_analog_dataframe,
     build_force_plate_dataframe,
+    build_force_plate_dataframe_from_calibration,
     detect_force_plate_channels,
     force_plate_columns,
 )
@@ -35,6 +36,7 @@ from ._c3d_models import (
     SCHEMA_VERSION,
     C3DEvent,
     C3DMetadata,
+    ForcePlateCalibration,
 )
 
 logger = get_logger(__name__)
@@ -44,6 +46,7 @@ __all__ = [
     "C3DEvent",
     "C3DMapping",
     "C3DMetadata",
+    "ForcePlateCalibration",
     "BIOMECHANICAL_MARKER_MAX_M",
     "BIOMECHANICAL_MARKER_MIN_M",
     "SCHEMA_VERSION",
@@ -227,9 +230,21 @@ class C3DDataReader:
             - mx, my, mz: Moment components [N·m]
             - cop_x, cop_y, cop_z: COP position [m] (if compute_cop=True)
         """
+        metadata = self.get_metadata()
+        if metadata.force_plates:
+            c3d_data = self._load()
+            return build_force_plate_dataframe_from_calibration(
+                c3d_data["data"]["analogs"],
+                metadata.force_plates,
+                metadata.analog_rate,
+                self.file_path.name,
+                plate_number,
+                include_time,
+                compute_cop,
+                ground_height,
+            )
         plate_channels = self.get_force_plate_channels()
         analog_df = self.analog_dataframe(include_time=False)
-        metadata = self.get_metadata()
         return build_force_plate_dataframe(
             plate_channels,
             analog_df,
@@ -242,7 +257,14 @@ class C3DDataReader:
         )
 
     def get_force_plate_count(self) -> int:
-        """Return the number of detected force plates."""
+        """Return the number of detected force plates.
+
+        Prefers ``FORCE_PLATFORM.USED`` from the C3D parameter group when
+        available; falls back to analog-channel-name regex detection otherwise.
+        """
+        metadata = self.get_metadata()
+        if metadata.force_plates:
+            return len(metadata.force_plates)
         return len(self.get_force_plate_channels())
 
     def _load(self) -> C3DMapping:

--- a/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
@@ -30,6 +30,7 @@ def _synthetic_c3d_dict(
     analog_subframes: int = 10,
     point_data: np.ndarray | None = None,
     analog_data: np.ndarray | None = None,
+    force_platform: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a dict shaped like the result of ``ezc3d.c3d(path)``.
 
@@ -114,6 +115,12 @@ def _synthetic_c3d_dict(
             else:
                 event_group["TIMES"] = {"value": np.asarray(times)}
         parameters["EVENT"] = event_group
+
+    if force_platform is not None:
+        fp_group: dict[str, Any] = {}
+        for key, value in force_platform.items():
+            fp_group[key] = {"value": value}
+        parameters["FORCE_PLATFORM"] = fp_group
 
     return {
         "header": {},

--- a/tests/unit/upstream_drift_tools/lab/bio/test_force_platform.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_force_platform.py
@@ -1,0 +1,339 @@
+"""Tests for the FORCE_PLATFORM parameter group parser and calibration path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from upstream_drift_tools.lab.bio._c3d_analog import (
+    build_force_plate_dataframe_from_calibration,
+)
+from upstream_drift_tools.lab.bio._c3d_io import build_metadata
+from upstream_drift_tools.lab.bio._c3d_models import ForcePlateCalibration
+
+from ._synthetic import _synthetic_c3d_dict
+
+pytestmark = pytest.mark.unit
+
+
+def _square_plate_corners(
+    centre: tuple[float, float, float], half_side_mm: float = 250.0
+) -> np.ndarray:
+    """Build a 3x4 corners array (mm) with corners ordered +x+y, -x+y, -x-y, +x-y."""
+    cx, cy, cz = centre
+    h = half_side_mm
+    # ezc3d returns corners as (3, 4) per plate.
+    return np.array(
+        [
+            [cx + h, cx - h, cx - h, cx + h],
+            [cy + h, cy + h, cy - h, cy - h],
+            [cz, cz, cz, cz],
+        ],
+        dtype=float,
+    )
+
+
+def test_build_metadata_parses_force_platform_type2() -> None:
+    """A type-2 plate with CAL_MATRIX should be exposed via metadata.force_plates."""
+    n_frames = 5
+    subframes = 10
+    n_analog = 6
+    cal_matrix = np.eye(6) * 2.0  # voltages -> forces, gain 2.0
+    fp = {
+        "USED": np.array([1]),
+        "TYPE": np.array([2]),
+        "CORNERS": _square_plate_corners((500.0, 400.0, 0.0))[:, :, np.newaxis],
+        "ORIGIN": np.array([[0.0], [0.0], [-30.0]]),  # mm, sensor 30 mm below top
+        "CAL_MATRIX": cal_matrix[:, :, np.newaxis],
+        "CHANNEL": np.arange(1, n_analog + 1).reshape(n_analog, 1),
+    }
+    raw = _synthetic_c3d_dict(
+        n_frames=n_frames,
+        n_analog=n_analog,
+        analog_labels=[f"FP1_{c}" for c in ("Fx", "Fy", "Fz", "Mx", "My", "Mz")],
+        analog_subframes=subframes,
+        force_platform=fp,
+    )
+
+    metadata = build_metadata(raw, Path("synthetic.c3d"))
+    assert len(metadata.force_plates) == 1
+    plate = metadata.force_plates[0]
+    assert plate.plate_type == 2
+    assert plate.corners.shape == (4, 3)
+    # Corners are returned in metres.
+    assert np.allclose(plate.corners[0], [0.75, 0.65, 0.0])
+    assert np.allclose(plate.origin, [0.0, 0.0, -0.030])
+    assert plate.cal_matrix is not None
+    assert plate.cal_matrix.shape == (6, 6)
+    assert plate.channel_indices == (0, 6)
+
+
+def test_build_metadata_type1_no_cal_matrix() -> None:
+    """Type-1 plates do not require a calibration matrix."""
+    fp = {
+        "USED": np.array([1]),
+        "TYPE": np.array([1]),
+        "CORNERS": _square_plate_corners((0.0, 0.0, 0.0))[:, :, np.newaxis],
+        "ORIGIN": np.array([[0.0], [0.0], [0.0]]),
+    }
+    raw = _synthetic_c3d_dict(
+        n_frames=2,
+        n_analog=6,
+        analog_labels=["Fx1", "Fy1", "Fz1", "Mx1", "My1", "Mz1"],
+        force_platform=fp,
+    )
+    metadata = build_metadata(raw, Path("synthetic.c3d"))
+    assert len(metadata.force_plates) == 1
+    assert metadata.force_plates[0].cal_matrix is None
+    assert metadata.force_plates[0].plate_type == 1
+
+
+def test_build_metadata_type4_full_cal_matrix() -> None:
+    """Type-4 plates carry an 8-channel calibration matrix (6x8)."""
+    cal_matrix = np.zeros((6, 8))
+    cal_matrix[:6, :6] = np.eye(6)
+    fp = {
+        "USED": np.array([1]),
+        "TYPE": np.array([4]),
+        "CORNERS": _square_plate_corners((0.0, 0.0, 0.0))[:, :, np.newaxis],
+        "ORIGIN": np.array([[0.0], [0.0], [-25.0]]),
+        "CAL_MATRIX": cal_matrix[:, :, np.newaxis],
+        "CHANNEL": np.arange(1, 9).reshape(8, 1),
+    }
+    raw = _synthetic_c3d_dict(
+        n_frames=2,
+        n_analog=8,
+        analog_labels=[f"FP_{i}" for i in range(8)],
+        force_platform=fp,
+    )
+    metadata = build_metadata(raw, Path("synthetic.c3d"))
+    assert len(metadata.force_plates) == 1
+    plate = metadata.force_plates[0]
+    assert plate.plate_type == 4
+    assert plate.cal_matrix is not None
+    assert plate.cal_matrix.shape == (6, 8)
+    assert plate.channel_indices == (0, 8)
+
+
+def test_build_metadata_used_zero_returns_empty() -> None:
+    """USED == 0 yields no force plates so the analog-regex fallback runs."""
+    fp = {
+        "USED": np.array([0]),
+        "TYPE": np.array([], dtype=int),
+        "CORNERS": np.zeros((3, 4, 0)),
+        "ORIGIN": np.zeros((3, 0)),
+    }
+    raw = _synthetic_c3d_dict(
+        n_frames=2,
+        n_analog=6,
+        analog_labels=["Fx1", "Fy1", "Fz1", "Mx1", "My1", "Mz1"],
+        force_platform=fp,
+    )
+    metadata = build_metadata(raw, Path("synthetic.c3d"))
+    assert metadata.force_plates == ()
+
+
+def test_build_metadata_no_force_platform_group() -> None:
+    """Files without a FORCE_PLATFORM group yield an empty tuple."""
+    raw = _synthetic_c3d_dict(n_frames=2, n_analog=0)
+    metadata = build_metadata(raw, Path("synthetic.c3d"))
+    assert metadata.force_plates == ()
+
+
+def test_force_plate_dataframe_applies_cal_matrix() -> None:
+    """A type-2 plate with a 2x gain matrix doubles the raw voltages."""
+    n_frames = 4
+    subframes = 5
+    n_analog = 6
+    # Build raw voltages such that channel i has a constant value (i+1).
+    analog = np.zeros((subframes, n_analog, n_frames))
+    for i in range(n_analog):
+        analog[:, i, :] = i + 1
+    cal_matrix = np.eye(6) * 2.0
+
+    plate = ForcePlateCalibration(
+        corners=np.array(
+            [
+                [0.25, 0.25, 0.0],
+                [-0.25, 0.25, 0.0],
+                [-0.25, -0.25, 0.0],
+                [0.25, -0.25, 0.0],
+            ]
+        ),
+        origin=np.array([0.0, 0.0, -0.030]),
+        cal_matrix=cal_matrix,
+        plate_type=2,
+        channel_indices=(0, 6),
+    )
+
+    df = build_force_plate_dataframe_from_calibration(
+        analog_array=analog,
+        calibrations=(plate,),
+        analog_rate=1000.0,
+        file_name="synthetic.c3d",
+        plate_number=None,
+        include_time=True,
+        compute_cop=True,
+        ground_height=0.0,
+    )
+
+    expected_rows = n_frames * subframes
+    assert len(df) == expected_rows
+    # Channel i had value i+1, gain 2 -> 2*(i+1).
+    assert np.allclose(df["fx"], 2.0)
+    assert np.allclose(df["fy"], 4.0)
+    assert np.allclose(df["fz"], 6.0)
+    assert np.allclose(df["mx"], 8.0)
+    assert np.allclose(df["my"], 10.0)
+    assert np.allclose(df["mz"], 12.0)
+    # CoP should be finite (fz=6 > threshold) and within plate bounds.
+    assert np.all(np.isfinite(df["cop_x"]))
+    assert np.all(np.isfinite(df["cop_y"]))
+
+
+def test_force_plate_dataframe_type1_passthrough() -> None:
+    """Type-1 plates return raw channel values directly without cal_matrix."""
+    n_frames = 2
+    subframes = 3
+    analog = np.zeros((subframes, 6, n_frames))
+    analog[:, 2, :] = 750.0  # fz constant
+    plate = ForcePlateCalibration(
+        corners=np.array(
+            [
+                [0.25, 0.25, 0.0],
+                [-0.25, 0.25, 0.0],
+                [-0.25, -0.25, 0.0],
+                [0.25, -0.25, 0.0],
+            ]
+        ),
+        origin=np.array([0.0, 0.0, 0.0]),
+        cal_matrix=None,
+        plate_type=1,
+        channel_indices=(0, 6),
+    )
+    df = build_force_plate_dataframe_from_calibration(
+        analog_array=analog,
+        calibrations=(plate,),
+        analog_rate=None,
+        file_name="synthetic.c3d",
+        plate_number=None,
+        include_time=False,
+        compute_cop=False,
+        ground_height=0.0,
+    )
+    assert np.allclose(df["fz"], 750.0)
+    assert "cop_x" not in df.columns
+
+
+def test_force_plate_dataframe_cop_in_lab_frame() -> None:
+    """CoP is rotated to lab frame using corners (plate centred at lab (1, 2, 0))."""
+    n_frames = 1
+    subframes = 1
+    analog = np.zeros((subframes, 6, n_frames))
+    analog[:, 2, :] = 1000.0  # fz = 1000 N
+    # mx, my zero -> cop_local = (0, 0, 0). With z0=0, lab CoP = plate centre.
+    centre = np.array([1.0, 2.0, 0.0])
+    half = 0.25
+    corners = np.array(
+        [
+            centre + [half, half, 0.0],
+            centre + [-half, half, 0.0],
+            centre + [-half, -half, 0.0],
+            centre + [half, -half, 0.0],
+        ]
+    )
+    plate = ForcePlateCalibration(
+        corners=corners,
+        origin=np.array([0.0, 0.0, 0.0]),
+        cal_matrix=None,
+        plate_type=1,
+        channel_indices=(0, 6),
+    )
+    df = build_force_plate_dataframe_from_calibration(
+        analog_array=analog,
+        calibrations=(plate,),
+        analog_rate=1000.0,
+        file_name="synthetic.c3d",
+        plate_number=None,
+        include_time=False,
+        compute_cop=True,
+        ground_height=0.0,
+    )
+    assert np.allclose(df["cop_x"].iloc[0], 1.0)
+    assert np.allclose(df["cop_y"].iloc[0], 2.0)
+    assert np.allclose(df["cop_z"].iloc[0], 0.0)
+
+
+def test_force_plate_dataframe_select_specific_plate() -> None:
+    """Selecting a specific plate filters to that plate only."""
+    plate1 = ForcePlateCalibration(
+        corners=np.array(
+            [
+                [0.25, 0.25, 0.0],
+                [-0.25, 0.25, 0.0],
+                [-0.25, -0.25, 0.0],
+                [0.25, -0.25, 0.0],
+            ]
+        ),
+        origin=np.array([0.0, 0.0, 0.0]),
+        cal_matrix=None,
+        plate_type=1,
+        channel_indices=(0, 6),
+    )
+    plate2 = ForcePlateCalibration(
+        corners=plate1.corners + np.array([1.0, 0.0, 0.0]),
+        origin=np.array([0.0, 0.0, 0.0]),
+        cal_matrix=None,
+        plate_type=1,
+        channel_indices=(6, 12),
+    )
+    analog = np.zeros((1, 12, 1))
+    df = build_force_plate_dataframe_from_calibration(
+        analog_array=analog,
+        calibrations=(plate1, plate2),
+        analog_rate=None,
+        file_name="synthetic.c3d",
+        plate_number=2,
+        include_time=False,
+        compute_cop=False,
+        ground_height=0.0,
+    )
+    assert set(df["plate"].unique()) == {2}
+
+
+def test_force_plate_calibration_validates_shapes() -> None:
+    """Bad shapes raise immediately at construction."""
+    with pytest.raises(ValueError, match="corners"):
+        ForcePlateCalibration(
+            corners=np.zeros((3, 3)),
+            origin=np.zeros(3),
+            cal_matrix=None,
+            plate_type=1,
+            channel_indices=(0, 6),
+        )
+    with pytest.raises(ValueError, match="origin"):
+        ForcePlateCalibration(
+            corners=np.zeros((4, 3)),
+            origin=np.zeros(2),
+            cal_matrix=None,
+            plate_type=1,
+            channel_indices=(0, 6),
+        )
+    with pytest.raises(ValueError, match="plate_type"):
+        ForcePlateCalibration(
+            corners=np.zeros((4, 3)),
+            origin=np.zeros(3),
+            cal_matrix=None,
+            plate_type=99,
+            channel_indices=(0, 6),
+        )
+    with pytest.raises(ValueError, match="channel_indices"):
+        ForcePlateCalibration(
+            corners=np.zeros((4, 3)),
+            origin=np.zeros(3),
+            cal_matrix=None,
+            plate_type=1,
+            channel_indices=(5, 2),
+        )


### PR DESCRIPTION
Closes #4711

## Summary
- Adds `ForcePlateCalibration` dataclass with corners (4x3 m), origin (3,), cal_matrix, plate_type, and analog channel range.
- `C3DMetadata` now carries `force_plates: tuple[ForcePlateCalibration, ...]` populated from the C3D `FORCE_PLATFORM` parameter group (USED, ZERO, TYPE, CORNERS, ORIGIN, CHANNEL, CAL_MATRIX).
- New `build_force_plate_dataframe_from_calibration` honours plate type and applies `cal_matrix` for type 2/3/4 plates; CoP is transformed from plate-local to lab frame using the four corners + origin offset.
- Legacy analog-channel-name regex path is preserved and used as a fallback when `FORCE_PLATFORM.USED == 0` or the group is missing.

## Test plan
- [x] `python -m pytest tests/unit/upstream_drift_tools/lab/bio/ -p no:cacheprovider --timeout=60` (113 passed)
- [x] `python -m ruff check` on touched files (clean)
- [x] `python -m ruff format --check` on touched files (clean)
- [x] `python scripts/ci/check_file_size_budget.py` (within budget)
- [x] New `test_force_platform.py` exercises type-1 (no cal matrix), type-2 (6x6 gain), type-4 (6x8) variants, lab-frame CoP, plate selection, validation, and the USED=0 fallback.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)