### PR TITLE
feat(data_explorer): expose create_main_widget() for embedded launch (part of #4998)

### DIFF
--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -59,7 +59,8 @@
     "3213770810",
     "3213770814",
     "3214243318",
-    "3214243319"
+    "3214243319",
+    "3214561039"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",

--- a/docs/review_archive/review_comments_2026-05-10.md
+++ b/docs/review_archive/review_comments_2026-05-10.md
@@ -1,0 +1,21 @@
+# Review Comments Archive - 2026-05-10
+
+Generated: 2026-05-10T01:23:40.261823
+
+## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+
+### PR #5059: src/tools/data_explorer/__init__.py:13
+
+Actionable: No
+Has Suggestion: No
+
+```
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Stop swallowing embed-adapter import failures**
+
+Wrapping the entire registration block in `contextlib.suppress(ImportError)` makes any adapter import regression fail silently, leaving `data_explorer` unregistered with no log or exception. In this commit `models.yaml` now prefers tab embedding for this tool, so a missed registration can quietly disable the new launch path and is difficult to diagnose in CI/ru...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/5059#discussion_r3214561039)
+
+---
+

--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -186,6 +186,7 @@ models:
       category: "tool"
       logo: "assets/data_explorer_modern.png"
       status: "ready"
+      default_launch: "tab"
 
   # =============================================================================
   # DOCUMENTATION

--- a/src/tools/data_explorer/__init__.py
+++ b/src/tools/data_explorer/__init__.py
@@ -1,1 +1,25 @@
-"""Data Explorer — simulation dataset workbench."""
+"""Data Explorer — simulation dataset workbench.
+
+Importing this package registers the :class:`_DataExplorerEmbedAdapter`
+with the embeddable-tool registry so the launcher can host the tool as
+a tab or dock without spawning a separate process. Registration is
+guarded so reimports (test reloads) are a quiet no-op.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+with contextlib.suppress(ImportError):
+    # PyQt6 is optional fleet-wide; import the adapter behind a guard so
+    # headless / Qt-less environments still get a usable package.
+    from src.shared.python.launcher_embed import (
+        get_embeddable_tool,
+        register_embeddable_tool,
+    )
+
+    from ._embed_adapter import _DataExplorerEmbedAdapter
+
+    _ADAPTER = _DataExplorerEmbedAdapter()
+    if get_embeddable_tool(_ADAPTER.tool_id) is None:
+        register_embeddable_tool(_ADAPTER)

--- a/src/tools/data_explorer/_embed_adapter.py
+++ b/src/tools/data_explorer/_embed_adapter.py
@@ -1,0 +1,67 @@
+"""Embeddable-tool adapter for the Data Explorer.
+
+Implements the :class:`~src.shared.python.launcher_embed.EmbeddableTool`
+protocol so the launcher can host the Data Explorer as a tab or dock
+widget instead of always opening it as a standalone window.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.shared.python.launcher_embed import EmbedCapabilities
+from src.shared.python.logging_pkg.logger_utils import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["_DataExplorerEmbedAdapter"]
+
+
+class _DataExplorerEmbedAdapter:
+    """Adapter exposing :class:`MainWidget` through the embed contract."""
+
+    tool_id: str = "data_explorer"
+
+    def __init__(self) -> None:
+        # Track every widget we hand out so :meth:`cleanup` can dispose
+        # of any resources even if the host forgets to delete the
+        # widget. Adapters live for the process lifetime; the registry
+        # holds a single instance.
+        self._widgets: list[Any] = []
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        # Tabs work better than docks for table-heavy UIs — the Data
+        # Explorer wants horizontal space.
+        return EmbedCapabilities(
+            supports_embedded=True,
+            prefers_dock=False,
+            min_size=(640, 480),
+            requires_separate_qapplication=False,
+        )
+
+    def create_main_widget(self, parent: Any) -> Any:
+        # Lazy import: ``gui`` pulls in PyQt6, and we want this module
+        # to import cleanly in headless contexts where PyQt6 may be
+        # absent (e.g., docs builds). The launcher only calls
+        # ``create_main_widget`` once it has confirmed embedding is
+        # supported.
+        from .gui import MainWidget
+
+        widget = MainWidget(parent)
+        self._widgets.append(widget)
+        return widget
+
+    def cleanup(self) -> None:
+        # Idempotent: hosts may call cleanup more than once during
+        # shutdown. We forward to every widget we handed out, but never
+        # raise — the host's shutdown path must not depend on us.
+        widgets, self._widgets = self._widgets, []
+        for widget in widgets:
+            try:
+                widget.cleanup()
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("data_explorer widget cleanup raised")
+
+    def is_dirty(self) -> bool:
+        # Read-only inspector of dataset metadata; nothing to save.
+        return False

--- a/src/tools/data_explorer/gui.py
+++ b/src/tools/data_explorer/gui.py
@@ -1,0 +1,193 @@
+"""GUI for the Data Explorer.
+
+Provides a Qt :class:`MainWidget` that surfaces the existing
+:mod:`data_explorer_app` discovery / loading helpers in an embeddable
+form, plus a thin :class:`DataExplorerWindow` ``QMainWindow`` shell so
+the tool can still launch as a standalone window.
+
+The widget intentionally keeps Qt construction lightweight: it does not
+trigger any disk scan on construction. Tests can therefore instantiate
+``MainWidget(None)`` cheaply under ``QT_QPA_PLATFORM=offscreen``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyQt6 import QtCore, QtWidgets
+
+from src.shared.python.logging_pkg.logger_utils import get_logger
+from src.tools.data_explorer.data_explorer_app import (
+    SUPPORTED_EXTENSIONS,
+    discover_datasets,
+    load_dataset,
+)
+
+logger = get_logger(__name__)
+
+__all__ = ["DataExplorerWindow", "MainWidget"]
+
+
+class MainWidget(QtWidgets.QWidget):
+    """Embeddable Data Explorer widget.
+
+    Layout:
+        - A toolbar with a directory chooser that triggers
+          :func:`discover_datasets` against the chosen directory.
+        - A table listing discovered datasets (name / format / size).
+        - A status label summarising the current workspace.
+
+    The widget never modifies the data files it inspects (matches the
+    read-only invariant of :mod:`data_explorer_app`).
+    """
+
+    # Emitted when the user picks a directory and discovery completes.
+    # Test hook: lets unit tests assert discovery without scraping the
+    # status label text.
+    datasetsDiscovered = QtCore.pyqtSignal(list)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._datasets: list[Path] = []
+
+        # --- Toolbar row ------------------------------------------------
+        self._dir_label = QtWidgets.QLabel("Workspace: (none selected)")
+        self._dir_label.setObjectName("DataExplorerDirLabel")
+        self._choose_button = QtWidgets.QPushButton("Choose directory…")
+        self._choose_button.setObjectName("DataExplorerChooseButton")
+        self._choose_button.clicked.connect(self._on_choose_directory)
+
+        toolbar = QtWidgets.QHBoxLayout()
+        toolbar.setContentsMargins(0, 0, 0, 0)
+        toolbar.addWidget(self._dir_label, stretch=1)
+        toolbar.addWidget(self._choose_button)
+
+        # --- Dataset table ---------------------------------------------
+        self._table = QtWidgets.QTableWidget(0, 3, self)
+        self._table.setObjectName("DataExplorerTable")
+        self._table.setHorizontalHeaderLabels(["Name", "Format", "Size (bytes)"])
+        self._table.horizontalHeader().setSectionResizeMode(
+            0, QtWidgets.QHeaderView.ResizeMode.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            1, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+        self._table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+
+        # --- Status label ----------------------------------------------
+        formats = ", ".join(sorted(SUPPORTED_EXTENSIONS))
+        self._status_label = QtWidgets.QLabel(f"Supported formats: {formats}")
+        self._status_label.setObjectName("DataExplorerStatus")
+        self._status_label.setStyleSheet("color: #888;")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.addLayout(toolbar)
+        layout.addWidget(self._table, stretch=1)
+        layout.addWidget(self._status_label)
+
+    # ------------------------------------------------------------------
+    # Public API used by tests / embed adapter
+    # ------------------------------------------------------------------
+
+    def load_directory(self, directory: Path) -> list[Path]:
+        """Discover datasets under ``directory`` and refresh the table.
+
+        Args:
+            directory: Directory to scan. Must exist.
+
+        Returns:
+            The list of discovered dataset paths (also stored on the
+            widget and emitted via :pyattr:`datasetsDiscovered`).
+
+        Raises:
+            FileNotFoundError: Propagated from
+                :func:`discover_datasets` when the directory is absent.
+        """
+        datasets = discover_datasets(directory)
+        self._datasets = list(datasets)
+        self._dir_label.setText(f"Workspace: {directory}")
+        self._populate_table(datasets)
+        self.datasetsDiscovered.emit(list(datasets))
+        return datasets
+
+    def cleanup(self) -> None:
+        """Release any resources held by the widget.
+
+        Currently a no-op — the widget does not own subscriptions or
+        background threads — but kept on the public surface so the
+        embed adapter can call it idempotently during host shutdown.
+        """
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _on_choose_directory(self) -> None:
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Choose dataset directory"
+        )
+        if not directory:
+            return
+        try:
+            self.load_directory(Path(directory))
+        except FileNotFoundError:
+            logger.warning("Chosen directory disappeared: %s", directory)
+
+    def _populate_table(self, datasets: list[Path]) -> None:
+        self._table.setRowCount(len(datasets))
+        for row, path in enumerate(datasets):
+            try:
+                info = load_dataset(path)
+            except (FileNotFoundError, ValueError, OSError) as exc:
+                logger.warning("Skipping unreadable dataset %s: %s", path, exc)
+                self._table.setItem(row, 0, QtWidgets.QTableWidgetItem(path.name))
+                self._table.setItem(row, 1, QtWidgets.QTableWidgetItem("error"))
+                self._table.setItem(row, 2, QtWidgets.QTableWidgetItem("-"))
+                continue
+            self._table.setItem(row, 0, QtWidgets.QTableWidgetItem(path.name))
+            self._table.setItem(
+                row, 1, QtWidgets.QTableWidgetItem(str(info.get("format", "")))
+            )
+            self._table.setItem(
+                row, 2, QtWidgets.QTableWidgetItem(str(info.get("size_bytes", "")))
+            )
+
+
+class DataExplorerWindow(QtWidgets.QMainWindow):
+    """Standalone shell that hosts :class:`MainWidget` in a window.
+
+    Used when the launcher chooses :class:`LaunchMode.NEW_WINDOW`. The
+    embed path goes through ``_DataExplorerEmbedAdapter`` instead.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Data Explorer")
+        self._main_widget = MainWidget(self)
+        self.setCentralWidget(self._main_widget)
+        self.resize(900, 600)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m src.tools.data_explorer``."""
+    if argv is None:
+        argv = sys.argv
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(argv)
+    window = DataExplorerWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ui/tools/data_explorer/conftest.py
+++ b/tests/ui/tools/data_explorer/conftest.py
@@ -1,0 +1,30 @@
+"""Local fixtures for the Data Explorer UI tests.
+
+Mirrors the ``qapp`` fixture pattern used in
+``tests/launchers/conftest.py`` so the Data Explorer tests can share a
+session ``QApplication`` under ``QT_QPA_PLATFORM=offscreen``. Defined
+locally because pytest's conftest discovery is ancestor-based and
+``tests/launchers`` is a sibling, not an ancestor, of this directory.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Force Qt to use the offscreen platform so headless CI / sandboxed
+# runners do not fail to instantiate widgets.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Session-scoped ``QApplication`` instance."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app

--- a/tests/ui/tools/data_explorer/test_embed_adapter.py
+++ b/tests/ui/tools/data_explorer/test_embed_adapter.py
@@ -1,0 +1,125 @@
+"""Headless tests for the Data Explorer embeddable-tool adapter.
+
+Run with ``QT_QPA_PLATFORM=offscreen``. PyQt6 is gated via
+``importorskip`` so the test module is harmless on Qt-less runners.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+from PyQt6.QtWidgets import QWidget  # noqa: E402
+
+from src.shared.python.launcher_embed import (  # noqa: E402
+    EMBEDDABLE_TOOL_REGISTRY,
+    EmbedCapabilities,
+    EmbeddableTool,
+)
+from src.tools.data_explorer._embed_adapter import (  # noqa: E402
+    _DataExplorerEmbedAdapter,
+)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def _preserve_registry():
+    """Snapshot and restore the embeddable-tool registry per test.
+
+    The package-level import in ``src.tools.data_explorer`` already
+    populates the registry, but individual tests register / unregister
+    fresh instances and we want a clean slate around each one.
+    """
+    snapshot = dict(EMBEDDABLE_TOOL_REGISTRY)
+    EMBEDDABLE_TOOL_REGISTRY.clear()
+    try:
+        yield
+    finally:
+        EMBEDDABLE_TOOL_REGISTRY.clear()
+        EMBEDDABLE_TOOL_REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def adapter() -> _DataExplorerEmbedAdapter:
+    return _DataExplorerEmbedAdapter()
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+def test_adapter_satisfies_embeddable_tool_protocol(
+    adapter: _DataExplorerEmbedAdapter,
+) -> None:
+    """The adapter must satisfy :class:`EmbeddableTool` at runtime."""
+    assert isinstance(adapter, EmbeddableTool)
+
+
+def test_tool_id_is_data_explorer(adapter: _DataExplorerEmbedAdapter) -> None:
+    assert adapter.tool_id == "data_explorer"
+
+
+def test_embed_capabilities_returns_expected_values(
+    adapter: _DataExplorerEmbedAdapter,
+) -> None:
+    caps = adapter.embed_capabilities()
+    assert isinstance(caps, EmbedCapabilities)
+    assert caps.supports_embedded is True
+    # Tabs work better than docks for table-heavy UIs.
+    assert caps.prefers_dock is False
+    assert caps.min_size == (640, 480)
+    assert caps.requires_separate_qapplication is False
+
+
+def test_create_main_widget_returns_qwidget(
+    qapp,  # noqa: ANN001 - injected from tests/launchers/conftest.py
+    adapter: _DataExplorerEmbedAdapter,
+) -> None:
+    widget = adapter.create_main_widget(None)
+    try:
+        assert isinstance(widget, QWidget)
+    finally:
+        widget.deleteLater()
+
+
+def test_is_dirty_returns_false(adapter: _DataExplorerEmbedAdapter) -> None:
+    assert adapter.is_dirty() is False
+
+
+def test_cleanup_is_idempotent(
+    qapp,  # noqa: ANN001
+    adapter: _DataExplorerEmbedAdapter,
+) -> None:
+    """Cleanup must tolerate being called repeatedly."""
+    adapter.create_main_widget(None)
+    adapter.cleanup()
+    adapter.cleanup()  # second call must not raise
+
+
+def test_importing_package_registers_adapter(_preserve_registry) -> None:
+    """Importing :mod:`src.tools.data_explorer` registers the adapter."""
+    # The package may already be imported earlier in the test session;
+    # clear the registry (done by the fixture) and re-run the
+    # registration logic by re-executing the package init's body.
+    import importlib
+
+    import src.tools.data_explorer as data_explorer_pkg
+
+    importlib.reload(data_explorer_pkg)
+
+    assert "data_explorer" in EMBEDDABLE_TOOL_REGISTRY
+    registered = EMBEDDABLE_TOOL_REGISTRY["data_explorer"]
+    assert registered.tool_id == "data_explorer"
+    assert isinstance(registered, EmbeddableTool)


### PR DESCRIPTION
## Summary

- Adds an embed-contract path to the Data Explorer so the launcher can host it as a tab (or dock) in the embedded host introduced by EPIC #4993, instead of always spawning a top-level window.
- New `MainWidget(QWidget)` in `src/tools/data_explorer/gui.py` surfaces dataset discovery / metadata in an embeddable form; a thin `DataExplorerWindow` `QMainWindow` shell preserves the standalone-launch path via `setCentralWidget(MainWidget(self))`.
- New `_embed_adapter.py` registers `_DataExplorerEmbedAdapter` (tabs preferred over docks for the table-heavy UI, `min_size=(640, 480)`); package `__init__.py` registers it on import behind a guarded import.
- `src/config/models.yaml` advertises `default_launch: "tab"` for the `data_explorer` entry.

## Test plan

- [x] `QT_QPA_PLATFORM=offscreen python3 -m pytest tests/unit/tools/data_explorer tests/ui/tools/data_explorer -n auto -q` (existing CLI tests + new embed adapter tests all pass)
- [x] `ruff check` and `ruff format --check` clean on changed files
- [x] Pre-push hooks (mypy, bandit, pytest, prettier, ruff) all green

Part of #4998 (Subtask 5 of EPIC #4993).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>