### PR TITLE
[c3d fix] Infer EVENT:USED from LABELS/TIMES when not set (#4753)

### DIFF
--- a/src/shared/python/upstream_drift_tools/lab/bio/_c3d_io.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/_c3d_io.py
@@ -110,18 +110,31 @@ def get_events(c3d_data: C3DMapping) -> list[C3DEvent]:
     if not event_parameters:
         return []
 
-    # EVENT:USED tells us how many events are actually defined
-    used = event_parameters.get("USED", {}).get("value", [0])
-    if not used or used[0] == 0:
-        return []
-    num_events = int(used[0])
-
     labels_raw: Iterable[str] = event_parameters.get("LABELS", {}).get("value", [])
     times = event_parameters.get("TIMES", {}).get("value")
     contexts_raw: Iterable[str] = event_parameters.get("CONTEXTS", {}).get("value", [])
 
     if times is None:
         return []
+
+    # EVENT:USED tells us how many events are actually defined.
+    # Real-world c3d files routinely omit USED while still containing valid
+    # LABELS/TIMES arrays. When USED is absent, infer the count from the
+    # available metadata rather than silently dropping all events.
+    # An explicit USED=0 is honored (caller deliberately marked the group empty).
+    used_param = event_parameters.get("USED")
+    if used_param is None:
+        # Missing USED: infer from LABELS / TIMES length.
+        labels_len = len(labels_raw) if hasattr(labels_raw, "__len__") else 0
+        times_len = int(np.asarray(times).shape[-1])
+        num_events = max(labels_len, times_len)
+        if num_events == 0:
+            return []
+    else:
+        used = used_param.get("value", [0])
+        if not used or used[0] == 0:
+            return []
+        num_events = int(used[0])
 
     times_array = np.asarray(times)
     if times_array.ndim == 2:
@@ -132,7 +145,11 @@ def get_events(c3d_data: C3DMapping) -> list[C3DEvent]:
     for idx in range(min(num_events, len(labels_raw))):
         time_value = float(times_array[idx]) if idx < len(times_array) else np.nan
         if np.isfinite(time_value):
-            label = str(labels_raw[idx]).strip() if idx < len(labels_raw) else f"Event_{idx}"
+            label = (
+                str(labels_raw[idx]).strip()
+                if idx < len(labels_raw)
+                else f"Event_{idx}"
+            )
             # Context is available but C3DEvent only has label/time for now
             # Could extend C3DEvent to include context if needed
             events.append(C3DEvent(label=label, time=time_value))

--- a/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/_synthetic.py
@@ -26,6 +26,8 @@ def _synthetic_c3d_dict(
     event_times: list[float] | None = None,
     event_times_2d: bool = False,
     event_times_missing: bool = False,
+    event_used: int | None = None,
+    event_used_omit: bool = True,
     omit_analog_group: bool = False,
     analog_subframes: int = 10,
     point_data: np.ndarray | None = None,
@@ -114,6 +116,9 @@ def _synthetic_c3d_dict(
                 event_group["TIMES"] = {"value": arr}
             else:
                 event_group["TIMES"] = {"value": np.asarray(times)}
+        if not event_used_omit:
+            count = event_used if event_used is not None else len(labels)
+            event_group["USED"] = {"value": np.array([count])}
         parameters["EVENT"] = event_group
 
     if force_platform is not None:

--- a/tests/unit/upstream_drift_tools/lab/bio/test_c3d_io.py
+++ b/tests/unit/upstream_drift_tools/lab/bio/test_c3d_io.py
@@ -151,6 +151,54 @@ def test_get_events_missing_times() -> None:
     assert get_events(data) == []
 
 
+def test_get_events_missing_used_infers_from_labels() -> None:
+    """Regression for #4753: missing EVENT:USED must not silently drop events.
+
+    Real-world c3d files routinely omit USED while still containing valid
+    LABELS/TIMES arrays. We must infer USED from the available metadata
+    rather than defaulting to 0.
+    """
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["FootStrike", "Toe-off"],
+        event_times=[0.5, 1.0],
+        event_used_omit=True,  # explicitly omit USED
+    )
+    events = get_events(data)
+    assert events == [C3DEvent("FootStrike", 0.5), C3DEvent("Toe-off", 1.0)]
+
+
+def test_get_events_explicit_used_parity() -> None:
+    """Regression for #4753: explicit USED=N yields same result as inferred."""
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["A", "B"],
+        event_times=[0.1, 0.5],
+        event_used_omit=False,
+        event_used=2,
+    )
+    events = get_events(data)
+    assert events == [C3DEvent("A", 0.1), C3DEvent("B", 0.5)]
+
+
+def test_get_events_explicit_used_zero_honored() -> None:
+    """Regression for #4753: explicit USED=0 still yields no events."""
+    data = _synthetic_c3d_dict(
+        with_events=True,
+        event_labels=["A", "B"],
+        event_times=[0.1, 0.5],
+        event_used_omit=False,
+        event_used=0,
+    )
+    assert get_events(data) == []
+
+
+def test_get_events_no_event_group_returns_empty() -> None:
+    """Regression for #4753: no EVENT group at all yields [] without error."""
+    data = _synthetic_c3d_dict()  # no EVENT group
+    assert get_events(data) == []
+
+
 def test_get_events_skips_non_finite_time() -> None:
     data = _synthetic_c3d_dict(
         with_events=True,


### PR DESCRIPTION
Fixes the P1 bug from the codex review of PR #4747.

## Bug
`_c3d_io.py` defaulted `EVENT:USED` to `[0]`, causing immediate return of `[]` whenever a c3d file had `EVENT:LABELS`/`TIMES`/`CONTEXTS` but omitted `USED`. Real-world c3d files routinely do this. Confirmed by 3 pre-existing tests that were silently broken.

## Fix
Infer USED from the length of LABELS/TIMES if available; default to 0 only when no event metadata exists. Explicit `USED=0` is still honored (caller deliberately marked the group empty).

## Test plan
- [x] Regression test with missing USED + present LABELS/TIMES yields N events
- [x] Explicit USED=N still honored
- [x] Explicit USED=0 still yields 0 events (no surprise)
- [x] Empty EVENT group yields 0 events with no exception
- [x] All 128 lab/bio unit tests pass

Closes #4753

Generated with Claude Code