### PR TITLE
fix(api/aip): expose public API through __init__.py exports

### DIFF
--- a/src/api/aip/__init__.py
+++ b/src/api/aip/__init__.py
@@ -2,6 +2,13 @@
 
 Provides a JSON-RPC 2.0 interface for external tool integration
 with UpstreamDrift simulation and analysis capabilities.
-
-See issue #763
 """
+
+from .dispatcher import dispatch
+from .methods import MethodRegistry, create_registry
+
+__all__: list[str] = [
+    "MethodRegistry",
+    "create_registry",
+    "dispatch",
+]


### PR DESCRIPTION
Previously `src/api/aip/__init__.py` only contained a docstring, forcing consumers to reach into submodules directly.

Expose the stable public API:
- MethodRegistry
- create_registry
- dispatch

Non-breaking change — existing deep imports continue to work.