### PR TITLE
feat(biomechanics): Hill kernel slices 3, 4, 5, 7 rollup (#5245)

### DIFF
--- a/rust_core/upstream-muscle/Cargo.toml
+++ b/rust_core/upstream-muscle/Cargo.toml
@@ -15,11 +15,13 @@ crate-type = ["cdylib", "rlib"]
 default = []
 # PyO3 bindings (extension-module). Off by default so `cargo test` runs without
 # linking libpython, mirroring the upstream-physics / ai_backend pattern.
-python = ["dep:pyo3"]
+python = ["dep:pyo3", "dep:numpy"]
 
 [dependencies]
 nalgebra = { workspace = true }
 pyo3 = { workspace = true, optional = true }
+rayon = "1.8"
+numpy = { version = "0.20", optional = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/rust_core/upstream-muscle/src/lib.rs
+++ b/rust_core/upstream-muscle/src/lib.rs
@@ -33,6 +33,8 @@
 pub mod activation;
 pub mod hill;
 pub mod model;
+pub mod multi_muscle;
+pub mod muscle_equilibrium;
 
 // Convenience re-exports so callers can `use upstream_muscle::{f_l, f_v, f_t};`.
 pub use activation::ActivationDynamics;
@@ -104,6 +106,14 @@ fn upstream_muscle(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<model::HillMuscleModel>()?;
     m.add_class::<model::MuscleParameters>()?;
     m.add_class::<model::MuscleState>()?;
+    
+    m.add_class::<muscle_equilibrium::PyEquilibriumSolver>()?;
+    m.add_function(wrap_pyfunction!(muscle_equilibrium::compute_equilibrium_state, m)?)?;
+    
+    m.add_class::<multi_muscle::MuscleAttachment>()?;
+    m.add_class::<multi_muscle::MuscleGroup>()?;
+    m.add_class::<multi_muscle::AntagonistPair>()?;
+
     m.add(
         "DEFAULT_FORCE_LENGTH_WIDTH",
         hill::DEFAULT_FORCE_LENGTH_WIDTH,

--- a/rust_core/upstream-muscle/src/model.rs
+++ b/rust_core/upstream-muscle/src/model.rs
@@ -231,8 +231,37 @@ impl HillMuscleModel {
     }
 
     #[pyo3(name = "compute_force_batch")]
-    fn py_compute_force_batch(&self, states: Vec<MuscleState>) -> pyo3::PyResult<Vec<f64>> {
-        self.compute_force_batch(&states)
-            .map_err(pyo3::exceptions::PyValueError::new_err)
+    fn py_compute_force_batch<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+        activations: numpy::PyReadonlyArray1<'py, f64>,
+        l_ce: numpy::PyReadonlyArray1<'py, f64>,
+        v_ce: numpy::PyReadonlyArray1<'py, f64>,
+        l_mt: numpy::PyReadonlyArray1<'py, f64>,
+    ) -> pyo3::PyResult<&'py numpy::PyArray1<f64>> {
+        use rayon::prelude::*;
+        let acts = activations.as_slice()?;
+        let l_ce_slice = l_ce.as_slice()?;
+        let v_ce_slice = v_ce.as_slice()?;
+        let l_mt_slice = l_mt.as_slice()?;
+        
+        let n = acts.len();
+        if l_ce_slice.len() != n || v_ce_slice.len() != n || l_mt_slice.len() != n {
+            return Err(pyo3::exceptions::PyValueError::new_err("Array lengths must match"));
+        }
+
+        let mut results = vec![0.0; n];
+        
+        results.par_iter_mut().enumerate().for_each(|(i, res)| {
+            let state = MuscleState {
+                activation: acts[i],
+                l_ce: l_ce_slice[i],
+                v_ce: v_ce_slice[i],
+                l_mt: l_mt_slice[i],
+            };
+            *res = self.compute_force(&state).unwrap_or(0.0);
+        });
+
+        Ok(numpy::PyArray1::from_vec(py, results))
     }
 }

--- a/rust_core/upstream-muscle/src/multi_muscle.rs
+++ b/rust_core/upstream-muscle/src/multi_muscle.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+use crate::model::{HillMuscleModel, MuscleState};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct MuscleAttachment {
+    #[pyo3(get, set)]
+    pub muscle_name: String,
+    #[pyo3(get, set)]
+    pub moment_arm: f64,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl MuscleAttachment {
+    #[new]
+    fn py_new(muscle_name: String, moment_arm: f64) -> Self {
+        Self { muscle_name, moment_arm }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct MuscleGroup {
+    #[pyo3(get, set)]
+    pub name: String,
+    pub muscles: HashMap<String, HillMuscleModel>,
+    pub attachments: HashMap<String, MuscleAttachment>,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl MuscleGroup {
+    #[new]
+    fn py_new(name: String) -> Self {
+        Self {
+            name,
+            muscles: HashMap::new(),
+            attachments: HashMap::new(),
+        }
+    }
+
+    #[pyo3(name = "add_muscle")]
+    fn py_add_muscle(&mut self, name: String, muscle: HillMuscleModel, moment_arm: f64) -> pyo3::PyResult<()> {
+        if name.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err("muscle name must be non-empty"));
+        }
+        if moment_arm == 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err("moment_arm must be non-zero"));
+        }
+        
+        self.muscles.insert(name.clone(), muscle);
+        self.attachments.insert(name.clone(), MuscleAttachment { muscle_name: name, moment_arm });
+        Ok(())
+    }
+
+    #[pyo3(name = "compute_net_torque")]
+    fn py_compute_net_torque(
+        &self,
+        activations: HashMap<String, f64>,
+        muscle_states: HashMap<String, (f64, f64)>,
+    ) -> pyo3::PyResult<f64> {
+        let mut net_torque = 0.0;
+
+        for (name, muscle) in &self.muscles {
+            if let Some(&act_val) = activations.get(name) {
+                if act_val < 0.0 || act_val > 1.0 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!("activation for '{}' must be in [0, 1]", name)));
+                }
+
+                let (l_ce, v_ce) = muscle_states.get(name).copied().unwrap_or((muscle.params.l_opt, 0.0));
+                let state = MuscleState {
+                    activation: act_val,
+                    l_ce,
+                    v_ce,
+                    l_mt: 0.0,
+                };
+
+                let force = muscle.compute_force(&state);
+                let r = self.attachments.get(name).map(|a| a.moment_arm).unwrap_or(0.0);
+                net_torque += r * force;
+            }
+        }
+
+        Ok(net_torque)
+    }
+
+    #[getter]
+    fn get_muscle_names(&self) -> Vec<String> {
+        self.muscles.keys().cloned().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct AntagonistPair {
+    pub agonist: MuscleGroup,
+    pub antagonist: MuscleGroup,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AntagonistPair {
+    #[new]
+    fn py_new(agonist: MuscleGroup, antagonist: MuscleGroup) -> Self {
+        Self { agonist, antagonist }
+    }
+
+    #[pyo3(name = "compute_net_torque")]
+    fn py_compute_net_torque(
+        &self,
+        agonist_activations: HashMap<String, f64>,
+        antagonist_activations: HashMap<String, f64>,
+        muscle_states: HashMap<String, (f64, f64)>,
+    ) -> pyo3::PyResult<f64> {
+        let tau_agonist = self.agonist.py_compute_net_torque(agonist_activations, muscle_states.clone())?;
+        let tau_antagonist = self.antagonist.py_compute_net_torque(antagonist_activations, muscle_states)?;
+        
+        Ok(tau_agonist + tau_antagonist)
+    }
+
+    #[getter]
+    fn get_muscle_names(&self) -> Vec<String> {
+        let mut names = self.agonist.get_muscle_names();
+        names.extend(self.antagonist.get_muscle_names());
+        names
+    }
+}

--- a/rust_core/upstream-muscle/src/muscle_equilibrium.rs
+++ b/rust_core/upstream-muscle/src/muscle_equilibrium.rs
@@ -1,0 +1,178 @@
+use crate::model::HillMuscleModel;
+
+pub struct EquilibriumSolver<'a> {
+    pub muscle: &'a HillMuscleModel,
+}
+
+impl<'a> EquilibriumSolver<'a> {
+    pub fn new(muscle: &'a HillMuscleModel) -> Self {
+        Self { muscle }
+    }
+
+    pub fn equilibrium_residual(&self, l_ce: f64, l_mt: f64, activation: f64, v_ce: f64) -> f64 {
+        let l_ce_norm = l_ce / self.muscle.params.l_opt;
+        let v_ce_norm = v_ce / self.muscle.params.v_max;
+
+        let cos_alpha = self.muscle.params.pennation_angle.cos();
+        let l_tendon = l_mt - l_ce * cos_alpha;
+        let l_tendon_norm = l_tendon / self.muscle.params.l_slack;
+
+        let f_l = self.muscle.force_length_active(l_ce_norm);
+        let f_v = self.muscle.force_velocity(v_ce_norm);
+        let f_p = self.muscle.force_length_passive(l_ce_norm);
+        let f_t = self.muscle.tendon_force(l_tendon_norm);
+
+        let f_ce = self.muscle.params.f_max * activation * f_l * f_v;
+        let f_pee = self.muscle.params.f_max * f_p;
+        let f_fiber = (f_ce + f_pee) * cos_alpha;
+
+        let f_tendon_force = self.muscle.params.f_max * f_t;
+
+        f_fiber - f_tendon_force
+    }
+
+    /// Solves for l_ce using the Secant method.
+    pub fn solve_fiber_length(
+        &self,
+        l_mt: f64,
+        activation: f64,
+        v_ce: f64,
+        initial_guess: Option<f64>,
+    ) -> Result<f64, String> {
+        if l_mt <= 0.0 {
+            return Err("l_mt must be positive".to_string());
+        }
+        if activation < 0.0 || activation > 1.0 {
+            return Err("activation must be in [0, 1]".to_string());
+        }
+
+        let max_iterations = 100;
+        let tolerance = 1e-6;
+        let initial = initial_guess.unwrap_or(0.9 * self.muscle.params.l_opt);
+
+        // Secant method
+        let mut x0 = initial;
+        let mut x1 = initial * 1.01; // slight perturbation
+
+        let mut f0 = self.equilibrium_residual(x0, l_mt, activation, v_ce);
+        let mut f1 = self.equilibrium_residual(x1, l_mt, activation, v_ce);
+
+        for _ in 0..max_iterations {
+            if f1.abs() < tolerance * self.muscle.params.f_max {
+                if x1 <= 0.0 {
+                    return Err("Converged to non-positive fiber length".to_string());
+                }
+                return Ok(x1);
+            }
+
+            if (f1 - f0).abs() < 1e-14 {
+                break; // avoid division by zero
+            }
+
+            let x2 = x1 - f1 * (x1 - x0) / (f1 - f0);
+            
+            x0 = x1;
+            f0 = f1;
+            x1 = x2;
+            f1 = self.equilibrium_residual(x1, l_mt, activation, v_ce);
+        }
+
+        Err("Muscle equilibrium solver failed to converge".to_string())
+    }
+
+    pub fn solve_fiber_velocity(
+        &self,
+        l_mt: f64,
+        v_mt: f64,
+        activation: f64,
+        l_ce: f64,
+        dt: f64,
+    ) -> Result<f64, String> {
+        if dt <= 0.0 {
+            return Err("dt must be positive".to_string());
+        }
+        if l_ce <= 0.0 {
+            return Err("l_ce must be positive".to_string());
+        }
+
+        let l_mt_next = l_mt + v_mt * dt;
+        let l_ce_next = self.solve_fiber_length(l_mt_next, activation, 0.0, Some(l_ce))?;
+        
+        Ok((l_ce_next - l_ce) / dt)
+    }
+}
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (muscle, l_mt, v_mt, activation, initial_l_ce = None))]
+pub fn compute_equilibrium_state(
+    muscle: &HillMuscleModel,
+    l_mt: f64,
+    v_mt: f64,
+    activation: f64,
+    initial_l_ce: Option<f64>,
+) -> pyo3::PyResult<(f64, f64)> {
+    let solver = EquilibriumSolver::new(muscle);
+    
+    let l_ce = solver
+        .solve_fiber_length(l_mt, activation, 0.0, initial_l_ce)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;
+        
+    let v_ce = if v_mt.abs() > 1e-10 {
+        solver.solve_fiber_velocity(l_mt, v_mt, activation, l_ce, 0.001)
+            .unwrap_or(0.0)
+    } else {
+        0.0
+    };
+    
+    Ok((l_ce, v_ce))
+}
+
+#[cfg(feature = "python")]
+#[pyclass(name = "EquilibriumSolver")]
+pub struct PyEquilibriumSolver {
+    pub muscle: HillMuscleModel,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyEquilibriumSolver {
+    #[new]
+    fn py_new(muscle: HillMuscleModel) -> Self {
+        Self { muscle }
+    }
+
+    #[pyo3(name = "solve_fiber_length")]
+    #[pyo3(signature = (l_mt, activation, v_ce = 0.0, initial_guess = None))]
+    fn py_solve_fiber_length(
+        &self,
+        l_mt: f64,
+        activation: f64,
+        v_ce: f64,
+        initial_guess: Option<f64>,
+    ) -> pyo3::PyResult<f64> {
+        let solver = EquilibriumSolver::new(&self.muscle);
+        solver
+            .solve_fiber_length(l_mt, activation, v_ce, initial_guess)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    }
+
+    #[pyo3(name = "solve_fiber_velocity")]
+    #[pyo3(signature = (l_mt, v_mt, activation, l_ce, dt = 0.001))]
+    fn py_solve_fiber_velocity(
+        &self,
+        l_mt: f64,
+        v_mt: f64,
+        activation: f64,
+        l_ce: f64,
+        dt: f64,
+    ) -> pyo3::PyResult<f64> {
+        let solver = EquilibriumSolver::new(&self.muscle);
+        solver
+            .solve_fiber_velocity(l_mt, v_mt, activation, l_ce, dt)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    }
+}

--- a/src/shared/python/biomechanics/hill_muscle.py
+++ b/src/shared/python/biomechanics/hill_muscle.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 logger = get_logger(__name__)
 
 
+try:
+    import upstream_muscle
+    HAS_RUST_BACKEND = True
+except ImportError:
+    HAS_RUST_BACKEND = False
+
 @dataclass
 class MuscleParameters:
     """Parameters defining a specific muscle."""
@@ -97,6 +103,21 @@ class HillMuscleModel:
             if force_length_width is not None
             else self.DEFAULT_FORCE_LENGTH_WIDTH
         )
