### PR TITLE
fix(launcher): resolve IndentationError keeping ruff red (closes #4844)

### DIFF
--- a/src/shared/python/gui_launcher/launcher.py
+++ b/src/shared/python/gui_launcher/launcher.py
@@ -392,7 +392,7 @@ def launch_pyqt6_app(config: LaunchConfig) -> int:
         import importlib
 
         from PyQt6.QtCore import QEvent, QObject
-                from PyQt6.QtWidgets import (
+        from PyQt6.QtWidgets import (
             QApplication,
             QComboBox,
             QDoubleSpinBox,


### PR DESCRIPTION
## Summary
- Fix stray over-indentation on `from PyQt6.QtWidgets import (` line in `launch_pyqt6_app()` in `src/shared/python/gui_launcher/launcher.py` that caused `IndentationError` and made the module unimportable.
- Restores ruff/py_compile parseability for the launcher module.

Closes #4844.

## Test plan
- [x] `python3 -m py_compile src/shared/python/gui_launcher/launcher.py` succeeds
- [x] `python3 -m ruff check src/shared/python/gui_launcher/` succeeds for the launcher path

🤖 Generated with [Claude Code](https://claude.com/claude-code)