### PR TITLE
chore/fix: repo hygiene patterns + chat context re-injection watermark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,12 @@ test.npz
 htmlcov/
 
 # Test output debris (prevent accumulation at root)
+crash_traceback.txt
+output_debug.log
+pytest_output.txt
+test_out.txt
+gh_run_*_failed.log
+*_failed.log
 test_*.txt
 *_output.txt
 *_results.txt

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import os
 from typing import Any
 
@@ -22,18 +23,43 @@ router = APIRouter()
 
 _CONTEXT_ENV_VAR = "UPSTREAMDRIFT_SIDEKICK_CONTEXT"
 
+# Metadata key used to record the SHA-256 of the last injected context so
+# identical state is not re-injected on every "send" action.
+_CONTEXT_HASH_KEY = "_context_injected_hash"
+
 
 def _context_injection_enabled() -> bool:
     """Return ``True`` when env-var-gated Sidekick context injection is on."""
     return os.environ.get(_CONTEXT_ENV_VAR, "1") != "0"
 
 
+def _context_section_hash(section: str) -> str:
+    """Return a truncated SHA-256 hex digest of *section*.
+
+    Args:
+        section: The formatted context string to hash. Must be a str.
+
+    Returns:
+        First 16 hex characters of the SHA-256 digest.
+    """
+    if not isinstance(section, str):
+        raise TypeError("section must be a str")
+    return hashlib.sha256(section.encode()).hexdigest()[:16]
+
+
 def _maybe_inject_chat_context(session: Any) -> str | None:
     """Inject a ``Recent app state`` system message into ``session``.
 
     The injection is gated on:
-      * the ``UPSTREAMDRIFT_SIDEKICK_CONTEXT`` env var (default on), and
-      * a non-empty :func:`get_chat_context` payload.
+      * the ``UPSTREAMDRIFT_SIDEKICK_CONTEXT`` env var (default on),
+      * a non-empty :func:`get_chat_context` payload, and
+      * the context content having changed since the last injection
+        (watermark check via a SHA-256 hash stored in
+        ``session.metadata[_CONTEXT_HASH_KEY]``).
+
+    Re-injection is skipped when the context hash matches the stored
+    watermark, preventing near-duplicate system messages from
+    accumulating in the conversation history on every "send" action.
 
     Args:
         session: The chat-service session/context object. Must expose an
@@ -58,6 +84,16 @@ def _maybe_inject_chat_context(session: Any) -> str | None:
     if not section:
         return None
 
+    # Watermark check: skip injection when the context has not changed.
+    new_hash = _context_section_hash(section)
+    metadata: dict[str, Any] | None = getattr(session, "metadata", None)
+    if isinstance(metadata, dict) and metadata.get(_CONTEXT_HASH_KEY) == new_hash:
+        logger.debug(
+            "Sidekick context unchanged (hash=%s); skipping re-injection",
+            new_hash,
+        )
+        return None
+
     add_message = getattr(session, "add_message", None)
     if not callable(add_message):
         logger.debug(
@@ -70,6 +106,10 @@ def _maybe_inject_chat_context(session: Any) -> str | None:
     except (TypeError, ValueError) as exc:
         logger.warning("Failed to inject Sidekick chat context: %s", exc)
         return None
+
+    # Store the watermark after a successful injection.
+    if isinstance(metadata, dict):
+        metadata[_CONTEXT_HASH_KEY] = new_hash
 
     return section
 

--- a/tests/unit/test_chat_context_injection.py
+++ b/tests/unit/test_chat_context_injection.py
@@ -1,0 +1,198 @@
+"""Tests for the context-injection watermark in chat_ws.
+
+Verifies that ``_maybe_inject_chat_context`` only re-injects app-state
+context into the conversation when the payload has changed, preventing
+near-duplicate system messages from accumulating on every "send" action.
+
+Coverage:
+    * Identical context is not injected twice.
+    * Changed context is re-injected after the state changes.
+    * A session without a ``metadata`` dict still gets injected (graceful
+      degradation — watermark is skipped, not errored).
+    * Hash helper rejects non-string input.
+    * history action: the existing ``test_chat_ws_context.py`` suite
+      already tests the injection path; this file focuses specifically
+      on deduplication semantics.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from src.shared.python.ai import chat_context
+
+
+# ── Module loader ────────────────────────────────────────────────────
+
+
+def _load_chat_ws() -> ModuleType:
+    """Load ``src/api/routes/chat_ws.py`` without running the package init.
+
+    The ``src.api.routes`` package ``__init__`` transitively imports a
+    module with a pre-existing bug (see test_chat_ws_context.py for
+    explanation); loading via ``spec_from_file_location`` sidesteps it.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    source = repo_root / "src" / "api" / "routes" / "chat_ws.py"
+    spec = importlib.util.spec_from_file_location("_chat_ws_dedup_under_test", source)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load chat_ws spec from {source}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_chat_ws = _load_chat_ws()
+
+
+# ── Session doubles ──────────────────────────────────────────────────
+
+
+class _SessionWithMetadata:
+    """Minimal session double that records injected messages and exposes metadata."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+        self.metadata: dict[str, Any] = {}
+
+    def add_message(self, role: str, content: str) -> None:
+        self.messages.append((role, content))
+
+
+class _SessionWithoutMetadata:
+    """Session double that has ``add_message`` but no ``metadata`` dict."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def add_message(self, role: str, content: str) -> None:
+        self.messages.append((role, content))
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffer_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset ring buffer and default env before every test."""
+    chat_context.reset_buffer()
+    monkeypatch.delenv("UPSTREAMDRIFT_SIDEKICK_CONTEXT", raising=False)
+
+
+# ── Deduplication tests ───────────────────────────────────────────────
+
+
+def test_same_context_injected_only_once() -> None:
+    """Calling ``_maybe_inject_chat_context`` twice with identical state injects once."""
+    chat_context.record_event("engine", {"status": "ok", "name": "mujoco"})
+    session = _SessionWithMetadata()
+
+    first = _chat_ws._maybe_inject_chat_context(session)
+    second = _chat_ws._maybe_inject_chat_context(session)
+
+    assert first is not None, "first injection should return the section string"
+    assert second is None, "second injection with same context should be skipped"
+    assert len(session.messages) == 1, "only one system message should be added"
+
+
+def test_changed_context_triggers_reinjection() -> None:
+    """After the app state changes, context is re-injected on the next call."""
+    chat_context.record_event("engine", {"status": "ok"})
+    session = _SessionWithMetadata()
+
+    first = _chat_ws._maybe_inject_chat_context(session)
+    assert first is not None
+
+    # Simulate new app state arriving in the buffer.
+    chat_context.record_event("engine", {"status": "error", "code": 42})
+
+    second = _chat_ws._maybe_inject_chat_context(session)
+
+    assert second is not None, "changed context should be re-injected"
+    assert first != second, "the two injections should carry different payloads"
+    assert len(session.messages) == 2
+
+
+def test_hash_stored_in_metadata_after_injection() -> None:
+    """After injection the watermark hash is persisted in ``session.metadata``."""
+    chat_context.record_event("diag", {"val": 1})
+    session = _SessionWithMetadata()
+
+    _chat_ws._maybe_inject_chat_context(session)
+
+    key = _chat_ws._CONTEXT_HASH_KEY
+    assert key in session.metadata
+    stored_hash = session.metadata[key]
+    assert isinstance(stored_hash, str)
+    assert len(stored_hash) == 16  # truncated hex digest
+
+
+def test_three_identical_sends_inject_exactly_once() -> None:
+    """Simulate three consecutive sends without state change — one injection."""
+    chat_context.record_event("swing", {"phase": "backswing"})
+    session = _SessionWithMetadata()
+
+    results = [_chat_ws._maybe_inject_chat_context(session) for _ in range(3)]
+
+    injected = [r for r in results if r is not None]
+    assert len(injected) == 1
+    assert len(session.messages) == 1
+
+
+def test_session_without_metadata_still_receives_injection() -> None:
+    """Sessions without ``metadata`` get the injection; watermark is gracefully skipped."""
+    chat_context.record_event("engine", {"name": "pinocchio"})
+    session = _SessionWithoutMetadata()
+
+    first = _chat_ws._maybe_inject_chat_context(session)
+    # No metadata dict, so no watermark is stored; injection fires again.
+    second = _chat_ws._maybe_inject_chat_context(session)
+
+    assert first is not None
+    assert second is not None
+    assert len(session.messages) == 2
+
+
+# ── Hash helper tests ─────────────────────────────────────────────────
+
+
+def test_context_section_hash_stable() -> None:
+    """Same input always produces the same truncated digest."""
+    h1 = _chat_ws._context_section_hash("hello world")
+    h2 = _chat_ws._context_section_hash("hello world")
+    assert h1 == h2
+
+
+def test_context_section_hash_differs_for_different_inputs() -> None:
+    """Different inputs produce different digests."""
+    h1 = _chat_ws._context_section_hash("aaa")
+    h2 = _chat_ws._context_section_hash("bbb")
+    assert h1 != h2
+
+
+def test_context_section_hash_rejects_non_str() -> None:
+    """Non-string input raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        _chat_ws._context_section_hash(42)  # type: ignore[arg-type]
+
+
+# ── Env-var gate still respected ─────────────────────────────────────
+
+
+def test_env_var_off_skips_even_fresh_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``UPSTREAMDRIFT_SIDEKICK_CONTEXT=0`` prevents any injection."""
+    monkeypatch.setenv("UPSTREAMDRIFT_SIDEKICK_CONTEXT", "0")
+    chat_context.record_event("diag", {"k": "v"})
+    session = _SessionWithMetadata()
+
+    result = _chat_ws._maybe_inject_chat_context(session)
+
+    assert result is None
+    assert session.messages == []


