### PR TITLE
docs(launcher-embed): user guide + ADR 0013 + AGENTS.md (closes #5000, part of EPIC #4993)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,32 @@ plot_cartesian_delta_summary, summarize_for_pr_comment}` —
   windows; those should be standalone `QMainWindow` subclasses
   registered as tiles in `src/config/models.yaml`.
 
+### Launcher embedding + cross-tool IPC
+
+`src/shared/python/launcher_embed/`
+
+- `EmbedCapabilities`, `EmbeddableTool` Protocol, registry.
+- See [ADR-0013](docs/adr/0013-launcher-composability.md) for design
+  rationale and
+  [`docs/development/embedding_a_tool.md`](docs/development/embedding_a_tool.md)
+  for the tool-author guide.
+
+`src/shared/python/realtime/`
+
+- File + WebSocket pub-sub behind one `subscribe`/`publish` facade.
+- Channel registry in `channels.py` chooses transport per channel.
+- See [`docs/development/realtime_ipc.md`](docs/development/realtime_ipc.md).
+
+`src/launchers/embedded_host.py`
+
+- `EmbeddedHostWidget` — central QTabWidget + QDockWidget area for
+  in-launcher tool hosting.
+
+`src/launchers/launch_routing.py`
+
+- `LaunchMode` enum + `resolve_launch_mode()` for per-tile routing
+  (AUTO / NEW_WINDOW / TAB / DOCK / EXTERNAL).
+
 ### Rust kernels
 
 - `rust_core/upstream-physics/` — RK4 integrator, aerodynamics, contact,
@@ -443,6 +469,23 @@ xlsx parser, neither of which Rust can help with.
   precondition lambdas wrapped in bool(); excel loader pandas-cell
   type ignores). If a hook fails on a file you didn't author, follow
   the same sidecar pattern.
