### PR TITLE
docs(body-part-viz): ADR + user guide (#4768)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,32 @@ the modules most often missed.
     plot_cartesian_delta_summary, summarize_for_pr_comment}` —
     input-MAT requested-vs-resolved diagnostics.
 
+### Body-part visualisation toolkit
+`src/shared/python/body_part_viz/`
+- `body_part_viz` package with shapes / fitters / renderers / asset
+  library — the **canonical shape stack** for any tool that draws body
+  segments.  See [ADR 0008](docs/adr/0008-body-part-viz-toolkit.md).
+- `BodyPartShape`, `ShapeFitter`, `ShapeRenderer` — runtime-checkable
+  Protocols.  Implementations live under `shapes/`, `fitters/`,
+  `renderers/`.
+- `MatplotlibRenderer` — **canonical 3D renderer for any new tool that
+  needs marker / mesh rendering.**  A `PyQtGLRenderer` ships alongside
+  for tools that need GPU-rate redraws; both implement the same
+  `ShapeRenderer` Protocol.
+- `default_body_segments` (in `motion_matching/`) — canonical full-body
+  segment label set; pair with this toolkit to drive segment lists in
+  the C3D Viewer, the matcher, and the URDF generator.
+- `SegmentVizSet` / `SegmentVizSpec` — JSON v2 persistence with
+  auto-migration from the legacy v1 `SegmentSet`.
+- `ShapeLibrary` — bundled mesh resolver under
+  `assets/body_part_shapes/default/`; named shapes (head, torso,
+  upper_arm, …) are available from a fresh install.
+- `urdf_bridge.shape_to_urdf_visual` — re-use the same shape vocabulary
+  as URDF visual elements; a custom mesh imported in the C3D Viewer is
+  re-usable as a URDF visual link without re-modelling.
+- See `docs/user_guide/body_part_viz/` for end-user workflow guides
+  and `docs/api/body_part_viz.md` for the full API surface.
+
 ### Pose editor (interactive joint-angle UI)
 `src/shared/python/pose_editor/`
 - `core.{JointType, JointInfo, PoseEditorState}` — joint metadata

--- a/docs/adr/0008-body-part-viz-toolkit.md
+++ b/docs/adr/0008-body-part-viz-toolkit.md
@@ -1,0 +1,210 @@
+# ADR 0008: Body-Part Visualisation Toolkit
+
+- Status: Accepted
+- Date: 2026-05-08
+- Related issues: #4755 (epic), #4768 (this docs pass)
+
+## Context
+
+The motion-matching pipeline ([ADR 0006](0006-multi-source-motion-targets.md))
+already accepts full-body capture targets and runs forward-kinematic
+predictions against them, but the rendering surface lagged behind the
+data surface. Body segments could only be drawn as lines or as fixed
+cylinders, and three different tools each grew their own ad-hoc
+geometry stack:
+
+- The C3D Viewer's Segments tab built per-frame line segments inline,
+  with hard-coded radii and colour groups in `segments_tab.py`.
+- The starting-pose matcher used a parallel "draw cylinder between two
+  markers" helper that was a sibling re-implementation of the viewer's,
+  not a shared call.
+- The humanoid character builder generated URDF visuals from yet
+  another set of geometry primitives that did not know about the
+  viewer's segment styling at all.
+
+That meant a user who imported a custom forearm mesh into the C3D
+Viewer could not re-use it as a URDF visual link without remodelling,
+and the matcher's "preview" pose could not match what the viewer
+actually drew. Three implementations of what is conceptually the same
+shape vocabulary had drifted, and every change to one had to be
+manually mirrored to the other two.
+
+A separate forcing function was extensibility. Adding capsule or
+ellipsoid shapes — which the matcher needs for limb visualisation that
+is closer to anatomy than a uniform-radius cylinder — would have meant
+touching all three call sites, plus the segment-set persistence layer,
+plus the URDF generator. The ad-hoc shape stacks made each addition
+cost more than the last.
+
+## Decision
+
+Ship `src/shared/python/body_part_viz/` as the canonical shape stack
+for every tool that draws body segments. The package defines three
+runtime-checkable Protocols (`BodyPartShape`, `ShapeFitter`,
+`ShapeRenderer`) and ships concrete implementations of each, plus an
+asset library of bundled default meshes:
+
+- **Shapes**: `LineShape`, `CylinderShape`, `EllipsoidShape`,
+  `CapsuleShape`, `MeshShape`, `CompositeShape`. Each reports its
+  rest-pose vertices / faces and applies a fitted transform.
+- **Fitters**: `BetweenTwoMarkersFitter`, `ClusterKabschFitter`,
+  `ProcrustesAnisotropicFitter`. Each computes a per-frame
+  `FittedShape` (centroid, rotation, scale, valid mask) from a
+  `MarkerBinding` and a dict of marker trajectories.
+- **Renderers**: `MatplotlibRenderer` is the canonical 3D backend;
+  a `PyQtGLRenderer` ships alongside for tools that need GPU-rate
+  redraws. Both implement the same `ShapeRenderer` Protocol so the
+  same shape / fitter pair targets either backend.
+- **Persistence**: `SegmentVizSet` / `SegmentVizSpec` define a JSON v2
+  schema that round-trips bindings, shape kinds, fitter kinds, and
+  themes. A `migrate_v1_to_v2` helper lifts the legacy `SegmentSet`
+  shape used by the C3D Viewer into v2 on load.
+- **URDF bridge**: `urdf_bridge.shape_to_urdf` / `urdf_to_shape` map
+  the same shape vocabulary onto URDF `<visual>` elements, so a mesh
+  imported into the Segments tab can be re-used as a URDF visual link
+  without re-modelling.
+- **Asset library**: `ShapeLibrary` resolves named shapes (head,
+  torso, upper_arm, …) to `MeshShape` instances backed by bundled
+  procedural STL meshes under `assets/body_part_shapes/default/`.
+
+The C3D Viewer's Segments tab, the starting-pose matcher, and the
+humanoid character builder all consume `body_part_viz` directly —
+there is no per-tool re-implementation left.
+
+### Generic-naming policy
+
+The naming policy carries forward unchanged from
+[ADR 0006](0006-multi-source-motion-targets.md):
+
+- File-on-disk names (vendor-specific xlsx workbooks, named C3D
+  files, the bundled STL meshes) remain whatever the source publishes
+  them as.
+- Everything in code, directories, and UI stays source-agnostic:
+  `BodyPartShape` not `GolferBodyShape`, `ShapeLibrary` not
+  `<vendor>_meshes`, `default_body_segments` not `<sport>_segments`.
+- This keeps the public surface stable when the same toolkit is used
+  for non-golf full-body captures (gait, climbing, generic
+  biomechanics).
+
+## Alternatives Considered
+
+### A. Extend the C3D Viewer's segment-tab geometry directly
+
+Keep the geometry stack inside `segments_tab.py` and grow it with
+new shape kinds in place. Other tools would either copy the helpers
+across or import from inside the viewer package.
+
+Rejected. The C3D Viewer is a desktop tool, not a shared library; its
+import surface pulls in PyQt6, matplotlib, and the viewer's
+configuration loaders. Forcing the URDF generator (a headless,
+test-friendly module) to depend on a Qt application root to draw a
+cylinder is the wrong direction. The viewer's segment-tab code was
+also already over the file-size budget when the epic started.
+
+### B. Per-tool implementation
+
+Let each tool keep its own shape stack, with a shared "spec" file
+listing the conventional dimensions and colours so the three
+implementations can converge by hand-coordination.
+
+Rejected. The three implementations had already drifted before the
+epic — that is the situation the epic exists to fix. A spec without
+an enforcement mechanism is the same trap repeated. DRY violations
+across tools are exactly the case AGENTS.md section A is meant to
+catch.
+
+### C. Reach for an external library
+
+Reuse one of the existing biomechanics-visualisation packages
+(`OpenSim`'s GUI, `meshcat`, the URDF visualiser inside `pinocchio`)
+in place of writing our own.
+
+Rejected. None of the candidates ship the combination we need: per-
+shape rest dimensions, anisotropic Procrustes fitting against mocap
+markers, JSON-roundtrippable segment sets, AND a URDF bridge that
+preserves the same shape kinds. We would still have written the
+fitters and the persistence layer; the renderer is a thin enough
+matplotlib wrapper that adopting an external dependency to avoid it
+costs more than it saves.
+
+## Consequences
+
+### Positive
+
+- Cross-tool consistency: the C3D Viewer, the matcher, and the URDF
+  generator share one source of truth for what a body segment looks
+  like.
+- Mesh import: a custom STL / OBJ / PLY / GLB imported in the Segments
+  tab is automatically usable as a URDF visual link.
+- Extensibility: adding a new shape kind means adding one module under
+  `shapes/` plus an entry in `VALID_SHAPE_KINDS`; no tool has to
+  change.
+- The `MatplotlibRenderer` becomes the canonical 3D rendering helper
+  for any new tool; tools that need GPU-rate redraws can drop in
+  `PyQtGLRenderer` without changing the shape or fitter code.
+
+### Negative
+
+- One extra package between the tools and matplotlib. Small in
+  practice — the package is pure Python with numpy + matplotlib
+  imports — but it is still a layer.
+- The URDF bridge encodes ellipsoid and capsule shapes as logical
+  mesh filenames (`__bpv_ellipsoid__a_b_c.obj`,
+  `__bpv_capsule__length_radius.obj`) because URDF has no native
+  capsule and only an isotropic-scale sphere. The convention is
+  documented in `urdf_bridge.py`, but it is a convention, not a
+  format.
+
+## Validation Strategy
+
+- Every public dataclass (`MarkerBinding`, `FittedShape`, `ShapeTheme`,
+  `SegmentVizSpec`, `SegmentVizSet`) runs post-init validation. Frozen
+  + validated is the design contract; cost terms and renderers can
+  trust the shape of what they receive.
+- The Protocols are `@runtime_checkable` so tests can assert that a
+  newly added shape / fitter / renderer satisfies the contract before
+  the type checker sees it.
+- Cross-tool integration tests pin the contract: a fixture builds a
+  `SegmentVizSet`, round-trips it through JSON, runs it through the
+  fitters, renders it via `MatplotlibRenderer`, and exports it to URDF
+  via `urdf_bridge`. Any divergence between tools surfaces as a
+  test failure, not as a runtime UI bug.
+- The asset library validates the manifest schema version and the
+  per-shape entries on load; an unknown schema version raises
+  `ValueError` with the supported set.
+
+## Migration
+
+- The legacy `SegmentSet` v1 JSON shape used by the C3D Viewer is
+  auto-migrated by `SegmentVizSet.from_dict` / `migrate_v1_to_v2`. No
+  on-disk format change is forced on existing users; saving always
+  writes v2.
+- Tools that previously inlined matplotlib geometry now construct a
+  `SegmentVizSet`, instantiate a `MatplotlibRenderer`, and add each
+  fitted shape via `add_shape`. The shim retains the same external
+  API (file open, segment list, frame slider) so user-visible
+  behaviour is unchanged apart from the new shape options.
+- The URDF generator path is opt-in: existing URDF outputs are
+  byte-stable until the caller flips to `shape_to_urdf` for visuals.
+
+## References
+
+- `src/shared/python/body_part_viz/` — the package itself.
+- `src/shared/python/body_part_viz/contracts.py` — the three Protocols.
+- `src/shared/python/body_part_viz/persistence.py` — JSON v2 schema +
+  v1 migration.
+- `src/shared/python/body_part_viz/asset_library.py` — bundled mesh
+  resolver.
+- `src/shared/python/body_part_viz/urdf_bridge.py` — shape-to-URDF
+  mapping.
+- `assets/body_part_shapes/default/` — bundled procedural STL meshes
+  + manifest + LICENSES.
+- `docs/user_guide/body_part_viz/quickstart.md` — companion user guide.
+- `docs/user_guide/body_part_viz/mesh_import.md` — custom-mesh import
+  guide.
+- `docs/user_guide/body_part_viz/asset_author_guide.md` — guide for
+  adding new shapes to the default library.
+- `docs/api/body_part_viz.md` — public API reference.
+- [ADR 0006 — Multi-Source Motion Targets](0006-multi-source-motion-targets.md)
+  — predecessor decision that introduced `BodyTarget` and
+  `default_body_segments`, on which this toolkit builds.

--- a/docs/api/body_part_viz.md
+++ b/docs/api/body_part_viz.md
@@ -1,0 +1,299 @@
+# `body_part_viz` — API Reference
+
+Public API surface of the `body_part_viz` toolkit. Hand-curated index;
+the docstrings on each symbol in `src/shared/python/body_part_viz/` are
+the authoritative reference.
+
+The toolkit has no Sphinx / pdoc auto-build configured in
+`pyproject.toml`; if a doc-build pipeline is added later, this file
+should be regenerated from the docstrings rather than maintained by
+hand.
+
+For design rationale see
+[ADR 0008](../adr/0008-body-part-viz-toolkit.md). For end-user
+workflows see [`docs/user_guide/body_part_viz/`](../user_guide/body_part_viz/quickstart.md).
+
+## Top-level package
+
+`src/shared/python/body_part_viz/__init__.py` re-exports the public
+surface:
+
+| Symbol | Kind | Source module |
+| --- | --- | --- |
+| `SCHEMA_VERSION` | `int` constant (currently `2`) | `persistence` |
+| `VALID_SHAPE_KINDS` | tuple of valid `shape_kind` strings | `persistence` |
+| `VALID_FITTER_KINDS` | tuple of valid `fitter_kind` strings | `persistence` |
+| `BindingKind` | `str`-enum (`BETWEEN_TWO`, `CLUSTER`, `ON_MARKER`) | `bindings` |
+| `BodyPartShape` | runtime-checkable Protocol | `contracts` |
+| `FittedShape` | frozen dataclass | `_types` |
+| `MarkerBinding` | frozen dataclass | `bindings` |
+| `SegmentVizSet` | frozen dataclass | `persistence` |
+| `SegmentVizSpec` | frozen dataclass | `persistence` |
+| `ShapeFitter` | runtime-checkable Protocol | `contracts` |
+| `ShapeRenderer` | runtime-checkable Protocol | `contracts` |
+| `ShapeTheme` | frozen dataclass | `theme` |
+| `migrate_v1_to_v2` | function | `persistence` |
+
+## Contracts (`body_part_viz.contracts`)
+
+Three runtime-checkable Protocols. Implementations live under the
+`shapes/`, `fitters/`, and `renderers/` sub-packages.
+
+### `BodyPartShape`
+
+```python
+class BodyPartShape(Protocol):
+    shape_id: str
+    rest_dimensions: tuple[float, ...]
+
+    def vertices_at_rest(self) -> np.ndarray: ...
+    def faces(self) -> np.ndarray: ...
+    def transform(self, fitted: FittedShape) -> np.ndarray: ...
+```
+
+A geometric body-part visualisation. Implementations expose rest-pose
+vertices / faces and apply a `FittedShape` transform per frame.
+
+### `ShapeFitter`
+
+```python
+class ShapeFitter(Protocol):
+    def fit(
+        self,
+        shape: BodyPartShape,
+        binding: MarkerBinding,
+        markers_xyz: dict[str, np.ndarray],
+    ) -> FittedShape: ...
+```
+
+Computes a per-frame `FittedShape` from a marker dictionary.
+
+### `ShapeRenderer`
+
+```python
+class ShapeRenderer(Protocol):
+    def add_shape(
+        self,
+        shape: BodyPartShape,
+        fitted: FittedShape,
+        theme: ShapeTheme,
+    ) -> str: ...
+    def update_frame(self, handle: str, frame_idx: int) -> None: ...
+    def set_visible(self, handle: str, visible: bool) -> None: ...
+    def remove(self, handle: str) -> None: ...
+```
+
+Backend-specific renderer. The contract is intentionally Qt- and
+matplotlib-free so the same shape / fitter pair targets any backend.
+
+## Dataclasses
+
+### `FittedShape` (`body_part_viz._types`)
+
+Frozen dataclass; per-frame placement output of any `ShapeFitter`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `shape_id` | `str` | Stable, non-empty identifier. |
+| `binding` | `MarkerBinding` | The binding used for this fit. |
+| `centroid` | `np.ndarray` shape `(T, 3)` | World-frame centroid per frame. |
+| `rotation_matrix` | `np.ndarray` shape `(T, 3, 3)` | Per-frame rotation. |
+| `scale` | `np.ndarray` shape `(T, 3)` | Anisotropic scale, strictly positive on valid frames. |
+| `valid_mask` | `np.ndarray` shape `(T,)`, dtype bool | Per-frame validity. |
+
+`__post_init__` validates shapes, dtypes, and per-frame finiteness on
+valid frames.
+
+### `MarkerBinding` (`body_part_viz.bindings`)
+
+Frozen dataclass; rest-pose binding of a shape to one or more markers.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `kind` | `BindingKind` | `BETWEEN_TWO`, `CLUSTER`, or `ON_MARKER`. |
+| `marker_names` | `tuple[str, ...]` | Length depends on `kind` (2, ≥3, or 1). |
+| `rest_dimensions` | `tuple[float, ...]` | Optional; entries strictly positive. |
+| `rest_orientation_quat` | `(w, x, y, z)` tuple | Unit quaternion within `1e-6`. |
+
+`__post_init__` enforces the per-kind marker count, finiteness +
+positivity of `rest_dimensions`, and unit-norm of the quaternion.
+
+### `ShapeTheme` (`body_part_viz.theme`)
+
+Frozen dataclass; visual styling for a shape. All colour strings
+validated via matplotlib's `is_color_like`.
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `color` | `str` | `"#1f77b4"` | Any matplotlib-recognised colour. |
+| `opacity` | `float` | `0.8` | In `[0, 1]`. |
+| `edge_color` | `str` | `"#000000"` | Any matplotlib-recognised colour. |
+| `edge_width` | `float` | `0.5` | Non-negative, in points. |
+| `flat_shaded` | `bool` | `True` | Per-face vs. smooth shading. |
+| `group` | `str` | `"default"` | Logical palette group. |
+
+### `BindingKind` (`body_part_viz.bindings`)
+
+`str`-valued enum:
+
+| Member | Value | Marker count |
+| --- | --- | --- |
+| `BETWEEN_TWO` | `"between_two"` | exactly 2 |
+| `CLUSTER` | `"cluster"` | ≥ 3 |
+| `ON_MARKER` | `"on_marker"` | exactly 1 |
+
+## Shapes (`body_part_viz.shapes`)
+
+Concrete `BodyPartShape` implementations, each in its own module.
+
+| Class | Module | Description |
+| --- | --- | --- |
+| `LineShape` | `line_shape` | Zero-volume line between two markers. |
+| `CylinderShape` | `cylinder_shape` | Radius + length along local Z. |
+| `EllipsoidShape` | `ellipsoid_shape` | Three semi-axes `(a, b, c)`. |
+| `CapsuleShape` | `capsule_shape` | Cylinder + hemispherical caps. |
+| `MeshShape` | `mesh_shape` | Triangle mesh from STL/OBJ/PLY/GLB. |
+| `CompositeShape` | `composite_shape` | Composition of child shapes. |
+
+`MeshShape` exposes a `MeshShape.load(path, max_vertices=5000)`
+classmethod that reads a file via `trimesh`, re-centres on OBB
+centroid, and decimates to the vertex budget.
+
+## Fitters (`body_part_viz.fitters`)
+
+Concrete `ShapeFitter` strategies.
+
+| Class | Module | Best for |
+| --- | --- | --- |
+| `BetweenTwoMarkersFitter` | `between_two` | Limbs (e.g. forearm between elbow + wrist). |
+| `ClusterKabschFitter` | `cluster_kabsch` | Rigid segments with a marker cluster (e.g. torso). |
+| `ProcrustesAnisotropicFitter` | `procrustes_anisotropic` | Cluster fit with per-axis scale. |
+
+## Renderers (`body_part_viz.renderers`)
+
+Concrete `ShapeRenderer` backends.
+
+| Class | Module | Notes |
+| --- | --- | --- |
+| `MatplotlibRenderer` | `matplotlib_renderer` | Canonical 3D backend; suitable for ≲ 5 000 triangles per segment. |
+| `PyQtGLRenderer` | `pyqtgl_renderer` | GPU-accelerated alternative for high-poly scenes; same Protocol. |
+
+`MatplotlibRenderer` is the canonical 3D rendering helper for any new
+tool that needs marker / mesh rendering — see AGENTS.md section B.
+
+## Persistence (`body_part_viz.persistence`)
+
+JSON v2 schema for saving / loading segment-viz configurations.
+
+### `SegmentVizSpec`
+
+Frozen dataclass; one segment's full spec.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `binding` | `MarkerBinding` | How the shape attaches to markers. |
+| `shape_kind` | `str` | One of `VALID_SHAPE_KINDS`. |
+| `shape_params` | `dict[str, Any]` | Validated per-`shape_kind`. |
+| `fitter_kind` | `str` | One of `VALID_FITTER_KINDS`. |
+| `theme` | `ShapeTheme` | Visual styling. |
+| `visible` | `bool` | Whether the segment is rendered. |
+
+Constructors: `SegmentVizSpec.from_dict(data)`. Serialisation:
+`spec.to_dict()`. Numerics are rounded to `1e-9` for stable JSON
+round-trip.
+
+### `SegmentVizSet`
+
+Frozen dataclass; schema-versioned collection.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `int` | Always `SCHEMA_VERSION` (currently `2`). |
+| `segments` | `tuple[SegmentVizSpec, ...]` | Ordered. |
+
+Methods:
+
+- `SegmentVizSet.from_dict(payload)` — parse a JSON-loaded dict;
+  auto-migrates v1.
+- `SegmentVizSet.load(path)` — read JSON file; auto-migrates v1.
+- `viz_set.to_dict()` — serialise to JSON-ready dict (always v2).
+- `viz_set.save(path)` — write JSON v2 file.
+
+### `migrate_v1_to_v2(v1_dict) -> dict`
+
+Lift a legacy v1 `SegmentSet` payload (the pre-toolkit C3D Viewer
+format) into a v2 dict. Maps `(a, b)` markers to a `between_two`
+binding, `geometry` to `shape_kind`, and carries forward the legacy
+`group` / `visible` / `radius` fields.
+
+## Asset library (`body_part_viz.asset_library`)
+
+### `ShapeLibrary`
+
+Resolves named body-part shapes to `MeshShape` instances backed by a
+manifest-described asset directory.
+
+```python
+from src.shared.python.body_part_viz.asset_library import ShapeLibrary
+
+lib = ShapeLibrary.default()           # bundled assets/body_part_shapes/default
+head_mesh = lib.get("head")            # cached MeshShape
+binding = lib.binding_template("head") # MarkerBinding from manifest
+names = lib.names()                    # tuple of available shape names
+```
+
+Constructors:
+
+- `ShapeLibrary()` — load the bundled default library.
+- `ShapeLibrary(asset_root)` — load any directory that follows the
+  `manifest.json` schema documented in
+  [`asset_author_guide.md`](../user_guide/body_part_viz/asset_author_guide.md).
+- `ShapeLibrary.default()` — class method, equivalent to `ShapeLibrary()`.
+
+Methods:
+
+- `names() -> tuple[str, ...]` — manifest shape names in insertion order.
+- `get(name) -> MeshShape` — load (and cache) the named mesh.
+- `binding_template(name) -> MarkerBinding` — return the manifest's
+  binding template.
+
+## URDF bridge (`body_part_viz.urdf_bridge`)
+
+Forward and inverse mapping between `BodyPartShape` and URDF
+`<visual>` elements.
+
+| Symbol | Kind | Notes |
+| --- | --- | --- |
+| `DEFAULT_PACKAGE` | `str` constant | Default `package://` prefix (`"body_part_viz"`). |
+| `shape_to_urdf_visual(shape, *, rest_origin_xyz=…, rest_origin_rpy=…, package_name=…)` | function | Returns an `xml.etree.ElementTree.Element` (`<visual>`) or a list of them for `CompositeShape`. |
+| `urdf_to_shape(visual)` | function | Inverse mapping; recovers the original shape within `1e-9` for supported kinds. |
+
+Mapping (forward):
+
+| Shape | URDF |
+| --- | --- |
+| `LineShape` | `ValueError` (URDF cannot render lines) |
+| `CylinderShape` | `<cylinder length=L radius=R>` |
+| `EllipsoidShape` | `<mesh filename="package://body_part_viz/__bpv_ellipsoid__a_b_c.obj">` |
+| `CapsuleShape` | `<mesh filename="package://body_part_viz/__bpv_capsule__length_radius.obj">` |
+| `MeshShape` | `<mesh filename="package://body_part_viz/<stem>.<ext>">` |
+| `CompositeShape` | `list[Element]` (caller wraps in `<link>`) |
+
+The `__bpv_ellipsoid__` / `__bpv_capsule__` filename conventions
+encode the geometry in the filename because URDF has no native
+capsule and only an isotropic-scale sphere; `urdf_to_shape` decodes
+them.
+
+## Tests
+
+Reference tests live under `tests/unit/body_part_viz/` mirroring the
+source layout. Useful entry points for adding new tests:
+
+- `test_imports.py` — smoke test that the public surface re-exports
+  cleanly.
+- `test_contracts.py` — Protocol satisfaction tests; copy the pattern
+  when adding a new shape / fitter / renderer.
+- `test_persistence.py` — JSON round-trip and v1→v2 migration tests.
+- `test_asset_library.py` — manifest validation; mirror this when
+  adding library entries.
+- `test_urdf_bridge.py` — forward / inverse URDF mapping tests.

