### PR TITLE
feat(body-part-viz): fitters (#4756)

### DIFF
--- a/src/shared/python/body_part_viz/fitters/__init__.py
+++ b/src/shared/python/body_part_viz/fitters/__init__.py
@@ -1,9 +1,18 @@
 """Fitter implementations sub-package.
 
-Concrete :class:`~body_part_viz.contracts.ShapeFitter` implementations
-land in follow-up issues of EPIC #4755.
+Concrete :class:`~body_part_viz.contracts.ShapeFitter` strategies covering
+the realistic mocap-to-shape attachments. Each fitter ships in its own
+module so adding a new strategy does not touch the existing ones.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .between_two import BetweenTwoMarkersFitter
+from .cluster_kabsch import ClusterKabschFitter
+from .procrustes_anisotropic import ProcrustesAnisotropicFitter
+
+__all__ = [
+    "BetweenTwoMarkersFitter",
+    "ClusterKabschFitter",
+    "ProcrustesAnisotropicFitter",
+]

--- a/src/shared/python/body_part_viz/fitters/_kabsch.py
+++ b/src/shared/python/body_part_viz/fitters/_kabsch.py
@@ -1,0 +1,88 @@
+"""Pure-NumPy Kabsch algorithm for optimal rigid rotation.
+
+Reused by :mod:`cluster_kabsch` and :mod:`procrustes_anisotropic`. Decoupled
+into its own module so additional fitters can adopt it without coupling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["kabsch_rotation", "stack_cluster"]
+
+
+def stack_cluster(
+    markers_xyz: dict[str, np.ndarray], names: tuple[str, ...]
+) -> np.ndarray:
+    """Stack named ``(T, 3)`` trajectories into a ``(T, N, 3)`` cluster.
+
+    Raises
+    ------
+    KeyError
+        If any named marker is missing from ``markers_xyz``.
+    ValueError
+        If a marker has the wrong shape or a different frame count from
+        the first marker.
+    """
+    arrays: list[np.ndarray] = []
+    n_frames: int | None = None
+    for name in names:
+        if name not in markers_xyz:
+            raise KeyError(f"missing marker {name!r} in markers_xyz")
+        arr = markers_xyz[name]
+        if arr.ndim != 2 or arr.shape[1] != 3:
+            raise ValueError(f"marker {name!r} must have shape (T, 3); got {arr.shape}")
+        if n_frames is None:
+            n_frames = arr.shape[0]
+        elif arr.shape[0] != n_frames:
+            raise ValueError(
+                f"marker {name!r} has {arr.shape[0]} frames; expected {n_frames}"
+            )
+        arrays.append(arr)
+    return np.stack(arrays, axis=1)
+
+
+def kabsch_rotation(p_centred: np.ndarray, q_centred: np.ndarray) -> np.ndarray:
+    """Return ``R`` minimising ``‖R @ P.T - Q.T‖_F`` with ``det(R) == +1``.
+
+    Parameters
+    ----------
+    p_centred:
+        ``(N, 3)`` source points, centroid-subtracted.
+    q_centred:
+        ``(N, 3)`` target points, centroid-subtracted.
+
+    Returns
+    -------
+    rotation:
+        ``(3, 3)`` proper rotation matrix (no reflection) such that
+        ``q_centred ≈ p_centred @ rotation.T``.
+
+    Raises
+    ------
+    ValueError
+        If shapes mismatch, are not 2-D, or do not have 3 columns.
+    """
+    if p_centred.ndim != 2 or q_centred.ndim != 2:
+        raise ValueError(
+            "kabsch_rotation expects 2-D arrays; "
+            f"got P.ndim={p_centred.ndim}, Q.ndim={q_centred.ndim}"
+        )
+    if p_centred.shape != q_centred.shape:
+        raise ValueError(
+            "kabsch_rotation requires matching shapes; "
+            f"got P.shape={p_centred.shape}, Q.shape={q_centred.shape}"
+        )
+    if p_centred.shape[1] != 3:
+        raise ValueError(
+            f"kabsch_rotation requires 3 columns; got {p_centred.shape[1]}"
+        )
+
+    covariance = p_centred.T @ q_centred
+    u_mat, _singular, vt_mat = np.linalg.svd(covariance)
+
+    # Reflection guard: ensure proper rotation (det == +1).
+    det_sign = float(np.linalg.det(vt_mat.T @ u_mat.T))
+    sign_diag = np.array([1.0, 1.0, 1.0 if det_sign > 0.0 else -1.0])
+    rotation = vt_mat.T @ np.diag(sign_diag) @ u_mat.T
+    return rotation

--- a/src/shared/python/body_part_viz/fitters/between_two.py
+++ b/src/shared/python/body_part_viz/fitters/between_two.py
@@ -1,0 +1,159 @@
+"""Between-two-markers shape fitter.
+
+Aligns a shape's local x-axis to the vector connecting two markers, with
+length-only anisotropic scale. Suitable for limb segments (femur, tibia,
+humerus, ...) attached to two surface markers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ..bindings import BindingKind, MarkerBinding
+from ..contracts import BodyPartShape
+
+__all__ = ["BetweenTwoMarkersFitter"]
+
+_AXIS_NEAR_Z_TOL = 1e-6
+
+
+class BetweenTwoMarkersFitter:
+    """Fitter for :data:`BindingKind.BETWEEN_TWO` bindings.
+
+    Per frame:
+
+    * centroid = midpoint(a, b)
+    * axis = (b - a) / ‖b - a‖
+    * rotation: shape's local x-axis aligned to ``axis``; up-vector chosen
+      via Gram-Schmidt against world Z (or world Y if axis is near Z).
+    * scale = ``(‖b - a‖ / rest_length, 1.0, 1.0)``.
+
+    A frame is invalid iff either marker has a non-finite coordinate.
+    """
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        """Fit ``shape`` between the two markers in ``binding``."""
+        if binding.kind is not BindingKind.BETWEEN_TWO:
+            raise TypeError(
+                "BetweenTwoMarkersFitter requires BindingKind.BETWEEN_TWO; "
+                f"got {binding.kind}"
+            )
+
+        name_a, name_b = binding.marker_names
+        marker_a = _require_marker(markers_xyz, name_a)
+        marker_b = _require_marker(markers_xyz, name_b)
+        if marker_a.shape != marker_b.shape:
+            raise ValueError(
+                "between-two markers must share shape; "
+                f"got {marker_a.shape} and {marker_b.shape}"
+            )
+
+        n_frames = marker_a.shape[0]
+        rest_length = _resolve_rest_length(shape, binding)
+
+        valid_mask = np.isfinite(marker_a).all(axis=1) & np.isfinite(marker_b).all(
+            axis=1
+        )
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+        scale = np.ones((n_frames, 3), dtype=float)
+
+        if not valid_mask.any():
+            return FittedShape(
+                shape_id=shape.shape_id,
+                binding=binding,
+                centroid=centroid,
+                rotation_matrix=rotation,
+                scale=scale,
+                valid_mask=valid_mask,
+            )
+
+        idx = np.flatnonzero(valid_mask)
+        a_valid = marker_a[idx]
+        b_valid = marker_b[idx]
+
+        midpoint = 0.5 * (a_valid + b_valid)
+        delta = b_valid - a_valid
+        length = np.linalg.norm(delta, axis=1)
+
+        # DbC: collinear markers (zero-length segment) cannot define orientation.
+        if not bool(np.all(length > 0.0)):
+            raise ValueError(
+                "between-two markers coincide on at least one valid frame; "
+                "cannot define an axis"
+            )
+
+        axis = delta / length[:, None]
+        rot_valid = _axis_to_rotation(axis)
+
+        centroid[idx] = midpoint
+        rotation[idx] = rot_valid
+        scale[idx, 0] = length / rest_length
+        scale[idx, 1] = 1.0
+        scale[idx, 2] = 1.0
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid_mask,
+        )
+
+
+def _require_marker(markers_xyz: dict[str, np.ndarray], name: str) -> np.ndarray:
+    """Return the ``(T, 3)`` trajectory for ``name`` or raise ``KeyError``."""
+    if name not in markers_xyz:
+        raise KeyError(f"missing marker {name!r} in markers_xyz")
+    arr = markers_xyz[name]
+    if arr.ndim != 2 or arr.shape[1] != 3:
+        raise ValueError(f"marker {name!r} must have shape (T, 3); got {arr.shape}")
+    return arr
+
+
+def _resolve_rest_length(shape: BodyPartShape, binding: MarkerBinding) -> float:
+    """Return the rest segment length, preferring binding over shape."""
+    if binding.rest_dimensions:
+        return float(binding.rest_dimensions[0])
+    if shape.rest_dimensions:
+        return float(shape.rest_dimensions[0])
+    raise ValueError("between-two fitter requires a rest length on binding or shape")
+
+
+def _axis_to_rotation(axis: np.ndarray) -> np.ndarray:
+    """Return ``(N, 3, 3)`` rotations sending world x to each ``axis`` row.
+
+    Up-vector is world Z by default and switches to world Y where the axis
+    is near-parallel to Z (avoids a degenerate Gram-Schmidt).
+    """
+    n_frames = axis.shape[0]
+    rot = np.zeros((n_frames, 3, 3), dtype=float)
+
+    z_dot = np.abs(axis @ np.array([0.0, 0.0, 1.0]))
+    near_z = z_dot > 1.0 - _AXIS_NEAR_Z_TOL
+
+    world_up = np.where(
+        near_z[:, None],
+        np.array([0.0, 1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    )
+
+    # Gram-Schmidt: project ``world_up`` onto plane perpendicular to ``axis``.
+    proj = (axis * world_up).sum(axis=1, keepdims=True) * axis
+    up_perp = world_up - proj
+    up_norm = np.linalg.norm(up_perp, axis=1, keepdims=True)
+    up_unit = up_perp / up_norm
+    side = np.cross(up_unit, axis)
+
+    rot[:, :, 0] = axis
+    rot[:, :, 1] = side
+    rot[:, :, 2] = up_unit
+    return rot

--- a/src/shared/python/body_part_viz/fitters/cluster_kabsch.py
+++ b/src/shared/python/body_part_viz/fitters/cluster_kabsch.py
@@ -1,0 +1,93 @@
+"""Cluster-Kabsch rigid shape fitter.
+
+Per-frame centroid + Kabsch rotation against the rest cluster. Optional
+uniform scale via centred-norm ratio when ``enable_scale=True``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .._types import FittedShape
+from ..bindings import BindingKind, MarkerBinding
+from ..contracts import BodyPartShape
+from ._kabsch import kabsch_rotation, stack_cluster
+
+__all__ = ["ClusterKabschFitter"]
+
+
+class ClusterKabschFitter:
+    """Fitter for :data:`BindingKind.CLUSTER` bindings (≥3 markers).
+
+    Pure rigid by default. With ``enable_scale=True`` an isotropic scale is
+    estimated from the per-frame centred-norm ratio.
+    """
+
+    def __init__(self, *, enable_scale: bool = False) -> None:
+        self._enable_scale = bool(enable_scale)
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        """Fit ``shape`` to the marker cluster in ``binding``."""
+        if binding.kind is not BindingKind.CLUSTER:
+            raise TypeError(
+                f"ClusterKabschFitter requires BindingKind.CLUSTER; got {binding.kind}"
+            )
+
+        cluster = stack_cluster(markers_xyz, binding.marker_names)
+        n_frames, n_markers, _ = cluster.shape
+
+        valid_mask = np.isfinite(cluster).all(axis=(1, 2))
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+        scale = np.ones((n_frames, 3), dtype=float)
+
+        if not valid_mask.any():
+            return FittedShape(
+                shape_id=shape.shape_id,
+                binding=binding,
+                centroid=centroid,
+                rotation_matrix=rotation,
+                scale=scale,
+                valid_mask=valid_mask,
+            )
+
+        rest_idx = int(np.flatnonzero(valid_mask)[0])
+        rest_cluster = cluster[rest_idx]
+        rest_centroid = rest_cluster.mean(axis=0)
+        rest_centred = rest_cluster - rest_centroid
+        rest_norm = float(np.linalg.norm(rest_centred))
+
+        for t in np.flatnonzero(valid_mask):
+            frame = cluster[t]
+            frame_centroid = frame.mean(axis=0)
+            frame_centred = frame - frame_centroid
+
+            rot = kabsch_rotation(rest_centred, frame_centred)
+            centroid[t] = frame_centroid
+            rotation[t] = rot
+
+            if self._enable_scale and rest_norm > 0.0:
+                ratio = float(np.linalg.norm(frame_centred)) / rest_norm
+                scale[t] = np.array([ratio, ratio, ratio])
+
+        # DbC: positive scale on valid frames is required by FittedShape.
+        if self._enable_scale and not bool(np.all(scale[valid_mask] > 0.0)):
+            raise ValueError(
+                "cluster collapsed to a point on at least one valid frame; "
+                "uniform scale is undefined"
+            )
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid_mask,
+        )

