### PR TITLE
chore(reviews): bulk-address 6 review-feedback issues

### DIFF
--- a/src/api/task_manager.py
+++ b/src/api/task_manager.py
@@ -202,7 +202,13 @@ class TaskManager:
         with self._lock:
             self._ensure_open()
             self._cleanup_expired_locked()
-            return task_id in self._tasks
+            if task_id in self._tasks:
+                # Refresh the TTL on membership so dict-style polling
+                # (``id in tm``) keeps long-running tasks alive,
+                # consistent with ``exists()`` / ``get()``. See #4871.
+                self._timestamps[task_id] = time.time()
+                return True
+            return False
 
     def __getitem__(self, task_id: str) -> dict[str, Any]:
         with self._lock:

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_tab.py
@@ -241,7 +241,7 @@ class Viewer3DTab(QtWidgets.QWidget):
         # could not be built (e.g. missing markers, missing mesh file)
         # and should be skipped on frame updates.
         self._renderer: MatplotlibRenderer | None = None
-        self._render_entries: list[tuple[str | None, str]] = []
+        self._render_entries: list[tuple[str | None, str, np.ndarray | None]] = []
         self._shape_library: ShapeLibrary | None = None
 
         # Playback timer.
@@ -1038,7 +1038,7 @@ class Viewer3DTab(QtWidgets.QWidget):
         """
         return sum(
             1
-            for handle, kind in self._render_entries
+            for handle, kind, _valid in self._render_entries
             if handle is not None and kind != "line"
         )
 
@@ -1047,7 +1047,7 @@ class Viewer3DTab(QtWidgets.QWidget):
         """Number of line-shape user segments currently rendered."""
         return sum(
             1
-            for handle, kind in self._render_entries
+            for handle, kind, _valid in self._render_entries
             if handle is not None and kind == "line"
         )
 
@@ -1118,16 +1118,16 @@ class Viewer3DTab(QtWidgets.QWidget):
         for spec in self._user_viz_segments:
             shape = _build_shape_from_spec(spec, library=library)
             if shape is None:
-                self._render_entries.append((None, spec.shape_kind))
+                self._render_entries.append((None, spec.shape_kind, None))
                 continue
             markers_xyz = self._markers_xyz(spec.binding.marker_names)
             if markers_xyz is None:
-                self._render_entries.append((None, spec.shape_kind))
+                self._render_entries.append((None, spec.shape_kind, None))
                 continue
             try:
                 fitter = _fitter_for_kind(spec.fitter_kind)
             except ValueError:
-                self._render_entries.append((None, spec.shape_kind))
+                self._render_entries.append((None, spec.shape_kind, None))
                 continue
             try:
                 # Library-shape mesh has its own shape_id; rebind the binding
@@ -1150,7 +1150,7 @@ class Viewer3DTab(QtWidgets.QWidget):
                     spec.binding.marker_names,
                     exc,
                 )
-                self._render_entries.append((None, spec.shape_kind))
+                self._render_entries.append((None, spec.shape_kind, None))
                 continue
             theme = self._theme_for_spec(spec)
             try:
@@ -1159,11 +1159,15 @@ class Viewer3DTab(QtWidgets.QWidget):
                 _LOGGER.warning(
                     "renderer.add_shape failed for %s: %s", spec.shape_kind, exc
                 )
-                self._render_entries.append((None, spec.shape_kind))
+                self._render_entries.append((None, spec.shape_kind, None))
                 continue
             if not spec.visible:
                 self._renderer.set_visible(handle, False)
-            self._render_entries.append((handle, spec.shape_kind))
+            # Capture the per-frame valid mask so the per-frame update path
+            # can hide segments on invalid frames (e.g. NaN-filled occluded
+            # markers) instead of drawing them at the origin. See #4835.
+            valid_mask = getattr(fitted, "valid_mask", None)
+            self._render_entries.append((handle, spec.shape_kind, valid_mask))
 
     def _update_user_segment_artists(self) -> None:
         if self._renderer is None or not self._user_viz_segments or self._n_frames <= 0:
@@ -1174,12 +1178,19 @@ class Viewer3DTab(QtWidgets.QWidget):
         for entry, spec in zip(
             self._render_entries, self._user_viz_segments, strict=False
         ):
-            handle, _kind = entry
+            handle, _kind, valid_mask = entry
             if handle is None:
                 continue
+            # If the fitter flagged this frame invalid (e.g. occluded marker
+            # NaNs), hide the segment for the frame instead of drawing it at
+            # the origin via the NaN->0 coercion in the renderer (#4835).
+            frame_valid = True
+            if valid_mask is not None and 0 <= frame < len(valid_mask):
+                frame_valid = bool(valid_mask[frame])
+            visible = bool(spec.visible) and frame_valid
             try:
-                self._renderer.set_visible(handle, bool(spec.visible))
-                if spec.visible:
+                self._renderer.set_visible(handle, visible)
+                if visible:
                     self._renderer.update_frame(handle, frame)
             except (KeyError, IndexError, TypeError) as exc:
                 _LOGGER.warning("renderer.update_frame failed: %s", exc)

--- a/src/shared/python/body_part_viz/asset_library.py
+++ b/src/shared/python/body_part_viz/asset_library.py
@@ -15,6 +15,8 @@ Typical usage::
 from __future__ import annotations
 
 import json
+import os
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -29,13 +31,45 @@ _SCHEMA_VERSION = 1
 def _default_asset_root() -> Path:
     """Return the on-disk location of the bundled ``default/`` library.
 
