### PR TITLE
feat(pinns): Phase 3 - ShadowModel, PhysicsMode factory, PINN launcher entries

### DIFF
--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -345,3 +345,25 @@ models:
       logo: "project_map.svg"
       status: "ready"
       default_launch: "tab"
+
+  # =============================================================================
+  # PHYSICS-INFORMED NEURAL NETWORKS
+  # =============================================================================
+
+  - id: "pinn_pure_rigid"
+    name: "Pure Rigid Body"
+    description: "Pinocchio inverse dynamics only — no ML"
+    type: "physics_informed"
+    mode: "pure_rigid"
+    launcher:
+      category: "biomechanics"
+      status: "experimental"
+
+  - id: "pinn_hybrid"
+    name: "PINN Hybrid"
+    description: "Rigid body + JAX residual torque MLP"
+    type: "physics_informed"
+    mode: "pinn_hybrid"
+    launcher:
+      category: "biomechanics"
+      status: "experimental"

--- a/src/shared/python/physics_informed/__init__.py
+++ b/src/shared/python/physics_informed/__init__.py
@@ -1,20 +1,30 @@
 """Physics-Informed Neural Network (PINN) hybrid architecture.
 
-Phases 1 & 2 of the PINNs epic (#5419):
+Phases 1-3 of the PINNs epic (#5419):
 
-Phase 1 — hybrid architecture:
+Phase 1 -- hybrid architecture:
 
 - :class:`RigidCore`: Pinocchio RNEA rigid-body inverse-dynamics torque.
 - :class:`MlpResidual`: JAX/Equinox MLP predicting unmodelled torque residuals.
-- :class:`HybridPINN`: Summed predictor ``τ = τ_rigid + τ_residual``.
+- :class:`HybridPINN`: Summed predictor ``tau = tau_rigid + tau_residual``.
 
-Phase 2 — three-component loss function:
+Phase 2 -- three-component loss function:
 
 - :class:`LossWeights`: frozen dataclass with DbC-validated positive weights.
 - :func:`data_loss`: MSE between predicted and actual motion kinematics.
 - :func:`physics_loss`: penalises joint-limit violations and energy anomalies.
 - :func:`contact_loss`: penalises non-zero torques during non-contact phases.
 - :func:`total_loss`: weighted sum of the three component losses.
+
+Phase 3 -- shadow model and mode factory:
+
+- :class:`SwingPhase`: Enum for the three golf-swing phases.
+- :class:`ShadowReport`: Dataclass holding peak residual torques per phase.
+- :class:`ShadowModel`: Observation-mode runner; records peaks without
+  modifying simulation state.
+- :class:`PhysicsMode`: Enum for model-creation modes.
+- :func:`create_model`: Factory returning RigidCore, MlpResidual, or
+  HybridPINN based on the requested :class:`PhysicsMode`.
 
 Optional dependencies
 ---------------------
@@ -38,14 +48,25 @@ from src.shared.python.physics_informed.loss import (
     total_loss,
 )
 from src.shared.python.physics_informed.mlp_residual import MlpResidual
+from src.shared.python.physics_informed.mode import PhysicsMode, create_model
 from src.shared.python.physics_informed.rigid_core import RigidCore
+from src.shared.python.physics_informed.shadow_model import (
+    ShadowModel,
+    ShadowReport,
+    SwingPhase,
+)
 
 __all__ = [
     "HybridPINN",
     "LossWeights",
     "MlpResidual",
+    "PhysicsMode",
     "RigidCore",
+    "ShadowModel",
+    "ShadowReport",
+    "SwingPhase",
     "contact_loss",
+    "create_model",
     "data_loss",
     "physics_loss",
     "total_loss",

--- a/src/shared/python/physics_informed/mode.py
+++ b/src/shared/python/physics_informed/mode.py
@@ -1,0 +1,184 @@
+"""Factory for creating physics-informed model instances by mode.
+
+Phase 3 of the PINNs epic (#5419). Provides:
+
+- :class:`PhysicsMode`: Enum for the three supported physics modes.
+- :func:`create_model`: Factory that returns a :class:`~.rigid_core.RigidCore`,
+  :class:`~.mlp_residual.MlpResidual`, or :class:`~.hybrid_model.HybridPINN`
+  depending on the requested mode.
+
+Optional dependencies:
+- Pinocchio: required for :attr:`PhysicsMode.PURE_RIGID` and
+  :attr:`PhysicsMode.PINN_HYBRID`.
+- JAX + Equinox: required for :attr:`PhysicsMode.PURE_AI` and
+  :attr:`PhysicsMode.PINN_HYBRID`.
+
+If a required dependency is not installed, :func:`create_model` raises
+:class:`ImportError` at call time rather than at module-import time.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class PhysicsMode(Enum):
+    """Mode selector for the physics-informed model factory.
+
+    Attributes:
+        PURE_RIGID:  Pinocchio inverse dynamics only; no ML.
+        PURE_AI:     JAX/Equinox MLP residual only; no rigid-body model.
+        PINN_HYBRID: Rigid body + JAX residual torque MLP (full PINN).
+    """
+
+    PURE_RIGID = "pure_rigid"
+    PURE_AI = "pure_ai"
+    PINN_HYBRID = "pinn_hybrid"
+
+
+def create_model(
+    mode: PhysicsMode,
+    config: dict,
+) -> object:
+    """Factory: return a model instance for the given PhysicsMode.
+
+    Supported modes and required ``config`` keys:
+
+    **PURE_RIGID** -> :class:`~.rigid_core.RigidCore`
+        - ``urdf_path`` (str): Path to URDF file.
+
+    **PURE_AI** -> :class:`~.mlp_residual.MlpResidual`
+        - ``input_dim``  (int): MLP input dimension.
+        - ``output_dim`` (int): MLP output dimension (should equal ``nv``).
+        - ``hidden_dims`` (list[int], optional): Hidden layer widths.
+          Default: ``[64, 64]``.
+        - ``key`` (jax.Array, optional): JAX PRNG key. Default: PRNGKey(0).
+
+    **PINN_HYBRID** -> :class:`~.hybrid_model.HybridPINN`
+        - All keys from both PURE_RIGID and PURE_AI.
+
+    DbC preconditions:
+    - ``mode`` must be a :class:`PhysicsMode` member.
+    - Raises :class:`ValueError` for any other value.
+
+    Args:
+        mode:   Desired physics mode.
+        config: Configuration dictionary; see above for required keys.
+
+    Returns:
+        An instance of :class:`~.rigid_core.RigidCore`,
+        :class:`~.mlp_residual.MlpResidual`, or
+        :class:`~.hybrid_model.HybridPINN`.
+
+    Raises:
+        ValueError:   If ``mode`` is not a recognised :class:`PhysicsMode`.
+        ImportError:  If a required optional dependency is not installed.
+    """
+    if not isinstance(mode, PhysicsMode):
+        raise ValueError(
+            f"Unrecognized PhysicsMode: {mode!r}. "
+            f"Expected one of: {[m.value for m in PhysicsMode]}"
+        )
+
+    logger.debug(
+        "create_model: mode=%s config_keys=%s", mode.value, list(config.keys())
+    )
+
+    if mode == PhysicsMode.PURE_RIGID:
+        return _create_rigid(config)
+    if mode == PhysicsMode.PURE_AI:
+        return _create_mlp(config)
+    if mode == PhysicsMode.PINN_HYBRID:
+        return _create_hybrid(config)
+
+    # Defensive: unreachable if the enum is complete, but satisfies type checkers.
+    raise ValueError(f"Unrecognized PhysicsMode: {mode!r}")  # pragma: no cover
+
+
+# =============================================================================
+# Private factory helpers
+# =============================================================================
+
+
+def _create_rigid(config: dict) -> object:
+    """Instantiate a :class:`~.rigid_core.RigidCore`.
+
+    Args:
+        config: Must contain ``urdf_path`` key.
+
+    Returns:
+        A configured :class:`~.rigid_core.RigidCore`.
+
+    Raises:
+        ImportError: If Pinocchio is not installed.
+        ValueError:  If ``urdf_path`` is missing, empty, or the file does
+            not exist.
+    """
+    from src.shared.python.physics_informed.rigid_core import RigidCore
+
+    urdf_path: str = config.get("urdf_path", "")
+    logger.debug("create_model PURE_RIGID: urdf_path=%r", urdf_path)
+    return RigidCore(urdf_path)
+
+
+def _create_mlp(config: dict) -> object:
+    """Instantiate an :class:`~.mlp_residual.MlpResidual`.
+
+    Args:
+        config: Must contain ``input_dim`` and ``output_dim``.  Optional keys:
+            ``hidden_dims`` (default ``[64, 64]``) and ``key`` (default
+            ``jax.random.PRNGKey(0)``).
+
+    Returns:
+        A configured :class:`~.mlp_residual.MlpResidual`.
+
+    Raises:
+        ImportError: If JAX or Equinox are not installed.
+        ValueError:  If ``input_dim`` or ``output_dim`` are invalid.
+    """
+    import jax
+
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+
+    input_dim: int = config["input_dim"]
+    output_dim: int = config["output_dim"]
+    hidden_dims: list[int] = config.get("hidden_dims", [64, 64])
+    key = config.get("key", jax.random.PRNGKey(0))
+
+    logger.debug(
+        "create_model PURE_AI: input=%d output=%d hidden=%s",
+        input_dim,
+        output_dim,
+        hidden_dims,
+    )
+    return MlpResidual(
+        input_dim=input_dim, output_dim=output_dim, hidden_dims=hidden_dims, key=key
+    )
+
+
+def _create_hybrid(config: dict) -> object:
+    """Instantiate a :class:`~.hybrid_model.HybridPINN`.
+
+    Args:
+        config: Combined keys required by :func:`_create_rigid` and
+            :func:`_create_mlp`.
+
+    Returns:
+        A configured :class:`~.hybrid_model.HybridPINN`.
+
+    Raises:
+        ImportError: If Pinocchio, JAX, or Equinox are not installed.
+        ValueError:  If any required config key is invalid.
+    """
+    from src.shared.python.physics_informed.hybrid_model import HybridPINN
+
+    rigid = _create_rigid(config)
+    mlp = _create_mlp(config)
+
+    logger.debug("create_model PINN_HYBRID: combining rigid + mlp")
+    return HybridPINN(rigid, mlp)  # type: ignore[arg-type]

--- a/src/shared/python/physics_informed/shadow_model.py
+++ b/src/shared/python/physics_informed/shadow_model.py
@@ -1,0 +1,241 @@
+"""Shadow model for non-intrusive observation of PINN residuals per swing phase.
+
+Phase 3 of the PINNs epic (#5419). Provides:
+
+- :class:`SwingPhase`: Enum for the three golf-swing phases.
+- :class:`ShadowReport`: Dataclass holding peak residual torques per phase.
+- :class:`ShadowModel`: Runs rigid simulation + PINN simultaneously in
+  *observation mode*, recording peak residual torques per phase without
+  modifying simulation state.
+
+The model degrades gracefully: if JAX (or any optional dependency) is not
+installed, :meth:`ShadowModel.observe` returns an empty :class:`ShadowReport`
+rather than raising.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+    from src.shared.python.physics_informed.rigid_core import RigidCore
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Enums and dataclasses
+# =============================================================================
+
+
+class SwingPhase(Enum):
+    """Segmentation of a golf swing into three biomechanical phases."""
+
+    TRANSITION = "transition"
+    IMPACT = "impact"
+    FOLLOW_THROUGH = "follow_through"
+
+
+@dataclass
+class ShadowReport:
+    """Container for peak residual torques recorded during shadow observation.
+
+    Attributes:
+        peak_residuals: Mapping from :attr:`SwingPhase.value` string to the
+            peak (max abs) residual torque magnitude recorded in that phase.
+            Empty when no frames were observed or when optional dependencies
+            are unavailable.
+    """
+
+    peak_residuals: dict[str, float] = field(default_factory=dict)
+
+
+# =============================================================================
+# Phase classification helpers
+# =============================================================================
+
+
+def _classify_phase(frame_idx: int, total_frames: int) -> SwingPhase:
+    """Return the SwingPhase for a given frame index.
+
+    Frame distribution (fraction of total):
+    - First 30 %  -> TRANSITION
+    - Middle 40 % -> IMPACT
+    - Last  30 %  -> FOLLOW_THROUGH
+
+    DbC preconditions:
+    - ``total_frames >= 1``
+    - ``0 <= frame_idx < total_frames``
+
+    Args:
+        frame_idx:    Zero-based index of the frame.
+        total_frames: Total number of frames in the sequence.
+
+    Returns:
+        The :class:`SwingPhase` for the given frame.
+    """
+    ratio = frame_idx / total_frames
+    if ratio < 0.30:
+        return SwingPhase.TRANSITION
+    if ratio < 0.70:
+        return SwingPhase.IMPACT
+    return SwingPhase.FOLLOW_THROUGH
+
+
+# =============================================================================
+# ShadowModel
+# =============================================================================
+
+
+class ShadowModel:
+    """Runs rigid simulation + PINN simultaneously in observation mode.
+
+    Records peak residual torques per swing phase *without* modifying
+    simulation state.  The "residual" is the MLP output -- what the rigid-body
+    model alone would miss.
+
+    Parameters
+    ----------
+    rigid_core:
+        Configured :class:`~.rigid_core.RigidCore` instance (Pinocchio).
+    mlp_residual:
+        Configured :class:`~.mlp_residual.MlpResidual` instance (JAX/Equinox).
+
+    Raises
+    ------
+    ValueError
+        If ``rigid_core`` or ``mlp_residual`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        rigid_core: RigidCore,
+        mlp_residual: MlpResidual,
+    ) -> None:
+        """Compose rigid-body core and MLP residual for shadow observation.
+
+        DbC preconditions:
+        - ``rigid_core`` must not be ``None``.
+        - ``mlp_residual`` must not be ``None``.
+
+        Args:
+            rigid_core:   Pinocchio-backed rigid-body torque calculator.
+            mlp_residual: JAX/Equinox MLP residual torque predictor.
+
+        Raises:
+            ValueError: If either argument is ``None``.
+        """
+        if rigid_core is None:
+            raise ValueError("rigid_core must not be None")
+        if mlp_residual is None:
+            raise ValueError("mlp_residual must not be None")
+
+        self._rigid = rigid_core
+        self._mlp = mlp_residual
+
+        logger.debug("ShadowModel created in observation mode")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def observe(self, frames: list[dict]) -> ShadowReport:
+        """Run one pass over simulation frames, recording peak residuals.
+
+        Each frame dict must contain:
+        - ``q``   -- configuration vector (numpy array)
+        - ``dq``  -- velocity vector (numpy array)
+        - ``ddq`` -- acceleration vector (numpy array)
+
+        The method classifies frames into phases by fractional index:
+        - first 30 % -> TRANSITION
+        - middle 40 % -> IMPACT
+        - last 30 %  -> FOLLOW_THROUGH
+
+        For each frame, the MLP residual (the part the rigid model misses)
+        is computed as ``mlp(concat([q, dq, ddq]))``.  The peak
+        ``max(abs(residual))`` is tracked per phase.
+
+        This method is *observation-only*: it never modifies input frames
+        or simulation state.
+
+        Args:
+            frames: List of frame dicts, each with keys ``q``, ``dq``, ``ddq``.
+
+        Returns:
+            :class:`ShadowReport` with ``peak_residuals`` keyed by
+            :attr:`SwingPhase.value` strings.  Returns an empty report if
+            ``frames`` is empty or if an :class:`ImportError` is raised by
+            an optional dependency (graceful degradation without JAX).
+        """
+        if not frames:
+            return ShadowReport()
+
+        phase_peaks: dict[str, float] = {}
+
+        try:
+            total = len(frames)
+            for idx, frame in enumerate(frames):
+                phase = _classify_phase(idx, total)
+                peak = self._compute_frame_peak(frame)
+                key = phase.value
+                if key not in phase_peaks or peak > phase_peaks[key]:
+                    phase_peaks[key] = peak
+
+        except ImportError as exc:
+            logger.warning(
+                "ShadowModel.observe: optional dependency unavailable (%s); "
+                "returning empty ShadowReport",
+                exc,
+            )
+            return ShadowReport()
+
+        logger.debug(
+            "ShadowModel.observe: %d frames -> peak_residuals=%s",
+            len(frames),
+            phase_peaks,
+        )
+        return ShadowReport(peak_residuals=phase_peaks)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _compute_frame_peak(self, frame: dict) -> float:
+        """Compute max(abs(mlp_residual)) for a single frame.
+
+        The MLP receives concat([q, dq, ddq]) and produces a residual torque
+        vector.  We then call rigid_core.compute_torques to ensure correctness
+        (e.g. raise ImportError early if Pinocchio is missing).
+
+        Args:
+            frame: Dict with keys ``q``, ``dq``, ``ddq``.
+
+        Returns:
+            Scalar peak residual magnitude.
+
+        Raises:
+            ImportError: Propagated from rigid_core or mlp_residual if
+                optional dependencies are missing.
+        """
+        q = np.asarray(frame["q"], dtype=np.float64)
+        dq = np.asarray(frame["dq"], dtype=np.float64)
+        ddq = np.asarray(frame["ddq"], dtype=np.float64)
+
+        # Compute rigid torques to surface any ImportError early
+        self._rigid.compute_torques(q, dq, ddq)
+
+        # MLP residual: predict what rigid misses
+        x = np.concatenate([q, dq, ddq])
+        mlp_out = self._mlp(x)
+        residuals = np.asarray(mlp_out, dtype=np.float64)
+
+        return float(np.max(np.abs(residuals)))

--- a/tests/unit/shared_python/test_pinn_shadow.py
+++ b/tests/unit/shared_python/test_pinn_shadow.py
@@ -1,0 +1,253 @@
+"""Tests for Phase 3 of the PINNs epic: ShadowModel, ShadowReport, and mode factory.
+
+Tests are written FIRST (TDD red phase) before implementation.
+JAX-dependent paths are skipped gracefully when JAX is not installed.
+
+Part of epic #5419. Closes #5499.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+try:
+    import jax  # noqa: F401
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+from src.shared.python.physics_informed.mode import PhysicsMode, create_model
+from src.shared.python.physics_informed.shadow_model import (
+    ShadowModel,
+    ShadowReport,
+    SwingPhase,
+)
+
+
+# =============================================================================
+# ShadowReport
+# =============================================================================
+
+
+def test_shadow_report_is_dataclass() -> None:
+    """ShadowReport must be a dataclass with a peak_residuals dict."""
+    report = ShadowReport()
+    assert hasattr(report, "peak_residuals")
+    assert isinstance(report.peak_residuals, dict)
+
+
+def test_shadow_report_defaults_empty_dict() -> None:
+    """Default peak_residuals must be an empty dict (not a shared mutable)."""
+    r1 = ShadowReport()
+    r2 = ShadowReport()
+    # Mutating one instance must not affect the other
+    r1.peak_residuals["x"] = 1.0
+    assert "x" not in r2.peak_residuals
+
+
+# =============================================================================
+# SwingPhase
+# =============================================================================
+
+
+def test_swing_phase_transition_value() -> None:
+    assert SwingPhase.TRANSITION.value == "transition"
+
+
+def test_swing_phase_impact_value() -> None:
+    assert SwingPhase.IMPACT.value == "impact"
+
+
+def test_swing_phase_follow_through_value() -> None:
+    assert SwingPhase.FOLLOW_THROUGH.value == "follow_through"
+
+
+# =============================================================================
+# ShadowModel -- DbC (construction preconditions)
+# =============================================================================
+
+
+def test_shadow_model_requires_non_none_rigid() -> None:
+    """ShadowModel must raise ValueError or TypeError when rigid_core is None."""
+    with pytest.raises((ValueError, TypeError)):
+        ShadowModel(None, MagicMock())
+
+
+def test_shadow_model_requires_non_none_mlp() -> None:
+    """ShadowModel must raise ValueError or TypeError when mlp_residual is None."""
+    with pytest.raises((ValueError, TypeError)):
+        ShadowModel(MagicMock(), None)
+
+
+# =============================================================================
+# ShadowModel -- observe()
+# =============================================================================
+
+
+def test_shadow_model_observe_returns_report() -> None:
+    """observe() must return a ShadowReport when given valid frames."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.zeros(6)
+    mlp = MagicMock()
+    mlp.return_value = np.zeros(6)
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [{"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}]
+    report = sm.observe(frames)
+    assert isinstance(report, ShadowReport)
+
+
+def test_shadow_model_observe_empty_frames_returns_empty_report() -> None:
+    """observe() with no frames must return an empty ShadowReport."""
+    sm = ShadowModel(MagicMock(), MagicMock())
+    report = sm.observe([])
+    assert isinstance(report, ShadowReport)
+    assert report.peak_residuals == {}
+
+
+def test_shadow_model_observe_peak_residuals_uses_phase_keys() -> None:
+    """Non-empty frame list must produce peak_residuals keyed by SwingPhase values."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.ones(6)
+    mlp = MagicMock()
+    mlp.return_value = np.full(6, 2.0)
+
+    sm = ShadowModel(rigid, mlp)
+    # 10 frames so all three phases are populated
+    frames = [
+        {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)} for _ in range(10)
+    ]
+    report = sm.observe(frames)
+
+    # Keys must be SwingPhase string values
+    valid_keys = {p.value for p in SwingPhase}
+    assert set(report.peak_residuals.keys()) <= valid_keys
+
+
+def test_shadow_model_observe_peak_residuals_are_non_negative() -> None:
+    """Peak residuals must be non-negative (they represent magnitudes)."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.ones(6) * 3.0
+    mlp = MagicMock()
+    mlp.return_value = np.ones(6) * 1.5
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [
+        {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)} for _ in range(9)
+    ]
+    report = sm.observe(frames)
+
+    for key, val in report.peak_residuals.items():
+        assert val >= 0.0, f"peak_residuals[{key!r}] = {val} must be >= 0"
+
+
+def test_shadow_model_does_not_modify_frames() -> None:
+    """observe() must not mutate input frames (observation mode only)."""
+    rigid = MagicMock()
+    rigid.compute_torques.return_value = np.zeros(6)
+    mlp = MagicMock()
+    mlp.return_value = np.zeros(6)
+
+    sm = ShadowModel(rigid, mlp)
+    frame = {"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}
+    original_keys = set(frame.keys())
+    sm.observe([frame])
+    assert set(frame.keys()) == original_keys
+
+
+def test_shadow_model_observe_graceful_without_jax() -> None:
+    """observe() must return an empty ShadowReport (not raise) when underlying
+    calls raise ImportError (simulating missing JAX).
+    """
+    rigid = MagicMock()
+    rigid.compute_torques.side_effect = ImportError("jax not available")
+    mlp = MagicMock()
+
+    sm = ShadowModel(rigid, mlp)
+    frames = [{"q": np.zeros(6), "dq": np.zeros(6), "ddq": np.zeros(6)}]
+    # Should NOT raise; returns an empty ShadowReport
+    report = sm.observe(frames)
+    assert isinstance(report, ShadowReport)
+
+
+# =============================================================================
+# PhysicsMode
+# =============================================================================
+
+
+def test_physics_mode_values() -> None:
+    """PhysicsMode enum must have the three expected string values."""
+    assert PhysicsMode.PURE_RIGID.value == "pure_rigid"
+    assert PhysicsMode.PURE_AI.value == "pure_ai"
+    assert PhysicsMode.PINN_HYBRID.value == "pinn_hybrid"
+
+
+def test_physics_mode_has_exactly_three_members() -> None:
+    """PhysicsMode must have exactly three members."""
+    assert len(PhysicsMode) == 3
+
+
+# =============================================================================
+# create_model factory
+# =============================================================================
+
+
+def test_create_model_invalid_mode_raises() -> None:
+    """create_model must raise ValueError for an unrecognised mode string."""
+    with pytest.raises(ValueError):
+        create_model("invalid_mode", {})  # type: ignore[arg-type]
+
+
+def test_create_model_invalid_mode_enum_like_string_raises() -> None:
+    """create_model must raise ValueError even for plausible-sounding bad modes."""
+    with pytest.raises(ValueError):
+        create_model("pure_hybrid", {})  # type: ignore[arg-type]
+
+
+def test_create_model_pure_rigid_returns_rigid_core_or_import_error() -> None:
+    """PURE_RIGID must return a RigidCore, or raise ImportError (pinocchio absent).
+
+    A nonexistent URDF path raises ValueError from RigidCore's DbC check when
+    Pinocchio is installed. That is the expected DbC precondition failure.
+    """
+    config = {"urdf_path": "/nonexistent.urdf"}
+    try:
+        model = create_model(PhysicsMode.PURE_RIGID, config)
+        from src.shared.python.physics_informed.rigid_core import RigidCore
+
+        assert isinstance(model, RigidCore)
+    except ImportError:
+        pass  # pinocchio not installed -- acceptable
+    except ValueError:
+        pass  # pinocchio installed but URDF doesn't exist -- acceptable DbC failure
+
+
+@pytest.mark.skipif(not HAS_JAX, reason="JAX not installed")
+def test_create_model_pure_ai_returns_mlp_residual() -> None:
+    """PURE_AI must return an MlpResidual when JAX is installed."""
+    import jax
+
+    config = {
+        "input_dim": 18,
+        "output_dim": 6,
+        "hidden_dims": [32, 32],
+        "key": jax.random.PRNGKey(42),
+    }
+    model = create_model(PhysicsMode.PURE_AI, config)
+    from src.shared.python.physics_informed.mlp_residual import MlpResidual
+
+    assert isinstance(model, MlpResidual)
+
+
+def test_create_model_pure_ai_raises_import_error_without_jax() -> None:
+    """PURE_AI must raise ImportError when JAX is not installed."""
+    if HAS_JAX:
+        pytest.skip("JAX is installed -- cannot test missing-JAX path")
+
+    config = {"input_dim": 18, "output_dim": 6}
+    with pytest.raises(ImportError):
+        create_model(PhysicsMode.PURE_AI, config)


### PR DESCRIPTION
## Summary

Phase 3 (final phase) of the PINNs epic (#5419), implementing observation-mode shadow runner and mode-toggle factory.

- **`shadow_model.py`**: `ShadowModel` runs rigid + PINN simultaneously in observation mode, recording peak residual torques per `SwingPhase` (TRANSITION/IMPACT/FOLLOW_THROUGH) without modifying simulation state. Degrades gracefully when JAX is absent (returns empty `ShadowReport`).
- **`mode.py`**: `PhysicsMode` enum (PURE_RIGID, PURE_AI, PINN_HYBRID) + `create_model()` factory that returns `RigidCore`, `MlpResidual`, or `HybridPINN`; raises `ValueError` for unrecognised modes.
- **`src/config/models.yaml`**: Added `pinn_pure_rigid` and `pinn_hybrid` launcher entries (status: experimental, category: biomechanics).
- **`__init__.py`**: Updated to export all Phase 3 symbols.
- **`tests/unit/shared_python/test_pinn_shadow.py`**: 20 TDD tests written first (red → green); 19 pass, 1 skipped when JAX not installed.

Depends on Phase 1 (PR #5562) and Phase 2 (PR #5563).

## Standards

- TDD: tests written before implementation
- DbC: `ValueError` raised for None args (ShadowModel) and unrecognised modes (create_model)
- LOD: no method chains >2 levels
- DRY: frame classification logic in a single `_classify_phase()` helper
- Logging: `logging` throughout, no `print()`
- File sizes: shadow_model.py 241 lines, mode.py 184 lines, test file 253 lines (all under 1200)
- Ruff check + format: all pass

## Test plan

- [ ] Run `python -m pytest tests/unit/shared_python/test_pinn_shadow.py -v` — 19 pass, 1 skipped
- [ ] Run `python -m ruff check src/shared/python/physics_informed/` — no violations
- [ ] Run `python -m ruff format --check src/shared/python/physics_informed/` — no diffs
- [ ] Verify `ShadowModel(None, ...)` and `ShadowModel(..., None)` raise `ValueError`
- [ ] Verify `create_model("invalid_mode", {})` raises `ValueError`
- [ ] Verify `ShadowModel.observe([])` returns empty `ShadowReport` (no exception)
- [ ] Verify `ShadowModel.observe(frames_with_import_error)` returns empty report gracefully

Closes #5499

🤖 Generated with [Claude Code](https://claude.com/claude-code)