### PR TITLE
fix(model_generation/humanoid): re-export public API from humanoid_character_builder

### DIFF
--- a/src/shared/python/model_generation/humanoid/__init__.py
+++ b/src/shared/python/model_generation/humanoid/__init__.py
@@ -7,53 +7,93 @@ for integration with the unified model_generation package.
 
 from __future__ import annotations
 
-# Import from humanoid_character_builder
-try:
-    from humanoid_character_builder.core.body_parameters import (
-        BodyParameters,
-        BuildType,
-        GenderModel,
-    )
-    from humanoid_character_builder.presets.loader import (
-        load_body_preset,
-    )
+from humanoid_character_builder import (
+    AnthropometryData,
+    BodyParameters,
+    CharacterBuilder,
+    CharacterBuildResult,
+    HumanoidURDFGenerator,
+    InertiaMode,
+    InertiaResult,
+    MeshInertiaCalculator,
+    PrimitiveInertiaCalculator,
+    PrimitiveShape,
+    URDFGeneratorConfig,
+    get_segment_length_ratio,
+    get_segment_mass_ratio,
+)
 
-    __all__ = [
-        # Body parameters
-        "BodyParameters",
-        "BuildType",
-        "GenderModel",
-        "AppearanceParameters",
-        "SegmentParameters",
-        # Anthropometry
-        "DE_LEVA_DATA",
-        "estimate_segment_masses",
-        "estimate_segment_dimensions",
-        "estimate_segment_inertia_from_gyration",
-        "get_segment_mass_ratio",
-        "get_segment_length_ratio",
-        "get_com_location",
-        # Segments
-        "HUMANOID_SEGMENTS",
-        "SegmentDefinition",
-        # Presets
-        "PRESET_NAMES",
-        "load_body_preset",
-        "list_available_presets",
-        "get_preset_info",
-    ]
+from humanoid_character_builder.core.anthropometry import (
+    DE_LEVA_DATA,
+    estimate_segment_dimensions,
+    estimate_segment_inertia_from_gyration,
+    estimate_segment_masses,
+    get_com_location,
+)
+from humanoid_character_builder.core.body_parameters import (
+    AppearanceParameters,
+    BuildType,
+    GenderModel,
+    SegmentParameters,
+)
+from humanoid_character_builder.core.segment_definitions import (
+    HUMANOID_JOINTS,
+    HUMANOID_SEGMENTS,
+    JointDefinition,
+    SegmentDefinition,
+)
+from humanoid_character_builder.interfaces import (
+    ExportOptions,
+    SegmentMeshInfo,
+    quick_build,
+    quick_urdf,
+)
+from humanoid_character_builder.presets.loader import (
+    PRESET_NAMES,
+    get_preset_info,
+    list_available_presets,
+    load_body_preset,
+)
 
-except ImportError:
-    # humanoid_character_builder not available
-    __all__ = []
-
-    def _not_available(*args, **kwargs) -> None:
-        raise ImportError(
-            "humanoid_character_builder not available. Ensure it is in the Python path."
-        )
-
-    # Create stubs
-    BodyParameters = _not_available
-    BuildType = _not_available
-    GenderModel = _not_available
-    load_body_preset = _not_available
+__all__: list[str] = [
+    # Body parameters
+    "BodyParameters",
+    "BuildType",
+    "GenderModel",
+    "AppearanceParameters",
+    "SegmentParameters",
+    # Anthropometry
+    "DE_LEVA_DATA",
+    "estimate_segment_masses",
+    "estimate_segment_dimensions",
+    "estimate_segment_inertia_from_gyration",
+    "get_segment_mass_ratio",
+    "get_segment_length_ratio",
+    "get_com_location",
+    "AnthropometryData",
+    # Segments
+    "HUMANOID_SEGMENTS",
+    "HUMANOID_JOINTS",
+    "SegmentDefinition",
+    "JointDefinition",
+    # Presets
+    "PRESET_NAMES",
+    "load_body_preset",
+    "list_available_presets",
+    "get_preset_info",
+    # Generators / API
+    "CharacterBuilder",
+    "CharacterBuildResult",
+    "ExportOptions",
+    "SegmentMeshInfo",
+    "HumanoidURDFGenerator",
+    "URDFGeneratorConfig",
+    "quick_build",
+    "quick_urdf",
+    # Inertia
+    "InertiaMode",
+    "InertiaResult",
+    "MeshInertiaCalculator",
+    "PrimitiveInertiaCalculator",
+    "PrimitiveShape",
+]


### PR DESCRIPTION
The previous `model_generation/humanoid/__init__.py` declared `__all__`
inside a `try` block without actually importing anything, leaving the
package with no usable public API.

Re-export the full humanoid model generation API:
- BodyParameters, BuildType, GenderModel, AppearanceParameters, SegmentParameters
- Anthropometry: DE_LEVA_DATA, estimate_segment_masses, estimate_segment_dimensions,
  estimate_segment_inertia_from_gyration, get_com_location
- Segment definitions: HUMANOID_SEGMENTS, HUMANOID_JOINTS, SegmentDefinition, JointDefinition
- Presets: PRESET_NAMES, load_body_preset, list_available_presets, get_preset_info
- CharacterBuilder, CharacterBuildResult, ExportOptions, SegmentMeshInfo, quick_build, quick_urdf
- URDF generation: HumanoidURDFGenerator, URDFGeneratorConfig
- Inertia: InertiaMode, InertiaResult, MeshInertiaCalculator, PrimitiveInertiaCalculator, PrimitiveShape

Non-breaking change — existing deep imports continue to work.
