### PR TITLE
fix: Add solver_status to CharacterBuildResult

### DIFF
--- a/src/shared/python/humanoid_character_builder/interfaces/api.py
+++ b/src/shared/python/humanoid_character_builder/interfaces/api.py
@@ -168,6 +168,7 @@ class CharacterBuilder:
                 urdf_xml=urdf_xml,
                 segments=segments,
                 mesh_result=mesh_result,
+                solver_status="success",
             )
 
         except ValueError as e:
@@ -178,6 +179,7 @@ class CharacterBuilder:
                 params=params,
                 error_message=str(e),
                 error_category=BuildErrorCategory.VALIDATION,
+                solver_status="failure",
             )
         except (PermissionError, OSError) as e:
             # Filesystem/IO errors
@@ -187,6 +189,7 @@ class CharacterBuilder:
                 params=params,
                 error_message=str(e),
                 error_category=BuildErrorCategory.IO,
+                solver_status="failure",
             )
         except ImportError as e:
             # Missing optional backend
@@ -196,6 +199,7 @@ class CharacterBuilder:
                 params=params,
                 error_message=str(e),
                 error_category=BuildErrorCategory.MISSING_BACKEND,
+                solver_status="failure",
             )
         except (KeyError, RuntimeError) as e:
             # Mesh generation or other runtime errors
@@ -205,6 +209,7 @@ class CharacterBuilder:
                 params=params,
                 error_message=str(e),
                 error_category=BuildErrorCategory.RUNTIME,
+                solver_status="failure",
             )
 
     def generate_urdf(


### PR DESCRIPTION
## Summary
This PR fixes issue #4524 by adding the missing solver_status field to CharacterBuildResult.

## Changes
- Added solver_status='success' on successful build paths
- Added solver_status='failure' on error paths (validation, IO, missing backend, runtime)

## Problem
The tests expected a solver_status field on CharacterBuildResult, but the class only had success: bool. This caused 6 tests to fail with AttributeError.

## Related
- Part of the URDF Hardening Campaign (#4520)
- Fixes #4524

## Testing
- All 6 previously failing tests should now pass:
  - test_build_default_params
  - test_build_custom_params
  - test_quick_build_default
  - test_quick_build_custom
  - test_quick_build_with_preset
  - test_quick_build_with_output