### PR TITLE
test: add test coverage for humanoid launchers

### DIFF
--- a/tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py
+++ b/tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py
@@ -1,0 +1,173 @@
+"""Tests for MuJoCo Python Humanoid Launchers."""
+
+import sys
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import numpy as np
+
+from src.shared.python.config.configuration_manager import ConfigurationManager
+
+from src.engines.physics_engines.mujoco.python.humanoid_launcher import (
+    RemoteRecorder,
+    HumanoidLauncher,
+)
+from PyQt6.QtWidgets import QApplication
+
+
+def test_remote_recorder():
+    """Test RemoteRecorder."""
+    recorder = RemoteRecorder()
+    assert recorder.data["times"] == []
+
+    # Test process_packet
+    packet = {
+        "time": 1.0,
+        "qpos": [0.1, 0.2],
+        "qvel": [0.3, 0.4],
+        "qfrc_actuator": [0.5, 0.6],
+        "iaa": {"source1": [1.0, 2.0]},
+        "cf": {"ztcf": [3.0, 4.0], "zvcf": [5.0, 6.0]},
+    }
+
+    recorder.process_packet(packet)
+
+    assert recorder.data["times"] == [1.0]
+    assert np.array_equal(recorder.data["joint_positions"][0], np.array([0.1, 0.2]))
+    assert np.array_equal(recorder.data["joint_velocities"][0], np.array([0.3, 0.4]))
+    assert np.array_equal(recorder.data["joint_torques"][0], np.array([0.5, 0.6]))
+    assert np.array_equal(
+        recorder.data["induced_accelerations"]["source1"][0], np.array([1.0, 2.0])
+    )
+    assert np.array_equal(recorder.data["ztcf_accel"][0], np.array([3.0, 4.0]))
+    assert np.array_equal(recorder.data["zvcf_accel"][0], np.array([5.0, 6.0]))
+
+    # Test get_time_series
+    times, vals = recorder.get_time_series("joint_positions")
+    assert np.array_equal(times, np.array([1.0]))
+    assert np.array_equal(vals[0], np.array([0.1, 0.2]))
+
+    # Test get_induced_acceleration_series
+    times, vals = recorder.get_induced_acceleration_series("source1")
+    assert np.array_equal(times, np.array([1.0]))
+    assert np.array_equal(vals[0], np.array([1.0, 2.0]))
+
+    # Test export
+    data = recorder.export_to_dict()
+    assert "times" in data
+
+
+@patch(
+    "src.engines.physics_engines.mujoco.python.humanoid_launcher.ConfigurationManager"
+)
+def test_humanoid_launcher_init(mock_config_manager):
+    """Test HumanoidLauncher initialization."""
+    app = QApplication.instance() or QApplication(sys.argv)
+    mock_cm_instance = MagicMock()
+    mock_config = MagicMock()
+    mock_cm_instance.load.return_value = mock_config
+    mock_config_manager.return_value = mock_cm_instance
+
+    # Instantiate
+    with patch.object(HumanoidLauncher, "setup_ui"):
+        launcher = HumanoidLauncher()
+
+        assert launcher.config == mock_config
+        assert launcher.recorder is not None
+
+
+@patch(
+    "src.engines.physics_engines.mujoco.python.humanoid_launcher.ConfigurationManager"
+)
+def test_humanoid_launcher_sim_mixin(mock_config_manager):
+    """Test SimulationMixin methods."""
+    app = QApplication.instance() or QApplication(sys.argv)
+    mock_cm_instance = MagicMock()
+    mock_config = MagicMock()
+    mock_config.live_view = False
+    mock_cm_instance.load.return_value = mock_config
+    mock_config_manager.return_value = mock_cm_instance
+
+    with patch.object(HumanoidLauncher, "setup_ui"):
+        launcher = HumanoidLauncher()
+
+        # test get_simulation_command
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            patch("platform.system", return_value="Linux"),
+        ):
+            cmd, env = launcher.get_simulation_command()
+            assert "docker" in cmd
+            assert "run" in cmd
+            assert "-e" in cmd
+            assert "MUJOCO_GL=osmesa" in cmd
+
+        # test start_simulation
+        with (
+            patch("humanoid_launcher_sim.ProcessWorker") as mock_pw,
+            patch.object(launcher, "save_config"),
+            patch.object(
+                launcher, "get_simulation_command", return_value=(["mock_cmd"], {})
+            ),
+        ):
+            mock_worker = MagicMock()
+            mock_pw.return_value = mock_worker
+
+            # Mock the buttons that start_simulation tries to enable/disable
+            launcher.btn_run = MagicMock()
+            launcher.btn_stop = MagicMock()
+            launcher.txt_log = MagicMock()
+
+            launcher.start_simulation()
+            assert launcher.simulation_thread == mock_worker
+            mock_worker.start.assert_called_once()
+
+
+@patch(
+    "src.engines.physics_engines.mujoco.python.humanoid_launcher.ConfigurationManager"
+)
+def test_humanoid_launcher_analysis_mixin(mock_config_manager):
+    """Test AnalysisMixin methods."""
+    app = QApplication.instance() or QApplication(sys.argv)
+    mock_cm_instance = MagicMock()
+    mock_config = MagicMock()
+    mock_cm_instance.load.return_value = mock_config
+    mock_config_manager.return_value = mock_cm_instance
+
+    with patch.object(HumanoidLauncher, "setup_ui"):
+        launcher = HumanoidLauncher()
+
+        launcher.txt_log = MagicMock()
+        launcher.live_plot = MagicMock()
+
+        # test log data stream
+        packet_str = 'DATA_JSON:{"time": 1.0, "qpos": [], "qvel": []}'
+        launcher.log(packet_str)
+        assert launcher.recorder.data["times"][-1] == 1.0
+        launcher.live_plot.update_plot.assert_called_once()
+
+        # test clear_log
+        launcher.clear_log()
+        launcher.txt_log.clear.assert_called_once()
+
+        # test save_config
+        launcher.spin_height = MagicMock()
+        launcher.spin_height.value.return_value = 1.8
+        launcher.slider_weight = MagicMock()
+        launcher.slider_weight.value.return_value = 100
+        launcher.slider_length = MagicMock()
+        launcher.slider_length.value.return_value = 100
+        launcher.slider_mass = MagicMock()
+        launcher.slider_mass.value.return_value = 100
+        launcher.chk_two_hand = MagicMock()
+        launcher.chk_two_hand.isChecked.return_value = True
+        launcher.chk_face = MagicMock()
+        launcher.chk_fingers = MagicMock()
+        launcher.txt_save_path = MagicMock()
+        launcher.txt_load_path = MagicMock()
+        launcher.chk_live = MagicMock()
+        launcher.combo_control = MagicMock()
+        launcher.combo_control.currentText.return_value = "PD"
+
+        launcher.save_config()
+        assert launcher.config.height_m == 1.8
+        mock_cm_instance.save.assert_called_once()


### PR DESCRIPTION
Adds near 100% test coverage for the humanoid launcher modules in the mujoco physics engine suite. Resolves UI dependency issues with mocking.