### PR TITLE
feat(plot-style): color resolvers (#4803)

### DIFF
--- a/src/shared/python/plot_style/resolvers/__init__.py
+++ b/src/shared/python/plot_style/resolvers/__init__.py
@@ -1,9 +1,33 @@
 """ColorResolver implementations sub-package.
 
 Concrete :class:`~src.shared.python.plot_style.contracts.ColorResolver`
-implementations land in follow-up issues of EPIC #4796.
+implementations:
+
+* :class:`StaticColorResolver` — passes through the constant RGBA of a
+  :class:`StaticColor`.
+* :class:`PaletteColorResolver` — looks up a named palette by index
+  (matplotlib palettes plus a project-local custom registry).
+* :class:`DataDrivenColorResolver` — normalises a
+  :class:`DataChannel` through ``vmin`` / ``vmax`` and samples a
+  matplotlib colormap (with bulk LUT pre-computation for the hot path).
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .data_driven import DataDrivenColorResolver
+from .palette import (
+    PaletteColorResolver,
+    list_custom_palettes,
+    register_palette,
+    unregister_palette,
+)
+from .static import StaticColorResolver
+
+__all__ = [
+    "DataDrivenColorResolver",
+    "PaletteColorResolver",
+    "StaticColorResolver",
+    "list_custom_palettes",
+    "register_palette",
+    "unregister_palette",
+]

--- a/src/shared/python/plot_style/resolvers/data_driven.py
+++ b/src/shared/python/plot_style/resolvers/data_driven.py
@@ -1,0 +1,259 @@
+"""Data-driven color resolver.
+
+A :class:`DataDrivenColorResolver` maps the scalar values of a
+:class:`DataChannel` through a ``vmin``/``vmax`` normalisation and a
+matplotlib colormap. The bulk path
+:meth:`DataDrivenColorResolver.resolve_array` pre-computes the LUT once
+and applies it to the entire ``(n_frames, [n_markers,] 4)`` block in a
+single vectorised pass — no per-frame Python loop in the hot path.
+
+Performance contract
+--------------------
+On a 38-marker × 654-frame dataset, :meth:`resolve_array` completes
+within 5 ms on a recent laptop. The implementation never iterates
+over individual frames or markers — normalisation, NaN masking, and
+LUT sampling are all expressed as ``numpy`` operations.
+
+Equivalence contract
+--------------------
+The three lookup paths must agree to 1e-12 atol on finite inputs:
+
+1. ``resolve_one(scale, frame, marker)`` (per (frame, marker)).
+2. ``resolve_one(scale, frame, None)`` (per frame, marker-mean).
+3. ``resolve_array(scale, n_frames, n_markers)[frame, marker]``.
+
+NaN inputs map to ``scale.nan_color`` on every path.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import numpy as np
+from matplotlib import cm, colormaps
+from matplotlib.colors import Colormap, is_color_like, to_rgba
+
+from .._types import RGBATuple
+from ..colormaps import ColormapId, resolve_colormap_alias
+from ..colors import ColorScale, DataDrivenColor
+
+__all__ = ["DataDrivenColorResolver"]
+
+
+# Cached colormap lookup table keyed by (matplotlib name, lut_size).
+_LUT_CACHE: dict[tuple[str, int], np.ndarray] = {}
+
+
+def _hex_to_rgba(hex_value: str) -> RGBATuple:
+    """Parse a matplotlib-recognised color string."""
+    rgba = to_rgba(cast(Any, hex_value))
+    return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+def _get_colormap(cmap_id: ColormapId) -> Colormap:
+    """Return the ``Colormap`` for ``cmap_id`` resolving semantic aliases."""
+    resolved = resolve_colormap_alias(cmap_id)
+    try:
+        return cast(Colormap, colormaps[resolved.value])
+    except (KeyError, ValueError):
+        return cast(Colormap, cm.get_cmap(resolved.value))
+
+
+def _get_lut(cmap_id: ColormapId, lut_size: int = 256) -> np.ndarray:
+    """Return a cached ``(lut_size, 4)`` RGBA LUT for ``cmap_id``.
+
+    The LUT is the colormap evaluated at ``lut_size`` evenly-spaced
+    points in ``[0, 1]``. Sampling is then a single ``np.searchsorted``
+    or integer-index call away — no per-element Python overhead.
+    """
+    resolved = resolve_colormap_alias(cmap_id).value
+    key = (resolved, lut_size)
+    cached = _LUT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    cmap = _get_colormap(cmap_id)
+    samples = np.linspace(0.0, 1.0, lut_size, dtype=np.float64)
+    lut = np.asarray(cmap(samples), dtype=np.float64)
+    if lut.ndim != 2 or lut.shape[1] != 4:
+        # Defensive: matplotlib always returns (N, 4); guard anyway.
+        raise RuntimeError(
+            f"unexpected colormap LUT shape {lut.shape} for {resolved!r}"
+        )
+    _LUT_CACHE[key] = lut
+    return lut
+
+
+def _resolved_bounds(scale: DataDrivenColor) -> tuple[float, float]:
+    """Return ``(vmin, vmax)`` with auto-detect filled in."""
+    if scale.vmin is not None and scale.vmax is not None:
+        return (float(scale.vmin), float(scale.vmax))
+    auto_lo, auto_hi = scale.channel.auto_range()
+    lo = float(scale.vmin) if scale.vmin is not None else auto_lo
+    hi = float(scale.vmax) if scale.vmax is not None else auto_hi
+    return (lo, hi)
+
+
+def _sample_lut(lut: np.ndarray, normalised: np.ndarray) -> np.ndarray:
+    """Sample ``lut`` at fractional positions in ``normalised``.
+
+    ``normalised`` is an ndarray of values in ``[0, 1]``; the function
+    returns an ``(*normalised.shape, 4)`` array of RGBA values.
+    """
+    lut_size = lut.shape[0]
+    # Clip just in case — caller already clipped, but cheap insurance.
+    clipped = np.clip(normalised, 0.0, 1.0)
+    indices = np.minimum(
+        (clipped * (lut_size - 1)).astype(np.intp),
+        lut_size - 1,
+    )
+    return lut[indices]
+
+
+class DataDrivenColorResolver:
+    """Resolver for :class:`DataDrivenColor` scales.
+
+    Implements the
+    :class:`~src.shared.python.plot_style.contracts.ColorResolver`
+    Protocol.
+    """
+
+    def __init__(self, lut_size: int = 256) -> None:
+        if not isinstance(lut_size, int) or lut_size < 2:
+            raise ValueError(f"lut_size must be an int ≥ 2; got {lut_size!r}")
+        self._lut_size = lut_size
+
+    # ------------------------------------------------------------------
+    # Single-pair resolution
+    # ------------------------------------------------------------------
+
+    def resolve_one(
+        self,
+        scale: ColorScale,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> tuple[float, float, float, float]:
+        """Resolve one ``(frame_idx, marker_idx)`` pair."""
+        if not isinstance(scale, DataDrivenColor):
+            raise TypeError(
+                "DataDrivenColorResolver only accepts DataDrivenColor; "
+                f"got {type(scale).__name__}"
+            )
+        scalar = scale.channel.value_at(frame_idx, marker_idx)
+        if not math.isfinite(scalar):
+            return _hex_to_rgba(scale.nan_color)
+        lo, hi = _resolved_bounds(scale)
+        if not (math.isfinite(lo) and math.isfinite(hi)):
+            return _hex_to_rgba(scale.nan_color)
+        if hi == lo:
+            # vmin == vmax: degenerate range. Map every value to the
+            # midpoint of the colormap.
+            normalised = 0.5
+        else:
+            normalised = (scalar - lo) / (hi - lo)
+            normalised = float(np.clip(normalised, 0.0, 1.0))
+        lut = _get_lut(scale.colormap, self._lut_size)
+        # Use the same integer-truncation scheme as the bulk path so
+        # ``resolve_one`` and ``resolve_array`` agree to 1e-12 on every
+        # (frame, marker) pair.
+        index = min(int(normalised * (self._lut_size - 1)), self._lut_size - 1)
+        rgba = lut[index]
+        return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+    # ------------------------------------------------------------------
+    # Bulk resolution
+    # ------------------------------------------------------------------
+
+    def resolve_array(
+        self,
+        scale: ColorScale,
+        n_frames: int,
+        n_markers: int | None = None,
+    ) -> np.ndarray:
+        """Bulk-resolve the entire ``(n_frames, [n_markers,] 4)`` block.
+
+        The colormap LUT is computed once (and cached), then applied to
+        all values in a single vectorised pass. No Python-level loops
+        run over frames or markers.
+        """
+        if not isinstance(scale, DataDrivenColor):
+            raise TypeError(
+                "DataDrivenColorResolver only accepts DataDrivenColor; "
+                f"got {type(scale).__name__}"
+            )
+        if not isinstance(n_frames, int) or n_frames <= 0:
+            raise ValueError(f"n_frames must be a positive int; got {n_frames!r}")
+        if n_markers is not None and (not isinstance(n_markers, int) or n_markers <= 0):
+            raise ValueError(
+                f"n_markers must be a positive int or None; got {n_markers!r}"
+            )
+        if not isinstance(scale.nan_color, str) or not is_color_like(scale.nan_color):
+            # Defensive: dataclass already validated; check anyway.
+            raise ValueError(
+                f"nan_color {scale.nan_color!r} is not a parseable matplotlib color"
+            )
+
+        nan_rgba = np.asarray(_hex_to_rgba(scale.nan_color), dtype=np.float64)
+
+        # ----- Build the per-(frame, marker) scalar grid --------------
+        values = scale.channel.values
+        channel_n_frames = scale.channel.n_frames
+        channel_n_markers = scale.channel.n_markers
+
+        if n_markers is None:
+            # 1-D output. Use frame scalars: for 1-D channel direct,
+            # for 2-D channel use NaN-aware mean across markers.
+            grid = np.full(n_frames, np.nan, dtype=np.float64)
+            usable = min(n_frames, channel_n_frames)
+            if usable > 0:
+                if values.ndim == 1:
+                    grid[:usable] = values[:usable].astype(np.float64, copy=False)
+                else:
+                    block = values[:usable].astype(np.float64, copy=False)
+                    # NaN-aware mean across the marker axis.
+                    with np.errstate(invalid="ignore"):
+                        mean = np.nanmean(block, axis=1)
+                    grid[:usable] = mean
+        else:
+            # 2-D output (n_frames, n_markers).
+            grid = np.full((n_frames, n_markers), np.nan, dtype=np.float64)
+            usable_frames = min(n_frames, channel_n_frames)
+            if usable_frames > 0:
+                if values.ndim == 1:
+                    # Broadcast the same scalar across every marker.
+                    grid[:usable_frames, :] = values[:usable_frames, None].astype(
+                        np.float64, copy=False
+                    )
+                else:
+                    assert channel_n_markers is not None  # ndim == 2 invariant
+                    usable_markers = min(n_markers, channel_n_markers)
+                    if usable_markers > 0:
+                        grid[:usable_frames, :usable_markers] = values[
+                            :usable_frames, :usable_markers
+                        ].astype(np.float64, copy=False)
+
+        # ----- Normalise + sample LUT ---------------------------------
+        lo, hi = _resolved_bounds(scale)
+        bounds_finite = math.isfinite(lo) and math.isfinite(hi)
+
+        finite_mask = np.isfinite(grid)
+        if not bounds_finite:
+            # No usable bounds — every output is the NaN color.
+            out_shape = (*grid.shape, 4)
+            return np.broadcast_to(nan_rgba, out_shape).copy()
+
+        if hi == lo:
+            # Degenerate range: every finite value collapses to the
+            # midpoint of the colormap.
+            normalised = np.where(finite_mask, 0.5, 0.0)
+        else:
+            with np.errstate(invalid="ignore"):
+                normalised = (grid - lo) / (hi - lo)
+            normalised = np.clip(np.where(finite_mask, normalised, 0.0), 0.0, 1.0)
+
+        lut = _get_lut(scale.colormap, self._lut_size)
+        rgba = _sample_lut(lut, normalised)
+
+        # Apply NaN color where the scalar was non-finite.
+        rgba[~finite_mask] = nan_rgba
+        return rgba

--- a/src/shared/python/plot_style/resolvers/palette.py
+++ b/src/shared/python/plot_style/resolvers/palette.py
@@ -1,0 +1,207 @@
+"""Palette color resolver.
+
+A :class:`PaletteColorResolver` looks up the ``palette_index`` slot of a
+:class:`PaletteColor` in a named matplotlib palette (``tab10``,
+``tab20``, ``Set2``, ...) or in a project-local custom-palette registry,
+and returns the resulting RGBA tuple. The bulk path broadcasts that
+single tuple over the requested ``(n_frames, [n_markers,] 4)`` shape.
+
+Custom palettes
+---------------
+The module-level :func:`register_palette` / :func:`unregister_palette`
+helpers manage a small registry of user-defined palettes. Registered
+palettes shadow matplotlib palettes of the same name, allowing a
+project to (for example) ship a brand-color palette under the friendly
+name ``"brand"`` without depending on a matplotlib release.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import numpy as np
+from matplotlib import colormaps
+from matplotlib.colors import Colormap, is_color_like, to_rgba
+
+from .._types import RGBATuple
+from ..colors import ColorScale, PaletteColor
+
+__all__ = [
+    "PaletteColorResolver",
+    "list_custom_palettes",
+    "register_palette",
+    "unregister_palette",
+]
+
+
+# Name -> tuple of RGBA tuples. Stored in fully-materialised form so
+# lookup never has to re-parse hex strings.
+_CUSTOM_PALETTES: dict[str, tuple[RGBATuple, ...]] = {}
+
+
+def register_palette(name: str, colors: Sequence[str]) -> None:
+    """Register a custom palette under ``name``.
+
+    Parameters
+    ----------
+    name:
+        Non-empty palette identifier. Subsequent registrations with the
+        same name overwrite the previous mapping.
+    colors:
+        Sequence of at least one matplotlib-recognised color string.
+        Each entry is parsed eagerly and stored as a 4-tuple of floats.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"name must be a non-empty string; got {name!r}")
+    if not isinstance(colors, Sequence) or isinstance(colors, (str, bytes)):
+        raise TypeError(
+            f"colors must be a sequence of strings; got {type(colors).__name__}"
+        )
+    if len(colors) == 0:
+        raise ValueError("colors must contain at least one entry")
+
+    parsed: list[RGBATuple] = []
+    for index, color in enumerate(colors):
+        if not isinstance(color, str) or not color:
+            raise ValueError(
+                f"color at index {index} must be a non-empty string; got {color!r}"
+            )
+        if not is_color_like(color):
+            raise ValueError(
+                f"color {color!r} at index {index} is not a parseable matplotlib color"
+            )
+        rgba = to_rgba(cast(Any, color))
+        parsed.append((float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3])))
+    _CUSTOM_PALETTES[name] = tuple(parsed)
+
+
+def unregister_palette(name: str) -> None:
+    """Remove ``name`` from the custom palette registry.
+
+    No-op if ``name`` is not registered.
+    """
+    _CUSTOM_PALETTES.pop(name, None)
+
+
+def list_custom_palettes() -> tuple[str, ...]:
+    """Return the names of all currently registered custom palettes."""
+    return tuple(sorted(_CUSTOM_PALETTES))
+
+
+def _matplotlib_palette_size(cmap: Colormap) -> int:
+    """Return the number of distinct colors in a qualitative palette."""
+    size = getattr(cmap, "N", 0) or 0
+    if size <= 0:
+        return 256  # continuous fallback
+    return int(size)
+
+
+def _available_palettes() -> tuple[str, ...]:
+    """Return the union of custom and matplotlib palette names."""
+    builtins = tuple(sorted(colormaps))
+    return tuple(sorted(set(builtins) | set(_CUSTOM_PALETTES)))
+
+
+def _resolve_palette_color(palette_name: str, palette_index: int) -> RGBATuple:
+    """Look up the RGBA at ``palette_index`` in ``palette_name``.
+
+    Custom palettes shadow matplotlib palettes of the same name. The
+    function raises :class:`ValueError` (with the offending parameters
+    in the message) on:
+
+    * unknown palette name,
+    * negative ``palette_index``,
+    * ``palette_index`` ≥ palette size for *qualitative* (small)
+      matplotlib palettes — listing the palette length so the caller
+      can fix the index.
+    """
+    if palette_index < 0:
+        raise ValueError(f"palette_index must be non-negative; got {palette_index}")
+
+    # Custom registry has priority.
+    if palette_name in _CUSTOM_PALETTES:
+        entries = _CUSTOM_PALETTES[palette_name]
+        if palette_index >= len(entries):
+            raise ValueError(
+                f"palette_index {palette_index} out of range for custom "
+                f"palette {palette_name!r} of length {len(entries)}"
+            )
+        return entries[palette_index]
+
+    if palette_name not in colormaps:
+        available = _available_palettes()
+        raise ValueError(
+            f"unknown palette {palette_name!r}; available palettes: {list(available)}"
+        )
+
+    cmap = cast(Colormap, colormaps[palette_name])
+    size = _matplotlib_palette_size(cmap)
+    # Qualitative palettes (tab10, Set2, ...) have small N; reject OOB
+    # so callers see configuration errors fast. Continuous palettes
+    # (viridis, ...) have N = 256, which is effectively unbounded for
+    # categorical use, so we let them wrap modulo size.
+    if size <= 32 and palette_index >= size:
+        raise ValueError(
+            f"palette_index {palette_index} out of range for palette "
+            f"{palette_name!r} of length {size}"
+        )
+    rgba = cmap(palette_index % size)
+    return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+class PaletteColorResolver:
+    """Resolver for :class:`PaletteColor` scales.
+
+    Implements the
+    :class:`~src.shared.python.plot_style.contracts.ColorResolver`
+    Protocol.
+    """
+
+    def resolve_one(
+        self,
+        scale: ColorScale,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> tuple[float, float, float, float]:
+        """Return the palette color for ``scale``.
+
+        ``frame_idx`` and ``marker_idx`` are accepted for Protocol
+        compatibility and ignored — palette colors are constant.
+        """
+        del frame_idx, marker_idx  # interface compatibility
+        if not isinstance(scale, PaletteColor):
+            raise TypeError(
+                "PaletteColorResolver only accepts PaletteColor; "
+                f"got {type(scale).__name__}"
+            )
+        return _resolve_palette_color(scale.palette_name, scale.palette_index)
+
+    def resolve_array(
+        self,
+        scale: ColorScale,
+        n_frames: int,
+        n_markers: int | None = None,
+    ) -> np.ndarray:
+        """Return a broadcast ``(n_frames, [n_markers,] 4)`` RGBA array."""
+        if not isinstance(scale, PaletteColor):
+            raise TypeError(
+                "PaletteColorResolver only accepts PaletteColor; "
+                f"got {type(scale).__name__}"
+            )
+        if not isinstance(n_frames, int) or n_frames <= 0:
+            raise ValueError(f"n_frames must be a positive int; got {n_frames!r}")
+        if n_markers is not None and (not isinstance(n_markers, int) or n_markers <= 0):
+            raise ValueError(
+                f"n_markers must be a positive int or None; got {n_markers!r}"
+            )
+
+        rgba = np.asarray(
+            _resolve_palette_color(scale.palette_name, scale.palette_index),
+            dtype=np.float64,
+        )
+        if n_markers is None:
+            out = np.broadcast_to(rgba, (n_frames, 4)).copy()
+        else:
+            out = np.broadcast_to(rgba, (n_frames, n_markers, 4)).copy()
+        return out

--- a/src/shared/python/plot_style/resolvers/static.py
+++ b/src/shared/python/plot_style/resolvers/static.py
@@ -1,0 +1,117 @@
+"""Static color resolver.
+
+A :class:`StaticColorResolver` is the trivial resolver: it returns the
+constant color carried by a :class:`StaticColor` for every
+``(frame_idx, marker_idx)`` query, and broadcasts that single RGBA
+tuple to a fully populated array on the bulk path.
+
+Design-by-Contract
+------------------
+* :meth:`resolve_one` ignores ``frame_idx`` and ``marker_idx`` —
+  they exist solely for Protocol compatibility.
+* :meth:`resolve_array` always returns a freshly allocated array;
+  callers may mutate it without affecting the resolver state.
+* The resolver only accepts :class:`StaticColor` instances. Passing any
+  other :data:`ColorScale` variant raises :class:`TypeError` listing the
+  unexpected type — early failure beats silent wrong behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+from matplotlib.colors import is_color_like, to_rgba
+
+from .._types import RGBATuple
+from ..colors import ColorScale, StaticColor
+
+__all__ = ["StaticColorResolver"]
+
+
+def _hex_to_rgba(hex_value: str) -> RGBATuple:
+    """Parse a matplotlib-recognised color string.
+
+    Raises
+    ------
+    ValueError
+        If ``hex_value`` is not a parseable matplotlib color. The error
+        message includes the offending input verbatim so callers can
+        spot typos at a glance.
+    """
+    if not isinstance(hex_value, str) or not hex_value:
+        raise ValueError(f"hex_value must be a non-empty string; got {hex_value!r}")
+    if not is_color_like(hex_value):
+        raise ValueError(f"hex_value {hex_value!r} is not a parseable matplotlib color")
+    rgba = to_rgba(cast(Any, hex_value))
+    return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
+class StaticColorResolver:
+    """Resolver for :class:`StaticColor` scales.
+
+    Implements the
+    :class:`~src.shared.python.plot_style.contracts.ColorResolver`
+    Protocol.
+    """
+
+    def resolve_one(
+        self,
+        scale: ColorScale,
+        frame_idx: int,
+        marker_idx: int | None = None,
+    ) -> tuple[float, float, float, float]:
+        """Return the constant RGBA for ``scale``.
+
+        Parameters
+        ----------
+        scale:
+            Must be a :class:`StaticColor`.
+        frame_idx, marker_idx:
+            Accepted for Protocol compatibility and ignored.
+        """
+        del frame_idx, marker_idx  # interface compatibility
+        if not isinstance(scale, StaticColor):
+            raise TypeError(
+                "StaticColorResolver only accepts StaticColor; "
+                f"got {type(scale).__name__}"
+            )
+        return _hex_to_rgba(scale.hex_value)
+
+    def resolve_array(
+        self,
+        scale: ColorScale,
+        n_frames: int,
+        n_markers: int | None = None,
+    ) -> np.ndarray:
+        """Return a broadcast ``(n_frames, [n_markers,] 4)`` RGBA array.
+
+        Parameters
+        ----------
+        scale:
+            Must be a :class:`StaticColor`.
+        n_frames:
+            Number of frames; must be ``> 0``.
+        n_markers:
+            Optional marker-axis size. ``None`` returns a 2-D
+            ``(n_frames, 4)`` array; an integer returns
+            ``(n_frames, n_markers, 4)``.
+        """
+        if not isinstance(scale, StaticColor):
+            raise TypeError(
+                "StaticColorResolver only accepts StaticColor; "
+                f"got {type(scale).__name__}"
+            )
+        if not isinstance(n_frames, int) or n_frames <= 0:
+            raise ValueError(f"n_frames must be a positive int; got {n_frames!r}")
+        if n_markers is not None and (not isinstance(n_markers, int) or n_markers <= 0):
+            raise ValueError(
+                f"n_markers must be a positive int or None; got {n_markers!r}"
+            )
+
+        rgba = np.asarray(_hex_to_rgba(scale.hex_value), dtype=np.float64)
+        if n_markers is None:
+            out = np.broadcast_to(rgba, (n_frames, 4)).copy()
+        else:
+            out = np.broadcast_to(rgba, (n_frames, n_markers, 4)).copy()
+        return out

--- a/tests/unit/plot_style/resolvers/__init__.py
+++ b/tests/unit/plot_style/resolvers/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for plot_style color resolvers."""

--- a/tests/unit/plot_style/resolvers/test_data_driven.py
+++ b/tests/unit/plot_style/resolvers/test_data_driven.py
@@ -1,0 +1,356 @@
+"""Unit tests for :class:`DataDrivenColorResolver`."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from src.shared.python.plot_style import (
+    ColormapId,
+    DataChannel,
+    DataDrivenColor,
+    PaletteColor,
+)
+from src.shared.python.plot_style.contracts import ColorResolver
+from src.shared.python.plot_style.resolvers import DataDrivenColorResolver
+
+
+@pytest.fixture
+def resolver() -> DataDrivenColorResolver:
+    return DataDrivenColorResolver()
+
+
+# ---------- Protocol conformance ---------------------------------------
+
+
+def test_data_driven_resolver_implements_protocol(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    assert isinstance(resolver, ColorResolver)
+
+
+# ---------- Single-pair resolution -------------------------------------
+
+
+def test_resolve_one_finite(resolver: DataDrivenColorResolver) -> None:
+    rng = np.random.default_rng(0)
+    values = rng.random((20, 5)).astype(np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+    )
+    rgba = resolver.resolve_one(scale, frame_idx=4, marker_idx=2)
+    assert len(rgba) == 4
+    for component in rgba:
+        assert 0.0 <= component <= 1.0
+
+
+def test_resolve_one_nan_yields_nan_color(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.array([[np.nan, 0.5], [1.0, 2.0]], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=2.0,
+        nan_color="#abcdef",
+    )
+    rgba = resolver.resolve_one(scale, 0, 0)
+    expected = (
+        0xAB / 255.0,
+        0xCD / 255.0,
+        0xEF / 255.0,
+        1.0,
+    )
+    assert rgba == pytest.approx(expected, abs=1e-6)
+
+
+def test_resolve_one_rejects_wrong_scale(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    with pytest.raises(TypeError, match="DataDrivenColorResolver"):
+        resolver.resolve_one(scale, 0)
+
+
+# ---------- Equivalence: per-frame, per-(frame,marker), bulk ----------
+
+
+def test_per_frame_marker_and_bulk_paths_agree(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    rng = np.random.default_rng(42)
+    n_frames, n_markers = 23, 9
+    values = rng.uniform(-3.0, 5.0, size=(n_frames, n_markers))
+    channel = DataChannel(name="speed", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.PLASMA,
+        vmin=-3.0,
+        vmax=5.0,
+    )
+
+    bulk = resolver.resolve_array(scale, n_frames, n_markers)
+    assert bulk.shape == (n_frames, n_markers, 4)
+
+    for frame in range(n_frames):
+        for marker in range(n_markers):
+            single = resolver.resolve_one(scale, frame, marker)
+            np.testing.assert_allclose(bulk[frame, marker], single, atol=1e-12)
+
+
+def test_per_frame_path_matches_bulk_1d(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    rng = np.random.default_rng(7)
+    n_frames = 30
+    values = rng.uniform(0.0, 10.0, size=n_frames)
+    channel = DataChannel(name="height", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.HEIGHT,
+        vmin=0.0,
+        vmax=10.0,
+    )
+
+    bulk = resolver.resolve_array(scale, n_frames)
+    assert bulk.shape == (n_frames, 4)
+    for frame in range(n_frames):
+        single = resolver.resolve_one(scale, frame, None)
+        np.testing.assert_allclose(bulk[frame], single, atol=1e-12)
+
+
+# ---------- NaN handling on bulk path ----------------------------------
+
+
+def test_bulk_nan_values_yield_nan_color(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.array(
+        [
+            [0.0, 1.0, np.nan],
+            [np.nan, 0.5, 0.25],
+        ],
+        dtype=np.float64,
+    )
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+        nan_color="#ff00ff",
+    )
+    bulk = resolver.resolve_array(scale, n_frames=2, n_markers=3)
+    nan_expected = np.array([1.0, 0.0, 1.0, 1.0])
+    np.testing.assert_allclose(bulk[0, 2], nan_expected, atol=1e-6)
+    np.testing.assert_allclose(bulk[1, 0], nan_expected, atol=1e-6)
+    # Finite values must NOT be the NaN color.
+    assert not np.allclose(bulk[0, 0], nan_expected, atol=1e-6)
+
+
+# ---------- Auto vmin / vmax -------------------------------------------
+
+
+def test_auto_range_vmin_vmax_none(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.array([[2.0, 4.0, 6.0], [3.0, 5.0, 7.0]], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=None,
+        vmax=None,
+    )
+
+    bulk = resolver.resolve_array(scale, 2, 3)
+    # The minimum value (2.0) maps to colormap[0]; the maximum (7.0)
+    # maps to colormap[N-1]. Both must equal the LUT endpoints to within
+    # the LUT-quantisation tolerance.
+    from matplotlib import colormaps
+
+    cmap = colormaps["viridis"]
+    expected_min = np.asarray(cmap(0.0), dtype=np.float64)
+    expected_max = np.asarray(cmap(1.0), dtype=np.float64)
+    np.testing.assert_allclose(bulk[0, 0], expected_min, atol=1e-2)
+    np.testing.assert_allclose(bulk[1, 2], expected_max, atol=1e-2)
+
+
+# ---------- Degenerate vmin == vmax -----------------------------------
+
+
+def test_vmin_equals_vmax_maps_to_midpoint(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    # vmin == vmax forbidden by DataDrivenColor.__post_init__, so we
+    # build the scale, then mutate to force the degenerate case.
+    values = np.array([[1.0, 1.0, 1.0]], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+    )
+    object.__setattr__(scale, "vmin", 1.0)
+    object.__setattr__(scale, "vmax", 1.0)
+
+    bulk = resolver.resolve_array(scale, 1, 3)
+    from matplotlib import colormaps
+
+    cmap = colormaps["viridis"]
+    expected = np.asarray(cmap(0.5), dtype=np.float64)
+    for marker in range(3):
+        np.testing.assert_allclose(bulk[0, marker], expected, atol=1e-2)
+
+    # And the single-pair path should agree.
+    single = resolver.resolve_one(scale, 0, 0)
+    np.testing.assert_allclose(np.asarray(single), expected, atol=1e-2)
+
+
+# ---------- No usable bounds -------------------------------------------
+
+
+def test_all_nan_channel_yields_nan_color(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.full((3, 4), np.nan, dtype=np.float64)
+    channel = DataChannel(name="empty", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=None,
+        vmax=None,
+        nan_color="#ff0000",
+    )
+    bulk = resolver.resolve_array(scale, 3, 4)
+    nan_rgba = np.array([1.0, 0.0, 0.0, 1.0])
+    for frame in range(3):
+        for marker in range(4):
+            np.testing.assert_allclose(bulk[frame, marker], nan_rgba, atol=1e-6)
+
+
+# ---------- Bulk shapes -------------------------------------------------
+
+
+def test_bulk_1d_channel_with_n_markers_broadcasts(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.linspace(0.0, 1.0, 10, dtype=np.float64)
+    channel = DataChannel(name="height", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+    )
+    bulk = resolver.resolve_array(scale, n_frames=10, n_markers=4)
+    assert bulk.shape == (10, 4, 4)
+    # Within a frame, every marker shares the same color.
+    for frame in range(10):
+        for marker in range(1, 4):
+            np.testing.assert_allclose(bulk[frame, marker], bulk[frame, 0], atol=1e-12)
+
+
+def test_bulk_2d_channel_no_n_markers_uses_mean(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.array([[0.0, 1.0], [0.5, 0.5]], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+    )
+    bulk = resolver.resolve_array(scale, n_frames=2)
+    assert bulk.shape == (2, 4)
+    # Both rows have mean 0.5 → identical color.
+    np.testing.assert_allclose(bulk[0], bulk[1], atol=1e-12)
+
+
+def test_bulk_oversized_frames_padded_with_nan_color(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    values = np.array([0.0, 1.0], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+        nan_color="#ff00ff",
+    )
+    bulk = resolver.resolve_array(scale, n_frames=5)
+    nan_rgba = np.array([1.0, 0.0, 1.0, 1.0])
+    for frame in range(2, 5):
+        np.testing.assert_allclose(bulk[frame], nan_rgba, atol=1e-6)
+
+
+def test_bulk_invalid_args(resolver: DataDrivenColorResolver) -> None:
+    values = np.array([0.0, 1.0], dtype=np.float64)
+    channel = DataChannel(name="x", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VIRIDIS,
+        vmin=0.0,
+        vmax=1.0,
+    )
+    with pytest.raises(ValueError, match="n_frames"):
+        resolver.resolve_array(scale, n_frames=0)
+    with pytest.raises(ValueError, match="n_markers"):
+        resolver.resolve_array(scale, n_frames=2, n_markers=0)
+    from src.shared.python.plot_style import StaticColor
+
+    with pytest.raises(TypeError, match="DataDrivenColorResolver"):
+        resolver.resolve_array(StaticColor(hex_value="#ffffff"), n_frames=4)
+
+
+def test_lut_size_validation() -> None:
+    with pytest.raises(ValueError, match="lut_size"):
+        DataDrivenColorResolver(lut_size=1)
+    with pytest.raises(ValueError, match="lut_size"):
+        DataDrivenColorResolver(lut_size=-3)
+
+
+# ---------- Performance contract ---------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bulk_perf_38_markers_654_frames(
+    resolver: DataDrivenColorResolver,
+) -> None:
+    """Bulk LUT must complete in ≤ 5 ms for the 38×654 target."""
+    n_frames, n_markers = 654, 38
+    rng = np.random.default_rng(2026)
+    values = rng.uniform(0.0, 10.0, size=(n_frames, n_markers))
+    channel = DataChannel(name="speed", values=values)
+    scale = DataDrivenColor(
+        channel=channel,
+        colormap=ColormapId.VELOCITY,
+        vmin=0.0,
+        vmax=10.0,
+    )
+
+    # Warm caches (LUT first build).
+    _ = resolver.resolve_array(scale, n_frames, n_markers)
+
+    # Best-of-5 to absorb noise.
+    runs = []
+    for _ in range(5):
+        start = time.perf_counter()
+        out = resolver.resolve_array(scale, n_frames, n_markers)
+        runs.append(time.perf_counter() - start)
+    elapsed_ms = min(runs) * 1000.0
+    assert out.shape == (n_frames, n_markers, 4)
+    assert elapsed_ms <= 5.0, (
+        f"bulk LUT took {elapsed_ms:.3f} ms, budget is 5.0 ms (≥ 60 fps)"
+    )

--- a/tests/unit/plot_style/resolvers/test_palette.py
+++ b/tests/unit/plot_style/resolvers/test_palette.py
@@ -1,0 +1,195 @@
+"""Unit tests for :class:`PaletteColorResolver`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from matplotlib import colormaps
+from matplotlib.colors import to_rgba
+
+from src.shared.python.plot_style import PaletteColor, StaticColor
+from src.shared.python.plot_style.contracts import ColorResolver
+from src.shared.python.plot_style.resolvers import (
+    PaletteColorResolver,
+    list_custom_palettes,
+    register_palette,
+    unregister_palette,
+)
+
+
+@pytest.fixture
+def resolver() -> PaletteColorResolver:
+    return PaletteColorResolver()
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_palettes():
+    """Ensure each test runs against a fresh custom palette registry."""
+    before = list_custom_palettes()
+    yield
+    # Unregister anything added during the test.
+    for name in list_custom_palettes():
+        if name not in before:
+            unregister_palette(name)
+
+
+# ---------- Protocol conformance ---------------------------------------
+
+
+def test_palette_resolver_implements_protocol(
+    resolver: PaletteColorResolver,
+) -> None:
+    assert isinstance(resolver, ColorResolver)
+
+
+# ---------- index in range ----------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["tab10", "tab20", "Set1", "Set2", "Pastel1"])
+def test_palette_in_range(name: str, resolver: PaletteColorResolver) -> None:
+    scale = PaletteColor(palette_name=name, palette_index=0)
+    rgba = resolver.resolve_one(scale, frame_idx=0)
+    cmap = colormaps[name]
+    expected = tuple(float(c) for c in cmap(0))
+    assert rgba == pytest.approx(expected, abs=1e-12)
+
+
+def test_palette_continuous_colormap_wraps(resolver: PaletteColorResolver) -> None:
+    # viridis_r has N=256; large indices wrap modulo N rather than raise.
+    scale = PaletteColor(palette_name="viridis_r", palette_index=300)
+    rgba = resolver.resolve_one(scale, frame_idx=0)
+    cmap = colormaps["viridis_r"]
+    expected = tuple(float(c) for c in cmap(300 % 256))
+    assert rgba == pytest.approx(expected, abs=1e-12)
+
+
+# ---------- OOB raises with palette length ------------------------------
+
+
+def test_palette_oob_lists_palette_length(resolver: PaletteColorResolver) -> None:
+    # tab10 has exactly 10 entries (qualitative palette).
+    scale = PaletteColor(palette_name="tab10", palette_index=42)
+    with pytest.raises(ValueError, match="length 10"):
+        resolver.resolve_one(scale, 0)
+
+
+def test_palette_oob_message_includes_index(
+    resolver: PaletteColorResolver,
+) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=42)
+    with pytest.raises(ValueError, match="42"):
+        resolver.resolve_one(scale, 0)
+
+
+# ---------- unknown palette ---------------------------------------------
+
+
+def test_unknown_palette_raises_at_construction() -> None:
+    """PaletteColor validates the palette name against matplotlib eagerly."""
+    with pytest.raises(ValueError, match="not_a_palette"):
+        PaletteColor(palette_name="definitely_not_a_palette", palette_index=0)
+
+
+def test_unknown_palette_lists_available_via_resolver(
+    resolver: PaletteColorResolver,
+) -> None:
+    """If a scale somehow carries an unknown palette, the resolver
+    surfaces it with a helpful message listing available palettes.
+
+    PaletteColor's ``__post_init__`` blocks construction of bad names,
+    so we mutate a freshly built scale with ``object.__setattr__`` to
+    sneak past the dataclass guard and exercise the resolver branch.
+    """
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    object.__setattr__(scale, "palette_name", "definitely_not_a_palette")
+    with pytest.raises(ValueError, match="unknown palette"):
+        resolver.resolve_one(scale, 0)
+
+
+# ---------- custom palettes ---------------------------------------------
+
+
+def test_register_palette_round_trip(resolver: PaletteColorResolver) -> None:
+    register_palette("brand_colors", ["#ff0000", "#00ff00", "#0000ff"])
+    assert "brand_colors" in list_custom_palettes()
+    # PaletteColor validation will not accept "brand_colors" because it
+    # is not in matplotlib.colormaps. We test the resolver's internal
+    # dispatch by constructing the scale lazily — the resolver should
+    # honour custom palettes via its own lookup path.
+    # Use the helper directly: register a name that *also* exists in
+    # matplotlib but with a custom palette that shadows it.
+    register_palette("Set2", ["#111111", "#222222"])
+    scale = PaletteColor(palette_name="Set2", palette_index=1)
+    rgba = resolver.resolve_one(scale, 0)
+    expected = tuple(float(c) for c in to_rgba("#222222"))
+    assert rgba == pytest.approx(expected, abs=1e-12)
+
+
+def test_register_palette_oob(resolver: PaletteColorResolver) -> None:
+    register_palette("Set2", ["#111111", "#222222"])
+    scale = PaletteColor(palette_name="Set2", palette_index=5)
+    with pytest.raises(ValueError, match="length 2"):
+        resolver.resolve_one(scale, 0)
+
+
+def test_register_palette_validation() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        register_palette("", ["#ff0000"])
+    with pytest.raises(ValueError, match="at least one"):
+        register_palette("empty", [])
+    with pytest.raises(ValueError, match="not a parseable"):
+        register_palette("bad", ["#zzzzzz"])
+    with pytest.raises(TypeError, match="sequence"):
+        register_palette("bad", "not_a_list")  # type: ignore[arg-type]
+
+
+def test_unregister_palette_no_op() -> None:
+    # Should silently succeed even if name is unknown.
+    unregister_palette("never_registered_palette")
+
+
+# ---------- bulk path ---------------------------------------------------
+
+
+def test_palette_resolve_array_2d(resolver: PaletteColorResolver) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=3)
+    out = resolver.resolve_array(scale, n_frames=4, n_markers=7)
+    assert out.shape == (4, 7, 4)
+    expected = np.asarray(colormaps["tab10"](3), dtype=np.float64)
+    np.testing.assert_allclose(out, np.broadcast_to(expected, (4, 7, 4)), atol=1e-12)
+
+
+def test_palette_resolve_array_1d(resolver: PaletteColorResolver) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=2)
+    out = resolver.resolve_array(scale, n_frames=10)
+    assert out.shape == (10, 4)
+
+
+def test_palette_resolve_array_invalid_args(
+    resolver: PaletteColorResolver,
+) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    with pytest.raises(ValueError, match="n_frames"):
+        resolver.resolve_array(scale, n_frames=-1)
+    with pytest.raises(ValueError, match="n_markers"):
+        resolver.resolve_array(scale, n_frames=4, n_markers=-2)
+
+
+def test_palette_resolver_rejects_wrong_scale(
+    resolver: PaletteColorResolver,
+) -> None:
+    static = StaticColor(hex_value="#ffffff")
+    with pytest.raises(TypeError, match="PaletteColorResolver"):
+        resolver.resolve_one(static, 0)
+    with pytest.raises(TypeError, match="PaletteColorResolver"):
+        resolver.resolve_array(static, n_frames=3)
+
+
+def test_palette_resolve_one_negative_index() -> None:
+    # PaletteColor itself rejects negative indices; the resolver path
+    # double-checks. Construct via dataclass.replace to bypass.
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    object.__setattr__(scale, "palette_index", -3)  # type: ignore[misc]
+    resolver = PaletteColorResolver()
+    with pytest.raises(ValueError, match="non-negative"):
+        resolver.resolve_one(scale, 0)

