### PR TITLE
chore(reviews): bulk-address 4 review-feedback issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ gui-tools = [
 body-part-viz-gl = [
     "pyqtgraph>=0.13",
     "PyOpenGL>=3.1",
+    "matplotlib>=3.10.8",  # required by _hex_or_name_to_rgba in PyQtGLRenderer
 ]
 
 # Everything

--- a/src/shared/python/body_part_viz/_types.py
+++ b/src/shared/python/body_part_viz/_types.py
@@ -64,6 +64,15 @@ class FittedShape:
                     f"{name} must be a numpy.ndarray; got {type(arr).__name__}"
                 )
 
+        # Floating-dtype enforcement for numeric fields. The contract and type
+        # hints require floating arrays; integer/object dtypes silently
+        # propagate into geometry math and cause precision/backend bugs.
+        # See issue #4776.
+        for name in ("centroid", "rotation_matrix", "scale"):
+            arr = getattr(self, name)
+            if arr.dtype.kind != "f":
+                raise TypeError(f"{name} must have a floating dtype; got {arr.dtype}")
+
         if self.centroid.ndim != 2 or self.centroid.shape[1] != 3:
             raise ValueError(
                 f"centroid must have shape (T, 3); got {self.centroid.shape}"

--- a/src/shared/python/body_part_viz/bindings.py
+++ b/src/shared/python/body_part_viz/bindings.py
@@ -58,11 +58,22 @@ class MarkerBinding:
         if not isinstance(self.kind, BindingKind):
             raise TypeError(f"kind must be BindingKind, got {type(self.kind).__name__}")
 
+        # Reject plain strings explicitly: a bare string is iterable and would
+        # otherwise be silently treated as a sequence of single-character
+        # marker names (e.g. "ab" -> ("a", "b")). See issue #4775.
+        if isinstance(self.marker_names, str):
+            raise TypeError("marker_names must be a tuple of strings, not a single str")
+        # Normalize sequence-like inputs (e.g. list) to an immutable tuple so
+        # callers cannot mutate the original after construction.
         if not isinstance(self.marker_names, tuple):
-            raise TypeError(
-                "marker_names must be a tuple of strings, "
-                f"got {type(self.marker_names).__name__}"
-            )
+            try:
+                normalized = tuple(self.marker_names)
+            except TypeError as exc:
+                raise TypeError(
+                    "marker_names must be a tuple of strings, "
+                    f"got {type(self.marker_names).__name__}"
+                ) from exc
+            object.__setattr__(self, "marker_names", normalized)
 
         for name in self.marker_names:
             if not isinstance(name, str) or not name:

--- a/src/shared/python/body_part_viz/renderers/pyqtgl_renderer.py
+++ b/src/shared/python/body_part_viz/renderers/pyqtgl_renderer.py
@@ -66,7 +66,7 @@ def _hex_or_name_to_rgba(
 class _ShapeEntry:
     """Internal bookkeeping for one shape registered with the renderer."""
 
-    __slots__ = ("shape", "fitted", "theme", "item", "is_line")
+    __slots__ = ("shape", "fitted", "theme", "item", "is_line", "user_visible")
 
     def __init__(
         self,
@@ -81,6 +81,10 @@ class _ShapeEntry:
         self.theme = theme
         self.item = item
         self.is_line = is_line
+        # User-controlled visibility — preserved across update_frame() calls so
+        # an explicit set_visible(handle, False) is not overridden by the next
+        # valid frame. See issue #4784.
+        self.user_visible = True
 
 
 class PyQtGLRenderer:
@@ -191,7 +195,11 @@ class PyQtGLRenderer:
         if not np.all(np.isfinite(verts)):
             entry.item.setVisible(False)
             return
-        entry.item.setVisible(True)
+        # Respect user-controlled visibility: if set_visible(handle, False)
+        # was called, do not silently re-show on the next valid frame.
+        entry.item.setVisible(entry.user_visible)
+        if not entry.user_visible:
+            return
 
         if entry.is_line:
             entry.item.setData(pos=verts)
@@ -205,6 +213,7 @@ class PyQtGLRenderer:
             raise KeyError(f"Unknown handle: {handle!r}")
         if not isinstance(visible, bool):
             raise TypeError(f"visible must be bool; got {type(visible).__name__}")
+        entry.user_visible = visible
         entry.item.setVisible(visible)
 
     def remove(self, handle: str) -> None:

--- a/tests/unit/body_part_viz/test_contracts.py
+++ b/tests/unit/body_part_viz/test_contracts.py
@@ -115,9 +115,27 @@ def test_marker_binding_kind_wrong_type_raises() -> None:
         MarkerBinding(kind="between_two", marker_names=("a", "b"))  # type: ignore[arg-type]
 
 
-def test_marker_binding_marker_names_not_tuple_raises() -> None:
+def test_marker_binding_marker_names_list_normalized_to_tuple() -> None:
+    # Lists are accepted but normalized to an immutable tuple so the caller
+    # cannot mutate the binding after construction (issue #4775).
+    src = ["a", "b"]
+    binding = MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=src)  # type: ignore[arg-type]
+    assert isinstance(binding.marker_names, tuple)
+    assert binding.marker_names == ("a", "b")
+    src.append("c")
+    assert binding.marker_names == ("a", "b")
+
+
+def test_marker_binding_marker_names_str_raises() -> None:
+    # A bare string would otherwise be silently treated as a sequence of
+    # single-character marker names (issue #4775).
     with pytest.raises(TypeError, match="marker_names"):
-        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=["a", "b"])  # type: ignore[arg-type]
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names="ab")  # type: ignore[arg-type]
+
+
+def test_marker_binding_marker_names_non_iterable_raises() -> None:
+    with pytest.raises(TypeError, match="marker_names"):
+        MarkerBinding(kind=BindingKind.BETWEEN_TWO, marker_names=42)  # type: ignore[arg-type]
 
 
 def test_marker_binding_empty_marker_name_raises() -> None:


### PR DESCRIPTION
## Summary

Bulk addresses 4 review-feedback issues from chatgpt-codex-connector with small mechanical fixes.

- **#4775** — `bindings.py`: Reject plain-string `marker_names`; normalize sequence inputs to an immutable tuple so the frozen `MarkerBinding` cannot be mutated after construction.
- **#4776** — `_types.py`: Enforce floating dtype on `FittedShape.centroid` / `rotation_matrix` / `scale` so integer/object arrays cannot propagate into geometry math.
- **#4783** — `pyproject.toml`: Add `matplotlib` to the `body-part-viz-gl` extra so `PyQtGLRenderer.add_shape()` (via `_hex_or_name_to_rgba`) works without `gui-tools`/`dev`.
- **#4784** — `pyqtgl_renderer.py`: Track user-controlled visibility on `_ShapeEntry` so `set_visible(handle, False)` survives subsequent `update_frame()` calls.

**Deferred:** #4791 references a file from PR #4785, which was closed without merge — nothing to fix on `main`.

Closes #4784, #4783, #4776, #4775.

## Test plan

- [x] `python3 -m ruff check` and `ruff format --check` clean on changed files
- [x] `pytest tests/unit/body_part_viz` — 298 passed, 1 skipped (pyqtgraph not installed locally)
- [x] Replaced obsolete `marker_names_not_tuple_raises` test with three tests covering the new normalize/reject contract
- [ ] CI: ruff + full pytest