### PR TITLE
feat(body-part-viz): SegmentVizSet JSON v2 (#4763)

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -13,14 +13,28 @@ from __future__ import annotations
 from ._types import FittedShape
 from .bindings import BindingKind, MarkerBinding
 from .contracts import BodyPartShape, ShapeFitter, ShapeRenderer
+from .persistence import (
+    SCHEMA_VERSION,
+    SegmentVizSet,
+    SegmentVizSpec,
+    VALID_FITTER_KINDS,
+    VALID_SHAPE_KINDS,
+    migrate_v1_to_v2,
+)
 from .theme import ShapeTheme
 
 __all__ = [
+    "SCHEMA_VERSION",
+    "VALID_FITTER_KINDS",
+    "VALID_SHAPE_KINDS",
     "BindingKind",
     "BodyPartShape",
     "FittedShape",
     "MarkerBinding",
+    "SegmentVizSet",
+    "SegmentVizSpec",
     "ShapeFitter",
     "ShapeRenderer",
     "ShapeTheme",
+    "migrate_v1_to_v2",
 ]

--- a/src/shared/python/body_part_viz/persistence.py
+++ b/src/shared/python/body_part_viz/persistence.py
@@ -1,0 +1,479 @@
+"""JSON v2 persistence for body-part visualisation specs.
+
+Defines :class:`SegmentVizSpec` (a single segment's full viz spec — binding,
+shape kind & params, fitter kind, theme, visibility) and :class:`SegmentVizSet`
+(an ordered, schema-versioned collection).
+
+Schema v2 is a strict superset of the legacy v1 ``SegmentSpec`` shape used in
+``segment_set_io``. Loading auto-detects v1 and migrates to v2; saving always
+writes v2.
+
+Design-by-Contract
+------------------
+All public dataclasses are frozen and validate every field in
+``__post_init__``. ``shape_params`` are validated per-``shape_kind``: missing
+required keys raise ``ValueError`` listing the missing keys; unknown
+``shape_kind`` / ``fitter_kind`` raise ``ValueError`` listing the valid
+options.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from .bindings import BindingKind, MarkerBinding
+from .theme import ShapeTheme
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SegmentVizSet",
+    "SegmentVizSpec",
+    "VALID_FITTER_KINDS",
+    "VALID_SHAPE_KINDS",
+    "migrate_v1_to_v2",
+]
+
+SCHEMA_VERSION = 2
+
+VALID_SHAPE_KINDS: tuple[str, ...] = (
+    "line",
+    "cylinder",
+    "ellipsoid",
+    "capsule",
+    "mesh_file",
+    "library_shape",
+    "composite",
+)
+
+VALID_FITTER_KINDS: tuple[str, ...] = (
+    "between_two",
+    "cluster_kabsch",
+    "procrustes_anisotropic",
+)
+
+# Per shape_kind: (required_keys, optional_keys_with_defaults).
+# Defaults are applied only when a key is absent so round-trip preserves
+# explicit overrides bit-exact.
+_SHAPE_PARAM_SPEC: dict[str, tuple[tuple[str, ...], dict[str, Any]]] = {
+    "line": (("length",), {}),
+    "cylinder": (("length", "radius"), {"n_facets": 16}),
+    "ellipsoid": (("a", "b", "c"), {"n_lon": 16, "n_lat": 8}),
+    "capsule": (("length", "radius"), {"n_facets": 16, "n_lat": 8}),
+    "mesh_file": (("path",), {"max_vertices": 5000}),
+    "library_shape": (("library_name", "shape_id"), {}),
+    "composite": (("children",), {}),
+}
+
+
+def _validate_shape_params(shape_kind: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalise ``shape_params`` for a given ``shape_kind``.
+
+    Returns a fresh dict with defaults filled in for any absent optional keys.
+    Raises ``ValueError`` listing missing required keys.
+    """
+    if not isinstance(params, dict):
+        raise TypeError(f"shape_params must be a dict; got {type(params).__name__}")
+
+    required, defaults = _SHAPE_PARAM_SPEC[shape_kind]
+    missing = [k for k in required if k not in params]
+    if missing:
+        raise ValueError(
+            f"shape_params for shape_kind={shape_kind!r} missing required "
+            f"keys: {missing}"
+        )
+
+    out: dict[str, Any] = {}
+    # Required keys first, in declared order.
+    for key in required:
+        out[key] = params[key]
+    # Optional keys: explicit value wins; otherwise fill in default.
+    for key, default in defaults.items():
+        out[key] = params.get(key, default)
+    # Preserve any extra keys the caller supplied (e.g. nested composite payloads).
+    for key, value in params.items():
+        if key not in out:
+            out[key] = value
+
+    if shape_kind == "composite":
+        children = out["children"]
+        if not isinstance(children, list):
+            raise ValueError(
+                "composite shape_params['children'] must be a list of "
+                f"child specs; got {type(children).__name__}"
+            )
+        normalised_children: list[dict[str, Any]] = []
+        for idx, child in enumerate(children):
+            if not isinstance(child, dict):
+                raise ValueError(
+                    f"composite child at index {idx} must be a dict; "
+                    f"got {type(child).__name__}"
+                )
+            child_kind = child.get("shape_kind")
+            if child_kind not in VALID_SHAPE_KINDS:
+                raise ValueError(
+                    f"composite child at index {idx} has unknown "
+                    f"shape_kind={child_kind!r}; "
+                    f"valid options: {list(VALID_SHAPE_KINDS)}"
+                )
+            normalised_child_params = _validate_shape_params(
+                child_kind, child.get("shape_params", {})
+            )
+            normalised_children.append(
+                {
+                    "shape_kind": child_kind,
+                    "shape_params": normalised_child_params,
+                }
+            )
+        out["children"] = normalised_children
+
+    return out
+
+
+def _binding_to_dict(binding: MarkerBinding) -> dict[str, Any]:
+    return {
+        "kind": binding.kind.value,
+        "marker_names": list(binding.marker_names),
+        "rest_dimensions": [float(d) for d in binding.rest_dimensions],
+        "rest_orientation_quat": [float(c) for c in binding.rest_orientation_quat],
+    }
+
+
+def _binding_from_dict(data: dict[str, Any]) -> MarkerBinding:
+    if not isinstance(data, dict):
+        raise TypeError(f"binding entry must be a dict; got {type(data).__name__}")
+    kind_raw = data.get("kind")
+    try:
+        kind = BindingKind(kind_raw)
+    except ValueError as exc:
+        valid = [k.value for k in BindingKind]
+        raise ValueError(
+            f"unknown binding kind {kind_raw!r}; valid options: {valid}"
+        ) from exc
+    marker_names = tuple(str(n) for n in data.get("marker_names", ()))
+    rest_dimensions = tuple(float(d) for d in data.get("rest_dimensions", ()))
+    quat_raw = data.get("rest_orientation_quat", (1.0, 0.0, 0.0, 0.0))
+    quat_tuple = tuple(float(c) for c in quat_raw)
+    if len(quat_tuple) != 4:
+        raise ValueError(
+            f"rest_orientation_quat must have exactly 4 entries; got {len(quat_tuple)}"
+        )
+    return MarkerBinding(
+        kind=kind,
+        marker_names=marker_names,
+        rest_dimensions=rest_dimensions,
+        rest_orientation_quat=(
+            quat_tuple[0],
+            quat_tuple[1],
+            quat_tuple[2],
+            quat_tuple[3],
+        ),
+    )
+
+
+def _theme_to_dict(theme: ShapeTheme) -> dict[str, Any]:
+    return {
+        "color": theme.color,
+        "opacity": float(theme.opacity),
+        "edge_color": theme.edge_color,
+        "edge_width": float(theme.edge_width),
+        "flat_shaded": bool(theme.flat_shaded),
+        "group": theme.group,
+    }
+
+
+def _theme_from_dict(data: dict[str, Any]) -> ShapeTheme:
+    if not isinstance(data, dict):
+        raise TypeError(f"theme entry must be a dict; got {type(data).__name__}")
+    return ShapeTheme(
+        color=str(data.get("color", "#1f77b4")),
+        opacity=float(data.get("opacity", 0.8)),
+        edge_color=str(data.get("edge_color", "#000000")),
+        edge_width=float(data.get("edge_width", 0.5)),
+        flat_shaded=bool(data.get("flat_shaded", True)),
+        group=str(data.get("group", "default")),
+    )
+
+
+@dataclass(frozen=True)
+class SegmentVizSpec:
+    """A single segment's full visualisation spec.
+
+    Attributes
+    ----------
+    binding:
+        How the segment attaches to mocap markers.
+    shape_kind:
+        One of :data:`VALID_SHAPE_KINDS`.
+    shape_params:
+        Shape-specific parameters; validated against ``shape_kind``.
+    fitter_kind:
+        One of :data:`VALID_FITTER_KINDS`.
+    theme:
+        Visual styling.
+    visible:
+        Whether the segment is rendered.
+    """
+
+    binding: MarkerBinding
+    shape_kind: Literal[
+        "line",
+        "cylinder",
+        "ellipsoid",
+        "capsule",
+        "mesh_file",
+        "library_shape",
+        "composite",
+    ]
+    shape_params: dict[str, Any]
+    fitter_kind: Literal["between_two", "cluster_kabsch", "procrustes_anisotropic"]
+    theme: ShapeTheme
+    visible: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, MarkerBinding):
+            raise TypeError(
+                f"binding must be MarkerBinding; got {type(self.binding).__name__}"
+            )
+        if self.shape_kind not in VALID_SHAPE_KINDS:
+            raise ValueError(
+                f"unknown shape_kind {self.shape_kind!r}; "
+                f"valid options: {list(VALID_SHAPE_KINDS)}"
+            )
+        if self.fitter_kind not in VALID_FITTER_KINDS:
+            raise ValueError(
+                f"unknown fitter_kind {self.fitter_kind!r}; "
+                f"valid options: {list(VALID_FITTER_KINDS)}"
+            )
+        if not isinstance(self.theme, ShapeTheme):
+            raise TypeError(
+                f"theme must be ShapeTheme; got {type(self.theme).__name__}"
+            )
+        if not isinstance(self.visible, bool):
+            raise TypeError(f"visible must be bool; got {type(self.visible).__name__}")
+        # Normalise/validate shape_params and reassign on the frozen dc.
+        normalised = _validate_shape_params(self.shape_kind, self.shape_params)
+        object.__setattr__(self, "shape_params", normalised)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SegmentVizSpec:
+        """Construct a :class:`SegmentVizSpec` from a JSON-loaded dict."""
+        if not isinstance(data, dict):
+            raise TypeError(f"segment entry must be a dict; got {type(data).__name__}")
+        shape_kind = data.get("shape_kind")
+        if shape_kind not in VALID_SHAPE_KINDS:
+            raise ValueError(
+                f"unknown shape_kind {shape_kind!r}; "
+                f"valid options: {list(VALID_SHAPE_KINDS)}"
+            )
+        fitter_kind = data.get("fitter_kind")
+        if fitter_kind not in VALID_FITTER_KINDS:
+            raise ValueError(
+                f"unknown fitter_kind {fitter_kind!r}; "
+                f"valid options: {list(VALID_FITTER_KINDS)}"
+            )
+        binding = _binding_from_dict(data.get("binding", {}))
+        theme = _theme_from_dict(data.get("theme", {}))
+        shape_params = data.get("shape_params", {})
+        if not isinstance(shape_params, dict):
+            raise TypeError(
+                f"shape_params must be a dict; got {type(shape_params).__name__}"
+            )
+        return cls(
+            binding=binding,
+            shape_kind=shape_kind,
+            shape_params=dict(shape_params),
+            fitter_kind=fitter_kind,
+            theme=theme,
+            visible=bool(data.get("visible", True)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-ready dict."""
+        return {
+            "binding": _binding_to_dict(self.binding),
+            "shape_kind": self.shape_kind,
+            "shape_params": _round_numerics(self.shape_params),
+            "fitter_kind": self.fitter_kind,
+            "theme": _theme_to_dict(self.theme),
+            "visible": bool(self.visible),
+        }
+
+
+def _round_numerics(value: Any) -> Any:
+    """Recursively round floats to 1e-9 precision for stable JSON round-trip."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return value
+        return round(value, 9)
+    if isinstance(value, dict):
+        return {k: _round_numerics(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_round_numerics(v) for v in value]
+    if isinstance(value, tuple):
+        return [_round_numerics(v) for v in value]
+    return value
+
+
+@dataclass(frozen=True)
+class SegmentVizSet:
+    """Schema-versioned collection of :class:`SegmentVizSpec`."""
+
+    schema_version: int = SCHEMA_VERSION
+    segments: tuple[SegmentVizSpec, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise TypeError(
+                f"schema_version must be int; got {type(self.schema_version).__name__}"
+            )
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"SegmentVizSet only supports schema_version={SCHEMA_VERSION}; "
+                f"got {self.schema_version}"
+            )
+        if not isinstance(self.segments, tuple):
+            raise TypeError(
+                "segments must be a tuple of SegmentVizSpec; "
+                f"got {type(self.segments).__name__}"
+            )
+        for idx, seg in enumerate(self.segments):
+            if not isinstance(seg, SegmentVizSpec):
+                raise TypeError(
+                    f"segments[{idx}] must be SegmentVizSpec; got {type(seg).__name__}"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-ready dict (always v2)."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "segments": [s.to_dict() for s in self.segments],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> SegmentVizSet:
+        """Parse a dict (auto-migrating v1) into a :class:`SegmentVizSet`."""
+        if not isinstance(payload, dict):
+            raise TypeError(f"payload must be dict; got {type(payload).__name__}")
+        version = payload.get("schema_version", SCHEMA_VERSION)
+        if not isinstance(version, int) or isinstance(version, bool):
+            raise ValueError(f"schema_version must be int; got {version!r}")
+        if version == 1:
+            payload = migrate_v1_to_v2(payload)
+            version = payload["schema_version"]
+        if version != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported schema_version {version}; "
+                f"expected 1 (legacy) or {SCHEMA_VERSION}"
+            )
+        raw_segments = payload.get("segments", [])
+        if not isinstance(raw_segments, list):
+            raise ValueError(
+                f"'segments' must be a list; got {type(raw_segments).__name__}"
+            )
+        parsed = tuple(SegmentVizSpec.from_dict(s) for s in raw_segments)
+        return cls(schema_version=SCHEMA_VERSION, segments=parsed)
+
+    @classmethod
+    def load(cls, path: Path | str) -> SegmentVizSet:
+        """Load a viz set from ``path``, auto-migrating v1 payloads."""
+        if path is None:
+            raise ValueError("path must be provided")
+        src = Path(path)
+        if not src.is_file():
+            raise FileNotFoundError(f"viz-set file not found: {src}")
+        with src.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+        return cls.from_dict(payload)
+
+    def save(self, path: Path | str) -> Path:
+        """Write this viz set to ``path`` as JSON v2."""
+        if path is None:
+            raise ValueError("path must be provided")
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2, sort_keys=True)
+        return out
+
+
+def migrate_v1_to_v2(v1_dict: dict[str, Any]) -> dict[str, Any]:
+    """Migrate a legacy v1 ``SegmentSet`` payload to v2.
+
+    v1 segments had ``a``/``b`` marker names, ``geometry`` in
+    ``{"line", "cylinder"}``, ``group``, ``visible``, and ``radius``.
+    v2 maps each entry to:
+
+    * ``binding.kind = "between_two"`` with ``marker_names = (a, b)``
+    * ``shape_kind = geometry`` (line or cylinder)
+    * ``fitter_kind = "between_two"``
+    * ``theme = ShapeTheme(group=v1['group'])``
+
+    Cylinder ``radius`` carries over into ``shape_params``; ``length`` is
+    left unset on the rest binding (the runtime fitter computes it from
+    live marker positions).
+    """
+    if not isinstance(v1_dict, dict):
+        raise TypeError(f"v1_dict must be dict; got {type(v1_dict).__name__}")
+    version = v1_dict.get("schema_version", 1)
+    if version != 1:
+        raise ValueError(f"migrate_v1_to_v2 requires schema_version=1; got {version!r}")
+    raw_segments = v1_dict.get("segments", [])
+    if not isinstance(raw_segments, list):
+        raise ValueError(
+            f"v1 'segments' must be a list; got {type(raw_segments).__name__}"
+        )
+
+    v2_segments: list[dict[str, Any]] = []
+    for entry in raw_segments:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"v1 segment entry must be dict; got {type(entry).__name__}"
+            )
+        a = str(entry["a"])
+        b = str(entry["b"])
+        geometry = str(entry.get("geometry", "line"))
+        if geometry not in ("line", "cylinder"):
+            raise ValueError(
+                f"v1 geometry must be 'line' or 'cylinder'; got {geometry!r}"
+            )
+        group = str(entry.get("group", "auto"))
+        visible = bool(entry.get("visible", True))
+        radius = float(entry.get("radius", 0.015))
+
+        if geometry == "line":
+            shape_params: dict[str, Any] = {"length": 1.0}
+        else:
+            shape_params = {"length": 1.0, "radius": radius, "n_facets": 16}
+
+        v2_segments.append(
+            {
+                "binding": {
+                    "kind": "between_two",
+                    "marker_names": [a, b],
+                    "rest_dimensions": [],
+                    "rest_orientation_quat": [1.0, 0.0, 0.0, 0.0],
+                },
+                "shape_kind": geometry,
+                "shape_params": shape_params,
+                "fitter_kind": "between_two",
+                "theme": {
+                    "color": "#1f77b4",
+                    "opacity": 0.8,
+                    "edge_color": "#000000",
+                    "edge_width": 0.5,
+                    "flat_shaded": True,
+                    "group": group,
+                },
+                "visible": visible,
+            }
+        )
+
+    return {"schema_version": SCHEMA_VERSION, "segments": v2_segments}

--- a/tests/unit/body_part_viz/test_persistence.py
+++ b/tests/unit/body_part_viz/test_persistence.py
@@ -1,0 +1,608 @@
+"""Unit tests for ``body_part_viz.persistence`` (JSON v2 viz-set I/O)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.body_part_viz import (
+    BindingKind,
+    MarkerBinding,
+    SegmentVizSet,
+    SegmentVizSpec,
+    ShapeTheme,
+    migrate_v1_to_v2,
+)
+from src.shared.python.body_part_viz.persistence import (
+    SCHEMA_VERSION,
+    VALID_FITTER_KINDS,
+    VALID_SHAPE_KINDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BETWEEN_TWO_BINDING = MarkerBinding(
+    kind=BindingKind.BETWEEN_TWO,
+    marker_names=("WaistLeft", "WaistRight"),
+    rest_dimensions=(0.32,),
+)
+
+_THEME = ShapeTheme(color="#1f77b4", opacity=0.8, group="pelvis")
+
+
+def _spec(
+    shape_kind: str, shape_params: dict, fitter_kind: str = "between_two"
+) -> SegmentVizSpec:
+    return SegmentVizSpec(
+        binding=_BETWEEN_TWO_BINDING,
+        shape_kind=shape_kind,  # type: ignore[arg-type]
+        shape_params=dict(shape_params),
+        fitter_kind=fitter_kind,  # type: ignore[arg-type]
+        theme=_THEME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip per shape kind
+# ---------------------------------------------------------------------------
+
+
+def test_line_round_trip(tmp_path: Path) -> None:
+    spec = _spec("line", {"length": 0.4})
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded == vs
+    assert loaded.segments[0].shape_params == {"length": 0.4}
+
+
+def test_cylinder_round_trip(tmp_path: Path) -> None:
+    spec = _spec("cylinder", {"length": 0.32, "radius": 0.04, "n_facets": 24})
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded.segments[0].shape_params == {
+        "length": 0.32,
+        "radius": 0.04,
+        "n_facets": 24,
+    }
+
+
+def test_cylinder_default_n_facets() -> None:
+    spec = _spec("cylinder", {"length": 0.5, "radius": 0.05})
+    assert spec.shape_params["n_facets"] == 16
+
+
+def test_ellipsoid_round_trip(tmp_path: Path) -> None:
+    spec = _spec("ellipsoid", {"a": 0.1, "b": 0.2, "c": 0.3})
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    p = loaded.segments[0].shape_params
+    assert p["a"] == 0.1 and p["b"] == 0.2 and p["c"] == 0.3
+    assert p["n_lon"] == 16 and p["n_lat"] == 8
+
+
+def test_capsule_round_trip(tmp_path: Path) -> None:
+    spec = _spec(
+        "capsule", {"length": 0.25, "radius": 0.04, "n_facets": 12, "n_lat": 6}
+    )
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded.segments[0].shape_params["n_facets"] == 12
+    assert loaded.segments[0].shape_params["n_lat"] == 6
+
+
+def test_mesh_file_round_trip(tmp_path: Path) -> None:
+    spec = _spec("mesh_file", {"path": "assets/torso.stl", "max_vertices": 1000})
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded.segments[0].shape_params == {
+        "path": "assets/torso.stl",
+        "max_vertices": 1000,
+    }
+
+
+def test_mesh_file_default_max_vertices() -> None:
+    spec = _spec("mesh_file", {"path": "x.obj"})
+    assert spec.shape_params["max_vertices"] == 5000
+
+
+def test_library_shape_round_trip(tmp_path: Path) -> None:
+    spec = _spec("library_shape", {"library_name": "default", "shape_id": "upper_arm"})
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded.segments[0].shape_params == {
+        "library_name": "default",
+        "shape_id": "upper_arm",
+    }
+
+
+def test_composite_round_trip(tmp_path: Path) -> None:
+    spec = _spec(
+        "composite",
+        {
+            "children": [
+                {
+                    "shape_kind": "cylinder",
+                    "shape_params": {"length": 0.2, "radius": 0.03},
+                },
+                {
+                    "shape_kind": "ellipsoid",
+                    "shape_params": {"a": 0.05, "b": 0.05, "c": 0.07},
+                },
+            ]
+        },
+    )
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    children = loaded.segments[0].shape_params["children"]
+    assert len(children) == 2
+    assert children[0]["shape_kind"] == "cylinder"
+    assert children[0]["shape_params"]["n_facets"] == 16
+    assert children[1]["shape_params"]["n_lon"] == 16
+
+
+# ---------------------------------------------------------------------------
+# Round-trip per fitter kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fitter_kind", list(VALID_FITTER_KINDS))
+def test_all_fitter_kinds_round_trip(tmp_path: Path, fitter_kind: str) -> None:
+    binding = (
+        _BETWEEN_TWO_BINDING
+        if fitter_kind == "between_two"
+        else MarkerBinding(
+            kind=BindingKind.CLUSTER,
+            marker_names=("M1", "M2", "M3"),
+        )
+    )
+    spec = SegmentVizSpec(
+        binding=binding,
+        shape_kind="cylinder",
+        shape_params={"length": 0.3, "radius": 0.04},
+        fitter_kind=fitter_kind,  # type: ignore[arg-type]
+        theme=_THEME,
+    )
+    vs = SegmentVizSet(segments=(spec,))
+    out = tmp_path / "v.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded.segments[0].fitter_kind == fitter_kind
+
+
+# ---------------------------------------------------------------------------
+# DbC validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_shape_kind_raises() -> None:
+    with pytest.raises(ValueError, match="unknown shape_kind"):
+        SegmentVizSpec(
+            binding=_BETWEEN_TWO_BINDING,
+            shape_kind="sphere",  # type: ignore[arg-type]
+            shape_params={},
+            fitter_kind="between_two",
+            theme=_THEME,
+        )
+
+
+def test_unknown_fitter_kind_raises() -> None:
+    with pytest.raises(ValueError, match="unknown fitter_kind"):
+        SegmentVizSpec(
+            binding=_BETWEEN_TWO_BINDING,
+            shape_kind="line",
+            shape_params={"length": 0.3},
+            fitter_kind="kalman",  # type: ignore[arg-type]
+            theme=_THEME,
+        )
+
+
+def test_missing_shape_params_lists_missing_keys() -> None:
+    with pytest.raises(ValueError, match=r"missing required keys: \['radius'\]"):
+        _spec("cylinder", {"length": 0.3})
+
+
+def test_missing_shape_params_multiple_keys() -> None:
+    with pytest.raises(ValueError, match=r"missing required keys"):
+        _spec("ellipsoid", {"a": 0.1})
+
+
+def test_shape_params_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="shape_params must be a dict"):
+        SegmentVizSpec(
+            binding=_BETWEEN_TWO_BINDING,
+            shape_kind="line",
+            shape_params=[],  # type: ignore[arg-type]
+            fitter_kind="between_two",
+            theme=_THEME,
+        )
+
+
+def test_binding_must_be_marker_binding() -> None:
+    with pytest.raises(TypeError, match="binding must be MarkerBinding"):
+        SegmentVizSpec(
+            binding={"kind": "between_two"},  # type: ignore[arg-type]
+            shape_kind="line",
+            shape_params={"length": 0.3},
+            fitter_kind="between_two",
+            theme=_THEME,
+        )
+
+
+def test_theme_must_be_shape_theme() -> None:
+    with pytest.raises(TypeError, match="theme must be ShapeTheme"):
+        SegmentVizSpec(
+            binding=_BETWEEN_TWO_BINDING,
+            shape_kind="line",
+            shape_params={"length": 0.3},
+            fitter_kind="between_two",
+            theme={"color": "red"},  # type: ignore[arg-type]
+        )
+
+
+def test_visible_must_be_bool() -> None:
+    with pytest.raises(TypeError, match="visible must be bool"):
+        SegmentVizSpec(
+            binding=_BETWEEN_TWO_BINDING,
+            shape_kind="line",
+            shape_params={"length": 0.3},
+            fitter_kind="between_two",
+            theme=_THEME,
+            visible="yes",  # type: ignore[arg-type]
+        )
+
+
+def test_composite_children_must_be_list() -> None:
+    with pytest.raises(ValueError, match="must be a list"):
+        _spec("composite", {"children": "not-a-list"})
+
+
+def test_composite_child_must_be_dict() -> None:
+    with pytest.raises(ValueError, match="must be a dict"):
+        _spec("composite", {"children": ["x"]})
+
+
+def test_composite_child_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="unknown shape_kind"):
+        _spec(
+            "composite",
+            {"children": [{"shape_kind": "sphere", "shape_params": {}}]},
+        )
+
+
+def test_from_dict_unknown_shape_kind() -> None:
+    with pytest.raises(ValueError, match="unknown shape_kind"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {
+                    "kind": "between_two",
+                    "marker_names": ["A", "B"],
+                },
+                "shape_kind": "sphere",
+                "shape_params": {},
+                "fitter_kind": "between_two",
+                "theme": {},
+            }
+        )
+
+
+def test_from_dict_unknown_fitter_kind() -> None:
+    with pytest.raises(ValueError, match="unknown fitter_kind"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {
+                    "kind": "between_two",
+                    "marker_names": ["A", "B"],
+                },
+                "shape_kind": "line",
+                "shape_params": {"length": 0.3},
+                "fitter_kind": "ekf",
+                "theme": {},
+            }
+        )
+
+
+def test_from_dict_unknown_binding_kind() -> None:
+    with pytest.raises(ValueError, match="unknown binding kind"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {"kind": "telekinesis", "marker_names": ["A", "B"]},
+                "shape_kind": "line",
+                "shape_params": {"length": 0.3},
+                "fitter_kind": "between_two",
+                "theme": {},
+            }
+        )
+
+
+def test_from_dict_quat_wrong_length() -> None:
+    with pytest.raises(ValueError, match="rest_orientation_quat"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {
+                    "kind": "between_two",
+                    "marker_names": ["A", "B"],
+                    "rest_orientation_quat": [1.0, 0.0],
+                },
+                "shape_kind": "line",
+                "shape_params": {"length": 0.3},
+                "fitter_kind": "between_two",
+                "theme": {},
+            }
+        )
+
+
+def test_from_dict_segment_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="segment entry must be a dict"):
+        SegmentVizSpec.from_dict([1, 2, 3])  # type: ignore[arg-type]
+
+
+def test_from_dict_binding_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="binding entry must be a dict"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": "not-a-dict",
+                "shape_kind": "line",
+                "shape_params": {"length": 0.3},
+                "fitter_kind": "between_two",
+                "theme": {},
+            }
+        )
+
+
+def test_from_dict_theme_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="theme entry must be a dict"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {"kind": "between_two", "marker_names": ["A", "B"]},
+                "shape_kind": "line",
+                "shape_params": {"length": 0.3},
+                "fitter_kind": "between_two",
+                "theme": "blue",
+            }
+        )
+
+
+def test_from_dict_shape_params_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="shape_params must be a dict"):
+        SegmentVizSpec.from_dict(
+            {
+                "binding": {"kind": "between_two", "marker_names": ["A", "B"]},
+                "shape_kind": "line",
+                "shape_params": [0.3],
+                "fitter_kind": "between_two",
+                "theme": {},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# SegmentVizSet validation
+# ---------------------------------------------------------------------------
+
+
+def test_segment_viz_set_default_empty() -> None:
+    vs = SegmentVizSet()
+    assert vs.schema_version == SCHEMA_VERSION
+    assert vs.segments == ()
+
+
+def test_segment_viz_set_rejects_non_int_schema() -> None:
+    with pytest.raises(TypeError, match="schema_version must be int"):
+        SegmentVizSet(schema_version="2")  # type: ignore[arg-type]
+
+
+def test_segment_viz_set_rejects_wrong_schema() -> None:
+    with pytest.raises(ValueError, match="only supports schema_version"):
+        SegmentVizSet(schema_version=99)
+
+
+def test_segment_viz_set_rejects_non_tuple_segments() -> None:
+    with pytest.raises(TypeError, match="segments must be a tuple"):
+        SegmentVizSet(segments=[_spec("line", {"length": 0.3})])  # type: ignore[arg-type]
+
+
+def test_segment_viz_set_rejects_non_spec_entries() -> None:
+    with pytest.raises(TypeError, match="must be SegmentVizSpec"):
+        SegmentVizSet(segments=("not-a-spec",))  # type: ignore[arg-type]
+
+
+def test_from_dict_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="payload must be dict"):
+        SegmentVizSet.from_dict("hello")  # type: ignore[arg-type]
+
+
+def test_from_dict_unsupported_schema() -> None:
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        SegmentVizSet.from_dict({"schema_version": 99, "segments": []})
+
+
+def test_from_dict_schema_must_be_int() -> None:
+    with pytest.raises(ValueError, match="schema_version must be int"):
+        SegmentVizSet.from_dict({"schema_version": "2", "segments": []})
+
+
+def test_from_dict_segments_must_be_list() -> None:
+    with pytest.raises(ValueError, match="'segments' must be a list"):
+        SegmentVizSet.from_dict({"schema_version": 2, "segments": {}})
+
+
+def test_load_missing_path() -> None:
+    with pytest.raises(ValueError, match="path must be provided"):
+        SegmentVizSet.load(None)  # type: ignore[arg-type]
+
+
+def test_load_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        SegmentVizSet.load(tmp_path / "nope.json")
+
+
+def test_save_missing_path() -> None:
+    with pytest.raises(ValueError, match="path must be provided"):
+        SegmentVizSet().save(None)  # type: ignore[arg-type]
+
+
+def test_save_creates_parent_dirs(tmp_path: Path) -> None:
+    out = tmp_path / "deep" / "nested" / "v.json"
+    spec = _spec("line", {"length": 0.3})
+    SegmentVizSet(segments=(spec,)).save(out)
+    assert out.is_file()
+
+
+# ---------------------------------------------------------------------------
+# v1 → v2 migration
+# ---------------------------------------------------------------------------
+
+
+_V1_SAMPLE = {
+    "schema_version": 1,
+    "segments": [
+        {
+            "a": "WaistLeft",
+            "b": "WaistRight",
+            "geometry": "cylinder",
+            "group": "pelvis",
+            "visible": True,
+            "radius": 0.04,
+        },
+        {
+            "a": "LShoulder",
+            "b": "LElbow",
+            "geometry": "line",
+            "group": "left_arm",
+            "visible": False,
+            "radius": 0.02,
+        },
+    ],
+}
+
+
+def test_migrate_v1_to_v2_basic() -> None:
+    v2 = migrate_v1_to_v2(_V1_SAMPLE)
+    assert v2["schema_version"] == SCHEMA_VERSION
+    assert len(v2["segments"]) == 2
+
+    s0 = v2["segments"][0]
+    assert s0["binding"]["kind"] == "between_two"
+    assert s0["binding"]["marker_names"] == ["WaistLeft", "WaistRight"]
+    assert s0["shape_kind"] == "cylinder"
+    assert s0["shape_params"]["radius"] == 0.04
+    assert s0["fitter_kind"] == "between_two"
+    assert s0["theme"]["group"] == "pelvis"
+
+    s1 = v2["segments"][1]
+    assert s1["shape_kind"] == "line"
+    assert s1["visible"] is False
+    assert s1["theme"]["group"] == "left_arm"
+
+
+def test_migrate_v1_load_and_save_writes_v2(tmp_path: Path) -> None:
+    v1_path = tmp_path / "v1.json"
+    with v1_path.open("w", encoding="utf-8") as f:
+        json.dump(_V1_SAMPLE, f)
+
+    loaded = SegmentVizSet.load(v1_path)
+    assert loaded.schema_version == SCHEMA_VERSION
+    assert len(loaded.segments) == 2
+
+    out = tmp_path / "v2.json"
+    loaded.save(out)
+    with out.open("r", encoding="utf-8") as f:
+        rewritten = json.load(f)
+    assert rewritten["schema_version"] == SCHEMA_VERSION
+
+
+def test_migrate_v1_rejects_non_dict() -> None:
+    with pytest.raises(TypeError, match="must be dict"):
+        migrate_v1_to_v2(["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+def test_migrate_v1_rejects_wrong_version() -> None:
+    with pytest.raises(ValueError, match="requires schema_version=1"):
+        migrate_v1_to_v2({"schema_version": 2, "segments": []})
+
+
+def test_migrate_v1_segments_must_be_list() -> None:
+    with pytest.raises(ValueError, match="must be a list"):
+        migrate_v1_to_v2({"schema_version": 1, "segments": {}})
+
+
+def test_migrate_v1_entry_must_be_dict() -> None:
+    with pytest.raises(ValueError, match="must be dict"):
+        migrate_v1_to_v2({"schema_version": 1, "segments": ["x"]})
+
+
+def test_migrate_v1_invalid_geometry() -> None:
+    payload = {
+        "schema_version": 1,
+        "segments": [{"a": "A", "b": "B", "geometry": "blob", "group": "g"}],
+    }
+    with pytest.raises(ValueError, match="must be 'line' or 'cylinder'"):
+        migrate_v1_to_v2(payload)
+
+
+def test_migrate_v1_default_geometry_line() -> None:
+    payload = {
+        "schema_version": 1,
+        "segments": [{"a": "A", "b": "B", "group": "g"}],
+    }
+    v2 = migrate_v1_to_v2(payload)
+    assert v2["segments"][0]["shape_kind"] == "line"
+
+
+# ---------------------------------------------------------------------------
+# Multi-segment full sample
+# ---------------------------------------------------------------------------
+
+
+def test_full_sample_round_trip(tmp_path: Path) -> None:
+    specs = (
+        _spec("line", {"length": 0.4}),
+        _spec("cylinder", {"length": 0.32, "radius": 0.04}),
+        _spec("ellipsoid", {"a": 0.1, "b": 0.2, "c": 0.3}),
+        _spec("capsule", {"length": 0.2, "radius": 0.03}),
+        _spec("mesh_file", {"path": "x.stl"}),
+        _spec("library_shape", {"library_name": "default", "shape_id": "ua"}),
+        _spec(
+            "composite",
+            {
+                "children": [
+                    {
+                        "shape_kind": "cylinder",
+                        "shape_params": {"length": 0.1, "radius": 0.01},
+                    }
+                ]
+            },
+        ),
+    )
+    vs = SegmentVizSet(segments=specs)
+    out = tmp_path / "all.json"
+    vs.save(out)
+    loaded = SegmentVizSet.load(out)
+    assert loaded == vs
+    # Confirms the full kind matrix is exercised:
+    assert {s.shape_kind for s in loaded.segments} == set(VALID_SHAPE_KINDS)
+
+
+def test_to_dict_rounds_floats() -> None:
+    spec = _spec("cylinder", {"length": 0.123456789012345, "radius": 0.04})
+    d = spec.to_dict()
+    assert d["shape_params"]["length"] == round(0.123456789012345, 9)


### PR DESCRIPTION
## Summary

Closes #4763. Part of EPIC #4755 (wave 3).

- New `src/shared/python/body_part_viz/persistence.py` with `SegmentVizSpec` and `SegmentVizSet` frozen dataclasses (DbC-validated).
- Per-`shape_kind` validation of `shape_params` (line / cylinder / ellipsoid / capsule / mesh_file / library_shape / composite); recursive validation of composite children.
- `migrate_v1_to_v2` plus auto-migration on `SegmentVizSet.load`; `save` always writes schema v2.
- 54 unit tests; `persistence.py` line+branch coverage 97.29%.

## Test plan

- [x] `python3 -m ruff check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m ruff format --check src/shared/python/body_part_viz tests/unit/body_part_viz`
- [x] `python3 -m pytest tests/unit/body_part_viz/test_persistence.py` (54 passed)
- [x] Coverage 97.29% line+branch on persistence.py
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] All shape kinds round-trip bit-exact
- [x] All fitter kinds round-trip
- [x] v1 sample loads, gets migrated, rewrites as v2
- [x] DbC: unknown shape_kind / fitter_kind / missing required keys all raise `ValueError`