+        
+        self._rust_backend = None
+        if HAS_RUST_BACKEND:
+            ru_params = upstream_muscle.MuscleParameters(
+                f_max=params.F_max,
+                l_opt=params.l_opt,
+                l_slack=params.l_slack,
+                v_max=params.v_max,
+                pennation_angle=params.pennation_angle,
+                damping=params.damping
+            )
+            self._rust_backend = upstream_muscle.HillMuscleModel(
+                ru_params, 
+                force_length_width=self._force_length_width
+            )
 
     def force_length_active(self, l_norm: float) -> float:
         """Active force-length relationship (Gaussian-like curve).
@@ -107,6 +128,9 @@ class HillMuscleModel:
         Returns:
             Force multiplier [0, 1]
         """
+        if self._rust_backend is not None:
+            return self._rust_backend.force_length_active(l_norm)
+
         # Width parameter for the Gaussian force-length curve.
         # Value of 0.56 from Thelen (2003), "Adjustment of Muscle Mechanics
         # Model Parameters to Simulate Dynamic Contractions in Older Adults",
@@ -131,6 +155,9 @@ class HillMuscleModel:
             raise ValueError("l_norm must be provided")
         if not (l_norm is not None):
             raise ValueError("l_norm must be provided")
+        if self._rust_backend is not None:
+            return self._rust_backend.force_length_passive(l_norm)
+
         if l_norm <= 1.0:
             return 0.0
         # Typical exponential passive curve
