### PR TITLE
feat(urdf-generator): body_part_viz bridge (#4765)

### DIFF
--- a/src/shared/python/body_part_viz/urdf_bridge.py
+++ b/src/shared/python/body_part_viz/urdf_bridge.py
@@ -1,0 +1,318 @@
+"""Bridge between :mod:`body_part_viz` shapes and URDF ``<visual>`` elements.
+
+This module gives URDF generators the same shape vocabulary the C3D Viewer
+and matcher already use. A user who imports a custom mesh into the viewer
+can re-use it as a URDF visual link without re-modelling.
+
+Mapping (forward):
+
+* :class:`LineShape`        -> :class:`ValueError` (URDF cannot render lines).
+* :class:`CylinderShape`    -> ``<cylinder length=L radius=R>``.
+* :class:`EllipsoidShape`   -> ``<mesh>`` referencing a generated icosphere
+  (logical filename ``__bpv_ellipsoid__a_b_c.obj``) with isotropic
+  ``scale="1 1 1"``; the three semi-axes are encoded in the filename.
+* :class:`CapsuleShape`     -> ``<mesh>`` (logical filename
+  ``__bpv_capsule__length_radius.obj``); URDF has no native capsule.
+* :class:`MeshShape`        -> ``<mesh filename="package://body_part_viz/<stem>.<ext>">``.
+* :class:`CompositeShape`   -> ``list[Element]`` (caller wraps in a ``<link>``).
+
+The inverse :func:`urdf_to_shape` recovers the original shape (within
+``1e-9``) for the supported kinds.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET  # noqa: S405 — generating, not parsing untrusted input
+from collections.abc import Callable
+from pathlib import Path
+
+from .contracts import BodyPartShape
+from .shapes import (
+    CapsuleShape,
+    CompositeShape,
+    CylinderShape,
+    EllipsoidShape,
+    LineShape,
+    MeshShape,
+)
+
+__all__ = [
+    "DEFAULT_PACKAGE",
+    "shape_to_urdf_visual",
+    "urdf_to_shape",
+]
+
+DEFAULT_PACKAGE = "body_part_viz"
+"""Default URDF ``package://`` name for :class:`MeshShape` references."""
+
+_ELLIPSOID_PREFIX = "__bpv_ellipsoid__"
+_CAPSULE_PREFIX = "__bpv_capsule__"
+_ELLIPSOID_EXT = ".obj"
+_CAPSULE_EXT = ".obj"
+
+
+def _add_origin(
+    parent: ET.Element,
+    xyz: tuple[float, float, float],
+    rpy: tuple[float, float, float],
+) -> None:
+    if all(v == 0.0 for v in xyz) and all(v == 0.0 for v in rpy):
+        return
+    ET.SubElement(
+        parent,
+        "origin",
+        xyz=f"{xyz[0]:.17g} {xyz[1]:.17g} {xyz[2]:.17g}",
+        rpy=f"{rpy[0]:.17g} {rpy[1]:.17g} {rpy[2]:.17g}",
+    )
+
+
+def _build_visual(
+    geometry_child: ET.Element,
+    rest_origin_xyz: tuple[float, float, float],
+    rest_origin_rpy: tuple[float, float, float],
+) -> ET.Element:
+    visual = ET.Element("visual")
+    _add_origin(visual, rest_origin_xyz, rest_origin_rpy)
+    geometry = ET.SubElement(visual, "geometry")
+    geometry.append(geometry_child)
+    return visual
+
+
+def _validate_origin(
+    name: str, value: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"{name} must be a length-3 tuple; got {value!r}")
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def shape_to_urdf_visual(
+    shape: BodyPartShape,
+    *,
+    rest_origin_xyz: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    rest_origin_rpy: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    package_name: str = DEFAULT_PACKAGE,
+) -> ET.Element | list[ET.Element]:
+    """Translate a :class:`BodyPartShape` to a URDF ``<visual>`` element.
+
+    Parameters
+    ----------
+    shape:
+        Shape to translate. Must satisfy the
+        :class:`~body_part_viz.contracts.BodyPartShape` Protocol.
+    rest_origin_xyz, rest_origin_rpy:
+        Optional rest-pose origin (added as ``<origin>`` when non-zero).
+    package_name:
+        ROS package name for ``package://`` URIs (mesh shapes only).
+
+    Returns
+    -------
+    ``ET.Element`` for atomic shapes; ``list[ET.Element]`` for
+    :class:`CompositeShape`. The caller is expected to attach the
+    ``<visual>`` element(s) to its ``<link>``.
+
+    Raises
+    ------
+    ValueError
+        If ``shape`` is a :class:`LineShape` (URDF cannot render lines).
+    TypeError
+        If ``shape`` is not one of the supported kinds.
+    """
+    if shape is None:
+        raise TypeError("shape must not be None")
+    if not isinstance(package_name, str) or not package_name:
+        raise ValueError(
+            f"package_name must be a non-empty string; got {package_name!r}"
+        )
+    rest_origin_xyz = _validate_origin("rest_origin_xyz", rest_origin_xyz)
+    rest_origin_rpy = _validate_origin("rest_origin_rpy", rest_origin_rpy)
+
+    if isinstance(shape, LineShape):
+        raise ValueError("URDF cannot render line visuals; use cylinder")
+
+    if isinstance(shape, CylinderShape):
+        length, radius = shape.rest_dimensions
+        cyl = ET.Element(
+            "cylinder",
+            length=f"{float(length):.17g}",
+            radius=f"{float(radius):.17g}",
+        )
+        return _build_visual(cyl, rest_origin_xyz, rest_origin_rpy)
+
+    if isinstance(shape, EllipsoidShape):
+        a, b, c = shape.rest_dimensions
+        filename = (
+            f"package://{package_name}/{_ELLIPSOID_PREFIX}"
+            f"{float(a):.17g}_{float(b):.17g}_{float(c):.17g}{_ELLIPSOID_EXT}"
+        )
+        mesh = ET.Element(
+            "mesh",
+            filename=filename,
+            scale="1 1 1",
+        )
+        return _build_visual(mesh, rest_origin_xyz, rest_origin_rpy)
+
+    if isinstance(shape, CapsuleShape):
+        length, radius = shape.rest_dimensions
+        filename = (
+            f"package://{package_name}/{_CAPSULE_PREFIX}"
+            f"{float(length):.17g}_{float(radius):.17g}{_CAPSULE_EXT}"
+        )
+        mesh = ET.Element(
+            "mesh",
+            filename=filename,
+            scale="1 1 1",
+        )
+        return _build_visual(mesh, rest_origin_xyz, rest_origin_rpy)
+
+    if isinstance(shape, MeshShape):
+        if shape.source_path is None:
+            raise ValueError(
+                "MeshShape must have a source_path to produce a URDF "
+                "package:// reference"
+            )
+        filename = f"package://{package_name}/{shape.source_path.name}"
+        mesh = ET.Element(
+            "mesh",
+            filename=filename,
+            scale="1 1 1",
+        )
+        return _build_visual(mesh, rest_origin_xyz, rest_origin_rpy)
+
+    if isinstance(shape, CompositeShape):
+        out: list[ET.Element] = []
+        for child_shape, transform in shape.children:
+            child_xyz = (
+                float(transform[0, 3]),
+                float(transform[1, 3]),
+                float(transform[2, 3]),
+            )
+            child_rpy = _rotation_matrix_to_rpy(transform[:3, :3])
+            child_visual = shape_to_urdf_visual(
+                child_shape,
+                rest_origin_xyz=child_xyz,
+                rest_origin_rpy=child_rpy,
+                package_name=package_name,
+            )
+            if isinstance(child_visual, list):
+                out.extend(child_visual)
+            else:
+                out.append(child_visual)
+        return out
+
+    raise TypeError(f"Unsupported shape type: {type(shape).__name__}")
+
+
+def urdf_to_shape(
+    visual_element: ET.Element,
+    asset_resolver: Callable[[str], Path],
+) -> BodyPartShape:
+    """Inverse mapping: URDF ``<visual>`` element back to a shape.
+
+    Parameters
+    ----------
+    visual_element:
+        A ``<visual>`` element produced by :func:`shape_to_urdf_visual`
+        (or compatible URDF input).
+    asset_resolver:
+        Callable that maps a ``package://`` URI to a filesystem
+        :class:`pathlib.Path` for :class:`MeshShape` reconstruction.
+
+    Returns
+    -------
+    The recovered :class:`BodyPartShape`. For round-trip pairs produced
+    by :func:`shape_to_urdf_visual`, identity is preserved within
+    ``1e-9`` numerical tolerance.
+
+    Raises
+    ------
+    ValueError
+        If the element cannot be interpreted.
+    """
+    if visual_element is None:
+        raise ValueError("visual_element must not be None")
+    if visual_element.tag != "visual":
+        raise ValueError(
+            f"visual_element.tag must be 'visual'; got {visual_element.tag!r}"
+        )
+    geometry = visual_element.find("geometry")
+    if geometry is None:
+        raise ValueError("visual_element must contain a <geometry> child")
+
+    children = list(geometry)
+    if len(children) != 1:
+        raise ValueError(
+            "URDF <geometry> must contain exactly one child element; "
+            f"got {len(children)}"
+        )
+    geom = children[0]
+
+    if geom.tag == "cylinder":
+        length = float(geom.attrib["length"])
+        radius = float(geom.attrib["radius"])
+        return CylinderShape(length=length, radius=radius)
+
+    if geom.tag == "mesh":
+        filename = geom.attrib.get("filename", "")
+        stem = _filename_stem(filename)
+        if stem.startswith(_ELLIPSOID_PREFIX):
+            payload = stem[len(_ELLIPSOID_PREFIX) :]
+            parts = payload.split("_")
+            if len(parts) != 3:
+                raise ValueError(
+                    f"Malformed ellipsoid filename: {filename!r} (expected "
+                    f"three underscore-separated semi-axes)"
+                )
+            a, b, c = (float(p) for p in parts)
+            return EllipsoidShape(a=a, b=b, c=c)
+        if stem.startswith(_CAPSULE_PREFIX):
+            payload = stem[len(_CAPSULE_PREFIX) :]
+            parts = payload.split("_")
+            if len(parts) != 2:
+                raise ValueError(
+                    f"Malformed capsule filename: {filename!r} (expected "
+                    f"two underscore-separated dimensions)"
+                )
+            length, radius = (float(p) for p in parts)
+            return CapsuleShape(length=length, radius=radius)
+        # Treat as a real on-disk mesh.
+        path = asset_resolver(filename)
+        return MeshShape.load(path)
+
+    raise ValueError(f"Unsupported URDF geometry tag: {geom.tag!r}")
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _filename_stem(filename: str) -> str:
+    """Return the filename stem from a ``package://`` URI or bare path."""
+    if not filename:
+        return ""
+    tail = filename.rsplit("/", 1)[-1]
+    return tail.rsplit(".", 1)[0]
+
+
+def _rotation_matrix_to_rpy(rot: object) -> tuple[float, float, float]:
+    """Decompose a 3x3 rotation matrix into URDF roll-pitch-yaw (XYZ)."""
+    import math
+
+    import numpy as np
+
+    matrix = np.asarray(rot, dtype=float)
+    if matrix.shape != (3, 3):
+        raise ValueError(f"rotation matrix must have shape (3, 3); got {matrix.shape}")
+    # URDF rpy is intrinsic XYZ: R = Rz(yaw) * Ry(pitch) * Rx(roll).
+    sy = -float(matrix[2, 0])
+    if abs(sy) >= 1.0 - 1e-9:
+        # Gimbal lock: choose roll = 0.
+        pitch = math.copysign(math.pi / 2.0, sy)
+        roll = 0.0
+        yaw = math.atan2(-matrix[0, 1], matrix[1, 1])
+    else:
+        pitch = math.asin(sy)
+        roll = math.atan2(matrix[2, 1], matrix[2, 2])
+        yaw = math.atan2(matrix[1, 0], matrix[0, 0])
+    return (roll, pitch, yaw)

--- a/src/shared/python/humanoid_character_builder/generators/_geometry_helpers.py
+++ b/src/shared/python/humanoid_character_builder/generators/_geometry_helpers.py
@@ -1,89 +1,39 @@
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET  # stdlib retained for Element/SubElement
+import xml.etree.ElementTree as ET  # noqa: F401  # backward-compat re-export
 from typing import Any
 
-from humanoid_character_builder.core.segment_definitions import (
-    GeometryType,
-    SegmentDefinition,
+from humanoid_character_builder.core.segment_definitions import SegmentDefinition
+from humanoid_character_builder.generators.urdf_geometry import (
+    add_geometry_element as _bridged_add_geometry_element,
 )
+from humanoid_character_builder.generators.urdf_geometry import (
+    create_geometry_dict as _bridged_create_geometry_dict,
+)
+from src.shared.python.body_part_viz.contracts import BodyPartShape
 
 
 def create_geometry_dict(
     segment_def: SegmentDefinition,
     dimensions: dict[str, float],
     is_collision: bool,
+    *,
+    shape: BodyPartShape | None = None,
 ) -> dict[str, Any]:
-    geom_spec = (
-        segment_def.get_collision_geometry()
-        if is_collision
-        else segment_def.visual_geometry
+    """Delegate to :func:`humanoid_character_builder.generators.urdf_geometry`.
+
+    Issue #4765 routes geometry-dict construction through the
+    :mod:`body_part_viz.urdf_bridge` so a per-link
+    :class:`~body_part_viz.contracts.BodyPartShape` (e.g. from
+    :class:`~body_part_viz.asset_library.ShapeLibrary`) can override the
+    legacy :class:`SegmentDefinition`-based payload.
+    """
+    return _bridged_create_geometry_dict(
+        segment_def, dimensions, is_collision, shape=shape
     )
-
-    length = dimensions.get("length", 0.1)
-    width = dimensions.get("width", 0.05)
-    depth = dimensions.get("depth", 0.05)
-
-    if geom_spec.geometry_type == GeometryType.BOX:
-        return {
-            "type": "box",
-            "size": (width, depth, length),
-        }
-    if geom_spec.geometry_type == GeometryType.CYLINDER:
-        radius = (width + depth) / 4
-        return {
-            "type": "cylinder",
-            "radius": radius,
-            "length": length,
-        }
-    if geom_spec.geometry_type == GeometryType.SPHERE:
-        radius = length / 2
-        return {
-            "type": "sphere",
-            "radius": radius,
-        }
-    if geom_spec.geometry_type == GeometryType.CAPSULE:
-        radius = (width + depth) / 4
-        return {
-            "type": "cylinder",
-            "radius": radius,
-            "length": max(0.01, length - 2 * radius),
-        }
-    if geom_spec.geometry_type == GeometryType.MESH:
-        return {
-            "type": "mesh",
-            "filename": geom_spec.mesh_path,
-            "scale": geom_spec.mesh_scale,
-        }
-    return {
-        "type": "box",
-        "size": (width, depth, length),
-    }
 
 
 def add_geometry_element(parent: ET.Element, geom: dict[str, Any]) -> None:
-    geometry = ET.SubElement(parent, "geometry")
-
-    geom_type = geom["type"]
-    if geom_type == "box":
-        size = geom["size"]
-        ET.SubElement(
-            geometry, "box", size=f"{size[0]:.6f} {size[1]:.6f} {size[2]:.6f}"
-        )
-    elif geom_type == "cylinder":
-        ET.SubElement(
-            geometry,
-            "cylinder",
-            radius=f"{geom['radius']:.6f}",
-            length=f"{geom['length']:.6f}",
-        )
-    elif geom_type == "sphere":
-        ET.SubElement(geometry, "sphere", radius=f"{geom['radius']:.6f}")
-    elif geom_type == "mesh":
-        scale = geom.get("scale", (1.0, 1.0, 1.0))
-        ET.SubElement(
-            geometry,
-            "mesh",
-            filename=geom["filename"],
-            scale=f"{scale[0]:.6f} {scale[1]:.6f} {scale[2]:.6f}",
-        )
+    """Delegate to the canonical implementation in
+    :mod:`humanoid_character_builder.generators.urdf_geometry`."""
+    _bridged_add_geometry_element(parent, geom)

--- a/src/shared/python/humanoid_character_builder/generators/_link_generation.py
+++ b/src/shared/python/humanoid_character_builder/generators/_link_generation.py
@@ -16,6 +16,7 @@ from humanoid_character_builder.mesh.inertia_calculator import (
     MeshInertiaCalculator,
 )
 from humanoid_character_builder.mesh.primitive_inertia import PrimitiveInertiaCalculator
+from src.shared.python.body_part_viz.contracts import BodyPartShape
 
 
 def apply_proportion_factors(
@@ -81,6 +82,7 @@ def generate_link(
     mesh_inertia_calc: MeshInertiaCalculator,
     primitive_inertia_calc: PrimitiveInertiaCalculator,
     generate_collision: bool,
+    visual_shape: BodyPartShape | None = None,
 ) -> GeneratedLink:
     seg_params = params.get_segment_params(segment_name)
 
@@ -97,9 +99,14 @@ def generate_link(
         mesh_dir,
     )
 
-    visual_geom = create_geometry_dict(segment_def, dimensions, is_collision=False)
+    visual_geom = create_geometry_dict(
+        segment_def, dimensions, is_collision=False, shape=visual_shape
+    )
     collision_geom: dict[str, Any] | None = None
     if generate_collision:
+        # Collision geometry stays on the legacy path: URDF collision
+        # checkers strongly prefer fast primitives, and reusing the
+        # visual mesh would explode collision-pair workload.
         collision_geom = create_geometry_dict(
             segment_def, dimensions, is_collision=True
         )

--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
@@ -15,7 +15,15 @@ from ._mesh_smplx import (
     _trimesh_module,  # type: ignore[attr-defined]
 )
 from ._mesh_types import (
-# Re-export capability flags for test compatibility (#4528)
+    GeneratedMeshResult,
+    MeshGeneratorBackend,
+    MeshGeneratorInterface,
+)
+
+# Re-export capability flags for test compatibility (#4528). The imports
+# above already pulled SMPLX_AVAILABLE / TRIMESH_AVAILABLE / _trimesh_module
+# from `_mesh_smplx`, so these blocks only matter when that import path
+# itself fails — e.g. on a partial install. Keep them as defensive fallbacks.
 try:
     from humanoid_character_builder.generators._mesh_smplx import SMPLX_AVAILABLE
 except ImportError:
@@ -28,10 +36,6 @@ try:
     from humanoid_character_builder.generators._mesh_smplx import _trimesh_module
 except ImportError:
     _trimesh_module = None
-    GeneratedMeshResult,
-    MeshGeneratorBackend,
-    MeshGeneratorInterface,
-)
 
 __all__ = [
     "GeneratedMeshResult",

--- a/src/shared/python/humanoid_character_builder/generators/urdf_config.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_config.py
@@ -7,8 +7,12 @@ Extracted from urdf_generator.py to isolate configuration concerns.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from humanoid_character_builder.mesh.inertia_calculator import InertiaMode
+
+if TYPE_CHECKING:
+    from src.shared.python.body_part_viz.asset_library import ShapeLibrary
 
 
 @dataclass
@@ -48,3 +52,8 @@ class URDFGeneratorConfig:
 
     # Include comments in URDF
     include_comments: bool = True
+
+    # Optional body_part_viz ShapeLibrary supplying per-link visuals.
+    # Issue #4765: when provided, named links draw their <visual> from the
+    # library instead of the legacy SegmentDefinition-derived primitives.
+    shape_library: ShapeLibrary | None = None

--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -76,6 +76,7 @@ from humanoid_character_builder.mesh.primitive_inertia import (
     PrimitiveInertiaCalculator,
     estimate_segment_primitive,
 )
+from src.shared.python.body_part_viz.contracts import BodyPartShape
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ class HumanoidURDFGenerator:
         self._materials = generate_materials(params)
 
         for segment_name, segment_def in HUMANOID_SEGMENTS.items():
+            visual_shape = self._lookup_library_shape(segment_name)
             self._links[segment_name] = generate_link(
                 segment_name,
                 segment_def,
@@ -167,6 +169,7 @@ class HumanoidURDFGenerator:
                 self.mesh_inertia_calc,
                 self.primitive_inertia_calc,
                 self.config.generate_collision,
+                visual_shape=visual_shape,
             )
 
         for joint_name, joint_def in HUMANOID_JOINTS.items():
@@ -180,6 +183,25 @@ class HumanoidURDFGenerator:
             self._joints.extend(joints)
 
         return HumanoidModel(self._links, self._joints)
+
+    def _lookup_library_shape(self, segment_name: str) -> BodyPartShape | None:
+        """Resolve a per-segment :class:`BodyPartShape` from the configured
+        :class:`ShapeLibrary`, if any. Strips left/right side prefixes so
+        the bundled default library (which has one ``upper_arm`` entry,
+        not two) covers both sides.
+        """
+        library = getattr(self.config, "shape_library", None)
+        if library is None:
+            return None
+        candidates = (segment_name,)
+        for prefix in ("left_", "right_"):
+            if segment_name.startswith(prefix):
+                candidates = (segment_name, segment_name[len(prefix) :])
+                break
+        for name in candidates:
+            if name in library.names():
+                return library.get(name)
+        return None
 
     @precondition(lambda params: params is not None, "params must not be None")
     @precondition(lambda params: params.height_m > 0, "Height must be positive")

--- a/src/shared/python/humanoid_character_builder/generators/urdf_geometry.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_geometry.py
@@ -4,7 +4,11 @@ URDF geometry helpers.
 Handles creation of geometry specification dicts from segment definitions
 and rendering of those dicts as XML elements.
 
-Extracted from urdf_generator.py to isolate geometry concerns.
+Extracted from urdf_generator.py to isolate geometry concerns. With Wave 4
+of EPIC #4755, this module is wired to the
+:mod:`body_part_viz.urdf_bridge` so a per-link
+:class:`~body_part_viz.contracts.BodyPartShape` can drive the visual
+payload alongside the legacy :class:`SegmentDefinition` path.
 """
 
 from __future__ import annotations
@@ -16,12 +20,65 @@ from humanoid_character_builder.core.segment_definitions import (
     GeometryType,
     SegmentDefinition,
 )
+from src.shared.python.body_part_viz.contracts import BodyPartShape
+from src.shared.python.body_part_viz.shapes import (
+    CompositeShape,
+    CylinderShape,
+)
+from src.shared.python.body_part_viz.urdf_bridge import shape_to_urdf_visual
+
+
+def shape_to_geometry_dict(shape: BodyPartShape) -> dict[str, Any]:
+    """Translate a :class:`BodyPartShape` into the dict form used by
+    :func:`add_geometry_element`.
+
+    This is the "thin wrapper" path mandated by issue #4765: the heavy
+    lifting (URDF schema, package:// URIs, mesh-encoded ellipsoids) lives
+    in :func:`shape_to_urdf_visual`; we just project the resulting
+    ``<geometry>`` child back to the legacy dict shape so the existing
+    XML emitter keeps working unchanged.
+    """
+    if shape is None:
+        raise ValueError("shape must be provided")
+    if isinstance(shape, CompositeShape):
+        # Composite shapes can't reduce to a single geometry dict; the
+        # XML builder must take the multi-visual path explicitly.
+        raise ValueError(
+            "CompositeShape cannot be expressed as a single geometry dict; "
+            "use shape_to_urdf_visual() and emit one <visual> per child"
+        )
+    visual = shape_to_urdf_visual(shape)
+    if isinstance(visual, list):  # pragma: no cover — guarded above
+        raise ValueError("CompositeShape produced multiple visuals")
+    geometry = visual.find("geometry")
+    if geometry is None or len(list(geometry)) != 1:  # pragma: no cover
+        raise ValueError("shape_to_urdf_visual produced an unexpected payload")
+    geom = list(geometry)[0]
+    if geom.tag == "cylinder":
+        return {
+            "type": "cylinder",
+            "radius": float(geom.attrib["radius"]),
+            "length": float(geom.attrib["length"]),
+        }
+    if geom.tag == "mesh":
+        scale_attr = geom.attrib.get("scale", "1 1 1").split()
+        scale = (float(scale_attr[0]), float(scale_attr[1]), float(scale_attr[2]))
+        return {
+            "type": "mesh",
+            "filename": geom.attrib["filename"],
+            "scale": scale,
+        }
+    raise ValueError(  # pragma: no cover — defensive
+        f"Unsupported geometry tag from bridge: {geom.tag!r}"
+    )
 
 
 def create_geometry_dict(
     segment_def: SegmentDefinition,
     dimensions: dict[str, float],
     is_collision: bool,
+    *,
+    shape: BodyPartShape | None = None,
 ) -> dict[str, Any]:
     """Create geometry specification dictionary.
 
@@ -29,10 +86,16 @@ def create_geometry_dict(
         segment_def: Segment definition containing visual/collision geometry specs.
         dimensions: Scaled segment dimensions (length, width, depth).
         is_collision: If True, use collision geometry spec; otherwise use visual.
+        shape: Optional :class:`BodyPartShape` (e.g. from the
+            :class:`~body_part_viz.asset_library.ShapeLibrary`). When
+            provided, the function delegates to :func:`shape_to_geometry_dict`
+            and the segment-definition geometry type is ignored.
 
     Returns:
         Dict describing the geometry (type + size parameters).
     """
+    if shape is not None:
+        return shape_to_geometry_dict(shape)
     if segment_def is None:
         raise ValueError("segment_def must be provided")
     geom_spec = (
@@ -45,18 +108,18 @@ def create_geometry_dict(
     width = dimensions.get("width", 0.05)
     depth = dimensions.get("depth", 0.05)
 
+    # Where possible, route through the body_part_viz bridge so the
+    # legacy segment-definition path produces the same XML schema as
+    # shape-library-driven links.
     if geom_spec.geometry_type == GeometryType.BOX:
+        # No body_part_viz BoxShape; keep the dict-only legacy path.
         return {
             "type": "box",
             "size": (width, depth, length),
         }
     if geom_spec.geometry_type == GeometryType.CYLINDER:
         radius = (width + depth) / 4
-        return {
-            "type": "cylinder",
-            "radius": radius,
-            "length": length,
-        }
+        return shape_to_geometry_dict(CylinderShape(length=length, radius=radius))
     if geom_spec.geometry_type == GeometryType.SPHERE:
         radius = length / 2
         return {
@@ -65,11 +128,9 @@ def create_geometry_dict(
         }
     if geom_spec.geometry_type == GeometryType.CAPSULE:
         radius = (width + depth) / 4
-        return {
-            "type": "cylinder",  # URDF doesn't have capsule, use cylinder
-            "radius": radius,
-            "length": max(0.01, length - 2 * radius),
-        }
+        return shape_to_geometry_dict(
+            CylinderShape(length=max(0.01, length - 2 * radius), radius=radius)
+        )
     if geom_spec.geometry_type == GeometryType.MESH:
         return {
             "type": "mesh",

--- a/tests/unit/body_part_viz/test_urdf_bridge.py
+++ b/tests/unit/body_part_viz/test_urdf_bridge.py
@@ -1,0 +1,380 @@
+"""Tests for :mod:`body_part_viz.urdf_bridge` (issue #4765)."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET  # noqa: S405 — generating, not parsing untrusted input
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.shared.python.body_part_viz.shapes import (
+    CapsuleShape,
+    CompositeShape,
+    CylinderShape,
+    EllipsoidShape,
+    LineShape,
+    MeshShape,
+)
+from src.shared.python.body_part_viz.urdf_bridge import (
+    DEFAULT_PACKAGE,
+    shape_to_urdf_visual,
+    urdf_to_shape,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolver_for_mesh(stl_path: Path) -> Callable[[str], Path]:
+    def resolver(uri: str) -> Path:
+        # Bridge always emits "package://body_part_viz/<filename>"; we ignore
+        # the URI and return the canonical on-disk file the test wrote.
+        del uri
+        return stl_path
+
+    return resolver
+
+
+def _no_mesh_resolver(uri: str) -> Path:
+    raise AssertionError(f"asset_resolver should not be called; got {uri!r}")
+
+
+def _make_mesh_shape(tmp_path: Path) -> MeshShape:
+    """Build a tiny on-disk STL (a non-degenerate tetrahedron) and load it."""
+    stl_path = tmp_path / "tiny.stl"
+    # Tetrahedron with vertices at (0,0,0), (1,0,0), (0,1,0), (0,0,1).
+    stl_path.write_text(
+        "solid tiny\n"
+        " facet normal 0 0 -1\n"
+        "  outer loop\n"
+        "   vertex 0 0 0\n"
+        "   vertex 0 1 0\n"
+        "   vertex 1 0 0\n"
+        "  endloop\n"
+        " endfacet\n"
+        " facet normal 0 -1 0\n"
+        "  outer loop\n"
+        "   vertex 0 0 0\n"
+        "   vertex 1 0 0\n"
+        "   vertex 0 0 1\n"
+        "  endloop\n"
+        " endfacet\n"
+        " facet normal -1 0 0\n"
+        "  outer loop\n"
+        "   vertex 0 0 0\n"
+        "   vertex 0 0 1\n"
+        "   vertex 0 1 0\n"
+        "  endloop\n"
+        " endfacet\n"
+        " facet normal 1 1 1\n"
+        "  outer loop\n"
+        "   vertex 1 0 0\n"
+        "   vertex 0 1 0\n"
+        "   vertex 0 0 1\n"
+        "  endloop\n"
+        " endfacet\n"
+        "endsolid tiny\n",
+        encoding="utf-8",
+    )
+    return MeshShape.load(stl_path)
+
+
+# ---------------------------------------------------------------------------
+# Forward translation
+# ---------------------------------------------------------------------------
+
+
+def test_line_shape_raises() -> None:
+    with pytest.raises(ValueError, match="URDF cannot render line visuals"):
+        shape_to_urdf_visual(LineShape(length=1.0))
+
+
+def test_cylinder_visual_payload() -> None:
+    cyl = CylinderShape(length=2.0, radius=0.05)
+    visual = shape_to_urdf_visual(cyl)
+    assert isinstance(visual, ET.Element)
+    assert visual.tag == "visual"
+    assert visual.find("origin") is None  # zero origin omitted
+    geom = visual.find("geometry")
+    assert geom is not None
+    cyl_elem = geom.find("cylinder")
+    assert cyl_elem is not None
+    assert float(cyl_elem.attrib["length"]) == pytest.approx(2.0, abs=1e-12)
+    assert float(cyl_elem.attrib["radius"]) == pytest.approx(0.05, abs=1e-12)
+
+
+def test_ellipsoid_emits_mesh_with_encoded_axes() -> None:
+    ell = EllipsoidShape(a=0.1, b=0.2, c=0.3)
+    visual = shape_to_urdf_visual(ell)
+    assert isinstance(visual, ET.Element)
+    mesh = visual.find("geometry/mesh")
+    assert mesh is not None
+    filename = mesh.attrib["filename"]
+    assert filename.startswith(f"package://{DEFAULT_PACKAGE}/__bpv_ellipsoid__")
+    assert filename.endswith(".obj")
+
+
+def test_capsule_emits_mesh_with_encoded_dims() -> None:
+    cap = CapsuleShape(length=0.4, radius=0.03)
+    visual = shape_to_urdf_visual(cap)
+    mesh = visual.find("geometry/mesh")
+    assert mesh is not None
+    filename = mesh.attrib["filename"]
+    assert filename.startswith(f"package://{DEFAULT_PACKAGE}/__bpv_capsule__")
+
+
+def test_mesh_shape_uses_package_uri(tmp_path: Path) -> None:
+    mesh_shape = _make_mesh_shape(tmp_path)
+    visual = shape_to_urdf_visual(mesh_shape)
+    mesh_elem = visual.find("geometry/mesh")
+    assert mesh_elem is not None
+    assert mesh_elem.attrib["filename"] == (
+        f"package://{DEFAULT_PACKAGE}/{mesh_shape.source_path.name}"
+    )
+
+
+def test_mesh_shape_without_source_path_raises() -> None:
+    mesh = MeshShape(
+        vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64),
+        faces=np.array([[0, 1, 2]], dtype=np.int64),
+        rest_dimensions=(1.0, 1.0, 0.001),
+    )
+    with pytest.raises(ValueError, match="source_path"):
+        shape_to_urdf_visual(mesh)
+
+
+def test_composite_returns_list_with_correct_child_count() -> None:
+    children = [
+        (CylinderShape(length=1.0, radius=0.02), np.eye(4)),
+        (CylinderShape(length=0.5, radius=0.03), np.eye(4)),
+        (CylinderShape(length=0.3, radius=0.04), np.eye(4)),
+    ]
+    composite = CompositeShape(children=children)
+    visuals = shape_to_urdf_visual(composite)
+    assert isinstance(visuals, list)
+    assert len(visuals) == 3
+    for visual in visuals:
+        assert visual.tag == "visual"
+        assert visual.find("geometry/cylinder") is not None
+
+
+def test_composite_propagates_child_local_transform() -> None:
+    transform = np.eye(4)
+    transform[0, 3] = 0.1
+    transform[1, 3] = -0.2
+    transform[2, 3] = 0.3
+    children = [(CylinderShape(length=1.0, radius=0.02), transform)]
+    composite = CompositeShape(children=children)
+    visuals = shape_to_urdf_visual(composite)
+    assert isinstance(visuals, list) and len(visuals) == 1
+    origin = visuals[0].find("origin")
+    assert origin is not None
+    xyz = [float(v) for v in origin.attrib["xyz"].split()]
+    assert xyz == pytest.approx([0.1, -0.2, 0.3], abs=1e-9)
+
+
+def test_origin_emitted_when_non_zero() -> None:
+    cyl = CylinderShape(length=1.0, radius=0.02)
+    visual = shape_to_urdf_visual(
+        cyl,
+        rest_origin_xyz=(0.0, 0.0, 0.5),
+        rest_origin_rpy=(0.0, 0.0, 0.0),
+    )
+    assert isinstance(visual, ET.Element)
+    origin = visual.find("origin")
+    assert origin is not None
+    xyz = [float(v) for v in origin.attrib["xyz"].split()]
+    assert xyz == pytest.approx([0.0, 0.0, 0.5], abs=1e-12)
+
+
+def test_invalid_shape_type_raises() -> None:
+    class _Bogus:
+        shape_id = "bogus"
+        rest_dimensions = (1.0,)
+
+        def vertices_at_rest(self):
+            return np.zeros((1, 3))
+
+        def faces(self):
+            return np.zeros((0, 3), dtype=np.int64)
+
+        def transform(self, fitted):
+            return self.vertices_at_rest()
+
+    with pytest.raises(TypeError, match="Unsupported shape type"):
+        shape_to_urdf_visual(_Bogus())
+
+
+def test_none_shape_raises() -> None:
+    with pytest.raises(TypeError, match="shape must not be None"):
+        shape_to_urdf_visual(None)  # type: ignore[arg-type]
+
+
+def test_invalid_origin_tuple_raises() -> None:
+    cyl = CylinderShape(length=1.0, radius=0.02)
+    with pytest.raises(TypeError, match="rest_origin_xyz"):
+        shape_to_urdf_visual(cyl, rest_origin_xyz=(0.0, 0.0))  # type: ignore[arg-type]
+
+
+def test_empty_package_name_raises() -> None:
+    cyl = CylinderShape(length=1.0, radius=0.02)
+    with pytest.raises(ValueError, match="package_name"):
+        shape_to_urdf_visual(cyl, package_name="")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_cylinder() -> None:
+    original = CylinderShape(length=1.234, radius=0.0567)
+    visual = shape_to_urdf_visual(original)
+    recovered = urdf_to_shape(visual, _no_mesh_resolver)
+    assert isinstance(recovered, CylinderShape)
+    assert recovered.rest_dimensions == pytest.approx(
+        original.rest_dimensions, abs=1e-9
+    )
+
+
+def test_round_trip_ellipsoid() -> None:
+    original = EllipsoidShape(a=0.123, b=0.234, c=0.345)
+    visual = shape_to_urdf_visual(original)
+    recovered = urdf_to_shape(visual, _no_mesh_resolver)
+    assert isinstance(recovered, EllipsoidShape)
+    assert recovered.rest_dimensions == pytest.approx(
+        original.rest_dimensions, abs=1e-9
+    )
+
+
+def test_round_trip_capsule() -> None:
+    original = CapsuleShape(length=0.42, radius=0.07)
+    visual = shape_to_urdf_visual(original)
+    recovered = urdf_to_shape(visual, _no_mesh_resolver)
+    assert isinstance(recovered, CapsuleShape)
+    assert recovered.rest_dimensions == pytest.approx(
+        original.rest_dimensions, abs=1e-9
+    )
+
+
+def test_round_trip_mesh(tmp_path: Path) -> None:
+    original = _make_mesh_shape(tmp_path)
+    visual = shape_to_urdf_visual(original)
+    recovered = urdf_to_shape(visual, _resolver_for_mesh(original.source_path))
+    assert isinstance(recovered, MeshShape)
+    assert recovered.source_path is not None
+    assert recovered.source_path.name == original.source_path.name
+
+
+def test_round_trip_composite() -> None:
+    children = [
+        (CylinderShape(length=1.0, radius=0.02), np.eye(4)),
+        (EllipsoidShape(a=0.1, b=0.1, c=0.2), np.eye(4)),
+    ]
+    composite = CompositeShape(children=children)
+    visuals = shape_to_urdf_visual(composite)
+    assert isinstance(visuals, list)
+    recovered = [urdf_to_shape(v, _no_mesh_resolver) for v in visuals]
+    assert isinstance(recovered[0], CylinderShape)
+    assert isinstance(recovered[1], EllipsoidShape)
+    assert recovered[0].rest_dimensions == pytest.approx((1.0, 0.02), abs=1e-9)
+    assert recovered[1].rest_dimensions == pytest.approx((0.1, 0.1, 0.2), abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Inverse-only error paths
+# ---------------------------------------------------------------------------
+
+
+def test_urdf_to_shape_rejects_none() -> None:
+    with pytest.raises(ValueError, match="must not be None"):
+        urdf_to_shape(None, _no_mesh_resolver)  # type: ignore[arg-type]
+
+
+def test_urdf_to_shape_rejects_non_visual_tag() -> None:
+    with pytest.raises(ValueError, match="must be 'visual'"):
+        urdf_to_shape(ET.Element("link"), _no_mesh_resolver)
+
+
+def test_urdf_to_shape_requires_geometry() -> None:
+    with pytest.raises(ValueError, match="<geometry>"):
+        urdf_to_shape(ET.Element("visual"), _no_mesh_resolver)
+
+
+def test_urdf_to_shape_rejects_multiple_geometries() -> None:
+    visual = ET.Element("visual")
+    geom = ET.SubElement(visual, "geometry")
+    ET.SubElement(geom, "cylinder", length="1", radius="0.1")
+    ET.SubElement(geom, "sphere", radius="0.5")
+    with pytest.raises(ValueError, match="exactly one child"):
+        urdf_to_shape(visual, _no_mesh_resolver)
+
+
+def test_urdf_to_shape_rejects_unknown_geometry() -> None:
+    visual = ET.Element("visual")
+    geom = ET.SubElement(visual, "geometry")
+    ET.SubElement(geom, "torus", inner_radius="0.1", outer_radius="0.5")
+    with pytest.raises(ValueError, match="Unsupported URDF geometry tag"):
+        urdf_to_shape(visual, _no_mesh_resolver)
+
+
+def test_urdf_to_shape_rejects_malformed_ellipsoid_filename() -> None:
+    visual = ET.Element("visual")
+    geom = ET.SubElement(visual, "geometry")
+    ET.SubElement(
+        geom,
+        "mesh",
+        filename="package://body_part_viz/__bpv_ellipsoid__1.0_2.0.obj",
+        scale="1 1 1",
+    )
+    with pytest.raises(ValueError, match="Malformed ellipsoid"):
+        urdf_to_shape(visual, _no_mesh_resolver)
+
+
+def test_urdf_to_shape_rejects_malformed_capsule_filename() -> None:
+    visual = ET.Element("visual")
+    geom = ET.SubElement(visual, "geometry")
+    ET.SubElement(
+        geom,
+        "mesh",
+        filename="package://body_part_viz/__bpv_capsule__1.0.obj",
+        scale="1 1 1",
+    )
+    with pytest.raises(ValueError, match="Malformed capsule"):
+        urdf_to_shape(visual, _no_mesh_resolver)
+
+
+# ---------------------------------------------------------------------------
+# Internal: rotation matrix decomposition
+# ---------------------------------------------------------------------------
+
+
+def test_composite_zero_rotation_omits_origin_when_at_origin() -> None:
+    children = [(CylinderShape(length=1.0, radius=0.02), np.eye(4))]
+    composite = CompositeShape(children=children)
+    visuals = shape_to_urdf_visual(composite)
+    assert isinstance(visuals, list) and len(visuals) == 1
+    assert visuals[0].find("origin") is None
+
+
+def test_composite_rotation_propagates_to_rpy() -> None:
+    transform = np.eye(4)
+    # 90-degree rotation about z: roll=0, pitch=0, yaw=pi/2.
+    cos_a, sin_a = np.cos(np.pi / 2), np.sin(np.pi / 2)
+    transform[:3, :3] = np.array(
+        [[cos_a, -sin_a, 0.0], [sin_a, cos_a, 0.0], [0.0, 0.0, 1.0]]
+    )
+    children = [(CylinderShape(length=1.0, radius=0.02), transform)]
+    composite = CompositeShape(children=children)
+    visuals = shape_to_urdf_visual(composite)
+    assert isinstance(visuals, list) and len(visuals) == 1
+    origin = visuals[0].find("origin")
+    assert origin is not None
+    rpy = [float(v) for v in origin.attrib["rpy"].split()]
+    assert rpy[2] == pytest.approx(np.pi / 2, abs=1e-9)
+    assert rpy[0] == pytest.approx(0.0, abs=1e-9)
+    assert rpy[1] == pytest.approx(0.0, abs=1e-9)

--- a/tests/unit/tools/humanoid_character_builder/test_urdf_generator_with_shapes.py
+++ b/tests/unit/tools/humanoid_character_builder/test_urdf_generator_with_shapes.py
@@ -1,0 +1,83 @@
+"""URDF generation driven by a body_part_viz ShapeLibrary (#4765).
+
+Exercises the end-to-end wiring: ``URDFGeneratorConfig.shape_library`` ->
+``HumanoidURDFGenerator._lookup_library_shape`` ->
+``urdf_geometry.create_geometry_dict(shape=...)`` ->
+``urdf_bridge.shape_to_urdf_visual``.
+"""
+
+from __future__ import annotations
+
+import defusedxml.ElementTree as ET  # nosec B405 — defusedxml is the safe parser
+from humanoid_character_builder.core.body_parameters import BodyParameters
+from humanoid_character_builder.generators.urdf_config import URDFGeneratorConfig
+from humanoid_character_builder.generators.urdf_generator import HumanoidURDFGenerator
+
+from src.shared.python.body_part_viz.asset_library import ShapeLibrary
+
+
+def _strip_xml_declaration(xml_str: str) -> str:
+    if xml_str.startswith("<?xml"):
+        return xml_str[xml_str.index("?>") + 2 :]
+    return xml_str
+
+
+def _link_visual(root: ET.Element, link_name: str) -> ET.Element | None:
+    for link in root.findall("link"):
+        if link.get("name") == link_name:
+            return link.find("visual/geometry")
+    return None
+
+
+def test_default_library_drives_link_visuals() -> None:
+    library = ShapeLibrary.default()
+    config = URDFGeneratorConfig(shape_library=library, generate_collision=False)
+    generator = HumanoidURDFGenerator(config)
+    params = BodyParameters()
+
+    urdf_xml = generator.generate(params)
+    root = ET.fromstring(_strip_xml_declaration(urdf_xml))
+
+    # Head should be a mesh referencing the bundled head asset.
+    head_geom = _link_visual(root, "head")
+    assert head_geom is not None
+    head_mesh = head_geom.find("mesh")
+    assert head_mesh is not None
+    assert "head.stl" in head_mesh.get("filename", "")
+    assert "package://body_part_viz/" in head_mesh.get("filename", "")
+
+    # Both upper_arm sides should resolve to the same library asset.
+    for link_name in ("left_upper_arm", "right_upper_arm"):
+        geom = _link_visual(root, link_name)
+        assert geom is not None, f"missing visual for {link_name}"
+        mesh = geom.find("mesh")
+        assert mesh is not None, f"{link_name} visual is not a mesh"
+        assert "upper_arm.stl" in mesh.get("filename", "")
+
+
+def test_no_shape_library_keeps_legacy_payload() -> None:
+    config = URDFGeneratorConfig(shape_library=None, generate_collision=False)
+    generator = HumanoidURDFGenerator(config)
+    urdf_xml = generator.generate(BodyParameters())
+    root = ET.fromstring(_strip_xml_declaration(urdf_xml))
+
+    # Without a library the existing behaviour should be untouched: the
+    # head segment uses a primitive (sphere) per the legacy mapping.
+    head_geom = _link_visual(root, "head")
+    assert head_geom is not None
+    # Either sphere (legacy) or another primitive — just assert no mesh.
+    assert head_geom.find("mesh") is None
+
+
+def test_segments_without_library_entry_fall_back() -> None:
+    library = ShapeLibrary.default()
+    config = URDFGeneratorConfig(shape_library=library, generate_collision=False)
+    generator = HumanoidURDFGenerator(config)
+    urdf_xml = generator.generate(BodyParameters())
+    root = ET.fromstring(_strip_xml_declaration(urdf_xml))
+
+    # The bundled library doesn't have a "pelvis" entry; the link must
+    # still exist with a non-mesh primitive payload.
+    pelvis_geom = _link_visual(root, "pelvis")
+    assert pelvis_geom is not None
+    assert pelvis_geom.find("mesh") is None


### PR DESCRIPTION
## Summary
- New `src/shared/python/body_part_viz/urdf_bridge.py` translates body_part_viz shapes to/from URDF `<visual>` elements (Cylinder, Ellipsoid, Capsule, Mesh, Composite; Line raises `ValueError`).
- `URDFGeneratorConfig.shape_library` lets `ShapeLibrary.default()` drive humanoid link visuals; `urdf_geometry.create_geometry_dict` becomes a thin wrapper over `shape_to_urdf_visual` for the cylinder path.
- Round-trip preserves shape identity within numerical tolerance (1e-9 for cylinder; full-precision float repr for mesh-encoded ellipsoid/capsule dimensions).

Closes #4765. Part of EPIC #4755 (Wave 4).

## Test plan
- [x] `python3 -m pytest tests/unit/body_part_viz/test_urdf_bridge.py` — 27 tests, 94.29% line+branch coverage on `urdf_bridge.py`.
- [x] `python3 -m pytest tests/unit/tools/humanoid_character_builder/` — 277 passed (includes 3 new shape-library integration tests).
- [x] `python3 -m pytest tests/unit/body_part_viz/` — 298 passed.
- [x] `python3 -m ruff check` and `python3 -m ruff format --check` clean on touched files.
- [x] `python3 scripts/ci/check_file_size_budget.py` clean.

## Drive-by
Repaired the interleaved import + try/except blocks in `generators/mesh_generator.py` (introduced by PR #4690) that prevented the entire `humanoid_character_builder` package from importing. The breakage was masked because CI was skipping the test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)