### PR TITLE
fix(launcher): add 10+ remaining tiles + close 12+ satisfied issues post-#5556 merge

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -706,4 +706,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-12 | 1.0.164 | Preserved registered symbolic model `source_root` aliases while still resolving provider-relative source roots, preventing aliases such as `movement_optimizer` from being rewritten under a provider checkout (#5353). |
 | 2026-05-13 | 1.0.165 | Documented the shared Tools-hosted video/data launcher surfaces, the launcher manifest contract, and the theme API client/server surface added for web UI parity. |
 | 2026-05-13 | 1.0.166 | Moved the PyQt launcher close control into the top menu-bar row while keeping the custom title strip for drag/minimize/maximize behavior (#5374). |
+| 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 ````

--- a/scripts/_add_audit_tiles.py
+++ b/scripts/_add_audit_tiles.py
@@ -1,0 +1,228 @@
+"""CI helper: adds the 14 post-#5556 audit tiles to launcher_manifest.json.
+
+Run from repo root: python scripts/_add_audit_tiles.py
+This script is idempotent (won't duplicate tiles).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+MANIFEST_PATH = Path("src/config/launcher_manifest.json")
+
+NEW_TILES = [
+    {
+        "id": "drake_dashboard",
+        "name": "Drake Dashboard",
+        "description": "Interactive Drake simulation dashboard",
+        "category": "physics_engine",
+        "type": "special_app",
+        "path": "src/launchers/drake_dashboard.py",
+        "engine_type": "drake",
+        "logo": "drake.svg",
+        "status": "experimental",
+        "web_route": "/tools/drake-dashboard",
+        "capabilities": ["rigid_body", "optimization", "dashboard"],
+        "order": 29,
+    },
+    {
+        "id": "mujoco_dashboard",
+        "name": "MuJoCo Dashboard",
+        "description": "Interactive MuJoCo simulation dashboard",
+        "category": "physics_engine",
+        "type": "special_app",
+        "path": "src/launchers/mujoco_dashboard.py",
+        "engine_type": "mujoco",
+        "logo": "mujoco_humanoid.svg",
+        "status": "experimental",
+        "web_route": "/tools/mujoco-dashboard",
+        "capabilities": ["rigid_body", "contact", "dashboard"],
+        "order": 30,
+    },
+    {
+        "id": "pinocchio_dashboard",
+        "name": "Pinocchio Dashboard",
+        "description": "Interactive Pinocchio simulation dashboard",
+        "category": "physics_engine",
+        "type": "special_app",
+        "path": "src/launchers/pinocchio_dashboard.py",
+        "engine_type": "pinocchio",
+        "logo": "pinocchio.svg",
+        "status": "experimental",
+        "web_route": "/tools/pinocchio-dashboard",
+        "capabilities": ["rigid_body", "inverse_kinematics", "dashboard"],
+        "order": 31,
+    },
+    {
+        "id": "analysis_tools_api",
+        "name": "Analysis Tools",
+        "description": "REST API access to 6 analysis endpoints (swing metrics, biomechanics)",
+        "category": "analysis",
+        "type": "special_app",
+        "path": "src/api/routes/analysis_tools.py",
+        "web_route": "/api/analysis",
+        "logo": "data_explorer.svg",
+        "status": "ready",
+        "capabilities": ["swing_metrics", "biomechanics", "api"],
+        "order": 32,
+    },
+    {
+        "id": "motion_pipeline",
+        "name": "Motion Pipeline",
+        "description": "Full markerless mocap to forward-dynamics pipeline (video in, motion out)",
+        "category": "motion_matching",
+        "type": "special_app",
+        "path": "src/shared/python/motion_pipeline/api.py",
+        "web_route": "/tools/motion-pipeline",
+        "logo": "c3d_icon.svg",
+        "status": "experimental",
+        "capabilities": ["markerless_mocap", "forward_dynamics", "pipeline"],
+        "order": 33,
+    },
+    {
+        "id": "perturbation_analysis",
+        "name": "Perturbation Analysis",
+        "description": "Cross-engine robustness analysis via perturbation testing",
+        "category": "analysis",
+        "type": "special_app",
+        "path": "src/api/routes/physics.py",
+        "web_route": "/api/perturbation",
+        "logo": "data_explorer.svg",
+        "status": "experimental",
+        "capabilities": ["perturbation", "robustness", "cross_engine"],
+        "order": 34,
+    },
+    {
+        "id": "force_overlays",
+        "name": "Force Overlays",
+        "description": "Physics visualization: joint forces and torques overlaid on 3D model",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/api/routes/force_overlays.py",
+        "web_route": "/api/force-overlays",
+        "logo": "mujoco_humanoid.svg",
+        "status": "experimental",
+        "capabilities": ["force_visualization", "joint_torques", "3d_overlay"],
+        "order": 35,
+    },
+    {
+        "id": "realtime_ws",
+        "name": "Realtime WebSocket",
+        "description": "Live simulation data stream via WebSocket pub-sub",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/api/routes/realtime.py",
+        "web_route": "/ws/realtime",
+        "logo": "data_explorer.svg",
+        "status": "experimental",
+        "capabilities": ["websocket", "realtime", "pubsub"],
+        "order": 36,
+    },
+    {
+        "id": "aip",
+        "name": "AI Protocol (AIP)",
+        "description": "AI-native simulation control protocol with structured method dispatch",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/api/routes/aip.py",
+        "web_route": "/api/aip",
+        "logo": "golf_logo.svg",
+        "status": "experimental",
+        "capabilities": ["ai_methods", "protocol", "dispatch"],
+        "order": 37,
+    },
+    {
+        "id": "actuator_controls",
+        "name": "Actuator Controls",
+        "description": "Live actuator parameter tuning and control scheme editor",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/api/routes/actuator_controls.py",
+        "web_route": "/api/actuator-controls",
+        "logo": "mujoco_humanoid.svg",
+        "status": "experimental",
+        "capabilities": ["actuator_tuning", "control_schemes", "realtime"],
+        "order": 38,
+    },
+    {
+        "id": "unreal_integration",
+        "name": "Unreal Integration",
+        "description": "Unreal Engine streaming and VR visualization for golf swing simulation",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/unreal_integration/__init__.py",
+        "web_route": "/docs/unreal-integration",
+        "logo": "golf_logo.svg",
+        "status": "external",
+        "capabilities": ["streaming", "vr", "visualization"],
+        "order": 39,
+    },
+    {
+        "id": "robotics_module",
+        "name": "Robotics Module",
+        "description": "Locomotion planning, contact mechanics, and robot control for humanoid models",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/robotics/__init__.py",
+        "web_route": "/docs/robotics",
+        "logo": "drake.svg",
+        "status": "experimental",
+        "capabilities": ["locomotion", "contact", "planning"],
+        "order": 40,
+    },
+    {
+        "id": "tools_calculator_hub",
+        "name": "Tools Calculator Suite",
+        "description": "Engineering process calculators from the Tools repo (50+ calculators)",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/data_processing/data_processor/launch_pyqt6.py",
+        "web_route": "/tools/calculators",
+        "logo": "data_explorer.svg",
+        "status": "external",
+        "capabilities": ["process_calculators", "engineering", "analysis"],
+        "order": 41,
+    },
+    {
+        "id": "pid_generator",
+        "name": "P&ID Generator",
+        "description": "Programmatic P&ID Generator from the Tools repo - create ISA-5.1 piping diagrams",
+        "category": "tool",
+        "type": "special_app",
+        "path": "src/tools/pid_generator/__main__.py",
+        "web_route": "/docs/pid-generator",
+        "logo": "data_explorer.svg",
+        "status": "external",
+        "capabilities": ["pid_generation", "isa_5_1", "diagrams"],
+        "order": 42,
+    },
+]
+
+
+def main() -> None:
+    """Add new tiles to the manifest (idempotent)."""
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    existing_ids = {t["id"] for t in data["tiles"]}
+
+    # Find the starting_pose_matcher (order=99) to insert before it
+    spm_index = next(
+        i for i, t in enumerate(data["tiles"]) if t["id"] == "starting_pose_matcher"
+    )
+
+    added = 0
+    for tile in NEW_TILES:
+        if tile["id"] not in existing_ids:
+            data["tiles"].insert(spm_index, tile)
+            spm_index += 1
+            added += 1
+
+    MANIFEST_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Added {added} tiles. Total: {len(data['tiles'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -550,6 +550,247 @@
       "order": 28
     },
     {
+      "id": "drake_dashboard",
+      "name": "Drake Dashboard",
+      "description": "Interactive Drake simulation dashboard",
+      "category": "physics_engine",
+      "type": "special_app",
+      "path": "src/launchers/drake_dashboard.py",
+      "engine_type": "drake",
+      "logo": "drake.svg",
+      "status": "experimental",
+      "web_route": "/tools/drake-dashboard",
+      "capabilities": [
+        "rigid_body",
+        "optimization",
+        "dashboard"
+      ],
+      "order": 29
+    },
+    {
+      "id": "mujoco_dashboard",
+      "name": "MuJoCo Dashboard",
+      "description": "Interactive MuJoCo simulation dashboard",
+      "category": "physics_engine",
+      "type": "special_app",
+      "path": "src/launchers/mujoco_dashboard.py",
+      "engine_type": "mujoco",
+      "logo": "mujoco_humanoid.svg",
+      "status": "experimental",
+      "web_route": "/tools/mujoco-dashboard",
+      "capabilities": [
+        "rigid_body",
+        "contact",
+        "dashboard"
+      ],
+      "order": 30
+    },
+    {
+      "id": "pinocchio_dashboard",
+      "name": "Pinocchio Dashboard",
+      "description": "Interactive Pinocchio simulation dashboard",
+      "category": "physics_engine",
+      "type": "special_app",
+      "path": "src/launchers/pinocchio_dashboard.py",
+      "engine_type": "pinocchio",
+      "logo": "pinocchio.svg",
+      "status": "experimental",
+      "web_route": "/tools/pinocchio-dashboard",
+      "capabilities": [
+        "rigid_body",
+        "inverse_kinematics",
+        "dashboard"
+      ],
+      "order": 31
+    },
+    {
+      "id": "analysis_tools_api",
+      "name": "Analysis Tools",
+      "description": "REST API access to 6 analysis endpoints (swing metrics, biomechanics)",
+      "category": "analysis",
+      "type": "special_app",
+      "path": "src/api/routes/analysis_tools.py",
+      "web_route": "/api/analysis",
+      "logo": "data_explorer.svg",
+      "status": "ready",
+      "capabilities": [
+        "swing_metrics",
+        "biomechanics",
+        "api"
+      ],
+      "order": 32
+    },
+    {
+      "id": "motion_pipeline",
+      "name": "Motion Pipeline",
+      "description": "Full markerless mocap to forward-dynamics pipeline (video in, motion out)",
+      "category": "motion_matching",
+      "type": "special_app",
+      "path": "src/shared/python/motion_pipeline/api.py",
+      "web_route": "/tools/motion-pipeline",
+      "logo": "c3d_icon.svg",
+      "status": "experimental",
+      "capabilities": [
+        "markerless_mocap",
+        "forward_dynamics",
+        "pipeline"
+      ],
+      "order": 33
+    },
+    {
+      "id": "perturbation_analysis",
+      "name": "Perturbation Analysis",
+      "description": "Cross-engine robustness analysis via perturbation testing",
+      "category": "analysis",
+      "type": "special_app",
+      "path": "src/api/routes/physics.py",
+      "web_route": "/api/perturbation",
+      "logo": "data_explorer.svg",
+      "status": "experimental",
+      "capabilities": [
+        "perturbation",
+        "robustness",
+        "cross_engine"
+      ],
+      "order": 34
+    },
+    {
+      "id": "force_overlays",
+      "name": "Force Overlays",
+      "description": "Physics visualization: joint forces and torques overlaid on 3D model",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/api/routes/force_overlays.py",
+      "web_route": "/api/force-overlays",
+      "logo": "mujoco_humanoid.svg",
+      "status": "experimental",
+      "capabilities": [
+        "force_visualization",
+        "joint_torques",
+        "3d_overlay"
+      ],
+      "order": 35
+    },
+    {
+      "id": "realtime_ws",
+      "name": "Realtime WebSocket",
+      "description": "Live simulation data stream via WebSocket pub-sub",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/api/routes/realtime.py",
+      "web_route": "/ws/realtime",
+      "logo": "data_explorer.svg",
+      "status": "experimental",
+      "capabilities": [
+        "websocket",
+        "realtime",
+        "pubsub"
+      ],
+      "order": 36
+    },
+    {
+      "id": "aip",
+      "name": "AI Protocol (AIP)",
+      "description": "AI-native simulation control protocol with structured method dispatch",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/api/routes/aip.py",
+      "web_route": "/api/aip",
+      "logo": "golf_logo.svg",
+      "status": "experimental",
+      "capabilities": [
+        "ai_methods",
+        "protocol",
+        "dispatch"
+      ],
+      "order": 37
+    },
+    {
+      "id": "actuator_controls",
+      "name": "Actuator Controls",
+      "description": "Live actuator parameter tuning and control scheme editor",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/api/routes/actuator_controls.py",
+      "web_route": "/api/actuator-controls",
+      "logo": "mujoco_humanoid.svg",
+      "status": "experimental",
+      "capabilities": [
+        "actuator_tuning",
+        "control_schemes",
+        "realtime"
+      ],
+      "order": 38
+    },
+    {
+      "id": "unreal_integration",
+      "name": "Unreal Integration",
+      "description": "Unreal Engine streaming and VR visualization for golf swing simulation",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/unreal_integration/__init__.py",
+      "web_route": "/docs/unreal-integration",
+      "logo": "golf_logo.svg",
+      "status": "external",
+      "capabilities": [
+        "streaming",
+        "vr",
+        "visualization"
+      ],
+      "order": 39
+    },
+    {
+      "id": "robotics_module",
+      "name": "Robotics Module",
+      "description": "Locomotion planning, contact mechanics, and robot control for humanoid models",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/robotics/__init__.py",
+      "web_route": "/docs/robotics",
+      "logo": "drake.svg",
+      "status": "experimental",
+      "capabilities": [
+        "locomotion",
+        "contact",
+        "planning"
+      ],
+      "order": 40
+    },
+    {
+      "id": "tools_calculator_hub",
+      "name": "Tools Calculator Suite",
+      "description": "Engineering process calculators from the Tools repo (50+ calculators)",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/data_processing/data_processor/launch_pyqt6.py",
+      "web_route": "/tools/calculators",
+      "logo": "data_explorer.svg",
+      "status": "external",
+      "capabilities": [
+        "process_calculators",
+        "engineering",
+        "analysis"
+      ],
+      "order": 41
+    },
+    {
+      "id": "pid_generator",
+      "name": "P&ID Generator",
+      "description": "Programmatic P&ID Generator from the Tools repo - create ISA-5.1 piping diagrams",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/tools/pid_generator/__main__.py",
+      "web_route": "/docs/pid-generator",
+      "logo": "data_explorer.svg",
+      "status": "external",
+      "capabilities": [
+        "pid_generation",
+        "isa_5_1",
+        "diagrams"
+      ],
+      "order": 42
+    },
+    {
       "id": "starting_pose_matcher",
       "name": "Starting-Pose Matcher (legacy)",
       "description": "Legacy alias for the motion-target preview tile. Hidden by default; kept for one release so saved layouts continue to resolve.",

--- a/tests/launchers/test_tile_coverage_post_5556.py
+++ b/tests/launchers/test_tile_coverage_post_5556.py
@@ -1,0 +1,167 @@
+"""Tests verifying tile coverage after the post-#5556 audit (PR: fix/6c-remaining-tiles).
+
+These tests assert that every tile added in the audit branch is present in
+the manifest, that no duplicate IDs exist, and that the manifest is valid
+JSON.  They serve as a permanent regression guard so future manifest edits
+cannot silently drop a tile that was deliberately added.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+MANIFEST_PATH = (
+    Path(__file__).parent.parent.parent / "src" / "config" / "launcher_manifest.json"
+)
+
+# ---------------------------------------------------------------------------
+# Tiles added by the post-#5556 audit (PR fix/6c-remaining-tiles-post-5556-audit)
+# ---------------------------------------------------------------------------
+TILES_ADDED_IN_AUDIT = [
+    # Engine-specific dashboards (#5515)
+    "drake_dashboard",
+    "mujoco_dashboard",
+    "pinocchio_dashboard",
+    # Analysis Tools API (#5521)
+    "analysis_tools_api",
+    # Motion Pipeline (#5523)
+    "motion_pipeline",
+    # Capability tiles (#5524-#5530)
+    "perturbation_analysis",
+    "force_overlays",
+    "realtime_ws",
+    "aip",
+    "actuator_controls",
+    # New feature tiles (#5532-#5535)
+    "unreal_integration",
+    "robotics_module",
+    "tools_calculator_hub",
+    "pid_generator",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def manifest_data() -> dict:
+    """Load the raw launcher manifest JSON once per test module."""
+    with open(MANIFEST_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def tile_ids(manifest_data: dict) -> set[str]:
+    """Return the set of all tile IDs present in the manifest."""
+    return {tile["id"] for tile in manifest_data["tiles"]}
+
+
+# ---------------------------------------------------------------------------
+# Manifest validity
+# ---------------------------------------------------------------------------
+
+
+class TestManifestValidity:
+    """Basic structural validity tests for the manifest file."""
+
+    def test_manifest_is_valid_json(self) -> None:
+        """The manifest file must parse as valid JSON without raising."""
+        raw = MANIFEST_PATH.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+        assert "tiles" in data
+
+    def test_manifest_has_tiles_list(self, manifest_data: dict) -> None:
+        """tiles must be a non-empty list."""
+        assert isinstance(manifest_data["tiles"], list)
+        assert len(manifest_data["tiles"]) > 0
+
+    def test_no_duplicate_ids(self, manifest_data: dict) -> None:
+        """No two tiles may share the same ID."""
+        ids = [tile["id"] for tile in manifest_data["tiles"]]
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for tid in ids:
+            if tid in seen:
+                duplicates.append(tid)
+            seen.add(tid)
+        assert not duplicates, f"Duplicate tile IDs found: {duplicates}"
+
+    def test_no_duplicate_orders(self, manifest_data: dict) -> None:
+        """No two tiles may share the same order value."""
+        orders = [tile["order"] for tile in manifest_data["tiles"]]
+        seen: set[int] = set()
+        duplicates: list[int] = []
+        for order in orders:
+            if order in seen:
+                duplicates.append(order)
+            seen.add(order)
+        assert not duplicates, f"Duplicate order values: {duplicates}"
+
+
+# ---------------------------------------------------------------------------
+# Audit tile presence
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTilesPresent:
+    """Verify every tile added in the post-#5556 audit is still in the manifest."""
+
+    @pytest.mark.parametrize("tile_id", TILES_ADDED_IN_AUDIT)
+    def test_audit_tile_is_present(self, tile_ids: set[str], tile_id: str) -> None:
+        """Each tile introduced in the audit must be present in the manifest."""
+        assert tile_id in tile_ids, (
+            f"Expected tile '{tile_id}' in manifest but it was not found. "
+            "This tile was added intentionally — restore it or update this test."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Audit tile field completeness
+# ---------------------------------------------------------------------------
+
+REQUIRED_FIELDS = [
+    "id",
+    "name",
+    "description",
+    "category",
+    "type",
+    "logo",
+    "status",
+    "capabilities",
+    "order",
+]
+
+
+class TestAuditTileFields:
+    """Verify every audit tile has all required fields and a path or web_route."""
+
+    def _get_audit_tiles(self, manifest_data: dict) -> list[dict]:
+        audit_set = set(TILES_ADDED_IN_AUDIT)
+        return [t for t in manifest_data["tiles"] if t["id"] in audit_set]
+
+    @pytest.mark.parametrize("field", REQUIRED_FIELDS)
+    def test_audit_tiles_have_required_field(
+        self, manifest_data: dict, field: str
+    ) -> None:
+        """Every audit tile must declare all required fields with a non-None value."""
+        missing: list[str] = []
+        for tile in self._get_audit_tiles(manifest_data):
+            if field not in tile or tile[field] is None:
+                missing.append(tile.get("id", "<unknown>"))
+        assert not missing, f"Audit tiles missing required field '{field}': {missing}"
+
+    def test_audit_tiles_have_path_or_web_route(self, manifest_data: dict) -> None:
+        """Every audit tile must have either a path or a web_route."""
+        missing: list[str] = []
+        for tile in self._get_audit_tiles(manifest_data):
+            if not tile.get("path") and not tile.get("web_route"):
+                missing.append(tile["id"])
+        assert not missing, (
+            f"Audit tiles with neither 'path' nor 'web_route': {missing}"
+        )


### PR DESCRIPTION
Closes #5515 #5521 #5523 #5524 #5527 #5528 #5529 #5530 #5532 #5533 #5534 #5535

## Summary

Post-audit after PR #5556 merge. Verifies which issues were already resolved by the merged manifest, closes them with explanatory comments, then adds the 14 tiles that PR #5560 (closed without merging) would have contributed:

- **Engine dashboards** (#5515): drake_dashboard, mujoco_dashboard, pinocchio_dashboard — launcher files exist at `src/launchers/`
- **Analysis Tools API** (#5521): analysis_tools_api — routes at `src/api/routes/analysis_tools.py`
- **Motion Pipeline** (#5523): motion_pipeline — module at `src/shared/python/motion_pipeline/api.py`
- **Capability tiles** (#5524-#5530): perturbation_analysis, force_overlays, realtime_ws, aip, actuator_controls — all backed by existing route files
- **Feature tiles** (#5532-#5535): unreal_integration (src/unreal_integration/), robotics_module (src/robotics/), tools_calculator_hub, pid_generator

**Issues already closed by #5556** (closed with comment): #5512 (shot_tracer), #5513 (pose_studio), #5516 (swing_optimizer), #5517 (injury_analysis), #5518 (terrain_engine), #5519 (dataset_generator), #5520 (motion_matching category), #5522 (chat_assistant), #5525 (character_builder), #5526 (pendulum_simulator), #5531 (bunkershot3d), #5539 (simulation sidebar)

**Closed by-design**: #5536 (Dashboard Recorder intentionally internal), #5537 (classification audit complete)

## Test plan

- [ ] All 28 new parametrized tests in `tests/launchers/test_tile_coverage_post_5556.py` pass
- [ ] No regression in existing manifest tests (5 pre-existing failures from #5556 remain unchanged)
- [ ] `python -c "import json; json.load(open('src/config/launcher_manifest.json'))"\ returns without error
- [ ] No duplicate tile IDs or order values
- [ ] All 14 new tiles have required fields (id, name, description, category, type, logo, status, capabilities, order) + path or web_route

🤖 Generated with [Claude Code](https://claude.com/claude-code)