--- a/src/shared/python/body_part_viz/fitters/procrustes_anisotropic.py
+++ b/src/shared/python/body_part_viz/fitters/procrustes_anisotropic.py
@@ -1,0 +1,131 @@
+"""Anisotropic-scale Procrustes fitter for marker clusters.
+
+Centroid + Kabsch rotation, then anisotropic per-axis scale solved via
+``scipy.linalg.lstsq`` on the centred-rotated cluster vs the rest cluster.
+
+Documented as the most-flexible but least-stable fitter; recommended only
+when ≥4 markers are available and the user wants anisotropic stretch. With
+fewer than 4 markers we log a warning and fall back to Kabsch behaviour
+(unit scale).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from scipy.linalg import lstsq
+
+from .._types import FittedShape
+from ..bindings import BindingKind, MarkerBinding
+from ..contracts import BodyPartShape
+from ._kabsch import kabsch_rotation, stack_cluster
+
+__all__ = ["ProcrustesAnisotropicFitter"]
+
+_LOG = logging.getLogger(__name__)
+_MIN_MARKERS_FOR_ANISO = 4
+
+
+class ProcrustesAnisotropicFitter:
+    """Fitter for :data:`BindingKind.CLUSTER` with anisotropic scale.
+
+    Per frame:
+
+    * centroid + Kabsch rotation (as in :class:`ClusterKabschFitter`).
+    * Solve ``rotated_centred @ diag(s) ≈ rest_centred`` for ``s`` via
+      least squares (``scipy.linalg.lstsq``).
+    """
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape:
+        """Fit ``shape`` to ``markers_xyz`` with anisotropic scale."""
+        if binding.kind is not BindingKind.CLUSTER:
+            raise TypeError(
+                "ProcrustesAnisotropicFitter requires BindingKind.CLUSTER; "
+                f"got {binding.kind}"
+            )
+
+        cluster = stack_cluster(markers_xyz, binding.marker_names)
+        n_frames, n_markers, _ = cluster.shape
+
+        aniso_enabled = n_markers >= _MIN_MARKERS_FOR_ANISO
+        if not aniso_enabled:
+            _LOG.warning(
+                "ProcrustesAnisotropicFitter: %d markers < %d; "
+                "falling back to Kabsch (unit scale).",
+                n_markers,
+                _MIN_MARKERS_FOR_ANISO,
+            )
+
+        valid_mask = np.isfinite(cluster).all(axis=(1, 2))
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+        scale = np.ones((n_frames, 3), dtype=float)
+
+        if not valid_mask.any():
+            return FittedShape(
+                shape_id=shape.shape_id,
+                binding=binding,
+                centroid=centroid,
+                rotation_matrix=rotation,
+                scale=scale,
+                valid_mask=valid_mask,
+            )
+
+        rest_idx = int(np.flatnonzero(valid_mask)[0])
+        rest_cluster = cluster[rest_idx]
+        rest_centroid = rest_cluster.mean(axis=0)
+        rest_centred = rest_cluster - rest_centroid
+
+        for t in np.flatnonzero(valid_mask):
+            frame = cluster[t]
+            frame_centroid = frame.mean(axis=0)
+            frame_centred = frame - frame_centroid
+
+            rot = kabsch_rotation(rest_centred, frame_centred)
+            centroid[t] = frame_centroid
+            rotation[t] = rot
+
+            if aniso_enabled:
+                # Bring frame back into rest-frame coordinates: ``frame_in_rest``
+                # ≈ rest_centred * scale_diag. Solve column-by-column for s.
+                frame_in_rest = frame_centred @ rot
+                scale[t] = _solve_axiswise_scale(rest_centred, frame_in_rest)
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid_mask,
+        )
+
+
+def _solve_axiswise_scale(
+    rest_centred: np.ndarray, frame_in_rest: np.ndarray
+) -> np.ndarray:
+    """Return ``(3,)`` positive scale solving ``rest * s ≈ frame_in_rest``.
+
+    Each axis is independent: ``s_i = lstsq(rest[:, i:i+1], frame[:, i])``.
+    """
+    out = np.ones(3, dtype=float)
+    for axis_idx in range(3):
+        col_rest = rest_centred[:, axis_idx : axis_idx + 1]
+        col_frame = frame_in_rest[:, axis_idx]
+        if float(np.linalg.norm(col_rest)) == 0.0:
+            out[axis_idx] = 1.0
+            continue
+        sol, *_ = lstsq(col_rest, col_frame)
+        value = float(sol[0])
+        # Guard FittedShape's strictly-positive postcondition.
+        if not np.isfinite(value) or value <= 0.0:
+            value = 1.0
+        out[axis_idx] = value
+    return out

--- a/tests/unit/body_part_viz/fitters/_stubs.py
+++ b/tests/unit/body_part_viz/fitters/_stubs.py
@@ -1,0 +1,28 @@
+"""Lightweight stub shapes for fitter unit tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.shared.python.body_part_viz import FittedShape
+
+
+class StubShape:
+    """Minimal :class:`BodyPartShape` implementation for tests."""
+
+    def __init__(
+        self,
+        shape_id: str = "stub",
+        rest_dimensions: tuple[float, ...] = (1.0,),
+    ) -> None:
+        self.shape_id = shape_id
+        self.rest_dimensions = rest_dimensions
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return np.zeros((0, 3))
+
+    def faces(self) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.int64)
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return np.zeros((0, 3))