### PR DESCRIPTION
## Summary

- **#5494 Repo hygiene**: Added explicit `.gitignore` patterns for build/test artifact filenames (`crash_traceback.txt`, `output_debug.log`, `pytest_output.txt`, `test_out.txt`, `*_failed.log`) that were previously missing. The named artifact files are not currently tracked in git (earlier cleanup commits removed them), but these patterns prevent re-accumulation.
- **#5492 Chat context re-injection**: Added a SHA-256 watermark (`_context_injected_hash`) stored in `session.metadata` to deduplicate app-state context injection. `_maybe_inject_chat_context` now skips re-injection when the context payload hash matches the stored watermark, preventing near-duplicate system messages from accumulating in conversation history on every "send" action. A new `_context_section_hash` helper is added alongside 9 unit tests.

## Files changed

- `.gitignore` — 6 new artifact patterns
- `src/api/routes/chat_ws.py` — watermark logic + `_context_section_hash` helper
- `tests/unit/test_chat_context_injection.py` — 9 new unit tests (dedup, hash stability, graceful degradation, env-var gate)

## Test plan

- [x] `python -m pytest tests/unit/test_chat_context_injection.py -v` — 9 passed
- [x] `python -m pytest tests/unit/api/test_chat_ws_context.py -v` — 13 passed (no regression)
- [x] `python -m ruff check src/api/routes/chat_ws.py tests/unit/test_chat_context_injection.py` — clean
- [x] `python -m ruff format --check ...` — no diffs

Fixes #5494
Fixes #5492

Generated with [Claude Code](https://claude.com/claude-code)