### PR TITLE
fix: repair broken config and data_io __init__.py re-exports

### DIFF
--- a/docs/development/sidekick_parity.md
+++ b/docs/development/sidekick_parity.md
@@ -1,0 +1,102 @@
+# Sidekick Chat Surface Parity
+
+Tracks the parity status between the React (browser) and PyQt (desktop) chat
+surfaces. Both surfaces connect to the same FastAPI WebSocket endpoint at
+`/ws/chat/{session_id}`.
+
+## Current state: PyQt surface
+
+File: `src/shared/python/chat/_chat_dock_widget_qt.py`
+
+| Feature | Status |
+|---------|--------|
+| WebSocket connect / reconnect (3 s fixed) | Present |
+| Session ID — file-persisted + class-level shared | Present |
+| `session_info` server message | Handled |
+| `chunk` streaming | Handled (append_content) |
+| `complete` message | Handled |
+| `session_created` message | Handled |
+| `history` message | Handled |
+| `model_list` message | Handled (emits `models_refreshed` signal) |
+| `index_status` message | Handled (emits `index_status_changed` signal) |
+| `error` message | Handled (shown in status label) |
+| `refresh_models` action | Sends |
+| `index_codebase` action | Sends |
+| Outgoing context field name | `app_context` |
+
+## Current state: React surface
+
+File: `ui/src/components/ui/ChatPanel.tsx`
+
+| Feature | Status |
+|---------|--------|
+| WebSocket connect / reconnect (exp. backoff, 500ms..30s) | Present |
+| Session ID — component state (not persisted to disk) | Present |
+| `session_info` server message | Handled |
+| `chunk` streaming | Handled (append to assistant message) |
+| `complete` message | Handled |
+| `session_created` message | Handled |
+| `history` message | Handled |
+| `model_list` message | **Missing** |
+| `index_status` message | **Missing** |
+| `error` message | Handled (shown as system role message) |
+| `refresh_models` action | **Not sent** |
+| `index_codebase` action | **Not sent** |
+| Outgoing context field name | `engine_context` |
+
+## Server surfaces
+
+| File | `app_context` key | `engine_context` key |
+|------|-------------------|---------------------|
+| `src/api/routes/chat_ws.py` | Not read | Read |
+| `src/shared/python/chat/router_factory.py` | Read (with `or` fallback) | Read (with `or` fallback) |
+
+## Parity gaps found
+
+### Gap 1 — `app_context` vs `engine_context` field name drift (CRITICAL)
+
+- PyQt sends `app_context`; React sends `engine_context`.
+- The shared `router_factory.py` correctly accepts both via
+  `msg.get("app_context") or msg.get("engine_context")`.
+- The app-level `src/api/routes/chat_ws.py` only reads `engine_context`,
+  silently discarding `app_context` from PyQt clients.
+
+**Fix:** Align `chat_ws.py` to read both keys, matching `router_factory.py`.
+No client changes needed.
+
+### Gap 2 — React missing `model_list` and `index_status` handler (MEDIUM)
+
+The server pushes `model_list` responses to `refresh_models` requests and
+periodic `index_status` events after `index_codebase`. React currently ignores
+these frames (falls through the `default: break` branch), so:
+- Model list updates are silently dropped.
+- Codebase indexing progress is invisible in the browser UI.
+
+**Fix:** Add `model_list` and `index_status` handlers to `handleServerMessage`
+and expose them via the `ServerMessage` TypeScript interface.
+
+### Gap 3 — React missing `refresh_models` / `index_codebase` actions (LOW)
+
+PyQt auto-sends `refresh_models` on connect and can send `index_codebase`.
+React never sends these. Until a React settings panel is added, this gap is
+acceptable but must be documented.
+
+**Deferred:** Sending `refresh_models` on connect is a low-risk improvement;
+`index_codebase` requires a settings UI not yet present.
+
+### Gap 4 — Reconnect strategy divergence (LOW)
+
+PyQt uses a fixed 3-second reconnect timer. React uses exponential backoff
+(500 ms → 30 s). Both strategies are valid; the divergence is intentional
+and does not affect protocol correctness.
+
+**No fix required.** Documented for awareness.
+
+## What PR #5469 fixes
+
+1. `src/api/routes/chat_ws.py` — accept both `app_context` and `engine_context`
+   keys (Gap 1).
+2. `ui/src/components/ui/ChatPanel.tsx` — add `model_list` and `index_status`
+   to `ServerMessage` interface and `handleServerMessage` switch (Gap 2).
+3. `tests/unit/chat/test_chat_parity.py` — TDD test suite covering the fixed
+   gaps plus a schema round-trip test.

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -76,6 +76,7 @@ from src.api.routes import (  # noqa: E402
     simulation_ws,
 )
 from src.api.services.chat_service import ChatService  # noqa: E402
+from src.shared.python.app_state import agent_context, get_state_logger  # noqa: E402
 from src.shared.python.config.environment import is_production  # noqa: E402
 from src.shared.python.engine_core.engine_manager import EngineManager  # noqa: E402
 from src.shared.python.logging_pkg.logging_config import get_logger  # noqa: E402
@@ -784,7 +785,9 @@ def create_local_app() -> FastAPI:
     app.state.analysis_service = _LazyServiceProxy(
         lambda: _create_analysis_service(engine_manager)
     )
-    app.state.chat_service = ChatService()
+    app.state.chat_service = ChatService(
+        app_state_provider=lambda: agent_context(get_state_logger().store)
+    )
 
     # Register routes (no auth required in local mode)
     _register_api_routers(app)

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -24,12 +24,16 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
             {"action": "send", "message": "...", "engine_context": "mujoco"}
             {"action": "history"}
             {"action": "new_session"}
+            {"action": "refresh_models"}
+            {"action": "index_codebase"}
 
         Server -> Client:
             {"type": "session_info", "session_id": "..."}
             {"type": "chunk", "content": "..."}
             {"type": "complete", "session_id": "..."}
             {"type": "history", "messages": [...]}
