### PR TITLE
feat(plot-style): colormap registry (#4802)

### DIFF
--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -29,6 +29,12 @@ from .colors import ColorScale, DataDrivenColor, PaletteColor, StaticColor
 from .contracts import ColorResolver, MarkerRenderer
 from .markers import CustomMeshSpec, MarkerShape, MarkerStyle
 from .persistence import SCHEMA_VERSION, PlotStyleSet, PlotStyleSpec
+from .registry import (
+    get_colormap,
+    list_colormaps,
+    register_custom_colormap,
+    unregister_custom_colormap,
+)
 
 __all__ = [
     "SCHEMA_VERSION",
@@ -49,7 +55,11 @@ __all__ = [
     "RGBATuple",
     "StaticColor",
     "derivative_channel",
+    "get_colormap",
+    "list_colormaps",
     "magnitude_channel",
+    "register_custom_colormap",
     "resolve_colormap_alias",
     "slice_channel",
+    "unregister_custom_colormap",
 ]

--- a/src/shared/python/plot_style/registry.py
+++ b/src/shared/python/plot_style/registry.py
@@ -1,0 +1,170 @@
+"""Colormap registry resolving :class:`ColormapId` and custom names.
+
+This module is the single entry point for retrieving an actual
+``matplotlib.colors.Colormap`` instance from a :class:`ColormapId`
+enum value, a semantic alias, or a custom-colormap name registered
+at runtime via :func:`register_custom_colormap`.
+
+The semantic-alias map (``VELOCITY``, ``FORCE``, ``ACCELERATION``,
+``HEIGHT``, ``GENERIC_DIVERGING``) is immutable at module load and
+delegates to the matplotlib built-in chosen for each kinematic /
+kinetic data family.
+
+Registration of :class:`CustomColormap` is *idempotent* — registering
+the same colormap (matched by ``name + stops``) twice is a no-op.
+Registering a *different* colormap under an existing name raises
+:class:`ValueError`.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import matplotlib.colors as mcolors
+from matplotlib import colormaps as _mpl_colormaps
+
+from .colormaps import ColormapId, CustomColormap, resolve_colormap_alias
+
+__all__ = [
+    "get_colormap",
+    "list_colormaps",
+    "register_custom_colormap",
+    "unregister_custom_colormap",
+]
+
+
+# ColormapId.value -> matplotlib registry name. Most ColormapId values
+# already match the matplotlib name; the exception is ``SPECTRAL``
+# which matplotlib spells with a capital S.
+_BUILTIN_MPL_NAME: Final[dict[ColormapId, str]] = {
+    ColormapId.VIRIDIS: "viridis",
+    ColormapId.PLASMA: "plasma",
+    ColormapId.MAGMA: "magma",
+    ColormapId.INFERNO: "inferno",
+    ColormapId.CIVIDIS: "cividis",
+    ColormapId.TURBO: "turbo",
+    ColormapId.COOLWARM: "coolwarm",
+    ColormapId.SPECTRAL: "Spectral",
+}
+
+
+# Process-global registry for user-defined colormaps. Keyed by
+# ``CustomColormap.name``; values are the original :class:`CustomColormap`
+# (for idempotency comparisons) plus the materialised matplotlib
+# :class:`~matplotlib.colors.LinearSegmentedColormap`.
+_CUSTOM_COLORMAPS: dict[str, tuple[CustomColormap, mcolors.Colormap]] = {}
+
+
+def _materialise_custom(cmap: CustomColormap) -> mcolors.Colormap:
+    """Build a matplotlib colormap from ``CustomColormap`` stops."""
+    return mcolors.LinearSegmentedColormap.from_list(
+        cmap.name, [(pos, hex_) for pos, hex_ in cmap.stops]
+    )
+
+
+def _resolve_builtin(cmap_id: ColormapId) -> mcolors.Colormap:
+    """Resolve a :class:`ColormapId` (or alias) to a matplotlib colormap."""
+    target = resolve_colormap_alias(cmap_id)
+    mpl_name = _BUILTIN_MPL_NAME.get(target)
+    if mpl_name is None:  # pragma: no cover - defensive guard
+        raise KeyError(f"ColormapId {target!r} has no matplotlib mapping")
+    return _mpl_colormaps[mpl_name]
+
+
+def get_colormap(cmap_id: ColormapId | str) -> mcolors.Colormap:
+    """Return the :class:`~matplotlib.colors.Colormap` for ``cmap_id``.
+
+    Parameters
+    ----------
+    cmap_id:
+        Either a :class:`ColormapId` enum value (built-in or semantic
+        alias) or the ``name`` of a previously registered
+        :class:`CustomColormap`.
+
+    Raises
+    ------
+    TypeError
+        If ``cmap_id`` is neither :class:`ColormapId` nor :class:`str`.
+    KeyError
+        If a string ``cmap_id`` does not match any registered custom
+        colormap name and is not a valid :class:`ColormapId` value.
+    """
+    if isinstance(cmap_id, ColormapId):
+        return _resolve_builtin(cmap_id)
+    if isinstance(cmap_id, str):
+        if cmap_id in _CUSTOM_COLORMAPS:
+            return _CUSTOM_COLORMAPS[cmap_id][1]
+        # Allow the *value* of a ColormapId (e.g. "viridis") as a
+        # convenience alias for the enum.
+        try:
+            return _resolve_builtin(ColormapId(cmap_id))
+        except ValueError as exc:
+            raise KeyError(
+                f"colormap {cmap_id!r} is not registered and is not a ColormapId value"
+            ) from exc
+    raise TypeError(f"cmap_id must be ColormapId or str; got {type(cmap_id).__name__}")
+
+
+def register_custom_colormap(cmap: CustomColormap) -> None:
+    """Register a :class:`CustomColormap` for retrieval by name.
+
+    Idempotent for the same logical colormap — registering a
+    :class:`CustomColormap` that compares equal (by ``name`` and
+    ``stops``) to one already registered is a no-op.
+
+    Raises
+    ------
+    TypeError
+        If ``cmap`` is not a :class:`CustomColormap`.
+    ValueError
+        If a different colormap is already registered under ``cmap.name``.
+    """
+    if not isinstance(cmap, CustomColormap):
+        raise TypeError(
+            f"cmap must be a CustomColormap instance; got {type(cmap).__name__}"
+        )
+    if cmap.name in _BUILTIN_MPL_NAME.values() or any(
+        cmap.name == cid.value for cid in ColormapId
+    ):
+        raise ValueError(
+            f"colormap name {cmap.name!r} clashes with a built-in "
+            "ColormapId value; choose a different name"
+        )
+
+    existing = _CUSTOM_COLORMAPS.get(cmap.name)
+    if existing is not None:
+        existing_cmap = existing[0]
+        if existing_cmap.stops == cmap.stops:
+            return  # idempotent: same logical colormap
+        raise ValueError(
+            f"colormap name {cmap.name!r} is already registered with "
+            f"different stops: existing={existing_cmap.stops!r} "
+            f"new={cmap.stops!r}"
+        )
+
+    _CUSTOM_COLORMAPS[cmap.name] = (cmap, _materialise_custom(cmap))
+
+
+def unregister_custom_colormap(name: str) -> None:
+    """Remove a previously registered custom colormap by ``name``.
+
+    Intended for tests that need to reset the global registry between
+    cases. Raises :class:`KeyError` if ``name`` is not registered.
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"name must be a string; got {type(name).__name__}")
+    if name not in _CUSTOM_COLORMAPS:
+        raise KeyError(f"no custom colormap named {name!r} is registered")
+    del _CUSTOM_COLORMAPS[name]
+
+
+def list_colormaps() -> tuple[str, ...]:
+    """Return the names of every available colormap.
+
+    The result contains every :class:`ColormapId` value (built-in and
+    semantic alias) followed by the names of currently registered
+    :class:`CustomColormap` instances, in registration order.
+    """
+    builtins = tuple(cid.value for cid in ColormapId)
+    customs = tuple(_CUSTOM_COLORMAPS.keys())
+    return builtins + customs

--- a/tests/unit/plot_style/test_registry.py
+++ b/tests/unit/plot_style/test_registry.py
@@ -1,0 +1,187 @@
+"""Unit tests for :mod:`src.shared.python.plot_style.registry`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import matplotlib.colors as mcolors
+import pytest
+
+from src.shared.python.plot_style import (
+    ColormapId,
+    CustomColormap,
+    get_colormap,
+    list_colormaps,
+    register_custom_colormap,
+    unregister_custom_colormap,
+)
+from src.shared.python.plot_style.colormaps import (
+    SEMANTIC_COLORMAP_ALIASES,
+    resolve_colormap_alias,
+)
+from src.shared.python.plot_style.registry import _BUILTIN_MPL_NAME
+
+
+@pytest.fixture
+def custom_cmap() -> CustomColormap:
+    return CustomColormap(
+        name="test_cmap_alpha",
+        stops=((0.0, "#000000"), (0.5, "#888888"), (1.0, "#ffffff")),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_registry() -> Iterator[None]:
+    """Snapshot + restore the process-global custom-colormap registry."""
+    from src.shared.python.plot_style import registry as _reg
+
+    snapshot = dict(_reg._CUSTOM_COLORMAPS)
+    try:
+        yield
+    finally:
+        _reg._CUSTOM_COLORMAPS.clear()
+        _reg._CUSTOM_COLORMAPS.update(snapshot)
+
+
+# ---------- get_colormap (built-ins + aliases) -------------------------
+
+
+def test_every_colormap_id_resolves_to_matplotlib_colormap() -> None:
+    for cmap_id in ColormapId:
+        result = get_colormap(cmap_id)
+        assert isinstance(result, mcolors.Colormap)
+
+
+def test_semantic_aliases_resolve_to_their_target() -> None:
+    for alias, target in SEMANTIC_COLORMAP_ALIASES.items():
+        assert get_colormap(alias).name == get_colormap(target).name
+
+
+def test_resolve_alias_helper_used_for_every_alias() -> None:
+    for alias in SEMANTIC_COLORMAP_ALIASES:
+        # sanity: the helper is what the registry delegates to
+        target = resolve_colormap_alias(alias)
+        assert get_colormap(alias).name == _BUILTIN_MPL_NAME[target]
+
+
+def test_string_value_of_colormap_id_resolves_too() -> None:
+    assert get_colormap("viridis").name == get_colormap(ColormapId.VIRIDIS).name
+
+
+def test_string_value_of_alias_resolves_too() -> None:
+    assert get_colormap("velocity").name == get_colormap(ColormapId.VELOCITY).name
+
+
+def test_get_colormap_rejects_unknown_string() -> None:
+    with pytest.raises(KeyError, match="not registered"):
+        get_colormap("nonexistent_colormap")
+
+
+def test_get_colormap_rejects_wrong_type() -> None:
+    with pytest.raises(TypeError, match="ColormapId or str"):
+        get_colormap(42)  # type: ignore[arg-type]
+
+
+def test_spectral_resolves_to_capitalised_matplotlib_name() -> None:
+    cmap = get_colormap(ColormapId.SPECTRAL)
+    assert cmap.name == "Spectral"
+
+
+# ---------- register_custom_colormap -----------------------------------
+
+
+def test_register_then_get_round_trips(custom_cmap: CustomColormap) -> None:
+    register_custom_colormap(custom_cmap)
+    result = get_colormap(custom_cmap.name)
+    assert isinstance(result, mcolors.LinearSegmentedColormap)
+    assert result.name == custom_cmap.name
+
+
+def test_register_is_idempotent_for_same_stops(
+    custom_cmap: CustomColormap,
+) -> None:
+    register_custom_colormap(custom_cmap)
+    first = get_colormap(custom_cmap.name)
+    # Equivalent CustomColormap (same name + stops) should be a no-op
+    # — i.e. the stored colormap object is unchanged.
+    twin = CustomColormap(name=custom_cmap.name, stops=custom_cmap.stops)
+    register_custom_colormap(twin)
+    assert get_colormap(custom_cmap.name) is first  # custom registry caches
+
+
+def test_register_rejects_conflicting_stops(
+    custom_cmap: CustomColormap,
+) -> None:
+    register_custom_colormap(custom_cmap)
+    conflict = CustomColormap(
+        name=custom_cmap.name,
+        stops=((0.0, "#ff0000"), (1.0, "#0000ff")),
+    )
+    with pytest.raises(ValueError, match="already registered with different stops"):
+        register_custom_colormap(conflict)
+
+
+def test_register_rejects_non_dataclass() -> None:
+    with pytest.raises(TypeError, match="CustomColormap"):
+        register_custom_colormap("viridis")  # type: ignore[arg-type]
+
+
+def test_register_rejects_name_clashing_with_builtin() -> None:
+    clash = CustomColormap(
+        name="viridis",
+        stops=((0.0, "#000"), (1.0, "#fff")),
+    )
+    with pytest.raises(ValueError, match="clashes"):
+        register_custom_colormap(clash)
+
+
+def test_register_rejects_name_clashing_with_semantic_alias() -> None:
+    clash = CustomColormap(
+        name="velocity",
+        stops=((0.0, "#000"), (1.0, "#fff")),
+    )
+    with pytest.raises(ValueError, match="clashes"):
+        register_custom_colormap(clash)
+
+
+# ---------- unregister_custom_colormap ---------------------------------
+
+
+def test_unregister_removes_the_entry(custom_cmap: CustomColormap) -> None:
+    register_custom_colormap(custom_cmap)
+    unregister_custom_colormap(custom_cmap.name)
+    with pytest.raises(KeyError):
+        get_colormap(custom_cmap.name)
+
+
+def test_unregister_unknown_name_raises_key_error() -> None:
+    with pytest.raises(KeyError, match="nonexistent"):
+        unregister_custom_colormap("nonexistent")
+
+
+def test_unregister_rejects_non_string() -> None:
+    with pytest.raises(TypeError, match="string"):
+        unregister_custom_colormap(123)  # type: ignore[arg-type]
+
+
+# ---------- list_colormaps ---------------------------------------------
+
+
+def test_list_includes_every_colormap_id_value() -> None:
+    names = list_colormaps()
+    for cmap_id in ColormapId:
+        assert cmap_id.value in names
+
+
+def test_list_includes_registered_custom_colormaps(
+    custom_cmap: CustomColormap,
+) -> None:
+    register_custom_colormap(custom_cmap)
+    names = list_colormaps()
+    assert custom_cmap.name in names
+    # Built-ins still come first.
+    assert names.index(custom_cmap.name) >= len(ColormapId)
+
+
+def test_list_returns_tuple() -> None:
+    assert isinstance(list_colormaps(), tuple)


### PR DESCRIPTION
## Summary

Wave 2 of plot_style EPIC #4796. Adds a process-wide colormap registry that resolves `ColormapId` enum values, semantic aliases, and runtime-registered `CustomColormap` names to `matplotlib.colors.Colormap` instances.

- Five semantic aliases bound to matplotlib built-ins:
  - `VELOCITY` -> `plasma`
  - `FORCE` -> `inferno`
  - `ACCELERATION` -> `turbo`
  - `HEIGHT` -> `viridis`
  - `GENERIC_DIVERGING` -> `coolwarm`
- `register_custom_colormap` is idempotent for the same logical colormap (matched by `name + stops`); a different colormap under an existing name raises `ValueError`. Names that clash with `ColormapId` values are rejected.
- `unregister_custom_colormap` exposed for tests; raises `KeyError` for unknown names.
- `list_colormaps()` returns built-ins followed by registered customs.

Closes #4802

Built on top of #4840 (contracts dataclasses) — that PR will land first.

## Test plan

- [x] `python3 -m ruff check src/shared/python/plot_style tests/unit/plot_style`
- [x] `python3 -m ruff format --check` (added files clean)
- [x] `python3 -m pytest tests/unit/plot_style/test_registry.py -p no:cacheprovider --timeout=60` -> 20 passed
- [x] `python3 -m pytest tests/unit/plot_style/ -p no:cacheprovider --timeout=60` -> 149 passed
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] Coverage on `registry.py`: 100% line, 100% branch

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>