### PR TITLE
fix(data_io): expose public API through __init__.py exports

### DIFF
--- a/src/shared/python/data_io/__init__.py
+++ b/src/shared/python/data_io/__init__.py
@@ -1,3 +1,37 @@
 """Data import/export, IO utilities, and provenance tracking."""
 
-__all__: list[str] = []
+from ._async_io import get_io_executor, shutdown_executor, submit_async_save
+from ._format_handlers import OutputFormat, dispatch_load, dispatch_save
+from ._path_utils import (
+    create_output_structure,
+    fast_dir_scan,
+    resolve_base_path,
+    sanitize_filename,
+)
+from ._report_generators import export_analysis_report
+from ._simulation_store import cleanup_old_files, get_simulation_list
+from .common_utils import get_logger, setup_structured_logging
+from .output_manager import OutputManager
+from .provenance import ProvenanceInfo, add_provenance_header, add_provenance_header_file
+
+__all__: list[str] = [
+    "OutputFormat",
+    "OutputManager",
+    "ProvenanceInfo",
+    "add_provenance_header",
+    "add_provenance_header_file",
+    "cleanup_old_files",
+    "create_output_structure",
+    "dispatch_load",
+    "dispatch_save",
+    "export_analysis_report",
+    "fast_dir_scan",
+    "get_io_executor",
+    "get_logger",
+    "get_simulation_list",
+    "resolve_base_path",
+    "sanitize_filename",
+    "setup_structured_logging",
+    "shutdown_executor",
+    "submit_async_save",
+]


### PR DESCRIPTION
## Summary

The  package previously exported nothing (), forcing all consumers to reach into internal submodules. This breaks IDE auto-import, type-checking boundary assumptions, and makes the package harder to discover.

## Changes

- Exports the stable public API from :
  - , , 
  - Format dispatchers: , 
  - Path utilities: , , , 
  - Async I/O helpers: , , 
  - Provenance: , 
  - Utilities: , , , , 

## Impact

- **Non-breaking**: existing deep submodule imports continue to work
- **IDE-friendly**: auto-import now suggests 
- **Type-safe**: mypy and other tools can resolve the package boundary correctly