### PR TITLE
fix(api/middleware): expose middleware API through __init__.py

### DIFF
--- a/src/api/middleware/__init__.py
+++ b/src/api/middleware/__init__.py
@@ -1,1 +1,20 @@
 """API middleware utilities."""
+
+from .error_handler import handle_api_errors
+from .security_headers import add_security_headers, add_security_headers_to_response
+from .upload_limits import (
+    iter_upload_file_chunks,
+    read_upload_file_bytes,
+    validate_upload_size,
+    write_upload_file_to_path,
+)
+
+__all__: list[str] = [
+    "add_security_headers",
+    "add_security_headers_to_response",
+    "handle_api_errors",
+    "iter_upload_file_chunks",
+    "read_upload_file_bytes",
+    "validate_upload_size",
+    "write_upload_file_to_path",
+]


### PR DESCRIPTION
Previously `src/api/middleware/__init__.py` was just a bare docstring, forcing consumers to reach into submodules directly.

Expose the stable public API:
- handle_api_errors
- add_security_headers, add_security_headers_to_response
- upload limit helpers (validate_upload_size, iter_upload_file_chunks, etc.)

Non-breaking change — existing deep imports continue to work.