### PR TITLE
fix(api): expose public API through __init__.py exports

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,1 +1,72 @@
-# API package for Golf Modeling Suite
+"""API package for Golf Modeling Suite."""
+
+from .auth import (
+    APIKeyAuth,
+    OAuth2Config,
+    RateLimitConfig,
+    TokenManager,
+    generate_token,
+    get_current_user,
+    refresh_token,
+    require_auth,
+    validate_token,
+)
+from .middleware import (
+    add_security_headers,
+    get_upload_limit_mb,
+    handle_api_errors,
+)
+from .models import (
+    ChatMessageCreate,
+    ChatRequest,
+    ChatResponse,
+    PhysicsAnalysisResponse,
+    PhysicsRequest,
+)
+from .routes import (
+    launcher_router,
+    models_router,
+    physics_router,
+    simulation_router,
+)
+from .services import (
+    AnalysisService,
+    ChatService,
+    LauncherService,
+    SimulationService,
+    SimulationStats,
+)
+
+__all__: list[str] = [
+    # auth
+    "APIKeyAuth",
+    "OAuth2Config",
+    "RateLimitConfig",
+    "TokenManager",
+    "generate_token",
+    "get_current_user",
+    "refresh_token",
+    "require_auth",
+    "validate_token",
+    # middleware
+    "add_security_headers",
+    "get_upload_limit_mb",
+    "handle_api_errors",
+    # models
+    "ChatMessageCreate",
+    "ChatRequest",
+    "ChatResponse",
+    "PhysicsAnalysisResponse",
+    "PhysicsRequest",
+    # routes
+    "launcher_router",
+    "models_router",
+    "physics_router",
+    "simulation_router",
+    # services
+    "AnalysisService",
+    "ChatService",
+    "LauncherService",
+    "SimulationService",
+    "SimulationStats",
+]


### PR DESCRIPTION
Previously `src/api/__init__.py` was empty, forcing every consumer to reach into submodules directly.

Expose the stable public API from all api subpackages:
- auth: APIKeyAuth, OAuth2Config, RateLimitConfig, TokenManager, helpers
- middleware: error handling, security headers, upload limits
- models: ChatRequest, ChatResponse, PhysicsRequest, PhysicsAnalysisResponse
- routes: launcher_router, models_router, physics_router, simulation_router
- services: AnalysisService, ChatService, LauncherService, SimulationService, SimulationStats

Non-breaking change — existing deep imports continue to work.