### PR TITLE
feat(pose-studio): interactive cross-engine pose editor tool (closes #4899, part of EPIC #4895)

### DIFF
--- a/docs/review_archive/review_comments_2026-05-09.md
+++ b/docs/review_archive/review_comments_2026-05-09.md
@@ -4,7 +4,7 @@ Generated: 2026-05-09T15:45:04.294158
 
 ## Reviewer (chatgpt-codex-connector[bot]) (2 comments)
 
-### PR #4934: src/shared/python/pose_interchange/services/_mock.py:110
+### PR #4934: src/shared/python/pose_interchange/services/\_mock.py:110
 
 Actionable: No
 Has Suggestion: No

--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -133,6 +133,15 @@ models:
       logo: "assets/data_explorer_modern.png"
       status: "ready"
 
+  - id: "pose_studio"
+    name: "Pose Studio"
+    description: "Cross-engine interactive pose editor. Drag the model, save as starting state or motion-matching target."
+    type: "special_app"
+    path: "src/tools/pose_studio/__main__.py"
+    launcher:
+      category: "tool"
+      status: "beta"
+
   - id: "project_map"
     name: "Project Map"
     description: "Complete map of all features, modules, and hidden gems in the suite"

--- a/src/shared/python/motion_matching/engine_init_profiler.py
+++ b/src/shared/python/motion_matching/engine_init_profiler.py
@@ -398,7 +398,7 @@ def _hash_parameters(params: dict[str, Any]) -> str:
         Hex hash string.
     """
     param_str = str(sorted(params.items()))
-    return hashlib.md5(param_str.encode()).hexdigest()
+    return hashlib.md5(param_str.encode(), usedforsecurity=False).hexdigest()
 
 
 def profile_initialization(

--- a/src/shared/python/motion_matching/engine_init_profiler.py
+++ b/src/shared/python/motion_matching/engine_init_profiler.py
@@ -398,7 +398,7 @@ def _hash_parameters(params: dict[str, Any]) -> str:
         Hex hash string.
     """
     param_str = str(sorted(params.items()))
-    return hashlib.md5(param_str.encode(), usedforsecurity=False).hexdigest()
+    return hashlib.md5(param_str.encode()).hexdigest()
 
 
 def profile_initialization(

--- a/src/shared/python/motion_matching/leaderboard.py
+++ b/src/shared/python/motion_matching/leaderboard.py
@@ -359,7 +359,7 @@ def _short_commit(commit: str | None) -> str:
         return "0000000"
     s = str(commit).strip().lower()
     if not re.match(r"^[0-9a-f]{7,40}$", s):
-        return hashlib.sha1(s.encode("utf-8")).hexdigest()[:12]
+        return hashlib.sha1(s.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
     return s
 
 

--- a/src/shared/python/motion_matching/leaderboard.py
+++ b/src/shared/python/motion_matching/leaderboard.py
@@ -359,7 +359,7 @@ def _short_commit(commit: str | None) -> str:
         return "0000000"
     s = str(commit).strip().lower()
     if not re.match(r"^[0-9a-f]{7,40}$", s):
-        return hashlib.sha1(s.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
+        return hashlib.sha1(s.encode("utf-8")).hexdigest()[:12]
     return s
 
 

--- a/src/tools/pose_studio/README.md
+++ b/src/tools/pose_studio/README.md
@@ -1,0 +1,54 @@
+# Pose Studio
+
+Interactive cross-engine pose editor. Subtask 5 of EPIC #4895.
+
+## Why
+
+Hand-edit a `CanonicalPose` and see the result rendered through any of
+the supported physics engines (Drake, MuJoCo, Pinocchio, OpenSim,
+Simscape) without restarting the process. The same canonical pose
+becomes the seed for the starting-pose matcher (#4899), the motion
+matcher target, and any future engine-comparison tooling.
+
+## Run
+
+```bash
+python -m src.tools.pose_studio
+```
+
+Requires the `gui-tools` extra (`pip install upstream-drift[gui-tools]`).
+
+## Architecture
+
+```
+src/tools/pose_studio/
+  core.py                — engine-agnostic state machine, no Qt
+  controllers/
+    engine_controller.py — owns active LiveKinematicsService + Adapter
+    history_controller.py— undo/redo stack of CanonicalPose snapshots
+  widgets/
+    engine_picker.py     — combo + status pill
+    joint_panel.py       — accordion of per-joint sliders
+    view_3d.py           — matplotlib 3D skeleton view
+    units_badge.py       — engine native-convention indicator
+  gui.py                 — QMainWindow composing the above
+```
+
+The pure-data layer (`core.py` + `controllers/*`) imports no Qt and is
+covered by `tests/unit/tools/pose_studio/`. The widget + GUI layer is
+covered by smoke tests in `tests/ui/tools/pose_studio/`.
+
+## Scope (v1)
+
+- Engine swap with mock fallback (yellow pill) when wheel absent.
+- Per-joint sliders grouped by body region.
+- Click a 3D landmark to highlight it.
+- Undo/redo (Ctrl+Z / Ctrl+Shift+Z).
+- Pose Library: load `canonical_zero_pose` or
+  `canonical_from_reference_setup`.
+
+## Out of scope (deferred follow-ups)
+
+- IK drag-handles — drag a clubhead, solve back through the chain.
+- Save/load to JSON — lives in Subtask 6 / #4900.
+- Mocap scrubbing — lives in Subtask 7 / #4901.

--- a/src/tools/pose_studio/__init__.py
+++ b/src/tools/pose_studio/__init__.py
@@ -1,0 +1,36 @@
+"""Pose Studio — interactive cross-engine pose editor.
+
+A single-purpose PyQt6 tool that lets the user hand-edit a
+:class:`CanonicalPose` and see the result rendered through any of the
+supported engines without restarting.
+
+Public entry point::
+
+    python -m src.tools.pose_studio
+
+Public modules:
+
+    .core            engine-agnostic pure-data primitives, no Qt
+    .controllers     EngineController + HistoryController (Qt-free)
+    .widgets         per-component PyQt6 widgets
+    .gui             :class:`PoseStudioWindow` + ``main()``
+
+Save/load is stubbed in v1; real save/load lives in Subtask 6 / #4900.
+IK drag-handles are deferred to a follow-up issue.
+"""
+
+from __future__ import annotations
+
+from src.tools.pose_studio.core import (
+    JOINT_REGION_LAYOUT,
+    SUPPORTED_ENGINES,
+    EngineStatus,
+    joint_region_partitions_reference_fields,
+)
+
+__all__ = [
+    "JOINT_REGION_LAYOUT",
+    "SUPPORTED_ENGINES",
+    "EngineStatus",
+    "joint_region_partitions_reference_fields",
+]

--- a/src/tools/pose_studio/__main__.py
+++ b/src/tools/pose_studio/__main__.py
@@ -1,0 +1,29 @@
+"""Run the Pose Studio GUI.
+
+Usage::
+
+    python -m src.tools.pose_studio
+
+Requires the ``gui-tools`` extra (PyQt6 + matplotlib QtAgg backend).
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    try:
+        from src.tools.pose_studio.gui import main as _gui_main
+    except ImportError as exc:
+        sys.stderr.write(
+            "Could not import the Pose Studio GUI dependencies "
+            f"(PyQt6 / matplotlib): {exc}\n\n"
+            "Install with:\n  pip install upstream-drift[gui-tools]\n"
+        )
+        return 1
+    return _gui_main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/pose_studio/controllers/__init__.py
+++ b/src/tools/pose_studio/controllers/__init__.py
@@ -1,0 +1,15 @@
+"""Pure-data controllers used by the Pose Studio GUI.
+
+Both controllers are deliberately Qt-free so they can be exercised from
+unit tests without an X server.  The GUI layer imports them and wires
+their public methods to Qt signals/slots.
+"""
+
+from __future__ import annotations
+
+from src.tools.pose_studio.controllers.engine_controller import EngineController
+from src.tools.pose_studio.controllers.history_controller import (
+    HistoryController,
+)
+
+__all__ = ["EngineController", "HistoryController"]

--- a/src/tools/pose_studio/controllers/engine_controller.py
+++ b/src/tools/pose_studio/controllers/engine_controller.py
@@ -1,0 +1,211 @@
+"""Owns the active live-kinematics service and pose adapter.
+
+The :class:`EngineController` is the single seam through which the GUI
+swaps between physics engines without restarting.  It encapsulates:
+
+* the active :class:`PoseConventionAdapter` (per-engine convention
+  translator from Subtask 2 of EPIC #4895);
+* the active :class:`LiveKinematicsService` (per-engine kinematics
+  surface from Subtask 3);
+* the most-recently-applied :class:`CanonicalPose`;
+* the :class:`EngineStatus` (mock / live / error) for the UI status
+  pill.
+
+It is **engine-agnostic and Qt-free**, so the unit tests can construct
+it directly and assert behaviour without an X server.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.pose_interchange.adapters import ADAPTER_REGISTRY
+from src.shared.python.pose_interchange.canonical import (
+    CanonicalPose,
+    canonical_zero_pose,
+)
+from src.shared.python.pose_interchange.protocol import PoseConventionAdapter
+from src.shared.python.pose_interchange.services import (
+    KINEMATICS_SERVICE_REGISTRY,
+    MockKinematicsService,
+)
+from src.shared.python.pose_interchange.live_kinematics import (
+    LiveKinematicsService,
+)
+from src.tools.pose_studio.core import SUPPORTED_ENGINES, EngineStatus
+
+logger = get_logger(__name__)
+
+
+class EngineController:
+    """Encapsulate the active engine adapter + kinematics service.
+
+    Parameters
+    ----------
+    engine_name
+        Initial engine name; must be a member of :data:`SUPPORTED_ENGINES`.
+    """
+
+    def __init__(self, engine_name: str = "drake") -> None:
+        if not isinstance(engine_name, str):
+            raise TypeError(
+                f"engine_name must be str, got {type(engine_name).__name__}"
+            )
+        if engine_name not in SUPPORTED_ENGINES:
+            raise ValueError(
+                f"engine_name {engine_name!r} not in SUPPORTED_ENGINES "
+                f"{SUPPORTED_ENGINES!r}"
+            )
+        self._engine_name: str = engine_name
+        self._pose: CanonicalPose = canonical_zero_pose()
+        self._adapter: PoseConventionAdapter | None = None
+        self._service: LiveKinematicsService | None = None
+        self._status: EngineStatus = EngineStatus.MOCK
+        self._last_error: str | None = None
+        self._activate(engine_name)
+
+    # ---- public surface ------------------------------------------------
+
+    @property
+    def engine_name(self) -> str:
+        """The currently active engine name."""
+        return self._engine_name
+
+    @property
+    def status(self) -> EngineStatus:
+        """The current :class:`EngineStatus` (mock / live / error)."""
+        return self._status
+
+    @property
+    def last_error(self) -> str | None:
+        """The most recent error message, or ``None`` if the controller
+        is in a healthy state."""
+        return self._last_error
+
+    @property
+    def adapter(self) -> PoseConventionAdapter | None:
+        """The currently active :class:`PoseConventionAdapter` or ``None``
+        when the controller is in :attr:`EngineStatus.ERROR`."""
+        return self._adapter
+
+    @property
+    def service(self) -> LiveKinematicsService | None:
+        """The currently active :class:`LiveKinematicsService` or ``None``
+        when the controller is in :attr:`EngineStatus.ERROR`."""
+        return self._service
+
+    @property
+    def pose(self) -> CanonicalPose:
+        """The most-recently-applied :class:`CanonicalPose`."""
+        return self._pose
+
+    def switch_engine(self, engine_name: str) -> EngineStatus:
+        """Switch to a different engine.
+
+        Parameters
+        ----------
+        engine_name
+            New engine name; must be a member of :data:`SUPPORTED_ENGINES`.
+
+        Returns
+        -------
+        EngineStatus
+            The status of the new engine after the swap.
+        """
+        if not isinstance(engine_name, str):
+            raise TypeError(
+                f"engine_name must be str, got {type(engine_name).__name__}"
+            )
+        if engine_name not in SUPPORTED_ENGINES:
+            raise ValueError(
+                f"engine_name {engine_name!r} not in SUPPORTED_ENGINES "
+                f"{SUPPORTED_ENGINES!r}"
+            )
+        self._engine_name = engine_name
+        self._activate(engine_name)
+        # Replay the current pose through the new service so the 3D
+        # view stays consistent across the swap.
+        self.set_pose(self._pose)
+        return self._status
+
+    def set_pose(self, pose: CanonicalPose) -> None:
+        """Apply *pose* to the active service and remember it.
+
+        If the live engine's :meth:`set_pose` raises
+        :class:`NotImplementedError` (some engine bridges are still
+        partial in EPIC #4895), the controller transparently downgrades
+        to a :class:`MockKinematicsService` so the rest of the GUI keeps
+        working.  Other exceptions flip the controller into
+        :attr:`EngineStatus.ERROR`.
+        """
+        if not isinstance(pose, CanonicalPose):
+            raise TypeError(f"pose must be a CanonicalPose, got {type(pose).__name__}")
+        self._pose = pose
+        if self._service is None:
+            return
+        try:
+            self._service.set_pose(pose)
+        except NotImplementedError as exc:
+            logger.info(
+                "EngineController(%s) live set_pose unimplemented; "
+                "downgrading to mock: %s",
+                self._engine_name,
+                exc,
+            )
+            self._service = MockKinematicsService(self._engine_name)
+            self._status = EngineStatus.MOCK
+            self._last_error = None
+            self._service.set_pose(pose)
+        except (RuntimeError, ValueError, TypeError) as exc:
+            self._status = EngineStatus.ERROR
+            self._last_error = f"set_pose failed: {exc}"
+            logger.warning(
+                "EngineController(%s) set_pose failed: %s",
+                self._engine_name,
+                exc,
+            )
+
+    # ---- internals -----------------------------------------------------
+
+    def _activate(self, engine_name: str) -> None:
+        """Construct adapter + service for *engine_name* and cache them."""
+        self._last_error = None
+        try:
+            adapter_cls = ADAPTER_REGISTRY[engine_name]
+            factory = KINEMATICS_SERVICE_REGISTRY[engine_name]
+        except KeyError as exc:  # pragma: no cover - guarded by SUPPORTED_ENGINES
+            self._adapter = None
+            self._service = None
+            self._status = EngineStatus.ERROR
+            self._last_error = f"registry miss for {engine_name!r}: {exc}"
+            return
+
+        try:
+            adapter = adapter_cls()
+            service = factory()
+        except (RuntimeError, ValueError, TypeError, ImportError) as exc:
+            self._adapter = None
+            self._service = None
+            self._status = EngineStatus.ERROR
+            self._last_error = f"engine activation failed: {exc}"
+            logger.warning(
+                "EngineController failed to activate %s: %s",
+                engine_name,
+                exc,
+            )
+            return
+
+        self._adapter = adapter
+        self._service = service
+        self._status = (
+            EngineStatus.MOCK
+            if isinstance(service, MockKinematicsService)
+            else EngineStatus.LIVE
+        )
+        logger.debug(
+            "EngineController activated engine=%s status=%s",
+            engine_name,
+            self._status.value,
+        )
+
+
+__all__ = ["EngineController"]

--- a/src/tools/pose_studio/controllers/history_controller.py
+++ b/src/tools/pose_studio/controllers/history_controller.py
@@ -1,0 +1,110 @@
+"""Undo/redo stack of :class:`CanonicalPose` snapshots.
+
+Pure-data — no Qt imports — so the unit tests can drive it directly.
+
+Stack semantics:
+
+* :meth:`push` records a snapshot.  Pushing after an undo discards the
+  redo branch (standard editor behaviour).
+* :meth:`undo` returns the previous snapshot, or ``None`` if the stack
+  is at the bottom.
+* :meth:`redo` returns the next snapshot, or ``None`` if there is no
+  redo branch.
+
+The controller never mutates :class:`CanonicalPose` instances; the
+caller is responsible for treating returned poses as the authoritative
+new state and re-applying them to the engine.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.pose_interchange.canonical import CanonicalPose
+
+
+class HistoryController:
+    """Bounded undo/redo stack of :class:`CanonicalPose` snapshots.
+
+    Parameters
+    ----------
+    initial_pose
+        The starting snapshot.  Cannot be undone past — the bottom of
+        the stack always returns ``None`` from :meth:`undo` when the
+        cursor would step below it.
+    max_depth
+        Soft cap on the number of snapshots retained.  Older entries
+        are discarded once the stack exceeds this depth.  Must be at
+        least ``2`` so a push-undo cycle is always possible.
+    """
+
+    def __init__(self, initial_pose: CanonicalPose, max_depth: int = 64) -> None:
+        if not isinstance(initial_pose, CanonicalPose):
+            raise TypeError(
+                "initial_pose must be a CanonicalPose, "
+                f"got {type(initial_pose).__name__}"
+            )
+        if not isinstance(max_depth, int):
+            raise TypeError(f"max_depth must be int, got {type(max_depth).__name__}")
+        if max_depth < 2:
+            raise ValueError(f"max_depth must be >= 2, got {max_depth}")
+        self._stack: list[CanonicalPose] = [initial_pose]
+        self._cursor: int = 0
+        self._max_depth: int = max_depth
+
+    # ---- public surface ------------------------------------------------
+
+    @property
+    def can_undo(self) -> bool:
+        """``True`` iff :meth:`undo` would return a snapshot."""
+        return self._cursor > 0
+
+    @property
+    def can_redo(self) -> bool:
+        """``True`` iff :meth:`redo` would return a snapshot."""
+        return self._cursor < len(self._stack) - 1
+
+    @property
+    def current(self) -> CanonicalPose:
+        """The snapshot at the current stack cursor."""
+        return self._stack[self._cursor]
+
+    @property
+    def depth(self) -> int:
+        """Total number of snapshots currently retained."""
+        return len(self._stack)
+
+    def push(self, pose: CanonicalPose) -> None:
+        """Push *pose* onto the stack.
+
+        Discards any redo branch above the cursor (so a push after an
+        undo creates a new branch and the old one is lost).
+        """
+        if not isinstance(pose, CanonicalPose):
+            raise TypeError(f"pose must be a CanonicalPose, got {type(pose).__name__}")
+        # Drop any redo branch.
+        if self._cursor < len(self._stack) - 1:
+            del self._stack[self._cursor + 1 :]
+        self._stack.append(pose)
+        self._cursor = len(self._stack) - 1
+        # Trim the bottom if we exceeded the cap.  Bottom entries are
+        # the oldest, so dropping them is safe; the cursor moves with
+        # the stack.
+        while len(self._stack) > self._max_depth:
+            self._stack.pop(0)
+            self._cursor -= 1
+
+    def undo(self) -> CanonicalPose | None:
+        """Return the snapshot one step earlier, or ``None`` at bottom."""
+        if not self.can_undo:
+            return None
+        self._cursor -= 1
+        return self._stack[self._cursor]
+
+    def redo(self) -> CanonicalPose | None:
+        """Return the snapshot one step later, or ``None`` at top."""
+        if not self.can_redo:
+            return None
+        self._cursor += 1
+        return self._stack[self._cursor]
+
+
+__all__ = ["HistoryController"]

--- a/src/tools/pose_studio/core.py
+++ b/src/tools/pose_studio/core.py
@@ -1,0 +1,121 @@
+"""Pure-data state machine for the Pose Studio tool.
+
+This module is **engine-agnostic** and contains **no Qt imports**.  It
+exposes the small pure-data primitives that the rest of the package
+composes:
+
+* :data:`SUPPORTED_ENGINES` — ordered list of engine names available in
+  the engine picker (pulled from the registries shipped by Subtasks 2/3
+  of EPIC #4895).
+* :class:`EngineStatus` — value enum reported by the controllers and
+  rendered as a colour pill in the UI.
+* :data:`JOINT_REGION_LAYOUT` — the canonical joint-name → body-region
+  grouping used by the joint accordion.  Lives here so the unit tests
+  can assert that every canonical field belongs to exactly one region.
+
+Everything in this file is deliberately import-cheap so that the unit
+tests can exercise the controllers without spinning up Qt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import Enum
+from typing import Final
+
+from src.shared.python.motion_matching.diagnostics.reference_pose import (
+    REFERENCE_GOLFER_FIELDS,
+)
+from src.shared.python.pose_interchange.adapters import ADAPTER_REGISTRY
+from src.shared.python.pose_interchange.services import (
+    KINEMATICS_SERVICE_REGISTRY,
+)
+
+
+class EngineStatus(str, Enum):
+    """Status pill values rendered by :class:`EnginePicker`.
+
+    Members map 1-to-1 to the colours rendered by the status pill:
+
+    * ``MOCK`` — yellow.  The engine wheel is not installed; we fell
+      back to :class:`MockKinematicsService`.
+    * ``LIVE`` — green.  Real engine wheel was loaded.
+    * ``ERROR`` — red.  The factory raised when constructing the
+      service or the adapter for the requested engine.
+    """
+
+    MOCK = "mock"
+    LIVE = "live"
+    ERROR = "error"
+
+
+# Engine names exposed by the picker, in display order.  Anchored on
+# the intersection of the two registries shipped by Subtasks 2 and 3 so
+# we never offer an engine that lacks either an adapter or a service.
+SUPPORTED_ENGINES: Final[tuple[str, ...]] = tuple(
+    name
+    for name in ("drake", "mujoco", "pinocchio", "opensim", "simscape")
+    if name in ADAPTER_REGISTRY and name in KINEMATICS_SERVICE_REGISTRY
+)
+
+
+# Body-region grouping for the joint accordion.  The values are the
+# canonical field names from :data:`REFERENCE_GOLFER_FIELDS`; together
+# the regions partition the field tuple (verified by a unit test).
+JOINT_REGION_LAYOUT: Final[Mapping[str, tuple[str, ...]]] = {
+    "Pelvis": (
+        "HipStartPositionX",
+        "HipStartPositionY",
+        "HipStartPositionZ",
+    ),
+    "Spine": (
+        "SpineStartPositionX",
+        "SpineStartPositionY",
+        "TorsoStartPosition",
+    ),
+    "Shoulders": (
+        "LScapStartPositionX",
+        "LScapStartPositionY",
+        "RScapStartPositionX",
+        "RScapStartPositionY",
+        "LSStartPositionX",
+        "LSStartPositionY",
+        "LSStartPositionZ",
+        "RSStartPositionX",
+        "RSStartPositionY",
+        "RSStartPositionZ",
+    ),
+    "Elbows": (
+        "LEStartPosition",
+        "REStartPosition",
+        "LFStartPosition",
+        "RFStartPosition",
+    ),
+    "Wrists": (
+        "LWStartPositionX",
+        "LWStartPositionY",
+        "RWStartPositionX",
+        "RWStartPositionY",
+    ),
+}
+
+
+def joint_region_partitions_reference_fields() -> bool:
+    """Return ``True`` iff :data:`JOINT_REGION_LAYOUT` partitions the
+    canonical field tuple :data:`REFERENCE_GOLFER_FIELDS`.
+
+    Used by the unit tests; exposed as a function so the property is
+    cheap to assert from the GUI layer too.
+    """
+    flat = tuple(name for region in JOINT_REGION_LAYOUT.values() for name in region)
+    return set(flat) == set(REFERENCE_GOLFER_FIELDS) and len(flat) == len(
+        REFERENCE_GOLFER_FIELDS
+    )
+
+
+__all__ = [
+    "JOINT_REGION_LAYOUT",
+    "SUPPORTED_ENGINES",
+    "EngineStatus",
+    "joint_region_partitions_reference_fields",
+]

--- a/src/tools/pose_studio/gui.py
+++ b/src/tools/pose_studio/gui.py
@@ -129,10 +129,23 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(central)
 
     def _build_menu(self) -> None:
+        # QMainWindow.menuBar() and QMenuBar.addMenu() return Optional in
+        # the Qt stubs, but always return real objects on a constructed
+        # main window. Pin them with asserts once here so mypy can follow
+        # without scattering casts through every addAction call.
         menubar = self.menuBar()
+        assert menubar is not None  # noqa: S101 — Qt invariant
+
+        file_menu = menubar.addMenu("&File")
+        edit_menu = menubar.addMenu("&Edit")
+        pose_menu = menubar.addMenu("&Pose Library")
+        view_menu = menubar.addMenu("&View")
+        assert file_menu is not None  # noqa: S101 — Qt invariant
+        assert edit_menu is not None  # noqa: S101 — Qt invariant
+        assert pose_menu is not None  # noqa: S101 — Qt invariant
+        assert view_menu is not None  # noqa: S101 — Qt invariant
 
         # File menu.
-        file_menu = menubar.addMenu("&File")
         act_save = QtGui.QAction("&Save Pose...", self)
         act_save.setToolTip(_SAVE_TOOLTIP)
         act_save.triggered.connect(self._on_save_clicked)
@@ -148,7 +161,6 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
         file_menu.addAction(act_quit)
 
         # Edit menu.
-        edit_menu = menubar.addMenu("&Edit")
         self.act_undo = QtGui.QAction("&Undo", self)
         self.act_undo.setShortcut(QtGui.QKeySequence("Ctrl+Z"))
         self.act_undo.triggered.connect(self._on_undo)
@@ -159,7 +171,6 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
         edit_menu.addAction(self.act_redo)
 
         # Pose Library menu.
-        pose_menu = menubar.addMenu("&Pose Library")
         act_zero = QtGui.QAction("Load &Zero Pose", self)
         act_zero.setToolTip("Reset to canonical_zero_pose() (T-pose at origin).")
         act_zero.triggered.connect(self._on_load_zero)
@@ -173,7 +184,6 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
         pose_menu.addAction(act_ref)
 
         # View menu.
-        view_menu = menubar.addMenu("&View")
         self.act_show_radians = QtGui.QAction("Show angles in &radians", self)
         self.act_show_radians.setCheckable(True)
         self.act_show_radians.toggled.connect(self.joint_panel.set_show_radians)

--- a/src/tools/pose_studio/gui.py
+++ b/src/tools/pose_studio/gui.py
@@ -1,0 +1,273 @@
+"""Pose Studio main window.
+
+Composes the pure-data controllers (:class:`EngineController`,
+:class:`HistoryController`) with the per-component widgets
+(:class:`EnginePicker`, :class:`JointPanel`, :class:`View3D`,
+:class:`UnitsBadge`) into a single :class:`QMainWindow`.
+
+This file is deliberately thin: layout + signal wiring only.  Math
+lives in :mod:`src.tools.pose_studio.core` and the controllers, and
+each widget owns its own internal state.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.pose_interchange.canonical import (
+    CanonicalPose,
+    canonical_from_reference_setup,
+    canonical_zero_pose,
+)
+from src.tools.pose_studio.controllers import (
+    EngineController,
+    HistoryController,
+)
+from src.tools.pose_studio.core import SUPPORTED_ENGINES, EngineStatus
+from src.tools.pose_studio.widgets import (
+    EnginePicker,
+    JointPanel,
+    UnitsBadge,
+    View3D,
+)
+
+logger = get_logger(__name__)
+
+
+_SAVE_TOOLTIP = (
+    "Save formats coming in #4900 (Subtask 6 of EPIC #4895). Currently a stub."
+)
+_LOAD_TOOLTIP = (
+    "Load formats coming in #4900 (Subtask 6 of EPIC #4895). Currently a stub."
+)
+
+
+class PoseStudioWindow(QtWidgets.QMainWindow):
+    """Top-level :class:`QMainWindow` for the Pose Studio tool."""
+
+    def __init__(
+        self,
+        initial_engine: str = "drake",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        if initial_engine not in SUPPORTED_ENGINES:
+            initial_engine = SUPPORTED_ENGINES[0]
+        self.setWindowTitle("Pose Studio")
+        self.resize(1200, 800)
+
+        self._engine_controller = EngineController(initial_engine)
+        self._history = HistoryController(canonical_zero_pose())
+
+        self._build_widgets(initial_engine)
+        self._build_layout()
+        self._build_menu()
+        self._wire_signals()
+
+        # Push the initial pose through the engine and refresh the view.
+        self._apply_pose(canonical_zero_pose(), record_history=False)
+
+    # ---- construction --------------------------------------------------
+
+    def _build_widgets(self, initial_engine: str) -> None:
+        self.engine_picker = EnginePicker(initial_engine)
+        self.engine_picker.set_status(self._engine_controller.status)
+
+        self.units_badge = UnitsBadge(initial_engine)
+
+        self.joint_panel = JointPanel()
+        self.view_3d = View3D()
+
+        self.btn_save = QtWidgets.QPushButton("Save Pose...")
+        self.btn_save.setToolTip(_SAVE_TOOLTIP)
+        self.btn_save.clicked.connect(self._on_save_clicked)
+
+        self.btn_load = QtWidgets.QPushButton("Load Pose...")
+        self.btn_load.setToolTip(_LOAD_TOOLTIP)
+        self.btn_load.clicked.connect(self._on_load_clicked)
+
+        self.btn_undo = QtWidgets.QPushButton("Undo")
+        self.btn_undo.setToolTip("Undo the last edit (Ctrl+Z).")
+        self.btn_undo.clicked.connect(self._on_undo)
+
+        self.btn_redo = QtWidgets.QPushButton("Redo")
+        self.btn_redo.setToolTip("Redo the last undone edit (Ctrl+Shift+Z).")
+        self.btn_redo.clicked.connect(self._on_redo)
+
+    def _build_layout(self) -> None:
+        central = QtWidgets.QWidget()
+        outer = QtWidgets.QVBoxLayout(central)
+        outer.setContentsMargins(8, 8, 8, 8)
+
+        # Top bar: engine picker on the left, units badge on the right.
+        top_bar = QtWidgets.QHBoxLayout()
+        top_bar.addWidget(self.engine_picker, stretch=1)
+        top_bar.addWidget(self.units_badge)
+        outer.addLayout(top_bar)
+
+        # Body: 3D view on the left, joint panel on the right.
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(self.view_3d)
+        splitter.addWidget(self.joint_panel)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 2)
+        outer.addWidget(splitter, stretch=1)
+
+        # Footer: undo/redo, save/load.
+        footer = QtWidgets.QHBoxLayout()
+        footer.addWidget(self.btn_undo)
+        footer.addWidget(self.btn_redo)
+        footer.addStretch(1)
+        footer.addWidget(self.btn_load)
+        footer.addWidget(self.btn_save)
+        outer.addLayout(footer)
+
+        self.setCentralWidget(central)
+
+    def _build_menu(self) -> None:
+        menubar = self.menuBar()
+
+        # File menu.
+        file_menu = menubar.addMenu("&File")
+        act_save = QtGui.QAction("&Save Pose...", self)
+        act_save.setToolTip(_SAVE_TOOLTIP)
+        act_save.triggered.connect(self._on_save_clicked)
+        file_menu.addAction(act_save)
+
+        act_load = QtGui.QAction("&Load Pose...", self)
+        act_load.setToolTip(_LOAD_TOOLTIP)
+        act_load.triggered.connect(self._on_load_clicked)
+        file_menu.addAction(act_load)
+        file_menu.addSeparator()
+        act_quit = QtGui.QAction("&Quit", self)
+        act_quit.triggered.connect(self.close)
+        file_menu.addAction(act_quit)
+
+        # Edit menu.
+        edit_menu = menubar.addMenu("&Edit")
+        self.act_undo = QtGui.QAction("&Undo", self)
+        self.act_undo.setShortcut(QtGui.QKeySequence("Ctrl+Z"))
+        self.act_undo.triggered.connect(self._on_undo)
+        edit_menu.addAction(self.act_undo)
+        self.act_redo = QtGui.QAction("&Redo", self)
+        self.act_redo.setShortcut(QtGui.QKeySequence("Ctrl+Shift+Z"))
+        self.act_redo.triggered.connect(self._on_redo)
+        edit_menu.addAction(self.act_redo)
+
+        # Pose Library menu.
+        pose_menu = menubar.addMenu("&Pose Library")
+        act_zero = QtGui.QAction("Load &Zero Pose", self)
+        act_zero.setToolTip("Reset to canonical_zero_pose() (T-pose at origin).")
+        act_zero.triggered.connect(self._on_load_zero)
+        pose_menu.addAction(act_zero)
+
+        act_ref = QtGui.QAction("Load &Reference Golfer Setup", self)
+        act_ref.setToolTip(
+            "Reset to canonical_from_reference_setup() (anatomical address)."
+        )
+        act_ref.triggered.connect(self._on_load_reference)
+        pose_menu.addAction(act_ref)
+
+        # View menu.
+        view_menu = menubar.addMenu("&View")
+        self.act_show_radians = QtGui.QAction("Show angles in &radians", self)
+        self.act_show_radians.setCheckable(True)
+        self.act_show_radians.toggled.connect(self.joint_panel.set_show_radians)
+        view_menu.addAction(self.act_show_radians)
+
+    def _wire_signals(self) -> None:
+        self.engine_picker.engine_selected.connect(self._on_engine_selected)
+        self.joint_panel.angle_edited.connect(self._on_angle_edited)
+
+    # ---- handlers ------------------------------------------------------
+
+    def _on_engine_selected(self, engine_name: str) -> None:
+        status = self._engine_controller.switch_engine(engine_name)
+        self.engine_picker.set_status(status)
+        self.units_badge.set_engine(engine_name)
+        self.view_3d.update_pose(self._engine_controller.pose)
+
+    def _on_angle_edited(self, name: str, value_deg: float) -> None:
+        current = self._engine_controller.pose
+        new_angles = dict(current.joint_angles_deg)
+        new_angles[name] = float(value_deg)
+        try:
+            new_pose = CanonicalPose(
+                pelvis_translation_m=np.asarray(
+                    current.pelvis_translation_m, dtype=float
+                ),
+                pelvis_rotation_xyz_deg=np.asarray(
+                    current.pelvis_rotation_xyz_deg, dtype=float
+                ),
+                joint_angles_deg=new_angles,
+            )
+        except (ValueError, TypeError) as exc:
+            logger.warning("Pose edit rejected: %s", exc)
+            return
+        self._apply_pose(new_pose, record_history=True)
+
+    def _on_undo(self) -> None:
+        pose = self._history.undo()
+        if pose is None:
+            return
+        self._apply_pose(pose, record_history=False)
+
+    def _on_redo(self) -> None:
+        pose = self._history.redo()
+        if pose is None:
+            return
+        self._apply_pose(pose, record_history=False)
+
+    def _on_load_zero(self) -> None:
+        self._apply_pose(canonical_zero_pose(), record_history=True)
+
+    def _on_load_reference(self) -> None:
+        self._apply_pose(canonical_from_reference_setup(), record_history=True)
+
+    def _on_save_clicked(self) -> None:
+        QtWidgets.QToolTip.showText(
+            self.btn_save.mapToGlobal(self.btn_save.rect().bottomLeft()),
+            _SAVE_TOOLTIP,
+            self.btn_save,
+        )
+
+    def _on_load_clicked(self) -> None:
+        QtWidgets.QToolTip.showText(
+            self.btn_load.mapToGlobal(self.btn_load.rect().bottomLeft()),
+            _LOAD_TOOLTIP,
+            self.btn_load,
+        )
+
+    # ---- core state plumbing -------------------------------------------
+
+    def _apply_pose(self, pose: CanonicalPose, *, record_history: bool) -> None:
+        """Apply *pose* to controller, view, and joint panel."""
+        self._engine_controller.set_pose(pose)
+        self.view_3d.update_pose(pose)
+        self.joint_panel.set_angles(pose.angles_full_dict_deg())
+        if record_history:
+            self._history.push(pose)
+        self._refresh_undo_redo_actions()
+
+    def _refresh_undo_redo_actions(self) -> None:
+        self.btn_undo.setEnabled(self._history.can_undo)
+        self.btn_redo.setEnabled(self._history.can_redo)
+        self.act_undo.setEnabled(self._history.can_undo)
+        self.act_redo.setEnabled(self._history.can_redo)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point used by ``python -m src.tools.pose_studio``."""
+    if argv is None:
+        argv = sys.argv
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(argv)
+    win = PoseStudioWindow()
+    win.show()
+    return app.exec()
+
+
+__all__ = ["PoseStudioWindow", "main"]

--- a/src/tools/pose_studio/widgets/__init__.py
+++ b/src/tools/pose_studio/widgets/__init__.py
@@ -1,0 +1,20 @@
+"""PyQt6 widgets composed by the Pose Studio main window.
+
+Each widget is a thin Qt shell over the pure-data controllers in
+:mod:`src.tools.pose_studio.controllers`.  Importing this package
+requires PyQt6.
+"""
+
+from __future__ import annotations
+
+from src.tools.pose_studio.widgets.engine_picker import EnginePicker
+from src.tools.pose_studio.widgets.joint_panel import JointPanel
+from src.tools.pose_studio.widgets.units_badge import UnitsBadge
+from src.tools.pose_studio.widgets.view_3d import View3D
+
+__all__ = [
+    "EnginePicker",
+    "JointPanel",
+    "UnitsBadge",
+    "View3D",
+]

--- a/src/tools/pose_studio/widgets/engine_picker.py
+++ b/src/tools/pose_studio/widgets/engine_picker.py
@@ -1,0 +1,112 @@
+"""Engine picker widget with status pill.
+
+A :class:`QComboBox` listing every engine in :data:`SUPPORTED_ENGINES`
+plus a coloured status pill (mock/yellow, live/green, error/red) so the
+user can see at a glance whether the selected engine is running on a
+real wheel or the headless mock fallback.
+
+The widget is purely presentational; the wiring to
+:class:`EngineController` lives in :mod:`src.tools.pose_studio.gui`.
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtWidgets
+
+from src.shared.python.theme.style_constants import Styles
+from src.tools.pose_studio.core import SUPPORTED_ENGINES, EngineStatus
+
+
+class EnginePicker(QtWidgets.QWidget):
+    """Combo box + colour pill for the active live-kinematics engine.
+
+    Signals
+    -------
+    engine_selected(str)
+        Emitted with the new engine name when the user changes the
+        combo selection.
+    """
+
+    engine_selected = QtCore.pyqtSignal(str)
+
+    def __init__(
+        self,
+        initial_engine: str = "drake",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        if initial_engine not in SUPPORTED_ENGINES:
+            raise ValueError(
+                f"initial_engine {initial_engine!r} not in SUPPORTED_ENGINES "
+                f"{SUPPORTED_ENGINES!r}"
+            )
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        layout.addWidget(QtWidgets.QLabel("Engine:"))
+
+        self.combo = QtWidgets.QComboBox()
+        self.combo.setToolTip(
+            "Select the active physics engine. Switching swaps the live "
+            "kinematics service and the pose-convention adapter without a "
+            "process restart."
+        )
+        for engine in SUPPORTED_ENGINES:
+            self.combo.addItem(engine)
+        self.combo.setCurrentText(initial_engine)
+        self.combo.currentTextChanged.connect(self._on_combo_changed)
+        layout.addWidget(self.combo)
+
+        self.status_pill = QtWidgets.QLabel(EngineStatus.MOCK.value)
+        self.status_pill.setToolTip(
+            "Engine status: 'live' (real engine wheel), 'mock' (headless "
+            "fallback when the wheel is not installed), or 'error' (engine "
+            "failed to activate; see log)."
+        )
+        self.status_pill.setMinimumWidth(48)
+        self.status_pill.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.set_status(EngineStatus.MOCK)
+        layout.addWidget(self.status_pill)
+
+        layout.addStretch(1)
+
+    # ---- public surface ------------------------------------------------
+
+    def current_engine(self) -> str:
+        """Return the currently selected engine name."""
+        return self.combo.currentText()
+
+    def set_status(self, status: EngineStatus) -> None:
+        """Re-paint the status pill for *status*."""
+        if not isinstance(status, EngineStatus):
+            raise TypeError(
+                f"status must be an EngineStatus, got {type(status).__name__}"
+            )
+        self.status_pill.setText(status.value)
+        if status is EngineStatus.LIVE:
+            self.status_pill.setStyleSheet(Styles.STATUS_SUCCESS_BOLD)
+        elif status is EngineStatus.MOCK:
+            self.status_pill.setStyleSheet(Styles.STATUS_WARNING)
+        else:
+            self.status_pill.setStyleSheet(Styles.STATUS_ERROR_BOLD)
+
+    def set_engine(self, engine_name: str) -> None:
+        """Programmatically set the combo to *engine_name* (no signal)."""
+        if engine_name not in SUPPORTED_ENGINES:
+            raise ValueError(
+                f"engine_name {engine_name!r} not in SUPPORTED_ENGINES "
+                f"{SUPPORTED_ENGINES!r}"
+            )
+        blocker = QtCore.QSignalBlocker(self.combo)
+        self.combo.setCurrentText(engine_name)
+        del blocker
+
+    # ---- internals -----------------------------------------------------
+
+    def _on_combo_changed(self, engine: str) -> None:
+        self.engine_selected.emit(engine)
+
+
+__all__ = ["EnginePicker"]

--- a/src/tools/pose_studio/widgets/joint_panel.py
+++ b/src/tools/pose_studio/widgets/joint_panel.py
@@ -1,0 +1,206 @@
+"""Accordion of per-joint sliders, grouped by body region.
+
+Each canonical joint (member of :data:`REFERENCE_GOLFER_FIELDS`) gets a
+:class:`QDoubleSpinBox` + :class:`QSlider` pair inside a
+:class:`QGroupBox` for its body region.  The widget emits a single
+``angle_edited(name, degrees)`` signal whenever any spinbox changes; the
+GUI wires this to :meth:`EngineController.set_pose` after applying the
+delta to the current :class:`CanonicalPose`.
+
+Note on units: this widget always presents angles in **degrees**
+internally (matching the canonical convention).  The
+:class:`UnitsBadge` reports the active engine's native convention; if
+the user toggles "show radians" the widget swaps the spinbox suffix
+and re-scales the displayed value but keeps the underlying canonical
+state in degrees.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+from PyQt6 import QtCore, QtWidgets
+
+from src.shared.python.motion_matching.diagnostics.reference_pose import (
+    REFERENCE_GOLFER_FIELDS,
+)
+from src.tools.pose_studio.core import JOINT_REGION_LAYOUT
+
+# Reasonable default range for a 1-DOF revolute golfer joint.  Engine
+# adapters can report tighter limits via their JointSlot; if so the
+# tighter range overrides this default.
+_DEFAULT_DEG_RANGE: tuple[float, float] = (-180.0, 180.0)
+
+
+class JointPanel(QtWidgets.QScrollArea):
+    """Accordion of per-region joint sliders.
+
+    Signals
+    -------
+    angle_edited(str, float)
+        Emitted whenever the user edits a joint angle.  First argument
+        is the canonical joint name (a member of
+        :data:`REFERENCE_GOLFER_FIELDS`); the second is the new value
+        in degrees.
+    """
+
+    angle_edited = QtCore.pyqtSignal(str, float)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWidgetResizable(True)
+        self._show_radians: bool = False
+        self._spinboxes: dict[str, QtWidgets.QDoubleSpinBox] = {}
+        self._sliders: dict[str, QtWidgets.QSlider] = {}
+        self._build_ui()
+
+    # ---- construction --------------------------------------------------
+
+    def _build_ui(self) -> None:
+        container = QtWidgets.QWidget()
+        outer = QtWidgets.QVBoxLayout(container)
+        outer.setContentsMargins(4, 4, 4, 4)
+
+        for region, joints in JOINT_REGION_LAYOUT.items():
+            group = QtWidgets.QGroupBox(region)
+            group.setCheckable(True)
+            group.setChecked(True)
+            group.setToolTip(f"Toggle to collapse/expand the {region} joint group.")
+            grid = QtWidgets.QGridLayout(group)
+            for row, joint in enumerate(joints):
+                self._add_joint_row(grid, row, joint)
+            outer.addWidget(group)
+
+        outer.addStretch(1)
+        self.setWidget(container)
+
+    def _add_joint_row(
+        self,
+        grid: QtWidgets.QGridLayout,
+        row: int,
+        joint: str,
+    ) -> None:
+        label = QtWidgets.QLabel(joint)
+        label.setToolTip(f"Canonical joint name: {joint}")
+        label.setMinimumWidth(160)
+
+        slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
+        slider.setMinimum(int(_DEFAULT_DEG_RANGE[0] * 10))
+        slider.setMaximum(int(_DEFAULT_DEG_RANGE[1] * 10))
+        slider.setValue(0)
+        slider.setToolTip(
+            f"Drag to set {joint} angle in the canonical degrees convention. "
+            f"Range {_DEFAULT_DEG_RANGE[0]:.0f} to {_DEFAULT_DEG_RANGE[1]:.0f} deg."
+        )
+        slider.valueChanged.connect(
+            lambda value, name=joint: self._on_slider_changed(name, value)
+        )
+
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setMinimum(_DEFAULT_DEG_RANGE[0])
+        spin.setMaximum(_DEFAULT_DEG_RANGE[1])
+        spin.setDecimals(2)
+        spin.setSingleStep(0.5)
+        spin.setSuffix(" deg")
+        spin.setMinimumWidth(96)
+        spin.setToolTip(
+            f"Type a precise value for {joint} (degrees in the canonical convention)."
+        )
+        spin.valueChanged.connect(
+            lambda value, name=joint: self._on_spinbox_changed(name, value)
+        )
+
+        grid.addWidget(label, row, 0)
+        grid.addWidget(slider, row, 1)
+        grid.addWidget(spin, row, 2)
+
+        self._sliders[joint] = slider
+        self._spinboxes[joint] = spin
+
+    # ---- public surface ------------------------------------------------
+
+    def set_angles(self, angles_deg: Mapping[str, float]) -> None:
+        """Update every spinbox + slider from *angles_deg* without
+        re-emitting ``angle_edited``."""
+        for name in REFERENCE_GOLFER_FIELDS:
+            value = float(angles_deg.get(name, 0.0))
+            spin = self._spinboxes[name]
+            slider = self._sliders[name]
+            spin_blocker = QtCore.QSignalBlocker(spin)
+            slider_blocker = QtCore.QSignalBlocker(slider)
+            spin.setValue(self._to_display_value(value))
+            slider.setValue(int(value * 10))
+            del spin_blocker
+            del slider_blocker
+
+    def set_show_radians(self, show_radians: bool) -> None:
+        """Switch the spinbox suffix and value scaling between deg/rad.
+
+        Sliders always tick in tenths of a degree; only the spinbox
+        display unit changes.
+        """
+        if not isinstance(show_radians, bool):
+            raise TypeError(
+                f"show_radians must be bool, got {type(show_radians).__name__}"
+            )
+        self._show_radians = show_radians
+        suffix = " rad" if show_radians else " deg"
+        for name, spin in self._spinboxes.items():
+            slider = self._sliders[name]
+            current_deg = slider.value() / 10.0
+            blocker = QtCore.QSignalBlocker(spin)
+            spin.setSuffix(suffix)
+            if show_radians:
+                spin.setMinimum(float(np.radians(_DEFAULT_DEG_RANGE[0])))
+                spin.setMaximum(float(np.radians(_DEFAULT_DEG_RANGE[1])))
+                spin.setDecimals(4)
+                spin.setSingleStep(0.01)
+                spin.setValue(float(np.radians(current_deg)))
+            else:
+                spin.setMinimum(_DEFAULT_DEG_RANGE[0])
+                spin.setMaximum(_DEFAULT_DEG_RANGE[1])
+                spin.setDecimals(2)
+                spin.setSingleStep(0.5)
+                spin.setValue(current_deg)
+            del blocker
+
+    def joint_widgets(self) -> dict[str, QtWidgets.QWidget]:
+        """Return a flat dict of every joint's spinbox + slider, keyed
+        ``"<joint>__spin"`` / ``"<joint>__slider"``.
+
+        Used by the help-coverage test to assert tooltips.
+        """
+        out: dict[str, QtWidgets.QWidget] = {}
+        for name, spin in self._spinboxes.items():
+            out[f"{name}__spin"] = spin
+        for name, slider in self._sliders.items():
+            out[f"{name}__slider"] = slider
+        return out
+
+    # ---- internals -----------------------------------------------------
+
+    def _to_display_value(self, deg: float) -> float:
+        return float(np.radians(deg)) if self._show_radians else deg
+
+    def _from_display_value(self, displayed: float) -> float:
+        return float(np.degrees(displayed)) if self._show_radians else displayed
+
+    def _on_slider_changed(self, name: str, value: int) -> None:
+        deg = value / 10.0
+        spin = self._spinboxes[name]
+        blocker = QtCore.QSignalBlocker(spin)
+        spin.setValue(self._to_display_value(deg))
+        del blocker
+        self.angle_edited.emit(name, deg)
+
+    def _on_spinbox_changed(self, name: str, displayed_value: float) -> None:
+        deg = self._from_display_value(displayed_value)
+        slider = self._sliders[name]
+        blocker = QtCore.QSignalBlocker(slider)
+        slider.setValue(int(deg * 10))
+        del blocker
+        self.angle_edited.emit(name, deg)
+
+
+__all__ = ["JointPanel"]

--- a/src/tools/pose_studio/widgets/units_badge.py
+++ b/src/tools/pose_studio/widgets/units_badge.py
@@ -1,0 +1,60 @@
+"""Read-only badge showing the active engine's native pose convention.
+
+Displayed in the top-right of the main window so the user can tell at
+a glance what convention the engine reports its ``q`` vector in (e.g.
+``"Drake URDF / RPY (rad)"``, ``"OpenSim / coordinates (rad)"``).
+
+The badge does NOT change the values in the joint panel — those are
+always displayed in the canonical convention (degrees by default,
+toggleable to radians via :meth:`JointPanel.set_show_radians`).  The
+badge simply tells the user which engine's Jacobian / FK is feeding
+the live kinematics service under the hood.
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+
+from src.shared.python.theme.style_constants import Styles
+
+# Hard-coded native-convention strings per engine.  These mirror the
+# Joint-Slot units reported by each adapter and the engine's own
+# documentation; they are not derived at runtime because the badge is
+# purely informational.
+_ENGINE_CONVENTIONS: dict[str, str] = {
+    "drake": "Drake URDF / RPY (rad)",
+    "mujoco": "MuJoCo MJCF / Euler (rad)",
+    "pinocchio": "Pinocchio URDF / RPY (rad)",
+    "opensim": "OpenSim .osim / coordinates (rad)",
+    "simscape": "Simscape Parameters / RPY (deg)",
+}
+
+
+class UnitsBadge(QtWidgets.QLabel):
+    """Read-only :class:`QLabel` showing the engine's native convention."""
+
+    def __init__(
+        self,
+        engine_name: str = "drake",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setStyleSheet(Styles.STATUS_INFO)
+        self.setToolTip(
+            "The active engine's native pose convention. Joint sliders "
+            "below always show angles in the canonical convention "
+            "(degrees by default; toggle radians from the View menu)."
+        )
+        self.set_engine(engine_name)
+
+    def set_engine(self, engine_name: str) -> None:
+        """Update the badge text for *engine_name*."""
+        if not isinstance(engine_name, str):
+            raise TypeError(
+                f"engine_name must be str, got {type(engine_name).__name__}"
+            )
+        text = _ENGINE_CONVENTIONS.get(engine_name, f"{engine_name} (unknown)")
+        self.setText(text)
+
+
+__all__ = ["UnitsBadge"]

--- a/src/tools/pose_studio/widgets/view_3d.py
+++ b/src/tools/pose_studio/widgets/view_3d.py
@@ -16,6 +16,7 @@ this widget's public surface.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any, cast
 
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
@@ -74,7 +75,11 @@ class View3D(QtWidgets.QWidget):
         self._figure = Figure(figsize=(5, 5), tight_layout=True)
         self._canvas = FigureCanvasQTAgg(self._figure)
         self._canvas.setToolTip(self.toolTip())
-        self._ax = self._figure.add_subplot(111, projection="3d")
+        # matplotlib 3D Axes carry methods (set_zlabel, set_zlim, set_box_aspect
+        # with 3-tuples) that the public Axes stub does not expose.  Use Any
+        # locally rather than importing mpl_toolkits.mplot3d.Axes3D, which is
+        # itself not present in older type stubs.
+        self._ax: Any = self._figure.add_subplot(111, projection="3d")
         self._ax.set_xlabel("X (m)")
         self._ax.set_ylabel("Y (m)")
         self._ax.set_zlabel("Z (m)")
@@ -83,12 +88,15 @@ class View3D(QtWidgets.QWidget):
         layout.addWidget(self._canvas)
 
         # Pre-create artists so update_pose mutates rather than rebuilds.
-        self._scatter = self._ax.scatter(
+        # ``s=40`` is the marker size keyword for Axes3D.scatter; the 2D
+        # Axes stub treats the same kwarg as positional which mypy flags.
+        self._scatter: Any = self._ax.scatter(
             [0.0], [0.0], [0.0], s=40, c="#5fa8ff", picker=True, pickradius=6
         )
         (self._bone_lines,) = self._ax.plot(
             [0.0], [0.0], [0.0], lw=2.0, color="#cccccc"
         )
+        self._bone_lines = cast(Any, self._bone_lines)
         self._highlighted_landmark: str | None = None
         self._landmarks_order: list[str] = []
 

--- a/src/tools/pose_studio/widgets/view_3d.py
+++ b/src/tools/pose_studio/widgets/view_3d.py
@@ -1,0 +1,175 @@
+"""3D skeleton viewport using matplotlib's QtAgg canvas.
+
+Renders the canonical skeleton derived from :func:`forward_kinematics`
+applied to the current :class:`CanonicalPose`.  Click-to-highlight is
+supported for v1; drag/IK is deferred to a follow-up issue.
+
+Why matplotlib instead of :class:`PyQtGLRenderer` from
+:mod:`body_part_viz`?  The body_part_viz renderer expects fitted shape
+primitives (cylinders/ellipsoids for body segments) that are out of
+scope for v1 — pose_studio only needs a lines-and-dots skeleton, which
+matplotlib draws cheaply.  When IK drag-handles ship in a follow-up
+the renderer can be swapped for a proper rigged view without changing
+this widget's public surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+from PyQt6 import QtCore, QtWidgets
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.motion_matching.diagnostics.forward_kinematics import (
+    forward_kinematics,
+)
+from src.shared.python.pose_interchange.canonical import CanonicalPose
+
+logger = get_logger(__name__)
+
+
+# Skeleton bones, expressed as ordered pairs of landmark names returned
+# by forward_kinematics().  See SkeletonPose.points for the canonical
+# landmark set.
+_BONES: tuple[tuple[str, str], ...] = (
+    ("pelvis", "spine_top"),
+    ("spine_top", "torso_top"),
+    ("torso_top", "l_shoulder"),
+    ("torso_top", "r_shoulder"),
+    ("l_shoulder", "l_elbow"),
+    ("l_elbow", "l_wrist"),
+    ("l_wrist", "l_hand"),
+    ("r_shoulder", "r_elbow"),
+    ("r_elbow", "r_wrist"),
+    ("r_wrist", "r_hand"),
+    ("butt", "clubhead"),
+)
+
+
+class View3D(QtWidgets.QWidget):
+    """3D matplotlib canvas drawing the canonical skeleton.
+
+    Signals
+    -------
+    landmark_picked(str)
+        Emitted with the canonical landmark name when the user clicks a
+        landmark dot.  Used by the joint panel to scroll the matching
+        joint into view.
+    """
+
+    landmark_picked = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setToolTip(
+            "3D skeleton view. Click a landmark dot to highlight the "
+            "joint. Drag-and-IK ships in a follow-up issue."
+        )
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._figure = Figure(figsize=(5, 5), tight_layout=True)
+        self._canvas = FigureCanvasQTAgg(self._figure)
+        self._canvas.setToolTip(self.toolTip())
+        self._ax = self._figure.add_subplot(111, projection="3d")
+        self._ax.set_xlabel("X (m)")
+        self._ax.set_ylabel("Y (m)")
+        self._ax.set_zlabel("Z (m)")
+        self._ax.set_box_aspect((1, 1, 1))
+
+        layout.addWidget(self._canvas)
+
+        # Pre-create artists so update_pose mutates rather than rebuilds.
+        self._scatter = self._ax.scatter(
+            [0.0], [0.0], [0.0], s=40, c="#5fa8ff", picker=True, pickradius=6
+        )
+        (self._bone_lines,) = self._ax.plot(
+            [0.0], [0.0], [0.0], lw=2.0, color="#cccccc"
+        )
+        self._highlighted_landmark: str | None = None
+        self._landmarks_order: list[str] = []
+
+        self._canvas.mpl_connect("pick_event", self._on_pick)
+
+        # Show a sensible initial pose so the canvas is not blank.
+        self.update_pose(CanonicalPose.__new__(CanonicalPose) if False else None)
+
+    # ---- public surface ------------------------------------------------
+
+    def update_pose(self, pose: CanonicalPose | None) -> None:
+        """Re-draw the skeleton for *pose*.
+
+        ``None`` clears to the all-zero canonical pose, which is the
+        T-pose at the world origin.
+        """
+        angles: Mapping[str, float]
+        if pose is None:
+            angles = {}
+        elif isinstance(pose, CanonicalPose):
+            angles = pose.angles_full_dict_deg()
+        else:
+            raise TypeError(
+                f"pose must be a CanonicalPose or None, got {type(pose).__name__}"
+            )
+
+        skeleton = forward_kinematics(angles)
+        names = list(skeleton.points.keys())
+        coords = np.array([skeleton.points[n] for n in names], dtype=float)
+
+        self._landmarks_order = names
+
+        # Update scatter
+        self._scatter._offsets3d = (coords[:, 0], coords[:, 1], coords[:, 2])
+
+        # Update bones
+        bone_x: list[float] = []
+        bone_y: list[float] = []
+        bone_z: list[float] = []
+        for a, b in _BONES:
+            if a in skeleton.points and b in skeleton.points:
+                pa = skeleton.points[a]
+                pb = skeleton.points[b]
+                bone_x.extend([float(pa[0]), float(pb[0]), np.nan])
+                bone_y.extend([float(pa[1]), float(pb[1]), np.nan])
+                bone_z.extend([float(pa[2]), float(pb[2]), np.nan])
+        self._bone_lines.set_data_3d(bone_x, bone_y, bone_z)
+
+        # Auto-fit axes around the skeleton with a small margin.
+        if coords.size:
+            mins = coords.min(axis=0)
+            maxs = coords.max(axis=0)
+            spans = np.maximum(maxs - mins, 0.5)
+            half = float(spans.max() * 0.6)
+            cx, cy, cz = (mins + maxs) / 2.0
+            self._ax.set_xlim(cx - half, cx + half)
+            self._ax.set_ylim(cy - half, cy + half)
+            self._ax.set_zlim(cz - half, cz + half)
+
+        self._canvas.draw_idle()
+
+    def highlighted_landmark(self) -> str | None:
+        """Return the most recently clicked landmark, or ``None``."""
+        return self._highlighted_landmark
+
+    # ---- internals -----------------------------------------------------
+
+    def _on_pick(self, event: object) -> None:
+        artist = getattr(event, "artist", None)
+        ind = getattr(event, "ind", None)
+        if artist is not self._scatter or ind is None:
+            return
+        try:
+            idx = int(ind[0])
+        except (IndexError, TypeError):
+            return
+        if 0 <= idx < len(self._landmarks_order):
+            name = self._landmarks_order[idx]
+            self._highlighted_landmark = name
+            logger.debug("View3D landmark picked: %s", name)
+            self.landmark_picked.emit(name)
+
+
+__all__ = ["View3D"]

--- a/tests/ui/tools/pose_studio/test_help_coverage.py
+++ b/tests/ui/tools/pose_studio/test_help_coverage.py
@@ -1,0 +1,87 @@
+"""Tooltip coverage test for Pose Studio.
+
+Mirrors ``tests/ui/test_help_coverage.py``: walks the main window's
+interactive widgets under ``QT_QPA_PLATFORM=offscreen`` and asserts
+that every widget on the curated whitelist exposes a non-empty
+``toolTip()``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.shared.python.engine_core.engine_availability import (
+    skip_if_unavailable,
+)
+
+pytestmark = [
+    skip_if_unavailable("pyqt6"),
+    skip_if_unavailable("matplotlib"),
+    pytest.mark.unit,
+]
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+# Curated whitelist of attribute paths whose tooltip we guarantee.
+# Dotted paths are resolved attribute-by-attribute on the main window.
+TOOLTIP_WHITELIST: tuple[str, ...] = (
+    "engine_picker.combo",
+    "engine_picker.status_pill",
+    "units_badge",
+    "view_3d",
+    "btn_save",
+    "btn_load",
+    "btn_undo",
+    "btn_redo",
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():  # noqa: ANN201
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def studio(qapp):  # noqa: ANN001, ANN201
+    from src.tools.pose_studio.gui import PoseStudioWindow
+
+    win = PoseStudioWindow()
+    yield win
+    win.close()
+
+
+def _resolve(obj: object, dotted: str) -> object | None:
+    cur: object | None = obj
+    for part in dotted.split("."):
+        if cur is None:
+            return None
+        cur = getattr(cur, part, None)
+    return cur
+
+
+def test_pose_studio_tooltip_whitelist(studio) -> None:  # noqa: ANN001
+    """Every whitelisted widget must have a non-empty tooltip."""
+    missing: list[str] = []
+    for path in TOOLTIP_WHITELIST:
+        widget = _resolve(studio, path)
+        if widget is None:
+            missing.append(f"{path}: attribute not present")
+            continue
+        tip = widget.toolTip() if hasattr(widget, "toolTip") else ""
+        if not tip:
+            missing.append(f"{path}: tooltip is empty")
+    assert not missing, "Missing tooltips:\n  - " + "\n  - ".join(missing)
+
+
+def test_joint_panel_widgets_have_tooltips(studio) -> None:  # noqa: ANN001
+    """Every spinbox + slider in the joint panel must have a tooltip."""
+    widgets = studio.joint_panel.joint_widgets()
+    assert widgets, "Joint panel exposed no widgets"
+    missing = [name for name, w in widgets.items() if not w.toolTip()]
+    assert not missing, "Joint widgets missing tooltips: " + ", ".join(missing)

--- a/tests/ui/tools/pose_studio/test_smoke.py
+++ b/tests/ui/tools/pose_studio/test_smoke.py
@@ -1,0 +1,92 @@
+"""Headless smoke test for the Pose Studio main window.
+
+Mirrors the offscreen pattern used by ``tests/ui/test_help_coverage.py``:
+runs under ``QT_QPA_PLATFORM=offscreen`` and skips cleanly when PyQt6
+or matplotlib is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.shared.python.engine_core.engine_availability import (
+    skip_if_unavailable,
+)
+
+pytestmark = [
+    skip_if_unavailable("pyqt6"),
+    skip_if_unavailable("matplotlib"),
+    pytest.mark.unit,
+]
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():  # noqa: ANN201
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def studio(qapp):  # noqa: ANN001, ANN201
+    from src.tools.pose_studio.gui import PoseStudioWindow
+
+    win = PoseStudioWindow()
+    yield win
+    win.close()
+
+
+def test_window_constructs_without_exception(studio) -> None:  # noqa: ANN001
+    """The window must instantiate without raising."""
+    assert studio is not None
+    assert studio.windowTitle() == "Pose Studio"
+
+
+def test_engine_picker_swap_succeeds(studio) -> None:  # noqa: ANN001
+    """Swapping the engine via the picker must not raise."""
+    from src.tools.pose_studio.core import SUPPORTED_ENGINES
+
+    if len(SUPPORTED_ENGINES) < 2:
+        pytest.skip("need >= 2 engines to exercise the picker")
+    target = SUPPORTED_ENGINES[1]
+    studio.engine_picker.combo.setCurrentText(target)
+    assert studio._engine_controller.engine_name == target  # noqa: SLF001
+    assert studio.units_badge.text()
+
+
+def test_load_reference_pose(studio) -> None:  # noqa: ANN001
+    """Loading the reference pose populates the joint panel."""
+    studio._on_load_reference()  # noqa: SLF001
+    angles = studio._engine_controller.pose.angles_full_dict_deg()  # noqa: SLF001
+    # The reference pose has a non-zero forward spine tilt.
+    assert angles["SpineStartPositionX"] != 0.0
+
+
+def test_undo_redo_cycle(studio) -> None:  # noqa: ANN001
+    """Undo/redo through the history controller must round-trip."""
+    studio._on_load_reference()  # push a pose  # noqa: SLF001
+    assert studio._history.can_undo  # noqa: SLF001
+    studio._on_undo()  # noqa: SLF001
+    assert studio._history.can_redo  # noqa: SLF001
+    studio._on_redo()  # noqa: SLF001
+    assert not studio._history.can_redo  # noqa: SLF001
+
+
+def test_view_3d_updates_with_pose(studio) -> None:  # noqa: ANN001
+    """The 3D view's update_pose must accept a CanonicalPose."""
+    from src.shared.python.pose_interchange.canonical import (
+        canonical_from_reference_setup,
+    )
+
+    studio.view_3d.update_pose(canonical_from_reference_setup())
+
+
+def test_save_load_buttons_show_stub_tooltip(studio) -> None:  # noqa: ANN001
+    """Save/Load buttons must surface the #4900 stub tooltip."""
+    assert "#4900" in studio.btn_save.toolTip()
+    assert "#4900" in studio.btn_load.toolTip()

--- a/tests/unit/tools/pose_studio/test_core.py
+++ b/tests/unit/tools/pose_studio/test_core.py
@@ -1,0 +1,204 @@
+"""Pure-data unit tests for the Pose Studio controllers and core layout.
+
+These tests never touch Qt — they exercise only the pure-data state
+machine and the two controllers, which is the load-bearing math for
+the Pose Studio tool (the rest is layout + signal wiring).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.pose_interchange.canonical import (
+    CanonicalPose,
+    canonical_from_reference_setup,
+    canonical_zero_pose,
+)
+from src.tools.pose_studio.controllers import (
+    EngineController,
+    HistoryController,
+)
+from src.tools.pose_studio.core import (
+    JOINT_REGION_LAYOUT,
+    SUPPORTED_ENGINES,
+    EngineStatus,
+    joint_region_partitions_reference_fields,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Layout / core
+# ---------------------------------------------------------------------------
+
+
+def test_supported_engines_non_empty() -> None:
+    """At least one engine must be available; otherwise the picker is dead."""
+    assert SUPPORTED_ENGINES, "SUPPORTED_ENGINES must be non-empty"
+
+
+def test_joint_region_layout_partitions_reference_fields() -> None:
+    """Every canonical field must belong to exactly one body region."""
+    assert joint_region_partitions_reference_fields()
+
+
+def test_joint_region_layout_groups_have_unique_fields() -> None:
+    """A field never appears in two regions."""
+    seen: set[str] = set()
+    for region, fields in JOINT_REGION_LAYOUT.items():
+        for f in fields:
+            assert f not in seen, f"{f} appears in two regions (incl. {region!r})"
+            seen.add(f)
+
+
+# ---------------------------------------------------------------------------
+# EngineController
+# ---------------------------------------------------------------------------
+
+
+def test_engine_controller_constructs_with_default() -> None:
+    ctrl = EngineController(SUPPORTED_ENGINES[0])
+    assert ctrl.engine_name == SUPPORTED_ENGINES[0]
+    assert ctrl.status in {EngineStatus.MOCK, EngineStatus.LIVE}
+    assert ctrl.adapter is not None
+    assert ctrl.service is not None
+    assert isinstance(ctrl.pose, CanonicalPose)
+
+
+def test_engine_controller_rejects_unknown_engine() -> None:
+    with pytest.raises(ValueError):
+        EngineController("not-a-real-engine")
+    with pytest.raises(TypeError):
+        EngineController(123)  # type: ignore[arg-type]
+
+
+def test_engine_controller_switches_engines() -> None:
+    if len(SUPPORTED_ENGINES) < 2:
+        pytest.skip("need >= 2 engines to exercise switch")
+    a, b = SUPPORTED_ENGINES[0], SUPPORTED_ENGINES[1]
+    ctrl = EngineController(a)
+    status = ctrl.switch_engine(b)
+    assert ctrl.engine_name == b
+    assert status == ctrl.status
+    assert ctrl.status in {EngineStatus.MOCK, EngineStatus.LIVE}
+
+
+def test_engine_controller_switch_engine_rejects_unknown() -> None:
+    ctrl = EngineController(SUPPORTED_ENGINES[0])
+    with pytest.raises(ValueError):
+        ctrl.switch_engine("not-a-real-engine")
+
+
+def test_engine_controller_set_pose_updates_state() -> None:
+    ctrl = EngineController(SUPPORTED_ENGINES[0])
+    ref = canonical_from_reference_setup()
+    ctrl.set_pose(ref)
+    assert ctrl.pose is ref
+
+
+def test_engine_controller_set_pose_type_validation() -> None:
+    ctrl = EngineController(SUPPORTED_ENGINES[0])
+    with pytest.raises(TypeError):
+        ctrl.set_pose("not a pose")  # type: ignore[arg-type]
+
+
+def test_engine_controller_replays_pose_across_switch() -> None:
+    if len(SUPPORTED_ENGINES) < 2:
+        pytest.skip("need >= 2 engines to exercise switch")
+    a, b = SUPPORTED_ENGINES[0], SUPPORTED_ENGINES[1]
+    ctrl = EngineController(a)
+    ref = canonical_from_reference_setup()
+    ctrl.set_pose(ref)
+    ctrl.switch_engine(b)
+    # Pose must survive the swap so the 3D view stays in sync.
+    assert np.allclose(
+        ctrl.pose.pelvis_translation_m,
+        ref.pelvis_translation_m,
+    )
+    for key in ref.angles_full_dict_deg():
+        assert ctrl.pose.angle_deg(key) == ref.angle_deg(key)
+
+
+# ---------------------------------------------------------------------------
+# HistoryController
+# ---------------------------------------------------------------------------
+
+
+def test_history_controller_initial_state() -> None:
+    h = HistoryController(canonical_zero_pose())
+    assert h.depth == 1
+    assert not h.can_undo
+    assert not h.can_redo
+    assert h.undo() is None
+    assert h.redo() is None
+
+
+def test_history_controller_push_undo_redo_cycle() -> None:
+    p0 = canonical_zero_pose()
+    p1 = canonical_from_reference_setup()
+    h = HistoryController(p0)
+    h.push(p1)
+
+    assert h.can_undo
+    assert not h.can_redo
+    assert h.depth == 2
+
+    undone = h.undo()
+    assert undone is p0
+    assert h.can_redo
+    assert h.current is p0
+
+    redone = h.redo()
+    assert redone is p1
+    assert h.current is p1
+
+
+def test_history_controller_push_after_undo_drops_redo_branch() -> None:
+    p0 = canonical_zero_pose()
+    p1 = canonical_from_reference_setup()
+    p2 = CanonicalPose(
+        pelvis_translation_m=np.zeros(3),
+        pelvis_rotation_xyz_deg=np.zeros(3),
+        joint_angles_deg={"HipStartPositionX": 1.0},
+    )
+    h = HistoryController(p0)
+    h.push(p1)
+    h.undo()
+    assert h.can_redo
+    h.push(p2)
+    # The redo branch (p1) must be discarded.
+    assert not h.can_redo
+    assert h.current is p2
+
+
+def test_history_controller_max_depth_trim() -> None:
+    p0 = canonical_zero_pose()
+    h = HistoryController(p0, max_depth=3)
+    poses = [
+        CanonicalPose(
+            pelvis_translation_m=np.zeros(3),
+            pelvis_rotation_xyz_deg=np.zeros(3),
+            joint_angles_deg={"HipStartPositionX": float(i + 1)},
+        )
+        for i in range(5)
+    ]
+    for p in poses:
+        h.push(p)
+    # Stack should be trimmed to the cap.
+    assert h.depth == 3
+    # The current cursor still points at the most recently pushed pose.
+    assert h.current is poses[-1]
+
+
+def test_history_controller_rejects_bad_inputs() -> None:
+    with pytest.raises(TypeError):
+        HistoryController("not a pose")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        HistoryController(canonical_zero_pose(), max_depth=1)
+    with pytest.raises(TypeError):
+        HistoryController(canonical_zero_pose(), max_depth="big")  # type: ignore[arg-type]
+    h = HistoryController(canonical_zero_pose())
+    with pytest.raises(TypeError):
+        h.push("not a pose")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Subtask 5 of EPIC #4895. Adds `src/tools/pose_studio` — a single-purpose
PyQt6 tool that lets the user hand-edit a `CanonicalPose` and see the
result rendered through any of the supported physics engines (Drake,
MuJoCo, Pinocchio, OpenSim, Simscape) without restarting the process.

Closes #4899.
Part of EPIC #4895.
Builds on:
- #4924 (canonical foundation, Subtask 1)
- #4934 (per-engine `PoseConventionAdapter`s, Subtask 2)
- #4935 (per-engine `LiveKinematicsService`s, Subtask 3)

## What's in the package

```
src/tools/pose_studio/
  core.py                — engine-agnostic state machine, no Qt
  controllers/
    engine_controller.py — owns active LiveKinematicsService + Adapter
    history_controller.py— undo/redo stack of CanonicalPose snapshots
  widgets/
    engine_picker.py     — combo + status pill (mock/live/error)
    joint_panel.py       — accordion of per-joint sliders by body region
    view_3d.py           — matplotlib 3D skeleton (click-to-highlight)
    units_badge.py       — engine native-convention indicator
  gui.py                 — QMainWindow composing the above
  __main__.py            — `python -m src.tools.pose_studio` entrypoint
```

The pure-data layer (`core.py` + `controllers/*`) imports no Qt and is
covered directly by `tests/unit/tools/pose_studio/`. The GUI layer is
covered by offscreen smoke tests in `tests/ui/tools/pose_studio/` plus
a tooltip-coverage guard mirroring the matcher's existing
`test_help_coverage.py`.

## Behaviour highlights

- Engine swap with **mock fallback** (yellow status pill) when the
  engine wheel isn't installed; transparent further downgrade if a live
  engine's `set_pose` is still `NotImplementedError` (some Subtask 3
  engine bridges are partial).
- **Undo/redo** stack with `Ctrl+Z` / `Ctrl+Shift+Z`.
- **Pose Library** menu loads `canonical_zero_pose` and
  `canonical_from_reference_setup`.
- **Units toggle** (View menu) flips the joint panel between degrees
  and radians; canonical state stays in degrees.
- Save/Load buttons surface a stub tooltip pointing at #4900.

## Launcher

Tile registered in `src/config/models.yaml` as `pose_studio`,
`status: beta`.

## Out of scope (deferred)

- IK drag-handles (issue called this stretch — split if needed)
- Real save/load — Subtask 6 / #4900 (running in parallel)
- Mocap scrubbing — Subtask 7 / #4901

## Test plan

- [x] `python3 -m ruff check .`
- [x] `python3 -m ruff format --check .`
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] `QT_QPA_PLATFORM=offscreen python3 -m pytest tests/unit/tools/pose_studio tests/ui/tools/pose_studio -q` (23 passed)
- [x] All pre-push hooks pass (ruff lint + format, mypy, bandit, prettier, pytest)
- [ ] Manual smoke: `python -m src.tools.pose_studio` opens the window, engine-swap re-paints status pill, joint sliders move the 3D skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)