### PR TITLE
feat(anthropometrics): contracts + dataclasses (#4800)

### DIFF
--- a/src/shared/python/anthropometrics/__init__.py
+++ b/src/shared/python/anthropometrics/__init__.py
@@ -1,0 +1,32 @@
+"""Canonical anthropometrics data model and Protocols.
+
+Foundation package for the anthropometrics EPIC. Provides:
+
+* :class:`SegmentProperties` — frozen dataclass describing the
+  inertial/dimensional properties of a single body segment.
+* :class:`SubjectAnthropometrics` — frozen dataclass bundling
+  all segments for one subject.
+* :class:`Estimator`, :class:`Reader`, :class:`Writer`,
+  :class:`EngineAdapter` — runtime-checkable Protocols for
+  downstream subsystems.
+
+All public objects are validated against physical-realisability
+invariants at construction time (Design by Contract).
+"""
+
+from __future__ import annotations
+
+from ._subject_anthropometrics import SubjectAnthropometrics
+from ._types import Sex
+from .contracts import EngineAdapter, Estimator, Reader, Writer
+from .segment_properties import SegmentProperties
+
+__all__ = [
+    "EngineAdapter",
+    "Estimator",
+    "Reader",
+    "SegmentProperties",
+    "Sex",
+    "SubjectAnthropometrics",
+    "Writer",
+]

--- a/src/shared/python/anthropometrics/_subject_anthropometrics.py
+++ b/src/shared/python/anthropometrics/_subject_anthropometrics.py
@@ -1,0 +1,108 @@
+"""Canonical :class:`SubjectAnthropometrics` dataclass.
+
+A :class:`SubjectAnthropometrics` instance bundles every
+:class:`SegmentProperties` that describes one human subject,
+along with the subject-level scalars required by downstream
+estimators (height, mass, optional age and sex).
+
+Like :class:`~.segment_properties.SegmentProperties`, the
+dataclass is frozen and validates all invariants on
+construction (Design by Contract).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ._types import Sex
+from .segment_properties import SegmentProperties
+
+
+def _require_non_empty_str(value: object, label: str) -> None:
+    """Raise ``ValueError`` if *value* is not a non-empty string."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string, got {value!r}")
+
+
+def _require_positive(value: float, label: str) -> None:
+    """Raise ``ValueError`` if *value* is not strictly positive."""
+    import math  # local import keeps top-level symbol surface small
+
+    if not (
+        isinstance(value, (int, float)) and math.isfinite(float(value)) and value > 0
+    ):
+        raise ValueError(f"{label} must be a positive finite number, got {value!r}")
+
+
+@dataclass(frozen=True)
+class SubjectAnthropometrics:
+    """All anthropometric data for a single subject, SI units only.
+
+    Invariants (all enforced in :meth:`__post_init__`)
+    --------------------------------------------------
+    * ``subject_id`` and ``source_method`` are non-empty strings.
+    * ``height_m`` and ``mass_kg`` are strictly positive finite floats.
+    * ``segments`` is a non-empty tuple of ``(name, props)`` pairs
+      where every ``props`` is a :class:`SegmentProperties` and
+      every ``name`` is a unique non-empty string.
+    * If provided, ``age_years`` is a non-negative finite float.
+    * ``sex`` is one of ``"M"``, ``"F"``, ``"unspecified"``.
+    """
+
+    subject_id: str
+    height_m: float
+    mass_kg: float
+    segments: tuple[tuple[str, SegmentProperties], ...]
+    source_method: str
+    age_years: float | None = None
+    sex: str = Sex.UNSPECIFIED.value
+
+    def __post_init__(self) -> None:
+        _require_non_empty_str(self.subject_id, "subject_id")
+        _require_non_empty_str(self.source_method, "source_method")
+        _require_positive(self.height_m, "height_m")
+        _require_positive(self.mass_kg, "mass_kg")
+
+        if not isinstance(self.segments, tuple):
+            raise ValueError(
+                f"segments must be a tuple, got {type(self.segments).__name__}"
+            )
+        if not self.segments:
+            raise ValueError("segments must be non-empty")
+
+        seen: set[str] = set()
+        for entry in self.segments:
+            if not (isinstance(entry, tuple) and len(entry) == 2):
+                raise ValueError(
+                    f"segments entries must be (name, SegmentProperties) "
+                    f"pairs, got {entry!r}"
+                )
+            seg_name, seg_props = entry
+            _require_non_empty_str(seg_name, "segment name")
+            if not isinstance(seg_props, SegmentProperties):
+                raise ValueError(
+                    f"segment {seg_name!r} must map to a SegmentProperties "
+                    f"instance, got {type(seg_props).__name__}"
+                )
+            if seg_name in seen:
+                raise ValueError(f"duplicate segment name: {seg_name!r}")
+            seen.add(seg_name)
+
+        if self.age_years is not None:
+            import math
+
+            if not (
+                isinstance(self.age_years, (int, float))
+                and math.isfinite(float(self.age_years))
+                and self.age_years >= 0
+            ):
+                raise ValueError(
+                    "age_years must be a non-negative finite number, "
+                    f"got {self.age_years!r}"
+                )
+
+        valid_sex = {member.value for member in Sex}
+        if self.sex not in valid_sex:
+            raise ValueError(
+                f"sex must be one of {sorted(valid_sex)}, got {self.sex!r}"
+            )

