### PR TITLE
fix(api/models): expose model types through __init__.py

### DIFF
--- a/src/api/models/__init__.py
+++ b/src/api/models/__init__.py
@@ -1,1 +1,46 @@
-# API models package
+"""API models."""
+
+from .chat import ChatMessageRequest, ChatModelInput, ChatModelOutput, style_prompt
+from .requests import (
+    AnalysisRequest,
+    BatchRequest,
+    ComparisonRequest,
+    ExportRequest,
+    FilterRequest,
+    PaginatedRequest,
+    SimulationRequest,
+)
+from .responses import (
+    AnalysisResponse,
+    BatchResponse,
+    ComparisonResponse,
+    ErrorResponse,
+    ExportResponse,
+    PaginatedResponse,
+    SimulationResponse,
+    StatusResponse,
+    SuccessResponse,
+)
+
+__all__: list[str] = [
+    "AnalysisRequest",
+    "AnalysisResponse",
+    "BatchRequest",
+    "BatchResponse",
+    "ChatMessageRequest",
+    "ChatModelInput",
+    "ChatModelOutput",
+    "ComparisonRequest",
+    "ComparisonResponse",
+    "ErrorResponse",
+    "ExportRequest",
+    "ExportResponse",
+    "FilterRequest",
+    "PaginatedRequest",
+    "PaginatedResponse",
+    "SimulationRequest",
+    "SimulationResponse",
+    "StatusResponse",
+    "SuccessResponse",
+    "style_prompt",
+]


### PR DESCRIPTION
Previously src/api/models/__init__.py was just a bare comment, forcing consumers to reach into submodules directly.

Expose the stable public API:
- Chat types (ChatMessageRequest, ChatModelInput, ChatModelOutput, style_prompt)
- Request types (AnalysisRequest, SimulationRequest, BatchRequest, etc.)
- Response types (AnalysisResponse, ErrorResponse, PaginatedResponse, etc.)

Non-breaking change — existing deep imports continue to work.