### PR TITLE
feat(body-part-viz): contracts + dataclasses (#4757)

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,0 +1,26 @@
+"""Body-part visualisation contracts and dataclasses.
+
+This package defines the abstract surface (Protocols + frozen dataclasses)
+that every shape, fitter, and renderer implementation talks across.
+
+Implementations of shapes, fitters, and rendering backends live in the
+``shapes``, ``fitters``, and ``renderers`` sub-packages and are added in
+follow-up issues of EPIC #4755.
+"""
+
+from __future__ import annotations
+
+from ._types import FittedShape
+from .bindings import BindingKind, MarkerBinding
+from .contracts import BodyPartShape, ShapeFitter, ShapeRenderer
+from .theme import ShapeTheme
+
+__all__ = [
+    "BindingKind",
+    "BodyPartShape",
+    "FittedShape",
+    "MarkerBinding",
+    "ShapeFitter",
+    "ShapeRenderer",
+    "ShapeTheme",
+]

--- a/src/shared/python/body_part_viz/_types.py
+++ b/src/shared/python/body_part_viz/_types.py
@@ -1,0 +1,105 @@
+"""Shared dataclasses for body_part_viz: per-frame fitted-shape state.
+
+``FittedShape`` is the output of any :class:`ShapeFitter`. It is consumed by
+:class:`BodyPartShape.transform` and :class:`ShapeRenderer.add_shape`.
+
+All fields are validated for shape and dtype consistency in
+``__post_init__`` (Design-by-Contract).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .bindings import MarkerBinding
+
+__all__ = ["FittedShape"]
+
+
+@dataclass(frozen=True)
+class FittedShape:
+    """Per-frame placement of a fitted shape.
+
+    Attributes
+    ----------
+    shape_id:
+        Stable, non-empty identifier of the shape this fit refers to.
+    binding:
+        The marker binding used to compute this fit.
+    centroid:
+        ``(T, 3)`` world-frame centroid per frame.
+    rotation_matrix:
+        ``(T, 3, 3)`` rotation matrix per frame.
+    scale:
+        ``(T, 3)`` anisotropic scale per frame; entries on valid frames
+        must be strictly positive.
+    valid_mask:
+        ``(T,)`` boolean mask. A frame is valid iff all source markers
+        contributing to it are finite.
+    """
+
+    shape_id: str
+    binding: MarkerBinding
+    centroid: np.ndarray
+    rotation_matrix: np.ndarray
+    scale: np.ndarray
+    valid_mask: np.ndarray
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.shape_id, str) or not self.shape_id:
+            raise ValueError(
+                f"shape_id must be a non-empty string; got {self.shape_id!r}"
+            )
+        if not isinstance(self.binding, MarkerBinding):
+            raise TypeError(
+                f"binding must be a MarkerBinding; got {type(self.binding).__name__}"
+            )
+
+        for name in ("centroid", "rotation_matrix", "scale", "valid_mask"):
+            arr = getattr(self, name)
+            if not isinstance(arr, np.ndarray):
+                raise TypeError(
+                    f"{name} must be a numpy.ndarray; got {type(arr).__name__}"
+                )
+
+        if self.centroid.ndim != 2 or self.centroid.shape[1] != 3:
+            raise ValueError(
+                f"centroid must have shape (T, 3); got {self.centroid.shape}"
+            )
+        n_frames = self.centroid.shape[0]
+
+        expected_rot = (n_frames, 3, 3)
+        if self.rotation_matrix.shape != expected_rot:
+            raise ValueError(
+                f"rotation_matrix must have shape {expected_rot}; "
+                f"got {self.rotation_matrix.shape}"
+            )
+
+        expected_scale = (n_frames, 3)
+        if self.scale.shape != expected_scale:
+            raise ValueError(
+                f"scale must have shape {expected_scale}; got {self.scale.shape}"
+            )
+
+        expected_mask = (n_frames,)
+        if self.valid_mask.shape != expected_mask:
+            raise ValueError(
+                f"valid_mask must have shape {expected_mask}; "
+                f"got {self.valid_mask.shape}"
+            )
+
+        if self.valid_mask.dtype != np.bool_:
+            raise TypeError(
+                f"valid_mask must have dtype=bool; got {self.valid_mask.dtype}"
+            )
+
+        if n_frames > 0 and bool(self.valid_mask.any()):
+            valid_scale = self.scale[self.valid_mask]
+            if not bool(np.all(np.isfinite(valid_scale))):
+                raise ValueError("scale entries on valid frames must be finite")
+            if not bool(np.all(valid_scale > 0.0)):
+                raise ValueError(
+                    "scale entries on valid frames must be strictly positive"
+                )

--- a/src/shared/python/body_part_viz/bindings.py
+++ b/src/shared/python/body_part_viz/bindings.py
@@ -1,0 +1,119 @@
+"""Marker-binding dataclass and binding-kind enum for body-part visualisations.
+
+Defines how a geometric shape attaches to mocap markers:
+
+* ``BETWEEN_TWO`` — length / orientation derived from two markers.
+* ``CLUSTER`` — rigid Kabsch fit on three or more markers.
+* ``ON_MARKER`` — anchored at a single marker (e.g. head sphere).
+
+The dataclass is frozen and validates all invariants in ``__post_init__``
+(Design-by-Contract).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+
+__all__ = ["BindingKind", "MarkerBinding"]
+
+
+class BindingKind(str, Enum):
+    """How a shape attaches to mocap markers."""
+
+    BETWEEN_TWO = "between_two"
+    CLUSTER = "cluster"
+    ON_MARKER = "on_marker"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class MarkerBinding:
+    """Rest-pose binding of a shape to one or more mocap markers.
+
+    Attributes
+    ----------
+    kind:
+        Which binding strategy to use.
+    marker_names:
+        Tuple of marker label strings. Length depends on ``kind``.
+    rest_dimensions:
+        Optional rest-pose dimensions (lengths / radii). All entries must
+        be strictly positive.
+    rest_orientation_quat:
+        Rest-pose orientation as a unit quaternion ``(w, x, y, z)``.
+    """
+
+    kind: BindingKind
+    marker_names: tuple[str, ...]
+    rest_dimensions: tuple[float, ...] = ()
+    rest_orientation_quat: tuple[float, float, float, float] = field(
+        default=(1.0, 0.0, 0.0, 0.0)
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, BindingKind):
+            raise TypeError(f"kind must be BindingKind, got {type(self.kind).__name__}")
+
+        if not isinstance(self.marker_names, tuple):
+            raise TypeError(
+                "marker_names must be a tuple of strings, "
+                f"got {type(self.marker_names).__name__}"
+            )
+
+        for name in self.marker_names:
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    f"marker_names entries must be non-empty strings; got {name!r}"
+                )
+
+        count = len(self.marker_names)
+        if self.kind is BindingKind.BETWEEN_TWO and count != 2:
+            raise ValueError(
+                f"BETWEEN_TWO binding requires exactly 2 markers, got {count}"
+            )
+        if self.kind is BindingKind.CLUSTER and count < 3:
+            raise ValueError(
+                f"CLUSTER binding requires at least 3 markers, got {count}"
+            )
+        if self.kind is BindingKind.ON_MARKER and count != 1:
+            raise ValueError(
+                f"ON_MARKER binding requires exactly 1 marker, got {count}"
+            )
+
+        if not isinstance(self.rest_dimensions, tuple):
+            raise TypeError(
+                "rest_dimensions must be a tuple of floats, "
+                f"got {type(self.rest_dimensions).__name__}"
+            )
+        for dim in self.rest_dimensions:
+            if not isinstance(dim, (int, float)) or isinstance(dim, bool):
+                raise TypeError(f"rest_dimensions entries must be numeric, got {dim!r}")
+            if not math.isfinite(float(dim)) or float(dim) <= 0.0:
+                raise ValueError(
+                    f"rest_dimensions entries must be finite and positive; got {dim!r}"
+                )
+
+        quat = self.rest_orientation_quat
+        if not isinstance(quat, tuple) or len(quat) != 4:
+            raise ValueError(
+                f"rest_orientation_quat must be a 4-tuple (w, x, y, z); got {quat!r}"
+            )
+        for component in quat:
+            if not isinstance(component, (int, float)) or isinstance(component, bool):
+                raise TypeError(
+                    f"rest_orientation_quat entries must be numeric; got {component!r}"
+                )
+            if not math.isfinite(float(component)):
+                raise ValueError(
+                    f"rest_orientation_quat entries must be finite; got {component!r}"
+                )
+        norm = math.sqrt(sum(float(c) * float(c) for c in quat))
+        if abs(norm - 1.0) > 1e-6:
+            raise ValueError(
+                "rest_orientation_quat must be unit-norm "
+                f"(within 1e-6); got norm={norm:.9f}"
+            )

