### PR TITLE
fix: Preserve true LRU order in ChatServiceBase session eviction

### DIFF
--- a/src/shared/python/chat/service_base.py
+++ b/src/shared/python/chat/service_base.py
@@ -123,6 +123,7 @@ class ChatServiceBase(abc.ABC):
 
             if session_id and session_id in self._sessions:
                 self._timestamps[session_id] = time.monotonic()
+                self._sessions.move_to_end(session_id)
                 return self._sessions[session_id]
 
             # Try app-specific session loading (e.g., from disk)


### PR DESCRIPTION
## Summary
This PR fixes issue #5126 by ensuring true LRU (Least Recently Used) eviction order in the ChatServiceBase session management.

## Changes
- Added  call when accessing existing sessions in 
- This ensures that  evicts the actual least recently used session

## Problem
The previous implementation updated the activity timestamp but did not move the accessed session to the end of the OrderedDict. With MAX_SESSIONS pressure, a frequently used older session could be evicted incorrectly because  removes the oldest inserted session rather than the least recently used one.

## Testing
- Existing tests should pass
- The fix ensures proper LRU eviction behavior under session pressure

Closes #5126