### PR TITLE
docs(anthropometrics): ADR + user guide + cross-engine pipeline guide

### DIFF
--- a/docs/adr/0009-anthropometrics-pipeline.md
+++ b/docs/adr/0009-anthropometrics-pipeline.md
@@ -1,0 +1,150 @@
+# ADR-0009: Unified Anthropometrics Pipeline
+
+- Status: Accepted
+- Date: 2026-05-08
+- Decision Makers: UpstreamDrift core maintainers
+- Related Issues/PRs: EPIC [#4797](https://github.com/D-sorganization/UpstreamDrift/issues/4797),
+  child issues [#4800](https://github.com/D-sorganization/UpstreamDrift/issues/4800),
+  [#4815](https://github.com/D-sorganization/UpstreamDrift/issues/4815)–[#4828](https://github.com/D-sorganization/UpstreamDrift/issues/4828),
+  this ADR closes [#4827](https://github.com/D-sorganization/UpstreamDrift/issues/4827)
+
+## Context
+
+Before this work, anthropometric scaling lived in three disconnected places:
+
+- `humanoid_character_builder/core/anthropometry.py` — de Leva (1996) ratio
+  table used by the character builder GUI only.
+- `motion_pipeline/scaling/anthropometric.py` — segment-length estimation
+  from mocap markers, used only by the matcher.
+- A handful of per-engine `inertia.py` modules that each computed inertia
+  tensors with subtly different conventions, axis orderings, and units.
+
+Symptoms:
+
+- The same subject produced different masses, lengths, and inertia tensors
+  in Drake, Pinocchio, MuJoCo, and OpenSim runs.
+- No GUI exposed the underlying numbers; users could not audit or override.
+- No round-trip: a subject calibrated in the matcher could not be exported
+  to OpenSim or re-imported from MJCF.
+- Triangle-inequality and positive-definiteness violations slipped through
+  silently when ratios were applied to extreme heights / masses.
+
+Constraints:
+
+- SI units only, frozen public dataclasses, Design-by-Contract validation.
+- No vendor / lab / person names in code identifiers (citations in
+  docstrings are fine).
+- Per-segment inertia tensor calc ≤ 1 ms; whole-subject pipeline ≤ 100 ms.
+- ≥ 85 % line coverage on new code; validation tests must reproduce
+  published table values to documented precision.
+
+## Decision
+
+Adopt a single canonical record, a small set of runtime-checkable
+Protocols, and URDF as the lingua franca for cross-engine exchange.
+
+**Canonical record.** `src/shared/python/anthropometrics/segment_properties.py`
+defines a frozen `SegmentProperties` dataclass with all SI-unit fields
+needed by every engine:
+
+```python
+from anthropometrics import SegmentProperties
+
+# Every instance is validated on construction:
+#   - positive scalar lengths / masses
+#   - inertia tensor symmetric, positive-definite,
+#     and triangle-inequality on principal moments
+#   - |com| <= 2 * length_m
+```
+
+A `SubjectAnthropometrics` bundles segments plus subject scalars.
+
+**Protocols** (`anthropometrics.contracts`):
+
+| Protocol        | Purpose                                              |
+| --------------- | ---------------------------------------------------- |
+| `Estimator`     | `(height, mass, sex, age) -> SubjectAnthropometrics` |
+| `Reader`        | `path -> SubjectAnthropometrics`                     |
+| `Writer`        | `(SubjectAnthropometrics, path) -> None`             |
+| `EngineAdapter` | `SegmentProperties -> engine-native object`          |
+
+All four are `@runtime_checkable` so call sites can fail fast.
+
+**URDF as interchange.** The URDF `<inertial>` reader/writer pair is the
+canonical cross-engine bridge. Drake, Pinocchio, MuJoCo, and Simscape all
+have first-class URDF importers; OpenSim `.osim` has a paired
+reader/writer in the same package.
+
+**Estimators.** Three regression estimators ship in-tree:
+
+| Module                                | Citation                                  |
+| ------------------------------------- | ----------------------------------------- |
+| `from_de_leva.DeLevaEstimator`        | de Leva, P. (1996), _J. Biomechanics_     |
+| `from_dempster.DempsterEstimator`     | Dempster (1955), WADC TR-55-159           |
+| `from_zatsiorsky.ZatsiorskyEstimator` | Zatsiorsky-Seluyanov (1985, revised 2002) |
+
+de Leva is the default — its sex-specific tables, modern measurement
+conventions, and CoM placement on the longitudinal axis match what every
+downstream engine expects without correction. Dempster is retained for
+legacy comparability with older biomechanics literature; Zatsiorsky is
+retained for studies that need raw cadaver-derived inertia tensors.
+
+## Alternatives Considered
+
+1. **Per-engine ad-hoc scaling.** Status quo. Rejected — the symptoms
+   above are inherent: every engine grew its own conventions because
+   nothing forced agreement.
+2. **OpenSim `.osim` as canonical interchange.** Rejected — `.osim` is
+   tightly coupled to the OpenSim wrapped-muscle / Body / Joint model.
+   Engines without that machinery (Pinocchio, plain Drake MultibodyPlant)
+   would need a lossy translation layer.
+3. **Single God-class subject record.** Rejected — would couple I/O,
+   estimation, and engine translation. Protocol-driven separation lets
+   each subsystem evolve on its own cadence.
+4. **Vendor a third-party library** (e.g. `opensim-core`, `biomechanics`).
+   Rejected — license incompatibility, install footprint, and none cover
+   all four engine targets.
+
+## Consequences
+
+- **Positive**
+  - One subject record, identical numbers across all engines.
+  - GUIs (matcher calibration dialog, `SegmentPropertiesPanel` in the
+    c3d-viewer) read and write the same canonical record.
+  - Round-trip URDF / `.osim` / MJCF guaranteed by the read↔write test
+    pairs in `tests/anthropometrics/`.
+  - DbC catches non-physical inputs at the dataclass boundary, not deep
+    inside an engine integrator.
+- **Negative**
+  - Adding a new engine requires writing an `EngineAdapter`. The
+    development guide
+    [`anthropometrics_pipeline.md`](../development/anthropometrics_pipeline.md)
+    walks through this end-to-end.
+  - Estimator ratio tables are now versioned data files
+    (`estimators/ratios/*.json`); editing them requires a regression test
+    update.
+- **Follow-ups**
+  - Issue #4828 — first-party adapters for Drake, Pinocchio, MuJoCo,
+    MyoSuite, Simscape.
+  - Issue #4823 — `SegmentPropertiesPanel` UI component.
+  - Issue #4819 — comprehensive validation against published tables.
+  - Future: subject-specific MRI / CT scan ingestion as an additional
+    `Estimator`.
+
+## Validation
+
+- `tests/anthropometrics/test_validation_published_tables.py` — every
+  estimator must reproduce its source paper's tabulated values to
+  documented precision (de Leva: 4 sig figs; Dempster: 3; Zatsiorsky: 4).
+- `tests/anthropometrics/test_roundtrip_*.py` — `read(write(x)) == x`
+  for URDF, `.osim`, and MJCF.
+- Property-based tests (`hypothesis`) on `SegmentProperties.__post_init__`
+  to confirm DbC invariants reject every class of malformed input.
+- CI gates: `ruff check`, `ruff format --check`, file-size budget,
+  pytest with the coverage `fail_under` from `pyproject.toml`.
+
+## See also
+
+- User guide: [`docs/user_guide/anthropometrics.md`](../user_guide/anthropometrics.md)
+- Cross-engine pipeline guide:
+  [`docs/development/anthropometrics_pipeline.md`](../development/anthropometrics_pipeline.md)

--- a/docs/development/anthropometrics_pipeline.md
+++ b/docs/development/anthropometrics_pipeline.md
@@ -1,0 +1,233 @@
+# Cross-Engine Anthropometrics Pipeline — Developer Guide
+
+This guide is for contributors adding a new physics engine to the
+anthropometrics pipeline, or extending an existing adapter.
+
+- Design rationale: [ADR-0009](../adr/0009-anthropometrics-pipeline.md)
+- End-user perspective:
+  [user guide](../user_guide/anthropometrics.md)
+
+## Architecture in one picture
+
+```
+   ┌──────────────┐    ┌──────────────────────┐    ┌────────────────┐
+   │ MoCap C3D    ├───►│  Estimator           ├───►│ SubjectAnthro- │
+   │ Height/Mass  │    │ (DeLeva / Dempster / │    │   pometrics    │
+   │ User dialog  │    │  Zatsiorsky / mocap) │    │   (canonical)  │
+   └──────────────┘    └──────────────────────┘    └───────┬────────┘
+                                                            │
+                            ┌───────────────────────────────┼────────────────┐
+                            ▼                               ▼                ▼
+                  ┌────────────────┐             ┌────────────────┐ ┌────────────────┐
+                  │ Writer         │             │ Writer         │ │ EngineAdapter  │
+                  │ URDF <inertial>│             │ .osim Body     │ │ (Drake, Pin,   │
+                  │ MJCF <body>    │             │                │ │  MuJoCo, …)    │
+                  └────────┬───────┘             └────────┬───────┘ └────────┬───────┘
+                           ▼                              ▼                  ▼
+                       Drake / Pinocchio /            OpenSim         Native engine
+                       MuJoCo / Simscape                              data structures
+```
+
+`SubjectAnthropometrics` is the single source of truth. Engines must
+either (a) consume URDF emitted by `write_urdf_inertial`, or (b)
+implement an `EngineAdapter` that translates `SegmentProperties`
+directly into the engine's native representation.
+
+## The `EngineAdapter` Protocol
+
+Defined in `src/shared/python/anthropometrics/contracts.py`:
+
+```python
+from typing import Protocol, runtime_checkable
+from anthropometrics import SegmentProperties
+
+@runtime_checkable
+class EngineAdapter(Protocol):
+    def to_engine_segment(self, props: SegmentProperties) -> object:
+        """Return the engine-native representation of *props*."""
+        ...
+```
+
+The Protocol is intentionally minimal: one method, one segment in, one
+opaque engine object out. Multi-segment composition is the caller's
+responsibility (engines disagree about whether a "subject" is a kinematic
+tree, a flat body list, or a compiled model handle).
+
+## Adding a new engine adapter
+
+Put your adapter under
+`src/shared/python/anthropometrics/adapters/<engine_name>.py`.
+
+### 1. Implement `to_engine_segment`
+
+Use the existing Pinocchio adapter as the canonical example. A new
+adapter for a hypothetical `MyEngine` that exposes a
+`MyEngine.RigidBody(mass, com, I)` constructor would look like:
+
+```python
+# src/shared/python/anthropometrics/adapters/myengine.py
+from __future__ import annotations
+
+from anthropometrics import SegmentProperties
+
+# Replace with the real engine import:
+# import myengine
+
+
+class MyEngineAdapter:
+    """Translate SegmentProperties into MyEngine.RigidBody."""
+
+    def to_engine_segment(self, props: SegmentProperties):
+        # SegmentProperties is already SI, CoM in segment-local frame,
+        # inertia at CoM, symmetric / PD / triangle-inequality verified.
+        return myengine.RigidBody(  # noqa: F821
+            mass=props.mass_kg,
+            com=tuple(props.com_xyz_m.tolist()),
+            inertia=props.inertia_tensor.tolist(),
+        )
+```
+
+Two non-negotiable rules:
+
+1. **Do not silently mutate physical quantities.** No unit conversions
+   inside the adapter — `SegmentProperties` is SI by contract. If the
+   engine expects grams or millimetres, convert at the call site and
+   document it loudly.
+2. **Do not skip the parallel-axis transform** if the engine expresses
+   inertia at a frame other than the CoM. URDF, MJCF, and `.osim` all
+   match the canonical CoM convention; some bespoke formats do not.
+
+### 2. Register a `runtime_checkable` self-test
+
+```python
+from anthropometrics import EngineAdapter
+
+assert isinstance(MyEngineAdapter(), EngineAdapter)
+```
+
+This belongs in the adapter's own module-level test file
+(`tests/anthropometrics/adapters/test_myengine_adapter.py`) — it is the
+cheapest possible regression check that the Protocol is satisfied.
+
+### 3. Validate against published tables
+
+Every adapter PR must include a test that:
+
+1. Builds a subject from a fixed `(height, mass, sex)` triple using
+   `DeLevaEstimator`.
+2. Runs every segment through the new adapter.
+3. Re-extracts mass, CoM, and inertia from the engine-native object.
+4. Asserts they match the canonical `SegmentProperties` to documented
+   precision (`rtol=1e-9, atol=1e-12` is the bar for in-process
+   adapters; lossy formats document and justify a wider tolerance).
+
+Skeleton:
+
+```python
+# tests/anthropometrics/adapters/test_myengine_adapter.py
+import numpy as np
+import pytest
+
+from anthropometrics.estimators import DeLevaEstimator
+from anthropometrics.adapters.myengine import MyEngineAdapter
+
+
+@pytest.mark.unit
+def test_myengine_roundtrip_preserves_inertia():
+    subject = DeLevaEstimator().estimate(
+        subject_id="ref",
+        height_m=1.78,
+        mass_kg=72.0,
+        sex="M",
+    )
+    adapter = MyEngineAdapter()
+
+    for _, props in subject.segments:
+        body = adapter.to_engine_segment(props)
+        assert body.mass == pytest.approx(props.mass_kg, rel=1e-12)
+        np.testing.assert_allclose(
+            body.com, props.com_xyz_m, rtol=1e-9, atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            body.inertia, props.inertia_tensor, rtol=1e-9, atol=1e-12,
+        )
+```
+
+### 4. Cross-engine parity test
+
+Once two or more adapters exist for the same subject, add a parity test
+that asserts identical mass-matrix entries within numerical tolerance.
+The Drake ↔ Pinocchio parity test in
+`tests/anthropometrics/test_cross_engine_parity.py` is the template.
+
+## Validation against published tables
+
+`tests/anthropometrics/test_validation_published_tables.py` is the
+authoritative reference for the precision bar:
+
+| Estimator  | Tolerance                                   | Source                             |
+| ---------- | ------------------------------------------- | ---------------------------------- |
+| de Leva    | 4 sig figs on CoM ratios and gyration radii | de Leva (1996), Tables 1–4         |
+| Dempster   | 3 sig figs on mass / length ratios          | Dempster (1955), WADC TR-55-159    |
+| Zatsiorsky | 4 sig figs on principal moments (kg·m²)     | Zatsiorsky-Seluyanov (1985 / 2002) |
+
+When you change a ratio JSON in `estimators/ratios/`, the validation
+test will fail until you also update the expected values block — this is
+intentional. The change must cite the paper, table, and column being
+amended in the PR description.
+
+## Adding a new file format reader/writer
+
+Pair every reader with a writer. The contract is `read(write(x)) == x`
+for every valid `SegmentProperties`:
+
+```python
+# tests/anthropometrics/test_<format>_roundtrip.py
+import numpy as np
+from anthropometrics.estimators import DeLevaEstimator
+from anthropometrics.readers.<format> import read_<format>
+from anthropometrics.writers.<format> import write_<format>
+
+
+def test_<format>_roundtrip_is_lossless(tmp_path):
+    subject = DeLevaEstimator().estimate(
+        subject_id="rt", height_m=1.78, mass_kg=72.0, sex="M",
+    )
+    for _, props in subject.segments:
+        elem = write_<format>(props)
+        restored = read_<format>(elem)
+        assert restored.mass_kg == props.mass_kg
+        np.testing.assert_allclose(
+            restored.com_xyz_m, props.com_xyz_m, rtol=1e-9, atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            restored.inertia_tensor, props.inertia_tensor,
+            rtol=1e-9, atol=1e-12,
+        )
+```
+
+## Performance budget
+
+From the EPIC ([#4797](https://github.com/D-sorganization/UpstreamDrift/issues/4797)):
+
+- Inertia tensor calc for one segment ≤ 1 ms.
+- Bulk pipeline (load C3D → 16 segments → URDF) ≤ 100 ms.
+
+Adapters are well below this bar — `to_engine_segment` is pure data
+shuffling. If your adapter needs heavyweight engine setup (e.g. compiling
+a MuJoCo XML), do that work once at module level and have
+`to_engine_segment` reuse the cached engine handle.
+
+## Checklist for an adapter PR
+
+- [ ] `adapters/<engine>.py` implements `to_engine_segment` and is
+      `isinstance(..., EngineAdapter)` true.
+- [ ] Roundtrip test against `DeLevaEstimator` reference subject.
+- [ ] Cross-engine parity test if a second adapter exists.
+- [ ] No unit conversions or axis re-orderings without an explicit
+      comment citing the engine's documented convention.
+- [ ] Coverage on new code ≥ 85 % line, ≥ 75 % branch.
+- [ ] No new `print()` in `src/`; use `logging`.
+- [ ] No new TODO/FIXME without a tracked issue.
+- [ ] User-facing changes are reflected in
+      [`docs/user_guide/anthropometrics.md`](../user_guide/anthropometrics.md).

--- a/docs/user_guide/anthropometrics.md
+++ b/docs/user_guide/anthropometrics.md
@@ -1,0 +1,213 @@
+# Anthropometrics — User Guide
+
+This guide shows how to build a subject-specific biomechanical model from
+nothing more than a height and a mass, export it to URDF, and use the
+result in any supported physics engine.
+
+- Background and design rationale:
+  [ADR-0009](../adr/0009-anthropometrics-pipeline.md)
+- Adding a new engine adapter:
+  [cross-engine pipeline guide](../development/anthropometrics_pipeline.md)
+
+## Quickstart (5 minutes)
+
+Build a subject from height + mass and write its `<inertial>` blocks to
+a URDF:
+
+```python
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from anthropometrics import save_subject
+from anthropometrics.estimators import DeLevaEstimator
+from anthropometrics.writers import write_urdf_inertial
+
+# 1. Estimate a full subject from two scalars.
+estimator = DeLevaEstimator()
+subject = estimator.estimate(
+    subject_id="demo_subject_01",
+    height_m=1.78,
+    mass_kg=72.0,
+    sex="M",
+)
+
+# 2. Persist the canonical record (JSON, schema-versioned).
+out_dir = Path("./out")
+out_dir.mkdir(exist_ok=True)
+save_subject(subject, out_dir / "demo_subject_01.json")
+
+# 3. Emit one URDF <inertial> block per segment.
+robot = ET.Element("robot", {"name": subject.subject_id})
+for name, props in subject.segments:
+    link = ET.SubElement(robot, "link", {"name": name})
+    link.append(write_urdf_inertial(props))
+
+ET.ElementTree(robot).write(
+    out_dir / "demo_subject_01.urdf",
+    encoding="utf-8",
+    xml_declaration=True,
+)
+print(f"Wrote {out_dir / 'demo_subject_01.urdf'}")
+```
+
+The output URDF can be loaded directly by Drake, Pinocchio, MuJoCo, or
+any URDF-aware engine. Every `<inertial>` block round-trips losslessly
+through the matching reader (`anthropometrics.readers.read_urdf_inertial`).
+
+## Cookbook
+
+### Pick the right estimator
+
+| Estimator             | When to use it                                                                       | Source                             |
+| --------------------- | ------------------------------------------------------------------------------------ | ---------------------------------- |
+| `DeLevaEstimator`     | Default. Sex-specific tables, modern measurement protocol, CoM on longitudinal axis. | de Leva (1996)                     |
+| `DempsterEstimator`   | Reproducing classic biomechanics studies that cite Dempster ratios.                  | Dempster (1955)                    |
+| `ZatsiorskyEstimator` | When you need raw cadaver-derived inertia tensors (e.g. for sensitivity analyses).   | Zatsiorsky-Seluyanov (1985 / 2002) |
+
+All three implement the `Estimator` Protocol and are interchangeable:
+
+```python
+from anthropometrics.estimators import (
+    DeLevaEstimator,
+    DempsterEstimator,
+    ZatsiorskyEstimator,
+)
+
+for cls in (DeLevaEstimator, DempsterEstimator, ZatsiorskyEstimator):
+    subject = cls().estimate(
+        subject_id="cmp",
+        height_m=1.78,
+        mass_kg=72.0,
+        sex="M",
+    )
+    print(cls.__name__, "->", len(subject.segments), "segments")
+```
+
+### Estimate segment lengths from mocap markers
+
+```python
+from anthropometrics.estimators import (
+    SegmentDef,
+    estimate_segment_lengths_from_markers,
+)
+import numpy as np
+
+# Mean marker positions in metres (one row per frame, or a (3,) mean).
+markers = {
+    "RSHO": np.array([0.20, 0.00, 1.45]),
+    "RELB": np.array([0.25, 0.00, 1.15]),
+    "RWRA": np.array([0.27, 0.00, 0.90]),
+}
+defs = [
+    SegmentDef(name="upper_arm_R", proximal="RSHO", distal="RELB"),
+    SegmentDef(name="forearm_R",   proximal="RELB", distal="RWRA"),
+]
+lengths = estimate_segment_lengths_from_markers(markers, defs)
+print(lengths)  # {'upper_arm_R': 0.30..., 'forearm_R': 0.25...}
+```
+
+Mocap-derived lengths can be combined with regression-derived masses by
+constructing `SegmentProperties` directly with
+`build_segment_properties_with_inertia`.
+
+### Compute an inertia tensor from primitive geometry
+
+When you need a non-tabulated segment (e.g. a piece of equipment):
+
+```python
+from anthropometrics.estimators import (
+    inertia_from_cylinder,
+    inertia_from_ellipsoid,
+    inertia_from_gyration_radii,
+)
+
+# Solid cylinder, mass 0.4 kg, radius 0.02 m, length 0.30 m, axis = +Z.
+I_cyl = inertia_from_cylinder(mass_kg=0.4, radius_m=0.02, length_m=0.30)
+# Solid ellipsoid with semi-axes (a, b, c) in metres.
+I_ell = inertia_from_ellipsoid(mass_kg=4.0, semi_axes_m=(0.05, 0.05, 0.20))
+# From radii of gyration (kx, ky, kz) about CoM.
+I_kg  = inertia_from_gyration_radii(mass_kg=4.0, gyration_m=(0.04, 0.04, 0.10))
+```
+
+Each helper returns a 3 × 3 ndarray that already satisfies the
+`SegmentProperties` invariants (symmetric, positive-definite, triangle
+inequality).
+
+### Persist and reload a subject
+
+```python
+from pathlib import Path
+from anthropometrics import load_subject, save_subject
+
+save_subject(subject, Path("subject.json"))
+restored = load_subject(Path("subject.json"))
+assert restored == subject  # frozen dataclasses compare by value
+```
+
+The on-disk format is schema-versioned (see `SCHEMA_VERSION`). Reloading
+re-runs every DbC invariant — corrupt files fail loudly at `load_subject`
+rather than mid-simulation.
+
+### Read C3D subject metadata
+
+Many C3D files carry `SUBJECT_INFO` / `PROCESSING` parameter blocks.
+`read_c3d_subject_metadata` extracts the height / mass / sex hints so
+you do not have to ask the user twice:
+
+```python
+from anthropometrics import read_c3d_subject_metadata
+from anthropometrics.estimators import DeLevaEstimator
+
+meta = read_c3d_subject_metadata("data/C3D_TA_Driver.c3d")
+subject = DeLevaEstimator().estimate(
+    subject_id=meta.subject_id or "ta_driver",
+    height_m=meta.height_m or 1.78,
+    mass_kg=meta.mass_kg or 72.0,
+    sex=meta.sex or "unspecified",
+)
+```
+
+## Troubleshooting
+
+**`ValueError: inertia_tensor violates triangle inequality on principal moments`**
+The principal moments fail `Ix + Iy >= Iz`. This usually means a custom
+inertia computation forgot the parallel-axis transform back to the CoM,
+or used inconsistent units. Re-derive with `inertia_from_*` helpers.
+
+**`ValueError: com_xyz_m magnitude exceeds 2 * length_m`**
+The CoM vector is in the wrong frame (e.g. world coordinates instead of
+the segment's local frame). `SegmentProperties.com_xyz_m` is expressed in
+the segment-local frame with the proximal joint at the origin.
+
+**`ValueError: segments must be non-empty`**
+You constructed `SubjectAnthropometrics` with an empty tuple. Estimators
+always produce a populated subject; this only happens when building one
+by hand.
+
+**Estimator sex defaults to male.**
+de Leva published only male and female tables. `sex="unspecified"` falls
+back to the male table to preserve historical behaviour. Pass `sex="F"`
+explicitly for female subjects.
+
+**Round-trip URDF mismatch.**
+The URDF spec expresses inertia at the link CoM. If your source URDF
+expresses inertia at the joint origin, apply the parallel-axis transform
+before constructing `SegmentProperties`.
+
+**Numbers disagree between Drake and Pinocchio.**
+Both engines should consume the same URDF emitted by `write_urdf_inertial`
+and produce identical mass matrices to numerical precision. If they
+diverge, the engine adapter is reordering axes or applying its own
+scaling — see the
+[cross-engine pipeline guide](../development/anthropometrics_pipeline.md)
+for the validation harness.
+
+## Where the code lives
+
+- Canonical record: `src/shared/python/anthropometrics/segment_properties.py`
+- Subject record: `src/shared/python/anthropometrics/_subject_anthropometrics.py`
+- Protocols: `src/shared/python/anthropometrics/contracts.py`
+- Estimators: `src/shared/python/anthropometrics/estimators/`
+- Readers / writers: `src/shared/python/anthropometrics/readers/`,
+  `…/writers/`
+- Persistence: `src/shared/python/anthropometrics/persistence.py`


### PR DESCRIPTION
## Summary
- ADR-0009 captures the rationale for the unified anthropometrics pipeline: canonical `SegmentProperties` / `SubjectAnthropometrics`, runtime-checkable Protocols, URDF as the cross-engine interchange.
- New user guide (`docs/user_guide/anthropometrics.md`) — 5-minute quickstart from height + mass to URDF, estimator cookbook (de Leva / Dempster / Zatsiorsky / mocap / primitive geometry), persistence, troubleshooting.
- New developer guide (`docs/development/anthropometrics_pipeline.md`) — `EngineAdapter` Protocol walkthrough, adapter authoring checklist, validation precision bar against published tables.
- All three docs cross-link; ADR follows `docs/adr/ADR_TEMPLATE.md` structure. ~600 LOC total.

Closes #4827. Part of EPIC #4797.

## Test plan
- [ ] Markdown renders correctly on GitHub (tables, code blocks, diagram)
- [ ] All cross-references between the three docs resolve
- [ ] Code snippets reference real public APIs in `src/shared/python/anthropometrics/`