### PR TITLE
fix(cmc): report success=False when torques are still placeholder (#5269)

### DIFF
--- a/src/shared/python/motion_pipeline/matching/cmc.py
+++ b/src/shared/python/motion_pipeline/matching/cmc.py
@@ -142,12 +142,12 @@ class CMCMatchingSolver(BaseMotionMatchingSolver):
 
         return MotionMatchingResult(
             request_id=request_id,
-            success=True,
+            success=False,
             tracked_trajectory=reference,
             torque_trajectory=torque_traj,
             residual_report=residual_report,
             fit_metrics={"rmse": 0.0, "max_error": 0.0},
             solve_time=float(solve_time),
-            message="CMC solver - rust outer loop active",
+            message="CMC solver - placeholder torques (full CMC not yet implemented)",
             metadata={"backend": self.backend_type.value, "status": "placeholder", "n_frames": n_frames},
         )


### PR DESCRIPTION
## Summary

Fixes #5269: The CMC solver was returning `success=True` even though both execution paths (Rust outer loop and non-Rust fallback) synthesize placeholder zero torques.

## Changes

- Changed `success=True` to `success=False` in the CMC `MotionMatchingResult`
- Updated the message to clearly indicate placeholder torques are being returned

## Testing

- Verified the file change is correct
- No test suite changes needed — the success flag is now accurately reflecting the placeholder state