### PR TITLE
fix(tools): expose public API through __init__.py exports

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -2,3 +2,29 @@
 
 Contains utilities for URDF generation, MATLAB integration, and other tools.
 """
+
+from .check_markdown_links import check_links, extract_links_from_markdown, resolve_and_verify_link
+from .code_quality_check import (
+    Colors,
+    check_ast_issues,
+    check_banned_patterns,
+    check_file,
+    check_magic_numbers,
+    is_legitimate_pass_context,
+    main,
+)
+
+__all__: list[str] = [
+    # check_markdown_links
+    "check_links",
+    "extract_links_from_markdown",
+    "resolve_and_verify_link",
+    # code_quality_check
+    "Colors",
+    "check_ast_issues",
+    "check_banned_patterns",
+    "check_file",
+    "check_magic_numbers",
+    "is_legitimate_pass_context",
+    "main",
+]


### PR DESCRIPTION
Previously `src/tools/__init__.py` only contained a docstring, forcing consumers to reach into submodules directly.

Expose the stable public API:
- check_markdown_links helpers
- code_quality_check helpers and Colors class

Non-breaking change — existing deep imports continue to work.