### PR TITLE
fix(launcher,a11y): sidebar proportional sizing + emoji->text + aria-live scope

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.173                                            |
+| **Spec Version**        | 1.0.174                                            |
 | **Last Spec Update**    | 2026-05-15                                         |
 
 ## 2. Purpose & Mission

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.0                                              |
-| **Spec Version**        | 1.0.172                                            |
+| **Spec Version**        | 1.0.173                                            |
 | **Last Spec Update**    | 2026-05-15                                         |
 
 ## 2. Purpose & Mission
@@ -555,7 +555,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 ## 12. Change Log
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| 2026-05-15 | 1.0.172 | Integrated Sidekick across the launcher: registered the AI chat panel as an EmbeddableTool tile (`src/tools/sidekick/`), bound React `ChatPanel` to `var(--sidekick-color-*)` design tokens with a Python/TypeScript parity test, added a redacted ring-buffer chat-context bridge that injects recent app state into the assistant prompt, registered a `summarize_simulation_run` agentic analytics tool, and surfaced Tools-sidebar availability through `LauncherDiagnostics`. Refs #5460 #5461 #5462 #5463 #5464 #5465. |
+| 2026-05-15 | 1.0.173 | Integrated Sidekick across the launcher: registered the AI chat panel as an EmbeddableTool tile (`src/tools/sidekick/`), bound React `ChatPanel` to `var(--sidekick-color-*)` design tokens with a Python/TypeScript parity test, added a redacted ring-buffer chat-context bridge that injects recent app state into the assistant prompt, registered a `summarize_simulation_run` agentic analytics tool, and surfaced Tools-sidebar availability through `LauncherDiagnostics`. Refs #5460 #5461 #5462 #5463 #5464 #5465. |
 | 2026-05-18 | 1.0.171 | ⚡ Bolt: Optimize norm calculations in plot_error_timecourse using np.einsum |
 | 2026-05-14 | 1.0.170 | ⚡ Bolt: Optimize sum of squares along axis in perstep train metrics |
 | 2026-05-14 | 1.0.169 | Added a shared row norm helper for vectorized norm calculations in motion-matching and validation paths. |

