### PR TITLE
test(coverage): raise fail_under 70->75 (Phase 4 step 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -418,7 +418,7 @@ omit = [
 #   - 85% for API routes, engine adapters, task management (production-critical)
 #   - 70% for shared utilities, services (important but lower risk)
 #   - 65% overall floor (raised from 55% per issue #4929)
-fail_under = 70
+fail_under = 75
 show_missing = true
 skip_empty = true
 precision = 1


### PR DESCRIPTION
## Summary
- Raise `[tool.coverage.report] fail_under` from 70 to 75 (+5pp toward tier target 85% for Core libraries).
- Phase 4 step 2 of EPIC #1140 (UpstreamDrift fleet testing).
- Follows step 1 PR #5145 (65 -> 70, merged).

Tier target: **85%** (Core libraries). Each step is +5pp.

## Test plan
- [ ] CI coverage gate passes at new threshold
- [ ] If coverage gate fails, revert and report gap on EPIC #1140

Refs EPIC #1140, follows #5145.