### PR TITLE
refactor: remove duplicated precondition checks in _id_solver_mixin.py

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_id_solver_mixin.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_id_solver_mixin.py
@@ -56,8 +56,6 @@ class _InverseDynamicsSolverMixin:
         # Note: This assumes qacc_primary satisfies the task constraints
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
-        if not (qpos is not None):
-            raise ValueError("qpos must be provided")
         primary_result = self.compute_required_torques(qpos, qvel, qacc_primary)
         tau_primary = primary_result.joint_torques  # Total generalized force
 
@@ -135,8 +133,6 @@ class _InverseDynamicsSolverMixin:
         """
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
-        if not (qpos is not None):
-            raise ValueError("qpos must be provided")
         self._perturb_data.qpos[:] = qpos
         self._perturb_data.qvel[:] = qvel
 
@@ -176,8 +172,6 @@ class _InverseDynamicsSolverMixin:
         """
         if not (times is not None):
             raise ValueError("times must be provided")
-        if not (times is not None):
-            raise ValueError("times must be provided")
         results = []
 
         for i in range(len(times)):
@@ -215,8 +209,6 @@ class _InverseDynamicsSolverMixin:
         # Full inverse dynamics
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
-        if not (qpos is not None):
-            raise ValueError("qpos must be provided")
         full_result = self.compute_required_torques(qpos, qvel, qacc)
 
         # Create selection matrix for actuated joints
@@ -250,8 +242,6 @@ class _InverseDynamicsSolverMixin:
         Returns:
             ForceDecomposition with all components
         """
-        if not (qpos is not None):
-            raise ValueError("qpos must be provided")
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
         result = self.compute_required_torques(qpos, qvel, qacc)
@@ -321,8 +311,6 @@ class _InverseDynamicsSolverMixin:
             End-effector force [3]
         """
         # Compute required torques
-        if not (qpos is not None):
-            raise ValueError("qpos must be provided")
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
         result = self.compute_required_torques(qpos, qvel, qacc)
@@ -423,8 +411,6 @@ class _InverseDynamicsSolverMixin:
         Returns:
             Efficiency metrics
         """
-        if not (result is not None):
-            raise ValueError("result must be provided")
         if not (result is not None):
             raise ValueError("result must be provided")
         torques = result.joint_torques


### PR DESCRIPTION
Remove seven duplicated `if not (x is not None): raise ValueError(...)` blocks from _InverseDynamicsSolverMixin methods. Follows DRY principle - same behavior, less noise.