### PR TITLE
feat(matching): formalize engine capability discovery and unify registries

### DIFF
--- a/src/engines/__init__.py
+++ b/src/engines/__init__.py
@@ -34,6 +34,15 @@ def get_engine_catalog() -> dict[str, dict[str, bool]]:
                 except ImportError:
                     pass
 
+            # If capable, try to import the provider to trigger registration
+            if fit_capable:
+                try:
+                    importlib.import_module(
+                        f"src.engines.physics_engines.{engine_name}.python.motion_matching.provider"
+                    )
+                except ImportError:
+                    pass
+
             catalog[engine_name] = {"fit_capable": fit_capable}
 
     return catalog

--- a/src/shared/python/motion_matching/provider_registry.py
+++ b/src/shared/python/motion_matching/provider_registry.py
@@ -27,108 +27,17 @@ __all__ = [
 ]
 
 
-_REGISTRY: dict[str, Any] = {}
-_LOCK = threading.Lock()
-_logger = logging.getLogger(__name__)
+from .provider import (
+    available_engines,
+    get_provider,
+    register_provider,
+)
 
-
-def _provider_qualname(provider: object) -> str:
-    """Return the fully-qualified ``module.qualname`` for ``provider``'s class.
-
-    Used to detect re-registrations that originate from the same logical
-    class even after :func:`importlib.reload` has rebuilt it (and thus
-    broken ``type(a) is type(b)`` identity).
-    """
-    cls = type(provider)
-    module = getattr(cls, "__module__", "") or ""
-    qualname = getattr(cls, "__qualname__", cls.__name__)
-    return f"{module}.{qualname}" if module else qualname
-
-
-def register_provider(provider: Any) -> None:
-    """Register an engine-side ``fit_swing`` provider.
-
-    Args:
-        provider: An object exposing ``engine_name`` (str) and a
-            ``fit_swing(target, opts) -> FitResult`` callable. The
-            registry stays Protocol-agnostic so it remains compatible
-            with the canonical Protocol introduced in issue #4514 once
-            that lands.
-
-    Behaviour:
-        Registration is idempotent: re-registering the *same* provider
-        instance, or any instance of the *same* provider class (matched
-        by fully-qualified ``module.qualname`` so :func:`importlib.reload`
-        shadows count), is a no-op and emits a DEBUG log. Registering a
-        *different* provider class for an already-occupied ``engine_name``
-        raises :class:`ValueError` naming both classes.
-
-    Raises:
-        TypeError: If ``provider`` lacks an ``engine_name`` string or a
-            callable ``fit_swing`` attribute.
-        ValueError: If a *different* provider class tries to register
-            under an ``engine_name`` already taken.
-    """
-    name = getattr(provider, "engine_name", None)
-    if not isinstance(name, str) or not name:
-        raise TypeError(
-            "provider must expose a non-empty 'engine_name' string attribute"
-        )
-    if not callable(getattr(provider, "fit_swing", None)):
-        raise TypeError(
-            f"provider for engine '{name}' must expose a callable 'fit_swing'"
-        )
-    with _LOCK:
-        existing = _REGISTRY.get(name)
-        if existing is provider:
-            _logger.debug(
-                "register_provider: %r already registered (same instance); no-op",
-                name,
-            )
-            return
-        if existing is not None and (
-            type(existing) is type(provider)
-            or _provider_qualname(existing) == _provider_qualname(provider)
-        ):
-            _logger.debug(
-                "register_provider: %r already registered to %s; no-op",
-                name,
-                _provider_qualname(existing),
-            )
-            return
-        if existing is not None:
-            raise ValueError(
-                f"engine_name {name!r} is already registered to "
-                f"{_provider_qualname(existing)}; got "
-                f"{_provider_qualname(provider)}"
-            )
-        _REGISTRY[name] = provider
-
-
-def get_provider(engine_name: str) -> Any:
-    """Look up a registered provider by engine name.
-
-    Raises:
-        KeyError: If no provider is registered under ``engine_name``.
-    """
-    with _LOCK:
-        try:
-            return _REGISTRY[engine_name]
-        except KeyError as exc:
-            available = sorted(_REGISTRY)
-            raise KeyError(
-                f"no fit_swing provider registered for engine '{engine_name}'; "
-                f"available={available}"
-            ) from exc
-
-
-def available_engines() -> list[str]:
-    """Return the sorted list of registered engine names."""
-    with _LOCK:
-        return sorted(_REGISTRY)
-
+# clear_registry is not in provider.py, but it's used in tests. We can implement it here by reaching into provider.py's internals, or we can just import the internal ones.
+from .provider import _REGISTRY, _REGISTRY_LOCK
 
 def clear_registry() -> None:
     """Remove every entry from the registry. Test helper only."""
-    with _LOCK:
+    with _REGISTRY_LOCK:
         _REGISTRY.clear()
+


### PR DESCRIPTION
Resolves the requirement to formalize engine-agnostic capability discovery for the Pendulum analytic provider and other motion-matching engines.

1. **Unify Registries**: Refactored \src.shared.python.motion_matching.provider_registry\ to import its registry dictionary and functions directly from \src.shared.python.motion_matching.provider\. This eliminates the split-brain registry issue where some engines (e.g. Drake) were registering to one dictionary while others (e.g. MuJoCo, Pendulum) registered to another.
2. **Dynamic Capability Discovery**: Updated \get_engine_catalog()\ in \src.engines.__init__.py\ to actively attempt to import the \provider.py\ module of each \it_capable\ engine. This formally evaluates capabilities at startup and safely invokes the \egister_provider\ hooks, effectively making all installed and capable motion-matching providers (including Pendulum) discoverable via \vailable_engines()\.

No changes to downstream API consumers are required since the registry interfaces remain intact.