### PR TITLE
fix(ci): pin Python 3.12 in rust-quality-gate matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -1102,6 +1102,20 @@ jobs:
         if: steps.rust-changes.outputs.has_changes != 'true'
         run: echo "No Rust changes detected; Rust quality gate is not required."
 
+      # Pin Python BEFORE installing Rust so PyO3-backed crates build cleanly
+      # on hosted macos-latest / windows-latest, which default to Python 3.14.
+      # `pyo3 0.24` (workspace pin) supports up to Python 3.13 only, so 3.14
+      # makes `pyo3-ffi` fail its build script with:
+      #   "the configured Python interpreter version (3.14) is newer than
+      #    PyO3's maximum supported version (3.13)"
+      # 3.12 is the safe middle of pyo3 0.24's supported range (3.7-3.13).
+      # Tracked: issue #5221.
+      - name: Set up Python (for PyO3 builds)
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
       - name: Install Rust toolchain
         if: steps.rust-changes.outputs.has_changes == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8


### PR DESCRIPTION
## Summary

The recently-added cross-platform `rust-quality-gate` matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`) is blocking every PR that touches Rust crates with PyO3 bindings because hosted GitHub Actions runners on macOS and Windows default to **Python 3.14**, but the workspace pin `pyo3 0.24` only supports up to **Python 3.13**:

```
error: failed to run custom build command for `pyo3-ffi v0.24.2`
  error: the configured Python interpreter version (3.14) is newer than
  PyO3's maximum supported version (3.13)
```

This PR adds `actions/setup-python@a309ff8b` (the canonical SHA-pinned form used everywhere else in this repo) before the Rust toolchain install in the `rust-quality-gate` job, pinning to Python **3.12** — the safe middle of pyo3 0.24's supported 3.7-3.13 range.

- No matrix legs disabled; goal is all three (`ubuntu-latest`, `windows-latest`, `macos-latest`) green.
- PyO3 itself is not bumped here — that's a larger scope.
- The Linux self-hosted runners already have a compatible Python, so the new step is effectively a no-op there and keeps the matrix uniform.

Refs tracking issue #5221 (cross-platform `rust-quality-gate` matrix). Doesn't fully close it because Windows + macOS coverage may still surface other platform-specific issues once the Python version no longer blocks the build.

## Test plan

- [ ] `rust-quality-gate (ubuntu-latest)` green on this PR
- [ ] `rust-quality-gate (windows-latest)` green on this PR
- [ ] `rust-quality-gate (macos-latest)` green on this PR
- [ ] No regressions in other workflows on this PR