--- a/tests/unit/body_part_viz/fitters/test_between_two.py
+++ b/tests/unit/body_part_viz/fitters/test_between_two.py
@@ -1,0 +1,164 @@
+"""Unit tests for :class:`BetweenTwoMarkersFitter`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    MarkerBinding,
+    ShapeFitter,
+)
+from src.shared.python.body_part_viz.fitters import BetweenTwoMarkersFitter
+
+from ._stubs import StubShape
+
+
+def _binding(rest: tuple[float, ...] = (1.0,)) -> MarkerBinding:
+    return MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+        rest_dimensions=rest,
+    )
+
+
+def test_implements_shape_fitter_protocol() -> None:
+    assert isinstance(BetweenTwoMarkersFitter(), ShapeFitter)
+
+
+def test_straight_line_centroids_are_midpoints() -> None:
+    n = 100
+    a = np.zeros((n, 3))
+    b = np.zeros((n, 3))
+    a[:, 0] = np.linspace(0.0, 1.0, n)
+    b[:, 0] = a[:, 0] + 1.0  # constant 1.0 spacing along x
+
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+    assert fitted.centroid.shape == (n, 3)
+    assert np.allclose(fitted.centroid, 0.5 * (a + b))
+    assert bool(fitted.valid_mask.all())
+
+
+def test_rotation_matrix_is_orthogonal_with_unit_determinant() -> None:
+    n = 20
+    a = np.zeros((n, 3))
+    b = np.zeros((n, 3))
+    angles = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    b[:, 0] = np.cos(angles)
+    b[:, 1] = np.sin(angles)
+
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+    for t in range(n):
+        rot = fitted.rotation_matrix[t]
+        assert np.allclose(rot @ rot.T, np.eye(3), atol=1e-10)
+        assert np.isclose(np.linalg.det(rot), 1.0, atol=1e-10)
+
+
+def test_rotation_first_column_is_axis() -> None:
+    a = np.zeros((1, 3))
+    b = np.array([[3.0, 4.0, 0.0]])  # length 5
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+    expected_axis = np.array([0.6, 0.8, 0.0])
+    assert np.allclose(fitted.rotation_matrix[0, :, 0], expected_axis)
+    # Length-only anisotropic scale
+    assert np.isclose(fitted.scale[0, 0], 5.0)
+    assert np.isclose(fitted.scale[0, 1], 1.0)
+    assert np.isclose(fitted.scale[0, 2], 1.0)
+
+
+def test_axis_near_world_z_uses_y_up() -> None:
+    a = np.zeros((1, 3))
+    b = np.array([[0.0, 0.0, 2.0]])
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+    rot = fitted.rotation_matrix[0]
+    assert np.allclose(rot @ rot.T, np.eye(3), atol=1e-10)
+    assert np.isclose(np.linalg.det(rot), 1.0, atol=1e-10)
+
+
+def test_nan_marker_marks_frame_invalid() -> None:
+    n = 100
+    a = np.zeros((n, 3))
+    b = np.zeros((n, 3))
+    a[:, 0] = np.linspace(0.0, 1.0, n)
+    b[:, 0] = a[:, 0] + 1.0
+    a[50:61, :] = np.nan
+
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+    assert not bool(fitted.valid_mask[50:61].any())
+    assert bool(fitted.valid_mask[:50].all())
+    assert bool(fitted.valid_mask[61:].all())
+
+
+def test_rest_length_falls_back_to_shape_when_binding_empty() -> None:
+    binding = MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b"))
+    a = np.zeros((1, 3))
+    b = np.array([[2.0, 0.0, 0.0]])
+    fitted = BetweenTwoMarkersFitter().fit(
+        StubShape(rest_dimensions=(4.0,)), binding, {"a": a, "b": b}
+    )
+    assert np.isclose(fitted.scale[0, 0], 0.5)
+
+
+def test_missing_rest_length_raises() -> None:
+    binding = MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b"))
+    a = np.zeros((1, 3))
+    b = np.array([[1.0, 0.0, 0.0]])
+    with pytest.raises(ValueError, match="rest length"):
+        BetweenTwoMarkersFitter().fit(
+            StubShape(rest_dimensions=()), binding, {"a": a, "b": b}
+        )
+
+
+def test_wrong_binding_kind_raises_type_error() -> None:
+    binding = MarkerBinding(kind=BindingKind.CLUSTER, marker_names=("a", "b", "c"))
+    with pytest.raises(TypeError, match="BETWEEN_TWO"):
+        BetweenTwoMarkersFitter().fit(
+            StubShape(),
+            binding,
+            {"a": np.zeros((1, 3)), "b": np.zeros((1, 3)), "c": np.zeros((1, 3))},
+        )
+
+
+def test_missing_marker_raises() -> None:
+    with pytest.raises(KeyError, match="missing marker"):
+        BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": np.zeros((1, 3))})
+
+
+def test_marker_wrong_shape_raises() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        BetweenTwoMarkersFitter().fit(
+            StubShape(),
+            _binding(),
+            {"a": np.zeros((1, 2)), "b": np.zeros((1, 2))},
+        )
+
+
+def test_marker_shape_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="share shape"):
+        BetweenTwoMarkersFitter().fit(
+            StubShape(),
+            _binding(),
+            {"a": np.zeros((1, 3)), "b": np.zeros((2, 3))},
+        )
+
+
+def test_zero_length_segment_raises() -> None:
+    a = np.zeros((1, 3))
+    b = np.zeros((1, 3))
+    with pytest.raises(ValueError, match="coincide"):
+        BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+
+
+def test_all_invalid_frames_returns_zero_centroid() -> None:
+    n = 4
+    a = np.full((n, 3), np.nan)
+    b = np.full((n, 3), np.nan)
+    fitted = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    assert not bool(fitted.valid_mask.any())
+    assert np.allclose(fitted.centroid, 0.0)

--- a/tests/unit/body_part_viz/fitters/test_cluster_kabsch.py
+++ b/tests/unit/body_part_viz/fitters/test_cluster_kabsch.py
@@ -1,0 +1,167 @@
+"""Unit tests for :class:`ClusterKabschFitter`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    MarkerBinding,
+    ShapeFitter,
+)
+from src.shared.python.body_part_viz.fitters import ClusterKabschFitter
+
+from ._stubs import StubShape
+
+
+def _binding(names: tuple[str, ...] = ("m0", "m1", "m2", "m3")) -> MarkerBinding:
+    return MarkerBinding(kind=BindingKind.CLUSTER, marker_names=names)
+
+
+def _rotation_z(angle: float) -> np.ndarray:
+    cos_a = np.cos(angle)
+    sin_a = np.sin(angle)
+    return np.array(
+        [
+            [cos_a, -sin_a, 0.0],
+            [sin_a, cos_a, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def _build_cluster(rest_points: np.ndarray, rotations: list[np.ndarray]) -> dict:
+    """Apply per-frame ``rotations`` to ``rest_points`` and split per marker."""
+    n_frames = len(rotations)
+    n_markers = rest_points.shape[0]
+    cluster = np.empty((n_frames, n_markers, 3))
+    for t, rot in enumerate(rotations):
+        cluster[t] = rest_points @ rot.T
+    markers: dict = {}
+    for j in range(n_markers):
+        markers[f"m{j}"] = cluster[:, j, :]
+    return markers
+
+
+def test_implements_shape_fitter_protocol() -> None:
+    assert isinstance(ClusterKabschFitter(), ShapeFitter)
+
+
+def test_recovers_known_z_rotation_within_tolerance() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    angle = np.deg2rad(45.0)
+    rot_known = _rotation_z(angle)
+    markers = _build_cluster(rest, [np.eye(3), rot_known])
+
+    fitted = ClusterKabschFitter().fit(StubShape(), _binding(), markers)
+
+    assert np.allclose(fitted.rotation_matrix[0], np.eye(3), atol=1e-9)
+    assert np.allclose(fitted.rotation_matrix[1], rot_known, atol=1e-9)
+    # Pure rigid: scale unchanged.
+    assert np.allclose(fitted.scale, 1.0)
+
+
+def test_reflection_guard_returns_proper_rotation() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    reflection = np.diag([1.0, 1.0, -1.0])
+    markers = _build_cluster(rest, [np.eye(3), reflection])
+
+    fitted = ClusterKabschFitter().fit(StubShape(), _binding(), markers)
+
+    det = float(np.linalg.det(fitted.rotation_matrix[1]))
+    assert np.isclose(det, 1.0, atol=1e-9)
+
+
+def test_isotropic_scale_recovered_when_enabled() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    scale_factor = 1.5
+    # Two frames: frame 0 = rest (scale 1.0), frame 1 = scaled (scale s).
+    cluster = np.stack([rest, rest * scale_factor], axis=0)
+    markers = {f"m{j}": cluster[:, j, :] for j in range(4)}
+
+    fitter = ClusterKabschFitter(enable_scale=True)
+    fitted = fitter.fit(StubShape(), _binding(), markers)
+
+    assert np.allclose(fitted.scale[0], 1.0, atol=1e-9)
+    assert np.allclose(fitted.scale[1], scale_factor, atol=1e-9)
+
+
+def test_nan_in_one_marker_invalidates_frame() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    markers = _build_cluster(rest, [np.eye(3), np.eye(3), np.eye(3)])
+    markers["m0"][1] = np.nan
+
+    fitted = ClusterKabschFitter().fit(StubShape(), _binding(), markers)
+
+    assert bool(fitted.valid_mask[0])
+    assert not bool(fitted.valid_mask[1])
+    assert bool(fitted.valid_mask[2])
+
+
+def test_leading_nan_frames_use_first_valid_as_rest() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    angle = np.deg2rad(30.0)
+    rot = _rotation_z(angle)
+    markers = _build_cluster(rest, [np.eye(3), np.eye(3), rot])
+    # Mark frame 0 invalid via NaN.
+    markers["m1"][0] = np.nan
+
+    fitted = ClusterKabschFitter().fit(StubShape(), _binding(), markers)
+
+    assert not bool(fitted.valid_mask[0])
+    assert bool(fitted.valid_mask[1])
+    # Rest taken from frame 1 (identity); frame 2 should recover rot.
+    assert np.allclose(fitted.rotation_matrix[2], rot, atol=1e-9)
+
+
+def test_wrong_binding_kind_raises_type_error() -> None:
+    binding = MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b"))
+    with pytest.raises(TypeError, match="CLUSTER"):
+        ClusterKabschFitter().fit(
+            StubShape(),
+            binding,
+            {"a": np.zeros((1, 3)), "b": np.zeros((1, 3))},
+        )
+
+
+def test_all_invalid_frames_returns_default() -> None:
+    n = 3
+    markers = {f"m{j}": np.full((n, 3), np.nan) for j in range(4)}
+    fitted = ClusterKabschFitter().fit(StubShape(), _binding(), markers)
+    assert not bool(fitted.valid_mask.any())

--- a/tests/unit/body_part_viz/fitters/test_kabsch_helper.py
+++ b/tests/unit/body_part_viz/fitters/test_kabsch_helper.py
@@ -1,0 +1,107 @@
+"""Unit tests for the pure-NumPy Kabsch helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.fitters._kabsch import (
+    kabsch_rotation,
+    stack_cluster,
+)
+
+
+def _rotation_z(angle: float) -> np.ndarray:
+    cos_a = np.cos(angle)
+    sin_a = np.sin(angle)
+    return np.array(
+        [
+            [cos_a, -sin_a, 0.0],
+            [sin_a, cos_a, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def test_kabsch_round_trip_recovers_known_rotation() -> None:
+    rng = np.random.default_rng(0)
+    points = rng.standard_normal((6, 3))
+    points -= points.mean(axis=0)
+    angle = np.deg2rad(37.5)
+    rot_known = _rotation_z(angle)
+    rotated = points @ rot_known.T
+
+    rot_recovered = kabsch_rotation(points, rotated)
+
+    assert np.allclose(rot_recovered, rot_known, atol=1e-9)
+    assert np.isclose(np.linalg.det(rot_recovered), 1.0, atol=1e-9)
+
+
+def test_kabsch_reflection_guard_returns_proper_rotation() -> None:
+    rng = np.random.default_rng(1)
+    points = rng.standard_normal((5, 3))
+    points -= points.mean(axis=0)
+    reflection = np.diag([1.0, 1.0, -1.0])
+    reflected = points @ reflection.T
+
+    rot = kabsch_rotation(points, reflected)
+
+    # The Kabsch reflection guard forces det == +1 even when the data
+    # demands a reflection — the closest *proper* rotation is returned.
+    assert np.isclose(np.linalg.det(rot), 1.0, atol=1e-9)
+
+
+def test_kabsch_collinear_cluster_returns_finite_rotation() -> None:
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+    )
+    centred = points - points.mean(axis=0)
+    rot_known = _rotation_z(np.deg2rad(15.0))
+    rotated = centred @ rot_known.T
+
+    rot = kabsch_rotation(centred, rotated)
+
+    assert np.all(np.isfinite(rot))
+    assert np.isclose(np.linalg.det(rot), 1.0, atol=1e-9)
+
+
+def test_kabsch_rejects_mismatched_shapes() -> None:
+    with pytest.raises(ValueError, match="matching"):
+        kabsch_rotation(np.zeros((4, 3)), np.zeros((5, 3)))
+
+
+def test_kabsch_rejects_non_3d_columns() -> None:
+    with pytest.raises(ValueError, match="3 columns"):
+        kabsch_rotation(np.zeros((4, 2)), np.zeros((4, 2)))
+
+
+def test_kabsch_rejects_non_2d_arrays() -> None:
+    with pytest.raises(ValueError, match="2-D"):
+        kabsch_rotation(np.zeros(3), np.zeros(3))
+
+
+def test_stack_cluster_happy_path() -> None:
+    markers = {
+        "a": np.zeros((5, 3)),
+        "b": np.ones((5, 3)),
+        "c": np.full((5, 3), 2.0),
+    }
+    cluster = stack_cluster(markers, ("a", "b", "c"))
+    assert cluster.shape == (5, 3, 3)
+    assert np.allclose(cluster[0, 1], 1.0)
+
+
+def test_stack_cluster_missing_marker_raises() -> None:
+    with pytest.raises(KeyError, match="missing marker"):
+        stack_cluster({"a": np.zeros((2, 3))}, ("a", "b"))
+
+
+def test_stack_cluster_wrong_shape_raises() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        stack_cluster({"a": np.zeros((2, 4))}, ("a",))
+
+
+def test_stack_cluster_inconsistent_frame_count_raises() -> None:
+    markers = {"a": np.zeros((4, 3)), "b": np.zeros((5, 3))}
+    with pytest.raises(ValueError, match="frames"):
+        stack_cluster(markers, ("a", "b"))

--- a/tests/unit/body_part_viz/fitters/test_procrustes_anisotropic.py
+++ b/tests/unit/body_part_viz/fitters/test_procrustes_anisotropic.py
@@ -1,0 +1,140 @@
+"""Unit tests for :class:`ProcrustesAnisotropicFitter`."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    MarkerBinding,
+    ShapeFitter,
+)
+from src.shared.python.body_part_viz.fitters import ProcrustesAnisotropicFitter
+
+from ._stubs import StubShape
+
+
+def _binding(n_markers: int = 4) -> MarkerBinding:
+    names = tuple(f"m{j}" for j in range(n_markers))
+    return MarkerBinding(kind=BindingKind.CLUSTER, marker_names=names)
+
+
+def test_implements_shape_fitter_protocol() -> None:
+    assert isinstance(ProcrustesAnisotropicFitter(), ShapeFitter)
+
+
+def test_recovers_anisotropic_scale_within_tolerance() -> None:
+    # Axis-aligned rest cluster: principal axes = world axes, so the
+    # Kabsch solution under anisotropic scaling is the identity. That
+    # decouples rotation and scale and lets us recover s exactly.
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    scale_known = np.array([1.0, 2.0, 0.5])
+    scaled = rest * scale_known
+
+    cluster = np.stack([rest, scaled], axis=0)  # (T=2, N=6, 3)
+    markers = {f"m{j}": cluster[:, j, :] for j in range(6)}
+    binding = _binding(n_markers=6)
+
+    fitted = ProcrustesAnisotropicFitter().fit(StubShape(), binding, markers)
+
+    # Frame 0 = rest → unit scale, identity rotation.
+    assert np.allclose(fitted.scale[0], 1.0, atol=1e-6)
+    assert np.allclose(fitted.rotation_matrix[0], np.eye(3), atol=1e-9)
+    # Frame 1 = anisotropically scaled → recover s.
+    assert np.allclose(fitted.scale[1], scale_known, atol=1e-6)
+
+
+def test_too_few_markers_logs_warning_and_falls_back_to_kabsch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    cluster = np.stack([rest, rest * 2.0], axis=0)
+    markers = {f"m{j}": cluster[:, j, :] for j in range(3)}
+    binding = _binding(n_markers=3)
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger=("src.shared.python.body_part_viz.fitters.procrustes_anisotropic"),
+    ):
+        fitted = ProcrustesAnisotropicFitter().fit(StubShape(), binding, markers)
+
+    assert any("falling back" in rec.message for rec in caplog.records)
+    # Fallback ⇒ unit scale even though the cluster was scaled by 2.
+    assert np.allclose(fitted.scale, 1.0)
+
+
+def test_wrong_binding_kind_raises_type_error() -> None:
+    binding = MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=("a", "b"))
+    with pytest.raises(TypeError, match="CLUSTER"):
+        ProcrustesAnisotropicFitter().fit(
+            StubShape(),
+            binding,
+            {"a": np.zeros((1, 3)), "b": np.zeros((1, 3))},
+        )
+
+
+def test_nan_frame_marked_invalid() -> None:
+    rest = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [-1.0, 1.0, 1.0],
+            [-1.0, -1.0, 1.0],
+            [1.0, -1.0, -1.0],
+        ]
+    )
+    cluster = np.stack([rest, rest, rest], axis=0)
+    markers = {f"m{j}": cluster[:, j, :] for j in range(4)}
+    markers["m2"][1] = np.nan
+
+    fitted = ProcrustesAnisotropicFitter().fit(StubShape(), _binding(), markers)
+
+    assert bool(fitted.valid_mask[0])
+    assert not bool(fitted.valid_mask[1])
+    assert bool(fitted.valid_mask[2])
+
+
+def test_all_invalid_frames_returns_default() -> None:
+    n = 3
+    markers = {f"m{j}": np.full((n, 3), np.nan) for j in range(4)}
+    fitted = ProcrustesAnisotropicFitter().fit(StubShape(), _binding(), markers)
+    assert not bool(fitted.valid_mask.any())
+
+
+def test_collinear_axis_keeps_unit_scale_for_zero_norm_axis() -> None:
+    # Cluster lying in the xy-plane → centred z-component is identically zero.
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    scale_known = np.array([2.0, 0.5, 1.0])
+    scaled = rest * scale_known
+    cluster = np.stack([rest, scaled], axis=0)
+    markers = {f"m{j}": cluster[:, j, :] for j in range(4)}
+
+    fitted = ProcrustesAnisotropicFitter().fit(StubShape(), _binding(), markers)
+
+    assert np.allclose(fitted.scale[1, :2], scale_known[:2], atol=1e-6)
+    # Z-axis is degenerate (zero variance) — fitter must keep it positive.
+    assert fitted.scale[1, 2] > 0.0