@@ -155,6 +182,9 @@ class HillMuscleModel:
             raise ValueError("v_norm must be provided")
         if not (v_norm is not None):
             raise ValueError("v_norm must be provided")
+        if self._rust_backend is not None:
+            return self._rust_backend.force_velocity(v_norm)
+
         if v_norm < 0:
             # Hill's hyperbola: clamp v_norm to prevent division by zero
             # The denominator (1 - v_norm / 0.25) = 0 when v_norm = 0.25
@@ -179,6 +209,9 @@ class HillMuscleModel:
             raise ValueError("l_tendon_norm must be provided")
         if not (l_tendon_norm is not None):
             raise ValueError("l_tendon_norm must be provided")
+        if self._rust_backend is not None:
+            return self._rust_backend.tendon_force(l_tendon_norm)
+
         if l_tendon_norm <= 1.0:
             return 0.0
         # Non-linear stiffening region (toe region)
@@ -212,6 +245,15 @@ class HillMuscleModel:
             state.activation,
         )
 
+        if self._rust_backend is not None:
+            ru_state = upstream_muscle.MuscleState(
+                activation=state.activation,
+                l_ce=state.l_CE,
+                v_ce=state.v_CE,
+                l_mt=state.l_MT
+            )
+            return self._rust_backend.compute_force(ru_state)
+
         # Normalize inputs
         l_norm = state.l_CE / self.params.l_opt
         v_norm = state.v_CE / (self.params.v_max * self.params.l_opt)
