### PR TITLE
feat(plot-style): DataChannel helpers (#4809)

### DIFF
--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -13,7 +13,12 @@ issues of EPIC #4796.
 from __future__ import annotations
 
 from ._types import RGBATuple
-from .channels import DataChannel
+from .channels import (
+    DataChannel,
+    derivative_channel,
+    magnitude_channel,
+    slice_channel,
+)
 from .colormaps import (
     SEMANTIC_COLORMAP_ALIASES,
     ColormapId,
@@ -43,5 +48,8 @@ __all__ = [
     "PlotStyleSpec",
     "RGBATuple",
     "StaticColor",
+    "derivative_channel",
+    "magnitude_channel",
     "resolve_colormap_alias",
+    "slice_channel",
 ]

--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -1,0 +1,47 @@
+"""Plot-style contracts and dataclasses.
+
+This package defines the abstract surface (Protocols + frozen
+dataclasses) used by every marker / trace styling implementation in
+UpstreamDrift.
+
+Concrete implementations of color resolvers, renderers, Qt widgets, and
+marker-shape primitives live in the ``resolvers``, ``renderers``,
+``widgets``, and ``shapes`` sub-packages and are added in follow-up
+issues of EPIC #4796.
+"""
+
+from __future__ import annotations
+
+from ._types import RGBATuple
+from .channels import DataChannel
+from .colormaps import (
+    SEMANTIC_COLORMAP_ALIASES,
+    ColormapId,
+    CustomColormap,
+    resolve_colormap_alias,
+)
+from .colors import ColorScale, DataDrivenColor, PaletteColor, StaticColor
+from .contracts import ColorResolver, MarkerRenderer
+from .markers import CustomMeshSpec, MarkerShape, MarkerStyle
+from .persistence import SCHEMA_VERSION, PlotStyleSet, PlotStyleSpec
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SEMANTIC_COLORMAP_ALIASES",
+    "ColorResolver",
+    "ColorScale",
+    "ColormapId",
+    "CustomColormap",
+    "CustomMeshSpec",
+    "DataChannel",
+    "DataDrivenColor",
+    "MarkerRenderer",
+    "MarkerShape",
+    "MarkerStyle",
+    "PaletteColor",
+    "PlotStyleSet",
+    "PlotStyleSpec",
+    "RGBATuple",
+    "StaticColor",
+    "resolve_colormap_alias",
+]

--- a/src/shared/python/plot_style/_types.py
+++ b/src/shared/python/plot_style/_types.py
@@ -1,0 +1,17 @@
+"""Internal type aliases shared by plot_style modules.
+
+These aliases are not part of the public API and may change without
+notice. Public re-exports live in :mod:`src.shared.python.plot_style`.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# (r, g, b, a) tuple with each component in [0, 1].
+RGBATuple = tuple[float, float, float, float]
+
+# Sentinel returned for non-finite / out-of-range channel values.
+NAN_RGBA_FALLBACK: Final[RGBATuple] = (0.5333, 0.5333, 0.5333, 1.0)
+
+__all__ = ["NAN_RGBA_FALLBACK", "RGBATuple"]

--- a/src/shared/python/plot_style/channels.py
+++ b/src/shared/python/plot_style/channels.py
@@ -1,0 +1,156 @@
+"""Per-frame (and per-(frame, marker)) scalar data channels.
+
+A :class:`DataChannel` wraps a numeric ``numpy`` array of shape ``(T,)``
+or ``(T, M)`` and exposes safe ``value_at`` / ``auto_range`` helpers used
+by :class:`~src.shared.python.plot_style.colors.DataDrivenColor`.
+
+Design-by-Contract
+------------------
+``DataChannel`` is frozen and validates every field in ``__post_init__``.
+``value_at`` returns ``NaN`` for out-of-bounds indices instead of
+raising — callers may safely vectorise without bounds-guarding.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+__all__ = ["DataChannel"]
+
+
+def _is_numeric_dtype(dtype: np.dtype[Any]) -> bool:
+    """Return True if ``dtype`` is a real numeric kind (i, u, f)."""
+    return dtype.kind in ("i", "u", "f")
+
+
+@dataclass(frozen=True)
+class DataChannel:
+    """A per-frame (or per-(frame, marker)) scalar source.
+
+    Attributes
+    ----------
+    name:
+        Non-empty unique identifier (e.g. ``"clubhead_speed"``).
+    values:
+        ``numpy.ndarray`` with ``ndim`` in ``{1, 2}``. A 1-D array of
+        shape ``(T,)`` denotes one scalar per frame. A 2-D array of
+        shape ``(T, M)`` denotes one scalar per (frame, marker).
+    unit:
+        Display unit string. May be empty.
+    """
+
+    name: str
+    values: np.ndarray = field(repr=False)
+    unit: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError(f"name must be a non-empty string; got {self.name!r}")
+        if not isinstance(self.unit, str):
+            raise TypeError(f"unit must be a string; got {type(self.unit).__name__}")
+        if not isinstance(self.values, np.ndarray):
+            raise TypeError(
+                f"values must be a numpy.ndarray; got {type(self.values).__name__}"
+            )
+        if self.values.ndim not in (1, 2):
+            raise ValueError(
+                "values must have ndim in {1, 2}; "
+                f"got ndim={self.values.ndim} (shape={self.values.shape})"
+            )
+        if not _is_numeric_dtype(self.values.dtype):
+            raise TypeError(
+                "values dtype must be numeric (int / uint / float); "
+                f"got {self.values.dtype}"
+            )
+
+    # ------------------------------------------------------------------
+    # Convenience constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_array(
+        cls,
+        name: str,
+        values: np.ndarray,
+        unit: str = "",
+    ) -> DataChannel:
+        """Construct a :class:`DataChannel` from an ``ndarray``.
+
+        Equivalent to the regular constructor; provided as an explicit
+        factory for readability at call sites.
+        """
+        return cls(name=name, values=values, unit=unit)
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def n_frames(self) -> int:
+        """Number of frames (length of axis 0)."""
+        return int(self.values.shape[0])
+
+    @property
+    def n_markers(self) -> int | None:
+        """Number of markers (length of axis 1) or ``None`` for 1-D channels."""
+        if self.values.ndim == 1:
+            return None
+        return int(self.values.shape[1])
+
+    @property
+    def is_per_marker(self) -> bool:
+        """True iff the channel has a marker axis (2-D)."""
+        return self.values.ndim == 2
+
+    def value_at(self, frame_idx: int, marker_idx: int | None = None) -> float:
+        """Return the scalar value at ``(frame_idx, marker_idx)``.
+
+        Returns ``NaN`` for out-of-bounds indices. For a 1-D channel,
+        ``marker_idx`` is ignored. For a 2-D channel, ``marker_idx`` of
+        ``None`` returns the *mean* over the marker axis (excluding NaN).
+        """
+        if not isinstance(frame_idx, int):
+            raise TypeError(f"frame_idx must be int; got {type(frame_idx).__name__}")
+        if marker_idx is not None and not isinstance(marker_idx, int):
+            raise TypeError(
+                f"marker_idx must be int or None; got {type(marker_idx).__name__}"
+            )
+
+        if frame_idx < 0 or frame_idx >= self.n_frames:
+            return float("nan")
+
+        if self.values.ndim == 1:
+            return float(self.values[frame_idx])
+
+        # 2-D path
+        n_markers = self.n_markers
+        assert n_markers is not None  # noqa: S101 — invariant guarded above
+        if marker_idx is None:
+            row = self.values[frame_idx]
+            finite_mask = np.isfinite(row)
+            if not bool(finite_mask.any()):
+                return float("nan")
+            return float(np.mean(row[finite_mask]))
+        if marker_idx < 0 or marker_idx >= n_markers:
+            return float("nan")
+        return float(self.values[frame_idx, marker_idx])
+
+    def auto_range(self) -> tuple[float, float]:
+        """Return ``(min, max)`` over all finite values.
+
+        Returns ``(NaN, NaN)`` if the channel contains no finite values.
+        """
+        finite = self.values[np.isfinite(self.values)]
+        if finite.size == 0:
+            nan = float("nan")
+            return (nan, nan)
+        return (float(np.min(finite)), float(np.max(finite)))
+
+    def has_finite_range(self) -> bool:
+        """True iff :meth:`auto_range` returns finite values."""
+        lo, hi = self.auto_range()
+        return math.isfinite(lo) and math.isfinite(hi)

--- a/src/shared/python/plot_style/channels.py
+++ b/src/shared/python/plot_style/channels.py
@@ -14,12 +14,18 @@ raising — callers may safely vectorise without bounds-guarding.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
 
-__all__ = ["DataChannel"]
+__all__ = [
+    "DataChannel",
+    "derivative_channel",
+    "magnitude_channel",
+    "slice_channel",
+]
 
 
 def _is_numeric_dtype(dtype: np.dtype[Any]) -> bool:
@@ -154,3 +160,208 @@ class DataChannel:
         """True iff :meth:`auto_range` returns finite values."""
         lo, hi = self.auto_range()
         return math.isfinite(lo) and math.isfinite(hi)
+
+
+# ---------------------------------------------------------------------------
+# Module-level derived-channel helpers (issue #4809)
+# ---------------------------------------------------------------------------
+
+
+def magnitude_channel(
+    name: str,
+    vector_per_frame: np.ndarray,
+    unit: str = "",
+) -> DataChannel:
+    """Build a :class:`DataChannel` of magnitudes from a vector field.
+
+    Parameters
+    ----------
+    name:
+        Non-empty channel identifier.
+    vector_per_frame:
+        Either a 2-D array of shape ``(T, 3)`` (one 3-vector per frame)
+        or a 3-D array of shape ``(T, M, 3)`` (one 3-vector per
+        ``(frame, marker)``). The last axis must be of length 3.
+    unit:
+        Display unit string of the resulting magnitudes.
+
+    Returns
+    -------
+    DataChannel
+        For ``(T, 3)`` input the result is 1-D of shape ``(T,)``. For
+        ``(T, M, 3)`` input the result is 2-D of shape ``(T, M)``.
+
+    Raises
+    ------
+    TypeError
+        If ``vector_per_frame`` is not a ``numpy.ndarray``.
+    ValueError
+        If ``vector_per_frame`` has unsupported ``ndim`` or its last
+        axis is not of length 3.
+    """
+    if not isinstance(vector_per_frame, np.ndarray):
+        raise TypeError(
+            "vector_per_frame must be a numpy.ndarray; "
+            f"got {type(vector_per_frame).__name__}"
+        )
+    if vector_per_frame.ndim not in (2, 3):
+        raise ValueError(
+            "vector_per_frame must have ndim in {2, 3}; "
+            f"got ndim={vector_per_frame.ndim} (shape={vector_per_frame.shape})"
+        )
+    if vector_per_frame.shape[-1] != 3:
+        raise ValueError(
+            "vector_per_frame last axis must be of length 3; "
+            f"got shape={vector_per_frame.shape}"
+        )
+
+    # ``np.linalg.norm`` propagates NaN — preserves the contract used by
+    # ``auto_range`` and ``value_at``.
+    magnitudes = np.linalg.norm(vector_per_frame, axis=-1)
+    return DataChannel(name=name, values=magnitudes, unit=unit)
+
+
+def derivative_channel(
+    name: str,
+    base_channel: DataChannel,
+    *,
+    timestep_s: float,
+    unit_suffix: str = "/s",
+) -> DataChannel:
+    """Numerical time derivative of a scalar :class:`DataChannel`.
+
+    Uses :func:`numpy.gradient` along the frame axis (axis 0) with a
+    uniform spacing of ``timestep_s``. NaNs in the source propagate
+    through the derivative.
+
+    Parameters
+    ----------
+    name:
+        Non-empty identifier of the new channel.
+    base_channel:
+        Source channel whose values will be differentiated.
+    timestep_s:
+        Uniform sample period in seconds. Must be strictly positive.
+    unit_suffix:
+        Suffix appended to ``base_channel.unit`` to form the derived
+        unit (default ``"/s"``). When the base channel has no unit, the
+        suffix is used as-is for transparency.
+
+    Raises
+    ------
+    TypeError
+        If ``base_channel`` is not a :class:`DataChannel`.
+    ValueError
+        If ``timestep_s`` is not finite or not strictly positive, or if
+        the base channel has fewer than 2 frames (gradient undefined).
+    """
+    if not isinstance(base_channel, DataChannel):
+        raise TypeError(
+            f"base_channel must be a DataChannel; got {type(base_channel).__name__}"
+        )
+    if not isinstance(timestep_s, (int, float)) or isinstance(timestep_s, bool):
+        raise TypeError(
+            f"timestep_s must be a real number; got {type(timestep_s).__name__}"
+        )
+    if not math.isfinite(timestep_s) or timestep_s <= 0.0:
+        raise ValueError(f"timestep_s must be finite and > 0; got {timestep_s!r}")
+    if base_channel.n_frames < 2:
+        raise ValueError(
+            "base_channel must have at least 2 frames to compute a derivative; "
+            f"got n_frames={base_channel.n_frames}"
+        )
+
+    derivative = np.gradient(base_channel.values, float(timestep_s), axis=0)
+    derived_unit = (
+        f"{base_channel.unit}{unit_suffix}" if base_channel.unit else unit_suffix
+    )
+    return DataChannel(name=name, values=derivative, unit=derived_unit)
+
+
+def slice_channel(
+    base_channel: DataChannel,
+    frame_range: slice,
+    marker_subset: Sequence[int] | None = None,
+) -> DataChannel:
+    """Build a derived :class:`DataChannel` by slicing the source.
+
+    The resulting channel re-uses ``base_channel.name`` and ``unit`` —
+    the slice is a *view-like* derived channel, not a rename. NaN
+    handling in :meth:`DataChannel.auto_range` and
+    :meth:`DataChannel.value_at` is preserved because the underlying
+    ``ndarray`` slice keeps the same dtype and finite-mask semantics.
+
+    Parameters
+    ----------
+    base_channel:
+        Source channel.
+    frame_range:
+        Python ``slice`` object describing the frame window. ``start``
+        and ``stop`` (when given) must lie within
+        ``[0, base_channel.n_frames]``. Negative bounds are rejected to
+        keep DbC explicit.
+    marker_subset:
+        Optional sequence of marker indices for 2-D channels. Each
+        index must lie in ``[0, n_markers)``. Ignored for 1-D channels.
+
+    Raises
+    ------
+    TypeError
+        If types are wrong (e.g. ``frame_range`` not a ``slice``).
+    ValueError
+        If ``frame_range`` bounds are out of range, if
+        ``marker_subset`` is provided for a 1-D channel, or if any
+        marker index is OOB.
+    """
+    if not isinstance(base_channel, DataChannel):
+        raise TypeError(
+            f"base_channel must be a DataChannel; got {type(base_channel).__name__}"
+        )
+    if not isinstance(frame_range, slice):
+        raise TypeError(
+            f"frame_range must be a slice; got {type(frame_range).__name__}"
+        )
+
+    n_frames = base_channel.n_frames
+    start = frame_range.start
+    stop = frame_range.stop
+    if start is not None and (
+        not isinstance(start, int) or start < 0 or start > n_frames
+    ):
+        raise ValueError(f"frame_range.start must be in [0, {n_frames}]; got {start!r}")
+    if stop is not None and (not isinstance(stop, int) or stop < 0 or stop > n_frames):
+        raise ValueError(f"frame_range.stop must be in [0, {n_frames}]; got {stop!r}")
+
+    if marker_subset is not None:
+        if not base_channel.is_per_marker:
+            raise ValueError(
+                "marker_subset is only valid for per-marker (2-D) channels"
+            )
+        if not isinstance(marker_subset, Sequence) or isinstance(marker_subset, str):
+            raise TypeError(
+                "marker_subset must be a sequence of ints; "
+                f"got {type(marker_subset).__name__}"
+            )
+        n_markers = base_channel.n_markers
+        assert n_markers is not None  # noqa: S101 — guarded above
+        for idx in marker_subset:
+            if not isinstance(idx, (int, np.integer)) or isinstance(idx, bool):
+                raise TypeError(
+                    f"marker_subset entries must be int; got {type(idx).__name__}"
+                )
+            if idx < 0 or idx >= n_markers:
+                raise ValueError(
+                    f"marker_subset index {idx} out of range [0, {n_markers})"
+                )
+
+    sliced = base_channel.values[frame_range]
+    if marker_subset is not None and base_channel.is_per_marker:
+        sliced = sliced[:, list(marker_subset)]
+
+    # ``np.ndarray`` slicing returns views; ``DataChannel`` is frozen so
+    # rewrapping is sufficient and avoids unnecessary copies.
+    return DataChannel(
+        name=base_channel.name,
+        values=np.asarray(sliced),
+        unit=base_channel.unit,
+    )

