### PR TITLE
fix(config): expose launcher manifest API through __init__.py

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,23 @@
+"""Launcher manifest configuration."""
+
+from .launcher_manifest_loader import (
+    ASSETS_DIR,
+    LAUNCHER_CATEGORIES,
+    LAUNCHER_CATEGORY_LABELS,
+    MANIFEST_PATH,
+    REGISTRY_PATH,
+    TOOL_LIKE_CATEGORIES,
+    LauncherManifest,
+    LauncherTile,
+)
+
+__all__: list[str] = [
+    "ASSETS_DIR",
+    "LAUNCHER_CATEGORIES",
+    "LAUNCHER_CATEGORY_LABELS",
+    "MANIFEST_PATH",
+    "REGISTRY_PATH",
+    "TOOL_LIKE_CATEGORIES",
+    "LauncherManifest",
+    "LauncherTile",
+]


### PR DESCRIPTION
Previously `src/config/__init__.py` was empty (0 lines), forcing consumers to import from `launcher_manifest_loader` directly.

Expose the stable public API:
- LauncherTile, LauncherManifest
- Category constants (LAUNCHER_CATEGORIES, LAUNCHER_CATEGORY_LABELS, TOOL_LIKE_CATEGORIES)
- Path constants (MANIFEST_PATH, ASSETS_DIR, REGISTRY_PATH)

Non-breaking change — existing deep imports continue to work.