### PR TITLE
fix(motion-matching): idempotent provider registration (#4712)

### DIFF
--- a/src/shared/python/motion_matching/provider.py
+++ b/src/shared/python/motion_matching/provider.py
@@ -23,6 +23,7 @@ Public API:
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -120,14 +121,31 @@ class FitSwingProvider(Protocol):
 
 _REGISTRY: dict[str, FitSwingProvider] = {}
 _REGISTRY_LOCK = threading.Lock()
+_logger = logging.getLogger(__name__)
+
+
+def _provider_qualname(provider: object) -> str:
+    """Return the fully-qualified ``module.qualname`` for a provider class.
+
+    Used to detect re-registrations that originate from the *same* logical
+    provider class even after :func:`importlib.reload` has rebuilt the
+    class object (and thus broken ``type(a) is type(b)`` identity).
+    """
+    cls = type(provider)
+    module = getattr(cls, "__module__", "") or ""
+    qualname = getattr(cls, "__qualname__", cls.__name__)
+    return f"{module}.{qualname}" if module else qualname
 
 
 def register_provider(provider: FitSwingProvider) -> None:
     """Register ``provider`` under its ``engine_name``.
 
-    Idempotent for identical re-registrations (same instance / same class
-    + same engine_name); raises :class:`ValueError` when a *different*
-    provider tries to claim an already-occupied slot.
+    Registration is idempotent: re-registering the same provider instance,
+    or any instance of the same provider class (matched by fully-qualified
+    ``module.qualname`` so :func:`importlib.reload` shadows still count),
+    is a no-op and emits a DEBUG log. Registering a *different* provider
+    class for an already-occupied ``engine_name`` raises :class:`ValueError`
+    naming both the existing and the incoming class.
     """
     name = getattr(provider, "engine_name", None)
     if not isinstance(name, str) or not name:
@@ -137,14 +155,29 @@ def register_provider(provider: FitSwingProvider) -> None:
     with _REGISTRY_LOCK:
         existing = _REGISTRY.get(name)
         if existing is provider:
+            _logger.debug(
+                "register_provider: %r already registered (same instance); no-op",
+                name,
+            )
             return
-        if existing is not None and type(existing) is type(provider):
-            # Re-import shadow: keep the first registered instance.
+        if existing is not None and (
+            type(existing) is type(provider)
+            or _provider_qualname(existing) == _provider_qualname(provider)
+        ):
+            # Same logical class — covers both ordinary re-imports and
+            # ``importlib.reload`` shadows (which rebuild the class object,
+            # so plain ``type`` identity is not enough).
+            _logger.debug(
+                "register_provider: %r already registered to %s; no-op",
+                name,
+                _provider_qualname(existing),
+            )
             return
         if existing is not None:
             raise ValueError(
                 f"engine_name {name!r} is already registered to "
-                f"{type(existing).__name__}; got {type(provider).__name__}"
+                f"{_provider_qualname(existing)}; got "
+                f"{_provider_qualname(provider)}"
             )
         _REGISTRY[name] = provider
 

--- a/src/shared/python/motion_matching/provider_registry.py
+++ b/src/shared/python/motion_matching/provider_registry.py
@@ -15,6 +15,7 @@ Public API:
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import Any
 
@@ -28,6 +29,20 @@ __all__ = [
 
 _REGISTRY: dict[str, Any] = {}
 _LOCK = threading.Lock()
+_logger = logging.getLogger(__name__)
+
+
+def _provider_qualname(provider: object) -> str:
+    """Return the fully-qualified ``module.qualname`` for ``provider``'s class.
+
+    Used to detect re-registrations that originate from the same logical
+    class even after :func:`importlib.reload` has rebuilt it (and thus
+    broken ``type(a) is type(b)`` identity).
+    """
+    cls = type(provider)
+    module = getattr(cls, "__module__", "") or ""
+    qualname = getattr(cls, "__qualname__", cls.__name__)
+    return f"{module}.{qualname}" if module else qualname
 
 
 def register_provider(provider: Any) -> None:
@@ -42,14 +57,17 @@ def register_provider(provider: Any) -> None:
 
     Behaviour:
         Registration is idempotent: re-registering the *same* provider
-        instance under the same ``engine_name`` is a no-op. Registering
-        a *different* provider under a name already in the registry
-        replaces the existing entry (last-writer-wins) so test fixtures
-        and reload cycles do the obvious thing.
+        instance, or any instance of the *same* provider class (matched
+        by fully-qualified ``module.qualname`` so :func:`importlib.reload`
+        shadows count), is a no-op and emits a DEBUG log. Registering a
+        *different* provider class for an already-occupied ``engine_name``
+        raises :class:`ValueError` naming both classes.
 
     Raises:
         TypeError: If ``provider`` lacks an ``engine_name`` string or a
             callable ``fit_swing`` attribute.
+        ValueError: If a *different* provider class tries to register
+            under an ``engine_name`` already taken.
     """
     name = getattr(provider, "engine_name", None)
     if not isinstance(name, str) or not name:
@@ -61,6 +79,29 @@ def register_provider(provider: Any) -> None:
             f"provider for engine '{name}' must expose a callable 'fit_swing'"
         )
     with _LOCK:
+        existing = _REGISTRY.get(name)
+        if existing is provider:
+            _logger.debug(
+                "register_provider: %r already registered (same instance); no-op",
+                name,
+            )
+            return
+        if existing is not None and (
+            type(existing) is type(provider)
+            or _provider_qualname(existing) == _provider_qualname(provider)
+        ):
+            _logger.debug(
+                "register_provider: %r already registered to %s; no-op",
+                name,
+                _provider_qualname(existing),
+            )
+            return
+        if existing is not None:
+            raise ValueError(
+                f"engine_name {name!r} is already registered to "
+                f"{_provider_qualname(existing)}; got "
+                f"{_provider_qualname(provider)}"
+            )
         _REGISTRY[name] = provider
 
 

--- a/tests/unit/motion_matching/mujoco/test_reimport_idempotent.py
+++ b/tests/unit/motion_matching/mujoco/test_reimport_idempotent.py
@@ -1,0 +1,39 @@
+"""Pin: re-importing the MuJoCo motion-matching package must be a no-op.
+
+Regression for issue #4712: importing the package twice (e.g. once via
+the package, once via ``provider.py``) raised
+``ValueError: engine_name 'mujoco' is already registered`` because
+``importlib.reload`` rebuilt the provider class, defeating the
+``type(existing) is type(provider)`` shortcut in ``register_provider``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_double_import_does_not_raise() -> None:
+    """Importing the MuJoCo motion-matching package twice is a no-op."""
+    pytest.importorskip("mujoco")
+    import src.engines.physics_engines.mujoco.python.motion_matching as m
+
+    importlib.reload(m)
+    importlib.reload(m)
+
+
+def test_provider_module_reload_does_not_raise() -> None:
+    """Pin: reloading ``provider.py`` directly is also a no-op.
+
+    The historical failure mode (#4712) reloaded ``provider.py`` itself,
+    which rebuilt :class:`MujocoFitSwingProvider` as a *new* class object
+    so the ``type(existing) is type(provider)`` shortcut in
+    ``register_provider`` was bypassed.
+    """
+    pytest.importorskip("mujoco")
+    import src.engines.physics_engines.mujoco.python.motion_matching  # noqa: F401
+    import src.engines.physics_engines.mujoco.python.motion_matching.provider as p
+
+    importlib.reload(p)
+    importlib.reload(p)

--- a/tests/unit/motion_matching/test_provider_registry_coverage.py
+++ b/tests/unit/motion_matching/test_provider_registry_coverage.py
@@ -37,13 +37,48 @@ def test_register_then_lookup() -> None:
     assert "drake" in available_engines()
 
 
-def test_register_replaces_existing() -> None:
-    """Pin: re-registering with a different instance overwrites."""
+def test_register_same_class_is_noop() -> None:
+    """Pin: re-registering an instance of the same class keeps the original.
+
+    Issue #4712 made registration strictly idempotent for same-class
+    re-registrations (covers both ordinary re-imports and
+    :func:`importlib.reload` shadows). To overwrite, callers must call
+    :func:`clear_registry` first.
+    """
     a = _FakeProvider("e1")
     b = _FakeProvider("e1")
     register_provider(a)
     register_provider(b)
-    assert get_provider("e1") is b
+    assert get_provider("e1") is a
+
+
+def test_register_different_class_raises() -> None:
+    """Pin: a different provider class for the same engine_name is rejected.
+
+    Per issue #4712 the error message names both the existing and
+    incoming provider class so debugging registry collisions is obvious.
+    """
+
+    class _OtherProvider:
+        engine_name = "e1"
+
+        def fit_swing(self, target, opts):  # noqa: ARG002
+            return None
+
+    register_provider(_FakeProvider("e1"))
+    with pytest.raises(ValueError, match="already registered") as exc:
+        register_provider(_OtherProvider())
+    msg = str(exc.value)
+    assert "_FakeProvider" in msg
+    assert "_OtherProvider" in msg
+
+
+def test_register_same_instance_twice_is_noop() -> None:
+    """Pin: registering the exact same instance twice is a silent no-op."""
+    p = _FakeProvider("e1")
+    register_provider(p)
+    register_provider(p)
+    assert get_provider("e1") is p
 
 
 def test_register_requires_engine_name() -> None:


### PR DESCRIPTION
## Summary
- Make `register_provider` idempotent across `importlib.reload` cycles in both `src/shared/python/motion_matching/provider.py` and `src/shared/python/motion_matching/provider_registry.py` by comparing provider classes via fully-qualified `module.qualname` instead of `type(a) is type(b)` identity.
- A genuinely different provider class for an already-occupied `engine_name` still raises `ValueError`, and the message now names both classes for fast triage.
- Add regression test that reloads `provider.py` directly (the historical failure path from #4712) plus same-instance / different-class coverage for the protocol-agnostic registry.

Closes #4712

## Test plan
- [x] `python3 -m pytest tests/unit/motion_matching/mujoco/test_reimport_idempotent.py tests/unit/motion_matching/test_provider_registry_coverage.py tests/unit/motion_matching/mujoco/ -p no:cacheprovider --timeout=60` -> 23 passed, 1 skipped (data-dependent skip pre-existing).
- [x] `python3 -m ruff check` and `ruff format --check` on changed files -> clean.
- [x] `python3 scripts/ci/check_file_size_budget.py` -> OK.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>