### PR TITLE
fix: declare mixin attributes to resolve mypy errors in _InverseDynamicsSolverMixin (#4991)

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_id_solver_mixin.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_id_solver_mixin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import mujoco
 import numpy as np
 from scipy.linalg import lstsq
@@ -23,6 +25,16 @@ class _InverseDynamicsSolverMixin:
     kinematic_analyzer: KinematicForceAnalyzer
     _perturb_data: mujoco.MjData
     _use_flat_jacobian: bool
+    _jacp: np.ndarray | None
+    _jacr: np.ndarray | None
+    _jacp_flat: np.ndarray | None
+    _jacr_flat: np.ndarray | None
+    has_constraints: bool
+    compute_required_torques: Any
+    _compute_gravity_force: Any
+    _compute_coriolis_force: Any
+    _compute_control_force: Any
+    _solve_component_accelerations: Any
 
     def compute_torques_with_posture(
         self,


### PR DESCRIPTION
## Summary
Declare `_jacp`, `_jacr`, `_jacp_flat`, `_jacr_flat`, `has_constraints`, and delegated method stubs at mixin class scope so mypy can resolve them when checking methods defined on `_InverseDynamicsSolverMixin`.

## Problem
`_InverseDynamicsSolverMixin` references attributes (`_jacp`, `_jacr`, `_jacp_flat`, `_jacr_flat`) and methods (`_compute_gravity_force`, `_compute_coriolis_force`, `_compute_control_force`, `_solve_component_accelerations`) that are only set on the concrete `InverseDynamicsSolver` class via `__init__`. Mypy cannot see these from within the mixin, resulting in 78+ errors across 17 files.

## Fix
The declarations as annotated class-level attributes with `np.ndarray | None` and `Any` types let mypy understand the interface contract without requiring Protocol refactoring.

Fixes #4991