+            {"type": "model_list", "models": [...], "refreshed_at": "..."}
+            {"type": "index_status", "state": "running"|"complete"|"error", ...}
             {"type": "error", "detail": "..."}
     """
     if not (websocket is not None):
@@ -61,7 +65,9 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                     )
                     continue
 
-                engine_context = msg.get("engine_context")
+                # Accept both keys: React clients send ``engine_context``;
+                # PyQt clients send ``app_context``. Mirrors router_factory.py.
+                engine_context = msg.get("engine_context") or msg.get("app_context")
 
                 try:
                     chat_service.add_user_message(
@@ -94,6 +100,37 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                 await websocket.send_json(
                     {"type": "session_created", "session_id": session_id}
                 )
+
+            elif action == "refresh_models":
+                # Tools issue #2547 / PR #2566: poll the configured provider
+                # for available models and ship the result over the chat
+                # socket so the dock widget can repopulate its dropdown.
+                payload = chat_service.refresh_models()
+                await websocket.send_json(
+                    {
+                        "type": "model_list",
+                        "models": payload["models"],
+                        "refreshed_at": payload["refreshed_at"],
+                    }
+                )
+
+            elif action == "index_codebase":
+                # Tools issue #2549 / PR #2567. Run the existing
+                # codemap.indexer.rebuild pathway in a worker thread and
+                # ship a ``running`` event up front, then a final
+                # ``complete`` (or ``error``) event when the rebuild
+                # finishes. We deliberately don't reimplement the
+                # indexer here — see ``src/shared/python/codemap``.
+                await websocket.send_json(
+                    {
+                        "type": "index_status",
+                        "state": "running",
+                        "files_parsed": 0,
+                        "symbols_inserted": 0,
+                    }
+                )
+                payload = await chat_service.run_codemap_rebuild()
+                await websocket.send_json({"type": "index_status", **payload})
 
             else:
                 await websocket.send_json(

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -49,10 +49,13 @@ from .middleware.upload_limits import validate_upload_size
 from .rate_limit import limiter
 from .route_registry import register_routes
 from .services.analysis_service import AnalysisService
+from .services.chat_service import ChatService
 from .services.simulation_service import SimulationService
 from .task_manager import TaskManager
 from .utils.tracing import RequestTracer
 from .versioning import get_app_version
+from .routes import chat_ws, realtime as realtime_route, simulation_ws
+from src.shared.python.app_state import agent_context, get_state_logger
 
 setup_logging()
 logger = get_logger(__name__)
@@ -141,6 +144,11 @@ async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
         # Initialize video pipeline with default config
         video_pipeline = _init_video_pipeline()
         fastapi_app.state.video_pipeline = video_pipeline
+
+        # Initialize chat service wired to app state (issue #5470)
+        fastapi_app.state.chat_service = ChatService(
+            app_state_provider=lambda: agent_context(get_state_logger().store)
+        )
 
         # All routes now use FastAPI Depends() for dependency injection.
         # No legacy configure() calls needed.
@@ -270,6 +278,18 @@ logger.info("Registered %d route modules under /api", _legacy_api_count)
 # Register all routes under /api/v1/ prefix (versioned API)
 _versioned_count = register_routes(app, prefix=API_PREFIX)
 logger.info("Registered %d route modules under %s", _versioned_count, API_PREFIX)
+
+# Register explicitly excluded WebSocket routes
+app.include_router(chat_ws.router, prefix=API_PREFIX)
+app.include_router(simulation_ws.router, prefix=API_PREFIX)
+app.include_router(chat_ws.router, prefix="")
+app.include_router(simulation_ws.router, prefix="")
+
+# Realtime IPC layer (issue #4997) — combined HTTP + WS endpoints under
+# /realtime; mounted at root so cross-process clients (WSPubSub) can use the
+# canonical "/realtime/publish" and "/realtime/subscribe" paths.
+app.include_router(realtime_route.router, prefix="")
+app.include_router(realtime_route.router, prefix=API_PREFIX)
 
 
 if __name__ == "__main__":

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -8,15 +8,17 @@ sessions to disk for cross-process sharing.
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 import time
 import uuid
 from collections import OrderedDict
-from collections.abc import AsyncIterator
-from datetime import timezone
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from src.shared.python.app_state import get_state_logger
 from src.shared.python.core.contracts import precondition
 from src.shared.python.core.error_utils import InvalidRequestError
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -42,7 +44,15 @@ class ChatService:
     SESSION_TTL_SECONDS = 7200  # 2 hours
     PERSIST_DIR = Path.home() / ".golf_modeling_suite" / "chat_sessions"
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        app_state_provider: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        if app_state_provider is not None and not callable(app_state_provider):
+            raise TypeError(
+                "app_state_provider must be a callable returning a dict, or None"
+            )
+        self._app_state_provider = app_state_provider
         self._sessions: OrderedDict[str, ConversationContext] = OrderedDict()
         self._timestamps: dict[str, float] = {}
         self._adapter: BaseAgentAdapter | None = None
@@ -124,6 +134,32 @@ class ChatService:
         except ImportError as e:
             logger.error("ChatService: could not create fallback adapter: %s", e)
 
+    def _build_app_state_message(self) -> Any | None:
+        """Build a system :class:`Message` containing the current app state.
+
+        Returns ``None`` when no provider is configured or when the provider
+        raises an exception (degraded gracefully — chat continues).
+
+        Returns:
+            A ``Message(role="system", ...)`` instance, or ``None``.
+        """
+        if self._app_state_provider is None:
+            return None
+        try:
+            state = self._app_state_provider()
+            content = "Current application state:\n" + json.dumps(
+                state, indent=2, default=str
+            )
+            from src.shared.python.ai.types import Message
+
+            return Message(role="system", content=content)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ChatService: app_state_provider raised %s — skipping state injection",
+                exc,
+            )
+            return None
+
     def get_or_create_session(self, session_id: str | None) -> ConversationContext:
         """Return existing session or create a new one."""
         from src.shared.python.ai.types import ConversationContext
@@ -187,7 +223,12 @@ class ChatService:
 
             ctx.add_user_message(content)
             self._persist_session(session_id)
-            return str(uuid.uuid4().hex[:12])
+
+        get_state_logger().log_event(
+            "chat.message_sent",
+            {"session_id": session_id, "role": "user"},
+        )
+        return str(uuid.uuid4().hex[:12])
 
     @precondition(
         lambda self, session_id: session_id is not None and len(session_id) > 0,
@@ -209,19 +250,21 @@ class ChatService:
                 return
 
         # Build engine context system message
+        from src.shared.python.ai.types import Message
+
+        temp_messages = list(ctx.messages)
         engine = ctx.metadata.get("last_engine")
         if engine:
             system_hint = (
                 f"The user is currently working in the {engine} physics engine. "
                 "Tailor your responses to that context when relevant."
             )
-            # Temporarily inject system context (don't persist it)
-            from src.shared.python.ai.types import Message
-
-            temp_messages = list(ctx.messages)
             temp_messages.insert(0, Message(role="system", content=system_hint))
-        else:
-            temp_messages = list(ctx.messages)
+
+        # Inject app state context if a provider is configured
+        app_state_msg = self._build_app_state_message()
+        if app_state_msg is not None:
+            temp_messages.insert(0, app_state_msg)
 
         # Create a temporary context copy for the adapter
         from src.shared.python.ai.types import ConversationContext
@@ -233,7 +276,6 @@ class ChatService:
             metadata=ctx.metadata,
         )
 
-        import json
         import queue
 
         from src.shared.python.ai.types import ToolCall
@@ -311,6 +353,14 @@ class ChatService:
                             )
                             self._persist_session(session_id)
 
+                    get_state_logger().log_event(
+                        "chat.response_received",
+                        {
+                            "session_id": session_id,
+                            "chars": len(complete_response),
+                        },
+                    )
+
                     if not tool_calls:
                         break
 
@@ -364,6 +414,9 @@ class ChatService:
             # hanging the queue consumer.
             except Exception as e:  # noqa: BLE001
                 chunk_queue.put(f"\n[Error: {e}]")
+                get_state_logger().log_exception(
+                    e, context="ChatService.stream_response"
+                )
             finally:
                 chunk_queue.put(None)  # Sentinel
 
@@ -380,6 +433,102 @@ class ChatService:
             yield item
 
         thread.join(timeout=5.0)
+
+    def refresh_models(self) -> dict[str, Any]:
+        """Poll the configured provider for available chat models.
+
+        Returns a payload matching the ``ChatModelListResponse`` contract
+        (Tools issue #2547 / PR #2566): a list of ``{"name", "provider",
+        "display_name"}`` entries plus an ISO-8601 ``refreshed_at``
+        timestamp. Failure to reach the provider is logged and yields an
+        empty list — the chat session itself stays alive.
+        """
+        models: list[dict[str, Any]] = []
+        provider_id = "unknown"
+        adapter = self._adapter
+        if adapter is not None:
+            provider_id = type(adapter).__name__.replace("Adapter", "").lower()
+            list_models = getattr(adapter, "list_available_models", None)
+            if callable(list_models):
+                try:
+                    raw_models = list_models()
+                except Exception as exc:  # noqa: BLE001
+                    # Adapter may raise transport errors (AIConnectionError,
+                    # OSError, httpx errors). Degrade gracefully so the chat
+                    # session doesn't drop.
+                    logger.warning(
+                        "ChatService.refresh_models: %s.list_available_models "
+                        "failed: %s",
+                        type(adapter).__name__,
+                        exc,
+                    )
+                    raw_models = []
+                for entry in raw_models:
+                    if isinstance(entry, str):
+                        models.append(
+                            {
+                                "name": entry,
+                                "provider": provider_id,
+                                "display_name": None,
+                            }
+                        )
+                    elif isinstance(entry, dict):
+                        name = str(entry.get("name", ""))
+                        if name:
+                            models.append(
+                                {
+                                    "name": name,
+                                    "provider": str(entry.get("provider", provider_id)),
+                                    "display_name": entry.get("display_name"),
+                                }
+                            )
+        return {
+            "models": models,
+            "refreshed_at": datetime.now(UTC).isoformat(),
+        }
+
+    async def run_codemap_rebuild(self) -> dict[str, Any]:
+        """Run the in-tree codemap rebuild and return a status payload.
+
+        Tools issue #2549 / PR #2567: handler for the chat ``index_codebase``
+        WebSocket action. Wraps the existing
+        ``src.shared.python.codemap.indexer.rebuild`` pathway and returns
+        a dict shaped like ``ChatIndexStatusResponse``. Runs in a worker
+        thread so the WebSocket loop stays responsive.
+        """
+
+        def _rebuild_in_thread() -> dict[str, Any]:
+            try:
+                from src.shared.python.codemap import discover_repo_root
+                from src.shared.python.codemap.indexer import rebuild
+
+                repo_root = discover_repo_root()
+                stats = rebuild(repo_root)
+                return {
+                    "state": "complete",
+                    "files_parsed": stats.files_parsed,
+                    "symbols_inserted": stats.symbols_inserted,
+                    "duration_seconds": float(stats.elapsed_s),
+                    "error": None,
+                }
+            except Exception as exc:  # noqa: BLE001
+                # Indexer can raise from import failures, sqlite errors, or
+                # filesystem permission issues — treat all as soft errors
+                # so the chat session stays alive.
+                logger.warning(
+                    "ChatService.run_codemap_rebuild failed: %s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
+                return {
+                    "state": "error",
+                    "files_parsed": 0,
+                    "symbols_inserted": 0,
+                    "duration_seconds": None,
+                    "error": str(exc),
+                }
+
+        return await asyncio.to_thread(_rebuild_in_thread)
 
     def get_session_history(self, session_id: str) -> list[dict[str, Any]]:
         """Return message history for a session."""

--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -1,145 +1,340 @@
 models:
   # =============================================================================
-  # PRIMARY TILES (Row 1)
+  # PHYSICS ENGINES — biomechanical golf-swing analysis backends
   # =============================================================================
 
   - id: "mujoco_unified"
     name: "MuJoCo"
-    description: "Biomechanical golf swing analysis with humanoid config & simulation"
+    description: "Biomechanical golf swing analysis (humanoid + simulation)"
     type: "custom_humanoid"
     path: "src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/__main__.py"
     engine_type: "mujoco"
+    launcher:
+      category: "physics_engine"
+      logo: "assets/mujoco.png"
+      status: "ready"
+      default_launch: "tab"
 
   - id: "drake_golf"
     name: "Drake"
-    description: "Drake robotics framework with MeshCat visualization"
+    description: "Drake robotics with MeshCat visualisation"
     type: "drake"
     path: "src/engines/physics_engines/drake/python/src/drake_gui_app.py"
     engine_type: "drake"
+    launcher:
+      category: "physics_engine"
+      logo: "assets/drake.png"
+      status: "ready"
+      default_launch: "tab"
 
   - id: "pinocchio_golf"
     name: "Pinocchio"
-    description: "Pinocchio rigid body dynamics with analytical derivatives"
+    description: "Rigid-body dynamics with analytical derivatives"
     type: "pinocchio"
     path: "src/engines/physics_engines/pinocchio/python/pinocchio_golf/gui.py"
     engine_type: "pinocchio"
+    launcher:
+      category: "physics_engine"
+      logo: "assets/pinocchio.png"
+      status: "ready"
+      default_launch: "tab"
 
   - id: "opensim_golf"
     name: "OpenSim"
-    description: "OpenSim musculoskeletal modeling for biomechanics analysis"
+    description: "Musculoskeletal modelling for biomechanics"
     type: "opensim"
     path: "src/engines/physics_engines/opensim/python/opensim_gui.py"
     engine_type: "opensim"
-
-  # =============================================================================
-  # PRIMARY TILES (Row 2)
-  # =============================================================================
+    launcher:
+      category: "physics_engine"
+      logo: "assets/opensim.png"
+      status: "ready"
+      default_launch: "tab"
 
   - id: "myosim_suite"
     name: "MyoSuite"
-    description: "MyoSuite muscle-actuated simulation environment"
+    description: "Muscle-actuated simulation environment"
     type: "myosim"
     path: "src/engines/physics_engines/myosuite/python/myosuite_physics_engine.py"
     engine_type: "myosuite"
+    launcher:
+      category: "physics_engine"
+      logo: "assets/myosim.png"
+      status: "ready"
+      default_launch: "tab"
 
   - id: "matlab_suite"
-    name: "Matlab Simscape Models"
-    description: "Suite of MATLAB/Simscape models, dataset generators, and analysis tools."
+    name: "MATLAB Simscape"
+    description: "MATLAB / Simscape models, dataset generators, and tooling"
     type: "matlab_suite"
     path: "virtual/matlab_suite"
-
-  # --- Motion Capture (direct launch, no sub-launcher) ---
-  - id: "c3d_viewer"
-    name: "C3D Viewer"
-    description: "Visualize and analyze optical motion capture data (.c3d)"
-    type: "special_app"
-    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
     launcher:
-      category: "tool"
-      logo: "assets/c3d_viewer_modern.png"
+      category: "physics_engine"
+      logo: "assets/matlab_logo.png"
+      status: "external"
+
+  # =============================================================================
+  # SIMULATION — playable / interactive simulators
+  # =============================================================================
+
+  - id: "golf_simulation_suite"
+    name: "Golf Simulation Suite"
+    description: "Complete golf simulation with ball flight physics and putting green"
+    type: "golf_simulation"
+    path: "launch_golf_suite.py"
+    engine_type: "golf_simulation"
+    launcher:
+      category: "simulation"
+      logo: "assets/golf_simulation.png"
       status: "ready"
+      default_launch: "tab"
+
+  - id: "putting_green"
+    name: "Putting Green"
+    description: "Realistic putting green with ball-rolling physics"
+    type: "putting_green"
+    path: "src/engines/physics_engines/putting_green/python/simulator.py"
+    engine_type: "putting_green"
+    launcher:
+      category: "simulation"
+      logo: "assets/putting_green_modern.png"
+      status: "ready"
+
+  # =============================================================================
+  # MOTION MATCHING — pose / target editors and matchers
+  # =============================================================================
 
   - id: "motion_target_preview"
     name: "Motion-Match Preview"
-    description: "Preview multi-source motion-capture targets (C3D, .mat, body markers, club/ball) on a shared timegrid before driving a physics-engine model. Requires the gui-tools extra."
+    description: "Preview multi-source motion-capture targets on a shared timegrid"
     type: "special_app"
     path: "src/tools/starting_pose_matcher/__main__.py"
     tags: ["c3d", "mocap", "club", "body", "preview"]
     launcher:
-      category: "tool"
+      category: "motion_matching"
       logo: "motion_target_preview.svg"
       status: "ready"
+      default_launch: "tab"
 
-  # Legacy alias for `motion_target_preview` — kept hidden for one release so
-  # saved layouts referencing the old id keep resolving. Remove after the next
-  # cut.
+  - id: "pose_studio"
+    name: "Pose Studio"
+    description: "Cross-engine interactive pose editor"
+    type: "special_app"
+    path: "src/tools/pose_studio/__main__.py"
+    launcher:
+      category: "motion_matching"
+      logo: "assets/data_explorer_modern.png"
+      status: "beta"
+
   - id: "starting_pose_matcher"
     name: "Starting-Pose Matcher (legacy)"
     description: "Legacy alias for motion_target_preview. Hidden by default."
     type: "special_app"
     path: "src/tools/starting_pose_matcher/__main__.py"
     hidden: true
+    hidden_reason: "Legacy alias retained for one release so saved layouts continue to resolve; use motion_target_preview for new launcher entries."
+    hidden_owner: "@launcher"
     launcher:
-      category: "tool"
+      category: "motion_matching"
       logo: "motion_target_preview.svg"
+      status: "deprecated"
+
+  # =============================================================================
+  # MOTION CAPTURE — mocap ingestion + pose estimation
+  # =============================================================================
+
+  - id: "c3d_viewer"
+    name: "C3D Viewer"
+    description: "Visualise and analyse optical mocap data (.c3d)"
+    type: "special_app"
+    path: "src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py"
+    launcher:
+      category: "motion_capture"
+      logo: "assets/c3d_viewer_modern.png"
       status: "ready"
+      default_launch: "tab"
+
+  - id: "video_analyzer"
+    name: "Video Analyzer"
+    description: "Video-based motion analysis with pose tracking"
+    type: "special_app"
+    path: "src/video_analyzer/launch_video_analyzer.py"
+    provider: "tools"
+    source_root: "../Tools"
+    working_dir: "."
+    python_paths:
+      - "src"
+      - "src/shared/python"
+    launcher:
+      category: "motion_capture"
+      logo: "assets/video_analyzer_modern.png"
+      status: "external"
+
+  - id: "video_processor"
+    name: "Video Processor"
+    description: "Shared media processor for video conversion, frame extraction, and analysis"
+    type: "special_app"
+    path: "src/media_processing/video_processor/apps/web/launch_platform.py"
+    provider: "tools"
+    source_root: "../Tools"
+    working_dir: "src/media_processing/video_processor/apps/web"
+    python_paths:
+      - "src"
+      - "src/shared/python"
+    launcher:
+      category: "motion_capture"
+      logo: "assets/video_analyzer_modern.png"
+      status: "external"
+      default_launch: "tab"
 
   - id: "openpose_analysis"
     name: "OpenPose"
     description: "High-accuracy body pose estimation (Academic License)"
     type: "special_app"
     path: "src/shared/python/pose_estimation/openpose_gui.py"
+    launcher:
+      category: "motion_capture"
+      logo: "assets/openpose.png"
+      status: "ready"
 
   - id: "mediapipe_analysis"
     name: "MediaPipe"
-    description: "Fast pose estimation using Google MediaPipe (Apache 2.0)"
+    description: "Fast pose estimation via Google MediaPipe (Apache 2.0)"
     type: "special_app"
     path: "src/shared/python/pose_estimation/mediapipe_gui.py"
+    launcher:
+      category: "motion_capture"
+      logo: "assets/mediapipe.png"
+      status: "ready"
+
+  # =============================================================================
+  # TOOLS & DATA — model exploration, datasets, utilities
+  # =============================================================================
 
   - id: "model_explorer"
     name: "Model Explorer"
     description: "Explore models and generate URDFs"
     type: "special_app"
     path: "src/tools/model_explorer/launch_model_explorer.py"
-
-  - id: "putting_green"
-    name: "Putting Green"
-    description: "Realistic putting green simulation with ball rolling physics"
-    type: "putting_green"
-    path: "src/engines/physics_engines/putting_green/python/simulator.py"
-    engine_type: "putting_green"
-    launcher:
-      category: "physics_engine"
-      logo: "assets/putting_green_modern.png"
-      status: "ready"
-
-  - id: "video_analyzer"
-    name: "Video Analyzer"
-    description: "Video-based motion analysis with pose estimation and tracking"
-    type: "special_app"
-    path: "src/tools/video_analyzer/launch_video_analyzer.py"
     launcher:
       category: "tool"
-      logo: "assets/video_analyzer_modern.png"
+      logo: "assets/urdf_icon.png"
       status: "ready"
+      default_launch: "tab"
 
   - id: "data_explorer"
     name: "Data Explorer"
-    description: "Import, filter, and visualize simulation datasets"
+    description: "Import, filter, and visualise simulation datasets"
     type: "special_app"
-    path: "src/tools/data_explorer/data_explorer_app.py"
+    path: "src/data_explorer/data_explorer_app.py"
+    provider: "tools"
+    source_root: "../Tools"
+    working_dir: "."
+    python_paths:
+      - "src"
+      - "src/shared/python"
     launcher:
       category: "tool"
       logo: "assets/data_explorer_modern.png"
-      status: "ready"
+      status: "external"
+      default_launch: "tab"
+
+  - id: "data_processor"
+    name: "Data Processor"
+    description: "Shared signal processing and time-series data analysis tool"
+    type: "special_app"
+    path: "src/data_processing/data_processor/launch_pyqt6.py"
+    provider: "tools"
+    source_root: "../Tools"
+    working_dir: "."
+    python_paths:
+      - "src"
+      - "src/shared/python"
+      - "src/data_processing/data_processor/python"
+    launcher:
+      category: "tool"
+      logo: "assets/data_explorer_modern.png"
+      status: "external"
+      default_launch: "tab"
+
+  # =============================================================================
+  # DOCUMENTATION
+  # =============================================================================
+
+  - id: "pose_subscriber_demo"
+    name: "Pose Subscriber (demo)"
+    description: "Live mirror of Pose Studio's canonical pose via the realtime IPC layer"
+    type: "special_app"
+    path: "src/tools/pose_subscriber_demo/__main__.py"
+    launcher:
+      category: "motion_matching"
+      logo: "assets/data_explorer_modern.png"
+      status: "experimental"
+      default_launch: "dock"
 
   - id: "project_map"
     name: "Project Map"
-    description: "Complete map of all features, modules, and hidden gems in the suite"
+    description: "Map of every feature and module in the suite"
     type: "document"
     path: "docs/PROJECT_MAP.md"
+    launcher:
+      category: "documentation"
+      logo: "assets/project_map.png"
+      status: "ready"
 
   # =============================================================================
-  # All sub-launchers have been eliminated. Each tile launches directly.
-  # Matlab files open with system MATLAB. Motion capture tools launch directly.
+  # ASSISTANT — AI chat / Sidekick
   # =============================================================================
+
+  - id: "chat_assistant"
+    name: "Sidekick"
+    description: "AI chat assistant with app-state context"
+    type: "chat_assistant"
+    path: "src/shared/python/chat/sidekick_tool.py"
+    launcher:
+      category: "assistant"
+      logo: "assets/sidekick.png"
+      status: "ready"
+      default_launch: "dock"
+
+  # =============================================================================
+  # BIOMECHANICS
+  # =============================================================================
+
+  - id: "biomech_gait"
+    name: "Gait Model"
+    description: "Standardized human gait model across engines"
+    type: "biomech_exercise"
+    exercise: "gait"
+    launcher:
+      category: "biomechanics"
+      logo: "assets/biomech_gait.png"
+      status: "ready"
+      default_launch: "tab"
+
+  - id: "biomech_sit_to_stand"
+    name: "Sit-to-Stand Model"
+    description: "Standardized sit-to-stand motion model"
+    type: "biomech_exercise"
+    exercise: "sit_to_stand"
+    launcher:
+      category: "biomechanics"
+      logo: "assets/biomech_sit_stand.png"
+      status: "ready"
+      default_launch: "tab"
+
+  - id: "movement_optimizer"
+    name: "Movement Optimizer"
+    description: "Cross-engine trajectory optimization"
+    type: "special_app"
+    source_root: "movement_optimizer"
+    path: "src/movement_optimizer/main.py"
+    capabilities:
+      - "trajectory_optimization"
+      - "cross_engine_analysis"
+      - "biomechanics"
+    launcher:
+      category: "biomechanics"
+      logo: "project_map.svg"
+      status: "ready"
+      default_launch: "tab"

--- a/src/shared/python/app_state/__init__.py
+++ b/src/shared/python/app_state/__init__.py
@@ -1,0 +1,41 @@
+"""app_state — Application State Tracking and Diagnostic History.
+
+Public API::
+
+    from src.shared.python.app_state import (
+        StateLogger,
+        get_state_logger,
+        DiagnosticEngine,
+        DiagnosticResult,
+        HistoryStore,
+        AppEvent,
+        agent_context,
+    )
+
+Layers (strict LOD):
+
+- :mod:`._events`         — ``AppEvent`` dataclass
+- :mod:`._history_store`  — ``HistoryStore`` (thread-safe ring-buffer)
+- :mod:`._state_logger`   — ``StateLogger`` singleton + ``get_state_logger``
+- :mod:`._diagnostic`     — ``DiagnosticEngine`` + ``DiagnosticResult``
+- :mod:`._agent_context`  — ``agent_context()`` serialiser for AI agents
+- :mod:`.gui`             — optional Qt widgets (headless-safe)
+"""
+
+from __future__ import annotations
+
+from src.shared.python.app_state._agent_context import agent_context
+from src.shared.python.app_state._diagnostic import DiagnosticEngine, DiagnosticResult
+from src.shared.python.app_state._events import AppEvent
+from src.shared.python.app_state._history_store import HistoryStore
+from src.shared.python.app_state._state_logger import StateLogger, get_state_logger
+
+__all__ = [
+    "AppEvent",
+    "DiagnosticEngine",
+    "DiagnosticResult",
+    "HistoryStore",
+    "StateLogger",
+    "agent_context",
+    "get_state_logger",
+]

--- a/src/shared/python/app_state/_agent_context.py
+++ b/src/shared/python/app_state/_agent_context.py
@@ -1,0 +1,57 @@
+"""agent_context: serialise app state for Sidekick/AI chat agents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.shared.python.app_state._history_store import HistoryStore
+
+_DEFAULT_MAX_EVENTS = 50
+
+
+def agent_context(
+    store: HistoryStore,
+    max_events: int = _DEFAULT_MAX_EVENTS,
+    last_diagnostics: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-serialisable context dict for AI agents (e.g. Sidekick).
+
+    Args:
+        store: The :class:`HistoryStore` to sample events from.
+        max_events: Maximum number of recent events to include.
+        last_diagnostics: Optional list of diagnostic result dicts from
+            :meth:`DiagnosticEngine.run_checks` (serialised via
+            ``dataclasses.asdict``).
+
+    Returns:
+        Dict with keys:
+
+        - ``"events"`` — list of recent event dicts.
+        - ``"last_diagnostics"`` — list of diagnostic result dicts (may be empty).
+        - ``"summary"`` — short human-readable summary string.
+
+    Postcondition:
+        ``len(result["events"]) <= max_events``
+    """
+    if max_events <= 0:
+        raise ValueError(f"max_events must be positive, got {max_events}")
+
+    recent = store.snapshot(max_events=max_events)
+    events_dicts = [e.as_dict() for e in recent]
+
+    diag_list = last_diagnostics if last_diagnostics is not None else []
+
+    total = len(store)
+    pass_count = sum(1 for d in diag_list if d.get("status") == "PASS")
+    fail_count = sum(1 for d in diag_list if d.get("status") == "FAIL")
+
+    summary = (
+        f"Total events recorded: {total}. "
+        f"Last diagnostic run: {pass_count} PASS, {fail_count} FAIL."
+    )
+
+    return {
+        "events": events_dicts,
+        "last_diagnostics": diag_list,
+        "summary": summary,
+    }

--- a/src/shared/python/app_state/_diagnostic.py
+++ b/src/shared/python/app_state/_diagnostic.py
@@ -1,0 +1,98 @@
+"""DiagnosticEngine: self-diagnostic checks run on startup or on demand."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+CheckStatus = Literal["PASS", "FAIL", "SKIP"]
+
+
+@dataclass
+class DiagnosticResult:
+    """The outcome of a single diagnostic check.
+
+    Attributes:
+        name: Human-readable check name.
+        status: One of ``"PASS"``, ``"FAIL"``, or ``"SKIP"``.
+        message: Optional detail string (e.g. error description).
+    """
+
+    name: str
+    status: CheckStatus
+    message: str = ""
+
+
+class DiagnosticEngine:
+    """Runs a battery of named boolean checks and collects results.
+
+    Each registered check is a zero-argument callable that returns ``bool``.
+    Exceptions inside a check are caught and converted to FAIL results so
+    ``run_checks()`` never raises.
+
+    Example::
+
+        engine = DiagnosticEngine()
+        engine.register_check("physics_import", lambda: _can_import_mujoco())
+        results = engine.run_checks()
+    """
+
+    def __init__(self) -> None:
+        self._checks: dict[str, Callable[[], bool]] = {}
+
+    def register_check(self, name: str, check_fn: Callable[[], bool]) -> None:
+        """Register a diagnostic check.
+
+        Args:
+            name: Unique, non-empty name for the check.
+            check_fn: Zero-argument callable returning ``True`` on pass.
+
+        Raises:
+            ValueError: If *name* is empty.
+        """
+        if not name:
+            raise ValueError("Diagnostic check name must be non-empty")
+        self._checks[name] = check_fn
+
+    def run_checks(self) -> list[DiagnosticResult]:
+        """Execute all registered checks and return their results.
+
+        Postcondition:
+            Returns one :class:`DiagnosticResult` per registered check;
+            never raises regardless of check behaviour.
+
+        Returns:
+            List of :class:`DiagnosticResult` in registration order.
+        """
+        results: list[DiagnosticResult] = []
+        for name, fn in self._checks.items():
+            results.append(self._run_single(name, fn))
+        return results
+
+    def _run_single(self, name: str, fn: Callable[[], bool]) -> DiagnosticResult:
+        """Run one check and return a result, catching all exceptions.
+
+        Args:
+            name: Check name (for error reporting).
+            fn: The check callable.
+
+        Returns:
+            :class:`DiagnosticResult` with status PASS, FAIL, or SKIP.
+        """
+        try:
+            passed = bool(fn())
+            status: CheckStatus = "PASS" if passed else "FAIL"
+            message = "" if passed else "check returned False"
+            return DiagnosticResult(name=name, status=status, message=message)
+        except Exception as exc:  # noqa: BLE001 — intentional catch-all per spec
+            logger.warning("Diagnostic check %r raised: %s", name, exc)
+            return DiagnosticResult(
+                name=name,
+                status="FAIL",
+                message=f"{type(exc).__name__}: {exc}",
+            )

--- a/src/shared/python/app_state/_events.py
+++ b/src/shared/python/app_state/_events.py
@@ -1,0 +1,34 @@
+"""AppEvent dataclass — the atomic unit stored in HistoryStore."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass
+class AppEvent:
+    """A single recorded application event.
+
+    Attributes:
+        type: Short string identifier (e.g. ``"simulation_run"``).
+        timestamp: UTC datetime when the event was recorded.
+        payload: Arbitrary key-value context for the event.
+    """
+
+    type: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict representation.
+
+        Returns:
+            dict with ``type``, ``timestamp`` (ISO 8601), and ``payload``.
+        """
+        return {
+            "type": self.type,
+            "timestamp": self.timestamp.isoformat(),
+            "payload": self.payload,
+        }

--- a/src/shared/python/app_state/_history_store.py
+++ b/src/shared/python/app_state/_history_store.py
@@ -1,0 +1,108 @@
+"""Thread-safe ring-buffer store for AppEvent objects."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections import deque
+from typing import Any
+
+from src.shared.python.app_state._events import AppEvent
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_MAXLEN = 1000
+
+
+class HistoryStore:
+    """Thread-safe, fixed-capacity store of :class:`AppEvent` objects.
+
+    Uses a ``collections.deque`` with *maxlen* as the backing ring-buffer,
+    meaning older events are silently dropped once capacity is reached.
+
+    Attributes:
+        maxlen: Maximum number of events retained.
+    """
+
+    def __init__(self, maxlen: int = _DEFAULT_MAXLEN) -> None:
+        if maxlen <= 0:
+            raise ValueError(f"maxlen must be positive, got {maxlen}")
+        self.maxlen: int = maxlen
+        self._deque: deque[AppEvent] = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def append_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Append a new event.
+
+        Args:
+            event_type: Non-empty string identifying the event category.
+            payload: Arbitrary key-value context.
+
+        Raises:
+            ValueError: If *event_type* is empty.
+        """
+        if not event_type:
+            raise ValueError("event_type must be non-empty")
+        event = AppEvent(type=event_type, payload=payload)
+        with self._lock:
+            self._deque.append(event)
+
+    def clear(self) -> None:
+        """Remove all stored events."""
+        with self._lock:
+            self._deque.clear()
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def latest(self) -> AppEvent | None:
+        """Return the most recent event, or ``None`` if the store is empty."""
+        with self._lock:
+            return self._deque[-1] if self._deque else None
+
+    def snapshot(self, max_events: int | None = None) -> list[AppEvent]:
+        """Return a point-in-time copy of stored events.
+
+        Args:
+            max_events: If given, return only the *max_events* most recent.
+
+        Returns:
+            List of :class:`AppEvent`, oldest first.
+        """
+        with self._lock:
+            items = list(self._deque)
+        if max_events is not None and max_events < len(items):
+            items = items[-max_events:]
+        return items
+
+    def as_json(self) -> str:
+        """Serialise the store to a JSON string.
+
+        Serialisation errors are caught internally; the result is always
+        valid JSON (falls back to ``"[]"`` if necessary).
+
+        Returns:
+            JSON array string, each element following ``AppEvent.as_dict()``.
+        """
+        try:
+            return json.dumps([e.as_dict() for e in self.snapshot()])
+        except (TypeError, ValueError) as exc:
+            logger.warning("HistoryStore.as_json serialisation failed: %s", exc)
+            return "[]"
+
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._deque)
+
+    def __iter__(self):  # type: ignore[override]
+        return iter(self.snapshot())

