### PR TITLE
fix(chat): Preserve true LRU order in session eviction (issue #5126)

### DIFF
--- a/src/shared/python/ai/adapters/__init__.py
+++ b/src/shared/python/ai/adapters/__init__.py
@@ -37,4 +37,3 @@ __all__ = [
     "ClineAdapter",
     "AdapterFactory",
 ]
-

--- a/src/shared/python/ai/tests/test_adapter_factory.py
+++ b/src/shared/python/ai/tests/test_adapter_factory.py
@@ -138,7 +138,7 @@ class TestAdapterFactory:
                 mod = MagicMock()
                 mod.CredentialManager.return_value = mock_mgr
                 return mod
-            return original_import(name, *args, **kwargs)
+            return original_import(name, *args, **kwargs)  # type: ignore
 
         with patch("builtins.__import__", side_effect=mock_import):
             key = AdapterFactory._resolve_api_key("openai")
@@ -157,7 +157,7 @@ class TestAdapterFactory:
         def mock_import(name: str, *args: object, **kwargs: object) -> object:
             if name == "chat.credentials":
                 raise ImportError("no chat.credentials")
-            return original_import(name, *args, **kwargs)
+            return original_import(name, *args, **kwargs)  # type: ignore
 
         with (
             patch("builtins.__import__", side_effect=mock_import),

--- a/src/shared/python/chat/quick_bar.py
+++ b/src/shared/python/chat/quick_bar.py
@@ -314,12 +314,16 @@ class ChatLauncherMixin:
         chat_toolbar = QToolBar("AI Chat")
         chat_toolbar.setMovable(False)
         chat_toolbar.addWidget(self._chat_quick_bar)
-        self.addToolBar(Qt.ToolBarArea.TopToolBarArea, chat_toolbar)
+
+        import typing
+
+        main_window = typing.cast(QMainWindow, self)
+        main_window.addToolBar(Qt.ToolBarArea.TopToolBarArea, chat_toolbar)
 
         # Keyboard shortcut (Ctrl+Shift+A)
         from PyQt6.QtGui import QKeySequence, QShortcut
 
-        shortcut = QShortcut(QKeySequence("Ctrl+Shift+A"), self)
+        shortcut = QShortcut(QKeySequence("Ctrl+Shift+A"), main_window)
         shortcut.activated.connect(self._chat_quick_bar.focus_input)
 
         # Auto-show dock if configured
@@ -339,12 +343,17 @@ class ChatLauncherMixin:
 
         # Lazy import to avoid circular deps
         from chat.chat_dock_widget import ChatDockWidget
+        import typing
+
+        main_window = typing.cast(QMainWindow, self)
 
         self._chat_dock = ChatDockWidget(
             app_context=app_context,
             app_name=app_name,
             server_url=server_url,
-            parent=self,
+            parent=main_window,
         )
-        self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self._chat_dock)
+        main_window.addDockWidget(
+            Qt.DockWidgetArea.RightDockWidgetArea, self._chat_dock
+        )
         self._chat_dock.show()

--- a/src/shared/python/chat/service_base.py
+++ b/src/shared/python/chat/service_base.py
@@ -122,6 +122,8 @@ class ChatServiceBase(abc.ABC):
             self._cleanup_expired()
 
             if session_id and session_id in self._sessions:
+                # Move to end of OrderedDict to preserve true LRU order
+                self._sessions.move_to_end(session_id)
                 self._timestamps[session_id] = time.monotonic()
                 return self._sessions[session_id]
 

--- a/tests/unit/realtime/test_facade.py
+++ b/tests/unit/realtime/test_facade.py
@@ -115,9 +115,7 @@ class TestPublish:
 
 
 class TestSubscribe:
-    def test_subscribe_returns_subscription(
-        self, patched_transport: MagicMock
-    ) -> None:
+    def test_subscribe_returns_subscription(self, patched_transport: MagicMock) -> None:
         cb = MagicMock()
         sub = subscribe("test/chan", cb)
         assert isinstance(sub, Subscription)
@@ -132,9 +130,7 @@ class TestSubscribe:
         with pytest.raises(TypeError):
             subscribe("test/chan", "not_callable")  # type: ignore[arg-type]
 
-    def test_unsubscribe_is_idempotent(
-        self, patched_transport: MagicMock
-    ) -> None:
+    def test_unsubscribe_is_idempotent(self, patched_transport: MagicMock) -> None:
         sub = subscribe("test/chan", MagicMock())
         sub.unsubscribe()
         assert sub._closed is True
@@ -142,9 +138,7 @@ class TestSubscribe:
         sub.unsubscribe()
         assert sub._closed is True
 
-    def test_unsubscribe_calls_transport(
-        self, patched_transport: MagicMock
-    ) -> None:
+    def test_unsubscribe_calls_transport(self, patched_transport: MagicMock) -> None:
         cb = MagicMock()
         sub = subscribe("test/chan", cb)
         sub.unsubscribe()


### PR DESCRIPTION
Fixes #5126.

Added move_to_end() call in get_or_create_session to preserve true LRU order before eviction.

Without this fix, accessing a session updates its timestamp but doesn't move it to the end of the OrderedDict, causing popitem(last=False) to evict the oldest-inserted session rather than the least-recently-used one.