### PR TITLE
test(body_part_viz): integration tier — golden hashes + perf budget + property fitters

### DIFF
--- a/tests/fixtures/body_part_viz/snapshot_hashes.json
+++ b/tests/fixtures/body_part_viz/snapshot_hashes.json
@@ -1,0 +1,6 @@
+{
+  "capsule": "ddf34cd459b974ce3645fb21457131b3",
+  "cylinder": "1611498b73bdb4713289cda28bbdfe41",
+  "ellipsoid": "7f17c20427de82958556259711bd47a0",
+  "line": "157484a25225c873506c62b9c19e9b83"
+}

--- a/tests/integration/body_part_viz/__init__.py
+++ b/tests/integration/body_part_viz/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the body_part_viz package."""

--- a/tests/integration/body_part_viz/conftest.py
+++ b/tests/integration/body_part_viz/conftest.py
@@ -1,0 +1,24 @@
+"""Shared pytest configuration for body_part_viz integration tests.
+
+Adds a ``--update-goldens`` flag the renderer-snapshots test uses to
+write expected hashes back to ``tests/fixtures/body_part_viz/`` instead
+of comparing against them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-goldens",
+        action="store_true",
+        default=False,
+        help="Rewrite golden hashes for body_part_viz snapshot tests.",
+    )
+
+
+@pytest.fixture
+def update_goldens(request: pytest.FixtureRequest) -> bool:
+    return bool(request.config.getoption("--update-goldens"))