--- a/tests/unit/plot_style/resolvers/test_static.py
+++ b/tests/unit/plot_style/resolvers/test_static.py
@@ -1,0 +1,128 @@
+"""Unit tests for :class:`StaticColorResolver`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from matplotlib.colors import to_rgba
+
+from src.shared.python.plot_style import PaletteColor, StaticColor
+from src.shared.python.plot_style.contracts import ColorResolver
+from src.shared.python.plot_style.resolvers import StaticColorResolver
+
+
+@pytest.fixture
+def resolver() -> StaticColorResolver:
+    return StaticColorResolver()
+
+
+# ---------- Protocol conformance ---------------------------------------
+
+
+def test_static_resolver_implements_protocol(resolver: StaticColorResolver) -> None:
+    assert isinstance(resolver, ColorResolver)
+
+
+# ---------- resolve_one --------------------------------------------------
+
+
+def test_static_resolve_one_round_trip(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="#ff0000")
+    rgba = resolver.resolve_one(scale, frame_idx=0, marker_idx=None)
+    expected = tuple(float(c) for c in to_rgba("#ff0000"))
+    assert rgba == pytest.approx(expected, abs=1e-12)
+
+
+def test_static_resolve_one_named_color(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="blue")
+    rgba = resolver.resolve_one(scale, 5, 3)
+    assert rgba[2] == pytest.approx(1.0)
+    assert rgba[3] == pytest.approx(1.0)
+
+
+def test_static_resolve_one_ignores_indices(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="#abcdef")
+    a = resolver.resolve_one(scale, 0)
+    b = resolver.resolve_one(scale, 999, 17)
+    assert a == b
+
+
+def test_static_resolve_one_rejects_wrong_scale(
+    resolver: StaticColorResolver,
+) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    with pytest.raises(TypeError, match="StaticColorResolver"):
+        resolver.resolve_one(scale, 0)
+
+
+# ---------- bad hex ------------------------------------------------------
+
+
+def test_static_color_bad_hex_construct_lists_bad_string() -> None:
+    # The dataclass itself validates hex_value, so the bad-hex error
+    # must surface there with the offending value mentioned.
+    bad = "#zzzzzz"
+    with pytest.raises(ValueError, match="zzzzzz"):
+        StaticColor(hex_value=bad)
+
+
+def test_static_resolver_handles_alpha_hex(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="#ff000080")
+    rgba = resolver.resolve_one(scale, 0)
+    assert rgba[0] == pytest.approx(1.0)
+    assert rgba[3] < 1.0
+
+
+# ---------- resolve_array ------------------------------------------------
+
+
+def test_static_resolve_array_1d(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="#00ff00")
+    out = resolver.resolve_array(scale, n_frames=10)
+    assert out.shape == (10, 4)
+    expected = np.asarray(to_rgba("#00ff00"), dtype=np.float64)
+    np.testing.assert_allclose(out, np.broadcast_to(expected, (10, 4)), atol=1e-12)
+
+
+def test_static_resolve_array_2d(resolver: StaticColorResolver) -> None:
+    scale = StaticColor(hex_value="#0000ff")
+    out = resolver.resolve_array(scale, n_frames=4, n_markers=7)
+    assert out.shape == (4, 7, 4)
+    expected = np.asarray(to_rgba("#0000ff"), dtype=np.float64)
+    np.testing.assert_allclose(out, np.broadcast_to(expected, (4, 7, 4)), atol=1e-12)
+
+
+def test_static_resolve_array_independent_of_caller_mutation(
+    resolver: StaticColorResolver,
+) -> None:
+    scale = StaticColor(hex_value="#123456")
+    a = resolver.resolve_array(scale, 5, 3)
+    a[0, 0, 0] = 0.0
+    b = resolver.resolve_array(scale, 5, 3)
+    assert b[0, 0, 0] != 0.0
+
+
+def test_static_resolve_array_invalid_n_frames(
+    resolver: StaticColorResolver,
+) -> None:
+    scale = StaticColor(hex_value="red")
+    with pytest.raises(ValueError, match="n_frames"):
+        resolver.resolve_array(scale, n_frames=0)
+    with pytest.raises(ValueError, match="n_frames"):
+        resolver.resolve_array(scale, n_frames=-1)
+
+
+def test_static_resolve_array_invalid_n_markers(
+    resolver: StaticColorResolver,
+) -> None:
+    scale = StaticColor(hex_value="red")
+    with pytest.raises(ValueError, match="n_markers"):
+        resolver.resolve_array(scale, n_frames=4, n_markers=0)
+
+
+def test_static_resolve_array_rejects_wrong_scale(
+    resolver: StaticColorResolver,
+) -> None:
+    scale = PaletteColor(palette_name="tab10", palette_index=0)
+    with pytest.raises(TypeError, match="StaticColorResolver"):
+        resolver.resolve_array(scale, n_frames=4)


### PR DESCRIPTION
Closes #4803

## Summary

Wave 2 of plot_style EPIC #4796. Three concrete `ColorResolver` Protocol implementations under `src/shared/python/plot_style/resolvers/`:

- **`StaticColorResolver`** — passes the constant hex through `matplotlib.colors.to_rgba`; bulk path broadcasts to a fully-populated `(n_frames, [n_markers,] 4)` array.
- **`PaletteColorResolver`** — looks up `palette_index` in named matplotlib palettes (`tab10`, `tab20`, `Set1`/`Set2`, `Pastel1`, `viridis_r`, ...) plus a project-local custom-palette registry exposed via `register_palette` / `unregister_palette` / `list_custom_palettes`. OOB indices on qualitative palettes raise `ValueError` listing the palette length; unknown names raise listing every available palette.
- **`DataDrivenColorResolver`** — channel scalar -> `vmin`/`vmax` normalisation -> cached LUT sampling. Bulk path is fully vectorised: builds the `(n_frames, [n_markers,] 4)` scalar grid, normalises with `np.errstate`-guarded ops, samples a 256-entry cached LUT in a single fancy-index call. NaN scalars and degenerate (`vmin == vmax`) ranges are handled at the array level.

Stacks on top of #4840 (foundation contracts). Base branch is `feat/plot-style-contracts` so this PR contains *only* the resolver work; rebase onto `main` once #4840 lands.

## Performance

Bulk LUT timing on the 38-marker × 654-frame target (best of 20 runs):

```
best:   1.014 ms
median: 1.245 ms
worst:  2.181 ms
```

Well under the 5 ms / 60 fps budget. Asserted by `test_bulk_perf_38_markers_654_frames`.

## Equivalence

`resolve_one(scale, frame, marker)`, `resolve_one(scale, frame, None)`, and `resolve_array(...)[frame, marker]` agree to `atol=1e-12` on every (frame, marker) pair (`test_per_frame_marker_and_bulk_paths_agree`, `test_per_frame_path_matches_bulk_1d`).

## Test plan

- [x] `python3 -m ruff check src/shared/python/plot_style tests/unit/plot_style` — clean
- [x] `python3 -m ruff format --check` — clean
- [x] `python3 -m pytest tests/unit/plot_style/resolvers/ -p no:cacheprovider -n auto --timeout=60` — 49 passed
- [x] `python3 -m pytest tests/unit/plot_style/` — 178 passed
- [x] Coverage on `src/shared/python/plot_style/resolvers`: **93.91%** (≥ 90% target)
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)