### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure deserialization via np.load

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -88,3 +88,8 @@
 **Vulnerability:** Arbitrary Code Execution via `np.load(..., allow_pickle=True)`
 **Learning:** Legacy ML saving routines (`_bc.py`, `_gail.py`) directly dumped nested dictionaries (neural net layers, training config) into `.npz` files, which mandated `allow_pickle=True` to reload. This creates a critical insecure deserialization vulnerability.
 **Prevention:** Always flatten complex objects before saving. Serialize dictionaries or configurations into JSON strings, and extract individual layer weights (`W`, `b`) into separate numpy arrays with a primitive naming schema (`layer_0_W`, `layer_0_b`). This pattern completely eliminates the need for Python pickling during deserialization.
+## 2024-05-15 - Insecure Deserialization via np.load
+
+**Vulnerability:** Found uses of `np.load` without explicitly passing `allow_pickle=False` when loading `.npy` and `.npz` files (e.g., in `src/shared/python/physics/_topography_io.py`, `src/shared/python/pose_interchange/pose_io.py`, `src/engines/physics_engines/putting_green/python/_green_loader.py`, `src/engines/physics_engines/putting_green/python/_surface_io.py`).
+**Learning:** `np.load` in older numpy versions and by default can allow loading pickled python objects which is prone to arbitrary code execution attacks. Always explicitly pass `allow_pickle=False` unless absolutely necessary and loading trusted data.
+**Prevention:** Explicitly pass `allow_pickle=False` when using `np.load` or `np.savez`.

--- a/src/engines/physics_engines/putting_green/python/_green_loader.py
+++ b/src/engines/physics_engines/putting_green/python/_green_loader.py
@@ -135,7 +135,7 @@ def load_topographical_data(
         sim.green.height = height
 
     if suffix == ".npy":
-        heightmap = np.load(filepath)
+        heightmap = np.load(filepath, allow_pickle=False)
         sim.green.set_heightmap(heightmap)
     elif suffix == ".csv" or suffix in (".tif", ".tiff"):
         sim.green.load_from_file(filepath)

--- a/src/engines/physics_engines/putting_green/python/_surface_io.py
+++ b/src/engines/physics_engines/putting_green/python/_surface_io.py
@@ -30,7 +30,7 @@ class SurfaceIOMixin:
         suffix = filepath.suffix.lower()
 
         if suffix == ".npy":
-            heightmap = np.load(filepath)
+            heightmap = np.load(filepath, allow_pickle=False)
             self.set_heightmap(heightmap)  # type: ignore[attr-defined]
 
         elif suffix == ".csv":

--- a/src/shared/python/physics/_topography_io.py
+++ b/src/shared/python/physics/_topography_io.py
@@ -73,7 +73,7 @@ class _TopographyIOMixin:
             raise ValueError("filepath must be provided")
         if not (filepath is not None):
             raise ValueError("filepath must be provided")
-        heightmap = np.load(filepath)
+        heightmap = np.load(filepath, allow_pickle=False)
 
         if width is not None:
             self._bounds.max_x = self._bounds.min_x + width

--- a/src/shared/python/pose_interchange/pose_io.py
+++ b/src/shared/python/pose_interchange/pose_io.py
@@ -208,7 +208,7 @@ def _load_pinocchio(path: Path) -> CanonicalPose:
     actual: Path | None = next((c for c in candidates if c.exists()), None)
     if actual is None:
         raise FileNotFoundError(f"pinocchio archive not found: {path}")
-    with np.load(actual) as bundle:
+    with np.load(actual, allow_pickle=False) as bundle:
         if "q" not in bundle.files:
             raise ValueError(f"{actual}: pinocchio archive missing required 'q' array")
         q = np.asarray(bundle["q"], dtype=float)

--- a/tests/unit/test_c3d_export_features.py
+++ b/tests/unit/test_c3d_export_features.py
@@ -139,7 +139,7 @@ class TestC3DExportFeatures:
             sample_dataframe, str(output_path), file_format="npz"
         )
 
-        with np.load(output_path) as archive:
+        with np.load(output_path, allow_pickle=False) as archive:
             assert "_metadata" in archive
             meta = json.loads(str(archive["_metadata"]))
             assert meta["schema_version"] == SCHEMA_VERSION


### PR DESCRIPTION
🚨 Severity: CRITICAL\n💡 Vulnerability: Used np.load without explicit allow_pickle=False\n🎯 Impact: An attacker who can supply a malicious .npz or .npy file can trigger arbitrary code execution upon load.\n🔧 Fix: Explicitly set allow_pickle=False\n✅ Verification: Tests passing

---
*PR created automatically by Jules for task [11258414184007093725](https://jules.google.com/task/11258414184007093725) started by @dieterolson*