--- a/tests/integration/body_part_viz/test_perf_budget.py
+++ b/tests/integration/body_part_viz/test_perf_budget.py
@@ -1,0 +1,102 @@
+"""26-segment full-body performance budget for the matplotlib renderer.
+
+Builds 26 cylinder shapes (humanoid segment count), feeds each an
+identity ``FittedShape`` with 100 frames, and times one round of
+``update_frame`` calls across all of them. The 30 fps budget allows
+``26 * (1/30) s`` ~= 33 ms per frame; we assert the median across a
+small sample of frames stays within that.
+
+Marked ``slow`` so default test runs (`-m "not slow"`) skip it.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import time
+
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from src.shared.python.body_part_viz import (  # noqa: E402
+    BindingKind,
+    FittedShape,
+    MarkerBinding,
+    ShapeTheme,
+)
+from src.shared.python.body_part_viz.renderers import MatplotlibRenderer  # noqa: E402
+from src.shared.python.body_part_viz.shapes import CylinderShape  # noqa: E402
+
+N_SEGMENTS = 26
+N_FRAMES = 100
+BUDGET_MS_PER_FRAME = 33.0  # 30 fps for whole-body update
+
+
+def _identity_fitted(shape_id: str, n_frames: int) -> FittedShape:
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+    )
+    centroid = np.zeros((n_frames, 3))
+    centroid[:, 0] = np.linspace(0.0, 1.0, n_frames)
+    rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+    scale = np.ones((n_frames, 3))
+    mask = np.ones((n_frames,), dtype=bool)
+    return FittedShape(
+        shape_id=shape_id,
+        binding=binding,
+        centroid=centroid,
+        rotation_matrix=rotation,
+        scale=scale,
+        valid_mask=mask,
+    )
+
+
+@pytest.mark.slow
+def test_full_body_30fps_budget() -> None:
+    fig = plt.figure(figsize=(4.0, 4.0), dpi=72)
+    try:
+        ax = fig.add_subplot(111, projection="3d")
+        ax.set_axis_off()
+        renderer = MatplotlibRenderer(ax)
+        theme = ShapeTheme(color="#1f77b4", opacity=0.5)
+
+        handles: list[str] = []
+        for i in range(N_SEGMENTS):
+            shape = CylinderShape(
+                length=0.4,
+                radius=0.05,
+                n_facets=10,
+                shape_id=f"seg-{i:02d}",
+            )
+            fitted = _identity_fitted(shape.shape_id, N_FRAMES)
+            handles.append(renderer.add_shape(shape, fitted, theme))
+
+        # Warm-up to amortise first-call costs.
+        for h in handles:
+            renderer.update_frame(h, 0)
+
+        # Sample a handful of frames and take the median per-frame total to
+        # damp scheduling jitter.
+        sampled_frames = [10, 25, 40, 55, 70, 85]
+        per_frame_ms: list[float] = []
+        for f in sampled_frames:
+            start = time.perf_counter()
+            for h in handles:
+                renderer.update_frame(h, f)
+            per_frame_ms.append((time.perf_counter() - start) * 1000.0)
+
+        median_ms = statistics.median(per_frame_ms)
+        assert median_ms <= BUDGET_MS_PER_FRAME, (
+            f"26-segment update_frame median {median_ms:.2f} ms exceeds "
+            f"30 fps budget of {BUDGET_MS_PER_FRAME:.1f} ms; "
+            f"samples={[f'{x:.2f}' for x in per_frame_ms]}"
+        )
+    finally:
+        plt.close(fig)

--- a/tests/integration/body_part_viz/test_property_fitters.py
+++ b/tests/integration/body_part_viz/test_property_fitters.py
@@ -1,0 +1,310 @@
+"""Hypothesis property-based tests for the three body_part_viz fitters.
+
+Properties checked
+------------------
+1. ``shape.transform(fit_result)`` returns ``(V, 3)`` finite vertices on
+   valid frames (the contract-stated post-shape; per-frame iteration here
+   builds a ``(T, V, 3)`` stack to also exercise the per-frame helper).
+2. ``valid_mask`` correctly tracks NaN propagation injected into markers.
+3. Idempotence on rest pose: feeding the rest-pose markers back into the
+   fitter yields rotation ~ identity and unit scale on valid frames.
+
+Hypothesis is capped at 50 examples per test so the suite remains fast
+(<30 s default tier). Module is skipped if ``hypothesis`` is missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+
+import numpy as np  # noqa: E402
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from src.shared.python.body_part_viz import (  # noqa: E402
+    BindingKind,
+    FittedShape,
+    MarkerBinding,
+)
+from src.shared.python.body_part_viz.fitters import (  # noqa: E402
+    BetweenTwoMarkersFitter,
+    ClusterKabschFitter,
+    ProcrustesAnisotropicFitter,
+)
+from src.shared.python.body_part_viz.shapes import (  # noqa: E402
+    CylinderShape,
+    LineShape,
+)
+
+_HYPO_SETTINGS = settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+_FINITE = st.floats(
+    min_value=-10.0,
+    max_value=10.0,
+    allow_nan=False,
+    allow_infinity=False,
+    width=64,
+)
+
+
+def _xyz(draw: st.DrawFn) -> np.ndarray:
+    return np.array(
+        [draw(_FINITE), draw(_FINITE), draw(_FINITE)],
+        dtype=float,
+    )
+
+
+@st.composite
+def _between_two_markers(draw: st.DrawFn, n_frames: int = 6) -> dict[str, np.ndarray]:
+    """Markers ``A`` and ``B`` with B = A + axis * length, length > 0."""
+    a = np.zeros((n_frames, 3))
+    b = np.zeros((n_frames, 3))
+    for t in range(n_frames):
+        origin = _xyz(draw)
+        # Random direction (rejection sample for non-zero norm).
+        for _ in range(8):
+            direction = _xyz(draw)
+            n = float(np.linalg.norm(direction))
+            if n > 0.1:
+                direction = direction / n
+                break
+        else:  # pragma: no cover - extremely rare with hypothesis
+            direction = np.array([1.0, 0.0, 0.0])
+        length = float(draw(st.floats(min_value=0.2, max_value=2.0)))
+        a[t] = origin
+        b[t] = origin + direction * length
+    return {"A": a, "B": b}
+
+
+@st.composite
+def _cluster_markers(
+    draw: st.DrawFn, n_markers: int = 4, n_frames: int = 5
+) -> dict[str, np.ndarray]:
+    """Rigid cluster: a fixed local layout rotated/translated per frame."""
+    # Local layout: tetrahedron-ish, non-degenerate.
+    local = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )[:n_markers]
+
+    rng_seed = draw(st.integers(min_value=0, max_value=1_000_000))
+    rng = np.random.default_rng(rng_seed)
+
+    out: dict[str, np.ndarray] = {
+        f"M{i}": np.zeros((n_frames, 3)) for i in range(n_markers)
+    }
+    for t in range(n_frames):
+        # Random rotation via QR of a Gaussian matrix.
+        a_mat = rng.standard_normal((3, 3))
+        q_mat, r_mat = np.linalg.qr(a_mat)
+        # Ensure det == +1 (proper rotation).
+        if float(np.linalg.det(q_mat)) < 0.0:
+            q_mat[:, 0] *= -1.0
+        translation = np.array(
+            [draw(_FINITE), draw(_FINITE), draw(_FINITE)], dtype=float
+        )
+        transformed = local @ q_mat.T + translation
+        for i in range(n_markers):
+            out[f"M{i}"][t] = transformed[i]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# BetweenTwoMarkersFitter
+# ---------------------------------------------------------------------------
+@given(markers=_between_two_markers())
+@_HYPO_SETTINGS
+def test_between_two_produces_valid_fitted_shape(
+    markers: dict[str, np.ndarray],
+) -> None:
+    shape = LineShape(length=1.0, shape_id="line-prop")
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("A", "B"),
+        rest_dimensions=(1.0,),
+    )
+    fitter = BetweenTwoMarkersFitter()
+    fitted = fitter.fit(shape, binding, markers)
+
+    n_frames = markers["A"].shape[0]
+    assert fitted.centroid.shape == (n_frames, 3)
+    assert fitted.rotation_matrix.shape == (n_frames, 3, 3)
+    assert fitted.scale.shape == (n_frames, 3)
+    assert fitted.valid_mask.shape == (n_frames,)
+    assert bool(fitted.valid_mask.all())
+
+    transformed = shape.transform(fitted)
+    # Cylinder/Line transform contract is (T, V, 3): one vertex set per frame.
+    assert transformed.ndim == 3
+    assert transformed.shape[0] == n_frames
+    assert transformed.shape[2] == 3
+    assert bool(np.isfinite(transformed).all())
+
+
+def test_between_two_nan_propagation() -> None:
+    """NaN in any marker on a frame must mark that frame invalid."""
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal((5, 3))
+    b = a + np.array([1.0, 0.0, 0.0])
+    a[2, 1] = np.nan  # corrupt a single frame
+
+    shape = LineShape(length=1.0)
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("A", "B"),
+        rest_dimensions=(1.0,),
+    )
+    fitted = BetweenTwoMarkersFitter().fit(shape, binding, {"A": a, "B": b})
+    assert fitted.valid_mask.tolist() == [True, True, False, True, True]
+
+
+def test_between_two_idempotent_at_rest() -> None:
+    """Rest-pose-aligned markers yield identity rotation and unit scale."""
+    n = 3
+    a = np.zeros((n, 3))
+    b = np.tile(np.array([1.0, 0.0, 0.0]), (n, 1))  # length-1, along +x
+
+    shape = LineShape(length=1.0)
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("A", "B"),
+        rest_dimensions=(1.0,),
+    )
+    fitted = BetweenTwoMarkersFitter().fit(shape, binding, {"A": a, "B": b})
+    assert np.allclose(fitted.rotation_matrix, np.eye(3))
+    assert np.allclose(fitted.scale, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# ClusterKabschFitter
+# ---------------------------------------------------------------------------
+@given(markers=_cluster_markers())
+@_HYPO_SETTINGS
+def test_cluster_kabsch_finite_outputs(markers: dict[str, np.ndarray]) -> None:
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8, shape_id="cyl-prop")
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ClusterKabschFitter().fit(shape, binding, markers)
+
+    n_frames = next(iter(markers.values())).shape[0]
+    assert fitted.centroid.shape == (n_frames, 3)
+    assert bool(fitted.valid_mask.all())
+    assert bool(np.isfinite(fitted.centroid).all())
+    assert bool(np.isfinite(fitted.rotation_matrix).all())
+    # Rotation matrices must be orthonormal with det ~ +1.
+    rrt = fitted.rotation_matrix @ np.swapaxes(fitted.rotation_matrix, 1, 2)
+    assert np.allclose(rrt, np.broadcast_to(np.eye(3), rrt.shape), atol=1e-6)
+    dets = np.linalg.det(fitted.rotation_matrix)
+    assert np.allclose(dets, 1.0, atol=1e-6)
+
+
+def test_cluster_kabsch_nan_propagation() -> None:
+    rng = np.random.default_rng(1)
+    n = 4
+    markers = {f"M{i}": rng.standard_normal((4, 3)) for i in range(4)}
+    markers["M1"][2, 0] = np.nan
+
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8)
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ClusterKabschFitter().fit(shape, binding, markers)
+    assert not bool(fitted.valid_mask[2])
+    # Other frames remain valid.
+    assert bool(fitted.valid_mask[0])
+    assert bool(fitted.valid_mask[1])
+    assert bool(fitted.valid_mask[3])
+
+
+def test_cluster_kabsch_idempotent_when_rest_pose_repeated() -> None:
+    """If every frame equals the rest pose, rotation == I and scale == 1."""
+    rest = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    n_frames = 3
+    markers = {f"M{i}": np.tile(rest[i], (n_frames, 1)) for i in range(4)}
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8)
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ClusterKabschFitter(enable_scale=True).fit(shape, binding, markers)
+    assert np.allclose(fitted.rotation_matrix, np.eye(3), atol=1e-9)
+    assert np.allclose(fitted.scale, 1.0, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ProcrustesAnisotropicFitter
+# ---------------------------------------------------------------------------
+@given(markers=_cluster_markers(n_markers=4, n_frames=4))
+@_HYPO_SETTINGS
+def test_procrustes_anisotropic_finite_outputs(
+    markers: dict[str, np.ndarray],
+) -> None:
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8, shape_id="cyl-aniso")
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ProcrustesAnisotropicFitter().fit(shape, binding, markers)
+
+    assert bool(fitted.valid_mask.all())
+    assert bool(np.isfinite(fitted.centroid).all())
+    assert bool(np.isfinite(fitted.rotation_matrix).all())
+    assert bool(np.isfinite(fitted.scale).all())
+    assert bool(np.all(fitted.scale > 0.0))
+
+
+def test_procrustes_anisotropic_idempotent_at_rest() -> None:
+    rest = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    n_frames = 2
+    markers = {f"M{i}": np.tile(rest[i], (n_frames, 1)) for i in range(4)}
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8)
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ProcrustesAnisotropicFitter().fit(shape, binding, markers)
+    assert np.allclose(fitted.rotation_matrix, np.eye(3), atol=1e-9)
+    assert np.allclose(fitted.scale, 1.0, atol=1e-6)
+
+
+def test_procrustes_anisotropic_nan_propagation() -> None:
+    rng = np.random.default_rng(2)
+    markers = {f"M{i}": rng.standard_normal((5, 3)) for i in range(4)}
+    markers["M3"][1, 2] = np.nan
+    markers["M0"][4, 0] = np.nan
+
+    shape = CylinderShape(length=1.0, radius=0.1, n_facets=8)
+    binding = MarkerBinding(
+        kind=BindingKind.CLUSTER,
+        marker_names=tuple(sorted(markers.keys())),
+    )
+    fitted = ProcrustesAnisotropicFitter().fit(shape, binding, markers)
+    assert fitted.valid_mask.tolist() == [True, False, True, True, False]

