### PR TITLE
fix(reinforcement_learning): expose TrajectoryFunnelBenchmark in __init__.py

### DIFF
--- a/src/reinforcement_learning/__init__.py
+++ b/src/reinforcement_learning/__init__.py
@@ -1,0 +1,7 @@
+"""Reinforcement learning benchmarking tools."""
+
+from .trajectory_funnel_benchmark import TrajectoryFunnelBenchmark
+
+__all__: list[str] = [
+    "TrajectoryFunnelBenchmark",
+]


### PR DESCRIPTION
Previously `src/reinforcement_learning/__init__.py` was empty (0 lines), so nothing was exported from the package. Consumers had to reach into `trajectory_funnel_benchmark` directly.

Expose `TrajectoryFunnelBenchmark` and its reward/convergence API.

Non-breaking change — existing deep imports continue to work.