### PR TITLE
fix: clean P0 patch to only include test file deletions for issue #4960

### DIFF
--- a/tests/security/test_no_secrets_in_tree.py
+++ b/tests/security/test_no_secrets_in_tree.py
@@ -44,6 +44,6 @@ def test_no_secrets_in_tree() -> None:
         timeout=300,
     )
 
-    assert (
-        result.returncode == 0
-    ), f"Trivy secret scan detected potential secrets:\n{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"Trivy secret scan detected potential secrets:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

This PR cleans the P0 patch file to only contain the 10 empty test file deletions, removing unrelated changes.

## Changes

- Removed `.coveragerc` deletion from patch
- Removed modifications to existing test files
- Patch now only contains pure test file deletions

## Related Issues

Fixes #4960

## Impact

When reverse-applied for recovery, this patch will only restore the deleted test files without affecting repository configuration or modifying existing files.