### PR TITLE
fix: render pose studio viewport from service transforms for issue #4942

### DIFF
--- a/src/tools/pose_studio/gui.py
+++ b/src/tools/pose_studio/gui.py
@@ -255,9 +255,27 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
     # ---- core state plumbing -------------------------------------------
 
     def _apply_pose(self, pose: CanonicalPose, *, record_history: bool) -> None:
-        """Apply *pose* to controller, view, and joint panel."""
+        """Apply *pose* to controller, view, and joint panel.
+        
+        When a live kinematics service is available, the viewport renders
+        from the service's computed transforms to show engine-specific
+        kinematics, constraints, or convention differences. Otherwise,
+        it renders from the canonical pose via forward_kinematics.
+        """
         self._engine_controller.set_pose(pose)
-        self.view_3d.update_pose(pose)
+        
+        # Try to render from live service transforms if available
+        service = self._engine_controller.service
+        if service is not None and hasattr(service, 'get_link_transforms'):
+            try:
+                transforms = service.get_link_transforms()
+                self.view_3d.update_from_service_transforms(transforms)
+            except (NotImplementedError, AttributeError, RuntimeError):
+                # Fall back to canonical forward kinematics
+                self.view_3d.update_pose(pose)
+        else:
+            self.view_3d.update_pose(pose)
+        
         self.joint_panel.set_angles(pose.angles_full_dict_deg())
         if record_history:
             self._history.push(pose)

--- a/src/tools/pose_studio/widgets/view_3d.py
+++ b/src/tools/pose_studio/widgets/view_3d.py
@@ -128,7 +128,31 @@ class View3D(QtWidgets.QWidget):
         coords = np.array([skeleton.points[n] for n in names], dtype=float)
 
         self._landmarks_order = names
+        self._update_skeleton_coords(coords)
 
+    def update_from_service_transforms(
+        self, transforms: Mapping[str, tuple[np.ndarray, np.ndarray]]
+    ) -> None:
+        """Re-draw the skeleton from service-provided link transforms.
+
+        Parameters
+        ----------
+        transforms
+            Mapping from landmark name to ``(position, orientation)`` tuples.
+            Position is a 3-element array (x, y, z); orientation is a 3x3
+            rotation matrix (not used for landmark rendering).
+
+        This method renders engine-specific kinematics that may differ
+        from canonical forward_kinematics due to engine conventions,
+        constraints, or numerical differences.
+        """
+        names = list(transforms.keys())
+        coords = np.array([transforms[n][0] for n in names], dtype=float)
+        self._landmarks_order = names
+        self._update_skeleton_coords(coords)
+
+    def _update_skeleton_coords(self, coords: np.ndarray) -> None:
+        """Update scatter and bones from landmark coordinates."""
         # Update scatter
         self._scatter._offsets3d = (coords[:, 0], coords[:, 1], coords[:, 2])
 
@@ -137,9 +161,11 @@ class View3D(QtWidgets.QWidget):
         bone_y: list[float] = []
         bone_z: list[float] = []
         for a, b in _BONES:
-            if a in skeleton.points and b in skeleton.points:
-                pa = skeleton.points[a]
-                pb = skeleton.points[b]
+            if a in self._landmarks_order and b in self._landmarks_order:
+                idx_a = self._landmarks_order.index(a)
+                idx_b = self._landmarks_order.index(b)
+                pa = coords[idx_a]
+                pb = coords[idx_b]
                 bone_x.extend([float(pa[0]), float(pb[0]), np.nan])
                 bone_y.extend([float(pa[1]), float(pb[1]), np.nan])
                 bone_z.extend([float(pa[2]), float(pb[2]), np.nan])


### PR DESCRIPTION
## Summary

This PR fixes the Pose Studio viewport to render from the active kinematics service transforms instead of always using canonical forward_kinematics.

## Changes

- Added `update_from_service_transforms()` method to `View3D` widget
- Modified `_apply_pose()` in gui.py to use service transforms when available
- Falls back to canonical forward_kinematics when service is unavailable or doesn't implement get_link_transforms

## Related Issues

Fixes #4942

## Impact

Engine swaps now correctly update the 3D view, showing engine-specific kinematics, constraints, or convention differences that the feature is meant to compare.