### PR TITLE
feat(body_part_viz): core contracts + dataclasses (closes #4757)

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,0 +1,48 @@
+"""Body-part visualisation toolkit.
+
+A cross-tool, cross-renderer package for displaying body segments as
+geometric shapes (lines, cylinders, ellipsoids, capsules, meshes) bound
+to mocap markers. Used by the C3D viewer, motion-match preview, and
+URDF generator.
+
+This top-level module exposes only **contracts and dataclasses**.
+Concrete shapes, fitters, and renderers live in sibling sub-packages
+and are added in subsequent issues:
+
+- :mod:`body_part_viz.shapes` — primitives (#4759) + meshes (#4758)
+- :mod:`body_part_viz.fitters` — fitter implementations (#4756)
+- :mod:`body_part_viz.renderers` — matplotlib (#4760) + pyqtgraph (#4762)
+
+Public API
+----------
+
+- :class:`BodyPartShape`, :class:`ShapeFitter`, :class:`ShapeRenderer`
+  — protocols
+- :class:`MarkerBinding`, :class:`BindingKind` — how shapes attach to
+  markers
+- :class:`ShapeTheme` — visual styling (color, opacity, edges)
+- :class:`FittedShape` — per-frame placement trajectory
+
+See the EPIC tracking issue #4755 for the campaign overview.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import (
+    BodyPartShape,
+    ShapeFitter,
+    ShapeRenderer,
+)
+from src.shared.python.body_part_viz.theme import ShapeTheme
+
+__all__ = [
+    "BindingKind",
+    "BodyPartShape",
+    "FittedShape",
+    "MarkerBinding",
+    "ShapeFitter",
+    "ShapeRenderer",
+    "ShapeTheme",
+]

--- a/src/shared/python/body_part_viz/_types.py
+++ b/src/shared/python/body_part_viz/_types.py
@@ -1,0 +1,102 @@
+"""Internal types and dataclasses for body-part visualisation.
+
+These are the runtime artefacts produced by fitters and consumed by
+renderers. The public-facing :class:`MarkerBinding`, :class:`ShapeTheme`,
+and the protocols live in their own modules; this one holds the
+:class:`FittedShape` trajectory representation that is shared across
+fitters and renderers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz.bindings import MarkerBinding
+
+__all__ = ["FittedShape"]
+
+
+@dataclass(frozen=True)
+class FittedShape:
+    """Per-frame placement of a body-part shape.
+
+    Attributes:
+        shape_id: ``BodyPartShape.shape_id`` of the source shape.
+        binding: Marker binding that produced this fit.
+        centroid: ``(T, 3)`` world-frame centroid per frame, in metres.
+        rotation_matrix: ``(T, 3, 3)`` proper rotation per frame.
+            Each ``R[t]`` is a right-handed orthonormal frame.
+        scale: ``(T, 3)`` anisotropic scale per frame. All entries
+            strictly positive.
+        valid_mask: ``(T,)`` boolean array. ``valid_mask[t]`` is True iff
+            every source marker provided a finite position at frame ``t``.
+
+    All arrays must agree on the leading time axis ``T``. Validation
+    happens in ``__post_init__``.
+    """
+
+    shape_id: str
+    binding: MarkerBinding
+    centroid: NDArray[np.floating]
+    rotation_matrix: NDArray[np.floating]
+    scale: NDArray[np.floating]
+    valid_mask: NDArray[np.bool_]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.shape_id, str) or not self.shape_id:
+            raise ValueError("shape_id must be a non-empty string")
+        if not isinstance(self.binding, MarkerBinding):
+            raise TypeError(
+                f"binding must be MarkerBinding, got {type(self.binding).__name__}"
+            )
+
+        # Each array must be a numpy.ndarray with the documented shape.
+        for name in ("centroid", "rotation_matrix", "scale", "valid_mask"):
+            arr = getattr(self, name)
+            if not isinstance(arr, np.ndarray):
+                raise TypeError(
+                    f"{name} must be numpy.ndarray, got {type(arr).__name__}"
+                )
+
+        if self.centroid.ndim != 2 or self.centroid.shape[1] != 3:
+            raise ValueError(
+                f"centroid must have shape (T, 3), got {self.centroid.shape}"
+            )
+        n_frames = self.centroid.shape[0]
+
+        if self.rotation_matrix.shape != (n_frames, 3, 3):
+            raise ValueError(
+                f"rotation_matrix must have shape ({n_frames}, 3, 3), "
+                f"got {self.rotation_matrix.shape}"
+            )
+        if self.scale.shape != (n_frames, 3):
+            raise ValueError(
+                f"scale must have shape ({n_frames}, 3), got {self.scale.shape}"
+            )
+        if self.valid_mask.shape != (n_frames,):
+            raise ValueError(
+                f"valid_mask must have shape ({n_frames},), got {self.valid_mask.shape}"
+            )
+
+        if self.valid_mask.dtype != np.bool_:
+            raise TypeError(
+                f"valid_mask must have dtype bool, got {self.valid_mask.dtype}"
+            )
+
+        # Scales must be strictly positive on valid frames; nan-safe check.
+        if n_frames > 0:
+            valid_scales = self.scale[self.valid_mask]
+            if valid_scales.size > 0 and not np.all(np.isfinite(valid_scales)):
+                raise ValueError(
+                    "scale must contain only finite values on valid frames"
+                )
+            if valid_scales.size > 0 and not np.all(valid_scales > 0.0):
+                raise ValueError("scale must be strictly positive on valid frames")
+
+    @property
+    def n_frames(self) -> int:
+        """Number of frames in this trajectory."""
+        return int(self.centroid.shape[0])

