### PR TITLE
docs: add Phase 3 Coverage Epic plan and dashboard generator

### DIFF
--- a/docs/development/test_coverage_epic.md
+++ b/docs/development/test_coverage_epic.md
@@ -1,13 +1,11 @@
 # Epic: Phase 3 - Systematic Coverage Ratcheting and Untested Module Remediation
 
 ## Executive Summary
-
 Following the successful completion of Phase 2 (Test Suite Modularization), where oversized test files (>500 lines) were systematically decomposed and legacy dead tests were archived, the UpstreamDrift repository has achieved a stabilized baseline. However, global test coverage remains stagnant around the ~55% threshold due to a significant backlog of entirely untested core modules.
 
 This Epic initiates **Phase 3: Coverage Ratcheting**, with the ultimate goal of achieving the organizational standard of 80% global coverage. This will be accomplished through systematic identification of untested modules, contract-based integration testing, and a strict CI/CD ratchet.
 
 ## Objectives
-
 1. **Identify and Classify Untested Modules:** Audit the entire `src/` tree to catalog the 800+ modules lacking test coverage, categorizing them by architectural tier (e.g., Domain Core vs. UI Launchers).
 2. **Prioritize High-Risk Domains:** Focus initial testing efforts on critical physics engines, API contracts, and spatial algebra modules that represent the highest technical risk.
 3. **Generate High-Quality Contract Tests:** Implement rigorous, decoupled tests utilizing `pytest` and `unittest.mock` to validate module boundaries and error-handling paths.
@@ -16,31 +14,26 @@ This Epic initiates **Phase 3: Coverage Ratcheting**, with the ultimate goal of 
 ## Implementation Plan
 
 ### Sprint 1: Global Coverage Audit and Baseline Generation
-
-- **Action:** Run a comprehensive `pytest --cov=src` pass and export the `coverage.xml` report.
-- **Action:** Parse the coverage report to generate a canonical "Hit List" of modules with 0% coverage.
-- **Deliverable:** A prioritized dashboard artifact categorizing untested modules by severity and impact.
+*   **Action:** Run a comprehensive `pytest --cov=src` pass and export the `coverage.xml` report.
+*   **Action:** Parse the coverage report to generate a canonical "Hit List" of modules with 0% coverage.
+*   **Deliverable:** A prioritized dashboard artifact categorizing untested modules by severity and impact.
 
 ### Sprint 2: Core Domain Remediation (Physics & Spatial Algebra)
-
-- **Action:** Target `src/shared/python/spatial_algebra/` and `src/shared/python/physics_core/` for immediate remediation.
-- **Action:** Implement parameterized tests covering boundary conditions, singular matrix handling, and cross-engine protocol compliance.
-- **Deliverable:** Core math domains elevated to >85% coverage.
+*   **Action:** Target `src/shared/python/spatial_algebra/` and `src/shared/python/physics_core/` for immediate remediation.
+*   **Action:** Implement parameterized tests covering boundary conditions, singular matrix handling, and cross-engine protocol compliance.
+*   **Deliverable:** Core math domains elevated to >85% coverage.
 
 ### Sprint 3: API and Backend Services Remediation
-
-- **Action:** Target `src/api/routers/` and `src/api/services/`.
-- **Action:** Implement `httpx` and `AsyncMock` based integration tests for all REST and WebSocket endpoints, focusing on authentication flows and payload validation.
-- **Deliverable:** API domain elevated to >80% coverage.
+*   **Action:** Target `src/api/routers/` and `src/api/services/`.
+*   **Action:** Implement `httpx` and `AsyncMock` based integration tests for all REST and WebSocket endpoints, focusing on authentication flows and payload validation.
+*   **Deliverable:** API domain elevated to >80% coverage.
 
 ### Sprint 4: CI/CD Ratchet Enforcement
-
-- **Action:** Update `pyproject.toml` and CI pipeline configurations to harden the per-package coverage thresholds based on the gains achieved in Sprints 1-3.
-- **Deliverable:** The global baseline permanently locked at a higher threshold, preventing future PRs from introducing untested code.
+*   **Action:** Update `pyproject.toml` and CI pipeline configurations to harden the per-package coverage thresholds based on the gains achieved in Sprints 1-3.
+*   **Deliverable:** The global baseline permanently locked at a higher threshold, preventing future PRs from introducing untested code.
 
 ## Acceptance Criteria
-
-- The global repository coverage metric reaches or exceeds **80%**.
-- No individual core module (`src/shared/`, `src/api/`, `src/engines/`) falls below 75% coverage.
-- All new tests adhere to the established "Independent Class" paradigm, ensuring CI parallelization is uninhibited.
-- The CI/CD coverage enforcer successfully gates PRs that reduce coverage.
+*   The global repository coverage metric reaches or exceeds **80%**.
+*   No individual core module (`src/shared/`, `src/api/`, `src/engines/`) falls below 75% coverage.
+*   All new tests adhere to the established "Independent Class" paradigm, ensuring CI parallelization is uninhibited.
+*   The CI/CD coverage enforcer successfully gates PRs that reduce coverage.

--- a/scripts/config/generate_untested_dashboard.py
+++ b/scripts/config/generate_untested_dashboard.py
@@ -1,0 +1,50 @@
+import xml.etree.ElementTree as ET
+import os
+
+
+def generate_untested_dashboard(
+    xml_path="coverage.xml", output_path="untested_modules_dashboard.md"
+):
+    if not os.path.exists(xml_path):
+        print(f"Coverage file not found at {xml_path}")
+        return
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    untested_modules = []
+
+    for package in root.findall(".//package"):
+        package_name = package.get("name")
+        for cls in package.findall(".//class"):
+            filename = cls.get("filename")
+            line_rate = float(cls.get("line-rate", 0))
+
+            # Identify modules with absolutely no coverage
+            if line_rate == 0.0:
+                untested_modules.append(filename)
+
+    # Sort for predictability
+    untested_modules.sort()
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("# Phase 3: Untested Modules Dashboard\n\n")
+        f.write(
+            "This dashboard tracks all core modules that currently possess **0% test coverage**. These modules form the primary target list for Phase 3 Coverage Ratcheting.\n\n"
+        )
+
+        f.write(f"**Total Untested Modules:** {len(untested_modules)}\n\n")
+
+        f.write("## Hit List\n")
+        f.write("| Module Path | Status |\n")
+        f.write("|-------------|--------|\n")
+
+        f.writelines(f"| `{mod}` | ❌ Untested |\n" for mod in untested_modules)
+
+    print(
+        f"Dashboard successfully generated at {output_path} with {len(untested_modules)} modules."
+    )
+
+
+if __name__ == "__main__":
+    generate_untested_dashboard()


### PR DESCRIPTION
Adds the Epic document for Phase 3 and the script to generate the untested module dashboard.