-    The repo layout is::
+    Resolution order (first existing directory wins):
 
-        <repo-root>/assets/body_part_shapes/default/
-        <repo-root>/src/shared/python/body_part_viz/asset_library.py
+    1. ``UD_BODY_PART_SHAPES_DIR`` environment variable, if set.
+    2. ``importlib.resources`` lookup of ``body_part_viz._assets`` /
+       ``default`` (so installed wheels can ship the library as package
+       data without depending on a source checkout).
+    3. The repo source layout
+       ``<repo-root>/assets/body_part_shapes/default/`` — five parents
+       up from this file.
 
-    so we walk five parents up from this file.
+    See #4798: the previous implementation only handled (3), making
+    ``ShapeLibrary.default()`` fail from an installed wheel/sdist where
+    the repo-relative path does not exist.
     """
+    env_root = os.environ.get("UD_BODY_PART_SHAPES_DIR")
+    if env_root:
+        candidate = Path(env_root)
+        if candidate.is_dir():
+            return candidate
+
+    # Try a package-data location adjacent to this module. This succeeds
+    # whenever the assets are shipped as ``body_part_viz._assets`` (or
+    # ``body_part_viz.assets``) in the installed distribution.
+    for pkg_subdir in ("_assets", "assets"):
+        try:
+            traversable = resources.files(__package__).joinpath(pkg_subdir, "default")
+        except (ModuleNotFoundError, TypeError):
+            traversable = None
+        if traversable is not None:
+            try:
+                # Materialise a real filesystem path. For wheel-installed
+                # packages this returns the on-disk directory directly.
+                with resources.as_file(traversable) as resolved:
+                    if resolved.is_dir():
+                        return Path(resolved)
+            except (FileNotFoundError, OSError):
+                pass
+
+    # Final fallback: source-checkout layout.
     return (
         Path(__file__).resolve().parents[4] / "assets" / "body_part_shapes" / "default"
     )

--- a/src/shared/python/body_part_viz/persistence.py
+++ b/src/shared/python/body_part_viz/persistence.py
@@ -282,13 +282,21 @@ class SegmentVizSpec:
             raise TypeError(
                 f"shape_params must be a dict; got {type(shape_params).__name__}"
             )
+        # Strict-bool validation for ``visible`` (#4793). ``bool(...)`` would
+        # silently accept truthy non-bool payloads such as ``"false"``, so
+        # reject any non-bool here and preserve the dataclass' contract.
+        visible_raw = data.get("visible", True)
+        if not isinstance(visible_raw, bool):
+            raise TypeError(
+                f"'visible' must be a JSON boolean; got {type(visible_raw).__name__}"
+            )
         return cls(
             binding=binding,
             shape_kind=shape_kind,
             shape_params=dict(shape_params),
             fitter_kind=fitter_kind,
             theme=theme,
-            visible=bool(data.get("visible", True)),
+            visible=visible_raw,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/shared/python/plot_style/renderers/pyqtgl.py
+++ b/src/shared/python/plot_style/renderers/pyqtgl.py
@@ -113,8 +113,11 @@ def _resolve_color_from_style(style: MarkerStyle) -> tuple[float, float, float, 
 def _coerce_positions(positions: np.ndarray) -> np.ndarray:
     """Validate / normalise a positions ndarray to ``(T, M, 3)``.
 
