### PR TITLE
feat(starting-pose-matcher): Run-fit QThread (#4707 slice 2)

### DIFF
--- a/src/tools/starting_pose_matcher/gui.py
+++ b/src/tools/starting_pose_matcher/gui.py
@@ -1282,22 +1282,34 @@ class StartingPoseMatcher(QMainWindow):
         v.addWidget(self.cb_fit_scale)
 
         # Engine selector — populated live from the canonical fit_swing
-        # provider registry (#4707 slice 1/3). The Run-fit QThread (slice 2)
-        # and Save-fit serialization (slice 3) are intentionally NOT wired
-        # here; this combo only exposes the user's engine choice.
-        # TODO(#4707 slice 2/3): wire `selected_engine` into a Run-fit
-        # QThread that calls provider_registry.get_provider(...).fit_swing
-        # and then into the save-fit JSON payload.
+        # provider registry (#4707 slice 1/3). The Run-fit QThread is
+        # wired below (slice 2/3). Save-fit JSON serialization is the
+        # remaining follow-up (slice 3/3).
+        # TODO(#4707 slice 3/3): persist `RunFitButton.last_result` into
+        # the save-fit JSON payload.
         engine_row = QHBoxLayout()
         engine_row.addWidget(QLabel("Fit engine:"))
         self.combo_fit_engine = QComboBox()
         self.combo_fit_engine.setToolTip(
-            "Physics engine used by the (upcoming) Run-fit action. "
+            "Physics engine used by the Run-fit action. "
             "Populated live from motion_matching.provider_registry."
         )
         self._populate_engine_combo()
+        self.combo_fit_engine.currentTextChanged.connect(self._on_fit_engine_changed)
         engine_row.addWidget(self.combo_fit_engine, stretch=1)
         v.addLayout(engine_row)
+
+        # Run-fit QThread widget — slice 2/3 of #4707.
+        from src.tools.starting_pose_matcher.widgets.run_fit_button import (
+            RunFitButton,
+        )
+
+        self.run_fit_button = RunFitButton(self)
+        self.run_fit_button.set_inputs(
+            target=self._live_body_target,
+            engine_name=self.combo_fit_engine.currentText(),
+        )
+        v.addWidget(self.run_fit_button)
 
         # One snap button per pose-slot
         for key, slot in self.poses.items():
@@ -1340,6 +1352,14 @@ class StartingPoseMatcher(QMainWindow):
                 combo.setCurrentText(default)
         finally:
             combo.blockSignals(False)
+
+    def _on_fit_engine_changed(self, engine_name: str) -> None:
+        """Forward combo selection to the run-fit widget (#4707 slice 2)."""
+        if hasattr(self, "run_fit_button"):
+            self.run_fit_button.set_inputs(
+                target=self._live_body_target,
+                engine_name=engine_name,
+            )
 
     @property
     def selected_engine(self) -> str:
@@ -1610,6 +1630,11 @@ class StartingPoseMatcher(QMainWindow):
             return
 
         self._live_body_target = body
+        if hasattr(self, "run_fit_button"):
+            self.run_fit_button.set_inputs(
+                target=body,
+                engine_name=self.combo_fit_engine.currentText(),
+            )
         n = int(body.marker_xyz.shape[0])
         m = int(body.marker_xyz.shape[1])
         self.lbl_c3d_body.setText(

--- a/src/tools/starting_pose_matcher/widgets/__init__.py
+++ b/src/tools/starting_pose_matcher/widgets/__init__.py
@@ -17,12 +17,15 @@ from .joint_slider_panel import (
     PoseState,
     JointSliderPanel,
 )
+from .run_fit_button import FitWorker, RunFitButton
 
 __all__ = [
     "CalibrationDialog",
     "CalibrationResult",
     "DEFAULT_JOINT_COORDS",
+    "FitWorker",
     "JointSliderPanel",
     "PoseState",
+    "RunFitButton",
     "build_subject_record",
 ]

--- a/src/tools/starting_pose_matcher/widgets/run_fit_button.py
+++ b/src/tools/starting_pose_matcher/widgets/run_fit_button.py
@@ -1,0 +1,178 @@
+"""Run-fit button + QThread worker for the starting-pose matcher.
+
+Slice 2/3 of issue #4707. Encapsulates a "Run fit" button, a Cancel
+button, a status label, and a :class:`QThread` worker that calls
+``provider_registry.get_provider(engine).fit_swing(target)`` off the
+GUI thread. Slice 3 (save-fit JSON) consumes :pyattr:`RunFitButton.last_result`.
+
+Design: DRY (delegates to ``provider_registry``), DbC (validates inputs
+before spawning the thread), LoD (callers use the public signals/methods
+only).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
+from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from src.shared.python.motion_matching import provider_registry
+
+__all__ = ["FitWorker", "RunFitButton"]
+
+
+class FitWorker(QObject):
+    """QObject worker that runs ``provider.fit_swing`` off the GUI thread."""
+
+    progress = pyqtSignal(str)
+    finished = pyqtSignal(object)
+    failed = pyqtSignal(str)
+    cancelled = pyqtSignal()
+
+    def __init__(self, engine_name: str, target: Any) -> None:
+        super().__init__()
+        if not isinstance(engine_name, str) or not engine_name:
+            raise ValueError("engine_name must be a non-empty string")
+        if target is None:
+            raise ValueError("target must not be None")
+        self._engine_name = engine_name
+        self._target = target
+        self._cancelled = False
+
+    def request_cancel(self) -> None:
+        """Cooperative-cancel flag checked before/after the fit call."""
+        self._cancelled = True
+
+    def run(self) -> None:
+        """Resolve the provider and run ``fit_swing(target)``."""
+        if self._cancelled:
+            self.cancelled.emit()
+            return
+        self.progress.emit(f"Resolving '{self._engine_name}' provider...")
+        try:
+            provider = provider_registry.get_provider(self._engine_name)
+        except KeyError as exc:
+            self.failed.emit(str(exc))
+            return
+        if self._cancelled:
+            self.cancelled.emit()
+            return
+        self.progress.emit(f"Running fit_swing on '{self._engine_name}'...")
+        try:
+            result = provider.fit_swing(self._target)
+        except Exception as exc:  # noqa: BLE001 — surface any engine error
+            self.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        if self._cancelled:
+            self.cancelled.emit()
+            return
+        self.finished.emit(result)
+
+
+class RunFitButton(QWidget):
+    """Self-contained Run-fit + Cancel + status widget."""
+
+    finished = pyqtSignal(object)
+    failed = pyqtSignal(str)
+    progress = pyqtSignal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._target: Any = None
+        self._engine: str = ""
+        self._thread: QThread | None = None
+        self._worker: FitWorker | None = None
+        self.last_result: Any = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        row = QHBoxLayout()
+        self.btn_run = QPushButton("Run fit")
+        self.btn_run.setObjectName("primary")
+        self.btn_run.setEnabled(False)
+        self.btn_run.setToolTip("Run fit_swing in a background thread.")
+        self.btn_run.clicked.connect(self.start_fit)
+        row.addWidget(self.btn_run)
+        self.btn_cancel = QPushButton("Cancel")
+        self.btn_cancel.setEnabled(False)
+        self.btn_cancel.setToolTip("Cancel the running fit and clean up the thread.")
+        self.btn_cancel.clicked.connect(self.cancel)
+        row.addWidget(self.btn_cancel)
+        layout.addLayout(row)
+        self.lbl_status = QLabel("Idle. Load a target and pick an engine.")
+        self.lbl_status.setObjectName("status")
+        self.lbl_status.setWordWrap(True)
+        layout.addWidget(self.lbl_status)
+
+    def set_inputs(self, *, target: Any, engine_name: str) -> None:
+        """Update the cached target/engine and refresh the run button."""
+        self._target = target
+        self._engine = engine_name or ""
+        ready = self._target is not None and bool(self._engine)
+        self.btn_run.setEnabled(ready and self._thread is None)
+
+    def start_fit(self) -> None:
+        """Validate inputs and spawn the worker thread."""
+        if self._thread is not None:
+            raise ValueError("a fit is already running; cancel it first")
+        if self._target is None:
+            raise ValueError("no target loaded; set_inputs(target=...) first")
+        if not self._engine:
+            raise ValueError("no engine selected; set_inputs(engine_name=...) first")
+        worker = FitWorker(self._engine, self._target)
+        thread = QThread(self)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._on_finished)
+        worker.failed.connect(self._on_failed)
+        worker.cancelled.connect(self._on_cancelled)
+        worker.progress.connect(self._on_progress)
+        worker.finished.connect(thread.quit)
+        worker.failed.connect(thread.quit)
+        worker.cancelled.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        self._worker = worker
+        self._thread = thread
+        self.btn_run.setEnabled(False)
+        self.btn_cancel.setEnabled(True)
+        self.lbl_status.setText(f"Starting fit on '{self._engine}'...")
+        thread.start()
+
+    def cancel(self) -> None:
+        """Request worker cancellation and wait briefly for cleanup."""
+        if self._worker is not None:
+            self._worker.request_cancel()
+        if self._thread is not None:
+            self._thread.requestInterruption()
+            self._thread.quit()
+            self._thread.wait(2000)
+        self._teardown("Cancelled.")
+
+    def _on_progress(self, text: str) -> None:
+        self.lbl_status.setText(text)
+        self.progress.emit(text)
+
+    def _on_finished(self, result: Any) -> None:
+        self.last_result = result
+        self._teardown("Fit complete.")
+        self.finished.emit(result)
+
+    def _on_failed(self, message: str) -> None:
+        self._teardown(f"Fit failed: {message}")
+        self.failed.emit(message)
+
+    def _on_cancelled(self) -> None:
+        self._teardown("Cancelled.")
+
+    def _teardown(self, status_text: str) -> None:
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait(2000)
+        self._thread = None
+        self._worker = None
+        self.btn_cancel.setEnabled(False)
+        self.lbl_status.setText(status_text)
+        ready = self._target is not None and bool(self._engine)
+        self.btn_run.setEnabled(ready)

--- a/tests/unit/tools/starting_pose_matcher/test_run_fit_button.py
+++ b/tests/unit/tools/starting_pose_matcher/test_run_fit_button.py
@@ -1,0 +1,199 @@
+"""Tests for the Run-fit QThread widget (issue #4707, slice 2/3)."""
+
+from __future__ import annotations
+
+import os
+
+# MUST set the platform BEFORE any Qt import.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip(
+    "PyQt6",
+    reason="PyQt6 required for Run-fit widget tests",
+    exc_type=ImportError,
+)
+pytest.importorskip(
+    "PyQt6.QtWidgets",
+    reason="PyQt6.QtWidgets not loadable in this environment",
+    exc_type=ImportError,
+)
+
+from PyQt6.QtCore import QEventLoop, QTimer  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from src.shared.python.motion_matching import provider_registry  # noqa: E402
+from src.tools.starting_pose_matcher.widgets.run_fit_button import (  # noqa: E402
+    FitWorker,
+    RunFitButton,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class _OkProvider:
+    engine_name = "ok-engine"
+
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+
+    def fit_swing(self, target):
+        self.calls.append(target)
+        return {"target": target, "ok": True}
+
+
+class _BoomProvider:
+    engine_name = "boom-engine"
+
+    def fit_swing(self, target):  # noqa: ARG002
+        raise RuntimeError("kaboom")
+
+
+class _SlowProvider:
+    """Provider that polls the worker's cancel flag in a tight loop."""
+
+    engine_name = "slow-engine"
+
+    def __init__(self) -> None:
+        self.worker_ref: FitWorker | None = None
+
+    def fit_swing(self, target):  # noqa: ARG002
+        import time
+
+        for _ in range(20):
+            if self.worker_ref is not None and self.worker_ref._cancelled:
+                return {"interrupted": True}
+            time.sleep(0.005)
+        return {"slow": True}
+
+
+@pytest.fixture
+def _qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def _clean_registry():
+    provider_registry.clear_registry()
+    yield provider_registry
+    provider_registry.clear_registry()
+
+
+def _spin_until(predicate, timeout_ms: int = 3000) -> bool:
+    """Pump the Qt event loop until ``predicate()`` is true or we time out."""
+    loop = QEventLoop()
+    timer = QTimer()
+    timer.setInterval(20)
+    deadline = {"left": timeout_ms}
+
+    def _tick() -> None:
+        if predicate() or deadline["left"] <= 0:
+            timer.stop()
+            loop.quit()
+        deadline["left"] -= timer.interval()
+
+    timer.timeout.connect(_tick)
+    timer.start()
+    loop.exec()
+    return predicate()
+
+
+def test_button_disabled_until_target_and_engine(_qapp, _clean_registry):
+    w = RunFitButton()
+    assert w.btn_run.isEnabled() is False
+    w.set_inputs(target=None, engine_name="ok-engine")
+    assert w.btn_run.isEnabled() is False
+    w.set_inputs(target=object(), engine_name="")
+    assert w.btn_run.isEnabled() is False
+    w.set_inputs(target=object(), engine_name="ok-engine")
+    assert w.btn_run.isEnabled() is True
+
+
+def test_start_fit_validates_inputs(_qapp, _clean_registry):
+    w = RunFitButton()
+    with pytest.raises(ValueError, match="no target"):
+        w.start_fit()
+    w.set_inputs(target=object(), engine_name="")
+    with pytest.raises(ValueError, match="no engine"):
+        w.start_fit()
+
+
+def test_fit_worker_rejects_bad_args():
+    with pytest.raises(ValueError):
+        FitWorker("", object())
+    with pytest.raises(ValueError):
+        FitWorker("ok-engine", None)
+
+
+def test_success_path_emits_result(_qapp, _clean_registry):
+    provider = _OkProvider()
+    _clean_registry.register_provider(provider)
+    w = RunFitButton()
+    target = {"sentinel": True}
+    w.set_inputs(target=target, engine_name="ok-engine")
+    received: list[object] = []
+    w.finished.connect(received.append)
+    w.start_fit()
+    assert _spin_until(lambda: bool(received))
+    assert received and received[0] == {"target": target, "ok": True}
+    assert provider.calls == [target]
+    assert w.last_result == {"target": target, "ok": True}
+    assert w.btn_cancel.isEnabled() is False
+    assert w.btn_run.isEnabled() is True
+    assert "complete" in w.lbl_status.text().lower()
+
+
+def test_failure_path_emits_error(_qapp, _clean_registry):
+    _clean_registry.register_provider(_BoomProvider())
+    w = RunFitButton()
+    w.set_inputs(target=object(), engine_name="boom-engine")
+    errors: list[str] = []
+    w.failed.connect(errors.append)
+    w.start_fit()
+    assert _spin_until(lambda: bool(errors))
+    assert errors and "kaboom" in errors[0]
+    assert w.last_result is None
+    assert "fail" in w.lbl_status.text().lower()
+    assert w.btn_run.isEnabled() is True
+
+
+def test_unknown_engine_emits_error(_qapp, _clean_registry):
+    w = RunFitButton()
+    w.set_inputs(target=object(), engine_name="missing-engine")
+    errors: list[str] = []
+    w.failed.connect(errors.append)
+    w.start_fit()
+    assert _spin_until(lambda: bool(errors))
+    assert errors and "missing-engine" in errors[0]
+
+
+def test_cancel_terminates_thread_cleanly(_qapp, _clean_registry):
+    provider = _SlowProvider()
+    _clean_registry.register_provider(provider)
+    w = RunFitButton()
+    w.set_inputs(target=object(), engine_name="slow-engine")
+    w.start_fit()
+    provider.worker_ref = w._worker
+    assert w.btn_cancel.isEnabled() is True
+    w.cancel()
+    assert _spin_until(lambda: w._thread is None)
+    assert w._thread is None
+    assert w._worker is None
+    assert w.btn_cancel.isEnabled() is False
+    assert "cancel" in w.lbl_status.text().lower()
+
+
+def test_cannot_start_while_running(_qapp, _clean_registry):
+    _clean_registry.register_provider(_SlowProvider())
+    w = RunFitButton()
+    w.set_inputs(target=object(), engine_name="slow-engine")
+    w.start_fit()
+    try:
+        with pytest.raises(ValueError, match="already running"):
+            w.start_fit()
+    finally:
+        w.cancel()
+        _spin_until(lambda: w._thread is None)


### PR DESCRIPTION
## Summary

Slice 2/3 of issue #4707. Wires the engine combo (slice 1, merged in #4834) into a real fit-execution path:

- New `RunFitButton` widget (`src/tools/starting_pose_matcher/widgets/run_fit_button.py`) encapsulating the button + `QThread` worker + Cancel button + status label.
- Worker calls `provider_registry.get_provider(engine).fit_swing(target)` off the GUI thread, emits `progress`, `finished`, `failed`, `cancelled` signals.
- Wired into `gui.py` next to the engine combo. Inputs (`target`, `engine_name`) refresh on engine-combo change and on body-target load.
- DRY: delegates to `provider_registry`. DbC: validates `target` and `engine_name` before spawning the thread. LoD: callers interact only via public signals/methods.

## Tests

8 new pytest-qt tests in `tests/unit/tools/starting_pose_matcher/test_run_fit_button.py` (under `QT_QPA_PLATFORM=offscreen`):

- button enable gating on (target + engine)
- `start_fit` precondition violations raise `ValueError`
- `FitWorker` constructor argument validation
- success path emits result and sets `last_result`
- failure path emits error and surfaces in status label
- unknown-engine path surfaces `KeyError` cleanly
- Cancel terminates the thread cleanly with no leaked worker/thread
- concurrent `start_fit` rejected while already running

## Test plan

- [x] `python3 -m ruff check` zero violations on changed files
- [x] `python3 -m ruff format --check` clean on changed files
- [x] `QT_QPA_PLATFORM=offscreen pytest tests/unit/tools/starting_pose_matcher/test_run_fit_button.py` — 8/8 pass
- [x] slice-1 engine-combo tests still pass

## Follow-up

Slice 3 (save-fit JSON serialization of `RunFitButton.last_result`) is the remaining follow-up. Issue #4707 stays OPEN until slice 3 lands.

Note: total LOC for new widget + wiring + tests came in at ~430, exceeding the 250-LOC budget in the spec. Trimming further would require either dropping tests or reducing thread-cleanup safety; happy to revisit if reviewers prefer a leaner cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)