--- a/src/shared/python/body_part_viz/bindings.py
+++ b/src/shared/python/body_part_viz/bindings.py
@@ -1,0 +1,131 @@
+"""Marker bindings for body-part visualisation.
+
+A :class:`MarkerBinding` describes how a body-part shape attaches to one
+or more mocap markers. There are three binding kinds:
+
+- :attr:`BindingKind.BETWEEN_TWO` — two markers; shape's primary axis
+  spans the segment ``markers[0] -> markers[1]`` and rest length is the
+  pair's distance.
+- :attr:`BindingKind.CLUSTER` — three or more markers; rigid Kabsch
+  registration with optional anisotropic scaling.
+- :attr:`BindingKind.ON_MARKER` — single marker; shape sits at the
+  marker location with no rotation.
+
+The class is intentionally minimal and stateless. Per-frame placement
+lives in :class:`body_part_viz.FittedShape`.
+
+Design by Contract
+------------------
+``__post_init__`` validates every invariant. See :func:`MarkerBinding.__post_init__`
+for the full list. Public callers should rely on construction-time
+validation rather than re-validating downstream.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ["BindingKind", "MarkerBinding"]
+
+
+class BindingKind(str, Enum):
+    """How a shape attaches to mocap markers.
+
+    Inherits ``str`` so that values serialise transparently through JSON
+    and YAML without a custom encoder.
+    """
+
+    BETWEEN_TWO = "between_two"
+    """Two markers; segment-style binding."""
+
+    CLUSTER = "cluster"
+    """Three or more markers; rigid + anisotropic-scale binding."""
+
+    ON_MARKER = "on_marker"
+    """Single marker; static placement."""
+
+
+# --- Module-level invariant helpers (DbC). Kept top-level so they're
+#     trivially unit-testable from test_contracts.py and reused by other
+#     dataclasses in the package without circular imports.
+
+
+def _check_unit_quaternion(q: tuple[float, float, float, float]) -> None:
+    """Raise :class:`ValueError` if ``q`` is not a unit quaternion.
+
+    Tolerance is ``1e-6`` on the sum-of-squares.
+    """
+    if len(q) != 4:
+        raise ValueError(f"quaternion must have 4 components, got {len(q)}")
+    norm_sq = sum(c * c for c in q)
+    if not math.isfinite(norm_sq):
+        raise ValueError(f"quaternion components must be finite, got {q}")
+    if abs(norm_sq - 1.0) > 1e-6:
+        raise ValueError(
+            f"quaternion must be unit-norm (got |q|^2 = {norm_sq:.9f}, expected 1.0)"
+        )
+
+
+def _check_positive_rest_dimensions(rest: tuple[float, ...]) -> None:
+    """Raise :class:`ValueError` if any rest dimension is non-positive or non-finite."""
+    for i, d in enumerate(rest):
+        if not math.isfinite(d):
+            raise ValueError(f"rest_dimensions[{i}] must be finite, got {d}")
+        if d <= 0.0:
+            raise ValueError(f"rest_dimensions[{i}] must be positive, got {d}")
+
+
+@dataclass(frozen=True)
+class MarkerBinding:
+    """Binding between a body-part shape and the markers that drive it.
+
+    Attributes:
+        kind: How the shape attaches; see :class:`BindingKind`.
+        marker_names: Names of the markers (length depends on ``kind``).
+        rest_dimensions: Rest-pose dimensions in metres. Semantics vary
+            per shape but every component must be strictly positive.
+        rest_orientation_quat: Unit quaternion ``(w, x, y, z)`` describing
+            the shape's rest orientation in the binding's local frame.
+            Defaults to identity.
+    """
+
+    kind: BindingKind
+    marker_names: tuple[str, ...]
+    rest_dimensions: tuple[float, ...] = ()
+    rest_orientation_quat: tuple[float, float, float, float] = (
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, BindingKind):
+            raise TypeError(f"kind must be BindingKind, got {type(self.kind).__name__}")
+
+        # Marker count invariants per kind.
+        n = len(self.marker_names)
+        if self.kind is BindingKind.BETWEEN_TWO and n != 2:
+            raise ValueError(f"BETWEEN_TWO binding requires exactly 2 markers, got {n}")
+        if self.kind is BindingKind.CLUSTER and n < 3:
+            raise ValueError(f"CLUSTER binding requires at least 3 markers, got {n}")
+        if self.kind is BindingKind.ON_MARKER and n != 1:
+            raise ValueError(f"ON_MARKER binding requires exactly 1 marker, got {n}")
+
+        # Marker names must be non-empty strings.
+        for i, name in enumerate(self.marker_names):
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"marker_names[{i}] must be str, got {type(name).__name__}"
+                )
+            if not name:
+                raise ValueError(f"marker_names[{i}] must be non-empty")
+
+        # Marker names must be unique.
+        if len(set(self.marker_names)) != n:
+            raise ValueError(f"marker_names must be unique, got {self.marker_names}")
+
+        _check_positive_rest_dimensions(self.rest_dimensions)
+        _check_unit_quaternion(self.rest_orientation_quat)

--- a/src/shared/python/body_part_viz/contracts.py
+++ b/src/shared/python/body_part_viz/contracts.py
@@ -1,0 +1,172 @@
+"""Protocols defining the body-part visualisation contracts.
+
+This module is the **stable** surface of the package. Implementations
+of shapes, fitters, and renderers will be added in sibling modules but
+must always conform to the protocols here.
+
+The protocols are :func:`runtime_checkable` so they integrate with
+``isinstance()`` checks for unit-test verification of duck-typed
+implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import MarkerBinding
+from src.shared.python.body_part_viz.theme import ShapeTheme
+
+__all__ = ["BodyPartShape", "ShapeFitter", "ShapeRenderer"]
+
+
+@runtime_checkable
+class BodyPartShape(Protocol):
+    """A geometric body-part visualisation.
+
+    Implementations: ``LineShape``, ``CylinderShape``, ``EllipsoidShape``,
+    ``CapsuleShape``, ``MeshShape``, ``CompositeShape`` (added in
+    later issues).
+
+    Attributes:
+        shape_id: Stable, human-readable identifier (e.g. ``"cylinder"``,
+            ``"mesh:head_v1"``). Used as a dictionary key in renderers
+            and persistence.
+        rest_dimensions: Rest-pose dimension tuple in metres. Semantics
+            vary per shape; see the individual shape docstrings.
+    """
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def vertices_at_rest(self) -> NDArray[np.floating]:
+        """Return ``(V, 3)`` vertex array in the shape's local frame.
+
+        Vertices are in the canonical rest-pose orientation defined by
+        the shape's binding. The returned array is read-only.
+
+        Postcondition: ``result.shape == (V, 3)`` for some ``V >= 1``;
+        ``result.dtype.kind == 'f'``.
+        """
+        ...
+
+    def faces(self) -> NDArray[np.integer]:
+        """Return ``(F, 3)`` triangle index array.
+
+        For 1-D shapes (lines), this is an empty ``(0, 3)`` array.
+
+        Postcondition: ``result.shape[1] == 3``;
+        ``result.dtype.kind in ('i', 'u')``.
+        """
+        ...
+
+    def transform(self, fitted: FittedShape) -> NDArray[np.floating]:
+        """Return ``(T, V, 3)`` vertices after fitting transformation.
+
+        Args:
+            fitted: Per-frame placement to apply. Must have
+                ``fitted.shape_id == self.shape_id``.
+
+        Postcondition: ``result.shape == (fitted.n_frames, V, 3)``
+        where ``V == self.vertices_at_rest().shape[0]``.
+        """
+        ...
+
+
+@runtime_checkable
+class ShapeFitter(Protocol):
+    """Compute a per-frame transform from markers to a fitted shape.
+
+    Implementations: ``BetweenTwoMarkersFitter``, ``ClusterKabschFitter``,
+    ``ProcrustesAnisotropicFitter`` (added in issue #4756).
+    """
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, NDArray[np.floating]],
+    ) -> FittedShape:
+        """Compute the per-frame fit.
+
+        Args:
+            shape: The shape to fit. Must satisfy the
+                :class:`BodyPartShape` protocol.
+            binding: Marker binding describing how the shape attaches.
+                Every name in ``binding.marker_names`` must be a key of
+                ``markers_xyz``.
+            markers_xyz: Mapping ``marker_name -> (T, 3) ndarray``. All
+                marker arrays must agree on ``T``. Missing samples are
+                represented as ``nan`` and propagate to
+                :attr:`FittedShape.valid_mask`.
+
+        Returns:
+            A :class:`FittedShape` whose ``shape_id`` matches
+            ``shape.shape_id`` and whose array-shape invariants are
+            checked at construction.
+
+        Raises:
+            ValueError: If ``binding.marker_names`` references markers
+                absent from ``markers_xyz``, or if marker arrays disagree
+                on the time dimension.
+        """
+        ...
+
+
+@runtime_checkable
+class ShapeRenderer(Protocol):
+    """Backend-specific renderer for body-part shapes.
+
+    Implementations live in :mod:`body_part_viz.renderers` and are added
+    in issues #4760 (matplotlib) and #4762 (pyqtgraph). This contract
+    intentionally exposes no Qt or matplotlib types so subclasses may
+    pick up the backend lazily.
+    """
+
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str:
+        """Add a shape to the scene.
+
+        Returns:
+            An opaque handle string that can be passed to
+            :meth:`update_frame`, :meth:`set_visible`, or :meth:`remove`.
+
+        Raises:
+            ValueError: If ``shape.shape_id != fitted.shape_id``.
+        """
+        ...
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        """Render the shape at the given frame.
+
+        Args:
+            handle: Handle returned from :meth:`add_shape`.
+            frame_idx: Frame index in ``range(0, fitted.n_frames)``.
+
+        Raises:
+            KeyError: If ``handle`` is unknown.
+            IndexError: If ``frame_idx`` is out of range.
+        """
+        ...
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        """Toggle visibility of a previously added shape.
+
+        Raises:
+            KeyError: If ``handle`` is unknown.
+        """
+        ...
+
+    def remove(self, handle: str) -> None:
+        """Remove a shape from the scene.
+
+        Idempotent: removing an unknown handle is a no-op.
+        """
+        ...

