### PR TITLE
feat(body_part_viz): three fitters (closes #4756)

### DIFF
--- a/src/shared/python/body_part_viz/fitters/__init__.py
+++ b/src/shared/python/body_part_viz/fitters/__init__.py
@@ -1,14 +1,26 @@
 """Body-part shape fitters.
 
-Implementations land in #4756:
+Public fitters added in #4756:
 
-- ``BetweenTwoMarkersFitter`` — for BETWEEN_TWO bindings
-- ``ClusterKabschFitter`` — rigid Kabsch over a marker cluster
-- ``ProcrustesAnisotropicFitter`` — Kabsch + anisotropic scale
-
-This module is currently a placeholder.
+- :class:`BetweenTwoMarkersFitter` — for BETWEEN_TWO bindings.
+- :class:`ClusterKabschFitter` — rigid Kabsch over a marker cluster.
+- :class:`ProcrustesAnisotropicFitter` — Kabsch + anisotropic scale.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from src.shared.python.body_part_viz.fitters.between_two import (
+    BetweenTwoMarkersFitter,
+)
+from src.shared.python.body_part_viz.fitters.cluster_kabsch import (
+    ClusterKabschFitter,
+)
+from src.shared.python.body_part_viz.fitters.procrustes_anisotropic import (
+    ProcrustesAnisotropicFitter,
+)
+
+__all__ = [
+    "BetweenTwoMarkersFitter",
+    "ClusterKabschFitter",
+    "ProcrustesAnisotropicFitter",
+]

--- a/src/shared/python/body_part_viz/fitters/_kabsch.py
+++ b/src/shared/python/body_part_viz/fitters/_kabsch.py
@@ -1,0 +1,83 @@
+"""Kabsch / Procrustes helpers for cluster fitters.
+
+Pure-NumPy implementation of the Kabsch algorithm with a reflection
+guard. Lives in its own module so multiple fitters can reuse it without
+importing from each other.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["kabsch_rotation", "anisotropic_scale"]
+
+
+def kabsch_rotation(
+    p: NDArray[np.floating],
+    q: NDArray[np.floating],
+) -> NDArray[np.floating]:
+    """Return the proper rotation ``R`` mapping centred ``p`` onto ``q``.
+
+    Solves ``min_R || R @ p.T - q.T ||_F`` subject to ``R^T R = I`` and
+    ``det(R) = +1``. Inputs must already be centred (zero mean).
+
+    Args:
+        p: ``(N, 3)`` source points (centred).
+        q: ``(N, 3)`` target points (centred).
+
+    Returns:
+        ``(3, 3)`` rotation matrix with ``det(R) == +1``.
+
+    Raises:
+        ValueError: If ``p`` and ``q`` do not have matching ``(N, 3)`` shape
+            or ``N < 1``.
+    """
+    if p.shape != q.shape:
+        raise ValueError(
+            f"p and q must have the same shape, got {p.shape} vs {q.shape}"
+        )
+    if p.ndim != 2 or p.shape[1] != 3:
+        raise ValueError(f"p and q must have shape (N, 3), got {p.shape}")
+    if p.shape[0] < 1:
+        raise ValueError("Kabsch requires at least one point")
+
+    h = p.T @ q
+    u, _s, vt = np.linalg.svd(h)
+
+    d = np.sign(np.linalg.det(vt.T @ u.T))
+    if d == 0.0:
+        d = 1.0
+    diag = np.array([1.0, 1.0, d], dtype=float)
+    rotation = vt.T @ np.diag(diag) @ u.T
+    return rotation
+
+
+def anisotropic_scale(
+    p_rot: NDArray[np.floating],
+    q: NDArray[np.floating],
+) -> NDArray[np.floating]:
+    """Return ``(sx, sy, sz)`` minimising ``|| diag(s) p_rot.T - q.T ||_F``.
+
+    Args:
+        p_rot: ``(N, 3)`` rotated source (centred).
+        q: ``(N, 3)`` target (centred).
+
+    Returns:
+        ``(3,)`` strictly positive scale vector. Each component falls back
+        to ``1.0`` if the corresponding axis has near-zero variance in the
+        source (degenerate case).
+    """
+    s = np.ones(3, dtype=float)
+    for axis in range(3):
+        denom = float(np.sum(p_rot[:, axis] * p_rot[:, axis]))
+        numer = float(np.sum(p_rot[:, axis] * q[:, axis]))
+        if denom > 1e-12:
+            value = numer / denom
+            if not np.isfinite(value) or value <= 0.0:
+                s[axis] = 1.0
+            else:
+                s[axis] = value
+        else:
+            s[axis] = 1.0
+    return s

--- a/src/shared/python/body_part_viz/fitters/between_two.py
+++ b/src/shared/python/body_part_viz/fitters/between_two.py
@@ -1,0 +1,122 @@
+"""``BetweenTwoMarkersFitter`` — fits a line/cylinder/capsule shape to two markers."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import BodyPartShape
+
+__all__ = ["BetweenTwoMarkersFitter"]
+
+
+def _stable_basis_from_axis(axis: NDArray[np.floating]) -> NDArray[np.floating]:
+    """Build a right-handed orthonormal basis whose +x column is ``axis``.
+
+    Picks an up-vector via Gram-Schmidt against world Z, falling back to
+    world Y when ``axis`` is near-parallel to Z.
+    """
+    x = axis / np.linalg.norm(axis)
+    world_z = np.array([0.0, 0.0, 1.0])
+    ref = np.array([0.0, 1.0, 0.0]) if abs(float(np.dot(x, world_z))) > 0.9 else world_z
+    y = ref - np.dot(ref, x) * x
+    y = y / np.linalg.norm(y)
+    z = np.cross(x, y)
+    return np.column_stack([x, y, z])
+
+
+class BetweenTwoMarkersFitter:
+    """Fits a shape's local +x axis along the segment between two markers.
+
+    Per-frame transform:
+
+    - ``centroid = (a + b) / 2``
+    - ``axis = (b - a) / ||b - a||``
+    - ``rotation`` aligns the shape's local +x to ``axis`` with a stable
+      up-vector chosen via Gram-Schmidt against world Z (or world Y when
+      ``axis`` is near-parallel to Z).
+    - ``scale = (||b - a|| / rest_length, 1.0, 1.0)``
+
+    Frames where either marker is non-finite are marked invalid; on those
+    frames the centroid is held at the previous valid frame's centroid
+    (or zeros if there is no prior valid frame), the rotation is the
+    identity, and the scale is ``(1, 1, 1)``.
+    """
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, NDArray[np.floating]],
+    ) -> FittedShape:
+        if binding.kind is not BindingKind.BETWEEN_TWO:
+            raise ValueError(
+                f"BetweenTwoMarkersFitter requires BETWEEN_TWO binding, "
+                f"got {binding.kind}"
+            )
+
+        for name in binding.marker_names:
+            if name not in markers_xyz:
+                raise ValueError(f"marker {name!r} not found in markers_xyz")
+
+        a_name, b_name = binding.marker_names
+        a = np.asarray(markers_xyz[a_name], dtype=float)
+        b = np.asarray(markers_xyz[b_name], dtype=float)
+
+        if a.ndim != 2 or a.shape[1] != 3:
+            raise ValueError(f"marker {a_name!r} must have shape (T, 3), got {a.shape}")
+        if b.shape != a.shape:
+            raise ValueError(
+                f"marker arrays disagree on shape: {a_name!r}={a.shape}, "
+                f"{b_name!r}={b.shape}"
+            )
+
+        n_frames = a.shape[0]
+        rest_length = (
+            float(binding.rest_dimensions[0]) if binding.rest_dimensions else 1.0
+        )
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.tile(np.eye(3), (n_frames, 1, 1))
+        scale = np.ones((n_frames, 3), dtype=float)
+        valid = np.zeros(n_frames, dtype=bool)
+
+        last_valid_centroid: NDArray[np.floating] | None = None
+
+        for t in range(n_frames):
+            a_t = a[t]
+            b_t = b[t]
+            if not (np.all(np.isfinite(a_t)) and np.all(np.isfinite(b_t))):
+                valid[t] = False
+                if last_valid_centroid is not None:
+                    centroid[t] = last_valid_centroid
+                continue
+
+            mid = 0.5 * (a_t + b_t)
+            diff = b_t - a_t
+            length = float(np.linalg.norm(diff))
+            if length < 1e-12:
+                valid[t] = False
+                if last_valid_centroid is not None:
+                    centroid[t] = last_valid_centroid
+                else:
+                    centroid[t] = mid
+                continue
+
+            axis = diff / length
+            centroid[t] = mid
+            rotation[t] = _stable_basis_from_axis(axis)
+            scale[t] = np.array([length / rest_length, 1.0, 1.0])
+            valid[t] = True
+            last_valid_centroid = mid
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid,
+        )

--- a/src/shared/python/body_part_viz/fitters/cluster_kabsch.py
+++ b/src/shared/python/body_part_viz/fitters/cluster_kabsch.py
@@ -1,0 +1,130 @@
+"""``ClusterKabschFitter`` — rigid Kabsch fit over a marker cluster."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import BodyPartShape
+from src.shared.python.body_part_viz.fitters._kabsch import kabsch_rotation
+
+__all__ = ["ClusterKabschFitter"]
+
+
+def _stack_markers(
+    binding: MarkerBinding,
+    markers_xyz: dict[str, NDArray[np.floating]],
+) -> NDArray[np.floating]:
+    """Return ``(T, N, 3)`` array stacking the binding's markers in order.
+
+    Validates name presence and time-axis agreement.
+    """
+    arrays: list[NDArray[np.floating]] = []
+    t_ref: int | None = None
+    for name in binding.marker_names:
+        if name not in markers_xyz:
+            raise ValueError(f"marker {name!r} not found in markers_xyz")
+        arr = np.asarray(markers_xyz[name], dtype=float)
+        if arr.ndim != 2 or arr.shape[1] != 3:
+            raise ValueError(f"marker {name!r} must have shape (T, 3), got {arr.shape}")
+        if t_ref is None:
+            t_ref = arr.shape[0]
+        elif arr.shape[0] != t_ref:
+            raise ValueError(
+                f"marker {name!r} has T={arr.shape[0]}; expected T={t_ref}"
+            )
+        arrays.append(arr)
+    return np.stack(arrays, axis=1)
+
+
+class ClusterKabschFitter:
+    """Rigid Kabsch (rotation + translation) fit over a marker cluster.
+
+    For each frame:
+
+    - centroid = mean of the cluster markers,
+    - rotation R from Kabsch against the rest-pose cluster (det == +1),
+    - scale = (1, 1, 1).
+
+    By default the fitter uses the *first valid frame* as its rest-pose
+    reference. Pass ``rest_positions`` to override.
+
+    Frames containing any non-finite marker sample are marked invalid;
+    on those frames the centroid is held at the previous valid frame
+    (or zeros if none yet), the rotation is the identity, and the scale
+    is ``(1, 1, 1)``.
+    """
+
+    def __init__(self, rest_positions: NDArray[np.floating] | None = None) -> None:
+        self._rest_override = (
+            None if rest_positions is None else np.asarray(rest_positions, dtype=float)
+        )
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, NDArray[np.floating]],
+    ) -> FittedShape:
+        if binding.kind is not BindingKind.CLUSTER:
+            raise ValueError(
+                f"ClusterKabschFitter requires CLUSTER binding, got {binding.kind}"
+            )
+
+        markers = _stack_markers(binding, markers_xyz)
+        n_frames, n_markers, _ = markers.shape
+
+        rest = self._resolve_rest(markers)
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.tile(np.eye(3), (n_frames, 1, 1))
+        scale = np.ones((n_frames, 3), dtype=float)
+        valid = np.zeros(n_frames, dtype=bool)
+
+        last_centroid: NDArray[np.floating] | None = None
+        for t in range(n_frames):
+            frame = markers[t]
+            if not np.all(np.isfinite(frame)):
+                valid[t] = False
+                if last_centroid is not None:
+                    centroid[t] = last_centroid
+                continue
+
+            c = frame.mean(axis=0)
+            centred = frame - c
+            r = kabsch_rotation(rest, centred)
+            centroid[t] = c
+            rotation[t] = r
+            valid[t] = True
+            last_centroid = c
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid,
+        )
+
+    def _resolve_rest(
+        self,
+        markers: NDArray[np.floating],
+    ) -> NDArray[np.floating]:
+        n_markers = markers.shape[1]
+        if self._rest_override is not None:
+            rest = self._rest_override
+            if rest.shape != (n_markers, 3):
+                raise ValueError(
+                    f"rest_positions must have shape ({n_markers}, 3), got {rest.shape}"
+                )
+            return rest - rest.mean(axis=0, keepdims=True)
+
+        for t in range(markers.shape[0]):
+            if np.all(np.isfinite(markers[t])):
+                ref = markers[t]
+                return ref - ref.mean(axis=0, keepdims=True)
+
+        return np.zeros((n_markers, 3), dtype=float)

