### PR TITLE
chore(motion_pipeline): bulk-address 4 review-feedback issues

### DIFF
--- a/tests/integration/motion_pipeline/adversarial/test_real_world_schema_drift.py
+++ b/tests/integration/motion_pipeline/adversarial/test_real_world_schema_drift.py
@@ -39,7 +39,11 @@ def test_mediapipe_landmarks_key_variant(tmp_path: Path) -> None:
     try:
         load_any(p)
     except Exception as e:
-        assert "mediapipe" in str(e).lower() or "landmark" in str(e).lower() or True
+        msg = str(e).lower()
+        assert "mediapipe" in msg or "landmark" in msg, (
+            f"Unexpected adapter error message (not a clean mediapipe/landmark "
+            f"failure): {type(e).__name__}: {e}"
+        )
 
 
 def test_mediapipe_pose_landmarks_key_variant(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #4685, #4686, #4695, #4728. Each is a small targeted fix per the codex-connector review comment.

## Summary
- **#4685** `tests/unit/motion_pipeline/_fixtures.py` — `make_motion_matching_result` now passes its `rig` through to `make_motion_trajectory`, so `matched_trajectory.skeleton` stays consistent with the `metadata['residual_report']` / `torque_trajectory` keying instead of being silently keyed to a fresh default rig.
- **#4686** `tests/unit/motion_pipeline/test_lod.py` — `_collect_imports` now also records imported submodule names for `ImportFrom` nodes (e.g. `from src import engines` → `src.engines`), closing the bypass where forbidden roots could be imported via `from <root> import <submodule>` without tripping the LoD architectural guard.
- **#4695** `tests/integration/motion_pipeline/test_full_pipeline.py` — `test_registry_loads_every_golden_fixture` now asserts `not errors` after the loop, so a regression in any individual adapter/fixture pair fails the test instead of being masked by an unrelated successful load.
- **#4728** `tests/integration/motion_pipeline/adversarial/test_real_world_schema_drift.py` — replaced the always-true `or True` in `test_mediapipe_landmarks_key_variant` with a real check that the adapter error message references mediapipe or landmark.

## Test plan
- [x] Targeted: `pytest tests/unit/motion_pipeline/test_lod.py tests/integration/motion_pipeline/test_full_pipeline.py tests/integration/motion_pipeline/adversarial/test_real_world_schema_drift.py` — 50 passed, 3 skipped, 1 xfailed.
- [x] `ruff check` — clean on all 4 edited files.
- [ ] CI green on the PR.