--- a/src/shared/python/body_part_viz/fitters/__init__.py
+++ b/src/shared/python/body_part_viz/fitters/__init__.py
@@ -1,0 +1,14 @@
+"""Body-part shape fitters.
+
+Implementations land in #4756:
+
+- ``BetweenTwoMarkersFitter`` — for BETWEEN_TWO bindings
+- ``ClusterKabschFitter`` — rigid Kabsch over a marker cluster
+- ``ProcrustesAnisotropicFitter`` — Kabsch + anisotropic scale
+
+This module is currently a placeholder.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/renderers/__init__.py
+++ b/src/shared/python/body_part_viz/renderers/__init__.py
@@ -1,0 +1,13 @@
+"""Body-part renderer backends.
+
+Implementations land in:
+
+- #4760 — :class:`MatplotlibRenderer` (matplotlib 3D Poly3DCollection)
+- #4762 — :class:`PyQtGLRenderer` (pyqtgraph.opengl)
+
+This module is currently a placeholder.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/shapes/__init__.py
+++ b/src/shared/python/body_part_viz/shapes/__init__.py
@@ -1,0 +1,14 @@
+"""Body-part shapes (primitives, mesh, composite).
+
+Concrete implementations land in:
+
+- #4759 — primitives (Line, Cylinder, Ellipsoid, Capsule, Composite)
+- #4758 — :class:`MeshShape` with STL/OBJ/PLY/GLB loaders via trimesh
+
+This module is currently a placeholder so callers can write
+``from body_part_viz.shapes import ...`` once implementations land.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/theme.py
+++ b/src/shared/python/body_part_viz/theme.py
@@ -1,0 +1,98 @@
+"""Visual theme for body-part shapes.
+
+Themes are intentionally small and stateless. They describe **how** a
+shape is rendered (color, opacity, edge style) without committing to a
+specific renderer backend.
+
+Design by Contract
+------------------
+``__post_init__`` validates every invariant.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+__all__ = ["ShapeTheme"]
+
+
+# Matplotlib's full color spec is rich; we accept a conservative subset
+# that's easy to validate without importing matplotlib. Allowed forms:
+#   - "#rgb" / "#rgba" / "#rrggbb" / "#rrggbbaa"
+#   - named colors (any non-empty alphabetic identifier; downstream
+#     renderers do the final validation)
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+_NAMED_COLOR_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_:-]*$")
+
+
+def _check_color(name: str, value: str) -> None:
+    """Validate that *value* parses as either ``#hex`` or a named color."""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be str, got {type(value).__name__}")
+    if not value:
+        raise ValueError(f"{name} must be non-empty")
+    if value.startswith("#"):
+        if not _HEX_COLOR_RE.match(value):
+            raise ValueError(
+                f"{name}={value!r} is not a valid hex color (#rgb / #rgba / "
+                "#rrggbb / #rrggbbaa)"
+            )
+        return
+    if not _NAMED_COLOR_RE.match(value):
+        raise ValueError(
+            f"{name}={value!r} is not a valid color (must be #hex or a named color)"
+        )
+
+
+@dataclass(frozen=True)
+class ShapeTheme:
+    """Visual styling for a body-part shape.
+
+    Attributes:
+        color: Fill color, either ``#hex`` or a named color string.
+        opacity: Alpha in [0.0, 1.0].
+        edge_color: Edge color, same format as ``color``.
+        edge_width: Edge width in points; must be ``>= 0``.
+        flat_shaded: True for flat shading, False for smooth (Gouraud).
+        group: Logical grouping name; used by themed colour palettes.
+            Must be a non-empty string.
+    """
+
+    color: str = "#1f77b4"
+    opacity: float = 0.8
+    edge_color: str = "#000000"
+    edge_width: float = 0.5
+    flat_shaded: bool = True
+    group: str = "default"
+
+    def __post_init__(self) -> None:
+        _check_color("color", self.color)
+        _check_color("edge_color", self.edge_color)
+
+        if not isinstance(self.opacity, (int, float)):
+            raise TypeError(f"opacity must be float, got {type(self.opacity).__name__}")
+        if not math.isfinite(self.opacity):
+            raise ValueError(f"opacity must be finite, got {self.opacity}")
+        if not 0.0 <= self.opacity <= 1.0:
+            raise ValueError(f"opacity must be in [0.0, 1.0], got {self.opacity}")
+
+        if not isinstance(self.edge_width, (int, float)):
+            raise TypeError(
+                f"edge_width must be float, got {type(self.edge_width).__name__}"
+            )
+        if not math.isfinite(self.edge_width):
+            raise ValueError(f"edge_width must be finite, got {self.edge_width}")
+        if self.edge_width < 0.0:
+            raise ValueError(f"edge_width must be >= 0, got {self.edge_width}")
+
+        if not isinstance(self.flat_shaded, bool):
+            raise TypeError(
+                f"flat_shaded must be bool, got {type(self.flat_shaded).__name__}"
+            )
+
+        if not isinstance(self.group, str):
+            raise TypeError(f"group must be str, got {type(self.group).__name__}")
+        if not self.group:
+            raise ValueError("group must be non-empty")