--- a/src/launchers/launcher_diagnostics.py
+++ b/src/launchers/launcher_diagnostics.py
@@ -833,9 +833,9 @@ class LauncherDiagnostics:
             else:
                 result = DiagnosticResult(
                     name="tools_sidebar",
-                    status="warning",
+                    status="info",
                     message=(
-                        "Tools sidebar not installed - launcher will run "
+                        "Tools sidebar not installed (expected) - launcher runs "
                         "without the optional PyQt sidebar (Sidekick tokens "
                         "still apply to the React/Tauri shell)"
                     ),

--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -198,8 +198,13 @@ class LauncherUISetupMixin:
         # Content Container
         content_container = QWidget()
         content_layout = QVBoxLayout(content_container)
-        content_layout.setSpacing(20)
-        content_layout.setContentsMargins(30, 30, 30, 30)
+        content_layout.setSpacing(Styles.SPACING_LG)
+        content_layout.setContentsMargins(
+            Styles.MARGIN_PAGE,
+            Styles.MARGIN_PAGE,
+            Styles.MARGIN_PAGE,
+            Styles.MARGIN_PAGE,
+        )
 
         # --- Top Bar ---
         top_bar = self._setup_top_bar()
@@ -236,10 +241,9 @@ class LauncherUISetupMixin:
 
         main_layout.addWidget(content_container)
 
-        # Set stretch factors: Sidebar shouldn't stretch by default, content should take the rest
-        main_layout.setStretchFactor(0, 0)
-        main_layout.setStretchFactor(1, 1)
-        main_layout.setSizes([85, 1200])
+        # Proportional sizing: sidebar gets ~1/6, content ~5/6.
+        main_layout.setStretchFactor(0, 1)
+        main_layout.setStretchFactor(1, 5)
 
         # Apply dark theme
         self.apply_styles()
@@ -253,7 +257,7 @@ class LauncherUISetupMixin:
     def _setup_global_sidebar(self) -> QWidget:
         """Create the global sidebar navigation."""
         sidebar = QWidget()
-        sidebar.setMinimumWidth(85)
+        sidebar.setMinimumWidth(Styles.SIDEBAR_MIN_WIDTH)
         sidebar.setSizePolicy(
             QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
         )

--- a/src/shared/python/ai/chat_context.py
+++ b/src/shared/python/ai/chat_context.py
@@ -25,6 +25,17 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = [
+    "AppStateRingBuffer",
+    "ChatContextProvider",
+    "DEFAULT_CAPACITY",
+    "DEFAULT_MAX_BYTES",
+    "format_context_section",
+    "get_chat_context",
+    "record_event",
+    "reset_buffer",
+]
+
 # ── Constants ────────────────────────────────────────────────────────
 
 DEFAULT_CAPACITY: int = 50

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -795,7 +795,7 @@ class AIAssistantPanel(QWidget):
 
         # Add welcome message
         self._add_system_message(
-            "👋 Welcome to the Golf Modeling Suite AI Assistant!\n\n"
+            "Welcome to the Golf Modeling Suite AI Assistant!\n\n"
             "I can help you:\n"
             "- Load and analyze C3D motion capture files\n"
             "- Run inverse dynamics simulations\n"
@@ -917,7 +917,7 @@ class AIAssistantPanel(QWidget):
             raise ValueError("message must be provided")
         if not self._adapter:
             self._add_system_message(
-                "⚠️ No AI provider configured. Click ⚙️ to set up a provider."
+                "No AI provider configured — open Settings to add one."
             )
             return
 
@@ -998,7 +998,7 @@ class AIAssistantPanel(QWidget):
         self._send_btn.setEnabled(True)
 
         if self._current_assistant_message:
-            self._current_assistant_message.append_content(f"\n\n⚠️ **Error:** {error}")
+            self._current_assistant_message.append_content(f"\n\n**Error:** {error}")
 
         self._current_assistant_message = None
         # Disconnect signals before clearing worker reference to prevent memory leaks
@@ -1105,7 +1105,7 @@ class AIAssistantPanel(QWidget):
         self._save_history()
 
         # Add welcome back
-        self._add_system_message("🔄 New chat started. How can I help you?")
+        self._add_system_message("New chat started. How can I help you?")
 
     def set_adapter(self, adapter: BaseAgentAdapter) -> None:
         """Set the AI adapter to use.
@@ -1153,13 +1153,13 @@ class AIAssistantPanel(QWidget):
         from src.shared.python.ai.types import ExpertiseLevel
 
         # Update Header Icons
-        provider_icons = {
-            AIProvider.OLLAMA: "🦙",
-            AIProvider.OPENAI: "🧠",
-            AIProvider.ANTHROPIC: "🤖",
-            AIProvider.GEMINI: "✨",
+        provider_labels = {
+            AIProvider.OLLAMA: "[Ollama]",
+            AIProvider.OPENAI: "[OpenAI]",
+            AIProvider.ANTHROPIC: "[Anthropic]",
+            AIProvider.GEMINI: "[Gemini]",
         }
-        icon = provider_icons.get(settings.provider, "🤖")
+        icon = provider_labels.get(settings.provider, "[AI]")
         self._provider_icon.setText(icon)
 
         # Update Model Label
@@ -1199,7 +1199,7 @@ class AIAssistantPanel(QWidget):
                     chat_path=chat_path,
                     embed_path=embed_path,
                 )
-                self._add_system_message("🚀 Using high-performance Rust AI backend.")
+                self._add_system_message("Using high-performance Rust AI backend.")
             except ImportError:
                 from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
 
@@ -1240,11 +1240,11 @@ class AIAssistantPanel(QWidget):
         if adapter:
             self.set_adapter(adapter)
             self._add_system_message(
-                f"✓ Connected to {settings.provider.name} ({settings.model})"
+                f"Connected to {settings.provider.name} ({settings.model})"
             )
         else:
             self._add_system_message(
-                f"⚠️ Could not connect to {settings.provider.name}. "
+                f"Could not connect to {settings.provider.name}. "
                 "Please check your settings."
             )
 

--- a/src/shared/python/theme/style_constants.py
+++ b/src/shared/python/theme/style_constants.py
@@ -345,6 +345,19 @@ class Styles:
     """No recording data (idle state)."""
 
     # ══════════════════════════════════════════════════════════════════
+    # Layout Dimension Constants (issue #5505)
+    # ══════════════════════════════════════════════════════════════════
+
+    SIDEBAR_MIN_WIDTH: int = 120
+    """Minimum width in pixels for the global launcher sidebar."""
+
+    SPACING_LG: int = 20
+    """Large spacing value (px) for layout setSpacing calls."""
+
+    MARGIN_PAGE: int = 30
+    """Page-level margin (px) for content layout setContentsMargins calls."""
+
+    # ══════════════════════════════════════════════════════════════════
     # Layout / Container Styles
     # ══════════════════════════════════════════════════════════════════
 

--- a/tests/unit/launchers/test_launcher_sidebar_sizing.py
+++ b/tests/unit/launchers/test_launcher_sidebar_sizing.py
@@ -1,0 +1,78 @@
+"""Tests for issue #5505 — proportional sidebar sizing.
+
+Verifies:
+- Styles.SIDEBAR_MIN_WIDTH, Styles.SPACING_LG, Styles.MARGIN_PAGE constants exist.
+- Launcher uses Styles.SIDEBAR_MIN_WIDTH for sidebar.setMinimumWidth().
+- Launcher replaces hard-coded setSizes([85, 1200]) with 1:5 stretch factors.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def _styles():
+    """Import Styles (safe; module has no top-level Qt calls)."""
+    from src.shared.python.theme.style_constants import Styles
+
+    return Styles
+
+
+def test_sidebar_minimum_width_constant_exists():
+    """Styles.SIDEBAR_MIN_WIDTH must exist and be >= 120 px (issue #5505)."""
+    Styles = _styles()
+    assert hasattr(Styles, "SIDEBAR_MIN_WIDTH"), "Styles.SIDEBAR_MIN_WIDTH not found"
+    assert isinstance(Styles.SIDEBAR_MIN_WIDTH, int)
+    assert Styles.SIDEBAR_MIN_WIDTH >= 120, (
+        f"Expected SIDEBAR_MIN_WIDTH >= 120, got {Styles.SIDEBAR_MIN_WIDTH}"
+    )
+
+
+def test_spacing_constant_exists():
+    """Styles.SPACING_LG must equal 20 (issue #5505)."""
+    Styles = _styles()
+    assert hasattr(Styles, "SPACING_LG"), "Styles.SPACING_LG not found"
+    assert Styles.SPACING_LG == 20, (
+        f"Expected SPACING_LG == 20, got {Styles.SPACING_LG}"
+    )
+
+
+def test_margin_page_constant_exists():
+    """Styles.MARGIN_PAGE must equal 30 (issue #5505)."""
+    Styles = _styles()
+    assert hasattr(Styles, "MARGIN_PAGE"), "Styles.MARGIN_PAGE not found"
+    assert Styles.MARGIN_PAGE == 30, (
+        f"Expected MARGIN_PAGE == 30, got {Styles.MARGIN_PAGE}"
+    )
+
+
+def test_sidebar_widget_minimum_width_uses_constant():
+    """_setup_global_sidebar must call setMinimumWidth(Styles.SIDEBAR_MIN_WIDTH)."""
+    source_path = "src/launchers/launcher_ui_setup.py"
+    with open(source_path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    assert "Styles.SIDEBAR_MIN_WIDTH" in source, (
+        "launcher_ui_setup.py must use Styles.SIDEBAR_MIN_WIDTH "
+        "instead of a hard-coded pixel value"
+    )
+    assert not re.search(r"setMinimumWidth\(85\)", source), (
+        "Hard-coded setMinimumWidth(85) still present; replace with Styles.SIDEBAR_MIN_WIDTH"
+    )
+
+
+def test_main_splitter_uses_stretch_factors_not_fixed_sizes():
+    """_setup_main_layout must use 1:5 stretch factors and drop setSizes([85,...])."""
+    source_path = "src/launchers/launcher_ui_setup.py"
+    with open(source_path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    assert not re.search(r"setSizes\(\s*\[85", source), (
+        "Hard-coded setSizes([85, ...]) still present; replace with setStretchFactor"
+    )
+
+    stretch_matches = re.findall(r"setStretchFactor\((\d+),\s*(\d+)\)", source)
+    factors = {int(f) for _, f in stretch_matches}
+    assert 1 in factors and 5 in factors, (
+        f"Expected setStretchFactor calls with factors 1 and 5; found factors {factors}"
+    )

--- a/tests/unit/test_sidekick_accessibility.py
+++ b/tests/unit/test_sidekick_accessibility.py
@@ -1,0 +1,186 @@
+"""Tests for issue #5506 — sidekick accessibility / hygiene.
+
+Covers:
+5506a: assistant_panel.py contains no emoji literals.
+5506b: chat_context.py exposes __all__.
+5506c: check_tools_sidebar diagnostic uses "info" (not "warning") when not installed.
+5506d: ChatPanel.tsx has aria-relevant="additions" and aria-atomic="false".
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+# Broad emoji regex: Miscellaneous Symbols, Dingbats, Emoticons, etc.
+_EMOJI_RE = re.compile(
+    r"[\U0001F300-\U0001F64F"
+    r"\U0001F680-\U0001F6FF"
+    r"\U0001F900-\U0001FAFF"
+    r"☀-➿"  # Misc symbols + dingbats
+    r"️]"  # Variation selector-16 (emoji presentation)
+)
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Module path used by check_tools_sidebar's internal import
+_SIDEBAR_INTEGRATION = "src.shared.python.gui_launcher.tools_sidebar_integration"
+
+
+# ---------------------------------------------------------------------------
+# 5506a — no emoji literals in assistant_panel.py
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_panel_no_emoji_literals():
+    """assistant_panel.py must not contain emoji literal characters (issue #5506a)."""
+    panel_path = (
+        _REPO_ROOT / "src" / "shared" / "python" / "ai" / "gui" / "assistant_panel.py"
+    )
+    assert panel_path.exists(), f"File not found: {panel_path}"
+    source = panel_path.read_text(encoding="utf-8")
+    matches = _EMOJI_RE.findall(source)
+    assert not matches, (
+        f"assistant_panel.py contains {len(matches)} emoji literal(s): "
+        f"{list(set(matches))[:10]}. Replace with text equivalents."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5506b — chat_context.py has __all__
+# ---------------------------------------------------------------------------
+
+
+def test_chat_context_has_all():
+    """chat_context must expose __all__ (issue #5506b)."""
+    from src.shared.python.ai import chat_context
+
+    assert hasattr(chat_context, "__all__"), "chat_context module is missing __all__"
+    assert len(chat_context.__all__) > 0, "__all__ must not be empty"
+
+
+def test_chat_context_all_contains_record_event():
+    """chat_context.__all__ must include the primary public helper (issue #5506b)."""
+    from src.shared.python.ai import chat_context
+
+    assert "record_event" in chat_context.__all__, (
+        "'record_event' must appear in chat_context.__all__"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5506c — check_tools_sidebar returns "info" when not installed
+# ---------------------------------------------------------------------------
+
+
+def _get_diag():
+    """Return a fresh LauncherDiagnostics instance with results list ready."""
+    from src.launchers.launcher_diagnostics import LauncherDiagnostics
+
+    diag = LauncherDiagnostics.__new__(LauncherDiagnostics)
+    diag.results = []
+    return diag
+
+
+def _make_sidebar_stub(available: bool) -> MagicMock:
+    """Build a sys.modules stub for tools_sidebar_integration."""
+    stub = MagicMock()
+    stub.is_tools_sidebar_available = MagicMock(return_value=available)
+    stub._resolved_sidebar_module_name = MagicMock(
+        return_value="vendor.ud_tools.shared_sidebar"
+    )
+    return stub
+
+
+def test_check_tools_sidebar_not_installed_returns_info():
+    """When the Tools sidebar module is absent, status must be 'info' (issue #5506c)."""
+    diag = _get_diag()
+    stub = _make_sidebar_stub(available=False)
+    prev = sys.modules.get(_SIDEBAR_INTEGRATION)
+    sys.modules[_SIDEBAR_INTEGRATION] = stub
+    try:
+        result = diag.check_tools_sidebar()
+    finally:
+        if prev is None:
+            sys.modules.pop(_SIDEBAR_INTEGRATION, None)
+        else:
+            sys.modules[_SIDEBAR_INTEGRATION] = prev
+
+    assert result.status == "info", (
+        f"Expected 'info' when Tools sidebar absent, got '{result.status}'"
+    )
+
+
+def test_check_tools_sidebar_import_error_returns_warning():
+    """An ImportError during import must still yield 'warning' (issue #5506c)."""
+    diag = _get_diag()
+
+    # Inject a stub whose attribute access raises ImportError so that the
+    # `from <mod> import is_tools_sidebar_available` inside check_tools_sidebar
+    # raises ImportError during execution.
+    class _BrokenModule:
+        """Stub module whose attribute access raises ImportError."""
+
+        def __getattr__(self, name: str):
+            raise ImportError(f"simulated import failure for {name}")
+
+    prev = sys.modules.get(_SIDEBAR_INTEGRATION)
+    sys.modules[_SIDEBAR_INTEGRATION] = _BrokenModule()  # type: ignore[assignment]
+    try:
+        result = diag.check_tools_sidebar()
+    finally:
+        if prev is None:
+            sys.modules.pop(_SIDEBAR_INTEGRATION, None)
+        else:
+            sys.modules[_SIDEBAR_INTEGRATION] = prev
+
+    assert result.status == "warning", (
+        f"Expected 'warning' on ImportError, got '{result.status}'"
+    )
+
+
+def test_check_tools_sidebar_available_returns_pass():
+    """When the sidebar IS importable the status must be 'pass'."""
+    diag = _get_diag()
+    stub = _make_sidebar_stub(available=True)
+    prev = sys.modules.get(_SIDEBAR_INTEGRATION)
+    sys.modules[_SIDEBAR_INTEGRATION] = stub
+    try:
+        result = diag.check_tools_sidebar()
+    finally:
+        if prev is None:
+            sys.modules.pop(_SIDEBAR_INTEGRATION, None)
+        else:
+            sys.modules[_SIDEBAR_INTEGRATION] = prev
+
+    assert result.status == "pass", (
+        f"Expected 'pass' when Tools sidebar available, got '{result.status}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5506d — ChatPanel.tsx aria-relevant + aria-atomic
+# ---------------------------------------------------------------------------
+
+
+def test_chat_panel_tsx_aria_relevant_additions():
+    """ChatPanel.tsx messages div must have aria-relevant='additions' (issue #5506d)."""
+    tsx_path = _REPO_ROOT / "ui" / "src" / "components" / "ui" / "ChatPanel.tsx"
+    assert tsx_path.exists(), f"File not found: {tsx_path}"
+    source = tsx_path.read_text(encoding="utf-8")
+    assert 'aria-relevant="additions"' in source, (
+        'ChatPanel.tsx messages div is missing aria-relevant="additions"'
+    )
+
+
+def test_chat_panel_tsx_aria_atomic_false():
+    """ChatPanel.tsx messages div must have aria-atomic='false' (issue #5506d)."""
+    tsx_path = _REPO_ROOT / "ui" / "src" / "components" / "ui" / "ChatPanel.tsx"
+    assert tsx_path.exists(), f"File not found: {tsx_path}"
+    source = tsx_path.read_text(encoding="utf-8")
+    assert 'aria-atomic="false"' in source, (
+        'ChatPanel.tsx messages div is missing aria-atomic="false"'
+    )

--- a/ui/src/components/ui/ChatPanel.tsx
+++ b/ui/src/components/ui/ChatPanel.tsx
@@ -381,6 +381,8 @@ export function ChatPanel({ engineContext, url }: ChatPanelProps = {}) {
         className="flex-1 overflow-y-auto p-3 space-y-2 text-sm"
         role="log"
         aria-live="polite"
+        aria-relevant="additions"
+        aria-atomic="false"
         aria-label="Chat messages"
         data-testid="chat-messages"
       >


### PR DESCRIPTION
## Summary

- **#5505**: Replace hard-coded `85 px` sidebar sizing with `Styles.SIDEBAR_MIN_WIDTH = 120` and proportional `setStretchFactor(0, 1)` / `setStretchFactor(1, 5)` (1:5 split). Add `Styles.SPACING_LG = 20` and `Styles.MARGIN_PAGE = 30` named constants.
- **#5506a**: Remove all emoji literals from `assistant_panel.py`; replace with bracketed text labels (`[AI]`, `[Ollama]`, `[OpenAI]`, `[Anthropic]`, `[Gemini]`) and plain prose.
- **#5506b**: Add `__all__` to `chat_context.py` (8 public symbols).
- **#5506c**: Reclassify `check_tools_sidebar` "not installed" result from `status="warning"` to `status="info"`; unexpected `ImportError` remains `"warning"`.
- **#5506d**: Add `aria-relevant="additions"` and `aria-atomic="false"` to the chat message log `<div>` in `ChatPanel.tsx`.

## Test plan

- [ ] 5 new sidebar-sizing unit tests pass: `tests/unit/launchers/test_launcher_sidebar_sizing.py`
- [ ] 8 new accessibility unit tests pass: `tests/unit/test_sidekick_accessibility.py`
- [ ] `ruff check` — zero violations
- [ ] `ruff format --check` — zero diffs
- [ ] No emoji literals in `assistant_panel.py` (verified by test)
- [ ] `chat_context.__all__` includes `record_event` (verified by test)
- [ ] `check_tools_sidebar` returns `"info"` when sidebar absent, `"warning"` on ImportError (verified by tests)
- [ ] `ChatPanel.tsx` messages div has `aria-relevant="additions"` and `aria-atomic="false"` (verified by tests)

Closes #5505, Closes #5506

🤖 Generated with [Claude Code](https://claude.com/claude-code)