--- a/docs/motion_matching/README.md
+++ b/docs/motion_matching/README.md
@@ -12,6 +12,10 @@ preview tool.
   Decision record for the `ClubTarget` / `ClubBallTarget` / `BodyTarget`
   + `MultiSourceTarget` aggregator surface and the format-agnostic
   loader dispatchers.
+- [ADR 0008 — Body-Part Visualisation Toolkit](../adr/0008-body-part-viz-toolkit.md)
+  Decision record for the shared `body_part_viz` package that backs
+  the C3D Viewer's Segments tab, the starting-pose matcher, and the
+  URDF generator with one shape / fitter / renderer stack.
 
 ### Specifications
 
@@ -30,6 +34,20 @@ preview tool.
 - [Loading Motion Targets](../user_guide/motion_matching/loading_targets.md)
   How to load club, ball-aware, and full-body targets from xlsx,
   `.mat`, and `.c3d` sources, including a worked example.
+- [Body-Part Viz — Quickstart](../user_guide/body_part_viz/quickstart.md)
+  Load a C3D, open the Segments tab, swap a line for a library shape,
+  save.
+- [Body-Part Viz — Custom Mesh Import](../user_guide/body_part_viz/mesh_import.md)
+  Bring in a custom STL / OBJ / PLY / GLB; sizing, rest-pose fitting,
+  performance considerations.
+- [Body-Part Viz — Asset Author Guide](../user_guide/body_part_viz/asset_author_guide.md)
+  Add a new shape to the bundled default library; manifest schema and
+  procedural-generation script.
+
+### API reference
+
+- [`body_part_viz`](../api/body_part_viz.md) — public API surface for
+  the shared shape / fitter / renderer toolkit.
 
 ### Related guides
 

