### PR TITLE
fix: populate launcher sidebar categories (biomechanics/simulation/motion_matching)

### DIFF
--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -120,7 +120,7 @@
       "id": "putting_green",
       "name": "Putting Green",
       "description": "Realistic putting green simulation with ball rolling physics",
-      "category": "physics_engine",
+      "category": "simulation",
       "type": "putting_green",
       "path": "src/engines/physics_engines/putting_green/python/simulator.py",
       "engine_type": "putting_green",
@@ -146,7 +146,7 @@
       "id": "motion_target_preview",
       "name": "Motion-Match Preview",
       "description": "Preview multi-source motion-capture targets (C3D, .mat, body markers, club/ball) on a shared timegrid before driving a physics-engine model.",
-      "category": "tool",
+      "category": "motion_matching",
       "type": "special_app",
       "path": "src.tools.starting_pose_matcher.__main__",
       "logo": "motion_target_preview.svg",
@@ -292,6 +292,58 @@
         "project_overview"
       ],
       "order": 15
+    },
+    {
+      "id": "cross_engine_dashboard",
+      "name": "Cross-Engine Dashboard",
+      "description": "Compare perturbation robustness and trajectories across physics engines side-by-side",
+      "category": "simulation",
+      "type": "special_app",
+      "path": "src/launchers/cross_engine_dashboard.py",
+      "logo": "golf_logo.png",
+      "status": "gui_ready",
+      "capabilities": [
+        "cross_engine",
+        "perturbation",
+        "comparison",
+        "visualization"
+      ],
+      "order": 16
+    },
+    {
+      "id": "exercise_dashboard",
+      "name": "Exercise Dashboard",
+      "description": "Cross-engine biomechanics exercise dashboard — select a movement (gait, sit-to-stand) and compare engine outputs",
+      "category": "biomechanics",
+      "type": "biomech_exercise",
+      "path": "src/launchers/exercise_dashboard.py",
+      "logo": "biomechanics.svg",
+      "status": "gui_ready",
+      "capabilities": [
+        "biomechanics",
+        "exercise",
+        "cross_engine",
+        "gait",
+        "sit_to_stand"
+      ],
+      "order": 17
+    },
+    {
+      "id": "golf_simulation_suite",
+      "name": "Golf Simulation Suite",
+      "description": "Complete golf simulation suite with ball-flight physics, putting green, and cross-engine playback",
+      "category": "simulation",
+      "type": "golf_simulation",
+      "path": "launch_golf_suite.py",
+      "logo": "golf_logo.png",
+      "status": "gui_ready",
+      "capabilities": [
+        "ball_flight",
+        "putting_green",
+        "cross_engine",
+        "golf_simulation"
+      ],
+      "order": 18
     }
   ]
 }

