### PR TITLE
fix(api/routes): expose public API through __init__.py exports

### DIFF
--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -1,3 +1,13 @@
-"""
-Auto-generated __init__.py
-"""
+"""API route registration."""
+
+from .launcher import router as launcher_router
+from .models import router as models_router
+from .physics import router as physics_router
+from .simulation import router as simulation_router
+
+__all__: list[str] = [
+    "launcher_router",
+    "models_router",
+    "physics_router",
+    "simulation_router",
+]


### PR DESCRIPTION
Previously `src/api/routes/__init__.py` exported nothing (`__all__ = []`), forcing every consumer to reach into submodules directly.

Expose the stable public API:
- launcher_router
- models_router
- physics_router
- simulation_router

Non-breaking change — existing deep imports continue to work.