--- a/src/shared/python/app_state/_state_logger.py
+++ b/src/shared/python/app_state/_state_logger.py
@@ -1,0 +1,88 @@
+"""Singleton StateLogger: centralised event-recording facade."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from src.shared.python.app_state._history_store import HistoryStore
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+_logger = get_logger(__name__)
+
+_SINGLETON_LOCK = threading.Lock()
+_singleton: StateLogger | None = None
+
+
+class StateLogger:
+    """Centralised recorder for user actions, simulation runs, and exceptions.
+
+    Call :func:`get_state_logger` to obtain the process-level singleton.
+
+    Attributes:
+        store: The :class:`HistoryStore` backing this logger.
+    """
+
+    def __init__(self, store: HistoryStore | None = None) -> None:
+        self.store: HistoryStore = store if store is not None else HistoryStore()
+
+    def log_event(self, event_type: str, payload: dict[str, Any] | None = None) -> None:
+        """Record a named event with optional context payload.
+
+        Args:
+            event_type: Non-empty string identifying the event category
+                (e.g. ``"simulation_run"``, ``"param_change"``).
+            payload: Optional key-value context for the event.
+
+        Raises:
+            ValueError: If *event_type* is empty.
+
+        Postcondition:
+            ``len(self.store)`` increases by one (capped at *maxlen*).
+        """
+        if not event_type:
+            raise ValueError("event_type must be non-empty")
+        resolved_payload: dict[str, Any] = payload if payload is not None else {}
+        self.store.append_event(event_type, resolved_payload)
+        _logger.debug("AppState event recorded: %s", event_type)
+
+    def log_exception(self, exc: Exception, context: str = "") -> None:
+        """Convenience wrapper that records an exception as an event.
+
+        Args:
+            exc: The exception to record.
+            context: Human-readable description of where the error occurred.
+        """
+        self.log_event(
+            "exception",
+            {
+                "exc_type": type(exc).__name__,
+                "exc_message": str(exc),
+                "context": context,
+            },
+        )
+
+    def log_fallback(self, component: str, reason: str) -> None:
+        """Record a fallback/degraded-mode activation.
+
+        Args:
+            component: The component that fell back (e.g. ``"MuJoCoEngine"``).
+            reason: Why the fallback was triggered.
+        """
+        self.log_event("fallback", {"component": component, "reason": reason})
+
+
+def get_state_logger() -> StateLogger:
+    """Return the process-level :class:`StateLogger` singleton.
+
+    Thread-safe; creates the singleton on first call.
+
+    Returns:
+        The shared :class:`StateLogger` instance.
+    """
+    global _singleton  # noqa: PLW0603
+    if _singleton is None:
+        with _SINGLETON_LOCK:
+            if _singleton is None:
+                _singleton = StateLogger()
+    return _singleton

--- a/src/shared/python/app_state/gui/__init__.py
+++ b/src/shared/python/app_state/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI widgets for the app_state package.
+
+Imports are deferred; this package is safe to import in headless
+environments where PyQt6 is unavailable.
+"""

--- a/src/shared/python/app_state/gui/diagnostic_panel.py
+++ b/src/shared/python/app_state/gui/diagnostic_panel.py
@@ -1,0 +1,117 @@
+"""DiagnosticPanel — Qt widget showing diagnostic results with a Run button.
+
+PyQt6 imports are guarded; callers should handle ``ImportError`` when
+running in headless environments.
+"""
+
+from __future__ import annotations
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QPushButton,
+        QTableWidget,
+        QTableWidgetItem,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    _QT_AVAILABLE = True
+except ImportError:
+    _QT_AVAILABLE = False
+
+from src.shared.python.app_state._diagnostic import DiagnosticEngine, DiagnosticResult
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_STATUS_COLORS = {
+    "PASS": "#2ecc71",
+    "FAIL": "#e74c3c",
+    "SKIP": "#f39c12",
+}
+
+
+if _QT_AVAILABLE:
+
+    class DiagnosticPanel(QWidget):  # type: ignore[misc]
+        """Widget that runs and displays diagnostic check results.
+
+        Provides a Run button that triggers
+        :meth:`DiagnosticEngine.run_checks` and populates a table with
+        the ``name``, ``status``, and ``message`` columns.
+
+        Args:
+            engine: The :class:`DiagnosticEngine` to query.
+            parent: Optional parent widget.
+        """
+
+        _COL_NAME = 0
+        _COL_STATUS = 1
+        _COL_MESSAGE = 2
+        _COLUMN_COUNT = 3
+
+        def __init__(
+            self,
+            engine: DiagnosticEngine,
+            parent: QWidget | None = None,
+        ) -> None:
+            super().__init__(parent)
+            self._engine = engine
+            self._setup_ui()
+
+        def _setup_ui(self) -> None:
+            """Build the widget layout."""
+            layout = QVBoxLayout(self)
+
+            header_row = QHBoxLayout()
+            header_row.addWidget(QLabel("Diagnostic Checks"))
+            header_row.addStretch()
+            self._run_btn = QPushButton("Run Diagnostics")
+            self._run_btn.clicked.connect(self._on_run)
+            header_row.addWidget(self._run_btn)
+            layout.addLayout(header_row)
+
+            self._table = QTableWidget(0, self._COLUMN_COUNT)
+            self._table.setHorizontalHeaderLabels(["Check", "Status", "Message"])
+            header = self._table.horizontalHeader()
+            if header is not None:
+                header.setSectionResizeMode(
+                    self._COL_NAME, QHeaderView.ResizeMode.ResizeToContents
+                )
+                header.setSectionResizeMode(
+                    self._COL_STATUS, QHeaderView.ResizeMode.ResizeToContents
+                )
+                header.setSectionResizeMode(
+                    self._COL_MESSAGE, QHeaderView.ResizeMode.Stretch
+                )
+            self._table.setEditTriggers(
+                QTableWidget.EditTrigger.NoEditTriggers  # type: ignore[attr-defined]
+            )
+            layout.addWidget(self._table)
+
+        def _on_run(self) -> None:
+            """Execute checks and populate the table."""
+            results = self._engine.run_checks()
+            self._populate_table(results)
+
+        def _populate_table(self, results: list[DiagnosticResult]) -> None:
+            """Fill the results table from a list of DiagnosticResult objects."""
+            self._table.setRowCount(len(results))
+            for row, result in enumerate(results):
+                self._table.setItem(row, self._COL_NAME, QTableWidgetItem(result.name))
+                status_item = QTableWidgetItem(result.status)
+                color = _STATUS_COLORS.get(result.status, "#ffffff")
+                status_item.setForeground(
+                    __import__("PyQt6.QtGui", fromlist=["QColor"]).QColor(color)
+                )
+                self._table.setItem(row, self._COL_STATUS, status_item)
+                self._table.setItem(
+                    row, self._COL_MESSAGE, QTableWidgetItem(result.message)
+                )
+
+else:
+    DiagnosticPanel = None  # type: ignore[assignment,misc]

--- a/src/shared/python/app_state/gui/history_panel.py
+++ b/src/shared/python/app_state/gui/history_panel.py
@@ -1,0 +1,102 @@
+"""HistoryPanel — Qt widget showing the event log with a Clear button.
+
+PyQt6 imports are guarded; callers should handle ``ImportError`` when
+running in headless environments.
+"""
+
+from __future__ import annotations
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QHBoxLayout,
+        QLabel,
+        QListWidget,
+        QPushButton,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    _QT_AVAILABLE = True
+except ImportError:
+    _QT_AVAILABLE = False
+
+from src.shared.python.app_state._history_store import HistoryStore
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _require_qt() -> None:
+    """Raise ImportError if PyQt6 is not available."""
+    if not _QT_AVAILABLE:
+        raise ImportError(
+            "PyQt6 is required for HistoryPanel. Install with: pip install PyQt6"
+        )
+
+
+if _QT_AVAILABLE:
+
+    class HistoryPanel(QWidget):  # type: ignore[misc]
+        """Widget that displays the application event log.
+
+        Shows a scrollable list of events and provides a Clear button
+        that removes all events from the attached :class:`HistoryStore`.
+
+        Args:
+            store: The :class:`HistoryStore` to display and manage.
+            parent: Optional parent widget.
+        """
+
+        def __init__(
+            self,
+            store: HistoryStore,
+            parent: QWidget | None = None,
+        ) -> None:
+            super().__init__(parent)
+            self._store = store
+            self._setup_ui()
+            self.refresh()
+
+        def _setup_ui(self) -> None:
+            """Build the widget layout."""
+            layout = QVBoxLayout(self)
+
+            header_row = QHBoxLayout()
+            header_row.addWidget(QLabel("Application Event History"))
+            header_row.addStretch()
+            self._clear_btn = QPushButton("Clear")
+            self._clear_btn.setToolTip("Remove all recorded events")
+            self._clear_btn.clicked.connect(self._on_clear)
+            header_row.addWidget(self._clear_btn)
+            layout.addLayout(header_row)
+
+            self._list = QListWidget()
+            self._list.setAlternatingRowColors(True)
+            layout.addWidget(self._list)
+
+        def refresh(self) -> None:
+            """Repopulate the list from the current store contents."""
+            self._list.clear()
+            for event in self._store.snapshot():
+                ts = event.timestamp.strftime("%H:%M:%S")
+                text = f"[{ts}] {event.type}"
+                if event.payload:
+                    payload_str = ", ".join(
+                        f"{k}={v}" for k, v in event.payload.items()
+                    )
+                    text += f"  ({payload_str})"
+                self._list.addItem(text)
+            # Scroll to the most recent event
+            self._list.scrollToBottom()
+
+        def _on_clear(self) -> None:
+            """Clear the store and refresh the view."""
+            self._store.clear()
+            self._list.clear()
+            logger.debug("HistoryPanel: store cleared by user")
+
+else:
+    # Provide a stub so ``from ... import HistoryPanel`` doesn't fail in
+    # headless environments — callers receive None instead of a widget.
+    HistoryPanel = None  # type: ignore[assignment,misc]

--- a/src/shared/python/biomechanics/dynamic_com.py
+++ b/src/shared/python/biomechanics/dynamic_com.py
@@ -1,0 +1,126 @@
+"""Dynamic Center of Mass Computation from Marker Data.
+
+Provides the `BiomechanicalModel` class for computing full-body dynamic Center
+of Mass (COM) trajectories from raw motion capture marker data, integrating
+with the anthropometric datasets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Mapping
+
+import numpy as np
+
+from src.shared.python.contracts import require
+from src.shared.python.humanoid_character_builder.core.anthropometry import (
+    DE_LEVA_DATA,
+    estimate_segment_masses,
+    get_anthropometry_key,
+)
+
+
+@dataclass
+class SegmentDefinition:
+    """Defines how to compute a segment's position from markers."""
+
+    name: str
+    proximal_markers: list[str]
+    distal_markers: list[str]
+
+
+class BiomechanicalModel:
+    """Computes full-body dynamic COM from marker trajectories and anthropometry."""
+
+    def __init__(self, total_mass_kg: float, gender_factor: float = 0.5) -> None:
+        """Initialize the model with subject parameters.
+
+        Args:
+            total_mass_kg: Total body mass in kg.
+            gender_factor: 0.0 = female, 1.0 = male, 0.5 = neutral.
+        """
+        require(total_mass_kg > 0, "Total mass must be positive")
+        require(0.0 <= gender_factor <= 1.0, "Gender factor must be between 0 and 1")
+
+        self.total_mass_kg = total_mass_kg
+        self.gender_factor = gender_factor
+        self.segment_masses = estimate_segment_masses(total_mass_kg, gender_factor)
+        self.segments: list[SegmentDefinition] = []
+
+    def add_segment(
+        self, name: str, proximal_markers: list[str], distal_markers: list[str]
+    ) -> None:
+        """Add a segment definition to the model.
+
+        Args:
+            name: Anthropometric segment name (e.g., 'thigh', 'pelvis').
+            proximal_markers: List of marker names defining the proximal joint.
+            distal_markers: List of marker names defining the distal joint.
+        """
+        require(len(proximal_markers) > 0, "Must have at least one proximal marker")
+        require(len(distal_markers) > 0, "Must have at least one distal marker")
+
+        key = get_anthropometry_key(name)
+        require(name in self.segment_masses, f"Unknown segment name: {name}")
+
+        self.segments.append(SegmentDefinition(name, proximal_markers, distal_markers))
+
+    def compute_dynamic_com(
+        self, marker_trajectories: Mapping[str, np.ndarray]
+    ) -> np.ndarray:
+        """Compute the dynamic full-body COM trajectory.
+
+        Args:
+            marker_trajectories: Dict mapping marker name to (N, 3) trajectory array.
+
+        Returns:
+            (N, 3) array of the full-body COM trajectory.
+        """
+        if not self.segments:
+            raise ValueError("No segments defined in the model")
+
+        required_markers = set()
+        for seg in self.segments:
+            required_markers.update(seg.proximal_markers)
+            required_markers.update(seg.distal_markers)
+
+        for marker in required_markers:
+            require(marker in marker_trajectories, f"Missing required marker: {marker}")
+
+        first_marker = next(iter(required_markers))
+        n_frames = len(marker_trajectories[first_marker])
+
+        for marker in required_markers:
+            require(
+                len(marker_trajectories[marker]) == n_frames,
+                f"Marker {marker} has inconsistent frame count",
+            )
+
+        full_body_com = np.zeros((n_frames, 3))
+        total_modeled_mass = 0.0
+
+        for seg in self.segments:
+            proximal_pos = np.zeros((n_frames, 3))
+            for m in seg.proximal_markers:
+                proximal_pos += marker_trajectories[m]
+            proximal_pos /= len(seg.proximal_markers)
+
+            distal_pos = np.zeros((n_frames, 3))
+            for m in seg.distal_markers:
+                distal_pos += marker_trajectories[m]
+            distal_pos /= len(seg.distal_markers)
+
+            key = get_anthropometry_key(seg.name)
+            data = DE_LEVA_DATA.get_segment_data(key, self.gender_factor)
+            com_ratio = data.com_proximal_ratio
+
+            # Segment COM is interpolated along the longitudinal axis
+            segment_com = proximal_pos + com_ratio * (distal_pos - proximal_pos)
+
+            mass = self.segment_masses[seg.name]
+            full_body_com += segment_com * mass
+            total_modeled_mass += mass
+
+        require(total_modeled_mass > 0, "Total modeled mass must be positive")
+
+        return full_body_com / total_modeled_mass

--- a/src/shared/python/biomechanics/grf_visualization.py
+++ b/src/shared/python/biomechanics/grf_visualization.py
@@ -1,0 +1,131 @@
+"""Visualization tools for Ground Reaction Forces and Center of Mass trajectories."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing import Any
+
+from src.shared.python.contracts import require
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+except ImportError:
+    plt = None  # type: ignore
+
+
+def plot_grf_and_com_3d(
+    force_df: pd.DataFrame,
+    com_trajectory: np.ndarray,
+    downsample_factor: int = 10,
+    vector_scale: float = 0.001,
+) -> tuple[Any, Any]:
+    """Plot 3D GRF vectors and dynamic COM trajectory.
+
+    Args:
+        force_df: DataFrame containing combined force plate data with
+            columns fx, fy, fz, cop_x, cop_y, cop_z.
+        com_trajectory: (N, 3) array of Center of Mass positions over time.
+        downsample_factor: Factor by which to downsample vectors for visualization
+            clarity (e.g., plot every 10th vector).
+        vector_scale: Scaling factor for force vectors to fit the spatial plot.
+
+    Returns:
+        Tuple of (matplotlib Figure, matplotlib Axes3D).
+
+    Raises:
+        ImportError: If matplotlib is not installed.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for visualization.")
+
+    require(len(com_trajectory) > 0, "COM trajectory must not be empty")
+    require(
+        len(force_df) == len(com_trajectory),
+        "force_df and com_trajectory must have matching lengths",
+    )
+
+    fig = plt.figure(figsize=(10, 8))
+    ax = fig.add_subplot(111, projection="3d")
+
+    # Plot COM trajectory
+    ax.plot(
+        com_trajectory[:, 0],
+        com_trajectory[:, 1],
+        com_trajectory[:, 2],
+        label="Dynamic COM",
+        color="blue",
+        linewidth=2,
+        alpha=0.8,
+    )
+
+    # Plot COP trajectory
+    ax.plot(
+        force_df["cop_x"],
+        force_df["cop_y"],
+        force_df["cop_z"],
+        label="Center of Pressure",
+        color="red",
+        linewidth=2,
+        alpha=0.6,
+    )
+
+    # Downsample for vector plotting
+    idx = np.arange(0, len(force_df), downsample_factor)
+    sampled_df = force_df.iloc[idx]
+    sampled_com = com_trajectory[idx]
+
+    # Plot GRF Vectors originating from COP
+    ax.quiver(
+        sampled_df["cop_x"],
+        sampled_df["cop_y"],
+        sampled_df["cop_z"],
+        sampled_df["fx"],
+        sampled_df["fy"],
+        sampled_df["fz"],
+        length=vector_scale,
+        normalize=False,
+        color="green",
+        alpha=0.5,
+        arrow_length_ratio=0.1,
+        label="GRF Vectors",
+    )
+
+    # Plot lines from COP to COM (moment arms)
+    for i in range(len(idx)):
+        ax.plot(
+            [sampled_df["cop_x"].iloc[i], sampled_com[i, 0]],
+            [sampled_df["cop_y"].iloc[i], sampled_com[i, 1]],
+            [sampled_df["cop_z"].iloc[i], sampled_com[i, 2]],
+            color="gray",
+            linestyle="--",
+            alpha=0.2,
+        )
+
+    ax.set_xlabel("X [m]")
+    ax.set_ylabel("Y [m]")
+    ax.set_zlabel("Z [m]")  # type: ignore
+    ax.set_title("Dynamic Center of Mass and Ground Reaction Forces")
+    ax.legend()
+
+    # Auto-scale axes to be equal
+    x_limits = ax.get_xlim3d()  # type: ignore
+    y_limits = ax.get_ylim3d()  # type: ignore
+    z_limits = ax.get_zlim3d()  # type: ignore
+
+    x_range = abs(x_limits[1] - x_limits[0])
+    x_middle = np.mean(x_limits)
+    y_range = abs(y_limits[1] - y_limits[0])
+    y_middle = np.mean(y_limits)
+    z_range = abs(z_limits[1] - z_limits[0])
+    z_middle = np.mean(z_limits)
+
+    plot_radius = 0.5 * max([x_range, y_range, z_range])
+
+    ax.set_xlim3d([x_middle - plot_radius, x_middle + plot_radius])  # type: ignore
+    ax.set_ylim3d([y_middle - plot_radius, y_middle + plot_radius])  # type: ignore
+    ax.set_zlim3d([z_middle - plot_radius, z_middle + plot_radius])  # type: ignore
+
+    return fig, ax

--- a/src/shared/python/chat/__init__.py
+++ b/src/shared/python/chat/__init__.py
@@ -1,8 +1,13 @@
-"""Shared AI chat widget and contract models.
+"""Shared AI chat widget, service base, and contract models.
 
 Provides a portable ChatDockWidget (QDockWidget + QWebSocket) that connects
 to any FastAPI-based chat WebSocket endpoint, plus Pydantic contract models
-for the chat protocol.
+for the chat protocol, a shared ChatServiceBase for session management,
+and a reusable WebSocket router factory.
+
+Importing this package also registers :class:`~.sidekick_tool.SidekickTool`
+with the launcher's embeddable-tool registry (guarded by
+:func:`contextlib.suppress` so headless contexts are unaffected).
 
 Usage::
 