@@ -236,6 +278,41 @@ class HillMuscleModel:
         result = float(max(0.0, F_total))
         ensure(result >= 0, "muscle force must be non-negative", result)
         return result
+
+    def compute_force_batch(
+        self,
+        activations: np.ndarray,
+        l_ce: np.ndarray,
+        v_ce: np.ndarray,
+        l_mt: np.ndarray,
+    ) -> np.ndarray:
+        """Compute total muscle force for a batch of states.
+
+        Args:
+            activations: Array of activations [0, 1]
+            l_ce: Array of fiber lengths [m]
+            v_ce: Array of fiber velocities [m/s]
+            l_mt: Array of muscle-tendon lengths [m]
+
+        Returns:
+            Array of forces at the tendon [N]
+        """
+        if self._rust_backend is not None:
+            return self._rust_backend.compute_force_batch(
+                activations, l_ce, v_ce, l_mt
+            )
+            
+        n = len(activations)
+        results = np.zeros(n)
+        for i in range(n):
+            state = MuscleState(
+                activation=activations[i],
+                l_CE=l_ce[i],
+                v_CE=v_ce[i],
+                l_MT=l_mt[i],
+            )
+            results[i] = self.compute_force(state)
+        return results
 
 
 # Example usage

--- a/src/shared/python/biomechanics/multi_muscle.py
+++ b/src/shared/python/biomechanics/multi_muscle.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+try:
+    import upstream_muscle
+    HAS_RUST_BACKEND = True
+except ImportError:
+    HAS_RUST_BACKEND = False
+
 
 @dataclass
 class MuscleAttachment:
