### PR TITLE
feat(anthropometrics): inertia + SegmentProperties builder (#4821)

### DIFF
--- a/src/shared/python/anthropometrics/estimators/__init__.py
+++ b/src/shared/python/anthropometrics/estimators/__init__.py
@@ -1,0 +1,30 @@
+"""Anthropometric inertia estimators.
+
+This sub-package hosts pluggable estimators that turn published
+anthropometric ratios (de Leva, Dempster, Zatsiorsky-Seluyanov)
+plus per-subject scalars (height, mass, segment length) into a
+fully validated :class:`anthropometrics.SegmentProperties`.
+
+Public estimators
+-----------------
+* :func:`from_inertia_calc.inertia_from_cylinder`
+* :func:`from_inertia_calc.inertia_from_ellipsoid`
+* :func:`from_inertia_calc.inertia_from_gyration_radii`
+* :func:`from_inertia_calc.build_segment_properties_with_inertia`
+"""
+
+from __future__ import annotations
+
+from .from_inertia_calc import (
+    build_segment_properties_with_inertia,
+    inertia_from_cylinder,
+    inertia_from_ellipsoid,
+    inertia_from_gyration_radii,
+)
+
+__all__ = [
+    "build_segment_properties_with_inertia",
+    "inertia_from_cylinder",
+    "inertia_from_ellipsoid",
+    "inertia_from_gyration_radii",
+]

--- a/src/shared/python/anthropometrics/estimators/from_inertia_calc.py
+++ b/src/shared/python/anthropometrics/estimators/from_inertia_calc.py
@@ -1,0 +1,344 @@
+"""Regression-based segment inertia estimator.
+
+Wave 2 of the anthropometrics EPIC (#4797). Foundation #4800
+already exposes the canonical :class:`SegmentProperties` data
+model; this module provides three closed-form inertia
+computations and a builder that composes them into a fully
+validated :class:`SegmentProperties` instance.
+
+Methods
+-------
+``cylinder``
+    Solid cylinder of given mass, length, and radius. Body axis
+    is along x; principal moments::
+
+        I_x        = m * r**2 / 2
+        I_y = I_z  = m * (3 * r**2 + L**2) / 12
+
+``ellipsoid``
+    Solid ellipsoid with semi-axes a, b, c::
+
+        I_x = m * (b**2 + c**2) / 5
+        I_y = m * (a**2 + c**2) / 5
+        I_z = m * (a**2 + b**2) / 5
+
+``gyration_radii``
+    de Leva-style radii of gyration. For a segment of length L and
+    dimensionless gyration ratios ``k = (k_x, k_y, k_z)``::
+
+        I_i = m * (k_i * L)**2
+
+DRY reuse
+---------
+The cylinder and ellipsoid analytical formulas already exist in
+:mod:`model_generation.inertia.primitives`
+(``cylinder_inertia``, ``ellipsoid_inertia``). Those primitives
+return component dicts; we delegate to them and pack the result
+into a 3x3 :class:`numpy.ndarray`. The gyration-radii method has
+no equivalent in :mod:`model_generation.inertia.primitives`, so
+it is implemented here.
+
+The composed :class:`SegmentProperties` carries its own
+positive-definiteness and triangle-inequality validation, so any
+inertia tensor that is non-physical for the supplied parameters
+will be rejected at construction time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+from model_generation.inertia.primitives import (
+    cylinder_inertia as _primitive_cylinder_inertia,
+)
+from model_generation.inertia.primitives import (
+    ellipsoid_inertia as _primitive_ellipsoid_inertia,
+)
+
+from anthropometrics.segment_properties import SegmentProperties
+
+if TYPE_CHECKING:
+    from anthropometrics._types import FloatArray
+
+
+# --------------------------------------------------------------------------- #
+# Internal validation helpers (DRY).                                          #
+# --------------------------------------------------------------------------- #
+def _require_positive(value: float, label: str) -> None:
+    """Raise ``ValueError`` if *value* is not a strictly positive finite float."""
+    if not (isinstance(value, (int, float)) and np.isfinite(value) and value > 0):
+        raise ValueError(f"{label} must be a positive finite number, got {value!r}")
+
+
+def _diag_tensor(ix: float, iy: float, iz: float) -> FloatArray:
+    """Return a 3x3 diagonal inertia tensor as a float ndarray."""
+    return np.diag(np.asarray([ix, iy, iz], dtype=float))
+
+
+# --------------------------------------------------------------------------- #
+# Inertia computations.                                                       #
+# --------------------------------------------------------------------------- #
+def inertia_from_cylinder(
+    mass_kg: float,
+    length_m: float,
+    radius_m: float,
+) -> FloatArray:
+    """Return the inertia tensor of a solid cylinder about its CoM.
+
+    The cylinder's body axis is **x**. Off-diagonal moments are zero.
+
+    Parameters
+    ----------
+    mass_kg
+        Segment mass (kg). Must be strictly positive.
+    length_m
+        Cylinder length along its axis (m). Must be strictly positive.
+    radius_m
+        Cylinder radius (m). Must be strictly positive.
+
+    Returns
+    -------
+    numpy.ndarray
+        A ``(3, 3)`` symmetric, positive-definite inertia tensor in kg*m^2.
+
+    Raises
+    ------
+    ValueError
+        If any input is not a strictly positive finite float.
+    """
+    _require_positive(mass_kg, "mass_kg")
+    _require_positive(length_m, "length_m")
+    _require_positive(radius_m, "radius_m")
+
+    primitive = _primitive_cylinder_inertia(
+        float(mass_kg), float(radius_m), float(length_m), axis="x"
+    )
+    return _diag_tensor(primitive["ixx"], primitive["iyy"], primitive["izz"])
+
+
+def inertia_from_ellipsoid(
+    mass_kg: float,
+    a_m: float,
+    b_m: float,
+    c_m: float,
+) -> FloatArray:
+    """Return the inertia tensor of a solid ellipsoid about its CoM.
+
+    The ellipsoid has semi-axes ``a_m``, ``b_m``, ``c_m`` aligned with
+    the x, y, z body axes respectively. Off-diagonal moments are zero.
+
+    Parameters
+    ----------
+    mass_kg
+        Segment mass (kg). Must be strictly positive.
+    a_m, b_m, c_m
+        Semi-axes (m). Each must be strictly positive.
+
+    Returns
+    -------
+    numpy.ndarray
+        A ``(3, 3)`` symmetric, positive-definite inertia tensor in kg*m^2.
+
+    Raises
+    ------
+    ValueError
+        If any input is not a strictly positive finite float.
+    """
+    _require_positive(mass_kg, "mass_kg")
+    _require_positive(a_m, "a_m")
+    _require_positive(b_m, "b_m")
+    _require_positive(c_m, "c_m")
+
+    primitive = _primitive_ellipsoid_inertia(
+        float(mass_kg), float(a_m), float(b_m), float(c_m)
+    )
+    return _diag_tensor(primitive["ixx"], primitive["iyy"], primitive["izz"])
+
+
+def inertia_from_gyration_radii(
+    mass_kg: float,
+    length_m: float,
+    gyration_ratios: tuple[float, float, float],
+) -> FloatArray:
+    """Return the inertia tensor implied by de-Leva-style radius-of-gyration ratios.
+
+    Given dimensionless ratios ``k = (k_x, k_y, k_z)`` and a segment
+    length ``L``, the principal moments about the segment CoM are
+    ``I_i = m * (k_i * L) ** 2``.
+
+    Parameters
+    ----------
+    mass_kg
+        Segment mass (kg). Must be strictly positive.
+    length_m
+        Segment length (m). Must be strictly positive.
+    gyration_ratios
+        Three dimensionless ratios ``(k_x, k_y, k_z)``. Each must be
+        strictly positive and finite.
+
+    Returns
+    -------
+    numpy.ndarray
+        A ``(3, 3)`` symmetric, positive-definite inertia tensor in kg*m^2.
+
+    Raises
+    ------
+    ValueError
+        If any input is not a strictly positive finite float, or if
+        ``gyration_ratios`` does not have exactly three elements.
+    """
+    _require_positive(mass_kg, "mass_kg")
+    _require_positive(length_m, "length_m")
+
+    ratios = tuple(gyration_ratios)
+    if len(ratios) != 3:
+        raise ValueError(
+            f"gyration_ratios must have exactly 3 elements, got {len(ratios)}"
+        )
+    for axis_label, ratio in zip(("k_x", "k_y", "k_z"), ratios, strict=True):
+        _require_positive(ratio, f"gyration_ratios[{axis_label}]")
+
+    moments = tuple(float(mass_kg) * (float(k) * float(length_m)) ** 2 for k in ratios)
+    return _diag_tensor(*moments)
+
+
+# --------------------------------------------------------------------------- #
+# Builder.                                                                    #
+# --------------------------------------------------------------------------- #
+_AllowedMethod = Literal["cylinder", "ellipsoid", "gyration_radii"]
+
+
+def _inertia_for_method(
+    method: _AllowedMethod,
+    *,
+    mass_kg: float,
+    length_m: float,
+    method_params: dict[str, Any],
+) -> FloatArray:
+    """Dispatch to the requested inertia computation.
+
+    Parameters
+    ----------
+    method
+        One of ``"cylinder"``, ``"ellipsoid"``, ``"gyration_radii"``.
+    mass_kg, length_m
+        Segment scalars forwarded to the chosen method.
+    method_params
+        Method-specific parameters:
+
+        * ``cylinder``      — ``{"radius_m": float}``
+        * ``ellipsoid``     — ``{"a_m": float, "b_m": float, "c_m": float}``
+        * ``gyration_radii`` — ``{"gyration_ratios": tuple[float, float, float]}``
+
+    Raises
+    ------
+    ValueError
+        If *method* is not one of the supported strings, or
+        if *method_params* is missing required keys.
+    """
+    if method == "cylinder":
+        try:
+            radius_m = method_params["radius_m"]
+        except KeyError as exc:  # pragma: no cover - re-raised below
+            raise ValueError(
+                "cylinder method requires method_params['radius_m']"
+            ) from exc
+        return inertia_from_cylinder(mass_kg, length_m, float(radius_m))
+
+    if method == "ellipsoid":
+        missing = [k for k in ("a_m", "b_m", "c_m") if k not in method_params]
+        if missing:
+            raise ValueError(f"ellipsoid method requires method_params keys {missing}")
+        return inertia_from_ellipsoid(
+            mass_kg,
+            float(method_params["a_m"]),
+            float(method_params["b_m"]),
+            float(method_params["c_m"]),
+        )
+
+    if method == "gyration_radii":
+        try:
+            gyration_ratios = method_params["gyration_ratios"]
+        except KeyError as exc:  # pragma: no cover - re-raised below
+            raise ValueError(
+                "gyration_radii method requires method_params['gyration_ratios']"
+            ) from exc
+        return inertia_from_gyration_radii(mass_kg, length_m, tuple(gyration_ratios))
+
+    raise ValueError(
+        "method must be one of 'cylinder', 'ellipsoid', "
+        f"'gyration_radii'; got {method!r}"
+    )
+
+
+def build_segment_properties_with_inertia(
+    name: str,
+    body_part_id: str,
+    *,
+    mass_kg: float,
+    length_m: float,
+    com_xyz_m: np.ndarray,
+    method: _AllowedMethod,
+    method_params: dict[str, Any],
+    source_method: str,
+    source_subject_height_m: float,
+    source_subject_mass_kg: float,
+    proximal_marker: str | None = None,
+    distal_marker: str | None = None,
+) -> SegmentProperties:
+    """Compose a :class:`SegmentProperties` with an inertia tensor.
+
+    The inertia tensor is computed by *method* using *method_params*.
+    All other arguments are forwarded directly to the
+    :class:`SegmentProperties` constructor, which performs the full
+    physical-realisability validation suite.
+
+    Parameters
+    ----------
+    name, body_part_id, source_method
+        Identifier strings; must be non-empty.
+    mass_kg, length_m, source_subject_height_m, source_subject_mass_kg
+        Strictly positive finite scalars in SI units.
+    com_xyz_m
+        Center-of-mass vector with shape ``(3,)``.
+    method
+        ``"cylinder"``, ``"ellipsoid"``, or ``"gyration_radii"``.
+    method_params
+        Method-specific keyword payload (see
+        :func:`_inertia_for_method`).
+    proximal_marker, distal_marker
+        Optional non-empty marker labels.
+
+    Returns
+    -------
+    SegmentProperties
+        Fully validated, frozen segment with the computed inertia.
+
+    Raises
+    ------
+    ValueError
+        If any precondition fails — propagated from the inertia
+        computation or from the :class:`SegmentProperties`
+        constructor.
+    """
+    inertia_tensor = _inertia_for_method(
+        method,
+        mass_kg=mass_kg,
+        length_m=length_m,
+        method_params=method_params,
+    )
+
+    return SegmentProperties(
+        name=name,
+        body_part_id=body_part_id,
+        length_m=float(length_m),
+        proximal_marker=proximal_marker,
+        distal_marker=distal_marker,
+        mass_kg=float(mass_kg),
+        com_xyz_m=np.asarray(com_xyz_m, dtype=float),
+        inertia_tensor=inertia_tensor,
+        source_method=source_method,
+        source_subject_height_m=float(source_subject_height_m),
+        source_subject_mass_kg=float(source_subject_mass_kg),
+    )

--- a/tests/unit/anthropometrics/estimators/test_from_inertia_calc.py
+++ b/tests/unit/anthropometrics/estimators/test_from_inertia_calc.py
@@ -1,0 +1,360 @@
+"""Unit tests for :mod:`anthropometrics.estimators.from_inertia_calc`.
+
+Verifies analytical correctness of all three inertia computations
+plus the :func:`build_segment_properties_with_inertia` builder, and
+asserts that every produced tensor is symmetric, positive-definite,
+and satisfies the triangle inequality (the latter via the
+:class:`SegmentProperties` constructor's own validation).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from anthropometrics import SegmentProperties
+from anthropometrics.estimators.from_inertia_calc import (
+    build_segment_properties_with_inertia,
+    inertia_from_cylinder,
+    inertia_from_ellipsoid,
+    inertia_from_gyration_radii,
+)
+
+ATOL = 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Helpers.                                                                    #
+# --------------------------------------------------------------------------- #
+def _assert_physical_inertia(tensor: np.ndarray) -> None:
+    """Verify symmetry, positive-definiteness, and triangle inequality."""
+    assert tensor.shape == (3, 3)
+    assert np.allclose(tensor, tensor.T, atol=ATOL)
+
+    eigenvalues = np.linalg.eigvalsh(tensor)
+    assert np.all(eigenvalues > 0), f"non positive-definite: {eigenvalues}"
+
+    ix, iy, iz = sorted(float(e) for e in eigenvalues)
+    assert ix + iy + ATOL >= iz
+    assert iy + iz + ATOL >= ix
+    assert ix + iz + ATOL >= iy
+
+
+def _default_kwargs() -> dict[str, object]:
+    """Return a ``SegmentProperties`` kwargs dict valid except for inertia."""
+    return {
+        "name": "upper_arm_left",
+        "body_part_id": "upper_arm",
+        "length_m": 0.30,
+        "proximal_marker": "L_SHO",
+        "distal_marker": "L_ELB",
+        "mass_kg": 2.0,
+        "com_xyz_m": np.array([0.15, 0.0, 0.0]),
+        "source_method": "de_leva",
+        "source_subject_height_m": 1.80,
+        "source_subject_mass_kg": 75.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Cylinder.                                                                   #
+# --------------------------------------------------------------------------- #
+class TestInertiaFromCylinder:
+    def test_canonical_values(self) -> None:
+        """Cylinder (m=1, L=2, r=0.1) matches analytic Ix and Iy=Iz."""
+        tensor = inertia_from_cylinder(mass_kg=1.0, length_m=2.0, radius_m=0.1)
+
+        expected_ix = 1.0 * 0.1**2 / 2.0  # 0.005
+        expected_iy = 1.0 * (3.0 * 0.1**2 + 2.0**2) / 12.0  # 0.33583333...
+
+        assert tensor[0, 0] == pytest.approx(expected_ix, abs=ATOL)
+        assert tensor[1, 1] == pytest.approx(expected_iy, abs=ATOL)
+        assert tensor[2, 2] == pytest.approx(expected_iy, abs=ATOL)
+
+        # Off-diagonals zero.
+        for i, j in [(0, 1), (0, 2), (1, 2)]:
+            assert tensor[i, j] == pytest.approx(0.0, abs=ATOL)
+            assert tensor[j, i] == pytest.approx(0.0, abs=ATOL)
+
+        _assert_physical_inertia(tensor)
+
+    def test_independent_scaling(self) -> None:
+        """Doubling mass doubles every principal moment."""
+        base = inertia_from_cylinder(mass_kg=1.0, length_m=2.0, radius_m=0.1)
+        scaled = inertia_from_cylinder(mass_kg=2.0, length_m=2.0, radius_m=0.1)
+        assert np.allclose(2.0 * base, scaled, atol=ATOL)
+
+    @pytest.mark.parametrize(
+        ("mass_kg", "length_m", "radius_m", "label"),
+        [
+            (0.0, 1.0, 0.1, "mass_kg"),
+            (-1.0, 1.0, 0.1, "mass_kg"),
+            (1.0, 0.0, 0.1, "length_m"),
+            (1.0, -1.0, 0.1, "length_m"),
+            (1.0, 1.0, 0.0, "radius_m"),
+            (1.0, 1.0, -0.1, "radius_m"),
+            (float("nan"), 1.0, 0.1, "mass_kg"),
+            (float("inf"), 1.0, 0.1, "mass_kg"),
+        ],
+    )
+    def test_rejects_non_positive(
+        self, mass_kg: float, length_m: float, radius_m: float, label: str
+    ) -> None:
+        with pytest.raises(ValueError, match=label):
+            inertia_from_cylinder(mass_kg=mass_kg, length_m=length_m, radius_m=radius_m)
+
+
+# --------------------------------------------------------------------------- #
+# Ellipsoid.                                                                  #
+# --------------------------------------------------------------------------- #
+class TestInertiaFromEllipsoid:
+    def test_unit_sphere(self) -> None:
+        """Unit sphere (m=1, a=b=c=1) gives 0.4 on every principal axis."""
+        tensor = inertia_from_ellipsoid(mass_kg=1.0, a_m=1.0, b_m=1.0, c_m=1.0)
+        for i in range(3):
+            assert tensor[i, i] == pytest.approx(0.4, abs=ATOL)
+        _assert_physical_inertia(tensor)
+
+    def test_general_ellipsoid_principal_moments(self) -> None:
+        """Non-degenerate ellipsoid gives the standard m/5 formula on each axis."""
+        m, a, b, c = 3.0, 0.4, 0.2, 0.1
+        tensor = inertia_from_ellipsoid(m, a, b, c)
+        assert tensor[0, 0] == pytest.approx(m * (b**2 + c**2) / 5.0, abs=ATOL)
+        assert tensor[1, 1] == pytest.approx(m * (a**2 + c**2) / 5.0, abs=ATOL)
+        assert tensor[2, 2] == pytest.approx(m * (a**2 + b**2) / 5.0, abs=ATOL)
+        _assert_physical_inertia(tensor)
+
+    @pytest.mark.parametrize(
+        ("mass_kg", "a_m", "b_m", "c_m", "label"),
+        [
+            (0.0, 1.0, 1.0, 1.0, "mass_kg"),
+            (1.0, 0.0, 1.0, 1.0, "a_m"),
+            (1.0, 1.0, 0.0, 1.0, "b_m"),
+            (1.0, 1.0, 1.0, 0.0, "c_m"),
+            (1.0, -1.0, 1.0, 1.0, "a_m"),
+        ],
+    )
+    def test_rejects_non_positive(
+        self,
+        mass_kg: float,
+        a_m: float,
+        b_m: float,
+        c_m: float,
+        label: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=label):
+            inertia_from_ellipsoid(mass_kg, a_m, b_m, c_m)
+
+
+# --------------------------------------------------------------------------- #
+# Gyration-radii.                                                             #
+# --------------------------------------------------------------------------- #
+class TestInertiaFromGyrationRadii:
+    def test_canonical_values(self) -> None:
+        """k=(0.5, 0.3, 0.4), L=1, m=1 gives I=(0.25, 0.09, 0.16)."""
+        tensor = inertia_from_gyration_radii(
+            mass_kg=1.0, length_m=1.0, gyration_ratios=(0.5, 0.3, 0.4)
+        )
+        assert tensor[0, 0] == pytest.approx(0.25, abs=ATOL)
+        assert tensor[1, 1] == pytest.approx(0.09, abs=ATOL)
+        assert tensor[2, 2] == pytest.approx(0.16, abs=ATOL)
+        _assert_physical_inertia(tensor)
+
+    def test_quadratic_in_length(self) -> None:
+        """Doubling length should quadruple every principal moment."""
+        ratios = (0.4, 0.3, 0.35)
+        base = inertia_from_gyration_radii(
+            mass_kg=1.5, length_m=0.4, gyration_ratios=ratios
+        )
+        doubled = inertia_from_gyration_radii(
+            mass_kg=1.5, length_m=0.8, gyration_ratios=ratios
+        )
+        assert np.allclose(4.0 * base, doubled, atol=ATOL)
+
+    @pytest.mark.parametrize(
+        ("mass_kg", "length_m", "ratios", "match"),
+        [
+            (0.0, 1.0, (0.5, 0.3, 0.4), "mass_kg"),
+            (1.0, 0.0, (0.5, 0.3, 0.4), "length_m"),
+            (1.0, 1.0, (0.0, 0.3, 0.4), "k_x"),
+            (1.0, 1.0, (0.5, -0.1, 0.4), "k_y"),
+            (1.0, 1.0, (0.5, 0.3, float("nan")), "k_z"),
+        ],
+    )
+    def test_rejects_invalid_inputs(
+        self,
+        mass_kg: float,
+        length_m: float,
+        ratios: tuple[float, float, float],
+        match: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            inertia_from_gyration_radii(
+                mass_kg=mass_kg, length_m=length_m, gyration_ratios=ratios
+            )
+
+    def test_rejects_wrong_arity(self) -> None:
+        with pytest.raises(ValueError, match="exactly 3 elements"):
+            inertia_from_gyration_radii(
+                mass_kg=1.0,
+                length_m=1.0,
+                gyration_ratios=(0.5, 0.3),  # type: ignore[arg-type]
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Builder.                                                                    #
+# --------------------------------------------------------------------------- #
+class TestBuildSegmentPropertiesWithInertia:
+    def test_cylinder_builder_matches_direct_call(self) -> None:
+        """Builder's tensor matches a direct ``inertia_from_cylinder`` call."""
+        kwargs = _default_kwargs()
+        seg = build_segment_properties_with_inertia(
+            kwargs["name"],
+            kwargs["body_part_id"],
+            mass_kg=kwargs["mass_kg"],
+            length_m=kwargs["length_m"],
+            com_xyz_m=kwargs["com_xyz_m"],
+            method="cylinder",
+            method_params={"radius_m": 0.04},
+            source_method=kwargs["source_method"],
+            source_subject_height_m=kwargs["source_subject_height_m"],
+            source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            proximal_marker=kwargs["proximal_marker"],
+            distal_marker=kwargs["distal_marker"],
+        )
+
+        assert isinstance(seg, SegmentProperties)
+        expected = inertia_from_cylinder(
+            mass_kg=kwargs["mass_kg"],
+            length_m=kwargs["length_m"],
+            radius_m=0.04,
+        )
+        assert np.allclose(seg.inertia_tensor, expected, atol=ATOL)
+        _assert_physical_inertia(seg.inertia_tensor)
+
+    def test_ellipsoid_builder(self) -> None:
+        kwargs = _default_kwargs()
+        seg = build_segment_properties_with_inertia(
+            kwargs["name"],
+            kwargs["body_part_id"],
+            mass_kg=kwargs["mass_kg"],
+            length_m=kwargs["length_m"],
+            com_xyz_m=kwargs["com_xyz_m"],
+            method="ellipsoid",
+            method_params={"a_m": 0.15, "b_m": 0.05, "c_m": 0.05},
+            source_method=kwargs["source_method"],
+            source_subject_height_m=kwargs["source_subject_height_m"],
+            source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+        )
+
+        expected = inertia_from_ellipsoid(
+            mass_kg=kwargs["mass_kg"], a_m=0.15, b_m=0.05, c_m=0.05
+        )
+        assert np.allclose(seg.inertia_tensor, expected, atol=ATOL)
+        _assert_physical_inertia(seg.inertia_tensor)
+
+    def test_gyration_radii_builder(self) -> None:
+        kwargs = _default_kwargs()
+        ratios = (0.322, 0.303, 0.158)  # de Leva-ish for upper arm
+        seg = build_segment_properties_with_inertia(
+            kwargs["name"],
+            kwargs["body_part_id"],
+            mass_kg=kwargs["mass_kg"],
+            length_m=kwargs["length_m"],
+            com_xyz_m=kwargs["com_xyz_m"],
+            method="gyration_radii",
+            method_params={"gyration_ratios": ratios},
+            source_method=kwargs["source_method"],
+            source_subject_height_m=kwargs["source_subject_height_m"],
+            source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+        )
+
+        expected = inertia_from_gyration_radii(
+            mass_kg=kwargs["mass_kg"],
+            length_m=kwargs["length_m"],
+            gyration_ratios=ratios,
+        )
+        assert np.allclose(seg.inertia_tensor, expected, atol=ATOL)
+        _assert_physical_inertia(seg.inertia_tensor)
+
+    def test_unknown_method_rejected(self) -> None:
+        kwargs = _default_kwargs()
+        with pytest.raises(ValueError, match="method must be one of"):
+            build_segment_properties_with_inertia(
+                kwargs["name"],
+                kwargs["body_part_id"],
+                mass_kg=kwargs["mass_kg"],
+                length_m=kwargs["length_m"],
+                com_xyz_m=kwargs["com_xyz_m"],
+                method="bogus",  # type: ignore[arg-type]
+                method_params={},
+                source_method=kwargs["source_method"],
+                source_subject_height_m=kwargs["source_subject_height_m"],
+                source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            )
+
+    def test_cylinder_missing_param_rejected(self) -> None:
+        kwargs = _default_kwargs()
+        with pytest.raises(ValueError, match="radius_m"):
+            build_segment_properties_with_inertia(
+                kwargs["name"],
+                kwargs["body_part_id"],
+                mass_kg=kwargs["mass_kg"],
+                length_m=kwargs["length_m"],
+                com_xyz_m=kwargs["com_xyz_m"],
+                method="cylinder",
+                method_params={},
+                source_method=kwargs["source_method"],
+                source_subject_height_m=kwargs["source_subject_height_m"],
+                source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            )
+
+    def test_ellipsoid_missing_param_rejected(self) -> None:
+        kwargs = _default_kwargs()
+        with pytest.raises(ValueError, match="a_m"):
+            build_segment_properties_with_inertia(
+                kwargs["name"],
+                kwargs["body_part_id"],
+                mass_kg=kwargs["mass_kg"],
+                length_m=kwargs["length_m"],
+                com_xyz_m=kwargs["com_xyz_m"],
+                method="ellipsoid",
+                method_params={"b_m": 0.1, "c_m": 0.1},
+                source_method=kwargs["source_method"],
+                source_subject_height_m=kwargs["source_subject_height_m"],
+                source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            )
+
+    def test_gyration_missing_param_rejected(self) -> None:
+        kwargs = _default_kwargs()
+        with pytest.raises(ValueError, match="gyration_ratios"):
+            build_segment_properties_with_inertia(
+                kwargs["name"],
+                kwargs["body_part_id"],
+                mass_kg=kwargs["mass_kg"],
+                length_m=kwargs["length_m"],
+                com_xyz_m=kwargs["com_xyz_m"],
+                method="gyration_radii",
+                method_params={},
+                source_method=kwargs["source_method"],
+                source_subject_height_m=kwargs["source_subject_height_m"],
+                source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            )
+
+    def test_segment_properties_validation_propagates(self) -> None:
+        """A non-positive ``mass_kg`` is caught before the SP is constructed."""
+        kwargs = _default_kwargs()
+        with pytest.raises(ValueError, match="mass_kg"):
+            build_segment_properties_with_inertia(
+                kwargs["name"],
+                kwargs["body_part_id"],
+                mass_kg=-1.0,
+                length_m=kwargs["length_m"],
+                com_xyz_m=kwargs["com_xyz_m"],
+                method="cylinder",
+                method_params={"radius_m": 0.04},
+                source_method=kwargs["source_method"],
+                source_subject_height_m=kwargs["source_subject_height_m"],
+                source_subject_mass_kg=kwargs["source_subject_mass_kg"],
+            )


### PR DESCRIPTION
## Summary

Wave 2 of the anthropometrics EPIC #4797 (foundation #4800 already merged).
Closes #4821.

- Three closed-form inertia computations:
  - `inertia_from_cylinder(mass_kg, length_m, radius_m)` — body axis along x
  - `inertia_from_ellipsoid(mass_kg, a_m, b_m, c_m)` — solid ellipsoid
  - `inertia_from_gyration_radii(mass_kg, length_m, (k_x, k_y, k_z))` — de Leva-style ratios
- `build_segment_properties_with_inertia(...)` composes any of the three into a fully validated `SegmentProperties`.
- DRY: cylinder and ellipsoid delegate to `model_generation.inertia.primitives.{cylinder_inertia, ellipsoid_inertia}`. The gyration-radii method has no equivalent there, so it lives here.

## Test plan

- [x] 33 unit tests pass: `tests/unit/anthropometrics/estimators/test_from_inertia_calc.py`
- [x] Coverage: 100% line + 100% branch on the new module (target was >=90%)
- [x] Analytical match to <1e-15 on every canonical case (cylinder, unit-sphere ellipsoid, gyration radii)
- [x] All produced tensors satisfy symmetry, positive-definiteness, and triangle inequality (also enforced by the `SegmentProperties` constructor)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `scripts/ci/check_file_size_budget.py` clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>