--- a/docs/user_guide/body_part_viz/asset_author_guide.md
+++ b/docs/user_guide/body_part_viz/asset_author_guide.md
@@ -1,0 +1,224 @@
+# Body-Part Viz — Asset Author Guide
+
+This guide is for contributors adding a new shape to the bundled
+default library, not end users picking shapes per capture. If you
+want to bring in a one-off custom mesh for your own use, see
+[`mesh_import.md`](mesh_import.md).
+
+The default library lives at `assets/body_part_shapes/default/` and
+is exposed through `body_part_viz.asset_library.ShapeLibrary`. Adding
+a shape here means it shows up in every C3D Viewer install, every
+matcher session, and every URDF generator output without the user
+having to import a file.
+
+## Layout of the default library
+
+```
+assets/body_part_shapes/default/
+├── _generate.py          # procedural mesh generator (deterministic)
+├── manifest.json         # schema-versioned shape index
+├── LICENSES.md           # per-file attribution
+├── head.stl
+├── torso.stl
+├── upper_arm.stl
+├── forearm.stl
+├── hand.stl
+├── thigh.stl
+├── shin.stl
+└── foot.stl
+```
+
+Three files are authoritative:
+
+1. **`manifest.json`** — the schema-versioned index. Every shape the
+   library exposes appears here.
+2. **`_generate.py`** — the procedural script that produces the
+   bundled STL meshes. Determinism is enforced via a fixed RNG seed
+   so re-runs are byte-stable on a given trimesh version.
+3. **`LICENSES.md`** — per-file attribution. Every entry in the
+   manifest must have a corresponding line in LICENSES.md naming the
+   licence and source.
+
+The STL files themselves are regenerated artefacts: editing them by
+hand is allowed for one-off tweaks, but the canonical source is
+`_generate.py`.
+
+## Manifest schema
+
+`manifest.json` is a JSON document keyed by shape name:
+
+```json
+{
+  "schema_version": 1,
+  "shapes": {
+    "<shape_name>": {
+      "file": "<filename.stl>",
+      "rest_dimensions": [<dx>, <dy>, <dz>],
+      "binding_template": {
+        "kind": "between_two | cluster | on_marker",
+        "marker_names": ["MARKER1", "MARKER2", "..."],
+        "rest_orientation_quat": [w, x, y, z]
+      },
+      "license": "<SPDX identifier>",
+      "source": "<short provenance string>"
+    }
+  }
+}
+```
+
+Every field is required. The loader (`ShapeLibrary.__init__`)
+validates `schema_version`, refuses unknown versions, and walks the
+`shapes` map; missing fields raise `ValueError` with the missing
+keys listed.
+
+### Field details
+
+- **`file`** — relative path under the library directory. Must point
+  to a file `trimesh` can load (`.stl`, `.obj`, `.ply`, `.glb`).
+- **`rest_dimensions`** — the OBB extents in metres, in the same
+  axis order as the mesh's local frame. The loader cross-checks these
+  against the loaded mesh; large drift triggers a load-time warning.
+- **`binding_template.kind`** — must match `BindingKind`:
+  `between_two` (exactly 2 markers), `cluster` (≥ 3 markers), or
+  `on_marker` (exactly 1 marker). The dataclass post-init validator
+  enforces the count.
+- **`binding_template.marker_names`** — names from the canonical
+  marker set returned by `default_body_segments`. Names that are not
+  in the canonical set are loadable, but a tool that auto-detects
+  bindings from a live capture will skip the shape.
+- **`binding_template.rest_orientation_quat`** — unit quaternion
+  (w, x, y, z). Identity is `[1.0, 0.0, 0.0, 0.0]`. The loader
+  enforces unit norm to within `1e-6`.
+- **`license`** — SPDX identifier. The bundled defaults are all
+  `CC0-1.0`. If you ship a non-CC0 mesh, see "Licensing" below.
+- **`source`** — short string. For procedural meshes use
+  `procedural-low-poly` (matches the existing entries). For meshes
+  drawn from external datasets, name the dataset.
+
+## Adding a procedural shape
+
+This is the recommended path for any anatomical shape that does not
+require captured data. Procedural shapes are CC0, deterministic, and
+regeneratable from source.
+
+1. **Edit `_generate.py`.** Add a `_build_<name>` function that
+   returns a `trimesh.Trimesh` sized in metres:
+
+   ```python
+   def _build_pelvis() -> trimesh.Trimesh:
+       return trimesh.creation.box(extents=(0.30, 0.20, 0.18))
+   ```
+
+   Stay with primitives from `trimesh.creation` (`box`, `cylinder`,
+   `icosphere`) so the output stays public-domain. The `_ellipsoid`
+   helper is a convenient wrapper around scaled icospheres.
+
+2. **Register it in the builder list.** Add `("pelvis",
+   _build_pelvis)` to the iteration list at the bottom of the file.
+   The script writes `<name>.stl` for each entry; the order does
+   not matter.
+
+3. **Run the generator.** From the asset directory:
+
+   ```bash
+   cd assets/body_part_shapes/default
+   python3 _generate.py
+   ```
+
+   The script is deterministic (`numpy.random.default_rng(42)`) and
+   decimates to ≤ 5 000 triangles. Re-runs on the same trimesh
+   version produce byte-identical STL output.
+
+4. **Add an entry to `manifest.json`** with the rest dimensions
+   from the generator (the script prints them after each write) and
+   a binding template that names markers from the canonical set.
+
+5. **Add an entry to `LICENSES.md`** under the table:
+
+   ```markdown
+   | `pelvis.stl` | CC0-1.0 | procedural-low-poly (box) |
+   ```
+
+6. **Add a unit test.** A new entry deserves a smoke test under
+   `tests/unit/body_part_viz/test_asset_library.py` that asserts
+   `ShapeLibrary.default().get("pelvis")` returns a non-empty
+   `MeshShape` whose `rest_dimensions` match the manifest within
+   `1e-9`.
+
+7. **Open the PR.** Reference the EPIC (#4755) and link the test.
+
+## Adding an externally sourced shape
+
+If you need anatomical fidelity beyond what `trimesh.creation`
+primitives can produce — for instance an actual scanned forearm with
+muscle bumps — the path is the same except for two things:
+
+1. **The file is not regenerated.** Drop the source mesh into the
+   library directory (re-centred on its OBB centroid, in metres,
+   with a sane axis convention; see [`mesh_import.md`](mesh_import.md)
+   for what the loader does with it). It is now a tracked binary
+   asset and any future change requires the same explicit pipeline.
+
+2. **Licensing must allow redistribution.** The default library is
+   bundled with the repo under MIT (the umbrella project licence).
+   A shape under a more restrictive licence (e.g. CC-BY-NC,
+   CC-BY-SA, or anything with a "no derivatives" clause) is **not
+   acceptable** — it would make the entire repo non-redistributable.
+   CC0, CC-BY (with attribution noted in `LICENSES.md`), and explicit
+   MIT/Apache-2.0 grants are fine.
+
+Add the file, then follow steps 4-7 from "Adding a procedural
+shape" above. The `LICENSES.md` line should name the upstream
+dataset and the licence:
+
+```markdown
+| `forearm_scan.stl` | CC-BY-4.0 | <Dataset Name> (https://...) |
+```
+
+## Licensing
+
+The repo ships under MIT (see `LICENSE` in the repo root). Asset
+licences must be compatible with redistribution.
+
+| OK | Notes |
+| --- | --- |
+| CC0-1.0 | Recommended for procedural shapes. |
+| MIT, Apache-2.0, BSD-2/3 | Fine; note attribution in `LICENSES.md`. |
+| CC-BY-4.0 | Fine; note attribution in `LICENSES.md`. |
+| Public domain | Fine. |
+
+| Not OK | Why |
+| --- | --- |
+| CC-BY-NC-* | Forbids commercial use; we cannot guarantee that. |
+| CC-BY-ND | Forbids derivatives, including the OBB re-centring + decimation. |
+| GPL / AGPL | Viral; would force the entire repo to that licence. |
+| "Free for personal use" | Not a real licence. |
+
+If you are not sure, ask in the PR.
+
+## Procedural-generation script reference
+
+`assets/body_part_shapes/default/_generate.py` is the canonical
+reference for what good procedural shapes look like. Highlights:
+
+- All builders return `trimesh.Trimesh` in metres.
+- The `_ellipsoid(a, b, c)` helper produces a unit icosphere scaled
+  to the given semi-axes; use it instead of hand-rolling spheres.
+- `_decimate(mesh, max_triangles)` clamps triangle count via
+  `trimesh.simplify_quadric_decimation`. The library budget is
+  5 000 triangles per shape; lowering it for individual shapes is
+  fine if you never need the silhouette resolution.
+- The script writes `<name>.stl` next to itself and prints the OBB
+  extents — copy those into the manifest.
+- The RNG (`numpy.random.default_rng(42)`) is fixed per process so
+  any shape that uses random sampling (none currently do) stays
+  deterministic across runs.
+
+## Where to next
+
+- [ADR 0008](../../adr/0008-body-part-viz-toolkit.md) — design rationale
+  for the toolkit and the asset-library boundary.
+- [`docs/api/body_part_viz.md`](../../api/body_part_viz.md) — the
+  `ShapeLibrary` public API.
+- `tests/unit/body_part_viz/test_asset_library.py` — the existing
+  smoke tests that any new entry should mirror.

--- a/docs/user_guide/body_part_viz/mesh_import.md
+++ b/docs/user_guide/body_part_viz/mesh_import.md
@@ -1,0 +1,153 @@
+# Body-Part Viz — Custom Mesh Import
+
+This guide covers bringing your own triangle mesh into the toolkit:
+which file formats are supported, how the mesh is sized and oriented,
+how the rest-pose fit works, and what to watch out for at high
+vertex counts.
+
+If you only want to use one of the bundled shapes, see
+[`quickstart.md`](quickstart.md). If you want to add a shape to the
+default library so every capture starts with it, see
+[`asset_author_guide.md`](asset_author_guide.md).
+
+## Supported formats
+
+`MeshShape` loads any of the formats `trimesh` can parse:
+
+| Extension | Notes |
+| --- | --- |
+| `.stl` | Binary or ASCII STL. The bundled defaults are STL. |
+| `.obj` | Triangulated; multi-material OBJs are flattened. |
+| `.ply` | Binary or ASCII; vertex colours are dropped. |
+| `.glb` | Embedded binary glTF; the first mesh primitive is used. |
+
+Loading goes through `body_part_viz.shapes._mesh_io.load_mesh`, which
+returns a `(vertices, faces)` pair and the mesh's oriented-bounding-
+box (OBB) extents. Anything `trimesh` can read should work; if your
+file fails to load, it almost certainly is failing inside `trimesh`
+and the error message will say so.
+
+## Importing in the C3D Viewer
+
+In the Segments tab:
+
+1. Pick the row whose segment you want to skin.
+2. Click **Shape → mesh_file**.
+3. In the file picker, choose your `.stl` / `.obj` / `.ply` / `.glb`.
+4. The viewer immediately re-fits the mesh against the live markers
+   and redraws.
+
+The picker remembers the last directory; for repeated imports it is
+fastest to keep your custom meshes under a known directory and reuse
+that.
+
+## Sizing — what happens to the mesh
+
+Three things happen to your file before it becomes a `MeshShape`:
+
+1. **Re-centring on the OBB centroid.** The mesh is translated so its
+   oriented-bounding-box centre sits at the origin. This makes the
+   subsequent fit independent of where the modeller put their origin.
+2. **OBB rest-dimensions.** `rest_dimensions` is set to the OBB
+   extents (not the axis-aligned bounding box). For a forearm
+   modelled along the +Z axis this ends up as roughly
+   `(0.07, 0.07, 0.27)` metres.
+3. **Decimation.** If the input has more than the per-shape vertex
+   budget (default 5000 triangles), `_mesh_decimation.decimate` runs
+   quadric decimation to bring the count down. The default budget is
+   conservative; it preserves silhouette but discards fine surface
+   detail.
+
+The final shape is in metres. If your mesh ships in millimetres or
+inches, scale it before import — there is no UI scale slider, and the
+fitter assumes metres throughout.
+
+## Fitting at rest pose
+
+Once the mesh is in place, the binding determines how it is fit each
+frame:
+
+- **`between_two`**. Pick two markers (e.g. elbow and wrist for a
+  forearm). The fitter aligns the mesh's longest OBB axis to the
+  marker-to-marker direction and stretches the mesh isotropically
+  along that axis to span the live distance. Cross-axis dimensions
+  stay at their rest values. Best for limbs.
+- **`cluster_kabsch`**. Pick three or more markers (e.g. four torso
+  markers). The fitter runs a rigid Kabsch fit between the rest-pose
+  marker positions and the live positions, applying only rotation +
+  translation. Best for rigid body segments where you trust the
+  marker cluster.
+- **`procrustes_anisotropic`**. Same as cluster_kabsch but allows
+  per-axis scale. Best when the rest-pose marker spread is a poor
+  match for the subject (e.g. you used a generic torso template
+  against a notably wider or narrower subject).
+
+Pick the binding from the Segments-tab row's **Fitter** column; the
+toolkit re-runs the fit on the active capture without reloading the
+mesh.
+
+## Performance considerations
+
+The matplotlib backend renders the full vertex list every frame.
+`MatplotlibRenderer` is sufficient for ≲ 5 000 triangles per segment
+across ≲ 25 segments. Beyond that, scrubbing the time slider gets
+sluggish. Two levers:
+
+1. **Lower the vertex budget.** Re-import with a lower
+   `max_vertices` (in code: `MeshShape(..., max_vertices=2000)`).
+   Re-decimating typically drops triangle count by 4-10× with no
+   perceptible silhouette change.
+2. **Switch to the Qt-GL backend.** `PyQtGLRenderer` shares the same
+   `ShapeRenderer` Protocol and pushes geometry to the GPU once, then
+   updates a small per-frame transform. The C3D Viewer's **View →
+   Backend → Qt-GL** menu item flips between the two; the matcher
+   exposes the same toggle in its preferences.
+
+If neither lever is enough — for instance you are visualising a high-
+poly clinical mesh — consider building a `CompositeShape` of cheaper
+primitives (an `EllipsoidShape` for the bulk plus a `CylinderShape`
+where the joint sits) instead of importing the high-poly geometry
+directly.
+
+## Handedness, axes, and units
+
+The toolkit assumes:
+
+- **Right-handed Z-up** coordinate frame.
+- **Metres** throughout.
+- The mesh's local +Z axis is the segment's "long" axis (matters
+  only for `between_two` fitters; the OBB pre-pass usually picks the
+  right axis automatically, but if your forearm comes out crosswise,
+  rotate the source file 90° before exporting).
+
+Source files exported from MeshLab, Blender, MakeHuman, OpenSim's
+GUI, and Blender-exported FBX-via-conversion all import cleanly at
+the correct scale and orientation in our test fixtures. If yours
+does not, the most common causes are unit mismatch (mm vs. m) and
+Y-up vs. Z-up convention.
+
+## Troubleshooting
+
+**Mesh loads but is invisible.** It almost certainly loaded with
+zero-area faces or got rejected by the OBB pre-pass. Check
+`MeshShape.rest_dimensions`; if any axis is `~0`, the source mesh has
+a degenerate dimension and needs cleanup in the source modeller.
+
+**Mesh loads but is the wrong scale.** Unit mismatch. Verify by
+inspecting `rest_dimensions` — if it reads in centimetres or
+millimetres, you have a unit-conversion issue at export time, not
+inside the toolkit.
+
+**Mesh loads but tracks the wrong markers.** The binding is wrong;
+swap markers in the Segments tab row and re-fit.
+
+**Frame scrubbing is sluggish.** See "Performance considerations"
+above. Lower the vertex budget or switch backends.
+
+## Where to next
+
+- [`asset_author_guide.md`](asset_author_guide.md) — turn a custom
+  mesh into a permanent library entry.
+- [`docs/api/body_part_viz.md`](../../api/body_part_viz.md) — public
+  API including the URDF bridge for re-using imported meshes as URDF
+  visuals.

--- a/docs/user_guide/body_part_viz/quickstart.md
+++ b/docs/user_guide/body_part_viz/quickstart.md
@@ -1,0 +1,134 @@
+# Body-Part Viz — Quickstart
+
+This guide walks through the most common workflow: load a C3D capture
+in the C3D Viewer, open the **Segments** tab, swap the default
+between-marker line for a richer library shape, and save the result so
+the next session re-opens with the same look.
+
+The toolkit lives in `src/shared/python/body_part_viz/` and is shared
+across the C3D Viewer, the starting-pose matcher, and the URDF
+generator. Anything you save here is portable across all three.
+
+## 1. Open a C3D file
+
+From the launcher (the **C3D Viewer** tile registered in
+`src/config/models.yaml`) or directly:
+
+```bash
+python3 src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py \
+    path/to/capture.c3d
+```
+
+The viewer opens with the marker cloud rendered in 3D and a row of
+tabs along the bottom. Click **Segments**.
+
+## 2. Read the default segment list
+
+The first time you open a capture, the Segments tab populates the
+table with the default body-segment set returned by
+`default_body_segments` (pelvis, spine, torso, shoulders, elbows,
+wrists, hands, feet — the same set the motion-matching cost terms
+dispatch on; see [ADR 0006](../../adr/0006-multi-source-motion-targets.md)).
+
+Each row shows:
+
+| Column | What it is |
+| --- | --- |
+| **Segment** | The canonical segment label (e.g. `LeftForearm`). |
+| **Binding** | Which markers the segment is attached to. |
+| **Shape** | The current shape kind — `line`, `cylinder`, `ellipsoid`, `capsule`, `mesh_file`, `library_shape`, or `composite`. |
+| **Fitter** | How the shape is positioned each frame — `between_two`, `cluster_kabsch`, or `procrustes_anisotropic`. |
+| **Visible** | Whether the segment is drawn. |
+
+The defaults are minimal — every row starts as a `line` between two
+markers — to keep the first render fast. The next step swaps in
+something more visual.
+
+## 3. Swap a line for a library shape
+
+Pick a row, e.g. `LeftForearm`. Click **Shape → library_shape**, then
+choose **forearm** from the library picker. The Segments tab now:
+
+1. Loads the bundled forearm mesh from
+   `assets/body_part_shapes/default/forearm.stl`.
+2. Looks up the binding template in
+   `assets/body_part_shapes/default/manifest.json` — for the forearm
+   that is `between_two` on `LELB` / `LWRA`.
+3. Re-fits the mesh against the live marker positions for every frame.
+
+The 3D view immediately re-draws the segment with the mesh in place
+of the line. The frame slider, time scrubber, and export-frame
+controls all keep working.
+
+The same swap works for any of the bundled shapes:
+
+- `head` (between two head markers, ellipsoid mesh)
+- `torso` (cluster fit, box mesh)
+- `upper_arm`, `forearm` (between two markers, cylinder mesh)
+- `hand` (anchored on a single marker, ellipsoid mesh)
+- `thigh`, `shin` (between two markers, cylinder mesh)
+- `foot` (between heel + toe markers, box mesh)
+
+If you want a shape that isn't in the library yet, see
+[`mesh_import.md`](mesh_import.md) for importing a custom mesh and
+[`asset_author_guide.md`](asset_author_guide.md) for adding it to the
+default library.
+
+## 4. Recolour by group
+
+The **Theme** column on each row controls the colour group. The
+matplotlib renderer applies the shared dark-theme palette
+(`src/shared/python/theme/matplotlib_style.py`); changing a group
+re-runs the palette without re-fitting the geometry, so it is cheap.
+
+Typical groupings:
+
+- `arms` — both upper arms + both forearms.
+- `legs` — both thighs + both shins.
+- `axial` — pelvis + spine + torso + head.
+- `extremities` — hands + feet.
+
+The colours match the matcher's pose-overlay plots, so a segment that
+looks blue in the C3D Viewer also looks blue in the matcher's
+clubhead-trace overlay.
+
+## 5. Save the segment-viz set
+
+**File → Save Segment Viz Set** writes a JSON v2 file (the
+`SegmentVizSet` schema; see
+[`docs/api/body_part_viz.md`](../../api/body_part_viz.md)). The default
+location is alongside the C3D capture, with a `.viz.json` extension.
+
+Re-opening the same capture auto-detects the sidecar file and applies
+it. Legacy `.segments.json` files written by the pre-toolkit Segments
+tab are still loadable — they auto-migrate from v1 to v2 on read,
+and are saved back as v2 the next time you save.
+
+The file is portable: copy it next to the same capture on another
+machine and the segment configuration travels with it.
+
+## 6. Hand it to another tool
+
+The starting-pose matcher and the humanoid character builder both read
+the same `SegmentVizSet` format. To use the same segment configuration
+in the matcher:
+
+```bash
+python3 -m src.tools.starting_pose_matcher \
+    --target path/to/capture.c3d \
+    --segment-viz path/to/capture.viz.json
+```
+
+The matcher's preview pane now shows the same shapes you configured
+in the C3D Viewer.
+
+To export the same shapes as URDF visuals, see the URDF bridge
+section of [`docs/api/body_part_viz.md`](../../api/body_part_viz.md).
+
+## Where to next
+
+- [`mesh_import.md`](mesh_import.md) — bring in a custom mesh.
+- [`asset_author_guide.md`](asset_author_guide.md) — add a shape to the
+  default library so every capture starts with it.
+- [ADR 0008](../../adr/0008-body-part-viz-toolkit.md) — design rationale
+  for the toolkit.


### PR DESCRIPTION
## Summary

Final docs pass for EPIC #4755 (body-part visualisation toolkit).

- New ADR 0008 — design rationale for the shared `body_part_viz` package, alternatives considered, validation strategy, generic-naming policy.
- New user-guide pages under `docs/user_guide/body_part_viz/`:
  - `quickstart.md` — load a C3D, swap a line for a library shape, save.
  - `mesh_import.md` — bring in a custom STL / OBJ / PLY / GLB; sizing, fitting, performance.
  - `asset_author_guide.md` — add a new shape to the bundled default library; manifest schema; procedural-generation script; licensing rules.
- New hand-curated API reference at `docs/api/body_part_viz.md` (no pdoc / sphinx auto-build configured in `pyproject.toml`).
- `AGENTS.md` updated: new "Body-part visualisation toolkit" entry under shared infrastructure pointing at the package, the canonical `MatplotlibRenderer`, the `default_body_segments` helper, and the `BodyPartShape` Protocol.
- `docs/motion_matching/README.md` updated to link the ADR, the three user-guide pages, and the API reference.

Closes #4768. Part of EPIC #4755.

## Test plan

- [ ] Markdown renders cleanly on GitHub (no broken links).
- [ ] All file paths referenced in the new docs resolve under the worktree (verified during authoring).
- [ ] AGENTS.md still parses as a flat list (no headings out of order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)