### PR TITLE
feat(motion_capture): real freemocap sidecar with subprocess isolation

### DIFF
--- a/docs/motion_capture/freemocap_sidecar.md
+++ b/docs/motion_capture/freemocap_sidecar.md
@@ -1,0 +1,179 @@
+# FreeMoCap sidecar pipeline
+
+UpstreamDrift uses [FreeMoCap](https://freemocap.org/) for markerless 3D
+motion capture from multiple-camera video. FreeMoCap is licensed AGPL,
+so we wrap it as an **out-of-process subprocess** to keep our MIT-licensed
+codebase from importing AGPL code at runtime.
+
+## Architecture
+
+```
++--------------------+         subprocess          +-------------------+
+|  UpstreamDrift     |  -------------------------> |  FreeMoCap venv   |
+|  (MIT licensed)    |    python -m freemocap      |  (AGPL licensed)  |
+|                    |                             |                   |
+|  src/tools/        |                             |  ~/.venvs/        |
+|    freemocap_      |                             |    freemocap/     |
+|    sidecar/        |                             |    bin/python     |
++--------------------+                             +-------------------+
+        |                                                    |
+        |    landmarks.csv  +  metadata.json (file system)   |
+        |  <-------------------------------------------------|
+        v
++--------------------+
+|  motion_pipeline   |
+|  reads outputs via |
+|  stdlib only       |
++--------------------+
+```
+
+No symbol from `freemocap` is ever imported in our process. AGPL code stays
+entirely on the other side of the subprocess boundary.
+
+## Usage
+
+### From the CLI
+
+```bash
+# Dry-run (no freemocap install needed) — writes stub artifacts
+python3 -m src.tools.freemocap_sidecar.run_freemocap \
+    --input ./session_recordings \
+    --output ./landmarks_out \
+    --dry-run
+
+# Real run — points at the freemocap venv's python
+python3 -m src.tools.freemocap_sidecar.run_freemocap \
+    --input ./session_recordings \
+    --output ./landmarks_out \
+    --env-python ~/.venvs/freemocap/bin/python
+```
+
+### Programmatically
+
+```python
+from src.tools.freemocap_sidecar import run_freemocap_sidecar
+
+result = run_freemocap_sidecar(
+    input_dir="./session_recordings",
+    output_dir="./landmarks_out",
+    freemocap_env_python="~/.venvs/freemocap/bin/python",
+)
+
+if result.success:
+    print(f"Wrote landmarks to {result.landmarks_csv}")
+else:
+    print(f"FreeMoCap failed (rc={result.return_code}): {result.stderr_tail}")
+```
+
+## Output contract
+
+After a successful run the output directory contains at minimum:
+
+- **`landmarks.csv`** — frame-by-frame 3D landmark positions:
+  ```
+  frame,landmark_id,x,y,z
+  0,0,0.123,-0.045,1.677
+  0,1,...
+  ```
+
+- **`metadata.json`** — session metadata:
+  ```json
+  {
+      "freemocap_version": "1.6.0",
+      "n_frames": 1234,
+      "n_landmarks": 33,
+      "fps": 60,
+      "duration_s": 20.5
+  }
+  ```
+
+When freemocap is unavailable (no env, not installed, dry-run), the
+sidecar still writes minimum stub artifacts following the same shape so
+downstream consumers can integration-test without needing the real
+install. Stub metadata carries `"stub": true` and
+`"freemocap_version": "stub"`.
+
+## Failure modes
+
+`run_freemocap_sidecar()` returns a `FreeMoCapResult` rather than
+raising on subprocess failure. Inspect:
+
+| Field | Meaning |
+|---|---|
+| `success` | True iff subprocess exited 0 AND output files exist |
+| `used_real_freemocap` | True if real freemocap was invoked, False if stub |
+| `return_code` | subprocess exit code (-1 = timeout, 127 = interpreter missing) |
+| `stderr_tail` | last 4 KB of subprocess stderr |
+| `landmarks_csv`, `metadata_json` | absolute paths if produced, else None |
+
+Common cases:
+
+- **`success=True, used_real_freemocap=True`** — real run worked.
+- **`success=True, used_real_freemocap=False`** — dry-run or fallback;
+  stub artifacts written.
+- **`success=False, used_real_freemocap=False, return_code=127`** —
+  user passed a `freemocap_env_python` that does not exist; stub written.
+- **`success=False, return_code=-1`** — subprocess timeout.
+
+## Setting up the freemocap venv
+
+```bash
+# One-time install in an isolated environment
+python3 -m venv ~/.venvs/freemocap
+~/.venvs/freemocap/bin/pip install --upgrade pip
+~/.venvs/freemocap/bin/pip install freemocap
+
+# Then point the sidecar at this venv's python
+export FREEMOCAP_PY=~/.venvs/freemocap/bin/python
+```
+
+## Why subprocess and not just `import freemocap`?
+
+1. **License hygiene.** AGPL contamination of our MIT codebase would
+   force the rest of UpstreamDrift to be AGPL-distributed too. Keeping
+   freemocap on the other side of an OS-process boundary keeps the
+   licenses cleanly separated.
+
+2. **Dependency isolation.** FreeMoCap pulls in heavy ML stacks
+   (mediapipe, OpenCV, etc.) that conflict with versions used elsewhere
+   in UpstreamDrift. The isolated venv keeps the dependency graph
+   untangled.
+
+3. **Crash isolation.** A crash inside freemocap (it does have lengthy
+   numerical pipelines that can OOM or segfault) does not take down
+   UpstreamDrift's process.
+
+## Tests
+
+The sidecar has full unit-test coverage in
+`tests/unit/tools/freemocap_sidecar/test_run_freemocap.py`:
+
+- Dry-run path produces stub artifacts.
+- Missing interpreter → graceful 127 with stub fallback.
+- Missing freemocap module in subprocess → graceful fallback with stub.
+- Genuine subprocess failure → reported, no stub.
+- Subprocess timeout → reported.
+- Real success path with outputs → reported.
+- Real success path without outputs → reported as failure.
+- CLI entrypoint dry-run and failure paths.
+
+Run them with:
+
+```bash
+python3 -m pytest tests/unit/tools/freemocap_sidecar/ -v
+```
+
+## Future work
+
+1. **motion_pipeline adapter** — a `FreeMoCapSource` adapter under
+   `src/shared/python/motion_pipeline/sources/` that consumes the
+   `landmarks.csv` / `metadata.json` outputs and emits the canonical
+   `BodyTarget` schema. Tracked as a follow-up.
+
+2. **Multi-camera calibration helper** — a small CLI that wraps
+   freemocap's calibration step so users don't have to run multiple
+   subprocesses by hand.
+
+3. **GUI tile** — a launcher tile in the desktop UI that lets users
+   point at a session directory and run the sidecar without dropping to
+   the command line.

--- a/src/tools/freemocap_sidecar/__init__.py
+++ b/src/tools/freemocap_sidecar/__init__.py
@@ -1,0 +1,36 @@
+"""FreeMoCap sidecar — markerless motion capture via subprocess isolation.
+
+This package wraps the AGPL-licensed `freemocap` library as an
+**out-of-process subprocess** so that UpstreamDrift's main codebase
+(MIT-licensed) never imports AGPL code at runtime. The user installs
+freemocap into a separate Python environment; the sidecar invokes that
+environment's interpreter to run a recording session and writes the
+results to a known directory the main app reads back.
+
+Public surface:
+
+    >>> from src.tools.freemocap_sidecar import (
+    ...     FreeMoCapResult,
+    ...     FreeMoCapSidecarError,
+    ...     run_freemocap_sidecar,
+    ... )
+
+The CLI entry point lives at :mod:`src.tools.freemocap_sidecar.run_freemocap`.
+
+See ``docs/motion_capture/freemocap_sidecar.md`` for the architectural
+rationale and the input/output contract.
+"""
+
+from __future__ import annotations
+
+from src.tools.freemocap_sidecar.run_freemocap import (
+    FreeMoCapResult,
+    FreeMoCapSidecarError,
+    run_freemocap_sidecar,
+)
+
+__all__ = [
+    "FreeMoCapResult",
+    "FreeMoCapSidecarError",
+    "run_freemocap_sidecar",
+]

--- a/src/tools/freemocap_sidecar/run_freemocap.py
+++ b/src/tools/freemocap_sidecar/run_freemocap.py
@@ -1,48 +1,336 @@
+"""FreeMoCap sidecar runner.
+
+Spawns FreeMoCap as an **isolated subprocess** so that UpstreamDrift's
+main environment never imports AGPL-licensed code at runtime. Called
+either as a CLI (``python -m src.tools.freemocap_sidecar.run_freemocap
+--input ... --output ...``) or programmatically via
+:func:`run_freemocap_sidecar`.
+
+Architecture
+------------
+
+UpstreamDrift is MIT-licensed; FreeMoCap is AGPL. To keep the licenses
+cleanly separated we never import freemocap from this codebase. Instead:
+
+1. The user installs freemocap into a separate Python environment (e.g.
+   ``~/.venvs/freemocap``).
+2. Our sidecar invokes ``<that env>/python -m freemocap ...`` as a
+   subprocess.
+3. The subprocess writes results to a known output directory.
+4. UpstreamDrift reads those results back via stdlib only.
+
+No symbol from freemocap is ever bound in our process. AGPL code stays
+entirely on the other side of the subprocess boundary.
+
+Output contract
+---------------
+
+After a successful run the output directory contains at minimum:
+
+- ``landmarks.csv`` -- frame-by-frame 3D landmark positions
+  ``frame,landmark_id,x,y,z``
+- ``metadata.json`` -- session metadata (camera count, fps, duration,
+  freemocap version)
+
+When real freemocap is unavailable (no env, no install, dry-run mode)
+the sidecar still writes minimum stub artifacts so downstream consumers
+have a stable contract to test against.
+"""
+
+from __future__ import annotations
+
 import argparse
+import json
+import logging
+import os
 import subprocess
 import sys
-import os
-import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-def run_freemocap_sidecar(input_dir, output_dir, freemocap_env_python=None):
-    """
-    Spawns FreeMoCap as an isolated subprocess.
-    This ensures that UpstreamDrift's main environment does not import
-    any AGPL-licensed code or heavy dependencies from FreeMoCap.
-    """
-    logger.info("Starting FreeMoCap sidecar process...")
-    logger.info(f"Input Directory: {input_dir}")
-    logger.info(f"Output Directory: {output_dir}")
-    
-    python_exe = freemocap_env_python if freemocap_env_python else sys.executable
-    
-    cmd = [
-        python_exe,
-        "-m", "freemocap",
-    ]
-    
-    try:
-        logger.info("FreeMoCap sidecar invoked successfully (scaffold).")
-        
-        os.makedirs(output_dir, exist_ok=True)
-        dummy_output = os.path.join(output_dir, "landmarks.csv")
-        with open(dummy_output, "w", encoding="utf-8") as f:
-            f.write("frame,landmark_id,x,y,z\n")
-            f.write("0,0,0.0,0.0,0.0\n")
-        logger.info(f"Generated output artifacts at {output_dir}")
-        
-    except subprocess.CalledProcessError as e:
-        logger.error(f"FreeMoCap process failed with error: {e}")
-        sys.exit(1)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="FreeMoCap Sidecar Runner")
+class FreeMoCapSidecarError(RuntimeError):
+    """Raised when the freemocap subprocess fails or its output is malformed."""
+
+
+@dataclass(frozen=True)
+class FreeMoCapResult:
+    """Result of a freemocap sidecar invocation.
+
+    Attributes:
+        success: True iff the subprocess exited 0 and the expected
+            output files exist.
+        output_dir: Directory containing landmarks.csv and metadata.json.
+        landmarks_csv: Absolute path to the landmarks file (None on failure).
+        metadata_json: Absolute path to the metadata file (None on failure).
+        return_code: Exit code from the subprocess.
+        stderr_tail: Last few KB of subprocess stderr (truncated for log
+            sanity).
+        used_real_freemocap: True iff a real freemocap install was
+            invoked. False when running in dry-run / scaffold mode.
+    """
+
+    success: bool
+    output_dir: Path
+    return_code: int
+    used_real_freemocap: bool
+    landmarks_csv: Path | None = None
+    metadata_json: Path | None = None
+    stderr_tail: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
+
+
+# Maximum bytes of stderr to retain in the result (avoid blowing context).
+_STDERR_TAIL_BYTES = 4096
+
+
+def _write_stub_artifacts(output_dir: Path) -> tuple[Path, Path]:
+    """Write minimum stub artifacts when real freemocap is unavailable.
+
+    Stubs follow the same shape as real freemocap output so downstream
+    consumers (motion_pipeline, tests) can integration-test without
+    needing the actual freemocap install.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    landmarks = output_dir / "landmarks.csv"
+    metadata = output_dir / "metadata.json"
+    landmarks.write_text("frame,landmark_id,x,y,z\n0,0,0.0,0.0,0.0\n", encoding="utf-8")
+    metadata.write_text(
+        json.dumps(
+            {
+                "stub": True,
+                "n_frames": 1,
+                "n_landmarks": 1,
+                "fps": 0,
+                "freemocap_version": "stub",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return landmarks, metadata
+
+
+def _validate_output(output_dir: Path) -> tuple[Path | None, Path | None]:
+    """Return (landmarks, metadata) paths if both exist, else (None, None)."""
+    landmarks = output_dir / "landmarks.csv"
+    metadata = output_dir / "metadata.json"
+    if landmarks.exists() and metadata.exists():
+        return landmarks, metadata
+    return None, None
+
+
+def run_freemocap_sidecar(
+    input_dir: str | os.PathLike[str],
+    output_dir: str | os.PathLike[str],
+    freemocap_env_python: str | os.PathLike[str] | None = None,
+    dry_run: bool = False,
+    timeout_s: float = 1800.0,
+) -> FreeMoCapResult:
+    """Run the freemocap sidecar.
+
+    Args:
+        input_dir: Path to the recording session videos.
+        output_dir: Path where landmarks.csv and metadata.json will be
+            written. Created if it does not exist.
+        freemocap_env_python: Path to the python interpreter in the
+            isolated freemocap venv. If None, defaults to ``sys.executable``.
+        dry_run: If True, skip the subprocess invocation and write only
+            stub artifacts. Useful for tests and CI matrices that don't
+            have freemocap installed.
+        timeout_s: Subprocess timeout. Defaults to 30 minutes.
+
+    Returns:
+        :class:`FreeMoCapResult` with paths and metadata.
+    """
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if dry_run:
+        logger.info("Dry-run mode: writing stub artifacts to %s", output_path)
+        landmarks, metadata = _write_stub_artifacts(output_path)
+        return FreeMoCapResult(
+            success=True,
+            output_dir=output_path,
+            return_code=0,
+            used_real_freemocap=False,
+            landmarks_csv=landmarks,
+            metadata_json=metadata,
+        )
+
+    python_exe = (
+        str(freemocap_env_python)
+        if freemocap_env_python is not None
+        else sys.executable
+    )
+
+    cmd: list[str] = [
+        python_exe,
+        "-m",
+        "freemocap",
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+    ]
+
+    logger.info(
+        "Invoking freemocap subprocess: python=%s input=%s output=%s",
+        python_exe,
+        input_path,
+        output_path,
+    )
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        logger.warning(
+            "freemocap interpreter %s not found (%s); falling back to stub artifacts",
+            python_exe,
+            exc,
+        )
+        landmarks, metadata = _write_stub_artifacts(output_path)
+        return FreeMoCapResult(
+            success=False,
+            output_dir=output_path,
+            return_code=127,
+            used_real_freemocap=False,
+            landmarks_csv=landmarks,
+            metadata_json=metadata,
+            stderr_tail=str(exc),
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.error("freemocap subprocess timed out after %.1fs", timeout_s)
+        return FreeMoCapResult(
+            success=False,
+            output_dir=output_path,
+            return_code=-1,
+            used_real_freemocap=True,
+            stderr_tail=f"timeout after {timeout_s}s: {exc}",
+        )
+
+    stderr_tail = (proc.stderr or "")[-_STDERR_TAIL_BYTES:]
+
+    if proc.returncode != 0:
+        if "No module named 'freemocap'" in (proc.stderr or ""):
+            logger.warning(
+                "freemocap module not installed at %s; writing stub artifacts",
+                python_exe,
+            )
+            landmarks, metadata = _write_stub_artifacts(output_path)
+            return FreeMoCapResult(
+                success=False,
+                output_dir=output_path,
+                return_code=proc.returncode,
+                used_real_freemocap=False,
+                landmarks_csv=landmarks,
+                metadata_json=metadata,
+                stderr_tail=stderr_tail,
+            )
+
+        logger.error("freemocap subprocess exited with code %d", proc.returncode)
+        return FreeMoCapResult(
+            success=False,
+            output_dir=output_path,
+            return_code=proc.returncode,
+            used_real_freemocap=True,
+            stderr_tail=stderr_tail,
+        )
+
+    landmarks, metadata = _validate_output(output_path)
+    if landmarks is None or metadata is None:
+        logger.error(
+            "freemocap exited 0 but expected output files are missing in %s",
+            output_path,
+        )
+        return FreeMoCapResult(
+            success=False,
+            output_dir=output_path,
+            return_code=proc.returncode,
+            used_real_freemocap=True,
+            stderr_tail=stderr_tail,
+        )
+
+    logger.info(
+        "freemocap sidecar completed successfully; landmarks=%s metadata=%s",
+        landmarks,
+        metadata,
+    )
+    return FreeMoCapResult(
+        success=True,
+        output_dir=output_path,
+        return_code=proc.returncode,
+        used_real_freemocap=True,
+        landmarks_csv=landmarks,
+        metadata_json=metadata,
+        stderr_tail=stderr_tail,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    parser = argparse.ArgumentParser(
+        description="FreeMoCap sidecar runner (subprocess isolation for AGPL freemocap)",
+    )
     parser.add_argument("--input", required=True, help="Path to input session videos")
-    parser.add_argument("--output", required=True, help="Path to output landmarks directory")
-    parser.add_argument("--env-python", required=False, help="Path to the python executable in the freemocap venv")
-    
-    args = parser.parse_args()
-    run_freemocap_sidecar(args.input, args.output, args.env_python)
+    parser.add_argument(
+        "--output", required=True, help="Path to output landmarks directory"
+    )
+    parser.add_argument(
+        "--env-python",
+        required=False,
+        default=None,
+        help="Path to the python executable in the freemocap venv",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip the subprocess and write stub artifacts only",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=1800.0,
+        help="Subprocess timeout in seconds (default 1800)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print the result as JSON to stdout"
+    )
+
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+
+    args = parser.parse_args(argv)
+
+    result = run_freemocap_sidecar(
+        input_dir=args.input,
+        output_dir=args.output,
+        freemocap_env_python=args.env_python,
+        dry_run=args.dry_run,
+        timeout_s=args.timeout,
+    )
+
+    if args.json:
+        payload = asdict(result)
+        for k, v in payload.items():
+            if isinstance(v, Path):
+                payload[k] = str(v)
+        sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+
+    return 0 if result.success else max(1, result.return_code)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/tools/freemocap_sidecar/test_run_freemocap.py
+++ b/tests/unit/tools/freemocap_sidecar/test_run_freemocap.py
@@ -1,0 +1,242 @@
+"""Unit tests for the freemocap sidecar.
+
+The freemocap library is AGPL and not a dependency of UpstreamDrift, so
+these tests never import it. Coverage is via:
+
+- ``dry_run=True`` for the happy path (writes stub artifacts).
+- A non-existent interpreter path for the FileNotFoundError branch.
+- A monkey-patched ``subprocess.run`` for the rest of the matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.tools.freemocap_sidecar import (
+    FreeMoCapResult,
+    run_freemocap_sidecar,
+)
+from src.tools.freemocap_sidecar.run_freemocap import main
+
+
+# ---------------------------------------------------------------------------
+# Dry-run / stub path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dry_run_writes_stub_artifacts(tmp_path: Path) -> None:
+    """Dry-run produces a successful result with stub landmarks + metadata."""
+    out = tmp_path / "out"
+    result = run_freemocap_sidecar(
+        input_dir=tmp_path / "in",
+        output_dir=out,
+        dry_run=True,
+    )
+    assert result.success is True
+    assert result.used_real_freemocap is False
+    assert result.return_code == 0
+    assert result.landmarks_csv is not None and result.landmarks_csv.exists()
+    assert result.metadata_json is not None and result.metadata_json.exists()
+
+    csv_text = result.landmarks_csv.read_text(encoding="utf-8")
+    assert csv_text.startswith("frame,landmark_id,x,y,z\n")
+
+    meta = json.loads(result.metadata_json.read_text(encoding="utf-8"))
+    assert meta["stub"] is True
+    assert meta["freemocap_version"] == "stub"
+
+
+@pytest.mark.unit
+def test_dry_run_creates_output_dir_if_missing(tmp_path: Path) -> None:
+    out = tmp_path / "deep" / "nested" / "out"
+    assert not out.exists()
+    result = run_freemocap_sidecar(
+        input_dir=tmp_path / "in", output_dir=out, dry_run=True
+    )
+    assert result.success
+    assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Real-subprocess paths (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_missing_interpreter_falls_back_to_stub(tmp_path: Path) -> None:
+    """A non-existent freemocap_env_python path falls back gracefully."""
+    out = tmp_path / "out"
+    result = run_freemocap_sidecar(
+        input_dir=tmp_path / "in",
+        output_dir=out,
+        freemocap_env_python="/no/such/python/interpreter_xyz",
+    )
+    # success=False because the user asked for real, but stub output exists.
+    assert result.success is False
+    assert result.used_real_freemocap is False
+    assert result.return_code == 127
+    assert result.landmarks_csv is not None and result.landmarks_csv.exists()
+
+
+@pytest.mark.unit
+def test_missing_freemocap_module_falls_back_to_stub(tmp_path: Path) -> None:
+    """If subprocess exits non-zero with `No module named 'freemocap'`, stub."""
+    out = tmp_path / "out"
+    fake_proc = subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr="ModuleNotFoundError: No module named 'freemocap'\n",
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        result = run_freemocap_sidecar(
+            input_dir=tmp_path / "in",
+            output_dir=out,
+            freemocap_env_python="/usr/bin/python3",  # exists-shaped path
+        )
+    assert result.success is False
+    assert result.used_real_freemocap is False
+    assert result.landmarks_csv is not None and result.landmarks_csv.exists()
+    assert "freemocap" in result.stderr_tail
+
+
+@pytest.mark.unit
+def test_real_subprocess_failure_returns_failure_no_stub(tmp_path: Path) -> None:
+    """A genuine non-zero exit (not a missing-module) is reported as failure."""
+    out = tmp_path / "out"
+    fake_proc = subprocess.CompletedProcess(
+        args=[],
+        returncode=2,
+        stdout="",
+        stderr="some other freemocap-internal error",
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        result = run_freemocap_sidecar(
+            input_dir=tmp_path / "in",
+            output_dir=out,
+            freemocap_env_python="/usr/bin/python3",
+        )
+    assert result.success is False
+    assert result.used_real_freemocap is True
+    assert result.return_code == 2
+    assert "freemocap-internal" in result.stderr_tail
+
+
+@pytest.mark.unit
+def test_real_subprocess_success_with_outputs(tmp_path: Path) -> None:
+    """If subprocess exits 0 AND outputs exist, success=True."""
+    out = tmp_path / "out"
+    out.mkdir()
+    # Pre-write the expected output files (simulates freemocap doing it)
+    (out / "landmarks.csv").write_text(
+        "frame,landmark_id,x,y,z\n0,0,1,2,3\n", encoding="utf-8"
+    )
+    (out / "metadata.json").write_text(
+        json.dumps({"freemocap_version": "1.6.0", "n_frames": 100}),
+        encoding="utf-8",
+    )
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        result = run_freemocap_sidecar(
+            input_dir=tmp_path / "in",
+            output_dir=out,
+            freemocap_env_python="/usr/bin/python3",
+        )
+    assert result.success is True
+    assert result.used_real_freemocap is True
+    assert result.return_code == 0
+
+
+@pytest.mark.unit
+def test_real_subprocess_success_but_missing_outputs(tmp_path: Path) -> None:
+    """Exit 0 but no output files = failure (broken freemocap install)."""
+    out = tmp_path / "out"
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        result = run_freemocap_sidecar(
+            input_dir=tmp_path / "in",
+            output_dir=out,
+            freemocap_env_python="/usr/bin/python3",
+        )
+    assert result.success is False
+    assert result.return_code == 0
+    assert result.used_real_freemocap is True
+
+
+@pytest.mark.unit
+def test_subprocess_timeout_reports_failure(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="freemocap", timeout=0.1),
+    ):
+        result = run_freemocap_sidecar(
+            input_dir=tmp_path / "in",
+            output_dir=out,
+            freemocap_env_python="/usr/bin/python3",
+            timeout_s=0.1,
+        )
+    assert result.success is False
+    assert result.return_code == -1
+    assert "timeout" in result.stderr_tail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_result_is_frozen() -> None:
+    r = FreeMoCapResult(
+        success=True, output_dir=Path("/tmp"), return_code=0, used_real_freemocap=False
+    )
+    with pytest.raises(Exception):  # noqa: B017 — FrozenInstanceError is a subclass
+        r.success = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_dry_run_returns_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "--input",
+            str(tmp_path / "in"),
+            "--output",
+            str(tmp_path / "out"),
+            "--dry-run",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["success"] is True
+    assert payload["used_real_freemocap"] is False
+
+
+@pytest.mark.unit
+def test_cli_real_failure_returns_nonzero(tmp_path: Path) -> None:
+    rc = main(
+        [
+            "--input",
+            str(tmp_path / "in"),
+            "--output",
+            str(tmp_path / "out"),
+            "--env-python",
+            "/no/such/python/interpreter_xyz",
+        ]
+    )
+    assert rc != 0


### PR DESCRIPTION
## Summary

Replaces the previous scaffold (which always wrote dummy output) with a production-grade subprocess-isolated freemocap runner. Establishes the freemocap sidecar pipeline as a future-ready integration surface.

## Architecture

UpstreamDrift is MIT-licensed; FreeMoCap is AGPL. To keep licenses cleanly separated:

- The user installs freemocap into a **separate Python environment** (e.g. \`~/.venvs/freemocap\`)
- Our sidecar invokes \`<that env>/python -m freemocap\` as a subprocess
- Outputs (landmarks.csv + metadata.json) are read back via stdlib only
- **No symbol from freemocap is ever bound in our process**

## What's new

| File | Purpose |
|---|---|
| \`src/tools/freemocap_sidecar/__init__.py\` | Public API |
| \`src/tools/freemocap_sidecar/run_freemocap.py\` | Real subprocess runner (full rewrite, 280 LOC) |
| \`tests/unit/tools/freemocap_sidecar/test_run_freemocap.py\` | 11 unit tests |
| \`docs/motion_capture/freemocap_sidecar.md\` | Architecture, usage, output contract, failure modes |

## Five distinct outcome paths

| Path | \`success\` | \`used_real_freemocap\` | \`return_code\` |
|---|---|---|---|
| Dry-run | True | False | 0 |
| Missing interpreter | False | False | 127 |
| Missing freemocap module | False | False | 1 (stub written) |
| Subprocess failure | False | True | propagated |
| Subprocess success + outputs | True | True | 0 |
| Subprocess success without outputs | False | True | 0 |
| Timeout | False | True | -1 |

## Test results

\`\`\`
$ pytest tests/unit/tools/freemocap_sidecar/ -v
======================== 11 passed in 3.62s ========================
\`\`\`

## Test plan

- [x] All 11 tests pass
- [x] \`ruff check\` and \`ruff format\` clean
- [x] CLI entrypoint works (verified via test)
- [x] Documentation written
- [ ] CI green
- [ ] (Future PR) motion_pipeline adapter consumes the output contract

## Future work (filed as follow-ups, not in this PR)

1. \`motion_pipeline\` adapter (\`FreeMoCapSource\`) that reads the sidecar's CSV+JSON and emits canonical \`BodyTarget\`
2. Multi-camera calibration helper CLI
3. GUI launcher tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)