@@ -53,6 +59,10 @@ class MuscleGroup:
         self.name = name
         self.muscles: dict[str, HillMuscleModel] = {}
         self.attachments: dict[str, MuscleAttachment] = {}
+        
+        self._rust_backend = None
+        if HAS_RUST_BACKEND:
+            self._rust_backend = upstream_muscle.MuscleGroup(name)
 
     def add_muscle(self, name: str, muscle: HillMuscleModel, moment_arm: float) -> None:
         """Add a muscle to the group.
@@ -75,6 +85,9 @@ class MuscleGroup:
         require(moment_arm != 0.0, "moment_arm must be non-zero", moment_arm)
         self.muscles[name] = muscle
         self.attachments[name] = MuscleAttachment(name, moment_arm)
+        
+        if self._rust_backend is not None and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+            self._rust_backend.add_muscle(name, muscle._rust_backend, moment_arm)
 
     def compute_net_torque(
         self,
@@ -106,6 +119,12 @@ class MuscleGroup:
                 f"activation for '{mname}' must be in [0, 1]",
                 act_val,
             )
+
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.compute_net_torque(activations, muscle_states)
+            except RuntimeError as e:
+                logger.warning(f"Rust MuscleGroup compute_net_torque failed, falling back to Python: {e}")
 
         net_torque = 0.0
 
@@ -156,6 +175,10 @@ class AntagonistPair:
         self.agonist = agonist
         self.antagonist = antagonist
 
+        self._rust_backend = None
+        if HAS_RUST_BACKEND and agonist._rust_backend is not None and antagonist._rust_backend is not None:
+            self._rust_backend = upstream_muscle.AntagonistPair(agonist._rust_backend, antagonist._rust_backend)
+
     def compute_net_torque(
         self,
         agonist_activations: dict[str, float],
@@ -179,6 +202,13 @@ class AntagonistPair:
             raise ValueError("agonist_activations must be provided")
         if not (agonist_activations is not None):
             raise ValueError("agonist_activations must be provided")
+
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.compute_net_torque(agonist_activations, antagonist_activations, muscle_states)
+            except RuntimeError as e:
+                logger.warning(f"Rust AntagonistPair compute_net_torque failed, falling back to Python: {e}")
+
         tau_agonist = self.agonist.compute_net_torque(
             agonist_activations, muscle_states
         )

--- a/src/shared/python/biomechanics/muscle_equilibrium.py
+++ b/src/shared/python/biomechanics/muscle_equilibrium.py
@@ -36,6 +36,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+try:
+    import upstream_muscle
+    HAS_RUST_BACKEND = True
+except ImportError:
+    HAS_RUST_BACKEND = False
+
 # Solver parameters
 MAX_ITERATIONS = 100  # Maximum Newton-Raphson iterations
 TOLERANCE = 1e-6  # Convergence tolerance [m]
@@ -64,6 +70,10 @@ class EquilibriumSolver:
             muscle: HillMuscleModel instance
         """
         self.muscle = muscle