--- a/tests/unit/body_part_viz/test_bindings.py
+++ b/tests/unit/body_part_viz/test_bindings.py
@@ -1,0 +1,272 @@
+"""Tests for ``body_part_viz.bindings``.
+
+Covers:
+- :class:`BindingKind` enum members and string round-trip.
+- :class:`MarkerBinding` invariants (per-kind marker count, name validity,
+  rest dimensions, quaternion unit norm).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.body_part_viz.bindings import (
+    BindingKind,
+    MarkerBinding,
+    _check_positive_rest_dimensions,
+    _check_unit_quaternion,
+)
+
+
+# ---------------------------------------------------------------------------
+# BindingKind enum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_binding_kind_values() -> None:
+    assert BindingKind.BETWEEN_TWO.value == "between_two"
+    assert BindingKind.CLUSTER.value == "cluster"
+    assert BindingKind.ON_MARKER.value == "on_marker"
+
+
+@pytest.mark.unit
+def test_binding_kind_string_roundtrip() -> None:
+    """BindingKind inherits ``str`` for transparent JSON serialisation."""
+    for kind in BindingKind:
+        assert kind == BindingKind(kind.value)
+        assert str(kind.value) == kind.value
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_between_two_happy_path() -> None:
+    b = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("shoulder_l", "elbow_l"),
+        rest_dimensions=(0.30,),
+    )
+    assert b.kind is BindingKind.BETWEEN_TWO
+    assert b.marker_names == ("shoulder_l", "elbow_l")
+    assert b.rest_dimensions == (0.30,)
+    assert b.rest_orientation_quat == (1.0, 0.0, 0.0, 0.0)
+
+
+@pytest.mark.unit
+def test_cluster_happy_path_three_markers() -> None:
+    b = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=("a", "b", "c"),
+        rest_dimensions=(0.10, 0.05, 0.05),
+    )
+    assert b.kind is BindingKind.CLUSTER
+
+
+@pytest.mark.unit
+def test_cluster_happy_path_more_markers() -> None:
+    """CLUSTER accepts arbitrary marker counts >= 3."""
+    b = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=("a", "b", "c", "d", "e"),
+    )
+    assert len(b.marker_names) == 5
+
+
+@pytest.mark.unit
+def test_on_marker_happy_path() -> None:
+    b = MarkerBinding(
+        kind=BindingKind.ON_MARKER,
+        marker_names=("head_top",),
+        rest_dimensions=(0.20, 0.20, 0.25),
+    )
+    assert b.marker_names == ("head_top",)
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — frozen invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_marker_binding_is_frozen() -> None:
+    b = MarkerBinding(BindingKind.ON_MARKER, ("head",))
+    with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+        b.kind = BindingKind.BETWEEN_TWO  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — DbC failures: marker count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_between_two_rejects_one_marker() -> None:
+    with pytest.raises(ValueError, match="exactly 2 markers"):
+        MarkerBinding(BindingKind.BETWEEN_TWO, ("solo",))
+
+
+@pytest.mark.unit
+def test_between_two_rejects_three_markers() -> None:
+    with pytest.raises(ValueError, match="exactly 2 markers"):
+        MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b", "c"))
+
+
+@pytest.mark.unit
+def test_cluster_rejects_two_markers() -> None:
+    with pytest.raises(ValueError, match="at least 3 markers"):
+        MarkerBinding(BindingKind.CLUSTER, ("a", "b"))
+
+
+@pytest.mark.unit
+def test_on_marker_rejects_two_markers() -> None:
+    with pytest.raises(ValueError, match="exactly 1 marker"):
+        MarkerBinding(BindingKind.ON_MARKER, ("a", "b"))
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — DbC failures: marker names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_marker_names_must_be_strings() -> None:
+    with pytest.raises(TypeError, match="must be str"):
+        MarkerBinding(BindingKind.BETWEEN_TWO, ("a", 42))  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_marker_names_must_be_non_empty() -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        MarkerBinding(BindingKind.BETWEEN_TWO, ("a", ""))
+
+
+@pytest.mark.unit
+def test_marker_names_must_be_unique() -> None:
+    with pytest.raises(ValueError, match="must be unique"):
+        MarkerBinding(BindingKind.CLUSTER, ("a", "b", "a"))
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — DbC failures: kind type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_kind_must_be_binding_kind_enum() -> None:
+    with pytest.raises(TypeError, match="kind must be BindingKind"):
+        MarkerBinding("between_two", ("a", "b"))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — DbC failures: rest dimensions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_rest_dimensions_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        MarkerBinding(
+            BindingKind.BETWEEN_TWO,
+            ("a", "b"),
+            rest_dimensions=(-0.1,),
+        )
+
+
+@pytest.mark.unit
+def test_rest_dimensions_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        MarkerBinding(
+            BindingKind.BETWEEN_TWO,
+            ("a", "b"),
+            rest_dimensions=(0.0,),
+        )
+
+
+@pytest.mark.unit
+def test_rest_dimensions_rejects_inf() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        MarkerBinding(
+            BindingKind.BETWEEN_TWO,
+            ("a", "b"),
+            rest_dimensions=(float("inf"),),
+        )
+
+
+@pytest.mark.unit
+def test_rest_dimensions_rejects_nan() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        MarkerBinding(
+            BindingKind.BETWEEN_TWO,
+            ("a", "b"),
+            rest_dimensions=(float("nan"),),
+        )
+
+
+# ---------------------------------------------------------------------------
+# MarkerBinding — DbC failures: quaternion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_quaternion_must_be_unit_norm() -> None:
+    with pytest.raises(ValueError, match="unit-norm"):
+        MarkerBinding(
+            BindingKind.ON_MARKER,
+            ("a",),
+            rest_orientation_quat=(2.0, 0.0, 0.0, 0.0),
+        )
+
+
+@pytest.mark.unit
+def test_quaternion_accepts_identity() -> None:
+    MarkerBinding(
+        BindingKind.ON_MARKER,
+        ("a",),
+        rest_orientation_quat=(1.0, 0.0, 0.0, 0.0),
+    )
+
+
+@pytest.mark.unit
+def test_quaternion_accepts_rotated_unit() -> None:
+    """A 90° rotation about z: q = (cos(45°), 0, 0, sin(45°))."""
+    import math
+
+    c = math.cos(math.radians(45))
+    s = math.sin(math.radians(45))
+    MarkerBinding(
+        BindingKind.ON_MARKER,
+        ("a",),
+        rest_orientation_quat=(c, 0.0, 0.0, s),
+    )
+
+
+@pytest.mark.unit
+def test_quaternion_rejects_wrong_length() -> None:
+    with pytest.raises(ValueError, match="4 components"):
+        _check_unit_quaternion((1.0, 0.0, 0.0))  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_quaternion_rejects_inf_components() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _check_unit_quaternion((float("inf"), 0.0, 0.0, 0.0))
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_check_positive_rest_dimensions_accepts_empty() -> None:
+    """Empty tuple is valid (some shapes have no rest dimensions)."""
+    _check_positive_rest_dimensions(())
+
+
+@pytest.mark.unit
+def test_check_positive_rest_dimensions_accepts_all_positive() -> None:
+    _check_positive_rest_dimensions((0.1, 0.2, 0.3))

--- a/tests/unit/body_part_viz/test_contracts.py
+++ b/tests/unit/body_part_viz/test_contracts.py
@@ -1,0 +1,209 @@
+"""Tests for ``body_part_viz.contracts``.
+
+Confirms that:
+
+- The three Protocols (`BodyPartShape`, `ShapeFitter`, `ShapeRenderer`) are
+  ``@runtime_checkable``.
+- A duck-typed implementation passes ``isinstance()`` checks.
+- The module's public API is what we expect.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import (
+    BodyPartShape,
+    ShapeFitter,
+    ShapeRenderer,
+)
+from src.shared.python.body_part_viz.theme import ShapeTheme
+
+
+# ---------------------------------------------------------------------------
+# BodyPartShape
+# ---------------------------------------------------------------------------
+
+
+class _StubShape:
+    """Minimal duck-typed BodyPartShape for protocol verification."""
+
+    shape_id = "stub"
+    rest_dimensions = (1.0,)
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
+    def faces(self) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.int64)
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        T = fitted.n_frames
+        V = self.vertices_at_rest().shape[0]
+        return np.zeros((T, V, 3))
+
+
+@pytest.mark.unit
+def test_stub_shape_satisfies_body_part_shape_protocol() -> None:
+    assert isinstance(_StubShape(), BodyPartShape)
+
+
+@pytest.mark.unit
+def test_object_missing_methods_fails_protocol() -> None:
+    class _Bad:
+        shape_id = "bad"
+        rest_dimensions = (1.0,)
+
+    assert not isinstance(_Bad(), BodyPartShape)
+
+
+# ---------------------------------------------------------------------------
+# ShapeFitter
+# ---------------------------------------------------------------------------
+
+
+class _StubFitter:
+    """Identity fitter for protocol verification."""
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        n_frames = next(iter(markers_xyz.values())).shape[0]
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=np.zeros((n_frames, 3)),
+            rotation_matrix=np.tile(np.eye(3), (n_frames, 1, 1)),
+            scale=np.ones((n_frames, 3)),
+            valid_mask=np.ones(n_frames, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_stub_fitter_satisfies_shape_fitter_protocol() -> None:
+    assert isinstance(_StubFitter(), ShapeFitter)
+
+
+@pytest.mark.unit
+def test_stub_fitter_round_trip() -> None:
+    """Stub fitter actually produces a valid FittedShape."""
+    fitter = _StubFitter()
+    shape = _StubShape()
+    binding = MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+    markers = {
+        "a": np.zeros((5, 3)),
+        "b": np.array([[1.0, 0.0, 0.0]] * 5),
+    }
+    fit = fitter.fit(shape, binding, markers)
+    assert fit.shape_id == "stub"
+    assert fit.n_frames == 5
+
+
+# ---------------------------------------------------------------------------
+# ShapeRenderer
+# ---------------------------------------------------------------------------
+
+
+class _StubRenderer:
+    """In-memory renderer that satisfies the protocol."""
+
+    def __init__(self) -> None:
+        self._handles: dict[str, tuple[BodyPartShape, FittedShape, ShapeTheme]] = {}
+        self._visible: dict[str, bool] = {}
+        self._frame: dict[str, int] = {}
+
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str:
+        if shape.shape_id != fitted.shape_id:
+            raise ValueError("shape.shape_id != fitted.shape_id")
+        handle = f"h{len(self._handles)}"
+        self._handles[handle] = (shape, fitted, theme)
+        self._visible[handle] = True
+        self._frame[handle] = 0
+        return handle
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        if handle not in self._handles:
+            raise KeyError(handle)
+        _, fitted, _ = self._handles[handle]
+        if not 0 <= frame_idx < fitted.n_frames:
+            raise IndexError(frame_idx)
+        self._frame[handle] = frame_idx
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        if handle not in self._handles:
+            raise KeyError(handle)
+        self._visible[handle] = visible
+
+    def remove(self, handle: str) -> None:
+        # Idempotent.
+        self._handles.pop(handle, None)
+        self._visible.pop(handle, None)
+        self._frame.pop(handle, None)
+
+
+@pytest.mark.unit
+def test_stub_renderer_satisfies_shape_renderer_protocol() -> None:
+    assert isinstance(_StubRenderer(), ShapeRenderer)
+
+
+@pytest.mark.unit
+def test_stub_renderer_lifecycle() -> None:
+    """Sanity: the stub renderer's add/update/visible/remove all work."""
+    renderer = _StubRenderer()
+    shape = _StubShape()
+    binding = MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+    fitted = FittedShape(
+        shape_id="stub",
+        binding=binding,
+        centroid=np.zeros((3, 3)),
+        rotation_matrix=np.tile(np.eye(3), (3, 1, 1)),
+        scale=np.ones((3, 3)),
+        valid_mask=np.ones(3, dtype=bool),
+    )
+    theme = ShapeTheme()
+
+    handle = renderer.add_shape(shape, fitted, theme)
+    assert isinstance(handle, str)
+
+    renderer.update_frame(handle, 1)
+    renderer.set_visible(handle, False)
+
+    with pytest.raises(IndexError):
+        renderer.update_frame(handle, 99)
+
+    with pytest.raises(KeyError):
+        renderer.update_frame("nonexistent", 0)
+
+    renderer.remove(handle)
+    renderer.remove(handle)  # idempotent
+
+    with pytest.raises(KeyError):
+        renderer.update_frame(handle, 0)
+
+
+@pytest.mark.unit
+def test_renderer_rejects_shape_id_mismatch() -> None:
+    renderer = _StubRenderer()
+    shape = _StubShape()
+    binding = MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+    wrong = FittedShape(
+        shape_id="other",
+        binding=binding,
+        centroid=np.zeros((1, 3)),
+        rotation_matrix=np.tile(np.eye(3), (1, 1, 1)),
+        scale=np.ones((1, 3)),
+        valid_mask=np.ones(1, dtype=bool),
+    )
+    with pytest.raises(ValueError, match="shape_id"):
+        renderer.add_shape(shape, wrong, ShapeTheme())

--- a/tests/unit/body_part_viz/test_fitted_shape.py
+++ b/tests/unit/body_part_viz/test_fitted_shape.py
@@ -1,0 +1,254 @@
+"""Tests for ``body_part_viz._types.FittedShape``.
+
+Covers shape invariants on the centroid / rotation / scale / valid_mask
+arrays, dtype enforcement, and the n_frames property.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+
+
+def _example_binding() -> MarkerBinding:
+    return MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+
+
+def _identity_fit(n_frames: int) -> FittedShape:
+    """Build a no-op identity FittedShape with ``n_frames`` frames."""
+    return FittedShape(
+        shape_id="example",
+        binding=_example_binding(),
+        centroid=np.zeros((n_frames, 3)),
+        rotation_matrix=np.tile(np.eye(3), (n_frames, 1, 1)),
+        scale=np.ones((n_frames, 3)),
+        valid_mask=np.ones(n_frames, dtype=bool),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_happy_path_construction() -> None:
+    fs = _identity_fit(10)
+    assert fs.n_frames == 10
+    assert fs.shape_id == "example"
+
+
+@pytest.mark.unit
+def test_zero_frames_is_valid() -> None:
+    """A 0-frame fit (e.g. empty trajectory) is a degenerate but valid case."""
+    fs = _identity_fit(0)
+    assert fs.n_frames == 0
+
+
+@pytest.mark.unit
+def test_n_frames_matches_centroid_shape() -> None:
+    fs = _identity_fit(42)
+    assert fs.n_frames == 42
+
+
+# ---------------------------------------------------------------------------
+# Frozen invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fitted_shape_is_frozen() -> None:
+    fs = _identity_fit(1)
+    with pytest.raises(Exception):  # noqa: B017
+        fs.shape_id = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DbC: shape_id and binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_rejects_empty_shape_id() -> None:
+    with pytest.raises(ValueError, match="shape_id must be a non-empty string"):
+        FittedShape(
+            shape_id="",
+            binding=_example_binding(),
+            centroid=np.zeros((1, 3)),
+            rotation_matrix=np.tile(np.eye(3), (1, 1, 1)),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones(1, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_non_marker_binding() -> None:
+    with pytest.raises(TypeError, match="binding must be MarkerBinding"):
+        FittedShape(
+            shape_id="x",
+            binding="not a binding",  # type: ignore[arg-type]
+            centroid=np.zeros((1, 3)),
+            rotation_matrix=np.tile(np.eye(3), (1, 1, 1)),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones(1, dtype=bool),
+        )
+
+
+# ---------------------------------------------------------------------------
+# DbC: array shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_rejects_non_numpy_arrays() -> None:
+    with pytest.raises(TypeError, match="centroid must be numpy.ndarray"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=[[0, 0, 0]],  # type: ignore[arg-type]
+            rotation_matrix=np.tile(np.eye(3), (1, 1, 1)),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones(1, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_centroid_wrong_shape() -> None:
+    with pytest.raises(ValueError, match=r"centroid must have shape \(T, 3\)"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((5, 4)),
+            rotation_matrix=np.tile(np.eye(3), (5, 1, 1)),
+            scale=np.ones((5, 3)),
+            valid_mask=np.ones(5, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_mismatched_rotation_matrix() -> None:
+    with pytest.raises(ValueError, match=r"rotation_matrix must have shape"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((5, 3)),
+            rotation_matrix=np.tile(np.eye(3), (3, 1, 1)),  # wrong T
+            scale=np.ones((5, 3)),
+            valid_mask=np.ones(5, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_mismatched_scale() -> None:
+    with pytest.raises(ValueError, match=r"scale must have shape"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((5, 3)),
+            rotation_matrix=np.tile(np.eye(3), (5, 1, 1)),
+            scale=np.ones((3, 3)),  # wrong T
+            valid_mask=np.ones(5, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_mismatched_valid_mask() -> None:
+    with pytest.raises(ValueError, match=r"valid_mask must have shape"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((5, 3)),
+            rotation_matrix=np.tile(np.eye(3), (5, 1, 1)),
+            scale=np.ones((5, 3)),
+            valid_mask=np.ones(3, dtype=bool),  # wrong T
+        )
+
+
+# ---------------------------------------------------------------------------
+# DbC: dtypes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_valid_mask_must_be_bool_dtype() -> None:
+    with pytest.raises(TypeError, match="valid_mask must have dtype bool"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((1, 3)),
+            rotation_matrix=np.tile(np.eye(3), (1, 1, 1)),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones(1, dtype=np.int64),
+        )
+
+
+# ---------------------------------------------------------------------------
+# DbC: scale positivity (only on valid frames)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scale_must_be_positive_on_valid_frames() -> None:
+    scale = np.ones((3, 3))
+    scale[1, 0] = -0.1  # invalid: negative
+    with pytest.raises(ValueError, match="scale must be strictly positive"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((3, 3)),
+            rotation_matrix=np.tile(np.eye(3), (3, 1, 1)),
+            scale=scale,
+            valid_mask=np.ones(3, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_scale_must_be_finite_on_valid_frames() -> None:
+    scale = np.ones((3, 3))
+    scale[1, 0] = np.nan
+    with pytest.raises(ValueError, match="scale must contain only finite"):
+        FittedShape(
+            shape_id="x",
+            binding=_example_binding(),
+            centroid=np.zeros((3, 3)),
+            rotation_matrix=np.tile(np.eye(3), (3, 1, 1)),
+            scale=scale,
+            valid_mask=np.ones(3, dtype=bool),
+        )
+
+
+@pytest.mark.unit
+def test_scale_invalid_value_ok_on_invalid_frames() -> None:
+    """Negative / nan scale on an invalid frame is allowed (it's not used)."""
+    scale = np.ones((3, 3))
+    scale[1, 0] = -1.0
+    scale[2, 1] = np.nan
+    valid = np.array([True, False, False])
+
+    # No exception — the bad scales are masked out.
+    fs = FittedShape(
+        shape_id="x",
+        binding=_example_binding(),
+        centroid=np.zeros((3, 3)),
+        rotation_matrix=np.tile(np.eye(3), (3, 1, 1)),
+        scale=scale,
+        valid_mask=valid,
+    )
+    assert fs.n_frames == 3
+
+
+@pytest.mark.unit
+def test_zero_frames_skips_scale_check() -> None:
+    """T=0 must not crash the scale-positivity check."""
+    fs = FittedShape(
+        shape_id="x",
+        binding=_example_binding(),
+        centroid=np.zeros((0, 3)),
+        rotation_matrix=np.zeros((0, 3, 3)),
+        scale=np.zeros((0, 3)),
+        valid_mask=np.zeros(0, dtype=bool),
+    )
+    assert fs.n_frames == 0

--- a/tests/unit/body_part_viz/test_imports.py
+++ b/tests/unit/body_part_viz/test_imports.py
@@ -1,0 +1,54 @@
+"""Public API import smoke test for body_part_viz.
+
+Confirms the documented public surface is importable in one statement
+and that nothing was forgotten in ``__all__``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_public_api_imports_without_error() -> None:
+    """The documented one-line import works."""
+    from src.shared.python.body_part_viz import (  # noqa: F401
+        BindingKind,
+        BodyPartShape,
+        FittedShape,
+        MarkerBinding,
+        ShapeFitter,
+        ShapeRenderer,
+        ShapeTheme,
+    )
+
+
+@pytest.mark.unit
+def test_all_lists_every_public_export() -> None:
+    """``__all__`` matches the documented public surface."""
+    from src.shared.python import body_part_viz
+
+    expected = {
+        "BindingKind",
+        "BodyPartShape",
+        "FittedShape",
+        "MarkerBinding",
+        "ShapeFitter",
+        "ShapeRenderer",
+        "ShapeTheme",
+    }
+    assert set(body_part_viz.__all__) == expected
+
+
+@pytest.mark.unit
+def test_subpackage_placeholders_load() -> None:
+    """The placeholder sub-packages import without raising."""
+    from src.shared.python.body_part_viz import (  # noqa: F401
+        fitters,
+        renderers,
+        shapes,
+    )
+
+    assert shapes.__all__ == []
+    assert fitters.__all__ == []
+    assert renderers.__all__ == []

--- a/tests/unit/body_part_viz/test_theme.py
+++ b/tests/unit/body_part_viz/test_theme.py
@@ -1,0 +1,201 @@
+"""Tests for ``body_part_viz.theme``.
+
+Covers :class:`ShapeTheme` validation: color string forms, opacity and
+edge-width ranges, frozen-dataclass invariant, and group string non-emptiness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.body_part_viz.theme import ShapeTheme
+
+
+# ---------------------------------------------------------------------------
+# Defaults + happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_defaults() -> None:
+    t = ShapeTheme()
+    assert t.color == "#1f77b4"
+    assert t.opacity == 0.8
+    assert t.edge_color == "#000000"
+    assert t.edge_width == 0.5
+    assert t.flat_shaded is True
+    assert t.group == "default"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "color",
+    [
+        "#fff",
+        "#ffff",
+        "#abcdef",
+        "#1f77b4",
+        "#1f77b4ff",
+        "red",
+        "tab:blue",
+        "C0",
+        "darkslategray",
+    ],
+)
+def test_accepts_valid_color_forms(color: str) -> None:
+    ShapeTheme(color=color, edge_color=color)
+
+
+@pytest.mark.unit
+def test_accepts_zero_opacity() -> None:
+    ShapeTheme(opacity=0.0)
+
+
+@pytest.mark.unit
+def test_accepts_full_opacity() -> None:
+    ShapeTheme(opacity=1.0)
+
+
+@pytest.mark.unit
+def test_accepts_zero_edge_width() -> None:
+    ShapeTheme(edge_width=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Frozen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_theme_is_frozen() -> None:
+    t = ShapeTheme()
+    with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+        t.color = "#ffffff"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Color validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_color_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="color must be non-empty"):
+        ShapeTheme(color="")
+
+
+@pytest.mark.unit
+def test_color_rejects_non_string() -> None:
+    with pytest.raises(TypeError, match="color must be str"):
+        ShapeTheme(color=42)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_hex",
+    [
+        "#ff",  # too short
+        "#fffff",  # 5 chars
+        "#fffffff",  # 7 chars
+        "#zzzzzz",  # invalid hex digits
+        "#1f77b4ffff",  # too long
+    ],
+)
+def test_color_rejects_invalid_hex(bad_hex: str) -> None:
+    with pytest.raises(ValueError, match="not a valid hex color"):
+        ShapeTheme(color=bad_hex)
+
+
+@pytest.mark.unit
+def test_color_rejects_starts_with_digit() -> None:
+    """Named colors must start with an alpha character."""
+    with pytest.raises(ValueError, match="not a valid color"):
+        ShapeTheme(color="123red")
+
+
+@pytest.mark.unit
+def test_edge_color_rejects_invalid_hex() -> None:
+    with pytest.raises(ValueError, match="edge_color"):
+        ShapeTheme(edge_color="#zz")
+
+
+# ---------------------------------------------------------------------------
+# Opacity validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_opacity_rejects_above_one() -> None:
+    with pytest.raises(ValueError, match=r"opacity must be in \[0.0, 1.0\]"):
+        ShapeTheme(opacity=1.1)
+
+
+@pytest.mark.unit
+def test_opacity_rejects_below_zero() -> None:
+    with pytest.raises(ValueError, match=r"opacity must be in \[0.0, 1.0\]"):
+        ShapeTheme(opacity=-0.1)
+
+
+@pytest.mark.unit
+def test_opacity_rejects_inf() -> None:
+    with pytest.raises(ValueError, match="opacity must be finite"):
+        ShapeTheme(opacity=float("inf"))
+
+
+@pytest.mark.unit
+def test_opacity_rejects_nan() -> None:
+    with pytest.raises(ValueError, match="opacity must be finite"):
+        ShapeTheme(opacity=float("nan"))
+
+
+@pytest.mark.unit
+def test_opacity_rejects_string() -> None:
+    with pytest.raises(TypeError, match="opacity must be float"):
+        ShapeTheme(opacity="0.5")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Edge width validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_edge_width_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="edge_width must be >= 0"):
+        ShapeTheme(edge_width=-0.5)
+
+
+@pytest.mark.unit
+def test_edge_width_rejects_inf() -> None:
+    with pytest.raises(ValueError, match="edge_width must be finite"):
+        ShapeTheme(edge_width=float("inf"))
+
+
+@pytest.mark.unit
+def test_edge_width_rejects_string() -> None:
+    with pytest.raises(TypeError, match="edge_width must be float"):
+        ShapeTheme(edge_width="0.5")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Other field validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_flat_shaded_rejects_int() -> None:
+    """Strict type: flat_shaded must be a bool, not int (per docstring)."""
+    with pytest.raises(TypeError, match="flat_shaded must be bool"):
+        ShapeTheme(flat_shaded=1)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_group_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="group must be non-empty"):
+        ShapeTheme(group="")
+
+
+@pytest.mark.unit
+def test_group_rejects_non_string() -> None:
+    with pytest.raises(TypeError, match="group must be str"):
+        ShapeTheme(group=42)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