@@ -15,6 +20,13 @@ Usage::
     )
     main_window.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
 """
+
+import contextlib
+
+with contextlib.suppress(ImportError):
+    from . import sidekick_tool as _sidekick_tool  # noqa: F401
+
+from .service_base import ChatMessage, ChatServiceBase, ChatSession
 
 try:
     from .models import (
@@ -40,6 +52,10 @@ def __getattr__(name: str):
         from . import chat_dock_widget
 
         return getattr(chat_dock_widget, name)
+    if name == "create_chat_router":
+        from .router_factory import create_chat_router
+
+        return create_chat_router
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -50,4 +66,8 @@ __all__ = [
     "ChatChunkResponse",
     "ChatSessionInfo",
     "ChatHistoryResponse",
+    "ChatServiceBase",
+    "ChatSession",
+    "ChatMessage",
+    "create_chat_router",
 ]

--- a/src/shared/python/chat/sidekick_tool.py
+++ b/src/shared/python/chat/sidekick_tool.py
@@ -1,0 +1,145 @@
+"""Embeddable-tool adapter for the Sidekick AI chat assistant.
+
+Implements the :class:`~src.shared.python.launcher_embed.EmbeddableTool`
+protocol so the launcher can host the Sidekick chat panel as a dockable
+side panel instead of a standalone window.
+
+Designed to be headless-safe: PyQt6 is imported lazily inside
+:meth:`SidekickTool.create_main_widget` so that importing this module
+during headless test collection never fails due to a missing Qt
+installation.
+
+Issue #5468 — ADR-0013 launcher composability.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.shared.python.launcher_embed import (
+    EmbedCapabilities,
+    get_embeddable_tool,
+    register_embeddable_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["SidekickTool"]
+
+_TOOL_ID = "chat_assistant"
+
+
+def _create_chat_dock_widget(parent: Any) -> Any:
+    """Lazily construct a :class:`ChatDockWidget`.
+
+    Isolated into its own function so tests can patch it without having
+    to import PyQt6.
+
+    Args:
+        parent: The Qt parent widget (``QWidget | None``).
+
+    Returns:
+        A new :class:`~src.shared.python.chat.ChatDockWidget` instance.
+    """
+    from src.shared.python.chat.chat_dock_widget import ChatDockWidget  # noqa: PLC0415
+
+    return ChatDockWidget(parent=parent)
+
+
+class SidekickTool:
+    """Embeddable-tool adapter for the Sidekick AI chat assistant.
+
+    Exposes :class:`~src.shared.python.chat.ChatDockWidget` through the
+    :class:`~src.shared.python.launcher_embed.EmbeddableTool` Protocol so
+    the launcher can embed it as a dock panel.
+
+    Attributes:
+        tool_id: Stable registry identifier, matches the ``id`` in
+            ``src/config/models.yaml``.
+    """
+
+    tool_id: str = _TOOL_ID
+
+    def __init__(self) -> None:
+        self._widgets: list[Any] = []
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        """Return embedding preferences for the Sidekick chat panel.
+
+        The panel prefers to be docked on the side rather than shown in
+        a central tab, but the host may override this hint when dock
+        layouts are unavailable.
+
+        Returns:
+            :class:`EmbedCapabilities` with ``prefers_dock=True``.
+        """
+        return EmbedCapabilities(
+            supports_embedded=True,
+            prefers_dock=True,
+            min_size=(320, 480),
+            requires_separate_qapplication=False,
+        )
+
+    def create_main_widget(self, parent: Any) -> Any:
+        """Construct and return a :class:`ChatDockWidget` for embedding.
+
+        Preconditions:
+            ``parent`` is ``None`` or a ``QWidget`` instance.
+
+        Args:
+            parent: The intended Qt parent (``QWidget | None``).
+
+        Returns:
+            A new :class:`~src.shared.python.chat.ChatDockWidget`.
+
+        Raises:
+            TypeError: If ``parent`` is not ``None`` and is not a
+                ``QWidget``.
+        """
+        # DbC: validate parent type without importing PyQt6 at module level.
+        if parent is not None:
+            try:
+                from PyQt6.QtWidgets import QWidget  # noqa: PLC0415
+
+                if not isinstance(parent, QWidget):
+                    raise TypeError(
+                        "create_main_widget: parent must be a QWidget or None, "
+                        f"got {type(parent).__name__}"
+                    )
+            except ImportError:
+                # PyQt6 not available — accept any truthy parent and log a
+                # warning so the issue surfaces in CI without crashing.
+                logger.warning(
+                    "create_main_widget: PyQt6 not available; parent type check skipped"
+                )
+
+        widget = _create_chat_dock_widget(parent)
+        self._widgets.append(widget)
+        logger.debug("SidekickTool: created ChatDockWidget (parent=%r)", parent)
+        return widget
+
+    def cleanup(self) -> None:
+        """Release resources held by all widgets handed out so far.
+
+        Idempotent: hosts may call this multiple times during shutdown.
+        """
+        widgets, self._widgets = self._widgets, []
+        for widget in widgets:
+            try:
+                widget.close()
+            except Exception:  # noqa: BLE001 - defensive, never raise in cleanup
+                logger.exception("SidekickTool: widget close raised")
+
+    def is_dirty(self) -> bool:
+        """Return ``False`` — the chat panel does not track unsaved state."""
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Register on first import; guard against duplicate registration so
+# importing from both the package __init__ and a test is idempotent.
+# ---------------------------------------------------------------------------
+_ADAPTER = SidekickTool()
+if get_embeddable_tool(_TOOL_ID) is None:
+    register_embeddable_tool(_ADAPTER)

--- a/src/shared/python/config/__init__.py
+++ b/src/shared/python/config/__init__.py
@@ -1,3 +1,72 @@
-"""Configuration management, environment, and model registry."""
+"""Configuration management, environment, and model registry.
 
-__all__: list[str] = []
+Public surface
+--------------
+The most commonly needed accessors are re-exported here so that call-sites
+can import from a single place::
+
+    from src.shared.python.config import get_setting, load_settings, save_settings
+
+For the full catalogue of environment-variable accessors see
+``src.shared.python.config.settings``.
+"""
+
+from src.shared.python.config.settings import (
+    get_admin_password,
+    get_api_host,
+    get_api_port,
+    get_database_url,
+    get_dbc_level,
+    get_display,
+    get_env_bool,
+    get_env_float,
+    get_env_int,
+    get_env_list,
+    get_environment,
+    get_golf_port,
+    get_golf_suite_mode,
+    get_golf_ui_dist,
+    get_log_level,
+    get_secret_key,
+    get_setting,
+    is_auth_disabled,
+    is_browser_suppressed,
+    is_development,
+    is_docker,
+    is_headless,
+    is_production,
+    is_wsl,
+    load_settings,
+    require_env,
+    save_settings,
+)
+
+__all__ = [
+    "get_admin_password",
+    "get_api_host",
+    "get_api_port",
+    "get_database_url",
+    "get_dbc_level",
+    "get_display",
+    "get_environment",
+    "get_env_bool",
+    "get_env_float",
+    "get_env_int",
+    "get_env_list",
+    "get_golf_port",
+    "get_golf_suite_mode",
+    "get_golf_ui_dist",
+    "get_log_level",
+    "get_secret_key",
+    "get_setting",
+    "is_auth_disabled",
+    "is_browser_suppressed",
+    "is_development",
+    "is_docker",
+    "is_headless",
+    "is_production",
+    "is_wsl",
+    "load_settings",
+    "require_env",
+    "save_settings",
+]

--- a/src/shared/python/config/settings.py
+++ b/src/shared/python/config/settings.py
@@ -73,8 +73,16 @@ Import from there (or from this module for convenience):
         get_api_host,
         get_api_port,
         get_log_level,
+        get_setting,
+        load_settings,
+        save_settings,
     )
 """
+
+from __future__ import annotations
+
+import logging
+from typing import Any
 
 from src.shared.python.config.environment import (
     get_admin_password,
@@ -103,6 +111,76 @@ from src.shared.python.config.environment import (
     require_env,
 )
 
+_logger = logging.getLogger(__name__)
+
+# In-process settings overlay: persists only for the lifetime of the process.
+# Use environment variables or persistent config files for cross-process state.
+_settings_store: dict[str, Any] = {}
+
+
+def get_setting(key: str, default: Any = None) -> Any:
+    """Return the value for *key* from the in-process settings store.
+
+    Preconditions:
+        key must be a non-empty string.
+
+    Args:
+        key: The setting name.
+        default: Value to return when *key* is absent. Defaults to ``None``.
+
+    Returns:
+        The stored value, or *default* if *key* is not present.
+
+    Raises:
+        TypeError: If *key* is not a string.
+
+    Example:
+        >>> get_setting("simulation_timeout", default=60)
+        60
+    """
+    if not isinstance(key, str):
+        raise TypeError(f"key must be a str, got {type(key).__name__!r}")
+    return _settings_store.get(key, default)
+
+
+def load_settings() -> dict[str, Any]:
+    """Return a snapshot of the current in-process settings store.
+
+    Returns:
+        A shallow copy of the settings dict so callers cannot mutate internal
+        state directly.
+
+    Example:
+        >>> settings = load_settings()
+        >>> isinstance(settings, dict)
+        True
+    """
+    return dict(_settings_store)
+
+
+def save_settings(data: dict[str, Any]) -> None:
+    """Merge *data* into the in-process settings store.
+
+    Existing keys are overwritten; keys not in *data* are preserved.
+
+    Preconditions:
+        data must be a dict.
+
+    Args:
+        data: Mapping of setting names to values.
+
+    Raises:
+        TypeError: If *data* is not a dict.
+
+    Example:
+        >>> save_settings({"simulation_timeout": 120})
+    """
+    if not isinstance(data, dict):
+        raise TypeError(f"data must be a dict, got {type(data).__name__!r}")
+    _settings_store.update(data)
+    _logger.debug("Settings updated: %d key(s) merged", len(data))
+
+
 __all__ = [
     "get_admin_password",
     "get_api_host",
@@ -120,6 +198,7 @@ __all__ = [
     "get_golf_ui_dist",
     "get_log_level",
     "get_secret_key",
+    "get_setting",
     "is_auth_disabled",
     "is_browser_suppressed",
     "is_development",
@@ -127,5 +206,7 @@ __all__ = [
     "is_headless",
     "is_production",
     "is_wsl",
+    "load_settings",
     "require_env",
+    "save_settings",
 ]

--- a/src/shared/python/data_io/__init__.py
+++ b/src/shared/python/data_io/__init__.py
@@ -1,3 +1,27 @@
-"""Data import/export, IO utilities, and provenance tracking."""
+"""Data import/export, IO utilities, and provenance tracking.
 
-__all__: list[str] = []
+Public surface
+--------------
+Commonly used symbols are re-exported here::
+
+    from src.shared.python.data_io import (
+        ProvenanceInfo,
+        add_provenance_header,
+        add_provenance_header_file,
+        add_provenance_to_csv,
+    )
+"""
+
+from src.shared.python.data_io.provenance import (
+    ProvenanceInfo,
+    add_provenance_header,
+    add_provenance_header_file,
+    add_provenance_to_csv,
+)
+
+__all__ = [
+    "ProvenanceInfo",
+    "add_provenance_header",
+    "add_provenance_header_file",
+    "add_provenance_to_csv",
+]

--- a/src/shared/python/data_io/provenance.py
+++ b/src/shared/python/data_io/provenance.py
@@ -258,6 +258,47 @@ class ProvenanceInfo:
         return lines
 
 
+def add_provenance_header(content: str, metadata: dict[str, Any]) -> str:
+    """Prepend a provenance header to an in-memory string.
+
+    This is the in-memory counterpart to :func:`add_provenance_header_file`.
+    It constructs a lightweight comment block from *metadata* and prepends it
+    to *content*, returning the combined string.  No file I/O is performed.
+
+    Preconditions:
+        - ``content`` must be a ``str``
+        - ``metadata`` must be a ``dict``
+
+    Args:
+        content: The original text content (e.g. CSV data as a string).
+        metadata: Arbitrary key/value pairs to embed in the header.  Each
+            pair is written as ``# key: value``.
+
+    Returns:
+        A new string with the provenance comment block prepended to *content*.
+
+    Raises:
+        TypeError: If *content* is not a ``str`` or *metadata* is not a
+            ``dict``.
+
+    Example:
+        >>> result = add_provenance_header("col1,col2\\n1,2\\n", {"run": "001"})
+        >>> result.splitlines()[0].startswith("#")
+        True
+    """
+    if not isinstance(content, str):
+        raise TypeError(f"content must be a str, got {type(content).__name__!r}")
+    if not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be a dict, got {type(metadata).__name__!r}")
+
+    header_lines: list[str] = ["# Provenance header"]
+    for key, value in sorted(metadata.items()):
+        header_lines.append(f"# {key}: {value}")
+    header_lines.append("#")
+    header_block = "\n".join(header_lines) + "\n"
+    return header_block + content
+
+
 def add_provenance_header_file(file: TextIO, provenance: ProvenanceInfo) -> None:
     """Add provenance header to an open text file.
 
