### PR TITLE
fix(api): TaskManager restores dict-like compatibility (closes #4843)

### DIFF
--- a/src/api/routes/export.py
+++ b/src/api/routes/export.py
@@ -52,10 +52,10 @@ async def export_results(
             f"Must be one of: {', '.join(sorted(VALID_EXPORT_FORMATS))}",
         )
 
-    if not await task_manager.exists(task_id):
+    if not task_manager.exists(task_id):
         raise HTTPException(status_code=404, detail="Task not found")
 
-    task = await task_manager.get(task_id)
+    task = task_manager.get(task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 

--- a/src/api/routes/simulation.py
+++ b/src/api/routes/simulation.py
@@ -105,7 +105,7 @@ async def run_simulation_async(
         raise ValueError("payload must be provided")
     task_id = str(uuid.uuid4())
 
-    await task_manager.set(
+    task_manager.set(
         task_id,
         {
             "status": "started",
@@ -144,8 +144,8 @@ async def get_simulation_status(
     Raises:
         HTTPException: If task not found.
     """
-    if not await task_manager.exists(task_id):
+    if not task_manager.exists(task_id):
         raise HTTPException(status_code=404, detail="Task not found")
 
-    task_data = await task_manager.get(task_id)
+    task_data = task_manager.get(task_id)
     return dict(task_data) if task_data else {}

--- a/src/api/routes/video.py
+++ b/src/api/routes/video.py
@@ -268,7 +268,7 @@ async def analyze_video_async(
     input_hash = hashlib.sha256(temp_path.read_bytes()).hexdigest()[:16]
 
     # Store task with durable metadata for replay (issue #3941 alignment)
-    await task_manager.set(
+    task_manager.set(
         task_id,
         {
             "status": "pending",
@@ -320,10 +320,10 @@ async def _process_video_background(
         task_manager: Task manager for status updates.
     """
     try:
-        task_data = await task_manager.get(task_id) or {}
+        task_data = task_manager.get(task_id) or {}
         created_at = task_data.get("created_at", datetime.now(UTC))
 
-        await task_manager.set(
+        task_manager.set(
             task_id,
             {
                 "status": "processing",
@@ -341,11 +341,11 @@ async def _process_video_background(
 
         result = await asyncio.to_thread(pipeline.process_video, video_path)
 
-        task_data = await task_manager.get(task_id) or {}
+        task_data = task_manager.get(task_id) or {}
         created_at = task_data.get("created_at", datetime.now(UTC))
 
         # Store comprehensive result metadata for reproducibility
-        await task_manager.set(
+        task_manager.set(
             task_id,
             {
                 "status": "completed",
@@ -365,11 +365,11 @@ async def _process_video_background(
         )
 
     except (RuntimeError, ValueError, OSError, ImportError, HTTPException) as e:
-        task_data = await task_manager.get(task_id) or {}
+        task_data = task_manager.get(task_id) or {}
         created_at = task_data.get("created_at", datetime.now(UTC))
         error = e.detail if isinstance(e, HTTPException) else str(e)
 
-        await task_manager.set(
+        task_manager.set(
             task_id,
             {
                 "status": "failed",

--- a/src/api/services/simulation_service.py
+++ b/src/api/services/simulation_service.py
@@ -233,12 +233,12 @@ class SimulationService:
             active_tasks: Dictionary to store task status
         """
         try:
-            await active_tasks.set(task_id, {"status": "running", "progress": 0})
+            active_tasks.set(task_id, {"status": "running", "progress": 0})
 
             result = await self.run_simulation(request)
 
             if result.success:
-                await active_tasks.set(
+                active_tasks.set(
                     task_id,
                     {
                         "status": "completed",
@@ -246,7 +246,7 @@ class SimulationService:
                     },
                 )
             else:
-                await active_tasks.set(
+                active_tasks.set(
                     task_id,
                     {
                         "status": "failed",
@@ -255,7 +255,7 @@ class SimulationService:
                 )
 
         except (GolfSuiteError, ValueError, RuntimeError, OSError) as e:
-            await active_tasks.set(task_id, {"status": "failed", "error": str(e)})
+            active_tasks.set(task_id, {"status": "failed", "error": str(e)})
 
     def _extract_simulation_data(
         self, recorder: GenericPhysicsRecorder

--- a/src/api/task_manager.py
+++ b/src/api/task_manager.py
@@ -9,12 +9,20 @@ Design by Contract:
     - Precondition: task_id must be a non-empty string
     - Postcondition: tasks are automatically cleaned up after TTL expiry
     - Invariant: at most MAX_CONCURRENT_ENGINES simulations run simultaneously
+
+Compatibility contract (#4843):
+    Public mutation/query methods (`set`, `get`, `exists`, `update_progress`,
+    `mark_completed`, `mark_failed`, `active_count`) are synchronous and
+    return raw values directly. Dict-like ``tm[task_id]``,
+    ``tm[task_id] = ...``, ``task_id in tm``, ``len(tm)``, ``iter(tm)``,
+    ``tm.keys()``, ``tm.values()``, and ``tm.items()`` are also supported.
 """
 
 from __future__ import annotations
 
 import asyncio
 import enum
+import threading
 import time
 from typing import Any
 
@@ -33,8 +41,14 @@ class TaskStatus(enum.Enum):
     CANCELLED = "cancelled"
 
 
+def _validate_task_id(task_id: str) -> None:
+    """Precondition: task_id must be a non-empty, non-whitespace string."""
+    if not isinstance(task_id, str) or not task_id or not task_id.strip():
+        raise ValueError("task_id must be a non-empty string")
+
+
 class TaskManager:
-    """Thread-safe task manager with TTL cleanup and size limits.
+    """Thread-safe task manager with TTL cleanup, size limits, and dict-like access.
 
     Prevents memory leak from unbounded task accumulation.
 
@@ -43,6 +57,7 @@ class TaskManager:
     - Maximum MAX_TASKS entries with LRU eviction
     - Automatic cleanup on each access
     - Concurrency semaphore for engine instances
+    - Synchronous API and dict-like access (#4843)
     """
 
     # Configuration constants
@@ -59,13 +74,9 @@ class TaskManager:
     ) -> None:
         """Initialize task manager.
 
-        Args:
-            ttl_seconds: Override default TTL for task expiry.
-            max_tasks: Override maximum number of stored tasks.
-            max_concurrent: Override maximum concurrent engine instances.
-
-        Note: Issue #2715 — Refactored to use asyncio.Lock exclusively to prevent
-              deadlock risks when mixed with asyncio.Semaphore.
+        Note: Issue #2715 — async semaphore for engine concurrency.
+              Issue #4843 — synchronous core protected by ``threading.RLock``
+              so calls work whether or not an event loop is running.
         """
         if ttl_seconds is not None:
             self.TTL_SECONDS = ttl_seconds
@@ -76,29 +87,17 @@ class TaskManager:
 
         self._tasks: dict[str, dict[str, Any]] = {}
         self._timestamps: dict[str, float] = {}
-        self._lock = asyncio.Lock()
+        self._lock = threading.RLock()
         self._engine_semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_ENGINES)
         self._closed = False
-
-    @property
-    def engine_semaphore(self) -> asyncio.Semaphore:
-        """Semaphore limiting concurrent engine instances.
-
-        Usage::
-
-            async with task_manager.engine_semaphore:
-                await run_simulation(...)
-        """
-        self._ensure_open()
-        return self._engine_semaphore
 
     def _ensure_open(self) -> None:
         """Raise when callers try to use a shutdown manager."""
         if self._closed:
             raise RuntimeError("TaskManager is closed")
 
-    async def _cleanup_expired(self) -> None:
-        """Remove expired tasks. Called internally under lock."""
+    def _cleanup_expired_locked(self) -> None:
+        """Remove expired tasks. Caller must hold ``self._lock``."""
         current_time = time.time()
         expired_keys = [
             task_id
@@ -111,135 +110,159 @@ class TaskManager:
         if expired_keys:
             logger.debug("Cleaned up %d expired tasks", len(expired_keys))
 
-    async def _enforce_size_limit(self) -> None:
-        """Remove oldest tasks if over limit. Called internally under lock."""
-        if len(self._tasks) <= self.MAX_TASKS:
+    def _enforce_size_limit_locked(self) -> None:
+        """Evict oldest tasks if over limit. Caller must hold ``self._lock``."""
+        overflow = len(self._tasks) - self.MAX_TASKS
+        if overflow <= 0:
             return
-
         sorted_by_age = sorted(self._timestamps.items(), key=lambda x: x[1])
-        to_remove = len(self._tasks) - self.MAX_TASKS
-        for task_id, _ in sorted_by_age[:to_remove]:
+        for task_id, _ in sorted_by_age[:overflow]:
             self._tasks.pop(task_id, None)
             self._timestamps.pop(task_id, None)
-        logger.debug("Evicted %d tasks due to size limit", to_remove)
+        logger.debug("Evicted %d tasks due to size limit", overflow)
 
-    async def set(self, task_id: str, data: dict[str, Any]) -> None:
-        """Store or update a task.
-
-        Args:
-            task_id: Unique task identifier (must be non-empty).
-            data: Task data dictionary.
-
-        Raises:
-            ValueError: If task_id is empty.
-        """
-        if not task_id or not task_id.strip():
-            raise ValueError("task_id must be a non-empty string")
+    @property
+    def engine_semaphore(self) -> asyncio.Semaphore:
+        """Semaphore limiting concurrent engine instances."""
         self._ensure_open()
-        async with self._lock:
+        return self._engine_semaphore
+
+    def set(self, task_id: str, data: dict[str, Any]) -> None:
+        """Store or update a task. Raises ``ValueError`` for empty IDs."""
+        _validate_task_id(task_id)
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             self._tasks[task_id] = data
             self._timestamps[task_id] = time.time()
-            await self._enforce_size_limit()
+            self._enforce_size_limit_locked()
 
-    async def get(self, task_id: str) -> dict[str, Any] | None:
-        """Retrieve a task by ID.
-
-        Args:
-            task_id: Task identifier.
-
-        Returns:
-            Task data or None if not found / expired.
-        """
-        self._ensure_open()
-        async with self._lock:
+    def get(self, task_id: str) -> dict[str, Any] | None:
+        """Return the task dict, or ``None`` if absent or expired."""
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             task = self._tasks.get(task_id)
             if task is not None:
                 self._timestamps[task_id] = time.time()
             return task
 
-    async def exists(self, task_id: str) -> bool:
+    def exists(self, task_id: str) -> bool:
         """Check if task exists and is not expired."""
-        self._ensure_open()
-        async with self._lock:
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
-            exists = task_id in self._tasks
-            if exists:
+            self._cleanup_expired_locked()
+            present = task_id in self._tasks
+            if present:
                 self._timestamps[task_id] = time.time()
-            return exists
+            return present
 
-    async def update_progress(self, task_id: str, progress: float) -> None:
-        """Update progress for a running task.
-
-        Args:
-            task_id: Task identifier.
-            progress: Progress percentage (0-100).
-        """
-        self._ensure_open()
-        async with self._lock:
+    def update_progress(self, task_id: str, progress: float) -> None:
+        """Update progress for a running task. Progress is clamped to [0, 100]."""
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             if task_id in self._tasks:
                 self._tasks[task_id]["progress"] = min(max(progress, 0.0), 100.0)
                 self._timestamps[task_id] = time.time()
 
-    async def mark_completed(self, task_id: str, result: dict[str, Any]) -> None:
-        """Mark a task as completed with its result.
-
-        Args:
-            task_id: Task identifier.
-            result: The task result data.
-        """
-        self._ensure_open()
-        async with self._lock:
+    def mark_completed(self, task_id: str, result: dict[str, Any]) -> None:
+        """Mark a task as completed with its result."""
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             if task_id in self._tasks:
                 self._tasks[task_id]["status"] = TaskStatus.COMPLETED.value
                 self._tasks[task_id]["result"] = result
                 self._tasks[task_id]["progress"] = 100.0
                 self._timestamps[task_id] = time.time()
 
-    async def mark_failed(self, task_id: str, error: str) -> None:
-        """Mark a task as failed with error information.
-
-        Args:
-            task_id: Task identifier.
-            error: Error message.
-        """
-        self._ensure_open()
-        async with self._lock:
+    def mark_failed(self, task_id: str, error: str) -> None:
+        """Mark a task as failed with error information."""
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             if task_id in self._tasks:
                 self._tasks[task_id]["status"] = TaskStatus.FAILED.value
                 self._tasks[task_id]["error"] = error
                 self._timestamps[task_id] = time.time()
 
-    async def active_count(self) -> int:
+    def active_count(self) -> int:
         """Return the number of active (non-expired) tasks."""
-        self._ensure_open()
-        async with self._lock:
+        with self._lock:
             self._ensure_open()
-            await self._cleanup_expired()
+            self._cleanup_expired_locked()
             return len(self._tasks)
 
-    async def shutdown(self) -> None:
-        """Cleanup resources on TaskManager shutdown (issue #2715).
+    # ── Dict-like compatibility surface (#4843) ──────────────────────
 
-        Closes the engine semaphore and prevents further operations.
-        Call this when the TaskManager is no longer needed.
-        """
-        async with self._lock:
+    def __contains__(self, task_id: object) -> bool:
+        if not isinstance(task_id, str):
+            return False
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return task_id in self._tasks
+
+    def __getitem__(self, task_id: str) -> dict[str, Any]:
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            if task_id not in self._tasks:
+                raise KeyError(task_id)
+            self._timestamps[task_id] = time.time()
+            return self._tasks[task_id]
+
+    def __setitem__(self, task_id: str, data: dict[str, Any]) -> None:
+        self.set(task_id, data)
+
+    def __delitem__(self, task_id: str) -> None:
+        with self._lock:
+            self._ensure_open()
+            if task_id not in self._tasks:
+                raise KeyError(task_id)
+            self._tasks.pop(task_id, None)
+            self._timestamps.pop(task_id, None)
+
+    def __len__(self) -> int:
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return len(self._tasks)
+
+    def __iter__(self) -> Any:
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return iter(list(self._tasks.keys()))
+
+    def keys(self) -> list[str]:
+        """Snapshot list of active (non-expired) task IDs."""
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return list(self._tasks.keys())
+
+    def values(self) -> list[dict[str, Any]]:
+        """Snapshot list of active task data dicts."""
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return list(self._tasks.values())
+
+    def items(self) -> list[tuple[str, dict[str, Any]]]:
+        """Snapshot list of (task_id, data) pairs."""
+        with self._lock:
+            self._ensure_open()
+            self._cleanup_expired_locked()
+            return list(self._tasks.items())
+
+    async def shutdown(self) -> None:
+        """Cleanup resources on TaskManager shutdown (issue #2715)."""
+        with self._lock:
             if self._closed:
                 return
             self._closed = True
             self._tasks.clear()
             self._timestamps.clear()
-            # asyncio.Semaphore cleanup happens implicitly on GC,
-            # but we log for diagnostics
             logger.debug("TaskManager shutdown: semaphore cleanup scheduled")

--- a/tests/unit/api/test_video_background_prod_readiness.py
+++ b/tests/unit/api/test_video_background_prod_readiness.py
@@ -48,7 +48,7 @@ async def test_process_video_background_does_not_block_event_loop(
     task_manager = TaskManager()
     video_path = tmp_path / "swing.mp4"
     video_path.write_bytes(b"video")
-    await task_manager.set("task-1", {"status": "started"})
+    task_manager.set("task-1", {"status": "started"})
 
     started = time.perf_counter()
     task = asyncio.create_task(
@@ -86,7 +86,7 @@ async def test_process_video_background_logs_cleanup_failure(
     task_manager = TaskManager()
     video_path = tmp_path / "swing.mp4"
     video_path.write_bytes(b"video")
-    await task_manager.set("task-1", {"status": "started"})
+    task_manager.set("task-1", {"status": "started"})
 
     original_unlink = Path.unlink
 

--- a/tests/unit/test_api_architecture.py
+++ b/tests/unit/test_api_architecture.py
@@ -331,6 +331,114 @@ class TestTaskManager:
         assert TaskStatus.CANCELLED.value == "cancelled"
 
 
+# ── Dict-like Compatibility Tests (#4843) ────────────────────────
+
+
+class TestTaskManagerDictContract:
+    """Pins the synchronous/dict-like compatibility contract (#4843)."""
+
+    def test_getitem_returns_task_data(self) -> None:
+        """``tm[task_id]`` returns the stored dict."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm.set("task-1", {"status": "running", "progress": 10})
+        assert tm["task-1"] == {"status": "running", "progress": 10}
+
+    def test_getitem_missing_raises_keyerror(self) -> None:
+        """``tm[missing]`` raises ``KeyError``."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        with pytest.raises(KeyError):
+            _ = tm["missing"]
+
+    def test_setitem_delegates_to_set(self) -> None:
+        """``tm[task_id] = data`` validates and stores."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm["task-1"] = {"status": "pending"}
+        assert tm["task-1"]["status"] == "pending"
+        with pytest.raises(ValueError, match="non-empty"):
+            tm[""] = {"status": "bad"}
+
+    def test_delitem_removes_task(self) -> None:
+        """``del tm[task_id]`` removes the task."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm.set("task-1", {"status": "pending"})
+        del tm["task-1"]
+        assert "task-1" not in tm
+        with pytest.raises(KeyError):
+            del tm["task-1"]
+
+    def test_contains_only_matches_strings(self) -> None:
+        """``__contains__`` returns False for non-string keys without raising."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm.set("task-1", {})
+        assert "task-1" in tm
+        assert 42 not in tm
+        assert None not in tm
+
+    def test_len_reflects_active_tasks(self) -> None:
+        """``len(tm)`` matches the count of non-expired tasks."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        assert len(tm) == 0
+        tm.set("task-1", {})
+        tm.set("task-2", {})
+        assert len(tm) == 2
+
+    def test_iter_yields_task_ids(self) -> None:
+        """Iterating yields a snapshot of currently active task IDs."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm.set("task-1", {})
+        tm.set("task-2", {})
+        assert sorted(tm) == ["task-1", "task-2"]
+
+    def test_keys_values_items_snapshots(self) -> None:
+        """``keys``/``values``/``items`` return snapshot lists."""
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        tm.set("task-1", {"status": "running"})
+        tm.set("task-2", {"status": "pending"})
+
+        keys = tm.keys()
+        values = tm.values()
+        items = tm.items()
+
+        assert sorted(keys) == ["task-1", "task-2"]
+        assert {"status": "running"} in values
+        assert ("task-1", {"status": "running"}) in items
+
+        # Snapshot is detached: mutating tm afterward does not change result.
+        tm.set("task-3", {})
+        assert "task-3" not in keys
+
+    def test_synchronous_calls_do_not_return_coroutines(self) -> None:
+        """Regression: methods must NOT return coroutine objects (#4843)."""
+        import inspect
+
+        from src.api.task_manager import TaskManager
+
+        tm = TaskManager()
+        assert not inspect.iscoroutine(tm.set("task-1", {"status": "running"}))
+        assert not inspect.iscoroutine(tm.get("task-1"))
+        assert not inspect.iscoroutine(tm.exists("task-1"))
+        assert not inspect.iscoroutine(tm.update_progress("task-1", 50.0))
+        assert not inspect.iscoroutine(tm.active_count())
+        assert isinstance(tm.active_count(), int)
+        assert isinstance(tm.exists("task-1"), bool)
+
+
 # ── API Versioning Tests ──────────────────────────────────────────
 
 

--- a/tests/unit/test_task_manager_concurrency.py
+++ b/tests/unit/test_task_manager_concurrency.py
@@ -1,29 +1,34 @@
-"""Regression test for issue #3506: TaskManager must use asyncio primitives only.
+"""Regression test for issues #3506 and #4843.
 
-Pins the contract that ``TaskManager._lock`` is an ``asyncio.Lock`` and
-``TaskManager._engine_semaphore`` is an ``asyncio.Semaphore``. This guards
-against re-introducing ``threading.Lock`` (which deadlocks when mixed with
-``asyncio.Semaphore``) and exercises high-concurrency set/get/active_count
-calls to ensure no deadlock occurs.
+Issue #3506 originally required asyncio-native locking inside an async-only
+TaskManager. Issue #4843 restored a synchronous + dict-like compatibility
+surface, so the data-store lock is now a ``threading.RLock`` (held only for
+in-memory dict mutations, never across an ``await``) while the engine
+concurrency primitive remains an ``asyncio.Semaphore``. The deadlock scenario
+guarded by #3506 (mixing a sync lock with an async semaphore *across awaits*)
+no longer applies because the two primitives are never composed.
 """
 
 from __future__ import annotations
 
 import asyncio
+import threading
 
 import pytest
 from src.api.task_manager import TaskManager
 
+_RLOCK_TYPE = type(threading.RLock())
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_lock_and_semaphore_are_asyncio_primitives() -> None:
-    """Regression guard: locking primitives must be asyncio-native (#3506)."""
+async def test_lock_and_semaphore_primitives() -> None:
+    """Regression guard: locking primitives match the #4843 contract."""
     tm = TaskManager(max_concurrent=2)
     try:
-        assert isinstance(tm._lock, asyncio.Lock), (
-            "TaskManager._lock must be asyncio.Lock to avoid deadlock with "
-            "asyncio.Semaphore (#3506)"
+        # Data-store lock is a threading.RLock to support sync callers (#4843).
+        assert isinstance(tm._lock, _RLOCK_TYPE), (
+            "TaskManager._lock must be threading.RLock for the sync API (#4843)"
         )
         assert isinstance(tm._engine_semaphore, asyncio.Semaphore), (
             "TaskManager._engine_semaphore must be asyncio.Semaphore (#3506)"
@@ -42,13 +47,13 @@ async def test_concurrent_set_get_active_count_no_deadlock() -> None:
         n_tasks = 20
 
         async def writer(i: int) -> None:
-            await tm.set(f"task-{i}", {"status": "pending", "value": i})
+            tm.set(f"task-{i}", {"status": "pending", "value": i})
 
         async def reader(i: int) -> dict | None:
-            return await tm.get(f"task-{i}")
+            return tm.get(f"task-{i}")
 
         async def counter() -> int:
-            return await tm.active_count()
+            return tm.active_count()
 
         # First wave: write all tasks concurrently.
         await asyncio.wait_for(
@@ -75,7 +80,7 @@ async def test_concurrent_set_get_active_count_no_deadlock() -> None:
             assert isinstance(count, int)
             assert 0 <= count <= n_tasks
 
-        final_count = await tm.active_count()
+        final_count = tm.active_count()
         assert final_count == n_tasks
     finally:
         await tm.shutdown()
@@ -117,13 +122,13 @@ async def test_get_touches_task_ttl() -> None:
     """Reading a task refreshes retention for active polling clients (#3941)."""
     tm = TaskManager(ttl_seconds=0.05)
     try:
-        await tm.set("task-1", {"status": "running"})
+        tm.set("task-1", {"status": "running"})
         await asyncio.sleep(0.03)
 
-        assert await tm.get("task-1") is not None
+        assert tm.get("task-1") is not None
 
         await asyncio.sleep(0.03)
-        assert await tm.get("task-1") is not None
+        assert tm.get("task-1") is not None
     finally:
         await tm.shutdown()
 
@@ -133,11 +138,11 @@ async def test_get_touches_task_ttl() -> None:
 async def test_shutdown_closes_and_clears_task_manager() -> None:
     """Shutdown prevents process-local task state from being reused (#3941)."""
     tm = TaskManager()
-    await tm.set("task-1", {"status": "running"})
+    tm.set("task-1", {"status": "running"})
 
     await tm.shutdown()
 
     with pytest.raises(RuntimeError, match="closed"):
-        await tm.set("task-2", {"status": "pending"})
+        tm.set("task-2", {"status": "pending"})
     with pytest.raises(RuntimeError, match="closed"):
-        await tm.get("task-1")
+        tm.get("task-1")


### PR DESCRIPTION
## Summary

- Restore the synchronous + dict-like compatibility surface on `TaskManager` that was removed in the async-only refactor (#4843). `set`/`get`/`exists`/`update_progress`/`mark_completed`/`mark_failed`/`active_count` are now plain synchronous methods returning raw values.
- Add full mapping protocol: `tm[id]`, `tm[id] = data`, `del tm[id]`, `id in tm`, `len(tm)`, `iter(tm)`, plus `keys()`/`values()`/`items()` snapshots. Dict-style assignment validates the task ID and raises `ValueError` for empty/whitespace input.
- Swap the data-store lock from `asyncio.Lock` to `threading.RLock` so calls work outside an event loop. The engine-concurrency `asyncio.Semaphore` is unchanged and is never composed with the data lock across an `await`, so the #3506 deadlock scenario does not regress.
- Update the four in-repo async callers (`routes/export.py`, `routes/simulation.py`, `routes/video.py`, `services/simulation_service.py`) and the corresponding async tests to drop now-unnecessary `await` keywords.

## Test plan

- [x] `pytest tests/unit/test_api_architecture.py::TestTaskManager` passes (the 13 previously failing tests).
- [x] New `TestTaskManagerDictContract` class adds coverage for `__getitem__`, `__setitem__`, `__delitem__`, `__contains__`, `__len__`, `__iter__`, `keys()`/`values()`/`items()`, and a regression assert that the methods do not return coroutine objects.
- [x] `tests/unit/test_task_manager_concurrency.py` updated to reflect the new locking contract; concurrency, TTL, and shutdown semantics still covered.
- [x] `ruff check` + `ruff format --check` clean on touched files.

Closes #4843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)