### PR TITLE
feat(myosuite): Mark MyoSuite as fit_swing-incapable with documentation

### DIFF
--- a/src/engines/physics_engines/myosuite/README.md
+++ b/src/engines/physics_engines/myosuite/README.md
@@ -243,6 +243,28 @@ MyoSuite models **require MuJoCo** and are not compatible with Drake or Pinocchi
 - Use MuJoCo for muscle-level biomechanics
 - Use Drake/Pinocchio for rigid-body dynamics only
 
+### Why no fit_swing?
+
+MyoSuite does **not** implement the `fit_swing` motion-matching interface. This is a deliberate design decision based on the fundamental differences between muscle-driven and joint-space control:
+
+**Technical Reasons:**
+
+1. **Control Paradigm**: MyoSuite uses muscle activations as inputs, not joint positions/velocities. The fit_swing interface assumes direct joint-space control.
+
+2. **Optimization Problem**: Motion matching in joint space optimizes joint trajectories directly. In MyoSuite, the optimization must solve for muscle activations that produce desired motions—a fundamentally different and more complex problem.
+
+3. **Physiological Constraints**: Muscle force generation depends on force-length-velocity relationships, activation dynamics, and recruitment patterns that don't map cleanly to joint-space tracking objectives.
+
+**Recommended Workflow:**
+
+For biomechanical analysis requiring motion matching:
+
+1. Use **MuJoCo's fit_swing** to optimize joint trajectories from motion capture data
+2. Apply the resulting motion to **MyoSuite** for muscle-level analysis
+3. Use **induced acceleration analysis** to understand individual muscle contributions to the motion
+
+This separation of concerns allows each engine to excel at its intended purpose: MuJoCo for trajectory optimization, MyoSuite for muscle dynamics.
+
 ### Model Complexity
 
 Full body model (290 muscles) requires:

--- a/src/engines/physics_engines/myosuite/_tier.py
+++ b/src/engines/physics_engines/myosuite/_tier.py
@@ -1,3 +1,21 @@
 """Tier metadata for the MyoSuite engine package."""
 
 TIER = "experimental"
+
+# MyoSuite is a musculoskeletal simulation framework focused on muscle dynamics.
+# It does not implement the fit_swing motion-matching interface because:
+# 1. MyoSuite uses muscle-driven control (activations) rather than joint-space tracking
+# 2. The optimization problem differs fundamentally from rigid-body IK/matching
+# 3. Users should use MuJoCo's fit_swing for trajectory optimization, then
+#    apply resulting motions to MyoSuite for muscle analysis
+FIT_INCAPABLE = True
+FIT_INCAPABLE_REASON = """
+MyoSuite is designed for muscle-driven forward dynamics simulation, not joint-space
+motion matching. The fit_swing interface assumes direct joint control, whereas MyoSuite
+requires muscle activation patterns to produce motion.
+
+For motion matching workflows:
+1. Use MuJoCo's fit_swing to optimize joint trajectories
+2. Apply the resulting motion to MyoSuite for muscle analysis
+3. Use induced acceleration analysis to understand muscle contributions
+"""


### PR DESCRIPTION
## Summary

This PR addresses issue #4716 by explicitly marking MyoSuite as fit_swing-incapable and documenting why.

## Changes

### src/engines/physics_engines/myosuite/_tier.py
- Added `FIT_INCAPABLE = True` flag
- Added `FIT_INCAPABLE_REASON` with detailed explanation

### src/engines/physics_engines/myosuite/README.md
- Added "Why no fit_swing?" section explaining:
  - Control paradigm differences (muscle activations vs joint control)
  - Optimization problem complexity differences
  - Physiological constraints
  - Recommended workflow for users

## Rationale

MyoSuite is designed for muscle-driven forward dynamics simulation, not joint-space motion matching. The fit_swing interface assumes direct joint control, whereas MyoSuite requires muscle activation patterns to produce motion.

## Recommended Workflow

For biomechanical analysis requiring motion matching:
1. Use MuJoCo's fit_swing to optimize joint trajectories
2. Apply resulting motion to MyoSuite for muscle analysis
3. Use induced acceleration analysis to understand muscle contributions

Fixes #4716