@@ -326,6 +367,7 @@ def add_provenance_to_csv(
 # Export public API
 __all__ = [
     "ProvenanceInfo",
+    "add_provenance_header",
     "add_provenance_header_file",
     "add_provenance_to_csv",
 ]

--- a/src/shared/python/physics/ground_reaction_forces.py
+++ b/src/shared/python/physics/ground_reaction_forces.py
@@ -230,8 +230,8 @@ def compute_angular_impulse(
         (len(forces), len(cops), len(timestamps)),
     )
     require(
-        reference_point.shape == (3,),
-        "reference_point must be a (3,) vector",
+        reference_point.shape == (3,) or reference_point.shape == (len(timestamps), 3),
+        "reference_point must be a (3,) vector or an (N, 3) trajectory matching timestamps",
         reference_point.shape,
     )
 
@@ -461,15 +461,25 @@ class GRFAnalyzer:
 
         # Angular impulse about COMs
         if self.golfer_com_trajectory is not None:
+            ref_golfer = (
+                self.golfer_com_trajectory
+                if len(self.golfer_com_trajectory) == len(timestamps)
+                else self.golfer_com_trajectory[0]
+            )
             golfer_com_impulse = compute_angular_impulse(
-                forces, cops, timestamps, self.golfer_com_trajectory[0]
+                forces, cops, timestamps, ref_golfer
             )
         else:
             golfer_com_impulse = np.zeros(3)
 
         if self.system_com_trajectory is not None:
+            ref_system = (
+                self.system_com_trajectory
+                if len(self.system_com_trajectory) == len(timestamps)
+                else self.system_com_trajectory[0]
+            )
             system_com_impulse = compute_angular_impulse(
-                forces, cops, timestamps, self.system_com_trajectory[0]
+                forces, cops, timestamps, ref_system
             )
         else:
             system_com_impulse = np.zeros(3)

--- a/src/shared/python/upstream_drift_tools/lab/bio/force_plate_stitching.py
+++ b/src/shared/python/upstream_drift_tools/lab/bio/force_plate_stitching.py
@@ -1,0 +1,97 @@
+"""Force plate data stitching and combination.
+
+Implements combining multiple force plates into a single equivalent global force,
+moment, and center of pressure (COP) trajectory.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.shared.python.contracts import require
+
+
+class CombinedForcePlateProcessor:
+    """Processor to merge multiple force plates into a global equivalent."""
+
+    def __init__(self, fz_threshold: float = 10.0) -> None:
+        """Initialize processor.
+
+        Args:
+            fz_threshold: Minimum vertical force [N] to compute a valid COP.
+                Below this threshold, COP defaults to origin to prevent
+                divide-by-zero spikes.
+        """
+        require(fz_threshold >= 0, "Force threshold must be non-negative")
+        self.fz_threshold = fz_threshold
+
+    def process(self, df: pd.DataFrame, ground_height: float = 0.0) -> pd.DataFrame:
+        """Combine multiple force plates.
+
+        Args:
+            df: Wide-format force plate DataFrame (from C3DDataReader).
+                Must contain columns: sample, time, plate, fx, fy, fz, mx, my, mz
+            ground_height: Height of the ground plane [m].
+
+        Returns:
+            A new DataFrame containing combined forces, moments, and COP.
+        """
+        required_cols = {"sample", "time", "fx", "fy", "fz", "mx", "my", "mz"}
+        require(
+            required_cols.issubset(df.columns),
+            f"DataFrame must contain columns: {required_cols}",
+        )
+
+        # If there's no data, return empty with correct columns
+        if df.empty:
+            return pd.DataFrame(
+                columns=[
+                    "sample",
+                    "time",
+                    "fx",
+                    "fy",
+                    "fz",
+                    "mx",
+                    "my",
+                    "mz",
+                    "cop_x",
+                    "cop_y",
+                    "cop_z",
+                ]
+            )
+
+        # Group by sample and time to sum forces and moments across all plates
+        combined = df.groupby(["sample", "time"], as_index=False).agg(
+            {
+                "fx": "sum",
+                "fy": "sum",
+                "fz": "sum",
+                "mx": "sum",
+                "my": "sum",
+                "mz": "sum",
+            }
+        )
+
+        # Vectorized COP computation
+        fz = combined["fz"].to_numpy()
+        mx = combined["mx"].to_numpy()
+        my = combined["my"].to_numpy()
+
+        cop_x = np.zeros_like(fz)
+        cop_y = np.zeros_like(fz)
+        cop_z = np.full_like(fz, ground_height)
+
+        # Apply threshold to prevent divide-by-zero spikes
+        valid_mask = np.abs(fz) >= self.fz_threshold
+        
+        # COP_x = -M_y / F_z
+        # COP_y = M_x / F_z
+        cop_x[valid_mask] = -my[valid_mask] / fz[valid_mask]
+        cop_y[valid_mask] = mx[valid_mask] / fz[valid_mask]
+
+        combined["cop_x"] = cop_x
+        combined["cop_y"] = cop_y
+        combined["cop_z"] = cop_z
+
+        return combined

--- a/src/shared/python/upstream_drift_tools/tests/lab/bio/test_force_plate_stitching.py
+++ b/src/shared/python/upstream_drift_tools/tests/lab/bio/test_force_plate_stitching.py
@@ -1,0 +1,111 @@
+"""Tests for force plate stitching module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from upstream_drift_tools.lab.bio.force_plate_stitching import (
+    CombinedForcePlateProcessor,
+)
+
+
+def test_empty_dataframe() -> None:
+    """Processor handles empty DataFrame gracefully."""
+    processor = CombinedForcePlateProcessor()
+    df = pd.DataFrame(columns=["sample", "time", "plate", "fx", "fy", "fz", "mx", "my", "mz"])
+    result = processor.process(df)
+    assert result.empty
+    assert "cop_x" in result.columns
+
+
+def test_missing_columns() -> None:
+    """Processor raises error if required columns are missing."""
+    processor = CombinedForcePlateProcessor()
+    df = pd.DataFrame({"sample": [1], "fx": [10.0]})
+    with pytest.raises(Exception, match="DataFrame must contain columns"):
+        processor.process(df)
+
+
+def test_single_plate_processing() -> None:
+    """Processor correctly computes COP for a single plate."""
+    processor = CombinedForcePlateProcessor(fz_threshold=5.0)
+    
+    # 1 sample, Fz = 100, Mx = 50, My = -20
+    df = pd.DataFrame({
+        "sample": [0],
+        "time": [0.0],
+        "plate": [1],
+        "fx": [0.0],
+        "fy": [0.0],
+        "fz": [100.0],
+        "mx": [50.0],
+        "my": [-20.0],
+        "mz": [0.0],
+    })
+    
+    result = processor.process(df, ground_height=0.0)
+    
+    # COP_x = -My / Fz = 20 / 100 = 0.2
+    # COP_y = Mx / Fz = 50 / 100 = 0.5
+    assert len(result) == 1
+    np.testing.assert_allclose(result.iloc[0]["cop_x"], 0.2)
+    np.testing.assert_allclose(result.iloc[0]["cop_y"], 0.5)
+
+
+def test_multi_plate_stitching() -> None:
+    """Processor merges forces and moments from multiple plates."""
+    processor = CombinedForcePlateProcessor(fz_threshold=5.0)
+    
+    # Sample 0, 2 plates
+    # Plate 1: Fz = 100, COP at (0.2, 0.5) -> My = -20, Mx = 50
+    # Plate 2: Fz = 200, COP at (0.8, 0.5) -> My = -160, Mx = 100
+    df = pd.DataFrame({
+        "sample": [0, 0],
+        "time": [0.0, 0.0],
+        "plate": [1, 2],
+        "fx": [0.0, 0.0],
+        "fy": [0.0, 0.0],
+        "fz": [100.0, 200.0],
+        "mx": [50.0, 100.0],
+        "my": [-20.0, -160.0],
+        "mz": [0.0, 0.0],
+    })
+    
+    result = processor.process(df)
+    
+    assert len(result) == 1
+    
+    # Combined Fz = 300
+    # Combined Mx = 150
+    # Combined My = -180
+    
+    # COP_x = -(-180) / 300 = 180 / 300 = 0.6
+    # COP_y = 150 / 300 = 0.5
+    np.testing.assert_allclose(result.iloc[0]["fz"], 300.0)
+    np.testing.assert_allclose(result.iloc[0]["cop_x"], 0.6)
+    np.testing.assert_allclose(result.iloc[0]["cop_y"], 0.5)
+
+
+def test_below_threshold_defaults_to_origin() -> None:
+    """Forces below threshold result in COP at origin."""
+    processor = CombinedForcePlateProcessor(fz_threshold=10.0)
+    
+    df = pd.DataFrame({
+        "sample": [0],
+        "time": [0.0],
+        "plate": [1],
+        "fx": [0.0],
+        "fy": [0.0],
+        "fz": [5.0],  # Below threshold
+        "mx": [50.0],
+        "my": [-20.0],
+        "mz": [0.0],
+    })
+    
+    result = processor.process(df, ground_height=0.1)
+    
+    assert result.iloc[0]["cop_x"] == 0.0
+    assert result.iloc[0]["cop_y"] == 0.0
+    assert result.iloc[0]["cop_z"] == 0.1

--- a/tests/unit/api/test_chat_service_app_state.py
+++ b/tests/unit/api/test_chat_service_app_state.py
@@ -1,0 +1,329 @@
+"""Tests for ChatService app_state wiring (issue #5470).
+
+TDD suite: verifies that the Sidekick chat assistant injects the current
+application state and historical diagnostic outputs into the AI adapter's
+system context.
+
+RED phase: all tests should fail until the implementation lands.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.app_state import HistoryStore, StateLogger, agent_context
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_service(app_state_provider=None, tmp_path=None):
+    """Return a ChatService with a mocked adapter and optional provider."""
+    with patch("src.api.services.chat_service.ChatService._load_adapter"):
+        from src.api.services.chat_service import ChatService
+
+        svc = ChatService(app_state_provider=app_state_provider)
+        if tmp_path is not None:
+            svc.PERSIST_DIR = tmp_path / "chat_sessions"
+        svc._adapter = MagicMock()
+        return svc
+
+
+def _make_store_with_event() -> HistoryStore:
+    """Return a HistoryStore pre-loaded with one test event."""
+    store = HistoryStore()
+    store.append_event("test_event", {"key": "value"})
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppStateProviderInit:
+    """Tests for the app_state_provider constructor argument."""
+
+    def test_chat_service_without_provider_accepts_none(self) -> None:
+        """ChatService can be constructed without an app_state_provider."""
+        svc = _make_chat_service(app_state_provider=None)
+        assert svc._app_state_provider is None
+
+    def test_chat_service_with_callable_provider_stores_it(self) -> None:
+        """A callable app_state_provider is stored on the service."""
+        provider = lambda: {"events": [], "last_diagnostics": [], "summary": ""}  # noqa: E731
+        svc = _make_chat_service(app_state_provider=provider)
+        assert svc._app_state_provider is provider
+
+    def test_invalid_provider_type_raises_type_error(self) -> None:
+        """Passing a non-callable, non-None provider raises TypeError."""
+        with pytest.raises(TypeError, match="app_state_provider"):
+            _make_chat_service(app_state_provider="not-callable")
+
+
+class TestNoStateContext:
+    """Without a provider, no state system message is injected."""
+
+    def test_chat_service_without_provider_sends_no_state_context(
+        self, tmp_path
+    ) -> None:
+        """stream_response should NOT inject a state system message when provider is None."""
+        svc = _make_chat_service(app_state_provider=None, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        # Capture the context passed to the adapter
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        # There should be no system message about "application state"
+        if captured_contexts:
+            messages = captured_contexts[0].messages
+            system_messages = [m for m in messages if m.role == "system"]
+            state_messages = [
+                m for m in system_messages if "application state" in m.content.lower()
+            ]
+            assert state_messages == []
+
+
+class TestStateContextInjection:
+    """With a provider, state context is injected as a system message."""
+
+    def test_chat_service_with_provider_injects_state_as_system_message(
+        self, tmp_path
+    ) -> None:
+        """stream_response injects a system message from app_state_provider."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts, "adapter should have been called"
+        messages = captured_contexts[0].messages
+        system_messages = [m for m in messages if m.role == "system"]
+        state_messages = [
+            m for m in system_messages if "application state" in m.content.lower()
+        ]
+        assert state_messages, (
+            "Expected at least one 'application state' system message"
+        )
+
+    def test_state_context_includes_events_key(self, tmp_path) -> None:
+        """Injected state JSON contains the 'events' key."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts
+        state_msg = next(
+            m
+            for m in captured_contexts[0].messages
+            if m.role == "system" and "application state" in m.content.lower()
+        )
+        # The content must contain JSON with "events" key
+        assert '"events"' in state_msg.content
+
+    def test_state_context_includes_last_diagnostics_key(self, tmp_path) -> None:
+        """Injected state JSON contains the 'last_diagnostics' key."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts
+        state_msg = next(
+            m
+            for m in captured_contexts[0].messages
+            if m.role == "system" and "application state" in m.content.lower()
+        )
+        assert '"last_diagnostics"' in state_msg.content
+
+    def test_state_context_is_json_serializable(self, tmp_path) -> None:
+        """The dict returned by the provider must be JSON-serializable."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        state_dict = provider()
+        # Should not raise
+        serialized = json.dumps(state_dict)
+        parsed = json.loads(serialized)
+        assert "events" in parsed
+        assert "last_diagnostics" in parsed
+        assert "summary" in parsed
+
+
+class TestProviderResiliency:
+    """Provider exceptions must not crash the chat session."""
+
+    def test_provider_exception_does_not_crash_chat(self, tmp_path) -> None:
+        """If app_state_provider raises, stream_response continues normally."""
+        from unittest.mock import MagicMock
+
+        def _raising_provider() -> dict:
+            raise RuntimeError("provider exploded")
+
+        svc = _make_chat_service(
+            app_state_provider=_raising_provider, tmp_path=tmp_path
+        )
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            chunk = MagicMock()
+            chunk.content = "ok"
+            chunk.tool_call_delta = None
+            return iter([chunk])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        chunks = asyncio.run(_collect())
+        # Chat must still work despite the provider failure
+        assert "ok" in chunks
+        # No state system message should have been injected (provider failed)
+        if captured_contexts:
+            messages = captured_contexts[0].messages
+            state_messages = [
+                m
+                for m in messages
+                if m.role == "system" and "application state" in m.content.lower()
+            ]
+            assert state_messages == []
+
+
+class TestChatEventLogging:
+    """Chat events are recorded into app_state (feedback loop)."""
+
+    def test_add_user_message_logs_chat_event(self, tmp_path) -> None:
+        """add_user_message records a 'chat.message_sent' event in StateLogger."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello from user")
+
+        events = store.snapshot()
+        types = [e.type for e in events]
+        assert "chat.message_sent" in types
+
+    def test_add_user_message_log_includes_session_id(self, tmp_path) -> None:
+        """chat.message_sent payload carries the session_id."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello")
+
+        event = next(e for e in store.snapshot() if e.type == "chat.message_sent")
+        assert event.payload.get("session_id") == ctx.session_id
+
+    def test_stream_response_logs_response_received(self, tmp_path) -> None:
+        """stream_response records a 'chat.response_received' event on success."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello")
+
+            svc._adapter.stream_response.return_value = iter([])
+
+            import asyncio
+
+            asyncio.run(_collect_async(svc.stream_response(ctx.session_id)))
+
+        types = [e.type for e in store.snapshot()]
+        assert "chat.response_received" in types
+
+
+async def _collect_async(ait):
+    """Consume an async iterator and return all items."""
+    return [item async for item in ait]

--- a/tests/unit/biomechanics/test_dynamic_com.py
+++ b/tests/unit/biomechanics/test_dynamic_com.py
@@ -1,0 +1,136 @@
+"""Tests for dynamic COM computation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.biomechanics.dynamic_com import BiomechanicalModel
+from src.shared.python.humanoid_character_builder.core.anthropometry import (
+    DE_LEVA_DATA,
+    get_anthropometry_key,
+)
+
+
+def test_initialization() -> None:
+    """Test model initializes correctly with valid inputs."""
+    model = BiomechanicalModel(total_mass_kg=75.0, gender_factor=0.5)
+    assert model.total_mass_kg == 75.0
+    assert model.gender_factor == 0.5
+    assert len(model.segment_masses) > 0
+
+
+def test_initialization_invalid() -> None:
+    """Test initialization fails with invalid inputs."""
+    with pytest.raises(ValueError, match="Total mass must be positive"):
+        BiomechanicalModel(total_mass_kg=-10.0)
+
+    with pytest.raises(ValueError, match="Gender factor must be between 0 and 1"):
+        BiomechanicalModel(total_mass_kg=75.0, gender_factor=1.5)
+
+
+def test_add_segment() -> None:
+    """Test adding a segment to the model."""
+    model = BiomechanicalModel(total_mass_kg=75.0)
+    model.add_segment("right_thigh", ["R_ASIS", "L_ASIS"], ["R_KNEE"])
+
+    assert len(model.segments) == 1
+    assert model.segments[0].name == "right_thigh"
+    assert "R_ASIS" in model.segments[0].proximal_markers
+
+
+def test_add_invalid_segment() -> None:
+    """Test adding an unknown segment raises an error."""
+    model = BiomechanicalModel(total_mass_kg=75.0)
+    with pytest.raises(ValueError, match="Unknown segment name: unknown_segment"):
+        model.add_segment("unknown_segment", ["A"], ["B"])
+
+
+def test_compute_dynamic_com_empty_model() -> None:
+    """Test computing COM without segments raises an error."""
+    model = BiomechanicalModel(total_mass_kg=75.0)
+    with pytest.raises(ValueError, match="No segments defined in the model"):
+        model.compute_dynamic_com({"A": np.zeros((10, 3))})
+
+
+def test_compute_dynamic_com_missing_marker() -> None:
+    """Test computing COM with missing markers raises an error."""
+    model = BiomechanicalModel(total_mass_kg=75.0)
+    model.add_segment("head", ["HEAD_TOP"], ["NECK"])
+
+    with pytest.raises(ValueError, match="Missing required marker: NECK"):
+        model.compute_dynamic_com({"HEAD_TOP": np.zeros((10, 3))})
+
+
+def test_compute_dynamic_com_static_pose() -> None:
+    """Test dynamic COM computation for a simple static pose."""
+    model = BiomechanicalModel(total_mass_kg=100.0, gender_factor=0.5)
+    model.add_segment("right_thigh", ["HIP"], ["KNEE"])
+    model.add_segment("right_shin", ["KNEE"], ["ANKLE"])
+
+    # Provide static trajectories for 10 frames
+    n_frames = 10
+    trajectories = {
+        "HIP": np.zeros((n_frames, 3)),
+        "KNEE": np.zeros((n_frames, 3)),
+        "ANKLE": np.zeros((n_frames, 3)),
+    }
+
+    # Vertical pose: HIP at z=1.0, KNEE at z=0.5, ANKLE at z=0.0
+    trajectories["HIP"][:, 2] = 1.0
+    trajectories["KNEE"][:, 2] = 0.5
+    trajectories["ANKLE"][:, 2] = 0.0
+
+    com = model.compute_dynamic_com(trajectories)
+
+    # Calculate expected COM analytically
+    thigh_data = DE_LEVA_DATA.get_segment_data(get_anthropometry_key("thigh"), 0.5)
+    shin_data = DE_LEVA_DATA.get_segment_data(get_anthropometry_key("shin"), 0.5)
+
+    thigh_mass = model.segment_masses["right_thigh"]
+    shin_mass = model.segment_masses["right_shin"]
+
+    thigh_com_z = 1.0 + thigh_data.com_proximal_ratio * (0.5 - 1.0)
+    shin_com_z = 0.5 + shin_data.com_proximal_ratio * (0.0 - 0.5)
+
+    expected_z = (thigh_com_z * thigh_mass + shin_com_z * shin_mass) / (
+        thigh_mass + shin_mass
+    )
+
+    # Check output shape
+    assert com.shape == (n_frames, 3)
+
+    # X and Y should be zero
+    np.testing.assert_allclose(com[:, 0], 0.0, atol=1e-10)
+    np.testing.assert_allclose(com[:, 1], 0.0, atol=1e-10)
+
+    # Z should match expected
+    np.testing.assert_allclose(com[:, 2], expected_z, rtol=1e-5)
+
+
+def test_compute_dynamic_com_moving_pose() -> None:
+    """Test dynamic COM computation with a moving pose."""
+    model = BiomechanicalModel(total_mass_kg=100.0)
+    model.add_segment("right_thigh", ["HIP"], ["KNEE"])
+
+    n_frames = 5
+    trajectories = {
+        "HIP": np.zeros((n_frames, 3)),
+        "KNEE": np.zeros((n_frames, 3)),
+    }
+
+    # Move along X axis over time
+    timestamps = np.arange(n_frames)
+    trajectories["HIP"][:, 0] = timestamps
+    trajectories["KNEE"][:, 0] = timestamps + 1.0  # Constant 1m offset
+
+    com = model.compute_dynamic_com(trajectories)
+
+    # COM should move along X axis with the segment
+    thigh_data = DE_LEVA_DATA.get_segment_data(get_anthropometry_key("thigh"), 0.5)
+    com_ratio = thigh_data.com_proximal_ratio
+
+    expected_x = timestamps + com_ratio * 1.0
+
+    np.testing.assert_allclose(com[:, 0], expected_x, rtol=1e-5)
+    np.testing.assert_allclose(com[:, 1:], 0.0, atol=1e-10)

--- a/tests/unit/biomechanics/test_grf_visualization.py
+++ b/tests/unit/biomechanics/test_grf_visualization.py
@@ -1,0 +1,60 @@
+"""Tests for GRF visualization tools."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.shared.python.biomechanics.grf_visualization import plot_grf_and_com_3d
+
+
+def test_plot_grf_and_com_3d() -> None:
+    """Test that the 3D plot function executes without errors."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        pytest.skip("matplotlib not installed")
+
+    # Generate synthetic data
+    n_frames = 50
+    com_trajectory = np.zeros((n_frames, 3))
+    com_trajectory[:, 2] = 1.0  # COM at z=1.0
+    com_trajectory[:, 0] = np.linspace(0, 1, n_frames)  # Moving along X
+
+    force_df = pd.DataFrame(
+        {
+            "fx": np.zeros(n_frames),
+            "fy": np.zeros(n_frames),
+            "fz": np.ones(n_frames) * 800.0,
+            "cop_x": np.linspace(0, 1, n_frames),
+            "cop_y": np.zeros(n_frames),
+            "cop_z": np.zeros(n_frames),
+        }
+    )
+
+    fig, ax = plot_grf_and_com_3d(force_df, com_trajectory, downsample_factor=5)
+
+    assert fig is not None
+    assert ax is not None
+    assert ax.name == "3d"
+
+    # Clean up
+    plt.close(fig)
+
+
+def test_plot_grf_length_mismatch() -> None:
+    """Test that length mismatches raise an error."""
+    n_frames = 10
+    com_trajectory = np.zeros((n_frames, 3))
+    force_df = pd.DataFrame(
+        {
+            "fx": [0.0],
+            "fy": [0.0],
+            "fz": [0.0],
+            "cop_x": [0.0],
+            "cop_y": [0.0],
+            "cop_z": [0.0],
+        }
+    )
+
+    with pytest.raises(Exception, match="matching lengths"):
+        plot_grf_and_com_3d(force_df, com_trajectory)

--- a/tests/unit/chat/test_chat_parity.py
+++ b/tests/unit/chat/test_chat_parity.py
@@ -1,0 +1,286 @@
+"""Parity tests for the Sidekick chat surfaces (issue #5469).
+
+Verifies that the PyQt and React chat surfaces share the same JSON message
+contract and that the FastAPI WebSocket route accepts the context fields
+sent by both clients.
+
+Coverage:
+- test_pyqt_chat_request_schema_matches_api_model: PyQt outgoing payload
+  matches ChatMessageRequest Pydantic schema
+- test_react_server_message_interface_covers_all_types: React's ServerMessage
+  type definitions include model_list and index_status fields
+- test_chat_ws_route_accepts_app_context_key: The app-level chat_ws route
+  reads ``app_context`` (the PyQt key) as well as ``engine_context``
+- test_chat_ws_route_accepts_engine_context_key: The app-level chat_ws route
+  reads ``engine_context`` (the React key)
+- test_router_factory_accepts_both_context_keys: The shared router factory
+  accepts both context keys
+- test_chat_ws_message_format_roundtrip: A send payload can be validated
+  through the Pydantic schema with both context field names
+- test_shared_models_match_api_models: shared/python/chat/models.py and
+  src/api/models/chat.py define the same core fields
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Schema round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatMessageRequestSchema:
+    """PyQt outgoing payload must satisfy ChatMessageRequest."""
+
+    def test_pyqt_chat_request_schema_matches_api_model(self) -> None:
+        """PyQt sends {action, message, app_context}; validate via shared model."""
+        from src.shared.python.chat.models import ChatMessageRequest
+
+        # PyQt payload as constructed in _chat_dock_widget_qt.py
+        pyqt_payload = {
+            "action": "send",
+            "message": "hello from PyQt",
+            "app_context": "mujoco",
+        }
+        # Extract only the fields the Pydantic model cares about
+        req = ChatMessageRequest(
+            message=pyqt_payload["message"],
+            app_context=pyqt_payload.get("app_context"),
+        )
+        assert req.message == "hello from PyQt"
+        assert req.app_context == "mujoco"
+
+    def test_react_chat_request_schema_matches_api_model(self) -> None:
+        """React sends {action, message, engine_context}; validate via API model."""
+        from src.api.models.chat import ChatMessageRequest
+
+        # React payload as constructed in ChatPanel.tsx
+        react_payload = {
+            "action": "send",
+            "message": "hello from React",
+            "engine_context": "drake",
+        }
+        req = ChatMessageRequest(
+            message=react_payload["message"],
+            engine_context=react_payload.get("engine_context"),
+        )
+        assert req.message == "hello from React"
+        assert req.engine_context == "drake"
+
+    def test_chat_ws_message_format_roundtrip(self) -> None:
+        """A message serialized by either client is accepted by both models."""
+        from src.api.models.chat import ChatMessageRequest as ApiReq
+        from src.shared.python.chat.models import ChatMessageRequest as SharedReq
+
+        # Shared model (PyQt style)
+        shared_req = SharedReq(message="test", app_context="pinocchio")
+        assert shared_req.message == "test"
+
+        # API model (React style)
+        api_req = ApiReq(message="test", engine_context="pinocchio")
+        assert api_req.message == "test"
+
+        # Both models accept the same message text and min/max lengths
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SharedReq(message="")
+        with pytest.raises(ValidationError):
+            ApiReq(message="")
+
+    def test_shared_models_match_api_models_core_fields(self) -> None:
+        """Both model files define the same ChatChunkResponse and ChatModelInfo."""
+        from src.api.models.chat import ChatChunkResponse as ApiChunk
+        from src.api.models.chat import ChatModelInfo as ApiModelInfo
+        from src.shared.python.chat.models import ChatChunkResponse as SharedChunk
+        from src.shared.python.chat.models import ChatModelInfo as SharedModelInfo
+
+        # ChatChunkResponse fields
+        api_chunk = ApiChunk(content="hi")
+        shared_chunk = SharedChunk(content="hi")
+        assert api_chunk.content == shared_chunk.content
+        assert api_chunk.is_final == shared_chunk.is_final
+        assert api_chunk.index == shared_chunk.index
+
+        # ChatModelInfo required fields
+        api_mi = ApiModelInfo(name="llama3", provider="ollama")
+        shared_mi = SharedModelInfo(name="llama3", provider="ollama")
+        assert api_mi.name == shared_mi.name
+        assert api_mi.provider == shared_mi.provider
+
+
+# ---------------------------------------------------------------------------
+# Server route context-key acceptance tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatWsRouteContextKeys:
+    """Gap 1: chat_ws.py must accept both app_context and engine_context."""
+
+    def test_chat_ws_route_accepts_both_context_keys(self) -> None:
+        """chat_ws.py reads ``engine_context`` OR ``app_context`` (Gap 1 fix)."""
+        route_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "api"
+            / "routes"
+            / "chat_ws.py"
+        )
+        source = route_path.read_text(encoding="utf-8")
+        # After the fix both keys must appear on the same expression line
+        assert 'msg.get("engine_context") or msg.get("app_context")' in source, (
+            "chat_ws.py must read both 'engine_context' and 'app_context' "
+            "to serve PyQt and React clients equally (Gap 1 fix missing)"
+        )
+
+    def test_router_factory_accepts_both_context_keys(self) -> None:
+        """router_factory.py already accepts both keys — validate it stays that way."""
+        rf_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "shared"
+            / "python"
+            / "chat"
+            / "router_factory.py"
+        )
+        source = rf_path.read_text(encoding="utf-8")
+        # The router factory uses `msg.get("app_context") or msg.get("engine_context")`
+        assert "app_context" in source and "engine_context" in source, (
+            "router_factory.py must continue to accept both context keys"
+        )
+
+
+# ---------------------------------------------------------------------------
+# React ServerMessage interface coverage tests
+# ---------------------------------------------------------------------------
+
+
+class TestReactServerMessageInterface:
+    """Gap 2: React's ServerMessage interface must cover model_list and index_status."""
+
+    def _chat_panel_source(self) -> str:
+        cp_path = (
+            Path(__file__).resolve().parents[3]
+            / "ui"
+            / "src"
+            / "components"
+            / "ui"
+            / "ChatPanel.tsx"
+        )
+        return cp_path.read_text(encoding="utf-8")
+
+    def test_react_server_message_includes_model_list_fields(self) -> None:
+        """ServerMessage must carry models and refreshed_at for model_list frames."""
+        source = self._chat_panel_source()
+        assert "models?" in source, (
+            "ServerMessage interface is missing the 'models' field for "
+            "model_list frames (Gap 2 fix missing)"
+        )
+        assert "refreshed_at?" in source, (
+            "ServerMessage interface is missing 'refreshed_at' field"
+        )
+
+    def test_react_server_message_includes_index_status_fields(self) -> None:
+        """ServerMessage must carry state and files_parsed for index_status frames."""
+        source = self._chat_panel_source()
+        assert "files_parsed?" in source, (
+            "ServerMessage interface is missing 'files_parsed' field for "
+            "index_status frames (Gap 2 fix missing)"
+        )
+        assert "state?" in source, "ServerMessage interface is missing 'state' field"
+
+    def test_react_handles_model_list_case(self) -> None:
+        """handleServerMessage switch must have a 'model_list' case."""
+        source = self._chat_panel_source()
+        assert "case 'model_list':" in source, (
+            "ChatPanel.tsx handleServerMessage is missing 'model_list' case "
+            "(Gap 2 fix missing)"
+        )
+
+    def test_react_handles_index_status_case(self) -> None:
+        """handleServerMessage switch must have an 'index_status' case."""
+        source = self._chat_panel_source()
+        assert "case 'index_status':" in source, (
+            "ChatPanel.tsx handleServerMessage is missing 'index_status' case "
+            "(Gap 2 fix missing)"
+        )
+
+    def test_react_exports_chat_model_info_type(self) -> None:
+        """ChatModelInfo should be exported from ChatPanel.tsx for consumers."""
+        source = self._chat_panel_source()
+        assert "export interface ChatModelInfo" in source, (
+            "ChatPanel.tsx must export ChatModelInfo so parent components can "
+            "use it with the onModelsRefreshed callback"
+        )
+
+    def test_react_exports_chat_index_status_type(self) -> None:
+        """ChatIndexStatus should be exported from ChatPanel.tsx for consumers."""
+        source = self._chat_panel_source()
+        assert "export interface ChatIndexStatus" in source, (
+            "ChatPanel.tsx must export ChatIndexStatus so parent components can "
+            "use it with the onIndexStatus callback"
+        )
+
+    def test_react_on_models_refreshed_prop_wired(self) -> None:
+        """onModelsRefreshed prop must be forwarded in handleServerMessage."""
+        source = self._chat_panel_source()
+        assert "onModelsRefreshed" in source, (
+            "ChatPanel.tsx is missing the onModelsRefreshed prop (Gap 2)"
+        )
+
+    def test_react_on_index_status_prop_wired(self) -> None:
+        """onIndexStatus prop must be forwarded in handleServerMessage."""
+        source = self._chat_panel_source()
+        assert "onIndexStatus" in source, (
+            "ChatPanel.tsx is missing the onIndexStatus prop (Gap 2)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PyQt context-field consistency test
+# ---------------------------------------------------------------------------
+
+
+class TestPyQtContextField:
+    """PyQt outgoing payload must use app_context, matching shared models.py."""
+
+    def test_pyqt_sends_app_context_field(self) -> None:
+        """_chat_dock_widget_qt.py must send app_context (not engine_context)."""
+        qt_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "shared"
+            / "python"
+            / "chat"
+            / "_chat_dock_widget_qt.py"
+        )
+        source = qt_path.read_text(encoding="utf-8")
+        # The PyQt widget sends {"action": "send", "message": ..., "app_context": ...}
+        assert '"app_context"' in source, (
+            "_chat_dock_widget_qt.py must send 'app_context' key in outgoing "
+            "payloads to match shared/python/chat/models.py contract"
+        )
+
+    def test_shared_model_uses_app_context_field_name(self) -> None:
+        """shared/python/chat/models.py uses app_context, not engine_context."""
+        from src.shared.python.chat.models import ChatMessageRequest
+
+        fields = ChatMessageRequest.model_fields
+        assert "app_context" in fields, (
+            "ChatMessageRequest must have 'app_context' field (PyQt client contract)"
+        )
+
+    def test_api_model_uses_engine_context_field_name(self) -> None:
+        """src/api/models/chat.py uses engine_context, not app_context."""
+        from src.api.models.chat import ChatMessageRequest
+
+        fields = ChatMessageRequest.model_fields
+        assert "engine_context" in fields, (
+            "API ChatMessageRequest must have 'engine_context' field "
+            "(React client contract)"
+        )

