### PR TITLE
perf(biomechanics): Hill kernel slice 3 & 4 (equilibrium and multi-muscle)

### DIFF
--- a/rust_core/upstream-muscle/src/lib.rs
+++ b/rust_core/upstream-muscle/src/lib.rs
@@ -16,14 +16,14 @@
 //! - [`hill::f_t`] — tendon force (SEE quadratic)
 //! - [`model::HillMuscleModel`] — state-bearing force assembly
 //! - [`activation::ActivationDynamics`] — first-order activation dynamics
+//! - [`muscle_equilibrium`] — equilibrium solver
+//! - [`multi_muscle`] — multi-muscle moment summation
 //!
 //! Numerical parity vs the Python source is asserted within 1e-6 in
 //! `tests/parity_hill.rs`.
 //!
 //! ## Out of scope (future slices, tracked separately)
 //!
-//! - Full muscle equilibrium solver (`muscle_equilibrium.py`)
-//! - Multi-muscle moment summation (`multi_muscle.py`)
 //! - Batched / `rayon`-parallel API for RL inner loops
 //! - OpenSim/MuJoCo parity test corpus
 //! - Python facade replacement
@@ -33,6 +33,8 @@
 pub mod activation;
 pub mod hill;
 pub mod model;
+pub mod muscle_equilibrium;
+pub mod multi_muscle;
 
 // Convenience re-exports so callers can `use upstream_muscle::{f_l, f_v, f_t};`.
 pub use activation::ActivationDynamics;
