### PR TITLE
feat(launcher-embed): embeddable-tool contract foundation (closes #4994, part of EPIC #4993)

### DIFF
--- a/src/shared/python/launcher_embed/__init__.py
+++ b/src/shared/python/launcher_embed/__init__.py
@@ -1,0 +1,41 @@
+"""Embeddable-tool contract foundation for the launcher.
+
+This package defines the public contract that allows tools to declare
+themselves embeddable inside a host launcher window (e.g., as a tab or a
+dock widget) instead of always opening as a standalone top-level window.
+
+Public surface:
+
+- :class:`EmbedCapabilities` — frozen dataclass describing how a tool wants
+  to be embedded.
+- :class:`EmbeddableTool` — runtime-checkable :class:`typing.Protocol` that
+  tools implement to participate in embedding.
+- :func:`register_embeddable_tool` / :func:`get_embeddable_tool` /
+  :func:`is_embeddable` / :func:`unregister_embeddable_tool` — registry API.
+- :data:`EMBEDDABLE_TOOL_REGISTRY` — the underlying registry mapping
+  ``tool_id`` to :class:`EmbeddableTool`.
+
+This module intentionally avoids importing PyQt6 at import time; PyQt6 is
+optional fleet-wide. Widget types are typed as :class:`typing.Any` in the
+protocol so that consumers do not need to import a Qt binding to satisfy
+the contract.
+"""
+
+from .contract import EmbedCapabilities, EmbeddableTool
+from .registry import (
+    EMBEDDABLE_TOOL_REGISTRY,
+    get_embeddable_tool,
+    is_embeddable,
+    register_embeddable_tool,
+    unregister_embeddable_tool,
+)
+
+__all__ = [
+    "EMBEDDABLE_TOOL_REGISTRY",
+    "EmbedCapabilities",
+    "EmbeddableTool",
+    "get_embeddable_tool",
+    "is_embeddable",
+    "register_embeddable_tool",
+    "unregister_embeddable_tool",
+]

--- a/src/shared/python/launcher_embed/contract.py
+++ b/src/shared/python/launcher_embed/contract.py
@@ -1,0 +1,138 @@
+"""Embeddable-tool contract types.
+
+This module defines the dataclass and protocol that describe how a tool
+wants to be embedded inside the launcher. It deliberately does not import
+PyQt6: widget types are spelled :class:`typing.Any` so that consumers
+without PyQt6 installed can still import this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = ["EmbedCapabilities", "EmbeddableTool"]
+
+
+@dataclass(frozen=True, slots=True)
+class EmbedCapabilities:
+    """Describes how a tool wants to be embedded inside the launcher.
+
+    Attributes:
+        supports_embedded: ``True`` if the tool can run as a child widget
+            inside the launcher window. If ``False`` the launcher must
+            fall back to opening it as a standalone top-level window.
+        prefers_dock: ``True`` if the tool prefers to be hosted in a
+            dockable side panel rather than a tab. Hosts may ignore this
+            hint when dock layouts are not available.
+        min_size: Minimum (width, height) in pixels the embedded widget
+            requires to render correctly. Both values must be positive
+            integers.
+        requires_separate_qapplication: ``True`` if the tool needs its
+            own ``QApplication`` instance (e.g., because it manages a
+            non-default GL context). Hosts that cannot honor this should
+            refuse to embed and fall back to standalone launch.
+
+    Invariants (enforced in :meth:`__post_init__`):
+        ``min_size`` is a 2-tuple of strictly positive ``int`` values.
+    """
+
+    supports_embedded: bool = True
+    prefers_dock: bool = False
+    min_size: tuple[int, int] = (640, 480)
+    requires_separate_qapplication: bool = False
+
+    def __post_init__(self) -> None:
+        # DbC: validate ``min_size`` is a positive 2-tuple of ints.
+        min_size = self.min_size
+        if not isinstance(min_size, tuple):
+            raise ValueError(
+                f"min_size must be a tuple of two positive ints, "
+                f"got {type(min_size).__name__}"
+            )
+        if len(min_size) != 2:
+            raise ValueError(
+                f"min_size must be a 2-tuple, got tuple of length {len(min_size)}"
+            )
+        width, height = min_size
+        # ``bool`` is a subclass of ``int``; reject it explicitly so that
+        # ``EmbedCapabilities(min_size=(True, True))`` does not silently
+        # succeed.
+        if (
+            not isinstance(width, int)
+            or not isinstance(height, int)
+            or isinstance(width, bool)
+            or isinstance(height, bool)
+        ):
+            raise ValueError(
+                f"min_size must contain ints, got ({type(width).__name__}, "
+                f"{type(height).__name__})"
+            )
+        if width <= 0 or height <= 0:
+            raise ValueError(
+                f"min_size must be strictly positive, got ({width}, {height})"
+            )
+
+
+@runtime_checkable
+class EmbeddableTool(Protocol):
+    """Protocol implemented by tools that can be embedded in the launcher.
+
+    Implementations must provide:
+
+    - ``tool_id``: a stable, non-empty string identifier (used as the
+      registry key and surfaced in launcher UI).
+    - :meth:`embed_capabilities`: returns an :class:`EmbedCapabilities`
+      describing how this tool wants to be embedded.
+    - :meth:`create_main_widget`: builds and returns the top-level
+      ``QWidget`` for the tool. The ``parent`` argument is typed as
+      :class:`typing.Any` so consumers do not need to import PyQt6 just
+      to satisfy this protocol; in practice it is a ``QWidget | None``.
+    - :meth:`cleanup`: tears down any resources held by the embedded
+      widget. Called by the host when the tool is being closed or
+      unembedded. Must be idempotent.
+    - :meth:`is_dirty`: returns ``True`` if the tool has unsaved state
+      that should prompt the user before close. Implementations that do
+      not track dirty state should return ``False``.
+
+    Notes:
+        Because :class:`typing.Protocol` cannot define method bodies, the
+        ``is_dirty`` "default of ``False``" is a documentation contract
+        rather than an inherited implementation. Implementations should
+        return ``False`` unless they have a meaningful dirty-state model.
+    """
+
+    tool_id: str
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        """Return how this tool wants to be embedded."""
+        ...
+
+    def create_main_widget(self, parent: Any) -> Any:
+        """Construct and return the top-level widget for this tool.
+
+        Args:
+            parent: The intended Qt parent (``QWidget | None``). Typed as
+                :class:`typing.Any` so consumers do not need to import a
+                Qt binding solely to satisfy this protocol.
+
+        Returns:
+            The newly created ``QWidget``.
+        """
+        ...
+
+    def cleanup(self) -> None:
+        """Release any resources held by the embedded widget.
+
+        Must be idempotent: hosts may call this multiple times during
+        shutdown.
+        """
+        ...
+
+    def is_dirty(self) -> bool:
+        """Return ``True`` if the tool has unsaved state.
+
+        Expected default: ``False`` for tools that do not track dirty
+        state.
+        """
+        ...

--- a/src/shared/python/launcher_embed/registry.py
+++ b/src/shared/python/launcher_embed/registry.py
@@ -1,0 +1,87 @@
+"""Process-wide registry of embeddable tools.
+
+The registry is a simple ``dict[str, EmbeddableTool]`` keyed by
+``tool_id``. Registration enforces non-empty ids and rejects duplicates;
+this matches the design-by-contract style used elsewhere in the codebase
+(public functions raise :class:`ValueError` on contract violations).
+
+The :func:`unregister_embeddable_tool` helper is intended primarily for
+test fixtures that need to clear state between tests.
+"""
+
+from __future__ import annotations
+
+from .contract import EmbeddableTool
+
+__all__ = [
+    "EMBEDDABLE_TOOL_REGISTRY",
+    "get_embeddable_tool",
+    "is_embeddable",
+    "register_embeddable_tool",
+    "unregister_embeddable_tool",
+]
+
+
+EMBEDDABLE_TOOL_REGISTRY: dict[str, EmbeddableTool] = {}
+"""Module-level mapping from ``tool_id`` to its :class:`EmbeddableTool`.
+
+Mutated by :func:`register_embeddable_tool` and
+:func:`unregister_embeddable_tool`. Tests should clear it via a fixture
+rather than mutating it directly.
+"""
+
+
+def register_embeddable_tool(tool: EmbeddableTool) -> None:
+    """Register ``tool`` under its ``tool_id``.
+
+    Args:
+        tool: The tool to register. Must expose a non-empty ``tool_id``
+            string and must not already be registered.
+
+    Raises:
+        ValueError: If ``tool.tool_id`` is empty or whitespace-only, or
+            if a tool with the same id is already registered.
+    """
+    tool_id = getattr(tool, "tool_id", "")
+    # DbC: id must be a non-empty, non-whitespace string.
+    if not isinstance(tool_id, str) or not tool_id.strip():
+        raise ValueError(
+            "register_embeddable_tool: tool.tool_id must be a non-empty string"
+        )
+    if tool_id in EMBEDDABLE_TOOL_REGISTRY:
+        raise ValueError(
+            f"register_embeddable_tool: tool_id {tool_id!r} is already registered"
+        )
+    EMBEDDABLE_TOOL_REGISTRY[tool_id] = tool
+
+
+def get_embeddable_tool(tool_id: str) -> EmbeddableTool | None:
+    """Return the registered tool for ``tool_id`` or ``None`` if absent."""
+    return EMBEDDABLE_TOOL_REGISTRY.get(tool_id)
+
+
+def is_embeddable(tool_id: str) -> bool:
+    """Return ``True`` if ``tool_id`` is registered and supports embedding.
+
+    Returns ``False`` when the tool is not registered or when its
+    :class:`EmbedCapabilities` reports ``supports_embedded=False``.
+    """
+    tool = EMBEDDABLE_TOOL_REGISTRY.get(tool_id)
+    if tool is None:
+        return False
+    return bool(tool.embed_capabilities().supports_embedded)
+
+
+def unregister_embeddable_tool(tool_id: str) -> None:
+    """Remove ``tool_id`` from the registry.
+
+    Intended for test fixtures.
+
+    Raises:
+        ValueError: If ``tool_id`` is not currently registered.
+    """
+    if tool_id not in EMBEDDABLE_TOOL_REGISTRY:
+        raise ValueError(
+            f"unregister_embeddable_tool: tool_id {tool_id!r} is not registered"
+        )
+    del EMBEDDABLE_TOOL_REGISTRY[tool_id]

--- a/tests/unit/launcher_embed/test_contract.py
+++ b/tests/unit/launcher_embed/test_contract.py
@@ -1,0 +1,71 @@
+"""Tests for :mod:`shared.python.launcher_embed.contract`."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from launcher_embed import EmbedCapabilities
+
+
+@pytest.mark.unit
+def test_defaults_round_trip() -> None:
+    """Default-constructed ``EmbedCapabilities`` exposes the documented values."""
+    caps = EmbedCapabilities()
+    assert caps.supports_embedded is True
+    assert caps.prefers_dock is False
+    assert caps.min_size == (640, 480)
+    assert caps.requires_separate_qapplication is False
+
+
+@pytest.mark.unit
+def test_explicit_values_round_trip() -> None:
+    caps = EmbedCapabilities(
+        supports_embedded=False,
+        prefers_dock=True,
+        min_size=(320, 240),
+        requires_separate_qapplication=True,
+    )
+    assert caps.supports_embedded is False
+    assert caps.prefers_dock is True
+    assert caps.min_size == (320, 240)
+    assert caps.requires_separate_qapplication is True
+
+
+@pytest.mark.unit
+def test_min_size_zero_rejected() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        EmbedCapabilities(min_size=(0, 0))
+
+
+@pytest.mark.unit
+def test_min_size_negative_rejected() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        EmbedCapabilities(min_size=(-1, 100))
+
+
+@pytest.mark.unit
+def test_min_size_wrong_shape_rejected() -> None:
+    with pytest.raises(ValueError, match="2-tuple"):
+        EmbedCapabilities(min_size=(100,))  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_min_size_not_tuple_rejected() -> None:
+    with pytest.raises(ValueError, match="tuple"):
+        EmbedCapabilities(min_size=[640, 480])  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_min_size_non_int_rejected() -> None:
+    with pytest.raises(ValueError, match="ints"):
+        EmbedCapabilities(min_size=(640.0, 480.0))  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_frozen_assignment_raises() -> None:
+    """``EmbedCapabilities`` is frozen; attribute assignment must fail."""
+    caps = EmbedCapabilities()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        caps.supports_embedded = False  # type: ignore[misc]

--- a/tests/unit/launcher_embed/test_protocol_compliance.py
+++ b/tests/unit/launcher_embed/test_protocol_compliance.py
@@ -1,0 +1,50 @@
+"""Runtime ``isinstance`` checks against the :class:`EmbeddableTool` protocol."""
+
+from __future__ import annotations
+
+import pytest
+
+from launcher_embed import EmbedCapabilities, EmbeddableTool
+
+
+class _FakeEmbeddableTool:
+    """Complete protocol implementation."""
+
+    tool_id = "fake"
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities()
+
+    def create_main_widget(self, parent: object) -> object:
+        return object()
+
+    def cleanup(self) -> None:
+        return None
+
+    def is_dirty(self) -> bool:
+        return False
+
+
+class _MissingCleanupTool:
+    """Implementation missing :meth:`cleanup`."""
+
+    tool_id = "missing-cleanup"
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities()
+
+    def create_main_widget(self, parent: object) -> object:
+        return object()
+
+    def is_dirty(self) -> bool:
+        return False
+
+
+@pytest.mark.unit
+def test_complete_implementation_passes_isinstance() -> None:
+    assert isinstance(_FakeEmbeddableTool(), EmbeddableTool)
+
+
+@pytest.mark.unit
+def test_missing_cleanup_fails_isinstance() -> None:
+    assert not isinstance(_MissingCleanupTool(), EmbeddableTool)

--- a/tests/unit/launcher_embed/test_registry.py
+++ b/tests/unit/launcher_embed/test_registry.py
@@ -1,0 +1,126 @@
+"""Tests for :mod:`shared.python.launcher_embed.registry`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from launcher_embed import (
+    EMBEDDABLE_TOOL_REGISTRY,
+    EmbedCapabilities,
+    EmbeddableTool,
+    get_embeddable_tool,
+    is_embeddable,
+    register_embeddable_tool,
+    unregister_embeddable_tool,
+)
+
+
+class _FakeEmbeddableTool:
+    """Minimal :class:`EmbeddableTool` implementation for tests."""
+
+    def __init__(
+        self,
+        tool_id: str,
+        *,
+        supports_embedded: bool = True,
+    ) -> None:
+        self.tool_id = tool_id
+        self._supports_embedded = supports_embedded
+        self.cleanup_calls = 0
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities(supports_embedded=self._supports_embedded)
+
+    def create_main_widget(self, parent: object) -> object:
+        return object()
+
+    def cleanup(self) -> None:
+        self.cleanup_calls += 1
+
+    def is_dirty(self) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterator[None]:
+    """Snapshot the registry, run the test, then restore prior state."""
+    snapshot = dict(EMBEDDABLE_TOOL_REGISTRY)
+    EMBEDDABLE_TOOL_REGISTRY.clear()
+    try:
+        yield
+    finally:
+        EMBEDDABLE_TOOL_REGISTRY.clear()
+        EMBEDDABLE_TOOL_REGISTRY.update(snapshot)
+
+
+@pytest.mark.unit
+def test_register_then_get_returns_same_instance() -> None:
+    tool = _FakeEmbeddableTool("alpha")
+    register_embeddable_tool(tool)
+    assert get_embeddable_tool("alpha") is tool
+
+
+@pytest.mark.unit
+def test_is_embeddable_true_for_registered_supporting_tool() -> None:
+    register_embeddable_tool(_FakeEmbeddableTool("alpha"))
+    assert is_embeddable("alpha") is True
+
+
+@pytest.mark.unit
+def test_is_embeddable_false_for_unregistered() -> None:
+    assert is_embeddable("ghost") is False
+
+
+@pytest.mark.unit
+def test_is_embeddable_false_when_capabilities_disable_embedding() -> None:
+    register_embeddable_tool(_FakeEmbeddableTool("alpha", supports_embedded=False))
+    assert is_embeddable("alpha") is False
+
+
+@pytest.mark.unit
+def test_duplicate_registration_raises() -> None:
+    register_embeddable_tool(_FakeEmbeddableTool("alpha"))
+    with pytest.raises(ValueError, match="already registered"):
+        register_embeddable_tool(_FakeEmbeddableTool("alpha"))
+
+
+@pytest.mark.unit
+def test_empty_tool_id_raises() -> None:
+    tool = _FakeEmbeddableTool("")
+    with pytest.raises(ValueError, match="non-empty"):
+        register_embeddable_tool(tool)
+
+
+@pytest.mark.unit
+def test_whitespace_tool_id_raises() -> None:
+    tool = _FakeEmbeddableTool("   ")
+    with pytest.raises(ValueError, match="non-empty"):
+        register_embeddable_tool(tool)
+
+
+@pytest.mark.unit
+def test_unregister_then_get_returns_none() -> None:
+    register_embeddable_tool(_FakeEmbeddableTool("alpha"))
+    unregister_embeddable_tool("alpha")
+    assert get_embeddable_tool("alpha") is None
+
+
+@pytest.mark.unit
+def test_unregister_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="not registered"):
+        unregister_embeddable_tool("ghost")
+
+
+@pytest.mark.unit
+def test_get_embeddable_tool_unknown_returns_none() -> None:
+    assert get_embeddable_tool("ghost") is None
+
+
+@pytest.mark.unit
+def test_registered_fake_satisfies_protocol() -> None:
+    tool = _FakeEmbeddableTool("alpha")
+    register_embeddable_tool(tool)
+    fetched = get_embeddable_tool("alpha")
+    assert isinstance(fetched, EmbeddableTool)


### PR DESCRIPTION
## Summary

Subtask 1 of EPIC #4993 — closes #4994.

Introduces the embeddable-tool contract foundation in `src/shared/python/launcher_embed/`. Tools opt into being hosted inside a launcher window (as a tab or dock widget) by implementing the `EmbeddableTool` protocol; the host looks them up through the registry. PyQt6 stays an optional dependency: widget types in the protocol are spelled `Any`, so importing `launcher_embed` does not pull in a Qt binding.

## Public surface

- `EmbedCapabilities` — frozen, slotted dataclass.
  - `supports_embedded: bool = True`
  - `prefers_dock: bool = False`
  - `min_size: tuple[int, int] = (640, 480)`
  - `requires_separate_qapplication: bool = False`
  - DbC: `__post_init__` rejects non-tuple, wrong-shape, non-int, or non-positive `min_size` with `ValueError`.
- `EmbeddableTool` — `@runtime_checkable` `Protocol` with `tool_id`, `embed_capabilities`, `create_main_widget(parent: Any)`, `cleanup`, `is_dirty`.
- Registry helpers: `register_embeddable_tool` (rejects empty / duplicate ids), `get_embeddable_tool`, `is_embeddable` (False for unknown ids and for tools that opt out via `supports_embedded=False`), `unregister_embeddable_tool` (raises if absent).
- `EMBEDDABLE_TOOL_REGISTRY: dict[str, EmbeddableTool]`.

## Tests

`tests/unit/launcher_embed/` — 21 tests, all `@pytest.mark.unit`.

- `test_contract.py` — defaults round-trip, explicit-value round-trip, `min_size` validation (zero, negative, wrong shape, non-tuple, non-int), `FrozenInstanceError` on assignment.
- `test_registry.py` — fixture snapshots/restores the registry; covers register/get round-trip, `is_embeddable` for registered/unregistered/opt-out tools, duplicate-registration, empty- and whitespace-only `tool_id`, `unregister` happy path and unknown-id error, `get` for unknown id, runtime `isinstance(..., EmbeddableTool)` on a registered fake.
- `test_protocol_compliance.py` — complete fake passes `isinstance`, a fake missing `cleanup()` does not.

## Pre-push gates

All passed locally and via pre-push hooks: `ruff check`, `ruff format --check`, file-size budget, `mypy`, `bandit`, `pytest -n auto`. No mypy skip needed — fleet debt in #4991 was not touched by this change.

## Test plan

- [x] `python3 -m ruff check src/shared/python/launcher_embed tests/unit/launcher_embed`
- [x] `python3 -m ruff format --check src/shared/python/launcher_embed tests/unit/launcher_embed`
- [x] `python3 scripts/ci/check_file_size_budget.py`
- [x] `QT_QPA_PLATFORM=offscreen python3 -m pytest tests/unit/launcher_embed -n auto -q` — 21 passed
- [x] Pre-push hooks (ruff, mypy, bandit, pytest) all passed