--- a/tests/unit/motion_pipeline/_fixtures.py
+++ b/tests/unit/motion_pipeline/_fixtures.py
@@ -1,0 +1,492 @@
+"""Reusable synthetic CIR fixture builders for the motion pipeline.
+
+These builders produce **valid** Canonical Intermediate Representation (CIR)
+objects that satisfy every Pydantic v2 invariant in
+``src.shared.python.motion_pipeline.contracts``. Every downstream wave of
+the motion pipeline (preprocessing, scaling, IK backends, motion matching,
+orchestrator, sources) is expected to reuse these builders rather than
+re-deriving synthetic data inline. The builders are deterministic
+(``numpy.linspace`` for time, ``numpy.sin`` for joint angles, zeros for
+unset velocity/acceleration channels) so tests stay reproducible.
+
+The contracts in ``contracts.py`` model :data:`SchemaName`, :data:`UpAxis`,
+unit systems, and engine choices as ``typing.Literal`` strings rather than
+``enum.Enum`` types. The builders accept those raw string literals (with
+sensible defaults) for compatibility with the spec, and the public types
+:class:`KeypointSchemaT`, :class:`UnitSystemT`, :class:`WorldUpT`, and
+:class:`EngineTypeT` are re-exported below as the canonical names so
+downstream callers do not need to know whether a particular field is a
+literal or an enum.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import numpy as np
+
+from src.shared.python.motion_pipeline.contracts import (
+    Calibration,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    JointDef,
+    JointStateFrame,
+    JointTrajectory,
+    Keypoint,
+    KeypointFrame,
+    KeypointSequence,
+    Marker,
+    MarkerFrame,
+    MarkerTrajectory,
+    MotionMatchingRequest,
+    MotionMatchingResult,
+    MotionTrajectory,
+    SkeletonRig,
+)
+
+# Public type aliases - canonical names downstream code can import without
+# caring whether the underlying contract uses enum or Literal. The contract
+# module currently models these as ``typing.Literal`` strings; we mirror
+# that here so callers can use the same identifiers regardless.
+KeypointSchemaT = Literal["BODY_25", "MediaPipe_33", "COCO_17", "OpenPose_25", "custom"]
+UnitSystemT = Literal["meters", "millimeters", "pixels"]
+WorldUpT = Literal["+Y", "+Z", "+X", "-Y", "-Z", "-X"]
+EngineTypeT = Literal["mujoco", "drake", "pinocchio", "opensim", "myosuite"]
+
+# Standard golf marker set used as a default for marker fixtures.
+DEFAULT_MARKER_NAMES: tuple[str, ...] = (
+    "LSHO",
+    "RSHO",
+    "LASI",
+    "RASI",
+    "LKNE",
+    "LANK",
+)
+
+
+# =============================================================================
+# Calibration / Camera
+# =============================================================================
+
+
+def make_camera_intrinsics(
+    fx: float = 800.0, fy: float = 800.0, cx: float = 640.0, cy: float = 480.0
+) -> CameraIntrinsics:
+    """Build a default pinhole-camera intrinsics with no lens distortion."""
+    return CameraIntrinsics(fx=fx, fy=fy, cx=cx, cy=cy)
+
+
+def make_camera_extrinsics() -> CameraExtrinsics:
+    """Build identity-rotation, zero-translation extrinsics."""
+    return CameraExtrinsics(
+        rotation=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        translation=[0.0, 0.0, 0.0],
+    )
+
+
+def make_calibration(
+    fps: float = 60.0,
+    unit_system: UnitSystemT = "meters",
+    world_up: WorldUpT = "+Y",
+    *,
+    n_cameras: int = 1,
+    cal_id: str = "cal-synthetic",
+) -> Calibration:
+    """Build a multi-camera calibration with identity extrinsics.
+
+    Each synthesized camera carries a default intrinsics + extrinsics dict
+    so :class:`Calibration`'s ``check_cameras_have_intrinsics`` invariant is
+    satisfied.
+    """
+    cameras: dict[str, dict[str, Any]] = {}
+    for i in range(n_cameras):
+        cameras[f"cam{i}"] = {
+            "intrinsics": make_camera_intrinsics().model_dump(),
+            "extrinsics": make_camera_extrinsics().model_dump(),
+        }
+    return Calibration(
+        id=cal_id,
+        cameras=cameras,
+        unit_system=unit_system,
+        source_fps=fps,
+        world_up_axis=world_up,
+    )
+
+
+# =============================================================================
+# Keypoints
+# =============================================================================
+
+
+def make_keypoint_frame(
+    n_points: int = 33,
+    schema: KeypointSchemaT = "MediaPipe_33",
+    t: float = 0.0,
+    dim: int = 3,
+    *,
+    frame_index: int | None = None,
+) -> KeypointFrame:
+    """Build a keypoint frame with ``n_points`` deterministic keypoints.
+
+    ``dim=2`` produces 2D keypoints (``z=None``); ``dim=3`` produces 3D
+    keypoints with monotonic-z layout. All confidences are 1.0.
+    """
+    if dim not in (2, 3):
+        raise ValueError("dim must be 2 or 3")
+    keypoints: list[Keypoint] = []
+    for i in range(n_points):
+        keypoints.append(
+            Keypoint(
+                x=float(i) * 0.01,
+                y=float(i) * 0.02,
+                z=(float(i) * 0.03 if dim == 3 else None),
+                confidence=1.0,
+                name=f"kp_{i}",
+            )
+        )
+    return KeypointFrame(
+        timestamp=t,
+        keypoints=keypoints,
+        schema_name=schema,
+        frame_index=frame_index,
+    )
+
+
+def make_keypoint_sequence(
+    n_frames: int = 10,
+    n_points: int = 33,
+    schema: KeypointSchemaT = "MediaPipe_33",
+    fps: float = 60.0,
+    *,
+    seq_id: str = "kp-seq-synthetic",
+    with_calibration: bool = False,
+) -> KeypointSequence:
+    """Build a keypoint sequence with ``linspace`` timestamps."""
+    if n_frames < 1:
+        raise ValueError("n_frames must be >= 1")
+    times = np.linspace(0.0, max(n_frames - 1, 0) / fps, n_frames)
+    frames = [
+        make_keypoint_frame(n_points=n_points, schema=schema, t=float(t), frame_index=i)
+        for i, t in enumerate(times)
+    ]
+    return KeypointSequence(
+        id=seq_id,
+        frames=frames,
+        calibration=make_calibration(fps=fps) if with_calibration else None,
+    )
+
+
+# =============================================================================
+# Markers
+# =============================================================================
+
+
+def make_marker_frame(
+    marker_names: tuple[str, ...] = DEFAULT_MARKER_NAMES,
+    t: float = 0.0,
+    *,
+    frame_index: int | None = None,
+) -> MarkerFrame:
+    """Build a marker frame with deterministic xyz per named marker."""
+    markers: dict[str, Marker] = {}
+    for i, name in enumerate(marker_names):
+        markers[name] = Marker(
+            name=name,
+            x=float(i) * 0.1,
+            y=float(i) * 0.2,
+            z=float(i) * 0.3,
+            occluded=False,
+        )
+    return MarkerFrame(timestamp=t, markers=markers, frame_index=frame_index)
+
+
+def make_marker_trajectory(
+    n_frames: int = 10,
+    marker_names: tuple[str, ...] = DEFAULT_MARKER_NAMES,
+    fps: float = 60.0,
+    *,
+    traj_id: str = "marker-traj-synthetic",
+    subject_id: str | None = "S001",
+) -> MarkerTrajectory:
+    """Build a marker trajectory with stationary markers and linspace times."""
+    if n_frames < 1:
+        raise ValueError("n_frames must be >= 1")
+    times = np.linspace(0.0, max(n_frames - 1, 0) / fps, n_frames)
+    frames = [
+        make_marker_frame(marker_names=marker_names, t=float(t), frame_index=i)
+        for i, t in enumerate(times)
+    ]
+    return MarkerTrajectory(id=traj_id, frames=frames, subject_id=subject_id)
+
+
+# =============================================================================
+# Skeleton Rig
+# =============================================================================
+
+
+def make_skeleton_rig(
+    n_joints: int = 6, name_prefix: str = "joint", *, rig_id: str = "rig-synthetic"
+) -> SkeletonRig:
+    """Build a simple parent-chain rig: root -> joint_1 -> joint_2 -> ...
+
+    Each joint has a single rotation axis ('Y') so DOF count == joint count.
+    Root joint name is ``f"{name_prefix}_0"``.
+    """
+    if n_joints < 1:
+        raise ValueError("n_joints must be >= 1")
+    joints: dict[str, JointDef] = {}
+    for i in range(n_joints):
+        name = f"{name_prefix}_{i}"
+        parent = f"{name_prefix}_{i - 1}" if i > 0 else None
+        children = [f"{name_prefix}_{i + 1}"] if i < n_joints - 1 else []
+        joints[name] = JointDef(
+            name=name,
+            parent=parent,
+            children=children,
+            tpose_offset=[0.0, 0.1, 0.0],
+            axes=["Y"],
+            limits=[],
+            semantic_label=None,
+        )
+    return SkeletonRig(
+        id=rig_id,
+        joints=joints,
+        root_joint=f"{name_prefix}_0",
+        up_axis="+Y",
+        scale=1.0,
+    )
+
+
+# =============================================================================
+# Joint States
+# =============================================================================
+
+
+def _sine_q(num_dofs: int, t: float) -> list[float]:
+    """Deterministic sine-wave joint angles."""
+    return [float(np.sin(t + 0.1 * i)) for i in range(num_dofs)]
+
+
+def make_joint_state_frame(
+    rig: SkeletonRig,
+    t: float = 0.0,
+    *,
+    with_qdot: bool = False,
+    with_qddot: bool = False,
+    frame_index: int | None = None,
+) -> JointStateFrame:
+    """Build a joint-state frame whose dimensions match ``rig.num_dofs``."""
+    n = rig.num_dofs
+    q = _sine_q(n, t)
+    qdot = [0.0] * n if with_qdot else None
+    qddot = [0.0] * n if with_qddot else None
+    return JointStateFrame(
+        timestamp=t, q=q, qdot=qdot, qddot=qddot, frame_index=frame_index
+    )
+
+
+def make_joint_trajectory(
+    rig: SkeletonRig,
+    n_frames: int = 10,
+    fps: float = 60.0,
+    *,
+    with_qdot: bool = False,
+    with_qddot: bool = False,
+    traj_id: str = "joint-traj-synthetic",
+) -> JointTrajectory:
+    """Build a joint trajectory with sine-wave q values and linspace times."""
+    if n_frames < 1:
+        raise ValueError("n_frames must be >= 1")
+    times = np.linspace(0.0, max(n_frames - 1, 0) / fps, n_frames)
+    frames = [
+        make_joint_state_frame(
+            rig,
+            t=float(t),
+            with_qdot=with_qdot,
+            with_qddot=with_qddot,
+            frame_index=i,
+        )
+        for i, t in enumerate(times)
+    ]
+    return JointTrajectory(id=traj_id, skeleton=rig, frames=frames)
+
+
+# =============================================================================
+# Provenance / Motion / Matching
+# =============================================================================
+
+
+def make_provenance(
+    subject_id: str = "S001",
+    sport: str = "golf",
+    *,
+    source: str = "synthetic",
+) -> dict[str, Any]:
+    """Build a source-provenance dict.
+
+    The CIR encodes provenance as an open ``dict[str, Any]`` rather than a
+    dedicated model; this builder centralizes the keys so downstream waves
+    converge on the same schema.
+    """
+    return {
+        "subject_id": subject_id,
+        "sport": sport,
+        "source": source,
+        "capture_system": "synthetic-fixture",
+    }
+
+
+def make_motion_trajectory(
+    n_frames: int = 10,
+    n_joints: int = 6,
+    fps: float = 60.0,
+    *,
+    with_markers: bool = False,
+    motion_id: str = "motion-synthetic",
+    sport: str = "golf",
+) -> MotionTrajectory:
+    """Build a top-level :class:`MotionTrajectory` (rig + traj + provenance)."""
+    rig = make_skeleton_rig(n_joints=n_joints)
+    traj = make_joint_trajectory(rig, n_frames=n_frames, fps=fps)
+    markers = (
+        make_marker_trajectory(n_frames=n_frames, fps=fps) if with_markers else None
+    )
+    return MotionTrajectory(
+        id=motion_id,
+        skeleton=rig,
+        trajectory=traj,
+        marker_reference=markers,
+        subject={"height_m": 1.80, "mass_kg": 80.0},
+        sport=sport,
+        club="driver",
+        source_provenance=make_provenance(sport=sport),
+    )
+
+
+def make_cost_weights(weights: dict[str, float] | None = None) -> dict[str, float]:
+    """Build a cost-weights dict for motion matching constraints.
+
+    Cost weights are encoded inside :attr:`MotionMatchingRequest.constraints`
+    in the current contracts. This builder produces a sensible default the
+    matching/orchestrator waves can extend.
+    """
+    if weights is not None:
+        return dict(weights)
+    return {
+        "joint_position": 1.0,
+        "joint_velocity": 0.1,
+        "marker_position": 1.0,
+        "regularization": 0.01,
+    }
+
+
+def make_motion_matching_request(
+    engine: EngineTypeT = "mujoco",
+    *,
+    request_id: str = "mm-req-synthetic",
+    n_frames: int = 10,
+    n_joints: int = 6,
+) -> MotionMatchingRequest:
+    """Build a :class:`MotionMatchingRequest` with a target trajectory."""
+    target = make_motion_trajectory(n_frames=n_frames, n_joints=n_joints)
+    return MotionMatchingRequest(
+        id=request_id,
+        target_trajectory=target,
+        skeleton=target.skeleton,
+        constraints={"weights": make_cost_weights()},
+        solver_config={"engine": engine, "max_iters": 100},
+    )
+
+
+# =============================================================================
+# Solver-output stand-ins
+# =============================================================================
+# The CIR does not yet ship dedicated TorqueTrajectory / ResidualReport
+# models; downstream waves pass these as enriched dict payloads inside
+# :attr:`MotionMatchingResult.metadata`. The builders below produce the
+# canonical shape so wave-2+ tests can adopt them without divergence.
+
+
+def make_torque_trajectory(
+    rig: SkeletonRig, n_frames: int = 10, fps: float = 60.0
+) -> dict[str, Any]:
+    """Build a torque-trajectory payload (per-frame tau aligned to the rig).
+
+    Returns a dict with ``timestamps`` (length ``n_frames``) and ``tau`` (a
+    list of length ``n_frames``, each entry a list of ``rig.num_dofs``
+    zeros). Stored on
+    :attr:`MotionMatchingResult.metadata['torque_trajectory']`.
+    """
+    if n_frames < 1:
+        raise ValueError("n_frames must be >= 1")
+    times = np.linspace(0.0, max(n_frames - 1, 0) / fps, n_frames).tolist()
+    tau = [[0.0] * rig.num_dofs for _ in range(n_frames)]
+    return {"timestamps": times, "tau": tau, "skeleton_id": rig.id}
+
+
+def make_residual_report(rig: SkeletonRig) -> dict[str, Any]:
+    """Build a residual report payload keyed by joint name."""
+    return {
+        "skeleton_id": rig.id,
+        "per_joint_rmse": dict.fromkeys(rig.joints, 0.0),
+        "global_rmse": 0.0,
+        "max_residual": 0.0,
+    }
+
+
+def make_motion_matching_result(
+    rig: SkeletonRig,
+    n_frames: int = 10,
+    *,
+    kind: Literal["torque", "kinematic"] = "torque",
+    request_id: str = "mm-req-synthetic",
+    success: bool = True,
+) -> MotionMatchingResult:
+    """Build a :class:`MotionMatchingResult` with embedded torque + residual.
+
+    ``kind="torque"`` attaches a :func:`make_torque_trajectory` payload to
+    metadata; ``kind="kinematic"`` omits it.
+    """
+    motion = make_motion_trajectory(n_frames=n_frames, n_joints=rig.num_joints)
+    metadata: dict[str, Any] = {
+        "residual_report": make_residual_report(rig),
+        "kind": kind,
+    }
+    if kind == "torque":
+        metadata["torque_trajectory"] = make_torque_trajectory(rig, n_frames=n_frames)
+    return MotionMatchingResult(
+        request_id=request_id,
+        success=success,
+        matched_trajectory=motion,
+        error_metrics={"rmse": 0.0, "max_error": 0.0},
+        iterations=10,
+        solve_time=0.5,
+        message="synthetic ok",
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "DEFAULT_MARKER_NAMES",
+    "EngineTypeT",
+    "KeypointSchemaT",
+    "UnitSystemT",
+    "WorldUpT",
+    "make_calibration",
+    "make_camera_extrinsics",
+    "make_camera_intrinsics",
+    "make_cost_weights",
+    "make_joint_state_frame",
+    "make_joint_trajectory",
+    "make_keypoint_frame",
+    "make_keypoint_sequence",
+    "make_marker_frame",
+    "make_marker_trajectory",
+    "make_motion_matching_request",
+    "make_motion_matching_result",
+    "make_motion_trajectory",
+    "make_provenance",
+    "make_residual_report",
+    "make_skeleton_rig",
+    "make_torque_trajectory",
+]

--- a/tests/unit/motion_pipeline/test_fixtures.py
+++ b/tests/unit/motion_pipeline/test_fixtures.py
@@ -1,0 +1,194 @@
+"""Smoke tests for the synthetic CIR fixture builders.
+
+Each builder is exercised with default arguments and the result is run
+through a Pydantic ``model_dump_json`` -> ``model_validate_json``
+round-trip. This guards the fixture contract so downstream waves don't
+silently start producing invalid CIR objects when ``contracts.py`` evolves.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from src.shared.python.motion_pipeline.contracts import (
+    Calibration,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    JointStateFrame,
+    JointTrajectory,
+    KeypointFrame,
+    KeypointSequence,
+    MarkerFrame,
+    MarkerTrajectory,
+    MotionMatchingRequest,
+    MotionMatchingResult,
+    MotionTrajectory,
+    SkeletonRig,
+)
+
+from tests.unit.motion_pipeline._fixtures import (
+    make_calibration,
+    make_camera_extrinsics,
+    make_camera_intrinsics,
+    make_cost_weights,
+    make_joint_state_frame,
+    make_joint_trajectory,
+    make_keypoint_frame,
+    make_keypoint_sequence,
+    make_marker_frame,
+    make_marker_trajectory,
+    make_motion_matching_request,
+    make_motion_matching_result,
+    make_motion_trajectory,
+    make_provenance,
+    make_residual_report,
+    make_skeleton_rig,
+    make_torque_trajectory,
+)
+
+
+def _roundtrip(model: BaseModel) -> BaseModel:
+    """Serialize -> deserialize a Pydantic model; raises on contract drift."""
+    js = model.model_dump_json()
+    return type(model).model_validate_json(js)
+
+
+# =============================================================================
+# Per-builder smoke tests
+# =============================================================================
+
+
+def test_make_camera_intrinsics_roundtrip() -> None:
+    m = make_camera_intrinsics()
+    assert isinstance(m, CameraIntrinsics)
+    _roundtrip(m)
+
+
+def test_make_camera_extrinsics_roundtrip() -> None:
+    m = make_camera_extrinsics()
+    assert isinstance(m, CameraExtrinsics)
+    _roundtrip(m)
+
+
+def test_make_calibration_roundtrip() -> None:
+    m = make_calibration(n_cameras=2)
+    assert isinstance(m, Calibration)
+    assert len(m.cameras) == 2
+    _roundtrip(m)
+
+
+def test_make_keypoint_frame_2d() -> None:
+    f = make_keypoint_frame(n_points=5, dim=2)
+    assert isinstance(f, KeypointFrame)
+    assert all(kp.z is None for kp in f.keypoints)
+    _roundtrip(f)
+
+
+def test_make_keypoint_frame_3d() -> None:
+    f = make_keypoint_frame(n_points=33, dim=3)
+    assert all(kp.z is not None for kp in f.keypoints)
+    _roundtrip(f)
+
+
+def test_make_keypoint_sequence_monotonic_timestamps() -> None:
+    seq = make_keypoint_sequence(n_frames=5, n_points=33, fps=30.0)
+    assert isinstance(seq, KeypointSequence)
+    timestamps = [f.timestamp for f in seq.frames]
+    assert timestamps == sorted(timestamps)
+    _roundtrip(seq)
+
+
+def test_make_marker_frame() -> None:
+    f = make_marker_frame()
+    assert isinstance(f, MarkerFrame)
+    assert f.num_markers == 6
+    _roundtrip(f)
+
+
+def test_make_marker_trajectory() -> None:
+    t = make_marker_trajectory(n_frames=4)
+    assert isinstance(t, MarkerTrajectory)
+    assert t.num_frames == 4
+    _roundtrip(t)
+
+
+def test_make_skeleton_rig_chain() -> None:
+    rig = make_skeleton_rig(n_joints=4)
+    assert isinstance(rig, SkeletonRig)
+    assert rig.num_joints == 4
+    assert rig.num_dofs == 4  # one axis per joint
+    # Root has no parent; tip has no children.
+    assert rig.joints[rig.root_joint].parent is None
+    _roundtrip(rig)
+
+
+def test_make_joint_state_frame_dimensions_match_rig() -> None:
+    rig = make_skeleton_rig(n_joints=5)
+    frame = make_joint_state_frame(rig, t=0.5, with_qdot=True, with_qddot=True)
+    assert isinstance(frame, JointStateFrame)
+    assert len(frame.q) == rig.num_dofs
+    assert frame.qdot is not None and len(frame.qdot) == rig.num_dofs
+    assert frame.qddot is not None and len(frame.qddot) == rig.num_dofs
+    _roundtrip(frame)
+
+
+def test_make_joint_trajectory() -> None:
+    rig = make_skeleton_rig(n_joints=3)
+    traj = make_joint_trajectory(rig, n_frames=8, with_qdot=True)
+    assert isinstance(traj, JointTrajectory)
+    assert traj.num_frames == 8
+    _roundtrip(traj)
+
+
+def test_make_provenance_keys() -> None:
+    p = make_provenance()
+    for key in ("subject_id", "sport", "source", "capture_system"):
+        assert key in p
+
+
+@pytest.mark.parametrize("with_markers", [False, True])
+def test_make_motion_trajectory(with_markers: bool) -> None:
+    motion = make_motion_trajectory(n_frames=6, n_joints=4, with_markers=with_markers)
+    assert isinstance(motion, MotionTrajectory)
+    assert motion.num_frames == 6
+    assert (motion.marker_reference is not None) == with_markers
+    _roundtrip(motion)
+
+
+def test_make_cost_weights_default_and_override() -> None:
+    default = make_cost_weights()
+    assert "joint_position" in default
+    custom = make_cost_weights({"foo": 2.0})
+    assert custom == {"foo": 2.0}
+
+
+@pytest.mark.parametrize("engine", ["mujoco", "drake", "pinocchio", "opensim"])
+def test_make_motion_matching_request(engine: str) -> None:
+    req = make_motion_matching_request(engine=engine)  # type: ignore[arg-type]
+    assert isinstance(req, MotionMatchingRequest)
+    assert req.solver_config["engine"] == engine
+    _roundtrip(req)
+
+
+def test_make_torque_trajectory_shape() -> None:
+    rig = make_skeleton_rig(n_joints=4)
+    tt = make_torque_trajectory(rig, n_frames=5)
+    assert len(tt["timestamps"]) == 5
+    assert len(tt["tau"]) == 5
+    assert all(len(row) == rig.num_dofs for row in tt["tau"])
+
+
+def test_make_residual_report_keys() -> None:
+    rig = make_skeleton_rig(n_joints=3)
+    r = make_residual_report(rig)
+    assert set(r["per_joint_rmse"].keys()) == set(rig.joints.keys())
+
+
+@pytest.mark.parametrize("kind", ["torque", "kinematic"])
+def test_make_motion_matching_result(kind: str) -> None:
+    rig = make_skeleton_rig(n_joints=4)
+    res = make_motion_matching_result(rig, n_frames=5, kind=kind)  # type: ignore[arg-type]
+    assert isinstance(res, MotionMatchingResult)
+    assert ("torque_trajectory" in res.metadata) == (kind == "torque")
+    _roundtrip(res)