-    Accepts ``(T, 3)`` (single marker per frame) and ``(M, 3)`` (single
-    frame). Returns a ``(T, M, 3)`` ``float32`` view.
+    Accepts ``(T, 3)`` (single-marker trajectory across ``T`` frames, as
+    documented by the :class:`MarkerRenderer` contract). Returns a
+    ``(T, M, 3)`` ``float32`` view; a 2-D ``(T, 3)`` input becomes
+    ``(T, 1, 3)`` so callers can still call ``update_frame`` for every
+    frame in the trajectory.
     """
     if not isinstance(positions, np.ndarray):
         raise TypeError(
@@ -123,10 +126,13 @@ def _coerce_positions(positions: np.ndarray) -> np.ndarray:
     if positions.ndim == 2:
         if positions.shape[1] != 3:
             raise ValueError(
-                f"2-D positions must have shape (N, 3); got {positions.shape}"
+                f"2-D positions must have shape (T, 3); got {positions.shape}"
             )
-        # Treat (N, 3) as 1 frame with N markers.
-        arr = positions.reshape(1, positions.shape[0], 3)
+        # Per the MarkerRenderer contract a 2-D (T, 3) input is a
+        # single-marker trajectory of length T, NOT a single frame with
+        # T markers. Reshape to (T, 1, 3) so update_frame(handle, t)
+        # works for every t in [0, T).
+        arr = positions.reshape(positions.shape[0], 1, 3)
     elif positions.ndim == 3:
         if positions.shape[2] != 3:
             raise ValueError(

--- a/tests/integration/anthropometrics/test_cross_engine_roundtrip.py
+++ b/tests/integration/anthropometrics/test_cross_engine_roundtrip.py
@@ -116,12 +116,36 @@ def test_json_persistence_round_trip(
 
 
 def _try_import_mjcf_pair():
-    """Return ``(write, read)`` for the MJCF adapter, or ``None`` if absent."""
+    """Return ``(write, read)`` for the MJCF adapter, or ``None`` if absent.
+
+    Only a *missing* adapter module returns ``None``. If the adapter module
+    exists but fails to import for some other reason (e.g. an internal import
+    typo or a missing dependency inside the adapter itself), the original
+    error propagates so the round-trip coverage cannot silently regress.
+    """
     try:
         writer_mod = importlib.import_module("anthropometrics.writers.mjcf_body")
+    except ModuleNotFoundError as exc:
+        # Only skip when *this* adapter module is the missing one. A
+        # ModuleNotFoundError raised from inside the adapter (i.e. its own
+        # imports) must surface as a real failure.
+        if exc.name in {
+            "anthropometrics.writers.mjcf_body",
+            "anthropometrics.writers",
+            "anthropometrics",
+        }:
+            return None
+        raise
+    try:
         reader_mod = importlib.import_module("anthropometrics.readers.mjcf_body")
-    except ModuleNotFoundError:
-        return None
+    except ModuleNotFoundError as exc:
+        if exc.name in {
+            "anthropometrics.readers.mjcf_body",
+            "anthropometrics.readers",
+            "anthropometrics",
+        }:
+            return None
+        raise
     write = getattr(writer_mod, "write_mjcf_body", None)
     read = getattr(reader_mod, "read_mjcf_body", None)
     if write is None or read is None:


### PR DESCRIPTION
## Summary

Bulk-addresses 6 chatgpt-codex-connector review-feedback issues in one focused PR. Each fix is small (5-30 LOC) and mechanical; tests on every touched file pass locally.

| Issue | Severity | File | Fix |
|-------|----------|------|-----|
| #4886 | P2 | tests/integration/anthropometrics/test_cross_engine_roundtrip.py | Only skip MJCF round-trip when the adapter module itself is absent; re-raise ModuleNotFoundError raised from inside the adapter so broken adapters can't silently lose coverage. |
| #4879 | P1 | src/shared/python/plot_style/renderers/pyqtgl.py | Preserve documented (T, 3) input as a single-marker trajectory of length T (reshape to (T, 1, 3)) instead of (1, T, 3), so update_frame works for every frame. |
| #4871 | P2 | src/api/task_manager.py | __contains__ now refreshes the per-task TTL on a hit, matching exists() / get() so dict-style polling (`id in tm`) keeps long-running tasks alive. |
| #4835 | P2 | src/engines/.../viewer_3d_tab.py | Stash the fitter's valid_mask per segment and hide segments on invalid frames during scrubbing instead of letting the renderer's NaN->0 coercion draw them at the origin. |
| #4798 | P1 | src/shared/python/body_part_viz/asset_library.py | _default_asset_root() resolves bundled assets via env override + importlib.resources package-data lookup before falling back to the source-checkout layout, so installed wheels can ship the assets. |
| #4793 | P2 | src/shared/python/body_part_viz/persistence.py | SegmentVizSpec.from_dict rejects non-bool `visible` payloads with TypeError instead of bool()-coercing them, preserving the dataclass' strict boolean contract. |

No issues were closed/skipped or deferred - all 6 were OPEN and small enough to land here.

## Test plan

- [x] pytest on all touched test files (124 passed, 2 skipped for missing pyqtgraph)
- [x] ruff check clean on changed scope
- [x] ruff format --check clean on changed scope

Closes #4886, #4879, #4871, #4835, #4798, #4793.