--- a/src/shared/python/plot_style/colormaps.py
+++ b/src/shared/python/plot_style/colormaps.py
@@ -1,0 +1,131 @@
+"""Colormap identifiers and user-defined colormap dataclass.
+
+:class:`ColormapId` enumerates matplotlib built-ins (passed through
+verbatim) plus a small set of *semantic* aliases this codebase
+registers for kinematic / kinetic data (velocity, force, ...).
+
+:class:`CustomColormap` defines a user-supplied colormap via a list of
+``(position, hex)`` stops. Strict validation of monotonic positions and
+parseable hex strings happens in ``__post_init__``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from matplotlib.colors import is_color_like
+
+__all__ = ["ColormapId", "CustomColormap", "SEMANTIC_COLORMAP_ALIASES"]
+
+
+class ColormapId(str, Enum):
+    """Built-in and semantic colormap identifiers.
+
+    Matplotlib built-ins are passed through to ``matplotlib.cm`` by name.
+    Semantic aliases (``VELOCITY``, ``FORCE``, ...) resolve to the
+    matplotlib name listed in :data:`SEMANTIC_COLORMAP_ALIASES`.
+    """
+
+    # ---- Matplotlib built-ins ----
+    VIRIDIS = "viridis"
+    PLASMA = "plasma"
+    MAGMA = "magma"
+    INFERNO = "inferno"
+    CIVIDIS = "cividis"
+    TURBO = "turbo"
+    COOLWARM = "coolwarm"
+    SPECTRAL = "spectral"
+
+    # ---- Semantic aliases (registered by this codebase) ----
+    VELOCITY = "velocity"
+    FORCE = "force"
+    ACCELERATION = "acceleration"
+    HEIGHT = "height"
+    GENERIC_DIVERGING = "generic_diverging"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# Resolve a semantic alias -> built-in matplotlib name.
+SEMANTIC_COLORMAP_ALIASES: dict[ColormapId, ColormapId] = {
+    ColormapId.VELOCITY: ColormapId.PLASMA,
+    ColormapId.FORCE: ColormapId.INFERNO,
+    ColormapId.ACCELERATION: ColormapId.TURBO,
+    ColormapId.HEIGHT: ColormapId.VIRIDIS,
+    ColormapId.GENERIC_DIVERGING: ColormapId.COOLWARM,
+}
+
+
+def resolve_colormap_alias(cmap_id: ColormapId) -> ColormapId:
+    """Resolve a semantic alias to its underlying matplotlib colormap.
+
+    Built-in identifiers are returned unchanged.
+    """
+    if not isinstance(cmap_id, ColormapId):
+        raise TypeError(f"cmap_id must be ColormapId; got {type(cmap_id).__name__}")
+    return SEMANTIC_COLORMAP_ALIASES.get(cmap_id, cmap_id)
+
+
+@dataclass(frozen=True)
+class CustomColormap:
+    """User-defined colormap built from ``(position, hex)`` stops.
+
+    Attributes
+    ----------
+    name:
+        Unique non-empty identifier.
+    stops:
+        Tuple of ``(position, hex)`` pairs. ``position`` lies in
+        ``[0, 1]`` and the sequence is strictly increasing.
+    """
+
+    name: str
+    stops: tuple[tuple[float, str], ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError(f"name must be a non-empty string; got {self.name!r}")
+        if not isinstance(self.stops, tuple):
+            raise TypeError(
+                "stops must be a tuple of (position, hex) pairs; "
+                f"got {type(self.stops).__name__}"
+            )
+        if len(self.stops) < 2:
+            raise ValueError(
+                f"stops must contain at least 2 entries; got {len(self.stops)}"
+            )
+
+        last_pos = -float("inf")
+        for index, stop in enumerate(self.stops):
+            if not isinstance(stop, tuple) or len(stop) != 2:
+                raise ValueError(
+                    "each stop must be a (position, hex) 2-tuple; "
+                    f"got {stop!r} at index {index}"
+                )
+            position, hex_value = stop
+            if not isinstance(position, (int, float)) or isinstance(position, bool):
+                raise TypeError(
+                    f"stop position must be numeric; got {position!r} at {index}"
+                )
+            position_f = float(position)
+            if not 0.0 <= position_f <= 1.0:
+                raise ValueError(
+                    "stop positions must lie in [0, 1]; "
+                    f"got {position_f} at index {index}"
+                )
+            if position_f <= last_pos:
+                raise ValueError(
+                    "stop positions must be strictly increasing; "
+                    f"got {position_f} after {last_pos} at index {index}"
+                )
+            last_pos = position_f
+            if not isinstance(hex_value, str) or not hex_value:
+                raise ValueError(
+                    f"stop hex must be a non-empty string; got {hex_value!r}"
+                )
+            if not is_color_like(hex_value):
+                raise ValueError(
+                    f"stop hex {hex_value!r} is not a parseable matplotlib color"
+                )

--- a/src/shared/python/plot_style/colors.py
+++ b/src/shared/python/plot_style/colors.py
@@ -1,0 +1,263 @@
+"""Color-scale dataclasses for marker fill colors.
+
+A *color scale* is anything that, given a ``(frame_idx, marker_idx)``
+pair, produces an ``(r, g, b, a)`` tuple in ``[0, 1]``. Three concrete
+variants are supported:
+
+* :class:`StaticColor` — single constant color.
+* :class:`PaletteColor` — categorical pick from a named palette.
+* :class:`DataDrivenColor` — channel value normalised through a
+  colormap.
+
+The :data:`ColorScale` alias unifies the three variants.
+
+Design-by-Contract
+------------------
+Each dataclass is frozen, validates its arguments in ``__post_init__``,
+and provides a ``resolve(frame_idx, marker_idx)`` method that returns a
+4-tuple of floats in ``[0, 1]``. ``resolve`` is total — non-finite
+inputs map to the ``nan_color`` (for :class:`DataDrivenColor`) or to the
+configured static color.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+from matplotlib import cm, colormaps
+from matplotlib.colors import Colormap, is_color_like, to_rgba
+
+from ._types import RGBATuple
+from .channels import DataChannel
+from .colormaps import ColormapId, resolve_colormap_alias
+
+__all__ = [
+    "ColorScale",
+    "DataDrivenColor",
+    "PaletteColor",
+    "StaticColor",
+]
+
+
+def _hex_to_rgba(hex_value: str) -> RGBATuple:
+    """Convert a matplotlib-recognised color string to an ``RGBATuple``."""
+    # matplotlib stubs are over-narrow on the input type — to_rgba accepts
+    # any color-like (str / tuple / ndarray) at runtime.
+    rgba = to_rgba(cast(Any, hex_value))
+    return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+def _get_matplotlib_colormap(cmap_id: ColormapId) -> Colormap:
+    """Resolve a :class:`ColormapId` (incl. semantic aliases) to a Colormap."""
+    resolved = resolve_colormap_alias(cmap_id)
+    try:
+        return cast(Colormap, colormaps[resolved.value])
+    except (KeyError, ValueError):
+        # Fallback: matplotlib older API
+        return cast(Colormap, cm.get_cmap(resolved.value))
+
+
+@dataclass(frozen=True)
+class StaticColor:
+    """A constant color shared by every marker on every frame.
+
+    Attributes
+    ----------
+    hex_value:
+        Any matplotlib-recognised color string (hex, name, rgb tuple as
+        string, etc.).
+    """
+
+    hex_value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.hex_value, str) or not self.hex_value:
+            raise ValueError(
+                f"hex_value must be a non-empty string; got {self.hex_value!r}"
+            )
+        if not is_color_like(self.hex_value):
+            raise ValueError(
+                f"hex_value {self.hex_value!r} is not a parseable matplotlib color"
+            )
+
+    def resolve(
+        self,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> RGBATuple:
+        """Return the constant ``(r, g, b, a)`` tuple in ``[0, 1]``.
+
+        Parameters are accepted for interface compatibility and ignored.
+        """
+        del frame_idx, marker_idx  # interface compatibility
+        return _hex_to_rgba(self.hex_value)
+
+
+@dataclass(frozen=True)
+class PaletteColor:
+    """A color picked from a named matplotlib qualitative palette.
+
+    Attributes
+    ----------
+    palette_name:
+        Name of a matplotlib colormap (e.g. ``"tab10"``, ``"Set2"``).
+    palette_index:
+        Non-negative integer index into the palette. Matplotlib palettes
+        wrap modulo the palette size; we record the raw index and let
+        the colormap handle wrap so palette-index 12 in ``"tab10"`` is
+        deterministic.
+    """
+
+    palette_name: str
+    palette_index: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.palette_name, str) or not self.palette_name:
+            raise ValueError(
+                f"palette_name must be a non-empty string; got {self.palette_name!r}"
+            )
+        if not isinstance(self.palette_index, int) or isinstance(
+            self.palette_index, bool
+        ):
+            raise TypeError(
+                f"palette_index must be int; got {type(self.palette_index).__name__}"
+            )
+        if self.palette_index < 0:
+            raise ValueError(
+                f"palette_index must be non-negative; got {self.palette_index}"
+            )
+        # Verify the palette actually exists.
+        try:
+            _ = colormaps[self.palette_name]
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                f"palette_name {self.palette_name!r} is not a registered "
+                "matplotlib colormap"
+            ) from exc
+
+    def resolve(
+        self,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> RGBATuple:
+        """Return the palette color at ``palette_index`` (modulo palette size)."""
+        del frame_idx, marker_idx  # interface compatibility
+        cmap = cast(Colormap, colormaps[self.palette_name])
+        size = getattr(cmap, "N", 10) or 10
+        index = self.palette_index % size
+        rgba = cmap(index)
+        return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+@dataclass(frozen=True)
+class DataDrivenColor:
+    """Color sampled from a colormap by normalised channel value.
+
+    For each ``(frame_idx, marker_idx)`` query, the channel scalar is
+    looked up, normalised against ``vmin`` / ``vmax`` (auto-detected
+    from the channel if either is ``None``), clamped to ``[0, 1]``, and
+    used to sample :attr:`colormap`. Non-finite values map to
+    :attr:`nan_color`.
+
+    Attributes
+    ----------
+    channel:
+        Source :class:`DataChannel`.
+    colormap:
+        Colormap identifier (built-in or semantic alias).
+    vmin, vmax:
+        Optional explicit normalisation bounds. ``None`` means
+        auto-detect via :meth:`DataChannel.auto_range`.
+    nan_color:
+        Color (matplotlib-recognised string) used for non-finite values
+        and the case when ``vmin == vmax`` (degenerate range).
+    """
+
+    channel: DataChannel
+    colormap: ColormapId
+    vmin: float | None = None
+    vmax: float | None = None
+    nan_color: str = "#888888"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.channel, DataChannel):
+            raise TypeError(
+                f"channel must be DataChannel; got {type(self.channel).__name__}"
+            )
+        if not isinstance(self.colormap, ColormapId):
+            raise TypeError(
+                f"colormap must be ColormapId; got {type(self.colormap).__name__}"
+            )
+        for attr_name, attr_val in (("vmin", self.vmin), ("vmax", self.vmax)):
+            if attr_val is None:
+                continue
+            if not isinstance(attr_val, (int, float)) or isinstance(attr_val, bool):
+                raise TypeError(
+                    f"{attr_name} must be numeric or None; got {attr_val!r}"
+                )
+            if not math.isfinite(float(attr_val)):
+                raise ValueError(
+                    f"{attr_name} must be finite when supplied; got {attr_val!r}"
+                )
+        if (
+            self.vmin is not None
+            and self.vmax is not None
+            and float(self.vmax) <= float(self.vmin)
+        ):
+            raise ValueError(
+                "vmax must be strictly greater than vmin when both are set; "
+                f"got vmin={self.vmin}, vmax={self.vmax}"
+            )
+        if not isinstance(self.nan_color, str) or not self.nan_color:
+            raise ValueError(
+                f"nan_color must be a non-empty string; got {self.nan_color!r}"
+            )
+        if not is_color_like(self.nan_color):
+            raise ValueError(
+                f"nan_color {self.nan_color!r} is not a parseable matplotlib color"
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolved_bounds(self) -> tuple[float, float]:
+        """Return ``(vmin, vmax)`` with auto-detect filled in.
+
+        Both values may be NaN if the channel has no finite samples.
+        """
+        if self.vmin is not None and self.vmax is not None:
+            return (float(self.vmin), float(self.vmax))
+        auto_lo, auto_hi = self.channel.auto_range()
+        lo = float(self.vmin) if self.vmin is not None else auto_lo
+        hi = float(self.vmax) if self.vmax is not None else auto_hi
+        return (lo, hi)
+
+    # ------------------------------------------------------------------
+    # Resolve
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> RGBATuple:
+        """Return the ``(r, g, b, a)`` color for the given index pair."""
+        scalar = self.channel.value_at(frame_idx, marker_idx)
+        if not math.isfinite(scalar):
+            return _hex_to_rgba(self.nan_color)
+        lo, hi = self._resolved_bounds()
+        if not (math.isfinite(lo) and math.isfinite(hi)) or hi <= lo:
+            return _hex_to_rgba(self.nan_color)
+        normalised = (scalar - lo) / (hi - lo)
+        normalised = float(np.clip(normalised, 0.0, 1.0))
+        cmap = _get_matplotlib_colormap(self.colormap)
+        rgba = cmap(normalised)
+        return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+# Public union over the three variants.
+ColorScale = StaticColor | PaletteColor | DataDrivenColor

--- a/src/shared/python/plot_style/contracts.py
+++ b/src/shared/python/plot_style/contracts.py
@@ -1,0 +1,111 @@
+"""Runtime-checkable Protocols for the plot_style package.
+
+These contracts define the abstract surface that every backend
+(matplotlib, pyqtgraph, ...) and color-resolver implementation must
+satisfy. Nothing in this module imports a rendering library — the
+contracts are intentionally backend-agnostic.
+
+* :class:`MarkerRenderer` — adds, updates, and removes markers in a
+  scene. Implementations live in
+  :mod:`src.shared.python.plot_style.renderers`.
+* :class:`ColorResolver` — resolves a :data:`ColorScale` to numeric
+  RGBA tuples. Implementations live in
+  :mod:`src.shared.python.plot_style.resolvers`.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from .colors import ColorScale
+from .markers import MarkerStyle
+
+__all__ = ["ColorResolver", "MarkerRenderer"]
+
+
+@runtime_checkable
+class MarkerRenderer(Protocol):
+    """Backend-specific marker renderer.
+
+    A renderer maintains a collection of marker primitives identified
+    by stable string handles. Concrete subclasses target matplotlib,
+    pyqtgraph, plotly, etc.
+    """
+
+    def add_markers(
+        self,
+        positions: np.ndarray,
+        style: MarkerStyle,
+        label: str = "",
+    ) -> str:
+        """Add a marker primitive and return a stable handle.
+
+        Parameters
+        ----------
+        positions:
+            ``(T, M, 3)`` or ``(T, 3)`` ndarray of marker world
+            positions per frame.
+        style:
+            Visual specification for these markers.
+        label:
+            Optional human-readable label.
+
+        Returns
+        -------
+        handle:
+            Non-empty string handle suitable for later
+            :meth:`update_frame`, :meth:`update_style`,
+            :meth:`set_visible`, and :meth:`remove` calls.
+        """
+        ...
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        """Move the markers identified by ``handle`` to ``frame_idx``."""
+        ...
+
+    def update_style(self, handle: str, style: MarkerStyle) -> None:
+        """Replace the style applied to ``handle``."""
+        ...
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        """Show or hide the markers identified by ``handle``."""
+        ...
+
+    def remove(self, handle: str) -> None:
+        """Remove the markers identified by ``handle`` from the scene."""
+        ...
+
+
+@runtime_checkable
+class ColorResolver(Protocol):
+    """Resolves a :data:`ColorScale` to numeric RGBA values."""
+
+    def resolve_one(
+        self,
+        scale: ColorScale,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> tuple[float, float, float, float]:
+        """Resolve a single ``(frame_idx, marker_idx)`` pair.
+
+        Returns
+        -------
+        rgba:
+            ``(r, g, b, a)`` tuple with each component in ``[0, 1]``.
+        """
+        ...
+
+    def resolve_array(
+        self,
+        scale: ColorScale,
+        n_frames: int,
+        n_markers: int | None = None,
+    ) -> np.ndarray:
+        """Bulk-resolve into an ``(n_frames, [n_markers,] 4)`` ndarray.
+
+        Useful for pre-computing per-frame look-up tables to avoid
+        per-frame Python overhead during animation.
+        """
+        ...

--- a/src/shared/python/plot_style/markers.py
+++ b/src/shared/python/plot_style/markers.py
@@ -1,0 +1,210 @@
+"""Marker shape enum and the :class:`MarkerStyle` dataclass.
+
+A *marker style* captures every visual attribute of a marker except the
+position itself (those are supplied per-frame at render time):
+
+* shape — sphere, cube, custom mesh, ...
+* size, edge color / width, opacity
+* fill color (any :data:`ColorScale` variant)
+
+Custom mesh markers attach a :class:`CustomMeshSpec` describing the
+geometry the renderer should draw.
+
+Design-by-Contract
+------------------
+Both dataclasses are frozen and validate every constraint in
+``__post_init__``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+
+import numpy as np
+from matplotlib.colors import is_color_like
+
+from .colors import ColorScale, DataDrivenColor, PaletteColor, StaticColor
+
+__all__ = ["CustomMeshSpec", "MarkerShape", "MarkerStyle"]
+
+
+class MarkerShape(str, Enum):
+    """Built-in marker shape identifiers.
+
+    ``CUSTOM_MESH`` is paired with a :class:`CustomMeshSpec` on the
+    enclosing :class:`MarkerStyle`.
+    """
+
+    SPHERE = "sphere"
+    CUBE = "cube"
+    CROSS = "cross"
+    STAR = "star"
+    DIAMOND = "diamond"
+    PLUS = "plus"
+    POINT = "point"
+    CUSTOM_MESH = "custom_mesh"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class CustomMeshSpec:
+    """Triangular mesh attached to a :class:`MarkerShape.CUSTOM_MESH`.
+
+    Attributes
+    ----------
+    vertices:
+        ``(V, 3)`` ``float`` ndarray of vertex positions in the marker's
+        local frame.
+    faces:
+        ``(F, 3)`` integer ndarray of triangle indices into
+        :attr:`vertices`.
+    name:
+        Non-empty identifier used when persisting / logging.
+    """
+
+    name: str
+    vertices: np.ndarray = field(repr=False)
+    faces: np.ndarray = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError(f"name must be a non-empty string; got {self.name!r}")
+        if not isinstance(self.vertices, np.ndarray):
+            raise TypeError(
+                f"vertices must be numpy.ndarray; got {type(self.vertices).__name__}"
+            )
+        if not isinstance(self.faces, np.ndarray):
+            raise TypeError(
+                f"faces must be numpy.ndarray; got {type(self.faces).__name__}"
+            )
+        if self.vertices.ndim != 2 or self.vertices.shape[1] != 3:
+            raise ValueError(
+                f"vertices must have shape (V, 3); got shape={self.vertices.shape}"
+            )
+        if self.faces.ndim != 2 or self.faces.shape[1] != 3:
+            raise ValueError(
+                f"faces must have shape (F, 3); got shape={self.faces.shape}"
+            )
+        if self.vertices.dtype.kind not in ("f", "i", "u"):
+            raise TypeError(
+                f"vertices dtype must be numeric; got {self.vertices.dtype}"
+            )
+        if self.faces.dtype.kind not in ("i", "u"):
+            raise TypeError(f"faces dtype must be integer; got {self.faces.dtype}")
+        if self.faces.size > 0:
+            max_idx = int(self.faces.max())
+            if max_idx >= self.vertices.shape[0]:
+                raise ValueError(
+                    "faces index out of bounds for vertices: "
+                    f"max index={max_idx}, n_vertices={self.vertices.shape[0]}"
+                )
+            if int(self.faces.min()) < 0:
+                raise ValueError("faces indices must be non-negative")
+
+
+def _default_fill_color() -> StaticColor:
+    """Default :class:`StaticColor` used by :class:`MarkerStyle`."""
+    return StaticColor("#1f77b4")
+
+
+@dataclass(frozen=True)
+class MarkerStyle:
+    """All visual properties of a marker except its position.
+
+    Attributes
+    ----------
+    shape:
+        Marker shape identifier.
+    size_px:
+        Diameter in pixels. Strictly positive.
+    edge_color:
+        Edge color (any matplotlib-recognised color string).
+    edge_width:
+        Edge stroke width in pixels. Non-negative.
+    fill_color:
+        Any :data:`ColorScale` variant (static, palette, or data-driven).
+    opacity:
+        Alpha multiplier in ``[0, 1]``.
+    custom_mesh:
+        Required iff :attr:`shape` is :attr:`MarkerShape.CUSTOM_MESH`.
+    """
+
+    shape: MarkerShape = MarkerShape.SPHERE
+    size_px: float = 6.0
+    edge_color: str = "#000000"
+    edge_width: float = 0.5
+    fill_color: ColorScale = field(default_factory=_default_fill_color)
+    opacity: float = 1.0
+    custom_mesh: CustomMeshSpec | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.shape, MarkerShape):
+            raise TypeError(
+                f"shape must be MarkerShape; got {type(self.shape).__name__}"
+            )
+        if not isinstance(self.size_px, (int, float)) or isinstance(self.size_px, bool):
+            raise TypeError(
+                f"size_px must be numeric; got {type(self.size_px).__name__}"
+            )
+        size_f = float(self.size_px)
+        if not math.isfinite(size_f) or size_f <= 0.0:
+            raise ValueError(f"size_px must be finite and > 0; got {self.size_px!r}")
+
+        if not isinstance(self.edge_width, (int, float)) or isinstance(
+            self.edge_width, bool
+        ):
+            raise TypeError(
+                f"edge_width must be numeric; got {type(self.edge_width).__name__}"
+            )
+        edge_f = float(self.edge_width)
+        if not math.isfinite(edge_f) or edge_f < 0.0:
+            raise ValueError(
+                f"edge_width must be finite and >= 0; got {self.edge_width!r}"
+            )
+
+        if not isinstance(self.opacity, (int, float)) or isinstance(self.opacity, bool):
+            raise TypeError(
+                f"opacity must be numeric; got {type(self.opacity).__name__}"
+            )
+        opacity_f = float(self.opacity)
+        if not math.isfinite(opacity_f) or not 0.0 <= opacity_f <= 1.0:
+            raise ValueError(f"opacity must lie in [0, 1]; got {self.opacity!r}")
+
+        if not isinstance(self.edge_color, str) or not self.edge_color:
+            raise ValueError(
+                f"edge_color must be a non-empty string; got {self.edge_color!r}"
+            )
+        if not is_color_like(self.edge_color):
+            raise ValueError(
+                f"edge_color {self.edge_color!r} is not a parseable matplotlib color"
+            )
+
+        if not isinstance(
+            self.fill_color, (StaticColor, PaletteColor, DataDrivenColor)
+        ):
+            raise TypeError(
+                "fill_color must be a ColorScale instance "
+                "(StaticColor / PaletteColor / DataDrivenColor); "
+                f"got {type(self.fill_color).__name__}"
+            )
+
+        is_custom_mesh = self.shape is MarkerShape.CUSTOM_MESH
+        has_mesh = self.custom_mesh is not None
+        if is_custom_mesh and not has_mesh:
+            raise ValueError(
+                "MarkerStyle.shape == CUSTOM_MESH requires custom_mesh to be set"
+            )
+        if has_mesh and not is_custom_mesh:
+            raise ValueError(
+                "custom_mesh is only allowed when shape == CUSTOM_MESH; "
+                f"got shape={self.shape}"
+            )
+        if has_mesh and not isinstance(self.custom_mesh, CustomMeshSpec):
+            raise TypeError(
+                "custom_mesh must be CustomMeshSpec; "
+                f"got {type(self.custom_mesh).__name__}"
+            )

