### PR TITLE
fix(launcher-embed): address codex-review feedback (closes #5054, #5062, #5088)

### DIFF
--- a/docs/ui/FEATURE_PARITY_MATRIX.md
+++ b/docs/ui/FEATURE_PARITY_MATRIX.md
@@ -23,6 +23,7 @@ This document provides a comprehensive feature parity analysis between the PyQt6
 ### React UI Role
 
 The React UI provides:
+
 - Remote access to simulations via browser
 - Lightweight visualization for shared sessions
 - Educational/demo purposes
@@ -33,52 +34,53 @@ The React UI provides:
 ## Feature Parity Matrix
 
 ### Legend
+
 - ✅ = Fully implemented
 - ⚠️ = Partially implemented
 - ❌ = Not implemented
 - 🔄 = In progress
 
-| Feature Category | Feature | PyQt6 | React/Tauri | Priority | Tracking Issue |
-|-----------------|---------|-------|-------------|----------|----------------|
-| **Launcher** | Model tile grid | ✅ | ❌ | High | - |
-| | Drag-and-drop reordering | ✅ | ❌ | Low | - |
-| | View modes (Comfortable/Compact/Dense/List) | ✅ | ❌ | Low | - |
-| | Zoom slider | ✅ | ❌ | Low | - |
-| | Search/filter | ✅ | ❌ | Medium | - |
-| | Status chips | ✅ | ❌ | Low | - |
-| | Sidebar navigation | ✅ | ❌ | Low | - |
-| **Simulation Controls** | Play/Pause/Stop | ✅ | ⚠️ | High | - |
-| | Step frame | ✅ | ❌ | Medium | #7 |
-| | Speed control (0.1x-5x) | ✅ | ❌ | Medium | #7 |
-| | Timestep adjustment | ✅ | ❌ | Low | - |
-| | Per-actuator sliders | ✅ | ❌ | High | #2 |
-| | Control type selection | ✅ | ❌ | High | #2 |
-| | Polynomial generator | ✅ | ❌ | Medium | #2 |
-| **Visualization** | 3D scene rendering | ✅ | ⚠️ | High | - |
-| | Force/torque overlays | ✅ | ❌ | High | #1 |
-| | Contact force visualization | ✅ | ❌ | Medium | #1 |
-| | Camera presets | ✅ | ❌ | Medium | #7 |
-| | Camera controls (azimuth/elevation) | ✅ | ⚠️ | Medium | - |
-| | Trajectory trails | ✅ | ⚠️ | Medium | - |
-| | Swing trajectory recording | ✅ | ❌ | Low | - |
-| **Model Interaction** | 6-DOF manipulation | ✅ | ❌ | Medium | #6 |
-| | Body selection (raycasting) | ✅ | ❌ | Medium | #6 |
-| | Pose library | ✅ | ❌ | Low | #6 |
-| | IK-based dragging | ✅ | ❌ | Low | #6 |
-| **Model Explorer** | URDF tree viewer | ✅ | ❌ | Medium | #3 |
-| | Frankenstein Editor | ✅ | ❌ | Medium | #3 |
-| | Character Builder | ✅ | ❌ | Medium | #4 |
-| | URDF export | ✅ | ❌ | Medium | #3 |
-| **Specialized Views** | Putting Green Simulator | ✅ | ❌ | Medium | #5 |
-| | C3D Motion Capture Viewer | ✅ | ❌ | Medium | - |
-| | Data Explorer | ✅ | ❌ | Low | - |
-| | Video Analyzer | ✅ | ❌ | Low | - |
-| **AI Features** | Chat panel | ✅ | ⚠️ | Medium | - |
-| | Context-aware help | ✅ | ❌ | Low | - |
-| **Settings** | Engine runtime config | ✅ | ❌ | High | - |
-| | Docker/WSL mode | ✅ | ❌ | High | - |
-| | Theme selection | ✅ | ❌ | Low | - |
-| | Layout customization | ✅ | ❌ | Low | - |
+| Feature Category        | Feature                                     | PyQt6 | React/Tauri | Priority | Tracking Issue |
+| ----------------------- | ------------------------------------------- | ----- | ----------- | -------- | -------------- |
+| **Launcher**            | Model tile grid                             | ✅    | ❌          | High     | -              |
+|                         | Drag-and-drop reordering                    | ✅    | ❌          | Low      | -              |
+|                         | View modes (Comfortable/Compact/Dense/List) | ✅    | ❌          | Low      | -              |
+|                         | Zoom slider                                 | ✅    | ❌          | Low      | -              |
+|                         | Search/filter                               | ✅    | ❌          | Medium   | -              |
+|                         | Status chips                                | ✅    | ❌          | Low      | -              |
+|                         | Sidebar navigation                          | ✅    | ❌          | Low      | -              |
+| **Simulation Controls** | Play/Pause/Stop                             | ✅    | ⚠️          | High     | -              |
+|                         | Step frame                                  | ✅    | ❌          | Medium   | #7             |
+|                         | Speed control (0.1x-5x)                     | ✅    | ❌          | Medium   | #7             |
+|                         | Timestep adjustment                         | ✅    | ❌          | Low      | -              |
+|                         | Per-actuator sliders                        | ✅    | ❌          | High     | #2             |
+|                         | Control type selection                      | ✅    | ❌          | High     | #2             |
+|                         | Polynomial generator                        | ✅    | ❌          | Medium   | #2             |
+| **Visualization**       | 3D scene rendering                          | ✅    | ⚠️          | High     | -              |
+|                         | Force/torque overlays                       | ✅    | ❌          | High     | #1             |
+|                         | Contact force visualization                 | ✅    | ❌          | Medium   | #1             |
+|                         | Camera presets                              | ✅    | ❌          | Medium   | #7             |
+|                         | Camera controls (azimuth/elevation)         | ✅    | ⚠️          | Medium   | -              |
+|                         | Trajectory trails                           | ✅    | ⚠️          | Medium   | -              |
+|                         | Swing trajectory recording                  | ✅    | ❌          | Low      | -              |
+| **Model Interaction**   | 6-DOF manipulation                          | ✅    | ❌          | Medium   | #6             |
+|                         | Body selection (raycasting)                 | ✅    | ❌          | Medium   | #6             |
+|                         | Pose library                                | ✅    | ❌          | Low      | #6             |
+|                         | IK-based dragging                           | ✅    | ❌          | Low      | #6             |
+| **Model Explorer**      | URDF tree viewer                            | ✅    | ❌          | Medium   | #3             |
+|                         | Frankenstein Editor                         | ✅    | ❌          | Medium   | #3             |
+|                         | Character Builder                           | ✅    | ❌          | Medium   | #4             |
+|                         | URDF export                                 | ✅    | ❌          | Medium   | #3             |
+| **Specialized Views**   | Putting Green Simulator                     | ✅    | ❌          | Medium   | #5             |
+|                         | C3D Motion Capture Viewer                   | ✅    | ❌          | Medium   | -              |
+|                         | Data Explorer                               | ✅    | ❌          | Low      | -              |
+|                         | Video Analyzer                              | ✅    | ❌          | Low      | -              |
+| **AI Features**         | Chat panel                                  | ✅    | ⚠️          | Medium   | -              |
+|                         | Context-aware help                          | ✅    | ❌          | Low      | -              |
+| **Settings**            | Engine runtime config                       | ✅    | ❌          | High     | -              |
+|                         | Docker/WSL mode                             | ✅    | ❌          | High     | -              |
+|                         | Theme selection                             | ✅    | ❌          | Low      | -              |
+|                         | Layout customization                        | ✅    | ❌          | Low      | -              |
 
 ---
 
@@ -87,16 +89,19 @@ The React UI provides:
 ### High Priority Gaps
 
 #### 1. Force & Torque Vector Overlay (#1)
+
 **Impact:** Critical for physics debugging and analysis  
 **Effort:** Medium (requires WebSocket protocol extension)  
 **Dependencies:** Backend must stream force/torque data per frame
 
-#### 2. Joint/Actuator Control Sliders (#2)  
+#### 2. Joint/Actuator Control Sliders (#2)
+
 **Impact:** Prevents interactive simulation tuning  
 **Effort:** Medium  
 **Dependencies:** Backend actuator metadata endpoint
 
 #### 3. Engine Runtime Configuration
+
 **Impact:** Users cannot select Docker/WSL mode in web UI  
 **Effort:** Low-Medium  
 **Dependencies:** None
@@ -104,26 +109,31 @@ The React UI provides:
 ### Medium Priority Gaps
 
 #### 4. Model Explorer / Frankenstein Editor (#3)
+
 **Impact:** Cannot create/modify URDF models in web UI  
 **Effort:** High  
 **Dependencies:** URDF parsing, Three.js URDF loader
 
 #### 5. Character Builder (#4)
+
 **Impact:** Cannot generate custom body models  
 **Effort:** Medium  
 **Dependencies:** Backend character-builder API
 
 #### 6. 6-DOF Model Manipulation (#6)
+
 **Impact:** Cannot interactively pose models  
 **Effort:** Medium  
 **Dependencies:** TransformControls, state sync API
 
 #### 7. Putting Green Simulator (#5)
+
 **Impact:** Specialized training tool unavailable  
 **Effort:** Medium  
 **Dependencies:** Backend putting green API integration
 
 #### 8. Full Simulation Control Panel (#7)
+
 **Impact:** Limited runtime control  
 **Effort:** Medium  
 **Dependencies:** None
@@ -131,11 +141,13 @@ The React UI provides:
 ### Low Priority Gaps
 
 #### 9. Launcher Features
+
 **Impact:** Web users cannot navigate models efficiently  
 **Effort:** Medium  
 **Note:** May not be needed if React UI serves different use case
 
 #### 10. Archive Old GUI Versions (#8)
+
 **Impact:** Repository clutter, confusion  
 **Effort:** Low  
 **Note:** Cleanup task, not feature development
@@ -147,11 +159,13 @@ The React UI provides:
 ### Immediate Actions (Wave 1)
 
 1. **Document Canonical UI Status**
+
    - Update React README to clarify canonical status
    - Add deprecation notice for feature-parity expectations
    - Link to this parity matrix
 
 2. **Implement Critical Controls**
+
    - Force/torque visualization (#1)
    - Joint/actuator sliders (#2)
    - Engine runtime selector
@@ -163,6 +177,7 @@ The React UI provides:
 ### Medium-Term (Wave 2)
 
 4. **Model Explorer Foundation** (#3, #4)
+
    - URDF tree viewer
    - Basic Character Builder
 
@@ -173,6 +188,7 @@ The React UI provides:
 ### Long-Term (Wave 3)
 
 6. **Specialized Views** (#5)
+
    - Putting Green Simulator
    - C3D Viewer integration
 
@@ -188,15 +204,15 @@ The React UI provides:
 
 For React UI to achieve parity, the following backend APIs are needed:
 
-| Endpoint | Method | Purpose | Priority |
-|----------|--------|---------|----------|
-| `/api/engines/{name}/actuators` | GET | Get actuator metadata | High |
-| `/api/simulation/forces` | WS | Stream force/torque data | High |
-| `/api/simulation/set_control` | WS | Set actuator values | High |
-| `/api/simulation/set_state` | POST | Apply position changes | Medium |
-| `/api/character-builder/generate` | POST | Generate character URDF | Medium |
-| `/api/models/{id}/urdf` | GET | Get model URDF | Medium |
-| `/api/putting-green/simulate` | POST | Run putting simulation | Low |
+| Endpoint                          | Method | Purpose                  | Priority |
+| --------------------------------- | ------ | ------------------------ | -------- |
+| `/api/engines/{name}/actuators`   | GET    | Get actuator metadata    | High     |
+| `/api/simulation/forces`          | WS     | Stream force/torque data | High     |
+| `/api/simulation/set_control`     | WS     | Set actuator values      | High     |
+| `/api/simulation/set_state`       | POST   | Apply position changes   | Medium   |
+| `/api/character-builder/generate` | POST   | Generate character URDF  | Medium   |
+| `/api/models/{id}/urdf`           | GET    | Get model URDF           | Medium   |
+| `/api/putting-green/simulate`     | POST   | Run putting simulation   | Low      |
 
 ### Frontend Architecture
 
@@ -233,19 +249,21 @@ ui/src/
 
 ## Success Metrics
 
-| Metric | Current | Target (6mo) | Target (12mo) |
-|--------|---------|--------------|---------------|
-| Feature Coverage | ~15% | 40% | 70% |
-| High-Priority Gaps | 5 | 1 | 0 |
-| Active React Users | TBD | TBD | TBD |
-| Backend API Coverage | ~30% | 60% | 90% |
+| Metric               | Current | Target (6mo) | Target (12mo) |
+| -------------------- | ------- | ------------ | ------------- |
+| Feature Coverage     | ~15%    | 40%          | 70%           |
+| High-Priority Gaps   | 5       | 1            | 0             |
+| Active React Users   | TBD     | TBD          | TBD           |
+| Backend API Coverage | ~30%    | 60%          | 90%           |
 
 ---
 
 ## Related Documents
 
 - [React UI Parity Issues](../assessments/issues/REACT_UI_PARITY_ISSUES.md)
-- [Launcher UI/UX Epic #4904](../development/launcher_parity_assessment.md)
+- [Launcher UI/UX Epic #4904](https://github.com/D-sorganization/UpstreamDrift/issues/4904)
+- [Launcher Parity Assessment](../development/launcher_parity_assessment.md)
+- [Embedding a Tool](../development/embedding_a_tool.md)
 - [React UI README](../../ui/README.md)
 
 ---
@@ -260,6 +278,7 @@ This parity matrix was generated by:
 4. Validating with running instances of both UIs
 
 **Tools Used:**
+
 - Source code grep/search
 - Component tree analysis
 - Runtime feature verification

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/_embed_adapter.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/_embed_adapter.py
@@ -5,8 +5,10 @@ protocol so the launcher can host the viewer as a tab or dock widget
 instead of spawning a standalone process.
 
 The viewer uses matplotlib canvases inside its plot tabs. :meth:`cleanup`
-releases all matplotlib figures via ``plt.close('all')`` so closing the
-embedded tab does not leak figure references in the host process.
+releases only the figures owned by widgets this adapter created — it
+does **not** call ``plt.close('all')`` because that would also tear
+down figures owned by other embedded tools sharing the host process
+(see review feedback on #5062).
 """
 
 from __future__ import annotations
@@ -23,6 +25,14 @@ class _C3DViewerEmbedAdapter:
 
     tool_id: str = "c3d_viewer"
 
+    def __init__(self) -> None:
+        # Track every ``MainWidget`` instance we hand to the host so
+        # ``cleanup`` can scope figure release to just our widgets'
+        # canvases instead of nuking every matplotlib figure in the
+        # process (which would also close figures owned by sibling
+        # embedded tools — see #5062).
+        self._created_widgets: list[Any] = []
+
     def embed_capabilities(self) -> EmbedCapabilities:
         return EmbedCapabilities(
             supports_embedded=True,
@@ -38,24 +48,40 @@ class _C3DViewerEmbedAdapter:
         # import time) load cleanly in headless contexts.
         from .c3d_viewer import MainWidget
 
-        return MainWidget(parent)
+        widget = MainWidget(parent)
+        self._created_widgets.append(widget)
+        return widget
 
     def cleanup(self) -> None:
-        """Release matplotlib figures held by the plot tabs.
+        """Release matplotlib figures held by *our* plot tabs only.
 
-        Must be idempotent; ``plt.close('all')`` is a no-op when no
-        figures remain. Wrapped in a defensive try/except so a
-        misbehaving matplotlib never blocks host shutdown.
+        Walks every ``MainWidget`` we created, finds its embedded
+        ``FigureCanvasQTAgg`` children, and closes each figure
+        individually. Wrapped in a defensive try/except so a misbehaving
+        matplotlib never blocks host shutdown, and idempotent so the
+        host can call cleanup more than once.
         """
         try:
             import matplotlib.pyplot as plt
+            from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 
-            plt.close("all")
+            for widget in list(self._created_widgets):
+                try:
+                    canvases = widget.findChildren(FigureCanvasQTAgg)
+                except Exception:  # pragma: no cover - widget may be deleted
+                    continue
+                for canvas in canvases:
+                    try:
+                        plt.close(canvas.figure)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
         except Exception:  # pragma: no cover - defensive
             # Host shutdown must not depend on us. Swallow rather than
             # raise; the registry contract requires ``cleanup`` to be
             # idempotent and non-fatal.
             pass
+        finally:
+            self._created_widgets.clear()
 
     def is_dirty(self) -> bool:
         # The viewer is read-only on the input C3D file; the export

--- a/src/launchers/embedded_tool_bootstrap.py
+++ b/src/launchers/embedded_tool_bootstrap.py
@@ -41,13 +41,23 @@ def bootstrap_embeddable_tools() -> list[str]:
     if _bootstrap_complete:
         return _registered_tools
 
-    # List of tool adapter modules that self-register on import
-    # Each module's __init__.py calls register_embeddable_tool()
+    # List of tool packages whose __init__.py self-registers on import.
+    # Each package's __init__.py calls register_embeddable_tool() behind a
+    # contextlib.suppress(ImportError) guard so optional engine wheels
+    # (mujoco, drake, pinocchio, opensim, myosuite, etc.) failing to load
+    # is a soft skip rather than a launcher startup error.
     adapter_modules = [
-        "src.tools.model_explorer._embed_adapter",
-        "src.tools.data_explorer._embed_adapter",
-        "src.tools.starting_pose_matcher._embed_adapter",
-        "src.tools.pose_subscriber_demo._embed_adapter",
+        "src.tools.pose_studio",
+        "src.tools.data_explorer",
+        "src.tools.model_explorer",
+        "src.tools.starting_pose_matcher",
+        "src.tools.pose_subscriber_demo",
+        "src.engines.physics_engines.mujoco.python.mujoco_humanoid_golf",
+        "src.engines.physics_engines.drake.python.src",
+        "src.engines.physics_engines.pinocchio.python.pinocchio_golf",
+        "src.engines.physics_engines.opensim.python",
+        "src.engines.physics_engines.myosuite.python",
+        "src.engines.Simscape_Multibody_Models.3D_Golf_Model.python.src.apps",
     ]
 
     registered = []
@@ -55,17 +65,18 @@ def bootstrap_embeddable_tools() -> list[str]:
         try:
             # Import the module - it self-registers at module level
             __import__(module_path)
-            # Extract tool_id from module name for tracking
+            # Track by last segment of the dotted path
             tool_id = module_path.split(".")[-1].replace("_embed_adapter", "")
             registered.append(tool_id)
             logger.debug(f"Bootstrapped embeddable tool: {tool_id}")
-        except ImportError as e:
-            # Tools may have optional dependencies (PyQt6, etc.)
-            # Log but don't fail - the tool just won't be embeddable
-            logger.warning(f"Failed to bootstrap {module_path}: {e}")
-        except Exception as e:  # noqa: BLE001
+        except (ImportError, ModuleNotFoundError) as e:
+            # Tools may have optional dependencies (PyQt6, optional engine
+            # wheels, etc.). Log at debug — a missing optional engine is
+            # not a launcher-level failure.
+            logger.debug(f"embed bootstrap skipped {module_path}: {e}")
+        except Exception:  # noqa: BLE001
             # Catch any other unexpected errors during registration
-            logger.warning(f"Error bootstrapping {module_path}: {e}")
+            logger.exception(f"embed bootstrap failed for {module_path}")
 
     _registered_tools = registered
     _bootstrap_complete = True

--- a/tests/launchers/test_embed_bootstrap.py
+++ b/tests/launchers/test_embed_bootstrap.py
@@ -1,0 +1,87 @@
+"""Tests for the embeddable-tool registry bootstrap.
+
+Addresses review feedback from #5054: the launcher-side context menu
+(``model_card.py``) is gated by :func:`is_embeddable`, so the registry
+*must* be populated at startup. These tests pin that contract — calling
+the bootstrap registers at least the always-available tools whose
+adapters do not depend on an optional physics-engine wheel.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+
+@pytest.mark.slow
+def test_bootstrap_registers_always_available_tools():
+    """pose_studio / data_explorer / model_explorer must always register.
+
+    These three adapters depend only on PyQt6 (already a hard requirement
+    for any launcher test) and the in-tree ``launcher_embed`` contract.
+    They must not silently fail to register, otherwise the Tab/Dock
+    context menu in ``model_card.py`` is permanently disabled.
+    """
+    from src.launchers.embedded_tool_bootstrap import (
+        bootstrap_embeddable_tools,
+        reset_bootstrap_state,
+    )
+    from src.shared.python.launcher_embed import EMBEDDABLE_TOOL_REGISTRY
+
+    reset_bootstrap_state()
+    bootstrap_embeddable_tools()
+
+    # The registry contains tool_ids (declared on each adapter), not
+    # module names. Assert against the tool_ids the always-available
+    # adapters self-register under.
+    expected_always_available = {"data_explorer", "model_explorer"}
+    actually_registered = set(EMBEDDABLE_TOOL_REGISTRY.keys())
+    missing = expected_always_available - actually_registered
+    assert not missing, (
+        f"bootstrap failed to register always-available tools: {missing}. "
+        f"Registry contents: {sorted(actually_registered)}"
+    )
+
+
+@pytest.mark.unit
+def test_bootstrap_is_idempotent():
+    """Calling bootstrap twice must not double-register or raise."""
+    from src.launchers.embedded_tool_bootstrap import (
+        bootstrap_embeddable_tools,
+        reset_bootstrap_state,
+    )
+
+    reset_bootstrap_state()
+    first = bootstrap_embeddable_tools()
+    second = bootstrap_embeddable_tools()
+    assert first == second
+
+
+@pytest.mark.unit
+def test_bootstrap_tolerates_missing_optional_engines(monkeypatch):
+    """Missing optional engine wheels must be a soft-skip, not a failure.
+
+    The spec requires the bootstrap to swallow ``ImportError`` /
+    ``ModuleNotFoundError`` from optional physics-engine packages
+    (mujoco, drake, etc.) so a vanilla install without those wheels
+    still produces a working launcher.
+    """
+    import builtins
+
+    from src.launchers.embedded_tool_bootstrap import (
+        bootstrap_embeddable_tools,
+        reset_bootstrap_state,
+    )
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("src.engines."):
+            raise ModuleNotFoundError(f"simulated missing engine: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    reset_bootstrap_state()
+    # Must not raise.
+    bootstrap_embeddable_tools()


### PR DESCRIPTION
## Summary

Bundles three codex-review-bot follow-ups into a single PR:

- **#5054 (P1)** — Bootstrap embeddable-tool registry at launcher startup. `src/launchers/embedded_tool_bootstrap.py` now imports every tool package (pose_studio, data_explorer, model_explorer, starting_pose_matcher, pose_subscriber_demo) plus the engine-side embed adapters (mujoco / drake / pinocchio / opensim / myosuite / Simscape C3D apps). Optional engine-wheel `ImportError` / `ModuleNotFoundError` is now a debug-level skip rather than a warning since those wheels are optional on most installs. Wired call already lives in `golf_launcher.GolfSwingLauncher.__init__`.
- **#5062 (P2)** — Scope C3D viewer cleanup to its own figures. The Simscape C3D adapter now tracks every `MainWidget` it hands to the host and closes only the `FigureCanvasQTAgg` figures inside those widgets, instead of the previous process-wide `plt.close('all')` that nuked sibling embedded tools' matplotlib figures.
- **#5088 (P2)** — Fix broken doc link in `docs/ui/FEATURE_PARITY_MATRIX.md`. Split the misleading "Launcher UI/UX Epic #4904" entry into a real GitHub issue URL plus the existing `launcher_parity_assessment.md` and `embedding_a_tool.md` references.

## Test plan

- [x] `python3 -m ruff check` on changed files — passes
- [x] `python3 -m ruff format --check` on changed files — passes
- [x] `python3 -m pytest tests/launchers/test_embed_bootstrap.py -x` — 3 passed (covers always-available registration, idempotency, and graceful handling of missing optional engine wheels)
- [ ] Full CI run on this PR

Closes #5054
Closes #5062
Closes #5088

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>