### PR TITLE
fix(bunkershot3d): expose root package public API

### DIFF
--- a/src/bunkershot3d/__init__.py
+++ b/src/bunkershot3d/__init__.py
@@ -1,5 +1,43 @@
-"""
-BunkerShot3D: A 3-D simulation of a golf bunker shot in which a clubhead impacts a bed of granular sand.
+"""BunkerShot3D: A 3-D simulation of a golf bunker shot.
+
+Re-exports the public API from all subpackages so consumers can import
+directly from \`bunkershot3d\` instead of reaching into submodules.
 """
 
 __version__ = "0.1.0"
+
+# Backend drivers
+from .backends import ChronoDriver, LiggghtsDriver, MPMDriver
+
+# Calibration
+from .calibration import AngleOfReposeExperiment, CalibrationOptimizer, DrainedShearCellExperiment
+
+# Geometry
+from .geometry import ClubheadGenerator
+
+# I/O
+from .io import BunkerShotResultReader, BunkerShotResultWriter
+
+# Kinematics
+from .kinematics import CoSimulator, MockDoublePendulum, SwingTrajectory, generate_reference_trajectory
+
+# Post-processing
+from .postproc import WrenchTrace
+
+__all__: list[str] = [
+    "AngleOfReposeExperiment",
+    "BunkerShotResultReader",
+    "BunkerShotResultWriter",
+    "CalibrationOptimizer",
+    "ChronoDriver",
+    "ClubheadGenerator",
+    "CoSimulator",
+    "DrainedShearCellExperiment",
+    "LiggghtsDriver",
+    "MPMDriver",
+    "MockDoublePendulum",
+    "SwingTrajectory",
+    "WrenchTrace",
+    "__version__",
+    "generate_reference_trajectory",
+]


### PR DESCRIPTION
Previously `src/bunkershot3d/__init__.py` only defined `__version__` but exported no symbols, forcing every consumer to import from deep submodules directly.

Expose the stable public API by re-exporting from the fixed subpackages:
- Backend drivers: ChronoDriver, LiggghtsDriver, MPMDriver
- Calibration: AngleOfReposeExperiment, DrainedShearCellExperiment, CalibrationOptimizer
- Geometry: ClubheadGenerator
- I/O: BunkerShotResultReader, BunkerShotResultWriter
- Kinematics: CoSimulator, MockDoublePendulum, SwingTrajectory, generate_reference_trajectory
- Post-processing: WrenchTrace

Non-breaking change — existing deep imports continue to work.