### PR TITLE
fix(api/services): expose public API through __init__.py exports

### DIFF
--- a/src/api/services/__init__.py
+++ b/src/api/services/__init__.py
@@ -1,1 +1,14 @@
-# API services package
+"""API business-logic services."""
+
+from .analysis_service import AnalysisService
+from .chat_service import ChatService
+from .launcher_service import LauncherService
+from .simulation_service import SimulationService, SimulationStats
+
+__all__: list[str] = [
+    "AnalysisService",
+    "ChatService",
+    "LauncherService",
+    "SimulationService",
+    "SimulationStats",
+]


### PR DESCRIPTION
Previously `src/api/services/__init__.py` was empty, forcing every consumer to reach into submodules directly.

Expose the stable public API:
- AnalysisService
- ChatService
- LauncherService
- SimulationService
- SimulationStats

Non-breaking change — existing deep imports continue to work.