### PR TITLE
feat(body_part_viz): MeshShape with STL/OBJ/PLY/GLB loaders (closes #4758)

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -53,7 +53,9 @@
     "3211158553",
     "3211902234",
     "3211902238",
-    "3212069067"
+    "3212069067",
+    "3212263391",
+    "3212263393"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -75,6 +77,7 @@
     "3211471651": "https://github.com/D-sorganization/UpstreamDrift/issues/4644",
     "3211158550": "https://github.com/D-sorganization/UpstreamDrift/issues/4685",
     "3211158553": "https://github.com/D-sorganization/UpstreamDrift/issues/4686",
-    "3211902238": "https://github.com/D-sorganization/UpstreamDrift/issues/4728"
+    "3211902238": "https://github.com/D-sorganization/UpstreamDrift/issues/4728",
+    "3212263393": "https://github.com/D-sorganization/UpstreamDrift/issues/4791"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-08.md
+++ b/docs/review_archive/review_comments_2026-05-08.md
@@ -1,21 +1,36 @@
 # Review Comments Archive - 2026-05-08
 
-Generated: 2026-05-08T17:54:16.933590
+Generated: 2026-05-08T19:30:08.409991
 
-## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+## Reviewer (chatgpt-codex-connector[bot]) (2 comments)
 
-### PR #4751: src/shared/python/motion_matching/loaders/c3d.py:133
+### PR #4785: src/shared/python/body_part_viz/shapes/mesh.py:263
 
 Actionable: No
 Has Suggestion: No
 
 ```
-**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Make marker_set_override actually select cluster handling**
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Apply scene transforms before concatenating GLB geometries**
 
-When `marker_set_override` is provided, it only bypasses the new `MarkerSetMismatchError` guard and is never used to choose the cluster-processing branch, so callers following the error guidance (`marker_set_override=MarkerSet.GOLF_CLUSTER`) can still immediately fail with `ValueError` in the non-cluster path if butt/head labels are missing. This me...
+When `trimesh.load(..., force="mesh")` yields a scene-like object, this code concatenates `loaded.geometry.values()` directly, which drops per-node transforms and instancing from the scene graph. For `.glb` files that position meshes via node transforms (a common case), the resulting `MeshShape` will have incorrect vertex positions/extents, causing...
 ```
 
-[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4751#discussion_r3212069067)
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4785#discussion_r3212263391)
+
+---
+
+### PR #4785: src/shared/python/body_part_viz/shapes/mesh.py:200
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Reject non-integer face arrays instead of truncating**
+
+`from_arrays` currently coerces non-integer `faces` to `int64`, so fractional inputs like `[[0.9, 1.1, 2.0]]` are silently truncated to `[[0, 1, 2]]` rather than being rejected. This violates the documented contract that face indices are integer triangles and can silently corrupt topology when upstream data is malformed. The constructor should raise on n...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4785#discussion_r3212263393)
 
 ---
 

--- a/src/shared/python/body_part_viz/shapes/__init__.py
+++ b/src/shared/python/body_part_viz/shapes/__init__.py
@@ -11,4 +11,9 @@ This module is currently a placeholder so callers can write
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from src.shared.python.body_part_viz.shapes.mesh import (
+    SUPPORTED_EXTENSIONS,
+    MeshShape,
+)
+
+__all__: list[str] = ["SUPPORTED_EXTENSIONS", "MeshShape"]

--- a/src/shared/python/body_part_viz/shapes/mesh.py
+++ b/src/shared/python/body_part_viz/shapes/mesh.py
@@ -1,0 +1,315 @@
+"""Triangle-mesh body-part shape backed by trimesh.
+
+This module provides :class:`MeshShape`, a concrete implementation of
+the :class:`BodyPartShape` protocol that wraps a triangle mesh loaded
+from disk (or constructed in-memory from raw vertex/face arrays).
+
+Loaders for ``.stl``, ``.obj``, ``.ply``, and ``.glb`` are exposed via
+:meth:`MeshShape.from_file`. ``trimesh`` is an **optional** dependency
+imported lazily — direct construction from numpy arrays does not require
+trimesh and is convenient for unit tests.
+
+Design by Contract
+------------------
+- Construction validates that ``vertices`` is ``(V, 3)`` finite float,
+  ``faces`` is ``(F, 3)`` integer, and every face index is in
+  ``range(V)``.
+- Empty meshes (``V == 0`` or ``F == 0``) are rejected.
+- The shape is a frozen dataclass; the stored arrays are made read-only
+  to discourage post-construction mutation.
+
+Geometry conventions
+--------------------
+- ``vertices_at_rest()`` returns the centroid-recentred vertices (so the
+  mesh is centred on its bounding-box centroid).
+- ``rest_dimensions`` is the axis-aligned bounding-box extent of the
+  recentred vertices.
+- :meth:`transform` applies, per frame: anisotropic scale, rotation, and
+  centroid translation, in that order.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz._types import FittedShape
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type hints
+    pass
+
+
+__all__ = ["MeshShape", "SUPPORTED_EXTENSIONS"]
+
+
+SUPPORTED_EXTENSIONS: tuple[str, ...] = (".stl", ".obj", ".ply", ".glb")
+"""File extensions accepted by :meth:`MeshShape.from_file`."""
+
+_TRIMESH_INSTALL_HINT = (
+    "trimesh is required for MeshShape.from_file(). Install with "
+    "'pip install trimesh' (and optionally 'pip install trimesh[easy]' "
+    "for full format support)."
+)
+
+
+def _load_trimesh_module() -> Any:
+    """Import :mod:`trimesh` lazily and raise a helpful error if missing."""
+    try:
+        import trimesh  # noqa: PLC0415 - intentional lazy import
+    except ImportError as exc:  # pragma: no cover - exercised only without trimesh
+        raise RuntimeError(_TRIMESH_INSTALL_HINT) from exc
+    return trimesh
+
+
+@dataclass(frozen=True)
+class MeshShape:
+    """Triangle-mesh body-part shape.
+
+    Attributes:
+        shape_id: Stable, human-readable identifier (e.g. ``"mesh:head_v1"``).
+        vertices: ``(V, 3)`` float vertex array, already centred on the
+            bounding-box centroid.
+        face_indices: ``(F, 3)`` integer triangle index array. Stored under
+            this name (rather than ``faces``) to avoid colliding with the
+            :meth:`faces` accessor required by the protocol.
+        rest_dimensions: Axis-aligned bounding-box extent of ``vertices``,
+            ``(extent_x, extent_y, extent_z)``.
+        source_path: Optional path the mesh was loaded from. ``None`` for
+            in-memory construction.
+    """
+
+    shape_id: str
+    vertices: NDArray[np.floating] = field(repr=False)
+    face_indices: NDArray[np.integer] = field(repr=False)
+    rest_dimensions: tuple[float, ...]
+    source_path: Path | None = None
+
+    SUPPORTED_EXTENSIONS: ClassVar[tuple[str, ...]] = SUPPORTED_EXTENSIONS
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.shape_id, str) or not self.shape_id:
+            raise ValueError("shape_id must be a non-empty string")
+
+        verts = np.asarray(self.vertices)
+        faces = np.asarray(self.face_indices)
+
+        if verts.ndim != 2 or verts.shape[1] != 3:
+            raise ValueError(f"vertices must have shape (V, 3), got {verts.shape}")
+        if verts.shape[0] == 0:
+            raise ValueError("vertices must be non-empty (got V=0)")
+        if verts.dtype.kind != "f":
+            raise TypeError(f"vertices must have a floating dtype, got {verts.dtype}")
+        if not np.all(np.isfinite(verts)):
+            raise ValueError("vertices must contain only finite values")
+
+        if faces.ndim != 2 or faces.shape[1] != 3:
+            raise ValueError(f"face_indices must have shape (F, 3), got {faces.shape}")
+        if faces.shape[0] == 0:
+            raise ValueError("face_indices must be non-empty (got F=0)")
+        if faces.dtype.kind not in ("i", "u"):
+            raise TypeError(
+                f"face_indices must have an integer dtype, got {faces.dtype}"
+            )
+        v_max = int(verts.shape[0])
+        if int(faces.min()) < 0 or int(faces.max()) >= v_max:
+            raise ValueError(
+                f"face_indices must reference vertex indices in [0, {v_max}); "
+                f"got min={int(faces.min())}, max={int(faces.max())}"
+            )
+
+        if not isinstance(self.rest_dimensions, tuple):
+            raise TypeError(
+                f"rest_dimensions must be a tuple, got {type(self.rest_dimensions).__name__}"
+            )
+        if len(self.rest_dimensions) != 3:
+            raise ValueError(
+                f"rest_dimensions must have length 3, got {len(self.rest_dimensions)}"
+            )
+        for i, d in enumerate(self.rest_dimensions):
+            if not np.isfinite(d):
+                raise ValueError(f"rest_dimensions[{i}] must be finite, got {d}")
+            if d <= 0.0:
+                raise ValueError(f"rest_dimensions[{i}] must be positive, got {d}")
+
+        # Make arrays read-only so the frozen dataclass invariant extends to
+        # the underlying buffers.
+        verts.setflags(write=False)
+        faces.setflags(write=False)
+        # Use object.__setattr__ to bypass the frozen guard.
+        object.__setattr__(self, "vertices", verts)
+        object.__setattr__(self, "face_indices", faces)
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_arrays(
+        cls,
+        shape_id: str,
+        vertices: NDArray[np.floating],
+        faces: NDArray[np.integer],
+        *,
+        source_path: Path | None = None,
+    ) -> MeshShape:
+        """Construct a :class:`MeshShape` from raw vertex/face arrays.
+
+        The vertices are recentred on their axis-aligned bounding-box
+        centroid; ``rest_dimensions`` is computed from the recentred
+        bounding-box extent.
+
+        Args:
+            shape_id: Stable identifier (e.g. ``"mesh:head_v1"``).
+            vertices: ``(V, 3)`` float array.
+            faces: ``(F, 3)`` integer array.
+            source_path: Optional source path for traceability.
+
+        Raises:
+            ValueError: If the arrays violate the documented contract.
+        """
+        verts = np.asarray(vertices, dtype=np.float64).copy()
+        if verts.ndim != 2 or verts.shape[1] != 3:
+            raise ValueError(f"vertices must have shape (V, 3), got {verts.shape}")
+        if verts.shape[0] == 0:
+            raise ValueError("vertices must be non-empty (got V=0)")
+        if not np.all(np.isfinite(verts)):
+            raise ValueError("vertices must contain only finite values")
+
+        # Centre on bounding-box centroid (mid-point of min/max per axis)
+        mins = verts.min(axis=0)
+        maxs = verts.max(axis=0)
+        centroid = (mins + maxs) * 0.5
+        centred = verts - centroid
+        extents = maxs - mins
+        if np.any(extents <= 0.0):
+            raise ValueError(
+                f"mesh bounding box must have positive extent on every axis, got {tuple(extents)}"
+            )
+        rest = (float(extents[0]), float(extents[1]), float(extents[2]))
+
+        face_arr = np.asarray(faces)
+        if face_arr.dtype.kind not in ("i", "u"):
+            face_arr = face_arr.astype(np.int64)
+        else:
+            face_arr = face_arr.copy()
+
+        return cls(
+            shape_id=shape_id,
+            vertices=centred,
+            face_indices=face_arr,
+            rest_dimensions=rest,
+            source_path=source_path,
+        )
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> MeshShape:
+        """Load a mesh from disk via :mod:`trimesh`.
+
+        Supported extensions: ``.stl``, ``.obj``, ``.ply``, ``.glb``.
+        ``.gltf`` is rejected with a hint to use ``.glb``.
+
+        Args:
+            path: Filesystem path to the mesh file.
+
+        Returns:
+            A :class:`MeshShape` whose ``shape_id`` is
+            ``"mesh:<basename_without_ext>"``.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            ValueError: If the extension is unsupported, or the loaded
+                mesh is empty/degenerate.
+            RuntimeError: If :mod:`trimesh` is not installed.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"mesh file not found: {p}")
+        if not p.is_file():
+            raise FileNotFoundError(f"mesh path is not a file: {p}")
+
+        ext = p.suffix.lower()
+        if ext == ".gltf":
+            raise ValueError(
+                f"unsupported extension '.gltf' for {p.name}; "
+                "convert to .glb (binary glTF) and try again"
+            )
+        if ext not in SUPPORTED_EXTENSIONS:
+            raise ValueError(
+                f"unsupported mesh extension '{ext}' for {p.name}; "
+                f"supported: {', '.join(SUPPORTED_EXTENSIONS)}"
+            )
+
+        trimesh = _load_trimesh_module()
+
+        loaded = trimesh.load(str(p), force="mesh")
+        if loaded is None:
+            raise ValueError(f"trimesh returned no mesh for {p}")
+
+        # ``trimesh.load`` may return a Scene when the file contains
+        # multiple geometries (common for .glb). Concatenate to a single
+        # mesh in that case.
+        if hasattr(loaded, "geometry") and not hasattr(loaded, "vertices"):
+            geometries = list(loaded.geometry.values())
+            if not geometries:
+                raise ValueError(f"mesh file {p} contains no geometry")
+            loaded = trimesh.util.concatenate(geometries)
+
+        verts = np.asarray(loaded.vertices, dtype=np.float64)
+        faces = np.asarray(loaded.faces, dtype=np.int64)
+        if verts.size == 0 or faces.size == 0:
+            raise ValueError(f"mesh file {p} produced an empty mesh")
+
+        shape_id = f"mesh:{p.stem}"
+        return cls.from_arrays(
+            shape_id=shape_id,
+            vertices=verts,
+            faces=faces,
+            source_path=p,
+        )
+
+    # ------------------------------------------------------------------
+    # BodyPartShape protocol
+    # ------------------------------------------------------------------
+
+    def vertices_at_rest(self) -> NDArray[np.floating]:
+        """Return ``(V, 3)`` centred, scale-normalised vertex array (read-only)."""
+        return self.vertices
+
+    def faces(self) -> NDArray[np.integer]:
+        """Return the ``(F, 3)`` triangle index array (read-only)."""
+        return self.face_indices
+
+    def transform(self, fitted: FittedShape) -> NDArray[np.floating]:
+        """Apply per-frame scale, rotation, and translation to rest vertices.
+
+        Args:
+            fitted: Per-frame placement. ``fitted.shape_id`` must match
+                ``self.shape_id``.
+
+        Returns:
+            ``(T, V, 3)`` array of world-frame vertices.
+
+        Raises:
+            ValueError: If ``fitted.shape_id != self.shape_id``.
+        """
+        if fitted.shape_id != self.shape_id:
+            raise ValueError(
+                f"fitted.shape_id={fitted.shape_id!r} does not match "
+                f"self.shape_id={self.shape_id!r}"
+            )
+
+        verts = self.vertices  # (V, 3)
+        # Anisotropic scale: (T, V, 3) = (V, 3) * (T, 1, 3)
+        scaled = verts[None, :, :] * fitted.scale[:, None, :]
+        # Rotation: (T, V, 3) = einsum('tij,tvj->tvi', R, scaled)
+        rotated = np.einsum("tij,tvj->tvi", fitted.rotation_matrix, scaled)
+        # Translation
+        return rotated + fitted.centroid[:, None, :]

--- a/tests/unit/body_part_viz/test_shapes_mesh.py
+++ b/tests/unit/body_part_viz/test_shapes_mesh.py
@@ -1,0 +1,560 @@
+"""Tests for :class:`body_part_viz.shapes.MeshShape`.
+
+These tests verify the protocol conformance, DbC validation, file-loader
+behaviour, and per-frame transform of :class:`MeshShape`.
+
+Most tests construct meshes directly from numpy arrays via
+:meth:`MeshShape.from_arrays`, which does **not** require trimesh. The
+loader tests use :func:`pytest.importorskip` so they skip cleanly in
+environments without trimesh installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import BodyPartShape
+from src.shared.python.body_part_viz.shapes import SUPPORTED_EXTENSIONS, MeshShape
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _unit_cube_arrays() -> tuple[np.ndarray, np.ndarray]:
+    """Return (vertices, faces) for a 1x2x3 axis-aligned box."""
+    # 8 corners spanning [-0.5, 0.5] x [-1, 1] x [-1.5, 1.5]
+    vertices = np.array(
+        [
+            [-0.5, -1.0, -1.5],
+            [0.5, -1.0, -1.5],
+            [0.5, 1.0, -1.5],
+            [-0.5, 1.0, -1.5],
+            [-0.5, -1.0, 1.5],
+            [0.5, -1.0, 1.5],
+            [0.5, 1.0, 1.5],
+            [-0.5, 1.0, 1.5],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2],
+            [0, 2, 3],  # -Z
+            [4, 6, 5],
+            [4, 7, 6],  # +Z
+            [0, 4, 5],
+            [0, 5, 1],  # -Y
+            [2, 6, 7],
+            [2, 7, 3],  # +Y
+            [1, 5, 6],
+            [1, 6, 2],  # +X
+            [0, 3, 7],
+            [0, 7, 4],  # -X
+        ],
+        dtype=np.int64,
+    )
+    return vertices, faces
+
+
+@pytest.fixture
+def box_shape() -> MeshShape:
+    verts, faces = _unit_cube_arrays()
+    return MeshShape.from_arrays("mesh:box", verts, faces)
+
+
+def _identity_fit(shape_id: str, n_frames: int = 3) -> FittedShape:
+    """Identity fit: zero centroid, identity rotation, unit scale."""
+    centroid = np.zeros((n_frames, 3), dtype=np.float64)
+    rot = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+    scale = np.ones((n_frames, 3), dtype=np.float64)
+    valid = np.ones((n_frames,), dtype=np.bool_)
+    binding = MarkerBinding(
+        kind=BindingKind.ON_MARKER,
+        marker_names=("m1",),
+        rest_dimensions=(1.0,),
+    )
+    return FittedShape(
+        shape_id=shape_id,
+        binding=binding,
+        centroid=centroid,
+        rotation_matrix=rot,
+        scale=scale,
+        valid_mask=valid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# from_arrays — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_from_arrays_constructs_shape(box_shape: MeshShape) -> None:
+    assert box_shape.shape_id == "mesh:box"
+    assert box_shape.vertices.shape == (8, 3)
+    assert box_shape.face_indices.shape == (12, 3)
+
+
+@pytest.mark.unit
+def test_from_arrays_recenters_vertices() -> None:
+    # Off-centre cube — centroid should land at origin.
+    verts = np.array(
+        [
+            [10.0, 10.0, 10.0],
+            [11.0, 10.0, 10.0],
+            [11.0, 11.0, 10.0],
+            [10.0, 11.0, 10.0],
+            [10.0, 10.0, 11.0],
+            [11.0, 10.0, 11.0],
+            [11.0, 11.0, 11.0],
+            [10.0, 11.0, 11.0],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array([[0, 1, 2], [4, 5, 6]], dtype=np.int64)
+    shape = MeshShape.from_arrays("mesh:offset", verts, faces)
+    centre = shape.vertices.mean(axis=0)
+    np.testing.assert_allclose(centre, np.zeros(3), atol=1e-12)
+
+
+@pytest.mark.unit
+def test_rest_dimensions_match_bbox(box_shape: MeshShape) -> None:
+    assert box_shape.rest_dimensions == (1.0, 2.0, 3.0)
+
+
+@pytest.mark.unit
+def test_vertices_at_rest_extents_match_rest_dimensions(box_shape: MeshShape) -> None:
+    v = box_shape.vertices_at_rest()
+    extents = v.max(axis=0) - v.min(axis=0)
+    np.testing.assert_allclose(extents, np.array(box_shape.rest_dimensions))
+
+
+@pytest.mark.unit
+def test_faces_returns_index_array(box_shape: MeshShape) -> None:
+    f = box_shape.faces()
+    assert f.shape == (12, 3)
+    assert f.dtype.kind in ("i", "u")
+
+
+@pytest.mark.unit
+def test_vertices_array_is_read_only(box_shape: MeshShape) -> None:
+    with pytest.raises(ValueError):
+        box_shape.vertices[0, 0] = 999.0
+
+
+@pytest.mark.unit
+def test_faces_array_is_read_only(box_shape: MeshShape) -> None:
+    with pytest.raises(ValueError):
+        box_shape.face_indices[0, 0] = 999
+
+
+# ---------------------------------------------------------------------------
+# Protocol + frozen invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_satisfies_body_part_shape_protocol(box_shape: MeshShape) -> None:
+    assert isinstance(box_shape, BodyPartShape)
+
+
+@pytest.mark.unit
+def test_is_frozen_dataclass(box_shape: MeshShape) -> None:
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        box_shape.shape_id = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DbC: rejects malformed input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_rejects_empty_vertices() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        MeshShape.from_arrays(
+            "mesh:e",
+            np.zeros((0, 3), dtype=np.float64),
+            np.zeros((0, 3), dtype=np.int64),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_nan_vertices() -> None:
+    verts, faces = _unit_cube_arrays()
+    verts[0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        MeshShape.from_arrays("mesh:nan", verts, faces)
+
+
+@pytest.mark.unit
+def test_rejects_inf_vertices() -> None:
+    verts, faces = _unit_cube_arrays()
+    verts[3, 1] = np.inf
+    with pytest.raises(ValueError, match="finite"):
+        MeshShape.from_arrays("mesh:inf", verts, faces)
+
+
+@pytest.mark.unit
+def test_rejects_wrong_vertex_shape() -> None:
+    bad_verts = np.zeros((5, 4), dtype=np.float64)
+    faces = np.array([[0, 1, 2]], dtype=np.int64)
+    with pytest.raises(ValueError, match=r"\(V, 3\)"):
+        MeshShape.from_arrays("mesh:bad", bad_verts, faces)
+
+
+@pytest.mark.unit
+def test_rejects_face_index_out_of_range() -> None:
+    verts, _faces = _unit_cube_arrays()
+    bad_faces = np.array([[0, 1, 99]], dtype=np.int64)
+    with pytest.raises(ValueError, match="face_indices must reference"):
+        MeshShape.from_arrays("mesh:oor", verts, bad_faces)
+
+
+@pytest.mark.unit
+def test_rejects_negative_face_index() -> None:
+    verts, _faces = _unit_cube_arrays()
+    bad_faces = np.array([[-1, 1, 2]], dtype=np.int64)
+    with pytest.raises(ValueError, match="face_indices must reference"):
+        MeshShape.from_arrays("mesh:neg", verts, bad_faces)
+
+
+@pytest.mark.unit
+def test_rejects_wrong_face_shape() -> None:
+    verts, _faces = _unit_cube_arrays()
+    bad_faces = np.array([[0, 1, 2, 3]], dtype=np.int64)
+    with pytest.raises(ValueError, match=r"\(F, 3\)"):
+        MeshShape.from_arrays("mesh:badface", verts, bad_faces)
+
+
+@pytest.mark.unit
+def test_rejects_empty_faces() -> None:
+    verts, _faces = _unit_cube_arrays()
+    with pytest.raises(ValueError, match="non-empty"):
+        MeshShape.from_arrays("mesh:nofaces", verts, np.zeros((0, 3), dtype=np.int64))
+
+
+@pytest.mark.unit
+def test_rejects_empty_shape_id() -> None:
+    verts, faces = _unit_cube_arrays()
+    with pytest.raises(ValueError, match="shape_id"):
+        MeshShape(
+            shape_id="",
+            vertices=verts,
+            face_indices=faces,
+            rest_dimensions=(1.0, 2.0, 3.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_degenerate_bbox() -> None:
+    # A planar mesh (all z=0) — bbox extent on z is 0.
+    verts = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float64,
+    )
+    faces = np.array([[0, 1, 2]], dtype=np.int64)
+    with pytest.raises(ValueError, match="positive extent"):
+        MeshShape.from_arrays("mesh:planar", verts, faces)
+
+
+@pytest.mark.unit
+def test_rejects_non_float_vertices_in_direct_construction() -> None:
+    int_verts = np.zeros((4, 3), dtype=np.int64)
+    int_verts[1, 0] = 1
+    int_verts[2, 1] = 1
+    int_verts[3, 2] = 1
+    faces = np.array([[0, 1, 2], [0, 1, 3]], dtype=np.int64)
+    with pytest.raises(TypeError, match="floating"):
+        MeshShape(
+            shape_id="mesh:int",
+            vertices=int_verts,  # type: ignore[arg-type]
+            face_indices=faces,
+            rest_dimensions=(1.0, 1.0, 1.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_non_integer_faces_in_direct_construction() -> None:
+    verts, _faces = _unit_cube_arrays()
+    bad = np.zeros((1, 3), dtype=np.float64)
+    with pytest.raises(TypeError, match="integer"):
+        MeshShape(
+            shape_id="mesh:floatfaces",
+            vertices=verts,
+            face_indices=bad,  # type: ignore[arg-type]
+            rest_dimensions=(1.0, 2.0, 3.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_bad_rest_dimensions_length() -> None:
+    verts, faces = _unit_cube_arrays()
+    with pytest.raises(ValueError, match="length 3"):
+        MeshShape(
+            shape_id="mesh:rd",
+            vertices=verts,
+            face_indices=faces,
+            rest_dimensions=(1.0, 2.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_negative_rest_dimension() -> None:
+    verts, faces = _unit_cube_arrays()
+    with pytest.raises(ValueError, match="positive"):
+        MeshShape(
+            shape_id="mesh:rd",
+            vertices=verts,
+            face_indices=faces,
+            rest_dimensions=(1.0, -2.0, 3.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_non_finite_rest_dimension() -> None:
+    verts, faces = _unit_cube_arrays()
+    with pytest.raises(ValueError, match="finite"):
+        MeshShape(
+            shape_id="mesh:rd",
+            vertices=verts,
+            face_indices=faces,
+            rest_dimensions=(1.0, float("nan"), 3.0),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_rest_dimensions_wrong_type() -> None:
+    verts, faces = _unit_cube_arrays()
+    with pytest.raises(TypeError, match="tuple"):
+        MeshShape(
+            shape_id="mesh:rd",
+            vertices=verts,
+            face_indices=faces,
+            rest_dimensions=[1.0, 2.0, 3.0],  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# transform()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_transform_identity_reproduces_vertices(box_shape: MeshShape) -> None:
+    fit = _identity_fit(box_shape.shape_id, n_frames=4)
+    out = box_shape.transform(fit)
+    assert out.shape == (4, 8, 3)
+    for t in range(4):
+        np.testing.assert_allclose(out[t], box_shape.vertices_at_rest())
+
+
+@pytest.mark.unit
+def test_transform_translation_only(box_shape: MeshShape) -> None:
+    fit = _identity_fit(box_shape.shape_id, n_frames=2)
+    fit = FittedShape(
+        shape_id=fit.shape_id,
+        binding=fit.binding,
+        centroid=np.array([[1.0, 2.0, 3.0], [-1.0, 0.0, 5.0]]),
+        rotation_matrix=fit.rotation_matrix,
+        scale=fit.scale,
+        valid_mask=fit.valid_mask,
+    )
+    out = box_shape.transform(fit)
+    np.testing.assert_allclose(
+        out[0], box_shape.vertices_at_rest() + np.array([1.0, 2.0, 3.0])
+    )
+    np.testing.assert_allclose(
+        out[1], box_shape.vertices_at_rest() + np.array([-1.0, 0.0, 5.0])
+    )
+
+
+@pytest.mark.unit
+def test_transform_anisotropic_scale_stretches(box_shape: MeshShape) -> None:
+    fit = _identity_fit(box_shape.shape_id, n_frames=1)
+    fit = FittedShape(
+        shape_id=fit.shape_id,
+        binding=fit.binding,
+        centroid=fit.centroid,
+        rotation_matrix=fit.rotation_matrix,
+        scale=np.array([[2.0, 0.5, 4.0]]),
+        valid_mask=fit.valid_mask,
+    )
+    out = box_shape.transform(fit)
+    extents = out[0].max(axis=0) - out[0].min(axis=0)
+    expected = np.array(box_shape.rest_dimensions) * np.array([2.0, 0.5, 4.0])
+    np.testing.assert_allclose(extents, expected)
+
+
+@pytest.mark.unit
+def test_transform_rotation_90_about_z(box_shape: MeshShape) -> None:
+    rot = np.array(
+        [
+            [
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ]
+    )
+    fit = _identity_fit(box_shape.shape_id, n_frames=1)
+    fit = FittedShape(
+        shape_id=fit.shape_id,
+        binding=fit.binding,
+        centroid=fit.centroid,
+        rotation_matrix=rot,
+        scale=fit.scale,
+        valid_mask=fit.valid_mask,
+    )
+    out = box_shape.transform(fit)
+    rest = box_shape.vertices_at_rest()
+    expected = (rot[0] @ rest.T).T
+    np.testing.assert_allclose(out[0], expected, atol=1e-12)
+
+
+@pytest.mark.unit
+def test_transform_shape_id_mismatch_raises(box_shape: MeshShape) -> None:
+    fit = _identity_fit("mesh:other")
+    with pytest.raises(ValueError, match="shape_id"):
+        box_shape.transform(fit)
+
+
+@pytest.mark.unit
+def test_transform_output_shape(box_shape: MeshShape) -> None:
+    fit = _identity_fit(box_shape.shape_id, n_frames=7)
+    out = box_shape.transform(fit)
+    assert out.shape == (7, box_shape.vertices_at_rest().shape[0], 3)
+
+
+# ---------------------------------------------------------------------------
+# from_file — loader behaviour (requires trimesh)
+# ---------------------------------------------------------------------------
+
+
+def _write_box_via_trimesh(trimesh_mod: object, path: Path) -> None:
+    box = trimesh_mod.creation.box(extents=(1.0, 2.0, 3.0))  # type: ignore[attr-defined]
+    box.export(str(path))
+
+
+@pytest.mark.unit
+def test_from_file_stl(tmp_path: Path) -> None:
+    trimesh = pytest.importorskip("trimesh")
+    p = tmp_path / "head_v1.stl"
+    _write_box_via_trimesh(trimesh, p)
+    shape = MeshShape.from_file(p)
+    assert shape.shape_id == "mesh:head_v1"
+    assert shape.vertices.shape[1] == 3
+    assert shape.face_indices.shape[1] == 3
+    assert shape.source_path == p
+
+
+@pytest.mark.unit
+def test_from_file_obj(tmp_path: Path) -> None:
+    trimesh = pytest.importorskip("trimesh")
+    p = tmp_path / "torso.obj"
+    _write_box_via_trimesh(trimesh, p)
+    shape = MeshShape.from_file(p)
+    assert shape.shape_id == "mesh:torso"
+    np.testing.assert_allclose(
+        np.array(shape.rest_dimensions),
+        np.array([1.0, 2.0, 3.0]),
+        atol=1e-9,
+    )
+
+
+@pytest.mark.unit
+def test_from_file_ply(tmp_path: Path) -> None:
+    trimesh = pytest.importorskip("trimesh")
+    p = tmp_path / "limb.ply"
+    _write_box_via_trimesh(trimesh, p)
+    shape = MeshShape.from_file(p)
+    assert shape.shape_id == "mesh:limb"
+    assert isinstance(shape, BodyPartShape)
+
+
+@pytest.mark.unit
+def test_from_file_glb(tmp_path: Path) -> None:
+    trimesh = pytest.importorskip("trimesh")
+    p = tmp_path / "head.glb"
+    _write_box_via_trimesh(trimesh, p)
+    shape = MeshShape.from_file(p)
+    assert shape.shape_id == "mesh:head"
+    np.testing.assert_allclose(
+        np.array(shape.rest_dimensions),
+        np.array([1.0, 2.0, 3.0]),
+        atol=1e-6,
+    )
+
+
+@pytest.mark.unit
+def test_from_file_accepts_string_path(tmp_path: Path) -> None:
+    trimesh = pytest.importorskip("trimesh")
+    p = tmp_path / "leg.stl"
+    _write_box_via_trimesh(trimesh, p)
+    shape = MeshShape.from_file(str(p))
+    assert shape.shape_id == "mesh:leg"
+
+
+@pytest.mark.unit
+def test_from_file_missing_raises_filenotfound(tmp_path: Path) -> None:
+    p = tmp_path / "nope.stl"
+    with pytest.raises(FileNotFoundError, match="not found"):
+        MeshShape.from_file(p)
+
+
+@pytest.mark.unit
+def test_from_file_directory_raises_filenotfound(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="not a file"):
+        MeshShape.from_file(tmp_path)
+
+
+@pytest.mark.unit
+def test_from_file_unsupported_extension_raises(tmp_path: Path) -> None:
+    p = tmp_path / "bad.xyz"
+    p.write_text("dummy")
+    with pytest.raises(ValueError, match="unsupported mesh extension"):
+        MeshShape.from_file(p)
+
+
+@pytest.mark.unit
+def test_from_file_gltf_rejected_with_hint(tmp_path: Path) -> None:
+    p = tmp_path / "model.gltf"
+    p.write_text("{}")
+    with pytest.raises(ValueError, match=r"\.gltf.*\.glb"):
+        MeshShape.from_file(p)
+
+
+@pytest.mark.unit
+def test_supported_extensions_constant() -> None:
+    assert ".stl" in SUPPORTED_EXTENSIONS
+    assert ".obj" in SUPPORTED_EXTENSIONS
+    assert ".ply" in SUPPORTED_EXTENSIONS
+    assert ".glb" in SUPPORTED_EXTENSIONS
+    assert ".gltf" not in SUPPORTED_EXTENSIONS
+
+
+@pytest.mark.unit
+def test_supported_extensions_class_var() -> None:
+    assert MeshShape.SUPPORTED_EXTENSIONS == SUPPORTED_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: bbox invariant after transform
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_bbox_invariant_after_identity_transform(box_shape: MeshShape) -> None:
+    fit = _identity_fit(box_shape.shape_id, n_frames=1)
+    out = box_shape.transform(fit)[0]
+    extents = out.max(axis=0) - out.min(axis=0)
+    np.testing.assert_allclose(extents, np.array(box_shape.rest_dimensions))


### PR DESCRIPTION
## Summary

- Adds `MeshShape`, a frozen-dataclass triangle-mesh implementation of the `BodyPartShape` protocol.
- Loads STL/OBJ/PLY/GLB via lazy `trimesh` import; rejects `.gltf` with a hint to convert to `.glb`.
- Provides `MeshShape.from_arrays(...)` for in-memory construction and unit testing without `trimesh`.
- Recentres vertices on their bounding-box centroid; `rest_dimensions` is the recentred bbox extent `(extent_x, extent_y, extent_z)`.
- `transform(fitted)` applies per-frame anisotropic scale, rotation, and translation, returning `(T, V, 3)`.
- DbC: rejects empty meshes, non-finite vertices, malformed face indices, degenerate bounding boxes, and unsupported extensions.

Closes #4758.

## Test plan

- [x] 43 unit tests in `tests/unit/body_part_viz/test_shapes_mesh.py`
- [x] `isinstance(shape, BodyPartShape)` passes
- [x] Frozen-dataclass invariant verified
- [x] Bounding-box invariant: `vertices_at_rest()` extents match `rest_dimensions`
- [x] `transform()` identity round-trip reproduces vertices
- [x] Anisotropic scale stretches axes independently
- [x] 90-degree rotation about Z verified
- [x] STL/OBJ/PLY/GLB loaders verified via `trimesh.creation.box` written to `tmp_path` (no checked-in fixtures)
- [x] Missing file -> `FileNotFoundError`; unsupported ext -> `ValueError`; `.gltf` -> `ValueError` with hint
- [x] Empty mesh / NaN vertices / out-of-range face indices rejected
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)