### PR TITLE
feat(body-part-viz): primitive shapes (#4759)

### DIFF
--- a/src/shared/python/body_part_viz/shapes/__init__.py
+++ b/src/shared/python/body_part_viz/shapes/__init__.py
@@ -1,10 +1,20 @@
 """Shape implementations sub-package.
 
-Concrete :class:`~body_part_viz.contracts.BodyPartShape` implementations
-(line, cylinder, ellipsoid, capsule, mesh, composite) land in follow-up
-issues of EPIC #4755.
+Concrete :class:`~body_part_viz.contracts.BodyPartShape` implementations.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .capsule_shape import CapsuleShape
+from .composite_shape import CompositeShape
+from .cylinder_shape import CylinderShape
+from .ellipsoid_shape import EllipsoidShape
+from .line_shape import LineShape
+
+__all__ = [
+    "CapsuleShape",
+    "CompositeShape",
+    "CylinderShape",
+    "EllipsoidShape",
+    "LineShape",
+]

--- a/src/shared/python/body_part_viz/shapes/_mesh_primitives.py
+++ b/src/shared/python/body_part_viz/shapes/_mesh_primitives.py
@@ -1,0 +1,125 @@
+"""Pure-NumPy mesh-primitive helpers for the body_part_viz shapes.
+
+Each helper returns a ``(vertices, faces)`` pair where ``vertices`` has
+shape ``(V, 3)`` (float64) and ``faces`` has shape ``(F, 3)`` (int64).
+
+These helpers are deliberately backend-agnostic: nothing here imports
+matplotlib, trimesh, or any rendering library. They are reused by the
+concrete :class:`BodyPartShape` implementations.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["make_uv_sphere", "make_cylinder", "make_ellipsoid"]
+
+
+def _validate_facets(n_facets: int, n_lat: int | None = None) -> None:
+    if not isinstance(n_facets, int) or isinstance(n_facets, bool):
+        raise TypeError(f"n_facets must be int; got {type(n_facets).__name__}")
+    if n_facets < 3:
+        raise ValueError(f"n_facets must be >= 3; got {n_facets}")
+    if n_lat is not None:
+        if not isinstance(n_lat, int) or isinstance(n_lat, bool):
+            raise TypeError(f"n_lat must be int; got {type(n_lat).__name__}")
+        if n_lat < 2:
+            raise ValueError(f"n_lat must be >= 2; got {n_lat}")
+
+
+def make_uv_sphere(n_lon: int, n_lat: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(vertices, faces)`` for a unit UV sphere.
+
+    The sphere has ``n_lon`` longitudinal segments and ``n_lat`` latitudinal
+    segments, yielding ``n_lon * (n_lat + 1)`` vertices.
+    """
+    _validate_facets(n_lon, n_lat)
+
+    lats = np.linspace(0.0, np.pi, n_lat + 1)
+    lons = np.linspace(0.0, 2.0 * np.pi, n_lon, endpoint=False)
+    lat_grid, lon_grid = np.meshgrid(lats, lons, indexing="ij")
+    sin_lat = np.sin(lat_grid)
+    x = sin_lat * np.cos(lon_grid)
+    y = sin_lat * np.sin(lon_grid)
+    z = np.cos(lat_grid)
+    vertices = np.stack([x, y, z], axis=-1).reshape(-1, 3).astype(np.float64)
+
+    faces: list[tuple[int, int, int]] = []
+    for i in range(n_lat):
+        for j in range(n_lon):
+            j_next = (j + 1) % n_lon
+            v00 = i * n_lon + j
+            v01 = i * n_lon + j_next
+            v10 = (i + 1) * n_lon + j
+            v11 = (i + 1) * n_lon + j_next
+            faces.append((v00, v10, v11))
+            faces.append((v00, v11, v01))
+    faces_arr = np.asarray(faces, dtype=np.int64)
+    return vertices, faces_arr
+
+
+def make_cylinder(
+    length: float, radius: float, n_facets: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(vertices, faces)`` for a closed cylinder along the x-axis.
+
+    The cylinder spans ``x in [0, length]``, with the side ring of radius
+    ``radius`` in the ``yz``-plane. Each cap is a triangle fan around its
+    centre. Total vertex count is ``2 * (n_facets + 1)``; total triangle
+    count is ``4 * n_facets`` (``2 * n_facets`` for the side, ``n_facets``
+    for each cap).
+    """
+    if length <= 0.0:
+        raise ValueError(f"length must be > 0; got {length}")
+    if radius <= 0.0:
+        raise ValueError(f"radius must be > 0; got {radius}")
+    _validate_facets(n_facets)
+
+    angles = np.linspace(0.0, 2.0 * np.pi, n_facets, endpoint=False)
+    cos_a = np.cos(angles)
+    sin_a = np.sin(angles)
+
+    base_ring = np.stack([np.zeros(n_facets), radius * cos_a, radius * sin_a], axis=-1)
+    top_ring = np.stack(
+        [np.full(n_facets, length), radius * cos_a, radius * sin_a], axis=-1
+    )
+    base_centre = np.array([[0.0, 0.0, 0.0]])
+    top_centre = np.array([[length, 0.0, 0.0]])
+
+    vertices = np.concatenate(
+        [base_ring, top_ring, base_centre, top_centre], axis=0
+    ).astype(np.float64)
+    base_centre_idx = 2 * n_facets
+    top_centre_idx = 2 * n_facets + 1
+
+    faces: list[tuple[int, int, int]] = []
+    for j in range(n_facets):
+        j_next = (j + 1) % n_facets
+        v_b0 = j
+        v_b1 = j_next
+        v_t0 = n_facets + j
+        v_t1 = n_facets + j_next
+        faces.append((v_b0, v_t0, v_t1))
+        faces.append((v_b0, v_t1, v_b1))
+    for j in range(n_facets):
+        j_next = (j + 1) % n_facets
+        faces.append((base_centre_idx, j_next, j))
+    for j in range(n_facets):
+        j_next = (j + 1) % n_facets
+        faces.append((top_centre_idx, n_facets + j, n_facets + j_next))
+
+    return vertices, np.asarray(faces, dtype=np.int64)
+
+
+def make_ellipsoid(
+    a: float, b: float, c: float, n_lon: int, n_lat: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(vertices, faces)`` for an ellipsoid with semi-axes ``(a, b, c)``.
+
+    Built from a unit UV sphere scaled by ``(a, b, c)``.
+    """
+    if a <= 0.0 or b <= 0.0 or c <= 0.0:
+        raise ValueError(f"a, b, c must be > 0; got ({a}, {b}, {c})")
+    vertices, faces = make_uv_sphere(n_lon, n_lat)
+    vertices = vertices * np.array([a, b, c], dtype=np.float64)
+    return vertices, faces

--- a/src/shared/python/body_part_viz/shapes/_transform.py
+++ b/src/shared/python/body_part_viz/shapes/_transform.py
@@ -1,0 +1,49 @@
+"""Shared per-frame transform helper for shape implementations.
+
+Applies anisotropic scale (in the shape's local frame) followed by
+rotation and translation, vectorised over frames. Frames marked invalid
+in ``fitted.valid_mask`` produce NaN-filled vertices rather than raising.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+
+__all__ = ["apply_fitted_to_rest_vertices"]
+
+
+def apply_fitted_to_rest_vertices(
+    rest_vertices: np.ndarray, fitted: FittedShape
+) -> np.ndarray:
+    """Return ``(T, V, 3)`` world-frame vertices for each frame.
+
+    For each frame ``t``:
+        ``world[t, v] = rotation[t] @ (scale[t] * rest[v]) + centroid[t]``.
+
+    On invalid frames (``valid_mask[t] == False``) every vertex is NaN.
+    """
+    if rest_vertices.ndim != 2 or rest_vertices.shape[1] != 3:
+        raise ValueError(f"rest_vertices must be (V, 3); got {rest_vertices.shape}")
+
+    n_frames = fitted.centroid.shape[0]
+    n_verts = rest_vertices.shape[0]
+    out = np.full((n_frames, n_verts, 3), np.nan, dtype=np.float64)
+    if n_frames == 0 or n_verts == 0:
+        return out
+
+    valid = fitted.valid_mask
+    if not bool(valid.any()):
+        return out
+
+    rest = rest_vertices.astype(np.float64, copy=False)
+    scale = fitted.scale[valid]
+    rot = fitted.rotation_matrix[valid]
+    cen = fitted.centroid[valid]
+
+    scaled = rest[None, :, :] * scale[:, None, :]
+    rotated = np.einsum("tij,tvj->tvi", rot, scaled)
+    world = rotated + cen[:, None, :]
+    out[valid] = world
+    return out

--- a/src/shared/python/body_part_viz/shapes/capsule_shape.py
+++ b/src/shared/python/body_part_viz/shapes/capsule_shape.py
@@ -1,0 +1,210 @@
+"""Capsule shape: cylinder body + two hemisphere caps.
+
+The capsule's local frame has the long axis along x. The cylinder portion
+spans ``x in [0, length]``; the hemispheres protrude beyond that, so the
+overall extent in x is ``[-radius, length + radius]``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ._transform import apply_fitted_to_rest_vertices
+
+__all__ = ["CapsuleShape"]
+
+
+def _hemisphere_vertices_faces(
+    radius: float, n_lon: int, n_lat: int, *, top: bool
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return vertices/faces for a hemisphere of ``radius``.
+
+    The hemisphere is centred at the origin with its open rim in the
+    ``yz``-plane. ``top=True`` returns the +x half (cap of x-axis); the
+    rim ring lies at ``x=0`` and the apex at ``x=+radius``.
+    ``top=False`` mirrors to the -x side.
+
+    Vertices are emitted from the rim toward the apex so that the rim
+    ring is the FIRST ``n_lon`` vertices — this lets the caller stitch
+    the hemisphere to a cylinder ring without duplicating those vertices.
+    """
+    sign = 1.0 if top else -1.0
+    rings = np.linspace(0.0, np.pi / 2.0, n_lat + 1)
+    lons = np.linspace(0.0, 2.0 * np.pi, n_lon, endpoint=False)
+    cos_lon = np.cos(lons)
+    sin_lon = np.sin(lons)
+
+    verts: list[np.ndarray] = []
+    for i, phi in enumerate(rings):
+        if i == n_lat:
+            continue
+        cos_phi = np.cos(phi)
+        sin_phi = np.sin(phi)
+        ring = np.stack(
+            [
+                np.full(n_lon, sign * radius * sin_phi),
+                radius * cos_phi * cos_lon,
+                radius * cos_phi * sin_lon,
+            ],
+            axis=-1,
+        )
+        verts.append(ring)
+    apex = np.array([[sign * radius, 0.0, 0.0]])
+    verts.append(apex)
+    vertices = np.concatenate(verts, axis=0).astype(np.float64)
+    apex_idx = n_lat * n_lon
+
+    faces: list[tuple[int, int, int]] = []
+    for i in range(n_lat - 1):
+        for j in range(n_lon):
+            j_next = (j + 1) % n_lon
+            v00 = i * n_lon + j
+            v01 = i * n_lon + j_next
+            v10 = (i + 1) * n_lon + j
+            v11 = (i + 1) * n_lon + j_next
+            if top:
+                faces.append((v00, v10, v11))
+                faces.append((v00, v11, v01))
+            else:
+                faces.append((v00, v11, v10))
+                faces.append((v00, v01, v11))
+    last_ring = (n_lat - 1) * n_lon
+    for j in range(n_lon):
+        j_next = (j + 1) % n_lon
+        if top:
+            faces.append((last_ring + j, apex_idx, last_ring + j_next))
+        else:
+            faces.append((last_ring + j, last_ring + j_next, apex_idx))
+    return vertices, np.asarray(faces, dtype=np.int64)
+
+
+class CapsuleShape:
+    """A capsule (cylinder body + two hemisphere caps) along the local x-axis."""
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def __init__(
+        self,
+        length: float,
+        radius: float,
+        n_facets: int = 16,
+        n_lat: int = 8,
+        *,
+        shape_id: str = "capsule",
+    ) -> None:
+        if not np.isfinite(float(length)) or float(length) <= 0.0:
+            raise ValueError(f"length must be finite and > 0; got {length}")
+        if not np.isfinite(float(radius)) or float(radius) <= 0.0:
+            raise ValueError(f"radius must be finite and > 0; got {radius}")
+        if not isinstance(n_facets, int) or isinstance(n_facets, bool):
+            raise TypeError(f"n_facets must be int; got {type(n_facets).__name__}")
+        if not isinstance(n_lat, int) or isinstance(n_lat, bool):
+            raise TypeError(f"n_lat must be int; got {type(n_lat).__name__}")
+        if n_facets < 3:
+            raise ValueError(f"n_facets must be >= 3; got {n_facets}")
+        if n_lat < 2:
+            raise ValueError(f"n_lat must be >= 2; got {n_lat}")
+        if not isinstance(shape_id, str) or not shape_id:
+            raise ValueError(f"shape_id must be non-empty str; got {shape_id!r}")
+
+        self.shape_id = shape_id
+        self.rest_dimensions = (float(length), float(radius))
+        self._n_facets = n_facets
+        self._n_lat = n_lat
+        self._build(float(length), float(radius), n_facets, n_lat)
+
+    def _build(self, length: float, radius: float, n_facets: int, n_lat: int) -> None:
+        angles = np.linspace(0.0, 2.0 * np.pi, n_facets, endpoint=False)
+        cos_a = np.cos(angles)
+        sin_a = np.sin(angles)
+        base_ring = np.stack(
+            [np.zeros(n_facets), radius * cos_a, radius * sin_a], axis=-1
+        )
+        top_ring = np.stack(
+            [np.full(n_facets, length), radius * cos_a, radius * sin_a], axis=-1
+        )
+
+        bot_verts, bot_faces = _hemisphere_vertices_faces(
+            radius, n_facets, n_lat, top=False
+        )
+        top_verts, top_faces = _hemisphere_vertices_faces(
+            radius, n_facets, n_lat, top=True
+        )
+        # Bottom hemisphere rim (first n_facets verts) is identical to base
+        # ring; reuse those vertices instead of duplicating. Translate the
+        # remaining hemisphere verts by (0, 0, 0) -- already at origin.
+        bot_extra = bot_verts[n_facets:]
+        # Top hemisphere rim should align with top_ring at x=length;
+        # translate the entire hemisphere by +length on x.
+        top_translated = top_verts + np.array([length, 0.0, 0.0])
+        top_extra = top_translated[n_facets:]
+
+        n_base = n_facets
+        n_top = n_facets
+        n_bot_extra = bot_extra.shape[0]
+
+        vertices = np.concatenate(
+            [base_ring, top_ring, bot_extra, top_extra], axis=0
+        ).astype(np.float64)
+
+        # Side faces (cylinder body), reusing base_ring (idx 0..n_facets-1)
+        # and top_ring (idx n_facets..2*n_facets-1).
+        side_faces: list[tuple[int, int, int]] = []
+        for j in range(n_facets):
+            j_next = (j + 1) % n_facets
+            v_b0 = j
+            v_b1 = j_next
+            v_t0 = n_facets + j
+            v_t1 = n_facets + j_next
+            side_faces.append((v_b0, v_t0, v_t1))
+            side_faces.append((v_b0, v_t1, v_b1))
+
+        # Re-index hemisphere faces.
+        # Bottom: indices < n_facets refer to its rim (== base_ring [0..n_facets));
+        # indices >= n_facets refer to bot_extra (offset by 2*n_facets).
+        bot_offset = 2 * n_facets - n_facets  # extra-block start - n_facets
+        bot_faces_remap = np.where(
+            bot_faces < n_facets, bot_faces, bot_faces + bot_offset
+        )
+        # Top: rim refers to top_ring [n_facets..2*n_facets); extras live
+        # after bot_extra, i.e. starting at 2*n_facets + n_bot_extra.
+        top_extra_start = 2 * n_facets + n_bot_extra
+        top_offset_rim = n_facets  # rim 0..n_facets -> top_ring n_facets..2n_facets
+        top_offset_extra = top_extra_start - n_facets
+        top_faces_remap = np.where(
+            top_faces < n_facets,
+            top_faces + top_offset_rim,
+            top_faces + top_offset_extra,
+        )
+
+        all_faces = np.concatenate(
+            [
+                np.asarray(side_faces, dtype=np.int64),
+                bot_faces_remap.astype(np.int64),
+                top_faces_remap.astype(np.int64),
+            ],
+            axis=0,
+        )
+        self._vertices = vertices
+        self._faces = all_faces
+        self._n_base = n_base
+        self._n_top = n_top
+
+    @property
+    def n_facets(self) -> int:
+        return self._n_facets
+
+    @property
+    def n_lat(self) -> int:
+        return self._n_lat
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return self._vertices.copy()
+
+    def faces(self) -> np.ndarray:
+        return self._faces.copy()
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return apply_fitted_to_rest_vertices(self._vertices, fitted)

--- a/src/shared/python/body_part_viz/shapes/composite_shape.py
+++ b/src/shared/python/body_part_viz/shapes/composite_shape.py
@@ -1,0 +1,121 @@
+"""Composite shape: a tree of child shapes with per-child local transforms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from .._types import FittedShape
+from ..contracts import BodyPartShape
+from ._transform import apply_fitted_to_rest_vertices
+
+__all__ = ["CompositeShape"]
+
+
+def _validate_local_transform(transform: np.ndarray, idx: int) -> np.ndarray:
+    if not isinstance(transform, np.ndarray):
+        raise TypeError(
+            f"child[{idx}] local_transform must be ndarray; "
+            f"got {type(transform).__name__}"
+        )
+    if transform.shape != (4, 4):
+        raise ValueError(
+            f"child[{idx}] local_transform must be (4, 4); got {transform.shape}"
+        )
+    if not bool(np.all(np.isfinite(transform))):
+        raise ValueError(f"child[{idx}] local_transform must be finite")
+    return transform.astype(np.float64, copy=False)
+
+
+def _apply_local(transform: np.ndarray, vertices: np.ndarray) -> np.ndarray:
+    rot = transform[:3, :3]
+    trans = transform[:3, 3]
+    return vertices @ rot.T + trans
+
+
+class CompositeShape:
+    """Composite of child :class:`BodyPartShape` instances.
+
+    Each child is paired with a 4x4 ``local_transform`` matrix that
+    positions the child within the composite's local frame.
+    ``rest_dimensions`` is the concatenation of every child's
+    ``rest_dimensions``; ``faces()`` re-indexes child faces into a single
+    flat vertex array.
+    """
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def __init__(
+        self,
+        children: Sequence[tuple[BodyPartShape, np.ndarray]],
+        *,
+        shape_id: str = "composite",
+    ) -> None:
+        if not isinstance(children, (list, tuple)):
+            raise TypeError(
+                f"children must be a list/tuple; got {type(children).__name__}"
+            )
+        if len(children) == 0:
+            raise ValueError("children must be non-empty")
+        if not isinstance(shape_id, str) or not shape_id:
+            raise ValueError(f"shape_id must be non-empty str; got {shape_id!r}")
+
+        validated: list[tuple[BodyPartShape, np.ndarray]] = []
+        rest_dims: list[float] = []
+        for idx, entry in enumerate(children):
+            if not isinstance(entry, tuple) or len(entry) != 2:
+                raise TypeError(
+                    f"children[{idx}] must be a (shape, local_transform) tuple"
+                )
+            child_shape, local_transform = entry
+            if not isinstance(child_shape, BodyPartShape):
+                raise TypeError(
+                    f"children[{idx}][0] must satisfy BodyPartShape; "
+                    f"got {type(child_shape).__name__}"
+                )
+            transform = _validate_local_transform(local_transform, idx)
+            validated.append((child_shape, transform))
+            rest_dims.extend(child_shape.rest_dimensions)
+
+        self.shape_id = shape_id
+        self.rest_dimensions = tuple(rest_dims)
+        self._children = tuple(validated)
+        self._build_combined()
+
+    def _build_combined(self) -> None:
+        verts_blocks: list[np.ndarray] = []
+        faces_blocks: list[np.ndarray] = []
+        offset = 0
+        for child_shape, transform in self._children:
+            child_verts = child_shape.vertices_at_rest()
+            child_faces = child_shape.faces()
+            placed = _apply_local(transform, child_verts)
+            verts_blocks.append(placed)
+            if child_faces.size > 0:
+                faces_blocks.append(child_faces.astype(np.int64) + offset)
+            offset += placed.shape[0]
+        self._vertices = (
+            np.concatenate(verts_blocks, axis=0).astype(np.float64)
+            if verts_blocks
+            else np.zeros((0, 3), dtype=np.float64)
+        )
+        self._faces = (
+            np.concatenate(faces_blocks, axis=0).astype(np.int64)
+            if faces_blocks
+            else np.zeros((0, 3), dtype=np.int64)
+        )
+
+    @property
+    def children(self) -> tuple[tuple[BodyPartShape, np.ndarray], ...]:
+        return self._children
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return self._vertices.copy()
+
+    def faces(self) -> np.ndarray:
+        return self._faces.copy()
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return apply_fitted_to_rest_vertices(self._vertices, fitted)

--- a/src/shared/python/body_part_viz/shapes/cylinder_shape.py
+++ b/src/shared/python/body_part_viz/shapes/cylinder_shape.py
@@ -1,0 +1,62 @@
+"""Cylinder shape: closed cylinder along the local x-axis."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ._mesh_primitives import make_cylinder
+from ._transform import apply_fitted_to_rest_vertices
+
+__all__ = ["CylinderShape"]
+
+
+class CylinderShape:
+    """A closed cylinder of length ``length`` and radius ``radius``.
+
+    The local frame has the cylinder axis along x; the cap rings lie in
+    the ``yz``-plane. Vertex count is ``2 * (n_facets + 1)``; triangle
+    count is ``4 * n_facets``.
+    """
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def __init__(
+        self,
+        length: float = 1.0,
+        radius: float = 0.05,
+        n_facets: int = 16,
+        *,
+        shape_id: str = "cylinder",
+    ) -> None:
+        if not np.isfinite(float(length)) or float(length) <= 0.0:
+            raise ValueError(f"length must be finite and > 0; got {length}")
+        if not np.isfinite(float(radius)) or float(radius) <= 0.0:
+            raise ValueError(f"radius must be finite and > 0; got {radius}")
+        if not isinstance(n_facets, int) or isinstance(n_facets, bool):
+            raise TypeError(f"n_facets must be int; got {type(n_facets).__name__}")
+        if n_facets < 3:
+            raise ValueError(f"n_facets must be >= 3; got {n_facets}")
+        if not isinstance(shape_id, str) or not shape_id:
+            raise ValueError(f"shape_id must be non-empty str; got {shape_id!r}")
+
+        self.shape_id = shape_id
+        self.rest_dimensions = (float(length), float(radius))
+        self._n_facets = n_facets
+        self._vertices, self._faces = make_cylinder(
+            float(length), float(radius), n_facets
+        )
+
+    @property
+    def n_facets(self) -> int:
+        return self._n_facets
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return self._vertices.copy()
+
+    def faces(self) -> np.ndarray:
+        return self._faces.copy()
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return apply_fitted_to_rest_vertices(self._vertices, fitted)

--- a/src/shared/python/body_part_viz/shapes/ellipsoid_shape.py
+++ b/src/shared/python/body_part_viz/shapes/ellipsoid_shape.py
@@ -1,0 +1,66 @@
+"""Ellipsoid shape: UV-sphere with three independent semi-axes."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ._mesh_primitives import make_ellipsoid
+from ._transform import apply_fitted_to_rest_vertices
+
+__all__ = ["EllipsoidShape"]
+
+
+class EllipsoidShape:
+    """An ellipsoid with semi-axes ``(a, b, c)`` along the local x/y/z."""
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def __init__(
+        self,
+        a: float,
+        b: float,
+        c: float,
+        n_lon: int = 16,
+        n_lat: int = 8,
+        *,
+        shape_id: str = "ellipsoid",
+    ) -> None:
+        for name, value in (("a", a), ("b", b), ("c", c)):
+            if not np.isfinite(float(value)) or float(value) <= 0.0:
+                raise ValueError(f"{name} must be finite and > 0; got {value}")
+        for name, value in (("n_lon", n_lon), ("n_lat", n_lat)):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"{name} must be int; got {type(value).__name__}")
+        if n_lon < 3:
+            raise ValueError(f"n_lon must be >= 3; got {n_lon}")
+        if n_lat < 2:
+            raise ValueError(f"n_lat must be >= 2; got {n_lat}")
+        if not isinstance(shape_id, str) or not shape_id:
+            raise ValueError(f"shape_id must be non-empty str; got {shape_id!r}")
+
+        self.shape_id = shape_id
+        self.rest_dimensions = (float(a), float(b), float(c))
+        self._n_lon = n_lon
+        self._n_lat = n_lat
+        self._vertices, self._faces = make_ellipsoid(
+            float(a), float(b), float(c), n_lon, n_lat
+        )
+
+    @property
+    def n_lon(self) -> int:
+        return self._n_lon
+
+    @property
+    def n_lat(self) -> int:
+        return self._n_lat
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return self._vertices.copy()
+
+    def faces(self) -> np.ndarray:
+        return self._faces.copy()
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return apply_fitted_to_rest_vertices(self._vertices, fitted)

--- a/src/shared/python/body_part_viz/shapes/line_shape.py
+++ b/src/shared/python/body_part_viz/shapes/line_shape.py
@@ -1,0 +1,42 @@
+"""Line shape: two endpoints along the local x-axis."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ._transform import apply_fitted_to_rest_vertices
+
+__all__ = ["LineShape"]
+
+
+class LineShape:
+    """A 1D line segment of length ``length`` along the local x-axis.
+
+    ``vertices_at_rest()`` returns the two endpoints; ``faces()`` returns
+    an empty ``(0, 3)`` array — line shapes are rendered as edges, not
+    triangles.
+    """
+
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def __init__(self, length: float, *, shape_id: str = "line") -> None:
+        if not isinstance(length, (int, float)) or isinstance(length, bool):
+            raise TypeError(f"length must be numeric; got {type(length).__name__}")
+        if not np.isfinite(float(length)) or float(length) <= 0.0:
+            raise ValueError(f"length must be finite and > 0; got {length}")
+        if not isinstance(shape_id, str) or not shape_id:
+            raise ValueError(f"shape_id must be non-empty str; got {shape_id!r}")
+        self.shape_id = shape_id
+        self.rest_dimensions = (float(length),)
+
+    def vertices_at_rest(self) -> np.ndarray:
+        length = self.rest_dimensions[0]
+        return np.array([[0.0, 0.0, 0.0], [length, 0.0, 0.0]], dtype=np.float64)
+
+    def faces(self) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.int64)
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return apply_fitted_to_rest_vertices(self.vertices_at_rest(), fitted)

--- a/tests/unit/body_part_viz/shapes/_helpers.py
+++ b/tests/unit/body_part_viz/shapes/_helpers.py
@@ -1,0 +1,41 @@
+"""Shared helpers for shape unit tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    FittedShape,
+    MarkerBinding,
+)
+
+
+def make_identity_fitted(
+    shape_id: str = "x",
+    n_frames: int = 1,
+    *,
+    valid: bool = True,
+    rotation: np.ndarray | None = None,
+    centroid: np.ndarray | None = None,
+    scale: np.ndarray | None = None,
+) -> FittedShape:
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+    )
+    if rotation is None:
+        rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+    if centroid is None:
+        centroid = np.zeros((n_frames, 3))
+    if scale is None:
+        scale = np.ones((n_frames, 3))
+    mask = np.full((n_frames,), valid, dtype=bool)
+    return FittedShape(
+        shape_id=shape_id,
+        binding=binding,
+        centroid=centroid,
+        rotation_matrix=rotation,
+        scale=scale,
+        valid_mask=mask,
+    )

--- a/tests/unit/body_part_viz/shapes/test_capsule_shape.py
+++ b/tests/unit/body_part_viz/shapes/test_capsule_shape.py
@@ -1,0 +1,71 @@
+"""Tests for CapsuleShape."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import BodyPartShape
+from src.shared.python.body_part_viz.shapes import CapsuleShape
+
+from ._helpers import make_identity_fitted
+
+
+def test_capsule_vertex_count() -> None:
+    n_facets, n_lat = 16, 8
+    cap = CapsuleShape(1.0, 0.2, n_facets=n_facets, n_lat=n_lat)
+    # Two cylinder rings (rim is shared with hemispheres) + per-hemisphere
+    # interior rings + apex == 2*n_facets + 2*((n_lat-1)*n_facets + 1).
+    expected = 2 * n_facets + 2 * ((n_lat - 1) * n_facets + 1)
+    assert cap.vertices_at_rest().shape == (expected, 3)
+
+
+def test_capsule_protocol() -> None:
+    assert isinstance(CapsuleShape(1.0, 0.2), BodyPartShape)
+
+
+def test_capsule_extent_in_x() -> None:
+    length, radius = 1.0, 0.3
+    cap = CapsuleShape(length, radius, n_facets=12, n_lat=6)
+    v = cap.vertices_at_rest()
+    np.testing.assert_allclose(v[:, 0].min(), -radius, atol=1e-9)
+    np.testing.assert_allclose(v[:, 0].max(), length + radius, atol=1e-9)
+
+
+def test_capsule_endcap_radius_constant() -> None:
+    cap = CapsuleShape(1.0, 0.4, n_facets=16, n_lat=8)
+    v = cap.vertices_at_rest()
+    # Vertices in the cylindrical body should sit on radius 0.4 in yz.
+    body = v[(v[:, 0] >= 0.0) & (v[:, 0] <= 1.0)]
+    yz = np.linalg.norm(body[:, 1:], axis=1)
+    assert yz.max() <= 0.4 + 1e-9
+
+
+def test_capsule_validation() -> None:
+    with pytest.raises(ValueError):
+        CapsuleShape(0.0, 0.1)
+    with pytest.raises(ValueError):
+        CapsuleShape(1.0, -0.1)
+    with pytest.raises(ValueError):
+        CapsuleShape(1.0, 0.1, n_facets=2)
+    with pytest.raises(ValueError):
+        CapsuleShape(1.0, 0.1, n_lat=1)
+    with pytest.raises(TypeError):
+        CapsuleShape(1.0, 0.1, n_facets=4.0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        CapsuleShape(1.0, 0.1, n_lat=4.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        CapsuleShape(1.0, 0.1, shape_id="")
+
+
+def test_capsule_props_and_faces() -> None:
+    cap = CapsuleShape(1.0, 0.1, n_facets=12, n_lat=6)
+    assert cap.n_facets == 12 and cap.n_lat == 6
+    assert cap.faces().shape[1] == 3
+
+
+def test_capsule_transform_identity() -> None:
+    cap = CapsuleShape(1.0, 0.1)
+    fitted = make_identity_fitted("c", n_frames=1)
+    out = cap.transform(fitted)
+    np.testing.assert_allclose(out[0], cap.vertices_at_rest(), atol=1e-12)

--- a/tests/unit/body_part_viz/shapes/test_composite_shape.py
+++ b/tests/unit/body_part_viz/shapes/test_composite_shape.py
@@ -1,0 +1,102 @@
+"""Tests for CompositeShape."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import BodyPartShape
+from src.shared.python.body_part_viz.shapes import (
+    CompositeShape,
+    CylinderShape,
+    LineShape,
+)
+
+from ._helpers import make_identity_fitted
+
+
+def _identity_4x4() -> np.ndarray:
+    return np.eye(4)
+
+
+def _translation_4x4(t: tuple[float, float, float]) -> np.ndarray:
+    m = np.eye(4)
+    m[:3, 3] = t
+    return m
+
+
+def test_composite_protocol() -> None:
+    comp = CompositeShape([(LineShape(1.0), _identity_4x4())])
+    assert isinstance(comp, BodyPartShape)
+
+
+def test_composite_two_cylinders_concat_vertices() -> None:
+    c1 = CylinderShape(1.0, 0.1, n_facets=8)
+    c2 = CylinderShape(1.0, 0.1, n_facets=8)
+    comp = CompositeShape(
+        [(c1, _identity_4x4()), (c2, _translation_4x4((1.0, 0.0, 0.0)))]
+    )
+    v = comp.vertices_at_rest()
+    assert v.shape[0] == c1.vertices_at_rest().shape[0] * 2
+    f = comp.faces()
+    assert f.shape[0] == c1.faces().shape[0] * 2
+    # Re-indexed faces: the second child's max index should reach
+    # 2*V_child - 1.
+    assert int(f.max()) == v.shape[0] - 1
+
+
+def test_composite_local_translation_applied() -> None:
+    line = LineShape(1.0)
+    comp = CompositeShape(
+        [
+            (line, _identity_4x4()),
+            (line, _translation_4x4((10.0, 0.0, 0.0))),
+        ]
+    )
+    v = comp.vertices_at_rest()
+    np.testing.assert_allclose(v[2], [10.0, 0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(v[3], [11.0, 0.0, 0.0], atol=1e-12)
+
+
+def test_composite_rest_dimensions_concat() -> None:
+    line = LineShape(2.0)
+    cyl = CylinderShape(1.0, 0.1)
+    comp = CompositeShape([(line, _identity_4x4()), (cyl, _identity_4x4())])
+    assert comp.rest_dimensions == (2.0, 1.0, 0.1)
+
+
+def test_composite_validation() -> None:
+    with pytest.raises(ValueError):
+        CompositeShape([])
+    with pytest.raises(TypeError):
+        CompositeShape("oops")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        CompositeShape([(LineShape(1.0),)])  # type: ignore[list-item]
+    with pytest.raises(TypeError):
+        CompositeShape([("not a shape", _identity_4x4())])  # type: ignore[list-item]
+    with pytest.raises(TypeError):
+        CompositeShape([(LineShape(1.0), [[1, 0], [0, 1]])])  # type: ignore[list-item]
+    with pytest.raises(ValueError):
+        CompositeShape([(LineShape(1.0), np.eye(3))])
+    with pytest.raises(ValueError):
+        bad = np.eye(4)
+        bad[0, 0] = np.nan
+        CompositeShape([(LineShape(1.0), bad)])
+    with pytest.raises(ValueError):
+        CompositeShape([(LineShape(1.0), _identity_4x4())], shape_id="")
+
+
+def test_composite_transform_identity() -> None:
+    line = LineShape(1.0)
+    comp = CompositeShape([(line, _identity_4x4())])
+    fitted = make_identity_fitted("comp", n_frames=2)
+    out = comp.transform(fitted)
+    assert out.shape == (2, 2, 3)
+    np.testing.assert_allclose(out[0], comp.vertices_at_rest(), atol=1e-12)
+
+
+def test_composite_children_property() -> None:
+    line = LineShape(1.0)
+    comp = CompositeShape([(line, _identity_4x4())])
+    assert len(comp.children) == 1
+    assert comp.children[0][0] is line

--- a/tests/unit/body_part_viz/shapes/test_cylinder_shape.py
+++ b/tests/unit/body_part_viz/shapes/test_cylinder_shape.py
@@ -1,0 +1,51 @@
+"""Tests for CylinderShape."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import BodyPartShape
+from src.shared.python.body_part_viz.shapes import CylinderShape
+
+from ._helpers import make_identity_fitted
+
+
+def test_cylinder_default_counts() -> None:
+    cyl = CylinderShape()
+    assert cyl.vertices_at_rest().shape == (2 * (16 + 1), 3)
+    assert cyl.faces().shape == (4 * 16, 3)
+    assert cyl.rest_dimensions == (1.0, 0.05)
+
+
+def test_cylinder_protocol() -> None:
+    assert isinstance(CylinderShape(), BodyPartShape)
+
+
+def test_cylinder_validation() -> None:
+    with pytest.raises(ValueError):
+        CylinderShape(n_facets=2)
+    with pytest.raises(ValueError):
+        CylinderShape(radius=-0.1)
+    with pytest.raises(ValueError):
+        CylinderShape(length=0.0)
+    with pytest.raises(TypeError):
+        CylinderShape(n_facets=4.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        CylinderShape(shape_id="")
+
+
+def test_cylinder_anisotropic_scale() -> None:
+    cyl = CylinderShape(length=1.0, radius=1.0, n_facets=8)
+    scale = np.array([[2.0, 3.0, 4.0]])
+    fitted = make_identity_fitted("c", n_frames=1, scale=scale)
+    out = cyl.transform(fitted)
+    rest = cyl.vertices_at_rest()
+    np.testing.assert_allclose(out[0, :, 0], rest[:, 0] * 2.0, atol=1e-12)
+    np.testing.assert_allclose(out[0, :, 1], rest[:, 1] * 3.0, atol=1e-12)
+    np.testing.assert_allclose(out[0, :, 2], rest[:, 2] * 4.0, atol=1e-12)
+
+
+def test_cylinder_n_facets_property() -> None:
+    cyl = CylinderShape(n_facets=20)
+    assert cyl.n_facets == 20

--- a/tests/unit/body_part_viz/shapes/test_ellipsoid_shape.py
+++ b/tests/unit/body_part_viz/shapes/test_ellipsoid_shape.py
@@ -1,0 +1,58 @@
+"""Tests for EllipsoidShape."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import BodyPartShape
+from src.shared.python.body_part_viz.shapes import EllipsoidShape
+
+from ._helpers import make_identity_fitted
+
+
+def test_ellipsoid_vertex_count() -> None:
+    e = EllipsoidShape(1.0, 1.0, 1.0)
+    assert e.vertices_at_rest().shape == (16 * 9, 3)
+
+
+def test_ellipsoid_protocol() -> None:
+    assert isinstance(EllipsoidShape(1.0, 1.0, 1.0), BodyPartShape)
+
+
+def test_ellipsoid_axis_relation() -> None:
+    a, b, c = 2.0, 1.5, 0.5
+    e = EllipsoidShape(a, b, c, n_lon=20, n_lat=10)
+    v = e.vertices_at_rest()
+    eq = (v[:, 0] / a) ** 2 + (v[:, 1] / b) ** 2 + (v[:, 2] / c) ** 2
+    np.testing.assert_allclose(eq, 1.0, atol=1e-9)
+
+
+def test_ellipsoid_validation() -> None:
+    with pytest.raises(ValueError):
+        EllipsoidShape(0.0, 1.0, 1.0)
+    with pytest.raises(ValueError):
+        EllipsoidShape(1.0, -1.0, 1.0)
+    with pytest.raises(ValueError):
+        EllipsoidShape(1.0, 1.0, 1.0, n_lon=2)
+    with pytest.raises(ValueError):
+        EllipsoidShape(1.0, 1.0, 1.0, n_lat=1)
+    with pytest.raises(TypeError):
+        EllipsoidShape(1.0, 1.0, 1.0, n_lon=4.0)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        EllipsoidShape(1.0, 1.0, 1.0, n_lat=4.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        EllipsoidShape(1.0, 1.0, 1.0, shape_id="")
+
+
+def test_ellipsoid_props_and_faces() -> None:
+    e = EllipsoidShape(1.0, 2.0, 3.0, n_lon=12, n_lat=6)
+    assert e.n_lon == 12 and e.n_lat == 6
+    assert e.faces().shape[1] == 3
+
+
+def test_ellipsoid_transform_identity() -> None:
+    e = EllipsoidShape(1.0, 1.0, 1.0)
+    fitted = make_identity_fitted("e", n_frames=1)
+    out = e.transform(fitted)
+    np.testing.assert_allclose(out[0], e.vertices_at_rest(), atol=1e-12)

--- a/tests/unit/body_part_viz/shapes/test_line_shape.py
+++ b/tests/unit/body_part_viz/shapes/test_line_shape.py
@@ -1,0 +1,66 @@
+"""Tests for LineShape."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import BodyPartShape
+from src.shared.python.body_part_viz.shapes import LineShape
+
+from ._helpers import make_identity_fitted
+
+
+def test_line_vertex_face_counts() -> None:
+    line = LineShape(2.0)
+    verts = line.vertices_at_rest()
+    assert verts.shape == (2, 3)
+    assert line.faces().shape == (0, 3)
+    np.testing.assert_allclose(verts, [[0, 0, 0], [2, 0, 0]])
+
+
+def test_line_protocol_isinstance() -> None:
+    assert isinstance(LineShape(1.0), BodyPartShape)
+
+
+def test_line_transform_identity_returns_input() -> None:
+    line = LineShape(1.0)
+    fitted = make_identity_fitted("line", n_frames=1)
+    out = line.transform(fitted)
+    assert out.shape == (1, 2, 3)
+    np.testing.assert_allclose(out[0], line.vertices_at_rest(), atol=1e-12)
+
+
+def test_line_transform_rotation() -> None:
+    line = LineShape(1.0)
+    rot = np.array(
+        [
+            [
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ]
+    )
+    fitted = make_identity_fitted("line", n_frames=1, rotation=rot)
+    out = line.transform(fitted)
+    np.testing.assert_allclose(out[0, 1], [0.0, 1.0, 0.0], atol=1e-12)
+
+
+def test_line_transform_invalid_frame_is_nan() -> None:
+    line = LineShape(1.0)
+    fitted = make_identity_fitted("line", n_frames=2, valid=False)
+    out = line.transform(fitted)
+    assert out.shape == (2, 2, 3)
+    assert np.all(np.isnan(out))
+
+
+def test_line_validation() -> None:
+    with pytest.raises(ValueError):
+        LineShape(0.0)
+    with pytest.raises(ValueError):
+        LineShape(-1.0)
+    with pytest.raises(TypeError):
+        LineShape("nope")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        LineShape(1.0, shape_id="")

--- a/tests/unit/body_part_viz/shapes/test_mesh_primitives.py
+++ b/tests/unit/body_part_viz/shapes/test_mesh_primitives.py
@@ -1,0 +1,71 @@
+"""Tests for shapes._mesh_primitives."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.shapes._mesh_primitives import (
+    make_cylinder,
+    make_ellipsoid,
+    make_uv_sphere,
+)
+
+
+def test_uv_sphere_vertex_count() -> None:
+    verts, faces = make_uv_sphere(16, 8)
+    assert verts.shape == (16 * 9, 3)
+    assert faces.shape[1] == 3
+    assert faces.shape[0] == 2 * 16 * 8
+
+
+def test_uv_sphere_unit_radius() -> None:
+    verts, _ = make_uv_sphere(20, 10)
+    norms = np.linalg.norm(verts, axis=1)
+    np.testing.assert_allclose(norms, 1.0, atol=1e-9)
+
+
+def test_uv_sphere_validates_facets() -> None:
+    with pytest.raises(ValueError):
+        make_uv_sphere(2, 4)
+    with pytest.raises(ValueError):
+        make_uv_sphere(8, 1)
+    with pytest.raises(TypeError):
+        make_uv_sphere(8.0, 4)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        make_uv_sphere(8, 4.0)  # type: ignore[arg-type]
+
+
+def test_cylinder_counts() -> None:
+    verts, faces = make_cylinder(1.0, 0.5, 16)
+    assert verts.shape == (2 * (16 + 1), 3)
+    assert faces.shape == (4 * 16, 3)
+
+
+def test_cylinder_watertight_indices_in_range() -> None:
+    verts, faces = make_cylinder(1.0, 0.5, 16)
+    assert int(faces.max()) == verts.shape[0] - 1
+    assert int(faces.min()) == 0
+
+
+def test_cylinder_validation() -> None:
+    with pytest.raises(ValueError):
+        make_cylinder(0.0, 0.5, 16)
+    with pytest.raises(ValueError):
+        make_cylinder(1.0, -0.1, 16)
+    with pytest.raises(ValueError):
+        make_cylinder(1.0, 0.5, 2)
+
+
+def test_ellipsoid_axis_ratio() -> None:
+    a, b, c = 2.0, 1.0, 0.5
+    verts, _ = make_ellipsoid(a, b, c, 16, 8)
+    eq = (verts[:, 0] / a) ** 2 + (verts[:, 1] / b) ** 2 + (verts[:, 2] / c) ** 2
+    np.testing.assert_allclose(eq, 1.0, atol=1e-9)
+
+
+def test_ellipsoid_validation() -> None:
+    with pytest.raises(ValueError):
+        make_ellipsoid(0.0, 1.0, 1.0, 16, 8)
+    with pytest.raises(ValueError):
+        make_ellipsoid(1.0, -1.0, 1.0, 16, 8)

--- a/tests/unit/body_part_viz/shapes/test_transform.py
+++ b/tests/unit/body_part_viz/shapes/test_transform.py
@@ -1,0 +1,24 @@
+"""Tests for the shared _transform helper edge cases."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.shapes._transform import (
+    apply_fitted_to_rest_vertices,
+)
+
+from ._helpers import make_identity_fitted
+
+
+def test_transform_rejects_bad_rest_shape() -> None:
+    fitted = make_identity_fitted("x", n_frames=1)
+    with pytest.raises(ValueError):
+        apply_fitted_to_rest_vertices(np.zeros((4, 2)), fitted)
+
+
+def test_transform_zero_frames_returns_empty_nan_block() -> None:
+    fitted = make_identity_fitted("x", n_frames=0)
+    out = apply_fitted_to_rest_vertices(np.zeros((3, 3)), fitted)
+    assert out.shape == (0, 3, 3)

--- a/tests/unit/body_part_viz/test_imports.py
+++ b/tests/unit/body_part_viz/test_imports.py
@@ -33,4 +33,12 @@ def test_subpackages_importable() -> None:
 
     for pkg in (shapes, fitters, renderers):
         assert hasattr(pkg, "__all__")
-        assert pkg.__all__ == []
+    # ``shapes`` is populated as concrete shapes land (issue #4759).
+    assert "LineShape" in shapes.__all__
+    assert "CylinderShape" in shapes.__all__
+    assert "EllipsoidShape" in shapes.__all__
+    assert "CapsuleShape" in shapes.__all__
+    assert "CompositeShape" in shapes.__all__
+    # ``fitters`` and ``renderers`` are still empty in this wave.
+    assert fitters.__all__ == []
+    assert renderers.__all__ == []


### PR DESCRIPTION
Closes #4759
Part of EPIC #4755 (wave 2).

## Summary

Adds five concrete `BodyPartShape` implementations plus a pure-NumPy
mesh-primitive helper module:

- `LineShape(length)` — 2 vertices, 0 faces.
- `CylinderShape(length, radius, n_facets=16)` — closed cylinder along
  local x. Default config: 34 vertices, 64 triangles.
- `EllipsoidShape(a, b, c, n_lon=16, n_lat=8)` — UV-sphere
  triangulation scaled to anisotropic semi-axes. Default config: 144
  vertices, 256 triangles.
- `CapsuleShape(length, radius, n_facets=16, n_lat=8)` — cylinder body
  stitched to two hemisphere caps; rim vertices shared with the body.
- `CompositeShape(children)` — list of `(child_shape, 4x4_transform)`
  pairs; concatenates child vertices/faces with re-indexing.
- `shapes/_mesh_primitives.py` — `make_uv_sphere`, `make_cylinder`,
  `make_ellipsoid`.
- `shapes/_transform.py` — shared per-frame transform applying
  anisotropic scale (local frame) -> rotation -> translation, returning
  `(T, V, 3)`. Invalid frames produce NaN-filled vertices, never
  raises.

All constructors DbC-validate dimensions (`length, radius, a, b, c > 0`)
and facet counts (`n_facets >= 3`, `n_lat >= 2`). All five shapes pass
`isinstance(shape, BodyPartShape)` runtime Protocol check.

Pre-existing `test_subpackages_importable` updated: `shapes.__all__` is
now populated; `fitters` and `renderers` remain empty.

## Coverage

`pytest --cov=src/shared/python/body_part_viz/shapes`: **100.00%** line
+ branch coverage across the seven new modules (380 statements, 114
branches, 0 missing). 91 tests pass total in `tests/unit/body_part_viz/`.

## Test plan

- [x] `python3 -m ruff check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m ruff format --check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m pytest tests/unit/body_part_viz/shapes/ -p no:cacheprovider --timeout=60`
- [x] `python3 -m pytest tests/unit/body_part_viz/ --cov=src/shared/python/body_part_viz/shapes --cov-branch` -> 100.00%
- [x] `python3 scripts/ci/check_file_size_budget.py`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>