### PR TITLE
fix(launchers): expose public API through __init__.py exports

### DIFF
--- a/src/launchers/__init__.py
+++ b/src/launchers/__init__.py
@@ -1,6 +1,19 @@
 """Launchers namespace package.
 
 Contains entry-point launcher modules for the various physics engines and GUI
-front-ends.  This package is a structural namespace marker; individual launcher
-modules are invoked directly (e.g. via ``python3 -m src.launchers.golf_launcher``).
+front-ends.
 """
+
+from .about_dialog import build_about_html, gather_version_info, show_about_dialog
+from .base import BaseLauncher, LaunchItem, run_launcher
+from .shot_tracer import main as shot_tracer_main
+
+__all__: list[str] = [
+    "BaseLauncher",
+    "LaunchItem",
+    "build_about_html",
+    "gather_version_info",
+    "run_launcher",
+    "show_about_dialog",
+    "shot_tracer_main",
+]


### PR DESCRIPTION
Previously `src/launchers/__init__.py` only contained a docstring, forcing consumers to reach into submodules directly.

Expose the stable public API:
- BaseLauncher, LaunchItem, run_launcher
- show_about_dialog, build_about_html, gather_version_info
- shot_tracer_main

Non-breaking change — existing deep imports continue to work.