### PR TITLE
feat: add untested module dashboard generator

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -57,7 +57,9 @@
     "3213721780",
     "3213721782",
     "3213770810",
-    "3213770814"
+    "3213770814",
+    "3214013231",
+    "3214013233"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",
@@ -80,6 +82,7 @@
     "3211158550": "https://github.com/D-sorganization/UpstreamDrift/issues/4685",
     "3211158553": "https://github.com/D-sorganization/UpstreamDrift/issues/4686",
     "3211902238": "https://github.com/D-sorganization/UpstreamDrift/issues/4728",
-    "3213721780": "https://github.com/D-sorganization/UpstreamDrift/issues/4926"
+    "3213721780": "https://github.com/D-sorganization/UpstreamDrift/issues/4926",
+    "3214013231": "https://github.com/D-sorganization/UpstreamDrift/issues/4974"
   }
 }

--- a/docs/review_archive/review_comments_2026-05-09.md
+++ b/docs/review_archive/review_comments_2026-05-09.md
@@ -1,35 +1,38 @@
 # Review Comments Archive - 2026-05-09
 
-Generated: 2026-05-09T15:45:04.294158
+Generated: 2026-05-09T16:11:25.667202
 
 ## Reviewer (chatgpt-codex-connector[bot]) (2 comments)
 
-### PR #4934: src/shared/python/pose_interchange/services/_mock.py:110
+### PR #4973: docs/development/test_coverage_epic.md:26
+
+Actionable: Yes
+Has Suggestion: No
+
+```
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Point Sprint 2 at existing physics package**
+
+The Sprint 2 action targets `src/shared/python/physics_core/`, but that directory does not exist in this repository (the shared physics code lives under `src/shared/python/physics/`). Keeping this path in the plan will send remediation work to a non-existent module tree and can cause the coverage effort to miss the actual high-risk physics code that should be ratc...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4973#discussion_r3214013231)
+
+---
+
+### PR #4973: docs/development/test_coverage_epic.md:32
 
 Actionable: No
 Has Suggestion: No
 
 ```
-**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Apply pelvis SE(3) to mock landmark transforms**
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Use the real API route directory in Sprint 3**
 
-`get_link_transforms()` currently derives landmarks from `forward_kinematics(angles)` and writes those points directly into each SE(3) translation, so any non-zero `pelvis_translation_m` / `pelvis_rotation_xyz_deg` in the last `set_pose()` is ignored. In scenarios where Pose Studio (or parity checks) places the canonical pose away from origin, the mock service...
+The Sprint 3 plan references `src/api/routers/`, but the codebase uses `src/api/routes/` for REST/WebSocket route modules. This mismatch makes the remediation instructions inaccurate and can derail coverage tooling/tasks that rely on path-based targeting, leaving the intended API surface under-tested.
+
+Useful? React with 👍 / 👎.
 ```
 
-[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4934#discussion_r3213770810)
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4973#discussion_r3214013233)
 
 ---
 
-### PR #4934: src/shared/python/pose_interchange/canonical.py:126
-
-Actionable: No
-Has Suggestion: No
-
-```
-**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Freeze joint-angle mapping to preserve CanonicalPose invariants**
-
-`CanonicalPose` is declared frozen and validated on construction, but `__post_init__` stores `joint_angles_deg` as a plain mutable `dict`. Callers can mutate that mapping after construction and bypass all validation (including canonical field-name and finiteness checks), which undermines immutability guarantees and can produce invalid or non-d...
-```
-
-[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/4934#discussion_r3213770814)
-
----

--- a/scripts/config/generate_untested_dashboard.py
+++ b/scripts/config/generate_untested_dashboard.py
@@ -1,0 +1,50 @@
+import xml.etree.ElementTree as ET
+import os
+
+
+def generate_untested_dashboard(
+    xml_path="coverage.xml", output_path="untested_modules_dashboard.md"
+):
+    if not os.path.exists(xml_path):
+        print(f"Coverage file not found at {xml_path}")
+        return
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    untested_modules = []
+
+    for package in root.findall(".//package"):
+        package_name = package.get("name")
+        for cls in package.findall(".//class"):
+            filename = cls.get("filename")
+            line_rate = float(cls.get("line-rate", 0))
+
+            # Identify modules with absolutely no coverage
+            if line_rate == 0.0:
+                untested_modules.append(filename)
+
+    # Sort for predictability
+    untested_modules.sort()
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("# Phase 3: Untested Modules Dashboard\n\n")
+        f.write(
+            "This dashboard tracks all core modules that currently possess **0% test coverage**. These modules form the primary target list for Phase 3 Coverage Ratcheting.\n\n"
+        )
+
+        f.write(f"**Total Untested Modules:** {len(untested_modules)}\n\n")
+
+        f.write("## Hit List\n")
+        f.write("| Module Path | Status |\n")
+        f.write("|-------------|--------|\n")
+
+        f.writelines(f"| `{mod}` | ❌ Untested |\n" for mod in untested_modules)
+
+    print(
+        f"Dashboard successfully generated at {output_path} with {len(untested_modules)} modules."
+    )
+
+
+if __name__ == "__main__":
+    generate_untested_dashboard()


### PR DESCRIPTION
Adds the script to parse coverage.xml and generate the dashboard of untested modules for Phase 3 Sprint 1.