### PR TITLE
fix(body_part_viz): cast delta to float64 before einsum norm (Fixes #5451)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-04-29
+  LAST UPDATED: 2026-05-15
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.

--- a/src/shared/python/body_part_viz/fitters/between_two.py
+++ b/src/shared/python/body_part_viz/fitters/between_two.py
@@ -80,7 +80,7 @@ class BetweenTwoMarkersFitter:
         b_valid = marker_b[idx]
 
         midpoint = 0.5 * (a_valid + b_valid)
-        delta = b_valid - a_valid
+        delta = (b_valid - a_valid).astype(np.float64)
         length = np.linalg.norm(delta, axis=1)
 
         # DbC: collinear markers (zero-length segment) cannot define orientation.


### PR DESCRIPTION
Cast `delta` to `float64` before norm computation in `BetweenTwoMarkersFitter`.

`np.einsum` accumulates in the input dtype, so `int32` deltas overflow above ~46340 per axis, producing negative sums and `nan` lengths. `np.linalg.norm` promoted to float automatically; this explicit cast restores that safety and guards against future performance optimisations (e.g. swapping back to `einsum`) re-introducing the regression.

Fixes #5451