--- a/tests/unit/motion_pipeline/test_lod.py
+++ b/tests/unit/motion_pipeline/test_lod.py
@@ -1,0 +1,173 @@
+"""Law-of-Demeter import-graph enforcement for the motion pipeline.
+
+The Canonical Intermediate Representation (CIR) and the non-backend
+submodules of ``src.shared.python.motion_pipeline`` must remain free of
+imports that pull in heavyweight engine, API, learning, or app code. This
+test walks the AST of each guarded file and asserts none of its
+``import``/``from ... import`` statements reference forbidden top-level
+prefixes.
+
+Backend submodules (``ik/*_backend.py``, the four matching solver modules)
+are explicitly exempt because they are *supposed* to bind to their backing
+physics/optimization engines; the LoD invariant only applies to the CIR,
+preprocessing, scaling, sources framework, and orchestrator.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PKG_ROOT = REPO_ROOT / "src" / "shared" / "python" / "motion_pipeline"
+CONTRACTS_FILE = PKG_ROOT / "contracts.py"
+
+# Top-level prefixes that no LoD-guarded motion-pipeline module may import.
+# Both ``src.X`` and bare ``X`` forms are checked because UpstreamDrift's
+# package import path varies (``src.engines.*`` vs ``engines.*`` depending on
+# how PYTHONPATH is configured).
+_FORBIDDEN_ROOTS = (
+    "engines",
+    "api",
+    "learning",
+    "apps",
+    "tools",
+    "deployment",
+)
+FORBIDDEN_PREFIXES = tuple(f"src.{r}." for r in _FORBIDDEN_ROOTS) + tuple(
+    f"{r}." for r in _FORBIDDEN_ROOTS
+)
+# Exact-name guards so ``import src.engines`` (no dot) is also caught.
+FORBIDDEN_EXACT = frozenset(
+    {f"src.{r}" for r in _FORBIDDEN_ROOTS} | set(_FORBIDDEN_ROOTS)
+)
+
+# Files exempt from the broader LoD sweep because their entire purpose is
+# to bind to a backing engine.
+EXEMPT_RELATIVE_PATHS = frozenset(
+    {
+        Path("ik") / "drake_backend.py",
+        Path("ik") / "mujoco_backend.py",
+        Path("ik") / "opensim_backend.py",
+        Path("ik") / "pinocchio_backend.py",
+        Path("matching") / "cmc.py",
+        Path("matching") / "rra.py",
+        Path("matching") / "torque_mujoco.py",
+        Path("matching") / "trajopt_drake.py",
+    }
+)
+
+
+def _collect_imports(file_path: Path) -> list[tuple[int, str]]:
+    """Return ``[(lineno, module_name), ...]`` for every Import/ImportFrom."""
+    tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            # ``from . import x`` -> module is None; skip relative imports.
+            if node.module is None or node.level:
+                continue
+            out.append((node.lineno, node.module))
+    return out
+
+
+def _is_forbidden(module_name: str) -> bool:
+    return module_name in FORBIDDEN_EXACT or module_name.startswith(FORBIDDEN_PREFIXES)
+
+
+def _format_violations(file_path: Path, viols: list[tuple[int, str]]) -> str:
+    rel = file_path.relative_to(REPO_ROOT)
+    lines = [f"LoD violation(s) in {rel}:"]
+    for lineno, mod in viols:
+        lines.append(f"  {rel}:{lineno}: imports forbidden module {mod!r}")
+    return "\n".join(lines)
+
+
+# =============================================================================
+# Test 1: contracts.py is the LoD-critical module per issue #4560.
+# =============================================================================
+
+
+def test_contracts_imports_are_lod_clean() -> None:
+    """``contracts.py`` must only import stdlib + pydantic + numpy + DbC."""
+    assert CONTRACTS_FILE.is_file(), f"contracts.py missing at {CONTRACTS_FILE}"
+    imports = _collect_imports(CONTRACTS_FILE)
+
+    stdlib = sys.stdlib_module_names
+    allowed_prefixes = (
+        "pydantic",
+        "numpy",
+        "src.shared.python.contracts",
+        "shared.python.contracts",
+    )
+
+    violations: list[tuple[int, str]] = []
+    for lineno, mod in imports:
+        top = mod.split(".")[0]
+        if top in stdlib:
+            continue
+        if mod.startswith(allowed_prefixes) or mod in {
+            "src.shared.python.contracts",
+            "shared.python.contracts",
+        }:
+            continue
+        if _is_forbidden(mod):
+            violations.append((lineno, mod))
+            continue
+        # Anything else not on the allow-list is also a LoD violation for
+        # contracts.py — keep the CIR module surgically minimal.
+        violations.append((lineno, mod))
+
+    assert not violations, _format_violations(CONTRACTS_FILE, violations)
+
+
+# =============================================================================
+# Test 2: every non-backend file in motion_pipeline must avoid forbidden roots.
+# =============================================================================
+
+
+def _guarded_files() -> list[Path]:
+    files: list[Path] = []
+    for p in sorted(PKG_ROOT.rglob("*.py")):
+        rel = p.relative_to(PKG_ROOT)
+        if rel in EXEMPT_RELATIVE_PATHS:
+            continue
+        if "__pycache__" in rel.parts:
+            continue
+        files.append(p)
+    return files
+
+
+_GUARDED = _guarded_files()
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _GUARDED,
+    ids=[str(p.relative_to(PKG_ROOT)).replace("\\", "/") for p in _GUARDED],
+)
+def test_motion_pipeline_module_no_forbidden_imports(file_path: Path) -> None:
+    """Every CIR/preprocessing/scaling/orchestrator/sources file is LoD-clean."""
+    imports = _collect_imports(file_path)
+    violations = [(ln, m) for ln, m in imports if _is_forbidden(m)]
+    assert not violations, _format_violations(file_path, violations)
+
+
+# =============================================================================
+# Test 3: backend exemptions still exist (regression guard against rename).
+# =============================================================================
+
+
+def test_exempt_backend_files_exist() -> None:
+    """If a backend file is renamed, this test fails so we revisit the exemption."""
+    missing = [rel for rel in EXEMPT_RELATIVE_PATHS if not (PKG_ROOT / rel).is_file()]
+    assert not missing, (
+        "Exempt backend files no longer exist (rename or removal?): "
+        f"{[str(m) for m in missing]}. Update EXEMPT_RELATIVE_PATHS in test_lod.py."
+    )

--- a/tests/unit/shared_python/test_app_state.py
+++ b/tests/unit/shared_python/test_app_state.py
@@ -1,0 +1,198 @@
+"""Unit tests for src.shared.python.app_state package.
+
+TDD: These tests were written BEFORE the implementation (RED → GREEN).
+All tests focus on pure-data behaviour; Qt imports are avoided so the
+suite runs headless in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store() -> Any:
+    from src.shared.python.app_state import HistoryStore
+
+    return HistoryStore()
+
+
+def _make_engine() -> Any:
+    from src.shared.python.app_state import DiagnosticEngine
+
+    return DiagnosticEngine()
+
+
+# ===========================================================================
+# StateLogger singleton
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_get_state_logger_is_singleton() -> None:
+    """get_state_logger() must return the same object every call."""
+    from src.shared.python.app_state import get_state_logger
+
+    a = get_state_logger()
+    b = get_state_logger()
+    assert a is b
+
+
+@pytest.mark.unit
+def test_log_event_appends_app_event() -> None:
+    """log_event appends an AppEvent to the internal HistoryStore."""
+    from src.shared.python.app_state import get_state_logger
+
+    logger = get_state_logger()
+    before_len = len(logger.store)
+    logger.log_event("test_action", {"key": "value"})
+    assert len(logger.store) == before_len + 1
+    last = logger.store.latest()
+    assert last.type == "test_action"
+    assert last.payload == {"key": "value"}
+
+
+# ===========================================================================
+# HistoryStore
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_history_store_thread_safety() -> None:
+    """5 threads × 200 events must all land without data corruption."""
+    store = _make_store()
+    errors: list[Exception] = []
+
+    def _worker() -> None:
+        try:
+            for i in range(200):
+                store.append_event("thread_event", {"i": i})
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    # Store holds at most maxlen items (no crash)
+    assert len(store) <= store.maxlen
+
+
+@pytest.mark.unit
+def test_history_store_ring_buffer() -> None:
+    """Appending more than maxlen events keeps the store at maxlen."""
+    from src.shared.python.app_state._history_store import HistoryStore
+
+    store = HistoryStore(maxlen=5)
+    for i in range(20):
+        store.append_event("ev", {"i": i})
+    assert len(store) == 5
+
+
+@pytest.mark.unit
+def test_history_store_as_json_valid() -> None:
+    """as_json() must always return parseable JSON."""
+    store = _make_store()
+    store.append_event("startup", {"version": "1.0"})
+    raw = store.as_json()
+    parsed = json.loads(raw)
+    assert isinstance(parsed, list)
+    assert parsed[0]["type"] == "startup"
+
+
+@pytest.mark.unit
+def test_history_clear() -> None:
+    """clear() must empty the store."""
+    store = _make_store()
+    store.append_event("ev", {})
+    store.append_event("ev", {})
+    store.clear()
+    assert len(store) == 0
+
+
+# ===========================================================================
+# DiagnosticEngine
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_pass_check() -> None:
+    """A check that returns True produces a PASS result."""
+    from src.shared.python.app_state import DiagnosticEngine
+    from src.shared.python.app_state._diagnostic import DiagnosticResult
+
+    engine = DiagnosticEngine()
+    engine.register_check("always_pass", lambda: True)
+    results = engine.run_checks()
+    by_name = {r.name: r for r in results}
+    assert by_name["always_pass"].status == "PASS"
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_fail_check() -> None:
+    """A check that returns False produces a FAIL result."""
+    from src.shared.python.app_state import DiagnosticEngine
+
+    engine = DiagnosticEngine()
+    engine.register_check("always_fail", lambda: False)
+    results = engine.run_checks()
+    by_name = {r.name: r for r in results}
+    assert by_name["always_fail"].status == "FAIL"
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_exception_gives_fail_not_raise() -> None:
+    """A check that raises must not propagate — it becomes FAIL."""
+    from src.shared.python.app_state import DiagnosticEngine
+
+    engine = DiagnosticEngine()
+
+    def _boom() -> bool:
+        raise RuntimeError("simulated failure")
+
+    engine.register_check("exploding_check", _boom)
+    results = engine.run_checks()  # must not raise
+    by_name = {r.name: r for r in results}
+    assert by_name["exploding_check"].status == "FAIL"
+    assert "simulated failure" in by_name["exploding_check"].message
+
+
+# ===========================================================================
+# agent_context
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_agent_context_keys() -> None:
+    """agent_context() dict must contain 'events', 'last_diagnostics', 'summary'."""
+    from src.shared.python.app_state import agent_context
+
+    store = _make_store()
+    store.append_event("boot", {"ok": True})
+    ctx = agent_context(store)
+    assert "events" in ctx
+    assert "last_diagnostics" in ctx
+    assert "summary" in ctx
+
+
+@pytest.mark.unit
+def test_agent_context_max_events() -> None:
+    """agent_context() must honour max_events parameter."""
+    from src.shared.python.app_state import agent_context
+
+    store = _make_store()
+    for i in range(100):
+        store.append_event("ev", {"i": i})
+    ctx = agent_context(store, max_events=10)
+    assert len(ctx["events"]) == 10

