### PR TITLE
feat(anthropometrics): C3D subject info reader (#4818)

### DIFF
--- a/src/shared/python/anthropometrics/__init__.py
+++ b/src/shared/python/anthropometrics/__init__.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 from ._subject_anthropometrics import SubjectAnthropometrics
 from ._types import Sex
 from .contracts import EngineAdapter, Estimator, Reader, Writer
+from .readers import C3DSubjectMetadata, read_c3d_subject_metadata
 from .segment_properties import SegmentProperties
 
 __all__ = [
+    "C3DSubjectMetadata",
     "EngineAdapter",
     "Estimator",
     "Reader",
@@ -29,4 +31,5 @@ __all__ = [
     "Sex",
     "SubjectAnthropometrics",
     "Writer",
+    "read_c3d_subject_metadata",
 ]

--- a/src/shared/python/anthropometrics/readers/__init__.py
+++ b/src/shared/python/anthropometrics/readers/__init__.py
@@ -1,0 +1,14 @@
+"""Readers for ingesting subject metadata from external file formats.
+
+Each module exposes a ``read_*`` function returning a frozen,
+format-specific metadata dataclass. Estimators downstream
+(:class:`anthropometrics.contracts.Estimator`) consume these
+dataclasses to build a fully-populated
+:class:`anthropometrics.SubjectAnthropometrics`.
+"""
+
+from __future__ import annotations
+
+from .c3d_subject_info import C3DSubjectMetadata, read_c3d_subject_metadata
+
+__all__ = ["C3DSubjectMetadata", "read_c3d_subject_metadata"]

--- a/src/shared/python/anthropometrics/readers/c3d_subject_info.py
+++ b/src/shared/python/anthropometrics/readers/c3d_subject_info.py
@@ -1,0 +1,266 @@
+"""Reader for C3D ``SUBJECT_INFO`` / ``PROCESSING`` parameter groups.
+
+The C3D file format reserves the ``PROCESSING`` parameter group for
+subject anthropometry written by motion-capture software (Vicon Nexus,
+Qualisys QTM, ...). Common fields:
+
+* ``PROCESSING:Bodymass``    — body mass in kilograms
+* ``PROCESSING:Height``      — stature in millimetres
+* ``PROCESSING:LeftLegLength`` / ``RightLegLength``  — millimetres
+* ``PROCESSING:LeftArmLength`` / ``RightArmLength``  — millimetres
+
+The ``SUBJECTS`` group holds session-level identifiers:
+
+* ``SUBJECTS:NAMES``  — session-display names (treated as identifier
+  only — generic-naming policy)
+* ``SUBJECTS:AGE``    — age in years
+* ``SUBJECTS:SEX``    — ``"M"`` / ``"F"`` (anything else maps to
+  :data:`anthropometrics.Sex.UNSPECIFIED`)
+
+Every field is **optional**: when a key is absent or non-finite the
+corresponding attribute on :class:`C3DSubjectMetadata` is ``None``
+(or :data:`Sex.UNSPECIFIED` for sex). Missing files raise
+:class:`FileNotFoundError`; that is the only hard failure mode.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from upstream_drift_tools.utils.logging import get_logger
+
+from .._types import Sex
+
+logger = get_logger(__name__)
+
+_MM_TO_M: float = 1.0e-3
+
+
+@dataclass(frozen=True)
+class C3DSubjectMetadata:
+    """Subject metadata extracted from a single C3D file.
+
+    Every field is optional — fields not present (or non-finite) in
+    the source file are ``None`` (or :data:`Sex.UNSPECIFIED` for
+    :attr:`sex`). All length fields are stored in **metres** and mass
+    in **kilograms** to match the rest of the anthropometrics package.
+    """
+
+    subject_id: str | None
+    height_m: float | None
+    mass_kg: float | None
+    age_years: float | None
+    sex: Sex
+    leg_length_m: float | None
+    arm_length_m: float | None
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point.                                                         #
+# --------------------------------------------------------------------------- #
+def read_c3d_subject_metadata(path: Path | str) -> C3DSubjectMetadata:
+    """Open a C3D file and return its :class:`C3DSubjectMetadata`.
+
+    Args:
+        path: Filesystem path to a ``.c3d`` file.
+
+    Returns:
+        A fully-populated :class:`C3DSubjectMetadata`. Fields whose
+        underlying parameter is missing or non-finite are ``None``
+        (or :data:`Sex.UNSPECIFIED`).
+
+    Raises:
+        FileNotFoundError: When *path* does not exist.
+        ImportError: When the optional ``ezc3d`` dependency is not
+            installed in the active environment.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"C3D file not found: {file_path}")
+
+    parameters = _load_parameters(file_path)
+    return _extract_subject_metadata(parameters)
+
+
+# --------------------------------------------------------------------------- #
+# I/O.                                                                        #
+# --------------------------------------------------------------------------- #
+def _load_parameters(file_path: Path) -> Mapping[str, Any]:
+    """Open *file_path* via ``ezc3d`` and return the parameters mapping."""
+    try:
+        import ezc3d  # local import: keep package importable without ezc3d
+    except ImportError as error:  # pragma: no cover - exercised via mocks
+        raise ImportError(
+            "ezc3d is required to read C3D subject metadata. "
+            "Install it with: pip install ezc3d"
+        ) from error
+
+    c3d_data = ezc3d.c3d(str(file_path))
+    return c3d_data["parameters"]  # type: ignore[no-any-return]
+
+
+# --------------------------------------------------------------------------- #
+# Pure extraction (testable without ezc3d).                                   #
+# --------------------------------------------------------------------------- #
+def _extract_subject_metadata(
+    parameters: Mapping[str, Any],
+) -> C3DSubjectMetadata:
+    """Return :class:`C3DSubjectMetadata` from a C3D parameters mapping.
+
+    This function is pure: it does no I/O. It accepts the structure
+    returned by ``ezc3d.c3d(...)["parameters"]`` and is the seam used
+    by the unit tests to inject synthetic fixtures.
+    """
+    processing = _get_group(parameters, "PROCESSING")
+    subjects = _get_group(parameters, "SUBJECTS")
+
+    mass_kg = _read_scalar(processing, "Bodymass")
+    height_mm = _read_scalar(processing, "Height")
+    height_m = height_mm * _MM_TO_M if height_mm is not None else None
+
+    leg_length_m = _read_average_length_m(processing, "LeftLegLength", "RightLegLength")
+    arm_length_m = _read_average_length_m(processing, "LeftArmLength", "RightArmLength")
+
+    subject_id = _read_first_string(subjects, "NAMES")
+    if subject_id is not None:
+        # Generic-naming policy: SUBJECTS:NAMES is informational only.
+        logger.info("C3D SUBJECTS:NAMES present (session id only): %s", subject_id)
+
+    age_years = _read_scalar(subjects, "AGE")
+    sex = _read_sex(subjects)
+
+    return C3DSubjectMetadata(
+        subject_id=subject_id,
+        height_m=height_m,
+        mass_kg=mass_kg,
+        age_years=age_years,
+        sex=sex,
+        leg_length_m=leg_length_m,
+        arm_length_m=arm_length_m,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Parameter helpers.                                                          #
+# --------------------------------------------------------------------------- #
+def _get_group(parameters: Mapping[str, Any], group_name: str) -> Mapping[str, Any]:
+    """Return *group_name* from *parameters* with case-insensitive lookup.
+
+    Returns an empty dict when the group is absent so downstream
+    helpers can treat "missing group" identically to "missing field".
+    """
+    for key, value in parameters.items():
+        if key.upper() == group_name.upper() and isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _get_param_value(group: Mapping[str, Any], key: str) -> Any | None:
+    """Return ``group[key]['value']`` with case-insensitive key matching."""
+    for candidate, entry in group.items():
+        if candidate.upper() != key.upper():
+            continue
+        if isinstance(entry, Mapping):
+            return entry.get("value")
+        return entry
+    return None
+
+
+def _read_scalar(group: Mapping[str, Any], key: str) -> float | None:
+    """Read the first scalar from ``group[key]``; ``None`` if missing/non-finite."""
+    value = _get_param_value(group, key)
+    if value is None:
+        return None
+    try:
+        flat = list(_iter_flat(value))
+    except TypeError:
+        return None
+    if not flat:
+        return None
+    try:
+        scalar = float(flat[0])
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(scalar):
+        return None
+    return scalar
+
+
+def _read_average_length_m(
+    group: Mapping[str, Any],
+    left_key: str,
+    right_key: str,
+) -> float | None:
+    """Average left/right millimetre lengths and convert to metres.
+
+    If only one side is present, that single side is returned. If
+    both sides are absent or non-finite, the result is ``None``.
+    """
+    left = _read_scalar(group, left_key)
+    right = _read_scalar(group, right_key)
+    available = [v for v in (left, right) if v is not None]
+    if not available:
+        return None
+    avg_mm = sum(available) / len(available)
+    return avg_mm * _MM_TO_M
+
+
+def _read_first_string(group: Mapping[str, Any], key: str) -> str | None:
+    """Read the first string from ``group[key]``; ``None`` if blank/missing."""
+    value = _get_param_value(group, key)
+    if value is None:
+        return None
+    try:
+        flat = list(_iter_flat(value))
+    except TypeError:
+        return None
+    if not flat:
+        return None
+    text = str(flat[0]).strip()
+    return text or None
+
+
+def _read_sex(group: Mapping[str, Any]) -> Sex:
+    """Parse ``SUBJECTS:SEX`` with ``"M"`` / ``"F"`` mapping; else unspecified."""
+    raw = _read_first_string(group, "SEX")
+    if raw is None:
+        return Sex.UNSPECIFIED
+    upper = raw.upper()
+    if upper == "M":
+        return Sex.MALE
+    if upper == "F":
+        return Sex.FEMALE
+    return Sex.UNSPECIFIED
+
+
+def _iter_flat(value: Any) -> Any:
+    """Yield scalars from *value*, descending one level into list-likes.
+
+    ezc3d returns parameter values as either Python scalars, Python
+    lists, or numpy arrays. This helper normalises the three so that
+    callers can pull a "first scalar" without branching.
+    """
+    if isinstance(value, (str, bytes)):
+        yield value
+        return
+    try:
+        import numpy as np
+    except ImportError:  # pragma: no cover - numpy is a hard dep elsewhere
+        np = None  # type: ignore[assignment]
+    if np is not None and isinstance(value, np.ndarray):
+        yield from value.ravel().tolist()
+        return
+    try:
+        iterator = iter(value)
+    except TypeError:
+        yield value
+        return
+    for item in iterator:
+        if isinstance(item, (list, tuple)):
+            yield from item
+        else:
+            yield item

--- a/tests/unit/anthropometrics/readers/test_c3d_subject_info.py
+++ b/tests/unit/anthropometrics/readers/test_c3d_subject_info.py
@@ -1,0 +1,279 @@
+"""Unit tests for ``anthropometrics.readers.c3d_subject_info``.
+
+The reader is exercised three ways:
+
+* **Synthetic fixture path** — extends ``_synthetic_c3d_dict`` with
+  ``PROCESSING`` / ``SUBJECTS`` parameter groups and feeds the
+  resulting mapping straight into the pure
+  :func:`~anthropometrics.readers.c3d_subject_info._extract_subject_metadata`
+  helper, asserting every attribute on the returned dataclass.
+* **Real-data path** — opens ``data/C3D_TA_Driver.c3d`` (which lacks
+  PROCESSING / SUBJECTS) and asserts every field is ``None``
+  (or :data:`Sex.UNSPECIFIED` for sex).
+* **Error paths** — missing file → ``FileNotFoundError``; malformed
+  ``Height`` (NaN) → ``height_m`` is ``None`` with no exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from anthropometrics import Sex
+from anthropometrics.readers import (
+    C3DSubjectMetadata,
+    read_c3d_subject_metadata,
+)
+from anthropometrics.readers.c3d_subject_info import (
+    _extract_subject_metadata,
+    _iter_flat,
+    _read_scalar,
+)
+from tests.unit.upstream_drift_tools.lab.bio._synthetic import (
+    _synthetic_c3d_dict,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture helpers.                                                            #
+# --------------------------------------------------------------------------- #
+def _with_processing(
+    base: dict[str, Any],
+    **fields: Any,
+) -> dict[str, Any]:
+    """Add a ``PROCESSING`` group with *fields* to the synthetic dict."""
+    base["parameters"]["PROCESSING"] = {
+        key: {"value": np.atleast_1d(np.asarray([value]).ravel())}
+        for key, value in fields.items()
+    }
+    return base
+
+
+def _with_subjects(
+    base: dict[str, Any],
+    **fields: Any,
+) -> dict[str, Any]:
+    """Add a ``SUBJECTS`` group with *fields* to the synthetic dict."""
+    group: dict[str, Any] = {}
+    for key, value in fields.items():
+        if isinstance(value, str):
+            group[key] = {"value": [value]}
+        else:
+            group[key] = {"value": np.atleast_1d(np.asarray([value]).ravel())}
+    base["parameters"]["SUBJECTS"] = group
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic happy path.                                                       #
+# --------------------------------------------------------------------------- #
+def test_extract_full_metadata_from_synthetic_fixture() -> None:
+    fixture = _synthetic_c3d_dict()
+    fixture = _with_processing(
+        fixture,
+        Bodymass=72.5,
+        Height=1780.0,  # mm
+        LeftLegLength=900.0,
+        RightLegLength=910.0,
+        LeftArmLength=620.0,
+        RightArmLength=630.0,
+    )
+    fixture = _with_subjects(
+        fixture,
+        NAMES="SUBJ-001",
+        AGE=42.0,
+        SEX="M",
+    )
+
+    metadata = _extract_subject_metadata(fixture["parameters"])
+
+    assert isinstance(metadata, C3DSubjectMetadata)
+    assert metadata.subject_id == "SUBJ-001"
+    assert metadata.mass_kg == pytest.approx(72.5)
+    assert metadata.height_m == pytest.approx(1.780)
+    assert metadata.leg_length_m == pytest.approx(0.905)
+    assert metadata.arm_length_m == pytest.approx(0.625)
+    assert metadata.age_years == pytest.approx(42.0)
+    assert metadata.sex is Sex.MALE
+
+
+def test_dataclass_is_frozen() -> None:
+    """Sanity check: the returned dataclass refuses attribute assignment."""
+    metadata = _extract_subject_metadata({})
+    with pytest.raises(AttributeError):
+        metadata.subject_id = "X"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Field-level partials.                                                       #
+# --------------------------------------------------------------------------- #
+def test_only_left_leg_length_uses_left_value() -> None:
+    fixture = _with_processing(_synthetic_c3d_dict(), LeftLegLength=880.0)
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.leg_length_m == pytest.approx(0.880)
+    assert metadata.arm_length_m is None
+
+
+def test_only_right_arm_length_uses_right_value() -> None:
+    fixture = _with_processing(_synthetic_c3d_dict(), RightArmLength=600.0)
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.arm_length_m == pytest.approx(0.600)
+
+
+def test_sex_female_maps_correctly() -> None:
+    fixture = _with_subjects(_synthetic_c3d_dict(), SEX="f")
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.sex is Sex.FEMALE
+
+
+def test_sex_unknown_value_falls_back_to_unspecified() -> None:
+    fixture = _with_subjects(_synthetic_c3d_dict(), SEX="other")
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.sex is Sex.UNSPECIFIED
+
+
+def test_blank_subject_name_treated_as_missing() -> None:
+    fixture = _with_subjects(_synthetic_c3d_dict(), NAMES="   ")
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.subject_id is None
+
+
+def test_case_insensitive_group_and_key_names() -> None:
+    fixture = _synthetic_c3d_dict()
+    fixture["parameters"]["processing"] = {
+        "bodymass": {"value": np.array([70.0])},
+        "HEIGHT": {"value": np.array([1700.0])},
+    }
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.mass_kg == pytest.approx(70.0)
+    assert metadata.height_m == pytest.approx(1.7)
+
+
+# --------------------------------------------------------------------------- #
+# Missing / malformed fields.                                                 #
+# --------------------------------------------------------------------------- #
+def test_no_processing_or_subjects_groups_returns_all_none() -> None:
+    fixture = _synthetic_c3d_dict()
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata == C3DSubjectMetadata(
+        subject_id=None,
+        height_m=None,
+        mass_kg=None,
+        age_years=None,
+        sex=Sex.UNSPECIFIED,
+        leg_length_m=None,
+        arm_length_m=None,
+    )
+
+
+def test_height_nan_does_not_raise_returns_none() -> None:
+    fixture = _with_processing(_synthetic_c3d_dict(), Height=float("nan"))
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.height_m is None
+
+
+def test_mass_inf_returns_none() -> None:
+    fixture = _with_processing(_synthetic_c3d_dict(), Bodymass=float("inf"))
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.mass_kg is None
+
+
+def test_empty_value_array_returns_none() -> None:
+    fixture = _synthetic_c3d_dict()
+    fixture["parameters"]["PROCESSING"] = {
+        "Bodymass": {"value": np.array([])},
+        "Height": {"value": np.array([])},
+    }
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.mass_kg is None
+    assert metadata.height_m is None
+
+
+def test_non_numeric_scalar_returns_none() -> None:
+    fixture = _synthetic_c3d_dict()
+    fixture["parameters"]["PROCESSING"] = {
+        "Bodymass": {"value": ["not-a-number"]},
+    }
+    metadata = _extract_subject_metadata(fixture["parameters"])
+    assert metadata.mass_kg is None
+
+
+def test_unreadable_value_type_returns_none() -> None:
+    """A value that is not iterable and not a scalar should not crash."""
+    assert _read_scalar({"key": {"value": object()}}, "key") is None
+
+
+def test_iter_flat_handles_string() -> None:
+    """``_iter_flat`` returns the string itself, not its characters."""
+    assert list(_iter_flat("abc")) == ["abc"]
+
+
+def test_iter_flat_handles_nested_lists() -> None:
+    assert list(_iter_flat([[1, 2], [3, 4]])) == [1, 2, 3, 4]
+
+
+def test_iter_flat_handles_scalar() -> None:
+    assert list(_iter_flat(7.0)) == [7.0]
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point — file-system / ezc3d wiring.                            #
+# --------------------------------------------------------------------------- #
+def test_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+    bogus = tmp_path / "does_not_exist.c3d"
+    with pytest.raises(FileNotFoundError):
+        read_c3d_subject_metadata(bogus)
+
+
+def test_real_c3d_file_returns_all_none_fields() -> None:
+    """``data/C3D_TA_Driver.c3d`` lacks PROCESSING / SUBJECTS groups."""
+    path = Path(__file__).resolve().parents[3].parent / "data" / "C3D_TA_Driver.c3d"
+    if not path.exists():  # pragma: no cover - data file always shipped
+        pytest.skip("Real C3D fixture not present")
+    metadata = read_c3d_subject_metadata(path)
+    assert metadata.subject_id is None
+    assert metadata.height_m is None
+    assert metadata.mass_kg is None
+    assert metadata.age_years is None
+    assert metadata.sex is Sex.UNSPECIFIED
+    assert metadata.leg_length_m is None
+    assert metadata.arm_length_m is None
+
+
+def test_read_uses_ezc3d_and_returns_metadata(tmp_path: Path) -> None:
+    """End-to-end through ``read_c3d_subject_metadata`` with ezc3d mocked."""
+    path = tmp_path / "fake.c3d"
+    path.write_bytes(b"")  # exists so FileNotFoundError is not raised
+
+    fixture = _with_processing(
+        _synthetic_c3d_dict(),
+        Bodymass=80.0,
+        Height=1820.0,
+    )
+    fixture = _with_subjects(fixture, SEX="F", AGE=29.0)
+
+    with patch(
+        "anthropometrics.readers.c3d_subject_info._load_parameters",
+        return_value=fixture["parameters"],
+    ):
+        metadata = read_c3d_subject_metadata(path)
+
+    assert metadata.mass_kg == pytest.approx(80.0)
+    assert metadata.height_m == pytest.approx(1.820)
+    assert metadata.sex is Sex.FEMALE
+    assert metadata.age_years == pytest.approx(29.0)
+
+
+def test_read_accepts_string_path(tmp_path: Path) -> None:
+    path = tmp_path / "fake.c3d"
+    path.write_bytes(b"")
+    with patch(
+        "anthropometrics.readers.c3d_subject_info._load_parameters",
+        return_value=_synthetic_c3d_dict()["parameters"],
+    ):
+        metadata = read_c3d_subject_metadata(str(path))
+    assert metadata.mass_kg is None


### PR DESCRIPTION
## Summary

- Adds `anthropometrics.readers.c3d_subject_info` with `C3DSubjectMetadata` (frozen dataclass) and `read_c3d_subject_metadata(path)`.
- Reads `PROCESSING.Bodymass`, `PROCESSING.Height` (mm to m), `LeftLegLength`/`RightLegLength`, `LeftArmLength`/`RightArmLength` (averaged when both present), `SUBJECTS.AGE`, `SUBJECTS.SEX`, `SUBJECTS.NAMES`.
- Missing or non-finite parameters return `None` (or `Sex.UNSPECIFIED`); only a missing file raises (`FileNotFoundError`).
- Generic-naming policy: `SUBJECTS.NAMES` is used as session-id only and logged at INFO.

Closes #4818. Part of EPIC #4797 (wave 2). Foundation #4800.

## Test plan

- [x] 21 new unit tests in `tests/unit/anthropometrics/readers/test_c3d_subject_info.py` (synthetic happy path with all fields, partial-side leg/arm length, case-insensitive group/key matching, NaN/Inf/empty value safety, blank `NAMES`, unknown sex fallback, real-data fixture `data/C3D_TA_Driver.c3d` returns all-None, missing file raises, `_iter_flat` direct edge cases).
- [x] `python3 -m ruff check src/shared/python/anthropometrics tests/unit/anthropometrics` -> clean.
- [x] `python3 -m ruff format --check` on touched files -> clean.
- [x] `python3 scripts/ci/check_file_size_budget.py` -> OK.
- [x] Coverage: 95.15% (122 stmts, 6 missed) on `anthropometrics.readers.c3d_subject_info` -> meets >=95% target.