### PR TITLE
refactor: remove duplicated precondition check in _osc_mixin.py

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_osc_mixin.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_osc_mixin.py
@@ -40,8 +40,6 @@ class OperationalSpaceControlMixin:
         # MuJoCo 3.3+ may require reshaped arrays - try both approaches
         if not (target_position is not None):
             raise ValueError("target_position must be provided")
-        if not (target_position is not None):
-            raise ValueError("target_position must be provided")
         try:
             jacp = np.zeros((3, self.model.nv))
             jacr = np.zeros((3, self.model.nv))


### PR DESCRIPTION
Remove duplicated `if not (target_position is not None): raise ValueError(...)` block. Follows DRY principle - same behavior, less noise.