### PR TITLE
feat(motion-matching): engine_version() on provider protocol (#4705)

### DIFF
--- a/src/engines/physics_engines/drake/python/motion_matching/provider.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/provider.py
@@ -103,3 +103,32 @@ class DrakeFitSwingProvider:
     def supports_ball_target(self) -> bool:
         """Ball-boundary-condition cost terms land separately (see #4488)."""
         return False
+
+    def engine_version(self) -> str:
+        """Return the installed ``pydrake`` version, or ``"unknown"``.
+
+        Stamps the resolved value into leaderboard rows so two runs
+        against different Drake wheels are distinguishable (issue
+        #4705). Falls back to :func:`importlib.metadata.version` when
+        the bindings expose no ``__version__`` attribute, and to
+        ``"unknown"`` when the wheel is not installed.
+        """
+        try:
+            import pydrake  # type: ignore[import-not-found]
+        except ImportError:
+            return "unknown"
+        version = getattr(pydrake, "__version__", None)
+        if isinstance(version, str) and version:
+            return version
+        try:
+            from importlib.metadata import PackageNotFoundError
+            from importlib.metadata import version as _v
+        except ImportError:  # pragma: no cover -- importlib.metadata is stdlib >=3.8
+            return "unknown"
+        try:
+            return _v("drake")
+        except PackageNotFoundError:
+            try:
+                return _v("pydrake")
+            except PackageNotFoundError:
+                return "unknown"

--- a/src/engines/physics_engines/mujoco/python/motion_matching/provider.py
+++ b/src/engines/physics_engines/mujoco/python/motion_matching/provider.py
@@ -93,6 +93,31 @@ class MujocoFitSwingProvider:
         """MuJoCo's swing fitter does not consume ball targets."""
         return False
 
+    def engine_version(self) -> str:
+        """Return the installed ``mujoco`` version, or ``"unknown"``.
+
+        Lets leaderboard rows distinguish runs across MuJoCo wheel
+        upgrades (issue #4705). Returns ``"unknown"`` when the
+        ``mujoco`` package is not installed so the provider stays
+        constructible in MuJoCo-less environments.
+        """
+        try:
+            import mujoco  # type: ignore[import-not-found]
+        except ImportError:
+            return "unknown"
+        version = getattr(mujoco, "__version__", None)
+        if isinstance(version, str) and version:
+            return version
+        try:
+            from importlib.metadata import PackageNotFoundError
+            from importlib.metadata import version as _v
+        except ImportError:  # pragma: no cover -- stdlib >=3.8
+            return "unknown"
+        try:
+            return _v("mujoco")
+        except PackageNotFoundError:
+            return "unknown"
+
     # --- Internal helpers ----------------------------------------------
 
     @staticmethod

--- a/src/engines/physics_engines/pinocchio/python/motion_matching/provider.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/provider.py
@@ -100,6 +100,34 @@ class PinocchioFitSwingProvider:
         """Return ``False`` -- Pinocchio MM is club-target only."""
         return False
 
+    def engine_version(self) -> str:
+        """Return the installed ``pinocchio`` version, or ``"unknown"``.
+
+        Stamped into leaderboard rows (issue #4705) so two runs against
+        different Pinocchio wheels stay distinguishable. Returns
+        ``"unknown"`` when the bindings are not installed; the provider
+        class itself imports cleanly even without them.
+        """
+        try:
+            import pinocchio  # type: ignore[import-not-found]
+        except ImportError:
+            return "unknown"
+        version = getattr(pinocchio, "__version__", None)
+        if isinstance(version, str) and version:
+            return version
+        try:
+            from importlib.metadata import PackageNotFoundError
+            from importlib.metadata import version as _v
+        except ImportError:  # pragma: no cover -- stdlib >=3.8
+            return "unknown"
+        try:
+            return _v("pin")
+        except PackageNotFoundError:
+            try:
+                return _v("pinocchio")
+            except PackageNotFoundError:
+                return "unknown"
+
 
 # --------------------------------------------------------------------------- #
 # Auto-registration

--- a/src/shared/python/motion_matching/provider.py
+++ b/src/shared/python/motion_matching/provider.py
@@ -101,6 +101,14 @@ class FitSwingProvider(Protocol):
         fit_swing(target, opts) -> CanonicalFitResult
         supports_body_target() -> bool
         supports_ball_target() -> bool
+
+    Optional methods:
+        engine_version() -> str
+            Version string of the underlying physics engine wheel
+            (e.g. ``pydrake.__version__``). Used to stamp leaderboard rows
+            so two runs against different wheels are distinguishable.
+            Defaults to ``"unknown"`` for back-compat with providers that
+            predate this hook (issue #4705).
     """
 
     engine_name: str
@@ -114,6 +122,17 @@ class FitSwingProvider(Protocol):
     def supports_body_target(self) -> bool: ...
 
     def supports_ball_target(self) -> bool: ...
+
+    def engine_version(self) -> str:
+        """Return the underlying engine's version string.
+
+        Default implementation returns ``"unknown"`` so providers
+        predating issue #4705 stay Protocol-compliant. Real providers
+        should override to query their engine's ``__version__``
+        attribute (with a ``try/except ImportError`` fallback so the
+        provider stays constructible without the engine wheel).
+        """
+        return "unknown"
 
 
 # --- Registry ---------------------------------------------------------------

--- a/tests/unit/motion_matching/test_engine_version.py
+++ b/tests/unit/motion_matching/test_engine_version.py
@@ -1,0 +1,174 @@
+"""Unit tests for the ``engine_version()`` provider hook (issue #4705).
+
+The :class:`FitSwingProvider` Protocol gained an optional
+``engine_version()`` method so that two cross-engine leaderboard rows
+produced against different engine wheels stay distinguishable. The
+default-implementation contract is:
+
+* Subclassing the Protocol without overriding the method MUST yield
+  ``"unknown"`` (back-compat for providers predating #4705).
+* Each shipped provider MUST override and return the underlying
+  engine's version string when the engine wheel is installed.
+* When the wheel is *not* installed, the provider MUST still return
+  ``"unknown"`` (rather than raising) so callers can construct the
+  provider in engine-less environments.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python.motion_matching.provider import FitSwingProvider
+
+
+def _engine_really_installed(name: str) -> bool:
+    """Return ``True`` only when ``name`` resolves to a real, non-mocked install.
+
+    The unit-test conftest pre-populates ``sys.modules`` with
+    :class:`MagicMock` shims for ``pydrake`` and ``pinocchio`` so that
+    Drake / Pinocchio test files can be collected on a CI runner that
+    does not actually have those wheels. ``pytest.importorskip`` would
+    consider those shims importable and run the test against the mock,
+    which is not what we want here -- the engine-version assertion is
+    *about* the real wheel being installed.
+    """
+    import sys
+
+    mod = sys.modules.get(name)
+    if isinstance(mod, MagicMock):
+        return False
+    if mod is not None:
+        # Real module already imported (not a mock) -- definitely installed.
+        return True
+    # Not yet imported. Probe the real loader.
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return False
+    return spec is not None
+
+
+class _StubProviderNoOverride(FitSwingProvider):
+    """Stub provider that does NOT override ``engine_version``.
+
+    Inherits the Protocol's default behaviour, which #4705 requires to
+    be ``"unknown"``.
+    """
+
+    engine_name = "stub"
+
+    def fit_swing(self, target, opts):  # pragma: no cover -- never called
+        raise NotImplementedError
+
+    def supports_body_target(self) -> bool:  # pragma: no cover -- never called
+        return False
+
+    def supports_ball_target(self) -> bool:  # pragma: no cover -- never called
+        return False
+
+
+class TestProtocolDefault:
+    """The Protocol's own default implementation returns ``"unknown"``."""
+
+    def test_protocol_default_returns_unknown(self) -> None:
+        # ``FitSwingProvider.engine_version`` is a regular function in the
+        # Protocol body, so it can be invoked as an unbound method on any
+        # object. We pass a sentinel because the default does not touch
+        # ``self`` -- this isolates "what does the default body return?"
+        # from any subclass behaviour.
+        sentinel = object()
+        assert FitSwingProvider.engine_version(sentinel) == "unknown"  # type: ignore[arg-type]
+
+    def test_subclass_without_override_returns_unknown(self) -> None:
+        """A provider that does not override the method inherits ``"unknown"``."""
+        provider = _StubProviderNoOverride()
+        assert provider.engine_version() == "unknown"
+
+
+class TestMujocoProvider:
+    """The MuJoCo provider returns a real version when ``mujoco`` is installed."""
+
+    def test_mujoco_provider_advertises_version(self) -> None:
+        if not _engine_really_installed("mujoco"):
+            pytest.skip("mujoco not installed")
+        import mujoco
+
+        from src.engines.physics_engines.mujoco.python.motion_matching import (
+            MujocoFitSwingProvider,
+        )
+
+        version = MujocoFitSwingProvider().engine_version()
+        assert isinstance(version, str)
+        assert version != "unknown"
+        # When mujoco is importable, the provider should surface the
+        # exact ``__version__`` string to keep leaderboard rows
+        # bit-reproducible across runs against the same wheel.
+        assert version == mujoco.__version__
+
+
+class TestDrakeProvider:
+    """The Drake provider returns a real version when ``pydrake`` is installed."""
+
+    def test_drake_provider_advertises_version(self) -> None:
+        if not _engine_really_installed("pydrake"):
+            pytest.skip(
+                "pydrake not installed (the unit-test conftest mock is ignored)"
+            )
+        import pydrake
+
+        from src.engines.physics_engines.drake.python.motion_matching.provider import (
+            DrakeFitSwingProvider,
+        )
+
+        version = DrakeFitSwingProvider().engine_version()
+        assert isinstance(version, str)
+        assert version != "unknown"
+        if isinstance(getattr(pydrake, "__version__", None), str):
+            assert version == pydrake.__version__
+
+    def test_drake_provider_returns_unknown_without_engine(self) -> None:
+        """Provider must stay queryable without a real Drake wheel."""
+        if _engine_really_installed("pydrake"):
+            pytest.skip("pydrake is installed; cannot test the missing-wheel path")
+        from src.engines.physics_engines.drake.python.motion_matching.provider import (
+            DrakeFitSwingProvider,
+        )
+
+        # The conftest installs a MagicMock under ``pydrake``; the provider
+        # must not be fooled by that and must still return ``"unknown"``
+        # because MagicMock's auto-attributes are not real version strings.
+        assert DrakeFitSwingProvider().engine_version() == "unknown"
+
+
+class TestPinocchioProvider:
+    """The Pinocchio provider returns a real version when installed."""
+
+    def test_pinocchio_provider_advertises_version(self) -> None:
+        if not _engine_really_installed("pinocchio"):
+            pytest.skip(
+                "pinocchio not installed (the unit-test conftest mock is ignored)"
+            )
+        import pinocchio
+
+        from src.engines.physics_engines.pinocchio.python.motion_matching.provider import (
+            PinocchioFitSwingProvider,
+        )
+
+        version = PinocchioFitSwingProvider().engine_version()
+        assert isinstance(version, str)
+        assert version != "unknown"
+        if isinstance(getattr(pinocchio, "__version__", None), str):
+            assert version == pinocchio.__version__
+
+    def test_pinocchio_provider_returns_unknown_without_engine(self) -> None:
+        """Provider must stay queryable without a real Pinocchio wheel."""
+        if _engine_really_installed("pinocchio"):
+            pytest.skip("pinocchio is installed; cannot test the missing-wheel path")
+        from src.engines.physics_engines.pinocchio.python.motion_matching.provider import (
+            PinocchioFitSwingProvider,
+        )
+
+        assert PinocchioFitSwingProvider().engine_version() == "unknown"


### PR DESCRIPTION
## Summary

Adds an optional `engine_version() -> str` method to the canonical `FitSwingProvider` Protocol so cross-engine leaderboard rows can be stamped with the underlying physics-engine wheel version. Default implementation returns `"unknown"` for back-compat with providers predating this hook.

- Protocol gains `engine_version()` with default body returning `"unknown"` (subclassing the Protocol inherits the default).
- `DrakeFitSwingProvider`, `MujocoFitSwingProvider`, `PinocchioFitSwingProvider` override to query `pydrake.__version__` / `mujoco.__version__` / `pinocchio.__version__`, with `importlib.metadata.version(...)` fallbacks and `try/except ImportError` so the providers stay constructible in engine-less environments.
- `CanonicalFitResult` already carried an `engine_version` field (no change needed there).

## Per-engine versions observed locally

| Engine | Reported `engine_version()` |
|--------|-----------------------------|
| MuJoCo | `3.8.0` (matches `mujoco.__version__`) |
| Drake | `unknown` (`pydrake` not installed in this dev env) |
| Pinocchio | `unknown` (`pinocchio` not installed in this dev env) |
| OpenSim | n/a (no `OpenSimFitSwingProvider` ships in `src/` yet; out of scope) |

## Test plan

- [x] `python3 -m pytest tests/unit/motion_matching/test_engine_version.py` -- 5 passed, 2 skipped (skips for `pydrake` / `pinocchio` not being installed; the conftest mock is detected and ignored).
- [x] `python3 -m pytest tests/unit/motion_matching/{mujoco,pinocchio,drake}` -- all pass except one pre-existing Drake test that requires a real `pydrake` wheel (also fails on `main`, unrelated to this change).
- [x] `python3 -m ruff check` / `ruff format --check` -- clean on all touched files.
- [x] `python3 scripts/ci/check_file_size_budget.py` -- OK.

Closes #4705

🤖 Generated with [Claude Code](https://claude.com/claude-code)