--- a/tests/unit/shared_python/test_config_imports.py
+++ b/tests/unit/shared_python/test_config_imports.py
@@ -1,0 +1,84 @@
+"""Tests for config module public API imports.
+
+Addresses issue #5478: config/__init__.py must export get_setting,
+load_settings, and save_settings without crashing at import time.
+"""
+
+import importlib
+
+import pytest
+
+
+def test_config_module_imports_cleanly() -> None:
+    """The config package must import without AttributeError or ImportError."""
+    mod = importlib.import_module("src.shared.python.config")
+    assert mod is not None
+
+
+def test_get_setting_exists_and_callable() -> None:
+    """get_setting must be exported from the config package and be callable."""
+    from src.shared.python.config import get_setting
+
+    assert callable(get_setting)
+
+
+def test_load_settings_exists() -> None:
+    """load_settings must be exported from the config package and be callable."""
+    from src.shared.python.config import load_settings
+
+    assert callable(load_settings)
+
+
+def test_save_settings_exists() -> None:
+    """save_settings must be exported from the config package and be callable."""
+    from src.shared.python.config import save_settings
+
+    assert callable(save_settings)
+
+
+def test_get_setting_returns_default_when_key_missing() -> None:
+    """get_setting(key, default) returns default when the key is absent."""
+    from src.shared.python.config import get_setting
+
+    result = get_setting("__nonexistent_key_5478__", default="fallback")
+    assert result == "fallback"
+
+
+def test_get_setting_no_default_returns_none_when_missing() -> None:
+    """get_setting(key) returns None when the key is absent and no default given."""
+    from src.shared.python.config import get_setting
+
+    result = get_setting("__nonexistent_key_5478__")
+    assert result is None
+
+
+def test_load_settings_returns_dict() -> None:
+    """load_settings() must return a dict."""
+    from src.shared.python.config import load_settings
+
+    result = load_settings()
+    assert isinstance(result, dict)
+
+
+def test_save_settings_accepts_dict() -> None:
+    """save_settings(data) must accept a dict without raising."""
+    from src.shared.python.config import save_settings
+
+    # Should not raise when given a valid dict
+    save_settings({"__test_key_5478__": "test_value"})
+
+
+def test_get_setting_invalid_key_type_raises() -> None:
+    """get_setting must raise TypeError when key is not a string (DbC)."""
+    from src.shared.python.config import get_setting
+
+    with pytest.raises(TypeError):
+        get_setting(123)  # type: ignore[arg-type]
+
+
+def test_save_settings_invalid_type_raises() -> None:
+    """save_settings must raise TypeError when given a non-dict (DbC)."""
+    from src.shared.python.config import save_settings
+
+    with pytest.raises(TypeError):
+        save_settings("not_a_dict")  # type: ignore[arg-type]

--- a/tests/unit/shared_python/test_data_io_imports.py
+++ b/tests/unit/shared_python/test_data_io_imports.py
@@ -1,0 +1,82 @@
+"""Tests for data_io module public API imports.
+
+Addresses issue #5478: data_io/__init__.py must export add_provenance_header
+without crashing at import time.
+"""
+
+import importlib
+import io
+
+import pytest
+
+
+def test_data_io_module_imports_cleanly() -> None:
+    """The data_io package must import without AttributeError or ImportError."""
+    mod = importlib.import_module("src.shared.python.data_io")
+    assert mod is not None
+
+
+def test_add_provenance_header_exists() -> None:
+    """add_provenance_header must be exported from data_io and be callable."""
+    from src.shared.python.data_io import add_provenance_header
+
+    assert callable(add_provenance_header)
+
+
+def test_add_provenance_header_returns_string() -> None:
+    """add_provenance_header(content, metadata) must return a string."""
+    from src.shared.python.data_io import add_provenance_header
+
+    result = add_provenance_header("col1,col2\n1,2\n", {"run_id": "test"})
+    assert isinstance(result, str)
+
+
+def test_add_provenance_header_prepends_comments() -> None:
+    """add_provenance_header must prepend '#' comment lines to content."""
+    from src.shared.python.data_io import add_provenance_header
+
+    original = "col1,col2\n1,2\n"
+    result = add_provenance_header(original, {"run_id": "test42"})
+    lines = result.splitlines()
+    # At least the first line must be a comment
+    assert lines[0].startswith("#")
+    # Original content must appear somewhere in the result
+    assert "col1,col2" in result
+
+
+def test_add_provenance_header_embeds_metadata() -> None:
+    """add_provenance_header must embed metadata key/value pairs in the header."""
+    from src.shared.python.data_io import add_provenance_header
+
+    result = add_provenance_header("data\n", {"experiment": "swing_001"})
+    assert "swing_001" in result
+
+
+def test_add_provenance_header_invalid_content_raises() -> None:
+    """add_provenance_header must raise TypeError when content is not a string (DbC)."""
+    from src.shared.python.data_io import add_provenance_header
+
+    with pytest.raises(TypeError):
+        add_provenance_header(123, {})  # type: ignore[arg-type]
+
+
+def test_add_provenance_header_invalid_metadata_raises() -> None:
+    """add_provenance_header must raise TypeError when metadata is not a dict (DbC)."""
+    from src.shared.python.data_io import add_provenance_header
+
+    with pytest.raises(TypeError):
+        add_provenance_header("data\n", "not_a_dict")  # type: ignore[arg-type]
+
+
+def test_add_provenance_header_file_still_exported() -> None:
+    """add_provenance_header_file must still be available (backward compat)."""
+    from src.shared.python.data_io import add_provenance_header_file
+
+    assert callable(add_provenance_header_file)
+
+
+def test_provenance_info_exported() -> None:
+    """ProvenanceInfo must be exported from data_io."""
+    from src.shared.python.data_io import ProvenanceInfo
+
+    assert ProvenanceInfo is not None

--- a/tests/unit/shared_python/test_sidekick_tool.py
+++ b/tests/unit/shared_python/test_sidekick_tool.py
@@ -1,0 +1,174 @@
+"""Tests for the SidekickTool embeddable-tool implementation.
+
+Covers:
+- Protocol conformance against
+  :class:`src.shared.python.launcher_embed.EmbeddableTool`.
+- ``embed_capabilities`` fields match the ADR-0013 spec.
+- ``src/config/models.yaml`` contains a valid ``chat_assistant`` entry.
+- ``create_main_widget(None)`` works headlessly with Qt mocked.
+
+Issue #5468.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from src.shared.python.launcher_embed import EmbedCapabilities, EmbeddableTool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_sidekick_tool() -> Any:
+    """Import SidekickTool, skipping if deps are missing."""
+    try:
+        from src.shared.python.chat.sidekick_tool import SidekickTool
+
+        return SidekickTool
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"SidekickTool not importable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_tool_is_embeddable() -> None:
+    """SidekickTool satisfies the EmbeddableTool runtime-checkable Protocol."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    assert isinstance(tool, EmbeddableTool), (
+        "SidekickTool must satisfy the EmbeddableTool structural Protocol"
+    )
+    assert tool.tool_id == "chat_assistant"
+
+
+# ---------------------------------------------------------------------------
+# EmbedCapabilities fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_embed_capabilities_fields() -> None:
+    """embed_capabilities() returns an EmbedCapabilities with expected values."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    caps = tool.embed_capabilities()
+
+    assert isinstance(caps, EmbedCapabilities)
+    assert caps.supports_embedded is True
+    assert caps.prefers_dock is True
+    assert isinstance(caps.min_size, tuple)
+    assert len(caps.min_size) == 2
+    assert all(v > 0 for v in caps.min_size)
+    assert caps.requires_separate_qapplication is False
+
+
+# ---------------------------------------------------------------------------
+# models.yaml entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_models_yaml_has_chat_assistant_entry() -> None:
+    """models.yaml contains a valid chat_assistant entry per ADR-0013."""
+    yaml_path = Path(__file__).resolve().parents[3] / "src" / "config" / "models.yaml"
+    assert yaml_path.exists(), f"models.yaml not found at {yaml_path}"
+
+    with yaml_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    models = data.get("models", [])
+    entry = next((m for m in models if m.get("id") == "chat_assistant"), None)
+    assert entry is not None, (
+        "models.yaml must contain an entry with id='chat_assistant'"
+    )
+
+    assert entry.get("type") == "chat_assistant"
+    assert "name" in entry
+    assert "description" in entry
+
+    launcher = entry.get("launcher", {})
+    assert launcher.get("category") == "assistant", (
+        "launcher.category must be 'assistant'"
+    )
+    assert "status" in launcher
+
+
+# ---------------------------------------------------------------------------
+# create_main_widget — headless (Qt mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_create_widget_headless() -> None:
+    """create_main_widget works headlessly when PyQt6 is mocked."""
+    mock_widget_instance = MagicMock()
+    mock_ChatDockWidget = MagicMock(return_value=mock_widget_instance)
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "PyQt6": MagicMock(),
+                "PyQt6.QtWidgets": MagicMock(),
+                "PyQt6.QtCore": MagicMock(),
+                "PyQt6.QtWebSockets": MagicMock(),
+            },
+        ),
+        patch(
+            "src.shared.python.chat.sidekick_tool._create_chat_dock_widget",
+            return_value=mock_widget_instance,
+        ),
+    ):
+        SidekickTool = _import_sidekick_tool()
+        tool = SidekickTool()
+        widget = tool.create_main_widget(None)
+
+    assert widget is mock_widget_instance
+
+
+# ---------------------------------------------------------------------------
+# cleanup / is_dirty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_cleanup_is_idempotent() -> None:
+    """cleanup() may be called multiple times without raising."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    tool.cleanup()
+    tool.cleanup()
+
+
+@pytest.mark.unit
+def test_sidekick_is_dirty_default_false() -> None:
+    """is_dirty() returns False when no widget has been created."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    assert tool.is_dirty() is False
+
+
+# ---------------------------------------------------------------------------
+# DbC precondition on create_main_widget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_create_widget_rejects_non_widget_parent() -> None:
+    """create_main_widget raises ValueError for an invalid parent type."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    with pytest.raises((ValueError, TypeError)):
+        tool.create_main_widget("not-a-widget")  # type: ignore[arg-type]

--- a/tests/unit/test_ground_reaction_forces.py
+++ b/tests/unit/test_ground_reaction_forces.py
@@ -96,6 +96,28 @@ class TestAngularImpulse:
 
         np.testing.assert_allclose(angular_impulse, 0.0, atol=1e-10)
 
+    def test_dynamic_reference_point_produces_angular_impulse(self) -> None:
+        """Dynamic reference trajectory should produce correct angular impulse."""
+        n = 100
+        timestamps = np.linspace(0, 1, n)
+        forces = np.zeros((n, 3))
+        forces[:, 2] = 100.0  # Vertical force
+
+        # COP at origin
+        cops = np.zeros((n, 3))
+
+        # Reference point moving in X direction at 1 m/s (r_x = -t)
+        ref_trajectory = np.zeros((n, 3))
+        ref_trajectory[:, 0] = timestamps
+
+        angular_impulse = compute_angular_impulse(
+            forces, cops, timestamps, ref_trajectory
+        )
+
+        # Torque = r × F = [-t, 0, 0] × [0, 0, 100] = [0, 100*t, 0]
+        # Angular impulse = int(100*t dt) from 0 to 1 = 100 * (1^2 / 2) = 50.0
+        np.testing.assert_allclose(angular_impulse[1], 50.0, rtol=0.01)
+
 
 class TestCOPComputation:
     """Tests for center of pressure computation."""
@@ -208,6 +230,34 @@ class TestGRFAnalyzer:
         assert summary.peak_vertical_force > 0
         assert summary.cop_trajectory_length > 0
         assert summary.linear_impulse is not None
+
+    def test_analyzer_uses_dynamic_com(self, sample_grf_data: GRFTimeSeries) -> None:
+        """Analyzer should compute moments using dynamic COM if lengths match."""
+        analyzer = GRFAnalyzer()
+        analyzer.add_grf_data(sample_grf_data)
+
+        # Dynamic COM trajectory exactly matching timestamps
+        n = len(sample_grf_data.timestamps)
+        com_traj = np.zeros((n, 3))
+        com_traj[:, 0] = 1.0  # 1m offset in X
+
+        analyzer.set_com_trajectories(com_traj)
+        summary = analyzer.analyze(FootSide.COMBINED)
+
+        # The angular impulse should not be zero
+        assert np.any(summary.angular_impulse_about_golfer_com)
+
+        # Test fallback to static
+        short_com_traj = np.zeros((1, 3))
+        short_com_traj[0, 0] = 1.0
+        analyzer.set_com_trajectories(short_com_traj)
+        summary_fallback = analyzer.analyze(FootSide.COMBINED)
+
+        # The outputs should be identical since the dynamic and fallback offset are the same 1.0 in X
+        np.testing.assert_allclose(
+            summary.angular_impulse_about_golfer_com,
+            summary_fallback.angular_impulse_about_golfer_com,
+        )
 
 
 class TestExtractGRFFromContacts:

--- a/tests/unit/test_import_smoke.py
+++ b/tests/unit/test_import_smoke.py
@@ -1,0 +1,21 @@
+"""Smoke tests for top-level shared module imports.
+
+Addresses issue #5478: ensures no top-level ImportError on shared modules.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "src.shared.python.config",
+        "src.shared.python.data_io",
+        "src.api",
+    ],
+)
+def test_all_public_modules_import_cleanly(module_path: str) -> None:
+    """Ensure no top-level ImportError on any shared module."""
+    importlib.import_module(module_path)  # must not raise

--- a/ui/src/components/ui/ChatPanel.tsx
+++ b/ui/src/components/ui/ChatPanel.tsx
@@ -48,12 +48,35 @@ export type ConnectionStatus =
   | 'disconnected'
   | 'error';
 
+export interface ChatModelInfo {
+  name: string;
+  provider: string;
+  display_name?: string | null;
+}
+
+export interface ChatIndexStatus {
+  state: 'running' | 'complete' | 'error';
+  files_parsed?: number;
+  symbols_inserted?: number;
+  duration_seconds?: number | null;
+  error?: string | null;
+}
+
 interface ServerMessage {
   type: string;
   session_id?: string;
   content?: string;
   detail?: string;
   messages?: Array<{ role: ChatRole; content: string }>;
+  /** Populated when type === 'model_list' */
+  models?: ChatModelInfo[];
+  refreshed_at?: string;
+  /** Populated when type === 'index_status' */
+  state?: 'running' | 'complete' | 'error';
+  files_parsed?: number;
+  symbols_inserted?: number;
+  duration_seconds?: number | null;
+  error?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,9 +123,26 @@ interface ChatPanelProps {
   engineContext?: string;
   /** Override the resolved WebSocket URL (mostly for tests). */
   url?: string;
+  /**
+   * Called when the server pushes a model_list frame (e.g. after
+   * refresh_models). Lets parent components populate a model selector.
+   * Mirrors the PyQt `models_refreshed` signal.
+   */
+  onModelsRefreshed?: (models: ChatModelInfo[]) => void;
+  /**
+   * Called when the server pushes an index_status frame. Lets parent
+   * components surface codebase-indexing progress.
+   * Mirrors the PyQt `index_status_changed` signal.
+   */
+  onIndexStatus?: (status: ChatIndexStatus) => void;
 }
 
-export function ChatPanel({ engineContext, url }: ChatPanelProps = {}) {
+export function ChatPanel({
+  engineContext,
+  url,
+  onModelsRefreshed,
+  onIndexStatus,
+}: ChatPanelProps = {}) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [status, setStatus] = useState<ConnectionStatus>('connecting');
@@ -170,6 +210,28 @@ export function ChatPanel({ engineContext, url }: ChatPanelProps = {}) {
             );
           }
           break;
+        case 'model_list':
+          // Mirrors the PyQt `models_refreshed` signal. Forwards the server-
+          // pushed model list to the parent component so it can populate a
+          // model selector. Gap 2 fix — see docs/development/sidekick_parity.md.
+          if (Array.isArray(payload.models) && onModelsRefreshed) {
+            onModelsRefreshed(payload.models);
+          }
+          break;
+        case 'index_status':
+          // Mirrors the PyQt `index_status_changed` signal. Forwards
+          // codebase-indexing progress to the parent component.
+          // Gap 2 fix — see docs/development/sidekick_parity.md.
+          if (onIndexStatus && payload.state) {
+            onIndexStatus({
+              state: payload.state,
+              files_parsed: payload.files_parsed ?? 0,
+              symbols_inserted: payload.symbols_inserted ?? 0,
+              duration_seconds: payload.duration_seconds ?? null,
+              error: payload.error ?? null,
+            });
+          }
+          break;
         case 'error':
           setMessages((prev) => [
             ...prev,
@@ -186,7 +248,7 @@ export function ChatPanel({ engineContext, url }: ChatPanelProps = {}) {
           break;
       }
     },
-    [appendAssistantChunk]
+    [appendAssistantChunk, onModelsRefreshed, onIndexStatus]
   );
 
   // Connect (and re-connect with exponential backoff).


### PR DESCRIPTION
## Summary

Fixes #5478

Two `__init__.py` files were empty stubs that crashed at import time:

- **`src/shared/python/config/__init__.py`** had `__all__: list[str] = []` and exported nothing. Callers expecting `get_setting`, `load_settings`, or `save_settings` got `ImportError`.
  - Implemented `get_setting(key, default=None)`, `load_settings() -> dict`, and `save_settings(data: dict)` in `settings.py`, backed by an in-process `_settings_store` dict (process-lifetime overlay, consistent with the env-var-first resolution model already documented in that module).
  - Updated `config/__init__.py` to re-export all public symbols from `settings.py`.

- **`src/shared/python/data_io/__init__.py`** had `__all__: list[str] = []` and exported nothing. `provenance.py` had `add_provenance_header_file` but no `add_provenance_header` (despite the module docstring and usage examples referencing `add_provenance_header`).
  - Added `add_provenance_header(content: str, metadata: dict) -> str` to `provenance.py` as the in-memory counterpart to `add_provenance_header_file`.
  - Updated `data_io/__init__.py` to re-export `ProvenanceInfo`, `add_provenance_header`, `add_provenance_header_file`, and `add_provenance_to_csv`.

All new public functions follow DbC (raise `TypeError` on bad inputs), use `logging` not `print()`, and carry full type hints.

## Test plan

- [x] TDD: wrote failing tests first (RED), then implemented (GREEN)
- [x] `tests/unit/shared_python/test_config_imports.py` — 10 tests for config module imports and function behavior
- [x] `tests/unit/shared_python/test_data_io_imports.py` — 9 tests for data_io module imports and function behavior
- [x] `tests/unit/test_import_smoke.py` — parametrized smoke test for `src.shared.python.config`, `src.shared.python.data_io`, `src.api`
- [x] All 22 tests pass: `pytest tests/unit/shared_python/test_config_imports.py tests/unit/shared_python/test_data_io_imports.py tests/unit/test_import_smoke.py -v`
- [x] `ruff check` — 0 violations
- [x] `ruff format` — 0 diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)