--- a/tests/launchers/test_launcher_manifest_categories.py
+++ b/tests/launchers/test_launcher_manifest_categories.py
@@ -1,0 +1,179 @@
+"""Tests for launcher manifest category coverage — issues #5509, #5510, #5511, #5514, #5538.
+
+Verifies that:
+- Every sidebar category (biomechanics, simulation, motion_matching) has at
+  least one visible tile in the combined manifest.
+- Specific tiles added/fixed by this PR exist with the correct category.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "config" / "launcher_manifest.json"
+)
+
+# Categories that the sidebar exposes as filter buttons (issues #5509).
+SIDEBAR_CATEGORIES = {"biomechanics", "simulation", "motion_matching"}
+
+
+def _load_manifest_tiles() -> list[dict]:
+    """Load only the base JSON manifest tiles (no provider augmentation)."""
+    assert MANIFEST_PATH.exists(), f"Manifest not found: {MANIFEST_PATH}"
+    with open(MANIFEST_PATH, encoding="utf-8") as fh:
+        raw = json.load(fh)
+    return [t for t in raw["tiles"] if not t.get("hidden", False)]
+
+
+def _tiles_by_category(tiles: list[dict], category: str) -> list[dict]:
+    return [t for t in tiles if t.get("category") == category]
+
+
+# ---------------------------------------------------------------------------
+# Issue #5509 — every sidebar category must have >= 1 tile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", sorted(SIDEBAR_CATEGORIES))
+def test_sidebar_category_has_at_least_one_tile(category: str) -> None:
+    """Each sidebar filter category must resolve to at least one visible tile.
+
+    Fixes #5509.
+    """
+    tiles = _load_manifest_tiles()
+    matching = _tiles_by_category(tiles, category)
+    assert matching, (
+        f"Sidebar category '{category}' has no visible tiles in the manifest. "
+        f"Available categories: {sorted({t.get('category') for t in tiles})}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5510 — cross_engine_dashboard tile exists and is in 'simulation'
+# ---------------------------------------------------------------------------
+
+
+def test_cross_engine_dashboard_tile_exists() -> None:
+    """cross_engine_dashboard tile must exist in the manifest.
+
+    Fixes #5510.
+    """
+    tiles = _load_manifest_tiles()
+    ids = [t["id"] for t in tiles]
+    assert "cross_engine_dashboard" in ids, (
+        f"Tile 'cross_engine_dashboard' not found. Present tiles: {ids}"
+    )
+
+
+def test_cross_engine_dashboard_category_is_simulation() -> None:
+    """cross_engine_dashboard tile must have category 'simulation'.
+
+    Fixes #5510.
+    """
+    tiles = _load_manifest_tiles()
+    tile = next((t for t in tiles if t["id"] == "cross_engine_dashboard"), None)
+    assert tile is not None, "Tile 'cross_engine_dashboard' not found in manifest"
+    assert tile["category"] == "simulation", (
+        f"Expected category 'simulation', got '{tile['category']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5511 — exercise_dashboard tile exists and is in 'biomechanics'
+# ---------------------------------------------------------------------------
+
+
+def test_exercise_dashboard_tile_exists() -> None:
+    """exercise_dashboard tile must exist in the manifest.
+
+    Fixes #5511.
+    """
+    tiles = _load_manifest_tiles()
+    ids = [t["id"] for t in tiles]
+    assert "exercise_dashboard" in ids, (
+        f"Tile 'exercise_dashboard' not found. Present tiles: {ids}"
+    )
+
+
+def test_exercise_dashboard_category_is_biomechanics() -> None:
+    """exercise_dashboard tile must have category 'biomechanics'.
+
+    Fixes #5511.
+    """
+    tiles = _load_manifest_tiles()
+    tile = next((t for t in tiles if t["id"] == "exercise_dashboard"), None)
+    assert tile is not None, "Tile 'exercise_dashboard' not found in manifest"
+    assert tile["category"] == "biomechanics", (
+        f"Expected category 'biomechanics', got '{tile['category']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5514 — golf_simulation_suite tile exists and is in 'simulation'
+# ---------------------------------------------------------------------------
+
+
+def test_golf_simulation_suite_tile_exists() -> None:
+    """golf_simulation_suite tile must exist in the manifest.
+
+    Fixes #5514.
+    """
+    tiles = _load_manifest_tiles()
+    ids = [t["id"] for t in tiles]
+    assert "golf_simulation_suite" in ids, (
+        f"Tile 'golf_simulation_suite' not found. Present tiles: {ids}"
+    )
+
+
+def test_golf_simulation_suite_category_is_simulation() -> None:
+    """golf_simulation_suite tile must have category 'simulation'.
+
+    Fixes #5514.
+    """
+    tiles = _load_manifest_tiles()
+    tile = next((t for t in tiles if t["id"] == "golf_simulation_suite"), None)
+    assert tile is not None, "Tile 'golf_simulation_suite' not found in manifest"
+    assert tile["category"] == "simulation", (
+        f"Expected category 'simulation', got '{tile['category']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #5538 — putting_green must be in 'simulation', not 'physics_engine'
+# ---------------------------------------------------------------------------
+
+
+def test_putting_green_category_is_simulation() -> None:
+    """putting_green tile must have category 'simulation', not 'physics_engine'.
+
+    Fixes #5538.
+    """
+    tiles = _load_manifest_tiles()
+    tile = next((t for t in tiles if t["id"] == "putting_green"), None)
+    assert tile is not None, "Tile 'putting_green' not found in manifest"
+    assert tile["category"] == "simulation", (
+        f"Expected category 'simulation', got '{tile['category']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bonus: motion_target_preview must be in 'motion_matching'
+# ---------------------------------------------------------------------------
+
+
+def test_motion_target_preview_category_is_motion_matching() -> None:
+    """motion_target_preview tile must have category 'motion_matching'."""
+    tiles = _load_manifest_tiles()
+    tile = next((t for t in tiles if t["id"] == "motion_target_preview"), None)
+    assert tile is not None, "Tile 'motion_target_preview' not found in manifest"
+    assert tile["category"] == "motion_matching", (
+        f"Expected category 'motion_matching', got '{tile['category']}'"
+    )


### PR DESCRIPTION
## Summary

- Fixes three empty sidebar category buttons (#5509) by ensuring every sidebar category (biomechanics, simulation, motion_matching) has at least one visible tile
- Adds `cross_engine_dashboard` tile to `simulation` category (#5510)
- Adds `exercise_dashboard` tile to `biomechanics` category (#5511)
- Adds `golf_simulation_suite` tile to `simulation` category (#5514)
- Fixes `putting_green` tile category from `physics_engine` -> `simulation` (#5538)
- Recategorizes `motion_target_preview` from `tool` -> `motion_matching` (needed for #5509)

## Changes

**`src/config/launcher_manifest.json`**
- `putting_green`: category `physics_engine` -> `simulation`
- `motion_target_preview`: category `tool` -> `motion_matching`
- New tile: `cross_engine_dashboard` (category: simulation, type: special_app, path: src/launchers/cross_engine_dashboard.py)
- New tile: `exercise_dashboard` (category: biomechanics, type: biomech_exercise, path: src/launchers/exercise_dashboard.py)
- New tile: `golf_simulation_suite` (category: simulation, type: golf_simulation, path: launch_golf_suite.py)

**`tests/launchers/test_launcher_manifest_categories.py`** (new, TDD)
- 11 tests verifying every sidebar category has >=1 tile, and each new/fixed tile has the correct category
- Written as failing tests first, then manifest updated to make them pass

## Test plan

- [x] `python -m pytest tests/launchers/test_launcher_manifest_categories.py -v` -- 11 passed
- [x] `python -m ruff check tests/launchers/test_launcher_manifest_categories.py` -- clean
- [x] `python -m ruff format --check tests/launchers/test_launcher_manifest_categories.py` -- clean

Fixes #5509
Fixes #5510
Fixes #5511
Fixes #5514
Fixes #5538

Generated with Claude Code