### PR TITLE
feat(body-part-viz): MatplotlibRenderer (#4760)

### DIFF
--- a/src/shared/python/body_part_viz/renderers/__init__.py
+++ b/src/shared/python/body_part_viz/renderers/__init__.py
@@ -1,9 +1,12 @@
 """Renderer implementations sub-package.
 
 Concrete :class:`~body_part_viz.contracts.ShapeRenderer` backends
-(matplotlib, pyqtgraph, ...) land in follow-up issues of EPIC #4755.
+(matplotlib, pyqtgraph, ...). Additional backends land in follow-up
+issues of EPIC #4755.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .matplotlib_renderer import MatplotlibRenderer
+
+__all__ = ["MatplotlibRenderer"]

--- a/src/shared/python/body_part_viz/renderers/matplotlib_renderer.py
+++ b/src/shared/python/body_part_viz/renderers/matplotlib_renderer.py
@@ -1,0 +1,230 @@
+"""Matplotlib 3D ``ShapeRenderer`` implementation.
+
+Renders :class:`~body_part_viz.contracts.BodyPartShape` instances onto a
+``mpl_toolkits.mplot3d.Axes3D`` using one matplotlib artist per shape:
+
+* Line shapes use :class:`~mpl_toolkits.mplot3d.art3d.Line3DCollection`.
+* Mesh-bearing shapes (cylinder, ellipsoid, capsule, composite, mesh)
+  use :class:`~mpl_toolkits.mplot3d.art3d.Poly3DCollection`.
+
+``update_frame`` mutates the existing artist's geometry via
+``set_segments`` / ``set_verts`` rather than rebuilding it. The scene is
+never cleared. This keeps the per-frame budget low enough to satisfy the
+60 fps target on the 26-shape × 200-vertex workload.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import matplotlib
+import numpy as np
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
+
+from .._types import FittedShape
+from ..contracts import BodyPartShape
+from ..theme import ShapeTheme
+
+if TYPE_CHECKING:
+    from mpl_toolkits.mplot3d import Axes3D
+
+__all__ = ["MatplotlibRenderer"]
+
+
+@dataclass
+class _ShapeEntry:
+    """Bookkeeping for a single registered shape."""
+
+    shape: BodyPartShape
+    fitted: FittedShape
+    faces: np.ndarray
+    world_vertices: np.ndarray  # (T, V, 3)
+    artist: Any  # Line3DCollection or Poly3DCollection
+    is_line: bool
+
+
+class MatplotlibRenderer:
+    """Render body_part_viz shapes onto a matplotlib :class:`Axes3D`.
+
+    Parameters
+    ----------
+    ax:
+        The 3D axes to draw into. The renderer owns the artists it adds
+        but never clears the axes.
+    """
+
+    def __init__(self, ax: Axes3D) -> None:
+        if ax is None:
+            raise TypeError("ax must not be None")
+        self._ax = ax
+        self._entries: dict[str, _ShapeEntry] = {}
+
+    # ------------------------------------------------------------------
+    # ShapeRenderer Protocol
+    # ------------------------------------------------------------------
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str:
+        """Add ``shape`` and return a stable handle.
+
+        Precomputes per-frame world vertices once, then constructs a
+        single matplotlib artist initialised at frame 0.
+        """
+        if not isinstance(shape, BodyPartShape):
+            raise TypeError(
+                f"shape must satisfy BodyPartShape; got {type(shape).__name__}"
+            )
+        if not isinstance(fitted, FittedShape):
+            raise TypeError(f"fitted must be FittedShape; got {type(fitted).__name__}")
+        if not isinstance(theme, ShapeTheme):
+            raise TypeError(f"theme must be ShapeTheme; got {type(theme).__name__}")
+
+        world = shape.transform(fitted)  # (T, V, 3)
+        faces = shape.faces()
+        is_line = faces.shape[0] == 0
+
+        frame0 = self._frame_geometry(world, 0)
+        if is_line:
+            segments = self._line_segments(frame0)
+            artist = Line3DCollection(
+                segments,
+                colors=theme.color,
+                linewidths=max(theme.edge_width, 1.0),
+                alpha=theme.opacity,
+            )
+        else:
+            polys = self._face_polys(frame0, faces)
+            artist = Poly3DCollection(
+                polys,
+                facecolors=theme.color,
+                edgecolors=theme.edge_color,
+                linewidths=theme.edge_width,
+                alpha=theme.opacity,
+            )
+
+        self._ax.add_collection3d(artist)
+        handle = uuid4().hex
+        self._entries[handle] = _ShapeEntry(
+            shape=shape,
+            fitted=fitted,
+            faces=faces,
+            world_vertices=world,
+            artist=artist,
+            is_line=is_line,
+        )
+        return handle
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        """Update the artist for ``handle`` to frame ``frame_idx``.
+
+        Calls ``set_segments`` / ``set_verts`` on the existing artist;
+        never clears the axes. Issues a single ``draw_idle`` at the end.
+        """
+        entry = self._require(handle)
+        if not isinstance(frame_idx, (int, np.integer)) or isinstance(frame_idx, bool):
+            raise TypeError(f"frame_idx must be int; got {type(frame_idx).__name__}")
+        n_frames = entry.world_vertices.shape[0]
+        if not 0 <= int(frame_idx) < n_frames:
+            raise IndexError(f"frame_idx {frame_idx} out of range [0, {n_frames})")
+
+        verts = self._frame_geometry(entry.world_vertices, int(frame_idx))
+        if entry.is_line:
+            entry.artist.set_segments(self._line_segments(verts))
+        else:
+            entry.artist.set_verts(self._face_polys(verts, entry.faces))
+
+        # Single redraw signal at the end. Only emit on interactive
+        # backends — under non-interactive ones (e.g. Agg in tests) the
+        # host drives the draw cycle, and a synchronous draw on every
+        # frame would obliterate the per-frame budget.
+        if matplotlib.is_interactive():
+            canvas = getattr(self._ax.figure, "canvas", None)
+            if canvas is not None and hasattr(canvas, "draw_idle"):
+                canvas.draw_idle()
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        """Show or hide the artist for ``handle``."""
+        if not isinstance(visible, bool):
+            raise TypeError(f"visible must be bool; got {type(visible).__name__}")
+        entry = self._require(handle)
+        entry.artist.set_visible(visible)
+
+    def remove(self, handle: str) -> None:
+        """Remove the artist for ``handle`` from the axes."""
+        entry = self._require(handle)
+        # If the artist is already detached, fall through and drop the
+        # bookkeeping anyway.
+        with contextlib.suppress(ValueError, NotImplementedError):
+            entry.artist.remove()
+        del self._entries[handle]
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+    def add_segment_set(
+        self,
+        segments: Iterable[tuple[BodyPartShape, FittedShape]],
+        theme_resolver: Callable[[FittedShape], ShapeTheme],
+    ) -> list[str]:
+        """Add many shapes; thin wrapper over :meth:`add_shape`.
+
+        ``segments`` is an iterable of ``(shape, fitted)`` pairs.
+        ``theme_resolver`` is called once per pair with the ``FittedShape``
+        and must return a :class:`ShapeTheme`.
+        """
+        if not callable(theme_resolver):
+            raise TypeError("theme_resolver must be callable")
+        handles: list[str] = []
+        for entry in segments:
+            if not isinstance(entry, tuple) or len(entry) != 2:
+                raise TypeError("segments must yield (shape, fitted) tuples")
+            shape, fitted = entry
+            theme = theme_resolver(fitted)
+            handles.append(self.add_shape(shape, fitted, theme))
+        return handles
+
+    def clear(self) -> None:
+        """Remove every shape this renderer owns. Does not clear the axes."""
+        for handle in list(self._entries.keys()):
+            self.remove(handle)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _require(self, handle: str) -> _ShapeEntry:
+        if handle not in self._entries:
+            raise KeyError(f"unknown shape handle: {handle!r}")
+        return self._entries[handle]
+
+    @staticmethod
+    def _frame_geometry(world: np.ndarray, frame_idx: int) -> np.ndarray:
+        verts = world[frame_idx]
+        # NaN-fill invalid frames to a safe zero so matplotlib does not
+        # raise; the artist is still hidden visually because subsequent
+        # frames will overwrite. Caller filters via valid_mask if needed.
+        if not np.all(np.isfinite(verts)):
+            verts = np.where(np.isfinite(verts), verts, 0.0)
+        return verts
+
+    @staticmethod
+    def _line_segments(vertices: np.ndarray) -> list[np.ndarray]:
+        # A line shape stores ordered endpoints; emit consecutive pairs.
+        if vertices.shape[0] < 2:
+            return []
+        return [
+            np.stack([vertices[i], vertices[i + 1]], axis=0)
+            for i in range(vertices.shape[0] - 1)
+        ]
+
+    @staticmethod
+    def _face_polys(vertices: np.ndarray, faces: np.ndarray) -> list[np.ndarray]:
+        if faces.shape[0] == 0:
+            return []
+        return [vertices[face] for face in faces]

--- a/tests/unit/body_part_viz/renderers/test_matplotlib_renderer.py
+++ b/tests/unit/body_part_viz/renderers/test_matplotlib_renderer.py
@@ -1,0 +1,323 @@
+"""Unit tests for ``MatplotlibRenderer``.
+
+Headless: forces matplotlib's ``Agg`` backend before importing pyplot.
+The 60 fps performance contract is enforced via a loose 1 ms / call
+mean budget over 1000 ``update_frame`` calls.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import matplotlib
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from mpl_toolkits.mplot3d.art3d import (  # noqa: E402
+    Line3DCollection,
+    Poly3DCollection,
+)
+
+from src.shared.python.body_part_viz import (  # noqa: E402
+    BindingKind,
+    FittedShape,
+    MarkerBinding,
+    ShapeRenderer,
+    ShapeTheme,
+)
+from src.shared.python.body_part_viz.renderers import (  # noqa: E402
+    MatplotlibRenderer,
+)
+from src.shared.python.body_part_viz.shapes import (  # noqa: E402
+    CylinderShape,
+    LineShape,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _fitted(shape_id: str, n_frames: int = 4) -> FittedShape:
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+    )
+    centroid = np.zeros((n_frames, 3))
+    centroid[:, 0] = np.arange(n_frames, dtype=float)
+    rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+    scale = np.ones((n_frames, 3))
+    mask = np.ones((n_frames,), dtype=bool)
+    return FittedShape(
+        shape_id=shape_id,
+        binding=binding,
+        centroid=centroid,
+        rotation_matrix=rotation,
+        scale=scale,
+        valid_mask=mask,
+    )
+
+
+@pytest.fixture
+def ax():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    yield ax
+    plt.close(fig)
+
+
+@pytest.fixture
+def theme():
+    return ShapeTheme(color="#1f77b4", opacity=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+def test_matplotlib_renderer_satisfies_shape_renderer_protocol(ax) -> None:
+    renderer = MatplotlibRenderer(ax)
+    assert isinstance(renderer, ShapeRenderer)
+
+
+def test_constructor_rejects_none() -> None:
+    with pytest.raises(TypeError):
+        MatplotlibRenderer(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# add_shape: artist creation
+# ---------------------------------------------------------------------------
+def test_add_shape_line_creates_line3dcollection(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = LineShape(length=1.0)
+    handle = renderer.add_shape(shape, _fitted("line"), theme)
+    entry = renderer._entries[handle]
+    assert isinstance(entry.artist, Line3DCollection)
+
+
+def test_add_shape_cylinder_creates_poly3dcollection(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = CylinderShape(length=1.0, radius=0.5, n_facets=12)
+    handle = renderer.add_shape(shape, _fitted("cyl"), theme)
+    entry = renderer._entries[handle]
+    assert isinstance(entry.artist, Poly3DCollection)
+
+
+def test_add_shape_validates_arguments(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = LineShape(length=1.0)
+    fitted = _fitted("line")
+    with pytest.raises(TypeError):
+        renderer.add_shape("not a shape", fitted, theme)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        renderer.add_shape(shape, "not fitted", theme)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        renderer.add_shape(shape, fitted, "not theme")  # type: ignore[arg-type]
+
+
+def test_add_three_cylinders_and_one_line_yields_four_artists(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handles = []
+    for i in range(3):
+        cyl = CylinderShape(length=1.0, radius=0.4, n_facets=8)
+        handles.append(renderer.add_shape(cyl, _fitted(f"cyl{i}"), theme))
+    handles.append(renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme))
+    assert len(renderer._entries) == 4
+    assert len(set(handles)) == 4
+
+
+# ---------------------------------------------------------------------------
+# update_frame
+# ---------------------------------------------------------------------------
+def test_update_frame_changes_geometry(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = LineShape(length=1.0)
+    handle = renderer.add_shape(shape, _fitted("line", n_frames=4), theme)
+    artist = renderer._entries[handle].artist
+
+    renderer.update_frame(handle, 0)
+    segs0 = [np.asarray(s).copy() for s in artist._segments3d]
+
+    renderer.update_frame(handle, 2)
+    segs2 = [np.asarray(s) for s in artist._segments3d]
+
+    assert len(segs0) == len(segs2) >= 1
+    assert not np.allclose(segs0[0], segs2[0])
+
+
+def test_update_frame_is_idempotent(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = CylinderShape(length=1.0, radius=0.4, n_facets=8)
+    handle = renderer.add_shape(shape, _fitted("cyl"), theme)
+    # Calling update_frame twice with the same index must not raise and
+    # must leave the renderer in a consistent state.
+    renderer.update_frame(handle, 2)
+    renderer.update_frame(handle, 2)
+    assert handle in renderer._entries
+
+
+def test_update_frame_unknown_handle_raises(ax) -> None:
+    renderer = MatplotlibRenderer(ax)
+    with pytest.raises(KeyError):
+        renderer.update_frame("nope", 0)
+
+
+def test_update_frame_validates_frame_idx(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handle = renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme)
+    with pytest.raises(TypeError):
+        renderer.update_frame(handle, "0")  # type: ignore[arg-type]
+    with pytest.raises(IndexError):
+        renderer.update_frame(handle, 999)
+    with pytest.raises(IndexError):
+        renderer.update_frame(handle, -1)
+
+
+def test_update_frame_handles_invalid_frame_without_raising(ax, theme) -> None:
+    """Invalid frames produce NaN vertices; renderer must substitute zeros."""
+    renderer = MatplotlibRenderer(ax)
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+    )
+    mask = np.array([True, False, True], dtype=bool)
+    fitted = FittedShape(
+        shape_id="line",
+        binding=binding,
+        centroid=np.zeros((3, 3)),
+        rotation_matrix=np.broadcast_to(np.eye(3), (3, 3, 3)).copy(),
+        scale=np.ones((3, 3)),
+        valid_mask=mask,
+    )
+    handle = renderer.add_shape(LineShape(length=1.0), fitted, theme)
+    renderer.update_frame(handle, 1)  # invalid frame, must not raise
+
+
+# ---------------------------------------------------------------------------
+# set_visible
+# ---------------------------------------------------------------------------
+def test_set_visible_toggles_artist(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handle = renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme)
+    renderer.set_visible(handle, False)
+    assert renderer._entries[handle].artist.get_visible() is False
+    renderer.set_visible(handle, True)
+    assert renderer._entries[handle].artist.get_visible() is True
+
+
+def test_set_visible_validates_args(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handle = renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme)
+    with pytest.raises(TypeError):
+        renderer.set_visible(handle, "yes")  # type: ignore[arg-type]
+    with pytest.raises(KeyError):
+        renderer.set_visible("missing", True)
+
+
+# ---------------------------------------------------------------------------
+# remove + clear
+# ---------------------------------------------------------------------------
+def test_remove_drops_artist(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handle = renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme)
+    renderer.remove(handle)
+    assert handle not in renderer._entries
+    with pytest.raises(KeyError):
+        renderer.update_frame(handle, 0)
+
+
+def test_remove_unknown_raises(ax) -> None:
+    renderer = MatplotlibRenderer(ax)
+    with pytest.raises(KeyError):
+        renderer.remove("missing")
+
+
+def test_remove_tolerates_already_detached_artist(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    handle = renderer.add_shape(LineShape(length=1.0), _fitted("line"), theme)
+    # Forcibly detach the artist from the axes to simulate a stale state.
+    renderer._entries[handle].artist.remove()
+    renderer.remove(handle)  # must not raise
+    assert handle not in renderer._entries
+
+
+def test_clear_drops_all(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    for i in range(3):
+        renderer.add_shape(LineShape(length=1.0), _fitted(f"l{i}"), theme)
+    renderer.clear()
+    assert renderer._entries == {}
+
+
+# ---------------------------------------------------------------------------
+# add_segment_set
+# ---------------------------------------------------------------------------
+def test_add_segment_set_wraps_add_shape(ax) -> None:
+    renderer = MatplotlibRenderer(ax)
+    pairs = [
+        (LineShape(length=1.0), _fitted("l0")),
+        (CylinderShape(length=1.0, radius=0.3, n_facets=8), _fitted("c0")),
+    ]
+    handles = renderer.add_segment_set(
+        pairs, lambda f: ShapeTheme(color="C1", opacity=0.6)
+    )
+    assert len(handles) == 2
+    assert all(h in renderer._entries for h in handles)
+
+
+def test_add_segment_set_validates(ax) -> None:
+    renderer = MatplotlibRenderer(ax)
+    with pytest.raises(TypeError):
+        renderer.add_segment_set([], "not callable")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        renderer.add_segment_set(
+            ["bad"],  # type: ignore[list-item]
+            lambda f: ShapeTheme(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# No ax.clear() ever
+# ---------------------------------------------------------------------------
+def test_renderer_never_calls_axes_clear(ax, theme, monkeypatch) -> None:
+    calls = {"n": 0}
+
+    def fake_clear(*args, **kwargs):
+        calls["n"] += 1
+
+    monkeypatch.setattr(ax, "clear", fake_clear)
+    monkeypatch.setattr(ax, "cla", fake_clear)
+    renderer = MatplotlibRenderer(ax)
+    h = renderer.add_shape(LineShape(length=1.0), _fitted("l"), theme)
+    renderer.update_frame(h, 1)
+    renderer.set_visible(h, False)
+    renderer.remove(h)
+    assert calls["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Performance contract: 60 fps (1 ms / update_frame, mean)
+# ---------------------------------------------------------------------------
+@pytest.mark.benchmark
+def test_update_frame_performance_contract(ax, theme) -> None:
+    renderer = MatplotlibRenderer(ax)
+    shape = CylinderShape(length=1.0, radius=0.5, n_facets=20)
+    fitted = _fitted("cyl", n_frames=10)
+    handle = renderer.add_shape(shape, fitted, theme)
+
+    # Warm-up.
+    for _ in range(10):
+        renderer.update_frame(handle, 0)
+
+    n = 1000
+    start = time.perf_counter()
+    for i in range(n):
+        renderer.update_frame(handle, i % 10)
+    elapsed = time.perf_counter() - start
+    mean_ms = (elapsed / n) * 1000.0
+    # 1 ms is the contract; print for visibility.
+    assert mean_ms <= 1.0, f"mean update_frame time {mean_ms:.3f} ms exceeds budget"

--- a/tests/unit/body_part_viz/test_imports.py
+++ b/tests/unit/body_part_viz/test_imports.py
@@ -33,7 +33,7 @@ def test_subpackages_importable() -> None:
 
     for pkg in (shapes, fitters, renderers):
         assert hasattr(pkg, "__all__")
-    # Shapes are populated by the primitives wave (#4759).
+    # Shapes populated by Wave 2 (#4759) — primitives.
     for shape_name in (
         "LineShape",
         "CylinderShape",
@@ -42,11 +42,11 @@ def test_subpackages_importable() -> None:
         "CompositeShape",
     ):
         assert shape_name in shapes.__all__
-    # Renderers land in a later wave — still empty.
-    assert renderers.__all__ == []
     # Fitters wave (#4756) ships three concrete strategies.
     assert set(fitters.__all__) == {
         "BetweenTwoMarkersFitter",
         "ClusterKabschFitter",
         "ProcrustesAnisotropicFitter",
     }
+    # Renderers wave (#4760 + #4762) ships matplotlib + pyqtgl backends.
+    assert "MatplotlibRenderer" in renderers.__all__


### PR DESCRIPTION
## Summary

- Implements `MatplotlibRenderer` (Wave 3 of EPIC #4755) — `ShapeRenderer` Protocol backend that owns one matplotlib artist per shape (`Line3DCollection` for lines, `Poly3DCollection` for cylinder / ellipsoid / capsule / mesh / composite).
- `update_frame` mutates the existing artist via `set_segments` / `set_verts`; the axes are never cleared. `draw_idle` is emitted once per call only on interactive backends so headless / Agg hosts keep their per-frame budget.
- Adds `add_segment_set` thin convenience over `add_shape`, plus `clear()` for tearing down all owned artists without touching the axes.

Closes #4760.

## Test plan

- [x] `python3 -m ruff check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m ruff format --check` (renderer + test files)
- [x] `python3 -m pytest tests/unit/body_part_viz/renderers/ -p no:cacheprovider --timeout=60` (21 passed)
- [x] Coverage on `renderers` package: 93.20% line / branch (≥ 90% target)
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] Performance contract: 0.16 ms / `update_frame` (1000-call mean, headless Agg, 20-facet cylinder × 10 frames) — well under the 1 ms / 60 fps budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)