--- a/src/shared/python/plot_style/persistence.py
+++ b/src/shared/python/plot_style/persistence.py
@@ -1,0 +1,342 @@
+"""JSON persistence for plot-style specifications.
+
+Defines :class:`PlotStyleSpec` (one named entry — usually one per
+marker group or trace) and :class:`PlotStyleSet` (an ordered,
+schema-versioned collection that round-trips through JSON).
+
+Schema v1 layout::
+
+    {
+      "schema_version": 1,
+      "entries": [
+        {
+          "name": "...",
+          "target": "...",
+          "style": { ...MarkerStyle JSON... }
+        },
+        ...
+      ]
+    }
+
+Unknown top-level keys and unknown keys *inside* an entry are tolerated
+on load (forward-compat) but never written back.
+
+Note
+----
+:class:`~src.shared.python.plot_style.markers.CustomMeshSpec` is *not*
+JSON-serialisable in v1: persisted MarkerStyles must use a built-in
+shape. Serialising custom meshes is tracked for a follow-up issue.
+
+Design-by-Contract
+------------------
+Both dataclasses are frozen and validate every constraint in
+``__post_init__``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from .channels import DataChannel
+from .colormaps import ColormapId
+from .colors import (
+    ColorScale,
+    DataDrivenColor,
+    PaletteColor,
+    StaticColor,
+)
+from .markers import MarkerShape, MarkerStyle
+
+__all__ = ["PlotStyleSet", "PlotStyleSpec", "SCHEMA_VERSION"]
+
+SCHEMA_VERSION = 1
+
+
+# ----------------------------------------------------------------------
+# JSON helpers (private)
+# ----------------------------------------------------------------------
+
+
+def _color_scale_to_json(scale: ColorScale) -> dict[str, Any]:
+    """Serialise a :data:`ColorScale` instance to a JSON-friendly dict."""
+    if isinstance(scale, StaticColor):
+        return {"kind": "static", "hex_value": scale.hex_value}
+    if isinstance(scale, PaletteColor):
+        return {
+            "kind": "palette",
+            "palette_name": scale.palette_name,
+            "palette_index": scale.palette_index,
+        }
+    if isinstance(scale, DataDrivenColor):
+        # DataChannel arrays are not JSON-serialisable here; persisted
+        # form references the channel by name and unit only. Round-trip
+        # tests reconstruct the channel separately.
+        return {
+            "kind": "data_driven",
+            "channel": {
+                "name": scale.channel.name,
+                "unit": scale.channel.unit,
+                "shape": list(scale.channel.values.shape),
+                "dtype": str(scale.channel.values.dtype),
+            },
+            "colormap": scale.colormap.value,
+            "vmin": scale.vmin,
+            "vmax": scale.vmax,
+            "nan_color": scale.nan_color,
+        }
+    raise TypeError(  # pragma: no cover — guarded by MarkerStyle DbC
+        f"unsupported ColorScale variant: {type(scale).__name__}"
+    )
+
+
+def _color_scale_from_json(
+    payload: dict[str, Any],
+    *,
+    channel_lookup: dict[str, DataChannel] | None = None,
+) -> ColorScale:
+    """Reconstruct a :data:`ColorScale` from JSON.
+
+    For ``data_driven`` entries, the caller may supply
+    ``channel_lookup`` mapping channel names to fully-built
+    :class:`DataChannel` instances. If the lookup is missing or doesn't
+    contain the referenced channel, a placeholder zero-length channel
+    with matching name is constructed.
+    """
+    kind = payload.get("kind")
+    if kind == "static":
+        return StaticColor(hex_value=str(payload["hex_value"]))
+    if kind == "palette":
+        return PaletteColor(
+            palette_name=str(payload["palette_name"]),
+            palette_index=int(payload["palette_index"]),
+        )
+    if kind == "data_driven":
+        ch_payload = cast(dict[str, Any], payload["channel"])
+        ch_name = str(ch_payload["name"])
+        if channel_lookup is not None and ch_name in channel_lookup:
+            channel = channel_lookup[ch_name]
+        else:
+            import numpy as np
+
+            channel = DataChannel(
+                name=ch_name,
+                values=np.zeros((0,), dtype=float),
+                unit=str(ch_payload.get("unit", "")),
+            )
+        return DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId(str(payload["colormap"])),
+            vmin=payload.get("vmin"),
+            vmax=payload.get("vmax"),
+            nan_color=str(payload.get("nan_color", "#888888")),
+        )
+    raise ValueError(f"unknown ColorScale kind: {kind!r}")
+
+
+def _marker_style_to_json(style: MarkerStyle) -> dict[str, Any]:
+    """Serialise a :class:`MarkerStyle` (without custom mesh) to JSON."""
+    if style.shape is MarkerShape.CUSTOM_MESH:
+        raise ValueError(
+            "MarkerStyle with shape=CUSTOM_MESH is not JSON-serialisable in v1"
+        )
+    return {
+        "shape": style.shape.value,
+        "size_px": float(style.size_px),
+        "edge_color": style.edge_color,
+        "edge_width": float(style.edge_width),
+        "fill_color": _color_scale_to_json(style.fill_color),
+        "opacity": float(style.opacity),
+    }
+
+
+def _marker_style_from_json(
+    payload: dict[str, Any],
+    *,
+    channel_lookup: dict[str, DataChannel] | None = None,
+) -> MarkerStyle:
+    """Reconstruct a :class:`MarkerStyle` from JSON."""
+    shape = MarkerShape(str(payload["shape"]))
+    fill_payload = cast(dict[str, Any], payload["fill_color"])
+    fill_color = _color_scale_from_json(fill_payload, channel_lookup=channel_lookup)
+    return MarkerStyle(
+        shape=shape,
+        size_px=float(payload.get("size_px", 6.0)),
+        edge_color=str(payload.get("edge_color", "#000000")),
+        edge_width=float(payload.get("edge_width", 0.5)),
+        fill_color=fill_color,
+        opacity=float(payload.get("opacity", 1.0)),
+    )
+
+
+# ----------------------------------------------------------------------
+# Public dataclasses
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlotStyleSpec:
+    """A single named style entry — usually one per marker group.
+
+    Attributes
+    ----------
+    name:
+        Unique non-empty identifier within an enclosing
+        :class:`PlotStyleSet`.
+    target:
+        Free-form non-empty target descriptor, e.g.
+        ``"marker_group:body"`` or ``"trace:clubhead"``.
+    style:
+        The :class:`MarkerStyle` to apply to ``target``.
+    """
+
+    name: str
+    target: str
+    style: MarkerStyle
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError(f"name must be a non-empty string; got {self.name!r}")
+        if not isinstance(self.target, str) or not self.target:
+            raise ValueError(f"target must be a non-empty string; got {self.target!r}")
+        if not isinstance(self.style, MarkerStyle):
+            raise TypeError(
+                f"style must be MarkerStyle; got {type(self.style).__name__}"
+            )
+
+    def to_json(self) -> dict[str, Any]:
+        """Serialise this spec to a JSON-friendly dict."""
+        return {
+            "name": self.name,
+            "target": self.target,
+            "style": _marker_style_to_json(self.style),
+        }
+
+    @classmethod
+    def from_json(
+        cls,
+        payload: dict[str, Any],
+        *,
+        channel_lookup: dict[str, DataChannel] | None = None,
+    ) -> PlotStyleSpec:
+        """Reconstruct a spec from a JSON payload.
+
+        Unknown keys at the top level are tolerated and ignored.
+        """
+        return cls(
+            name=str(payload["name"]),
+            target=str(payload["target"]),
+            style=_marker_style_from_json(
+                cast(dict[str, Any], payload["style"]),
+                channel_lookup=channel_lookup,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PlotStyleSet:
+    """An ordered, schema-versioned collection of :class:`PlotStyleSpec`.
+
+    Attributes
+    ----------
+    schema_version:
+        Integer schema marker. Currently :data:`SCHEMA_VERSION`.
+    entries:
+        Tuple of named style entries. Names must be unique within a set.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    entries: tuple[PlotStyleSpec, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise TypeError(
+                f"schema_version must be int; got {type(self.schema_version).__name__}"
+            )
+        if self.schema_version < 1:
+            raise ValueError(f"schema_version must be >= 1; got {self.schema_version}")
+        if not isinstance(self.entries, tuple):
+            raise TypeError(
+                "entries must be a tuple of PlotStyleSpec; "
+                f"got {type(self.entries).__name__}"
+            )
+        seen_names: set[str] = set()
+        for index, entry in enumerate(self.entries):
+            if not isinstance(entry, PlotStyleSpec):
+                raise TypeError(
+                    f"entries[{index}] must be PlotStyleSpec; "
+                    f"got {type(entry).__name__}"
+                )
+            if entry.name in seen_names:
+                raise ValueError(f"duplicate entry name {entry.name!r} in PlotStyleSet")
+            seen_names.add(entry.name)
+
+    # ------------------------------------------------------------------
+    # JSON round-trip
+    # ------------------------------------------------------------------
+
+    def to_json(self) -> dict[str, Any]:
+        """Serialise this set to a JSON-friendly dict."""
+        return {
+            "schema_version": self.schema_version,
+            "entries": [entry.to_json() for entry in self.entries],
+        }
+
+    @classmethod
+    def from_json(
+        cls,
+        payload: dict[str, Any],
+        *,
+        channel_lookup: dict[str, DataChannel] | None = None,
+    ) -> PlotStyleSet:
+        """Reconstruct a set from JSON.
+
+        Unknown keys at any level are tolerated for forward
+        compatibility.
+        """
+        if not isinstance(payload, dict):
+            raise TypeError(f"payload must be a dict; got {type(payload).__name__}")
+        schema_version = int(payload.get("schema_version", SCHEMA_VERSION))
+        raw_entries = payload.get("entries", [])
+        if not isinstance(raw_entries, list):
+            raise TypeError(
+                f"entries must be a JSON list; got {type(raw_entries).__name__}"
+            )
+        entries = tuple(
+            PlotStyleSpec.from_json(
+                cast(dict[str, Any], raw_entry),
+                channel_lookup=channel_lookup,
+            )
+            for raw_entry in raw_entries
+        )
+        return cls(schema_version=schema_version, entries=entries)
+
+    @classmethod
+    def load(
+        cls,
+        path: Path,
+        *,
+        channel_lookup: dict[str, DataChannel] | None = None,
+    ) -> PlotStyleSet:
+        """Load and parse a :class:`PlotStyleSet` from a JSON file."""
+        if not isinstance(path, Path):
+            raise TypeError(f"path must be pathlib.Path; got {type(path).__name__}")
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        return cls.from_json(raw, channel_lookup=channel_lookup)
+
+    def save(self, path: Path) -> None:
+        """Serialise to JSON and write to ``path``.
+
+        Pretty-prints with two-space indent and a trailing newline.
+        """
+        if not isinstance(path, Path):
+            raise TypeError(f"path must be pathlib.Path; got {type(path).__name__}")
+        payload = self.to_json()
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=False)
+            handle.write("\n")

