### PR TITLE
fix(logging_pkg): expose public API through __init__.py exports

### DIFF
--- a/src/shared/python/logging_pkg/__init__.py
+++ b/src/shared/python/logging_pkg/__init__.py
@@ -1,12 +1,26 @@
-"""Logging configuration and utilities.
+"""Logging configuration and utilities for the Golf Modeling Suite."""
 
-Source of Truth: UpstreamDrift (this repository)
-Consumers: Tools (utils/logging_utils.py), Gasification_Model (internal)
-Cross-repo install: pip install upstream-drift-shared
+from .logging_config import (
+    LogLevel,
+    SensitiveDataFilter,
+    add_file_handler,
+    add_rotating_file_handler,
+    configure_gui_logging,
+    configure_test_logging,
+    get_logger,
+    setup_logging,
+)
+from .logger_utils import log_execution_time, set_seeds
 
-This package provides:
-- logging_config: Centralized setup_logging(), get_logger(), log format constants
-- logger_utils: Fallback-safe logging for standalone engine usage
-"""
-
-__all__: list[str] = []
+__all__: list[str] = [
+    "LogLevel",
+    "SensitiveDataFilter",
+    "add_file_handler",
+    "add_rotating_file_handler",
+    "configure_gui_logging",
+    "configure_test_logging",
+    "get_logger",
+    "log_execution_time",
+    "set_seeds",
+    "setup_logging",
+]


### PR DESCRIPTION
Expose the stable public API from the logging package.