### PR TITLE
fix(ai-backend): switch reqwest to rustls-tls to unblock rust-quality-gate

### DIFF
--- a/rust_core/ai_backend/Cargo.toml
+++ b/rust_core/ai_backend/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tools-core = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
 futures = "0.3"
 rusqlite = { version = "0.29", features = ["bundled"] }
 walkdir = "2.3"


### PR DESCRIPTION
## Summary
- Self-hosted runners don't have OpenSSL dev libs in a discoverable location → `openssl-sys` build fails on every clippy run.
- `cargo clippy --all-targets -- -D warnings` failure with `Could not find directory of OpenSSL installation` blocked PR #5225 (codemap CLI) and every subsequent rust-quality-gate run.
- Switching reqwest's default TLS backend from native-tls (OpenSSL) to rustls-tls eliminates the C dependency. Pure Rust, builds hermetically, functionally equivalent for the HTTPS calls ai_backend makes against LLM provider endpoints.

## Test plan
- [x] `cargo build -p ai_backend` succeeds locally
- [ ] rust-quality-gate clippy passes in CI

Refs #5217 (codemap CLI blocked downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)