### PR TITLE
fix(model_generation/mesh): re-export public API from humanoid_character_builder.mesh

### DIFF
--- a/src/shared/python/model_generation/mesh/__init__.py
+++ b/src/shared/python/model_generation/mesh/__init__.py
@@ -4,13 +4,40 @@ Mesh processing utilities for model generation.
 Re-exports mesh processing components from humanoid_character_builder.
 """
 
-try:
-    __all__ = [
-        "MeshProcessor",
-        "MeshExportConfig",
-        "MeshSegmentResult",
-        "PrimitiveMeshGenerator",
-        "MeshInertiaCalculator",
-    ]
-except ImportError:
-    __all__ = []
+from __future__ import annotations
+
+from humanoid_character_builder.mesh import (
+    CollisionGeometry,
+    CollisionGeometryGenerator,
+    InertiaMode,
+    InertiaResult,
+    LODGenerationResult,
+    LODGenerator,
+    LODLevel,
+    MeshInertiaCalculator,
+    MeshProcessor,
+    MeshSegmentResult,
+    PrimitiveInertiaCalculator,
+    PrimitiveShape,
+)
+from humanoid_character_builder.mesh.mesh_processor import (
+    MeshExportConfig,
+    PrimitiveMeshGenerator,
+)
+
+__all__: list[str] = [
+    "CollisionGeometry",
+    "CollisionGeometryGenerator",
+    "InertiaMode",
+    "InertiaResult",
+    "LODGenerationResult",
+    "LODGenerator",
+    "LODLevel",
+    "MeshExportConfig",
+    "MeshInertiaCalculator",
+    "MeshProcessor",
+    "MeshSegmentResult",
+    "PrimitiveInertiaCalculator",
+    "PrimitiveMeshGenerator",
+    "PrimitiveShape",
+]


### PR DESCRIPTION
The previous `model_generation/mesh/__init__.py` defined `__all__` inside a
`try` block without actually importing anything, leaving the package
with no usable public API.

Re-export the full mesh processing API from `humanoid_character_builder.mesh`:
- MeshProcessor, MeshSegmentResult, MeshExportConfig
- PrimitiveMeshGenerator
- MeshInertiaCalculator, PrimitiveInertiaCalculator, InertiaResult, InertiaMode
- LODGenerator, LODLevel, LODGenerationResult
- CollisionGeometry, CollisionGeometryGenerator
- PrimitiveShape

Non-breaking change — existing deep imports continue to work.