--- a/src/shared/python/body_part_viz/contracts.py
+++ b/src/shared/python/body_part_viz/contracts.py
@@ -1,0 +1,98 @@
+"""Runtime-checkable Protocols for the body_part_viz package.
+
+These contracts define the abstract surface every shape, fitter, and
+renderer implementation must satisfy. They are intentionally backend-
+agnostic: nothing in this module imports matplotlib, pyqtgraph, or any
+other rendering library.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from ._types import FittedShape
+from .bindings import MarkerBinding
+from .theme import ShapeTheme
+
+__all__ = ["BodyPartShape", "ShapeFitter", "ShapeRenderer"]
+
+
+@runtime_checkable
+class BodyPartShape(Protocol):
+    """A geometric body-part visualisation.
+
+    Implementations include line, cylinder, ellipsoid, capsule, mesh, and
+    composite shapes. Each shape exposes its rest-pose vertices / faces
+    and knows how to apply a :class:`FittedShape` transform.
+    """
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def vertices_at_rest(self) -> np.ndarray:
+        """Return ``(V, 3)`` vertex array in the shape's local frame."""
+        ...
+
+    def faces(self) -> np.ndarray:
+        """Return ``(F, 3)`` triangle indices, or empty array for line shapes."""
+        ...
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        """Return ``(V, 3)`` vertices after applying the fitted transform."""
+        ...
+
+
+@runtime_checkable
+class ShapeFitter(Protocol):
+    """Compute a per-frame transform from markers to a fitted shape."""
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        """Fit ``shape`` to ``markers_xyz`` according to ``binding``.
+
+        Parameters
+        ----------
+        shape:
+            The geometric shape being fitted.
+        binding:
+            Marker binding describing how the shape attaches to markers.
+        markers_xyz:
+            Mapping ``marker_name -> (T, 3)`` world-frame positions.
+        """
+        ...
+
+
+@runtime_checkable
+class ShapeRenderer(Protocol):
+    """Backend-specific renderer (matplotlib, pyqtgraph, ...).
+
+    The contract intentionally exposes no Qt or matplotlib types so the
+    same shape / fitter implementations can target any backend.
+    """
+
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str:
+        """Add ``shape`` to the scene and return a stable handle."""
+        ...
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        """Update the geometry referred to by ``handle`` to ``frame_idx``."""
+        ...
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        """Show or hide the geometry referred to by ``handle``."""
+        ...
+
+    def remove(self, handle: str) -> None:
+        """Remove the geometry referred to by ``handle`` from the scene."""
+        ...