--- a/src/shared/python/plot_style/renderers/__init__.py
+++ b/src/shared/python/plot_style/renderers/__init__.py
@@ -1,0 +1,10 @@
+"""Renderer implementations sub-package.
+
+Concrete :class:`~src.shared.python.plot_style.contracts.MarkerRenderer`
+backends (matplotlib, pyqtgraph, plotly, ...) land in follow-up issues
+of EPIC #4796.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/plot_style/resolvers/__init__.py
+++ b/src/shared/python/plot_style/resolvers/__init__.py
@@ -1,0 +1,9 @@
+"""ColorResolver implementations sub-package.
+
+Concrete :class:`~src.shared.python.plot_style.contracts.ColorResolver`
+implementations land in follow-up issues of EPIC #4796.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/plot_style/shapes/__init__.py
+++ b/src/shared/python/plot_style/shapes/__init__.py
@@ -1,0 +1,9 @@
+"""Marker-shape primitive sub-package.
+
+Concrete marker shape primitives (mesh templates, parametric meshes,
+...) land in follow-up issues of EPIC #4796.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/shared/python/plot_style/widgets/__init__.py
+++ b/src/shared/python/plot_style/widgets/__init__.py
@@ -1,0 +1,9 @@
+"""Qt widget implementations sub-package.
+
+Concrete widgets (color picker, marker style editor, ...) land in
+follow-up issues of EPIC #4796.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tests/unit/plot_style/test_channel_helpers.py
+++ b/tests/unit/plot_style/test_channel_helpers.py
@@ -1,0 +1,287 @@
+"""Unit tests for module-level :mod:`channels` helpers (issue #4809).
+
+Covers ``magnitude_channel``, ``derivative_channel``, and
+``slice_channel`` — including all Design-by-Contract violations.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import (
+    DataChannel,
+    derivative_channel,
+    magnitude_channel,
+    slice_channel,
+)
+
+# ---------------------------------------------------------------------------
+# magnitude_channel
+# ---------------------------------------------------------------------------
+
+
+def test_magnitude_channel_two_d_round_trip_constant_velocity() -> None:
+    # constant velocity (3, 4, 0) at every frame -> magnitude 5.0
+    velocities = np.tile(np.array([3.0, 4.0, 0.0]), (10, 1))
+    ch = magnitude_channel("speed", velocities, unit="m/s")
+
+    assert isinstance(ch, DataChannel)
+    assert ch.name == "speed"
+    assert ch.unit == "m/s"
+    assert ch.n_frames == 10
+    assert ch.n_markers is None
+    np.testing.assert_allclose(ch.values, np.full(10, 5.0))
+
+
+def test_magnitude_channel_three_d_per_marker() -> None:
+    # Two frames, three markers, each marker has a known 3-vector
+    vectors = np.zeros((2, 3, 3))
+    vectors[:, 0, :] = (3.0, 4.0, 0.0)  # |.|=5
+    vectors[:, 1, :] = (1.0, 0.0, 0.0)  # |.|=1
+    vectors[:, 2, :] = (0.0, 0.0, 2.0)  # |.|=2
+
+    ch = magnitude_channel("residual", vectors)
+    assert ch.n_frames == 2
+    assert ch.n_markers == 3
+    assert ch.is_per_marker is True
+    expected = np.array([[5.0, 1.0, 2.0], [5.0, 1.0, 2.0]])
+    np.testing.assert_allclose(ch.values, expected)
+
+
+def test_magnitude_channel_default_unit_is_empty() -> None:
+    ch = magnitude_channel("v", np.zeros((3, 3)))
+    assert ch.unit == ""
+
+
+def test_magnitude_channel_propagates_nan() -> None:
+    vectors = np.array([[1.0, 0.0, 0.0], [np.nan, 0.0, 0.0]])
+    ch = magnitude_channel("v", vectors)
+    assert ch.values[0] == pytest.approx(1.0)
+    assert math.isnan(float(ch.values[1]))
+
+
+def test_magnitude_channel_rejects_non_ndarray() -> None:
+    with pytest.raises(TypeError, match="numpy.ndarray"):
+        magnitude_channel("v", [[1.0, 2.0, 3.0]])  # type: ignore[arg-type]
+
+
+def test_magnitude_channel_rejects_one_d_input() -> None:
+    with pytest.raises(ValueError, match="ndim"):
+        magnitude_channel("v", np.array([1.0, 2.0, 3.0]))
+
+
+def test_magnitude_channel_rejects_four_d_input() -> None:
+    with pytest.raises(ValueError, match="ndim"):
+        magnitude_channel("v", np.zeros((2, 2, 2, 3)))
+
+
+def test_magnitude_channel_rejects_wrong_last_axis() -> None:
+    with pytest.raises(ValueError, match="last axis"):
+        magnitude_channel("v", np.zeros((4, 2)))
+    with pytest.raises(ValueError, match="last axis"):
+        magnitude_channel("v", np.zeros((4, 5, 2)))
+
+
+# ---------------------------------------------------------------------------
+# derivative_channel
+# ---------------------------------------------------------------------------
+
+
+def test_derivative_channel_recovers_analytic_derivative_one_d() -> None:
+    # x(t) = t^2  =>  dx/dt = 2t
+    dt = 0.01
+    t = np.arange(0.0, 1.0, dt)
+    base = DataChannel.from_array("x", t**2, unit="m")
+
+    deriv = derivative_channel("xdot", base, timestep_s=dt)
+    assert deriv.name == "xdot"
+    assert deriv.unit == "m/s"
+    # numpy.gradient is 2nd-order accurate in the interior
+    np.testing.assert_allclose(deriv.values[2:-2], (2.0 * t)[2:-2], atol=1e-10)
+
+
+def test_derivative_channel_two_d_along_frame_axis() -> None:
+    # values_{t,m} = t * (m+1)  =>  d/dt = (m+1)
+    dt = 0.5
+    n_frames, n_markers = 8, 3
+    t = np.arange(n_frames, dtype=float)
+    m_scale = np.arange(1, n_markers + 1, dtype=float)
+    base_vals = (t[:, None] * dt) * m_scale[None, :]
+    base = DataChannel.from_array("v", base_vals)
+
+    deriv = derivative_channel("a", base, timestep_s=dt)
+    expected = np.broadcast_to(m_scale, (n_frames, n_markers))
+    np.testing.assert_allclose(deriv.values, expected, atol=1e-10)
+
+
+def test_derivative_channel_unit_suffix_default_when_no_unit() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]))
+    deriv = derivative_channel("xdot", base, timestep_s=1.0)
+    assert deriv.unit == "/s"
+
+
+def test_derivative_channel_custom_unit_suffix() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]), unit="rad")
+    deriv = derivative_channel("xdot", base, timestep_s=1.0, unit_suffix="/ms")
+    assert deriv.unit == "rad/ms"
+
+
+def test_derivative_channel_propagates_nan() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, np.nan, 2.0, 3.0]))
+    deriv = derivative_channel("xdot", base, timestep_s=1.0)
+    # NaN at idx 1 contaminates the forward edge at idx 0 and the
+    # central difference at idx 2 via numpy.gradient.
+    assert math.isnan(float(deriv.values[0]))
+    assert math.isnan(float(deriv.values[2]))
+
+
+def test_derivative_channel_rejects_non_channel() -> None:
+    with pytest.raises(TypeError, match="DataChannel"):
+        derivative_channel("d", np.array([1.0, 2.0]), timestep_s=0.1)  # type: ignore[arg-type]
+
+
+def test_derivative_channel_rejects_zero_timestep() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]))
+    with pytest.raises(ValueError, match="> 0"):
+        derivative_channel("d", base, timestep_s=0.0)
+
+
+def test_derivative_channel_rejects_negative_timestep() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]))
+    with pytest.raises(ValueError, match="> 0"):
+        derivative_channel("d", base, timestep_s=-0.1)
+
+
+def test_derivative_channel_rejects_nonfinite_timestep() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]))
+    with pytest.raises(ValueError, match="finite"):
+        derivative_channel("d", base, timestep_s=float("inf"))
+    with pytest.raises(ValueError, match="finite"):
+        derivative_channel("d", base, timestep_s=float("nan"))
+
+
+def test_derivative_channel_rejects_non_numeric_timestep() -> None:
+    base = DataChannel.from_array("x", np.array([0.0, 1.0]))
+    with pytest.raises(TypeError, match="real number"):
+        derivative_channel("d", base, timestep_s="0.1")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="real number"):
+        derivative_channel("d", base, timestep_s=True)  # type: ignore[arg-type]
+
+
+def test_derivative_channel_rejects_single_frame() -> None:
+    base = DataChannel.from_array("x", np.array([1.0]))
+    with pytest.raises(ValueError, match="at least 2 frames"):
+        derivative_channel("d", base, timestep_s=0.1)
+
+
+# ---------------------------------------------------------------------------
+# slice_channel
+# ---------------------------------------------------------------------------
+
+
+def test_slice_channel_one_d_basic_window() -> None:
+    base = DataChannel.from_array("v", np.arange(10, dtype=float), unit="m")
+    sliced = slice_channel(base, slice(2, 6))
+    assert sliced.name == "v"
+    assert sliced.unit == "m"
+    np.testing.assert_array_equal(sliced.values, np.array([2.0, 3.0, 4.0, 5.0]))
+
+
+def test_slice_channel_preserves_nan_tolerant_auto_range() -> None:
+    base_vals = np.array([np.nan, 10.0, 5.0, np.nan, 7.0, np.nan])
+    base = DataChannel.from_array("v", base_vals)
+    sliced = slice_channel(base, slice(0, 4))
+
+    lo, hi = sliced.auto_range()
+    assert lo == pytest.approx(5.0)
+    assert hi == pytest.approx(10.0)
+    # value_at preserves NaN pass-through
+    assert math.isnan(sliced.value_at(0))
+    assert sliced.value_at(1) == pytest.approx(10.0)
+
+
+def test_slice_channel_two_d_with_marker_subset() -> None:
+    base_vals = np.arange(20, dtype=float).reshape(4, 5)
+    base = DataChannel.from_array("r", base_vals)
+
+    sliced = slice_channel(base, slice(1, 3), marker_subset=[0, 2, 4])
+    assert sliced.n_frames == 2
+    assert sliced.n_markers == 3
+    np.testing.assert_array_equal(sliced.values, base_vals[1:3][:, [0, 2, 4]])
+
+
+def test_slice_channel_all_nan_window_keeps_nan_pair_auto_range() -> None:
+    base_vals = np.array([1.0, np.nan, np.nan, 4.0])
+    base = DataChannel.from_array("v", base_vals)
+    sliced = slice_channel(base, slice(1, 3))
+    lo, hi = sliced.auto_range()
+    assert math.isnan(lo)
+    assert math.isnan(hi)
+
+
+def test_slice_channel_open_slice_bounds_allowed() -> None:
+    base = DataChannel.from_array("v", np.arange(5, dtype=float))
+    sliced = slice_channel(base, slice(None, None))
+    np.testing.assert_array_equal(sliced.values, base.values)
+
+
+def test_slice_channel_rejects_non_channel() -> None:
+    with pytest.raises(TypeError, match="DataChannel"):
+        slice_channel(np.zeros(3), slice(0, 2))  # type: ignore[arg-type]
+
+
+def test_slice_channel_rejects_non_slice_range() -> None:
+    base = DataChannel.from_array("v", np.zeros(4))
+    with pytest.raises(TypeError, match="slice"):
+        slice_channel(base, (0, 2))  # type: ignore[arg-type]
+
+
+def test_slice_channel_rejects_oob_start() -> None:
+    base = DataChannel.from_array("v", np.zeros(4))
+    with pytest.raises(ValueError, match="frame_range.start"):
+        slice_channel(base, slice(-1, 2))
+    with pytest.raises(ValueError, match="frame_range.start"):
+        slice_channel(base, slice(99, 100))
+
+
+def test_slice_channel_rejects_oob_stop() -> None:
+    base = DataChannel.from_array("v", np.zeros(4))
+    with pytest.raises(ValueError, match="frame_range.stop"):
+        slice_channel(base, slice(0, 99))
+    with pytest.raises(ValueError, match="frame_range.stop"):
+        slice_channel(base, slice(0, -1))
+
+
+def test_slice_channel_rejects_marker_subset_for_one_d() -> None:
+    base = DataChannel.from_array("v", np.zeros(4))
+    with pytest.raises(ValueError, match="per-marker"):
+        slice_channel(base, slice(0, 2), marker_subset=[0])
+
+
+def test_slice_channel_rejects_string_marker_subset() -> None:
+    base = DataChannel.from_array("r", np.zeros((4, 3)))
+    with pytest.raises(TypeError, match="sequence of ints"):
+        slice_channel(base, slice(0, 2), marker_subset="012")  # type: ignore[arg-type]
+
+
+def test_slice_channel_rejects_non_int_marker_index() -> None:
+    base = DataChannel.from_array("r", np.zeros((4, 3)))
+    with pytest.raises(TypeError, match="int"):
+        slice_channel(base, slice(0, 2), marker_subset=[1.5])  # type: ignore[list-item]
+
+
+def test_slice_channel_rejects_oob_marker_index() -> None:
+    base = DataChannel.from_array("r", np.zeros((4, 3)))
+    with pytest.raises(ValueError, match="out of range"):
+        slice_channel(base, slice(0, 2), marker_subset=[5])
+    with pytest.raises(ValueError, match="out of range"):
+        slice_channel(base, slice(0, 2), marker_subset=[-1])
+
+
+def test_slice_channel_rejects_bool_marker_index() -> None:
+    base = DataChannel.from_array("r", np.zeros((4, 3)))
+    with pytest.raises(TypeError, match="int"):
+        slice_channel(base, slice(0, 2), marker_subset=[True])

--- a/tests/unit/plot_style/test_channels.py
+++ b/tests/unit/plot_style/test_channels.py
@@ -1,0 +1,147 @@
+"""Unit tests for :class:`DataChannel`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import DataChannel
+
+
+# ---------- Construction ------------------------------------------------
+
+
+def test_from_array_one_d_happy_path() -> None:
+    values = np.array([1.0, 2.0, 3.0])
+    channel = DataChannel.from_array("speed", values, unit="m/s")
+    assert channel.name == "speed"
+    assert channel.unit == "m/s"
+    assert channel.n_frames == 3
+    assert channel.n_markers is None
+    assert channel.is_per_marker is False
+
+
+def test_from_array_two_d_happy_path() -> None:
+    values = np.zeros((4, 5))
+    channel = DataChannel.from_array("residuals", values)
+    assert channel.n_frames == 4
+    assert channel.n_markers == 5
+    assert channel.is_per_marker is True
+
+
+def test_constructor_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        DataChannel(name="", values=np.zeros(3))
+
+
+def test_constructor_rejects_non_string_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        DataChannel(name=None, values=np.zeros(3))  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_non_string_unit() -> None:
+    with pytest.raises(TypeError, match="unit must be a string"):
+        DataChannel(name="x", values=np.zeros(3), unit=123)  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_non_array_values() -> None:
+    with pytest.raises(TypeError, match="numpy.ndarray"):
+        DataChannel(name="x", values=[1.0, 2.0])  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_zero_d_array() -> None:
+    with pytest.raises(ValueError, match="ndim"):
+        DataChannel(name="x", values=np.array(1.0))
+
+
+def test_constructor_rejects_three_d_array() -> None:
+    with pytest.raises(ValueError, match="ndim"):
+        DataChannel(name="x", values=np.zeros((2, 3, 4)))
+
+
+def test_constructor_rejects_non_numeric_dtype() -> None:
+    with pytest.raises(TypeError, match="dtype must be numeric"):
+        DataChannel(name="x", values=np.array(["a", "b", "c"]))
+
+
+# ---------- value_at ----------------------------------------------------
+
+
+def test_value_at_one_d_returns_scalar() -> None:
+    channel = DataChannel.from_array("v", np.array([10.0, 20.0, 30.0]))
+    assert channel.value_at(1) == 20.0
+
+
+def test_value_at_one_d_ignores_marker_idx() -> None:
+    channel = DataChannel.from_array("v", np.array([10.0, 20.0, 30.0]))
+    assert channel.value_at(1, marker_idx=999) == 20.0
+
+
+def test_value_at_oob_frame_returns_nan() -> None:
+    channel = DataChannel.from_array("v", np.array([1.0, 2.0]))
+    assert math.isnan(channel.value_at(5))
+    assert math.isnan(channel.value_at(-1))
+
+
+def test_value_at_two_d_with_marker_idx() -> None:
+    values = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    channel = DataChannel.from_array("r", values)
+    assert channel.value_at(0, marker_idx=2) == 3.0
+    assert channel.value_at(1, marker_idx=0) == 4.0
+
+
+def test_value_at_two_d_oob_marker_returns_nan() -> None:
+    values = np.array([[1.0, 2.0]])
+    channel = DataChannel.from_array("r", values)
+    assert math.isnan(channel.value_at(0, marker_idx=999))
+    assert math.isnan(channel.value_at(0, marker_idx=-1))
+
+
+def test_value_at_two_d_marker_none_returns_finite_mean() -> None:
+    values = np.array([[1.0, 3.0, np.nan]])
+    channel = DataChannel.from_array("r", values)
+    assert channel.value_at(0) == pytest.approx(2.0)
+
+
+def test_value_at_two_d_marker_none_all_nan_returns_nan() -> None:
+    values = np.array([[np.nan, np.nan]])
+    channel = DataChannel.from_array("r", values)
+    assert math.isnan(channel.value_at(0))
+
+
+def test_value_at_rejects_non_int_frame() -> None:
+    channel = DataChannel.from_array("v", np.array([1.0, 2.0]))
+    with pytest.raises(TypeError, match="frame_idx"):
+        channel.value_at(1.5)  # type: ignore[arg-type]
+
+
+def test_value_at_rejects_non_int_marker() -> None:
+    channel = DataChannel.from_array("v", np.zeros((2, 3)))
+    with pytest.raises(TypeError, match="marker_idx"):
+        channel.value_at(0, marker_idx=1.0)  # type: ignore[arg-type]
+
+
+# ---------- auto_range --------------------------------------------------
+
+
+def test_auto_range_finite() -> None:
+    channel = DataChannel.from_array("v", np.array([1.0, 5.0, 3.0, np.nan]))
+    lo, hi = channel.auto_range()
+    assert lo == 1.0
+    assert hi == 5.0
+
+
+def test_auto_range_all_nan_returns_nan_pair() -> None:
+    channel = DataChannel.from_array("v", np.array([np.nan, np.nan]))
+    lo, hi = channel.auto_range()
+    assert math.isnan(lo)
+    assert math.isnan(hi)
+
+
+def test_has_finite_range_true_and_false() -> None:
+    finite = DataChannel.from_array("v", np.array([0.0, 1.0]))
+    infinite = DataChannel.from_array("v", np.array([np.nan]))
+    assert finite.has_finite_range() is True
+    assert infinite.has_finite_range() is False

