### PR TITLE
fix(matlab_utilities): add explicit __all__ to package __init__.py

### DIFF
--- a/src/tools/matlab_utilities/__init__.py
+++ b/src/tools/matlab_utilities/__init__.py
@@ -1,1 +1,3 @@
 """MATLAB utilities package for Golf Modeling Suite."""
+
+__all__: list[str] = []


### PR DESCRIPTION
Add an explicit `__all__` to `src/tools/matlab_utilities/__init__.py` since it previously had none, which can lead to unexpected wildcard import behavior. The package currently contains only MATLAB scripts.