--- a/src/shared/python/body_part_viz/fitters/__init__.py
+++ b/src/shared/python/body_part_viz/fitters/__init__.py
@@ -1,0 +1,9 @@
+"""Fitter implementations sub-package.
+
+Concrete :class:`~body_part_viz.contracts.ShapeFitter` implementations
+land in follow-up issues of EPIC #4755.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/renderers/__init__.py
+++ b/src/shared/python/body_part_viz/renderers/__init__.py
@@ -1,0 +1,9 @@
+"""Renderer implementations sub-package.
+
+Concrete :class:`~body_part_viz.contracts.ShapeRenderer` backends
+(matplotlib, pyqtgraph, ...) land in follow-up issues of EPIC #4755.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/shapes/__init__.py
+++ b/src/shared/python/body_part_viz/shapes/__init__.py
@@ -1,0 +1,10 @@
+"""Shape implementations sub-package.
+
+Concrete :class:`~body_part_viz.contracts.BodyPartShape` implementations
+(line, cylinder, ellipsoid, capsule, mesh, composite) land in follow-up
+issues of EPIC #4755.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/body_part_viz/theme.py
+++ b/src/shared/python/body_part_viz/theme.py
@@ -1,0 +1,91 @@
+"""Shape theme dataclass — colour, opacity, edge styling.
+
+Frozen dataclass; validates colour strings via matplotlib's
+``is_color_like`` so the renderers can rely on well-formed input.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from matplotlib.colors import is_color_like
+
+__all__ = ["ShapeTheme"]
+
+
+@dataclass(frozen=True)
+class ShapeTheme:
+    """Visual styling for a single body-part shape.
+
+    Attributes
+    ----------
+    color:
+        Any matplotlib-recognised colour string (e.g. ``"#1f77b4"``,
+        ``"red"``, ``"C0"``).
+    opacity:
+        Alpha in ``[0.0, 1.0]``.
+    edge_color:
+        Edge colour string (matplotlib-recognised).
+    edge_width:
+        Edge line width in points; must be ``>= 0``.
+    flat_shaded:
+        If ``True`` use flat (per-face) shading; else smooth.
+    group:
+        Logical group name used by themed colour palettes.
+    """
+
+    color: str = "#1f77b4"
+    opacity: float = 0.8
+    edge_color: str = "#000000"
+    edge_width: float = 0.5
+    flat_shaded: bool = True
+    group: str = "default"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.color, str) or not self.color:
+            raise ValueError(f"color must be a non-empty string; got {self.color!r}")
+        if not is_color_like(self.color):
+            raise ValueError(
+                f"color {self.color!r} is not a recognised matplotlib colour"
+            )
+
+        if not isinstance(self.edge_color, str) or not self.edge_color:
+            raise ValueError(
+                f"edge_color must be a non-empty string; got {self.edge_color!r}"
+            )
+        if not is_color_like(self.edge_color):
+            raise ValueError(
+                f"edge_color {self.edge_color!r} is not a recognised matplotlib colour"
+            )
+
+        if not isinstance(self.opacity, (int, float)) or isinstance(self.opacity, bool):
+            raise TypeError(
+                f"opacity must be numeric; got {type(self.opacity).__name__}"
+            )
+        opacity = float(self.opacity)
+        if not math.isfinite(opacity) or opacity < 0.0 or opacity > 1.0:
+            raise ValueError(
+                f"opacity must be a finite value in [0, 1]; got {self.opacity!r}"
+            )
+
+        if not isinstance(self.edge_width, (int, float)) or isinstance(
+            self.edge_width, bool
+        ):
+            raise TypeError(
+                f"edge_width must be numeric; got {type(self.edge_width).__name__}"
+            )
+        edge_width = float(self.edge_width)
+        if not math.isfinite(edge_width) or edge_width < 0.0:
+            raise ValueError(
+                f"edge_width must be a finite, non-negative number; "
+                f"got {self.edge_width!r}"
+            )
+
+        if not isinstance(self.flat_shaded, bool):
+            raise TypeError(
+                f"flat_shaded must be bool; got {type(self.flat_shaded).__name__}"
+            )
+
+        if not isinstance(self.group, str) or not self.group:
+            raise ValueError(f"group must be a non-empty string; got {self.group!r}")

