### PR TITLE
fix(launchers/assets): expose public API through __init__.py exports

### DIFF
--- a/src/launchers/assets/__init__.py
+++ b/src/launchers/assets/__init__.py
@@ -1,3 +1,37 @@
-"""
-Auto-generated __init__.py
-"""
+"""Launcher asset utilities: tile image generation and asset optimization."""
+
+from .generate_tile_images import (
+    TILE_CONFIGS,
+    create_png,
+    draw_letter,
+    draw_rounded_rect_with_text,
+    generate_all_tiles,
+    hex_to_rgb,
+)
+from .optimize_assets import (
+    ICON_SIZES,
+    MAX_ICON_SIZE_KB,
+    MAX_IMAGE_SIZE_KB,
+    analyze_assets,
+    check_dependencies,
+    get_image_info,
+    main,
+    optimize_png,
+)
+
+__all__: list[str] = [
+    "ICON_SIZES",
+    "MAX_ICON_SIZE_KB",
+    "MAX_IMAGE_SIZE_KB",
+    "TILE_CONFIGS",
+    "analyze_assets",
+    "check_dependencies",
+    "create_png",
+    "draw_letter",
+    "draw_rounded_rect_with_text",
+    "generate_all_tiles",
+    "get_image_info",
+    "hex_to_rgb",
+    "main",
+    "optimize_png",
+]


### PR DESCRIPTION
Previously `src/launchers/assets/__init__.py` was an auto-generated stub that exported nothing, forcing consumers to reach into individual submodules directly.

Expose the stable public API:
- Tile generation: TILE_CONFIGS, hex_to_rgb, create_png, draw_rounded_rect_with_text, draw_letter, generate_all_tiles
- Asset optimization: ICON_SIZES, MAX_ICON_SIZE_KB, MAX_IMAGE_SIZE_KB, check_dependencies, get_image_info, optimize_png, analyze_assets, main

Non-breaking change — existing deep imports continue to work.