--- a/tests/unit/body_part_viz/test_imports.py
+++ b/tests/unit/body_part_viz/test_imports.py
@@ -33,12 +33,20 @@ def test_subpackages_importable() -> None:
 
     for pkg in (shapes, fitters, renderers):
         assert hasattr(pkg, "__all__")
-    # ``shapes`` is populated as concrete shapes land (issue #4759).
-    assert "LineShape" in shapes.__all__
-    assert "CylinderShape" in shapes.__all__
-    assert "EllipsoidShape" in shapes.__all__
-    assert "CapsuleShape" in shapes.__all__
-    assert "CompositeShape" in shapes.__all__
-    # ``fitters`` and ``renderers`` are still empty in this wave.
-    assert fitters.__all__ == []
+    # Shapes are populated by the primitives wave (#4759).
+    for shape_name in (
+        "LineShape",
+        "CylinderShape",
+        "EllipsoidShape",
+        "CapsuleShape",
+        "CompositeShape",
+    ):
+        assert shape_name in shapes.__all__
+    # Renderers land in a later wave — still empty.
     assert renderers.__all__ == []
+    # Fitters wave (#4756) ships three concrete strategies.
+    assert set(fitters.__all__) == {
+        "BetweenTwoMarkersFitter",
+        "ClusterKabschFitter",
+        "ProcrustesAnisotropicFitter",
+    }


