### PR TITLE
feat(shallowing): Phase 2 -- passive squaring torque + plane classification

### DIFF
--- a/src/shared/python/biomechanics/shallowing/__init__.py
+++ b/src/shared/python/biomechanics/shallowing/__init__.py
@@ -1,7 +1,8 @@
 """Shallowing analysis sub-package.
 
 Provides tools for analysing the shallowing phase of the golf downswing,
-including hand-path plane computation (Phase 1 of epic #5422).
+including hand-path plane computation (Phase 1 of epic #5422) and passive
+squaring torque + plane classification (Phase 2 of epic #5422).
 """
 
 from __future__ import annotations
@@ -11,9 +12,19 @@ from .hand_path_plane import (
     compute_hand_path_plane,
     extract_lead_hand_trajectory,
 )
+from .passive_squaring import (
+    ShallowingMetrics,
+    classify_swing_plane,
+    compute_club_com_offset,
+    compute_passive_squaring_torque,
+)
 
 __all__: list[str] = [
     "Plane3D",
+    "ShallowingMetrics",
+    "classify_swing_plane",
+    "compute_club_com_offset",
     "compute_hand_path_plane",
+    "compute_passive_squaring_torque",
     "extract_lead_hand_trajectory",
 ]

--- a/src/shared/python/biomechanics/shallowing/passive_squaring.py
+++ b/src/shared/python/biomechanics/shallowing/passive_squaring.py
@@ -1,0 +1,180 @@
+"""Passive squaring torque and swing-plane classification (Phase 2, epic #5422).
+
+Implements the centrifugal-torque model from MacKenzie (2012): a club centre
+of mass that lies *off* the hand-path plane experiences a centripetal
+acceleration whose moment about the wrist behaves as an external torque.
+This torque passively rotates the club face toward (or away from) square,
+depending on the sign of the perpendicular offset.
+
+Sign conventions
+----------------
+The hand-path plane normal is oriented upward (``normal[2] >= 0`` per
+:mod:`hand_path_plane`).  A *positive* offset means the club CoM is on the
+upper (steepening) side of the plane.  A *negative* offset means it is on
+the lower (shallowing) side.  The passive torque carries the same sign as
+the offset so that downstream code can simply add it to the active wrist
+torque.
+
+Design by Contract
+------------------
+- :func:`compute_club_com_offset`: ``club_com_3d`` must be shape ``(3,)``;
+  ``hand_path_plane.normal`` should be unit length (we tolerate non-unit
+  input by normalising internally rather than raising).
+- :func:`compute_passive_squaring_torque`: ``club_mass`` must be strictly
+  positive; raises :class:`ValueError` otherwise.
+- :func:`classify_swing_plane`: threshold of 0.02 m on
+  ``|steepness_index - shallowing_index|`` separates ``on_plane`` from the
+  steep/shallow labels.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .hand_path_plane import Plane3D
+
+_LOG = logging.getLogger(__name__)
+
+# Threshold (metres) below which the swing is considered to be on-plane.
+_ON_PLANE_THRESHOLD_M: float = 0.02
+
+
+def compute_club_com_offset(club_com_3d: np.ndarray, hand_path_plane: Plane3D) -> float:
+    """Signed perpendicular distance from the club CoM to the hand-path plane.
+
+    Positive values indicate the CoM lies above the plane (steepening
+    contribution); negative values indicate it lies below (shallowing
+    contribution).  The sign convention follows the upward-hemisphere
+    orientation enforced by :func:`compute_hand_path_plane`.
+
+    Design by Contract:
+        Preconditions:
+            - ``club_com_3d`` must be a NumPy array of shape ``(3,)``.
+            - ``hand_path_plane.normal`` should be unit length; non-unit
+              vectors are normalised internally (with a warning).
+        Postconditions:
+            - Returns a finite ``float``.
+
+    Args:
+        club_com_3d: 3-D position of the club centre of mass (metres).
+        hand_path_plane: Best-fit plane through the lead-hand trajectory.
+
+    Returns:
+        Signed perpendicular distance in metres.
+
+    Raises:
+        ValueError: If ``club_com_3d`` is not shape ``(3,)``.
+        ValueError: If ``hand_path_plane.normal`` has zero length.
+    """
+    com = np.asarray(club_com_3d, dtype=float)
+    if com.shape != (3,):
+        raise ValueError(f"club_com_3d must have shape (3,), got shape {com.shape}")
+
+    normal = np.asarray(hand_path_plane.normal, dtype=float)
+    norm_len = float(np.linalg.norm(normal))
+    if norm_len == 0.0:
+        raise ValueError("hand_path_plane.normal must be non-zero")
+    if not np.isclose(norm_len, 1.0):
+        _LOG.debug(
+            "hand_path_plane.normal not unit length (%.6f); normalising", norm_len
+        )
+        normal = normal / norm_len
+
+    offset = float(np.dot(com - hand_path_plane.point_on_plane, normal))
+    return offset
+
+
+def compute_passive_squaring_torque(
+    com_offset: float, angular_velocity: float, club_mass: float
+) -> float:
+    """External torque on the wrist from centrifugal force on out-of-plane CoM.
+
+    Model:
+        ``tau = club_mass * angular_velocity**2 * com_offset``
+
+    The torque magnitude scales with the square of the angular velocity
+    (centripetal acceleration) and the perpendicular offset of the CoM.  The
+    sign tracks ``com_offset`` so that a positive offset (CoM above the
+    plane) yields a positive restoring torque toward the plane.
+
+    Design by Contract:
+        Preconditions:
+            - ``club_mass`` must be strictly positive.
+            - ``angular_velocity`` may be any real number (signed angular
+              speed).
+            - ``com_offset`` may be any real number.
+        Postconditions:
+            - Returns a finite ``float`` in N*m.
+            - ``sign(tau) == sign(com_offset)`` when ``com_offset != 0``.
+
+    Args:
+        com_offset: Signed perpendicular distance of CoM from plane (m).
+        angular_velocity: Angular speed of the club about the wrist (rad/s).
+        club_mass: Mass of the club (kg).
+
+    Returns:
+        Passive squaring torque in newton-metres.
+
+    Raises:
+        ValueError: If ``club_mass <= 0``.
+    """
+    if club_mass <= 0.0:
+        raise ValueError(f"club_mass must be strictly positive, got {club_mass!r}")
+    return float(club_mass * (angular_velocity**2) * com_offset)
+
+
+@dataclass(frozen=True)
+class ShallowingMetrics:
+    """Summary metrics describing shallowing behaviour across a full swing.
+
+    Attributes:
+        com_offset: Instantaneous signed offset at a representative frame
+            (e.g. mid-downswing), metres.
+        passive_torque: Instantaneous passive squaring torque at the same
+            frame, newton-metres.
+        steepness_index: Maximum *positive* offset observed over the swing,
+            metres.  Captures the strongest steepening excursion.
+        shallowing_index: Maximum *magnitude* of the negative offset observed
+            over the swing, metres.  Captures the strongest shallowing
+            excursion (always non-negative).
+    """
+
+    com_offset: float
+    passive_torque: float
+    steepness_index: float
+    shallowing_index: float
+
+
+def classify_swing_plane(
+    metrics: ShallowingMetrics,
+) -> Literal["steep", "on_plane", "shallow"]:
+    """Classify a swing as steep, on-plane, or shallow.
+
+    The two indices are compared:
+
+    - If ``|steepness_index - shallowing_index| < 0.02 m`` the swing is
+      ``on_plane``.
+    - Otherwise the larger index wins: ``steep`` if
+      ``steepness_index > shallowing_index``, else ``shallow``.
+
+    Design by Contract:
+        Postconditions:
+            - Returns one of the literal strings ``"steep"``, ``"on_plane"``,
+              ``"shallow"``.
+
+    Args:
+        metrics: Aggregated shallowing metrics over the swing.
+
+    Returns:
+        Classification label as a string literal.
+    """
+    delta = abs(metrics.steepness_index - metrics.shallowing_index)
+    if delta < _ON_PLANE_THRESHOLD_M:
+        return "on_plane"
+    if metrics.steepness_index > metrics.shallowing_index:
+        return "steep"
+    return "shallow"

--- a/tests/unit/shared_python/test_passive_squaring.py
+++ b/tests/unit/shared_python/test_passive_squaring.py
@@ -1,0 +1,144 @@
+"""Tests for passive squaring torque + plane classification (Phase 2, epic #5422)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.biomechanics.shallowing.hand_path_plane import Plane3D
+from src.shared.python.biomechanics.shallowing.passive_squaring import (
+    ShallowingMetrics,
+    classify_swing_plane,
+    compute_club_com_offset,
+    compute_passive_squaring_torque,
+)
+
+
+@pytest.fixture
+def horizontal_plane() -> Plane3D:
+    return Plane3D(
+        normal=np.array([0.0, 0.0, 1.0]),
+        point_on_plane=np.array([0.0, 0.0, 0.0]),
+        residuals=0.0,
+    )
+
+
+def test_zero_offset_on_plane(horizontal_plane: Plane3D) -> None:
+    com = np.array([1.0, 1.0, 0.0])  # on plane
+    assert compute_club_com_offset(com, horizontal_plane) == pytest.approx(0.0)
+
+
+def test_positive_offset_above_plane(horizontal_plane: Plane3D) -> None:
+    com = np.array([0.0, 0.0, 0.5])
+    assert compute_club_com_offset(com, horizontal_plane) == pytest.approx(0.5)
+
+
+def test_negative_offset_below_plane(horizontal_plane: Plane3D) -> None:
+    com = np.array([0.0, 0.0, -0.3])
+    assert compute_club_com_offset(com, horizontal_plane) == pytest.approx(-0.3)
+
+
+def test_zero_offset_zero_torque() -> None:
+    assert compute_passive_squaring_torque(0.0, 30.0, 0.3) == pytest.approx(0.0)
+
+
+def test_positive_offset_positive_torque() -> None:
+    # com 0.1 m above plane, omega 30 rad/s, mass 0.3 kg
+    # tau = 0.3 * 30^2 * 0.1 = 27 N*m
+    tau = compute_passive_squaring_torque(0.1, 30.0, 0.3)
+    assert tau == pytest.approx(27.0)
+
+
+def test_negative_offset_negative_torque() -> None:
+    tau = compute_passive_squaring_torque(-0.1, 30.0, 0.3)
+    assert tau == pytest.approx(-27.0)
+
+
+def test_torque_zero_mass_raises() -> None:
+    with pytest.raises(ValueError):
+        compute_passive_squaring_torque(0.1, 30.0, 0.0)
+
+
+def test_torque_negative_mass_raises() -> None:
+    with pytest.raises(ValueError):
+        compute_passive_squaring_torque(0.1, 30.0, -0.3)
+
+
+def test_classify_steep() -> None:
+    m = ShallowingMetrics(
+        com_offset=0.05,
+        passive_torque=10.0,
+        steepness_index=0.15,
+        shallowing_index=0.02,
+    )
+    assert classify_swing_plane(m) == "steep"
+
+
+def test_classify_shallow() -> None:
+    m = ShallowingMetrics(
+        com_offset=-0.05,
+        passive_torque=-10.0,
+        steepness_index=0.02,
+        shallowing_index=0.15,
+    )
+    assert classify_swing_plane(m) == "shallow"
+
+
+def test_classify_on_plane() -> None:
+    m = ShallowingMetrics(
+        com_offset=0.0,
+        passive_torque=0.0,
+        steepness_index=0.05,
+        shallowing_index=0.05,
+    )
+    assert classify_swing_plane(m) == "on_plane"
+
+
+def test_classify_near_threshold() -> None:
+    # |0.05 - 0.04| = 0.01 < 0.02 -> on_plane
+    m = ShallowingMetrics(
+        com_offset=0.005,
+        passive_torque=1.0,
+        steepness_index=0.05,
+        shallowing_index=0.04,
+    )
+    assert classify_swing_plane(m) == "on_plane"
+
+
+def test_metrics_all_finite() -> None:
+    m = ShallowingMetrics(
+        com_offset=0.05,
+        passive_torque=10.0,
+        steepness_index=0.1,
+        shallowing_index=0.02,
+    )
+    for field_name in [
+        "com_offset",
+        "passive_torque",
+        "steepness_index",
+        "shallowing_index",
+    ]:
+        assert np.isfinite(getattr(m, field_name))
+
+
+def test_com_offset_dbc_wrong_shape(horizontal_plane: Plane3D) -> None:
+    with pytest.raises((ValueError, TypeError)):
+        compute_club_com_offset(np.array([0.0, 0.0]), horizontal_plane)
+
+
+def test_com_offset_normal_assumed_unit_length(horizontal_plane: Plane3D) -> None:
+    # Plane with non-unit normal: function should still compute correctly
+    # OR raise -- pick one and stick with it (raising is cleaner)
+    bad_plane = Plane3D(
+        normal=np.array([0.0, 0.0, 2.0]),  # length 2, not 1
+        point_on_plane=np.array([0.0, 0.0, 0.0]),
+        residuals=0.0,
+    )
+    # Either: raises ValueError, OR normalizes internally and returns correct value
+    com = np.array([0.0, 0.0, 0.5])
+    try:
+        result = compute_club_com_offset(com, bad_plane)
+        # If it accepted: must return correct distance ignoring normal length
+        assert result == pytest.approx(0.5)
+    except ValueError:
+        pass  # Also acceptable behavior


### PR DESCRIPTION
Closes #5501 -- completes epic #5422.

Depends on #5565 (Phase 1). Should merge after that lands.

## What

Implements the centrifugal torque model from MacKenzie (2012) plus a steep/on-plane/shallow swing classifier on top of the Phase 1 hand-path plane:

- `compute_club_com_offset(com, plane) -> float` -- signed perpendicular distance.
- `compute_passive_squaring_torque(offset, omega, mass) -> float` -- `tau = m * omega^2 * offset` with positive-mass DbC.
- `ShallowingMetrics` -- frozen dataclass (com_offset, passive_torque, steepness_index, shallowing_index).
- `classify_swing_plane(metrics) -> "steep" | "on_plane" | "shallow"` -- 0.02 m on-plane band; otherwise larger index wins.

Sign convention follows Phase 1's upward-hemisphere plane normal: positive offset = CoM above plane = steepening contribution; negative = shallowing.

## Tests

15 new unit tests in `tests/unit/shared_python/test_passive_squaring.py` covering:

- On-plane / above / below offset signs.
- Torque scaling and sign tracking.
- DbC: non-positive mass raises `ValueError`; wrong-shape CoM raises.
- Classifier branches: steep / shallow / on_plane / near-threshold.
- Non-unit plane normal handled (normalised internally).

All 31 shallowing tests pass (15 new + 16 existing). `ruff check` + `ruff format --check` clean.