--- a/tests/unit/plot_style/test_colormaps.py
+++ b/tests/unit/plot_style/test_colormaps.py
@@ -1,0 +1,110 @@
+"""Unit tests for :class:`ColormapId` and :class:`CustomColormap`."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.plot_style import ColormapId, CustomColormap
+from src.shared.python.plot_style.colormaps import (
+    SEMANTIC_COLORMAP_ALIASES,
+    resolve_colormap_alias,
+)
+
+
+# ---------- ColormapId --------------------------------------------------
+
+
+def test_colormap_id_round_trip_through_string() -> None:
+    for cmap_id in ColormapId:
+        assert str(cmap_id) == cmap_id.value
+        assert ColormapId(cmap_id.value) is cmap_id
+
+
+def test_resolve_alias_passes_through_builtins() -> None:
+    assert resolve_colormap_alias(ColormapId.VIRIDIS) is ColormapId.VIRIDIS
+
+
+def test_resolve_alias_resolves_semantic_to_builtin() -> None:
+    for alias, target in SEMANTIC_COLORMAP_ALIASES.items():
+        assert resolve_colormap_alias(alias) is target
+
+
+def test_resolve_alias_rejects_non_enum() -> None:
+    with pytest.raises(TypeError, match="ColormapId"):
+        resolve_colormap_alias("viridis")  # type: ignore[arg-type]
+
+
+# ---------- CustomColormap ---------------------------------------------
+
+
+def test_custom_colormap_happy_path() -> None:
+    cmap = CustomColormap(
+        name="my_cmap",
+        stops=((0.0, "#000000"), (0.5, "#888888"), (1.0, "#ffffff")),
+    )
+    assert cmap.name == "my_cmap"
+    assert len(cmap.stops) == 3
+
+
+def test_custom_colormap_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        CustomColormap(name="", stops=((0.0, "#000"), (1.0, "#fff")))
+
+
+def test_custom_colormap_rejects_non_tuple_stops() -> None:
+    with pytest.raises(TypeError, match="tuple"):
+        CustomColormap(
+            name="x",
+            stops=[(0.0, "#000"), (1.0, "#fff")],  # type: ignore[arg-type]
+        )
+
+
+def test_custom_colormap_rejects_too_few_stops() -> None:
+    with pytest.raises(ValueError, match="at least 2"):
+        CustomColormap(name="x", stops=((0.0, "#000"),))
+
+
+def test_custom_colormap_rejects_non_monotonic_stops() -> None:
+    with pytest.raises(ValueError, match="strictly increasing"):
+        CustomColormap(
+            name="x",
+            stops=((0.0, "#000"), (0.5, "#888"), (0.4, "#fff")),
+        )
+
+
+def test_custom_colormap_rejects_duplicate_positions() -> None:
+    with pytest.raises(ValueError, match="strictly increasing"):
+        CustomColormap(
+            name="x",
+            stops=((0.0, "#000"), (0.5, "#888"), (0.5, "#fff")),
+        )
+
+
+def test_custom_colormap_rejects_position_out_of_range() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        CustomColormap(name="x", stops=((-0.1, "#000"), (1.0, "#fff")))
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        CustomColormap(name="x", stops=((0.0, "#000"), (1.5, "#fff")))
+
+
+def test_custom_colormap_rejects_non_parseable_hex() -> None:
+    with pytest.raises(ValueError, match="parseable"):
+        CustomColormap(name="x", stops=((0.0, "not_a_color"), (1.0, "#fff")))
+
+
+def test_custom_colormap_rejects_malformed_stop_tuple() -> None:
+    with pytest.raises(ValueError, match="2-tuple"):
+        CustomColormap(name="x", stops=((0.0,), (1.0, "#fff")))  # type: ignore[arg-type]
+
+
+def test_custom_colormap_rejects_non_numeric_position() -> None:
+    with pytest.raises(TypeError, match="numeric"):
+        CustomColormap(
+            name="x",
+            stops=(("zero", "#000"), (1.0, "#fff")),  # type: ignore[arg-type]
+        )
+
+
+def test_custom_colormap_rejects_empty_hex() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        CustomColormap(name="x", stops=((0.0, ""), (1.0, "#fff")))

--- a/tests/unit/plot_style/test_colors.py
+++ b/tests/unit/plot_style/test_colors.py
@@ -1,0 +1,259 @@
+"""Unit tests for :class:`StaticColor`, :class:`PaletteColor`, :class:`DataDrivenColor`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import (
+    ColormapId,
+    DataChannel,
+    DataDrivenColor,
+    PaletteColor,
+    StaticColor,
+)
+
+
+# ---------- StaticColor -------------------------------------------------
+
+
+def test_static_color_happy_path() -> None:
+    color = StaticColor(hex_value="#ff0000")
+    rgba = color.resolve(0)
+    assert len(rgba) == 4
+    for component in rgba:
+        assert 0.0 <= component <= 1.0
+    assert rgba[0] == pytest.approx(1.0)
+    assert rgba[3] == pytest.approx(1.0)
+
+
+def test_static_color_resolve_ignores_indices() -> None:
+    color = StaticColor(hex_value="blue")
+    assert color.resolve(0) == color.resolve(99, marker_idx=42)
+
+
+def test_static_color_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        StaticColor(hex_value="")
+
+
+def test_static_color_rejects_non_string() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        StaticColor(hex_value=123)  # type: ignore[arg-type]
+
+
+def test_static_color_rejects_non_parseable() -> None:
+    with pytest.raises(ValueError, match="parseable"):
+        StaticColor(hex_value="not_a_color")
+
+
+# ---------- PaletteColor ------------------------------------------------
+
+
+def test_palette_color_happy_path() -> None:
+    color = PaletteColor(palette_name="tab10", palette_index=3)
+    rgba = color.resolve(0)
+    assert len(rgba) == 4
+    for component in rgba:
+        assert 0.0 <= component <= 1.0
+
+
+def test_palette_color_index_wraps() -> None:
+    a = PaletteColor(palette_name="tab10", palette_index=2)
+    b = PaletteColor(palette_name="tab10", palette_index=12)
+    assert a.resolve(0) == b.resolve(0)
+
+
+def test_palette_color_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        PaletteColor(palette_name="", palette_index=0)
+
+
+def test_palette_color_rejects_unknown_palette() -> None:
+    with pytest.raises(ValueError, match="not a registered"):
+        PaletteColor(palette_name="not_a_real_palette_xyz", palette_index=0)
+
+
+def test_palette_color_rejects_negative_index() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        PaletteColor(palette_name="tab10", palette_index=-1)
+
+
+def test_palette_color_rejects_non_int_index() -> None:
+    with pytest.raises(TypeError, match="int"):
+        PaletteColor(palette_name="tab10", palette_index=1.5)  # type: ignore[arg-type]
+
+
+# ---------- DataDrivenColor --------------------------------------------
+
+
+def _make_channel_1d() -> DataChannel:
+    return DataChannel.from_array("v", np.array([0.0, 5.0, 10.0]), unit="m/s")
+
+
+def _make_channel_2d() -> DataChannel:
+    values = np.array([[0.0, 5.0], [5.0, 10.0]])
+    return DataChannel.from_array("v", values)
+
+
+def test_data_driven_color_happy_path() -> None:
+    channel = _make_channel_1d()
+    color = DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS)
+    rgba = color.resolve(1)
+    assert len(rgba) == 4
+    for component in rgba:
+        assert 0.0 <= component <= 1.0
+
+
+def test_data_driven_color_explicit_bounds() -> None:
+    channel = _make_channel_1d()
+    color = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.PLASMA,
+        vmin=0.0,
+        vmax=10.0,
+    )
+    low = color.resolve(0)
+    high = color.resolve(2)
+    assert low != high
+
+
+def test_data_driven_color_with_2d_channel() -> None:
+    channel = _make_channel_2d()
+    color = DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS)
+    rgba = color.resolve(0, marker_idx=1)
+    assert len(rgba) == 4
+
+
+def test_data_driven_color_uses_semantic_alias() -> None:
+    channel = _make_channel_1d()
+    color = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VELOCITY,
+        vmin=0.0,
+        vmax=10.0,
+    )
+    rgba = color.resolve(1)
+    assert len(rgba) == 4
+
+
+def test_data_driven_color_nan_returns_nan_color() -> None:
+    channel = DataChannel.from_array("v", np.array([np.nan, 1.0]))
+    color = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        nan_color="#123456",
+    )
+    rgba = color.resolve(0)
+    # Should equal the nan color
+    expected = StaticColor(hex_value="#123456").resolve(0)
+    assert rgba == expected
+
+
+def test_data_driven_color_oob_index_returns_nan_color() -> None:
+    channel = _make_channel_1d()
+    color = DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS)
+    rgba = color.resolve(999)
+    expected = StaticColor(hex_value="#888888").resolve(0)
+    assert rgba == expected
+
+
+def test_data_driven_color_degenerate_range_returns_nan_color() -> None:
+    # Single finite value -> auto_range yields equal min/max.
+    channel = DataChannel.from_array("v", np.array([1.0, 1.0, 1.0]))
+    color = DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS)
+    rgba = color.resolve(0)
+    expected = StaticColor(hex_value="#888888").resolve(0)
+    assert rgba == expected
+
+
+def test_data_driven_color_clamps_out_of_bounds_value() -> None:
+    channel = _make_channel_1d()
+    color = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=2.0,
+    )
+    # frame 2 has value 10, clamps to 1.0 -> top of colormap
+    rgba_high = color.resolve(2)
+    rgba_top = color.resolve(2)
+    assert rgba_high == rgba_top  # deterministic
+
+
+def test_data_driven_color_rejects_non_channel() -> None:
+    with pytest.raises(TypeError, match="DataChannel"):
+        DataDrivenColor(channel="not a channel", colormap=ColormapId.VIRIDIS)  # type: ignore[arg-type]
+
+
+def test_data_driven_color_rejects_non_colormap_id() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(TypeError, match="ColormapId"):
+        DataDrivenColor(channel=channel, colormap="viridis")  # type: ignore[arg-type]
+
+
+def test_data_driven_color_rejects_non_finite_vmin() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(ValueError, match="finite"):
+        DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId.VIRIDIS,
+            vmin=math.inf,
+        )
+
+
+def test_data_driven_color_rejects_non_numeric_vmin() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(TypeError, match="numeric"):
+        DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId.VIRIDIS,
+            vmin="zero",  # type: ignore[arg-type]
+        )
+
+
+def test_data_driven_color_rejects_inverted_bounds() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(ValueError, match="strictly greater"):
+        DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId.VIRIDIS,
+            vmin=5.0,
+            vmax=1.0,
+        )
+
+
+def test_data_driven_color_rejects_empty_nan_color() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(ValueError, match="non-empty"):
+        DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId.VIRIDIS,
+            nan_color="",
+        )
+
+
+def test_data_driven_color_rejects_unparseable_nan_color() -> None:
+    channel = _make_channel_1d()
+    with pytest.raises(ValueError, match="parseable"):
+        DataDrivenColor(
+            channel=channel,
+            colormap=ColormapId.VIRIDIS,
+            nan_color="bogus_color",
+        )
+
+
+def test_resolve_returns_components_in_unit_interval_for_all_variants() -> None:
+    channel = _make_channel_1d()
+    scales = (
+        StaticColor("#ff00ff"),
+        PaletteColor(palette_name="Set2", palette_index=0),
+        DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS),
+    )
+    for scale in scales:
+        rgba = scale.resolve(0)
+        assert len(rgba) == 4
+        for component in rgba:
+            assert 0.0 <= component <= 1.0