--- a/src/shared/python/anthropometrics/_types.py
+++ b/src/shared/python/anthropometrics/_types.py
@@ -1,0 +1,38 @@
+"""Internal type aliases for the anthropometrics package.
+
+These names exist purely so the public-facing modules
+(:mod:`segment_properties`, :mod:`_subject_anthropometrics`,
+:mod:`contracts`) read uniformly. They are not part of the
+package's public API.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+# A floating-point ndarray of arbitrary shape.
+FloatArray: TypeAlias = NDArray[np.floating]
+
+# A canonical body-segment identifier (e.g. "head", "torso",
+# "upper_arm_left"). Kept as a plain ``str`` alias for now; a
+# stricter ``Literal`` set may be introduced in a later issue.
+BodyPartId: TypeAlias = str
+
+# Tolerance for inertia-tensor symmetry / triangle-inequality checks.
+INERTIA_NUMERIC_TOL: float = 1e-9
+
+
+class Sex(str, Enum):
+    """Subject sex.
+
+    ``StrEnum`` is unavailable on Python 3.10, so we subclass
+    ``(str, Enum)`` to retain string-equality semantics.
+    """
+
+    MALE = "M"
+    FEMALE = "F"
+    UNSPECIFIED = "unspecified"

--- a/src/shared/python/anthropometrics/contracts.py
+++ b/src/shared/python/anthropometrics/contracts.py
@@ -1,0 +1,75 @@
+"""Public Protocols for the anthropometrics subsystem.
+
+Every concrete implementation in downstream child issues of the
+anthropometrics EPIC must satisfy one of these Protocols. They
+are intentionally minimal so that estimators, persistence
+layers, and engine adapters can evolve independently.
+
+All Protocols are :func:`~typing.runtime_checkable` so callers
+can use ``isinstance`` checks for fail-fast validation without
+incurring an import of every concrete subclass.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ._subject_anthropometrics import SubjectAnthropometrics
+    from .segment_properties import SegmentProperties
+
+
+@runtime_checkable
+class Estimator(Protocol):
+    """Produce :class:`SubjectAnthropometrics` from raw subject metadata.
+
+    Implementations apply published ratio tables (de Leva,
+    Dempster, Zatsiorsky-Seluyanov) or scan-derived models.
+    """
+
+    def estimate(
+        self,
+        *,
+        subject_id: str,
+        height_m: float,
+        mass_kg: float,
+        sex: str = "unspecified",
+        age_years: float | None = None,
+    ) -> SubjectAnthropometrics:
+        """Return a fully-populated :class:`SubjectAnthropometrics`."""
+        ...
+
+
+@runtime_checkable
+class Reader(Protocol):
+    """Load a previously-persisted :class:`SubjectAnthropometrics`."""
+
+    def read(self, path: Path) -> SubjectAnthropometrics:
+        """Return the :class:`SubjectAnthropometrics` stored at *path*."""
+        ...
+
+
+@runtime_checkable
+class Writer(Protocol):
+    """Persist a :class:`SubjectAnthropometrics` to a backing store."""
+
+    def write(self, anthro: SubjectAnthropometrics, path: Path) -> None:
+        """Write *anthro* to *path*."""
+        ...
+
+
+@runtime_checkable
+class EngineAdapter(Protocol):
+    """Translate canonical segments into engine-specific structures.
+
+    Each physics engine (Pinocchio, Drake, MuJoCo, Bullet, ...)
+    has its own representation of inertial parameters; concrete
+    adapters bridge between :class:`SegmentProperties` and that
+    representation.
+    """
+
+    def to_engine_segment(self, props: SegmentProperties) -> object:
+        """Return the engine-native representation of *props*."""
+        ...

