### PR TITLE
fix: re-arm Qt file watcher after atomic file replacement for issue #5007

### DIFF
--- a/src/shared/python/realtime/file_pubsub.py
+++ b/src/shared/python/realtime/file_pubsub.py
@@ -218,7 +218,14 @@ class FilePubSub:
 
         try:
             qfsw = QFileSystemWatcher([str(path)])
-            qfsw.fileChanged.connect(lambda _p: deliver())
+
+            def _on_file_changed(_p: str) -> None:
+                # QFileSystemWatcher stops tracking after file is replaced
+                # (e.g., via os.replace). Re-arm the watcher after each event.
+                qfsw.addPath(_p)
+                deliver()
+
+            qfsw.fileChanged.connect(_on_file_changed)
         except Exception:
             return None
 


### PR DESCRIPTION
## Summary

This PR fixes the Qt file watcher to re-arm itself after atomic file replacement.

## Changes

- Modified `_on_file_changed` handler to call `qfsw.addPath(_p)` after each event
- QFileSystemWatcher stops tracking files after they are replaced via os.replace()
- Without this fix, subscribers on the Qt backend stop receiving updates after first publish

## Related Issues

Fixes #5007

## Impact

PySide6 GUI processes using the file pub-sub backend will now correctly receive all updates, not just the first one.