**Foundation PR for the body_part_viz EPIC (#4755).** Pure contracts and dataclasses — no shapes, no fitters, no rendering yet. Establishes the abstract surface that every implementation in #4756, #4758, #4759, #4760, #4762, #4763 will conform to.

## Closes

- **#4757** — feat(body_part_viz): core contracts + dataclasses (Shape / Binding / Fitter / Theme)

## What's new

```
src/shared/python/body_part_viz/
├── __init__.py              # public API re-exports
├── bindings.py              # MarkerBinding + BindingKind enum
├── theme.py                 # ShapeTheme dataclass
├── _types.py                # FittedShape per-frame trajectory
├── contracts.py             # BodyPartShape, ShapeFitter, ShapeRenderer protocols
├── shapes/__init__.py       # placeholder (impls in #4759, #4758)
├── fitters/__init__.py      # placeholder (impls in #4756)
└── renderers/__init__.py    # placeholder (impls in #4760, #4762)
```

## Quality bar

| Criterion | Result |
|---|---|
| Test count | 86 |
| Coverage on body_part_viz | **100%** every file |
| `ruff check` | clean |
| `ruff format --check` | clean |
| Test runtime | 2.66s |

### DbC (Design by Contract)

Every dataclass is frozen. Every `__post_init__` validates: enum types, marker counts per binding kind, marker-name uniqueness + non-emptiness, rest dimension positivity + finiteness, quaternion unit-norm, color string forms, opacity range [0,1], edge_width >= 0, group non-emptiness, all array shapes + dtypes.

### DRY

Validation helpers (`_check_unit_quaternion`, `_check_positive_rest_dimensions`, `_check_color`) extracted to module level rather than duplicated across dataclass `__post_init__` bodies.

### LoD (Law of Demeter)

Dataclasses expose direct attributes only. `FittedShape.n_frames` is the one derived property to avoid `centroid.shape[0]` chains downstream.

### Test coverage breakdown

- `test_imports.py` (3) — one-line public API import + `__all__` contract.
- `test_bindings.py` (26) — enum values, per-kind invariants, name validation, quaternion + rest_dimensions DbC failures.
- `test_theme.py` (33) — color forms (parametrised over hex + named), opacity / edge_width ranges, group non-empty, frozen invariant, every type-error branch.
- `test_fitted_shape.py` (16) — array shapes, dtypes, scale positivity on **valid** frames only, frozen invariant, T=0 edge case.
- `test_contracts.py` (7) — `runtime_checkable` Protocol verification with stub implementations including a working in-memory renderer.

## Out of scope (tracked under EPIC #4755)

- Concrete shapes — #4759 (primitives), #4758 (mesh)
- Concrete fitters — #4756
- Concrete renderers — #4760 (matplotlib), #4762 (pyqtgraph)
- Asset library — #4761
- Persistence schema — #4763
- Integrations — #4764, #4765, #4767
- Comprehensive tests + golden snapshots — #4766
- Docs — #4768

## Test plan

- [x] All 86 tests pass
- [x] 100% line coverage on every file in the package
- [x] `ruff check` + `ruff format` clean
- [x] No production code outside `src/shared/python/body_part_viz/` is touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)