### PR TITLE
fix: correct expected chat symbols in smoke test

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.161                                            |
+| **Spec Version**        | 1.0.162                                            |
 | **Last Spec Update**    | 2026-05-13                                         |
 
 ## 2. Purpose & Mission
@@ -684,6 +684,7 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-12 | 1.0.156 | Finalized motion-matching Rust loop optimizations, including MuJoCo torque outer-loop acceleration (slice 4) and end-to-end facade benchmarks (slice 5) (PR #5295, PR #5296). |
 | 2026-05-12 | 1.0.157 | Normalized Rust-backed Ollama chat and embedding endpoint suffixes so a configured base URL ending in `/v1` does not produce duplicate `/v1/v1/...` paths, while plain Ollama hosts still receive `/v1/chat/completions` and `/v1/embeddings`; added focused regression coverage for both URL forms. |
 | 2026-05-12 | 1.0.158 | Restricted review-comment archive commits to manual workflow dispatch runs so pull request synchronize events cannot push `docs/review_archive` churn onto feature branches, erase current-head checks, or block focused chat and GUI fixes behind generated archive drift. |
+| 2026-05-12 | 1.0.162 | Clarified shared chat smoke coverage so the public API contract asserts the exported `ChatDockWidget` and `ChatMessageBubble` symbols from `src/shared/python/chat/__init__.py`. |
 | 2026-05-12 | 1.0.159 | Updated workflow governance for the Rust realtime soak workflow by pinning its Rust toolchain action to a full commit SHA and registering the workflow in the active inventory with the current 71-workflow no-growth cap. |
 | 2026-05-12 | 1.0.160 | Added a documented hidden-launcher contract so hidden feature entries must carry an owner and reason, preventing undiscoverable app features from drifting without accountability (#5314). |
 ````

--- a/tests/smoke/test_chat_launcher_discovery.py
+++ b/tests/smoke/test_chat_launcher_discovery.py
@@ -38,11 +38,11 @@ class TestSharedChatImport:
 
     def test_shared_chat_public_api(self) -> None:
         """Shared chat should expose public API for consumption."""
+        # The shared chat module exports ChatDockWidget and ChatMessageBubble
+        # as its primary public API (see src/shared/python/chat/__init__.py)
         expected_exports = {
             "ChatDockWidget",
             "ChatMessageBubble",
-            "ChatPanel",
-            "ChatWidget",
         }
         chat_init = SRC_ROOT / "chat" / "__init__.py"
         if chat_init.exists():


### PR DESCRIPTION
## Summary
Fixes review feedback from issue #5328 by correcting the expected chat symbols in the smoke test.

## Changes
- Updated `test_shared_chat_public_api` to check for `ChatDockWidget` and `ChatMessageBubble` instead of non-existent `ChatWidget`/`ChatPanel`
- This aligns the test with the actual exports in `src/shared/python/chat/__init__.py`

## Related
- Fixes review comment in #5328
- Parent epic: #5309