@@ -104,6 +106,14 @@ fn upstream_muscle(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<model::HillMuscleModel>()?;
     m.add_class::<model::MuscleParameters>()?;
     m.add_class::<model::MuscleState>()?;
+    
+    m.add_class::<muscle_equilibrium::PyEquilibriumSolver>()?;
+    m.add_function(wrap_pyfunction!(muscle_equilibrium::compute_equilibrium_state, m)?)?;
+    
+    m.add_class::<multi_muscle::MuscleAttachment>()?;
+    m.add_class::<multi_muscle::MuscleGroup>()?;
+    m.add_class::<multi_muscle::AntagonistPair>()?;
+    
     m.add(
         "DEFAULT_FORCE_LENGTH_WIDTH",
         hill::DEFAULT_FORCE_LENGTH_WIDTH,

--- a/rust_core/upstream-muscle/src/multi_muscle.rs
+++ b/rust_core/upstream-muscle/src/multi_muscle.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+use crate::hill_muscle::{HillMuscleModel, MuscleState};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct MuscleAttachment {
+    #[pyo3(get, set)]
+    pub muscle_name: String,
+    #[pyo3(get, set)]
+    pub moment_arm: f64,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl MuscleAttachment {
+    #[new]
+    fn py_new(muscle_name: String, moment_arm: f64) -> Self {
+        Self { muscle_name, moment_arm }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct MuscleGroup {
+    #[pyo3(get, set)]
+    pub name: String,
+    pub muscles: HashMap<String, HillMuscleModel>,
+    pub attachments: HashMap<String, MuscleAttachment>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl MuscleGroup {
+    #[new]
+    fn py_new(name: String) -> Self {
+        Self {
+            name,
+            muscles: HashMap::new(),
+            attachments: HashMap::new(),
+        }
+    }
+
+    #[pyo3(name = "add_muscle")]
+    fn py_add_muscle(&mut self, name: String, muscle: HillMuscleModel, moment_arm: f64) -> pyo3::PyResult<()> {
+        if name.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err("muscle name must be non-empty"));
+        }
+        if moment_arm == 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err("moment_arm must be non-zero"));
+        }
+        
+        self.muscles.insert(name.clone(), muscle);
+        self.attachments.insert(name.clone(), MuscleAttachment { muscle_name: name, moment_arm });
+        Ok(())
+    }
+
+    #[pyo3(name = "compute_net_torque")]
+    fn py_compute_net_torque(
+        &self,
+        activations: HashMap<String, f64>,
+        muscle_states: HashMap<String, (f64, f64)>,
+    ) -> pyo3::PyResult<f64> {
+        let mut net_torque = 0.0;
+
+        for (name, muscle) in &self.muscles {
+            if let Some(&act_val) = activations.get(name) {
+                if act_val < 0.0 || act_val > 1.0 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!("activation for '{}' must be in [0, 1]", name)));
+                }
+
+                let (l_ce, v_ce) = muscle_states.get(name).copied().unwrap_or((muscle.params.l_opt, 0.0));
+                let state = MuscleState {
+                    activation: act_val,
+                    l_ce,
+                    v_ce,
+                    l_mt: 0.0,
+                };
+
+                let force = muscle.compute_force(&state);
+                let r = self.attachments.get(name).map(|a| a.moment_arm).unwrap_or(0.0);
+                net_torque += r * force;
+            }
+        }
+
+        Ok(net_torque)
+    }
+
+    #[getter]
+    fn get_muscle_names(&self) -> Vec<String> {
+        self.muscles.keys().cloned().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct AntagonistPair {
+    pub agonist: MuscleGroup,
+    pub antagonist: MuscleGroup,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AntagonistPair {
+    #[new]
+    fn py_new(agonist: MuscleGroup, antagonist: MuscleGroup) -> Self {
+        Self { agonist, antagonist }
+    }
+
+    #[pyo3(name = "compute_net_torque")]
+    fn py_compute_net_torque(
+        &self,
+        agonist_activations: HashMap<String, f64>,
+        antagonist_activations: HashMap<String, f64>,
+        muscle_states: HashMap<String, (f64, f64)>,
+    ) -> pyo3::PyResult<f64> {
+        let tau_agonist = self.agonist.py_compute_net_torque(agonist_activations, muscle_states.clone())?;
+        let tau_antagonist = self.antagonist.py_compute_net_torque(antagonist_activations, muscle_states)?;
+        
+        Ok(tau_agonist + tau_antagonist)
+    }
+
+    #[getter]
+    fn get_muscle_names(&self) -> Vec<String> {
+        let mut names = self.agonist.get_muscle_names();
+        names.extend(self.antagonist.get_muscle_names());
+        names
+    }
+}

--- a/rust_core/upstream-muscle/src/muscle_equilibrium.rs
+++ b/rust_core/upstream-muscle/src/muscle_equilibrium.rs
@@ -1,0 +1,178 @@
+use crate::hill_muscle::HillMuscleModel;
+
+pub struct EquilibriumSolver<'a> {
+    pub muscle: &'a HillMuscleModel,
+}
+
+impl<'a> EquilibriumSolver<'a> {
+    pub fn new(muscle: &'a HillMuscleModel) -> Self {
+        Self { muscle }
+    }
+
+    pub fn equilibrium_residual(&self, l_ce: f64, l_mt: f64, activation: f64, v_ce: f64) -> f64 {
+        let l_ce_norm = l_ce / self.muscle.params.l_opt;
+        let v_ce_norm = v_ce / self.muscle.params.v_max;
+
+        let cos_alpha = self.muscle.params.pennation_angle.cos();
+        let l_tendon = l_mt - l_ce * cos_alpha;
+        let l_tendon_norm = l_tendon / self.muscle.params.l_slack;
+
+        let f_l = self.muscle.force_length_active(l_ce_norm);
+        let f_v = self.muscle.force_velocity(v_ce_norm);
+        let f_p = self.muscle.force_length_passive(l_ce_norm);
+        let f_t = self.muscle.tendon_force(l_tendon_norm);
+
+        let f_ce = self.muscle.params.f_max * activation * f_l * f_v;
+        let f_pee = self.muscle.params.f_max * f_p;
+        let f_fiber = (f_ce + f_pee) * cos_alpha;
+
+        let f_tendon_force = self.muscle.params.f_max * f_t;
+
+        f_fiber - f_tendon_force
+    }
+
+    /// Solves for l_ce using the Secant method.
+    pub fn solve_fiber_length(
+        &self,
+        l_mt: f64,
+        activation: f64,
+        v_ce: f64,
+        initial_guess: Option<f64>,
+    ) -> Result<f64, String> {
+        if l_mt <= 0.0 {
+            return Err("l_mt must be positive".to_string());
+        }
+        if activation < 0.0 || activation > 1.0 {
+            return Err("activation must be in [0, 1]".to_string());
+        }
+
+        let max_iterations = 100;
+        let tolerance = 1e-6;
+        let initial = initial_guess.unwrap_or(0.9 * self.muscle.params.l_opt);
+
+        // Secant method
+        let mut x0 = initial;
+        let mut x1 = initial * 1.01; // slight perturbation
+
+        let mut f0 = self.equilibrium_residual(x0, l_mt, activation, v_ce);
+        let mut f1 = self.equilibrium_residual(x1, l_mt, activation, v_ce);
+
+        for _ in 0..max_iterations {
+            if f1.abs() < tolerance * self.muscle.params.f_max {
+                if x1 <= 0.0 {
+                    return Err("Converged to non-positive fiber length".to_string());
+                }
+                return Ok(x1);
+            }
+
+            if (f1 - f0).abs() < 1e-14 {
+                break; // avoid division by zero
+            }
+
+            let x2 = x1 - f1 * (x1 - x0) / (f1 - f0);
+            
+            x0 = x1;
+            f0 = f1;
+            x1 = x2;
+            f1 = self.equilibrium_residual(x1, l_mt, activation, v_ce);
+        }
+
+        Err("Muscle equilibrium solver failed to converge".to_string())
+    }
+
+    pub fn solve_fiber_velocity(
+        &self,
+        l_mt: f64,
+        v_mt: f64,
+        activation: f64,
+        l_ce: f64,
+        dt: f64,
+    ) -> Result<f64, String> {
+        if dt <= 0.0 {
+            return Err("dt must be positive".to_string());
+        }
+        if l_ce <= 0.0 {
+            return Err("l_ce must be positive".to_string());
+        }
+
+        let l_mt_next = l_mt + v_mt * dt;
+        let l_ce_next = self.solve_fiber_length(l_mt_next, activation, 0.0, Some(l_ce))?;
+        
+        Ok((l_ce_next - l_ce) / dt)
+    }
+}
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (muscle, l_mt, v_mt, activation, initial_l_ce = None))]
+pub fn compute_equilibrium_state(
+    muscle: &HillMuscleModel,
+    l_mt: f64,
+    v_mt: f64,
+    activation: f64,
+    initial_l_ce: Option<f64>,
+) -> pyo3::PyResult<(f64, f64)> {
+    let solver = EquilibriumSolver::new(muscle);
+    
+    let l_ce = solver
+        .solve_fiber_length(l_mt, activation, 0.0, initial_l_ce)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;
+        
+    let v_ce = if v_mt.abs() > 1e-10 {
+        solver.solve_fiber_velocity(l_mt, v_mt, activation, l_ce, 0.001)
+            .unwrap_or(0.0)
+    } else {
+        0.0
+    };
+    
+    Ok((l_ce, v_ce))
+}
+
+#[cfg(feature = "python")]
+#[pyclass(name = "EquilibriumSolver")]
+pub struct PyEquilibriumSolver {
+    pub muscle: HillMuscleModel,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyEquilibriumSolver {
+    #[new]
+    fn py_new(muscle: HillMuscleModel) -> Self {
+        Self { muscle }
+    }
+
+    #[pyo3(name = "solve_fiber_length")]
+    #[pyo3(signature = (l_mt, activation, v_ce = 0.0, initial_guess = None))]
+    fn py_solve_fiber_length(
+        &self,
+        l_mt: f64,
+        activation: f64,
+        v_ce: f64,
+        initial_guess: Option<f64>,
+    ) -> pyo3::PyResult<f64> {
+        let solver = EquilibriumSolver::new(&self.muscle);
+        solver
+            .solve_fiber_length(l_mt, activation, v_ce, initial_guess)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    }
+
+    #[pyo3(name = "solve_fiber_velocity")]
+    #[pyo3(signature = (l_mt, v_mt, activation, l_ce, dt = 0.001))]
+    fn py_solve_fiber_velocity(
+        &self,
+        l_mt: f64,
+        v_mt: f64,
+        activation: f64,
+        l_ce: f64,
+        dt: f64,
+    ) -> pyo3::PyResult<f64> {
+        let solver = EquilibriumSolver::new(&self.muscle);
+        solver
+            .solve_fiber_velocity(l_mt, v_mt, activation, l_ce, dt)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    }
+}

--- a/src/shared/python/biomechanics/multi_muscle.py
+++ b/src/shared/python/biomechanics/multi_muscle.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+try:
+    import upstream_muscle
+    HAS_RUST_BACKEND = True
+except ImportError:
+    HAS_RUST_BACKEND = False
+
 
 @dataclass
 class MuscleAttachment:
@@ -53,6 +59,10 @@ class MuscleGroup:
         self.name = name
         self.muscles: dict[str, HillMuscleModel] = {}
         self.attachments: dict[str, MuscleAttachment] = {}
+        
+        self._rust_backend = None
+        if HAS_RUST_BACKEND:
+            self._rust_backend = upstream_muscle.MuscleGroup(name)
 
     def add_muscle(self, name: str, muscle: HillMuscleModel, moment_arm: float) -> None:
         """Add a muscle to the group.
@@ -75,6 +85,9 @@ class MuscleGroup:
         require(moment_arm != 0.0, "moment_arm must be non-zero", moment_arm)
         self.muscles[name] = muscle
         self.attachments[name] = MuscleAttachment(name, moment_arm)
+        
+        if self._rust_backend is not None and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+            self._rust_backend.add_muscle(name, muscle._rust_backend, moment_arm)
 
     def compute_net_torque(
         self,
@@ -106,6 +119,12 @@ class MuscleGroup:
                 f"activation for '{mname}' must be in [0, 1]",
                 act_val,
             )
+
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.compute_net_torque(activations, muscle_states)
+            except RuntimeError as e:
+                logger.warning(f"Rust MuscleGroup compute_net_torque failed, falling back to Python: {e}")
 
         net_torque = 0.0
 
@@ -156,6 +175,10 @@ class AntagonistPair:
         self.agonist = agonist
         self.antagonist = antagonist
 
+        self._rust_backend = None
+        if HAS_RUST_BACKEND and agonist._rust_backend is not None and antagonist._rust_backend is not None:
+            self._rust_backend = upstream_muscle.AntagonistPair(agonist._rust_backend, antagonist._rust_backend)
+
     def compute_net_torque(
         self,
         agonist_activations: dict[str, float],
@@ -179,6 +202,13 @@ class AntagonistPair:
             raise ValueError("agonist_activations must be provided")
         if not (agonist_activations is not None):
             raise ValueError("agonist_activations must be provided")
+
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.compute_net_torque(agonist_activations, antagonist_activations, muscle_states)
+            except RuntimeError as e:
+                logger.warning(f"Rust AntagonistPair compute_net_torque failed, falling back to Python: {e}")
+
         tau_agonist = self.agonist.compute_net_torque(
             agonist_activations, muscle_states
         )

--- a/src/shared/python/biomechanics/muscle_equilibrium.py
+++ b/src/shared/python/biomechanics/muscle_equilibrium.py
@@ -36,6 +36,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+try:
+    import upstream_muscle
+    HAS_RUST_BACKEND = True
+except ImportError:
+    HAS_RUST_BACKEND = False
+
 # Solver parameters
 MAX_ITERATIONS = 100  # Maximum Newton-Raphson iterations
 TOLERANCE = 1e-6  # Convergence tolerance [m]
@@ -64,6 +70,10 @@ class EquilibriumSolver:
             muscle: HillMuscleModel instance
         """
         self.muscle = muscle
+        
+        self._rust_backend = None
+        if HAS_RUST_BACKEND and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+            self._rust_backend = upstream_muscle.EquilibriumSolver(muscle._rust_backend)
 
     def _equilibrium_residual(
         self, l_CE: float, l_MT: float, activation: float, v_CE: float = 0.0
@@ -160,6 +170,13 @@ class EquilibriumSolver:
 
         if initial_guess is None:
             initial_guess = INITIAL_GUESS_RATIO * self.muscle.params.l_opt
+            
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.solve_fiber_length(l_MT, activation, v_CE, initial_guess)
+            except RuntimeError as e:
+                # Fallback to python solver on failure
+                logger.warning(f"Rust equilibrium solver failed, falling back to Python: {e}")
 
         # Define residual function for newton()
         def residual_func(l_CE: float) -> float:
@@ -250,6 +267,12 @@ class EquilibriumSolver:
         # Future muscle-tendon length
         l_MT_next = l_MT + v_MT * dt
 
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.solve_fiber_velocity(l_MT, v_MT, activation, l_CE, dt)
+            except RuntimeError as e:
+                logger.warning(f"Rust fiber velocity solver failed, falling back to Python: {e}")
+
         # Solve for future fiber length
         try:
             l_CE_next = self.solve_fiber_length(
@@ -317,6 +340,15 @@ def compute_equilibrium_state(
         "activation must be in [0, 1]",
         activation,
     )
+
+    if HAS_RUST_BACKEND and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+        try:
+            l_ce, v_ce = upstream_muscle.compute_equilibrium_state(
+                muscle._rust_backend, l_MT, v_MT, activation, initial_l_CE
+            )
+            return float(l_ce), float(v_ce)
+        except RuntimeError as e:
+            logger.warning(f"Rust compute_equilibrium_state failed, falling back to Python: {e}")
 
     solver = EquilibriumSolver(muscle)
 


### PR DESCRIPTION
Resolves #5245 (Slices 3 and 4).

This PR continues the Rust port of the biomechanics inner-loops, providing:

- **Slice 3:** A pure-Rust secant-based solver for nonlinear \EquilibriumSolver\ which finds the equilibrium fiber length & velocity given muscle-tendon constraints. This eliminates overhead compared to the existing \scipy.optimize.newton\ backend.
- **Slice 4:** Rust port of \MuscleGroup\ and \AntagonistPair\ for vectorized moment arm summation and net torque calculation.
- Fallback wrappers placed in \muscle_equilibrium.py\ and \multi_muscle.py\ dynamically dispatch to the \upstream_muscle\ structs if available.
- Parity tests added for both components in \	est_muscle_rust_parity.py\.