### PR TITLE
feat: add Tauri routes for terrain, dataset generator, and analysis tools pages

### DIFF
--- a/reports/feature_navigation_gaps/00_INDEX.md
+++ b/reports/feature_navigation_gaps/00_INDEX.md
@@ -1,0 +1,200 @@
+# Feature Navigation Gap Analysis -- UpstreamDrift
+
+## Executive Summary
+
+The launcher manifest defines 15 tiles, but the codebase contains **27+ implemented features** that users cannot discover or reach from the tiled layout. Three sidebar category buttons (Biomechanics, Simulation, Motion Matching) filter to **zero tiles** -- a broken navigation experience. Several features have complete GUIs and handler registrations but are invisible in the manifest.
+
+This analysis classifies every gap into three tiers:
+
+- **Tile-worthy**: A standalone feature that users would explicitly seek. Needs its own manifest entry.
+- **Internal library**: Consumed by other features. Should be documented in capabilities, not given a tile.
+- **Borderline**: Has standalone value but could also be a sub-feature. Needs a judgment call.
+
+---
+
+## Current State
+
+### Manifest Tiles (15 visible + 1 hidden)
+
+| #   | Tile ID               | Category       | Route                  |
+| --- | --------------------- | -------------- | ---------------------- |
+| 1   | model_explorer        | tool           | /tools/model-explorer  |
+| 2   | mujoco_unified        | physics_engine | --                     |
+| 3   | drake_golf            | physics_engine | --                     |
+| 4   | pinocchio_golf        | physics_engine | --                     |
+| 5   | opensim_golf          | physics_engine | --                     |
+| 6   | myosim_suite          | physics_engine | --                     |
+| 7   | putting_green         | physics_engine | /tools/putting-green   |
+| 8   | matlab_unified        | external       | --                     |
+| 9   | motion_target_preview | tool           | --                     |
+| 10  | motion_capture        | tool           | /tools/motion-capture  |
+| 11  | video_analyzer        | tool           | /tools/video-analyzer  |
+| 12  | video_processor       | tool           | /tools/video-processor |
+| 13  | data_explorer         | tool           | /tools/data-explorer   |
+| 14  | data_processor        | tool           | /tools/data-processor  |
+| 15  | project_map           | tool           | --                     |
+| --  | starting_pose_matcher | tool           | HIDDEN (legacy alias)  |
+
+### Sidebar Categories
+
+| Category            | Tile Count | Status                                      |
+| ------------------- | ---------- | ------------------------------------------- |
+| Home (All)          | 15         | OK                                          |
+| Physics Engines     | 5          | OK                                          |
+| **Biomechanics**    | **0**      | **EMPTY**                                   |
+| **Simulation**      | **0**      | **EMPTY** (Putting Green is physics_engine) |
+| **Motion Matching** | **0**      | **EMPTY**                                   |
+| Motion Capture      | 1          | OK                                          |
+| Tools & Data        | 8          | OK                                          |
+
+### Tauri Routes
+
+/ | /simulation | /tools/model-explorer | /tools/putting-green | /tools/video-analyzer | /tools/data-explorer | /tools/motion-capture | /chat
+
+---
+
+## Issue Index
+
+### P0 -- Broken Navigation (3 issues)
+
+| Issue | File                                | Summary                                            |
+| ----- | ----------------------------------- | -------------------------------------------------- |
+| #01   | `01_empty_sidebar_categories.md`    | Three sidebar categories show zero tiles           |
+| #02   | `02_cross_engine_dashboard_tile.md` | Cross-Engine Dashboard (core feature F6) invisible |
+| #03   | `03_exercise_dashboard_tile.md`     | Exercise Dashboard has handler but no tile         |
+
+### P1 -- Core Features Invisible (8 issues)
+
+| Issue | File                                   | Summary                                           |
+| ----- | -------------------------------------- | ------------------------------------------------- |
+| #04   | `04_shot_tracer_tile.md`               | Shot Tracer GUI unreachable from unified launcher |
+| #05   | `05_pose_studio_tile.md`               | Pose Studio standalone GUI completely hidden      |
+| #06   | `06_golf_simulation_suite_tile.md`     | Golf Simulation Suite has handler, no tile        |
+| #07   | `07_engine_dashboards_unreachable.md`  | MuJoCo/Drake/Pinocchio dashboards unreachable     |
+| #08   | `08_swing_optimization_tile.md`        | Swing Optimization (F11) no UI entry              |
+| #09   | `09_injury_risk_analysis_tile.md`      | Injury Risk Analysis no UI entry                  |
+| #10   | `10_terrain_api_no_tile.md`            | Terrain API (6 endpoints) no tile                 |
+| #11   | `11_dataset_generation_no_tile.md`     | Dataset Generation API (9 endpoints) no tile      |
+| #12   | `12_motion_matching_category_empty.md` | Motion Matching sidebar has zero tiles            |
+| #13   | `13_analysis_tools_api_no_tile.md`     | Analysis Tools API (6 endpoints) no tile          |
+
+### P2 -- Important but Less Urgent (7 issues)
+
+| Issue | File                                       | Summary                                    |
+| ----- | ------------------------------------------ | ------------------------------------------ |
+| #14   | `14_chat_ai_sidekick_no_manifest_entry.md` | Chat/AI Sidekick no manifest entry         |
+| #15   | `15_motion_pipeline_no_tile.md`            | Motion Pipeline only partially covered     |
+| #16   | `16_perturbation_analysis_no_ui.md`        | Perturbation/robustness scoring no UI      |
+| #17   | `17_character_builder_no_tile.md`          | URDF Character Builder no tile             |
+| #18   | `18_pendulum_simulator_tile.md`            | Educational Pendulum Simulator unreachable |
+| #30   | `30_putting_green_category_mismatch.md`    | Putting Green miscategorized               |
+| #31   | `31_simulation_category_needs_tiles.md`    | Simulation category needs population       |
+
+### P3 -- Niche / Advanced / Internal (7 issues)
+
+| Issue | File                                        | Summary                             |
+| ----- | ------------------------------------------- | ----------------------------------- |
+| #19   | `19_force_overlays_api_no_tile.md`          | Internal: add to capabilities       |
+| #20   | `20_realtime_websocket_no_tile.md`          | Internal: document as capability    |
+| #21   | `21_aip_no_tile.md`                         | Internal: surface through Chat tile |
+| #22   | `22_actuator_controls_api_no_tile.md`       | Internal: add to capabilities       |
+| #23   | `23_bunkershot3d_no_tile.md`                | Tile-worthy but niche               |
+| #24   | `24_unreal_integration_no_tile.md`          | Advanced: sub-feature of engines    |
+| #25   | `25_robotics_module_no_presence.md`         | Internal: control scheme config     |
+| #26   | `26_upstream_drift_tools_breadth_hidden.md` | Expand Data Processor description   |
+| #27   | `27_programmatic_pid_hidden.md`             | Niche: may not warrant tile         |
+| #28   | `28_dashboard_recorder_hidden.md`           | Internal: sub-feature of dashboards |
+| #29   | `29_internal_libraries_no_tile_needed.md`   | Audit: correctly internal           |
+
+---
+
+## Classification: Tile-worthy vs. Internal Library
+
+### Tile-worthy (need manifest entries)
+
+| Feature                        | Proposed Category | Rationale                                 |
+| ------------------------------ | ----------------- | ----------------------------------------- |
+| Cross-Engine Dashboard         | simulation        | Core feature F6, complete GUI             |
+| Exercise Dashboard             | biomechanics      | Complete GUI with handler                 |
+| Shot Tracer                    | simulation        | Complete GUI, only in deprecated launcher |
+| Pose Studio                    | tool              | Standalone GUI with main()                |
+| Golf Simulation Suite          | simulation        | Has handler, no tile                      |
+| Swing Optimization             | simulation        | Core feature F11                          |
+| Injury Risk Analysis           | biomechanics      | Distinct analysis workflow                |
+| Motion Matching (recategorize) | motion_matching   | Sidebar exists, needs tiles               |
+| Terrain                        | tool              | 6 API endpoints                           |
+| Dataset Generation             | tool              | 9 API endpoints                           |
+| BunkerShot3D                   | physics_engine    | Complete simulation system                |
+| Pendulum Simulator             | physics_engine    | Educational entry point                   |
+| Chat/AI Sidekick               | tool              | Major feature, no manifest entry          |
+| Character Builder              | tool              | Distinct workflow from Model Explorer     |
+
+### Internal Library (document in capabilities, no tile)
+
+| Module                | Consumed By               | Action                                 |
+| --------------------- | ------------------------- | -------------------------------------- |
+| Biomechanics library  | MuJoCo, OpenSim, MyoSuite | Add `biomechanics` capability tag      |
+| Screw theory          | Physics engines           | Add `screw_theory` capability tag      |
+| Spatial algebra       | Physics engines           | Add `spatial_algebra` capability tag   |
+| Data I/O              | Data Explorer, export     | Add `data_io` capability tag           |
+| Plot engine           | Dashboards                | Internal, no action needed             |
+| Reporting             | Analysis/export           | Internal, no action needed             |
+| Realtime transport    | Simulation WS             | Add `realtime` capability tag          |
+| Dashboard recorder    | Engine dashboards         | Expose when dashboards are exposed     |
+| Robotics control      | Drake, MuJoCo             | Add `control_schemes` capability tag   |
+| Rust physics kernels  | Physics engines           | Document in engine descriptions        |
+| Actuator controls API | Simulation page           | Add `actuator_controls` capability tag |
+| Force overlays API    | Simulation page           | Add `force_overlays` capability tag    |
+| AIP                   | Chat/Sidekick             | Add `ai_methods` capability tag        |
+| Freemocap ingest      | Motion Capture            | Internal, no action needed             |
+| Deployment modules    | Production                | Internal, no action needed             |
+| Perturbation analysis | Cross-Engine Dashboard    | Surface in dashboard when exposed      |
+
+---
+
+## Recommended Manifest Changes
+
+### New tiles to add
+
+``json
+[
+{""id"": ""cross_engine"", ""name"": ""Cross-Engine Dashboard"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/launchers/cross_engine_dashboard.py"", ""capabilities"": [""cross_validation"", ""perturbation"", ""robustness_scoring""], ""order"": 20},
+{""id"": ""biomech_exercise"", ""name"": ""Exercise Dashboard"", ""category"": ""biomechanics"", ""type"": ""biomech_exercise"", ""path"": ""src/launchers/exercise_dashboard.py"", ""capabilities"": [""injury_risk"", ""joint_stress"", ""swing_modification""], ""order"": 21},
+{""id"": ""shot_tracer"", ""name"": ""Shot Tracer"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/launchers/\_shot_tracer_gui.py"", ""capabilities"": [""trajectory_visualization"", ""multi_model_comparison""], ""order"": 22},
+{""id"": ""pose_studio"", ""name"": ""Pose Studio"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": ""src/tools/pose_studio/**main**.py"", ""capabilities"": [""pose_editing"", ""retargeting""], ""order"": 23},
+{""id"": ""golf_simulation_suite"", ""name"": ""Golf Simulation Suite"", ""category"": ""simulation"", ""type"": ""golf_simulation"", ""path"": ""src/tools/golf_simulation_suite/**main**.py"", ""capabilities"": [""full_simulation"", ""parameter_sweep""], ""order"": 24},
+{""id"": ""swing_optimization"", ""name"": ""Swing Optimizer"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/shared/python/optimization/swing_optimizer.py"", ""capabilities"": [""trajectory_optimization"", ""constraint_solving""], ""order"": 25},
+{""id"": ""injury_analysis"", ""name"": ""Injury Risk Analysis"", ""category"": ""biomechanics"", ""type"": ""special_app"", ""path"": ""src/shared/python/injury/injury_risk.py"", ""capabilities"": [""injury_risk"", ""joint_stress"", ""spinal_load""], ""order"": 26},
+{""id"": ""terrain"", ""name"": ""Terrain Engine"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/tools/terrain"", ""capabilities"": [""surface_modeling"", ""ball_physics"", ""topography""], ""order"": 27},
+{""id"": ""dataset_generator"", ""name"": ""Dataset Generator"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/tools/dataset"", ""capabilities"": [""dataset_generation"", ""swing_import"", ""parameter_sweep""], ""order"": 28},
+{""id"": ""bunkershot3d"", ""name"": ""BunkerShot3D"", ""category"": ""physics_engine"", ""type"": ""special_app"", ""path"": ""src/bunkershot3d/"", ""capabilities"": [""sand_simulation"", ""mpm"", ""calibration""], ""order"": 29},
+{""id"": ""pendulum"", ""name"": ""Pendulum Simulator"", ""category"": ""physics_engine"", ""type"": ""special_app"", ""path"": ""src/shared/python/pendulum_simulator/**main**.py"", ""capabilities"": [""educational"", ""2dof""], ""order"": 30},
+{""id"": ""chat"", ""name"": ""AI Assistant"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/chat"", ""capabilities"": [""ai_methods"", ""calculator"", ""workspace""], ""order"": 31},
+{""id"": ""character_builder"", ""name"": ""Character Builder"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": ""src/shared/python/model_generation/cli/main.py"", ""capabilities"": [""urdf_generation"", ""anthropometry"", ""mesh_generation""], ""order"": 32}
+]
+
+```
+
+### Category changes to existing tiles
+
+| Tile ID | Current Category | Proposed Category |
+|---------|------------------|--------------------|
+| putting_green | physics_engine | **simulation** |
+| motion_target_preview | tool | **motion_matching** |
+
+### Capability tag additions to existing tiles
+
+| Tile ID | Capabilities to Add |
+|---------|-------------------|
+| mujoco_unified | biomechanics, screw_theory, spatial_algebra, actuator_controls, force_overlays, control_schemes, realtime |
+| drake_golf | actuator_controls, force_overlays, control_schemes, realtime |
+| pinocchio_golf | actuator_controls, force_overlays |
+| opensim_golf | biomechanics, actuator_controls |
+| data_processor | process_calculators |
+
+---
+
+## Files
+
+All issue files are in: `reports/feature_navigation_gaps/`
+```

--- a/reports/feature_navigation_gaps/00_classification_criteria.md
+++ b/reports/feature_navigation_gaps/00_classification_criteria.md
@@ -1,0 +1,12 @@
+"# Feature Navigation Gap Review: Internal vs. Exposed
+
+## Classification Criteria
+
+**Tile-worthy** (exposed in launcher): Standalone user-facing feature with its own GUI
+or meaningful entry point. Users would explicitly seek it out.
+
+**Internal library** (no tile): Underlying module consumed by other features. Users
+interact with it indirectly through other tiles or APIs.
+
+**Borderline**: Has some standalone value but is also used by other features. Needs
+judgment call on whether the standalone use case justifies a tile.

--- a/reports/feature_navigation_gaps/01_empty_sidebar_categories.md
+++ b/reports/feature_navigation_gaps/01_empty_sidebar_categories.md
@@ -1,0 +1,38 @@
+---
+title: Empty sidebar categories show no tiles (Biomechanics, Simulation, Motion Matching)
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+The PyQt6 launcher sidebar defines 7 category filter buttons (Home, Physics Engines, Biomechanics, Simulation, Motion Matching, Motion Capture, Tools & Data). Three of these categories currently filter to **zero tiles**:
+
+| Category        | Tiles in Manifest                   | User Experience |
+| --------------- | ----------------------------------- | --------------- |
+| Biomechanics    | 0                                   | Empty grid      |
+| Simulation      | 0 (Putting Green is physics_engine) | Empty grid      |
+| Motion Matching | 0                                   | Empty grid      |
+
+When a user clicks any of these three sidebar buttons, they see an entirely empty launcher grid. This is a broken navigation path.
+
+## Source
+
+- Sidebar categories are defined in src/launchers/launcher_ui_setup.py lines ~295-413
+- Tile categories come from src/config/launcher_manifest.json
+- Category definitions are in src/config/launcher_manifest_loader.py lines 47-71
+
+## Acceptance Criteria
+
+- [ ] Every sidebar category button filters to at least one visible tile
+- [ ] Either add tiles that map to these categories, or remove/merge the empty categories
+- [ ] Verify the Tauri React dashboard also handles empty categories gracefully (show a message instead of a blank grid)
+
+## Suggested Fixes
+
+**Option A -- Add tiles (preferred):** Add manifest entries for features that belong in these categories:
+
+- **Biomechanics**: Exercise Dashboard, Injury Risk Analysis, Swing Comparison
+- **Simulation**: Cross-Engine Dashboard, Golf Simulation Suite, Shot Tracer
+- **Motion Matching**: Motion-Match Preview already exists; add Motion Pipeline and Surrogate Training
+
+**Option B -- Merge categories:** If these features aren't ready for standalone tiles, merge them into existing categories and remove the empty sidebar buttons to avoid dead-end navigation.

--- a/reports/feature_navigation_gaps/02_cross_engine_dashboard_tile.md
+++ b/reports/feature_navigation_gaps/02_cross_engine_dashboard_tile.md
@@ -1,0 +1,27 @@
+---
+title: Cross-Engine Dashboard has no launcher tile (core feature F6 invisible)
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+Cross-engine validation is a **core feature (F6)** in SPEC.md with full ✅ status. The CrossEngineDashboardWindow class (src/launchers/cross_engine_dashboard.py) is a complete PyQt6 application for multi-engine comparison. It has a dedicated UnifiedDashboardWindow base class, tests, and CLI entry points.
+
+Despite being fully implemented, it has **no tile in the launcher manifest** and no way for users to discover or launch it from the main UI.
+
+## Evidence
+
+- src/launchers/cross_engine_dashboard.py -- full CrossEngineDashboardWindow class
+- src/launchers/base.py -- BaseLauncher with dashboard infrastructure
+-     ests/launchers/test_cross_engine_dashboard.py -- full test suite
+-     ests/launchers/test_cross_engine_dashboard_cli.py -- CLI tests
+- SPEC.md F6: "Cross-engine validation ✅"
+- No entry in src/config/launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a cross_engine tile to launcher_manifest.json
+- [ ] Assign it to the simulation category
+- [ ] Add appropriate SVG logo to src/launchers/assets/
+- [ ] Verify tile launches the Cross-Engine Dashboard
+- [ ] Verify Tauri dashboard renders the new tile

--- a/reports/feature_navigation_gaps/03_exercise_dashboard_tile.md
+++ b/reports/feature_navigation_gaps/03_exercise_dashboard_tile.md
@@ -1,0 +1,24 @@
+---
+title: Exercise Dashboard has a handler but no launcher tile
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+The ExerciseDashboard class (src/launchers/exercise_dashboard.py) is a complete PyQt6 application for biomechanics exercise workflows. It has a registered BiomechExerciseHandler in src/launchers/launcher_model_handlers.py (model type iomech_exercise).
+
+The sidebar has a **Biomechanics** category button that currently filters to zero tiles. The Exercise Dashboard belongs in that category but cannot be launched from the UI.
+
+## Evidence
+
+- src/launchers/exercise_dashboard.py -- full ExerciseDashboard(QMainWindow)
+- src/launchers/launcher_model_handlers.py:243 -- BiomechExerciseHandler registered
+- src/launchers/launcher_ui_setup.py:295 -- tn_biomechanics sidebar button exists
+- No iomech_exercise tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a iomech_exercise tile to launcher_manifest.json
+- [ ] Assign it to the iomechanics category
+- [ ] Add appropriate SVG logo
+- [ ] Verify launch from the Biomechanics sidebar category

--- a/reports/feature_navigation_gaps/04_shot_tracer_tile.md
+++ b/reports/feature_navigation_gaps/04_shot_tracer_tile.md
@@ -1,0 +1,26 @@
+---
+title: Shot Tracer GUI has no launcher tile (only reachable from deprecated launcher)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The MultiModelShotTracerWindow (src/launchers/\_shot_tracer_gui.py) is a complete PyQt6 application for trajectory visualization and comparison. It's a user-facing tool that researchers would actively seek out.
+
+Currently it's only launchable from golf_suite_launcher.py (deprecated), which shows a deprecation warning pointing users to the unified launcher. But the unified launcher manifest has no Shot Tracer tile.
+
+## Evidence
+
+- src/launchers/\_shot_tracer_gui.py -- MultiModelShotTracerWindow(QMainWindow) with full GUI
+- src/launchers/shot_tracer.py -- CLI wrapper
+- src/launchers/golf_suite_launcher.py -- deprecated launcher has \_launch_shot_tracer()
+- src/launchers/launcher_model_handlers.py -- no handler for shot_tracer type
+- No tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a shot_tracer tile to launcher_manifest.json
+- [ ] Add ShotTracerHandler to launcher_model_handlers.py
+- [ ] Assign to the simulation category
+- [ ] Add SVG logo (a trajectory/arc icon)
+- [ ] Remove \_launch_shot_tracer from deprecated golf_suite_launcher.py or redirect it

--- a/reports/feature_navigation_gaps/05_pose_studio_tile.md
+++ b/reports/feature_navigation_gaps/05_pose_studio_tile.md
@@ -1,0 +1,23 @@
+---
+title: Pose Studio has no launcher tile (standalone GUI completely hidden)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Pose Studio (src/tools/pose_studio/) is a standalone PyQt6 application for interactive pose editing. It has a full GUI (gui.py), CLI entry point (**main**.py), and documentation. Users who want to manipulate joint angles or retarget poses would look for this feature, but it's completely invisible in the launcher.
+
+## Evidence
+
+- src/tools/pose_studio/gui.py -- full PoseStudioApp with main window
+- src/tools/pose_studio/**main**.py -- CLI entry point
+- No entry in launcher_manifest.json
+- No handler in launcher_model_handlers.py
+
+## Acceptance Criteria
+
+- [ ] Add a pose_studio tile to launcher_manifest.json
+- [ ] Add PoseStudioHandler to launcher_model_handlers.py (as special_app type)
+- [ ] Assign to the ool category
+- [ ] Add SVG logo
+- [ ] Verify standalone launch from both PyQt and Tauri launchers

--- a/reports/feature_navigation_gaps/06_golf_simulation_suite_tile.md
+++ b/reports/feature_navigation_gaps/06_golf_simulation_suite_tile.md
@@ -1,0 +1,21 @@
+---
+title: Golf Simulation Suite has a handler but no launcher tile
+labels: bug, ui, priority/P1
+---
+
+## Problem
+
+The Golf Simulation Suite (src/tools/golf_simulation_suite/) has a full CLI entry point and a GolfSimulationSuiteHandler registered in launcher_model_handlers.py (model type golf_simulation). It's a complete application that should be launchable from the tiled UI.
+
+## Evidence
+
+- src/tools/golf_simulation_suite/**main**.py -- CLI entry with main()
+- src/launchers/launcher_model_handlers.py:293 -- GolfSimulationSuiteHandler registered
+- No tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a golf_simulation_suite tile to launcher_manifest.json
+- [ ] Assign to the simulation category
+- [ ] Add SVG logo
+- [ ] Verify launch through the tile

--- a/reports/feature_navigation_gaps/07_engine_dashboards_unreachable.md
+++ b/reports/feature_navigation_gaps/07_engine_dashboards_unreachable.md
@@ -1,0 +1,28 @@
+---
+title: Engine-specific dashboards unreachable from launcher (Drake, MuJoCo, Pinocchio)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Three engine-specific dashboard classes exist but have no launcher tiles:
+
+1. **MuJoCo Dashboard** (src/launchers/mujoco_dashboard.py) -- MuJoCoDashboard(UnifiedDashboardWindow)
+2. **Drake Dashboard** (src/launchers/drake_dashboard.py) -- DrakeDashboard(UnifiedDashboardWindow)
+3. **Pinocchio Dashboard** (src/launchers/pinocchio_dashboard.py) -- PinocchioDashboard(UnifiedDashboardWindow)
+
+These are richer analytics views than the basic engine launchers. Currently, clicking a MuJoCo tile launches the Humanoid Golf simulation, but there's no way to access the dedicated analytics dashboard that shows force vectors, energy plots, and advanced metrics.
+
+The unified launcher tiles each launch a single entry point (e.g., mujoco_unified_launcher.py), but the dashboards are separate, more feature-rich views.
+
+## Options
+
+1. **Add dashboard tiles** for each engine alongside the existing simulation tiles
+2. **Merge dashboards into the unified launcher** -- the unified launcher could offer a "Switch to Dashboard" mode
+3. **Add a dashboard toggle** within each engine tile (e.g., a dropdown or secondary click option)
+
+## Acceptance Criteria
+
+- [ ] Decide on approach (separate tiles vs. merged vs. toggle)
+- [ ] Expose engine dashboards through the launcher
+- [ ] Add tests verifying dashboard launch paths

--- a/reports/feature_navigation_gaps/08_swing_optimization_tile.md
+++ b/reports/feature_navigation_gaps/08_swing_optimization_tile.md
@@ -1,0 +1,26 @@
+---
+title: Swing Optimization has no UI entry (core analysis feature invisible)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Swing optimization (src/shared/python/optimization/) is a fully implemented module with:
+
+- `swing_optimizer.py` -- trajectory optimization with constraint support
+- `_swing_constraints.py`, `_swing_kinematics.py`, `_swing_models.py`, `_swing_objectives.py`
+- `swing_bridge.py` -- bridge to engine simulations
+- `examples/optimize_arm.py` -- runnable example
+
+This is a core analysis capability (trajectory optimization is F11 in SPEC.md), but it has no launcher tile, no dedicated API route, and no web route. Users cannot discover it.
+
+## Classification
+
+**Tile-worthy**: Trajectory optimization is a first-class feature in the spec. Researchers would seek it out independently.
+
+## Acceptance Criteria
+
+- [ ] Add a `swing_optimization` tile to `launcher_manifest.json`
+- [ ] Create a launcher entry point (CLI or GUI wrapper)
+- [ ] Add an API route for optimization endpoints (`/analysis/optimize`)
+- [ ] Assign to the `simulation` or `biomechanics` category

--- a/reports/feature_navigation_gaps/09_injury_risk_analysis_tile.md
+++ b/reports/feature_navigation_gaps/09_injury_risk_analysis_tile.md
@@ -1,0 +1,26 @@
+---
+title: Injury Risk Analysis has no UI entry
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The injury analysis module (src/shared/python/injury/) is fully implemented with:
+
+- `injury_risk.py` -- injury risk computation
+- `joint_stress.py` -- joint stress analysis
+- `spinal_load_analysis.py` -- spinal loading during swing
+- `swing_modifications.py` -- swing modifications to reduce injury risk
+
+This is a unique and valuable feature -- sports medicine researchers would specifically seek injury risk analysis. It has no launcher tile, no API route, and no dashboard.
+
+## Classification
+
+**Tile-worthy**: Injury risk is a distinct analysis workflow that researchers seek independently. It's not just an internal library -- it computes and reports on injury metrics.
+
+## Acceptance Criteria
+
+- [ ] Add an `injury_analysis` tile to `launcher_manifest.json`
+- [ ] Create a launcher entry point or integrate into Exercise Dashboard
+- [ ] Assign to the `biomechanics` category
+- [ ] Add API routes for injury computation endpoints

--- a/reports/feature_navigation_gaps/10_terrain_api_no_tile.md
+++ b/reports/feature_navigation_gaps/10_terrain_api_no_tile.md
@@ -1,0 +1,31 @@
+---
+title: Terrain API has 6 endpoints but no launcher tile or web route
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The terrain engine (src/api/routes/terrain.py) exposes a full REST API:
+
+- `GET /terrain/presets` -- preset terrain configurations
+- `POST /terrain/load` -- load terrain data
+- `POST /terrain/query` -- query terrain properties at coordinates
+- `GET /terrain/materials` -- surface material types
+- `GET /terrain/types` -- terrain type catalog
+- `GET /terrain/active` -- currently active terrain
+
+The underlying module (src/shared/python/physics/terrain_engine.py, topography, terrain physics, representations) is complete.
+
+There's also a comprehensive terrain implementation under `src/shared/python/physics/` (terrain*engine.py, topography.py, terrain_representation.py, terrain_physics.py, \_terrain*\*.py).
+
+Yet there's no tile and no `web_route` in the manifest. The Putting Green tile uses terrain but doesn't expose the general terrain system.
+
+## Classification
+
+**Tile-worthy**: Terrain configuration is a distinct workflow (design greens, configure surfaces, import elevation data). Researchers configuring simulation environments need this independently.
+
+## Acceptance Criteria
+
+- [ ] Add a `terrain` tile to `launcher_manifest.json` with `web_route: /tools/terrain`
+- [ ] Create a Tauri route for the terrain configuration page
+- [ ] Assign to the `tool` category

--- a/reports/feature_navigation_gaps/11_dataset_generation_no_tile.md
+++ b/reports/feature_navigation_gaps/11_dataset_generation_no_tile.md
@@ -1,0 +1,31 @@
+---
+title: Dataset Generation API has full endpoints but no tile or frontend
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The dataset generation API (src/api/routes/dataset.py) has comprehensive endpoints:
+
+- `POST /dataset/generate` -- generate synthetic swing datasets
+- `POST /dataset/import-swing` -- import swing data
+- `GET /dataset/control/state` -- dataset generator state
+- `POST /dataset/control/configure` -- configure generation
+- `GET /dataset/control/strategies` -- available strategies
+- `GET /dataset/features` -- feature catalog
+- `POST /dataset/execute` -- execute generation
+- `GET /dataset/plots/types` -- plot type catalog
+- `GET /dataset/export/formats` -- export format catalog
+
+This is a significant feature for researchers who need training data, but it has no launcher tile and no Tauri frontend page.
+
+## Classification
+
+**Tile-worthy**: Dataset generation is a distinct workflow that researchers use independently of data exploration.
+
+## Acceptance Criteria
+
+- [ ] Add a `dataset_generator` tile to `launcher_manifest.json` with `web_route: /tools/dataset`
+- [ ] Create a Tauri DatasetGenerator page component
+- [ ] Add route in `ui/src/App.tsx`
+- [ ] Assign to the `tool` category

--- a/reports/feature_navigation_gaps/12_motion_matching_category_empty.md
+++ b/reports/feature_navigation_gaps/12_motion_matching_category_empty.md
@@ -1,0 +1,26 @@
+---
+title: Motion Matching sidebar category has zero tiles
+labels: bug, ui, priority/P1
+---
+
+## Problem
+
+The sidebar has a `Motion Matching` button, but no tile in the manifest carries the `motion_matching` category. The Motion-Match Preview tile (id: `motion_target_preview`) is categorized as `tool`, not `motion_matching`.
+
+Meanwhile, the motion matching module (src/shared/python/motion_matching/) is extensive:
+
+- CVAE and regressor models for surrogate training
+- Multi-source target synthesis (club, body, C3D, .mat)
+- Clubhead trace analysis, forward kinematics
+- Performance baselines and leaderboard
+- Per-step optimization with training scripts
+
+## Classification
+
+**Tile-worthy**: Motion matching is a major feature area. The sidebar button exists specifically for it, and the module has standalone GUI entry points.
+
+## Acceptance Criteria
+
+- [ ] Recategorize `motion_target_preview` to `motion_matching` category, or add a separate `motion_matching` tile
+- [ ] Consider adding a `motion_matching_training` tile for the surrogate training workflow
+- [ ] Verify the Motion Matching sidebar button shows at least one tile

--- a/reports/feature_navigation_gaps/13_analysis_tools_api_no_tile.md
+++ b/reports/feature_navigation_gaps/13_analysis_tools_api_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Analysis Tools API has 6 endpoints but no tile or frontend page
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The analysis tools API (src/api/routes/analysis_tools.py) exposes:
+
+- `GET /analysis/metrics` -- biomechanical metrics
+- `GET /analysis/statistics` -- statistical summaries
+- `POST /analysis/export` -- export analysis data
+- `POST /simulation/position` -- set body position
+- `POST /simulation/measure` -- take measurements
+- `GET /simulation/measurements` -- available measurement tools
+
+These are distinct from the generic `/analyze/biomechanics` route in `analysis.py`. They provide interactive measurement and analysis tooling with no launcher presence.
+
+## Classification
+
+**Borderline -- Tile-worthy**: The analysis tools are interactive measurement features that complement the simulation experience. They could be a sub-feature of the Simulation page or a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Expose analysis tools through either a dedicated tile or the Simulation page UI
+- [ ] If tile: add `analysis_tools` to manifest with `web_route: /tools/analysis`
+- [ ] If sub-feature: add measurement/analysis panels to the Simulation page

--- a/reports/feature_navigation_gaps/14_chat_ai_sidekick_no_manifest_entry.md
+++ b/reports/feature_navigation_gaps/14_chat_ai_sidekick_no_manifest_entry.md
@@ -1,0 +1,21 @@
+---
+title: Chat/AI Sidekick panel has no manifest entry
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The PyQt6 launcher has an AI Sidekick panel (`src/shared/python/upstream_drift_tools/ui/tools_sidebar/`) with a full sidebar, calculator assist, command history, workspace persistence, and data explorer integration. The Tauri UI has a `/chat` route.
+
+Neither appears in the launcher manifest. The AI panel is activated by a sidebar button in the PyQt6 launcher but has no corresponding tile. The Tauri manifest does not know it exists.
+
+## Classification
+
+**Tile-worthy**: The AI Sidekick is a major feature that users would look for. It should appear in the manifest so both launchers can render it consistently.
+
+## Acceptance Criteria
+
+- [ ] Add a `chat` tile to `launcher_manifest.json` with `web_route: /chat`
+- [ ] Assign to the `tool` category
+- [ ] Ensure the PyQt6 launcher shows it as a tile in addition to the sidebar button
+- [ ] Verify Tauri dashboard renders the chat tile

--- a/reports/feature_navigation_gaps/15_motion_pipeline_no_tile.md
+++ b/reports/feature_navigation_gaps/15_motion_pipeline_no_tile.md
@@ -1,0 +1,26 @@
+---
+title: Motion Pipeline has no dedicated tile (only partially covered by Motion Capture)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The Motion Pipeline (`src/shared/python/motion_pipeline/`) is a comprehensive system:
+
+- **Orchestrator** for end-to-end motion processing
+- **ID backends**: CMC, RRA, torque (MuJoCo), trajectory optimization (Drake)
+- **Signal processing**: filter, resample, gap fill, normalize
+- **Retargeting adapters**: C3D, BVH, TRC, OpenPose, MediaPipe, HRNet, AlphaPose, STO/MOT, CSV
+- **Scaling**: anthropometric scaling, marker maps, OpenSim scale
+
+The `motion_capture` tile only covers C3D viewing and OpenPose/MediaPipe. The full pipeline (retargeting, ID solving, signal processing, scaling) is unreachable from the UI.
+
+## Classification
+
+**Borderline**: The Motion Capture tile covers the capture part. The pipeline's processing capabilities (retargeting, ID, scaling) are distinct workflows that researchers need independently. Could be a separate tile or a mode within the Motion Capture page.
+
+## Acceptance Criteria
+
+- [ ] Decide: separate `motion_pipeline` tile or expand the Motion Capture page
+- [ ] Expose retargeting, ID solving, and signal processing workflows
+- [ ] Add API route coverage for pipeline operations beyond capture

--- a/reports/feature_navigation_gaps/16_perturbation_analysis_no_ui.md
+++ b/reports/feature_navigation_gaps/16_perturbation_analysis_no_ui.md
@@ -1,0 +1,26 @@
+---
+title: Perturbation Analysis (cross-engine robustness) has no UI
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The perturbation analysis module (`src/shared/python/perturbation/`) provides cross-engine robustness scoring:
+
+- `cross_engine_runner.py` -- run perturbed simulations across engines
+- `noise.py` -- noise injection (Gaussian, uniform, etc.)
+- `robustness_score.py` -- compute robustness metrics
+- `statistics.py` -- statistical analysis of perturbation results
+- `analyzer_base.py` -- extensible analyzer framework
+
+This directly supports the cross-engine validation feature (F6) and the `Simulation` sidebar category, but has no UI entry point.
+
+## Classification
+
+**Internal library** with **borderline tile potential**: Perturbation analysis is primarily a programmatic feature, but researchers doing robustness studies would want a way to configure and launch it. Could be a mode within the Cross-Engine Dashboard rather than a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Add perturbation analysis configuration to the Cross-Engine Dashboard
+- [ ] Or: add a `perturbation` tile if the workflow is distinct enough
+- [ ] Add API route for configuring and running perturbation studies

--- a/reports/feature_navigation_gaps/17_character_builder_no_tile.md
+++ b/reports/feature_navigation_gaps/17_character_builder_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Character Builder / URDF Generator has no launcher tile
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The humanoid character builder (`src/shared/python/humanoid_character_builder/`) is a complete system:
+
+- Anthropometric body parameter scaling
+- URDF generation with mesh, collision, and physics validation
+- MakeHuman and SMPL-X mesh generators
+- Collision geometry (convex hull, decimation, primitive fitting)
+- Preview and quick-build modes
+- CLI entry point (`src/shared/python/model_generation/cli/main.py`)
+
+The Model Explorer tile allows browsing URDFs but not building them. Users who want to create custom humanoid models have no way to discover or launch the builder.
+
+## Classification
+
+**Tile-worthy with caveats**: Building a character is a distinct workflow from browsing models. The builder has both a GUI preview mode and a CLI. It could be exposed as a mode within Model Explorer (`Open in Builder`) or as a separate tile.
+
+## Acceptance Criteria
+
+- [ ] Add either a `character_builder` tile or a `Build Model` action in Model Explorer
+- [ ] If separate tile: add to manifest with path to `model_generation` CLI
+- [ ] If integrated: add a `Create Model` button in Model Explorer that launches the builder

--- a/reports/feature_navigation_gaps/18_pendulum_simulator_tile.md
+++ b/reports/feature_navigation_gaps/18_pendulum_simulator_tile.md
@@ -1,0 +1,21 @@
+---
+title: Pendulum Simulator has no launcher tile (educational models unreachable)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The pendulum simulator (`src/shared/python/pendulum_simulator/`) has a CLI entry point (`__main__.py`) and was reachable from the deprecated `golf_suite_launcher.py`. The SPEC.md explicitly lists educational 2-DOF pendulums as a supported model type.
+
+Users looking for simple educational models have no way to launch them from the tiled UI.
+
+## Classification
+
+**Tile-worthy**: The pendulum is explicitly called out in SPEC.md as a supported model complexity tier. It provides an approachable entry point for new users.
+
+## Acceptance Criteria
+
+- [ ] Add a `pendulum` tile to `launcher_manifest.json`
+- [ ] Add a handler for the pendulum simulator type
+- [ ] Assign to `physics_engine` category (or a new `educational` category)
+- [ ] Consider grouping with other educational/quick-start models

--- a/reports/feature_navigation_gaps/19_force_overlays_api_no_tile.md
+++ b/reports/feature_navigation_gaps/19_force_overlays_api_no_tile.md
@@ -1,0 +1,18 @@
+---
+title: Force Overlays API has no tile (physics visualization feature hidden)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The force overlays API (`src/api/routes/force_overlays.py`) provides force/torque vector visualization for simulations. This is a distinct visualization feature that users would want to enable independently, but it has no launcher presence.
+
+## Classification
+
+**Internal library**: Force overlays are used by the simulation views (MuJoCo, Drake) internally. They don't need their own tile but should be documented as a capability of the simulation pages.
+
+## Acceptance Criteria
+
+- [ ] Add `force_overlays` to the MuJoCo and Drake tile `capabilities` arrays
+- [ ] Document the force overlay API in the simulation page UI
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/20_realtime_websocket_no_tile.md
+++ b/reports/feature_navigation_gaps/20_realtime_websocket_no_tile.md
@@ -1,0 +1,23 @@
+---
+title: Realtime WebSocket API has no UI presence
+labels: documentation, priority/P2
+---
+
+## Problem
+
+The realtime API (`src/api/routes/realtime.py`) provides:
+
+- `POST /realtime/publish` -- publish real-time events
+- `WebSocket /realtime/subscribe` -- subscribe to real-time event stream
+
+This enables live simulation updates and is used by the simulation WebSocket (`simulation_ws.py`), but it has no manifest entry and no documentation in the launcher UI.
+
+## Classification
+
+**Internal infrastructure**: This is a transport layer, not a user-facing feature. It should be documented as a capability, not exposed as a tile.
+
+## Acceptance Criteria
+
+- [ ] Add `realtime` to relevant tile `capabilities` arrays
+- [ ] Document the realtime API in developer docs
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/21_aip_no_tile.md
+++ b/reports/feature_navigation_gaps/21_aip_no_tile.md
@@ -1,0 +1,24 @@
+---
+title: AIP (AI Protocol) has no tile or documentation in UI
+labels: feature, priority/P2
+---
+
+## Problem
+
+The AIP module (`src/api/routes/aip.py`) provides structured AI method dispatch:
+
+- `GET /aip/capabilities` -- list available AI methods
+- `POST /aip/rpc` -- invoke AI methods via RPC
+- `GET /aip/methods` -- enumerate methods
+
+This powers the AI Sidekick but has no manifest entry. Users and developers who want to understand what AI capabilities are available have no way to discover them from the UI.
+
+## Classification
+
+**Borderline**: AIP is infrastructure that powers the Chat/Sidekick feature. It doesn't need its own tile, but its capabilities should be surfaced through the Chat tile's description and capabilities.
+
+## Acceptance Criteria
+
+- [ ] Add `ai_methods` to the chat tile `capabilities` array
+- [ ] Update the chat tile description to mention AI method access
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/22_actuator_controls_api_no_tile.md
+++ b/reports/feature_navigation_gaps/22_actuator_controls_api_no_tile.md
@@ -1,0 +1,24 @@
+---
+title: Actuator Controls API has no tile (simulation sub-feature)
+labels: documentation, priority/P2
+---
+
+## Problem
+
+The actuator controls API (`src/api/routes/actuator_controls.py`) provides:
+
+- `GET /simulation/actuators` -- list actuators
+- `POST /simulation/actuators` -- configure actuator controls
+- `POST /simulation/actuators/control` -- send control commands
+
+This is a simulation sub-feature, not a standalone workflow. It should be documented as a capability of the Simulation page.
+
+## Classification
+
+**Internal library**: Actuator controls are used within simulation sessions. No tile needed.
+
+## Acceptance Criteria
+
+- [ ] Add `actuator_controls` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Expose actuator controls in the Simulation page UI
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/23_bunkershot3d_no_tile.md
+++ b/reports/feature_navigation_gaps/23_bunkershot3d_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: BunkerShot3D has no launcher tile
+labels: feature, ui, priority/P3
+---
+
+## Problem
+
+BunkerShot3D (`src/bunkershot3d/`) is a complete sand-shot simulation with:
+
+- MPM, LIGGGHTS, and Chrono backends
+- Calibration system (angle of repose, drained shear cell)
+- Clubhead geometry and kinematics
+- Configuration system (`configs/bunkershot3d/canonical.yaml`)
+- I/O and post-processing
+
+It has no manifest tile and no way for users to discover or launch it.
+
+## Classification
+
+**Tile-worthy**: BunkerShot3D is a distinct simulation domain (sand bunkers). Golf researchers would seek this out specifically. It's not just a sub-feature of MuJoCo.
+
+## Acceptance Criteria
+
+- [ ] Add a `bunkershot3d` tile to `launcher_manifest.json`
+- [ ] Add a handler for launching the BunkerShot3D simulator
+- [ ] Assign to the `physics_engine` category
+- [ ] Add appropriate SVG logo

--- a/reports/feature_navigation_gaps/24_unreal_integration_no_tile.md
+++ b/reports/feature_navigation_gaps/24_unreal_integration_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Unreal Integration (streaming/VR) has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The Unreal integration module (`src/unreal_integration/`) provides:
+
+- Streaming server for real-time simulation streaming
+- Unreal Engine bridge
+- Meshcat and PyVista viewer backends
+- VR interaction support
+- Simulation streamer
+
+This is an advanced visualization capability, but it has no manifest entry and no way for users to discover it.
+
+## Classification
+
+**Borderline**: Unreal integration is an advanced/power-user feature. Most users don't need it, but those who do would actively look for it. Could be a sub-feature of simulation tiles (`Launch in Unreal`) rather than a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Add `unreal_streaming` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Consider adding an `Advanced Visualization` section in settings or engine dashboards
+- [ ] Document the streaming setup in user-facing docs
+- [ ] Standalone tile may not be needed; sub-feature access is sufficient

--- a/reports/feature_navigation_gaps/25_robotics_module_no_presence.md
+++ b/reports/feature_navigation_gaps/25_robotics_module_no_presence.md
@@ -1,0 +1,29 @@
+---
+title: Robotics module has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The robotics module (`src/robotics/`) provides:
+
+- Motion planning: RRT, RRT\* planners
+- Control: impedance, admittance, hybrid force-position
+- Sensing: sensor models
+- Whole-body control
+- Locomotion: footstep planning
+- Collision detection
+
+These capabilities are referenced in SPEC.md (control schemes F12, constraint analysis) but have no UI entry point.
+
+## Classification
+
+**Internal library**: The robotics module is consumed by the physics engines (Drake, MuJoCo) for control and planning. Users access these features through simulation configuration, not through a standalone tool.
+
+However, the control scheme selection (impedance vs. admittance vs. operational space) is something users might want to configure per-simulation.
+
+## Acceptance Criteria
+
+- [ ] Add `control_schemes` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Expose control scheme selection in the Simulation page
+- [ ] No standalone tile needed; these are configuration options

--- a/reports/feature_navigation_gaps/26_upstream_drift_tools_breadth_hidden.md
+++ b/reports/feature_navigation_gaps/26_upstream_drift_tools_breadth_hidden.md
@@ -1,0 +1,29 @@
+---
+title: UpstreamDrift Tools calculator suite breadth is hidden
+labels: feature, priority/P3
+---
+
+## Problem
+
+The UpstreamDrift Tools (`src/shared/python/upstream_drift_tools/`) contains a comprehensive process-engineering calculator suite:
+
+- **Process calculators**: pressure drop, syngas compression, scrubber, PSA, acid gas dewpoint, flare, baghouse, WGS reactor, electrode advancement
+- **Thermo**: steam tables, properties, vapor pressure
+- **Mechanical**: pipe database, fittings, friction factors
+- **Electrical**: electrical model
+- **Data processing**: operations, widget
+- **Unit conversion**: widget and preferences manager
+- **Lab UI**: full workspace with file navigation, command history, tab system, reporting
+
+Only the `Data Processor` tile surfaces this suite. The calculator breadth is invisible.
+
+## Classification
+
+**Borderline**: The calculators are domain-specific (process engineering) and may not match the core biomechanics audience. However, they are fully functional tools.
+
+## Acceptance Criteria
+
+- [ ] Expand the `Data Processor` tile description to mention calculators
+- [ ] Consider adding an `upstream_drift_tools` category or expanding the `tool` category description
+- [ ] Add `process_calculators` to the Data Processor tile `capabilities` array
+- [ ] Low priority: could add individual calculator tiles if demand exists

--- a/reports/feature_navigation_gaps/27_programmatic_pid_hidden.md
+++ b/reports/feature_navigation_gaps/27_programmatic_pid_hidden.md
@@ -1,0 +1,24 @@
+---
+title: Programmatic P&ID Generator has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The programmatic PID module (`src/shared/python/programmatic_pid/`) generates Piping & Instrumentation Diagrams with:
+
+- Controls, equipment, instruments, layout, rendering
+- Streams, title blocks, validation
+- CLI entry point (`cli.py`)
+
+This is a niche but complete tool with no way for users to discover it.
+
+## Classification
+
+**Borderline / Niche**: P&ID generation is tangential to biomechanics simulation. It may not warrant a standalone tile in a golf physics launcher, but could be useful for facility/process engineers.
+
+## Acceptance Criteria
+
+- [ ] Consider adding a `pid_generator` tile if there's user demand
+- [ ] Alternative: document as an advanced tool accessible via CLI
+- [ ] If added, assign to `developer_tools` category

--- a/reports/feature_navigation_gaps/28_dashboard_recorder_hidden.md
+++ b/reports/feature_navigation_gaps/28_dashboard_recorder_hidden.md
@@ -1,0 +1,25 @@
+---
+title: Dashboard Recorder / Advanced Analysis is internal-only
+labels: documentation, priority/P3
+---
+
+## Problem
+
+The dashboard module (`src/shared/python/dashboard/`) provides:
+
+- Recorder: playback, recording, analysis buffers
+- Advanced analysis window
+- Runner for launching analyses
+- Dashboard-specific widgets
+
+This is only accessible within the engine-specific dashboards (MuJoCo, Drake, Pinocchio), which themselves are not exposed from the launcher (see issue #07).
+
+## Classification
+
+**Internal library**: The recorder is a sub-feature of the engine dashboards. It should become accessible once the dashboards are exposed.
+
+## Acceptance Criteria
+
+- [ ] Expose engine dashboards (see issue #07)
+- [ ] Document the recorder as a dashboard capability
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/29_internal_libraries_no_tile_needed.md
+++ b/reports/feature_navigation_gaps/29_internal_libraries_no_tile_needed.md
@@ -1,0 +1,33 @@
+---
+title: Internal libraries that correctly have no tile (classification audit)
+labels: documentation, priority/none
+---
+
+## Summary
+
+The following modules are internal libraries consumed by other features. They correctly have no launcher tile and should remain internal:
+
+| Module               | Path                                   | Consumed By                                   |
+| -------------------- | -------------------------------------- | --------------------------------------------- |
+| Biomechanics library | `src/shared/python/biomechanics/`      | MuJoCo, OpenSim, MyoSuite, Exercise Dashboard |
+| Screw theory         | `src/shared/python/screw_theory/`      | Physics engines                               |
+| Spatial algebra      | `src/shared/python/spatial_algebra/`   | Physics engines                               |
+| Data I/O             | `src/shared/python/data_io/`           | Data Explorer, export                         |
+| Plot engine          | `src/shared/python/plot_engine/`       | Dashboards, analysis                          |
+| Reporting            | `src/shared/python/reporting/`         | Analysis/export flows                         |
+| Realtime transport   | `src/shared/python/realtime/`          | Simulation WS, realtime API                   |
+| Scripting env        | `src/shared/python/scripting/`         | Internal                                      |
+| Pose editor widgets  | `src/shared/python/pose_editor/`       | Pose Studio                                   |
+| Chat framework       | `src/shared/python/chat/`              | AI Sidekick                                   |
+| Rust physics kernels | `rust_core/`                           | Physics engines                               |
+| Robotics control     | `src/robotics/`                        | Drake, MuJoCo                                 |
+| Freemocap ingest     | `src/motion_capture/freemocap_ingest/` | Motion Capture                                |
+| Deployment modules   | `src/deployment/`                      | Production deployment                         |
+
+These modules should be documented in capabilities arrays of the tiles that consume them, not given their own tiles.
+
+## Acceptance Criteria
+
+- [ ] Add capability tags to consuming tiles (e.g., `screw_theory` on MuJoCo tile)
+- [ ] Update PROJECT_MAP.md to reflect these as internal modules
+- [ ] No tiles needed

--- a/reports/feature_navigation_gaps/30_putting_green_category_mismatch.md
+++ b/reports/feature_navigation_gaps/30_putting_green_category_mismatch.md
@@ -1,0 +1,34 @@
+---
+title: Putting Green miscategorized as physics_engine (should be simulation)
+labels: bug, ui, priority/P2
+---
+
+## Problem
+
+The Putting Green tile has `category: physics_engine` but it's actually a specialized simulation tool (putting green physics). The `simulation` sidebar category currently shows zero tiles. Moving Putting Green to the `simulation` category would populate it and more accurately reflect its nature.
+
+## Current
+
+```json
+{
+  ""id"": ""putting_green"",
+  ""category"": ""physics_engine"",
+  ...
+}
+```
+
+## Suggested
+
+```json
+{
+  ""id"": ""putting_green"",
+  ""category"": ""simulation"",
+  ...
+}
+```
+
+## Acceptance Criteria
+
+- [ ] Change Putting Green category from `physics_engine` to `simulation`
+- [ ] Verify the Simulation sidebar button now shows at least one tile
+- [ ] Update the Putting Green description to clarify it's a simulation tool

--- a/reports/feature_navigation_gaps/31_simulation_category_needs_tiles.md
+++ b/reports/feature_navigation_gaps/31_simulation_category_needs_tiles.md
@@ -1,0 +1,23 @@
+---
+title: Simulation sidebar category needs tiles (Putting Green + others)
+labels: bug, ui, priority/P2
+---
+
+## Problem
+
+This is a companion to issues #01, #02, #06, and #30. The `simulation` sidebar category currently has zero tiles because:
+
+1. Putting Green is categorized as `physics_engine` instead of `simulation`
+2. Cross-Engine Dashboard has no tile at all
+3. Golf Simulation Suite has no tile
+4. Shot Tracer has no tile
+
+Even after fixing #30 (re-categorizing Putting Green), the category would have only one tile. It needs more.
+
+## Acceptance Criteria
+
+- [ ] Move Putting Green to `simulation` category
+- [ ] Add Cross-Engine Dashboard tile to `simulation`
+- [ ] Add Golf Simulation Suite tile to `simulation`
+- [ ] Add Shot Tracer tile to `simulation`
+- [ ] Verify Simulation sidebar shows all tiles

--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -41,8 +41,10 @@ from PyQt6.QtWidgets import (
 )
 
 
-def _get_theme_colors() -> dict[str, str]:
+def _get_theme_colors(theme_provider: Any = None) -> dict[str, str]:
     """Get the current theme colors, falling back to defaults."""
+    if theme_provider is not None and hasattr(theme_provider, "get_current_colors"):
+        return theme_provider.get_current_colors()
     try:
         from src.shared.python.theme.theme_manager import get_theme_manager
 
@@ -88,6 +90,7 @@ class ChatMessageBubble(QFrame):
         role: str,
         content: str,
         accent_color: str = "#FF8800",
+        theme_provider: Any = None,
         parent: QWidget | None = None,
     ) -> None:
         if not (role is not None):
@@ -95,12 +98,13 @@ class ChatMessageBubble(QFrame):
         super().__init__(parent)
         self._role = role
         self._content = content
+        self._theme_provider = theme_provider
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(6, 4, 6, 4)
         layout.setSpacing(2)
 
-        colors = _get_theme_colors()
+        colors = _get_theme_colors(self._theme_provider)
         text_primary = colors.get("text", "#e0e0e0")
         bg_alt = colors.get("group_bg", "#2d2d2d")
         bg_secondary = colors.get("input_bg", "#252526")
@@ -181,6 +185,8 @@ class ChatDockWidget(QDockWidget):
         placeholder_text: str = "Ask a question...",
         accent_color: str = "#FF8800",
         auto_index_on_open: bool = False,
+        project_root: str | Path | None = None,
+        theme_provider: Any = None,
         parent: QWidget | None = None,
     ) -> None:
         if not (app_context is not None):
@@ -193,6 +199,8 @@ class ChatDockWidget(QDockWidget):
         self._accent_color = accent_color
         self._placeholder_text = placeholder_text
         self._auto_index_on_open = bool(auto_index_on_open)
+        self._project_root = Path(project_root) if project_root else None
+        self._theme_provider = theme_provider
         self._is_streaming = False
         self._current_bubble: ChatMessageBubble | None = None
         self._socket: QWebSocket | None = None
@@ -216,7 +224,7 @@ class ChatDockWidget(QDockWidget):
         self._connect_on_show = True
 
     def _setup_ui(self) -> None:
-        colors = _get_theme_colors()
+        colors = _get_theme_colors(self._theme_provider)
         bg_primary = colors.get("bg", "#1e1e1e")
         bg_alt = colors.get("group_bg", "#2d2d2d")
         text_primary = colors.get("text", "#e0e0e0")
@@ -453,7 +461,12 @@ class ChatDockWidget(QDockWidget):
         """Add a message bubble to the scroll area."""
         if not (role is not None):
             raise ValueError("role must be provided")
-        bubble = ChatMessageBubble(role, content, accent_color=self._accent_color)
+        bubble = ChatMessageBubble(
+            role,
+            content,
+            accent_color=self._accent_color,
+            theme_provider=self._theme_provider,
+        )
         # Insert before the stretch item at the end
         count = self._message_layout.count()
         self._message_layout.insertWidget(count - 1, bubble)

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
@@ -1,0 +1,504 @@
+"""Embedded Sidekick runtime widgets for shared utility tabs."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import logging
+import types
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+from . import design_tokens as theme
+from .calculator_assist import (
+    calculator_predictive_text_enabled,
+    calculator_startup_config,
+    set_calculator_predictive_text_enabled,
+)
+from .calculator_runtime import (
+    SidekickCalculatorWidget,
+)
+from .calculator_startup import (
+    apply_calculator_startup_imports,
+    default_calculator_startup_config,
+)
+from .help_content import DEFAULT_SIDEBAR_TAB_HELP
+from .qt_compat import QT_API, QtCore, QtWidgets
+from .registry import WorkspaceRegistry
+
+logger = logging.getLogger(__name__)
+
+SIDEKICK_CHAT_RUNTIME_OBJECT_NAME = "SidekickChatRuntimeTab"
+SIDEKICK_TERMINAL_OBJECT_NAME = "SidekickTerminalTab"
+SIDEKICK_NOTES_OBJECT_NAME = "SidekickNotesTab"
+
+_RESERVED_NAMESPACE_NAMES = {
+    "__builtins__",
+    "np",
+    "numpy",
+    "pd",
+    "pandas",
+    "scipy",
+}
+
+SetVariable = Callable[[str, Any], None]
+
+
+def build_chat_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build the embedded chat tab for a Sidekick sidebar."""
+    if QT_API == "PyQt6":
+        widget = _build_pyqt_chat_dock(sidebar)
+        if widget is not None:
+            widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["chat"]["summary"])
+            return widget
+    return _build_chat_status_tab(sidebar)
+
+
+def build_terminal_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build an embedded Python terminal tab bound to the workspace registry."""
+    widget = SidekickTerminalWidget(
+        registry=sidebar.registry,
+        set_variable=sidebar.set_context_variable,
+        terminal_theme=theme.SidekickTerminalTheme.inherited(
+            getattr(sidebar, "_design_tokens", None),
+        ),
+        parent=sidebar,
+    )
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["terminal"]["summary"])
+    return widget
+
+
+def build_calculator_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build an embedded symbolic calculator tab bound to workspace state."""
+    widget = SidekickCalculatorWidget(
+        registry=sidebar.registry,
+        set_variable=sidebar.set_context_variable,
+        predictive_text_enabled=calculator_predictive_text_enabled(sidebar),
+        startup_import_config=calculator_startup_config(sidebar),
+        set_predictive_text_enabled=partial(
+            set_calculator_predictive_text_enabled,
+            sidebar,
+        ),
+        refresh_workspace=sidebar.refresh_workspace,
+        parent=sidebar,
+    )
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["calculator"]["summary"])
+    return widget
+
+
+def build_notes_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build a project-persistent notes tab."""
+    widget = SidekickNotesWidget(project_root=sidebar.project_root, parent=sidebar)
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["notes"]["summary"])
+    return widget
+
+
+class SidekickTerminalWidget(QtWidgets.QWidget):
+    """Small Python execution surface sharing values with Workspace."""
+
+    def __init__(
+        self,
+        *,
+        registry: WorkspaceRegistry,
+        set_variable: SetVariable,
+        terminal_theme: theme.SidekickTerminalTheme | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        if registry is None:
+            raise ValueError("registry must be provided")
+        if set_variable is None:
+            raise ValueError("set_variable must be provided")
+        super().__init__(parent)
+        self.setObjectName(SIDEKICK_TERMINAL_OBJECT_NAME)
+        self._registry = registry
+        self._set_variable = set_variable
+        self._terminal_theme = terminal_theme or theme.SidekickTerminalTheme.inherited()
+        self._namespace: dict[str, Any] = {}
+        self._load_workspace_namespace()
+        _preload_scientific_namespace(self._namespace)
+        self._build_ui()
+        self.apply_terminal_theme(self._terminal_theme)
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        self._input = QtWidgets.QPlainTextEdit(self)
+        self._input.setObjectName("SidekickTerminalInput")
+        self._input.setPlaceholderText("result = np.array([1, 2, 3]).sum()")
+        self._input.setToolTip(
+            "Enter Python code that can read and write shared workspace variables."
+        )
+        layout.addWidget(self._input, stretch=2)
+
+        self._run_button = QtWidgets.QPushButton("Run", self)
+        self._run_button.setObjectName("SidekickTerminalRun")
+        self._run_button.setToolTip(
+            "Execute the current terminal script and export assigned variables."
+        )
+        self._run_button.clicked.connect(self.execute_script)
+        layout.addWidget(self._run_button)
+
+        self._output = QtWidgets.QPlainTextEdit(self)
+        self._output.setObjectName("SidekickTerminalOutput")
+        self._output.setReadOnly(True)
+        self._output.setToolTip("Shows terminal stdout, stderr, and execution errors.")
+        layout.addWidget(self._output, stretch=3)
+
+    def execute_script(self) -> None:
+        """Execute the current script and export user variables."""
+        script = self._input.toPlainText()
+        if not script.strip():
+            self._append_output("No code to run.")
+            return
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            compiled = compile(script, "<sidekick-terminal>", "exec")
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                exec(compiled, self._namespace, self._namespace)  # noqa: S102  # nosec B102
+        except Exception as exc:  # noqa: BLE001 - terminal reports user code errors
+            logger.debug("Sidekick terminal execution failed: %s", exc)
+            self._append_output(_format_terminal_output(stdout, stderr, exc))
+            return
+
+        self._sync_namespace_to_registry()
+        self._append_output(_format_terminal_output(stdout, stderr, None))
+
+    def _load_workspace_namespace(self) -> None:
+        for name in self._registry.list_names():
+            self._namespace[name] = self._registry.get(name)
+
+    def _sync_namespace_to_registry(self) -> None:
+        for name, value in _exportable_values(self._namespace).items():
+            self._set_variable(name, value)
+
+    def _append_output(self, text: str) -> None:
+        existing = self._output.toPlainText().strip()
+        combined = f"{existing}\n{text}" if existing else text
+        self._output.setPlainText(combined.strip())
+
+    def apply_terminal_theme(self, terminal_theme: theme.SidekickTerminalTheme) -> None:
+        """Apply terminal-scoped colors without changing global Sidekick QSS."""
+        if terminal_theme is None:
+            raise ValueError("terminal_theme must be provided")
+        self._terminal_theme = terminal_theme
+        self.setStyleSheet(terminal_theme.qss(SIDEKICK_TERMINAL_OBJECT_NAME))
+
+
+class SidekickNotesWidget(QtWidgets.QWidget):
+    """Project note-card editor with explicit save and debounced persistence."""
+
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        if project_root is None:
+            raise ValueError("project_root must be provided")
+        super().__init__(parent)
+        self.setObjectName(SIDEKICK_NOTES_OBJECT_NAME)
+        self._store = _note_card_store(project_root)
+        self._active_card_id: str | None = None
+        self._autosave = QtCore.QTimer(self)
+        self._autosave.setSingleShot(True)
+        self._autosave.setInterval(500)
+        self._autosave.timeout.connect(self.save_notes)
+        self._build_ui()
+        self._load_first_card()
+        self._apply_board_style()
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        self._status = QtWidgets.QLabel("Ready", self)
+        self._status.setObjectName("SidekickNotesStatus")
+        self._status.setToolTip("Reports the latest notes persistence status.")
+        layout.addWidget(self._status)
+
+        self._card_frame = QtWidgets.QFrame(self)
+        self._card_frame.setObjectName("SidekickNotesCard")
+        card_layout = QtWidgets.QVBoxLayout(self._card_frame)
+        card_layout.setContentsMargins(8, 8, 8, 8)
+        card_layout.setSpacing(8)
+
+        self._color = QtWidgets.QLineEdit(self._card_frame)
+        self._color.setObjectName("SidekickNotesCardColor")
+        self._color.setPlaceholderText("#fff7cc")
+        self._color.setToolTip("Sets the active note card color as a #RRGGBB value.")
+        card_layout.addWidget(self._color)
+
+        self._editor = QtWidgets.QPlainTextEdit(self)
+        self._editor.setObjectName("SidekickNotesEditor")
+        self._editor.setPlaceholderText("Project notes")
+        self._editor.setToolTip("Edit the active project-scoped markdown note card.")
+        self._editor.textChanged.connect(self._schedule_autosave)
+        card_layout.addWidget(self._editor, stretch=1)
+        layout.addWidget(self._card_frame, stretch=1)
+
+        self._board_color = QtWidgets.QLineEdit(self)
+        self._board_color.setObjectName("SidekickNotesBoardColor")
+        self._board_color.setPlaceholderText("#f7f7f7")
+        self._board_color.setToolTip("Sets the notes screen background color.")
+        layout.addWidget(self._board_color)
+
+        row = QtWidgets.QHBoxLayout()
+        self._save = QtWidgets.QPushButton("Save", self)
+        self._save.setObjectName("SidekickNotesSave")
+        self._save.setToolTip("Persist the current notes text immediately.")
+        self._save.clicked.connect(self.save_notes)
+        row.addWidget(self._save)
+
+        clear = QtWidgets.QPushButton("Clear", self)
+        clear.setObjectName("SidekickNotesClear")
+        clear.setToolTip(
+            "Clear the current note text while keeping the notes file available."
+        )
+        clear.clicked.connect(self.clear_notes)
+        row.addWidget(clear)
+
+        restore = QtWidgets.QPushButton("Restore", self)
+        restore.setObjectName("SidekickNotesRestore")
+        restore.setToolTip(
+            "Restore the latest recycled notes snapshot when one exists."
+        )
+        restore.clicked.connect(self.restore_latest)
+        row.addWidget(restore)
+
+        apply_colors = QtWidgets.QPushButton("Apply Colors", self)
+        apply_colors.setObjectName("SidekickNotesApplyColors")
+        apply_colors.setToolTip("Validate and persist note and screen colors.")
+        apply_colors.clicked.connect(self.apply_colors)
+        row.addWidget(apply_colors)
+        layout.addLayout(row)
+
+    def save_notes(self) -> None:
+        """Persist the current notes text to the active markdown card."""
+        color = self._color.text().strip() or "#fff7cc"
+        if self._active_card_id is None:
+            card = self._store.create_note(
+                "Project Notes",
+                self._editor.toPlainText(),
+                color=color,
+            )
+            self._active_card_id = card.note_id
+        else:
+            self._store.update_note(
+                self._active_card_id,
+                title="Project Notes",
+                markdown_body=self._editor.toPlainText(),
+                color=color,
+            )
+        self.apply_colors(save_note=False)
+        self._status.setText("Saved")
+
+    def clear_notes(self) -> None:
+        """Clear notes while preserving the active markdown card."""
+        self._editor.setPlainText("")
+        self.save_notes()
+        self._status.setText("Cleared")
+
+    def restore_latest(self) -> None:
+        """Restore the latest recycled note file when available."""
+        item_id = self._store.latest_recycled_id()
+        restored = None if item_id is None else self._store.restore_note(item_id)
+        if restored is None:
+            self._status.setText("Nothing to restore")
+            return
+        self._active_card_id = restored.note_id
+        self._editor.setPlainText(restored.markdown_body)
+        self._color.setText(restored.color)
+        self._apply_card_style(restored.color)
+        self._status.setText("Restored")
+
+    def apply_colors(self, *, save_note: bool = True) -> None:
+        """Validate and persist note-card and board colors."""
+        from notes.models import NotesBoardSettings, normalize_color
+
+        note_color = normalize_color(self._color.text().strip() or "#fff7cc")
+        board = NotesBoardSettings(
+            background_color=self._board_color.text().strip() or "#f7f7f7"
+        )
+        self._color.setText(note_color)
+        self._board_color.setText(board.background_color)
+        self._store.save_settings(board)
+        self._apply_card_style(note_color)
+        self._apply_board_style()
+        if save_note:
+            self.save_notes()
+
+    def _load_first_card(self) -> None:
+        card = self._store.migrate_legacy_text_note()
+        if card is None:
+            notes = self._store.list_notes()
+            card = notes[0] if notes else None
+        if card is not None:
+            self._active_card_id = card.note_id
+            self._editor.setPlainText(card.markdown_body)
+            self._color.setText(card.color)
+            self._apply_card_style(card.color)
+        else:
+            self._color.setText("#fff7cc")
+        self._board_color.setText(self._store.load_settings().background_color)
+
+    def _apply_board_style(self) -> None:
+        color = self._store.load_settings().background_color
+        self.setStyleSheet(f"#{SIDEKICK_NOTES_OBJECT_NAME} {{ background: {color}; }}")
+
+    def _apply_card_style(self, color: str) -> None:
+        self._card_frame.setStyleSheet(
+            "#SidekickNotesCard { "
+            f"background: {color}; border: 1px solid #d0d0d0; border-radius: 6px;"
+            " }"
+        )
+
+    def _schedule_autosave(self) -> None:
+        self._autosave.start()
+
+
+def _build_pyqt_chat_dock(sidebar: Any) -> QtWidgets.QWidget | None:
+    try:
+        chat_module = importlib.import_module("chat.chat_dock_widget")
+    except Exception as exc:  # noqa: BLE001 - optional chat dependency
+        logger.debug("PyQt chat dock unavailable for Sidekick: %s", exc)
+        return None
+
+    # Wire application state and diagnostic history into the chat agent context
+    try:
+        from src.shared.python.ai.chat_context import record_event
+
+        # Record diagnostic history
+        try:
+            from src.launchers.launcher_diagnostics import LauncherDiagnostics
+
+            diag = LauncherDiagnostics()
+            record_event("diagnostic", {"diagnostic_history": diag.run_all_checks()})
+        except ImportError:
+            pass
+
+        # Record application state via the registry
+        if hasattr(sidebar, "registry") and hasattr(sidebar.registry, "export_all"):
+            record_event(
+                "app_state", {"registry_export": sidebar.registry.export_all()}
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Failed to wire Sidekick chat context: %s", exc)
+
+    # Sidekick: unify React and PyQt chat surfaces and verify cross-shell parity
+    # Inject an adapter that implements ThemeProviderProtocol over the Sidekick tokens
+    tokens = getattr(sidebar, "_design_tokens", None)
+    theme_provider: Any = None
+    if tokens is not None:
+
+        class _SidekickThemeAdapter:
+            def __init__(self, t: Any) -> None:
+                self.t = t
+
+            def get_current_colors(self) -> dict[str, str]:
+                return {
+                    "bg": self.t.color.canvas,
+                    "group_bg": self.t.color.surface,
+                    "input_bg": self.t.color.input,
+                    "text": self.t.color.text,
+                    "text_secondary": self.t.color.text_subtle,
+                    "border": self.t.color.border,
+                    "button_hover": self.t.color.accent_hover,
+                    "accent": self.t.color.accent,
+                }
+
+        theme_provider = _SidekickThemeAdapter(tokens)
+    else:
+        try:
+            theme_module = importlib.import_module("theme.theme_manager")
+            theme_provider = theme_module.get_theme_manager()
+        except Exception as exc:  # noqa: BLE001 - theme is optional at this layer
+            logger.debug("Theme manager unavailable for chat dock: %s", exc)
+
+    dock = chat_module.ChatDockWidget(
+        app_context="sidekick",
+        app_name="sidekick",
+        project_root=sidebar.project_root,
+        theme_provider=theme_provider,
+        parent=sidebar,
+    )
+    dock.setObjectName(SIDEKICK_CHAT_RUNTIME_OBJECT_NAME)
+    dock.setTitleBarWidget(QtWidgets.QWidget(dock))
+    _disable_dock_chrome(dock)
+    return dock
+
+
+def _build_chat_status_tab(sidebar: Any) -> QtWidgets.QWidget:
+    widget = QtWidgets.QWidget(sidebar)
+    widget.setObjectName(SIDEKICK_CHAT_RUNTIME_OBJECT_NAME)
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["chat"]["summary"])
+    layout = QtWidgets.QVBoxLayout(widget)
+    layout.setContentsMargins(8, 8, 8, 8)
+    label = QtWidgets.QLabel(
+        "Shared chat is available when the PyQt chat dock is loaded.",
+        widget,
+    )
+    label.setWordWrap(True)
+    layout.addWidget(label)
+    layout.addStretch(1)
+    return widget
+
+
+def _disable_dock_chrome(dock: Any) -> None:
+    feature_type = getattr(QtWidgets.QDockWidget, "DockWidgetFeature", None)
+    if feature_type is not None:
+        dock.setFeatures(feature_type.NoDockWidgetFeatures)
+        return
+    dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
+
+
+def _note_card_store(project_root: Path) -> Any:
+    from notes.card_store import NoteCardStore
+
+    return NoteCardStore(project_dir=project_root)
+
+
+def _preload_scientific_namespace(namespace: dict[str, Any]) -> None:
+    apply_calculator_startup_imports(
+        namespace,
+        default_calculator_startup_config(),
+    )
+
+
+def _exportable_values(namespace: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: value
+        for name, value in namespace.items()
+        if _is_exportable_name(name) and _is_exportable_value(value)
+    }
+
+
+def _is_exportable_name(name: str) -> bool:
+    return (
+        bool(name)
+        and not name.startswith("_")
+        and name not in _RESERVED_NAMESPACE_NAMES
+    )
+
+
+def _is_exportable_value(value: Any) -> bool:
+    return not isinstance(value, types.ModuleType) and not callable(value)
+
+
+def _format_terminal_output(
+    stdout: io.StringIO,
+    stderr: io.StringIO,
+    exc: Exception | None,
+) -> str:
+    parts = [text for text in (stdout.getvalue(), stderr.getvalue()) if text]
+    if exc is not None:
+        parts.append(f"{type(exc).__name__}: {exc}")
+    if not parts:
+        return "Executed."
+    return "".join(parts).strip()

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,9 @@ import { VideoAnalyzerPage } from './pages/VideoAnalyzer';
 import { DataExplorerPage } from './pages/DataExplorer';
 import { MotionCapturePage } from './pages/MotionCapture';
 import { ChatPage } from './pages/Chat';
+import { TerrainPage } from './pages/Terrain';
+import { DatasetGeneratorPage } from './pages/DatasetGenerator';
+import { AnalysisToolsPage } from './pages/AnalysisTools';
 import { ToastProvider } from './components/ui/Toast';
 import { DiagnosticsPanel } from './components/ui/DiagnosticsPanel';
 import { HelpPanel } from './components/ui/HelpPanel';
@@ -28,6 +31,9 @@ function App() {
           <Route path="/tools/video-analyzer" element={<VideoAnalyzerPage />} />
           <Route path="/tools/data-explorer" element={<DataExplorerPage />} />
           <Route path="/tools/motion-capture" element={<MotionCapturePage />} />
+          <Route path="/tools/terrain" element={<TerrainPage />} />
+          <Route path="/tools/dataset" element={<DatasetGeneratorPage />} />
+          <Route path="/tools/analysis" element={<AnalysisToolsPage />} />
           {/* Chat (#3505): wires chat_ws backend into the UI */}
           <Route path="/chat" element={<ChatPage />} />
         </Routes>

--- a/ui/src/api/useAnalysisTools.ts
+++ b/ui/src/api/useAnalysisTools.ts
@@ -1,0 +1,124 @@
+/**
+ * Analysis Tools Hook — Fetches biomechanical metrics, statistical summaries,
+ * and export functionality from the backend REST API.
+ */
+
+import { useState, useCallback, useRef } from 'react';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface MetricInfo {
+  id: string;
+  name: string;
+  description: string;
+  unit: string;
+  category: string;
+  value?: number;
+}
+
+export interface StatisticsSummary {
+  dataset_id: string;
+  metric_count: number;
+  summary: Record<string, {
+    min: number;
+    max: number;
+    mean: number;
+    median: number;
+    std: number;
+  }>;
+}
+
+export interface ExportResult {
+  format: string;
+  url: string;
+  filename: string;
+  size_bytes: number;
+}
+
+export type AnalysisLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+// ── Hook ───────────────────────────────────────────────────────────────
+
+export function useAnalysisTools() {
+  const [metrics, setMetrics] = useState<MetricInfo[]>([]);
+  const [statistics, setStatistics] = useState<StatisticsSummary | null>(null);
+  const [exportResult, setExportResult] = useState<ExportResult | null>(null);
+  const [loadState, setLoadState] = useState<AnalysisLoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  const fetchMetrics = useCallback(async () => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/analysis/metrics');
+      if (!res.ok) throw new Error(`Failed to fetch metrics: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setMetrics(data.metrics ?? data ?? []);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  const fetchStatistics = useCallback(async () => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/analysis/statistics');
+      if (!res.ok) throw new Error(`Failed to fetch statistics: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setStatistics(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch statistics');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  const exportAnalysis = useCallback(async (format: string, datasetId?: string) => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/analysis/export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format, dataset_id: datasetId }),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || `Export failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setExportResult(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Export failed');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  return {
+    metrics,
+    statistics,
+    exportResult,
+    loadState,
+    error,
+    fetchMetrics,
+    fetchStatistics,
+    exportAnalysis,
+  };
+}

--- a/ui/src/api/useDatasetGenerator.ts
+++ b/ui/src/api/useDatasetGenerator.ts
@@ -1,0 +1,201 @@
+/**
+ * Dataset Generator Hook — Fetches dataset generation controls, features,
+ * plot types, and export formats from the backend REST API.
+ *
+ * Provides methods for generating datasets, importing swing data, and
+ * managing dataset control parameters.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface FeatureInfo {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+}
+
+export interface PlotType {
+  id: string;
+  name: string;
+  description: string;
+  axes: string[];
+}
+
+export interface ExportFormat {
+  id: string;
+  name: string;
+  extension: string;
+  mime_type: string;
+}
+
+export interface DatasetControl {
+  id: string;
+  name: string;
+  type: string;
+  value: unknown;
+  options?: string[];
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface GenerateResult {
+  dataset_id: string;
+  name: string;
+  rows: number;
+  columns: string[];
+  created_at: string;
+}
+
+export type DatasetLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+// ── Hook ───────────────────────────────────────────────────────────────
+
+export function useDatasetGenerator() {
+  const [features, setFeatures] = useState<FeatureInfo[]>([]);
+  const [plotTypes, setPlotTypes] = useState<PlotType[]>([]);
+  const [exportFormats, setExportFormats] = useState<ExportFormat[]>([]);
+  const [controls, setControls] = useState<DatasetControl[]>([]);
+  const [generateResult, setGenerateResult] = useState<GenerateResult | null>(null);
+  const [loadState, setLoadState] = useState<DatasetLoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  const fetchFeatures = useCallback(async () => {
+    try {
+      const res = await fetch('/api/dataset/features');
+      if (!res.ok) throw new Error(`Failed to fetch features: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setFeatures(data.features ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch features');
+    }
+  }, []);
+
+  const fetchPlotTypes = useCallback(async () => {
+    try {
+      const res = await fetch('/api/dataset/plots/types');
+      if (!res.ok) throw new Error(`Failed to fetch plot types: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setPlotTypes(data.plot_types ?? data.types ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch plot types');
+    }
+  }, []);
+
+  const fetchExportFormats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/dataset/export/formats');
+      if (!res.ok) throw new Error(`Failed to fetch export formats: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setExportFormats(data.formats ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch export formats');
+    }
+  }, []);
+
+  const fetchControls = useCallback(async () => {
+    try {
+      const res = await fetch('/api/dataset/control');
+      if (!res.ok) throw new Error(`Failed to fetch controls: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setControls(data.controls ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch controls');
+    }
+  }, []);
+
+  const generateDataset = useCallback(async (params: Record<string, unknown>) => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/dataset/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || `Generation failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setGenerateResult(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Dataset generation failed');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  const importSwing = useCallback(async (filePath: string, format?: string) => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/dataset/import-swing', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_path: filePath, format }),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || `Import failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setGenerateResult(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Swing import failed');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  const updateControl = useCallback(async (controlId: string, value: unknown) => {
+    try {
+      const res = await fetch(`/api/dataset/control/${controlId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      });
+      if (!res.ok) throw new Error(`Control update failed: ${res.status}`);
+      // Refresh controls after update
+      await fetchControls();
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Control update failed');
+    }
+  }, [fetchControls]);
+
+  // Fetch catalog data on mount
+  useEffect(() => {
+    isMountedRef.current = true;
+    fetchFeatures();
+    fetchPlotTypes();
+    fetchExportFormats();
+    fetchControls();
+    return () => { isMountedRef.current = false; };
+  }, [fetchFeatures, fetchPlotTypes, fetchExportFormats, fetchControls]);
+
+  return {
+    features,
+    plotTypes,
+    exportFormats,
+    controls,
+    generateResult,
+    loadState,
+    error,
+    generateDataset,
+    importSwing,
+    updateControl,
+    refetch: () => { fetchFeatures(); fetchPlotTypes(); fetchExportFormats(); fetchControls(); },
+  };
+}

--- a/ui/src/api/useTerrain.ts
+++ b/ui/src/api/useTerrain.ts
@@ -1,0 +1,178 @@
+/**
+ * Terrain Engine Hook — Fetches terrain configuration, presets, materials,
+ * and types from the backend REST API.
+ *
+ * Provides methods for loading terrain, querying properties, and managing
+ * the active terrain session.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface TerrainPreset {
+  id: string;
+  name: string;
+  description: string;
+  terrain_type: string;
+  defaults: Record<string, unknown>;
+}
+
+export interface TerrainMaterial {
+  id: string;
+  name: string;
+  friction_coefficient: number;
+  restitution: number;
+  color: string;
+}
+
+export interface TerrainTypeInfo {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface TerrainProperties {
+  dimensions: [number, number, number];
+  resolution: number;
+  material: string;
+  elevation_range: [number, number];
+  slope_range: [number, number];
+  features: string[];
+}
+
+export interface ActiveTerrain {
+  id: string;
+  name: string;
+  terrain_type: string;
+  material: string;
+  properties: TerrainProperties;
+  loaded_at: string;
+}
+
+export type TerrainLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+
+// ── Hook ───────────────────────────────────────────────────────────────
+
+export function useTerrain() {
+  const [presets, setPresets] = useState<TerrainPreset[]>([]);
+  const [materials, setMaterials] = useState<TerrainMaterial[]>([]);
+  const [terrainTypes, setTerrainTypes] = useState<TerrainTypeInfo[]>([]);
+  const [activeTerrain, setActiveTerrain] = useState<ActiveTerrain | null>(null);
+  const [queryResult, setQueryResult] = useState<TerrainProperties | null>(null);
+  const [loadState, setLoadState] = useState<TerrainLoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  const fetchPresets = useCallback(async () => {
+    try {
+      const res = await fetch('/api/terrain/presets');
+      if (!res.ok) throw new Error(`Failed to fetch presets: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setPresets(data.presets ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch presets');
+    }
+  }, []);
+
+  const fetchMaterials = useCallback(async () => {
+    try {
+      const res = await fetch('/api/terrain/materials');
+      if (!res.ok) throw new Error(`Failed to fetch materials: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setMaterials(data.materials ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch materials');
+    }
+  }, []);
+
+  const fetchTerrainTypes = useCallback(async () => {
+    try {
+      const res = await fetch('/api/terrain/types');
+      if (!res.ok) throw new Error(`Failed to fetch terrain types: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setTerrainTypes(data.types ?? data ?? []);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch terrain types');
+    }
+  }, []);
+
+  const fetchActiveTerrain = useCallback(async () => {
+    try {
+      const res = await fetch('/api/terrain/active');
+      if (!res.ok && res.status !== 404) throw new Error(`Failed to fetch active terrain: ${res.status}`);
+      if (res.status === 404) {
+        if (isMountedRef.current) setActiveTerrain(null);
+        return;
+      }
+      const data = await res.json();
+      if (isMountedRef.current) setActiveTerrain(data);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Failed to fetch active terrain');
+    }
+  }, []);
+
+  const loadTerrain = useCallback(async (presetId: string, overrides?: Record<string, unknown>) => {
+    setLoadState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/terrain/load', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preset_id: presetId, ...overrides }),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || `Failed to load terrain: ${res.status}`);
+      }
+      const data = await res.json();
+      if (isMountedRef.current) {
+        setActiveTerrain(data);
+        setLoadState('loaded');
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load terrain');
+        setLoadState('error');
+      }
+    }
+  }, []);
+
+  const queryTerrain = useCallback(async (property: string) => {
+    try {
+      const res = await fetch('/api/terrain/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ property }),
+      });
+      if (!res.ok) throw new Error(`Query failed: ${res.status}`);
+      const data = await res.json();
+      if (isMountedRef.current) setQueryResult(data);
+    } catch (err) {
+      if (isMountedRef.current) setError(err instanceof Error ? err.message : 'Terrain query failed');
+    }
+  }, []);
+
+  // Fetch catalog data on mount
+  useEffect(() => {
+    isMountedRef.current = true;
+    fetchPresets();
+    fetchMaterials();
+    fetchTerrainTypes();
+    fetchActiveTerrain();
+    return () => { isMountedRef.current = false; };
+  }, [fetchPresets, fetchMaterials, fetchTerrainTypes, fetchActiveTerrain]);
+
+  return {
+    presets,
+    materials,
+    terrainTypes,
+    activeTerrain,
+    queryResult,
+    loadState,
+    error,
+    loadTerrain,
+    queryTerrain,
+    refetch: () => { fetchPresets(); fetchMaterials(); fetchTerrainTypes(); fetchActiveTerrain(); },
+  };
+}

--- a/ui/src/pages/AnalysisTools.test.tsx
+++ b/ui/src/pages/AnalysisTools.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for AnalysisTools page.
+ *
+ * Validates data structures and type contracts for analysis tools.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type {
+  MetricInfo,
+  StatisticsSummary,
+  ExportResult,
+  AnalysisLoadState,
+} from './AnalysisTools';
+
+describe('AnalysisTools data structures', () => {
+  it('should parse metric info', () => {
+    const metric: MetricInfo = {
+      id: 'club_speed',
+      name: 'Club Speed',
+      description: 'Speed of the club head at impact',
+      unit: 'm/s',
+      category: 'kinematics',
+    };
+
+    expect(metric.id).toBe('club_speed');
+    expect(metric.unit).toBe('m/s');
+    expect(metric.category).toBe('kinematics');
+  });
+
+  it('should parse metric info with value', () => {
+    const metric: MetricInfo = {
+      id: 'launch_angle',
+      name: 'Launch Angle',
+      description: 'Vertical launch angle',
+      unit: 'degrees',
+      category: 'launch',
+      value: 12.5,
+    };
+
+    expect(metric.value).toBe(12.5);
+    expect(typeof metric.value).toBe('number');
+  });
+
+  it('should group metrics by category', () => {
+    const metrics: MetricInfo[] = [
+      { id: 'club_speed', name: 'Club Speed', description: 'Club head speed', unit: 'm/s', category: 'kinematics' },
+      { id: 'ball_speed', name: 'Ball Speed', description: 'Ball speed', unit: 'm/s', category: 'kinematics' },
+      { id: 'launch_angle', name: 'Launch Angle', description: 'Launch angle', unit: 'degrees', category: 'launch' },
+      { id: 'spin_rate', name: 'Spin Rate', description: 'Backspin rate', unit: 'rpm', category: 'launch' },
+      { id: 'carry_distance', name: 'Carry Distance', description: 'Carry distance', unit: 'm', category: 'result' },
+    ];
+
+    const grouped = metrics.reduce<Record<string, MetricInfo[]>>((acc, m) => {
+      if (!acc[m.category]) acc[m.category] = [];
+      acc[m.category].push(m);
+      return acc;
+    }, {});
+
+    expect(Object.keys(grouped)).toHaveLength(3);
+    expect(grouped['kinematics']).toHaveLength(2);
+    expect(grouped['launch']).toHaveLength(2);
+    expect(grouped['result']).toHaveLength(1);
+  });
+
+  it('should parse statistics summary', () => {
+    const stats: StatisticsSummary = {
+      dataset_id: 'ds_001',
+      metric_count: 3,
+      summary: {
+        club_speed: { min: 25.0, max: 55.0, mean: 42.3, median: 43.1, std: 5.2 },
+        ball_speed: { min: 35.0, max: 80.0, mean: 61.5, median: 62.0, std: 8.1 },
+        launch_angle: { min: -5.0, max: 25.0, mean: 11.2, median: 10.8, std: 4.5 },
+      },
+    };
+
+    expect(stats.metric_count).toBe(3);
+    expect(Object.keys(stats.summary)).toHaveLength(3);
+    expect(stats.summary.club_speed.mean).toBeCloseTo(42.3, 1);
+    expect(stats.summary.ball_speed.max).toBe(80.0);
+  });
+
+  it('should compute derived statistics', () => {
+    const summary = { min: 25.0, max: 55.0, mean: 42.3, median: 43.1, std: 5.2 };
+    const range = summary.max - summary.min;
+
+    expect(range).toBeCloseTo(30.0, 1);
+    expect(summary.mean).toBeGreaterThanOrEqual(summary.min);
+    expect(summary.mean).toBeLessThanOrEqual(summary.max);
+    expect(summary.std).toBeGreaterThan(0);
+  });
+
+  it('should parse export result', () => {
+    const result: ExportResult = {
+      format: 'csv',
+      url: '/api/analysis/export/ds_001.csv',
+      filename: 'analysis_ds_001.csv',
+      size_bytes: 102400,
+    };
+
+    expect(result.format).toBe('csv');
+    expect(result.filename).toContain('analysis');
+    expect(result.size_bytes).toBeGreaterThan(0);
+    expect((result.size_bytes / 1024).toFixed(1)).toBe('100.0');
+  });
+
+  it('should validate analysis load state transitions', () => {
+    const states: AnalysisLoadState[] = ['idle', 'loading', 'loaded', 'error'];
+
+    expect(states).toContain('idle');
+    expect(states).toContain('loading');
+    expect(states).toHaveLength(4);
+  });
+
+  it('should filter metrics by category', () => {
+    const metrics: MetricInfo[] = [
+      { id: 'club_speed', name: 'Club Speed', description: 'Club head speed', unit: 'm/s', category: 'kinematics' },
+      { id: 'launch_angle', name: 'Launch Angle', description: 'Launch angle', unit: 'degrees', category: 'launch' },
+      { id: 'carry_distance', name: 'Carry Distance', description: 'Carry distance', unit: 'm', category: 'result' },
+    ];
+
+    const kinematics = metrics.filter((m) => m.category === 'kinematics');
+    expect(kinematics).toHaveLength(1);
+    expect(kinematics[0].id).toBe('club_speed');
+  });
+
+  it('should format size in KB', () => {
+    const sizes = [1024, 5120, 1048576];
+    const formatted = sizes.map((s) => (s / 1024).toFixed(1));
+
+    expect(formatted[0]).toBe('1.0');
+    expect(formatted[1]).toBe('5.0');
+    expect(formatted[2]).toBe('1024.0');
+  });
+});

--- a/ui/src/pages/AnalysisTools.tsx
+++ b/ui/src/pages/AnalysisTools.tsx
@@ -1,0 +1,204 @@
+/**
+ * Analysis Tools Page — Biomechanical metrics, statistics summaries,
+ * and export functionality.
+ */
+
+import { useState, useCallback } from 'react';
+import { useAnalysisTools } from '@/api/useAnalysisTools';
+import type { MetricInfo } from '@/api/useAnalysisTools';
+
+/**
+ * AnalysisToolsPage - Full analysis tools page.
+ */
+export function AnalysisToolsPage() {
+  const {
+    metrics,
+    statistics,
+    exportResult,
+    loadState,
+    error,
+    fetchMetrics,
+    fetchStatistics,
+    exportAnalysis,
+  } = useAnalysisTools();
+
+  const [exportFormat, setExportFormat] = useState('csv');
+
+  const isLoading = loadState === 'loading';
+
+  const handleExport = useCallback(() => {
+    exportAnalysis(exportFormat);
+  }, [exportFormat, exportAnalysis]);
+
+  // Group metrics by category
+  const metricsByCategory = metrics.reduce<Record<string, MetricInfo[]>>((acc, m) => {
+    const cat = m.category || 'General';
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(m);
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-gray-100">
+      {/* Left Sidebar - Metrics List */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-200">Metrics</h2>
+          <p className="text-xs text-gray-500 mt-1">{metrics.length} metric{metrics.length !== 1 ? 's' : ''} available</p>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {metrics.length === 0 && !isLoading && (
+            <div className="text-xs text-gray-500 italic text-center py-4">
+              No metrics loaded. Click Refresh to fetch.
+            </div>
+          )}
+
+          {Object.entries(metricsByCategory).map(([category, categoryMetrics]) => (
+            <div key={category} className="mb-4">
+              <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">{category}</h3>
+              <div className="space-y-1.5">
+                {categoryMetrics.map((m: MetricInfo) => (
+                  <div key={m.id} className="p-2 bg-gray-700/30 rounded border border-gray-600">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-gray-200">{m.name}</span>
+                      {m.value != null && (
+                        <span className="text-xs text-blue-400 font-mono">{m.value}</span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">{m.description}</div>
+                    <div className="text-xs text-gray-500 mt-0.5">Unit: {m.unit}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="p-4 border-t border-gray-700">
+          <button
+            onClick={fetchMetrics}
+            disabled={isLoading}
+            className="w-full py-1.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-gray-200 text-xs rounded transition-colors"
+          >
+            Refresh Metrics
+          </button>
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
+          <h1 className="text-lg font-semibold text-gray-100">Analysis Tools</h1>
+          <p className="text-xs text-gray-400 mt-1">Biomechanical metrics and statistical analysis</p>
+        </div>
+
+        {/* Error Banner */}
+        {error && (
+          <div className="bg-red-900/30 border-b border-red-800 px-6 py-3 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {/* Content Area */}
+        <div className="flex-1 p-6 overflow-y-auto">
+          <div className="max-w-3xl mx-auto space-y-6">
+            {/* Statistics Summary */}
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold text-gray-300">Statistics Summary</h3>
+                <button
+                  onClick={fetchStatistics}
+                  disabled={isLoading}
+                  className="px-3 py-1 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:cursor-not-allowed text-gray-200 text-xs rounded transition-colors"
+                >
+                  Load Statistics
+                </button>
+              </div>
+
+              {statistics ? (
+                <div data-testid="statistics-panel">
+                  <div className="text-xs text-gray-400 mb-3">
+                    {statistics.metric_count} metrics summarized
+                  </div>
+                  <div className="space-y-2">
+                    {Object.entries(statistics.summary).map(([key, stat]) => (
+                      <div key={key} className="bg-gray-700/50 p-3 rounded">
+                        <div className="text-xs font-medium text-gray-300 mb-1">{key}</div>
+                        <div className="grid grid-cols-5 gap-2 text-xs">
+                          <div>
+                            <span className="text-gray-500">min</span>
+                            <div className="text-gray-200 font-mono">{stat.min.toFixed(3)}</div>
+                          </div>
+                          <div>
+                            <span className="text-gray-500">max</span>
+                            <div className="text-gray-200 font-mono">{stat.max.toFixed(3)}</div>
+                          </div>
+                          <div>
+                            <span className="text-gray-500">mean</span>
+                            <div className="text-gray-200 font-mono">{stat.mean.toFixed(3)}</div>
+                          </div>
+                          <div>
+                            <span className="text-gray-500">median</span>
+                            <div className="text-gray-200 font-mono">{stat.median.toFixed(3)}</div>
+                          </div>
+                          <div>
+                            <span className="text-gray-500">std</span>
+                            <div className="text-gray-200 font-mono">{stat.std.toFixed(3)}</div>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="text-xs text-gray-500 italic text-center py-4">
+                  Click "Load Statistics" to view summary data
+                </div>
+              )}
+            </div>
+
+            {/* Export Section */}
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <h3 className="text-sm font-semibold text-gray-300 mb-3">Export Analysis</h3>
+              <div className="flex gap-2 items-end">
+                <div className="flex-1">
+                  <label className="text-xs text-gray-400 block mb-1">Format</label>
+                  <select
+                    value={exportFormat}
+                    onChange={(e) => setExportFormat(e.target.value)}
+                    className="w-full bg-gray-700 text-gray-200 rounded px-2 py-1.5 text-xs border border-gray-600"
+                  >
+                    <option value="csv">CSV</option>
+                    <option value="json">JSON</option>
+                    <option value="xlsx">Excel (.xlsx)</option>
+                    <option value="pdf">PDF Report</option>
+                  </select>
+                </div>
+                <button
+                  onClick={handleExport}
+                  disabled={isLoading}
+                  className="px-4 py-1.5 bg-purple-600 hover:bg-purple-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs rounded transition-colors"
+                >
+                  Export
+                </button>
+              </div>
+
+              {exportResult && (
+                <div className="mt-3 bg-gray-700/50 p-3 rounded text-xs" data-testid="export-result">
+                  <div className="text-green-400 font-medium mb-1">Export Complete</div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div><span className="text-gray-500">Format:</span> <span className="text-gray-200 font-mono">{exportResult.format}</span></div>
+                    <div><span className="text-gray-500">File:</span> <span className="text-gray-200 font-mono">{exportResult.filename}</span></div>
+                    <div><span className="text-gray-500">Size:</span> <span className="text-gray-200 font-mono">{(exportResult.size_bytes / 1024).toFixed(1)} KB</span></div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/DatasetGenerator.test.tsx
+++ b/ui/src/pages/DatasetGenerator.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for DatasetGenerator page.
+ *
+ * Validates data structures and type contracts for dataset generation.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type {
+  FeatureInfo,
+  PlotType,
+  ExportFormat,
+  DatasetControl,
+  GenerateResult,
+  DatasetLoadState,
+} from './DatasetGenerator';
+
+describe('DatasetGenerator data structures', () => {
+  it('should parse feature info', () => {
+    const feature: FeatureInfo = {
+      id: 'club_speed',
+      name: 'Club Speed',
+      description: 'Speed of the club head at impact',
+      category: 'kinematics',
+    };
+
+    expect(feature.id).toBe('club_speed');
+    expect(feature.category).toBe('kinematics');
+    expect(feature.description.length).toBeGreaterThan(0);
+  });
+
+  it('should group features by category', () => {
+    const features: FeatureInfo[] = [
+      { id: 'club_speed', name: 'Club Speed', description: 'Club head speed', category: 'kinematics' },
+      { id: 'ball_speed', name: 'Ball Speed', description: 'Ball speed after impact', category: 'kinematics' },
+      { id: 'launch_angle', name: 'Launch Angle', description: 'Vertical launch angle', category: 'launch' },
+      { id: 'spin_rate', name: 'Spin Rate', description: 'Backspin rate', category: 'launch' },
+    ];
+
+    const grouped = features.reduce<Record<string, FeatureInfo[]>>((acc, f) => {
+      if (!acc[f.category]) acc[f.category] = [];
+      acc[f.category].push(f);
+      return acc;
+    }, {});
+
+    expect(Object.keys(grouped)).toHaveLength(2);
+    expect(grouped['kinematics']).toHaveLength(2);
+    expect(grouped['launch']).toHaveLength(2);
+  });
+
+  it('should parse plot type info', () => {
+    const plotType: PlotType = {
+      id: 'scatter',
+      name: 'Scatter Plot',
+      description: 'Two-variable scatter plot',
+      axes: ['x', 'y'],
+    };
+
+    expect(plotType.id).toBe('scatter');
+    expect(plotType.axes).toContain('x');
+    expect(plotType.axes).toHaveLength(2);
+  });
+
+  it('should parse export format info', () => {
+    const format: ExportFormat = {
+      id: 'csv',
+      name: 'CSV',
+      extension: 'csv',
+      mime_type: 'text/csv',
+    };
+
+    expect(format.extension).toBe('csv');
+    expect(format.mime_type).toContain('text/');
+  });
+
+  it('should handle multiple export formats', () => {
+    const formats: ExportFormat[] = [
+      { id: 'csv', name: 'CSV', extension: 'csv', mime_type: 'text/csv' },
+      { id: 'json', name: 'JSON', extension: 'json', mime_type: 'application/json' },
+      { id: 'hdf5', name: 'HDF5', extension: 'h5', mime_type: 'application/x-hdf5' },
+    ];
+
+    expect(formats).toHaveLength(3);
+    const extensions = formats.map((f) => `.${f.extension}`);
+    expect(extensions).toContain('.csv');
+    expect(extensions).toContain('.json');
+    expect(extensions).toContain('.h5');
+  });
+
+  it('should parse dataset control', () => {
+    const control: DatasetControl = {
+      id: 'num_samples',
+      name: 'Number of Samples',
+      type: 'range',
+      value: 1000,
+      min: 100,
+      max: 10000,
+      step: 100,
+    };
+
+    expect(control.type).toBe('range');
+    expect(control.min).toBeLessThanOrEqual(control.value as number);
+    expect(control.max).toBeGreaterThanOrEqual(control.value as number);
+  });
+
+  it('should parse select-type control with options', () => {
+    const control: DatasetControl = {
+      id: 'swing_type',
+      name: 'Swing Type',
+      type: 'select',
+      value: 'driver',
+      options: ['driver', 'iron', 'wedge', 'putter'],
+    };
+
+    expect(control.type).toBe('select');
+    expect(control.options).toContain('driver');
+    expect(control.options).toHaveLength(4);
+  });
+
+  it('should parse generate result', () => {
+    const result: GenerateResult = {
+      dataset_id: 'ds_abc123',
+      name: 'swing_analysis_batch_1',
+      rows: 5000,
+      columns: ['time', 'club_speed', 'ball_speed', 'launch_angle', 'spin_rate'],
+      created_at: '2026-05-15T12:00:00Z',
+    };
+
+    expect(result.dataset_id).toBe('ds_abc123');
+    expect(result.rows).toBeGreaterThan(0);
+    expect(result.columns).toHaveLength(5);
+    expect(result.columns).toContain('club_speed');
+  });
+
+  it('should validate dataset load state transitions', () => {
+    const states: DatasetLoadState[] = ['idle', 'loading', 'loaded', 'error'];
+
+    expect(states).toContain('idle');
+    expect(states).toContain('loading');
+    expect(states).toHaveLength(4);
+  });
+
+  it('should filter features by search term', () => {
+    const features: FeatureInfo[] = [
+      { id: 'club_speed', name: 'Club Speed', description: 'Club head speed at impact', category: 'kinematics' },
+      { id: 'ball_speed', name: 'Ball Speed', description: 'Ball speed after impact', category: 'kinematics' },
+      { id: 'smash_factor', name: 'Smash Factor', description: 'Ratio of ball speed to club speed', category: 'efficiency' },
+    ];
+
+    const filtered = features.filter(
+      (f) => f.name.toLowerCase().includes('speed') || f.description.toLowerCase().includes('speed'),
+    );
+    expect(filtered).toHaveLength(3);
+  });
+});

--- a/ui/src/pages/DatasetGenerator.tsx
+++ b/ui/src/pages/DatasetGenerator.tsx
@@ -1,0 +1,305 @@
+/**
+ * Dataset Generator Page — Controls for generating datasets, importing swing
+ * data, managing generation parameters, and exploring features/plots/exports.
+ */
+
+import { useState, useCallback } from 'react';
+import { useDatasetGenerator } from '@/api/useDatasetGenerator';
+import type { FeatureInfo, PlotType, ExportFormat, DatasetControl } from '@/api/useDatasetGenerator';
+
+/**
+ * DatasetGeneratorPage - Full dataset generation tool page.
+ */
+export function DatasetGeneratorPage() {
+  const {
+    features,
+    plotTypes,
+    exportFormats,
+    controls,
+    generateResult,
+    loadState,
+    error,
+    generateDataset,
+    importSwing,
+    updateControl,
+  } = useDatasetGenerator();
+
+  const [sidebarTab, setSidebarTab] = useState<'features' | 'plots' | 'export'>('features');
+  const [swingFilePath, setSwingFilePath] = useState('');
+  const [controlValues, setControlValues] = useState<Record<string, unknown>>({});
+  const [exportFormat, setExportFormat] = useState('csv');
+
+  const isLoading = loadState === 'loading';
+
+  const handleGenerate = useCallback(() => {
+    generateDataset(controlValues);
+  }, [controlValues, generateDataset]);
+
+  const handleImportSwing = useCallback(() => {
+    if (!swingFilePath.trim()) return;
+    importSwing(swingFilePath.trim());
+  }, [swingFilePath, importSwing]);
+
+  const handleControlChange = useCallback((controlId: string, value: unknown) => {
+    setControlValues((prev) => ({ ...prev, [controlId]: value }));
+    updateControl(controlId, value);
+  }, [updateControl]);
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-gray-100">
+      {/* Left Sidebar */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-200">Dataset Generator</h2>
+          <p className="text-xs text-gray-500 mt-1">Generate and import datasets</p>
+        </div>
+
+        {/* Sidebar Tabs */}
+        <div className="flex border-b border-gray-700">
+          {(['features', 'plots', 'export'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setSidebarTab(tab)}
+              className={`flex-1 py-2 text-xs font-medium capitalize transition-colors ${
+                sidebarTab === tab
+                  ? 'bg-gray-700 text-white border-b-2 border-blue-500'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 p-4 overflow-y-auto">
+          {/* Features Tab */}
+          {sidebarTab === 'features' && (
+            <div className="space-y-2">
+              {features.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No features available</div>
+              ) : (
+                features.map((f: FeatureInfo) => (
+                  <div key={f.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
+                    <div className="text-sm font-medium text-gray-200">{f.name}</div>
+                    <div className="text-xs text-gray-400 mt-0.5">{f.description}</div>
+                    <span className="mt-1 inline-block px-1.5 py-0.5 bg-gray-600 text-gray-300 text-xs rounded">
+                      {f.category}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Plots Tab */}
+          {sidebarTab === 'plots' && (
+            <div className="space-y-2">
+              {plotTypes.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No plot types available</div>
+              ) : (
+                plotTypes.map((pt: PlotType) => (
+                  <div key={pt.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
+                    <div className="text-sm font-medium text-gray-200">{pt.name}</div>
+                    <div className="text-xs text-gray-400 mt-0.5">{pt.description}</div>
+                    {pt.axes.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {pt.axes.map((axis: string) => (
+                          <span key={axis} className="px-1.5 py-0.5 bg-gray-600 text-gray-300 text-xs rounded">{axis}</span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Export Tab */}
+          {sidebarTab === 'export' && (
+            <div className="space-y-2">
+              {exportFormats.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No export formats available</div>
+              ) : (
+                exportFormats.map((ef: ExportFormat) => (
+                  <div key={ef.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-gray-200">{ef.name}</span>
+                      <span className="px-1.5 py-0.5 bg-gray-600 text-gray-300 text-xs rounded font-mono">
+                        .{ef.extension}
+                      </span>
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">{ef.mime_type}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
+          <h1 className="text-lg font-semibold text-gray-100">Dataset Generator</h1>
+          <p className="text-xs text-gray-400 mt-1">
+            {generateResult
+              ? `Last: ${generateResult.name} (${generateResult.rows} rows)`
+              : 'Configure parameters and generate a dataset'}
+          </p>
+        </div>
+
+        {/* Error Banner */}
+        {error && (
+          <div className="bg-red-900/30 border-b border-red-800 px-6 py-3 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {/* Content Area */}
+        <div className="flex-1 p-6 overflow-y-auto">
+          <div className="max-w-2xl mx-auto space-y-6">
+            {/* Generation Controls */}
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <h3 className="text-sm font-semibold text-gray-300 mb-3">Generation Controls</h3>
+
+              {controls.length > 0 ? (
+                <div className="space-y-3">
+                  {controls.map((ctrl: DatasetControl) => (
+                    <div key={ctrl.id} className="flex items-center gap-3">
+                      <label className="text-xs text-gray-400 w-32 shrink-0">{ctrl.name}</label>
+                      {ctrl.type === 'select' && ctrl.options ? (
+                        <select
+                          value={String(controlValues[ctrl.id] ?? ctrl.value)}
+                          onChange={(e) => handleControlChange(ctrl.id, e.target.value)}
+                          className="flex-1 bg-gray-700 text-gray-200 rounded px-2 py-1 text-xs border border-gray-600"
+                        >
+                          {ctrl.options.map((opt: string) => (
+                            <option key={opt} value={opt}>{opt}</option>
+                          ))}
+                        </select>
+                      ) : ctrl.type === 'range' ? (
+                        <input
+                          type="range"
+                          min={ctrl.min ?? 0}
+                          max={ctrl.max ?? 100}
+                          step={ctrl.step ?? 1}
+                          value={Number(controlValues[ctrl.id] ?? ctrl.value)}
+                          onChange={(e) => handleControlChange(ctrl.id, Number(e.target.value))}
+                          className="flex-1"
+                        />
+                      ) : (
+                        <input
+                          type="text"
+                          value={String(controlValues[ctrl.id] ?? ctrl.value ?? '')}
+                          onChange={(e) => handleControlChange(ctrl.id, e.target.value)}
+                          className="flex-1 bg-gray-700 text-gray-200 rounded px-2 py-1 text-xs border border-gray-600"
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-xs text-gray-500 italic">No controls available</div>
+              )}
+
+              <div className="mt-4 flex gap-2">
+                <button
+                  onClick={handleGenerate}
+                  disabled={isLoading}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs rounded transition-colors"
+                >
+                  {isLoading ? 'Generating...' : 'Generate Dataset'}
+                </button>
+              </div>
+            </div>
+
+            {/* Import Swing Data */}
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <h3 className="text-sm font-semibold text-gray-300 mb-3">Import Swing Data</h3>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={swingFilePath}
+                  onChange={(e) => setSwingFilePath(e.target.value)}
+                  placeholder="File path or data source..."
+                  className="flex-1 bg-gray-700 text-gray-200 rounded px-3 py-1.5 text-xs border border-gray-600 focus:border-blue-500 focus:outline-none"
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleImportSwing(); }}
+                />
+                <button
+                  onClick={handleImportSwing}
+                  disabled={!swingFilePath.trim() || isLoading}
+                  className="px-4 py-1.5 bg-green-600 hover:bg-green-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs rounded transition-colors"
+                >
+                  Import
+                </button>
+              </div>
+            </div>
+
+            {/* Export Section */}
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <h3 className="text-sm font-semibold text-gray-300 mb-3">Export</h3>
+              <div className="flex gap-2 items-end">
+                <div className="flex-1">
+                  <label className="text-xs text-gray-400 block mb-1">Format</label>
+                  <select
+                    value={exportFormat}
+                    onChange={(e) => setExportFormat(e.target.value)}
+                    className="w-full bg-gray-700 text-gray-200 rounded px-2 py-1.5 text-xs border border-gray-600"
+                  >
+                    {exportFormats.length > 0 ? (
+                      exportFormats.map((ef: ExportFormat) => (
+                        <option key={ef.id} value={ef.id}>{ef.name} (.{ef.extension})</option>
+                      ))
+                    ) : (
+                      <>
+                        <option value="csv">CSV (.csv)</option>
+                        <option value="json">JSON (.json)</option>
+                        <option value="hdf5">HDF5 (.h5)</option>
+                      </>
+                    )}
+                  </select>
+                </div>
+                <button
+                  disabled={!generateResult || isLoading}
+                  className="px-4 py-1.5 bg-purple-600 hover:bg-purple-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs rounded transition-colors"
+                >
+                  Export
+                </button>
+              </div>
+            </div>
+
+            {/* Result */}
+            {generateResult && (
+              <div className="bg-gray-800 rounded-lg border border-blue-500/30 p-4" data-testid="generate-result">
+                <h3 className="text-sm font-semibold text-blue-300 mb-2">Generated Dataset</h3>
+                <div className="grid grid-cols-2 gap-3 text-xs">
+                  <div>
+                    <span className="text-gray-500">ID</span>
+                    <div className="text-gray-200 font-mono">{generateResult.dataset_id}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Name</span>
+                    <div className="text-gray-200 font-mono">{generateResult.name}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Rows</span>
+                    <div className="text-gray-200 font-mono">{generateResult.rows}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Columns</span>
+                    <div className="text-gray-200 font-mono">{generateResult.columns.length}</div>
+                  </div>
+                  <div className="col-span-2">
+                    <span className="text-gray-500">Created</span>
+                    <div className="text-gray-200 font-mono">{generateResult.created_at}</div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/pages/Terrain.test.tsx
+++ b/ui/src/pages/Terrain.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for Terrain page.
+ *
+ * Validates data structures and type contracts for the terrain engine.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type {
+  TerrainPreset,
+  TerrainMaterial,
+  TerrainTypeInfo,
+  TerrainProperties,
+  ActiveTerrain,
+  TerrainLoadState,
+} from './Terrain';
+
+describe('Terrain data structures', () => {
+  it('should parse a terrain preset', () => {
+    const preset: TerrainPreset = {
+      id: 'highlands',
+      name: 'Highlands',
+      description: 'Rolling highland terrain with moderate slopes',
+      terrain_type: 'procedural',
+      defaults: { resolution: 256, elevation_scale: 5.0 },
+    };
+
+    expect(preset.id).toBe('highlands');
+    expect(preset.name).toBe('Highlands');
+    expect(preset.terrain_type).toBe('procedural');
+    expect(preset.defaults).toHaveProperty('resolution');
+  });
+
+  it('should parse terrain material properties', () => {
+    const material: TerrainMaterial = {
+      id: 'grass',
+      name: 'Grass',
+      friction_coefficient: 0.65,
+      restitution: 0.3,
+      color: '#2d5a27',
+    };
+
+    expect(material.id).toBe('grass');
+    expect(material.friction_coefficient).toBeGreaterThan(0);
+    expect(material.restitution).toBeLessThanOrEqual(1);
+    expect(material.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+
+  it('should parse terrain type info', () => {
+    const terrainType: TerrainTypeInfo = {
+      id: 'procedural',
+      name: 'Procedural',
+      description: 'Generated using noise algorithms',
+    };
+
+    expect(terrainType.id).toBe('procedural');
+    expect(terrainType.name).toBe('Procedural');
+    expect(terrainType.description.length).toBeGreaterThan(0);
+  });
+
+  it('should parse terrain properties', () => {
+    const props: TerrainProperties = {
+      dimensions: [100, 100, 10],
+      resolution: 256,
+      material: 'grass',
+      elevation_range: [0, 50],
+      slope_range: [0, 45],
+      features: ['water_hazard', 'bunker'],
+    };
+
+    expect(props.dimensions).toHaveLength(3);
+    expect(props.resolution).toBeGreaterThan(0);
+    expect(props.features).toContain('water_hazard');
+  });
+
+  it('should parse active terrain', () => {
+    const active: ActiveTerrain = {
+      id: 'terrain_001',
+      name: 'Augusta National',
+      terrain_type: 'procedural',
+      material: 'grass',
+      properties: {
+        dimensions: [200, 200, 20],
+        resolution: 512,
+        material: 'grass',
+        elevation_range: [0, 30],
+        slope_range: [0, 35],
+        features: ['sand_bunker', 'water_hazard', 'trees'],
+      },
+      loaded_at: '2026-05-15T10:00:00Z',
+    };
+
+    expect(active.id).toBe('terrain_001');
+    expect(active.properties.dimensions[0]).toBe(200);
+    expect(active.properties.features).toHaveLength(3);
+    expect(active.loaded_at).toBeTruthy();
+  });
+
+  it('should validate terrain load state transitions', () => {
+    const states: TerrainLoadState[] = ['idle', 'loading', 'loaded', 'error'];
+
+    expect(states).toContain('idle');
+    expect(states).toContain('loading');
+    expect(states).toContain('loaded');
+    expect(states).toHaveLength(4);
+  });
+
+  it('should validate elevation range ordering', () => {
+    const props: TerrainProperties = {
+      dimensions: [100, 100, 10],
+      resolution: 256,
+      material: 'grass',
+      elevation_range: [0, 50],
+      slope_range: [0, 45],
+      features: [],
+    };
+
+    expect(props.elevation_range[0]).toBeLessThanOrEqual(props.elevation_range[1]);
+    expect(props.slope_range[0]).toBeLessThanOrEqual(props.slope_range[1]);
+  });
+
+  it('should handle multiple material friction values', () => {
+    const materials: TerrainMaterial[] = [
+      { id: 'grass', name: 'Grass', friction_coefficient: 0.65, restitution: 0.3, color: '#2d5a27' },
+      { id: 'sand', name: 'Sand', friction_coefficient: 0.35, restitution: 0.1, color: '#c2b280' },
+      { id: 'water', name: 'Water', friction_coefficient: 0.05, restitution: 0.0, color: '#1a6b8a' },
+    ];
+
+    const sorted = [...materials].sort((a, b) => b.friction_coefficient - a.friction_coefficient);
+    expect(sorted[0].id).toBe('grass');
+    expect(sorted[2].id).toBe('water');
+  });
+});

--- a/ui/src/pages/Terrain.tsx
+++ b/ui/src/pages/Terrain.tsx
@@ -1,0 +1,289 @@
+/**
+ * Terrain Engine Page — Terrain presets, materials, types, and active terrain.
+ *
+ * Provides controls for loading terrain presets, querying terrain properties,
+ * and viewing available materials and terrain types.
+ */
+
+import { useState, useCallback } from 'react';
+import { useTerrain } from '@/api/useTerrain';
+import type { TerrainPreset, TerrainMaterial, TerrainTypeInfo } from '@/api/useTerrain';
+
+/**
+ * TerrainPage - Full terrain engine tool page.
+ */
+export function TerrainPage() {
+  const {
+    presets,
+    materials,
+    terrainTypes,
+    activeTerrain,
+    queryResult,
+    loadState,
+    error,
+    loadTerrain,
+    queryTerrain,
+  } = useTerrain();
+
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  const [queryProperty, setQueryProperty] = useState('');
+  const [sidebarTab, setSidebarTab] = useState<'presets' | 'materials' | 'types'>('presets');
+
+  const handleLoadPreset = useCallback(() => {
+    if (!selectedPreset) return;
+    loadTerrain(selectedPreset);
+  }, [selectedPreset, loadTerrain]);
+
+  const handleQuery = useCallback(() => {
+    if (!queryProperty.trim()) return;
+    queryTerrain(queryProperty.trim());
+  }, [queryProperty, queryTerrain]);
+
+  const isLoading = loadState === 'loading';
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-gray-100">
+      {/* Left Sidebar */}
+      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
+        <div className="p-4 border-b border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-200">Terrain Engine</h2>
+          <p className="text-xs text-gray-500 mt-1">Load and configure terrain</p>
+        </div>
+
+        {/* Sidebar Tabs */}
+        <div className="flex border-b border-gray-700">
+          {(['presets', 'materials', 'types'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setSidebarTab(tab)}
+              className={`flex-1 py-2 text-xs font-medium capitalize transition-colors ${
+                sidebarTab === tab
+                  ? 'bg-gray-700 text-white border-b-2 border-blue-500'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 p-4 overflow-y-auto">
+          {/* Presets Tab */}
+          {sidebarTab === 'presets' && (
+            <div className="space-y-2">
+              {presets.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No presets available</div>
+              ) : (
+                presets.map((preset: TerrainPreset) => (
+                  <button
+                    key={preset.id}
+                    onClick={() => setSelectedPreset(preset.id)}
+                    className={`w-full text-left p-3 rounded-md transition-colors ${
+                      selectedPreset === preset.id
+                        ? 'bg-blue-600/30 border border-blue-500'
+                        : 'bg-gray-700/30 border border-gray-600 hover:bg-gray-700/50'
+                    }`}
+                  >
+                    <div className="text-sm font-medium text-gray-200">{preset.name}</div>
+                    <div className="text-xs text-gray-400 mt-0.5">{preset.description}</div>
+                    <div className="text-xs text-gray-500 mt-1">Type: {preset.terrain_type}</div>
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Materials Tab */}
+          {sidebarTab === 'materials' && (
+            <div className="space-y-2">
+              {materials.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No materials available</div>
+              ) : (
+                materials.map((mat: TerrainMaterial) => (
+                  <div key={mat.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-4 h-4 rounded-full border border-gray-500"
+                        style={{ backgroundColor: mat.color }}
+                      />
+                      <span className="text-sm font-medium text-gray-200">{mat.name}</span>
+                    </div>
+                    <div className="text-xs text-gray-400 mt-1 space-y-0.5">
+                      <div>Friction: {mat.friction_coefficient}</div>
+                      <div>Restitution: {mat.restitution}</div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Types Tab */}
+          {sidebarTab === 'types' && (
+            <div className="space-y-2">
+              {terrainTypes.length === 0 ? (
+                <div className="text-xs text-gray-500 italic text-center py-4">No terrain types available</div>
+              ) : (
+                terrainTypes.map((tt: TerrainTypeInfo) => (
+                  <div key={tt.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
+                    <div className="text-sm font-medium text-gray-200">{tt.name}</div>
+                    <div className="text-xs text-gray-400 mt-0.5">{tt.description}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Load Button */}
+        <div className="p-4 border-t border-gray-700">
+          <button
+            onClick={handleLoadPreset}
+            disabled={!selectedPreset || isLoading}
+            className="w-full py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-sm rounded-md transition-colors"
+          >
+            {isLoading ? 'Loading...' : 'Load Terrain'}
+          </button>
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
+          <h1 className="text-lg font-semibold text-gray-100">Terrain Engine</h1>
+          <p className="text-xs text-gray-400 mt-1">
+            {activeTerrain
+              ? `Active: ${activeTerrain.name} (${activeTerrain.terrain_type})`
+              : 'No terrain loaded'}
+          </p>
+        </div>
+
+        {/* Error Banner */}
+        {error && (
+          <div className="bg-red-900/30 border-b border-red-800 px-6 py-3 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {/* Content Area */}
+        <div className="flex-1 p-6 overflow-y-auto">
+          {!activeTerrain && !isLoading && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center">
+                <div className="text-4xl mb-4 text-gray-600">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-16 h-16 mx-auto text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M3 15l5-7 4 4 4-6 5 9H3z" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-gray-400 mb-2">Load a Terrain</h3>
+                <p className="text-sm text-gray-500 max-w-xs">
+                  Select a terrain preset from the sidebar and click Load to begin.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {isLoading && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-sm text-gray-400">Loading terrain...</div>
+            </div>
+          )}
+
+          {activeTerrain && !isLoading && (
+            <div className="space-y-6">
+              {/* Active Terrain Info */}
+              <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+                <h3 className="text-sm font-semibold text-gray-300 mb-3">Active Terrain</h3>
+                <div className="grid grid-cols-2 gap-3 text-xs">
+                  <div>
+                    <span className="text-gray-500">Name</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.name}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Type</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.terrain_type}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Material</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.material}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Loaded</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.loaded_at}</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Properties */}
+              <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+                <h3 className="text-sm font-semibold text-gray-300 mb-3">Terrain Properties</h3>
+                <div className="grid grid-cols-2 gap-3 text-xs">
+                  <div>
+                    <span className="text-gray-500">Dimensions</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.properties.dimensions.join(' x ')}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Resolution</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.properties.resolution}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Elevation Range</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.properties.elevation_range.join(' - ')}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Slope Range</span>
+                    <div className="text-gray-200 font-mono">{activeTerrain.properties.slope_range.join(' - ')}°</div>
+                  </div>
+                </div>
+                {activeTerrain.properties.features.length > 0 && (
+                  <div className="mt-3">
+                    <span className="text-gray-500 text-xs">Features: </span>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {activeTerrain.properties.features.map((f: string) => (
+                        <span key={f} className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded">{f}</span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Query Panel */}
+              <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+                <h3 className="text-sm font-semibold text-gray-300 mb-3">Query Terrain</h3>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={queryProperty}
+                    onChange={(e) => setQueryProperty(e.target.value)}
+                    placeholder="Property name (e.g. elevation_profile)"
+                    className="flex-1 bg-gray-700 text-gray-200 rounded px-3 py-1.5 text-xs border border-gray-600 focus:border-blue-500 focus:outline-none"
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleQuery(); }}
+                  />
+                  <button
+                    onClick={handleQuery}
+                    disabled={!queryProperty.trim()}
+                    className="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white text-xs rounded transition-colors"
+                  >
+                    Query
+                  </button>
+                </div>
+
+                {queryResult && (
+                  <div className="mt-3 bg-gray-700/50 p-3 rounded text-xs">
+                    <div className="text-gray-400 mb-1">Query Result:</div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div><span className="text-gray-500">Dimensions:</span> <span className="text-gray-200 font-mono">{queryResult.dimensions?.join(' x ') ?? 'N/A'}</span></div>
+                      <div><span className="text-gray-500">Resolution:</span> <span className="text-gray-200 font-mono">{queryResult.resolution ?? 'N/A'}</span></div>
+                      <div><span className="text-gray-500">Material:</span> <span className="text-gray-200 font-mono">{queryResult.material ?? 'N/A'}</span></div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds Tauri/React routes and page components for previously hidden API features:

- Terrain page at /tools/terrain
- Dataset Generator page at /tools/dataset  
- Analysis Tools page at /tools/analysis

Each page includes API hooks, proper TypeScript types, loading/error states, and tests.

Addresses issues #5518 (Terrain), #5519 (Dataset Generation), #5521 (Analysis Tools).