### PR TITLE
feat(matcher): subject-anthropometrics calibration dialog (closes #4820)

### DIFF
--- a/src/tools/starting_pose_matcher/gui.py
+++ b/src/tools/starting_pose_matcher/gui.py
@@ -57,6 +57,7 @@ from PyQt6.QtWidgets import (
     QApplication,
     QCheckBox,
     QComboBox,
+    QDialog,
     QDoubleSpinBox,
     QFileDialog,
     QFrame,
@@ -1489,6 +1490,22 @@ class StartingPoseMatcher(QMainWindow):
         ses_row.addWidget(self.btn_load_session)
         v.addLayout(ses_row)
 
+        # Subject-anthropometrics calibration (issue #4820).
+        self.btn_calibrate_subject = QPushButton("Calibrate subject…")
+        self.btn_calibrate_subject.setToolTip(
+            "Build a SubjectAnthropometrics record from height/mass/age/sex "
+            "and persist it to ~/.golf_modeling_suite/subjects/<id>.json."
+        )
+        self.btn_calibrate_subject.setStatusTip(
+            "Open the subject-anthropometrics calibration dialog."
+        )
+        self.btn_calibrate_subject.clicked.connect(self._on_calibrate_subject_clicked)
+        v.addWidget(self.btn_calibrate_subject)
+        self.lbl_subject = QLabel("Subject: (not calibrated)")
+        self.lbl_subject.setObjectName("status")
+        self.lbl_subject.setWordWrap(True)
+        v.addWidget(self.lbl_subject)
+
         self.lbl_residual = QLabel("Residuals: (no data)")
         self.lbl_residual.setObjectName("residual")
         self.lbl_residual.setWordWrap(True)
@@ -2162,6 +2179,18 @@ class StartingPoseMatcher(QMainWindow):
         return "Events:  " + "  ".join(parts)
 
     # ---------- save ------------------------------------------------------ #
+
+    def _on_calibrate_subject_clicked(self) -> None:
+        """Open the subject-anthropometrics calibration dialog (issue #4820)."""
+        from .widgets.calibration_dialog import CalibrationDialog
+
+        dlg = CalibrationDialog(self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            res = dlg.result_record
+            if res is not None:
+                self.lbl_subject.setText(
+                    f"Subject: {res.record.subject_id} → {res.saved_path}"
+                )
 
     def _on_save_clicked(self) -> None:
         path, _ = QFileDialog.getSaveFileName(

--- a/src/tools/starting_pose_matcher/widgets/__init__.py
+++ b/src/tools/starting_pose_matcher/widgets/__init__.py
@@ -7,6 +7,11 @@ full matcher window.
 
 from __future__ import annotations
 
+from .calibration_dialog import (
+    CalibrationDialog,
+    CalibrationResult,
+    build_subject_record,
+)
 from .joint_slider_panel import (
     DEFAULT_JOINT_COORDS,
     PoseState,
@@ -14,7 +19,10 @@ from .joint_slider_panel import (
 )
 
 __all__ = [
+    "CalibrationDialog",
+    "CalibrationResult",
     "DEFAULT_JOINT_COORDS",
     "JointSliderPanel",
     "PoseState",
+    "build_subject_record",
 ]

--- a/src/tools/starting_pose_matcher/widgets/calibration_dialog.py
+++ b/src/tools/starting_pose_matcher/widgets/calibration_dialog.py
@@ -1,0 +1,293 @@
+"""Subject-anthropometrics calibration dialog (issue #4820).
+
+Modal Qt dialog that asks the user for the four scalars needed by the
+anthropometrics regression estimators (height, mass, age, sex), lets them
+pick an estimator (de Leva / Dempster / Zatsiorsky), and on accept builds
+a :class:`SubjectAnthropometrics` and persists it as JSON via
+:func:`anthropometrics.persistence.save_subject`.
+
+Design-by-contract: every public input is validated at the dialog
+boundary. Out-of-range values disable the OK button and surface a status
+message; the dialog never propagates a partial / invalid record to the
+estimator. The dialog delegates all biomechanical math to the estimators
+(DRY) and never reaches into estimator internals (LoD).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.anthropometrics._subject_anthropometrics import (
+    SubjectAnthropometrics,
+)
+from src.shared.python.anthropometrics.estimators.from_de_leva import DeLevaEstimator
+from src.shared.python.anthropometrics.estimators.from_dempster import DempsterEstimator
+from src.shared.python.anthropometrics.estimators.from_zatsiorsky import (
+    ZatsiorskyEstimator,
+)
+from src.shared.python.anthropometrics.persistence import (
+    default_subjects_dir,
+    save_subject,
+)
+
+logger = logging.getLogger(__name__)
+
+EstimatorName = Literal["de_leva", "dempster", "zatsiorsky"]
+
+ESTIMATORS: dict[str, type] = {
+    "de_leva": DeLevaEstimator,
+    "dempster": DempsterEstimator,
+    "zatsiorsky": ZatsiorskyEstimator,
+}
+
+SEX_VALUES: tuple[str, ...] = ("M", "F", "unspecified")
+SEX_LABELS: dict[str, str] = {
+    "M": "Male",
+    "F": "Female",
+    "unspecified": "Unspecified",
+}
+
+# Validation bounds — guard against absurd inputs at the boundary.
+HEIGHT_MIN_M, HEIGHT_MAX_M = 0.5, 2.5
+MASS_MIN_KG, MASS_MAX_KG = 10.0, 250.0
+AGE_MIN, AGE_MAX = 1, 120
+
+
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Immutable handle returned after a successful calibration."""
+
+    record: SubjectAnthropometrics
+    saved_path: Path
+
+
+def build_subject_record(
+    *,
+    subject_id: str,
+    height_m: float,
+    mass_kg: float,
+    age_years: int,
+    sex: str,
+    estimator: str,
+) -> SubjectAnthropometrics:
+    """Validate inputs and delegate to the chosen estimator.
+
+    Raises ``ValueError`` on any out-of-range / invalid argument.
+    """
+    if not subject_id or not subject_id.strip():
+        raise ValueError("subject_id must be a non-empty string")
+    if not (HEIGHT_MIN_M <= height_m <= HEIGHT_MAX_M):
+        raise ValueError(
+            f"height_m must be in [{HEIGHT_MIN_M}, {HEIGHT_MAX_M}], got {height_m!r}"
+        )
+    if not (MASS_MIN_KG <= mass_kg <= MASS_MAX_KG):
+        raise ValueError(
+            f"mass_kg must be in [{MASS_MIN_KG}, {MASS_MAX_KG}], got {mass_kg!r}"
+        )
+    if not (AGE_MIN <= age_years <= AGE_MAX):
+        raise ValueError(
+            f"age_years must be in [{AGE_MIN}, {AGE_MAX}], got {age_years!r}"
+        )
+    if sex not in SEX_VALUES:
+        raise ValueError(f"sex must be one of {SEX_VALUES}, got {sex!r}")
+    if estimator not in ESTIMATORS:
+        raise ValueError(
+            f"estimator must be one of {tuple(ESTIMATORS)}, got {estimator!r}"
+        )
+
+    estimator_obj = ESTIMATORS[estimator]()
+    return estimator_obj.estimate(
+        subject_id=subject_id.strip(),
+        height_m=float(height_m),
+        mass_kg=float(mass_kg),
+        sex=sex,
+        age_years=float(age_years),
+    )
+
+
+class CalibrationDialog(QDialog):
+    """Modal subject-calibration dialog.
+
+    Emits :pyattr:`calibrated` with the produced
+    :class:`SubjectAnthropometrics` whenever the user accepts a valid form.
+    """
+
+    calibrated = pyqtSignal(object)  # SubjectAnthropometrics
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        subjects_dir: Path | None = None,
+        default_subject_id: str = "subject_001",
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Subject Anthropometrics Calibration")
+        self.setModal(True)
+        self._subjects_dir: Path = (
+            subjects_dir if subjects_dir is not None else default_subjects_dir()
+        )
+        self._result: CalibrationResult | None = None
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.id_edit = QLineEdit(default_subject_id)
+        self.id_edit.setObjectName("subject_id")
+        self.id_edit.textChanged.connect(self._refresh_validity)
+        form.addRow("Subject ID:", self.id_edit)
+
+        self.height_spin = QDoubleSpinBox()
+        self.height_spin.setObjectName("height_m")
+        self.height_spin.setRange(HEIGHT_MIN_M, HEIGHT_MAX_M)
+        self.height_spin.setSingleStep(0.01)
+        self.height_spin.setDecimals(3)
+        self.height_spin.setSuffix(" m")
+        self.height_spin.setValue(1.78)
+        form.addRow("Height:", self.height_spin)
+
+        self.mass_spin = QDoubleSpinBox()
+        self.mass_spin.setObjectName("mass_kg")
+        self.mass_spin.setRange(MASS_MIN_KG, MASS_MAX_KG)
+        self.mass_spin.setSingleStep(0.5)
+        self.mass_spin.setDecimals(2)
+        self.mass_spin.setSuffix(" kg")
+        self.mass_spin.setValue(75.0)
+        form.addRow("Mass:", self.mass_spin)
+
+        self.age_spin = QSpinBox()
+        self.age_spin.setObjectName("age_years")
+        self.age_spin.setRange(AGE_MIN, AGE_MAX)
+        self.age_spin.setSuffix(" yr")
+        self.age_spin.setValue(30)
+        form.addRow("Age:", self.age_spin)
+
+        self.sex_combo = QComboBox()
+        self.sex_combo.setObjectName("sex")
+        for value in SEX_VALUES:
+            self.sex_combo.addItem(SEX_LABELS[value], value)
+        form.addRow("Sex:", self.sex_combo)
+
+        self.estimator_combo = QComboBox()
+        self.estimator_combo.setObjectName("estimator")
+        self.estimator_combo.addItems(tuple(ESTIMATORS))
+        form.addRow("Estimator:", self.estimator_combo)
+
+        layout.addLayout(form)
+
+        self.status_label = QLabel("")
+        self.status_label.setObjectName("status")
+        self.status_label.setWordWrap(True)
+        self.status_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        layout.addWidget(self.status_label)
+
+        self.buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        ok_btn = self.buttons.button(QDialogButtonBox.StandardButton.Ok)
+        if ok_btn is not None:
+            ok_btn.setText("Calibrate && Save")
+            ok_btn.setObjectName("calibrate_button")
+        self.buttons.accepted.connect(self._on_accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+
+        self._refresh_validity()
+
+    # ------------------------------------------------------------------ #
+    # Public API.                                                        #
+    # ------------------------------------------------------------------ #
+    @property
+    def result_record(self) -> CalibrationResult | None:
+        """The :class:`CalibrationResult` produced on accept, or ``None``."""
+        return self._result
+
+    def current_form_values(self) -> dict[str, object]:
+        """Return the current form state as a plain dict (testing aid)."""
+        return {
+            "subject_id": self.id_edit.text().strip(),
+            "height_m": float(self.height_spin.value()),
+            "mass_kg": float(self.mass_spin.value()),
+            "age_years": int(self.age_spin.value()),
+            "sex": str(self.sex_combo.currentData() or self.sex_combo.currentText()),
+            "estimator": self.estimator_combo.currentText(),
+        }
+
+    # ------------------------------------------------------------------ #
+    # Internals.                                                         #
+    # ------------------------------------------------------------------ #
+    def _refresh_validity(self) -> None:
+        """Enable/disable OK based on a non-empty subject id."""
+        ok_btn = self.buttons.button(QDialogButtonBox.StandardButton.Ok)
+        if ok_btn is None:
+            return
+        valid = bool(self.id_edit.text().strip())
+        ok_btn.setEnabled(valid)
+        if not valid:
+            self.status_label.setText("Subject ID is required.")
+        else:
+            self.status_label.setText("")
+
+    def _on_accept(self) -> None:
+        values = self.current_form_values()
+        try:
+            record = build_subject_record(
+                subject_id=str(values["subject_id"]),
+                height_m=float(values["height_m"]),  # type: ignore[arg-type]
+                mass_kg=float(values["mass_kg"]),  # type: ignore[arg-type]
+                age_years=int(values["age_years"]),  # type: ignore[arg-type]
+                sex=str(values["sex"]),
+                estimator=str(values["estimator"]),
+            )
+        except (ValueError, TypeError) as exc:
+            logger.warning("Calibration validation failed: %s", exc)
+            self.status_label.setText(f"Invalid input: {exc}")
+            return
+
+        try:
+            saved_path = self._persist(record)
+        except OSError as exc:
+            logger.exception("Failed to persist subject record")
+            self.status_label.setText(f"Could not save subject: {exc}")
+            return
+
+        self._result = CalibrationResult(record=record, saved_path=saved_path)
+        self.calibrated.emit(record)
+        self.accept()
+
+    def _persist(self, record: SubjectAnthropometrics) -> Path:
+        """Write *record* to ``<subjects_dir>/<subject_id>.json``."""
+        target_dir = Path(self._subjects_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        out_path = target_dir / f"{record.subject_id}.json"
+        save_subject(record, out_path)
+        return out_path
+
+
+__all__ = [
+    "CalibrationDialog",
+    "CalibrationResult",
+    "ESTIMATORS",
+    "SEX_VALUES",
+    "build_subject_record",
+]

--- a/tests/unit/tools/starting_pose_matcher/test_calibration_dialog.py
+++ b/tests/unit/tools/starting_pose_matcher/test_calibration_dialog.py
@@ -1,0 +1,274 @@
+"""Headless pytest-qt tests for the calibration dialog (issue #4820)."""
+
+from __future__ import annotations
+
+import os
+
+# Headless Qt platform must be set before any PyQt6 import.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+if "PySide6" in sys.modules:
+    pytest.skip(
+        "PySide6 already loaded — PyQt6 DLLs unavailable", allow_module_level=True
+    )
+
+try:
+    from PyQt6.QtWidgets import QApplication, QDialogButtonBox  # noqa: F401
+
+    _HAVE_QT = True
+except Exception:  # noqa: BLE001
+    _HAVE_QT = False
+
+if not _HAVE_QT:  # pragma: no cover
+    pytest.skip("PyQt6.QtWidgets unavailable", allow_module_level=True)
+
+
+from PyQt6.QtWidgets import QApplication, QDialog, QDialogButtonBox  # noqa: E402
+
+from src.shared.python.anthropometrics._subject_anthropometrics import (  # noqa: E402
+    SubjectAnthropometrics,
+)
+from src.tools.starting_pose_matcher.widgets.calibration_dialog import (  # noqa: E402
+    ESTIMATORS,
+    SEX_VALUES,
+    CalibrationDialog,
+    build_subject_record,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    return app  # type: ignore[return-value]
+
+
+@pytest.fixture
+def dialog(qapp: QApplication, tmp_path: Path) -> CalibrationDialog:
+    dlg = CalibrationDialog(subjects_dir=tmp_path, default_subject_id="test_subj")
+    yield dlg
+    dlg.deleteLater()
+
+
+# --------------------------------------------------------------------- #
+# Construction & form state                                             #
+# --------------------------------------------------------------------- #
+def test_dialog_constructs_with_expected_widgets(dialog: CalibrationDialog) -> None:
+    assert dialog.windowTitle() == "Subject Anthropometrics Calibration"
+    assert dialog.isModal()
+    values = dialog.current_form_values()
+    assert set(values) == {
+        "subject_id",
+        "height_m",
+        "mass_kg",
+        "age_years",
+        "sex",
+        "estimator",
+    }
+
+
+def test_default_form_values_are_in_range(dialog: CalibrationDialog) -> None:
+    values = dialog.current_form_values()
+    assert 0.5 <= values["height_m"] <= 2.5  # type: ignore[operator]
+    assert 10.0 <= values["mass_kg"] <= 250.0  # type: ignore[operator]
+    assert 1 <= values["age_years"] <= 120  # type: ignore[operator]
+    assert values["sex"] in SEX_VALUES
+    assert values["estimator"] in ESTIMATORS
+
+
+def test_estimator_combo_lists_all_three(dialog: CalibrationDialog) -> None:
+    items = [
+        dialog.estimator_combo.itemText(i)
+        for i in range(dialog.estimator_combo.count())
+    ]
+    assert set(items) == {"de_leva", "dempster", "zatsiorsky"}
+
+
+def test_sex_combo_lists_all_options(dialog: CalibrationDialog) -> None:
+    data = [dialog.sex_combo.itemData(i) for i in range(dialog.sex_combo.count())]
+    assert set(data) == set(SEX_VALUES)
+
+
+# --------------------------------------------------------------------- #
+# Validation (boundary)                                                 #
+# --------------------------------------------------------------------- #
+def test_empty_subject_id_disables_ok(dialog: CalibrationDialog) -> None:
+    dialog.id_edit.setText("   ")
+    ok_btn = dialog.buttons.button(QDialogButtonBox.StandardButton.Ok)
+    assert ok_btn is not None
+    assert not ok_btn.isEnabled()
+    assert "required" in dialog.status_label.text().lower()
+
+
+def test_non_empty_subject_id_enables_ok(dialog: CalibrationDialog) -> None:
+    dialog.id_edit.setText("subject_42")
+    ok_btn = dialog.buttons.button(QDialogButtonBox.StandardButton.Ok)
+    assert ok_btn is not None
+    assert ok_btn.isEnabled()
+
+
+def test_build_subject_record_rejects_bad_height() -> None:
+    with pytest.raises(ValueError, match="height_m"):
+        build_subject_record(
+            subject_id="x",
+            height_m=10.0,  # absurd
+            mass_kg=70.0,
+            age_years=30,
+            sex="M",
+            estimator="de_leva",
+        )
+
+
+def test_build_subject_record_rejects_bad_mass() -> None:
+    with pytest.raises(ValueError, match="mass_kg"):
+        build_subject_record(
+            subject_id="x",
+            height_m=1.7,
+            mass_kg=5.0,
+            age_years=30,
+            sex="M",
+            estimator="de_leva",
+        )
+
+
+def test_build_subject_record_rejects_bad_age() -> None:
+    with pytest.raises(ValueError, match="age_years"):
+        build_subject_record(
+            subject_id="x",
+            height_m=1.7,
+            mass_kg=70.0,
+            age_years=0,
+            sex="M",
+            estimator="de_leva",
+        )
+
+
+def test_build_subject_record_rejects_bad_sex() -> None:
+    with pytest.raises(ValueError, match="sex"):
+        build_subject_record(
+            subject_id="x",
+            height_m=1.7,
+            mass_kg=70.0,
+            age_years=30,
+            sex="other",
+            estimator="de_leva",
+        )
+
+
+def test_build_subject_record_rejects_bad_estimator() -> None:
+    with pytest.raises(ValueError, match="estimator"):
+        build_subject_record(
+            subject_id="x",
+            height_m=1.7,
+            mass_kg=70.0,
+            age_years=30,
+            sex="M",
+            estimator="bogus",
+        )
+
+
+def test_build_subject_record_rejects_empty_subject_id() -> None:
+    with pytest.raises(ValueError, match="subject_id"):
+        build_subject_record(
+            subject_id="   ",
+            height_m=1.7,
+            mass_kg=70.0,
+            age_years=30,
+            sex="M",
+            estimator="de_leva",
+        )
+
+
+# --------------------------------------------------------------------- #
+# Pure helper                                                           #
+# --------------------------------------------------------------------- #
+def test_build_subject_record_returns_subject_anthropometrics() -> None:
+    record = build_subject_record(
+        subject_id="alice",
+        height_m=1.70,
+        mass_kg=65.0,
+        age_years=28,
+        sex="F",
+        estimator="de_leva",
+    )
+    assert isinstance(record, SubjectAnthropometrics)
+    assert record.subject_id == "alice"
+    assert record.height_m == pytest.approx(1.70)
+    assert record.mass_kg == pytest.approx(65.0)
+
+
+@pytest.mark.parametrize("estimator", list(ESTIMATORS))
+def test_each_estimator_produces_valid_record(estimator: str) -> None:
+    record = build_subject_record(
+        subject_id=f"s_{estimator}",
+        height_m=1.78,
+        mass_kg=75.0,
+        age_years=30,
+        sex="M",
+        estimator=estimator,
+    )
+    assert isinstance(record, SubjectAnthropometrics)
+    assert record.subject_id == f"s_{estimator}"
+    assert len(record.segments) > 0
+
+
+# --------------------------------------------------------------------- #
+# Accept flow / persistence                                             #
+# --------------------------------------------------------------------- #
+def test_accept_persists_subject_json(
+    dialog: CalibrationDialog, tmp_path: Path
+) -> None:
+    captured: list[object] = []
+    dialog.calibrated.connect(captured.append)
+
+    dialog.id_edit.setText("alpha")
+    dialog.height_spin.setValue(1.80)
+    dialog.mass_spin.setValue(80.0)
+    dialog.age_spin.setValue(35)
+    dialog.sex_combo.setCurrentIndex(dialog.sex_combo.findData("M"))
+    dialog.estimator_combo.setCurrentText("dempster")
+
+    dialog._on_accept()
+
+    assert dialog.result() == int(QDialog.DialogCode.Accepted)
+    res = dialog.result_record
+    assert res is not None
+    assert res.saved_path == tmp_path / "alpha.json"
+    assert res.saved_path.exists()
+    payload = json.loads(res.saved_path.read_text())
+    assert payload["subject_id"] == "alpha"
+    assert len(captured) == 1
+
+
+def test_accept_with_invalid_subject_id_does_not_emit(
+    dialog: CalibrationDialog,
+) -> None:
+    captured: list[object] = []
+    dialog.calibrated.connect(captured.append)
+    dialog.id_edit.setText("")
+    dialog._on_accept()
+    # Should not have closed/accepted; status reports the error.
+    assert dialog.result_record is None
+    assert captured == []
+    assert dialog.status_label.text() != ""
+
+
+def test_persist_creates_subjects_dir_if_missing(
+    qapp: QApplication, tmp_path: Path
+) -> None:
+    nested = tmp_path / "nested" / "deeper"
+    assert not nested.exists()
+    dlg = CalibrationDialog(subjects_dir=nested, default_subject_id="bob")
+    try:
+        dlg._on_accept()
+        assert nested.exists()
+        assert (nested / "bob.json").exists()
+    finally:
+        dlg.deleteLater()


### PR DESCRIPTION
## Summary
- Adds a modal `CalibrationDialog` (`src/tools/starting_pose_matcher/widgets/calibration_dialog.py`) that gathers subject height/mass/age/sex, lets the user pick an estimator (de Leva / Dempster / Zatsiorsky), builds a `SubjectAnthropometrics`, and persists it via `save_subject` to `~/.golf_modeling_suite/subjects/<id>.json`.
- Wires the dialog into the matcher GUI's Output panel via a "Calibrate subject..." button, with a status label that reports the resulting subject id and saved JSON path.
- DbC validation lives at the dialog boundary (`build_subject_record`); biomechanical math is delegated to the existing estimators (DRY/LoD).

## Test plan
- [x] 19 pytest-qt tests under `QT_QPA_PLATFORM=offscreen` covering construction, default form state, combo population, OK-enable/disable, every validation rejection path, signal emission, JSON persistence, parent-dir creation, and per-estimator record generation
- [x] `python -m ruff check` — zero violations
- [x] `python -m ruff format --check` — clean

Closes #4820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)