### PR TITLE
fix(ai-backend): remove needless .into_iter() call in rag.rs

### DIFF
--- a/rust_core/ai_backend/src/rag.rs
+++ b/rust_core/ai_backend/src/rag.rs
@@ -218,7 +218,7 @@ pub fn index_with_embedder<E: Embedder>(
             );
             continue;
         }
-        for (chunk, emb) in chunks.into_iter().zip(embeddings_batch.into_iter()) {
+        for (chunk, emb) in chunks.into_iter().zip(embeddings_batch) {
             // Tag chunks with their source path so retrieval surfaces the
             // file location alongside the snippet. Keeps payload one string
             // (matches MemoryManager's payload-is-string contract).


### PR DESCRIPTION
Closes #5284

Fixes remaining clippy::useless_conversion warning in the ai-backend crate. The memory.rs needless_borrow issue from #5280 was already resolved on main by #5294; this PR cleans up the only remaining clippy warning.

## Fix
- `rag.rs` line 221: removed `.into_iter()` on `embeddings_batch` which already implements `IntoIterator`