### PR TITLE
perf(biomechanics): Hill muscle + activation dynamics as Rust kernel

### DIFF
--- a/rust_core/upstream-muscle/src/activation.rs
+++ b/rust_core/upstream-muscle/src/activation.rs
@@ -1,0 +1,135 @@
+//! Activation dynamics for Hill-type muscle models.
+//!
+//! This is a direct scalar port of
+//! `src/shared/python/biomechanics/activation_dynamics.py`.
+
+/// Default activation time constant, seconds.
+pub const DEFAULT_TAU_ACT: f64 = 0.010;
+
+/// Default deactivation time constant, seconds.
+pub const DEFAULT_TAU_DEACT: f64 = 0.040;
+
+/// Default lower activation floor.
+pub const DEFAULT_MIN_ACTIVATION: f64 = 0.001;
+
+/// First-order neural excitation to muscle activation dynamics.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct ActivationDynamics {
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub tau_act: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub tau_deact: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub min_activation: f64,
+}
+
+impl Default for ActivationDynamics {
+    fn default() -> Self {
+        Self {
+            tau_act: DEFAULT_TAU_ACT,
+            tau_deact: DEFAULT_TAU_DEACT,
+            min_activation: DEFAULT_MIN_ACTIVATION,
+        }
+    }
+}
+
+impl ActivationDynamics {
+    /// Construct activation dynamics after validating DbC preconditions.
+    pub fn new(tau_act: f64, tau_deact: f64, min_activation: f64) -> Result<Self, String> {
+        let dynamics = Self {
+            tau_act,
+            tau_deact,
+            min_activation,
+        };
+        dynamics.validate()?;
+        Ok(dynamics)
+    }
+
+    /// Validate constructor preconditions from the Python implementation.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.tau_act <= 0.0 {
+            return Err(format!("tau_act must be positive, got {}", self.tau_act));
+        }
+        if self.tau_deact <= 0.0 {
+            return Err(format!(
+                "tau_deact must be positive, got {}",
+                self.tau_deact
+            ));
+        }
+        if self.min_activation <= 0.0 || self.min_activation >= 1.0 {
+            return Err(format!(
+                "min_activation must be in (0, 1), got {}",
+                self.min_activation
+            ));
+        }
+        Ok(())
+    }
+
+    /// Compute `da/dt` after clamping excitation and activation.
+    #[inline]
+    pub fn compute_derivative(&self, u: f64, a: f64) -> f64 {
+        let u_clamped = u.clamp(self.min_activation, 1.0);
+        let a_clamped = a.clamp(self.min_activation, 1.0);
+
+        let tau = if u_clamped > a_clamped {
+            self.tau_act * (0.5 + 1.5 * a_clamped)
+        } else {
+            self.tau_deact / (0.5 + 1.5 * a_clamped)
+        };
+
+        (u_clamped - a_clamped) / tau
+    }
+
+    /// Euler-update activation by one positive timestep.
+    pub fn update(&self, u: f64, a: f64, dt: f64) -> Result<f64, String> {
+        if dt <= 0.0 {
+            return Err(format!("time step dt must be positive, got {dt}"));
+        }
+        let a_new = a + self.compute_derivative(u, a) * dt;
+        Ok(a_new.clamp(self.min_activation, 1.0))
+    }
+
+    /// Batch update helper for lower-overhead Python/RL loops.
+    pub fn update_batch(&self, u: &[f64], a: &[f64], dt: f64) -> Result<Vec<f64>, String> {
+        if u.len() != a.len() {
+            return Err(format!(
+                "Batch sizes must match: u has {}, a has {}",
+                u.len(),
+                a.len()
+            ));
+        }
+        u.iter()
+            .zip(a.iter())
+            .map(|(&u_i, &a_i)| self.update(u_i, a_i, dt))
+            .collect()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl ActivationDynamics {
+    #[new]
+    #[pyo3(signature = (tau_act = DEFAULT_TAU_ACT, tau_deact = DEFAULT_TAU_DEACT, min_activation = DEFAULT_MIN_ACTIVATION))]
+    fn py_new(tau_act: f64, tau_deact: f64, min_activation: f64) -> pyo3::PyResult<Self> {
+        Self::new(tau_act, tau_deact, min_activation)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
+    #[pyo3(name = "compute_derivative")]
+    fn py_compute_derivative(&self, u: f64, a: f64) -> f64 {
+        self.compute_derivative(u, a)
+    }
+
+    #[pyo3(name = "update")]
+    fn py_update(&self, u: f64, a: f64, dt: f64) -> pyo3::PyResult<f64> {
+        self.update(u, a, dt)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
+    #[pyo3(name = "update_batch")]
+    fn py_update_batch(&self, u: Vec<f64>, a: Vec<f64>, dt: f64) -> pyo3::PyResult<Vec<f64>> {
+        self.update_batch(&u, &a, dt)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+}

--- a/rust_core/upstream-muscle/src/lib.rs
+++ b/rust_core/upstream-muscle/src/lib.rs
@@ -5,7 +5,7 @@
 //! training loops (`stable_baselines3`) where releasing the GIL during
 //! batched evaluation is the win.
 //!
-//! ## Slice 1 (this crate)
+//! ## Implemented slices
 //!
 //! Pure scalar contractile/passive/tendon curves ported from
 //! `src/shared/python/biomechanics/hill_muscle.py`:
@@ -14,6 +14,8 @@
 //! - [`hill::f_p`] — passive force-length (PEE exponential spring)
 //! - [`hill::f_v`] — force-velocity (Hill hyperbola + eccentric plateau)
 //! - [`hill::f_t`] — tendon force (SEE quadratic)
+//! - [`model::HillMuscleModel`] — state-bearing force assembly
+//! - [`activation::ActivationDynamics`] — first-order activation dynamics
 //!
 //! Numerical parity vs the Python source is asserted within 1e-6 in
 //! `tests/parity_hill.rs`.
@@ -21,7 +23,6 @@
 //! ## Out of scope (future slices, tracked separately)
 //!
 //! - Full muscle equilibrium solver (`muscle_equilibrium.py`)
-//! - Activation dynamics Euler step (`activation_dynamics.py`)
 //! - Multi-muscle moment summation (`multi_muscle.py`)
 //! - Batched / `rayon`-parallel API for RL inner loops
 //! - OpenSim/MuJoCo parity test corpus
@@ -29,10 +30,14 @@
 //!
 //! See the umbrella issue UD#5216 and the slice-1 follow-up for status.
 
+pub mod activation;
 pub mod hill;
+pub mod model;
 
 // Convenience re-exports so callers can `use upstream_muscle::{f_l, f_v, f_t};`.
+pub use activation::ActivationDynamics;
 pub use hill::{f_l, f_l_with_width, f_p, f_t, f_v};
+pub use model::{HillMuscleModel, MuscleParameters, MuscleState};
 
 // ── Python bindings (feature-gated) ──────────────────────────────────────────
 //
@@ -95,6 +100,10 @@ fn upstream_muscle(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_f_p, m)?)?;
     m.add_function(wrap_pyfunction!(py_f_v, m)?)?;
     m.add_function(wrap_pyfunction!(py_f_t, m)?)?;
+    m.add_class::<activation::ActivationDynamics>()?;
+    m.add_class::<model::HillMuscleModel>()?;
+    m.add_class::<model::MuscleParameters>()?;
+    m.add_class::<model::MuscleState>()?;
     m.add(
         "DEFAULT_FORCE_LENGTH_WIDTH",
         hill::DEFAULT_FORCE_LENGTH_WIDTH,

--- a/rust_core/upstream-muscle/src/model.rs
+++ b/rust_core/upstream-muscle/src/model.rs
@@ -1,0 +1,238 @@
+//! State-bearing Hill muscle model.
+//!
+//! Direct scalar port of `src/shared/python/biomechanics/hill_muscle.py`.
+
+use crate::hill::{f_l_with_width, f_p, f_v};
+
+/// Parameters defining a specific muscle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct MuscleParameters {
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub f_max: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub l_opt: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub l_slack: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub v_max: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub pennation_angle: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub damping: f64,
+}
+
+impl MuscleParameters {
+    /// Construct parameters after validating the Python dataclass invariants.
+    pub fn new(
+        f_max: f64,
+        l_opt: f64,
+        l_slack: f64,
+        v_max: f64,
+        pennation_angle: f64,
+        damping: f64,
+    ) -> Result<Self, String> {
+        let params = Self {
+            f_max,
+            l_opt,
+            l_slack,
+            v_max,
+            pennation_angle,
+            damping,
+        };
+        params.validate()?;
+        Ok(params)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.f_max <= 0.0 {
+            return Err(format!("f_max must be positive, got {}", self.f_max));
+        }
+        if self.l_opt <= 0.0 {
+            return Err(format!("l_opt must be positive, got {}", self.l_opt));
+        }
+        if self.l_slack <= 0.0 {
+            return Err(format!("l_slack must be positive, got {}", self.l_slack));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl MuscleParameters {
+    #[new]
+    #[pyo3(signature = (f_max, l_opt, l_slack, v_max = 10.0, pennation_angle = 0.0, damping = 0.05))]
+    fn py_new(
+        f_max: f64,
+        l_opt: f64,
+        l_slack: f64,
+        v_max: f64,
+        pennation_angle: f64,
+        damping: f64,
+    ) -> pyo3::PyResult<Self> {
+        Self::new(f_max, l_opt, l_slack, v_max, pennation_angle, damping)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+}
+
+/// Current muscle state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct MuscleState {
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub activation: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub l_ce: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub v_ce: f64,
+    #[cfg_attr(feature = "python", pyo3(get, set))]
+    pub l_mt: f64,
+}
+
+impl Default for MuscleState {
+    fn default() -> Self {
+        Self {
+            activation: 0.0,
+            l_ce: 0.0,
+            v_ce: 0.0,
+            l_mt: 0.0,
+        }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl MuscleState {
+    #[new]
+    #[pyo3(signature = (activation = 0.0, l_ce = 0.0, v_ce = 0.0, l_mt = 0.0))]
+    fn py_new(activation: f64, l_ce: f64, v_ce: f64, l_mt: f64) -> Self {
+        Self {
+            activation,
+            l_ce,
+            v_ce,
+            l_mt,
+        }
+    }
+}
+
+/// Standard state-bearing Hill-type muscle model.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct HillMuscleModel {
+    pub params: MuscleParameters,
+    pub force_length_width: f64,
+}
+
+impl HillMuscleModel {
+    pub fn new(params: MuscleParameters, force_length_width: Option<f64>) -> Self {
+        Self {
+            params,
+            force_length_width: force_length_width
+                .unwrap_or(crate::hill::DEFAULT_FORCE_LENGTH_WIDTH),
+        }
+    }
+
+    #[inline]
+    pub fn force_length_active(&self, l_norm: f64) -> f64 {
+        f_l_with_width(l_norm, self.force_length_width)
+    }
+
+    #[inline]
+    pub fn force_length_passive(&self, l_norm: f64) -> f64 {
+        f_p(l_norm)
+    }
+
+    #[inline]
+    pub fn force_velocity(&self, v_norm: f64) -> f64 {
+        f_v(v_norm)
+    }
+
+    #[inline]
+    pub fn tendon_force(&self, l_tendon_norm: f64) -> f64 {
+        crate::hill::f_t(l_tendon_norm)
+    }
+
+    /// Compute total fiber force projected onto the tendon line of action.
+    pub fn compute_force(&self, state: &MuscleState) -> Result<f64, String> {
+        if !(0.0..=1.0).contains(&state.activation) {
+            return Err(format!(
+                "activation must be in [0, 1], got {}",
+                state.activation
+            ));
+        }
+
+        let l_norm = state.l_ce / self.params.l_opt;
+        let v_norm = state.v_ce / (self.params.v_max * self.params.l_opt);
+
+        let active = self.params.f_max
+            * state.activation
+            * self.force_length_active(l_norm)
+            * self.force_velocity(v_norm);
+        let passive = self.params.f_max * self.force_length_passive(l_norm);
+        let damping = self.params.damping * state.v_ce;
+        let total = (active + passive + damping) * self.params.pennation_angle.cos();
+
+        Ok(total.max(0.0))
+    }
+
+    /// Batch helper for lower-overhead Python/RL loops.
+    pub fn compute_force_batch(&self, states: &[MuscleState]) -> Result<Vec<f64>, String> {
+        states
+            .iter()
+            .map(|state| self.compute_force(state))
+            .collect()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl HillMuscleModel {
+    #[new]
+    #[pyo3(signature = (params, force_length_width = None))]
+    fn py_new(params: MuscleParameters, force_length_width: Option<f64>) -> Self {
+        Self::new(params, force_length_width)
+    }
+
+    #[getter]
+    fn params(&self) -> MuscleParameters {
+        self.params
+    }
+
+    #[getter]
+    fn force_length_width(&self) -> f64 {
+        self.force_length_width
+    }
+
+    #[pyo3(name = "force_length_active")]
+    fn py_force_length_active(&self, l_norm: f64) -> f64 {
+        self.force_length_active(l_norm)
+    }
+
+    #[pyo3(name = "force_length_passive")]
+    fn py_force_length_passive(&self, l_norm: f64) -> f64 {
+        self.force_length_passive(l_norm)
+    }
+
+    #[pyo3(name = "force_velocity")]
+    fn py_force_velocity(&self, v_norm: f64) -> f64 {
+        self.force_velocity(v_norm)
+    }
+
+    #[pyo3(name = "tendon_force")]
+    fn py_tendon_force(&self, l_tendon_norm: f64) -> f64 {
+        self.tendon_force(l_tendon_norm)
+    }
+
+    #[pyo3(name = "compute_force")]
+    fn py_compute_force(&self, state: &MuscleState) -> pyo3::PyResult<f64> {
+        self.compute_force(state)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
+    #[pyo3(name = "compute_force_batch")]
+    fn py_compute_force_batch(&self, states: Vec<MuscleState>) -> pyo3::PyResult<Vec<f64>> {
+        self.compute_force_batch(&states)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+}

--- a/rust_core/upstream-muscle/tests/state_activation.rs
+++ b/rust_core/upstream-muscle/tests/state_activation.rs
@@ -1,0 +1,90 @@
+use approx::assert_relative_eq;
+use upstream_muscle::{ActivationDynamics, HillMuscleModel, MuscleParameters, MuscleState};
+
+#[test]
+fn activation_update_matches_python_formula() {
+    let dynamics = ActivationDynamics::new(0.010, 0.040, 0.001).expect("valid dynamics");
+
+    let cases = [
+        (1.0, 0.001, 0.001, 0.20020239282153543),
+        (0.2, 0.6, 0.005, 0.53),
+        (0.0, 0.2, 0.010, 0.1602),
+        (0.9, 0.8, 0.002, 0.8117647058823529),
+    ];
+
+    for (u, a, dt, expected) in cases {
+        let actual = dynamics.update(u, a, dt).expect("positive dt");
+        assert_relative_eq!(actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[test]
+fn activation_rejects_invalid_contract_inputs() {
+    assert!(ActivationDynamics::new(0.0, 0.040, 0.001).is_err());
+    assert!(ActivationDynamics::new(0.010, -1.0, 0.001).is_err());
+    assert!(ActivationDynamics::new(0.010, 0.040, 1.0).is_err());
+
+    let dynamics = ActivationDynamics::default();
+    assert!(dynamics.update(1.0, 0.0, 0.0).is_err());
+    assert!(dynamics.update_batch(&[1.0], &[0.1, 0.2], 0.001).is_err());
+}
+
+#[test]
+fn hill_model_compute_force_matches_python_formula() {
+    let params = MuscleParameters::new(1000.0, 0.15, 0.20, 10.0, 0.1, 0.05).expect("valid params");
+    let model = HillMuscleModel::new(params, None);
+    let state = MuscleState {
+        activation: 0.8,
+        l_ce: 0.16,
+        v_ce: -0.5,
+        l_mt: 0.35,
+    };
+
+    let actual = model.compute_force(&state).expect("valid activation");
+    assert_relative_eq!(actual, 229.87747417119178, epsilon = 1e-10);
+}
+
+#[test]
+fn hill_model_batch_matches_scalar_results() {
+    let params = MuscleParameters::new(1000.0, 0.15, 0.20, 10.0, 0.1, 0.05).expect("valid params");
+    let model = HillMuscleModel::new(params, None);
+    let states = vec![
+        MuscleState {
+            activation: 0.2,
+            l_ce: 0.15,
+            v_ce: 0.0,
+            l_mt: 0.35,
+        },
+        MuscleState {
+            activation: 0.8,
+            l_ce: 0.16,
+            v_ce: -0.5,
+            l_mt: 0.35,
+        },
+    ];
+
+    let batch = model.compute_force_batch(&states).expect("valid batch");
+
+    assert_eq!(batch.len(), states.len());
+    for (state, actual) in states.iter().zip(batch.iter()) {
+        let expected = model.compute_force(state).expect("valid scalar");
+        assert_relative_eq!(*actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[test]
+fn hill_model_rejects_invalid_contract_inputs() {
+    assert!(MuscleParameters::new(0.0, 0.15, 0.20, 10.0, 0.0, 0.05).is_err());
+    assert!(MuscleParameters::new(1000.0, 0.0, 0.20, 10.0, 0.0, 0.05).is_err());
+    assert!(MuscleParameters::new(1000.0, 0.15, -1.0, 10.0, 0.0, 0.05).is_err());
+
+    let params = MuscleParameters::new(1000.0, 0.15, 0.20, 10.0, 0.0, 0.05).expect("valid params");
+    let model = HillMuscleModel::new(params, None);
+    let state = MuscleState {
+        activation: 1.1,
+        l_ce: 0.15,
+        v_ce: 0.0,
+        l_mt: 0.35,
+    };
+    assert!(model.compute_force(&state).is_err());
+}


### PR DESCRIPTION
Part of #5216 and #5245 (Slice 2).

This rebuild keeps the landed `rust_core/upstream-muscle` scaffold from #5244 and adds the next state-bearing biomechanics kernel layer without carrying unrelated AI backend, pendulum, or workflow changes from the stale branch history.

Scope:
- Add `ActivationDynamics` in Rust with the same clamping, Euler update, batch helper, and DbC preconditions as `src/shared/python/biomechanics/activation_dynamics.py`.
- Add `MuscleParameters`, `MuscleState`, and `HillMuscleModel` in Rust with state-bearing `compute_force` and `compute_force_batch` parity with `src/shared/python/biomechanics/hill_muscle.py`.
- Expose the new structs through the existing PyO3 `upstream_muscle` module when the `python` feature is enabled.
- Add focused Rust regression tests for activation updates, Hill force assembly, batch/scalar parity, and invalid contract inputs.

Validation run locally:
- `cargo fmt -p upstream-muscle --check`
- `cargo test -p upstream-muscle`
- `git diff --check`

This intentionally does not claim the full #5216 acceptance criteria yet: OpenSim/MuJoCo parity corpus, >=20x representative batched throughput proof, multi-muscle, equilibrium solver, and full Python facade replacement remain tracked in #5245.