### PR TITLE
enhancement(ai-backend): load sqlite-vss extension at runtime (#5240)

### DIFF
--- a/rust_core/ai_backend/Cargo.toml
+++ b/rust_core/ai_backend/Cargo.toml
@@ -22,7 +22,6 @@ python = ["dep:pyo3"]
 pyo3 = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tools-core = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
 futures = "0.3"

--- a/rust_core/ai_backend/Cargo.toml
+++ b/rust_core/ai_backend/Cargo.toml
@@ -25,6 +25,6 @@ serde_json = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
 futures = "0.3"
-rusqlite = { version = "0.29", features = ["bundled"] }
+rusqlite = { version = "0.29", features = ["bundled", "load_extension"] }
 walkdir = "2.3"
 regex = "1.10"

--- a/rust_core/ai_backend/src/memory.rs
+++ b/rust_core/ai_backend/src/memory.rs
@@ -50,8 +50,14 @@ impl MemoryManager {
         )
         .map_err(|e| format!("DB init error: {}", e))?;
 
-        // Note: In a real deployment, sqlite-vss extension must be loaded here
-        // using sqlite3_enable_load_extension.
+        unsafe {
+            let _ = conn.load_extension_enable();
+            // Try loading the extensions. If they fail, we proceed anyway (fallback mode).
+            let _ = conn.load_extension("vector0", None);
+            let _ = conn.load_extension("vss0", None);
+            let _ = conn.load_extension_disable();
+        }
+
         let _ = conn.execute(
             "CREATE VIRTUAL TABLE IF NOT EXISTS vss_documents USING vss0(
                 embedding(384)


### PR DESCRIPTION
Resolves #5240. Enables the \load_extension\ feature in rusqlite and safely loads the \ector0\ and \ss0\ extensions at runtime during \MemoryManager::try_initialize\. Fallback behavior is preserved if the extensions fail to load.