### PR TITLE
fix(api/auth): expose auth public API through __init__.py

### DIFF
--- a/src/api/auth/__init__.py
+++ b/src/api/auth/__init__.py
@@ -1,1 +1,55 @@
-# Authentication and authorization module
+"""Authentication and authorization."""
+
+from .dependencies import (
+    get_current_user,
+    get_current_user_flexible,
+    get_current_user_from_api_key,
+    require_role,
+)
+from .middleware import LocalUser, OptionalAuth
+from .models import (
+    APIKey,
+    APIKeyCreate,
+    APIKeyResponse,
+    LoginRequest,
+    LoginResponse,
+    RefreshTokenRequest,
+    Session,
+    SubscriptionStatus,
+    UsageQuotas,
+    User,
+    UserBase,
+    UserCreate,
+    UserResponse,
+    UserRole,
+    UserUpdate,
+)
+from .security import AuthCache, RoleChecker, SecurityManager, UsageTracker
+
+__all__: list[str] = [
+    "APIKey",
+    "APIKeyCreate",
+    "APIKeyResponse",
+    "AuthCache",
+    "LocalUser",
+    "LoginRequest",
+    "LoginResponse",
+    "OptionalAuth",
+    "RefreshTokenRequest",
+    "RoleChecker",
+    "SecurityManager",
+    "Session",
+    "SubscriptionStatus",
+    "UsageQuotas",
+    "UsageTracker",
+    "User",
+    "UserBase",
+    "UserCreate",
+    "UserResponse",
+    "UserRole",
+    "UserUpdate",
+    "get_current_user",
+    "get_current_user_flexible",
+    "get_current_user_from_api_key",
+    "require_role",
+]


### PR DESCRIPTION
Previously `src/api/auth/__init__.py` was just a bare comment, forcing consumers to reach into `dependencies`, `middleware`, `models`, and `security` submodules directly.

Expose the stable public API:
- Auth dependencies (get_current_user, get_current_user_flexible, get_current_user_from_api_key, require_role)
- Middleware types (LocalUser, OptionalAuth)
- Auth models (User, APIKey, Session, UserRole, LoginRequest, etc.)
- Security (SecurityManager, RoleChecker, UsageTracker, AuthCache)

Non-breaking change — existing deep imports continue to work.