--- a/tests/unit/plot_style/test_contracts.py
+++ b/tests/unit/plot_style/test_contracts.py
@@ -1,0 +1,142 @@
+"""Unit tests for the runtime-checkable Protocols."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.shared.python.plot_style import (
+    ColorResolver,
+    ColorScale,
+    DataChannel,
+    DataDrivenColor,
+    MarkerRenderer,
+    MarkerStyle,
+    PaletteColor,
+    StaticColor,
+)
+from src.shared.python.plot_style import ColormapId
+
+
+class _StubRenderer:
+    """Minimal MarkerRenderer-conforming stub for runtime checks."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self._next_handle = 0
+
+    def add_markers(
+        self,
+        positions: np.ndarray,
+        style: MarkerStyle,
+        label: str = "",
+    ) -> str:
+        self._next_handle += 1
+        handle = f"h{self._next_handle}"
+        self.calls.append(("add_markers", (positions, style, label)))
+        return handle
+
+    def update_frame(self, handle: str, frame_idx: int) -> None:
+        self.calls.append(("update_frame", (handle, frame_idx)))
+
+    def update_style(self, handle: str, style: MarkerStyle) -> None:
+        self.calls.append(("update_style", (handle, style)))
+
+    def set_visible(self, handle: str, visible: bool) -> None:
+        self.calls.append(("set_visible", (handle, visible)))
+
+    def remove(self, handle: str) -> None:
+        self.calls.append(("remove", (handle,)))
+
+
+class _StubResolver:
+    """Minimal ColorResolver-conforming stub for runtime checks."""
+
+    def resolve_one(
+        self,
+        scale: ColorScale,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> tuple[float, float, float, float]:
+        rgba = scale.resolve(frame_idx, marker_idx)
+        return (rgba[0], rgba[1], rgba[2], rgba[3])
+
+    def resolve_array(
+        self,
+        scale: ColorScale,
+        n_frames: int,
+        n_markers: int | None = None,
+    ) -> np.ndarray:
+        if n_markers is None:
+            out = np.zeros((n_frames, 4), dtype=float)
+            for i in range(n_frames):
+                out[i] = scale.resolve(i)
+            return out
+        out2 = np.zeros((n_frames, n_markers, 4), dtype=float)
+        for i in range(n_frames):
+            for j in range(n_markers):
+                out2[i, j] = scale.resolve(i, j)
+        return out2
+
+
+def test_marker_renderer_runtime_checkable() -> None:
+    stub = _StubRenderer()
+    assert isinstance(stub, MarkerRenderer)
+
+
+def test_color_resolver_runtime_checkable() -> None:
+    stub = _StubResolver()
+    assert isinstance(stub, ColorResolver)
+
+
+def test_marker_renderer_stub_round_trip() -> None:
+    stub = _StubRenderer()
+    style = MarkerStyle()
+    handle = stub.add_markers(np.zeros((1, 3)), style, label="x")
+    stub.update_frame(handle, 0)
+    stub.update_style(handle, style)
+    stub.set_visible(handle, False)
+    stub.remove(handle)
+    methods = [name for (name, _) in stub.calls]
+    assert methods == [
+        "add_markers",
+        "update_frame",
+        "update_style",
+        "set_visible",
+        "remove",
+    ]
+
+
+def test_color_resolver_resolves_static() -> None:
+    stub = _StubResolver()
+    scale = StaticColor("#ff0000")
+    rgba = stub.resolve_one(scale, 0)
+    assert rgba[0] == 1.0
+
+
+def test_color_resolver_resolves_palette_array() -> None:
+    stub = _StubResolver()
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    arr = stub.resolve_array(scale, n_frames=3)
+    assert arr.shape == (3, 4)
+
+
+def test_color_resolver_resolves_data_driven_2d_array() -> None:
+    stub = _StubResolver()
+    channel = DataChannel.from_array("v", np.array([[0.0, 1.0], [2.0, 3.0]]))
+    scale = DataDrivenColor(channel=channel, colormap=ColormapId.VIRIDIS)
+    arr = stub.resolve_array(scale, n_frames=2, n_markers=2)
+    assert arr.shape == (2, 2, 4)
+
+
+def test_non_conforming_object_is_not_renderer() -> None:
+    class _NotARenderer:
+        pass
+
+    assert not isinstance(_NotARenderer(), MarkerRenderer)
+
+
+def test_non_conforming_object_is_not_resolver() -> None:
+    class _NotAResolver:
+        pass
+
+    assert not isinstance(_NotAResolver(), ColorResolver)

--- a/tests/unit/plot_style/test_imports.py
+++ b/tests/unit/plot_style/test_imports.py
@@ -1,0 +1,60 @@
+"""Smoke tests: every public name imports cleanly."""
+
+from __future__ import annotations
+
+
+def test_top_level_imports() -> None:
+    from src.shared.python.plot_style import (
+        SCHEMA_VERSION,
+        SEMANTIC_COLORMAP_ALIASES,
+        ColormapId,
+        ColorResolver,
+        ColorScale,
+        CustomColormap,
+        CustomMeshSpec,
+        DataChannel,
+        DataDrivenColor,
+        MarkerRenderer,
+        MarkerShape,
+        MarkerStyle,
+        PaletteColor,
+        PlotStyleSet,
+        PlotStyleSpec,
+        RGBATuple,
+        StaticColor,
+        resolve_colormap_alias,
+    )
+
+    # Anchor a reference to each name so unused-import lint is happy and
+    # the smoke test does some runtime work.
+    assert SCHEMA_VERSION >= 1
+    assert isinstance(SEMANTIC_COLORMAP_ALIASES, dict)
+    assert ColorResolver is not None
+    assert ColorScale is not None
+    assert CustomColormap is not None
+    assert CustomMeshSpec is not None
+    assert DataChannel is not None
+    assert DataDrivenColor is not None
+    assert MarkerRenderer is not None
+    assert MarkerShape is not None
+    assert MarkerStyle is not None
+    assert PaletteColor is not None
+    assert PlotStyleSet is not None
+    assert PlotStyleSpec is not None
+    assert RGBATuple is not None
+    assert StaticColor is not None
+    assert ColormapId is not None
+    assert callable(resolve_colormap_alias)
+
+
+def test_subpackages_import() -> None:
+    import importlib
+
+    for name in (
+        "src.shared.python.plot_style.widgets",
+        "src.shared.python.plot_style.renderers",
+        "src.shared.python.plot_style.resolvers",
+        "src.shared.python.plot_style.shapes",
+    ):
+        module = importlib.import_module(name)
+        assert hasattr(module, "__all__")

--- a/tests/unit/plot_style/test_markers.py
+++ b/tests/unit/plot_style/test_markers.py
@@ -1,0 +1,249 @@
+"""Unit tests for :class:`MarkerShape`, :class:`CustomMeshSpec`, :class:`MarkerStyle`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import (
+    CustomMeshSpec,
+    MarkerShape,
+    MarkerStyle,
+    StaticColor,
+)
+
+
+# ---------- MarkerShape -------------------------------------------------
+
+
+def test_marker_shape_round_trip_through_string() -> None:
+    for shape in MarkerShape:
+        assert str(shape) == shape.value
+        assert MarkerShape(shape.value) is shape
+
+
+# ---------- CustomMeshSpec ---------------------------------------------
+
+
+def _tetra() -> CustomMeshSpec:
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
+    faces = np.array([[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]], dtype=np.int32)
+    return CustomMeshSpec(name="tetra", vertices=vertices, faces=faces)
+
+
+def test_custom_mesh_spec_happy_path() -> None:
+    mesh = _tetra()
+    assert mesh.name == "tetra"
+    assert mesh.vertices.shape == (4, 3)
+    assert mesh.faces.shape == (4, 3)
+
+
+def test_custom_mesh_spec_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        CustomMeshSpec(name="", vertices=np.zeros((3, 3)), faces=np.array([[0, 1, 2]]))
+
+
+def test_custom_mesh_spec_rejects_non_array_vertices() -> None:
+    with pytest.raises(TypeError, match="numpy.ndarray"):
+        CustomMeshSpec(
+            name="x",
+            vertices=[[0, 0, 0]],  # type: ignore[arg-type]
+            faces=np.zeros((1, 3), dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_wrong_vertex_shape() -> None:
+    with pytest.raises(ValueError, match=r"\(V, 3\)"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((4, 2)),
+            faces=np.zeros((1, 3), dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_wrong_face_shape() -> None:
+    with pytest.raises(ValueError, match=r"\(F, 3\)"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((3, 3)),
+            faces=np.zeros((1, 4), dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_float_face_indices() -> None:
+    with pytest.raises(TypeError, match="integer"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((3, 3)),
+            faces=np.zeros((1, 3), dtype=float),
+        )
+
+
+def test_custom_mesh_spec_rejects_oob_face_index() -> None:
+    with pytest.raises(ValueError, match="out of bounds"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((3, 3)),
+            faces=np.array([[0, 1, 99]], dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_negative_face_index() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        # Need int dtype since negative -> int kind
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((3, 3)),
+            faces=np.array([[0, 1, -1]], dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_non_string_vertices() -> None:
+    with pytest.raises(TypeError, match="vertices dtype"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.array([["a", "b", "c"]], dtype=object),
+            faces=np.array([[0, 0, 0]], dtype=np.int32),
+        )
+
+
+def test_custom_mesh_spec_rejects_non_array_faces() -> None:
+    with pytest.raises(TypeError, match="numpy.ndarray"):
+        CustomMeshSpec(
+            name="x",
+            vertices=np.zeros((3, 3)),
+            faces=[[0, 1, 2]],  # type: ignore[arg-type]
+        )
+
+
+# ---------- MarkerStyle -------------------------------------------------
+
+
+def test_marker_style_default_construction() -> None:
+    style = MarkerStyle()
+    assert style.shape is MarkerShape.SPHERE
+    assert math.isclose(style.size_px, 6.0)
+    assert isinstance(style.fill_color, StaticColor)
+
+
+def test_marker_style_explicit_fields() -> None:
+    style = MarkerStyle(
+        shape=MarkerShape.CUBE,
+        size_px=10.0,
+        edge_color="red",
+        edge_width=1.5,
+        fill_color=StaticColor("#00ff00"),
+        opacity=0.5,
+    )
+    assert style.shape is MarkerShape.CUBE
+    assert style.size_px == 10.0
+    assert style.edge_color == "red"
+
+
+def test_marker_style_rejects_non_enum_shape() -> None:
+    with pytest.raises(TypeError, match="MarkerShape"):
+        MarkerStyle(shape="sphere")  # type: ignore[arg-type]
+
+
+def test_marker_style_rejects_zero_size() -> None:
+    with pytest.raises(ValueError, match="> 0"):
+        MarkerStyle(size_px=0.0)
+
+
+def test_marker_style_rejects_negative_size() -> None:
+    with pytest.raises(ValueError, match="> 0"):
+        MarkerStyle(size_px=-1.0)
+
+
+def test_marker_style_rejects_non_finite_size() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        MarkerStyle(size_px=math.inf)
+
+
+def test_marker_style_rejects_non_numeric_size() -> None:
+    with pytest.raises(TypeError, match="numeric"):
+        MarkerStyle(size_px="6")  # type: ignore[arg-type]
+
+
+def test_marker_style_rejects_negative_edge_width() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        MarkerStyle(edge_width=-0.1)
+
+
+def test_marker_style_allows_zero_edge_width() -> None:
+    style = MarkerStyle(edge_width=0.0)
+    assert style.edge_width == 0.0
+
+
+def test_marker_style_rejects_non_numeric_edge_width() -> None:
+    with pytest.raises(TypeError, match="numeric"):
+        MarkerStyle(edge_width="0.5")  # type: ignore[arg-type]
+
+
+def test_marker_style_rejects_opacity_above_one() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        MarkerStyle(opacity=1.5)
+
+
+def test_marker_style_rejects_opacity_below_zero() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        MarkerStyle(opacity=-0.1)
+
+
+def test_marker_style_rejects_non_numeric_opacity() -> None:
+    with pytest.raises(TypeError, match="numeric"):
+        MarkerStyle(opacity="full")  # type: ignore[arg-type]
+
+
+def test_marker_style_rejects_empty_edge_color() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        MarkerStyle(edge_color="")
+
+
+def test_marker_style_rejects_unparseable_edge_color() -> None:
+    with pytest.raises(ValueError, match="parseable"):
+        MarkerStyle(edge_color="not_a_color")
+
+
+def test_marker_style_rejects_non_color_scale_fill() -> None:
+    with pytest.raises(TypeError, match="ColorScale"):
+        MarkerStyle(fill_color="#ff0000")  # type: ignore[arg-type]
+
+
+def test_marker_style_custom_mesh_requires_mesh() -> None:
+    with pytest.raises(ValueError, match="custom_mesh"):
+        MarkerStyle(shape=MarkerShape.CUSTOM_MESH)
+
+
+def test_marker_style_custom_mesh_pair_happy_path() -> None:
+    mesh = _tetra()
+    style = MarkerStyle(shape=MarkerShape.CUSTOM_MESH, custom_mesh=mesh)
+    assert style.custom_mesh is mesh
+
+
+def test_marker_style_mesh_without_custom_mesh_shape_fails() -> None:
+    mesh = _tetra()
+    with pytest.raises(ValueError, match="only allowed"):
+        MarkerStyle(shape=MarkerShape.SPHERE, custom_mesh=mesh)
+
+
+def test_marker_style_rejects_non_mesh_object() -> None:
+    with pytest.raises(ValueError, match="custom_mesh"):
+        # We pass a non-CustomMeshSpec object with shape=CUSTOM_MESH; the
+        # type-check raises only after the iff check. Use SPHERE+object
+        # instead to hit the type branch.
+        MarkerStyle(shape=MarkerShape.CUSTOM_MESH, custom_mesh=None)
+
+
+def test_marker_style_custom_mesh_wrong_type_branch() -> None:
+    # MarkerShape is CUSTOM_MESH but custom_mesh is not CustomMeshSpec.
+    with pytest.raises(TypeError, match="CustomMeshSpec"):
+        MarkerStyle(
+            shape=MarkerShape.CUSTOM_MESH,
+            custom_mesh="not a mesh",  # type: ignore[arg-type]
+        )

--- a/tests/unit/plot_style/test_persistence.py
+++ b/tests/unit/plot_style/test_persistence.py
@@ -1,0 +1,287 @@
+"""Unit tests for :class:`PlotStyleSpec` and :class:`PlotStyleSet` persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import (
+    SCHEMA_VERSION,
+    ColormapId,
+    DataChannel,
+    DataDrivenColor,
+    MarkerShape,
+    MarkerStyle,
+    PaletteColor,
+    PlotStyleSet,
+    PlotStyleSpec,
+    StaticColor,
+)
+
+
+# ---------- PlotStyleSpec ----------------------------------------------
+
+
+def test_plot_style_spec_happy_path() -> None:
+    spec = PlotStyleSpec(
+        name="body",
+        target="marker_group:body",
+        style=MarkerStyle(),
+    )
+    assert spec.name == "body"
+
+
+def test_plot_style_spec_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        PlotStyleSpec(name="", target="t", style=MarkerStyle())
+
+
+def test_plot_style_spec_rejects_empty_target() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        PlotStyleSpec(name="x", target="", style=MarkerStyle())
+
+
+def test_plot_style_spec_rejects_non_marker_style() -> None:
+    with pytest.raises(TypeError, match="MarkerStyle"):
+        PlotStyleSpec(name="x", target="t", style="not a style")  # type: ignore[arg-type]
+
+
+# ---------- PlotStyleSet -----------------------------------------------
+
+
+def test_plot_style_set_default_construction() -> None:
+    style_set = PlotStyleSet()
+    assert style_set.schema_version == SCHEMA_VERSION
+    assert style_set.entries == ()
+
+
+def test_plot_style_set_rejects_duplicate_names() -> None:
+    a = PlotStyleSpec(name="x", target="t1", style=MarkerStyle())
+    b = PlotStyleSpec(name="x", target="t2", style=MarkerStyle())
+    with pytest.raises(ValueError, match="duplicate"):
+        PlotStyleSet(entries=(a, b))
+
+
+def test_plot_style_set_rejects_non_int_schema_version() -> None:
+    with pytest.raises(TypeError, match="schema_version"):
+        PlotStyleSet(schema_version="1")  # type: ignore[arg-type]
+
+
+def test_plot_style_set_rejects_zero_schema_version() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        PlotStyleSet(schema_version=0)
+
+
+def test_plot_style_set_rejects_non_tuple_entries() -> None:
+    with pytest.raises(TypeError, match="tuple"):
+        PlotStyleSet(entries=[])  # type: ignore[arg-type]
+
+
+def test_plot_style_set_rejects_non_spec_entry() -> None:
+    with pytest.raises(TypeError, match="PlotStyleSpec"):
+        PlotStyleSet(entries=("not a spec",))  # type: ignore[arg-type]
+
+
+# ---------- JSON round-trip --------------------------------------------
+
+
+def _make_set_with_static_only() -> PlotStyleSet:
+    spec = PlotStyleSpec(
+        name="body",
+        target="marker_group:body",
+        style=MarkerStyle(
+            shape=MarkerShape.SPHERE,
+            size_px=8.0,
+            edge_color="#000000",
+            edge_width=0.5,
+            fill_color=StaticColor("#1f77b4"),
+            opacity=0.9,
+        ),
+    )
+    return PlotStyleSet(entries=(spec,))
+
+
+def _make_set_with_palette() -> PlotStyleSet:
+    spec = PlotStyleSpec(
+        name="club",
+        target="trace:clubhead",
+        style=MarkerStyle(
+            shape=MarkerShape.STAR,
+            fill_color=PaletteColor(palette_name="tab10", palette_index=3),
+        ),
+    )
+    return PlotStyleSet(entries=(spec,))
+
+
+def _make_set_with_data_driven() -> tuple[PlotStyleSet, DataChannel]:
+    channel = DataChannel.from_array("speed", np.array([0.0, 5.0, 10.0]), unit="m/s")
+    spec = PlotStyleSpec(
+        name="speed",
+        target="trace:hand",
+        style=MarkerStyle(
+            shape=MarkerShape.DIAMOND,
+            fill_color=DataDrivenColor(
+                channel=channel,
+                colormap=ColormapId.VELOCITY,
+                vmin=0.0,
+                vmax=10.0,
+                nan_color="#444444",
+            ),
+        ),
+    )
+    return PlotStyleSet(entries=(spec,)), channel
+
+
+def test_round_trip_static_color(tmp_path: Path) -> None:
+    style_set = _make_set_with_static_only()
+    path = tmp_path / "set.json"
+    style_set.save(path)
+    loaded = PlotStyleSet.load(path)
+    assert loaded == style_set
+
+
+def test_round_trip_palette_color(tmp_path: Path) -> None:
+    style_set = _make_set_with_palette()
+    path = tmp_path / "set.json"
+    style_set.save(path)
+    loaded = PlotStyleSet.load(path)
+    assert loaded == style_set
+
+
+def test_round_trip_data_driven_color(tmp_path: Path) -> None:
+    style_set, channel = _make_set_with_data_driven()
+    path = tmp_path / "set.json"
+    style_set.save(path)
+    loaded = PlotStyleSet.load(path, channel_lookup={channel.name: channel})
+    # The reconstructed channel matches by name; equality of arrays is
+    # covered by reusing the supplied lookup.
+    assert loaded == style_set
+
+
+def test_round_trip_data_driven_without_lookup(tmp_path: Path) -> None:
+    """Without channel_lookup, the loader builds a placeholder channel."""
+    style_set, _ = _make_set_with_data_driven()
+    path = tmp_path / "set.json"
+    style_set.save(path)
+    loaded = PlotStyleSet.load(path)
+    # Same colormap, same name; placeholder channel has zero-length values.
+    assert len(loaded.entries) == 1
+    fill = loaded.entries[0].style.fill_color
+    assert isinstance(fill, DataDrivenColor)
+    assert fill.channel.name == "speed"
+    assert fill.channel.values.size == 0
+
+
+def test_unknown_top_level_keys_are_tolerated() -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "entries": [],
+        "future_field": "ignored",
+        "another_unknown": {"nested": True},
+    }
+    style_set = PlotStyleSet.from_json(payload)
+    assert style_set.entries == ()
+
+
+def test_unknown_entry_keys_are_tolerated() -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "entries": [
+            {
+                "name": "body",
+                "target": "marker_group:body",
+                "style": {
+                    "shape": "sphere",
+                    "size_px": 6.0,
+                    "edge_color": "#000000",
+                    "edge_width": 0.5,
+                    "fill_color": {"kind": "static", "hex_value": "#1f77b4"},
+                    "opacity": 1.0,
+                    "future_field": "ignored",
+                },
+                "label": "ignored",
+            }
+        ],
+    }
+    style_set = PlotStyleSet.from_json(payload)
+    assert len(style_set.entries) == 1
+
+
+def test_load_reads_actual_json_file(tmp_path: Path) -> None:
+    path = tmp_path / "set.json"
+    payload = {"schema_version": SCHEMA_VERSION, "entries": []}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = PlotStyleSet.load(path)
+    assert loaded == PlotStyleSet()
+
+
+def test_save_writes_pretty_json(tmp_path: Path) -> None:
+    style_set = _make_set_with_static_only()
+    path = tmp_path / "set.json"
+    style_set.save(path)
+    text = path.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    assert "  " in text  # indented
+
+
+def test_save_rejects_custom_mesh(tmp_path: Path) -> None:
+    """CUSTOM_MESH is not v1-serialisable."""
+    import numpy as np
+
+    from src.shared.python.plot_style import CustomMeshSpec
+
+    mesh = CustomMeshSpec(
+        name="t",
+        vertices=np.zeros((3, 3)),
+        faces=np.array([[0, 1, 2]], dtype=np.int32),
+    )
+    spec = PlotStyleSpec(
+        name="m",
+        target="t",
+        style=MarkerStyle(shape=MarkerShape.CUSTOM_MESH, custom_mesh=mesh),
+    )
+    style_set = PlotStyleSet(entries=(spec,))
+    with pytest.raises(ValueError, match="CUSTOM_MESH"):
+        style_set.save(tmp_path / "set.json")
+
+
+def test_save_rejects_non_path() -> None:
+    style_set = PlotStyleSet()
+    with pytest.raises(TypeError, match="pathlib.Path"):
+        style_set.save("not_a_path")  # type: ignore[arg-type]
+
+
+def test_load_rejects_non_path() -> None:
+    with pytest.raises(TypeError, match="pathlib.Path"):
+        PlotStyleSet.load("not_a_path")  # type: ignore[arg-type]
+
+
+def test_from_json_rejects_non_dict() -> None:
+    with pytest.raises(TypeError, match="dict"):
+        PlotStyleSet.from_json("not a dict")  # type: ignore[arg-type]
+
+
+def test_from_json_rejects_non_list_entries() -> None:
+    with pytest.raises(TypeError, match="list"):
+        PlotStyleSet.from_json({"entries": "nope"})
+
+
+def test_from_json_unknown_color_kind_raises() -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "entries": [
+            {
+                "name": "x",
+                "target": "t",
+                "style": {
+                    "shape": "sphere",
+                    "fill_color": {"kind": "mystery"},
+                },
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="unknown"):
+        PlotStyleSet.from_json(payload)


### PR DESCRIPTION
## Summary
- Adds module-level helpers `magnitude_channel`, `derivative_channel`, and `slice_channel` to `src/shared/python/plot_style/channels.py`, extending the `DataChannel` contract from #4799.
- Keeps the `DataChannel` dataclass pure — helpers live at module scope, exported from the package `__init__`.
- 100% line + branch coverage on `channels.py` via `tests/unit/plot_style/test_channel_helpers.py` (32 new tests).

## DbC enforced
- `magnitude_channel` rejects non-ndarray, wrong `ndim` (must be 2 or 3), and last axis != 3.
- `derivative_channel` rejects non-`DataChannel` source, non-numeric / non-positive / non-finite `timestep_s`, and channels with < 2 frames.
- `slice_channel` rejects non-`DataChannel` source, non-`slice` range, OOB start/stop, marker subset on 1-D channels, non-int / OOB / bool marker indices.
- NaN handling preserved: `auto_range` still returns `(NaN, NaN)` for all-NaN windows; magnitude/derivative propagate NaN via numpy.

## Notes
- Branched off `feat/plot-style-contracts` (#4840) since the foundation contracts haven't merged to `main` yet — this PR will rebase cleanly onto `main` once #4840 lands.
- Part of EPIC #4796 (Wave 2).

Closes #4809

## Test plan
- [x] `python3 -m ruff check src/shared/python/plot_style tests/unit/plot_style` — clean
- [x] `python3 -m ruff format --check` — clean
- [x] `python3 -m pytest tests/unit/plot_style/test_channel_helpers.py tests/unit/plot_style/test_channels.py -p no:cacheprovider --timeout=60` — 54 passed
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget
- [x] Coverage: 100% on `channels.py` (117 stmts / 64 branches, 0 miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)