--- a/src/shared/python/anthropometrics/segment_properties.py
+++ b/src/shared/python/anthropometrics/segment_properties.py
@@ -1,0 +1,164 @@
+"""Canonical :class:`SegmentProperties` dataclass.
+
+A :class:`SegmentProperties` instance fully describes the
+anthropometric properties of a single rigid body segment in SI
+units. Every instance is validated on construction against a
+strict set of physical-realisability invariants (Design by
+Contract). Once an instance exists, it is guaranteed to be
+self-consistent and physically plausible.
+
+References for published ratios used by downstream estimators
+(public scientific literature):
+
+* de Leva, P. (1996). *Adjustments to Zatsiorsky-Seluyanov's
+  segment inertia parameters.* Journal of Biomechanics.
+* Dempster, W. T. (1955). *Space requirements of the seated
+  operator.* WADC Technical Report.
+* Zatsiorsky, V. M. (2002). *Kinetics of Human Motion.*
+
+This module itself contains no ratios — it only enforces the
+contract every estimator must satisfy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._types import INERTIA_NUMERIC_TOL
+
+if TYPE_CHECKING:
+    from ._types import FloatArray
+
+
+# --------------------------------------------------------------------------- #
+# Validation helpers (module-private, DRY).                                   #
+# --------------------------------------------------------------------------- #
+def _require_non_empty_str(value: object, label: str) -> None:
+    """Raise ``ValueError`` if *value* is not a non-empty string."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string, got {value!r}")
+
+
+def _require_positive(value: float, label: str) -> None:
+    """Raise ``ValueError`` if *value* is not strictly positive."""
+    if not (isinstance(value, (int, float)) and np.isfinite(value) and value > 0):
+        raise ValueError(f"{label} must be a positive finite number, got {value!r}")
+
+
+def _coerce_array(value: object, label: str, shape: tuple[int, ...]) -> FloatArray:
+    """Return *value* as a finite ndarray of *shape* or raise."""
+    arr = np.asarray(value, dtype=float)
+    if arr.shape != shape:
+        raise ValueError(f"{label} must have shape {shape}, got {arr.shape}")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{label} must contain only finite values")
+    return arr
+
+
+def _validate_inertia_tensor(tensor: FloatArray) -> None:
+    """Enforce all physical invariants on a 3x3 inertia tensor.
+
+    Raises
+    ------
+    ValueError
+        If the tensor is not symmetric, not positive-definite, or
+        violates the triangle inequality on its principal moments.
+    """
+    if not np.allclose(tensor, tensor.T, atol=INERTIA_NUMERIC_TOL):
+        raise ValueError(
+            "inertia_tensor must be symmetric "
+            f"(max asymmetry={np.max(np.abs(tensor - tensor.T)):.3e})"
+        )
+
+    eigenvalues = np.linalg.eigvalsh(tensor)
+    if np.any(eigenvalues <= 0):
+        raise ValueError(
+            "inertia_tensor must be positive-definite "
+            f"(eigenvalues={eigenvalues.tolist()})"
+        )
+
+    ix, iy, iz = sorted(float(e) for e in eigenvalues)
+    pairs = (
+        ("Ix+Iy >= Iz", ix + iy, iz),
+        ("Iy+Iz >= Ix", iy + iz, ix),
+        ("Ix+Iz >= Iy", ix + iz, iy),
+    )
+    for label, lhs, rhs in pairs:
+        if lhs + INERTIA_NUMERIC_TOL < rhs:
+            raise ValueError(
+                "inertia_tensor violates triangle inequality on "
+                f"principal moments: {label} (got {lhs:.6e} < {rhs:.6e}); "
+                f"sorted eigenvalues=({ix:.6e}, {iy:.6e}, {iz:.6e})"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Public dataclass.                                                           #
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class SegmentProperties:
+    """Anthropometric properties of a single body segment, SI units only.
+
+    Invariants (all enforced in :meth:`__post_init__`)
+    --------------------------------------------------
+    * ``name``, ``body_part_id``, ``source_method`` are non-empty strings.
+    * ``length_m``, ``mass_kg``, ``source_subject_height_m``, and
+      ``source_subject_mass_kg`` are strictly positive finite floats.
+    * ``com_xyz_m`` has shape ``(3,)`` and ``|com| <= 2 * length_m``.
+    * ``inertia_tensor`` has shape ``(3, 3)``, is symmetric to
+      ``1e-9``, is positive-definite, and its principal moments
+      satisfy the triangle inequality.
+
+    The dataclass is frozen — mutate by constructing a new
+    instance via :func:`dataclasses.replace`.
+    """
+
+    name: str
+    body_part_id: str
+    length_m: float
+    proximal_marker: str | None
+    distal_marker: str | None
+    mass_kg: float
+    com_xyz_m: FloatArray = field()
+    inertia_tensor: FloatArray = field()
+    source_method: str
+    source_subject_height_m: float
+    source_subject_mass_kg: float
+
+    def __post_init__(self) -> None:
+        # 1. String identifiers.
+        _require_non_empty_str(self.name, "name")
+        _require_non_empty_str(self.body_part_id, "body_part_id")
+        _require_non_empty_str(self.source_method, "source_method")
+
+        # 2. Positive scalars.
+        _require_positive(self.length_m, "length_m")
+        _require_positive(self.mass_kg, "mass_kg")
+        _require_positive(self.source_subject_height_m, "source_subject_height_m")
+        _require_positive(self.source_subject_mass_kg, "source_subject_mass_kg")
+
+        # 3. Optional marker labels — if present, must be non-empty.
+        for label, value in (
+            ("proximal_marker", self.proximal_marker),
+            ("distal_marker", self.distal_marker),
+        ):
+            if value is not None:
+                _require_non_empty_str(value, label)
+
+        # 4. Center-of-mass vector, normalised to a contiguous ndarray.
+        com = _coerce_array(self.com_xyz_m, "com_xyz_m", (3,))
+        com_norm = float(np.linalg.norm(com))
+        if com_norm > 2.0 * self.length_m:
+            raise ValueError(
+                "com_xyz_m magnitude exceeds 2 * length_m "
+                f"(|com|={com_norm:.6e}, length={self.length_m:.6e})"
+            )
+        object.__setattr__(self, "com_xyz_m", com)
+
+        # 5. Inertia tensor — full physical invariant suite.
+        tensor = _coerce_array(self.inertia_tensor, "inertia_tensor", (3, 3))
+        _validate_inertia_tensor(tensor)
+        object.__setattr__(self, "inertia_tensor", tensor)

--- a/tests/unit/anthropometrics/test_contracts.py
+++ b/tests/unit/anthropometrics/test_contracts.py
@@ -1,0 +1,335 @@
+"""Unit tests for the anthropometrics canonical data model + Protocols.
+
+Covers every validation rule on :class:`SegmentProperties` and
+:class:`SubjectAnthropometrics` plus a runtime-checkable
+isinstance assertion for each Protocol.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from anthropometrics import (
+    EngineAdapter,
+    Estimator,
+    Reader,
+    SegmentProperties,
+    Sex,
+    SubjectAnthropometrics,
+    Writer,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / builders.                                                        #
+# --------------------------------------------------------------------------- #
+def _diag_inertia(ix: float, iy: float, iz: float) -> np.ndarray:
+    """Return a diagonal inertia tensor with the given principal moments."""
+    return np.diag([ix, iy, iz]).astype(float)
+
+
+def _make_segment(**overrides: Any) -> SegmentProperties:
+    """Return a default-valid :class:`SegmentProperties`, with overrides."""
+    defaults: dict[str, Any] = {
+        "name": "upper_arm_left",
+        "body_part_id": "upper_arm",
+        "length_m": 0.30,
+        "proximal_marker": "L_SHO",
+        "distal_marker": "L_ELB",
+        "mass_kg": 2.0,
+        "com_xyz_m": np.array([0.15, 0.0, 0.0]),
+        "inertia_tensor": _diag_inertia(0.02, 0.02, 0.005),
+        "source_method": "de_leva",
+        "source_subject_height_m": 1.80,
+        "source_subject_mass_kg": 75.0,
+    }
+    defaults.update(overrides)
+    return SegmentProperties(**defaults)
+
+
+def _make_subject(**overrides: Any) -> SubjectAnthropometrics:
+    """Return a default-valid :class:`SubjectAnthropometrics`."""
+    seg = _make_segment()
+    defaults: dict[str, Any] = {
+        "subject_id": "SUBJ001",
+        "height_m": 1.80,
+        "mass_kg": 75.0,
+        "segments": ((seg.name, seg),),
+        "source_method": "de_leva",
+    }
+    defaults.update(overrides)
+    return SubjectAnthropometrics(**defaults)
+
+
+# --------------------------------------------------------------------------- #
+# Happy paths.                                                                #
+# --------------------------------------------------------------------------- #
+def test_segment_properties_happy_path_constructs_and_freezes() -> None:
+    seg = _make_segment()
+    assert seg.name == "upper_arm_left"
+    assert seg.length_m == pytest.approx(0.30)
+    # frozen dataclass: assignment must raise.
+    with pytest.raises(AttributeError):
+        seg.length_m = 0.5  # type: ignore[misc]
+    # com_xyz_m + inertia_tensor coerced to ndarray.
+    assert isinstance(seg.com_xyz_m, np.ndarray)
+    assert isinstance(seg.inertia_tensor, np.ndarray)
+    assert seg.inertia_tensor.shape == (3, 3)
+
+
+def test_subject_anthropometrics_happy_path() -> None:
+    subj = _make_subject()
+    assert subj.subject_id == "SUBJ001"
+    assert subj.sex == Sex.UNSPECIFIED.value
+    assert len(subj.segments) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Mass / length scalar validation.                                            #
+# --------------------------------------------------------------------------- #
+def test_segment_zero_mass_rejected() -> None:
+    with pytest.raises(ValueError, match="mass_kg"):
+        _make_segment(mass_kg=0.0)
+
+
+def test_segment_negative_length_rejected() -> None:
+    with pytest.raises(ValueError, match="length_m"):
+        _make_segment(length_m=-0.1)
+
+
+def test_segment_non_finite_mass_rejected() -> None:
+    with pytest.raises(ValueError, match="mass_kg"):
+        _make_segment(mass_kg=float("nan"))
+
+
+# --------------------------------------------------------------------------- #
+# String identifiers.                                                         #
+# --------------------------------------------------------------------------- #
+def test_segment_empty_name_rejected() -> None:
+    with pytest.raises(ValueError, match="name"):
+        _make_segment(name="")
+
+
+def test_segment_blank_body_part_id_rejected() -> None:
+    with pytest.raises(ValueError, match="body_part_id"):
+        _make_segment(body_part_id="   ")
+
+
+def test_segment_empty_source_method_rejected() -> None:
+    with pytest.raises(ValueError, match="source_method"):
+        _make_segment(source_method="")
+
+
+def test_segment_empty_proximal_marker_rejected() -> None:
+    with pytest.raises(ValueError, match="proximal_marker"):
+        _make_segment(proximal_marker="")
+
+
+def test_segment_optional_markers_may_be_none() -> None:
+    seg = _make_segment(proximal_marker=None, distal_marker=None)
+    assert seg.proximal_marker is None
+    assert seg.distal_marker is None
+
+
+# --------------------------------------------------------------------------- #
+# Center-of-mass validation.                                                  #
+# --------------------------------------------------------------------------- #
+def test_segment_com_wrong_shape_rejected() -> None:
+    with pytest.raises(ValueError, match="com_xyz_m"):
+        _make_segment(com_xyz_m=np.zeros(2))
+
+
+def test_segment_com_outside_bounds_rejected() -> None:
+    # length_m=0.30, so |com| must be <= 0.60.
+    with pytest.raises(ValueError, match="com_xyz_m"):
+        _make_segment(com_xyz_m=np.array([1.0, 0.0, 0.0]))
+
+
+def test_segment_com_non_finite_rejected() -> None:
+    with pytest.raises(ValueError, match="com_xyz_m"):
+        _make_segment(com_xyz_m=np.array([np.inf, 0.0, 0.0]))
+
+
+# --------------------------------------------------------------------------- #
+# Inertia tensor invariants.                                                  #
+# --------------------------------------------------------------------------- #
+def test_inertia_wrong_shape_rejected() -> None:
+    with pytest.raises(ValueError, match="inertia_tensor"):
+        _make_segment(inertia_tensor=np.eye(2))
+
+
+def test_inertia_asymmetric_rejected() -> None:
+    asym = np.array(
+        [[1.0, 0.5, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
+        dtype=float,
+    )
+    with pytest.raises(ValueError, match="symmetric"):
+        _make_segment(inertia_tensor=asym)
+
+
+def test_inertia_negative_eigenvalue_rejected() -> None:
+    # Symmetric but with one negative eigenvalue.
+    tensor = _diag_inertia(1.0, 1.0, -0.5)
+    with pytest.raises(ValueError, match="positive-definite"):
+        _make_segment(inertia_tensor=tensor)
+
+
+def test_inertia_zero_eigenvalue_rejected() -> None:
+    tensor = _diag_inertia(1.0, 1.0, 0.0)
+    with pytest.raises(ValueError, match="positive-definite"):
+        _make_segment(inertia_tensor=tensor)
+
+
+def test_inertia_triangle_inequality_violation_rejected() -> None:
+    # eigenvalues (1, 1, 3): 1 + 1 < 3 violates triangle inequality.
+    tensor = _diag_inertia(1.0, 1.0, 3.0)
+    with pytest.raises(ValueError, match="triangle inequality"):
+        _make_segment(inertia_tensor=tensor)
+
+
+def test_inertia_triangle_inequality_message_names_failing_pair() -> None:
+    tensor = _diag_inertia(1.0, 1.0, 3.0)
+    with pytest.raises(ValueError) as info:
+        _make_segment(inertia_tensor=tensor)
+    msg = str(info.value)
+    assert "Ix+Iy >= Iz" in msg
+
+
+def test_inertia_off_diagonal_symmetric_accepted() -> None:
+    tensor = np.array(
+        [[0.020, 0.001, 0.0], [0.001, 0.020, 0.0], [0.0, 0.0, 0.005]],
+        dtype=float,
+    )
+    seg = _make_segment(inertia_tensor=tensor)
+    assert seg.inertia_tensor[0, 1] == pytest.approx(0.001)
+
+
+# --------------------------------------------------------------------------- #
+# SubjectAnthropometrics validation.                                          #
+# --------------------------------------------------------------------------- #
+def test_subject_empty_id_rejected() -> None:
+    with pytest.raises(ValueError, match="subject_id"):
+        _make_subject(subject_id="")
+
+
+def test_subject_zero_height_rejected() -> None:
+    with pytest.raises(ValueError, match="height_m"):
+        _make_subject(height_m=0.0)
+
+
+def test_subject_negative_mass_rejected() -> None:
+    with pytest.raises(ValueError, match="mass_kg"):
+        _make_subject(mass_kg=-1.0)
+
+
+def test_subject_segments_not_tuple_rejected() -> None:
+    seg = _make_segment()
+    with pytest.raises(ValueError, match="segments"):
+        _make_subject(segments=[(seg.name, seg)])  # type: ignore[arg-type]
+
+
+def test_subject_empty_segments_rejected() -> None:
+    with pytest.raises(ValueError, match="segments"):
+        _make_subject(segments=())
+
+
+def test_subject_duplicate_segment_names_rejected() -> None:
+    seg = _make_segment()
+    with pytest.raises(ValueError, match="duplicate"):
+        _make_subject(segments=((seg.name, seg), (seg.name, seg)))
+
+
+def test_subject_segment_entry_must_be_pair() -> None:
+    seg = _make_segment()
+    with pytest.raises(ValueError, match="pairs"):
+        _make_subject(segments=((seg,),))  # type: ignore[arg-type]
+
+
+def test_subject_segment_value_must_be_segment_properties() -> None:
+    with pytest.raises(ValueError, match="SegmentProperties"):
+        _make_subject(segments=(("upper_arm_left", "not-a-segment"),))  # type: ignore[arg-type]
+
+
+def test_subject_invalid_sex_rejected() -> None:
+    with pytest.raises(ValueError, match="sex"):
+        _make_subject(sex="other")
+
+
+def test_subject_negative_age_rejected() -> None:
+    with pytest.raises(ValueError, match="age_years"):
+        _make_subject(age_years=-5.0)
+
+
+def test_subject_age_none_accepted() -> None:
+    subj = _make_subject(age_years=None)
+    assert subj.age_years is None
+
+
+def test_subject_empty_source_method_rejected() -> None:
+    with pytest.raises(ValueError, match="source_method"):
+        _make_subject(source_method="")
+
+
+# --------------------------------------------------------------------------- #
+# Protocol runtime-checkable conformance.                                     #
+# --------------------------------------------------------------------------- #
+class _StubEstimator:
+    def estimate(
+        self,
+        *,
+        subject_id: str,
+        height_m: float,
+        mass_kg: float,
+        sex: str = "unspecified",
+        age_years: float | None = None,
+    ) -> SubjectAnthropometrics:
+        return _make_subject(
+            subject_id=subject_id,
+            height_m=height_m,
+            mass_kg=mass_kg,
+            sex=sex,
+            age_years=age_years,
+        )
+
+
+class _StubReader:
+    def read(self, path: Path) -> SubjectAnthropometrics:
+        del path
+        return _make_subject()
+
+
+class _StubWriter:
+    def write(self, anthro: SubjectAnthropometrics, path: Path) -> None:
+        del anthro, path
+
+
+class _StubEngineAdapter:
+    def to_engine_segment(self, props: SegmentProperties) -> object:
+        return {"mass": props.mass_kg, "length": props.length_m}
+
+
+def test_estimator_protocol_satisfied_by_stub() -> None:
+    assert isinstance(_StubEstimator(), Estimator)
+
+
+def test_reader_protocol_satisfied_by_stub() -> None:
+    assert isinstance(_StubReader(), Reader)
+
+
+def test_writer_protocol_satisfied_by_stub() -> None:
+    assert isinstance(_StubWriter(), Writer)
+
+
+def test_engine_adapter_protocol_satisfied_by_stub() -> None:
+    assert isinstance(_StubEngineAdapter(), EngineAdapter)
+
+
+def test_protocol_rejects_non_conforming_object() -> None:
+    class _NotAnEstimator:
+        pass
+
+    assert not isinstance(_NotAnEstimator(), Estimator)


### PR DESCRIPTION
Closes #4800
Part of EPIC #4797

## Summary

Foundation issue of the anthropometrics EPIC. Pure data model + Protocols — every other child issue depends on these contracts.

New package `src/shared/python/anthropometrics/`:

- `segment_properties.py` — `SegmentProperties` frozen dataclass with full DbC validation (positive masses/lengths, symmetric + positive-definite inertia tensor, triangle-inequality on principal moments, CoM bounded by 2*length).
- `_subject_anthropometrics.py` — `SubjectAnthropometrics` frozen dataclass (positive height/mass, unique segment names, validated sex enum, optional age).
- `contracts.py` — four `@runtime_checkable` Protocols: `Estimator`, `Reader`, `Writer`, `EngineAdapter`.
- `_types.py` — internal aliases + `Sex` `(str, Enum)` (Python 3.10 compatible, no `StrEnum`).
- `__init__.py` — re-exports the public API.

37 unit tests in `tests/unit/anthropometrics/test_contracts.py` covering every validation rule (happy + fail) plus Protocol conformance via stubs.

## Verification

- `ruff check`: passes
- `ruff format --check`: passes
- pytest: 37 passed
- coverage: **99.46%** line + branch on the new package (target: ≥95%)
- file size budget: passes
- mypy strict on the new package: 0 errors (the single error reported under `--strict` is pre-existing in `src/shared/python/__init__.py` and outside the scope of this PR).

## Test plan

- [x] `python3 -m ruff check src/shared/python/anthropometrics tests/unit/anthropometrics`
- [x] `python3 -m ruff format --check src/shared/python/anthropometrics tests/unit/anthropometrics`
- [x] `python3 -m pytest tests/unit/anthropometrics/ -p no:cacheprovider -n auto --timeout=60`
- [x] `python3 -m pytest tests/unit/anthropometrics/ --cov=src/shared/python/anthropometrics --cov-branch --cov-report=term-missing`
- [x] `python3 scripts/ci/check_file_size_budget.py`