### PR DESCRIPTION
## Summary

- Adds three orthogonal `ShapeFitter` strategies for `body_part_viz`: `BetweenTwoMarkersFitter`, `ClusterKabschFitter`, `ProcrustesAnisotropicFitter`.
- Pure-NumPy `kabsch_rotation` helper (with reflection guard) plus a shared `stack_cluster` utility, both reused by the cluster-based fitters.
- All fitters NaN-safe via per-frame `valid_mask`; cluster fitters pick the rest cluster from the first valid frame to tolerate leading NaNs.
- Procrustes fitter logs a warning and falls back to Kabsch behaviour (unit scale) when given <4 markers; uses `scipy.linalg.lstsq` axis-wise for anisotropic scale.
- Closes #4756. Part of EPIC #4755 (Wave 2).

## Test plan

- [x] `python3 -m ruff check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m ruff format --check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m pytest tests/unit/body_part_viz/fitters/ -p no:cacheprovider -n auto --timeout=60` (39 passed)
- [x] `python3 -m pytest tests/unit/body_part_viz/ --cov=src/shared/python/body_part_viz/fitters --cov-branch --cov-report=term-missing` (89 passed, 98.44% coverage)
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] Recovered values: reflection-guard rotation = identity with `det = 1.0`; anisotropic scale recovered exactly as `[1.0, 2.0, 0.5]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)