--- a/src/shared/python/body_part_viz/fitters/procrustes_anisotropic.py
+++ b/src/shared/python/body_part_viz/fitters/procrustes_anisotropic.py
@@ -1,0 +1,125 @@
+"""``ProcrustesAnisotropicFitter`` — Kabsch rotation plus per-axis scale."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.body_part_viz._types import FittedShape
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import BodyPartShape
+from src.shared.python.body_part_viz.fitters._kabsch import (
+    anisotropic_scale,
+    kabsch_rotation,
+)
+from src.shared.python.body_part_viz.fitters.cluster_kabsch import _stack_markers
+
+__all__ = ["ProcrustesAnisotropicFitter"]
+
+
+class ProcrustesAnisotropicFitter:
+    """Kabsch rotation + anisotropic scale ``(sx, sy, sz)`` along principal axes.
+
+    For each frame, alternating minimisation between Kabsch (rotation
+    given current scale) and per-axis least squares (scale given current
+    rotation) is run to convergence; this jointly recovers ``R`` and
+    ``diag(s)`` in the model ``current ≈ R diag(s) rest + t``.
+
+    Frames with any non-finite marker are invalid; on those frames the
+    centroid is held at the previous valid frame (or zeros), the rotation
+    is the identity, and the scale is ``(1, 1, 1)``.
+    """
+
+    def __init__(self, rest_positions: NDArray[np.floating] | None = None) -> None:
+        self._rest_override = (
+            None if rest_positions is None else np.asarray(rest_positions, dtype=float)
+        )
+
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, NDArray[np.floating]],
+    ) -> FittedShape:
+        if binding.kind is not BindingKind.CLUSTER:
+            raise ValueError(
+                f"ProcrustesAnisotropicFitter requires CLUSTER binding, "
+                f"got {binding.kind}"
+            )
+
+        markers = _stack_markers(binding, markers_xyz)
+        n_frames, n_markers, _ = markers.shape
+
+        rest = self._resolve_rest(markers)
+
+        centroid = np.zeros((n_frames, 3), dtype=float)
+        rotation = np.tile(np.eye(3), (n_frames, 1, 1))
+        scale = np.ones((n_frames, 3), dtype=float)
+        valid = np.zeros(n_frames, dtype=bool)
+
+        last_centroid: NDArray[np.floating] | None = None
+        for t in range(n_frames):
+            frame = markers[t]
+            if not np.all(np.isfinite(frame)):
+                valid[t] = False
+                if last_centroid is not None:
+                    centroid[t] = last_centroid
+                continue
+
+            c = frame.mean(axis=0)
+            centred = frame - c
+            r, s = self._fit_rotation_and_scale(rest, centred)
+
+            centroid[t] = c
+            rotation[t] = r
+            scale[t] = s
+            valid[t] = True
+            last_centroid = c
+
+        return FittedShape(
+            shape_id=shape.shape_id,
+            binding=binding,
+            centroid=centroid,
+            rotation_matrix=rotation,
+            scale=scale,
+            valid_mask=valid,
+        )
+
+    @staticmethod
+    def _fit_rotation_and_scale(
+        rest: NDArray[np.floating],
+        centred: NDArray[np.floating],
+    ) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+        """Alternating-minimisation solve for ``R`` and ``diag(s)``."""
+        s = np.ones(3, dtype=float)
+        r = np.eye(3)
+        for _ in range(30):
+            scaled_rest = rest * s
+            r_new = kabsch_rotation(scaled_rest, centred)
+            q_in_rest = centred @ r_new
+            s_new = anisotropic_scale(rest, q_in_rest)
+            if np.linalg.norm(r_new - r) < 1e-12 and np.linalg.norm(s_new - s) < 1e-12:
+                return r_new, s_new
+            r = r_new
+            s = s_new
+        return r, s
+
+    def _resolve_rest(
+        self,
+        markers: NDArray[np.floating],
+    ) -> NDArray[np.floating]:
+        n_markers = markers.shape[1]
+        if self._rest_override is not None:
+            rest = self._rest_override
+            if rest.shape != (n_markers, 3):
+                raise ValueError(
+                    f"rest_positions must have shape ({n_markers}, 3), got {rest.shape}"
+                )
+            return rest - rest.mean(axis=0, keepdims=True)
+
+        for t in range(markers.shape[0]):
+            if np.all(np.isfinite(markers[t])):
+                ref = markers[t]
+                return ref - ref.mean(axis=0, keepdims=True)
+
+        return np.zeros((n_markers, 3), dtype=float)

--- a/tests/unit/body_part_viz/fitters/_stubs.py
+++ b/tests/unit/body_part_viz/fitters/_stubs.py
@@ -1,0 +1,24 @@
+"""Shared stub shape for fitter tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.shared.python.body_part_viz._types import FittedShape
+
+
+class StubShape:
+    """Minimal duck-typed BodyPartShape for fitter tests."""
+
+    def __init__(self, shape_id: str = "stub") -> None:
+        self.shape_id = shape_id
+        self.rest_dimensions: tuple[float, ...] = (1.0,)
+
+    def vertices_at_rest(self) -> np.ndarray:
+        return np.array([[0.0, 0.0, 0.0]])
+
+    def faces(self) -> np.ndarray:
+        return np.zeros((0, 3), dtype=np.int64)
+
+    def transform(self, fitted: FittedShape) -> np.ndarray:
+        return np.zeros((fitted.n_frames, 1, 3))

