### PR TITLE
[Mocap Pipeline fix] FastAPI registration + CLI shim + typed c3d errors (#4722, #4721, #4723)

### DIFF
--- a/docs/motion_pipeline/README.md
+++ b/docs/motion_pipeline/README.md
@@ -2,91 +2,87 @@
 
 > Part of epic #4558. Make the new pipeline immediately usable by anyone joining the project.
 
-## From Video to Tracked Golf Swing in 5 Commands
+## From a mocap file to a tracked motion in one command
 
-This guide walks you through processing a golf swing video into a fully tracked motion using the UpstreamDrift motion pipeline.
+This guide walks you through running the UpstreamDrift motion pipeline on
+an existing mocap source file (C3D, TRC, BVH, CSV, or one of the JSON
+keypoint formats).
 
-### Step 1: Extract Frames from Video
+> **Note** Earlier drafts of this guide advertised five separate
+> commands (`extract_frames`, `pose_estimation`, `lift_3d`, `retarget`,
+> `inverse_kinematics`). Those modules were never shipped. The pipeline
+> ships as a single composed entry point that runs adapter ->
+> preprocessing -> scaling -> IK -> motion-matching for the input file.
+> See issue #4723 for the history.
 
-```bash
-python3 -m src.shared.python.motion_pipeline.extract_frames \
-    --input swing_video.mp4 \
-    --output frames/ \
-    --fps 60
-```
-
-### Step 2: Run Pose Estimation (OpenPose or MediaPipe)
-
-```bash
-# Option A: OpenPose (higher accuracy, requires GPU)
-python3 -m src.shared.python.motion_pipeline.pose_estimation \
-    --input frames/ \
-    --output pose_2d.json \
-    --engine openpose
-
-# Option B: MediaPipe (CPU-friendly, faster)
-python3 -m src.shared.python.motion_pipeline.pose_estimation \
-    --input frames/ \
-    --output pose_2d.json \
-    --engine mediapipe
-```
-
-### Step 3: Lift 2D to 3D (Optional — Use Existing Mocap)
+### Quickstart
 
 ```bash
-python3 -m src.shared.python.motion_pipeline.lift_3d \
-    --input pose_2d.json \
-    --output motion_3d.json \
-    --method triangulation  # or 'learned' for ML-based lifting
+python3 -m src.shared.python.motion_pipeline run \
+    path/to/capture.c3d \
+    --engine mujoco \
+    --output result.json
 ```
 
-### Step 4: Retarget to Humanoid Model
+Common flags:
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--engine {mujoco,drake,pinocchio,opensim}` | IK and motion-matching backend. |
+| `--source-format c3d` | Override the adapter format. Auto-detected from extension when omitted. |
+| `--output result.json` | Write the JSON result here. Defaults to stdout. |
+| `--verbose` / `-v` | Enable INFO-level logging. |
+
+The CLI is a thin shim over `MotionPipeline.run()` in
+`src/shared/python/motion_pipeline/orchestrator.py`. For programmatic
+use, prefer importing the orchestrator directly:
+
+```python
+from pathlib import Path
+from src.shared.python.motion_pipeline.orchestrator import (
+    AdapterOverride,
+    MotionPipeline,
+    PipelineConfig,
+)
+
+config = PipelineConfig(
+    adapter=AdapterOverride(format="c3d"),
+    ik_backend="mujoco",
+    matching_backend="mujoco",
+)
+result = MotionPipeline(config).run(Path("capture.c3d"))
+```
+
+### HTTP API
+
+A FastAPI surface is also available for service deployments:
 
 ```bash
-python3 -m src.shared.python.motion_pipeline.retarget \
-    --input motion_3d.json \
-    --output retargeted_motion.json \
-    --model preset:golfer_standard
+uvicorn src.shared.python.motion_pipeline.api:app --host 0.0.0.0 --port 8000
 ```
 
-### Step 5: Run Inverse Kinematics and Export
-
-```bash
-python3 -m src.shared.python.motion_pipeline.inverse_kinematics \
-    --input retargeted_motion.json \
-    --output final_motion.mocap \
-    --engine mujoco  # or drake, pinocchio
-```
+| Endpoint | Method | Notes |
+| -------- | ------ | ----- |
+| `/health` | GET | Returns `{"status": "healthy"}`. |
+| `/api/v1/motion-pipeline/run` | POST | Multipart upload + form fields (`source_format`, `ik_backend`, `matching_backend`). |
+| `/api/v1/motion-pipeline/run-config` | POST | JSON body matching `PipelineRequest`. |
 
 ---
 
 ## Worked Example for Each Engine
 
-### MuJoCo Pipeline
-
 ```bash
-# Complete MuJoCo workflow
-python3 scripts/motion_pipeline/run_mujoco_pipeline.py \
-    --video swing_video.mp4 \
-    --output mujoco_output/
-```
+# MuJoCo (default — best for contact-rich dynamics)
+python3 -m src.shared.python.motion_pipeline run capture.c3d --engine mujoco --output mujoco_result.json
 
-### Drake Trajectory Optimization
+# Drake (trajectory optimization)
+python3 -m src.shared.python.motion_pipeline run capture.c3d --engine drake --output drake_result.json
 
-```bash
-# Drake trajopt workflow
-python3 scripts/motion_pipeline/run_drake_pipeline.py \
-    --input motion_3d.json \
-    --output drake_trajopt/
-```
+# Pinocchio (fast IK)
+python3 -m src.shared.python.motion_pipeline run capture.c3d --engine pinocchio --output pino_result.json
 
-### Pinocchio Inverse Kinematics
-
-```bash
-# Pinocchio IK workflow
-python3 scripts/motion_pipeline/run_pinocchio_pipeline.py \
-    --input motion_3d.json \
-    --output pinocchio_ik/
+# OpenSim (biomechanics validation)
+python3 -m src.shared.python.motion_pipeline run capture.c3d --engine opensim --output osim_result.json
 ```
 
 ---

--- a/src/shared/python/motion_pipeline/__main__.py
+++ b/src/shared/python/motion_pipeline/__main__.py
@@ -1,0 +1,133 @@
+"""Command-line entry point for the motion-capture pipeline.
+
+Run ``python -m src.shared.python.motion_pipeline --help`` to see the
+available subcommands. The entry point is intentionally minimal: it
+dispatches into :class:`MotionPipeline` from :mod:`orchestrator` and
+serialises the resulting :class:`MotionMatchingResult` to JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from collections.abc import Sequence
+
+from .orchestrator import AdapterOverride, MotionPipeline, PipelineConfig
+
+logger = logging.getLogger("motion_pipeline.cli")
+
+_KNOWN_ENGINES = ("mujoco", "drake", "pinocchio", "opensim")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m src.shared.python.motion_pipeline",
+        description=(
+            "Motion-capture pipeline CLI. Runs adapter -> preprocessing -> "
+            "scaling -> IK -> motion-matching for a single input file."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser(
+        "run",
+        help="Run the full pipeline on an input file.",
+        description=(
+            "Run the full motion pipeline on INPUT and write a JSON result "
+            "to --output. Replaces the (never-shipped) extract_frames / "
+            "pose_estimation / lift_3d / retarget / inverse_kinematics "
+            "module-style commands once advertised in the README."
+        ),
+    )
+    run_p.add_argument("input", type=Path, help="Path to a mocap source file.")
+    run_p.add_argument(
+        "--engine",
+        choices=_KNOWN_ENGINES,
+        default="mujoco",
+        help="IK and motion-matching backend (default: mujoco).",
+    )
+    run_p.add_argument(
+        "--source-format",
+        default=None,
+        help="Adapter format hint (c3d, trc, bvh, csv, json...). "
+        "Auto-detected from extension when omitted.",
+    )
+    run_p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the JSON result here. Defaults to stdout.",
+    )
+    run_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable INFO-level logging.",
+    )
+    return parser
+
+
+def _infer_format(path: Path, override: str | None) -> str:
+    if override:
+        return override
+    suffix = path.suffix.lower().lstrip(".")
+    return suffix or "auto"
+
+
+def _run(args: argparse.Namespace) -> int:
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    src: Path = args.input
+    if not src.exists():
+        sys.stderr.write(f"error: input file does not exist: {src}\n")
+        return 2
+    if args.engine not in _KNOWN_ENGINES:
+        # argparse already enforces this, defensive check kept for clarity.
+        sys.stderr.write(f"error: unknown engine: {args.engine}\n")
+        return 2
+
+    fmt = _infer_format(src, args.source_format)
+    config = PipelineConfig(
+        adapter=AdapterOverride(format=fmt),
+        ik_backend=args.engine,
+        matching_backend=args.engine,
+    )
+    pipeline = MotionPipeline(config)
+    try:
+        result = pipeline.run(src)
+    except (RuntimeError, ValueError) as e:
+        sys.stderr.write(f"error: pipeline failed: {e}\n")
+        return 1
+
+    payload = {
+        "success": getattr(result, "success", True),
+        "request_id": getattr(result, "request_id", None),
+        "result": result.model_dump() if hasattr(result, "model_dump") else None,
+        "audit_log": pipeline.get_audit_log()
+        if hasattr(pipeline, "get_audit_log")
+        else [],
+    }
+    text = json.dumps(payload, indent=2, default=str)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text + "\n")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "run":
+        return _run(args)
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/shared/python/motion_pipeline/api.py
+++ b/src/shared/python/motion_pipeline/api.py
@@ -4,24 +4,27 @@ FastAPI API endpoint for MotionPipeline.
 Part of issue #4569. Provides REST API for motion capture pipeline.
 
 Usage:
-    from motion_pipeline.api import create_app
-    
+    from src.shared.python.motion_pipeline.api import app
+    # or
+    from src.shared.python.motion_pipeline.api import create_app
     app = create_app()
-    # Run with: uvicorn motion_pipeline.api:app --host 0.0.0.0 --port 8000
+
+    # Run with: uvicorn src.shared.python.motion_pipeline.api:app --host 0.0.0.0 --port 8000
 """
 
 from __future__ import annotations
 
 import logging
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, File, HTTPException, UploadFile, status
-from pydantic import BaseModel, Field
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel, ConfigDict, Field
 
 from .contracts import MotionMatchingResult
-from .orchestrator import MotionPipeline, PipelineConfig, AdapterOverride
+from .orchestrator import AdapterOverride, MotionPipeline, PipelineConfig, Stage
 
 logger = logging.getLogger(__name__)
 
@@ -32,100 +35,89 @@ logger = logging.getLogger(__name__)
 
 
 class PipelineRequest(BaseModel):
+    """Pydantic-validated request model for motion pipeline API.
+
+    Matches the PipelineConfig from orchestrator with additional file
+    handling fields. Used as the JSON body for the ``/run`` endpoint.
     """
-    Pydantic-validated request model for motion pipeline API.
-    
-    Matches the PipelineConfig from orchestrator with additional file handling.
-    """
-    
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     # Adapter configuration
     source_format: str = Field(
-        ...,
-        description="Source format (c3d, trc, bvh, json, mat, fbx)"
+        ..., description="Source format (c3d, trc, bvh, json, mat, fbx)"
     )
     adapter_options: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Format-specific adapter options"
+        default_factory=dict, description="Format-specific adapter options"
     )
-    
+
     # Preprocessing steps
     preprocessing: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description="Ordered list of preprocessing steps"
+        default_factory=list, description="Ordered list of preprocessing steps"
     )
-    
+
     # Scaling configuration
     scaling: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Scaling marker map and options"
+        default_factory=dict, description="Scaling marker map and options"
     )
-    
+
     # Backend selection
     ik_backend: str = Field(
-        default="mujoco",
-        description="IK backend (mujoco, drake, pinocchio, opensim)"
+        default="mujoco", description="IK backend (mujoco, drake, pinocchio, opensim)"
     )
     matching_backend: str = Field(
-        default="mujoco",
-        description="Motion matching backend"
+        default="mujoco", description="Motion matching backend"
     )
-    
+
     # Cost weights
     cost_weights: dict[str, float] = Field(
-        default_factory=dict,
-        description="Cost function weights"
+        default_factory=dict, description="Cost function weights"
     )
-    
-    class Config:
-        """Pydantic config."""
-        arbitrary_types_allowed = True
-    
+
     def to_pipeline_config(self) -> PipelineConfig:
-        """Convert to PipelineConfig for orchestrator."""
+        """Convert this API request to an orchestrator PipelineConfig."""
         return PipelineConfig(
             adapter=AdapterOverride(
-                format=self.source_format,
-                options=self.adapter_options
+                format=self.source_format, options=self.adapter_options
             ),
             preprocessing=[
-                {"name": step.get("name", ""), "enabled": step.get("enabled", True), "params": step.get("params", {})}
+                {
+                    "name": step.get("name", ""),
+                    "enabled": step.get("enabled", True),
+                    "params": step.get("params", {}),
+                }
                 for step in self.preprocessing
             ],
             scaling=self.scaling,
             ik_backend=self.ik_backend,
             matching_backend=self.matching_backend,
-            cost_weights=self.cost_weights
+            cost_weights=self.cost_weights,
         )
 
 
 class PipelineResponse(BaseModel):
-    """
-    Response model for motion pipeline API.
-    
+    """Response model for motion pipeline API.
+
     Wraps MotionMatchingResult with additional metadata.
     """
-    
+
     request_id: str = Field(..., description="Associated request identifier")
     success: bool = Field(..., description="Whether processing succeeded")
     result: dict[str, Any] | None = Field(
-        default=None,
-        description="Matched trajectory and metrics (if success)"
+        default=None, description="Matched trajectory and metrics (if success)"
     )
-    error: str | None = Field(
-        default=None,
-        description="Error message (if failed)"
-    )
+    error: str | None = Field(default=None, description="Error message (if failed)")
     audit_log: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description="Per-stage audit log for provenance"
+        default_factory=list, description="Per-stage audit log for provenance"
     )
     metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional metadata"
+        default_factory=dict, description="Additional metadata"
     )
-    
+
     @classmethod
-    def from_result(cls, result: MotionMatchingResult, audit_log: list[dict[str, Any]]) -> PipelineResponse:
+    def from_result(
+        cls, result: MotionMatchingResult, audit_log: list[dict[str, Any]]
+    ) -> PipelineResponse:
         """Create response from MotionMatchingResult."""
         return cls(
             request_id=result.request_id,
@@ -133,18 +125,52 @@ class PipelineResponse(BaseModel):
             result=result.model_dump() if result.success else None,
             error=result.message if not result.success else None,
             audit_log=audit_log,
-            metadata=result.metadata
+            metadata=result.metadata,
         )
-    
+
     @classmethod
     def from_error(cls, request_id: str, error: str) -> PipelineResponse:
         """Create error response."""
-        return cls(
-            request_id=request_id,
-            success=False,
-            error=error,
-            audit_log=[]
-        )
+        return cls(request_id=request_id, success=False, error=error, audit_log=[])
+
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+
+def _save_upload_to_temp(file: UploadFile, content: bytes) -> Path:
+    """Persist an uploaded file to a temp path and return it."""
+    suffix = Path(file.filename).suffix if file.filename else ".tmp"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(content)
+        return Path(tmp.name)
+
+
+def _run_pipeline_sync(
+    config: PipelineConfig, tmp_path: Path, request_id: str
+) -> PipelineResponse:
+    """Run the orchestrator and convert exceptions into a typed response."""
+    pipeline = MotionPipeline(config)
+
+    def log_hook(payload: Any) -> None:
+        logger.info("Request %s: stage %s completed", request_id, payload.stage.value)
+
+    for stage in Stage:
+        pipeline.add_hook(stage, log_hook)
+
+    try:
+        result = pipeline.run(tmp_path)
+        audit_log = pipeline.get_audit_log()
+        return PipelineResponse.from_result(result, audit_log)
+    except RuntimeError as e:
+        logger.error("Request %s: pipeline error: %s", request_id, e)
+        return PipelineResponse.from_error(request_id, str(e))
+    except Exception as e:  # noqa: BLE001 - API boundary, all errors must surface as JSON
+        logger.exception("Request %s: unexpected error", request_id)
+        return PipelineResponse.from_error(request_id, f"Internal error: {e}")
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 # =============================================================================
@@ -153,35 +179,29 @@ class PipelineResponse(BaseModel):
 
 
 def create_app() -> FastAPI:
-    """
-    Create FastAPI application with motion pipeline endpoints.
-    
-    Returns:
-        FastAPI application
-    """
+    """Create FastAPI application with motion pipeline endpoints."""
     app = FastAPI(
         title="Motion Capture Pipeline API",
         description="REST API for motion capture processing",
-        version="1.0.0"
+        version="1.0.0",
     )
-    
+
     @app.get("/health")
     async def health_check() -> dict[str, str]:
         """Health check endpoint."""
         return {"status": "healthy"}
-    
+
     @app.post(
         "/api/v1/motion-pipeline/run",
         response_model=PipelineResponse,
         status_code=status.HTTP_200_OK,
-        summary="Run motion pipeline",
-        description="""
-Process motion capture data through the full pipeline:
-adapter → preprocessing → scaling → IK → motion-matching
-
-Accepts file uploads in supported formats (C3D, TRC, BVH, JSON, MAT, FBX).
-Returns MotionMatchingResult with matched trajectory and error metrics.
-        """,
+        summary="Run motion pipeline (multipart form)",
+        description=(
+            "Process motion capture data through the full pipeline:\n"
+            "adapter -> preprocessing -> scaling -> IK -> motion-matching.\n\n"
+            "Multipart form upload. For full configuration control, use "
+            "``/api/v1/motion-pipeline/run-config`` with a JSON body."
+        ),
         responses={
             200: {"description": "Processing completed", "model": PipelineResponse},
             400: {"description": "Invalid input or configuration"},
@@ -191,136 +211,73 @@ Returns MotionMatchingResult with matched trajectory and error metrics.
     )
     async def run_pipeline(
         file: UploadFile = File(..., description="Motion capture file"),
-        source_format: str = Field(..., description="Source format"),
-        ik_backend: str = Field(default="mujoco", description="IK backend"),
-        matching_backend: str = Field(default="mujoco", description="Matching backend"),
+        source_format: str = Form(
+            ..., description="Source format (c3d, trc, bvh, ...)"
+        ),
+        ik_backend: str = Form("mujoco", description="IK backend"),
+        matching_backend: str = Form("mujoco", description="Matching backend"),
     ) -> PipelineResponse:
-        """
-        Run motion pipeline on uploaded file.
-        
-        Args:
-            file: Uploaded motion capture file
-            source_format: Format of the source file
-            ik_backend: IK backend to use
-            matching_backend: Motion matching backend to use
-        
-        Returns:
-            PipelineResponse with results or error
-        """
-        import uuid
-        
+        """Run motion pipeline on an uploaded file using form fields."""
         request_id = f"req-{uuid.uuid4().hex[:12]}"
-        logger.info(f"Received pipeline request {request_id} for {file.filename}")
-        
-        # Validate file
+        logger.info("Received pipeline request %s for %s", request_id, file.filename)
+
         if not file.filename:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No filename provided"
+                detail="No filename provided",
             )
-        
-        # Save uploaded file temporarily
-        try:
-            with tempfile.NamedTemporaryFile(
-                delete=False,
-                suffix=Path(file.filename).suffix
-            ) as tmp:
-                content = await file.read()
-                tmp.write(content)
-                tmp_path = Path(tmp.name)
-            
-            # Configure pipeline
-            config = PipelineConfig(
-                adapter=AdapterOverride(format=source_format),
-                ik_backend=ik_backend,
-                matching_backend=matching_backend,
-            )
-            
-            # Create and run pipeline
-            pipeline = MotionPipeline(config)
-            
-            # Add logging hook
-            def log_hook(payload) -> None:
-                logger.info(f"Request {request_id}: Stage {payload.stage.value} completed")
-            
-            from .orchestrator import Stage
-            for stage in Stage:
-                pipeline.add_hook(stage, log_hook)
-            
-            # Run pipeline
-            result = pipeline.run(tmp_path)
-            audit_log = pipeline.get_audit_log()
-            
-            # Clean up temp file
-            tmp_path.unlink(missing_ok=True)
-            
-            logger.info(f"Request {request_id}: Pipeline completed success={result.success}")
-            
-            return PipelineResponse.from_result(result, audit_log)
-            
-        except RuntimeError as e:
-            logger.error(f"Request {request_id}: Pipeline error: {e}")
-            return PipelineResponse.from_error(request_id, str(e))
-        except Exception as e:
-            logger.exception(f"Request {request_id}: Unexpected error: {e}")
-            return PipelineResponse.from_error(request_id, f"Internal error: {e}")
-    
+
+        content = await file.read()
+        tmp_path = _save_upload_to_temp(file, content)
+
+        config = PipelineConfig(
+            adapter=AdapterOverride(format=source_format),
+            ik_backend=ik_backend,
+            matching_backend=matching_backend,
+        )
+        return _run_pipeline_sync(config, tmp_path, request_id)
+
     @app.post(
         "/api/v1/motion-pipeline/run-config",
         response_model=PipelineResponse,
         status_code=status.HTTP_200_OK,
-        summary="Run motion pipeline with full config",
-        description="""
-Run motion pipeline with full configuration control.
-Accepts JSON config body plus file upload.
-        """,
+        summary="Run motion pipeline with full JSON config",
+        description=(
+            "Run motion pipeline with full configuration control. "
+            "Accepts a JSON body matching ``PipelineRequest``."
+        ),
     )
     async def run_pipeline_with_config(
-        file: UploadFile = File(..., description="Motion capture file"),
-        config: PipelineRequest = Field(..., description="Pipeline configuration"),
+        request: PipelineRequest,
     ) -> PipelineResponse:
+        """Run motion pipeline with a full JSON config body.
+
+        For uploads, use ``/api/v1/motion-pipeline/run`` (multipart).
+        This endpoint expects the source file to be referenced via
+        ``adapter_options['path']``.
         """
-        Run motion pipeline with full configuration.
-        
-        Args:
-            file: Uploaded motion capture file
-            config: Pipeline configuration
-        
-        Returns:
-            PipelineResponse with results or error
-        """
-        import uuid
-        
         request_id = f"req-{uuid.uuid4().hex[:12]}"
-        logger.info(f"Received pipeline request {request_id} with config")
-        
-        try:
-            # Save uploaded file temporarily
-            with tempfile.NamedTemporaryFile(
-                delete=False,
-                suffix=Path(file.filename).suffix if file.filename else ".tmp"
-            ) as tmp:
-                content = await file.read()
-                tmp.write(content)
-                tmp_path = Path(tmp.name)
-            
-            # Convert config and run pipeline
-            pipeline_config = config.to_pipeline_config()
-            pipeline = MotionPipeline(pipeline_config)
-            
-            result = pipeline.run(tmp_path)
-            audit_log = pipeline.get_audit_log()
-            
-            tmp_path.unlink(missing_ok=True)
-            
-            return PipelineResponse.from_result(result, audit_log)
-            
-        except RuntimeError as e:
-            return PipelineResponse.from_error(request_id, str(e))
-        except Exception as e:
-            return PipelineResponse.from_error(request_id, f"Internal error: {e}")
-    
+        logger.info("Received config-only pipeline request %s", request_id)
+
+        path_str = request.adapter_options.get("path")
+        if not path_str:
+            return PipelineResponse.from_error(
+                request_id,
+                "adapter_options.path is required for /run-config endpoint",
+            )
+        tmp_path = Path(path_str)
+        if not tmp_path.exists():
+            return PipelineResponse.from_error(
+                request_id, f"Source file does not exist: {tmp_path}"
+            )
+
+        return _run_pipeline_sync(request.to_pipeline_config(), tmp_path, request_id)
+
     return app
+
+
+# Module-level app for `uvicorn motion_pipeline.api:app` and direct imports.
+app = create_app()
 
 
 # =============================================================================
@@ -330,6 +287,5 @@ Accepts JSON config body plus file upload.
 
 if __name__ == "__main__":
     import uvicorn
-    
-    app = create_app()
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/shared/python/motion_pipeline/sources/c3d_adapter.py
+++ b/src/shared/python/motion_pipeline/sources/c3d_adapter.py
@@ -16,6 +16,7 @@ from src.shared.python.motion_pipeline.contracts import (
     MarkerTrajectory,
 )
 from src.shared.python.motion_pipeline.sources.base import (
+    AdapterContractError,
     MocapSourceAdapter,
     SourceMetadata,
 )
@@ -46,7 +47,10 @@ class C3DAdapter(MocapSourceAdapter):
     def metadata(self, path: Path) -> SourceMetadata:  # pragma: no cover
         if not _HAS_EZC3D:
             raise RuntimeError("ezc3d is not installed; cannot read C3D metadata")
-        c = _ezc3d.c3d(str(path))
+        try:
+            c = _ezc3d.c3d(str(path))
+        except (OSError, RuntimeError) as e:
+            raise AdapterContractError(f"failed to read c3d file {path!s}: {e}") from e
         params = c["parameters"]
         point = c["data"]["points"]
         fps = float(params["POINT"]["RATE"]["value"][0])
@@ -75,7 +79,14 @@ class C3DAdapter(MocapSourceAdapter):
         p = Path(path)
         if not p.exists():
             raise FileNotFoundError(f"C3D file not found: {p}")
-        c = _ezc3d.c3d(str(p))
+        if p.stat().st_size == 0:
+            raise AdapterContractError(
+                f"failed to read c3d file {p!s}: file is empty (0 bytes)"
+            )
+        try:
+            c = _ezc3d.c3d(str(p))
+        except (OSError, RuntimeError, ValueError) as e:
+            raise AdapterContractError(f"failed to read c3d file {p!s}: {e}") from e
         params = c["parameters"]
         points = c["data"]["points"]  # shape (4, N_markers, N_frames)
         labels_raw = params["POINT"]["LABELS"]["value"]
@@ -105,7 +116,9 @@ class C3DAdapter(MocapSourceAdapter):
                 MarkerFrame(timestamp=fi / fps, markers=markers, frame_index=fi)
             )
         if not frames:
-            raise ValueError(f"C3D {p} produced no frames")
+            raise AdapterContractError(
+                f"failed to read c3d file {p!s}: no frames decoded"
+            )
         return MarkerTrajectory(
             id=f"c3d-{p.stem}",
             frames=frames,

--- a/tests/unit/motion_pipeline/orchestrator/test_api_registration.py
+++ b/tests/unit/motion_pipeline/orchestrator/test_api_registration.py
@@ -1,0 +1,73 @@
+"""Regression tests for issue #4722: FastAPI registration crash.
+
+Before the fix, ``create_app()`` crashed with::
+
+    AssertionError: non-body parameters must be in path, query, header
+    or cookie: source_format
+
+These tests guard the module-level ``app`` symbol, the route surface,
+and the request/response schemas.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi.testclient")
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.shared.python.motion_pipeline import api as api_module  # noqa: E402
+
+
+def test_app_module_attr_exists() -> None:
+    """``from ...api import app`` must succeed (issue #4722)."""
+    assert hasattr(api_module, "app")
+    assert isinstance(api_module.app, FastAPI)
+
+
+def test_create_app_does_not_crash() -> None:
+    """``create_app()`` must not raise at registration time."""
+    app = api_module.create_app()
+    assert isinstance(app, FastAPI)
+
+
+def test_app_has_expected_routes() -> None:
+    paths = {getattr(r, "path", None) for r in api_module.app.routes}
+    assert "/health" in paths
+    assert "/api/v1/motion-pipeline/run" in paths
+    assert "/api/v1/motion-pipeline/run-config" in paths
+
+
+def test_health_endpoint_returns_200() -> None:
+    client = TestClient(api_module.app)
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+def test_run_endpoint_validates_request_body() -> None:
+    """Empty multipart body must produce a 422, not a crash."""
+    client = TestClient(api_module.app)
+    r = client.post("/api/v1/motion-pipeline/run")
+    assert r.status_code == 422
+
+
+def test_run_config_endpoint_validates_request_body() -> None:
+    client = TestClient(api_module.app)
+    r = client.post("/api/v1/motion-pipeline/run-config", json={})
+    assert r.status_code == 422
+
+
+def test_openapi_schema_advertises_form_fields() -> None:
+    """The /run endpoint must expose source_format as a form field."""
+    client = TestClient(api_module.app)
+    schema = client.get("/openapi.json").json()
+    run_post = schema["paths"]["/api/v1/motion-pipeline/run"]["post"]
+    body_schema = run_post["requestBody"]["content"]["multipart/form-data"]["schema"]
+    # Either inline properties or a $ref to a generated body model
+    if "$ref" in body_schema:
+        ref = body_schema["$ref"].split("/")[-1]
+        body_schema = schema["components"]["schemas"][ref]
+    props = body_schema.get("properties", {})
+    assert "file" in props
+    assert "source_format" in props

--- a/tests/unit/motion_pipeline/orchestrator/test_cli_main_module.py
+++ b/tests/unit/motion_pipeline/orchestrator/test_cli_main_module.py
@@ -1,0 +1,59 @@
+"""Regression tests for issue #4723: package CLI entry point.
+
+The README advertised ``python -m src.shared.python.motion_pipeline``
+plus five subcommand modules that were never implemented. This test
+file pins the actual contract: a single ``run`` subcommand backed by
+``__main__.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_PACKAGE = "src.shared.python.motion_pipeline"
+
+
+def _run_module(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", _PACKAGE, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_main_module_help_works() -> None:
+    """``python -m motion_pipeline --help`` must exit 0."""
+    result = _run_module("--help")
+    assert result.returncode == 0, result.stderr
+    assert "run" in result.stdout.lower()
+
+
+def test_run_subcommand_help_lists_engines() -> None:
+    result = _run_module("run", "--help")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.lower()
+    for engine in ("mujoco", "drake", "pinocchio", "opensim"):
+        assert engine in out
+
+
+def test_run_with_unknown_input_exits_nonzero(tmp_path: Path) -> None:
+    fake = tmp_path / "no_such_input.c3d"
+    result = _run_module("run", str(fake), "--engine", "mujoco")
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "not exist" in combined or "error" in combined
+
+
+def test_run_with_unknown_engine_exits_nonzero(tmp_path: Path) -> None:
+    fake = tmp_path / "input.c3d"
+    fake.write_bytes(b"")
+    result = _run_module("run", str(fake), "--engine", "nonsense_engine")
+    assert result.returncode != 0
+
+
+def test_no_subcommand_exits_nonzero() -> None:
+    result = _run_module()
+    assert result.returncode != 0

--- a/tests/unit/motion_pipeline/sources/test_c3d_typed_errors.py
+++ b/tests/unit/motion_pipeline/sources/test_c3d_typed_errors.py
@@ -1,0 +1,59 @@
+"""Regression tests for issue #4721: c3d adapter must raise typed errors.
+
+Before the fix, an empty or corrupt ``.c3d`` file leaked the underlying
+``ezc3d`` ``OSError`` instead of the canonical
+``AdapterContractError``. These tests guard the typed-error contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ezc3d = pytest.importorskip(
+    "ezc3d", reason="c3d typed-error contract requires ezc3d at runtime"
+)
+
+from src.shared.python.motion_pipeline.sources.base import (  # noqa: E402
+    AdapterContractError,
+)
+from src.shared.python.motion_pipeline.sources.c3d_adapter import (  # noqa: E402
+    C3DAdapter,
+)
+
+
+@pytest.fixture
+def adapter() -> C3DAdapter:
+    return C3DAdapter()
+
+
+def test_empty_c3d_file_raises_typed_error(tmp_path: Path, adapter: C3DAdapter) -> None:
+    p = tmp_path / "empty.c3d"
+    p.write_bytes(b"")
+    with pytest.raises(AdapterContractError, match="empty"):
+        adapter.load(p)
+
+
+def test_truncated_c3d_file_raises_typed_error(
+    tmp_path: Path, adapter: C3DAdapter
+) -> None:
+    p = tmp_path / "truncated.c3d"
+    p.write_bytes(b"\x02\x50" + b"\x00" * 14)  # 16 bytes of pseudo-header
+    with pytest.raises(AdapterContractError):
+        adapter.load(p)
+
+
+def test_non_c3d_file_raises_typed_error(tmp_path: Path, adapter: C3DAdapter) -> None:
+    p = tmp_path / "nope.c3d"
+    p.write_text("this is not a c3d file at all\n" * 4)
+    with pytest.raises(AdapterContractError):
+        adapter.load(p)
+
+
+def test_typed_error_message_mentions_path(tmp_path: Path, adapter: C3DAdapter) -> None:
+    p = tmp_path / "missing-bytes.c3d"
+    p.write_bytes(b"")
+    with pytest.raises(AdapterContractError) as excinfo:
+        adapter.load(p)
+    assert str(p) in str(excinfo.value)


### PR DESCRIPTION
## Summary

Three findings from Wave theta's adversarial review of the motion pipeline. Non-overlapping files, shipped together.

### #4722 CRITICAL — FastAPI create_app() crashed at registration

Before:
```
AssertionError: non-body parameters must be in path, query, header or cookie: source_format
  in fastapi/dependencies/utils.py:537
  while registering POST /api/v1/motion-pipeline/run
```

The route handler typed scalar params with `Field(...)` (a Pydantic model field) instead of `Form(...)` / `Body(...)`. Combined with a multipart `UploadFile`, FastAPI couldn't classify them and asserted.

Fix:
- `/run` (multipart) now declares `source_format: str = Form(...)`, plus `ik_backend` / `matching_backend` as form fields.
- `/run-config` (JSON) takes a `PipelineRequest` Pydantic body directly.
- Module-level `app = create_app()` is now exported so `from ...api import app` and `uvicorn ...api:app` both work.
- Refactored: shared `_run_pipeline_sync()` helper removes duplication between the two endpoints.

### #4721 — c3d adapter leaked raw OSError

`c3d_adapter.py` now wraps `ezc3d.c3d(...)` in a typed exception layer:
- `OSError | RuntimeError | ValueError` -> `AdapterContractError("failed to read c3d file <path>: <reason>")`.
- Empty-file shortcut: `p.stat().st_size == 0` raises `AdapterContractError` directly with an actionable message before reaching ezc3d.
- Same wrapping applied to `metadata()`.
- Trailing `ValueError("produced no frames")` upgraded to `AdapterContractError` for consistency.

### #4723 — README advertised 5 CLI modules that never existed

Before:
- `python3 -m src.shared.python.motion_pipeline.extract_frames`
- `python3 -m src.shared.python.motion_pipeline.pose_estimation`
- `python3 -m src.shared.python.motion_pipeline.lift_3d`
- `python3 -m src.shared.python.motion_pipeline.retarget`
- `python3 -m src.shared.python.motion_pipeline.inverse_kinematics`

After:
- A single `python3 -m src.shared.python.motion_pipeline run <input> --engine <name> --output <path>` backed by a real `__main__.py` shim that dispatches into `MotionPipeline.run()`.
- Engines validated via `argparse.choices` (mujoco/drake/pinocchio/opensim).
- README rewritten to document the actual surface, with an explicit note pointing back to #4723.
- HTTP API surface (`/health`, `/run`, `/run-config`) also documented now that #4722 is fixed.

## Test plan

- [x] `from src.shared.python.motion_pipeline.api import app` succeeds (was a hard crash on main).
- [x] `python -m src.shared.python.motion_pipeline --help` exits 0.
- [x] 16 new tests pass (7 API registration + 5 CLI + 4 c3d typed errors).
- [x] Existing orchestrator API/CLI tests (11) still pass.
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [x] No regression: failures in motion_pipeline test suite went from 28+4err on main to 17 on this branch; all remaining failures pre-existing (sources.loader missing, contracts NaN handling, pinocchio backends, etc).

Closes #4721
Closes #4722
Closes #4723
Refs #4558, #4569

🤖 Generated with [Claude Code](https://claude.com/claude-code)