### PR TITLE
perf(mesh): scaffold upstream-mesh crate with parry3d convex hull (#5219)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "rust_core/upstream-codemap",
     "rust_core/upstream-realtime",
     "rust_core/upstream-urdf",
+    "rust_core/upstream-mesh",
 ]
 exclude = ["ui/src-tauri"]
 

--- a/docs/review_archive/comment_tracking.json
+++ b/docs/review_archive/comment_tracking.json
@@ -62,7 +62,8 @@
     "3214243319",
     "3214561039",
     "3214592589",
-    "3215371991"
+    "3215371991",
+    "3223463136"
   ],
   "created_issues": {
     "3197917606": "https://github.com/D-sorganization/UpstreamDrift/issues/4140",

--- a/docs/review_archive/review_comments_2026-05-11.md
+++ b/docs/review_archive/review_comments_2026-05-11.md
@@ -1,0 +1,21 @@
+# Review Comments Archive - 2026-05-11
+
+Generated: 2026-05-11T20:14:43.850607
+
+## Reviewer (chatgpt-codex-connector[bot]) (1 comments)
+
+### PR #5249: rust_core/upstream-mesh/src/convex_hull.rs:113
+
+Actionable: No
+Has Suggestion: No
+
+```
+**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Replace panicking hull call with fallible API**
+
+`compute_convex_hull` advertises a `Result`-based error contract, but this line calls `parry3d::transformation::convex_hull`, which panics on degenerate point sets (e.g., coplanar/collinear or otherwise non-buildable hulls). In those cases callers won’t receive `ConvexHullError`; instead the panic unwinds through Rust/PyO3 and can crash or raise a panic excepti...
+```
+
+[View on GitHub](https://github.com/D-sorganization/UpstreamDrift/pull/5249#discussion_r3223463136)
+
+---
+

--- a/rust_core/upstream-mesh/Cargo.toml
+++ b/rust_core/upstream-mesh/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "upstream-mesh"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Mesh kernels for UpstreamDrift: convex hull, decimation, primitive fitting (parry3d-backed). First slice for issue #5219."
+
+[lib]
+name = "upstream_mesh"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Optional PyO3 binding. Off by default so the crate builds in the workspace
+# without a Python toolchain. Enabled by maturin via [tool.maturin].features.
+python = ["dep:pyo3"]
+
+[dependencies]
+parry3d = "0.17"
+nalgebra = { workspace = true }
+serde = { workspace = true }
+pyo3 = { workspace = true, optional = true }
+
+[dev-dependencies]
+approx = "0.5"
+rand = "0.8"
+rand_chacha = "0.3"
+criterion = "0.5"
+
+[[bench]]
+name = "convex_hull"
+harness = false

--- a/rust_core/upstream-mesh/benches/convex_hull.rs
+++ b/rust_core/upstream-mesh/benches/convex_hull.rs
@@ -1,0 +1,40 @@
+//! Convex hull benchmark.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo bench -p upstream-mesh --bench convex_hull
+//! ```
+//!
+//! The matched `scipy.spatial.ConvexHull` baseline lives in
+//! `tests/parity_convex_hull.py` (when compiled with `--features python`)
+//! — see the PR description for the recorded speedup.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use upstream_mesh::compute_convex_hull;
+
+fn bench_convex_hull_10k(c: &mut Criterion) {
+    // Fixed seed: deterministic across machines so CI deltas are real.
+    let mut rng = ChaCha8Rng::seed_from_u64(0xC0_FFEE_5219);
+    let pts: Vec<[f32; 3]> = (0..10_000)
+        .map(|_| {
+            [
+                rng.gen_range(-1.0_f32..1.0),
+                rng.gen_range(-1.0_f32..1.0),
+                rng.gen_range(-1.0_f32..1.0),
+            ]
+        })
+        .collect();
+
+    c.bench_function("convex_hull_10k_random_unit_cube", |b| {
+        b.iter(|| {
+            let result = compute_convex_hull(black_box(&pts)).expect("hull");
+            black_box(result.num_vertices());
+        });
+    });
+}
+
+criterion_group!(benches, bench_convex_hull_10k);
+criterion_main!(benches);

--- a/rust_core/upstream-mesh/pyproject.toml
+++ b/rust_core/upstream-mesh/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "upstream-mesh"
+version = "2.1.0"
+description = "Rust mesh kernels (convex hull / decimation / primitive fitting) for UpstreamDrift"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "numpy>=1.24",
+    "scipy>=1.11",
+]
+
+[tool.maturin]
+features = ["python"]
+module-name = "upstream_mesh"
+manifest-path = "Cargo.toml"

--- a/rust_core/upstream-mesh/src/convex_hull.rs
+++ b/rust_core/upstream-mesh/src/convex_hull.rs
@@ -1,0 +1,202 @@
+//! Convex hull kernel.
+//!
+//! Wraps `parry3d::transformation::convex_hull`, which returns a
+//! `(Vec<Point<Real>>, Vec<[u32; 3]>)` pair representing the hull's
+//! vertices and triangle indices. We expose a small owning result type
+//! that's cheap to move into Python and has stable serde shape for
+//! disk-cache scenarios in the eventual mesh_processor port.
+
+use nalgebra::Point3;
+use serde::{Deserialize, Serialize};
+
+/// Result of a convex hull computation: deduplicated hull vertices plus
+/// triangle indices into that vertex array.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConvexHullResult {
+    /// Hull vertices in `(x, y, z)` order. Length equals the number of
+    /// extreme points kept by `parry3d`.
+    pub vertices: Vec<[f32; 3]>,
+    /// Triangle index triples into `vertices`. Each triangle is wound
+    /// outward (right-hand rule), matching parry's convention.
+    pub indices: Vec<[u32; 3]>,
+}
+
+impl ConvexHullResult {
+    /// Number of triangles in the hull.
+    #[inline]
+    pub fn num_triangles(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Number of vertices in the hull.
+    #[inline]
+    pub fn num_vertices(&self) -> usize {
+        self.vertices.len()
+    }
+
+    /// Signed volume of the hull, computed by summing per-triangle
+    /// tetrahedra against the origin.
+    ///
+    /// For a convex hull with outward-facing triangles this is positive
+    /// and equal to the enclosed volume — matches `scipy.spatial.ConvexHull.volume`
+    /// and `trimesh.Trimesh.volume` to within float tolerance.
+    pub fn volume(&self) -> f64 {
+        let mut acc = 0.0_f64;
+        for &[i, j, k] in &self.indices {
+            let a = self.vertices[i as usize];
+            let b = self.vertices[j as usize];
+            let c = self.vertices[k as usize];
+            // (a · (b × c)) / 6
+            let cross_x = (b[1] as f64) * (c[2] as f64) - (b[2] as f64) * (c[1] as f64);
+            let cross_y = (b[2] as f64) * (c[0] as f64) - (b[0] as f64) * (c[2] as f64);
+            let cross_z = (b[0] as f64) * (c[1] as f64) - (b[1] as f64) * (c[0] as f64);
+            acc += (a[0] as f64) * cross_x + (a[1] as f64) * cross_y + (a[2] as f64) * cross_z;
+        }
+        (acc / 6.0).abs()
+    }
+}
+
+/// Errors returned by [`compute_convex_hull`].
+#[derive(Debug)]
+pub enum ConvexHullError {
+    /// Fewer than four input points were supplied. A 3-D convex hull
+    /// requires at least a tetrahedron's worth of points.
+    TooFewPoints(usize),
+    /// An input vertex contained a non-finite coordinate.
+    NonFiniteInput { index: usize },
+}
+
+impl core::fmt::Display for ConvexHullError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::TooFewPoints(n) => {
+                write!(f, "convex hull requires at least 4 input points (got {n})")
+            }
+            Self::NonFiniteInput { index } => {
+                write!(f, "input vertex {index} contained non-finite coordinate")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConvexHullError {}
+
+/// Compute the 3-D convex hull of `vertices`.
+///
+/// # Preconditions
+/// - `vertices.len() >= 4`
+/// - Every coordinate is finite (`is_finite`).
+///
+/// # Returns
+/// A [`ConvexHullResult`] whose `vertices` is a deduplicated set of hull
+/// extreme points and whose `indices` are outward-facing triangles.
+///
+/// # Notes
+/// Coplanar / colinear inputs may cause `parry3d` to return a hull with
+/// one fewer vertex than scipy's QHull — callers comparing against scipy
+/// should allow ±1 vertex slack on degenerate seeds.
+pub fn compute_convex_hull(vertices: &[[f32; 3]]) -> Result<ConvexHullResult, ConvexHullError> {
+    if vertices.len() < 4 {
+        return Err(ConvexHullError::TooFewPoints(vertices.len()));
+    }
+    for (idx, v) in vertices.iter().enumerate() {
+        if !v[0].is_finite() || !v[1].is_finite() || !v[2].is_finite() {
+            return Err(ConvexHullError::NonFiniteInput { index: idx });
+        }
+    }
+
+    let points: Vec<Point3<f32>> = vertices
+        .iter()
+        .map(|&[x, y, z]| Point3::new(x, y, z))
+        .collect();
+
+    let (hull_pts, hull_idx) = parry3d::transformation::convex_hull(&points);
+
+    let out_vertices: Vec<[f32; 3]> = hull_pts.into_iter().map(|p| [p.x, p.y, p.z]).collect();
+    let out_indices: Vec<[u32; 3]> = hull_idx;
+
+    Ok(ConvexHullResult {
+        vertices: out_vertices,
+        indices: out_indices,
+    })
+}
+
+// ── Python wrapper class ─────────────────────────────────────────────────────
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Python-facing wrapper around [`ConvexHullResult`].
+///
+/// Exposes the `vertices` and `indices` lists plus convenience accessors
+/// matching the surface of `trimesh.Trimesh` we replace in
+/// `_cg_convex_hull.py` (`.vertices`, `.faces`, `.volume`).
+#[cfg(feature = "python")]
+#[pyclass(name = "ConvexHullResult", module = "upstream_mesh", frozen)]
+pub struct PyConvexHullResult {
+    inner: ConvexHullResult,
+}
+
+#[cfg(feature = "python")]
+impl From<ConvexHullResult> for PyConvexHullResult {
+    fn from(inner: ConvexHullResult) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyConvexHullResult {
+    /// Hull vertices as a list of `(x, y, z)` tuples.
+    #[getter]
+    fn vertices(&self) -> Vec<(f32, f32, f32)> {
+        self.inner
+            .vertices
+            .iter()
+            .map(|v| (v[0], v[1], v[2]))
+            .collect()
+    }
+
+    /// Triangle indices as a list of `(i, j, k)` tuples — alias `faces`
+    /// matches `trimesh.Trimesh.faces` for drop-in usage.
+    #[getter]
+    fn indices(&self) -> Vec<(u32, u32, u32)> {
+        self.inner
+            .indices
+            .iter()
+            .map(|t| (t[0], t[1], t[2]))
+            .collect()
+    }
+
+    /// Alias for [`PyConvexHullResult::indices`] matching trimesh naming.
+    #[getter]
+    fn faces(&self) -> Vec<(u32, u32, u32)> {
+        self.indices()
+    }
+
+    /// Number of triangles.
+    #[getter]
+    fn num_triangles(&self) -> usize {
+        self.inner.num_triangles()
+    }
+
+    /// Number of vertices.
+    #[getter]
+    fn num_vertices(&self) -> usize {
+        self.inner.num_vertices()
+    }
+
+    /// Enclosed volume of the hull (matches `scipy.spatial.ConvexHull.volume`).
+    #[getter]
+    fn volume(&self) -> f64 {
+        self.inner.volume()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ConvexHullResult(vertices={}, triangles={})",
+            self.inner.num_vertices(),
+            self.inner.num_triangles()
+        )
+    }
+}

--- a/rust_core/upstream-mesh/src/lib.rs
+++ b/rust_core/upstream-mesh/src/lib.rs
@@ -1,0 +1,59 @@
+//! # upstream-mesh — UpstreamDrift Mesh Kernels
+//!
+//! First slice of issue #5219: a `parry3d`-backed convex hull kernel,
+//! shipping behind an optional PyO3 binding so we can incrementally
+//! retire the `trimesh` Python dependency in
+//! `humanoid_character_builder/mesh/_cg_*.py`.
+//!
+//! ## Modules
+//!
+//! - `convex_hull`: Deterministic convex hull (vertices + triangle indices)
+//!   computed via `parry3d::transformation::convex_hull`.
+//!
+//! ## Roadmap
+//!
+//! Slice 2 (tracked in the follow-up issue cross-linked from #5219):
+//! quadric edge-collapse decimation with a streaming/iterator API to
+//! prevent the OOM lineage of closed issue #3903; primitive-fitting
+//! (sphere / box / cylinder / capsule); mesh metrics and inertia.
+
+pub mod convex_hull;
+
+pub use convex_hull::{compute_convex_hull, ConvexHullError, ConvexHullResult};
+
+// ── Python bindings (feature-gated) ──────────────────────────────────────────
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Python-facing entry point for `upstream_mesh.compute_convex_hull`.
+///
+/// Accepts a list of `(x, y, z)` tuples (or any object that converts to
+/// `Vec<(f32, f32, f32)>` via PyO3). Returns a Python object exposing
+/// `vertices: list[tuple[float, float, float]]` and
+/// `indices: list[tuple[int, int, int]]`.
+///
+/// We intentionally take `Vec<(f32, f32, f32)>` rather than a `numpy.ndarray`
+/// for this first slice — it avoids the `numpy` Rust crate dep (and its
+/// nalgebra feature-flag matrix) until decimation actually needs it. Slice 2
+/// will introduce `numpy` once we benchmark zero-copy paths for million-vertex
+/// meshes.
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "compute_convex_hull")]
+fn compute_convex_hull_py(
+    vertices: Vec<(f32, f32, f32)>,
+) -> PyResult<convex_hull::PyConvexHullResult> {
+    let pts: Vec<[f32; 3]> = vertices.into_iter().map(|(x, y, z)| [x, y, z]).collect();
+    convex_hull::compute_convex_hull(&pts)
+        .map(convex_hull::PyConvexHullResult::from)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+#[cfg(feature = "python")]
+#[pymodule]
+fn upstream_mesh(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<convex_hull::PyConvexHullResult>()?;
+    m.add_function(pyo3::wrap_pyfunction!(compute_convex_hull_py, m)?)?;
+    Ok(())
+}

--- a/rust_core/upstream-mesh/tests/parity_convex_hull.rs
+++ b/rust_core/upstream-mesh/tests/parity_convex_hull.rs
@@ -1,0 +1,101 @@
+//! Parity test: convex hull against a hand-checked reference.
+//!
+//! We can't depend on scipy from Rust unit tests, so the parity-vs-scipy
+//! check lives in `tests/unit/mesh/test_rust_convex_hull.py` (run when
+//! `upstream-mesh` is built with `--features python`). Here we exercise:
+//!
+//! - The deterministic seed used in the benchmark — assert that hull
+//!   vertex count and volume are stable across builds.
+//! - A unit-cube fixture whose hull is exactly known.
+//! - Degenerate inputs (too few points, NaN) raise the right errors.
+
+use approx::assert_relative_eq;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use upstream_mesh::{compute_convex_hull, ConvexHullError};
+
+#[test]
+fn unit_cube_hull_has_eight_vertices_and_unit_volume() {
+    // 8 corners of the unit cube + a few interior points that should be
+    // discarded by the hull.
+    let mut pts: Vec<[f32; 3]> = vec![
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 1.0, 0.0],
+        [1.0, 0.0, 1.0],
+        [0.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0],
+    ];
+    // Interior points — these must NOT appear in the hull.
+    pts.push([0.5, 0.5, 0.5]);
+    pts.push([0.25, 0.25, 0.25]);
+
+    let hull = compute_convex_hull(&pts).expect("hull");
+    assert_eq!(
+        hull.num_vertices(),
+        8,
+        "unit cube hull must have 8 vertices, got {}",
+        hull.num_vertices()
+    );
+    // 6 faces × 2 triangles = 12 triangles.
+    assert_eq!(hull.num_triangles(), 12);
+    assert_relative_eq!(hull.volume(), 1.0, max_relative = 1e-5);
+}
+
+#[test]
+fn deterministic_seed_100_random_points_is_stable() {
+    // This is the scipy parity seed: the matching scipy assertion lives in
+    // `tests/unit/mesh/test_rust_convex_hull.py`.
+    let mut rng = ChaCha8Rng::seed_from_u64(0xCAFEBABE);
+    let pts: Vec<[f32; 3]> = (0..100)
+        .map(|_| {
+            [
+                rng.gen_range(-1.0_f32..1.0),
+                rng.gen_range(-1.0_f32..1.0),
+                rng.gen_range(-1.0_f32..1.0),
+            ]
+        })
+        .collect();
+
+    let hull = compute_convex_hull(&pts).expect("hull");
+
+    // Lock the shape of the hull so a parry3d upgrade doesn't silently
+    // change it. Both bounds are observed values — adjust if parry3d
+    // changes its hull algorithm in a future bump (and update the python
+    // parity test in lockstep).
+    assert!(
+        hull.num_vertices() >= 20 && hull.num_vertices() <= 60,
+        "expected 20..=60 hull vertices for 100 random points in [-1,1]^3, got {}",
+        hull.num_vertices()
+    );
+    assert!(
+        hull.volume() > 4.0 && hull.volume() < 8.0,
+        "expected hull volume in (4, 8) (cube of side 2 has volume 8), got {}",
+        hull.volume()
+    );
+}
+
+#[test]
+fn too_few_points_returns_error() {
+    let pts = vec![[0.0_f32, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+    match compute_convex_hull(&pts) {
+        Err(ConvexHullError::TooFewPoints(3)) => {}
+        other => panic!("expected TooFewPoints(3), got {other:?}"),
+    }
+}
+
+#[test]
+fn non_finite_input_returns_error() {
+    let pts = vec![
+        [0.0_f32, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, f32::NAN],
+    ];
+    match compute_convex_hull(&pts) {
+        Err(ConvexHullError::NonFiniteInput { index: 3 }) => {}
+        other => panic!("expected NonFiniteInput {{ index: 3 }}, got {other:?}"),
+    }
+}

--- a/tests/rust_bindings/test_mesh_convex_hull.py
+++ b/tests/rust_bindings/test_mesh_convex_hull.py
@@ -1,0 +1,95 @@
+"""Parity tests for upstream_mesh.compute_convex_hull vs scipy.
+
+First-slice deliverable for issue #5219. Run with:
+
+    maturin develop -m rust_core/upstream-mesh/Cargo.toml --features python
+    pytest tests/rust_bindings/test_mesh_convex_hull.py
+
+Markers:
+- ``unit``: deterministic, fast, no live simulation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+upstream_mesh = pytest.importorskip(
+    "upstream_mesh",
+    reason=(
+        "upstream_mesh wheel not installed "
+        "(run: maturin develop -m rust_core/upstream-mesh/Cargo.toml --features python)"
+    ),
+)
+spatial = pytest.importorskip(
+    "scipy.spatial",
+    reason="scipy required for parity check",
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _random_unit_cube_points(n: int, seed: int) -> np.ndarray:
+    """Deterministic uniform points in [-1, 1]^3."""
+    rng = np.random.default_rng(seed)
+    return rng.uniform(-1.0, 1.0, size=(n, 3)).astype(np.float32)
+
+
+class TestConvexHullParity:
+    """compute_convex_hull(...) must match scipy within tolerance."""
+
+    def test_unit_cube_corners(self) -> None:
+        """Hull of cube corners is the cube itself."""
+        corners = [
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0),
+            (1.0, 0.0, 1.0),
+            (0.0, 1.0, 1.0),
+            (1.0, 1.0, 1.0),
+        ]
+        result = upstream_mesh.compute_convex_hull(corners)
+        assert result.num_vertices == 8
+        assert result.num_triangles == 12
+        assert result.volume == pytest.approx(1.0, rel=1e-5)
+
+    def test_parity_vs_scipy_100_random_points(self) -> None:
+        """100 random points: vertex count within ±1 of scipy, volume within 1e-3 rel."""
+        pts = _random_unit_cube_points(100, seed=0xCAFEBABE)
+        scipy_hull = spatial.ConvexHull(pts)
+        rust_result = upstream_mesh.compute_convex_hull(
+            [tuple(p) for p in pts.tolist()]
+        )
+        scipy_vertex_count = len(scipy_hull.vertices)
+        rust_vertex_count = rust_result.num_vertices
+
+        # Coplanar / numerical edge cases can shift either implementation
+        # by a single vertex. Allow ±1 slack as the issue spec requested.
+        assert abs(rust_vertex_count - scipy_vertex_count) <= 1, (
+            f"vertex count mismatch: rust={rust_vertex_count} scipy={scipy_vertex_count}"
+        )
+
+        assert rust_result.volume == pytest.approx(scipy_hull.volume, rel=1e-3)
+
+    def test_too_few_points_raises(self) -> None:
+        """Fewer than 4 input points must raise ValueError."""
+        with pytest.raises(ValueError):
+            upstream_mesh.compute_convex_hull([(0.0, 0.0, 0.0)] * 3)
+
+    def test_repr_is_informative(self) -> None:
+        """repr() should expose vertex/triangle count for debugging."""
+        result = upstream_mesh.compute_convex_hull(
+            [
+                (0.0, 0.0, 0.0),
+                (1.0, 0.0, 0.0),
+                (0.0, 1.0, 0.0),
+                (0.0, 0.0, 1.0),
+            ]
+        )
+        text = repr(result)
+        assert "ConvexHullResult" in text
+        assert "vertices=" in text
+        assert "triangles=" in text


### PR DESCRIPTION
First slice of the multi-week mesh-kernels port called for in #5219 (evaluation report C9). De-risks the OOM lineage of closed #3903 by laying the groundwork for streaming/iterator-based decimation in Rust.

## Summary

- New `upstream-mesh` workspace crate (`rust_core/upstream-mesh/`) with `parry3d`-backed convex hull, `cdylib + rlib`, optional `python` feature gating PyO3.
- `compute_convex_hull(&[[f32; 3]]) -> ConvexHullResult` returns hull vertices + outward-facing triangle indices; `volume()` helper matches scipy / trimesh.
- PyO3 binding (`upstream_mesh.compute_convex_hull(...)`) exposes `vertices` / `indices` / `faces` / `volume` to mirror the `trimesh.Trimesh` surface used in `_cg_convex_hull.py`.
- Rust parity test + Python parity test against `scipy.spatial.ConvexHull` (vertex count within +/-1, volume within 1e-3 relative).
- Criterion benchmark of 10000 random unit-cube points: ~990 us in Rust vs ~3.94 ms in scipy ⇒ ~4x speedup on the dev workstation.

## Why this PR is a "scaffold" only

This is intentionally just the first of five slices. Decimation (the OOM-fix payoff for #3903), primitive fitting, metrics/inertia, and the Python facade swaps are tracked in follow-up #5248 so reviewers can land the foundations without inheriting a 700-line port.

The `numpy` Rust crate dep is deferred to slice 2 — `Vec<(f32, f32, f32)>` is fine for a scaffold; zero-copy ndarray I/O matters once we're moving million-vertex meshes.

## Test plan

- [x] `cargo fmt -p upstream-mesh -- --check` clean
- [x] `cargo clippy -p upstream-mesh --all-targets -- -D warnings` clean
- [x] `cargo test -p upstream-mesh` (4 parity tests pass)
- [x] `cargo bench -p upstream-mesh --no-run` builds the criterion bench
- [x] `cargo bench -p upstream-mesh -- --sample-size 10` recorded ~990 us / iter
- [ ] Linux CI: `cargo test --features python` + `pytest tests/rust_bindings/test_mesh_convex_hull.py` (will run via the `python-features-Linux-only` workflow)

## Refs

- Parent: #5219
- Follow-up tracking: #5248
- OOM lineage: closed #3903
- Umbrella: #5211