### PR TITLE
feat(anthropometrics): from_mocap (#4815)

### DIFF
--- a/src/shared/python/anthropometrics/estimators/__init__.py
+++ b/src/shared/python/anthropometrics/estimators/__init__.py
@@ -1,9 +1,12 @@
-"""Anthropometric inertia estimators.
+"""Anthropometric estimators.
 
 This sub-package hosts pluggable estimators that turn published
 anthropometric ratios (de Leva, Dempster, Zatsiorsky-Seluyanov)
 plus per-subject scalars (height, mass, segment length) into a
-fully validated :class:`anthropometrics.SegmentProperties`.
+fully validated :class:`anthropometrics.SegmentProperties`, and
+estimator implementations producing :class:`~anthropometrics.SegmentProperties`
+or related primitives from various input modalities (mocap, regression
+tables, manual measurements).
 
 Public estimators
 -----------------
@@ -11,6 +14,7 @@ Public estimators
 * :func:`from_inertia_calc.inertia_from_ellipsoid`
 * :func:`from_inertia_calc.inertia_from_gyration_radii`
 * :func:`from_inertia_calc.build_segment_properties_with_inertia`
+* :func:`from_mocap.estimate_segment_lengths_from_markers`
 """
 
 from __future__ import annotations
@@ -21,9 +25,12 @@ from .from_inertia_calc import (
     inertia_from_ellipsoid,
     inertia_from_gyration_radii,
 )
+from .from_mocap import SegmentDef, estimate_segment_lengths_from_markers
 
 __all__ = [
+    "SegmentDef",
     "build_segment_properties_with_inertia",
+    "estimate_segment_lengths_from_markers",
     "inertia_from_cylinder",
     "inertia_from_ellipsoid",
     "inertia_from_gyration_radii",

--- a/src/shared/python/anthropometrics/estimators/from_mocap.py
+++ b/src/shared/python/anthropometrics/estimators/from_mocap.py
@@ -1,0 +1,188 @@
+"""Segment-length estimator from mocap marker trajectories.
+
+Wave 2 of the anthropometrics EPIC (#4797). Closes #4815.
+
+This module is a *thin wrapper* around the per-frame distance helper
+in :mod:`motion_pipeline.scaling.anthropometric`. The wrap exists
+because the existing module's public entry point
+(:func:`scale_skeleton`) returns a :class:`SkeletonRig`, whereas the
+anthropometrics pipeline needs a plain ``{segment_name: length_m}``
+mapping with NaN-tolerant inputs that the rest of the pipeline can
+feed into :class:`anthropometrics.SegmentProperties`. Wrapping (rather
+than re-implementing the Euclidean-distance arithmetic) keeps the
+distance algorithm in a single place — see DRY assertion in the
+matching test module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+# DRY: reuse the per-frame distance computation from the motion pipeline.
+# Importing the contracts here lets us construct the per-frame MarkerFrame
+# the helper expects without duplicating the Euclidean-distance kernel.
+from motion_pipeline.contracts import Marker, MarkerFrame
+from motion_pipeline.scaling.anthropometric import _compute_segment_length
+
+__all__ = [
+    "SegmentDef",
+    "estimate_segment_lengths_from_markers",
+]
+
+
+_Method = Literal["mean_distance", "median_distance", "min_distance"]
+_VALID_METHODS: tuple[_Method, ...] = (
+    "mean_distance",
+    "median_distance",
+    "min_distance",
+)
+
+
+@dataclass(frozen=True)
+class SegmentDef:
+    """Definition of a body segment in terms of its bounding markers.
+
+    Attributes:
+        name: Segment name (used as the key in the returned mapping).
+        proximal_marker: Name of the marker at the proximal end.
+        distal_marker: Name of the marker at the distal end.
+    """
+
+    name: str
+    proximal_marker: str
+    distal_marker: str
+
+
+def _reduce(values: list[float], method: _Method) -> float:
+    """Reduce a list of per-frame distances to a single segment length."""
+    arr = np.asarray(values, dtype=float)
+    if method == "mean_distance":
+        return float(np.mean(arr))
+    if method == "median_distance":
+        return float(np.median(arr))
+    if method == "min_distance":
+        return float(np.min(arr))
+    # Defensive — Literal-typed but validated explicitly for runtime callers.
+    raise ValueError(f"Unknown method {method!r}. Expected one of {_VALID_METHODS}.")
+
+
+def estimate_segment_lengths_from_markers(
+    markers: dict[str, np.ndarray],
+    segment_definitions: Sequence[SegmentDef],
+    *,
+    method: _Method = "median_distance",
+) -> dict[str, float]:
+    """Per-segment length in metres from marker trajectories.
+
+    NaN-tolerant: frames where either the proximal or distal marker is
+    non-finite (NaN/Inf in any coordinate) are excluded from the
+    reduction. The remaining finite frames are reduced via *method*.
+
+    Args:
+        markers: Mapping of marker name to ``(T, 3)`` ``np.ndarray`` in
+            metres. Each array gives the trajectory of one marker over
+            ``T`` frames; non-finite rows mark missing/occluded samples.
+        segment_definitions: Iterable of :class:`SegmentDef` describing
+            which marker pairs delimit each segment. Order is preserved
+            in the result.
+        method: Reduction strategy across the finite frames.
+            ``"mean_distance"`` — arithmetic mean (sensitive to
+            outliers).
+            ``"median_distance"`` — robust median (default).
+            ``"min_distance"`` — conservative minimum.
+
+    Returns:
+        Dict mapping segment name to its estimated length in metres.
+
+    Raises:
+        ValueError: If *segment_definitions* is empty, if a required
+            marker is missing from *markers*, if marker arrays are not
+            ``(T, 3)`` with consistent ``T``, if *method* is unknown,
+            or if no finite frames remain for any required segment
+            (the message lists the offending segment(s) and missing
+            markers).
+    """
+    if method not in _VALID_METHODS:
+        raise ValueError(
+            f"Unknown method {method!r}. Expected one of {_VALID_METHODS}."
+        )
+
+    seg_list = list(segment_definitions)
+    if not seg_list:
+        raise ValueError("segment_definitions must be non-empty.")
+
+    # Identify required markers and report all missing ones at once
+    # for a more useful error message.
+    required: set[str] = set()
+    for seg in seg_list:
+        required.add(seg.proximal_marker)
+        required.add(seg.distal_marker)
+
+    missing = sorted(name for name in required if name not in markers)
+    if missing:
+        raise ValueError(
+            "Missing required marker(s) in `markers` mapping: "
+            f"{missing}. Required markers: {sorted(required)}."
+        )
+
+    # Validate shapes and infer the common frame count T.
+    frame_counts: set[int] = set()
+    for name in required:
+        arr = np.asarray(markers[name])
+        if arr.ndim != 2 or arr.shape[1] != 3:
+            raise ValueError(
+                f"Marker {name!r} must be a (T, 3) array; got shape {arr.shape}."
+            )
+        frame_counts.add(arr.shape[0])
+    if len(frame_counts) != 1:
+        raise ValueError(
+            "All marker arrays must share the same number of frames T; "
+            f"got {sorted(frame_counts)}."
+        )
+    (n_frames,) = frame_counts
+    if n_frames == 0:
+        raise ValueError("Marker arrays have zero frames (T == 0).")
+
+    # Per-frame: build a MarkerFrame containing only the finite markers,
+    # then delegate to the motion-pipeline distance helper. This routes
+    # through the canonical Euclidean-distance kernel (DRY) instead of
+    # recomputing it here.
+    per_segment_values: dict[str, list[float]] = {seg.name: [] for seg in seg_list}
+    finite_mask: dict[str, np.ndarray] = {
+        name: np.all(np.isfinite(np.asarray(markers[name])), axis=1)
+        for name in required
+    }
+
+    for t in range(n_frames):
+        frame_markers: dict[str, Marker] = {}
+        for name in required:
+            if finite_mask[name][t]:
+                xyz = np.asarray(markers[name])[t]
+                frame_markers[name] = Marker(
+                    name=name,
+                    x=float(xyz[0]),
+                    y=float(xyz[1]),
+                    z=float(xyz[2]),
+                )
+        # Timestamp is not used by the distance helper; supply a
+        # monotonically-increasing placeholder to satisfy contracts.
+        marker_frame = MarkerFrame(timestamp=float(t), markers=frame_markers)
+        for seg in seg_list:
+            length = _compute_segment_length(
+                marker_frame, seg.proximal_marker, seg.distal_marker
+            )
+            if length is not None:
+                per_segment_values[seg.name].append(length)
+
+    empty = [name for name, vals in per_segment_values.items() if not vals]
+    if empty:
+        raise ValueError(
+            "No finite frames available for segment(s): "
+            f"{sorted(empty)}. Check marker NaN coverage and definitions."
+        )
+
+    return {seg.name: _reduce(per_segment_values[seg.name], method) for seg in seg_list}

--- a/tests/unit/anthropometrics/estimators/test_from_mocap.py
+++ b/tests/unit/anthropometrics/estimators/test_from_mocap.py
@@ -1,0 +1,249 @@
+"""Unit tests for :mod:`anthropometrics.estimators.from_mocap`.
+
+Covers exact-recovery on synthetic data, NaN tolerance, error paths,
+method comparison (mean / median / min), and a DRY assertion that the
+production code routes through ``motion_pipeline.scaling.anthropometric``
+for the per-frame distance kernel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from anthropometrics.estimators.from_mocap import (
+    SegmentDef,
+    estimate_segment_lengths_from_markers,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures / builders.                                                        #
+# --------------------------------------------------------------------------- #
+_KNOWN_LENGTH = 0.30  # metres
+
+
+def _trajectory(
+    n_frames: int = 100, length: float = _KNOWN_LENGTH
+) -> dict[str, np.ndarray]:
+    """Two markers separated by a constant Euclidean distance.
+
+    Both markers translate together along an arbitrary path so that the
+    inter-marker distance is constant at *length* on every frame.
+    """
+    rng = np.random.default_rng(seed=0)
+    base = rng.normal(scale=1.0, size=(n_frames, 3))
+    offset = np.array([length, 0.0, 0.0])
+    return {
+        "PROX": base.copy(),
+        "DIST": base + offset,
+    }
+
+
+def _seg() -> list[SegmentDef]:
+    return [SegmentDef(name="forearm", proximal_marker="PROX", distal_marker="DIST")]
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: exact recovery.                                                 #
+# --------------------------------------------------------------------------- #
+def test_recovers_known_length_to_machine_precision() -> None:
+    markers = _trajectory()
+    out = estimate_segment_lengths_from_markers(markers, _seg())
+    assert set(out) == {"forearm"}
+    assert out["forearm"] == pytest.approx(_KNOWN_LENGTH, abs=1e-9)
+
+
+def test_default_method_is_median() -> None:
+    markers = _trajectory()
+    default = estimate_segment_lengths_from_markers(markers, _seg())
+    explicit = estimate_segment_lengths_from_markers(
+        markers, _seg(), method="median_distance"
+    )
+    assert default == explicit
+
+
+def test_preserves_segment_order() -> None:
+    rng = np.random.default_rng(seed=1)
+    base = rng.normal(size=(20, 3))
+    markers = {
+        "A": base,
+        "B": base + np.array([0.4, 0.0, 0.0]),
+        "C": base + np.array([0.0, 0.5, 0.0]),
+    }
+    segs = [
+        SegmentDef("seg_ac", "A", "C"),
+        SegmentDef("seg_ab", "A", "B"),
+    ]
+    out = estimate_segment_lengths_from_markers(markers, segs)
+    assert list(out.keys()) == ["seg_ac", "seg_ab"]
+    assert out["seg_ab"] == pytest.approx(0.4, abs=1e-9)
+    assert out["seg_ac"] == pytest.approx(0.5, abs=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# NaN tolerance.                                                              #
+# --------------------------------------------------------------------------- #
+def test_nan_tolerance_recovers_from_remaining_frames() -> None:
+    markers = _trajectory()
+    # Knock out half of the proximal marker rows.
+    markers["PROX"][::2] = np.nan
+    out = estimate_segment_lengths_from_markers(markers, _seg())
+    assert out["forearm"] == pytest.approx(_KNOWN_LENGTH, abs=1e-9)
+
+
+def test_inf_marker_rows_are_treated_as_missing() -> None:
+    markers = _trajectory()
+    markers["DIST"][10] = np.inf
+    out = estimate_segment_lengths_from_markers(markers, _seg())
+    assert out["forearm"] == pytest.approx(_KNOWN_LENGTH, abs=1e-9)
+
+
+def test_all_nan_for_segment_raises_value_error() -> None:
+    markers = _trajectory(n_frames=10)
+    markers["DIST"][:] = np.nan
+    with pytest.raises(ValueError, match="No finite frames"):
+        estimate_segment_lengths_from_markers(markers, _seg())
+
+
+# --------------------------------------------------------------------------- #
+# Error paths.                                                                #
+# --------------------------------------------------------------------------- #
+def test_empty_markers_raises_listing_required_markers() -> None:
+    with pytest.raises(ValueError, match="Missing required marker") as exc_info:
+        estimate_segment_lengths_from_markers({}, _seg())
+    msg = str(exc_info.value)
+    assert "PROX" in msg
+    assert "DIST" in msg
+
+
+def test_missing_one_marker_raises() -> None:
+    markers = _trajectory()
+    del markers["DIST"]
+    with pytest.raises(ValueError, match="Missing required marker"):
+        estimate_segment_lengths_from_markers(markers, _seg())
+
+
+def test_empty_segment_definitions_raises() -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        estimate_segment_lengths_from_markers({"PROX": np.zeros((1, 3))}, [])
+
+
+def test_wrong_shape_raises() -> None:
+    markers = {
+        "PROX": np.zeros((10, 2)),  # not (T, 3)
+        "DIST": np.zeros((10, 3)),
+    }
+    with pytest.raises(ValueError, match=r"\(T, 3\)"):
+        estimate_segment_lengths_from_markers(markers, _seg())
+
+
+def test_inconsistent_frame_counts_raise() -> None:
+    markers = {
+        "PROX": np.zeros((10, 3)),
+        "DIST": np.zeros((11, 3)),
+    }
+    with pytest.raises(ValueError, match="same number of frames"):
+        estimate_segment_lengths_from_markers(markers, _seg())
+
+
+def test_zero_frames_raises() -> None:
+    markers = {
+        "PROX": np.zeros((0, 3)),
+        "DIST": np.zeros((0, 3)),
+    }
+    with pytest.raises(ValueError, match="zero frames"):
+        estimate_segment_lengths_from_markers(markers, _seg())
+
+
+def test_unknown_method_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown method"):
+        estimate_segment_lengths_from_markers(
+            _trajectory(),
+            _seg(),
+            method="bogus",  # type: ignore[arg-type]
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Method comparison.                                                          #
+# --------------------------------------------------------------------------- #
+def _markers_with_outliers() -> dict[str, np.ndarray]:
+    """Mostly clean trajectory plus a handful of inflated frames.
+
+    Frames 0..89 give a constant inter-marker distance of 0.30 m;
+    frames 90..99 inflate the distance to 1.30 m (outliers). Result:
+
+    * mean ~ 0.40 m  (pulled up by outliers)
+    * median = 0.30 m  (robust)
+    * min = 0.30 m  (conservative — drops to clean lower bound)
+    """
+    n = 100
+    rng = np.random.default_rng(seed=2)
+    base = rng.normal(size=(n, 3))
+    dist = base + np.array([0.30, 0.0, 0.0])
+    # Inflate the last 10 frames by an extra 1.0 m along x.
+    dist[90:] += np.array([1.0, 0.0, 0.0])
+    return {"PROX": base, "DIST": dist}
+
+
+def test_mean_distance_is_pulled_up_by_outliers() -> None:
+    out = estimate_segment_lengths_from_markers(
+        _markers_with_outliers(), _seg(), method="mean_distance"
+    )
+    # 90 frames at 0.30 + 10 frames at 1.30 = mean of 0.40
+    assert out["forearm"] == pytest.approx(0.40, abs=1e-9)
+
+
+def test_median_distance_is_robust_to_outliers() -> None:
+    out = estimate_segment_lengths_from_markers(
+        _markers_with_outliers(), _seg(), method="median_distance"
+    )
+    assert out["forearm"] == pytest.approx(0.30, abs=1e-9)
+
+
+def test_min_distance_is_conservative() -> None:
+    out = estimate_segment_lengths_from_markers(
+        _markers_with_outliers(), _seg(), method="min_distance"
+    )
+    # Minimum across the clean frames is exactly 0.30.
+    assert out["forearm"] == pytest.approx(0.30, abs=1e-9)
+
+
+def test_method_ordering_under_outliers() -> None:
+    markers = _markers_with_outliers()
+    mean = estimate_segment_lengths_from_markers(
+        markers, _seg(), method="mean_distance"
+    )["forearm"]
+    median = estimate_segment_lengths_from_markers(
+        markers, _seg(), method="median_distance"
+    )["forearm"]
+    minimum = estimate_segment_lengths_from_markers(
+        markers, _seg(), method="min_distance"
+    )["forearm"]
+    # Mean is dragged up by outliers; median equals the clean value;
+    # min sits at-or-below the clean value (it equals 0.30 here).
+    assert minimum <= median < mean
+
+
+# --------------------------------------------------------------------------- #
+# DRY assertion: production code routes through motion_pipeline.              #
+# --------------------------------------------------------------------------- #
+def test_production_code_references_motion_pipeline_distance_kernel() -> None:
+    """The estimator must reuse the motion-pipeline distance helper.
+
+    Guards against silent drift where someone reimplements the
+    Euclidean kernel in this module instead of delegating.
+    """
+    src = Path("src/shared/python/anthropometrics/estimators/from_mocap.py").read_text(
+        encoding="utf-8"
+    )
+    assert "motion_pipeline.scaling.anthropometric" in src, (
+        "from_mocap.py must import the per-frame distance helper from "
+        "motion_pipeline.scaling.anthropometric (DRY)."
+    )
+    assert "_compute_segment_length" in src, (
+        "from_mocap.py must call _compute_segment_length, not reimplement "
+        "the Euclidean-distance kernel."
+    )


### PR DESCRIPTION
## Summary

Wave 2 of the anthropometrics EPIC (#4797). Foundation #4800 merged.

- New estimator `anthropometrics.estimators.from_mocap.estimate_segment_lengths_from_markers` returning a plain `{segment_name: length_m}` mapping suitable for the anthropometrics pipeline.
- Thin wrapper around `motion_pipeline.scaling.anthropometric._compute_segment_length` (DRY) — the existing public entry point in that module returns a `SkeletonRig`, so a wrapper is required to expose the plain-length output without duplicating the Euclidean-distance kernel.
- NaN-tolerant: per-frame masking on `np.isfinite`; non-finite frames are excluded from reduction.
- Three reduction methods: `mean_distance`, `median_distance` (default, robust), `min_distance` (conservative).

Closes #4815.

## Test plan

- [x] 18 unit tests pass — `python3 -m pytest tests/unit/anthropometrics/estimators/test_from_mocap.py -p no:cacheprovider --timeout=60`
- [x] Coverage 97.98% on `from_mocap.py` (target ≥ 90%)
- [x] `python3 -m ruff check src/shared/python/anthropometrics tests/unit/anthropometrics` — clean
- [x] `python3 -m ruff format --check ...` — clean
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget
- [x] DRY assertion test verifies production code references `motion_pipeline.scaling.anthropometric`
- [x] Outlier-robustness test verifies `min_distance <= median_distance < mean_distance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)