### PR TITLE
feat(opensim): fit_swing provider (#4708)

### DIFF
--- a/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/__init__.py
@@ -22,6 +22,8 @@ Public surface (lazily imported to keep ``import opensim`` optional):
 
 from __future__ import annotations
 
+import logging
+
 from src.engines.physics_engines.opensim.python.motion_matching.coord_map import (
     OPENSIM_COORD_ORDER,
     OPENSIM_NEUTRAL_POSE,
@@ -59,6 +61,9 @@ from src.engines.physics_engines.opensim.python.motion_matching.simulate import 
     evaluate_polynomial_torque,
     simulate_with_coefficients,
 )
+from src.engines.physics_engines.opensim.python.motion_matching.provider import (
+    OpenSimFitSwingProvider,
+)
 from src.engines.physics_engines.opensim.python.motion_matching.synthesize import (
     SynthOptions,
     synthesize_target_from_coefficients,
@@ -76,6 +81,7 @@ __all__ = [
     "OPENSIM_TO_SIMSCAPE",
     "POLY_DEGREE",
     "SIMSCAPE_COORD_ORDER",
+    "OpenSimFitSwingProvider",
     "SimOptions",
     "SimOut",
     "SynthOptions",
@@ -96,3 +102,43 @@ __all__ = [
     "to_simscape",
     "viz",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Auto-register the OpenSim provider at import time (issue #4708).
+# ---------------------------------------------------------------------------
+# The cross-engine matcher (issue #4513) discovers engines by importing
+# ``src.engines.physics_engines.<engine>.python.motion_matching`` and
+# expecting the module to have called ``register_provider`` as a side
+# effect. We register against both the canonical Protocol-based registry
+# (``provider``) and the engine-agnostic surface (``provider_registry``)
+# so that downstream code using either lookup path sees the OpenSim
+# entry. Each call is idempotent on repeat imports.
+#
+# The try/except blocks ensure that callers without an OpenSim wheel
+# (or with partial-rollout shared modules) can still ``import`` this
+# package without crashing -- the registration silently no-ops if the
+# canonical registry surface is unavailable.
+try:
+    from src.shared.python.motion_matching.provider import (
+        register_provider as _register_canonical,
+    )
+except ImportError:  # pragma: no cover - defensive
+    pass
+else:
+    try:
+        _register_canonical(OpenSimFitSwingProvider())
+    except Exception:  # pragma: no cover - defensive idempotency
+        logging.getLogger(__name__).debug(
+            "OpenSimFitSwingProvider canonical registration skipped",
+            exc_info=True,
+        )
+
+try:
+    from src.shared.python.motion_matching.provider_registry import (
+        register_provider as _register_legacy,
+    )
+except ImportError:  # pragma: no cover - defensive
+    pass
+else:
+    _register_legacy(OpenSimFitSwingProvider())

--- a/src/engines/physics_engines/opensim/python/motion_matching/provider.py
+++ b/src/engines/physics_engines/opensim/python/motion_matching/provider.py
@@ -1,0 +1,163 @@
+"""``OpenSimFitSwingProvider`` -- canonical motion-matching adapter for OpenSim.
+
+Per #4708 (and the cross-engine parity spec #4513), every engine ships a
+provider that adapts the canonical ``MultiSourceTarget`` / ``FitOptions``
+inputs to the engine's existing fit driver. This module is a thin
+adapter on top of :func:`fit_swing_opensim` (issue #4128); it does NOT
+touch the optimiser, the polynomial-torque controller, or the forward
+simulator.
+
+The provider auto-registers at import time so::
+
+    import src.engines.physics_engines.opensim.python.motion_matching  # noqa
+    from src.shared.python.motion_matching.provider_registry import (
+        get_provider,
+    )
+    provider = get_provider("opensim")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.shared.python.motion_matching.club_ball_target import ClubBallTarget
+from src.shared.python.motion_matching.club_target import ClubTarget
+from src.shared.python.motion_matching.provider import (
+    FitOptions,
+    MultiSourceTarget,
+)
+
+from .fit_swing import FitOptions as OpenSimFitOptions
+from .fit_swing import fit_swing_opensim
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import
+    from src.shared.python.motion_matching.fit_result import (
+        CanonicalFitResult,
+    )
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["OpenSimFitSwingProvider"]
+
+
+class OpenSimFitSwingProvider:
+    """Canonical-API adapter wrapping :func:`fit_swing_opensim`.
+
+    The provider:
+
+    1. accepts a :class:`MultiSourceTarget` (reading ``target.club``), a
+       bare :class:`ClubTarget` (back-compat), or a :class:`ClubBallTarget`
+       (the club portion is consumed; the ball boundary is ignored until
+       OpenSim grows ball-target support);
+    2. unwraps the canonical :class:`FitOptions` to the engine's native
+       :class:`OpenSimFitOptions`, preserving any user-supplied
+       ``engine_options`` and projecting ``opts.maxiter`` /
+       ``opts.rng_seed`` onto a fresh native options object when none is
+       supplied;
+    3. delegates to :func:`fit_swing_opensim` and returns the engine's
+       :class:`CanonicalFitResult` unchanged.
+    """
+
+    engine_name: str = "opensim"
+
+    def fit_swing(
+        self,
+        target: MultiSourceTarget | ClubTarget | ClubBallTarget,
+        opts: FitOptions,
+    ) -> CanonicalFitResult:
+        """Adapt canonical inputs and call :func:`fit_swing_opensim`.
+
+        Args:
+            target: One of:
+                * a :class:`MultiSourceTarget` (whose ``.club`` slot MUST
+                  be a :class:`ClubTarget`),
+                * a bare :class:`ClubTarget`, or
+                * a :class:`ClubBallTarget` (the wrapped ``.club`` is
+                  used; the ball boundary is ignored).
+            opts: Canonical :class:`FitOptions`. ``opts.engine_options``,
+                if supplied, MUST be an :class:`OpenSimFitOptions`; when
+                absent, defaults are used and ``opts.maxiter`` /
+                ``opts.rng_seed`` are projected onto the native options.
+
+        Returns:
+            :class:`CanonicalFitResult` directly from
+            :func:`fit_swing_opensim`.
+
+        Raises:
+            ValueError: when the canonical target has no ``.club`` slot
+                or carries a non-:class:`ClubTarget` payload.
+            TypeError: when ``target`` is not one of the supported types,
+                or when ``opts.engine_options`` is supplied but is not an
+                :class:`OpenSimFitOptions`.
+        """
+        club = self._extract_club(target)
+        native = self._build_native_options(opts)
+        return fit_swing_opensim(club, native)
+
+    def supports_body_target(self) -> bool:
+        """OpenSim's swing fitter consumes only the club trajectory."""
+        return False
+
+    def supports_ball_target(self) -> bool:
+        """OpenSim's swing fitter does not consume ball targets yet."""
+        return False
+
+    # --- Internal helpers ----------------------------------------------
+
+    @staticmethod
+    def _extract_club(
+        target: MultiSourceTarget | ClubTarget | ClubBallTarget,
+    ) -> ClubTarget:
+        """Return the :class:`ClubTarget` payload from ``target``.
+
+        Accepts bare :class:`ClubTarget`, :class:`ClubBallTarget` (whose
+        ``.club`` is unwrapped), and :class:`MultiSourceTarget` (whose
+        ``.club`` slot is unwrapped). The ball-impact boundary on a
+        :class:`ClubBallTarget` is intentionally discarded -- the OpenSim
+        fitter does not consume it.
+        """
+        if isinstance(target, ClubTarget):
+            return target
+        if isinstance(target, ClubBallTarget):
+            return target.club
+        if isinstance(target, MultiSourceTarget):
+            if target.club is None:
+                raise ValueError(
+                    "OpenSimFitSwingProvider requires target.club to be set; "
+                    "got MultiSourceTarget with club=None"
+                )
+            if not isinstance(target.club, ClubTarget):
+                raise ValueError(
+                    f"target.club must be a ClubTarget, "
+                    f"got {type(target.club).__name__}"
+                )
+            return target.club
+        raise TypeError(
+            f"target must be MultiSourceTarget, ClubTarget, or ClubBallTarget, "
+            f"got {type(target).__name__}"
+        )
+
+    @staticmethod
+    def _build_native_options(opts: FitOptions) -> OpenSimFitOptions:
+        """Convert canonical :class:`FitOptions` -> :class:`OpenSimFitOptions`.
+
+        Honors ``opts.engine_options`` when it carries an
+        :class:`OpenSimFitOptions`; otherwise builds a default options
+        object and projects ``maxiter`` / ``rng_seed`` onto it.
+        """
+        if opts.engine_options is None:
+            from dataclasses import replace
+
+            base = OpenSimFitOptions()
+            return replace(
+                base,
+                max_iter=int(opts.maxiter),
+                rng_seed=int(opts.rng_seed),
+            )
+        if isinstance(opts.engine_options, OpenSimFitOptions):
+            return opts.engine_options
+        raise TypeError(
+            f"opts.engine_options must be OpenSimFitOptions or None, "
+            f"got {type(opts.engine_options).__name__}"
+        )

--- a/tests/unit/motion_matching/opensim/test_provider.py
+++ b/tests/unit/motion_matching/opensim/test_provider.py
@@ -1,0 +1,318 @@
+"""Unit tests for :class:`OpenSimFitSwingProvider` (#4708).
+
+Coverage:
+
+* The provider auto-registers against both the canonical Protocol-based
+  registry (``provider``) and the engine-agnostic registry
+  (``provider_registry``) as soon as the engine package is imported.
+* The provider's :meth:`fit_swing` accepts wrapped
+  :class:`MultiSourceTarget`, raw :class:`ClubTarget`, and
+  :class:`ClubBallTarget` inputs.
+* :meth:`_build_native_options` projects ``maxiter`` / ``rng_seed``
+  onto a default :class:`OpenSimFitOptions`, and passes through a
+  user-supplied native options object unchanged.
+* The provider declines body / ball target consumption.
+* Re-importing the package is idempotent for registration.
+* End-to-end :meth:`fit_swing` against an injected deterministic
+  ``simulate_fn`` (no real OpenSim wheel required) returns a
+  :class:`CanonicalFitResult` with the expected shape.
+
+The optimiser-driven tests inject a ``simulate_fn`` so the OpenSim
+SWIG wheel is *not* required. A guarded ``pytest.importorskip`` block
+is reserved for any future scenario that needs the real engine.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from src.engines.physics_engines.opensim.python.motion_matching import (
+    OpenSimFitSwingProvider,
+)
+from src.engines.physics_engines.opensim.python.motion_matching.fit_swing import (
+    FitOptions as OpenSimFitOptions,
+)
+from src.shared.python.motion_matching.club_ball_target import (
+    BallImpactState,
+    ClubBallTarget,
+)
+from src.shared.python.motion_matching.club_target import (
+    ClubTarget,
+    SourceProvenance,
+)
+from src.shared.python.motion_matching.cost import SimOutput
+from src.shared.python.motion_matching.fit_result import CanonicalFitResult
+from src.shared.python.motion_matching.provider import (
+    FitOptions,
+    MultiSourceTarget,
+)
+from src.shared.python.motion_matching.provider import (
+    available_engines as canonical_available_engines,
+)
+from src.shared.python.motion_matching.provider import (
+    get_provider as canonical_get_provider,
+)
+from src.shared.python.motion_matching.provider_registry import (
+    available_engines as registry_available_engines,
+)
+from src.shared.python.motion_matching.provider_registry import (
+    get_provider as registry_get_provider,
+)
+
+
+# --------------------------------------------------------------------------
+# Shared fixtures
+# --------------------------------------------------------------------------
+
+
+def _provenance() -> SourceProvenance:
+    return SourceProvenance(
+        filename="synth.bin",
+        format="synthetic",
+        subject_id="UNIT",
+        trial_id="opensim-provider",
+        sha256="0" * 64,
+    )
+
+
+def _synthetic_target(n: int = 11) -> ClubTarget:
+    """Tiny but valid ClubTarget for adapter-level smoke tests."""
+    time = np.linspace(0.0, 0.01, n, dtype=np.float64)
+    butt = np.column_stack([time, np.zeros_like(time), np.zeros_like(time)]).astype(
+        np.float64
+    )
+    clubhead = butt + np.array([0.0, 0.0, 1.0])
+    quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (n, 1)).astype(np.float64)
+    return ClubTarget(
+        time=time,
+        butt=butt,
+        clubhead=clubhead,
+        club_quat=quat,
+        impact_idx=n,
+        source=_provenance(),
+    )
+
+
+def _ball_state() -> BallImpactState:
+    return BallImpactState(
+        position_at_impact_m=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+        launch_direction=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        launch_speed_mps=50.0,
+        spin_rpm=0.0,
+    )
+
+
+class _DeterministicSimFn:
+    """Echo a club-target-shaped :class:`SimOutput` regardless of theta.
+
+    The output simulates a perfect roll-out so :func:`compute_cost`
+    surfaces only the regularizer term and the cost is finite for any
+    theta. ``n_joints`` advertises the per-joint coefficient count to
+    :func:`fit_swing_opensim` so the warm-start dimensionality is small
+    (3 joints * 7 coeffs = 21) and SLSQP converges in one iteration.
+    """
+
+    n_joints: int = 3
+
+    def __init__(self, target: ClubTarget) -> None:
+        self._target = target
+
+    def __call__(self, theta: np.ndarray) -> SimOutput:
+        n = self._target.time.shape[0]
+        n_joints = self.n_joints
+        return SimOutput(
+            butt=self._target.butt.copy(),
+            clubhead=self._target.clubhead.copy(),
+            club_quat=self._target.club_quat.copy(),
+            time=self._target.time.copy(),
+            tau=np.zeros((n, n_joints), dtype=np.float64),
+            omega=np.zeros((n, n_joints), dtype=np.float64),
+        )
+
+
+# --------------------------------------------------------------------------
+# Registration tests
+# --------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """The opensim provider must register at import time."""
+
+    def test_engine_name_is_opensim(self) -> None:
+        assert OpenSimFitSwingProvider.engine_name == "opensim"
+
+    def test_registered_in_canonical_registry(self) -> None:
+        assert "opensim" in canonical_available_engines()
+
+    def test_registered_in_engine_agnostic_registry(self) -> None:
+        assert "opensim" in registry_available_engines()
+
+    def test_canonical_get_provider_returns_instance(self) -> None:
+        provider = canonical_get_provider("opensim")
+        assert isinstance(provider, OpenSimFitSwingProvider)
+        assert provider.engine_name == "opensim"
+
+    def test_registry_get_provider_returns_instance(self) -> None:
+        provider = registry_get_provider("opensim")
+        assert isinstance(provider, OpenSimFitSwingProvider)
+
+    def test_capability_flags(self) -> None:
+        provider = OpenSimFitSwingProvider()
+        assert provider.supports_body_target() is False
+        assert provider.supports_ball_target() is False
+
+    def test_reimport_is_idempotent(self) -> None:
+        # Re-importing the package must not raise (the registries handle
+        # idempotency for repeated registrations of the same provider type).
+        before = sorted(canonical_available_engines())
+        importlib.import_module(
+            "src.engines.physics_engines.opensim.python.motion_matching"
+        )
+        after = sorted(canonical_available_engines())
+        assert "opensim" in before
+        assert before == after
+
+
+# --------------------------------------------------------------------------
+# I/O adapter tests (target unwrapping)
+# --------------------------------------------------------------------------
+
+
+class TestExtractClub:
+    """Adapter must accept canonical inputs and reject malformed ones."""
+
+    def test_extract_from_raw_clubtarget(self) -> None:
+        club = _synthetic_target()
+        assert OpenSimFitSwingProvider._extract_club(club) is club
+
+    def test_extract_from_multisource(self) -> None:
+        club = _synthetic_target()
+        wrapped = MultiSourceTarget(club=club)
+        assert OpenSimFitSwingProvider._extract_club(wrapped) is club
+
+    def test_extract_from_clubballtarget(self) -> None:
+        club = _synthetic_target()
+        cbt = ClubBallTarget(club=club, ball_impact=_ball_state())
+        assert OpenSimFitSwingProvider._extract_club(cbt) is club
+
+    def test_multisource_with_body_only_rejected(self) -> None:
+        wrapped = MultiSourceTarget(body=object())
+        with pytest.raises(ValueError, match="target.club"):
+            OpenSimFitSwingProvider._extract_club(wrapped)
+
+    def test_multisource_with_non_clubtarget_rejected(self) -> None:
+        # Bypass MultiSourceTarget validation by setting club to a non-None
+        # non-ClubTarget value directly via __dict__ surrogate -- here we
+        # rely on MultiSourceTarget(club=<bogus>) which will fail provider
+        # validation rather than dataclass validation (dataclass does not
+        # type-check beyond None / not-None).
+        wrapped = MultiSourceTarget(club=None, body=object())
+        with pytest.raises(ValueError, match="target.club"):
+            OpenSimFitSwingProvider._extract_club(wrapped)
+
+    def test_non_target_input_raises_typeerror(self) -> None:
+        with pytest.raises(TypeError, match="MultiSourceTarget"):
+            OpenSimFitSwingProvider._extract_club(object())  # type: ignore[arg-type]
+
+    def test_string_input_raises_typeerror(self) -> None:
+        with pytest.raises(TypeError):
+            OpenSimFitSwingProvider._extract_club("not a target")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Options-projection tests
+# --------------------------------------------------------------------------
+
+
+class TestBuildNativeOptions:
+    """Canonical FitOptions must project onto OpenSimFitOptions correctly."""
+
+    def test_default_options_project_maxiter_and_seed(self) -> None:
+        native = OpenSimFitSwingProvider._build_native_options(
+            FitOptions(maxiter=7, rng_seed=99)
+        )
+        assert isinstance(native, OpenSimFitOptions)
+        assert native.max_iter == 7
+        assert native.rng_seed == 99
+
+    def test_engine_options_passed_through(self) -> None:
+        engine_opts = OpenSimFitOptions(max_iter=3, rng_seed=11)
+        out = OpenSimFitSwingProvider._build_native_options(
+            FitOptions(engine_options=engine_opts)
+        )
+        assert out is engine_opts
+
+    def test_engine_options_type_mismatch_rejected(self) -> None:
+        opts = FitOptions(engine_options=object())
+        with pytest.raises(TypeError, match="OpenSimFitOptions"):
+            OpenSimFitSwingProvider._build_native_options(opts)
+
+
+# --------------------------------------------------------------------------
+# End-to-end fit_swing through the provider (uses injected simulate_fn).
+# --------------------------------------------------------------------------
+
+
+class TestFitSwingEndToEnd:
+    """Drive the provider with an injected sim_fn and validate the result."""
+
+    def _opts_with_simfn(self, target: ClubTarget, *, max_iter: int = 1) -> FitOptions:
+        sim_fn = _DeterministicSimFn(target)
+        engine_opts = OpenSimFitOptions(
+            max_iter=max_iter,
+            simulate_fn=sim_fn,
+            n_joints=sim_fn.n_joints,
+            rng_seed=0,
+        )
+        return FitOptions(maxiter=max_iter, rng_seed=0, engine_options=engine_opts)
+
+    def test_fit_swing_returns_canonical_result(self) -> None:
+        provider = OpenSimFitSwingProvider()
+        target = _synthetic_target(n=11)
+        result = provider.fit_swing(
+            MultiSourceTarget(club=target),
+            self._opts_with_simfn(target, max_iter=1),
+        )
+        assert isinstance(result, CanonicalFitResult)
+        assert isinstance(result.theta_optimal, np.ndarray)
+        assert result.theta_optimal.ndim == 1
+        # 3 joints * 7 coeffs = 21
+        assert result.theta_optimal.shape == (21,)
+        assert np.isfinite(result.final_cost)
+
+    def test_fit_swing_accepts_raw_clubtarget(self) -> None:
+        provider = OpenSimFitSwingProvider()
+        target = _synthetic_target(n=11)
+        result = provider.fit_swing(target, self._opts_with_simfn(target, max_iter=1))
+        assert isinstance(result, CanonicalFitResult)
+
+    def test_fit_swing_accepts_clubballtarget(self) -> None:
+        provider = OpenSimFitSwingProvider()
+        target = _synthetic_target(n=11)
+        cbt = ClubBallTarget(club=target, ball_impact=_ball_state())
+        result = provider.fit_swing(cbt, self._opts_with_simfn(target, max_iter=1))
+        assert isinstance(result, CanonicalFitResult)
+
+    def test_maxiter_respected_via_history_bound(self) -> None:
+        """Engine options carry ``max_iter`` end-to-end.
+
+        SLSQP performs at least one objective evaluation per iteration,
+        so a very small ``max_iter`` keeps the recorded history short.
+        """
+        provider = OpenSimFitSwingProvider()
+        target = _synthetic_target(n=11)
+        result = provider.fit_swing(target, self._opts_with_simfn(target, max_iter=1))
+        # SLSQP records >=1 evaluation. With max_iter=1 the optimiser
+        # should not run away; assert the recorded history is bounded.
+        assert len(result.history) >= 1
+        assert result.iterations <= 5  # comfortably above SLSQP's 1-iter
+
+    def test_fit_swing_rejects_non_target_inputs(self) -> None:
+        provider = OpenSimFitSwingProvider()
+        target = _synthetic_target(n=11)
+        opts = self._opts_with_simfn(target, max_iter=1)
+        with pytest.raises(TypeError):
+            provider.fit_swing(object(), opts)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Adds `OpenSimFitSwingProvider` as a thin adapter wrapping `fit_swing_opensim`, mirroring the MuJoCo provider pattern.
- Auto-registers at package import time against both the canonical Protocol-based registry (`provider`) and the engine-agnostic `provider_registry` so `available_engines()` lists `"opensim"`.
- Provider accepts `MultiSourceTarget`, raw `ClubTarget`, and `ClubBallTarget` inputs; declines body / ball target consumption until OpenSim grows that support.

Closes #4708

## Test plan
- [x] `python -m pytest tests/unit/motion_matching/opensim/ --timeout=60` (22 passed)
- [x] `python -m ruff check` / `format --check` clean for new files
- [x] `python scripts/ci/check_file_size_budget.py` passes
- [x] `python -c "import src.engines.physics_engines.opensim.python.motion_matching; from src.shared.python.motion_matching.provider_registry import available_engines; print(sorted(available_engines()))"` includes `opensim`

Generated with [Claude Code](https://claude.com/claude-code)