--- a/tests/unit/body_part_viz/test_contracts.py
+++ b/tests/unit/body_part_viz/test_contracts.py
@@ -1,0 +1,475 @@
+"""Unit tests for body_part_viz contracts and dataclasses."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    BodyPartShape,
+    FittedShape,
+    MarkerBinding,
+    ShapeFitter,
+    ShapeRenderer,
+    ShapeTheme,
+)
+
+
+# ---------- BindingKind --------------------------------------------------
+
+
+def test_binding_kind_round_trip_through_str() -> None:
+    for kind in BindingKind:
+        as_str = str(kind)
+        assert as_str == kind.value
+        assert BindingKind(as_str) is kind
+
+
+# ---------- MarkerBinding ------------------------------------------------
+
+
+def test_marker_binding_between_two_happy_path() -> None:
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+        rest_dimensions=(0.5,),
+    )
+    assert binding.marker_names == ("a", "b")
+
+
+def test_marker_binding_between_two_wrong_count_raises() -> None:
+    with pytest.raises(ValueError, match="BETWEEN_TWO"):
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a",))
+    with pytest.raises(ValueError, match="BETWEEN_TWO"):
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b", "c"))
+
+
+def test_marker_binding_cluster_happy_path() -> None:
+    binding = MarkerBinding(kind=BindingKind.CLUSTER, marker_names=("a", "b", "c"))
+    assert binding.kind is BindingKind.CLUSTER
+
+
+def test_marker_binding_cluster_too_few_raises() -> None:
+    with pytest.raises(ValueError, match="CLUSTER"):
+        MarkerBinding(kind=BindingKind.CLUSTER, marker_names=("a", "b"))
+
+
+def test_marker_binding_on_marker_happy_path() -> None:
+    binding = MarkerBinding(kind=BindingKind.ON_MARKER, marker_names=("h",))
+    assert binding.marker_names == ("h",)
+
+
+def test_marker_binding_on_marker_wrong_count_raises() -> None:
+    with pytest.raises(ValueError, match="ON_MARKER"):
+        MarkerBinding(kind=BindingKind.ON_MARKER, marker_names=("h1", "h2"))
+
+
+def test_marker_binding_negative_rest_dimensions_raises() -> None:
+    with pytest.raises(ValueError, match="rest_dimensions"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_dimensions=(-1.0,),
+        )
+
+
+def test_marker_binding_zero_rest_dimensions_raises() -> None:
+    with pytest.raises(ValueError, match="rest_dimensions"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_dimensions=(0.0,),
+        )
+
+
+def test_marker_binding_non_unit_quaternion_raises() -> None:
+    with pytest.raises(ValueError, match="unit-norm"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_orientation_quat=(2.0, 0.0, 0.0, 0.0),
+        )
+
+
+def test_marker_binding_quaternion_wrong_length_raises() -> None:
+    with pytest.raises(ValueError, match="rest_orientation_quat"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_orientation_quat=(1.0, 0.0, 0.0),  # type: ignore[arg-type]
+        )
+
+
+def test_marker_binding_quaternion_non_finite_raises() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_orientation_quat=(float("nan"), 0.0, 0.0, 0.0),
+        )
+
+
+def test_marker_binding_kind_wrong_type_raises() -> None:
+    with pytest.raises(TypeError, match="kind"):
+        MarkerBinding(kind="between_two", marker_names=("a", "b"))  # type: ignore[arg-type]
+
+
+def test_marker_binding_marker_names_not_tuple_raises() -> None:
+    with pytest.raises(TypeError, match="marker_names"):
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=["a", "b"])  # type: ignore[arg-type]
+
+
+def test_marker_binding_empty_marker_name_raises() -> None:
+    with pytest.raises(ValueError, match="marker_names"):
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", ""))
+
+
+def test_marker_binding_rest_dimensions_not_tuple_raises() -> None:
+    with pytest.raises(TypeError, match="rest_dimensions"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_dimensions=[1.0],  # type: ignore[arg-type]
+        )
+
+
+def test_marker_binding_rest_dimensions_non_numeric_raises() -> None:
+    with pytest.raises(TypeError, match="rest_dimensions"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_dimensions=("oops",),  # type: ignore[arg-type]
+        )
+
+
+def test_marker_binding_quaternion_non_numeric_raises() -> None:
+    with pytest.raises(TypeError, match="rest_orientation_quat"):
+        MarkerBinding(
+            kind=BindingKind.BETWEEN_TWO,
+            marker_names=("a", "b"),
+            rest_orientation_quat=("a", "b", "c", "d"),  # type: ignore[arg-type]
+        )
+
+
+# ---------- ShapeTheme ---------------------------------------------------
+
+
+def test_shape_theme_defaults() -> None:
+    theme = ShapeTheme()
+    assert 0.0 <= theme.opacity <= 1.0
+    assert theme.edge_width >= 0.0
+
+
+def test_shape_theme_rejects_opacity_above_one() -> None:
+    with pytest.raises(ValueError, match="opacity"):
+        ShapeTheme(opacity=1.5)
+
+
+def test_shape_theme_rejects_opacity_below_zero() -> None:
+    with pytest.raises(ValueError, match="opacity"):
+        ShapeTheme(opacity=-0.1)
+
+
+def test_shape_theme_rejects_negative_edge_width() -> None:
+    with pytest.raises(ValueError, match="edge_width"):
+        ShapeTheme(edge_width=-0.5)
+
+
+def test_shape_theme_rejects_empty_color() -> None:
+    with pytest.raises(ValueError, match="color"):
+        ShapeTheme(color="")
+
+
+def test_shape_theme_rejects_invalid_color() -> None:
+    with pytest.raises(ValueError, match="matplotlib colour"):
+        ShapeTheme(color="not-a-real-colour-name")
+
+
+def test_shape_theme_rejects_invalid_edge_color() -> None:
+    with pytest.raises(ValueError, match="edge_color"):
+        ShapeTheme(edge_color="definitely-not-a-colour")
+
+
+def test_shape_theme_rejects_empty_edge_color() -> None:
+    with pytest.raises(ValueError, match="edge_color"):
+        ShapeTheme(edge_color="")
+
+
+def test_shape_theme_rejects_non_finite_opacity() -> None:
+    with pytest.raises(ValueError, match="opacity"):
+        ShapeTheme(opacity=float("nan"))
+
+
+def test_shape_theme_rejects_non_numeric_opacity() -> None:
+    with pytest.raises(TypeError, match="opacity"):
+        ShapeTheme(opacity="0.5")  # type: ignore[arg-type]
+
+
+def test_shape_theme_rejects_non_numeric_edge_width() -> None:
+    with pytest.raises(TypeError, match="edge_width"):
+        ShapeTheme(edge_width="0.5")  # type: ignore[arg-type]
+
+
+def test_shape_theme_rejects_non_finite_edge_width() -> None:
+    with pytest.raises(ValueError, match="edge_width"):
+        ShapeTheme(edge_width=float("inf"))
+
+
+def test_shape_theme_rejects_non_bool_flat_shaded() -> None:
+    with pytest.raises(TypeError, match="flat_shaded"):
+        ShapeTheme(flat_shaded="yes")  # type: ignore[arg-type]
+
+
+def test_shape_theme_rejects_empty_group() -> None:
+    with pytest.raises(ValueError, match="group"):
+        ShapeTheme(group="")
+
+
+# ---------- Protocol runtime checks --------------------------------------
+
+
+class _StubShape:
+    shape_id = "stub"
+    rest_dimensions: tuple[float, ...] = (1.0,)
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return np.zeros((0, 3))
+
+    def faces(self) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.int64)
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return np.zeros((0, 3))
+
+
+class _StubFitter:
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        n = 1
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=np.zeros((n, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (n, 3, 3)).copy(),
+            scale=np.ones((n, 3)),
+            valid_mask=np.ones((n,), dtype=bool),
+        )
+
+
+class _StubRenderer:
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str:
+        return "h0"
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        return None
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        return None
+
+    def remove(self, handle: str) -> None:
+        return None
+
+
+def test_stub_shape_satisfies_protocol() -> None:
+    assert isinstance(_StubShape(), BodyPartShape)
+
+
+def test_stub_fitter_satisfies_protocol() -> None:
+    assert isinstance(_StubFitter(), ShapeFitter)
+
+
+def test_stub_renderer_satisfies_protocol() -> None:
+    assert isinstance(_StubRenderer(), ShapeRenderer)
+
+
+# ---------- FittedShape --------------------------------------------------
+
+
+def _ok_binding() -> MarkerBinding:
+    return MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b"))
+
+
+def _ok_fitted(n: int = 4) -> FittedShape:
+    return FittedShape(
+        shape_id="stub",
+        binding=_ok_binding(),
+        centroid=np.zeros((n, 3)),
+        rotation_matrix=np.broadcast_to(np.eye(3), (n, 3, 3)).copy(),
+        scale=np.ones((n, 3)),
+        valid_mask=np.ones((n,), dtype=bool),
+    )
+
+
+def test_fitted_shape_happy_path() -> None:
+    fitted = _ok_fitted()
+    assert fitted.centroid.shape == (4, 3)
+
+
+def test_fitted_shape_mismatched_rotation_matrix_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(ValueError, match="rotation_matrix"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((4, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (5, 3, 3)).copy(),
+            scale=np.ones((4, 3)),
+            valid_mask=np.ones((4,), dtype=bool),
+        )
+
+
+def test_fitted_shape_valid_mask_dtype_must_be_bool() -> None:
+    binding = _ok_binding()
+    with pytest.raises(TypeError, match="dtype"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((3, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (3, 3, 3)).copy(),
+            scale=np.ones((3, 3)),
+            valid_mask=np.ones((3,), dtype=np.int64),
+        )
+
+
+def test_fitted_shape_empty_shape_id_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(ValueError, match="shape_id"):
+        FittedShape(
+            shape_id="",
+            binding=binding,
+            centroid=np.zeros((1, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (1, 3, 3)).copy(),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones((1,), dtype=bool),
+        )
+
+
+def test_fitted_shape_binding_wrong_type_raises() -> None:
+    with pytest.raises(TypeError, match="binding"):
+        FittedShape(
+            shape_id="stub",
+            binding="not-a-binding",  # type: ignore[arg-type]
+            centroid=np.zeros((1, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (1, 3, 3)).copy(),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones((1,), dtype=bool),
+        )
+
+
+def test_fitted_shape_centroid_wrong_shape_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(ValueError, match="centroid"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((4, 2)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (4, 3, 3)).copy(),
+            scale=np.ones((4, 3)),
+            valid_mask=np.ones((4,), dtype=bool),
+        )
+
+
+def test_fitted_shape_centroid_not_ndarray_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(TypeError, match="centroid"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=[[0.0, 0.0, 0.0]],  # type: ignore[arg-type]
+            rotation_matrix=np.broadcast_to(np.eye(3), (1, 3, 3)).copy(),
+            scale=np.ones((1, 3)),
+            valid_mask=np.ones((1,), dtype=bool),
+        )
+
+
+def test_fitted_shape_scale_wrong_shape_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(ValueError, match="scale"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((4, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (4, 3, 3)).copy(),
+            scale=np.ones((4, 2)),
+            valid_mask=np.ones((4,), dtype=bool),
+        )
+
+
+def test_fitted_shape_valid_mask_wrong_shape_raises() -> None:
+    binding = _ok_binding()
+    with pytest.raises(ValueError, match="valid_mask"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((4, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (4, 3, 3)).copy(),
+            scale=np.ones((4, 3)),
+            valid_mask=np.ones((5,), dtype=bool),
+        )
+
+
+def test_fitted_shape_non_positive_scale_on_valid_frame_raises() -> None:
+    binding = _ok_binding()
+    scale = np.ones((2, 3))
+    scale[0, 0] = 0.0
+    with pytest.raises(ValueError, match="positive"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((2, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (2, 3, 3)).copy(),
+            scale=scale,
+            valid_mask=np.ones((2,), dtype=bool),
+        )
+
+
+def test_fitted_shape_nan_scale_on_valid_frame_raises() -> None:
+    binding = _ok_binding()
+    scale = np.ones((2, 3))
+    scale[1, 2] = float("nan")
+    with pytest.raises(ValueError, match="finite"):
+        FittedShape(
+            shape_id="stub",
+            binding=binding,
+            centroid=np.zeros((2, 3)),
+            rotation_matrix=np.broadcast_to(np.eye(3), (2, 3, 3)).copy(),
+            scale=scale,
+            valid_mask=np.ones((2,), dtype=bool),
+        )
+
+
+def test_fitted_shape_zero_frames_allowed() -> None:
+    binding = _ok_binding()
+    fitted = FittedShape(
+        shape_id="stub",
+        binding=binding,
+        centroid=np.zeros((0, 3)),
+        rotation_matrix=np.zeros((0, 3, 3)),
+        scale=np.zeros((0, 3)),
+        valid_mask=np.zeros((0,), dtype=bool),
+    )
+    assert fitted.centroid.shape == (0, 3)
+
+
+def test_fitted_shape_invalid_frames_skip_scale_check() -> None:
+    binding = _ok_binding()
+    scale = np.zeros((2, 3))  # zeros would fail if validated
+    fitted = FittedShape(
+        shape_id="stub",
+        binding=binding,
+        centroid=np.zeros((2, 3)),
+        rotation_matrix=np.broadcast_to(np.eye(3), (2, 3, 3)).copy(),
+        scale=scale,
+        valid_mask=np.zeros((2,), dtype=bool),
+    )
+    assert not bool(fitted.valid_mask.any())

--- a/tests/unit/body_part_viz/test_imports.py
+++ b/tests/unit/body_part_viz/test_imports.py
@@ -1,0 +1,36 @@
+"""Public-API smoke test for the body_part_viz package."""
+
+from __future__ import annotations
+
+
+def test_public_api_imports() -> None:
+    from src.shared.python.body_part_viz import (
+        BindingKind,
+        BodyPartShape,
+        FittedShape,
+        MarkerBinding,
+        ShapeFitter,
+        ShapeRenderer,
+        ShapeTheme,
+    )
+
+    expected = {
+        BindingKind,
+        BodyPartShape,
+        FittedShape,
+        MarkerBinding,
+        ShapeFitter,
+        ShapeRenderer,
+        ShapeTheme,
+    }
+    assert all(obj is not None for obj in expected)
+
+
+def test_subpackages_importable() -> None:
+    import src.shared.python.body_part_viz.fitters as fitters
+    import src.shared.python.body_part_viz.renderers as renderers
+    import src.shared.python.body_part_viz.shapes as shapes
+
+    for pkg in (shapes, fitters, renderers):
+        assert hasattr(pkg, "__all__")
+        assert pkg.__all__ == []


### PR DESCRIPTION
Closes #4757
Part of EPIC #4755

## Summary

Foundation for the body_part_viz EPIC. Pure contracts and dataclasses;
no shape primitives, no fitters, no renderers (those are follow-up
issues that drop their files into the new sub-packages).

- Three runtime-checkable Protocols in `contracts.py`: `BodyPartShape`,
  `ShapeFitter`, `ShapeRenderer`.
- Four frozen dataclasses with full DbC validation in `__post_init__`:
  `MarkerBinding` (`bindings.py`), `ShapeTheme` (`theme.py`),
  `FittedShape` (`_types.py`), and the `BindingKind` enum.
- `__init__.py` re-exports the public surface.
- Stub sub-packages `shapes/`, `fitters/`, `renderers/` so #4759/#4756/#4760
  can drop their files in.

## Verification

- ruff check: clean
- ruff format --check: clean
- pytest: 50 passed
- Coverage on `src/shared/python/body_part_viz`: **100.00%** (line + branch)
- File-size budget: clean (largest new file 119 lines)
- mypy --strict: clean on the new module (only diagnostic is a
  pre-existing untyped function in `src/shared/python/__init__.py:64`)

## Test plan

- [x] `python3 -m ruff check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m ruff format --check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m pytest tests/unit/body_part_viz/ -p no:cacheprovider --timeout=60`
- [x] `python3 -m pytest tests/unit/body_part_viz/ --cov=src/shared/python/body_part_viz --cov-branch --cov-report=term-missing`
- [x] `python3 scripts/ci/check_file_size_budget.py`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>