### PR TITLE
docs: add feature navigation gap analysis and issue references

### DIFF
--- a/reports/feature_navigation_gaps/00_INDEX.md
+++ b/reports/feature_navigation_gaps/00_INDEX.md
@@ -1,0 +1,200 @@
+# Feature Navigation Gap Analysis -- UpstreamDrift
+
+## Executive Summary
+
+The launcher manifest defines 15 tiles, but the codebase contains **27+ implemented features** that users cannot discover or reach from the tiled layout. Three sidebar category buttons (Biomechanics, Simulation, Motion Matching) filter to **zero tiles** -- a broken navigation experience. Several features have complete GUIs and handler registrations but are invisible in the manifest.
+
+This analysis classifies every gap into three tiers:
+
+- **Tile-worthy**: A standalone feature that users would explicitly seek. Needs its own manifest entry.
+- **Internal library**: Consumed by other features. Should be documented in capabilities, not given a tile.
+- **Borderline**: Has standalone value but could also be a sub-feature. Needs a judgment call.
+
+---
+
+## Current State
+
+### Manifest Tiles (15 visible + 1 hidden)
+
+| #   | Tile ID               | Category       | Route                  |
+| --- | --------------------- | -------------- | ---------------------- |
+| 1   | model_explorer        | tool           | /tools/model-explorer  |
+| 2   | mujoco_unified        | physics_engine | --                     |
+| 3   | drake_golf            | physics_engine | --                     |
+| 4   | pinocchio_golf        | physics_engine | --                     |
+| 5   | opensim_golf          | physics_engine | --                     |
+| 6   | myosim_suite          | physics_engine | --                     |
+| 7   | putting_green         | physics_engine | /tools/putting-green   |
+| 8   | matlab_unified        | external       | --                     |
+| 9   | motion_target_preview | tool           | --                     |
+| 10  | motion_capture        | tool           | /tools/motion-capture  |
+| 11  | video_analyzer        | tool           | /tools/video-analyzer  |
+| 12  | video_processor       | tool           | /tools/video-processor |
+| 13  | data_explorer         | tool           | /tools/data-explorer   |
+| 14  | data_processor        | tool           | /tools/data-processor  |
+| 15  | project_map           | tool           | --                     |
+| --  | starting_pose_matcher | tool           | HIDDEN (legacy alias)  |
+
+### Sidebar Categories
+
+| Category            | Tile Count | Status                                      |
+| ------------------- | ---------- | ------------------------------------------- |
+| Home (All)          | 15         | OK                                          |
+| Physics Engines     | 5          | OK                                          |
+| **Biomechanics**    | **0**      | **EMPTY**                                   |
+| **Simulation**      | **0**      | **EMPTY** (Putting Green is physics_engine) |
+| **Motion Matching** | **0**      | **EMPTY**                                   |
+| Motion Capture      | 1          | OK                                          |
+| Tools & Data        | 8          | OK                                          |
+
+### Tauri Routes
+
+/ | /simulation | /tools/model-explorer | /tools/putting-green | /tools/video-analyzer | /tools/data-explorer | /tools/motion-capture | /chat
+
+---
+
+## Issue Index
+
+### P0 -- Broken Navigation (3 issues)
+
+| Issue | File                                | Summary                                            |
+| ----- | ----------------------------------- | -------------------------------------------------- |
+| #01   | `01_empty_sidebar_categories.md`    | Three sidebar categories show zero tiles           |
+| #02   | `02_cross_engine_dashboard_tile.md` | Cross-Engine Dashboard (core feature F6) invisible |
+| #03   | `03_exercise_dashboard_tile.md`     | Exercise Dashboard has handler but no tile         |
+
+### P1 -- Core Features Invisible (8 issues)
+
+| Issue | File                                   | Summary                                           |
+| ----- | -------------------------------------- | ------------------------------------------------- |
+| #04   | `04_shot_tracer_tile.md`               | Shot Tracer GUI unreachable from unified launcher |
+| #05   | `05_pose_studio_tile.md`               | Pose Studio standalone GUI completely hidden      |
+| #06   | `06_golf_simulation_suite_tile.md`     | Golf Simulation Suite has handler, no tile        |
+| #07   | `07_engine_dashboards_unreachable.md`  | MuJoCo/Drake/Pinocchio dashboards unreachable     |
+| #08   | `08_swing_optimization_tile.md`        | Swing Optimization (F11) no UI entry              |
+| #09   | `09_injury_risk_analysis_tile.md`      | Injury Risk Analysis no UI entry                  |
+| #10   | `10_terrain_api_no_tile.md`            | Terrain API (6 endpoints) no tile                 |
+| #11   | `11_dataset_generation_no_tile.md`     | Dataset Generation API (9 endpoints) no tile      |
+| #12   | `12_motion_matching_category_empty.md` | Motion Matching sidebar has zero tiles            |
+| #13   | `13_analysis_tools_api_no_tile.md`     | Analysis Tools API (6 endpoints) no tile          |
+
+### P2 -- Important but Less Urgent (7 issues)
+
+| Issue | File                                       | Summary                                    |
+| ----- | ------------------------------------------ | ------------------------------------------ |
+| #14   | `14_chat_ai_sidekick_no_manifest_entry.md` | Chat/AI Sidekick no manifest entry         |
+| #15   | `15_motion_pipeline_no_tile.md`            | Motion Pipeline only partially covered     |
+| #16   | `16_perturbation_analysis_no_ui.md`        | Perturbation/robustness scoring no UI      |
+| #17   | `17_character_builder_no_tile.md`          | URDF Character Builder no tile             |
+| #18   | `18_pendulum_simulator_tile.md`            | Educational Pendulum Simulator unreachable |
+| #30   | `30_putting_green_category_mismatch.md`    | Putting Green miscategorized               |
+| #31   | `31_simulation_category_needs_tiles.md`    | Simulation category needs population       |
+
+### P3 -- Niche / Advanced / Internal (7 issues)
+
+| Issue | File                                        | Summary                             |
+| ----- | ------------------------------------------- | ----------------------------------- |
+| #19   | `19_force_overlays_api_no_tile.md`          | Internal: add to capabilities       |
+| #20   | `20_realtime_websocket_no_tile.md`          | Internal: document as capability    |
+| #21   | `21_aip_no_tile.md`                         | Internal: surface through Chat tile |
+| #22   | `22_actuator_controls_api_no_tile.md`       | Internal: add to capabilities       |
+| #23   | `23_bunkershot3d_no_tile.md`                | Tile-worthy but niche               |
+| #24   | `24_unreal_integration_no_tile.md`          | Advanced: sub-feature of engines    |
+| #25   | `25_robotics_module_no_presence.md`         | Internal: control scheme config     |
+| #26   | `26_upstream_drift_tools_breadth_hidden.md` | Expand Data Processor description   |
+| #27   | `27_programmatic_pid_hidden.md`             | Niche: may not warrant tile         |
+| #28   | `28_dashboard_recorder_hidden.md`           | Internal: sub-feature of dashboards |
+| #29   | `29_internal_libraries_no_tile_needed.md`   | Audit: correctly internal           |
+
+---
+
+## Classification: Tile-worthy vs. Internal Library
+
+### Tile-worthy (need manifest entries)
+
+| Feature                        | Proposed Category | Rationale                                 |
+| ------------------------------ | ----------------- | ----------------------------------------- |
+| Cross-Engine Dashboard         | simulation        | Core feature F6, complete GUI             |
+| Exercise Dashboard             | biomechanics      | Complete GUI with handler                 |
+| Shot Tracer                    | simulation        | Complete GUI, only in deprecated launcher |
+| Pose Studio                    | tool              | Standalone GUI with main()                |
+| Golf Simulation Suite          | simulation        | Has handler, no tile                      |
+| Swing Optimization             | simulation        | Core feature F11                          |
+| Injury Risk Analysis           | biomechanics      | Distinct analysis workflow                |
+| Motion Matching (recategorize) | motion_matching   | Sidebar exists, needs tiles               |
+| Terrain                        | tool              | 6 API endpoints                           |
+| Dataset Generation             | tool              | 9 API endpoints                           |
+| BunkerShot3D                   | physics_engine    | Complete simulation system                |
+| Pendulum Simulator             | physics_engine    | Educational entry point                   |
+| Chat/AI Sidekick               | tool              | Major feature, no manifest entry          |
+| Character Builder              | tool              | Distinct workflow from Model Explorer     |
+
+### Internal Library (document in capabilities, no tile)
+
+| Module                | Consumed By               | Action                                 |
+| --------------------- | ------------------------- | -------------------------------------- |
+| Biomechanics library  | MuJoCo, OpenSim, MyoSuite | Add `biomechanics` capability tag      |
+| Screw theory          | Physics engines           | Add `screw_theory` capability tag      |
+| Spatial algebra       | Physics engines           | Add `spatial_algebra` capability tag   |
+| Data I/O              | Data Explorer, export     | Add `data_io` capability tag           |
+| Plot engine           | Dashboards                | Internal, no action needed             |
+| Reporting             | Analysis/export           | Internal, no action needed             |
+| Realtime transport    | Simulation WS             | Add `realtime` capability tag          |
+| Dashboard recorder    | Engine dashboards         | Expose when dashboards are exposed     |
+| Robotics control      | Drake, MuJoCo             | Add `control_schemes` capability tag   |
+| Rust physics kernels  | Physics engines           | Document in engine descriptions        |
+| Actuator controls API | Simulation page           | Add `actuator_controls` capability tag |
+| Force overlays API    | Simulation page           | Add `force_overlays` capability tag    |
+| AIP                   | Chat/Sidekick             | Add `ai_methods` capability tag        |
+| Freemocap ingest      | Motion Capture            | Internal, no action needed             |
+| Deployment modules    | Production                | Internal, no action needed             |
+| Perturbation analysis | Cross-Engine Dashboard    | Surface in dashboard when exposed      |
+
+---
+
+## Recommended Manifest Changes
+
+### New tiles to add
+
+``json
+[
+{""id"": ""cross_engine"", ""name"": ""Cross-Engine Dashboard"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/launchers/cross_engine_dashboard.py"", ""capabilities"": [""cross_validation"", ""perturbation"", ""robustness_scoring""], ""order"": 20},
+{""id"": ""biomech_exercise"", ""name"": ""Exercise Dashboard"", ""category"": ""biomechanics"", ""type"": ""biomech_exercise"", ""path"": ""src/launchers/exercise_dashboard.py"", ""capabilities"": [""injury_risk"", ""joint_stress"", ""swing_modification""], ""order"": 21},
+{""id"": ""shot_tracer"", ""name"": ""Shot Tracer"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/launchers/\_shot_tracer_gui.py"", ""capabilities"": [""trajectory_visualization"", ""multi_model_comparison""], ""order"": 22},
+{""id"": ""pose_studio"", ""name"": ""Pose Studio"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": ""src/tools/pose_studio/**main**.py"", ""capabilities"": [""pose_editing"", ""retargeting""], ""order"": 23},
+{""id"": ""golf_simulation_suite"", ""name"": ""Golf Simulation Suite"", ""category"": ""simulation"", ""type"": ""golf_simulation"", ""path"": ""src/tools/golf_simulation_suite/**main**.py"", ""capabilities"": [""full_simulation"", ""parameter_sweep""], ""order"": 24},
+{""id"": ""swing_optimization"", ""name"": ""Swing Optimizer"", ""category"": ""simulation"", ""type"": ""special_app"", ""path"": ""src/shared/python/optimization/swing_optimizer.py"", ""capabilities"": [""trajectory_optimization"", ""constraint_solving""], ""order"": 25},
+{""id"": ""injury_analysis"", ""name"": ""Injury Risk Analysis"", ""category"": ""biomechanics"", ""type"": ""special_app"", ""path"": ""src/shared/python/injury/injury_risk.py"", ""capabilities"": [""injury_risk"", ""joint_stress"", ""spinal_load""], ""order"": 26},
+{""id"": ""terrain"", ""name"": ""Terrain Engine"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/tools/terrain"", ""capabilities"": [""surface_modeling"", ""ball_physics"", ""topography""], ""order"": 27},
+{""id"": ""dataset_generator"", ""name"": ""Dataset Generator"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/tools/dataset"", ""capabilities"": [""dataset_generation"", ""swing_import"", ""parameter_sweep""], ""order"": 28},
+{""id"": ""bunkershot3d"", ""name"": ""BunkerShot3D"", ""category"": ""physics_engine"", ""type"": ""special_app"", ""path"": ""src/bunkershot3d/"", ""capabilities"": [""sand_simulation"", ""mpm"", ""calibration""], ""order"": 29},
+{""id"": ""pendulum"", ""name"": ""Pendulum Simulator"", ""category"": ""physics_engine"", ""type"": ""special_app"", ""path"": ""src/shared/python/pendulum_simulator/**main**.py"", ""capabilities"": [""educational"", ""2dof""], ""order"": 30},
+{""id"": ""chat"", ""name"": ""AI Assistant"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": """", ""web_route"": ""/chat"", ""capabilities"": [""ai_methods"", ""calculator"", ""workspace""], ""order"": 31},
+{""id"": ""character_builder"", ""name"": ""Character Builder"", ""category"": ""tool"", ""type"": ""special_app"", ""path"": ""src/shared/python/model_generation/cli/main.py"", ""capabilities"": [""urdf_generation"", ""anthropometry"", ""mesh_generation""], ""order"": 32}
+]
+
+```
+
+### Category changes to existing tiles
+
+| Tile ID | Current Category | Proposed Category |
+|---------|------------------|--------------------|
+| putting_green | physics_engine | **simulation** |
+| motion_target_preview | tool | **motion_matching** |
+
+### Capability tag additions to existing tiles
+
+| Tile ID | Capabilities to Add |
+|---------|-------------------|
+| mujoco_unified | biomechanics, screw_theory, spatial_algebra, actuator_controls, force_overlays, control_schemes, realtime |
+| drake_golf | actuator_controls, force_overlays, control_schemes, realtime |
+| pinocchio_golf | actuator_controls, force_overlays |
+| opensim_golf | biomechanics, actuator_controls |
+| data_processor | process_calculators |
+
+---
+
+## Files
+
+All issue files are in: `reports/feature_navigation_gaps/`
+```

--- a/reports/feature_navigation_gaps/00_classification_criteria.md
+++ b/reports/feature_navigation_gaps/00_classification_criteria.md
@@ -1,0 +1,12 @@
+"# Feature Navigation Gap Review: Internal vs. Exposed
+
+## Classification Criteria
+
+**Tile-worthy** (exposed in launcher): Standalone user-facing feature with its own GUI
+or meaningful entry point. Users would explicitly seek it out.
+
+**Internal library** (no tile): Underlying module consumed by other features. Users
+interact with it indirectly through other tiles or APIs.
+
+**Borderline**: Has some standalone value but is also used by other features. Needs
+judgment call on whether the standalone use case justifies a tile.

--- a/reports/feature_navigation_gaps/01_empty_sidebar_categories.md
+++ b/reports/feature_navigation_gaps/01_empty_sidebar_categories.md
@@ -1,0 +1,38 @@
+---
+title: Empty sidebar categories show no tiles (Biomechanics, Simulation, Motion Matching)
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+The PyQt6 launcher sidebar defines 7 category filter buttons (Home, Physics Engines, Biomechanics, Simulation, Motion Matching, Motion Capture, Tools & Data). Three of these categories currently filter to **zero tiles**:
+
+| Category        | Tiles in Manifest                   | User Experience |
+| --------------- | ----------------------------------- | --------------- |
+| Biomechanics    | 0                                   | Empty grid      |
+| Simulation      | 0 (Putting Green is physics_engine) | Empty grid      |
+| Motion Matching | 0                                   | Empty grid      |
+
+When a user clicks any of these three sidebar buttons, they see an entirely empty launcher grid. This is a broken navigation path.
+
+## Source
+
+- Sidebar categories are defined in src/launchers/launcher_ui_setup.py lines ~295-413
+- Tile categories come from src/config/launcher_manifest.json
+- Category definitions are in src/config/launcher_manifest_loader.py lines 47-71
+
+## Acceptance Criteria
+
+- [ ] Every sidebar category button filters to at least one visible tile
+- [ ] Either add tiles that map to these categories, or remove/merge the empty categories
+- [ ] Verify the Tauri React dashboard also handles empty categories gracefully (show a message instead of a blank grid)
+
+## Suggested Fixes
+
+**Option A -- Add tiles (preferred):** Add manifest entries for features that belong in these categories:
+
+- **Biomechanics**: Exercise Dashboard, Injury Risk Analysis, Swing Comparison
+- **Simulation**: Cross-Engine Dashboard, Golf Simulation Suite, Shot Tracer
+- **Motion Matching**: Motion-Match Preview already exists; add Motion Pipeline and Surrogate Training
+
+**Option B -- Merge categories:** If these features aren't ready for standalone tiles, merge them into existing categories and remove the empty sidebar buttons to avoid dead-end navigation.

--- a/reports/feature_navigation_gaps/02_cross_engine_dashboard_tile.md
+++ b/reports/feature_navigation_gaps/02_cross_engine_dashboard_tile.md
@@ -1,0 +1,27 @@
+---
+title: Cross-Engine Dashboard has no launcher tile (core feature F6 invisible)
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+Cross-engine validation is a **core feature (F6)** in SPEC.md with full ✅ status. The CrossEngineDashboardWindow class (src/launchers/cross_engine_dashboard.py) is a complete PyQt6 application for multi-engine comparison. It has a dedicated UnifiedDashboardWindow base class, tests, and CLI entry points.
+
+Despite being fully implemented, it has **no tile in the launcher manifest** and no way for users to discover or launch it from the main UI.
+
+## Evidence
+
+- src/launchers/cross_engine_dashboard.py -- full CrossEngineDashboardWindow class
+- src/launchers/base.py -- BaseLauncher with dashboard infrastructure
+-     ests/launchers/test_cross_engine_dashboard.py -- full test suite
+-     ests/launchers/test_cross_engine_dashboard_cli.py -- CLI tests
+- SPEC.md F6: "Cross-engine validation ✅"
+- No entry in src/config/launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a cross_engine tile to launcher_manifest.json
+- [ ] Assign it to the simulation category
+- [ ] Add appropriate SVG logo to src/launchers/assets/
+- [ ] Verify tile launches the Cross-Engine Dashboard
+- [ ] Verify Tauri dashboard renders the new tile

--- a/reports/feature_navigation_gaps/03_exercise_dashboard_tile.md
+++ b/reports/feature_navigation_gaps/03_exercise_dashboard_tile.md
@@ -1,0 +1,24 @@
+---
+title: Exercise Dashboard has a handler but no launcher tile
+labels: bug, ui, priority/P0
+---
+
+## Problem
+
+The ExerciseDashboard class (src/launchers/exercise_dashboard.py) is a complete PyQt6 application for biomechanics exercise workflows. It has a registered BiomechExerciseHandler in src/launchers/launcher_model_handlers.py (model type iomech_exercise).
+
+The sidebar has a **Biomechanics** category button that currently filters to zero tiles. The Exercise Dashboard belongs in that category but cannot be launched from the UI.
+
+## Evidence
+
+- src/launchers/exercise_dashboard.py -- full ExerciseDashboard(QMainWindow)
+- src/launchers/launcher_model_handlers.py:243 -- BiomechExerciseHandler registered
+- src/launchers/launcher_ui_setup.py:295 -- tn_biomechanics sidebar button exists
+- No iomech_exercise tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a iomech_exercise tile to launcher_manifest.json
+- [ ] Assign it to the iomechanics category
+- [ ] Add appropriate SVG logo
+- [ ] Verify launch from the Biomechanics sidebar category

--- a/reports/feature_navigation_gaps/04_shot_tracer_tile.md
+++ b/reports/feature_navigation_gaps/04_shot_tracer_tile.md
@@ -1,0 +1,26 @@
+---
+title: Shot Tracer GUI has no launcher tile (only reachable from deprecated launcher)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The MultiModelShotTracerWindow (src/launchers/\_shot_tracer_gui.py) is a complete PyQt6 application for trajectory visualization and comparison. It's a user-facing tool that researchers would actively seek out.
+
+Currently it's only launchable from golf_suite_launcher.py (deprecated), which shows a deprecation warning pointing users to the unified launcher. But the unified launcher manifest has no Shot Tracer tile.
+
+## Evidence
+
+- src/launchers/\_shot_tracer_gui.py -- MultiModelShotTracerWindow(QMainWindow) with full GUI
+- src/launchers/shot_tracer.py -- CLI wrapper
+- src/launchers/golf_suite_launcher.py -- deprecated launcher has \_launch_shot_tracer()
+- src/launchers/launcher_model_handlers.py -- no handler for shot_tracer type
+- No tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a shot_tracer tile to launcher_manifest.json
+- [ ] Add ShotTracerHandler to launcher_model_handlers.py
+- [ ] Assign to the simulation category
+- [ ] Add SVG logo (a trajectory/arc icon)
+- [ ] Remove \_launch_shot_tracer from deprecated golf_suite_launcher.py or redirect it

--- a/reports/feature_navigation_gaps/05_pose_studio_tile.md
+++ b/reports/feature_navigation_gaps/05_pose_studio_tile.md
@@ -1,0 +1,23 @@
+---
+title: Pose Studio has no launcher tile (standalone GUI completely hidden)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Pose Studio (src/tools/pose_studio/) is a standalone PyQt6 application for interactive pose editing. It has a full GUI (gui.py), CLI entry point (**main**.py), and documentation. Users who want to manipulate joint angles or retarget poses would look for this feature, but it's completely invisible in the launcher.
+
+## Evidence
+
+- src/tools/pose_studio/gui.py -- full PoseStudioApp with main window
+- src/tools/pose_studio/**main**.py -- CLI entry point
+- No entry in launcher_manifest.json
+- No handler in launcher_model_handlers.py
+
+## Acceptance Criteria
+
+- [ ] Add a pose_studio tile to launcher_manifest.json
+- [ ] Add PoseStudioHandler to launcher_model_handlers.py (as special_app type)
+- [ ] Assign to the ool category
+- [ ] Add SVG logo
+- [ ] Verify standalone launch from both PyQt and Tauri launchers

--- a/reports/feature_navigation_gaps/06_golf_simulation_suite_tile.md
+++ b/reports/feature_navigation_gaps/06_golf_simulation_suite_tile.md
@@ -1,0 +1,21 @@
+---
+title: Golf Simulation Suite has a handler but no launcher tile
+labels: bug, ui, priority/P1
+---
+
+## Problem
+
+The Golf Simulation Suite (src/tools/golf_simulation_suite/) has a full CLI entry point and a GolfSimulationSuiteHandler registered in launcher_model_handlers.py (model type golf_simulation). It's a complete application that should be launchable from the tiled UI.
+
+## Evidence
+
+- src/tools/golf_simulation_suite/**main**.py -- CLI entry with main()
+- src/launchers/launcher_model_handlers.py:293 -- GolfSimulationSuiteHandler registered
+- No tile in launcher_manifest.json
+
+## Acceptance Criteria
+
+- [ ] Add a golf_simulation_suite tile to launcher_manifest.json
+- [ ] Assign to the simulation category
+- [ ] Add SVG logo
+- [ ] Verify launch through the tile

--- a/reports/feature_navigation_gaps/07_engine_dashboards_unreachable.md
+++ b/reports/feature_navigation_gaps/07_engine_dashboards_unreachable.md
@@ -1,0 +1,28 @@
+---
+title: Engine-specific dashboards unreachable from launcher (Drake, MuJoCo, Pinocchio)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Three engine-specific dashboard classes exist but have no launcher tiles:
+
+1. **MuJoCo Dashboard** (src/launchers/mujoco_dashboard.py) -- MuJoCoDashboard(UnifiedDashboardWindow)
+2. **Drake Dashboard** (src/launchers/drake_dashboard.py) -- DrakeDashboard(UnifiedDashboardWindow)
+3. **Pinocchio Dashboard** (src/launchers/pinocchio_dashboard.py) -- PinocchioDashboard(UnifiedDashboardWindow)
+
+These are richer analytics views than the basic engine launchers. Currently, clicking a MuJoCo tile launches the Humanoid Golf simulation, but there's no way to access the dedicated analytics dashboard that shows force vectors, energy plots, and advanced metrics.
+
+The unified launcher tiles each launch a single entry point (e.g., mujoco_unified_launcher.py), but the dashboards are separate, more feature-rich views.
+
+## Options
+
+1. **Add dashboard tiles** for each engine alongside the existing simulation tiles
+2. **Merge dashboards into the unified launcher** -- the unified launcher could offer a "Switch to Dashboard" mode
+3. **Add a dashboard toggle** within each engine tile (e.g., a dropdown or secondary click option)
+
+## Acceptance Criteria
+
+- [ ] Decide on approach (separate tiles vs. merged vs. toggle)
+- [ ] Expose engine dashboards through the launcher
+- [ ] Add tests verifying dashboard launch paths

--- a/reports/feature_navigation_gaps/08_swing_optimization_tile.md
+++ b/reports/feature_navigation_gaps/08_swing_optimization_tile.md
@@ -1,0 +1,26 @@
+---
+title: Swing Optimization has no UI entry (core analysis feature invisible)
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+Swing optimization (src/shared/python/optimization/) is a fully implemented module with:
+
+- `swing_optimizer.py` -- trajectory optimization with constraint support
+- `_swing_constraints.py`, `_swing_kinematics.py`, `_swing_models.py`, `_swing_objectives.py`
+- `swing_bridge.py` -- bridge to engine simulations
+- `examples/optimize_arm.py` -- runnable example
+
+This is a core analysis capability (trajectory optimization is F11 in SPEC.md), but it has no launcher tile, no dedicated API route, and no web route. Users cannot discover it.
+
+## Classification
+
+**Tile-worthy**: Trajectory optimization is a first-class feature in the spec. Researchers would seek it out independently.
+
+## Acceptance Criteria
+
+- [ ] Add a `swing_optimization` tile to `launcher_manifest.json`
+- [ ] Create a launcher entry point (CLI or GUI wrapper)
+- [ ] Add an API route for optimization endpoints (`/analysis/optimize`)
+- [ ] Assign to the `simulation` or `biomechanics` category

--- a/reports/feature_navigation_gaps/09_injury_risk_analysis_tile.md
+++ b/reports/feature_navigation_gaps/09_injury_risk_analysis_tile.md
@@ -1,0 +1,26 @@
+---
+title: Injury Risk Analysis has no UI entry
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The injury analysis module (src/shared/python/injury/) is fully implemented with:
+
+- `injury_risk.py` -- injury risk computation
+- `joint_stress.py` -- joint stress analysis
+- `spinal_load_analysis.py` -- spinal loading during swing
+- `swing_modifications.py` -- swing modifications to reduce injury risk
+
+This is a unique and valuable feature -- sports medicine researchers would specifically seek injury risk analysis. It has no launcher tile, no API route, and no dashboard.
+
+## Classification
+
+**Tile-worthy**: Injury risk is a distinct analysis workflow that researchers seek independently. It's not just an internal library -- it computes and reports on injury metrics.
+
+## Acceptance Criteria
+
+- [ ] Add an `injury_analysis` tile to `launcher_manifest.json`
+- [ ] Create a launcher entry point or integrate into Exercise Dashboard
+- [ ] Assign to the `biomechanics` category
+- [ ] Add API routes for injury computation endpoints

--- a/reports/feature_navigation_gaps/10_terrain_api_no_tile.md
+++ b/reports/feature_navigation_gaps/10_terrain_api_no_tile.md
@@ -1,0 +1,31 @@
+---
+title: Terrain API has 6 endpoints but no launcher tile or web route
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The terrain engine (src/api/routes/terrain.py) exposes a full REST API:
+
+- `GET /terrain/presets` -- preset terrain configurations
+- `POST /terrain/load` -- load terrain data
+- `POST /terrain/query` -- query terrain properties at coordinates
+- `GET /terrain/materials` -- surface material types
+- `GET /terrain/types` -- terrain type catalog
+- `GET /terrain/active` -- currently active terrain
+
+The underlying module (src/shared/python/physics/terrain_engine.py, topography, terrain physics, representations) is complete.
+
+There's also a comprehensive terrain implementation under `src/shared/python/physics/` (terrain*engine.py, topography.py, terrain_representation.py, terrain_physics.py, \_terrain*\*.py).
+
+Yet there's no tile and no `web_route` in the manifest. The Putting Green tile uses terrain but doesn't expose the general terrain system.
+
+## Classification
+
+**Tile-worthy**: Terrain configuration is a distinct workflow (design greens, configure surfaces, import elevation data). Researchers configuring simulation environments need this independently.
+
+## Acceptance Criteria
+
+- [ ] Add a `terrain` tile to `launcher_manifest.json` with `web_route: /tools/terrain`
+- [ ] Create a Tauri route for the terrain configuration page
+- [ ] Assign to the `tool` category

--- a/reports/feature_navigation_gaps/11_dataset_generation_no_tile.md
+++ b/reports/feature_navigation_gaps/11_dataset_generation_no_tile.md
@@ -1,0 +1,31 @@
+---
+title: Dataset Generation API has full endpoints but no tile or frontend
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The dataset generation API (src/api/routes/dataset.py) has comprehensive endpoints:
+
+- `POST /dataset/generate` -- generate synthetic swing datasets
+- `POST /dataset/import-swing` -- import swing data
+- `GET /dataset/control/state` -- dataset generator state
+- `POST /dataset/control/configure` -- configure generation
+- `GET /dataset/control/strategies` -- available strategies
+- `GET /dataset/features` -- feature catalog
+- `POST /dataset/execute` -- execute generation
+- `GET /dataset/plots/types` -- plot type catalog
+- `GET /dataset/export/formats` -- export format catalog
+
+This is a significant feature for researchers who need training data, but it has no launcher tile and no Tauri frontend page.
+
+## Classification
+
+**Tile-worthy**: Dataset generation is a distinct workflow that researchers use independently of data exploration.
+
+## Acceptance Criteria
+
+- [ ] Add a `dataset_generator` tile to `launcher_manifest.json` with `web_route: /tools/dataset`
+- [ ] Create a Tauri DatasetGenerator page component
+- [ ] Add route in `ui/src/App.tsx`
+- [ ] Assign to the `tool` category

--- a/reports/feature_navigation_gaps/12_motion_matching_category_empty.md
+++ b/reports/feature_navigation_gaps/12_motion_matching_category_empty.md
@@ -1,0 +1,26 @@
+---
+title: Motion Matching sidebar category has zero tiles
+labels: bug, ui, priority/P1
+---
+
+## Problem
+
+The sidebar has a `Motion Matching` button, but no tile in the manifest carries the `motion_matching` category. The Motion-Match Preview tile (id: `motion_target_preview`) is categorized as `tool`, not `motion_matching`.
+
+Meanwhile, the motion matching module (src/shared/python/motion_matching/) is extensive:
+
+- CVAE and regressor models for surrogate training
+- Multi-source target synthesis (club, body, C3D, .mat)
+- Clubhead trace analysis, forward kinematics
+- Performance baselines and leaderboard
+- Per-step optimization with training scripts
+
+## Classification
+
+**Tile-worthy**: Motion matching is a major feature area. The sidebar button exists specifically for it, and the module has standalone GUI entry points.
+
+## Acceptance Criteria
+
+- [ ] Recategorize `motion_target_preview` to `motion_matching` category, or add a separate `motion_matching` tile
+- [ ] Consider adding a `motion_matching_training` tile for the surrogate training workflow
+- [ ] Verify the Motion Matching sidebar button shows at least one tile

--- a/reports/feature_navigation_gaps/13_analysis_tools_api_no_tile.md
+++ b/reports/feature_navigation_gaps/13_analysis_tools_api_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Analysis Tools API has 6 endpoints but no tile or frontend page
+labels: feature, ui, priority/P1
+---
+
+## Problem
+
+The analysis tools API (src/api/routes/analysis_tools.py) exposes:
+
+- `GET /analysis/metrics` -- biomechanical metrics
+- `GET /analysis/statistics` -- statistical summaries
+- `POST /analysis/export` -- export analysis data
+- `POST /simulation/position` -- set body position
+- `POST /simulation/measure` -- take measurements
+- `GET /simulation/measurements` -- available measurement tools
+
+These are distinct from the generic `/analyze/biomechanics` route in `analysis.py`. They provide interactive measurement and analysis tooling with no launcher presence.
+
+## Classification
+
+**Borderline -- Tile-worthy**: The analysis tools are interactive measurement features that complement the simulation experience. They could be a sub-feature of the Simulation page or a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Expose analysis tools through either a dedicated tile or the Simulation page UI
+- [ ] If tile: add `analysis_tools` to manifest with `web_route: /tools/analysis`
+- [ ] If sub-feature: add measurement/analysis panels to the Simulation page

--- a/reports/feature_navigation_gaps/14_chat_ai_sidekick_no_manifest_entry.md
+++ b/reports/feature_navigation_gaps/14_chat_ai_sidekick_no_manifest_entry.md
@@ -1,0 +1,21 @@
+---
+title: Chat/AI Sidekick panel has no manifest entry
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The PyQt6 launcher has an AI Sidekick panel (`src/shared/python/upstream_drift_tools/ui/tools_sidebar/`) with a full sidebar, calculator assist, command history, workspace persistence, and data explorer integration. The Tauri UI has a `/chat` route.
+
+Neither appears in the launcher manifest. The AI panel is activated by a sidebar button in the PyQt6 launcher but has no corresponding tile. The Tauri manifest does not know it exists.
+
+## Classification
+
+**Tile-worthy**: The AI Sidekick is a major feature that users would look for. It should appear in the manifest so both launchers can render it consistently.
+
+## Acceptance Criteria
+
+- [ ] Add a `chat` tile to `launcher_manifest.json` with `web_route: /chat`
+- [ ] Assign to the `tool` category
+- [ ] Ensure the PyQt6 launcher shows it as a tile in addition to the sidebar button
+- [ ] Verify Tauri dashboard renders the chat tile

--- a/reports/feature_navigation_gaps/15_motion_pipeline_no_tile.md
+++ b/reports/feature_navigation_gaps/15_motion_pipeline_no_tile.md
@@ -1,0 +1,26 @@
+---
+title: Motion Pipeline has no dedicated tile (only partially covered by Motion Capture)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The Motion Pipeline (`src/shared/python/motion_pipeline/`) is a comprehensive system:
+
+- **Orchestrator** for end-to-end motion processing
+- **ID backends**: CMC, RRA, torque (MuJoCo), trajectory optimization (Drake)
+- **Signal processing**: filter, resample, gap fill, normalize
+- **Retargeting adapters**: C3D, BVH, TRC, OpenPose, MediaPipe, HRNet, AlphaPose, STO/MOT, CSV
+- **Scaling**: anthropometric scaling, marker maps, OpenSim scale
+
+The `motion_capture` tile only covers C3D viewing and OpenPose/MediaPipe. The full pipeline (retargeting, ID solving, signal processing, scaling) is unreachable from the UI.
+
+## Classification
+
+**Borderline**: The Motion Capture tile covers the capture part. The pipeline's processing capabilities (retargeting, ID, scaling) are distinct workflows that researchers need independently. Could be a separate tile or a mode within the Motion Capture page.
+
+## Acceptance Criteria
+
+- [ ] Decide: separate `motion_pipeline` tile or expand the Motion Capture page
+- [ ] Expose retargeting, ID solving, and signal processing workflows
+- [ ] Add API route coverage for pipeline operations beyond capture

--- a/reports/feature_navigation_gaps/16_perturbation_analysis_no_ui.md
+++ b/reports/feature_navigation_gaps/16_perturbation_analysis_no_ui.md
@@ -1,0 +1,26 @@
+---
+title: Perturbation Analysis (cross-engine robustness) has no UI
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The perturbation analysis module (`src/shared/python/perturbation/`) provides cross-engine robustness scoring:
+
+- `cross_engine_runner.py` -- run perturbed simulations across engines
+- `noise.py` -- noise injection (Gaussian, uniform, etc.)
+- `robustness_score.py` -- compute robustness metrics
+- `statistics.py` -- statistical analysis of perturbation results
+- `analyzer_base.py` -- extensible analyzer framework
+
+This directly supports the cross-engine validation feature (F6) and the `Simulation` sidebar category, but has no UI entry point.
+
+## Classification
+
+**Internal library** with **borderline tile potential**: Perturbation analysis is primarily a programmatic feature, but researchers doing robustness studies would want a way to configure and launch it. Could be a mode within the Cross-Engine Dashboard rather than a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Add perturbation analysis configuration to the Cross-Engine Dashboard
+- [ ] Or: add a `perturbation` tile if the workflow is distinct enough
+- [ ] Add API route for configuring and running perturbation studies

--- a/reports/feature_navigation_gaps/17_character_builder_no_tile.md
+++ b/reports/feature_navigation_gaps/17_character_builder_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Character Builder / URDF Generator has no launcher tile
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The humanoid character builder (`src/shared/python/humanoid_character_builder/`) is a complete system:
+
+- Anthropometric body parameter scaling
+- URDF generation with mesh, collision, and physics validation
+- MakeHuman and SMPL-X mesh generators
+- Collision geometry (convex hull, decimation, primitive fitting)
+- Preview and quick-build modes
+- CLI entry point (`src/shared/python/model_generation/cli/main.py`)
+
+The Model Explorer tile allows browsing URDFs but not building them. Users who want to create custom humanoid models have no way to discover or launch the builder.
+
+## Classification
+
+**Tile-worthy with caveats**: Building a character is a distinct workflow from browsing models. The builder has both a GUI preview mode and a CLI. It could be exposed as a mode within Model Explorer (`Open in Builder`) or as a separate tile.
+
+## Acceptance Criteria
+
+- [ ] Add either a `character_builder` tile or a `Build Model` action in Model Explorer
+- [ ] If separate tile: add to manifest with path to `model_generation` CLI
+- [ ] If integrated: add a `Create Model` button in Model Explorer that launches the builder

--- a/reports/feature_navigation_gaps/18_pendulum_simulator_tile.md
+++ b/reports/feature_navigation_gaps/18_pendulum_simulator_tile.md
@@ -1,0 +1,21 @@
+---
+title: Pendulum Simulator has no launcher tile (educational models unreachable)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The pendulum simulator (`src/shared/python/pendulum_simulator/`) has a CLI entry point (`__main__.py`) and was reachable from the deprecated `golf_suite_launcher.py`. The SPEC.md explicitly lists educational 2-DOF pendulums as a supported model type.
+
+Users looking for simple educational models have no way to launch them from the tiled UI.
+
+## Classification
+
+**Tile-worthy**: The pendulum is explicitly called out in SPEC.md as a supported model complexity tier. It provides an approachable entry point for new users.
+
+## Acceptance Criteria
+
+- [ ] Add a `pendulum` tile to `launcher_manifest.json`
+- [ ] Add a handler for the pendulum simulator type
+- [ ] Assign to `physics_engine` category (or a new `educational` category)
+- [ ] Consider grouping with other educational/quick-start models

--- a/reports/feature_navigation_gaps/19_force_overlays_api_no_tile.md
+++ b/reports/feature_navigation_gaps/19_force_overlays_api_no_tile.md
@@ -1,0 +1,18 @@
+---
+title: Force Overlays API has no tile (physics visualization feature hidden)
+labels: feature, ui, priority/P2
+---
+
+## Problem
+
+The force overlays API (`src/api/routes/force_overlays.py`) provides force/torque vector visualization for simulations. This is a distinct visualization feature that users would want to enable independently, but it has no launcher presence.
+
+## Classification
+
+**Internal library**: Force overlays are used by the simulation views (MuJoCo, Drake) internally. They don't need their own tile but should be documented as a capability of the simulation pages.
+
+## Acceptance Criteria
+
+- [ ] Add `force_overlays` to the MuJoCo and Drake tile `capabilities` arrays
+- [ ] Document the force overlay API in the simulation page UI
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/20_realtime_websocket_no_tile.md
+++ b/reports/feature_navigation_gaps/20_realtime_websocket_no_tile.md
@@ -1,0 +1,23 @@
+---
+title: Realtime WebSocket API has no UI presence
+labels: documentation, priority/P2
+---
+
+## Problem
+
+The realtime API (`src/api/routes/realtime.py`) provides:
+
+- `POST /realtime/publish` -- publish real-time events
+- `WebSocket /realtime/subscribe` -- subscribe to real-time event stream
+
+This enables live simulation updates and is used by the simulation WebSocket (`simulation_ws.py`), but it has no manifest entry and no documentation in the launcher UI.
+
+## Classification
+
+**Internal infrastructure**: This is a transport layer, not a user-facing feature. It should be documented as a capability, not exposed as a tile.
+
+## Acceptance Criteria
+
+- [ ] Add `realtime` to relevant tile `capabilities` arrays
+- [ ] Document the realtime API in developer docs
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/21_aip_no_tile.md
+++ b/reports/feature_navigation_gaps/21_aip_no_tile.md
@@ -1,0 +1,24 @@
+---
+title: AIP (AI Protocol) has no tile or documentation in UI
+labels: feature, priority/P2
+---
+
+## Problem
+
+The AIP module (`src/api/routes/aip.py`) provides structured AI method dispatch:
+
+- `GET /aip/capabilities` -- list available AI methods
+- `POST /aip/rpc` -- invoke AI methods via RPC
+- `GET /aip/methods` -- enumerate methods
+
+This powers the AI Sidekick but has no manifest entry. Users and developers who want to understand what AI capabilities are available have no way to discover them from the UI.
+
+## Classification
+
+**Borderline**: AIP is infrastructure that powers the Chat/Sidekick feature. It doesn't need its own tile, but its capabilities should be surfaced through the Chat tile's description and capabilities.
+
+## Acceptance Criteria
+
+- [ ] Add `ai_methods` to the chat tile `capabilities` array
+- [ ] Update the chat tile description to mention AI method access
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/22_actuator_controls_api_no_tile.md
+++ b/reports/feature_navigation_gaps/22_actuator_controls_api_no_tile.md
@@ -1,0 +1,24 @@
+---
+title: Actuator Controls API has no tile (simulation sub-feature)
+labels: documentation, priority/P2
+---
+
+## Problem
+
+The actuator controls API (`src/api/routes/actuator_controls.py`) provides:
+
+- `GET /simulation/actuators` -- list actuators
+- `POST /simulation/actuators` -- configure actuator controls
+- `POST /simulation/actuators/control` -- send control commands
+
+This is a simulation sub-feature, not a standalone workflow. It should be documented as a capability of the Simulation page.
+
+## Classification
+
+**Internal library**: Actuator controls are used within simulation sessions. No tile needed.
+
+## Acceptance Criteria
+
+- [ ] Add `actuator_controls` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Expose actuator controls in the Simulation page UI
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/23_bunkershot3d_no_tile.md
+++ b/reports/feature_navigation_gaps/23_bunkershot3d_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: BunkerShot3D has no launcher tile
+labels: feature, ui, priority/P3
+---
+
+## Problem
+
+BunkerShot3D (`src/bunkershot3d/`) is a complete sand-shot simulation with:
+
+- MPM, LIGGGHTS, and Chrono backends
+- Calibration system (angle of repose, drained shear cell)
+- Clubhead geometry and kinematics
+- Configuration system (`configs/bunkershot3d/canonical.yaml`)
+- I/O and post-processing
+
+It has no manifest tile and no way for users to discover or launch it.
+
+## Classification
+
+**Tile-worthy**: BunkerShot3D is a distinct simulation domain (sand bunkers). Golf researchers would seek this out specifically. It's not just a sub-feature of MuJoCo.
+
+## Acceptance Criteria
+
+- [ ] Add a `bunkershot3d` tile to `launcher_manifest.json`
+- [ ] Add a handler for launching the BunkerShot3D simulator
+- [ ] Assign to the `physics_engine` category
+- [ ] Add appropriate SVG logo

--- a/reports/feature_navigation_gaps/24_unreal_integration_no_tile.md
+++ b/reports/feature_navigation_gaps/24_unreal_integration_no_tile.md
@@ -1,0 +1,27 @@
+---
+title: Unreal Integration (streaming/VR) has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The Unreal integration module (`src/unreal_integration/`) provides:
+
+- Streaming server for real-time simulation streaming
+- Unreal Engine bridge
+- Meshcat and PyVista viewer backends
+- VR interaction support
+- Simulation streamer
+
+This is an advanced visualization capability, but it has no manifest entry and no way for users to discover it.
+
+## Classification
+
+**Borderline**: Unreal integration is an advanced/power-user feature. Most users don't need it, but those who do would actively look for it. Could be a sub-feature of simulation tiles (`Launch in Unreal`) rather than a standalone tile.
+
+## Acceptance Criteria
+
+- [ ] Add `unreal_streaming` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Consider adding an `Advanced Visualization` section in settings or engine dashboards
+- [ ] Document the streaming setup in user-facing docs
+- [ ] Standalone tile may not be needed; sub-feature access is sufficient

--- a/reports/feature_navigation_gaps/25_robotics_module_no_presence.md
+++ b/reports/feature_navigation_gaps/25_robotics_module_no_presence.md
@@ -1,0 +1,29 @@
+---
+title: Robotics module has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The robotics module (`src/robotics/`) provides:
+
+- Motion planning: RRT, RRT\* planners
+- Control: impedance, admittance, hybrid force-position
+- Sensing: sensor models
+- Whole-body control
+- Locomotion: footstep planning
+- Collision detection
+
+These capabilities are referenced in SPEC.md (control schemes F12, constraint analysis) but have no UI entry point.
+
+## Classification
+
+**Internal library**: The robotics module is consumed by the physics engines (Drake, MuJoCo) for control and planning. Users access these features through simulation configuration, not through a standalone tool.
+
+However, the control scheme selection (impedance vs. admittance vs. operational space) is something users might want to configure per-simulation.
+
+## Acceptance Criteria
+
+- [ ] Add `control_schemes` to MuJoCo and Drake tile `capabilities` arrays
+- [ ] Expose control scheme selection in the Simulation page
+- [ ] No standalone tile needed; these are configuration options

--- a/reports/feature_navigation_gaps/26_upstream_drift_tools_breadth_hidden.md
+++ b/reports/feature_navigation_gaps/26_upstream_drift_tools_breadth_hidden.md
@@ -1,0 +1,29 @@
+---
+title: UpstreamDrift Tools calculator suite breadth is hidden
+labels: feature, priority/P3
+---
+
+## Problem
+
+The UpstreamDrift Tools (`src/shared/python/upstream_drift_tools/`) contains a comprehensive process-engineering calculator suite:
+
+- **Process calculators**: pressure drop, syngas compression, scrubber, PSA, acid gas dewpoint, flare, baghouse, WGS reactor, electrode advancement
+- **Thermo**: steam tables, properties, vapor pressure
+- **Mechanical**: pipe database, fittings, friction factors
+- **Electrical**: electrical model
+- **Data processing**: operations, widget
+- **Unit conversion**: widget and preferences manager
+- **Lab UI**: full workspace with file navigation, command history, tab system, reporting
+
+Only the `Data Processor` tile surfaces this suite. The calculator breadth is invisible.
+
+## Classification
+
+**Borderline**: The calculators are domain-specific (process engineering) and may not match the core biomechanics audience. However, they are fully functional tools.
+
+## Acceptance Criteria
+
+- [ ] Expand the `Data Processor` tile description to mention calculators
+- [ ] Consider adding an `upstream_drift_tools` category or expanding the `tool` category description
+- [ ] Add `process_calculators` to the Data Processor tile `capabilities` array
+- [ ] Low priority: could add individual calculator tiles if demand exists

--- a/reports/feature_navigation_gaps/27_programmatic_pid_hidden.md
+++ b/reports/feature_navigation_gaps/27_programmatic_pid_hidden.md
@@ -1,0 +1,24 @@
+---
+title: Programmatic P&ID Generator has no launcher presence
+labels: feature, priority/P3
+---
+
+## Problem
+
+The programmatic PID module (`src/shared/python/programmatic_pid/`) generates Piping & Instrumentation Diagrams with:
+
+- Controls, equipment, instruments, layout, rendering
+- Streams, title blocks, validation
+- CLI entry point (`cli.py`)
+
+This is a niche but complete tool with no way for users to discover it.
+
+## Classification
+
+**Borderline / Niche**: P&ID generation is tangential to biomechanics simulation. It may not warrant a standalone tile in a golf physics launcher, but could be useful for facility/process engineers.
+
+## Acceptance Criteria
+
+- [ ] Consider adding a `pid_generator` tile if there's user demand
+- [ ] Alternative: document as an advanced tool accessible via CLI
+- [ ] If added, assign to `developer_tools` category

--- a/reports/feature_navigation_gaps/28_dashboard_recorder_hidden.md
+++ b/reports/feature_navigation_gaps/28_dashboard_recorder_hidden.md
@@ -1,0 +1,25 @@
+---
+title: Dashboard Recorder / Advanced Analysis is internal-only
+labels: documentation, priority/P3
+---
+
+## Problem
+
+The dashboard module (`src/shared/python/dashboard/`) provides:
+
+- Recorder: playback, recording, analysis buffers
+- Advanced analysis window
+- Runner for launching analyses
+- Dashboard-specific widgets
+
+This is only accessible within the engine-specific dashboards (MuJoCo, Drake, Pinocchio), which themselves are not exposed from the launcher (see issue #07).
+
+## Classification
+
+**Internal library**: The recorder is a sub-feature of the engine dashboards. It should become accessible once the dashboards are exposed.
+
+## Acceptance Criteria
+
+- [ ] Expose engine dashboards (see issue #07)
+- [ ] Document the recorder as a dashboard capability
+- [ ] No separate tile needed

--- a/reports/feature_navigation_gaps/29_internal_libraries_no_tile_needed.md
+++ b/reports/feature_navigation_gaps/29_internal_libraries_no_tile_needed.md
@@ -1,0 +1,33 @@
+---
+title: Internal libraries that correctly have no tile (classification audit)
+labels: documentation, priority/none
+---
+
+## Summary
+
+The following modules are internal libraries consumed by other features. They correctly have no launcher tile and should remain internal:
+
+| Module               | Path                                   | Consumed By                                   |
+| -------------------- | -------------------------------------- | --------------------------------------------- |
+| Biomechanics library | `src/shared/python/biomechanics/`      | MuJoCo, OpenSim, MyoSuite, Exercise Dashboard |
+| Screw theory         | `src/shared/python/screw_theory/`      | Physics engines                               |
+| Spatial algebra      | `src/shared/python/spatial_algebra/`   | Physics engines                               |
+| Data I/O             | `src/shared/python/data_io/`           | Data Explorer, export                         |
+| Plot engine          | `src/shared/python/plot_engine/`       | Dashboards, analysis                          |
+| Reporting            | `src/shared/python/reporting/`         | Analysis/export flows                         |
+| Realtime transport   | `src/shared/python/realtime/`          | Simulation WS, realtime API                   |
+| Scripting env        | `src/shared/python/scripting/`         | Internal                                      |
+| Pose editor widgets  | `src/shared/python/pose_editor/`       | Pose Studio                                   |
+| Chat framework       | `src/shared/python/chat/`              | AI Sidekick                                   |
+| Rust physics kernels | `rust_core/`                           | Physics engines                               |
+| Robotics control     | `src/robotics/`                        | Drake, MuJoCo                                 |
+| Freemocap ingest     | `src/motion_capture/freemocap_ingest/` | Motion Capture                                |
+| Deployment modules   | `src/deployment/`                      | Production deployment                         |
+
+These modules should be documented in capabilities arrays of the tiles that consume them, not given their own tiles.
+
+## Acceptance Criteria
+
+- [ ] Add capability tags to consuming tiles (e.g., `screw_theory` on MuJoCo tile)
+- [ ] Update PROJECT_MAP.md to reflect these as internal modules
+- [ ] No tiles needed

--- a/reports/feature_navigation_gaps/30_putting_green_category_mismatch.md
+++ b/reports/feature_navigation_gaps/30_putting_green_category_mismatch.md
@@ -1,0 +1,34 @@
+---
+title: Putting Green miscategorized as physics_engine (should be simulation)
+labels: bug, ui, priority/P2
+---
+
+## Problem
+
+The Putting Green tile has `category: physics_engine` but it's actually a specialized simulation tool (putting green physics). The `simulation` sidebar category currently shows zero tiles. Moving Putting Green to the `simulation` category would populate it and more accurately reflect its nature.
+
+## Current
+
+```json
+{
+  ""id"": ""putting_green"",
+  ""category"": ""physics_engine"",
+  ...
+}
+```
+
+## Suggested
+
+```json
+{
+  ""id"": ""putting_green"",
+  ""category"": ""simulation"",
+  ...
+}
+```
+
+## Acceptance Criteria
+
+- [ ] Change Putting Green category from `physics_engine` to `simulation`
+- [ ] Verify the Simulation sidebar button now shows at least one tile
+- [ ] Update the Putting Green description to clarify it's a simulation tool

--- a/reports/feature_navigation_gaps/31_simulation_category_needs_tiles.md
+++ b/reports/feature_navigation_gaps/31_simulation_category_needs_tiles.md
@@ -1,0 +1,23 @@
+---
+title: Simulation sidebar category needs tiles (Putting Green + others)
+labels: bug, ui, priority/P2
+---
+
+## Problem
+
+This is a companion to issues #01, #02, #06, and #30. The `simulation` sidebar category currently has zero tiles because:
+
+1. Putting Green is categorized as `physics_engine` instead of `simulation`
+2. Cross-Engine Dashboard has no tile at all
+3. Golf Simulation Suite has no tile
+4. Shot Tracer has no tile
+
+Even after fixing #30 (re-categorizing Putting Green), the category would have only one tile. It needs more.
+
+## Acceptance Criteria
+
+- [ ] Move Putting Green to `simulation` category
+- [ ] Add Cross-Engine Dashboard tile to `simulation`
+- [ ] Add Golf Simulation Suite tile to `simulation`
+- [ ] Add Shot Tracer tile to `simulation`
+- [ ] Verify Simulation sidebar shows all tiles


### PR DESCRIPTION
Adds the comprehensive feature navigation gap analysis report in reports/feature_navigation_gaps/.

This report documents 31 issues covering:
- P0: Empty sidebar categories, missing Cross-Engine Dashboard, missing Exercise Dashboard
- P1: Missing tiles for Shot Tracer, Pose Studio, Golf Simulation Suite, Swing Optimizer, Injury Analysis, Terrain, Dataset Generator, Motion Matching, Analysis Tools
- P2: Chat/AI Sidekick, Motion Pipeline, Perturbation, Character Builder, Pendulum, Putting Green category fix
- P3: BunkerShot3D, Unreal Integration, Robotics, UpstreamDrift Tools, Programmatic P&ID, Dashboard Recorder

The full index is in reports/feature_navigation_gaps/00_INDEX.md.

GitHub issues #5509-#5539 track these gaps.