### PR TITLE
feat(putting_green): Mark Putting Green as fit_swing-incapable

### DIFF
--- a/src/engines/physics_engines/putting_green/_tier.py
+++ b/src/engines/physics_engines/putting_green/_tier.py
@@ -1,3 +1,19 @@
 """Tier metadata for the Putting Green engine package."""
 
 TIER = "core"
+
+# Putting Green is a golf-specific simulation for putting dynamics.
+# It does not implement fit_swing because:
+# 1. Putting Green models putting stroke dynamics, not full golf swing
+# 2. The physics model is specialized for low-speed ball-green interaction
+# 3. Users should use MuJoCo's fit_swing for full swing trajectory optimization
+FIT_INCAPABLE = True
+FIT_INCAPABLE_REASON = """
+Putting Green is designed for simulating putting stroke dynamics and ball-green
+interaction, not full golf swing motion matching. The fit_swing interface is
+designed for full-body swing trajectory optimization.
+
+For putting analysis:
+- Use Putting Green's native putting stroke interface
+- For full swing analysis, use MuJoCo's fit_swing
+"""


### PR DESCRIPTION
## Summary

This PR addresses part of issue #4715 by explicitly marking Putting Green as fit_swing-incapable.

## Changes

- Added FIT_INCAPABLE = True flag to _tier.py
- Added FIT_INCAPABLE_REASON explaining why fit_swing is not implemented

## Rationale

Putting Green is specialized for putting stroke dynamics and ball-green interaction, not full golf swing motion matching.

Addresses #4715