### PR TITLE
fix(opensim): restore writable delegated state on OpenSimGolfGUI

### DIFF
--- a/src/engines/physics_engines/opensim/python/opensim_gui.py
+++ b/src/engines/physics_engines/opensim/python/opensim_gui.py
@@ -87,21 +87,41 @@ class OpenSimGolfGUI(QMainWindow):
 
     # The original public surface delegated through the central widget
     # so existing callers (and any downstream tests) continue to work.
+    # These properties expose setters so callers that previously assigned
+    # plain attributes on ``OpenSimGolfGUI`` (e.g. reusing a window with a
+    # new ``model_path`` or test harnesses injecting ``model``/``result``)
+    # continue to work unchanged.
     @property
     def model(self) -> "GolfSwingModel | None":
         return self._main_widget.model
+
+    @model.setter
+    def model(self, value: "GolfSwingModel | None") -> None:
+        self._main_widget.model = value
 
     @property
     def model_path(self) -> str | None:
         return self._main_widget.model_path
 
+    @model_path.setter
+    def model_path(self, value: str | None) -> None:
+        self._main_widget.model_path = value
+
     @property
     def result(self) -> Any:
         return self._main_widget.result
 
+    @result.setter
+    def result(self, value: Any) -> None:
+        self._main_widget.result = value
+
     @property
     def initialization_error(self) -> str | None:
         return self._main_widget.initialization_error
+
+    @initialization_error.setter
+    def initialization_error(self, value: str | None) -> None:
+        self._main_widget.initialization_error = value
 
     @property
     def btn_run(self) -> QPushButton:

--- a/tests/ui/engines/opensim/test_opensim_gui_writable_state.py
+++ b/tests/ui/engines/opensim/test_opensim_gui_writable_state.py
@@ -1,0 +1,75 @@
+"""Regression tests for the writable delegated state on OpenSimGolfGUI.
+
+Issue #5071: a refactor previously turned ``model``, ``model_path``,
+``result``, and ``initialization_error`` into read-only ``@property``
+shims that delegated to the embedded :class:`MainWidget`. That broke
+existing callers (and test harnesses) that assigned new values onto a
+window instance after construction. These tests pin the public surface
+back to "writable, with delegation".
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# The dashboard pulls in PyQt6 and Matplotlib's Qt backend. Skip the
+# whole module rather than failing collection on hosts where PyQt6 is
+# missing.
+PyQt6 = pytest.importorskip("PyQt6")
+
+_GUI_MOD_NAME = "src.engines.physics_engines.opensim.python.opensim_gui"
+
+
+def _import_gui_module():
+    try:
+        return importlib.import_module(_GUI_MOD_NAME)
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"OpenSim GUI module not importable: {exc}")
+
+
+@pytest.fixture
+def gui(qapp):
+    """Construct a real ``OpenSimGolfGUI`` window with no model."""
+    gui_mod = _import_gui_module()
+    window = gui_mod.OpenSimGolfGUI(model_path=None)
+    try:
+        yield window
+    finally:
+        window.close()
+        window.deleteLater()
+
+
+@pytest.mark.unit
+def test_model_path_is_writable(gui) -> None:
+    """Assigning ``model_path`` must propagate to the inner widget."""
+    gui.model_path = "/tmp/example.osim"
+    assert gui.model_path == "/tmp/example.osim"
+    assert gui._main_widget.model_path == "/tmp/example.osim"
+
+
+@pytest.mark.unit
+def test_model_is_writable(gui) -> None:
+    """Test harnesses that inject ``model`` must continue to work."""
+    sentinel = object()
+    gui.model = sentinel  # type: ignore[assignment]
+    assert gui.model is sentinel
+    assert gui._main_widget.model is sentinel
+
+
+@pytest.mark.unit
+def test_result_is_writable(gui) -> None:
+    """Assigning ``result`` must propagate to the inner widget."""
+    sentinel = object()
+    gui.result = sentinel
+    assert gui.result is sentinel
+    assert gui._main_widget.result is sentinel
+
+
+@pytest.mark.unit
+def test_initialization_error_is_writable(gui) -> None:
+    """Assigning ``initialization_error`` must propagate."""
+    gui.initialization_error = "boom"
+    assert gui.initialization_error == "boom"
+    assert gui._main_widget.initialization_error == "boom"


### PR DESCRIPTION
## Summary

Fixes #5071. The PR #5069 refactor turned `OpenSimGolfGUI.model`, `model_path`, `result`, and `initialization_error` into read-only `@property` shims that delegated to the embedded `MainWidget`. Existing callers that re-assigned these fields after construction (and test harnesses injecting `model`/`result`) started raising `AttributeError`, despite the surrounding compatibility comment.

This change adds matching setters on each property so the public surface stays identical to the pre-refactor behaviour, with the assignment delegated through to the central widget.

## Changes

- `src/engines/physics_engines/opensim/python/opensim_gui.py`: add `@<name>.setter` on `model`, `model_path`, `result`, and `initialization_error` properties.
- `tests/ui/engines/opensim/test_opensim_gui_writable_state.py`: new regression tests pinning the writable contract.

## Test plan

- [x] `python3 -m ruff check` on changed files
- [x] `python3 -m ruff format --check` on changed files
- [x] `pytest tests/ui/engines/opensim/test_opensim_gui_writable_state.py` — 4 passed

Fixes #5071

🤖 Generated by `address-issues` skill (agent: addr-5071)