### PR TITLE
fix(bunkershot3d): expose public API in all subpackage __init__.py files

### DIFF
--- a/src/bunkershot3d/calibration/__init__.py
+++ b/src/bunkershot3d/calibration/__init__.py
@@ -1,3 +1,13 @@
 """
 Calibration module for BunkerShot3D.
 """
+
+from .angle_of_repose import AngleOfReposeExperiment
+from .drained_shear_cell import DrainedShearCellExperiment
+from .optimizer import CalibrationOptimizer
+
+__all__: list[str] = [
+    "AngleOfReposeExperiment",
+    "CalibrationOptimizer",
+    "DrainedShearCellExperiment",
+]

--- a/src/bunkershot3d/geometry/__init__.py
+++ b/src/bunkershot3d/geometry/__init__.py
@@ -1,3 +1,9 @@
 """
 Geometry module for BunkerShot3D.
 """
+
+from .clubhead import ClubheadGenerator
+
+__all__: list[str] = [
+    "ClubheadGenerator",
+]

--- a/src/bunkershot3d/io/__init__.py
+++ b/src/bunkershot3d/io/__init__.py
@@ -1,3 +1,10 @@
 """
 I/O module for BunkerShot3D.
 """
+
+from .schema import BunkerShotResultReader, BunkerShotResultWriter
+
+__all__: list[str] = [
+    "BunkerShotResultReader",
+    "BunkerShotResultWriter",
+]

--- a/src/bunkershot3d/kinematics/__init__.py
+++ b/src/bunkershot3d/kinematics/__init__.py
@@ -1,3 +1,13 @@
 """
 Kinematics module for BunkerShot3D.
 """
+
+from .coupling import CoSimulator, MockDoublePendulum
+from .trajectory import SwingTrajectory, generate_reference_trajectory
+
+__all__: list[str] = [
+    "CoSimulator",
+    "MockDoublePendulum",
+    "SwingTrajectory",
+    "generate_reference_trajectory",
+]

--- a/src/bunkershot3d/postproc/__init__.py
+++ b/src/bunkershot3d/postproc/__init__.py
@@ -1,3 +1,9 @@
 """
 Post-processing module for BunkerShot3D results.
 """
+
+from .wrench_trace import WrenchTrace
+
+__all__: list[str] = [
+    "WrenchTrace",
+]


### PR DESCRIPTION
Five bunkershot3d subpackages had empty `__init__.py` files (docstring only), forcing every consumer to reach into submodules directly.

This PR exposes the stable public API:

- kinematics: SwingTrajectory, MockDoublePendulum, CoSimulator, generate_reference_trajectory
- geometry: ClubheadGenerator
- io: BunkerShotResultWriter, BunkerShotResultReader
- postproc: WrenchTrace
- calibration: AngleOfReposeExperiment, DrainedShearCellExperiment, CalibrationOptimizer

Non-breaking change — existing deep imports continue to work.