--- a/tests/unit/body_part_viz/fitters/test_fitters_between_two.py
+++ b/tests/unit/body_part_viz/fitters/test_fitters_between_two.py
@@ -1,0 +1,193 @@
+"""Unit tests for ``BetweenTwoMarkersFitter``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import ShapeFitter
+from src.shared.python.body_part_viz.fitters import BetweenTwoMarkersFitter
+from tests.unit.body_part_viz.fitters._stubs import StubShape
+
+
+def _binding(rest_length: float = 1.0) -> MarkerBinding:
+    return MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+        rest_dimensions=(rest_length,),
+    )
+
+
+@pytest.mark.unit
+def test_satisfies_shape_fitter_protocol() -> None:
+    assert isinstance(BetweenTwoMarkersFitter(), ShapeFitter)
+
+
+@pytest.mark.unit
+def test_centroid_is_midpoint() -> None:
+    n = 7
+    a = np.tile(np.array([0.0, 0.0, 0.0]), (n, 1))
+    b = np.column_stack([np.linspace(1.0, 7.0, n), np.zeros(n), np.zeros(n)])
+    fitter = BetweenTwoMarkersFitter()
+    fit = fitter.fit(StubShape(), _binding(rest_length=2.0), {"a": a, "b": b})
+    expected_mid = 0.5 * (a + b)
+    np.testing.assert_allclose(fit.centroid, expected_mid, atol=1e-12)
+    assert fit.shape_id == "stub"
+    assert fit.valid_mask.all()
+
+
+@pytest.mark.unit
+def test_rotation_aligns_x_axis_to_segment_x() -> None:
+    a = np.array([[0.0, 0.0, 0.0]])
+    b = np.array([[3.0, 0.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(
+        StubShape(), _binding(rest_length=1.0), {"a": a, "b": b}
+    )
+    r = fit.rotation_matrix[0]
+    np.testing.assert_allclose(r[:, 0], np.array([1.0, 0.0, 0.0]), atol=1e-12)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-12)
+    np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-12)
+    np.testing.assert_allclose(fit.scale[0], np.array([3.0, 1.0, 1.0]), atol=1e-12)
+
+
+@pytest.mark.unit
+def test_rotation_aligns_x_axis_to_segment_y() -> None:
+    a = np.array([[0.0, 0.0, 0.0]])
+    b = np.array([[0.0, 2.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(
+        StubShape(), _binding(rest_length=1.0), {"a": a, "b": b}
+    )
+    r = fit.rotation_matrix[0]
+    np.testing.assert_allclose(r[:, 0], np.array([0.0, 1.0, 0.0]), atol=1e-12)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-12)
+    np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-12)
+
+
+@pytest.mark.unit
+def test_rotation_aligns_x_axis_to_segment_z() -> None:
+    """Near-Z axis should still produce a stable orthonormal basis."""
+    a = np.array([[0.0, 0.0, 0.0]])
+    b = np.array([[0.0, 0.0, 4.0]])
+    fit = BetweenTwoMarkersFitter().fit(
+        StubShape(), _binding(rest_length=2.0), {"a": a, "b": b}
+    )
+    r = fit.rotation_matrix[0]
+    np.testing.assert_allclose(r[:, 0], np.array([0.0, 0.0, 1.0]), atol=1e-12)
+    np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-12)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-12)
+    np.testing.assert_allclose(fit.scale[0], np.array([2.0, 1.0, 1.0]), atol=1e-12)
+
+
+@pytest.mark.unit
+def test_nan_marker_marks_frame_invalid() -> None:
+    n = 5
+    a = np.zeros((n, 3))
+    b = np.column_stack([np.arange(1.0, n + 1), np.zeros(n), np.zeros(n)])
+    a[2] = np.nan
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    assert not fit.valid_mask[2]
+    assert fit.valid_mask[0] and fit.valid_mask[1] and fit.valid_mask[3]
+    np.testing.assert_allclose(fit.rotation_matrix[2], np.eye(3))
+    np.testing.assert_allclose(fit.scale[2], np.ones(3))
+
+
+@pytest.mark.unit
+def test_invalid_frame_centroid_falls_back_to_previous_valid() -> None:
+    a = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [np.nan, np.nan, np.nan]])
+    b = np.array([[2.0, 0.0, 0.0], [3.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    np.testing.assert_allclose(fit.centroid[2], fit.centroid[1])
+
+
+@pytest.mark.unit
+def test_leading_invalid_frame_uses_zero_centroid() -> None:
+    a = np.array([[np.nan, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    b = np.array([[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    assert not fit.valid_mask[0]
+    np.testing.assert_allclose(fit.centroid[0], np.zeros(3))
+
+
+@pytest.mark.unit
+def test_coincident_markers_are_invalid() -> None:
+    a = np.array([[1.0, 1.0, 1.0]])
+    b = np.array([[1.0, 1.0, 1.0]])
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    assert not fit.valid_mask[0]
+    np.testing.assert_allclose(fit.centroid[0], np.array([1.0, 1.0, 1.0]))
+
+
+@pytest.mark.unit
+def test_coincident_then_valid_holds_centroid() -> None:
+    """Mid-trajectory coincident frame uses prior-valid centroid fallback."""
+    a = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]])
+    b = np.array([[1.0, 0.0, 0.0], [2.0, 2.0, 2.0]])
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), _binding(), {"a": a, "b": b})
+    assert fit.valid_mask[0]
+    assert not fit.valid_mask[1]
+    np.testing.assert_allclose(fit.centroid[1], fit.centroid[0])
+
+
+@pytest.mark.unit
+def test_wrong_binding_kind_raises() -> None:
+    binding = MarkerBinding(kind=BindingKind.CLUSTER, marker_names=("a", "b", "c"))
+    fitter = BetweenTwoMarkersFitter()
+    with pytest.raises(ValueError, match="BETWEEN_TWO"):
+        fitter.fit(
+            StubShape(),
+            binding,
+            {
+                "a": np.zeros((1, 3)),
+                "b": np.zeros((1, 3)),
+                "c": np.zeros((1, 3)),
+            },
+        )
+
+
+@pytest.mark.unit
+def test_missing_marker_raises() -> None:
+    fitter = BetweenTwoMarkersFitter()
+    with pytest.raises(ValueError, match="not found"):
+        fitter.fit(StubShape(), _binding(), {"a": np.zeros((1, 3))})
+
+
+@pytest.mark.unit
+def test_marker_shape_mismatch_raises() -> None:
+    fitter = BetweenTwoMarkersFitter()
+    with pytest.raises(ValueError, match="disagree"):
+        fitter.fit(
+            StubShape(),
+            _binding(),
+            {"a": np.zeros((3, 3)), "b": np.zeros((4, 3))},
+        )
+
+
+@pytest.mark.unit
+def test_marker_array_must_be_T3() -> None:
+    fitter = BetweenTwoMarkersFitter()
+    with pytest.raises(ValueError, match=r"\(T, 3\)"):
+        fitter.fit(
+            StubShape(),
+            _binding(),
+            {"a": np.zeros((3, 2)), "b": np.zeros((3, 2))},
+        )
+
+
+@pytest.mark.unit
+def test_default_rest_length_when_unspecified() -> None:
+    binding = MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+    a = np.array([[0.0, 0.0, 0.0]])
+    b = np.array([[5.0, 0.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(StubShape(), binding, {"a": a, "b": b})
+    np.testing.assert_allclose(fit.scale[0], np.array([5.0, 1.0, 1.0]))
+
+
+@pytest.mark.unit
+def test_shape_id_propagates() -> None:
+    a = np.zeros((1, 3))
+    b = np.array([[1.0, 0.0, 0.0]])
+    fit = BetweenTwoMarkersFitter().fit(
+        StubShape("custom_id"), _binding(), {"a": a, "b": b}
+    )
+    assert fit.shape_id == "custom_id"

--- a/tests/unit/body_part_viz/fitters/test_fitters_cluster_kabsch.py
+++ b/tests/unit/body_part_viz/fitters/test_fitters_cluster_kabsch.py
@@ -1,0 +1,245 @@
+"""Unit tests for ``ClusterKabschFitter``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import ShapeFitter
+from src.shared.python.body_part_viz.fitters import ClusterKabschFitter
+from tests.unit.body_part_viz.fitters._stubs import StubShape
+
+
+def _rotation_about(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    k = np.array(
+        [
+            [0.0, -axis[2], axis[1]],
+            [axis[2], 0.0, -axis[0]],
+            [-axis[1], axis[0], 0.0],
+        ]
+    )
+    return np.eye(3) + np.sin(angle) * k + (1 - np.cos(angle)) * (k @ k)
+
+
+def _binding(n: int = 4) -> MarkerBinding:
+    names = tuple(f"m{i}" for i in range(n))
+    return MarkerBinding(kind=BindingKind.CLUSTER, marker_names=names)
+
+
+@pytest.mark.unit
+def test_satisfies_shape_fitter_protocol() -> None:
+    assert isinstance(ClusterKabschFitter(), ShapeFitter)
+
+
+@pytest.mark.unit
+def test_recovers_known_rotation_and_translation() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    r_true = _rotation_about(np.array([0.0, 0.0, 1.0]), np.pi / 4)
+    t_true = np.array([10.0, -3.0, 2.0])
+    moved = (rest @ r_true.T) + t_true
+
+    binding = _binding(4)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(4)}
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+
+    assert fit.valid_mask.all()
+    np.testing.assert_allclose(fit.rotation_matrix[0], np.eye(3), atol=1e-9)
+    np.testing.assert_allclose(fit.centroid[0], rest.mean(axis=0), atol=1e-12)
+    np.testing.assert_allclose(fit.rotation_matrix[1], r_true, atol=1e-9)
+    expected_centroid = rest.mean(axis=0) @ r_true.T + t_true
+    np.testing.assert_allclose(fit.centroid[1], expected_centroid, atol=1e-9)
+    np.testing.assert_allclose(fit.scale, np.ones_like(fit.scale))
+
+
+@pytest.mark.unit
+def test_determinant_is_plus_one() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [-1.0, -1.0, -1.0],
+        ]
+    )
+    r_true = _rotation_about(np.array([1.0, 1.0, 0.0]), 0.7)
+    moved = rest @ r_true.T
+    binding = _binding(4)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(4)}
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+    for r in fit.rotation_matrix:
+        assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_reflection_input_yields_proper_rotation() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    reflect = np.diag([-1.0, 1.0, 1.0])
+    moved = rest @ reflect.T
+    binding = _binding(4)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(4)}
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+    for r in fit.rotation_matrix:
+        assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_coplanar_markers_still_produce_valid_rotation() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ]
+    )
+    r_true = _rotation_about(np.array([0.0, 0.0, 1.0]), 0.5)
+    moved = rest @ r_true.T
+    binding = _binding(3)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(3)}
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+    np.testing.assert_allclose(fit.rotation_matrix[1], r_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_nan_in_frame_marks_invalid() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    binding = _binding(3)
+    markers = {
+        "m0": np.array([rest[0], rest[0], [np.nan, np.nan, np.nan]]),
+        "m1": np.array([rest[1], rest[1], rest[1]]),
+        "m2": np.array([rest[2], rest[2], rest[2]]),
+    }
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+    assert fit.valid_mask[0]
+    assert fit.valid_mask[1]
+    assert not fit.valid_mask[2]
+    np.testing.assert_allclose(fit.centroid[2], fit.centroid[1])
+    np.testing.assert_allclose(fit.rotation_matrix[2], np.eye(3))
+
+
+@pytest.mark.unit
+def test_leading_invalid_frame_uses_zero_centroid() -> None:
+    binding = _binding(3)
+    markers = {
+        "m0": np.array([[np.nan, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        "m1": np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
+        "m2": np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+    }
+    fit = ClusterKabschFitter().fit(StubShape(), binding, markers)
+    assert not fit.valid_mask[0]
+    np.testing.assert_allclose(fit.centroid[0], np.zeros(3))
+
+
+@pytest.mark.unit
+def test_wrong_binding_kind_raises() -> None:
+    binding = MarkerBinding(BindingKind.BETWEEN_TWO, ("a", "b"))
+    with pytest.raises(ValueError, match="CLUSTER"):
+        ClusterKabschFitter().fit(
+            StubShape(),
+            binding,
+            {"a": np.zeros((1, 3)), "b": np.zeros((1, 3))},
+        )
+
+
+@pytest.mark.unit
+def test_missing_marker_raises() -> None:
+    binding = _binding(3)
+    with pytest.raises(ValueError, match="not found"):
+        ClusterKabschFitter().fit(
+            StubShape(), binding, {"m0": np.zeros((1, 3)), "m1": np.zeros((1, 3))}
+        )
+
+
+@pytest.mark.unit
+def test_time_axis_mismatch_raises() -> None:
+    binding = _binding(3)
+    with pytest.raises(ValueError, match="expected T="):
+        ClusterKabschFitter().fit(
+            StubShape(),
+            binding,
+            {
+                "m0": np.zeros((3, 3)),
+                "m1": np.zeros((3, 3)),
+                "m2": np.zeros((4, 3)),
+            },
+        )
+
+
+@pytest.mark.unit
+def test_marker_must_be_T3() -> None:
+    binding = _binding(3)
+    with pytest.raises(ValueError, match=r"\(T, 3\)"):
+        ClusterKabschFitter().fit(
+            StubShape(),
+            binding,
+            {
+                "m0": np.zeros((3, 2)),
+                "m1": np.zeros((3, 2)),
+                "m2": np.zeros((3, 2)),
+            },
+        )
+
+
+@pytest.mark.unit
+def test_explicit_rest_positions_override() -> None:
+    rest_override = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    r_true = _rotation_about(np.array([0.0, 0.0, 1.0]), np.pi / 6)
+    moved = rest_override @ r_true.T
+    binding = _binding(4)
+    markers = {f"m{i}": moved[i : i + 1] for i in range(4)}
+    fit = ClusterKabschFitter(rest_positions=rest_override).fit(
+        StubShape(), binding, markers
+    )
+    np.testing.assert_allclose(fit.rotation_matrix[0], r_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_explicit_rest_positions_shape_validated() -> None:
+    bad = np.zeros((2, 3))
+    binding = _binding(3)
+    markers = {
+        "m0": np.zeros((1, 3)),
+        "m1": np.zeros((1, 3)),
+        "m2": np.zeros((1, 3)),
+    }
+    with pytest.raises(ValueError, match="rest_positions"):
+        ClusterKabschFitter(rest_positions=bad).fit(StubShape(), binding, markers)
+
+
+@pytest.mark.unit
+def test_all_invalid_frames_are_handled() -> None:
+    binding = _binding(3)
+    nan = np.full((2, 3), np.nan)
+    fit = ClusterKabschFitter().fit(
+        StubShape(), binding, {"m0": nan, "m1": nan, "m2": nan}
+    )
+    assert not fit.valid_mask.any()
+    np.testing.assert_allclose(fit.centroid, np.zeros((2, 3)))

--- a/tests/unit/body_part_viz/fitters/test_fitters_procrustes_anisotropic.py
+++ b/tests/unit/body_part_viz/fitters/test_fitters_procrustes_anisotropic.py
@@ -1,0 +1,181 @@
+"""Unit tests for ``ProcrustesAnisotropicFitter``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.bindings import BindingKind, MarkerBinding
+from src.shared.python.body_part_viz.contracts import ShapeFitter
+from src.shared.python.body_part_viz.fitters import ProcrustesAnisotropicFitter
+from tests.unit.body_part_viz.fitters._stubs import StubShape
+
+
+def _rotation_about(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    k = np.array(
+        [
+            [0.0, -axis[2], axis[1]],
+            [axis[2], 0.0, -axis[0]],
+            [-axis[1], axis[0], 0.0],
+        ]
+    )
+    return np.eye(3) + np.sin(angle) * k + (1 - np.cos(angle)) * (k @ k)
+
+
+def _binding(n: int = 6) -> MarkerBinding:
+    return MarkerBinding(BindingKind.CLUSTER, tuple(f"m{i}" for i in range(n)))
+
+
+@pytest.mark.unit
+def test_satisfies_shape_fitter_protocol() -> None:
+    assert isinstance(ProcrustesAnisotropicFitter(), ShapeFitter)
+
+
+@pytest.mark.unit
+def test_recovers_anisotropic_scale_only() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    s_true = np.array([2.0, 0.5, 1.5])
+    moved = rest * s_true
+    binding = _binding(6)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(6)}
+    fit = ProcrustesAnisotropicFitter().fit(StubShape(), binding, markers)
+    np.testing.assert_allclose(fit.rotation_matrix[0], np.eye(3), atol=1e-9)
+    np.testing.assert_allclose(fit.scale[0], np.ones(3), atol=1e-9)
+    np.testing.assert_allclose(fit.rotation_matrix[1], np.eye(3), atol=1e-9)
+    np.testing.assert_allclose(fit.scale[1], s_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_recovers_rotation_plus_anisotropic_scale() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    s_true = np.array([1.5, 2.0, 0.7])
+    r_true = _rotation_about(np.array([0.0, 0.0, 1.0]), np.pi / 3)
+    t_true = np.array([4.0, -2.0, 0.5])
+    moved = ((rest * s_true) @ r_true.T) + t_true
+
+    binding = _binding(6)
+    markers = {f"m{i}": np.array([rest[i], moved[i]]) for i in range(6)}
+    fit = ProcrustesAnisotropicFitter().fit(StubShape(), binding, markers)
+
+    np.testing.assert_allclose(fit.rotation_matrix[1], r_true, atol=1e-6)
+    np.testing.assert_allclose(fit.scale[1], s_true, atol=1e-6)
+    np.testing.assert_allclose(fit.centroid[1], t_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_nan_handling() -> None:
+    rest = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    binding = _binding(3)
+    markers = {
+        "m0": np.array([rest[0], [np.nan, np.nan, np.nan]]),
+        "m1": np.array([rest[1], rest[1]]),
+        "m2": np.array([rest[2], rest[2]]),
+    }
+    fit = ProcrustesAnisotropicFitter().fit(StubShape(), binding, markers)
+    assert fit.valid_mask[0]
+    assert not fit.valid_mask[1]
+    np.testing.assert_allclose(fit.scale[1], np.ones(3))
+    np.testing.assert_allclose(fit.rotation_matrix[1], np.eye(3))
+    np.testing.assert_allclose(fit.centroid[1], fit.centroid[0])
+
+
+@pytest.mark.unit
+def test_wrong_binding_kind_raises() -> None:
+    with pytest.raises(ValueError, match="CLUSTER"):
+        ProcrustesAnisotropicFitter().fit(
+            StubShape(),
+            MarkerBinding(BindingKind.ON_MARKER, ("a",)),
+            {"a": np.zeros((1, 3))},
+        )
+
+
+@pytest.mark.unit
+def test_missing_marker_raises() -> None:
+    binding = _binding(3)
+    with pytest.raises(ValueError, match="not found"):
+        ProcrustesAnisotropicFitter().fit(
+            StubShape(), binding, {"m0": np.zeros((1, 3)), "m1": np.zeros((1, 3))}
+        )
+
+
+@pytest.mark.unit
+def test_time_axis_mismatch_raises() -> None:
+    binding = _binding(3)
+    with pytest.raises(ValueError, match="expected T="):
+        ProcrustesAnisotropicFitter().fit(
+            StubShape(),
+            binding,
+            {
+                "m0": np.zeros((3, 3)),
+                "m1": np.zeros((4, 3)),
+                "m2": np.zeros((3, 3)),
+            },
+        )
+
+
+@pytest.mark.unit
+def test_explicit_rest_positions_override() -> None:
+    rest_override = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    s_true = np.array([3.0, 1.0, 0.25])
+    moved = rest_override * s_true
+    binding = _binding(6)
+    markers = {f"m{i}": moved[i : i + 1] for i in range(6)}
+    fit = ProcrustesAnisotropicFitter(rest_positions=rest_override).fit(
+        StubShape(), binding, markers
+    )
+    np.testing.assert_allclose(fit.scale[0], s_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_explicit_rest_positions_shape_validated() -> None:
+    binding = _binding(3)
+    markers = {f"m{i}": np.zeros((1, 3)) for i in range(3)}
+    with pytest.raises(ValueError, match="rest_positions"):
+        ProcrustesAnisotropicFitter(rest_positions=np.zeros((4, 3))).fit(
+            StubShape(), binding, markers
+        )
+
+
+@pytest.mark.unit
+def test_all_invalid_frames_are_handled() -> None:
+    binding = _binding(3)
+    nan = np.full((2, 3), np.nan)
+    fit = ProcrustesAnisotropicFitter().fit(
+        StubShape(), binding, {"m0": nan, "m1": nan, "m2": nan}
+    )
+    assert not fit.valid_mask.any()
+    np.testing.assert_allclose(fit.scale, np.ones((2, 3)))

--- a/tests/unit/body_part_viz/fitters/test_kabsch_helper.py
+++ b/tests/unit/body_part_viz/fitters/test_kabsch_helper.py
@@ -1,0 +1,105 @@
+"""Unit tests for ``body_part_viz.fitters._kabsch``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.fitters._kabsch import (
+    anisotropic_scale,
+    kabsch_rotation,
+)
+
+
+def _rotation_about(axis: np.ndarray, angle: float) -> np.ndarray:
+    axis = axis / np.linalg.norm(axis)
+    k = np.array(
+        [
+            [0.0, -axis[2], axis[1]],
+            [axis[2], 0.0, -axis[0]],
+            [-axis[1], axis[0], 0.0],
+        ]
+    )
+    return np.eye(3) + np.sin(angle) * k + (1 - np.cos(angle)) * (k @ k)
+
+
+@pytest.mark.unit
+def test_kabsch_recovers_known_rotation_z() -> None:
+    rng = np.random.default_rng(0)
+    p = rng.standard_normal((20, 3))
+    p = p - p.mean(axis=0)
+    r_true = _rotation_about(np.array([0.0, 0.0, 1.0]), np.pi / 3)
+    q = p @ r_true.T
+    r = kabsch_rotation(p, q)
+    np.testing.assert_allclose(r, r_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_kabsch_recovers_known_rotation_general() -> None:
+    rng = np.random.default_rng(7)
+    p = rng.standard_normal((10, 3))
+    p = p - p.mean(axis=0)
+    r_true = _rotation_about(np.array([1.0, 2.0, -3.0]), 1.234)
+    q = p @ r_true.T
+    r = kabsch_rotation(p, q)
+    np.testing.assert_allclose(r, r_true, atol=1e-9)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_kabsch_reflection_guard() -> None:
+    """Reflected target must yield a proper rotation (no determinant -1)."""
+    p = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
+    reflect = np.diag([-1.0, 1.0, 1.0])
+    q = p @ reflect.T
+    r = kabsch_rotation(p, q)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_kabsch_collinear_input_does_not_crash() -> None:
+    """Degenerate (collinear) input still returns a proper rotation."""
+    p = np.array([[-1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    r_true = _rotation_about(np.array([0.0, 1.0, 0.0]), np.pi / 4)
+    q = p @ r_true.T
+    r = kabsch_rotation(p, q)
+    assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-9)
+    np.testing.assert_allclose(p @ r.T, q, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_kabsch_shape_validation() -> None:
+    with pytest.raises(ValueError, match="same shape"):
+        kabsch_rotation(np.zeros((3, 3)), np.zeros((4, 3)))
+    with pytest.raises(ValueError, match=r"shape \(N, 3\)"):
+        kabsch_rotation(np.zeros((3, 2)), np.zeros((3, 2)))
+    with pytest.raises(ValueError, match="at least one point"):
+        kabsch_rotation(np.zeros((0, 3)), np.zeros((0, 3)))
+
+
+@pytest.mark.unit
+def test_anisotropic_scale_recovers_known_factors() -> None:
+    rng = np.random.default_rng(2)
+    p = rng.standard_normal((20, 3))
+    p = p - p.mean(axis=0)
+    s_true = np.array([2.0, 0.5, 1.5])
+    q = p * s_true
+    s = anisotropic_scale(p, q)
+    np.testing.assert_allclose(s, s_true, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_anisotropic_scale_falls_back_on_degenerate_axis() -> None:
+    p = np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]])
+    q = np.array([[2.0, 5.0, 5.0], [-2.0, -5.0, 5.0]])
+    s = anisotropic_scale(p, q)
+    assert s[0] == pytest.approx(2.0)
+    assert s[1] == pytest.approx(1.0)
+    assert s[2] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

- Adds `BetweenTwoMarkersFitter`, `ClusterKabschFitter`, and `ProcrustesAnisotropicFitter`, plus a shared `_kabsch` helper module (pure-NumPy SVD with reflection guard, anisotropic-scale least squares).
- All three fitters conform to the `ShapeFitter` protocol from `contracts.py`, are NaN-safe (invalid frames hold previous valid centroid or zeros, identity rotation, unit scale), and validate inputs (binding-kind mismatch, missing markers, time-axis disagreement).
- Procrustes uses alternating minimisation (Kabsch given current scale; per-axis least squares given current rotation) to recover R and diag(s) jointly in the model `current = R diag(s) rest + t`.

Closes #4756.

## Test plan

- [x] 47 unit tests across 4 modules under `tests/unit/body_part_viz/fitters/`
- [x] Coverage on the fitters package: 98%
- [x] `ruff check` and `ruff format --check` clean
- [x] `pytest` green; pre-commit hooks (ruff, format, mypy, no-print-in-src, no-wildcard-imports) all pass

## Notes

Branched off `feat/4757-body-part-viz-contracts` (PR #4773) so the new tests can import the contracts and `FittedShape` types. Merge into the contracts branch first, then into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)