### PR TITLE
fix(bunkershot3d/backends): expose public API through __init__.py exports

### DIFF
--- a/src/bunkershot3d/backends/__init__.py
+++ b/src/bunkershot3d/backends/__init__.py
@@ -1,3 +1,11 @@
-"""
-Backend drivers for BunkerShot3D.
-"""
+"""Backend drivers for BunkerShot3D."""
+
+from .chrono.driver import ChronoDriver
+from .liggghts.driver import LiggghtsDriver
+from .mpm.driver import MPMDriver
+
+__all__: list[str] = [
+    "ChronoDriver",
+    "LiggghtsDriver",
+    "MPMDriver",
+]

--- a/src/bunkershot3d/backends/chrono/__init__.py
+++ b/src/bunkershot3d/backends/chrono/__init__.py
@@ -1,3 +1,5 @@
-"""
-Chrono backend driver.
-"""
+"""Chrono backend driver."""
+
+from .driver import ChronoDriver
+
+__all__: list[str] = ["ChronoDriver"]

--- a/src/bunkershot3d/backends/liggghts/__init__.py
+++ b/src/bunkershot3d/backends/liggghts/__init__.py
@@ -1,3 +1,5 @@
-"""
-LIGGGHTS backend driver.
-"""
+"""LIGGGHTS backend driver."""
+
+from .driver import LiggghtsDriver
+
+__all__: list[str] = ["LiggghtsDriver"]

--- a/src/bunkershot3d/backends/mpm/__init__.py
+++ b/src/bunkershot3d/backends/mpm/__init__.py
@@ -1,3 +1,5 @@
-"""
-MPM backend driver.
-"""
+"""MPM backend driver."""
+
+from .driver import MPMDriver
+
+__all__: list[str] = ["MPMDriver"]


### PR DESCRIPTION
Previously the backends package and all subpackages had empty __init__.py files, forcing consumers to reach into driver modules directly.

This PR re-exports ChronoDriver, LiggghtsDriver, and MPMDriver.

Non-breaking change — existing deep imports continue to work.