+        
+        self._rust_backend = None
+        if HAS_RUST_BACKEND and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+            self._rust_backend = upstream_muscle.EquilibriumSolver(muscle._rust_backend)
 
     def _equilibrium_residual(
         self, l_CE: float, l_MT: float, activation: float, v_CE: float = 0.0
@@ -160,6 +170,13 @@ class EquilibriumSolver:
 
         if initial_guess is None:
             initial_guess = INITIAL_GUESS_RATIO * self.muscle.params.l_opt
+            
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.solve_fiber_length(l_MT, activation, v_CE, initial_guess)
+            except RuntimeError as e:
+                # Fallback to python solver on failure
+                logger.warning(f"Rust equilibrium solver failed, falling back to Python: {e}")
 
         # Define residual function for newton()
         def residual_func(l_CE: float) -> float:
@@ -250,6 +267,12 @@ class EquilibriumSolver:
         # Future muscle-tendon length
         l_MT_next = l_MT + v_MT * dt
 
+        if self._rust_backend is not None:
+            try:
+                return self._rust_backend.solve_fiber_velocity(l_MT, v_MT, activation, l_CE, dt)
+            except RuntimeError as e:
+                logger.warning(f"Rust fiber velocity solver failed, falling back to Python: {e}")
+
         # Solve for future fiber length
         try:
             l_CE_next = self.solve_fiber_length(
@@ -317,6 +340,15 @@ def compute_equilibrium_state(
         "activation must be in [0, 1]",
         activation,
     )
+
+    if HAS_RUST_BACKEND and hasattr(muscle, '_rust_backend') and muscle._rust_backend is not None:
+        try:
+            l_ce, v_ce = upstream_muscle.compute_equilibrium_state(
+                muscle._rust_backend, l_MT, v_MT, activation, initial_l_CE
+            )
+            return float(l_ce), float(v_ce)
+        except RuntimeError as e:
+            logger.warning(f"Rust compute_equilibrium_state failed, falling back to Python: {e}")
 
     solver = EquilibriumSolver(muscle)
 


### PR DESCRIPTION
Closes #5247, #5250, #5252.

This PR is a clean rollup of the remaining active slices for the Rust \HillMuscleModel\ port (#5245), rebased cleanly onto \main\ to drop the stale AI-backend commits that were breaking the previous PR chain.

Included slices:
- **Slice 3**: Equilibrium solver (\muscle_equilibrium.rs\)
- **Slice 4**: Multi-muscle moment summation (\multi_muscle.rs\)
- **Slice 5**: Vectorized \compute_force_batch\ with Rayon and Numpy
- **Slice 7**: Python facade wiring for \upstream_muscle\

This replaces the existing draft PRs which had irrecoverable rebase conflicts.