### PR TITLE
test(plot_style): integration tier — golden hashes + perf budget + properties (#4814)

### DIFF
--- a/tests/fixtures/plot_style/snapshot_hashes.json
+++ b/tests/fixtures/plot_style/snapshot_hashes.json
@@ -1,0 +1,14 @@
+{
+  "colormap::coolwarm": "0a8546a00f8e0a34e34d45a01411355ca044ed6335f18ce61a541fd9a64eccd6",
+  "colormap::plasma": "467c1c8a59f6ec8e5d27fc929c2878a462c472f14f0e98a1604347a2cb9f632a",
+  "colormap::turbo": "8a0acb3bbcc62cba5e6a0ee50245230905bd96073cd79286cb39634ddd448502",
+  "colormap::velocity": "467c1c8a59f6ec8e5d27fc929c2878a462c472f14f0e98a1604347a2cb9f632a",
+  "colormap::viridis": "f4ebccbb9a00176c49919136400c7533d4f038c9177458f20f376b139b9abde6",
+  "shape_static::cross": "e9571fcf3674b0f3470664d32a486b747f4823bfc73a2cb70860291bcc007df2",
+  "shape_static::cube": "43dfdd23a8277ec1614044019434f3945d81ef6bd541f1a99f6abe5258af7a42",
+  "shape_static::diamond": "d0daa2559a8fa8199064a8e4277fa39cfc53a8256f0d68c968a265e088bf2473",
+  "shape_static::plus": "eceeb065e87ad6fb213c466a65e2460b912802984a0d01638acc695de1494f2a",
+  "shape_static::point": "8161268225a2ec7c099c84338aaa90b3a95aaaddb87ca9e87dee270887aeefc2",
+  "shape_static::sphere": "bf687a0a84c0bbdc5c4c3414cbd024c68d9034b2c150c0d1802439adc5d9b186",
+  "shape_static::star": "25045f0a422bd128e75b178eb836e62ff1e8b6c5310f12b46bbb8b6c7f6467e6"
+}

--- a/tests/integration/plot_style/test_perf_budget.py
+++ b/tests/integration/plot_style/test_perf_budget.py
@@ -1,0 +1,82 @@
+"""Performance budget regression for the plot_style matplotlib renderer.
+
+100-marker scene must update at >= 30 fps mean (33 ms / frame).
+
+Skipped if matplotlib is unavailable. Marked ``slow`` so it does not run
+in default fast CI.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
+np = pytest.importorskip("numpy")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from src.shared.python.plot_style import (  # noqa: E402
+    MarkerShape,
+    MarkerStyle,
+    MatplotlibMarkerRenderer,
+    StaticColor,
+)
+
+N_MARKERS = 100
+N_FRAMES = 60
+SCALE = float(os.environ.get("PLOT_STYLE_PERF_BUDGET_SCALE", "1.0"))
+BUDGET_MS = 33.0 * SCALE  # 30 fps
+SEED = 4814
+
+
+def _trajectory(n_markers: int, n_frames: int) -> np.ndarray:
+    """Deterministic ``(T, M, 2)`` trajectory."""
+    rng = np.random.default_rng(SEED)
+    base = rng.uniform(-1.0, 1.0, size=(n_markers, 2))
+    t = np.linspace(0.0, 2.0 * np.pi, n_frames)
+    out = np.empty((n_frames, n_markers, 2), dtype=np.float64)
+    for f in range(n_frames):
+        out[f, :, 0] = base[:, 0] + 0.05 * np.cos(t[f])
+        out[f, :, 1] = base[:, 1] + 0.05 * np.sin(t[f])
+    return out
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perf_100_markers_30fps() -> None:
+    fig = plt.figure(figsize=(3.0, 3.0), dpi=80)
+    try:
+        ax = fig.add_subplot(111)
+        ax.set_xlim(-1.5, 1.5)
+        ax.set_ylim(-1.5, 1.5)
+        renderer = MatplotlibMarkerRenderer(ax)
+        style = MarkerStyle(
+            shape=MarkerShape.SPHERE,
+            size_px=6.0,
+            fill_color=StaticColor("#1f77b4"),
+        )
+        positions = _trajectory(N_MARKERS, N_FRAMES)
+        handle = renderer.add_markers(positions, style)
+
+        # Warm-up.
+        for _ in range(3):
+            renderer.update_frame(handle, 0)
+
+        start = time.perf_counter()
+        for f in range(N_FRAMES):
+            renderer.update_frame(handle, f)
+        elapsed = time.perf_counter() - start
+        mean_ms = (elapsed / N_FRAMES) * 1000.0
+
+        assert mean_ms <= BUDGET_MS, (
+            f"100 markers mean per-frame {mean_ms:.2f} ms exceeds "
+            f"{BUDGET_MS:.2f} ms budget (30 fps)"
+        )
+    finally:
+        plt.close(fig)

--- a/tests/integration/plot_style/test_property_color_resolution.py
+++ b/tests/integration/plot_style/test_property_color_resolution.py
@@ -1,0 +1,132 @@
+"""Hypothesis property tests for plot_style color resolution.
+
+Asserts that for any valid input combination, every color resolver
+(StaticColor / PaletteColor / DataDrivenColor) returns an RGBA tuple of
+4 floats in ``[0, 1]`` and that downstream conversion to a 7-char hex
+string ``#RRGGBB`` succeeds.
+
+Skipped cleanly if hypothesis or matplotlib is unavailable. Each test
+caps at 50 examples to stay under the 30 s fast-test budget.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+matplotlib = pytest.importorskip("matplotlib")
+np = pytest.importorskip("numpy")
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from src.shared.python.plot_style import (  # noqa: E402
+    ColormapId,
+    DataChannel,
+    DataDrivenColor,
+    PaletteColor,
+    StaticColor,
+)
+
+HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+MAX_EXAMPLES = 50
+
+_VALID_HEX_STRATEGY = st.from_regex(r"^#[0-9a-f]{6}$", fullmatch=True)
+_PALETTE_NAMES = ["tab10", "tab20", "Set1", "Set2", "Set3", "Paired", "Dark2"]
+# NOTE: ColormapId.SPECTRAL is excluded — its enum value ``"spectral"``
+# does not match matplotlib's case-sensitive ``"Spectral"`` registration
+# (a pre-existing plot_style issue tracked separately; out of scope here).
+_COLORMAP_IDS = [c for c in ColormapId if c is not ColormapId.SPECTRAL]
+
+
+def _rgba_to_hex(rgba: tuple[float, float, float, float]) -> str:
+    r, g, b, _a = rgba
+    ri = int(round(r * 255.0))
+    gi = int(round(g * 255.0))
+    bi = int(round(b * 255.0))
+    return f"#{ri:02x}{gi:02x}{bi:02x}"
+
+
+def _assert_valid_rgba(rgba: object) -> None:
+    assert isinstance(rgba, tuple) and len(rgba) == 4
+    for c in rgba:
+        assert isinstance(c, float)
+        assert 0.0 <= c <= 1.0
+
+
+@given(hex_value=_VALID_HEX_STRATEGY, frame=st.integers(0, 1000))
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+def test_static_color_round_trips_to_hex(hex_value: str, frame: int) -> None:
+    rgba = StaticColor(hex_value).resolve(frame, 0)
+    _assert_valid_rgba(rgba)
+    hex_out = _rgba_to_hex(rgba)
+    assert HEX_RE.match(hex_out), hex_out
+
+
+@given(
+    palette_name=st.sampled_from(_PALETTE_NAMES),
+    palette_index=st.integers(0, 256),
+    frame=st.integers(0, 1000),
+    marker=st.integers(0, 100),
+)
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+def test_palette_color_returns_valid_hex(
+    palette_name: str, palette_index: int, frame: int, marker: int
+) -> None:
+    rgba = PaletteColor(palette_name, palette_index).resolve(frame, marker)
+    _assert_valid_rgba(rgba)
+    assert HEX_RE.match(_rgba_to_hex(rgba))
+
+
+@given(
+    cmap=st.sampled_from(_COLORMAP_IDS),
+    raw=st.lists(
+        st.floats(min_value=-100.0, max_value=100.0, allow_nan=False),
+        min_size=1,
+        max_size=16,
+    ),
+    frame=st.integers(0, 1000),
+)
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+def test_data_driven_color_returns_valid_hex(
+    cmap: ColormapId, raw: list[float], frame: int
+) -> None:
+    values = np.asarray(raw, dtype=np.float64).reshape(1, -1)
+    channel = DataChannel(name="ch", values=values)
+    lo = float(values.min())
+    hi = float(values.max())
+    if hi <= lo:
+        hi = lo + 1.0
+    color = DataDrivenColor(channel=channel, colormap=cmap, vmin=lo, vmax=hi)
+    rgba = color.resolve(frame, 0)
+    _assert_valid_rgba(rgba)
+    assert HEX_RE.match(_rgba_to_hex(rgba))
+
+
+@given(
+    cmap=st.sampled_from(_COLORMAP_IDS),
+    raw=st.lists(
+        st.one_of(
+            st.floats(min_value=-10.0, max_value=10.0, allow_nan=False),
+            st.just(float("nan")),
+            st.just(float("inf")),
+            st.just(float("-inf")),
+        ),
+        min_size=1,
+        max_size=8,
+    ),
+    nan_color=_VALID_HEX_STRATEGY,
+)
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+def test_data_driven_handles_non_finite(
+    cmap: ColormapId, raw: list[float], nan_color: str
+) -> None:
+    """Non-finite or degenerate inputs must still produce a valid hex."""
+    values = np.asarray(raw, dtype=np.float64).reshape(1, -1)
+    channel = DataChannel(name="ch", values=values)
+    color = DataDrivenColor(channel=channel, colormap=cmap, nan_color=nan_color)
+    rgba = color.resolve(0, 0)
+    _assert_valid_rgba(rgba)
+    assert HEX_RE.match(_rgba_to_hex(rgba))

--- a/tests/integration/plot_style/test_renderer_snapshots.py
+++ b/tests/integration/plot_style/test_renderer_snapshots.py
@@ -1,0 +1,174 @@
+"""Golden hash snapshot tests for the plot_style matplotlib renderer.
+
+Each combination of (built-in MarkerShape) x (ColormapId variant) is
+rendered to an RGBA buffer at fixed DPI/size on the headless ``Agg``
+backend, the buffer is hashed (sha256), and the hash is compared against
+``tests/fixtures/plot_style/snapshot_hashes.json``.
+
+Set ``PLOT_STYLE_REGEN_GOLDENS=1`` to overwrite the committed hashes.
+
+Skipped cleanly if matplotlib is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
+np = pytest.importorskip("numpy")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from src.shared.python.plot_style import (  # noqa: E402
+    ColormapId,
+    DataChannel,
+    DataDrivenColor,
+    MarkerShape,
+    MarkerStyle,
+    MatplotlibMarkerRenderer,
+    StaticColor,
+)
+
+SNAPSHOT_DPI = 80
+SNAPSHOT_FIGSIZE = (3.0, 3.0)
+N_MARKERS = 12
+SEED = 4814
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "plot_style"
+HASHES_PATH = FIXTURES_DIR / "snapshot_hashes.json"
+REGEN = os.environ.get("PLOT_STYLE_REGEN_GOLDENS", "").strip() not in (
+    "",
+    "0",
+    "false",
+    "False",
+)
+
+# Subset that maps cleanly to matplotlib glyphs (CUSTOM_MESH excluded:
+# requires a CustomMeshSpec and is exercised in unit tests).
+_BUILTIN_SHAPES = [
+    MarkerShape.SPHERE,
+    MarkerShape.CUBE,
+    MarkerShape.CROSS,
+    MarkerShape.STAR,
+    MarkerShape.DIAMOND,
+    MarkerShape.PLUS,
+    MarkerShape.POINT,
+]
+
+_COLORMAPS = [
+    ColormapId.VIRIDIS,
+    ColormapId.PLASMA,
+    ColormapId.TURBO,
+    ColormapId.COOLWARM,
+    ColormapId.VELOCITY,  # semantic alias
+]
+
+
+def _deterministic_positions(n: int) -> np.ndarray:
+    rng = np.random.default_rng(SEED)
+    pts = rng.uniform(-1.0, 1.0, size=(n, 2))
+    return pts.astype(np.float64)
+
+
+def _channel_values(n: int) -> np.ndarray:
+    rng = np.random.default_rng(SEED + 1)
+    return rng.uniform(0.0, 1.0, size=(1, n)).astype(np.float64)
+
+
+def _hash_rgba(arr: np.ndarray) -> str:
+    h = hashlib.sha256()
+    h.update(np.ascontiguousarray(arr, dtype=np.uint8).tobytes())
+    h.update(str(arr.shape).encode("utf-8"))
+    return h.hexdigest()
+
+
+def _render_buffer(style: MarkerStyle) -> np.ndarray:
+    fig = plt.figure(figsize=SNAPSHOT_FIGSIZE, dpi=SNAPSHOT_DPI)
+    try:
+        ax = fig.add_subplot(111)
+        ax.set_xlim(-1.5, 1.5)
+        ax.set_ylim(-1.5, 1.5)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_axis_off()
+        renderer = MatplotlibMarkerRenderer(ax)
+        positions = _deterministic_positions(N_MARKERS)
+        renderer.add_markers(positions, style)
+        fig.canvas.draw()
+        w, h = fig.canvas.get_width_height()
+        buf = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)
+        return buf.reshape(int(h), int(w), 4).copy()
+    finally:
+        plt.close(fig)
+
+
+def _load_hashes() -> dict[str, str]:
+    if not HASHES_PATH.is_file():
+        return {}
+    return json.loads(HASHES_PATH.read_text(encoding="utf-8"))
+
+
+def _save_hashes(hashes: dict[str, str]) -> None:
+    HASHES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    HASHES_PATH.write_text(
+        json.dumps(dict(sorted(hashes.items())), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _compare_or_regen(key: str, digest: str) -> None:
+    hashes = _load_hashes()
+    if REGEN or key not in hashes:
+        hashes[key] = digest
+        _save_hashes(hashes)
+        if not REGEN:
+            pytest.skip(
+                f"Generated missing golden hash for {key!r} on first run; "
+                "rerun the test to compare."
+            )
+        return
+    expected = hashes[key]
+    assert digest == expected, (
+        f"snapshot {key!r} sha256 mismatch: got {digest!r}, expected {expected!r}"
+    )
+
+
+@pytest.mark.parametrize("shape", _BUILTIN_SHAPES, ids=lambda s: s.value)
+def test_shape_static_color_snapshot(shape: MarkerShape) -> None:
+    """Each built-in shape with a constant fill renders to a stable hash."""
+    style = MarkerStyle(
+        shape=shape,
+        size_px=10.0,
+        edge_color="#000000",
+        edge_width=0.5,
+        fill_color=StaticColor("#1f77b4"),
+        opacity=1.0,
+    )
+    buf = _render_buffer(style)
+    digest = _hash_rgba(buf)
+    _compare_or_regen(f"shape_static::{shape.value}", digest)
+
+
+@pytest.mark.parametrize("cmap", _COLORMAPS, ids=lambda c: c.value)
+def test_colormap_data_driven_snapshot(cmap: ColormapId) -> None:
+    """Each colormap, sampled by a deterministic channel, renders stably."""
+    channel = DataChannel(name="ch", values=_channel_values(N_MARKERS))
+    style = MarkerStyle(
+        shape=MarkerShape.SPHERE,
+        size_px=12.0,
+        edge_color="#000000",
+        edge_width=0.5,
+        fill_color=DataDrivenColor(channel=channel, colormap=cmap, vmin=0.0, vmax=1.0),
+        opacity=1.0,
+    )
+    buf = _render_buffer(style)
+    digest = _hash_rgba(buf)
+    _compare_or_regen(f"colormap::{cmap.value}", digest)


### PR DESCRIPTION
## Summary
- Adds the integration test tier for `plot_style` requested in #4814, mirroring what landed for `body_part_viz` (#4766).
- `tests/integration/plot_style/test_renderer_snapshots.py`: deterministic sha256 golden-hash snapshots per built-in `MarkerShape` and per `ColormapId`, comparing against `tests/fixtures/plot_style/snapshot_hashes.json`.
- `tests/integration/plot_style/test_perf_budget.py`: 100-marker x 60-frame matplotlib renderer must hold >= 30 fps mean (33 ms/frame, scalable via `PLOT_STYLE_PERF_BUDGET_SCALE`). Marked `slow` + `benchmark`.
- `tests/integration/plot_style/test_property_color_resolution.py`: hypothesis property tests over `StaticColor` / `PaletteColor` / `DataDrivenColor` (incl. NaN / +/-inf handling) capped at 50 examples each, asserting every valid input produces an RGBA tuple in `[0, 1]` that round-trips to a `#RRGGBB` string.

All tests skip cleanly when `matplotlib` / `hypothesis` are missing. Total 388 LOC under the 500-LOC budget; non-slow suite runs in ~2 s on a dev box.

`ColormapId.SPECTRAL` is excluded from the property strategy: its enum value `"spectral"` does not match matplotlib's case-sensitive `"Spectral"` registration. Pre-existing plot_style bug, out of scope for this issue.

## Test plan
- [x] `python3 -m pytest tests/integration/plot_style/` — 17 passed locally
- [x] `python3 -m ruff check tests/integration/plot_style/` clean
- [x] `python3 -m ruff format --check tests/integration/plot_style/` clean
- [ ] CI passes on PR
- [ ] Slow perf test passes under `-m slow`

Closes #4814

Generated with [Claude Code](https://claude.com/claude-code)