+- **Two-tool live coupling.** When a tool publishes high-frequency
+  state (e.g. Pose Studio's canonical pose at 30 Hz), use the
+  WebSocket transport — file pub-sub adds 100+ ms of disk latency.
+  The `realtime` facade picks automatically via the channel
+  registry; don't hard-code. See
+  [`docs/development/realtime_ipc.md`](docs/development/realtime_ipc.md).
+- **Embed adapters keep PyQt6 imports lazy.** The
+  `EmbeddableTool` Protocol module deliberately doesn't import
+  PyQt6 (widget types are spelled `typing.Any`) so headless CI and
+  the docs builder can introspect adapters without the GUI extras.
+  Your `_embed_adapter.py` should follow the same pattern: import
+  PyQt6 inside `create_main_widget`, not at module top.
+- **`cleanup()` must be idempotent.** The host calls it on tab
+  close, on parent shutdown, and on `closeEvent` — sometimes more
+  than once during teardown. Drop the widget reference first, then
+  tear down resources, and guard with `if widget is None: return`
+  at the top.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ Optional Rust extensions built via Maturin for performance-critical paths.
 
 - `src/` — core library: physics wrappers, URDF loaders, simulation runner
 - `src/shared/python/pose_interchange/` — engine-agnostic canonical pose + per-engine adapters / services
+- `src/shared/python/launcher_embed/` — embeddable-tool contract + registry (see [ADR-0013](docs/adr/0013-launcher-composability.md))
+- `src/shared/python/realtime/` — file + WebSocket pub-sub IPC
+- `src/launchers/embedded_host.py` — in-launcher tool host (tabs + docks)
 - `src/tools/pose_studio/` — interactive cross-engine pose editor (launcher tile: `pose_studio`)
 - `tests/` — pytest suite (unit, integration, live simulation)
 - `scripts/` — CI helpers including `check_file_size_budget.py`

--- a/docs/adr/0013-launcher-composability.md
+++ b/docs/adr/0013-launcher-composability.md
@@ -1,0 +1,251 @@
+# ADR 0013: Launcher Composability — Embeddable-tool contract and IPC layer
+
+- Status: Accepted
+- Date: 2026-05-09
+- Decision Makers: UpstreamDrift core maintainers
+- Related Issues/PRs: EPIC
+  [#4993](https://github.com/D-sorganization/UpstreamDrift/issues/4993),
+  this ADR closes the design portion of
+  [#5000](https://github.com/D-sorganization/UpstreamDrift/issues/5000).
+  Builds on the per-subtask PRs:
+  [#5003](https://github.com/D-sorganization/UpstreamDrift/pull/5003)
+  (embeddable-tool contract foundation, closes
+  [#4994](https://github.com/D-sorganization/UpstreamDrift/issues/4994)),
+  [#5013](https://github.com/D-sorganization/UpstreamDrift/pull/5013)
+  (tab/dock host widget, closes
+  [#4995](https://github.com/D-sorganization/UpstreamDrift/issues/4995)),
+  [#5044](https://github.com/D-sorganization/UpstreamDrift/pull/5044)
+  (launch-mode routing, closes
+  [#4996](https://github.com/D-sorganization/UpstreamDrift/issues/4996)),
+  [#5006](https://github.com/D-sorganization/UpstreamDrift/pull/5006)
+  (file + WebSocket pub-sub IPC layer, closes
+  [#4997](https://github.com/D-sorganization/UpstreamDrift/issues/4997)),
+  [#5012](https://github.com/D-sorganization/UpstreamDrift/pull/5012)
+  (Pose Studio `create_main_widget()`, part of
+  [#4998](https://github.com/D-sorganization/UpstreamDrift/issues/4998))
+  and the cross-tool live-pose demo
+  ([#4999](https://github.com/D-sorganization/UpstreamDrift/issues/4999)).
+
+## Context
+
+Until this EPIC, every tile in the GolfLauncher launched its tool via
+`subprocess.Popen` with the system Python. The launcher acted as a
+shortcut grid; once a tool was running it was a separate top-level
+window with no relationship to the launcher process. Two problems
+followed:
+
+1. **No in-app composition.** Users who wanted to compare two tools
+   side-by-side had to alt-tab between top-level windows. There was no
+   way to dock one tool as a sidebar to another, no shared
+   keyboard-shortcut surface, and no shared layout persistence.
+2. **No cross-tool data flow.** Pose Studio publishing a canonical
+   pose, a downstream subscriber re-rendering it as an FK skeleton,
+   and a third tool reacting to that — none of this was possible
+   without each tool re-implementing its own IPC. The MATLAB-side and
+   FastAPI-side tools each had their own ad-hoc channels (file polling
+   for the former, WebSocket for the latter); the desktop tools had
+   nothing.
+
+The launch model also encoded a hidden assumption: every tool ran
+its own `QApplication` and owned its own GL context. That was true
+for one or two tools (legacy Drake dashboards) but wrong for the
+modern `src/tools/` cohort — they all use the shared theme stack and
+matplotlib QtAgg backend and would happily live as child widgets.
+
+The EPIC body
+([#4993](https://github.com/D-sorganization/UpstreamDrift/issues/4993))
+calls out the user-visible target: open Pose Studio in a tab, open a
+canonical-pose subscriber tool in a dock, drag a slider, watch both
+update at 30 Hz. Hitting that target needs three things simultaneously:
+
+- A **contract** that lets tools opt in to embedding without forcing
+  every tool to refactor at once.
+- A **host widget** that can mount embedded tools as tabs and as
+  dock widgets, with sensible close, focus, and dirty-state behaviour.
+- A **pub-sub facade** with a transport that handles 30 Hz canonical
+  poses without 100+ ms of disk latency.
+
+## Decision
+
+We adopt a three-piece architecture, each piece independently
+unit-testable and replaceable:
+
+### 1. `EmbeddableTool` Protocol + capability declaration
+
+Lives in `src/shared/python/launcher_embed/`:
+
+- `EmbedCapabilities` — frozen dataclass that declares
+  `supports_embedded`, `prefers_dock`, `min_size`, and
+  `requires_separate_qapplication`. Validated in `__post_init__`.
+- `EmbeddableTool` — `runtime_checkable` Protocol with `tool_id`,
+  `embed_capabilities()`, `create_main_widget(parent)`, `cleanup()`,
+  and `is_dirty()`. Importing this module does **not** import PyQt6;
+  widget types are spelled `typing.Any` so registries on headless
+  CI can still introspect the contract.
+- A small registry (`registry.py`) lets tools `register_embeddable_tool(tool)`
+  and lets the launcher query `is_embeddable(tool_id)` and
+  `get_embeddable_tool(tool_id)`.
+
+### 2. `EmbeddedHostWidget` — tabs + docks under one roof
+
+Lives in `src/launchers/embedded_host.py`. A `QWidget` whose central
+area is a `QTabWidget` and whose internal `QMainWindow` provides a
+dock surface so callers can add `QDockWidget` instances without the
+host itself having to be a top-level window. Public API:
+`open_tab(tool_id)`, `close_tab(target)`, `open_dock(tool_id, area)`,
+`close_dock(tool_id)`, `set_focus_mode(enabled)`, `state_snapshot()`,
+`restore_state(state)`. Dirty tools prompt the user via `QMessageBox`
+on close. Double-clicking the tab bar toggles focus mode (the tab bar
+hides so the active tab fills the host).
+
+### 3. `LaunchMode` + `resolve_launch_mode()` routing
+
+Lives in `src/launchers/launch_routing.py`. A pure-Python (PyQt-free)
+helper that resolves a requested `LaunchMode` (`AUTO`, `NEW_WINDOW`,
+`TAB`, `DOCK`, `EXTERNAL`) plus a model record into the concrete
+mode that `LauncherSimulationMixin.launch_model()` should dispatch.
+Resolution prefers `model.launcher.default_launch` if declared, then
+`prefers_dock` if the tool's `EmbedCapabilities` requests it,
+otherwise `TAB`. Tools that aren't embeddable always fall through
+to `NEW_WINDOW`.
+
+### 4. `realtime` pub-sub facade
+
+Lives in `src/shared/python/realtime/`. One `subscribe(channel, callback)`
+/ `publish(channel, payload)` API on top of two transports:
+
+- **File transport** for low-frequency channels — JSONL append under
+  `~/.upstream_drift/realtime/<channel>.jsonl`. Polling subscribers,
+  durable across process boundaries, easy to inspect with `tail -F`.
+- **WebSocket transport** for high-frequency channels — multiplexed
+  through the existing FastAPI server (`src/api/`). Sub-millisecond
+  fan-out within the same host.
+
+Channel-to-transport routing lives in a single registry (`channels.py`).
+Tool authors call `subscribe`/`publish` and the registry picks the
+transport; they don't hard-code either side. Default for unregistered
+channels is the file transport (durable, low setup cost, easy to
+debug).
+
+The cross-tool live-pose demo
+([#4999](https://github.com/D-sorganization/UpstreamDrift/issues/4999))
+exercises all three pieces end-to-end: Pose Studio refactored to
+expose `create_main_widget()`, a tiny `pose_subscriber_demo`
+embeddable tool, and the WebSocket transport carrying
+`pose/canonical` at 30 Hz between them inside one launcher window.
+
+## Alternatives Considered
+
+1. **`QMdiArea` instead of `QTabWidget` for the host.** Qt's MDI area
+   gives free-floating sub-windows-within-the-window. **Rejected**:
+   the desktop-app audience for this project (biomechanics
+   researchers, not Eclipse refugees) found MDI confusing in
+   prototypes — too many overlapping subwindows, a second window
+   manager bolted on top of the OS one. Tabs + docks is the modern
+   IDE pattern (VS Code, JetBrains, Qt Creator itself) and matches
+   user mental models.
+2. **REST-only IPC.** Reuse the existing FastAPI surface for
+   request/response only; have subscribers poll. **Rejected**: HTTP
+   round-trip latency on Windows loopback is 5-15 ms per request even
+   with keep-alive; at 30 Hz that's 30-50 % of the budget gone before
+   the payload is serialised. Subscribers would also have to manage
+   their own polling cadence per channel.
+3. **Pure file-based IPC for everything.** A single transport, no
+   server dependency, durable. **Rejected**: file watchers on Windows
+   add 100-200 ms of latency in the worst case (NTFS notification
+   coalescing); JSONL append + read coordination across processes
+   needs locking we'd otherwise avoid. Acceptable for low-frequency
+   channels (`status/*`, configuration changes), unacceptable for
+   `pose/canonical` and the planned `engine/*/state` channels.
+4. **Qt LocalSocket / DBus.** Qt's local-socket IPC is fast and
+   in-process. **Rejected**: ties the IPC layer to Qt, which means
+   the MATLAB-side and any future headless tool (CLI fitter, batch
+   runner) cannot subscribe. DBus is Linux-only in practice — the
+   Windows build is unmaintained — and we need Windows as a
+   first-class platform per [CLAUDE.md](../../CLAUDE.md).
+5. **Per-tool ad-hoc IPC, no facade.** What we had before. **Rejected**
+   for the same reason ADR 0012 rejected per-engine ad-hoc converters:
+   one shared abstraction with one transport-routing point is far
+   cheaper to maintain than N tools each rolling their own.
+6. **A single `QApplication`-shared-everything model with no
+   embeddable contract.** Rip out `subprocess.Popen`, run every tool
+   as a child widget unconditionally. **Rejected**: a handful of
+   legacy tools genuinely need their own `QApplication` (custom GL
+   contexts, pygame). The Protocol-with-capability-flag approach lets
+   them keep working as standalone subprocesses while the modern
+   tools migrate to embedding.
+
+## Consequences
+
+- **Positive:**
+  - Tools opt in to embedding incrementally — Pose Studio first,
+    then the rest of `src/tools/` over the next few subtasks. Nothing
+    breaks for tools that haven't migrated.
+  - The dispatcher (`LauncherSimulationMixin.launch_model()`) is a
+    one-line conditional on the resolved `LaunchMode`; legacy
+    `subprocess.Popen` is the `NEW_WINDOW` / `EXTERNAL` branch.
+  - Pub-sub channel definitions become a single source of truth
+    (`channels.py`). Tools publish without caring whether the
+    subscriber is local, remote, or another instance of themselves.
+  - Layout persistence is free: `EmbeddedHostWidget.state_snapshot()`
+    serialises to a small JSON dict that the launcher can save and
+    restore between sessions.
+- **Negative:**
+  - `EmbeddedHostWidget` keeps a hidden internal `QMainWindow` to
+    host docks, which means dock state lives one level deeper than a
+    naïve subclass would expect. Documented in
+    [`docs/development/embedding_a_tool.md`](../development/embedding_a_tool.md).
+  - The pub-sub layer adds one network dependency (FastAPI must be
+    reachable at `localhost:<port>` for WebSocket channels). The
+    fallback when the server is down is degradation to file
+    transport, but that is silent unless the tool explicitly checks
+    transport health.
+  - Tool authors now have two embedding-related Protocols to learn
+    (`EmbeddableTool`, plus `EmbedCapabilities`). The cheat-sheet in
+    [`docs/development/embedding_a_tool.md`](../development/embedding_a_tool.md)
+    is the mitigation.
+- **Follow-ups:**
+  - Per-tool refactors track under
+    [#4998](https://github.com/D-sorganization/UpstreamDrift/issues/4998).
+    Pose Studio is done; Cross-Engine Dashboard, Drake Dashboard,
+    MuJoCo Dashboard, Pinocchio Dashboard, and Motion Capture
+    launcher are the next batch.
+  - A future ADR may revisit the WebSocket transport choice if we
+    grow a cross-host fleet need (currently all tools live on one
+    workstation).
+  - Layout persistence (save/restore the launcher's tab/dock
+    arrangement across sessions) is wired in `state_snapshot()` /
+    `restore_state()` but the launcher does not yet persist it to
+    disk — tracked separately.
+
+## Validation
+
+The cross-tool live-pose demo
+([#4999](https://github.com/D-sorganization/UpstreamDrift/issues/4999))
+is the integration gate for this ADR:
+
+1. Open the launcher.
+2. Right-click the Pose Studio tile → **Launch in Tab**.
+3. Right-click the `pose_subscriber_demo` tile → **Launch in Dock**.
+4. Drag any joint slider in Pose Studio.
+5. The subscriber's FK skeleton updates within 50 ms (WebSocket
+   transport, asserted by
+   `tests/integration/realtime/test_pose_studio_demo.py`).
+
+Per-piece tests:
+
+- `tests/unit/launcher_embed/test_contract.py` — `EmbedCapabilities`
+  DbC validation; `EmbeddableTool` runtime-check.
+- `tests/unit/launcher_embed/test_registry.py` — register / lookup /
+  unregister; `is_embeddable` semantics.
+- `tests/unit/launchers/test_embedded_host.py` — open/close/focus
+  semantics for tabs and docks; dirty-close prompt; idempotency on
+  duplicate opens.
+- `tests/unit/launchers/test_launch_routing.py` —
+  `resolve_launch_mode` decision table.
+- `tests/unit/realtime/` — file and WebSocket transports under their
+  own pytest markers; a transport-agnostic round-trip test confirms
+  the facade picks the registered transport per channel.
+- `tests/docs/test_launcher_embed_doc_links.py` — every internal
+  Markdown link in the new user-guide and developer-guide pages
+  resolves to a real file.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 | [0005](0005-rust-tools-core-git-dependency.md)     | Pin `tools-core` as a Git Dependency                            | Accepted | 2026-04-23 |
 | [0007](0007-motion-pipeline-architecture.md)       | Motion Pipeline Architecture (CIR)                              | Proposed | 2026-05-08 |
 | [0012](0012-canonical-pose-interchange.md)         | Canonical Pose Interchange                                      | Accepted | 2026-05-09 |
+| [0013](0013-launcher-composability.md)             | Launcher Composability — Embeddable-tool contract and IPC layer | Accepted | 2026-05-09 |
 
 ## ADR Backlog
 

--- a/docs/development/embedding_a_tool.md
+++ b/docs/development/embedding_a_tool.md
@@ -1,0 +1,358 @@
+# Embedding a Tool in the Launcher
+
+For tool authors. This page explains how to make a `src/tools/<your_tool>/`
+package mountable as a tab or dock in the launcher's
+[embedded view](../user_guide/launcher/embedded_view.md), using the
+`EmbeddableTool` Protocol.
+
+> **Background.** Design rationale lives in
+> [ADR-0013](../adr/0013-launcher-composability.md). For the
+> end-user experience you're enabling, see
+> [`docs/user_guide/launcher/embedded_view.md`](../user_guide/launcher/embedded_view.md).
+
+---
+
+## A. The contract surface
+
+The full contract lives in
+[`src/shared/python/launcher_embed/contract.py`](../../src/shared/python/launcher_embed/contract.py).
+Two pieces:
+
+### `EmbedCapabilities` — declare how you want to be embedded
+
+```python
+from src.shared.python.launcher_embed import EmbedCapabilities
+
+caps = EmbedCapabilities(
+    supports_embedded=True,         # default; False for legacy tools
+    prefers_dock=False,              # True for sidebars / status panels
+    min_size=(640, 480),             # rule of thumb: your design size
+    requires_separate_qapplication=False,  # True only for GL / pygame
+)
+```
+
+Frozen dataclass, validated in `__post_init__`. `min_size` must be a
+2-tuple of strictly positive ints; passing `(True, True)` (which
+Python would otherwise treat as `(1, 1)` because `bool` is a subclass
+of `int`) is explicitly rejected.
+
+### `EmbeddableTool` — the runtime-checkable Protocol
+
+```python
+class EmbeddableTool(Protocol):
+    tool_id: str
+    def embed_capabilities(self) -> EmbedCapabilities: ...
+    def create_main_widget(self, parent: Any) -> Any: ...
+    def cleanup(self) -> None: ...
+    def is_dirty(self) -> bool: ...
+```
+
+The Protocol is `@runtime_checkable`, so you can `isinstance(x,
+EmbeddableTool)` to validate at registration time. Note that
+`parent` and the widget return type are spelled `typing.Any` —
+that's deliberate, so the contract module doesn't need to import
+PyQt6 (and headless CI / docs builders can introspect it without
+the GUI extras installed).
+
+Once you've implemented the Protocol, register your tool:
+
+```python
+from src.shared.python.launcher_embed import register_embeddable_tool
+
+register_embeddable_tool(MyEmbeddableTool())
+```
+
+The launcher discovers registered tools via the registry; the
+right-click menu's **Launch in Tab** / **Launch in Dock** items
+become live for any model whose `tool_id` matches a registered
+embeddable.
+
+---
+
+## B. The standard refactor — `QMainWindow` → `MainWidget` factory
+
+Most existing tools are written as `QMainWindow` subclasses with
+their UI built in `__init__` and their resources owned by the
+window itself. To embed cleanly you split that into:
+
+1. A `MainWidget` (a plain `QWidget` subclass) that holds **all**
+   the UI and runtime state.
+2. A thin `QMainWindow` wrapper for standalone launches that just
+   sets `MainWidget` as its central widget.
+3. A `_embed_adapter.py` module that implements `EmbeddableTool`
+   and registers itself.
+
+Pose Studio is the canonical worked example. The adapter looks like:
+
+```python
+# src/tools/pose_studio/_embed_adapter.py
+"""EmbeddableTool adapter for Pose Studio.
+
+Wraps PoseStudioMainWidget so the launcher can mount it as a tab or
+dock without owning a QMainWindow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.shared.python.launcher_embed import (
+    EmbedCapabilities,
+    register_embeddable_tool,
+)
+
+
+class PoseStudioEmbedAdapter:
+    """EmbeddableTool implementation for Pose Studio."""
+
+    tool_id = "pose_studio"
+
+    def __init__(self) -> None:
+        self._widget: Any = None  # PoseStudioMainWidget | None
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        # Pose Studio is a primary workspace tool — wants a tab, not a dock.
+        return EmbedCapabilities(
+            supports_embedded=True,
+            prefers_dock=False,
+            min_size=(960, 720),
+            requires_separate_qapplication=False,
+        )
+
+    def create_main_widget(self, parent: Any) -> Any:
+        # Lazy import keeps the contract module Qt-free.
+        from src.tools.pose_studio.gui import PoseStudioMainWidget
+
+        if self._widget is None:
+            self._widget = PoseStudioMainWidget(parent=parent)
+        return self._widget
+
+    def cleanup(self) -> None:
+        widget = self._widget
+        self._widget = None
+        if widget is None:
+            return
+        # Stop timers, close engine sessions, save dirty state, etc.
+        if hasattr(widget, "shutdown"):
+            widget.shutdown()
+        widget.deleteLater()
+
+    def is_dirty(self) -> bool:
+        widget = self._widget
+        if widget is None or not hasattr(widget, "is_dirty"):
+            return False
+        return bool(widget.is_dirty())
+
+
+register_embeddable_tool(PoseStudioEmbedAdapter())
+```
+
+Key shape notes:
+
+- The adapter is **separate from the widget**. It owns the registry
+  identity (`tool_id`) and the lifecycle hooks; the widget owns the
+  UI. This split means the widget can stay PyQt-heavy while the
+  adapter stays import-cheap.
+- `create_main_widget` is **idempotent**: opening the same tool in a
+  tab twice surfaces the existing tab rather than building a second
+  widget. The host enforces this via its registry, but your adapter
+  should still cache so the host's `restore_state()` path works
+  cleanly.
+- `cleanup()` is **idempotent**. The host calls it on close, on
+  parent shutdown, and during `closeEvent`. Drop the widget
+  reference first, then tear down resources.
+- The PyQt6 import is **lazy** — inside `create_main_widget`, not
+  at module top-level. This lets the launcher introspect adapters
+  on a headless system without `DLL load failed` blowups.
+
+For the legacy `QMainWindow` standalone path, leave your existing
+`__main__.py` alone — it can continue to construct a `QMainWindow`
+that embeds the same `MainWidget`. Both code paths share the widget
+class; only the chrome differs.
+
+---
+
+## C. Capability declaration cheat-sheet
+
+| Flag                             | Set to `True` when…                                                                                                                                               | Set to `False` when…                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `supports_embedded`              | Your tool can run as a child widget (no top-level window required).                                                                                               | The tool needs camera / audio capture, uses pygame, or otherwise hard-codes its window setup. |
+| `prefers_dock`                   | The tool is a small status panel, parameter sidebar, or live-preview widget that pairs with a primary workspace.                                                  | The tool is a primary workspace (Pose Studio, Cross-Engine Dashboard).                        |
+| `requires_separate_qapplication` | The tool manages its own GL context that conflicts with the launcher's `QApplication` (rare — almost always a sign the tool should be `supports_embedded=False`). | Default. The vast majority of tools share the launcher's `QApplication`.                      |
+
+Notes:
+
+- **Camera / audio capture.** If your tool opens a webcam or
+  microphone via Qt's multimedia APIs, set `supports_embedded=False`.
+  Multiple `QMediaCaptureSession` instances in the same process
+  fight over device handles on Windows; running as a separate
+  subprocess sidesteps the issue entirely.
+- **pygame.** If your tool uses pygame for rendering or input,
+  `supports_embedded=False`. pygame creates its own window and
+  event loop and does not coexist with a Qt event loop.
+- **Tools that need their own `QApplication`.** Almost always
+  legacy. If you're writing a new tool and you think you need this,
+  you almost certainly don't — share the launcher's `QApplication`
+  and use `QOpenGLWidget` for any GL surface.
+- **`min_size` rule of thumb.** Set to your tool's "smallest layout
+  that still works." For Pose Studio that's `(960, 720)` because the
+  joint tree, 3D viewer, and inspector each need ~300 px wide.
+  For a status panel, `(280, 180)` is plenty. The host respects this
+  as a minimum when sizing the tab pane or floating dock.
+
+---
+
+## D. Cleanup contract — what to release
+
+Your `cleanup()` runs when:
+
+- The user closes the tab or dock (and confirmed any dirty-state
+  prompt).
+- The launcher window's `closeEvent` fires.
+- A test fixture tears down the host.
+
+Release these things, in this order:
+
+1. **Stop timers.** `QTimer` instances keep running after the widget
+   hides. Call `timer.stop()`. Forgotten timers fire on a destroyed
+   widget and crash on Linux.
+2. **Disconnect signals you connected to objects with longer
+   lifetimes.** If you `register_callback`-ed onto a singleton or
+   a `realtime` channel, call its unregister/unsubscribe partner.
+3. **Save dirty state.** If `is_dirty()` would have returned `True`
+   and the user clicked through the prompt, you should still write
+   any auto-save artifacts (crash recovery files, etc.) before
+   destruction.
+4. **Release file handles, network sockets, engine sessions.** Call
+   `engine.close()` on any physics-engine instance you opened. Drop
+   open file handles. Disconnect from FastAPI WebSocket channels.
+5. **Drop the widget reference.** Set `self._widget = None` and call
+   `widget.deleteLater()` to let Qt schedule destruction.
+
+`cleanup()` must be **idempotent**: calling it twice is safe.
+Defensive guards (`if widget is None: return`) at the top are the
+norm, not the exception.
+
+---
+
+## E. Testing template
+
+Every embed adapter should ship with a minimal smoke test that
+exercises capability declaration and the create/cleanup loop. The
+template:
+
+```python
+# tests/unit/tools/pose_studio/test_embed_adapter.py
+"""Smoke test for the Pose Studio EmbeddableTool adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+# pytest-qt's qtbot fixture is the canonical way to drive widget
+# lifecycle in tests. ``qtbot`` requires PyQt6 — skip if the
+# environment doesn't have the GUI extras.
+PyQt6 = pytest.importorskip("PyQt6")
+
+
+def test_adapter_capabilities_are_valid() -> None:
+    from src.shared.python.launcher_embed import EmbedCapabilities
+    from src.tools.pose_studio._embed_adapter import PoseStudioEmbedAdapter
+
+    adapter = PoseStudioEmbedAdapter()
+    caps = adapter.embed_capabilities()
+    assert isinstance(caps, EmbedCapabilities)
+    assert caps.supports_embedded is True
+    assert caps.min_size == (960, 720)
+
+
+def test_adapter_create_and_cleanup_round_trip(qtbot) -> None:  # noqa: ANN001
+    from src.tools.pose_studio._embed_adapter import PoseStudioEmbedAdapter
+
+    adapter = PoseStudioEmbedAdapter()
+
+    widget = adapter.create_main_widget(parent=None)
+    qtbot.addWidget(widget)
+    assert widget is not None
+
+    # Idempotent: a second call returns the same widget instance.
+    assert adapter.create_main_widget(parent=None) is widget
+
+    # cleanup() must be safe to call twice.
+    adapter.cleanup()
+    adapter.cleanup()
+
+
+def test_adapter_implements_protocol() -> None:
+    from src.shared.python.launcher_embed import EmbeddableTool
+    from src.tools.pose_studio._embed_adapter import PoseStudioEmbedAdapter
+
+    assert isinstance(PoseStudioEmbedAdapter(), EmbeddableTool)
+
+
+def test_adapter_is_dirty_default() -> None:
+    from src.tools.pose_studio._embed_adapter import PoseStudioEmbedAdapter
+
+    adapter = PoseStudioEmbedAdapter()
+    # Before create_main_widget, no widget exists, so dirty must be False.
+    assert adapter.is_dirty() is False
+```
+
+Mark the test `headless_safe` if your `MainWidget` builds without a
+display server (matplotlib QtAgg works under `QT_QPA_PLATFORM=offscreen`;
+GL widgets sometimes don't). Mark it `requires_gl` otherwise — CI
+will skip on non-GL runners.
+
+---
+
+## F. Wiring it into the launcher
+
+Once the adapter is registered, two more lines wire your tool into
+the launcher UI:
+
+1. **Tile entry** — `src/config/models.yaml`:
+
+   ```yaml
+   - id: "pose_studio"
+     name: "Pose Studio"
+     description: "Interactive cross-engine pose editor"
+     type: "special_app"
+     path: "src/tools/pose_studio/__main__.py"
+     launcher:
+       category: "tool"
+       logo: "assets/pose_studio.png"
+       status: "ready"
+       default_launch: "tab" # auto-resolves to TAB on right-click → Launch
+   ```
+
+   `default_launch` accepts `window`, `tab`, `dock`, or `external`.
+   The dispatcher rules are documented in
+   `resolve_launch_mode()` and the
+   [embedded view user guide](../user_guide/launcher/embedded_view.md#b-right-click-menu--launch-in-new-window--tab--dock).
+
+2. **Adapter import** — somewhere in your tool's `__init__.py`:
+
+   ```python
+   from . import _embed_adapter  # noqa: F401  -- registers on import
+   ```
+
+   The launcher discovers adapters at startup by importing tool
+   packages; the registration side-effect in `_embed_adapter` does
+   the rest.
+
+---
+
+## See also
+
+- [ADR-0013](../adr/0013-launcher-composability.md) — design
+  rationale.
+- [`realtime_ipc.md`](realtime_ipc.md) — pub-sub IPC for tools that
+  need to publish or subscribe to live state across the embedded
+  view.
+- [`docs/user_guide/launcher/embedded_view.md`](../user_guide/launcher/embedded_view.md)
+  — the user-facing experience your adapter enables.
+- The Pose Studio package
+  ([`src/tools/pose_studio/`](../../src/tools/pose_studio/)) —
+  canonical worked example.

--- a/docs/development/realtime_ipc.md
+++ b/docs/development/realtime_ipc.md
@@ -1,0 +1,284 @@
+# Real-Time IPC — `subscribe` / `publish` for embedded tools
+
+For tool authors. This page documents
+`src/shared/python/realtime/`, the pub-sub facade that lets two
+tools talk to each other live — Pose Studio publishing a canonical
+pose at 30 Hz, a downstream subscriber re-rendering it as an FK
+skeleton, and so on.
+
+> **Background.** Design rationale lives in
+> [ADR-0013](../adr/0013-launcher-composability.md). For the
+> embedding contract that the publisher and subscriber both
+> implement, see
+> [`embedding_a_tool.md`](embedding_a_tool.md).
+
+---
+
+## A. The API
+
+Two functions. That's the whole surface area:
+
+```python
+from src.shared.python.realtime import publish, subscribe
+
+# Publish a payload on a channel.
+publish("pose/canonical", {"version": "canonical-v1", "joints": {...}})
+
+# Subscribe to a channel; the callback runs each time someone publishes.
+def _on_pose(payload: dict) -> None:
+    ...
+
+unsubscribe = subscribe("pose/canonical", _on_pose)
+
+# Later, when the tool is being torn down:
+unsubscribe()
+```
+
+`subscribe()` returns a callable; invoking it removes the
+subscription. Subscribers should call that from their `cleanup()`
+hook (see
+[`embedding_a_tool.md`](embedding_a_tool.md#d-cleanup-contract--what-to-release))
+so a closed dock doesn't keep firing callbacks on a destroyed
+widget.
+
+`publish()` is fire-and-forget — it does not block on subscribers.
+The transport layer handles fan-out asynchronously.
+
+Payloads should be **JSON-serialisable** dicts. The file transport
+serialises with `json.dumps`; the WebSocket transport serialises
+with the same FastAPI JSON encoder used for REST endpoints.
+
+---
+
+## B. Channel naming convention
+
+Channels use a `<scope>/<topic>` shape:
+
+| Scope     | Examples                                          | Notes                                                                                   |
+| --------- | ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `pose/`   | `pose/canonical`                                  | Canonical pose interchange (see [ADR-0012](../adr/0012-canonical-pose-interchange.md)). |
+| `engine/` | `engine/mujoco/state`, `engine/drake/qpos`        | Per-engine live state.                                                                  |
+| `tool/`   | `tool/pose_studio/dirty`, `tool/<tool_id>/status` | Tool-internal lifecycle events.                                                         |
+| `status/` | `status/launcher`                                 | Cross-process health and progress.                                                      |
+| `mocap/`  | `mocap/preview`                                   | Live mocap loaders.                                                                     |
+
+Rules:
+
+- **Lowercase, slash-separated.** No spaces, no dots, no leading
+  slash.
+- **Stable.** A published channel is part of the tool's public API
+  surface. Renaming one is a breaking change for subscribers.
+- **Unique within a scope.** Two tools should not publish to the
+  same channel unless they're publishing the same shape of payload
+  (the payload schema is the contract; the channel name is just the
+  routing key).
+- **Document new channels** in the registry (`channels.py`) so the
+  routing decision is reviewable in code review, not buried in a
+  call site.
+
+---
+
+## C. File vs. WebSocket transport — the registry picks
+
+Channel-to-transport routing lives in
+`src/shared/python/realtime/channels.py`. You don't pass a
+transport name to `publish()` or `subscribe()`; the registry picks
+based on the channel.
+
+The registry's defaults:
+
+| Channel pattern        | Transport     | Why                                                                         |
+| ---------------------- | ------------- | --------------------------------------------------------------------------- |
+| `pose/*`, `engine/*/*` | **WebSocket** | High-frequency (30 Hz +), latency budget < 50 ms.                           |
+| `tool/*/*`, `status/*` | **File**      | Low-frequency, durability-friendly, cross-process visible without a server. |
+| Unregistered           | **File**      | Conservative default — works without a FastAPI server running.              |
+
+**File transport** writes JSONL append under
+`~/.upstream_drift/realtime/<channel-with-slashes-replaced>.jsonl`.
+Subscribers tail the file via OS-level file watchers (or polling on
+platforms where watchers aren't reliable). Latency: 50-200 ms on
+NTFS; 10-50 ms on ext4 / APFS.
+
+**WebSocket transport** multiplexes through the existing FastAPI
+server (`src/api/`). Each channel is one WS message type; fan-out
+is sub-millisecond within the same host. Requires the FastAPI
+server to be running (the launcher starts it automatically when
+embedded view is in use).
+
+To force a transport for a one-off case, pass `transport="file"` or
+`transport="websocket"` to `publish()` / `subscribe()` — but prefer
+to add the channel to the registry instead. Hard-coding transport
+at the call site means a future operations change (move WS server
+off-host, e.g.) requires touching every call site.
+
+---
+
+## D. Latency budgets
+
+| Transport | p50 latency | p99 latency | Notes                                |
+| --------- | ----------- | ----------- | ------------------------------------ |
+| WebSocket | 2-5 ms      | 20-30 ms    | Localhost loopback; same host.       |
+| File      | 50-100 ms   | 200-500 ms  | NTFS worst case; ext4 / APFS faster. |
+
+These are end-to-end measurements (publisher's `publish()` call
+returning to subscriber's callback being invoked) under the
+integration test `tests/integration/realtime/`. Beyond p99 you're
+into FastAPI server pressure (WS) or filesystem-watcher backoff
+(file) — usually a sign the channel is being misused.
+
+If your tool needs anything below 2 ms p50 you're outside the
+intended use case for `realtime`. Direct Qt signal/slot inside one
+process is the right answer; the IPC layer is for cross-tool, not
+inside-tool.
+
+---
+
+## E. Debugging
+
+### File-transport channels
+
+Inspect `~/.upstream_drift/realtime/`:
+
+```bash
+# List active channel files
+ls ~/.upstream_drift/realtime/
+
+# Tail one in real time
+tail -F ~/.upstream_drift/realtime/tool_pose_studio_dirty.jsonl
+```
+
+Each line is one published payload as JSON. Channel names map to
+filenames by replacing `/` with `_`. The directory is created on
+first publish; it's safe to delete files between sessions to clear
+backlog (subscribers re-subscribe on next publish).
+
+### WebSocket-transport channels
+
+The FastAPI server logs every subscribe / publish at `INFO` level
+when started with `--log-level info`. Look for entries like:
+
+```
+INFO     realtime: SUB pose/canonical client=127.0.0.1:54221
+INFO     realtime: PUB pose/canonical 480 bytes -> 2 subscribers
+```
+
+For deeper inspection, the server exposes
+`GET /realtime/_debug/channels` (only when started with the
+`--debug-channels` flag) which returns the live registry plus
+per-channel subscriber counts.
+
+### Tracing in the publisher
+
+If you suspect a payload isn't getting through, wrap the publish
+in a debug log:
+
+```python
+import logging
+
+from src.shared.python.realtime import publish
+
+log = logging.getLogger(__name__)
+
+payload = pose.to_dict()
+log.debug("publishing pose/canonical: %d bytes", len(json.dumps(payload)))
+publish("pose/canonical", payload)
+```
+
+`get_logger()` from
+`src/shared/python/logging_pkg/logging_config.py` is the canonical
+factory — it routes through the JSON-config + rotation pipeline
+that the launcher uses elsewhere.
+
+---
+
+## F. Worked example — Pose Studio publishing canonical pose
+
+Pose Studio's `EngineController` publishes a canonical pose every
+time a joint slider moves. The hook lives behind a feature flag
+(`POSE_STUDIO_PUBLISH_REALTIME=1`) so unit tests don't have to
+subscribe.
+
+```python
+# src/tools/pose_studio/controllers/engine_controller.py
+"""Pose Studio engine controller — drives engines from canonical pose."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from src.shared.python.realtime import publish
+
+_PUBLISH_FLAG = "POSE_STUDIO_PUBLISH_REALTIME"
+_DEBOUNCE_S = 1.0 / 30.0  # 30 Hz cap
+
+
+class EngineController:
+    def __init__(self) -> None:
+        self._last_publish_t = 0.0
+
+    def set_canonical_pose(self, pose: Any) -> None:
+        # ... drive engines ...
+        self._maybe_publish(pose)
+
+    def _maybe_publish(self, pose: Any) -> None:
+        if os.environ.get(_PUBLISH_FLAG) != "1":
+            return
+        now = time.monotonic()
+        if now - self._last_publish_t < _DEBOUNCE_S:
+            return
+        self._last_publish_t = now
+        publish("pose/canonical", pose.to_dict())
+```
+
+The 30 Hz debounce matters — without it, a slider drag emits one
+publish per Qt mouseMove (often 100+ Hz on a high-refresh trackpad)
+and the WebSocket layer buffers them faster than subscribers can
+drain.
+
+The matching subscriber (the cross-tool demo
+`pose_subscriber_demo`) is straightforward:
+
+```python
+# src/tools/pose_subscriber_demo/gui.py (excerpt)
+from src.shared.python.realtime import subscribe
+
+class PoseSubscriberWidget(QWidget):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._unsubscribe = subscribe("pose/canonical", self._on_pose)
+        # ... build UI ...
+
+    def _on_pose(self, payload: dict) -> None:
+        # NB: callback runs on the transport's thread. Marshal back
+        # to the GUI thread before touching widgets:
+        QMetaObject.invokeMethod(
+            self,
+            lambda: self._render_pose(payload),
+            Qt.ConnectionType.QueuedConnection,
+        )
+
+    def cleanup(self) -> None:
+        self._unsubscribe()
+```
+
+The `QMetaObject.invokeMethod` marshalling is required for both
+transports — file and WebSocket callbacks both fire on a worker
+thread, not the GUI thread, so direct widget mutation from inside
+the callback will crash on Linux and corrupt state on Windows.
+
+---
+
+## See also
+
+- [ADR-0013](../adr/0013-launcher-composability.md) — design
+  rationale for the IPC layer and why we picked file + WebSocket
+  rather than DBus / LocalSocket / REST-only.
+- [`embedding_a_tool.md`](embedding_a_tool.md) — the embedding
+  contract that the publisher and subscriber both live behind.
+- [`docs/user_guide/launcher/embedded_view.md`](../user_guide/launcher/embedded_view.md)
+  — the user-facing experience this IPC enables.
+- [ADR-0003](../adr/0003-websocket-realtime-simulation.md) — the
+  original WebSocket-for-real-time decision that the WS transport
+  builds on.

--- a/docs/user_guide/launcher/embedded_view.md
+++ b/docs/user_guide/launcher/embedded_view.md
@@ -1,0 +1,182 @@
+# Embedded View — Tabs, Docks, and the In-Launcher Tool Host
+
+Until recently, every tile in the GolfLauncher opened its tool in a
+separate top-level window. With the launcher composability work
+(EPIC [#4993](https://github.com/D-sorganization/UpstreamDrift/issues/4993))
+you can now host tools as tabs and dock panels **inside** the
+launcher itself — keep Pose Studio open in a tab, dock a canonical-pose
+subscriber to the side, and drive both with one keyboard.
+
+> **Background.** Design rationale lives in
+> [ADR-0013](../../adr/0013-launcher-composability.md). For
+> tool-author docs see
+> [`embedding_a_tool.md`](../../development/embedding_a_tool.md) and
+> [`realtime_ipc.md`](../../development/realtime_ipc.md).
+
+> **Screenshots.** Image references in this doc point at
+> `docs/assets/launcher/`. Screenshots will be added in a follow-up
+> capture PR — the placeholder paths below are the contract for that
+> follow-up to satisfy.
+
+---
+
+## A. What the embedded view is
+
+The embedded view is a region of the launcher window that hosts
+running tools as **tabs** (the central area) and **dock widgets**
+(left, right, top, bottom). It is implemented by
+`EmbeddedHostWidget` in
+[`src/launchers/embedded_host.py`](../../../src/launchers/embedded_host.py).
+
+You should use it when:
+
+- You want to compare two tools side-by-side without alt-tabbing.
+- A tool publishes data another tool consumes (e.g. Pose Studio →
+  `pose_subscriber_demo`) and you want to watch both update live.
+- A small tool (status panel, preview, parameter editor) belongs as
+  a sidebar to a larger workspace tool.
+
+You should still launch in a **new window** when:
+
+- You want the tool fullscreen.
+- The tool needs its own `QApplication` (rare — see
+  [`embedding_a_tool.md`](../../development/embedding_a_tool.md)
+  for which tools).
+- You're running a CLI / batch / external program (those route
+  through `LaunchMode.EXTERNAL`).
+
+![Launcher with embedded view enabled](../../assets/launcher/embedded_view_overview.png)
+
+---
+
+## B. Right-click menu — Launch in New Window / Tab / Dock
+
+Right-clicking any tile in the launcher grid opens a context menu
+with up to four launch options. Which ones are enabled depends on
+the tool's declared capabilities:
+
+| Menu item                | When enabled                                             | What it does                                                             |
+| ------------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Launch (default)**     | Always.                                                  | Uses the tool's declared `default_launch` from `src/config/models.yaml`. |
+| **Launch in New Window** | Always.                                                  | Falls back to the legacy subprocess path. Top-level `QMainWindow`.       |
+| **Launch in Tab**        | Tool implements `EmbeddableTool`.                        | Adds a tab to the embedded host's central tab area.                      |
+| **Launch in Dock**       | Tool implements `EmbeddableTool` and didn't refuse dock. | Adds a `QDockWidget` to the embedded host (right side by default).       |
+
+The mapping from menu choice to dispatcher behaviour lives in
+`resolve_launch_mode()` in
+[`src/launchers/launch_routing.py`](../../../src/launchers/launch_routing.py).
+If you ask for **Launch in Tab** on a tool that doesn't support
+embedding (legacy dashboards, tools that need their own
+`QApplication`) the launcher logs a warning and silently falls back
+to **Launch in New Window** — you'll see your tool open as a
+top-level window and a one-line entry in the launcher diagnostic
+log.
+
+![Right-click context menu on a launcher tile](../../assets/launcher/embedded_view_context_menu.png)
+
+---
+
+## C. Closing a tab or dock — and the dirty-state prompt
+
+Click the **×** on a tab or the dock's title-bar close button to
+close it. If the tool reports unsaved state (its `is_dirty()` returns
+`True`), you'll see a confirmation dialog:
+
+> **Unsaved changes.** The tool `'pose_studio'` has unsaved changes.
+> Close anyway?
+
+Choose **Cancel** to keep the tool open (you can then save manually
+inside the tool). Choose **Yes** to close anyway — `cleanup()` runs
+on the tool, the widget is destroyed, and any in-memory state is
+lost.
+
+Tools that don't track dirty state never trigger this prompt. The
+`is_dirty()` contract is documented in
+[`embedding_a_tool.md`](../../development/embedding_a_tool.md).
+
+Closing the launcher window itself runs `cleanup()` on every active
+tab and dock — you don't need to close them individually first.
+
+---
+
+## D. Focus mode — double-click a tab
+
+Double-click anywhere on the tab bar (including empty space to the
+right of the last tab) to enter **focus mode**. The tab bar hides
+and the active tool fills the entire embedded host area. Double-click
+again to exit.
+
+Focus mode is per-host, not per-tool — it's a view setting, so
+opening a new tab while in focus mode keeps the bar hidden. Use it
+when you want to use a tool fullscreen-style without giving up the
+ability to flip back to your dock layout.
+
+Dock widgets stay visible in focus mode; only the tab **bar** hides.
+If you want a true minimal-chrome view, drag the docks closed first.
+
+---
+
+## E. Keyboard shortcuts
+
+| Shortcut         | Action                                          |
+| ---------------- | ----------------------------------------------- |
+| `Ctrl+Shift+T`   | Open the currently-selected tile as a **tab**.  |
+| `Ctrl+Shift+D`   | Open the currently-selected tile as a **dock**. |
+| `Ctrl+W`         | Close the active tab (with dirty-state prompt). |
+| `Ctrl+Tab`       | Cycle to the next tab.                          |
+| `Ctrl+Shift+Tab` | Cycle to the previous tab.                      |
+
+`Ctrl+Shift+T` and `Ctrl+Shift+D` mirror the right-click menu — they
+go through the same `resolve_launch_mode()` fallback, so asking for
+a tab on a non-embeddable tool still works (it opens a new window
+and logs the fallback).
+
+The standard close/cycle bindings (`Ctrl+W`, `Ctrl+Tab`) are wired
+to the tab widget's built-in slots and behave the way they do
+everywhere else on your platform.
+
+---
+
+## F. View → Show Embedded Host
+
+The launcher's **View** menu has a checkbox: **Show Embedded Host**.
+
+- **Checked** (default once any tool is opened in a tab or dock) —
+  the embedded view region is visible. The tile grid stays above it
+  so you can launch additional tools without leaving the launcher.
+- **Unchecked** — the embedded view collapses to zero height. Active
+  tabs and docks keep running (they just become invisible); toggling
+  the menu back on restores them. Use this when you want the
+  pure-tile-grid look.
+
+If you uncheck the box while a dirty tool has unsaved changes, the
+tool stays alive (no `cleanup()`, no dirty-state prompt) — hiding
+the host is not the same as closing tools.
+
+---
+
+## G. Layout persistence
+
+`EmbeddedHostWidget.state_snapshot()` returns a small JSON-shaped
+dict (`{"tabs": [...], "docks": {...}, "active_tab": int}`) that the
+launcher can save between sessions. As of this writing the launcher
+captures the snapshot but does **not** yet persist it to disk —
+that's tracked as a follow-up to
+[#4993](https://github.com/D-sorganization/UpstreamDrift/issues/4993).
+For now, expect to re-open your tabs each time the launcher starts;
+your tool-internal state (Pose Studio's open project, etc.) is
+preserved by the tool itself, not the host.
+
+---
+
+## See also
+
+- [ADR-0013](../../adr/0013-launcher-composability.md) — design
+  rationale for the contract, host, and IPC layer.
+- [`embedding_a_tool.md`](../../development/embedding_a_tool.md) —
+  for tool authors adding embedding support.
+- [`realtime_ipc.md`](../../development/realtime_ipc.md) — pub-sub
+  IPC between embedded tools.
+- The Pose Studio user guide
+  ([`docs/user_guide/pose_studio/quickstart.md`](../pose_studio/quickstart.md))
+  — the first tool that adopted the embedded view.

--- a/tests/docs/test_launcher_embed_doc_links.py
+++ b/tests/docs/test_launcher_embed_doc_links.py
@@ -1,0 +1,120 @@
+"""Verify internal Markdown links in the launcher-embed docs resolve.
+
+Subtask 7 of EPIC #4993 (issue #5000) introduces a small cluster of
+cross-linked Markdown pages under
+``docs/user_guide/launcher/`` and the launcher-embed pages under
+``docs/development/`` (``embedding_a_tool.md`` and
+``realtime_ipc.md``). This test parses every internal link in those
+pages and asserts that the target file exists on disk.
+
+External links (``http://`` / ``https://`` / ``mailto:``) and pure
+anchors (``#section``) are skipped. Image links pointing at the
+screenshot placeholder directory ``docs/assets/launcher/`` are
+tolerated as missing (screenshots are scheduled for a follow-up
+capture PR).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER_USER_GUIDE = ROOT / "docs" / "user_guide" / "launcher"
+DEVELOPMENT_DOCS = ROOT / "docs" / "development"
+
+# The launcher-embed-specific developer pages (other files under
+# ``docs/development/`` are out of scope for this subtask's link
+# validation).
+_DEV_PAGES = ("embedding_a_tool.md", "realtime_ipc.md")
+
+# ``[text](target)`` — standard Markdown link. Image links
+# (``![alt](target)``) are matched too.
+_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+
+def _is_external(target: str) -> bool:
+    return target.startswith(("http://", "https://", "mailto:"))
+
+
+def _is_anchor_only(target: str) -> bool:
+    return target.startswith("#")
+
+
+def _strip_anchor(target: str) -> str:
+    """Return the path portion of ``path#anchor``."""
+    return target.split("#", 1)[0]
+
+
+def _is_image_placeholder(target: str) -> bool:
+    """Image links in the launcher user guide point at unresolved
+    screenshot placeholders under ``docs/assets/launcher/``. Those
+    are scheduled for a follow-up capture PR — we tolerate them as
+    missing files, exactly like the Pose Studio link test does.
+    """
+    return target.endswith((".png", ".jpg", ".jpeg", ".gif", ".svg"))
+
+
+def _iter_user_guide_md_files() -> list[Path]:
+    if not LAUNCHER_USER_GUIDE.is_dir():
+        return []
+    return sorted(p for p in LAUNCHER_USER_GUIDE.glob("*.md") if p.is_file())
+
+
+def _iter_dev_md_files() -> list[Path]:
+    files: list[Path] = []
+    for name in _DEV_PAGES:
+        path = DEVELOPMENT_DOCS / name
+        if path.is_file():
+            files.append(path)
+    return sorted(files)
+
+
+def _iter_all_target_md_files() -> list[Path]:
+    return _iter_user_guide_md_files() + _iter_dev_md_files()
+
+
+def test_launcher_user_guide_directory_exists() -> None:
+    assert LAUNCHER_USER_GUIDE.is_dir(), LAUNCHER_USER_GUIDE
+
+
+def test_launcher_user_guide_has_expected_pages() -> None:
+    names = {p.name for p in _iter_user_guide_md_files()}
+    expected = {"embedded_view.md"}
+    assert expected <= names, f"missing pages: {expected - names}"
+
+
+def test_development_docs_have_expected_pages() -> None:
+    for name in _DEV_PAGES:
+        path = DEVELOPMENT_DOCS / name
+        assert path.is_file(), f"missing developer-guide page: {path}"
+
+
+def test_launcher_embed_internal_links_resolve() -> None:
+    files = _iter_all_target_md_files()
+    assert files, "expected at least one launcher-embed .md page"
+
+    failures: list[str] = []
+    for md_file in files:
+        text = md_file.read_text(encoding="utf-8")
+        for target in _LINK_RE.findall(text):
+            if _is_external(target) or _is_anchor_only(target):
+                continue
+            if _is_image_placeholder(target):
+                # Screenshot capture is scheduled for a follow-up PR.
+                continue
+            path_part = _strip_anchor(target)
+            if not path_part:
+                continue
+            resolved = (md_file.parent / path_part).resolve()
+            if not resolved.exists():
+                failures.append(
+                    f"{md_file.relative_to(ROOT)} -> {target!r} "
+                    f"(resolved to {resolved})"
+                )
+
+    assert not failures, "Unresolved internal links:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
Closes #5000. Part of EPIC #4993.

Capstone of the documentation surface for the launcher composability work — written rolling alongside the implementation subtasks (#5003, #5006, #5012, #5013, #5044) and the cross-tool live-pose demo (#4999).

## Summary

- **ADR 0013** (`docs/adr/0013-launcher-composability.md`) — embeddable-tool contract, `EmbeddedHostWidget`, the `realtime` pub-sub facade with file + WebSocket transports. Alternatives considered cover QMdiArea, REST-only IPC, pure-file IPC, Qt LocalSocket, and DBus. Cross-links every prior subtask PR. Index row added in `docs/adr/README.md`.
- **End-user guide** (`docs/user_guide/launcher/embedded_view.md`) — what the embedded view is and when to use it; the right-click Launch in New Window / Tab / Dock menu; close behaviour and the dirty-state prompt; focus mode (double-click tab); `Ctrl+Shift+T` and `Ctrl+Shift+D` shortcuts; View → Show Embedded Host toggle; layout-persistence note. Two screenshot placeholders.
- **Tool-author guide** (`docs/development/embedding_a_tool.md`) — `EmbeddableTool` Protocol surface; `QMainWindow` → `MainWidget` factory refactor pattern with Pose Studio's `_embed_adapter.py` as the canonical excerpt; capability declaration cheat-sheet (when each flag should be set); `cleanup()` contract; minimal `test_embed_adapter.py` template; tile-wiring snippet for `models.yaml`.
- **Realtime IPC guide** (`docs/development/realtime_ipc.md`) — `subscribe`/`publish` API; channel naming convention (`<scope>/<topic>`); file-vs-WebSocket transport selection via the channel registry; latency budgets; debugging tips for both transports; worked example publishing `CanonicalPose` from Pose Studio's `EngineController` and consuming it from a subscriber widget.
- **AGENTS.md** — §B adds `launcher_embed/`, `realtime/`, `embedded_host.py`, `launch_routing.py` to the shared-infrastructure directory. §G adds three lessons learned (high-frequency channels need WebSocket; embed adapters keep PyQt6 imports lazy; `cleanup()` must be idempotent).
- **CLAUDE.md** — three new entries in "Key Directories".
- **Tests** — `tests/docs/test_launcher_embed_doc_links.py` (`@pytest.mark.unit`) parses every internal Markdown link in the new pages and asserts each path resolves on disk. 4/4 passing locally.

## Test plan

- [x] `tests/docs/test_launcher_embed_doc_links.py` — all 4 tests pass.
- [x] `ruff check` — clean on the new test file.
- [x] `ruff format --check` — no diffs.
- [x] Pre-commit hooks (incl. prettier on `.md`) pass.
- [ ] Reviewer spot-check: every internal link in the new pages resolves to an existing file (the test enforces this; manual confirmation welcome).
- [ ] Reviewer spot-check: ADR cross-references to subtask PRs are correct.

## Cross-links

- EPIC: #4993
- Subtask 1 (contract foundation): #5003
- Subtask 2 (host widget): #5013
- Subtask 3 (launch-mode routing): #5044
- Subtask 4 (realtime pub-sub): #5006
- Subtask 5 (Pose Studio refactor): #5012
- Subtask 6 (cross-tool demo): #4999

🤖 Generated with [Claude Code](https://claude.com/claude-code)