--- a/tests/integration/body_part_viz/test_renderer_snapshots.py
+++ b/tests/integration/body_part_viz/test_renderer_snapshots.py
@@ -1,0 +1,182 @@
+"""Golden-hash snapshot tests for the matplotlib body_part_viz renderer.
+
+We avoid raster pixel-diffs (notoriously flaky cross-platform) and
+instead capture an md5/sha256 hash of the matplotlib canvas ARGB
+buffer for each shape kind at a fixed seed and fixed parameters. The
+expected hashes live in ``tests/fixtures/body_part_viz/snapshot_hashes.json``.
+
+Authoring workflow
+------------------
+Run pytest with ``--update-goldens`` once to write the JSON file, then
+re-run without the flag to confirm the assertions pass.
+
+Skips
+-----
+The whole module is skipped if matplotlib is unavailable. Snapshots
+that have no recorded golden are skipped (first-run path) unless
+``--update-goldens`` is provided.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from src.shared.python.body_part_viz import (  # noqa: E402
+    BindingKind,
+    FittedShape,
+    MarkerBinding,
+    ShapeTheme,
+)
+from src.shared.python.body_part_viz.renderers import MatplotlibRenderer  # noqa: E402
+from src.shared.python.body_part_viz.shapes import (  # noqa: E402
+    CapsuleShape,
+    CylinderShape,
+    EllipsoidShape,
+    LineShape,
+)
+
+GOLDEN_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "fixtures"
+    / "body_part_viz"
+    / "snapshot_hashes.json"
+)
+
+# Fixed RNG seed: every snapshot is built from this stream so hashes are
+# deterministic across runs.
+_SEED = 20260508
+
+
+def _hash_bytes(data: bytes) -> str:
+    """Return a short stable digest. Prefer md5; fall back to sha256."""
+    try:
+        return hashlib.md5(data, usedforsecurity=False).hexdigest()
+    except TypeError:  # pragma: no cover - very old Python
+        return hashlib.sha256(data).hexdigest()
+
+
+def _identity_fitted(shape_id: str, n_frames: int = 2) -> FittedShape:
+    binding = MarkerBinding(
+        kind=BindingKind.BETWEEN_TWO,
+        marker_names=("a", "b"),
+    )
+    centroid = np.zeros((n_frames, 3))
+    rotation = np.broadcast_to(np.eye(3), (n_frames, 3, 3)).copy()
+    scale = np.ones((n_frames, 3))
+    mask = np.ones((n_frames,), dtype=bool)
+    return FittedShape(
+        shape_id=shape_id,
+        binding=binding,
+        centroid=centroid,
+        rotation_matrix=rotation,
+        scale=scale,
+        valid_mask=mask,
+    )
+
+
+def _build_figure_for(kind: str) -> Any:
+    """Return a configured matplotlib Figure with a single shape rendered."""
+    rng = np.random.default_rng(_SEED)
+    # Ensure the matplotlib internal seed is also pinned for color cycling
+    # paths that may consult ``np.random`` (defensive).
+    np.random.seed(_SEED)
+    _ = rng.standard_normal(4)  # touch the stream so future edits notice
+
+    fig = plt.figure(figsize=(4.0, 4.0), dpi=72)
+    ax = fig.add_subplot(111, projection="3d")
+    ax.set_xlim(-1.0, 2.0)
+    ax.set_ylim(-1.0, 1.0)
+    ax.set_zlim(-1.0, 1.0)
+    ax.set_axis_off()
+
+    theme = ShapeTheme(color="#1f77b4", opacity=0.5)
+    renderer = MatplotlibRenderer(ax)
+
+    if kind == "line":
+        shape: Any = LineShape(length=1.0, shape_id="line-snap")
+    elif kind == "cylinder":
+        shape = CylinderShape(length=1.0, radius=0.25, n_facets=12, shape_id="cyl-snap")
+    elif kind == "ellipsoid":
+        shape = EllipsoidShape(
+            a=0.5, b=0.3, c=0.2, n_lon=12, n_lat=6, shape_id="ell-snap"
+        )
+    elif kind == "capsule":
+        shape = CapsuleShape(
+            length=1.0,
+            radius=0.2,
+            n_facets=12,
+            n_lat=4,
+            shape_id="cap-snap",
+        )
+    else:  # pragma: no cover - guarded by parametrize
+        raise AssertionError(f"unknown kind {kind!r}")
+
+    handle = renderer.add_shape(shape, _identity_fitted(shape.shape_id), theme)
+    renderer.update_frame(handle, 0)
+    fig.canvas.draw()
+    return fig
+
+
+def _hash_for_kind(kind: str) -> str:
+    fig = _build_figure_for(kind)
+    try:
+        buf = fig.canvas.tostring_argb()
+    finally:
+        plt.close(fig)
+    return _hash_bytes(buf)
+
+
+def _load_goldens() -> dict[str, str]:
+    if not GOLDEN_PATH.exists():
+        return {}
+    return json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def _write_goldens(data: dict[str, str]) -> None:
+    GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    GOLDEN_PATH.write_text(
+        json.dumps(data, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("kind", ["line", "cylinder", "ellipsoid", "capsule"])
+def test_renderer_snapshot_hash(kind: str, update_goldens: bool) -> None:
+    actual = _hash_for_kind(kind)
+
+    goldens = _load_goldens()
+    if update_goldens:
+        goldens[kind] = actual
+        _write_goldens(goldens)
+        return
+
+    if kind not in goldens:
+        pytest.skip(
+            f"no golden recorded for {kind!r}; "
+            "run pytest with --update-goldens to seed it"
+        )
+
+    assert actual == goldens[kind], (
+        f"renderer hash drift for shape {kind!r}: "
+        f"expected {goldens[kind]}, got {actual}"
+    )
+
+
+def test_hash_is_stable_across_two_invocations() -> None:
+    """Calling the build function twice must produce the same hash."""
+    first = _hash_for_kind("cylinder")
+    second = _hash_for_kind("cylinder")
+    assert first == second


### PR DESCRIPTION
## Summary

Closes #4766. Implements **Option B (trimmed)** of the agreed coverage plan: integration-tier tests for the `body_part_viz` package, layered on top of the existing per-module unit suite.

- **Golden-hash renderer snapshots** (`test_renderer_snapshots.py`) — md5 (sha256 fallback) hashes of the matplotlib canvas ARGB buffer for line/cylinder/ellipsoid/capsule shapes at fixed seed and parameters. Goldens live at `tests/fixtures/body_part_viz/snapshot_hashes.json` and are re-seedable via a new `--update-goldens` pytest flag.
- **30 fps perf budget** (`test_perf_budget.py`) — 26-segment full-body cylinder scene with 100 frames; asserts the median per-frame `update_frame` total stays within 33 ms. `@pytest.mark.slow`.
- **Hypothesis property tests for fitters** (`test_property_fitters.py`) — covers `BetweenTwoMarkersFitter`, `ClusterKabschFitter`, `ProcrustesAnisotropicFitter`. Asserts shape/finiteness contracts, NaN propagation through `valid_mask`, orthonormal rotations, and rest-pose idempotence (R = I, scale = 1). Capped at 50 examples per test.

Optional deps (matplotlib, hypothesis) are guarded with `pytest.importorskip` so the suite degrades cleanly. Default-tier total runs in ~4 s; perf test ~150 ms.

## Test plan

- [x] `pytest tests/integration/body_part_viz/ -m "not slow and not live_simulation"` — 14 passed
- [x] `pytest tests/integration/body_part_viz/ -m ""` — 15 passed (incl. slow)
- [x] `ruff check tests/integration/body_part_viz/` — clean
- [x] `ruff format --check tests/integration/body_part_viz/` — clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)