### PR TITLE
test: add test coverage for four bar linkage and catalog

### DIFF
--- a/tests/unit/engines/physics_engines/mujoco/mujoco_humanoid_golf/linkage_mechanisms/test_four_bar.py
+++ b/tests/unit/engines/physics_engines/mujoco/mujoco_humanoid_golf/linkage_mechanisms/test_four_bar.py
@@ -1,0 +1,43 @@
+"""Unit tests for four_bar.py linkage mechanism generators."""
+
+import pytest
+
+from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.linkage_mechanisms.four_bar import (
+    generate_four_bar_linkage_xml,
+)
+
+
+def test_generate_four_bar_linkage_xml_defaults():
+    """Test generating four-bar linkage XML with default arguments."""
+    xml = generate_four_bar_linkage_xml()
+    assert isinstance(xml, str)
+    assert '<mujoco model="four_bar_linkage_grashof_crank_rocker">' in xml
+    assert "<worldbody>" in xml
+    assert "crank_motor" in xml
+
+
+@pytest.mark.parametrize(
+    "link_type, expected_model_name",
+    [
+        ("grashof_crank_rocker", "four_bar_linkage_grashof_crank_rocker"),
+        ("grashof_double_crank", "four_bar_linkage_grashof_double_crank"),
+        ("grashof_double_rocker", "four_bar_linkage_grashof_double_rocker"),
+        ("non_grashof", "four_bar_linkage_non_grashof"),
+        ("parallel", "four_bar_linkage_parallel"),
+        ("antiparallel", "four_bar_linkage_antiparallel"),
+    ],
+)
+def test_generate_four_bar_linkage_xml_types(link_type, expected_model_name):
+    """Test generating four-bar linkage XML for different types."""
+    xml = generate_four_bar_linkage_xml(link_type=link_type)
+    assert isinstance(xml, str)
+    assert f'<mujoco model="{expected_model_name}">' in xml
+
+
+def test_generate_four_bar_linkage_xml_custom_lengths():
+    """Test generating four-bar linkage XML with custom link lengths."""
+    lengths = [5.0, 1.5, 4.0, 3.5]
+    xml = generate_four_bar_linkage_xml(link_lengths=lengths)
+    assert isinstance(xml, str)
+    # The follower pivot is at x=ground, so we check for '5.0 0 0.5'
+    assert 'pos="5.0 0 0.5"' in xml

--- a/tests/unit/engines/physics_engines/mujoco/mujoco_humanoid_golf/linkage_mechanisms/test_linkage_catalog.py
+++ b/tests/unit/engines/physics_engines/mujoco/mujoco_humanoid_golf/linkage_mechanisms/test_linkage_catalog.py
@@ -1,0 +1,40 @@
+"""Unit tests for linkage mechanisms catalog."""
+
+from src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf.linkage_mechanisms.catalog import (
+    LINKAGE_CATALOG,
+)
+
+
+def test_linkage_catalog_structure():
+    """Test the structure of the LINKAGE_CATALOG dictionary."""
+    assert isinstance(LINKAGE_CATALOG, dict)
+    assert len(LINKAGE_CATALOG) > 0
+
+    for name, metadata in LINKAGE_CATALOG.items():
+        assert isinstance(name, str)
+        assert isinstance(metadata, dict)
+
+        # Check required keys
+        assert "xml" in metadata
+        assert "actuators" in metadata
+        assert "category" in metadata
+        assert "description" in metadata
+
+        # Check types
+        assert isinstance(metadata["xml"], str)
+        assert isinstance(metadata["actuators"], list)
+        assert isinstance(metadata["category"], str)
+        assert isinstance(metadata["description"], str)
+
+        # Verify XML is not empty
+        assert len(metadata["xml"]) > 0
+        assert "<mujoco" in metadata["xml"]
+
+
+def test_catalog_categories():
+    """Test that categories match expected values."""
+    categories = {meta["category"] for meta in LINKAGE_CATALOG.values()}
+    assert "Four-Bar Linkages" in categories
+    assert "Slider Mechanisms" in categories
+    assert "Straight-Line Mechanisms" in categories
+    assert "Parallel Mechanisms" in categories


### PR DESCRIPTION
Phase 3 of next wave of test coverage expansion. Adds tests for four_bar.py and catalog.py