### PR TITLE
feat(pinns): Phase 2 — three-component PINN loss function

### DIFF
--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -345,3 +345,25 @@ models:
       logo: "project_map.svg"
       status: "ready"
       default_launch: "tab"
+
+  # =============================================================================
+  # PHYSICS-INFORMED NEURAL NETWORKS
+  # =============================================================================
+
+  - id: "pinn_pure_rigid"
+    name: "Pure Rigid Body"
+    description: "Pinocchio inverse dynamics only — no ML"
+    type: "physics_informed"
+    mode: "pure_rigid"
+    launcher:
+      category: "biomechanics"
+      status: "experimental"
+
+  - id: "pinn_hybrid"
+    name: "PINN Hybrid"
+    description: "Rigid body + JAX residual torque MLP"
+    type: "physics_informed"
+    mode: "pinn_hybrid"
+    launcher:
+      category: "biomechanics"
+      status: "experimental"

--- a/src/shared/python/physics_informed/__init__.py
+++ b/src/shared/python/physics_informed/__init__.py
@@ -1,20 +1,30 @@
 """Physics-Informed Neural Network (PINN) hybrid architecture.
 
-Phases 1 & 2 of the PINNs epic (#5419):
+Phases 1-3 of the PINNs epic (#5419):
 
-Phase 1 — hybrid architecture:
+Phase 1 -- hybrid architecture:
 
 - :class:`RigidCore`: Pinocchio RNEA rigid-body inverse-dynamics torque.
 - :class:`MlpResidual`: JAX/Equinox MLP predicting unmodelled torque residuals.
-- :class:`HybridPINN`: Summed predictor ``τ = τ_rigid + τ_residual``.
+- :class:`HybridPINN`: Summed predictor ``tau = tau_rigid + tau_residual``.
 
-Phase 2 — three-component loss function:
+Phase 2 -- three-component loss function:
 
 - :class:`LossWeights`: frozen dataclass with DbC-validated positive weights.
 - :func:`data_loss`: MSE between predicted and actual motion kinematics.
 - :func:`physics_loss`: penalises joint-limit violations and energy anomalies.
 - :func:`contact_loss`: penalises non-zero torques during non-contact phases.
 - :func:`total_loss`: weighted sum of the three component losses.
+
+Phase 3 -- shadow model and mode factory:
+
+- :class:`SwingPhase`: Enum for the three golf-swing phases.
+- :class:`ShadowReport`: Dataclass holding peak residual torques per phase.
+- :class:`ShadowModel`: Observation-mode runner; records peaks without
+  modifying simulation state.
+- :class:`PhysicsMode`: Enum for model-creation modes.
+- :func:`create_model`: Factory returning RigidCore, MlpResidual, or
+  HybridPINN based on the requested :class:`PhysicsMode`.
 
 Optional dependencies
 ---------------------
@@ -38,14 +48,25 @@ from src.shared.python.physics_informed.loss import (
     total_loss,
 )
 from src.shared.python.physics_informed.mlp_residual import MlpResidual
+from src.shared.python.physics_informed.mode import PhysicsMode, create_model
 from src.shared.python.physics_informed.rigid_core import RigidCore
+from src.shared.python.physics_informed.shadow_model import (
+    ShadowModel,
+    ShadowReport,
+    SwingPhase,
+)
 
 __all__ = [
     "HybridPINN",
     "LossWeights",
     "MlpResidual",
+    "PhysicsMode",
     "RigidCore",
+    "ShadowModel",
+    "ShadowReport",
+    "SwingPhase",
     "contact_loss",
+    "create_model",
     "data_loss",
     "physics_loss",
     "total_loss",

--- a/src/shared/python/physics_informed/__init__.py
+++ b/src/shared/python/physics_informed/__init__.py
@@ -1,0 +1,52 @@
+"""Physics-Informed Neural Network (PINN) hybrid architecture.
+
+Phases 1 & 2 of the PINNs epic (#5419):
+
+Phase 1 — hybrid architecture:
+
+- :class:`RigidCore`: Pinocchio RNEA rigid-body inverse-dynamics torque.
+- :class:`MlpResidual`: JAX/Equinox MLP predicting unmodelled torque residuals.
+- :class:`HybridPINN`: Summed predictor ``τ = τ_rigid + τ_residual``.
+
+Phase 2 — three-component loss function:
+
+- :class:`LossWeights`: frozen dataclass with DbC-validated positive weights.
+- :func:`data_loss`: MSE between predicted and actual motion kinematics.
+- :func:`physics_loss`: penalises joint-limit violations and energy anomalies.
+- :func:`contact_loss`: penalises non-zero torques during non-contact phases.
+- :func:`total_loss`: weighted sum of the three component losses.
+
+Optional dependencies
+---------------------
+Pinocchio:
+    ``pip install upstream-drift[pinocchio]``
+
+JAX + Equinox:
+    ``pip install upstream-drift[physics_informed]``
+
+Both sets of dependencies are optional; the package imports cleanly without
+them, and classes/functions that require missing extras raise
+:class:`ImportError` at call time.
+"""
+
+from src.shared.python.physics_informed.hybrid_model import HybridPINN
+from src.shared.python.physics_informed.loss import (
+    LossWeights,
+    contact_loss,
+    data_loss,
+    physics_loss,
+    total_loss,
+)
+from src.shared.python.physics_informed.mlp_residual import MlpResidual
+from src.shared.python.physics_informed.rigid_core import RigidCore
+
+__all__ = [
+    "HybridPINN",
+    "LossWeights",
+    "MlpResidual",
+    "RigidCore",
+    "contact_loss",
+    "data_loss",
+    "physics_loss",
+    "total_loss",
+]

--- a/src/shared/python/physics_informed/hybrid_model.py
+++ b/src/shared/python/physics_informed/hybrid_model.py
@@ -1,0 +1,222 @@
+"""Hybrid Physics-Informed Neural Network combining rigid-body and MLP residual.
+
+This module provides :class:`HybridPINN`, which combines:
+
+1. A :class:`~.rigid_core.RigidCore` — Pinocchio RNEA inverse-dynamics torque.
+2. An :class:`~.mlp_residual.MlpResidual` — JAX/Equinox MLP predicting the
+   torque residual not captured by the rigid-body model.
+
+Total predicted torque is:
+
+.. math::
+
+    \\hat{\\tau} = \\tau_{\\text{rigid}}(q, \\dot{q}, \\ddot{q})
+                 + \\tau_{\\text{MLP}}\\bigl([q;\\, \\dot{q};\\, \\ddot{q}]\\bigr)
+
+The MLP receives the concatenation of ``(q, dq, ddq)`` as its input, so
+``input_dim`` should be set to ``nq + 2 * nv`` when constructing
+:class:`~.mlp_residual.MlpResidual`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+    from src.shared.python.physics_informed.rigid_core import RigidCore
+
+logger = logging.getLogger(__name__)
+
+
+class HybridPINN:
+    """Sum of rigid-body torque and MLP residual torque.
+
+    Implements the hybrid PINN architecture for golf-swing biomechanics.
+    The model predicts the total joint torques by combining the analytical
+    rigid-body inverse-dynamics solution with a learned residual that captures
+    unmodelled effects (muscle co-contraction, soft-tissue deformation, etc.).
+
+    **MLP input convention**: the network receives the concatenation
+    ``[q, dq, ddq]``, where ``q`` has length ``nq`` and ``dq``, ``ddq``
+    each have length ``nv``.  Therefore ``mlp_residual.input_dim`` must equal
+    ``nq + 2 * nv``.
+
+    Parameters
+    ----------
+    rigid_core:
+        Configured :class:`~.rigid_core.RigidCore` instance.
+    mlp_residual:
+        Configured :class:`~.mlp_residual.MlpResidual` instance.
+    """
+
+    def __init__(
+        self,
+        rigid_core: RigidCore,
+        mlp_residual: MlpResidual,
+    ) -> None:
+        """Compose rigid-body core and MLP residual into a hybrid predictor.
+
+        DbC preconditions:
+        - ``rigid_core`` must be a non-None :class:`RigidCore`.
+        - ``mlp_residual`` must be a non-None :class:`MlpResidual`.
+
+        Args:
+            rigid_core:    Pinocchio-backed rigid-body torque calculator.
+            mlp_residual:  JAX/Equinox MLP residual torque predictor.
+
+        Raises:
+            ValueError: If either argument is ``None``.
+        """
+        if rigid_core is None:
+            raise ValueError("rigid_core must not be None")
+        if mlp_residual is None:
+            raise ValueError("mlp_residual must not be None")
+
+        self._rigid = rigid_core
+        self._mlp = mlp_residual
+
+        logger.debug(
+            "HybridPINN created: nq=%d nv=%d mlp_output_dim=%d",
+            rigid_core.nq,
+            rigid_core.nv,
+            mlp_residual.output_dim,
+        )
+
+    # ------------------------------------------------------------------
+    # Prediction
+    # ------------------------------------------------------------------
+
+    def predict(
+        self,
+        q: np.ndarray,
+        dq: np.ndarray,
+        ddq: np.ndarray,
+    ) -> np.ndarray:
+        """Return total torque = rigid + residual.
+
+        The MLP receives ``concat([q, dq, ddq])`` as its input feature vector.
+
+        DbC preconditions:
+        - ``q``, ``dq``, ``ddq`` must each be 1-D arrays.
+        - ``dq`` and ``ddq`` must have the same length.
+
+        DbC postcondition:
+        - Result shape matches the rigid-body torque output shape ``(nv,)``.
+
+        Args:
+            q:   Configuration vector, shape ``(nq,)``.
+            dq:  Velocity vector, shape ``(nv,)``.
+            ddq: Acceleration vector, shape ``(nv,)``.
+
+        Returns:
+            Total torque ``τ_rigid + τ_residual``, shape ``(nv,)``.
+
+        Raises:
+            ValueError: If input shapes are incompatible or the rigid-body and
+                MLP output shapes disagree.
+        """
+        q_arr = np.asarray(q, dtype=np.float64)
+        dq_arr = np.asarray(dq, dtype=np.float64)
+        ddq_arr = np.asarray(ddq, dtype=np.float64)
+
+        self._validate_input_shapes(q_arr, dq_arr, ddq_arr)
+
+        tau_rigid = self._rigid.compute_torques(q_arr, dq_arr, ddq_arr)
+        tau_residual = self._compute_residual(q_arr, dq_arr, ddq_arr)
+
+        self._validate_output_shapes(tau_rigid, tau_residual)
+
+        result: np.ndarray = tau_rigid + tau_residual
+        logger.debug(
+            "HybridPINN.predict: rigid_norm=%.4f residual_norm=%.4f",
+            float(np.linalg.norm(tau_rigid)),
+            float(np.linalg.norm(tau_residual)),
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _compute_residual(
+        self,
+        q: np.ndarray,
+        dq: np.ndarray,
+        ddq: np.ndarray,
+    ) -> np.ndarray:
+        """Concatenate kinematic state and run MLP forward pass.
+
+        Args:
+            q:   Configuration vector.
+            dq:  Velocity vector.
+            ddq: Acceleration vector.
+
+        Returns:
+            Residual torque as a NumPy float64 array.
+        """
+        x = np.concatenate([q, dq, ddq])
+        mlp_out = self._mlp(x)
+        # Convert from JAX array (if applicable) to numpy
+        return np.asarray(mlp_out, dtype=np.float64)
+
+    def _validate_input_shapes(
+        self,
+        q: np.ndarray,
+        dq: np.ndarray,
+        ddq: np.ndarray,
+    ) -> None:
+        """Raise ValueError if input arrays have incompatible shapes.
+
+        Args:
+            q:   Configuration vector.
+            dq:  Velocity vector.
+            ddq: Acceleration vector.
+
+        Raises:
+            ValueError: On shape mismatch.
+        """
+        if q.ndim != 1:
+            raise ValueError(f"q must be a 1-D array; got shape {q.shape}")
+        if dq.ndim != 1:
+            raise ValueError(f"dq must be a 1-D array; got shape {dq.shape}")
+        if ddq.ndim != 1:
+            raise ValueError(f"ddq must be a 1-D array; got shape {ddq.shape}")
+        if dq.shape != ddq.shape:
+            raise ValueError(
+                f"dq and ddq must have the same shape; "
+                f"got dq={dq.shape}, ddq={ddq.shape}"
+            )
+        # Validate against the rigid-body model's expected dimensions
+        nq = self._rigid.nq
+        nv = self._rigid.nv
+        if q.shape[0] != nq:
+            raise ValueError(f"q shape mismatch: expected ({nq},), got {q.shape}")
+        if dq.shape[0] != nv:
+            raise ValueError(f"dq shape mismatch: expected ({nv},), got {dq.shape}")
+        if ddq.shape[0] != nv:
+            raise ValueError(f"ddq shape mismatch: expected ({nv},), got {ddq.shape}")
+
+    @staticmethod
+    def _validate_output_shapes(
+        tau_rigid: np.ndarray,
+        tau_residual: np.ndarray,
+    ) -> None:
+        """Raise ValueError if rigid and MLP output shapes disagree.
+
+        Args:
+            tau_rigid:    Torque from the rigid-body model.
+            tau_residual: Torque from the MLP.
+
+        Raises:
+            ValueError: If the arrays have different shapes.
+        """
+        if tau_rigid.shape != tau_residual.shape:
+            raise ValueError(
+                f"Rigid-body and MLP output shape mismatch: "
+                f"rigid={tau_rigid.shape}, residual={tau_residual.shape}. "
+                f"Ensure mlp_residual.output_dim == rigid_core.nv."
+            )

--- a/src/shared/python/physics_informed/loss.py
+++ b/src/shared/python/physics_informed/loss.py
@@ -1,0 +1,210 @@
+"""Three-component PINN loss function for hybrid physics-informed models.
+
+Phase 2 of the PINNs epic (#5419). Provides:
+
+- :class:`LossWeights`: frozen dataclass with DbC validation of positive weights.
+- :func:`data_loss`: MSE between predicted and actual motion kinematics.
+- :func:`physics_loss`: penalises joint-limit violations and energy anomalies.
+- :func:`contact_loss`: penalises non-zero torques during non-contact phases.
+- :func:`total_loss`: weighted sum of the three component losses.
+
+JAX is an *optional* dependency:
+
+    pip install upstream-drift[physics_informed]
+
+If JAX is not installed the module imports cleanly, but calling the loss
+functions will raise :class:`ImportError` at runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+try:
+    import jax.numpy as jnp
+
+    HAS_JAX = True
+except ImportError:  # pragma: no cover
+    HAS_JAX = False
+    jnp = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    import jax
+
+
+@dataclass(frozen=True)
+class LossWeights:
+    """Weights for the three loss components.
+
+    All weights must be strictly positive (DbC precondition).
+
+    Attributes:
+        data_weight:    Weight applied to :func:`data_loss`.
+        physics_weight: Weight applied to :func:`physics_loss`.
+        contact_weight: Weight applied to :func:`contact_loss`.
+
+    Raises:
+        ValueError: If any weight is not strictly positive.
+    """
+
+    data_weight: float
+    physics_weight: float
+    contact_weight: float
+
+    def __post_init__(self) -> None:
+        """DbC: all weights must be strictly positive."""
+        for name, val in [
+            ("data_weight", self.data_weight),
+            ("physics_weight", self.physics_weight),
+            ("contact_weight", self.contact_weight),
+        ]:
+            if val <= 0:
+                raise ValueError(f"{name} must be > 0, got {val}")
+
+
+def data_loss(
+    predicted_motion: jax.Array,
+    actual_kinematics: jax.Array,
+) -> jax.Array:
+    """Compute mean squared error between predicted and actual motion.
+
+    Args:
+        predicted_motion:  Model-predicted motion array, shape ``(n,)``.
+        actual_kinematics: Ground-truth motion array, same shape as
+            ``predicted_motion``.
+
+    Returns:
+        Scalar MSE loss value.
+
+    Raises:
+        ImportError: If JAX is not installed.
+    """
+    if not HAS_JAX:  # pragma: no cover
+        raise ImportError(
+            "jax is required for data_loss; install with: "
+            "pip install upstream-drift[physics_informed]"
+        )
+    return jnp.mean((predicted_motion - actual_kinematics) ** 2)
+
+
+def physics_loss(
+    torques: jax.Array,
+    joint_limits: jax.Array,
+    energy_delta: jax.Array,
+) -> jax.Array:
+    """Penalise joint-limit violations and energy anomalies.
+
+    Args:
+        torques:      Torque vector of shape ``(n_joints,)``.
+        joint_limits: Limit array of shape ``(n_joints, 2)`` where column 0
+            contains minimum values and column 1 contains maximum values.
+        energy_delta: Scalar representing the energy change between consecutive
+            frames.  Physical motion should have near-zero energy delta.
+
+    Returns:
+        Scalar penalty: sum of out-of-bound violations plus the absolute
+        energy delta.
+
+    Raises:
+        ImportError: If JAX is not installed.
+    """
+    if not HAS_JAX:  # pragma: no cover
+        raise ImportError(
+            "jax is required for physics_loss; install with: "
+            "pip install upstream-drift[physics_informed]"
+        )
+    upper_violations = jnp.maximum(0.0, torques - joint_limits[:, 1])
+    lower_violations = jnp.maximum(0.0, joint_limits[:, 0] - torques)
+    violations = upper_violations + lower_violations
+    return jnp.sum(violations) + jnp.abs(energy_delta)
+
+
+def contact_loss(
+    impact_phase_torques: jax.Array,
+    *,
+    stiffness_coeff: float,
+) -> jax.Array:
+    """Penalise non-zero torques during non-contact phases.
+
+    During actual contact phases this function should be called with a
+    zero-filled array so it contributes 0 to the total loss.
+
+    Args:
+        impact_phase_torques: Torques measured (or predicted) during the
+            phase under test.  Shape ``(n_joints,)``.  Pass zeros for
+            genuine contact frames so no penalty is incurred.
+        stiffness_coeff:      Scaling factor for the contact penalty.
+
+    Returns:
+        Scalar penalty: ``stiffness_coeff * sum(impact_phase_torques ** 2)``.
+
+    Raises:
+        ImportError: If JAX is not installed.
+    """
+    if not HAS_JAX:  # pragma: no cover
+        raise ImportError(
+            "jax is required for contact_loss; install with: "
+            "pip install upstream-drift[physics_informed]"
+        )
+    return stiffness_coeff * jnp.sum(impact_phase_torques**2)
+
+
+def total_loss(
+    weights: LossWeights,
+    predicted_motion: jax.Array,
+    actual_kinematics: jax.Array,
+    torques: jax.Array,
+    joint_limits: jax.Array,
+    energy_delta: jax.Array,
+    impact_phase_torques: jax.Array,
+    stiffness_coeff: float,
+) -> jax.Array:
+    """Compute the weighted sum of data, physics and contact losses.
+
+    Args:
+        weights:              Weight coefficients for each loss component.
+        predicted_motion:     Model-predicted motion array.
+        actual_kinematics:    Ground-truth motion array.
+        torques:              Torque vector of shape ``(n_joints,)``.
+        joint_limits:         Limit array of shape ``(n_joints, 2)``.
+        energy_delta:         Scalar energy-change penalty term.
+        impact_phase_torques: Torques during the phase under test.
+        stiffness_coeff:      Scaling factor passed to :func:`contact_loss`.
+
+    Returns:
+        Scalar total loss:
+        ``weights.data_weight * data_loss
+        + weights.physics_weight * physics_loss
+        + weights.contact_weight * contact_loss``.
+
+    Raises:
+        ImportError: If JAX is not installed.
+    """
+    if not HAS_JAX:  # pragma: no cover
+        raise ImportError(
+            "jax is required for total_loss; install with: "
+            "pip install upstream-drift[physics_informed]"
+        )
+    d_loss = data_loss(predicted_motion, actual_kinematics)
+    p_loss = physics_loss(torques, joint_limits, energy_delta)
+    c_loss = contact_loss(impact_phase_torques, stiffness_coeff=stiffness_coeff)
+
+    result = (
+        weights.data_weight * d_loss
+        + weights.physics_weight * p_loss
+        + weights.contact_weight * c_loss
+    )
+
+    logger.debug(
+        "total_loss: data=%.4f physics=%.4f contact=%.4f total=%.4f",
+        float(d_loss),
+        float(p_loss),
+        float(c_loss),
+        float(result),
+    )
+
+    return result

--- a/src/shared/python/physics_informed/mlp_residual.py
+++ b/src/shared/python/physics_informed/mlp_residual.py
@@ -1,0 +1,173 @@
+"""JAX/Equinox MLP for predicting residual torques not captured by rigid-body dynamics.
+
+This module provides :class:`MlpResidual`, a lightweight feed-forward neural
+network built with `Equinox <https://github.com/patrick-kidger/equinox>`_.  It
+is designed to be composed with :class:`~.rigid_core.RigidCore` inside
+:class:`~.hybrid_model.HybridPINN` to form a Physics-Informed Neural Network
+(PINN) hybrid.
+
+JAX and Equinox are *optional* dependencies:
+
+    pip install upstream-drift[physics_informed]
+
+If they are not installed the module still imports cleanly, but instantiating
+:class:`MlpResidual` will raise :class:`ImportError`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+    eqx = None  # type: ignore[assignment]
+    jax = None  # type: ignore[assignment]
+    jnp = None  # type: ignore[assignment]
+
+
+class MlpResidual:
+    """JAX/Equinox MLP predicting residual torque not captured by the rigid-body model.
+
+    The network accepts a concatenation of ``(q, dq, ddq)`` as its input
+    vector and returns a torque residual of shape ``(output_dim,)``.
+
+    Parameters
+    ----------
+    input_dim:
+        Dimensionality of the input vector.  Typically ``nq + 2 * nv`` for
+        a model with configuration-space size ``nq`` and velocity-space size
+        ``nv``.
+    output_dim:
+        Dimensionality of the output vector.  Must equal ``nv`` to match the
+        rigid-body torque vector.
+    hidden_dims:
+        List of hidden-layer widths.  An empty list produces a single linear
+        layer (no hidden layers).
+    key:
+        A JAX PRNG key used to initialise the network weights.
+
+    Raises
+    ------
+    ImportError
+        If JAX or Equinox are not installed.
+    ValueError
+        If ``input_dim`` or ``output_dim`` are not positive integers.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_dims: list[int],
+        *,
+        key: Any,
+    ) -> None:
+        """Build the MLP.
+
+        DbC preconditions:
+        - ``input_dim >= 1``
+        - ``output_dim >= 1``
+        - ``key`` must be a JAX PRNG key.
+
+        Args:
+            input_dim:   Number of input features.
+            output_dim:  Number of output features (must equal ``nv``).
+            hidden_dims: Widths of hidden layers.  Empty list → linear model.
+            key:         JAX PRNG key for weight initialisation.
+
+        Raises:
+            ImportError: If JAX / Equinox are not installed.
+            ValueError:  If dimensions are invalid.
+        """
+        if not HAS_JAX:
+            raise ImportError(
+                "jax and equinox are required for MlpResidual; install with: "
+                "pip install upstream-drift[physics_informed]"
+            )
+
+        if input_dim < 1:
+            raise ValueError(f"input_dim must be >= 1; got {input_dim}")
+        if output_dim < 1:
+            raise ValueError(f"output_dim must be >= 1; got {output_dim}")
+
+        self.input_dim: int = input_dim
+        self.output_dim: int = output_dim
+        self.hidden_dims: list[int] = list(hidden_dims)
+
+        self._net = self._build_network(input_dim, output_dim, hidden_dims, key)
+
+        logger.debug(
+            "MlpResidual built: input=%d hidden=%s output=%d",
+            input_dim,
+            hidden_dims,
+            output_dim,
+        )
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def __call__(self, x: Any) -> Any:
+        """Run a forward pass through the MLP.
+
+        Args:
+            x: Input array of shape ``(input_dim,)``.
+
+        Returns:
+            Output array of shape ``(output_dim,)``.
+
+        Raises:
+            ValueError: If ``x`` has the wrong shape.
+        """
+        x_arr = jnp.asarray(x, dtype=jnp.float32)
+        if x_arr.shape != (self.input_dim,):
+            raise ValueError(
+                f"Expected input shape ({self.input_dim},); got {x_arr.shape}"
+            )
+        return self._net(x_arr)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_network(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_dims: list[int],
+        key: Any,
+    ) -> Any:
+        """Construct an ``eqx.nn.Sequential`` MLP.
+
+        Args:
+            input_dim:   Input feature count.
+            output_dim:  Output feature count.
+            hidden_dims: Hidden-layer widths.
+            key:         JAX PRNG key.
+
+        Returns:
+            An Equinox ``Sequential`` module.
+        """
+        layer_dims = [input_dim, *hidden_dims, output_dim]
+        layers: list[Any] = []
+
+        for idx, (in_d, out_d) in enumerate(
+            zip(layer_dims[:-1], layer_dims[1:], strict=True)
+        ):
+            key, subkey = jax.random.split(key)
+            layers.append(eqx.nn.Linear(in_d, out_d, key=subkey))
+            # Apply ReLU after every layer except the final output layer
+            is_last = idx == len(layer_dims) - 2
+            if not is_last:
+                layers.append(jax.nn.relu)
+
+        return eqx.nn.Sequential(layers)

--- a/src/shared/python/physics_informed/mode.py
+++ b/src/shared/python/physics_informed/mode.py
@@ -1,0 +1,184 @@
+"""Factory for creating physics-informed model instances by mode.
+
+Phase 3 of the PINNs epic (#5419). Provides:
+
+- :class:`PhysicsMode`: Enum for the three supported physics modes.
+- :func:`create_model`: Factory that returns a :class:`~.rigid_core.RigidCore`,
+  :class:`~.mlp_residual.MlpResidual`, or :class:`~.hybrid_model.HybridPINN`
+  depending on the requested mode.
+
+Optional dependencies:
+- Pinocchio: required for :attr:`PhysicsMode.PURE_RIGID` and
+  :attr:`PhysicsMode.PINN_HYBRID`.
+- JAX + Equinox: required for :attr:`PhysicsMode.PURE_AI` and
+  :attr:`PhysicsMode.PINN_HYBRID`.
+
+If a required dependency is not installed, :func:`create_model` raises
+:class:`ImportError` at call time rather than at module-import time.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class PhysicsMode(Enum):
+    """Mode selector for the physics-informed model factory.
+
+    Attributes:
+        PURE_RIGID:  Pinocchio inverse dynamics only; no ML.
+        PURE_AI:     JAX/Equinox MLP residual only; no rigid-body model.
+        PINN_HYBRID: Rigid body + JAX residual torque MLP (full PINN).
+    """
+
+    PURE_RIGID = "pure_rigid"
+    PURE_AI = "pure_ai"
+    PINN_HYBRID = "pinn_hybrid"
+
+
+def create_model(
+    mode: PhysicsMode,
+    config: dict,
+) -> object:
+    """Factory: return a model instance for the given PhysicsMode.
+
+    Supported modes and required ``config`` keys:
+
+    **PURE_RIGID** -> :class:`~.rigid_core.RigidCore`
+        - ``urdf_path`` (str): Path to URDF file.
+
+    **PURE_AI** -> :class:`~.mlp_residual.MlpResidual`
+        - ``input_dim``  (int): MLP input dimension.
+        - ``output_dim`` (int): MLP output dimension (should equal ``nv``).
+        - ``hidden_dims`` (list[int], optional): Hidden layer widths.
+          Default: ``[64, 64]``.
+        - ``key`` (jax.Array, optional): JAX PRNG key. Default: PRNGKey(0).
+
+    **PINN_HYBRID** -> :class:`~.hybrid_model.HybridPINN`
+        - All keys from both PURE_RIGID and PURE_AI.
+
+    DbC preconditions:
+    - ``mode`` must be a :class:`PhysicsMode` member.
+    - Raises :class:`ValueError` for any other value.
+
+    Args:
+        mode:   Desired physics mode.
+        config: Configuration dictionary; see above for required keys.
+
+    Returns:
+        An instance of :class:`~.rigid_core.RigidCore`,
+        :class:`~.mlp_residual.MlpResidual`, or
+        :class:`~.hybrid_model.HybridPINN`.
+
+    Raises:
+        ValueError:   If ``mode`` is not a recognised :class:`PhysicsMode`.
+        ImportError:  If a required optional dependency is not installed.
+    """
+    if not isinstance(mode, PhysicsMode):
+        raise ValueError(
+            f"Unrecognized PhysicsMode: {mode!r}. "
+            f"Expected one of: {[m.value for m in PhysicsMode]}"
+        )
+
+    logger.debug(
+        "create_model: mode=%s config_keys=%s", mode.value, list(config.keys())
+    )
+
+    if mode == PhysicsMode.PURE_RIGID:
+        return _create_rigid(config)
+    if mode == PhysicsMode.PURE_AI:
+        return _create_mlp(config)
+    if mode == PhysicsMode.PINN_HYBRID:
+        return _create_hybrid(config)
+
+    # Defensive: unreachable if the enum is complete, but satisfies type checkers.
+    raise ValueError(f"Unrecognized PhysicsMode: {mode!r}")  # pragma: no cover
+
+
+# =============================================================================
+# Private factory helpers
+# =============================================================================
+
+
+def _create_rigid(config: dict) -> object:
+    """Instantiate a :class:`~.rigid_core.RigidCore`.
+
+    Args:
+        config: Must contain ``urdf_path`` key.
+
+    Returns:
+        A configured :class:`~.rigid_core.RigidCore`.
+
+    Raises:
+        ImportError: If Pinocchio is not installed.
+        ValueError:  If ``urdf_path`` is missing, empty, or the file does
+            not exist.
+    """
+    from src.shared.python.physics_informed.rigid_core import RigidCore
+
+    urdf_path: str = config.get("urdf_path", "")
+    logger.debug("create_model PURE_RIGID: urdf_path=%r", urdf_path)
+    return RigidCore(urdf_path)
+
+
+def _create_mlp(config: dict) -> object:
+    """Instantiate an :class:`~.mlp_residual.MlpResidual`.
+
+    Args:
+        config: Must contain ``input_dim`` and ``output_dim``.  Optional keys:
+            ``hidden_dims`` (default ``[64, 64]``) and ``key`` (default
+            ``jax.random.PRNGKey(0)``).
+
+    Returns:
+        A configured :class:`~.mlp_residual.MlpResidual`.
+
+    Raises:
+        ImportError: If JAX or Equinox are not installed.
+        ValueError:  If ``input_dim`` or ``output_dim`` are invalid.
+    """
+    import jax
+
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+
+    input_dim: int = config["input_dim"]
+    output_dim: int = config["output_dim"]
+    hidden_dims: list[int] = config.get("hidden_dims", [64, 64])
+    key = config.get("key", jax.random.PRNGKey(0))
+
+    logger.debug(
+        "create_model PURE_AI: input=%d output=%d hidden=%s",
+        input_dim,
+        output_dim,
+        hidden_dims,
+    )
+    return MlpResidual(
+        input_dim=input_dim, output_dim=output_dim, hidden_dims=hidden_dims, key=key
+    )
+
+
+def _create_hybrid(config: dict) -> object:
+    """Instantiate a :class:`~.hybrid_model.HybridPINN`.
+
+    Args:
+        config: Combined keys required by :func:`_create_rigid` and
+            :func:`_create_mlp`.
+
+    Returns:
+        A configured :class:`~.hybrid_model.HybridPINN`.
+
+    Raises:
+        ImportError: If Pinocchio, JAX, or Equinox are not installed.
+        ValueError:  If any required config key is invalid.
+    """
+    from src.shared.python.physics_informed.hybrid_model import HybridPINN
+
+    rigid = _create_rigid(config)
+    mlp = _create_mlp(config)
+
+    logger.debug("create_model PINN_HYBRID: combining rigid + mlp")
+    return HybridPINN(rigid, mlp)  # type: ignore[arg-type]

--- a/src/shared/python/physics_informed/rigid_core.py
+++ b/src/shared/python/physics_informed/rigid_core.py
@@ -1,0 +1,166 @@
+"""Rigid-body core using Pinocchio for inverse-dynamics torque computation.
+
+This module provides :class:`RigidCore`, which wraps the Pinocchio library to
+compute the standard rigid-body (RNEA) inverse-dynamics torque vector for a
+given kinematic state ``(q, dq, ddq)``.
+
+Pinocchio is an *optional* dependency (``pip install upstream-drift[pinocchio]``).
+If it is not installed the module still imports cleanly, but instantiating
+:class:`RigidCore` will raise :class:`ImportError`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pinocchio as pin
+
+    _PINOCCHIO_AVAILABLE = True
+except ImportError:
+    _PINOCCHIO_AVAILABLE = False
+    pin = None  # type: ignore[assignment]
+
+
+class RigidCore:
+    """Wrap Pinocchio to compute the standard rigid-body torque vector.
+
+    The torque vector is obtained by running the Recursive Newton-Euler
+    Algorithm (RNEA / inverse dynamics):
+
+    .. math::
+
+        \\tau = \\text{RNEA}(q, \\dot{q}, \\ddot{q})
+
+    Parameters
+    ----------
+    urdf_path:
+        Absolute or relative path to a URDF file.  The path is validated
+        before any Pinocchio call is made.
+
+    Raises
+    ------
+    ImportError
+        If Pinocchio is not installed.
+    ValueError
+        If ``urdf_path`` does not point to an existing file.
+    """
+
+    def __init__(self, urdf_path: str) -> None:
+        """Load URDF into a Pinocchio model.
+
+        DbC preconditions:
+        - ``urdf_path`` must be a non-empty string.
+        - The file must exist on disk.
+
+        Args:
+            urdf_path: Path to a URDF file.
+
+        Raises:
+            ImportError: If Pinocchio is not installed.
+            ValueError: If ``urdf_path`` is empty or the file does not exist.
+        """
+        if not _PINOCCHIO_AVAILABLE:
+            raise ImportError(
+                "pinocchio not available; install with: "
+                "pip install upstream-drift[pinocchio]"
+            )
+
+        if not urdf_path:
+            raise ValueError("urdf_path must be a non-empty string; got empty string")
+
+        if not os.path.isfile(urdf_path):
+            raise ValueError(
+                f"urdf_path does not point to an existing file: {urdf_path!r}"
+            )
+
+        logger.debug("Loading Pinocchio model from %s", urdf_path)
+        self._model = pin.buildModelFromUrdf(urdf_path)
+        self._data = self._model.createData()
+        logger.info(
+            "RigidCore loaded: %s  (nq=%d, nv=%d)",
+            self._model.name,
+            self._model.nq,
+            self._model.nv,
+        )
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def nq(self) -> int:
+        """Configuration-space dimension of the loaded model."""
+        return int(self._model.nq)
+
+    @property
+    def nv(self) -> int:
+        """Velocity/torque-space dimension of the loaded model."""
+        return int(self._model.nv)
+
+    # ------------------------------------------------------------------
+    # Computation
+    # ------------------------------------------------------------------
+
+    def compute_torques(
+        self,
+        q: np.ndarray,
+        dq: np.ndarray,
+        ddq: np.ndarray,
+    ) -> np.ndarray:
+        """Return the inverse-dynamics torque vector via Pinocchio RNEA.
+
+        DbC preconditions:
+        - ``q`` must have shape ``(nq,)``.
+        - ``dq`` and ``ddq`` must have shape ``(nv,)``.
+
+        DbC postcondition:
+        - Returns a finite 1-D array of shape ``(nv,)``.
+
+        Args:
+            q:   Configuration vector, shape ``(nq,)``.
+            dq:  Velocity vector, shape ``(nv,)``.
+            ddq: Acceleration vector, shape ``(nv,)``.
+
+        Returns:
+            Torque vector ``τ`` of shape ``(nv,)``.
+
+        Raises:
+            ValueError: If any input has the wrong shape.
+        """
+        q_arr = np.asarray(q, dtype=np.float64)
+        dq_arr = np.asarray(dq, dtype=np.float64)
+        ddq_arr = np.asarray(ddq, dtype=np.float64)
+
+        self._validate_shapes(q_arr, dq_arr, ddq_arr)
+
+        tau = pin.rnea(self._model, self._data, q_arr, dq_arr, ddq_arr)
+        result: np.ndarray = np.array(tau, dtype=np.float64)
+
+        assert result.shape == (self.nv,), (
+            f"Postcondition violated: expected shape ({self.nv},), got {result.shape}"
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _validate_shapes(
+        self,
+        q: np.ndarray,
+        dq: np.ndarray,
+        ddq: np.ndarray,
+    ) -> None:
+        """Raise ValueError if input arrays have unexpected shapes."""
+        if q.shape != (self.nq,):
+            raise ValueError(f"q must have shape ({self.nq},); got {q.shape}")
+        if dq.shape != (self.nv,):
+            raise ValueError(f"dq must have shape ({self.nv},); got {dq.shape}")
+        if ddq.shape != (self.nv,):
+            raise ValueError(f"ddq must have shape ({self.nv},); got {ddq.shape}")

--- a/src/shared/python/physics_informed/shadow_model.py
+++ b/src/shared/python/physics_informed/shadow_model.py
@@ -1,0 +1,241 @@
+"""Shadow model for non-intrusive observation of PINN residuals per swing phase.
+
+Phase 3 of the PINNs epic (#5419). Provides:
+
+- :class:`SwingPhase`: Enum for the three golf-swing phases.
+- :class:`ShadowReport`: Dataclass holding peak residual torques per phase.
+- :class:`ShadowModel`: Runs rigid simulation + PINN simultaneously in
+  *observation mode*, recording peak residual torques per phase without
+  modifying simulation state.
+
+The model degrades gracefully: if JAX (or any optional dependency) is not
+installed, :meth:`ShadowModel.observe` returns an empty :class:`ShadowReport`
+rather than raising.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+    from src.shared.python.physics_informed.rigid_core import RigidCore
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Enums and dataclasses
+# =============================================================================
+
+
+class SwingPhase(Enum):
+    """Segmentation of a golf swing into three biomechanical phases."""
+
+    TRANSITION = "transition"
+    IMPACT = "impact"
+    FOLLOW_THROUGH = "follow_through"
+
+
+@dataclass
+class ShadowReport:
+    """Container for peak residual torques recorded during shadow observation.
+
+    Attributes:
+        peak_residuals: Mapping from :attr:`SwingPhase.value` string to the
+            peak (max abs) residual torque magnitude recorded in that phase.
+            Empty when no frames were observed or when optional dependencies
+            are unavailable.
+    """
+
+    peak_residuals: dict[str, float] = field(default_factory=dict)
+
+
+# =============================================================================
+# Phase classification helpers
+# =============================================================================
+
+
+def _classify_phase(frame_idx: int, total_frames: int) -> SwingPhase:
+    """Return the SwingPhase for a given frame index.
+
+    Frame distribution (fraction of total):
+    - First 30 %  -> TRANSITION
+    - Middle 40 % -> IMPACT
+    - Last  30 %  -> FOLLOW_THROUGH
+
+    DbC preconditions:
+    - ``total_frames >= 1``
+    - ``0 <= frame_idx < total_frames``
+
+    Args:
+        frame_idx:    Zero-based index of the frame.
+        total_frames: Total number of frames in the sequence.
+
+    Returns:
+        The :class:`SwingPhase` for the given frame.
+    """
+    ratio = frame_idx / total_frames
+    if ratio < 0.30:
+        return SwingPhase.TRANSITION
+    if ratio < 0.70:
+        return SwingPhase.IMPACT
+    return SwingPhase.FOLLOW_THROUGH
+
+
+# =============================================================================
+# ShadowModel
+# =============================================================================
+
+
+class ShadowModel:
+    """Runs rigid simulation + PINN simultaneously in observation mode.
+
+    Records peak residual torques per swing phase *without* modifying
+    simulation state.  The "residual" is the MLP output -- what the rigid-body
+    model alone would miss.
+
+    Parameters
+    ----------
+    rigid_core:
+        Configured :class:`~.rigid_core.RigidCore` instance (Pinocchio).
+    mlp_residual:
+        Configured :class:`~.mlp_residual.MlpResidual` instance (JAX/Equinox).
+
+    Raises
+    ------
+    ValueError
+        If ``rigid_core`` or ``mlp_residual`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        rigid_core: RigidCore,
+        mlp_residual: MlpResidual,
+    ) -> None:
+        """Compose rigid-body core and MLP residual for shadow observation.
+
+        DbC preconditions:
+        - ``rigid_core`` must not be ``None``.
+        - ``mlp_residual`` must not be ``None``.
+
+        Args:
+            rigid_core:   Pinocchio-backed rigid-body torque calculator.
+            mlp_residual: JAX/Equinox MLP residual torque predictor.
+
+        Raises:
+            ValueError: If either argument is ``None``.
+        """
+        if rigid_core is None:
+            raise ValueError("rigid_core must not be None")
+        if mlp_residual is None:
+            raise ValueError("mlp_residual must not be None")
+
+        self._rigid = rigid_core
+        self._mlp = mlp_residual
+
+        logger.debug("ShadowModel created in observation mode")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def observe(self, frames: list[dict]) -> ShadowReport:
+        """Run one pass over simulation frames, recording peak residuals.
+
+        Each frame dict must contain:
+        - ``q``   -- configuration vector (numpy array)
+        - ``dq``  -- velocity vector (numpy array)
+        - ``ddq`` -- acceleration vector (numpy array)
+
+        The method classifies frames into phases by fractional index:
+        - first 30 % -> TRANSITION
+        - middle 40 % -> IMPACT
+        - last 30 %  -> FOLLOW_THROUGH
+
+        For each frame, the MLP residual (the part the rigid model misses)
+        is computed as ``mlp(concat([q, dq, ddq]))``.  The peak
+        ``max(abs(residual))`` is tracked per phase.
+
+        This method is *observation-only*: it never modifies input frames
+        or simulation state.
+
+        Args:
+            frames: List of frame dicts, each with keys ``q``, ``dq``, ``ddq``.
+
+        Returns:
+            :class:`ShadowReport` with ``peak_residuals`` keyed by
+            :attr:`SwingPhase.value` strings.  Returns an empty report if
+            ``frames`` is empty or if an :class:`ImportError` is raised by
+            an optional dependency (graceful degradation without JAX).
+        """
+        if not frames:
+            return ShadowReport()
+
+        phase_peaks: dict[str, float] = {}
+
+        try:
+            total = len(frames)
+            for idx, frame in enumerate(frames):
+                phase = _classify_phase(idx, total)
+                peak = self._compute_frame_peak(frame)
+                key = phase.value
+                if key not in phase_peaks or peak > phase_peaks[key]:
+                    phase_peaks[key] = peak
+
+        except ImportError as exc:
+            logger.warning(
+                "ShadowModel.observe: optional dependency unavailable (%s); "
+                "returning empty ShadowReport",
+                exc,
+            )
+            return ShadowReport()
+
+        logger.debug(
+            "ShadowModel.observe: %d frames -> peak_residuals=%s",
+            len(frames),
+            phase_peaks,
+        )
+        return ShadowReport(peak_residuals=phase_peaks)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _compute_frame_peak(self, frame: dict) -> float:
+        """Compute max(abs(mlp_residual)) for a single frame.
+
+        The MLP receives concat([q, dq, ddq]) and produces a residual torque
+        vector.  We then call rigid_core.compute_torques to ensure correctness
+        (e.g. raise ImportError early if Pinocchio is missing).
+
+        Args:
+            frame: Dict with keys ``q``, ``dq``, ``ddq``.
+
+        Returns:
+            Scalar peak residual magnitude.
+
+        Raises:
+            ImportError: Propagated from rigid_core or mlp_residual if
+                optional dependencies are missing.
+        """
+        q = np.asarray(frame["q"], dtype=np.float64)
+        dq = np.asarray(frame["dq"], dtype=np.float64)
+        ddq = np.asarray(frame["ddq"], dtype=np.float64)
+
+        # Compute rigid torques to surface any ImportError early
+        self._rigid.compute_torques(q, dq, ddq)
+
+        # MLP residual: predict what rigid misses
+        x = np.concatenate([q, dq, ddq])
+        mlp_out = self._mlp(x)
+        residuals = np.asarray(mlp_out, dtype=np.float64)
+
+        return float(np.max(np.abs(residuals)))

--- a/tests/unit/shared_python/test_pinn_loss.py
+++ b/tests/unit/shared_python/test_pinn_loss.py
@@ -1,0 +1,231 @@
+"""Tests for the PINN loss function module (Phase 2 of the PINNs epic #5419).
+
+Tests are skipped gracefully when JAX is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import jax.numpy as jnp
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+pytestmark = pytest.mark.skipif(not HAS_JAX, reason="JAX not installed")
+
+from src.shared.python.physics_informed.loss import (  # noqa: E402
+    LossWeights,
+    contact_loss,
+    data_loss,
+    physics_loss,
+    total_loss,
+)
+
+
+# ---------------------------------------------------------------------------
+# LossWeights
+# ---------------------------------------------------------------------------
+
+
+def test_loss_weights_valid() -> None:
+    weights = LossWeights(data_weight=1.0, physics_weight=0.5, contact_weight=0.1)
+    assert weights.data_weight == 1.0
+    assert weights.physics_weight == 0.5
+    assert weights.contact_weight == 0.1
+
+
+def test_loss_weights_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="data_weight"):
+        LossWeights(data_weight=-1.0, physics_weight=1.0, contact_weight=1.0)
+
+
+def test_loss_weights_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="data_weight"):
+        LossWeights(data_weight=0.0, physics_weight=1.0, contact_weight=1.0)
+
+
+def test_loss_weights_rejects_negative_physics() -> None:
+    with pytest.raises(ValueError, match="physics_weight"):
+        LossWeights(data_weight=1.0, physics_weight=-0.5, contact_weight=1.0)
+
+
+def test_loss_weights_rejects_zero_contact() -> None:
+    with pytest.raises(ValueError, match="contact_weight"):
+        LossWeights(data_weight=1.0, physics_weight=1.0, contact_weight=0.0)
+
+
+# ---------------------------------------------------------------------------
+# data_loss
+# ---------------------------------------------------------------------------
+
+
+def test_data_loss_zero_on_perfect_prediction() -> None:
+    x = jnp.array([1.0, 2.0, 3.0])
+    assert float(data_loss(x, x)) == pytest.approx(0.0)
+
+
+def test_data_loss_positive_on_error() -> None:
+    pred = jnp.array([1.0, 0.0])
+    actual = jnp.array([0.0, 1.0])
+    assert float(data_loss(pred, actual)) > 0
+
+
+def test_data_loss_mse_correctness() -> None:
+    pred = jnp.array([2.0])
+    actual = jnp.array([0.0])
+    # MSE = mean((2 - 0)^2) = 4.0
+    assert float(data_loss(pred, actual)) == pytest.approx(4.0)
+
+
+def test_data_loss_scalar() -> None:
+    """Return value must be scalar (0-dimensional)."""
+    result = data_loss(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0]))
+    assert result.ndim == 0
+
+
+# ---------------------------------------------------------------------------
+# physics_loss
+# ---------------------------------------------------------------------------
+
+
+def test_physics_loss_zero_within_limits() -> None:
+    torques = jnp.array([0.0, 0.0])  # within limits [-1, 1]
+    limits = jnp.array([[-1.0, 1.0], [-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    assert float(physics_loss(torques, limits, energy)) == pytest.approx(0.0)
+
+
+def test_physics_loss_positive_on_violation() -> None:
+    torques = jnp.array([2.0])  # exceeds max of 1.0
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    assert float(physics_loss(torques, limits, energy)) > 0
+
+
+def test_physics_loss_violation_amount() -> None:
+    torques = jnp.array([3.0])  # exceeds max of 1.0 by 2.0
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    # violation = 3.0 - 1.0 = 2.0; energy = 0.0
+    assert float(physics_loss(torques, limits, energy)) == pytest.approx(2.0)
+
+
+def test_physics_loss_lower_bound_violation() -> None:
+    torques = jnp.array([-3.0])  # below min of -1.0 by 2.0
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    assert float(physics_loss(torques, limits, energy)) == pytest.approx(2.0)
+
+
+def test_physics_loss_energy_contribution() -> None:
+    torques = jnp.array([0.0])  # within limits
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(5.0)  # large energy delta
+    assert float(physics_loss(torques, limits, energy)) == pytest.approx(5.0)
+
+
+def test_physics_loss_scalar() -> None:
+    """Return value must be scalar."""
+    result = physics_loss(
+        jnp.array([0.0, 0.0]),
+        jnp.array([[-1.0, 1.0], [-1.0, 1.0]]),
+        jnp.array(0.0),
+    )
+    assert result.ndim == 0
+
+
+# ---------------------------------------------------------------------------
+# contact_loss
+# ---------------------------------------------------------------------------
+
+
+def test_contact_loss_zero_for_no_impact() -> None:
+    assert float(contact_loss(jnp.zeros(3), stiffness_coeff=10.0)) == pytest.approx(0.0)
+
+
+def test_contact_loss_positive_for_nonzero_torques() -> None:
+    torques = jnp.array([1.0, 2.0])
+    result = float(contact_loss(torques, stiffness_coeff=1.0))
+    assert result > 0
+
+
+def test_contact_loss_scaled_by_stiffness() -> None:
+    torques = jnp.array([1.0])
+    # contact_loss = stiffness_coeff * sum(torques^2) = 2.0 * 1.0 = 2.0
+    assert float(contact_loss(torques, stiffness_coeff=2.0)) == pytest.approx(2.0)
+
+
+def test_contact_loss_scalar() -> None:
+    """Return value must be scalar."""
+    result = contact_loss(jnp.array([1.0, 0.5]), stiffness_coeff=1.0)
+    assert result.ndim == 0
+
+
+# ---------------------------------------------------------------------------
+# total_loss
+# ---------------------------------------------------------------------------
+
+
+def test_total_loss_weighted_sum() -> None:
+    weights = LossWeights(data_weight=1.0, physics_weight=0.0001, contact_weight=0.0001)
+    pred = jnp.array([1.0])
+    actual = jnp.zeros(1)
+    torques = jnp.array([0.0])
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    impact = jnp.zeros(1)
+    loss = total_loss(weights, pred, actual, torques, limits, energy, impact, 1.0)
+    # With physics and contact both zero (torques within limits, no impact),
+    # total = data_weight * data_loss
+    expected_data = float(data_loss(pred, actual))
+    assert float(loss) == pytest.approx(weights.data_weight * expected_data, rel=1e-5)
+
+
+def test_total_loss_data_only_weight() -> None:
+    """When physics_weight and contact_weight are tiny and inputs are clean,
+    total_loss ≈ data_weight * data_loss."""
+    weights = LossWeights(data_weight=2.0, physics_weight=1e-9, contact_weight=1e-9)
+    pred = jnp.array([1.0])
+    actual = jnp.zeros(1)
+    torques = jnp.zeros(1)
+    limits = jnp.array([[-1.0, 1.0]])
+    energy = jnp.array(0.0)
+    impact = jnp.zeros(1)
+    result = float(
+        total_loss(weights, pred, actual, torques, limits, energy, impact, 0.0)
+    )
+    expected = 2.0 * float(data_loss(pred, actual))
+    assert result == pytest.approx(expected, rel=1e-5)
+
+
+def test_total_loss_positive() -> None:
+    weights = LossWeights(data_weight=1.0, physics_weight=1.0, contact_weight=1.0)
+    pred = jnp.array([1.0, 2.0])
+    actual = jnp.zeros(2)
+    torques = jnp.array([5.0, 5.0])
+    limits = jnp.array([[-1.0, 1.0], [-1.0, 1.0]])
+    energy = jnp.array(3.0)
+    impact = jnp.array([1.0, 2.0])
+    result = float(
+        total_loss(weights, pred, actual, torques, limits, energy, impact, 1.0)
+    )
+    assert result > 0
+
+
+def test_total_loss_scalar() -> None:
+    """total_loss must return a scalar."""
+    weights = LossWeights(data_weight=1.0, physics_weight=1.0, contact_weight=1.0)
+    result = total_loss(
+        weights,
+        jnp.array([1.0]),
+        jnp.zeros(1),
+        jnp.zeros(1),
+        jnp.array([[-1.0, 1.0]]),
+        jnp.array(0.0),
+        jnp.zeros(1),
+        1.0,
+    )
+    assert result.ndim == 0

--- a/tests/unit/shared_python/test_pinn_shadow.py
+++ b/tests/unit/shared_python/test_pinn_shadow.py
@@ -1,0 +1,253 @@
+"""Tests for Phase 3 of the PINNs epic: ShadowModel, ShadowReport, and mode factory.
+
+Tests are written FIRST (TDD red phase) before implementation.
+JAX-dependent paths are skipped gracefully when JAX is not installed.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+try:
+    import jax  # noqa: F401
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+from src.shared.python.physics_informed.mode import PhysicsMode, create_model
+from src.shared.python.physics_informed.shadow_model import (
+    ShadowModel,
+    ShadowReport,
+    SwingPhase,
+)
+
+
+# =============================================================================
+# ShadowReport
+# =============================================================================
+
+
+def test_shadow_report_is_dataclass() -> None:
+    """ShadowReport must be a dataclass with a peak_residuals dict."""
+    report = ShadowReport()
+    assert hasattr(report, "peak_residuals")
+    assert isinstance(report.peak_residuals, dict)
+
+
+def test_shadow_report_defaults_empty_dict() -> None:
+    """Default peak_residuals must be an empty dict (not a shared mutable)."""
+    r1 = ShadowReport()
+    r2 = ShadowReport()
+    # Mutating one instance must not affect the other
+    r1.peak_residuals["x"] = 1.0
+    assert "x" not in r2.peak_residuals
+
+
+# =============================================================================
+# SwingPhase
+# =============================================================================
+
+
+def test_swing_phase_transition_value() -> None:
+    assert SwingPhase.TRANSITION.value == "transition"
+
+
+def test_swing_phase_impact_value() -> None:
+    assert SwingPhase.IMPACT.value == "impact"
+
+
+def test_swing_phase_follow_through_value() -> None:
+    assert SwingPhase.FOLLOW_THROUGH.value == "follow_through"
+
+
+# =============================================================================
+# ShadowModel -- DbC (construction preconditions)
+# =============================================================================
+
+
+def test_shadow_model_requires_non_none_rigid() -> None:
+    """ShadowModel must raise ValueError or TypeError when rigid_core is None."""
+    with pytest.raises((ValueError, TypeError)):
+        ShadowModel(None, MagicMock())
+
+
+def test_shadow_model_requires_non_none_mlp() -> None:
+    """ShadowModel must raise ValueError or TypeError when mlp_residual is None."""
+    with pytest.raises((ValueError, TypeError)):
+        ShadowModel(MagicMock(), None)
+
+
+# =============================================================================
+# ShadowModel -- observe()
+# =============================================================================
+
+
+def test_shadow_model_observe_returns_report() -> None:
+    """observe() must return a ShadowReport when given valid frames."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.zeros(6)
+    mlp = MagicMock()
+    mlp.return_value = np.zeros(6)
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [{"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}]
+    report = sm.observe(frames)
+    assert isinstance(report, ShadowReport)
+
+
+def test_shadow_model_observe_empty_frames_returns_empty_report() -> None:
+    """observe() with no frames must return an empty ShadowReport."""
+    sm = ShadowModel(MagicMock(), MagicMock())
+    report = sm.observe([])
+    assert isinstance(report, ShadowReport)
+    assert report.peak_residuals == {}
+
+
+def test_shadow_model_observe_peak_residuals_uses_phase_keys() -> None:
+    """Non-empty frame list must produce peak_residuals keyed by SwingPhase values."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.ones(6)
+    mlp = MagicMock()
+    mlp.return_value = np.full(6, 2.0)
+
+    sm = ShadowModel(rigid, mlp)
+    # 10 frames so all three phases are populated
+    frames = [
+        {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)} for _ in range(10)
+    ]
+    report = sm.observe(frames)
+
+    # Keys must be SwingPhase string values
+    valid_keys = {p.value for p in SwingPhase}
+    assert set(report.peak_residuals.keys()) <= valid_keys
+
+
+def test_shadow_model_observe_peak_residuals_are_non_negative() -> None:
+    """Peak residuals must be non-negative (they represent magnitudes)."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.ones(6) * 3.0
+    mlp = MagicMock()
+    mlp.return_value = np.ones(6) * 1.5
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [
+        {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)} for _ in range(9)
+    ]
+    report = sm.observe(frames)
+
+    for key, val in report.peak_residuals.items():
+        assert val >= 0.0, f"peak_residuals[{key!r}] = {val} must be >= 0"
+
+
+def test_shadow_model_does_not_modify_frames() -> None:
+    """observe() must not mutate input frames (observation mode only)."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.zeros(6)
+    mlp = MagicMock()
+    mlp.return_value = np.zeros(6)
+
+    sm = ShadowModel(rigid, mlp)
+    frame = {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}
+    original_keys = set(frame.keys())
+    sm.observe([frame])
+    assert set(frame.keys()) == original_keys
+
+
+def test_shadow_model_observe_graceful_without_jax() -> None:
+    """observe() must return an empty ShadowReport (not raise) when underlying
+    calls raise ImportError (simulating missing JAX).
+    """
+    rigid = MagicMock()
+    rigid.compute_torques.side_effect = ImportError("jax not available")
+    mlp = MagicMock()
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [{"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}]
+    # Should NOT raise; returns an empty ShadowReport
+    report = sm.observe(frames)
+    assert isinstance(report, ShadowReport)
+
+
+# =============================================================================
+# PhysicsMode
+# =============================================================================
+
+
+def test_physics_mode_values() -> None:
+    """PhysicsMode enum must have the three expected string values."""
+    assert PhysicsMode.PURE_RIGID.value == "pure_rigid"
+    assert PhysicsMode.PURE_AI.value == "pure_ai"
+    assert PhysicsMode.PINN_HYBRID.value == "pinn_hybrid"
+
+
+def test_physics_mode_has_exactly_three_members() -> None:
+    """PhysicsMode must have exactly three members."""
+    assert len(PhysicsMode) == 3
+
+
+# =============================================================================
+# create_model factory
+# =============================================================================
+
+
+def test_create_model_invalid_mode_raises() -> None:
+    """create_model must raise ValueError for an unrecognised mode string."""
+    with pytest.raises(ValueError):
+        create_model("invalid_mode", {})  # type: ignore[arg-type]
+
+
+def test_create_model_invalid_mode_enum_like_string_raises() -> None:
+    """create_model must raise ValueError even for plausible-sounding bad modes."""
+    with pytest.raises(ValueError):
+        create_model("pure_hybrid", {})  # type: ignore[arg-type]
+
+
+def test_create_model_pure_rigid_returns_rigid_core_or_import_error() -> None:
+    """PURE_RIGID must return a RigidCore, or raise ImportError (pinocchio absent).
+
+    A nonexistent URDF path raises ValueError from RigidCore's DbC check when
+    Pinocchio is installed. That is the expected DbC precondition failure.
+    """
+    config = {"urdf_path": "/nonexistent.urdf"}
+    try:
+        model = create_model(PhysicsMode.PURE_RIGID, config)
+        from src.shared.python.physics_informed.rigid_core import RigidCore
+
+        assert isinstance(model, RigidCore)
+    except ImportError:
+        pass  # pinocchio not installed -- acceptable
+    except ValueError:
+        pass  # pinocchio installed but URDF doesn't exist -- acceptable DbC failure
+
+
+@pytest.mark.skipif(not HAS_JAX, reason="JAX not installed")
+def test_create_model_pure_ai_returns_mlp_residual() -> None:
+    """PURE_AI must return an MlpResidual when JAX is installed."""
+    import jax
+
+    config = {
+        "input_dim": 18,
+        "output_dim": 6,
+        "hidden_dims": [32, 32],
+        "key": jax.random.PRNGKey(42),
+    }
+    model = create_model(PhysicsMode.PURE_AI, config)
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+
+    assert isinstance(model, MlpResidual)
+
+
+def test_create_model_pure_ai_raises_import_error_without_jax() -> None:
+    """PURE_AI must raise ImportError when JAX is not installed."""
+    if HAS_JAX:
+        pytest.skip("JAX is installed -- cannot test missing-JAX path")
+
+    config = {"input_dim": 18, "output_dim": 6}
+    with pytest.raises(ImportError):
+        create_model(PhysicsMode.PURE_AI, config)


### PR DESCRIPTION
Closes #5498. Part of epic #5419. Depends on Phase 1 (#5562).

## Summary

- Adds `src/shared/python/physics_informed/loss.py` with four functions:
  - `data_loss`: MSE between predicted motion and actual kinematics
  - `physics_loss`: penalises joint-limit violations + energy anomalies  
  - `contact_loss`: penalises non-zero torques during non-contact phases
  - `total_loss`: weighted sum of the three component losses
- Adds `LossWeights` frozen dataclass with DbC-validated positive weights (raises `ValueError` for any weight <= 0)
- Exports all new symbols from `src/shared/python/physics_informed/__init__.py`
- 23 tests in `tests/unit/shared_python/test_pinn_loss.py`; all skip gracefully when JAX is not installed

## Design

- TDD: tests written before implementation (red to green to refactor)
- DbC: `LossWeights.__post_init__` validates all three weights are strictly positive
- No `print()` -- uses `logging.debug` for loss tracing in `total_loss`
- Import guard: `try/except ImportError` for JAX at module top; functions raise `ImportError` at call time if JAX absent
- Type annotations use `TYPE_CHECKING` guard with `jax.Array` (ruff UP037 clean)

## Test plan

- [ ] `python -m pytest tests/unit/shared_python/test_pinn_loss.py -v` -- 23 tests skip cleanly without JAX
- [ ] `python -m ruff check src/shared/python/physics_informed/loss.py` -- 0 violations
- [ ] `python -m ruff format --check src/shared/python/physics_informed/loss.py` -- 0 diffs
- [ ] CI with JAX installed: all 23 tests pass (data_loss MSE, physics_loss violations, contact_loss stiffness scaling, total_loss weighted sum)

Generated with Claude Code