### PR TITLE
feat(bunkershot3d): implement LIGGGHTS DEM backend

### DIFF
--- a/src/bunkershot3d/__init__.py
+++ b/src/bunkershot3d/__init__.py
@@ -1,7 +1,7 @@
 """BunkerShot3D: A 3-D simulation of a golf bunker shot.
 
 Re-exports the public API from all subpackages so consumers can import
-directly from \`bunkershot3d\` instead of reaching into submodules.
+directly from `bunkershot3d` instead of reaching into submodules.
 """
 
 __version__ = "0.1.0"
@@ -11,6 +11,9 @@ from .backends import ChronoDriver, LiggghtsDriver, MPMDriver
 
 # Calibration
 from .calibration import AngleOfReposeExperiment, CalibrationOptimizer, DrainedShearCellExperiment
+
+# Exceptions
+from .exceptions import BackendNotImplementedError
 
 # Geometry
 from .geometry import ClubheadGenerator
@@ -26,6 +29,7 @@ from .postproc import WrenchTrace
 
 __all__: list[str] = [
     "AngleOfReposeExperiment",
+    "BackendNotImplementedError",
     "BunkerShotResultReader",
     "BunkerShotResultWriter",
     "CalibrationOptimizer",

--- a/src/bunkershot3d/backends/liggghts/driver.py
+++ b/src/bunkershot3d/backends/liggghts/driver.py
@@ -1,13 +1,22 @@
 """
 LIGGGHTS backend driver for BunkerShot3D.
+
+LIGGGHTS is invoked as a subprocess: ``liggghts -in <input_deck>``.
+Install from https://www.lammps.org/download.html (LIGGGHTS-PUBLIC fork).
 """
 
-from pathlib import Path
-import contextlib
+from __future__ import annotations
+
+import math
 import subprocess
 import tempfile
+from pathlib import Path
+
+import numpy as np
 
 from bunkershot3d.config import BunkerShotConfig
+from bunkershot3d.exceptions import BackendNotImplementedError
+from bunkershot3d.io.schema import BunkerShotResultWriter
 
 
 class LiggghtsDriver:
@@ -17,40 +26,277 @@ class LiggghtsDriver:
         self.config_path = Path(config_path)
         self.config = BunkerShotConfig.from_yaml(self.config_path)
 
+        # Work directory and input deck path set during setup()
+        self._work_dir: tempfile.TemporaryDirectory | None = None  # type: ignore[type-arg]
+        self._work_path: Path | None = None
+        self._input_deck_path: Path | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     def setup(self) -> None:
-        """Setup the LIGGGHTS system.
+        """Generate the LIGGGHTS input deck in a temporary work directory.
 
         Raises:
-            NotImplementedError: LiggghtsDriver is not yet implemented.
-                Use the MPM backend instead.
+            BackendNotImplementedError: If LIGGGHTS binary is not on PATH.
         """
-        raise NotImplementedError(  # tracked: #5486
-            "LiggghtsDriver is not yet implemented. Use the MPM backend instead."
-        )
+        import shutil
 
-    def _generate_input_deck(self, work_dir: Path) -> Path:
-        """Generate the LIGGGHTS LIGGGHTS.in script."""
-        input_deck_path = work_dir / "in.bunkershot"
-        with open(input_deck_path, "w") as f:
-            f.write("# LIGGGHTS input script for BunkerShot3D\n")
-            f.write("atom_style granular\n")
-            f.write("boundary f f f\n")
-            f.write("newton off\n")
-            f.write("communicate single vel yes\n")
-            f.write("units si\n")
-            f.write(
-                "# Placeholder deck — full LIGGGHTS commands tracked in issue #5486\n"
+        if shutil.which("liggghts") is None:
+            raise BackendNotImplementedError(
+                "LIGGGHTS not installed. Install from lammps.org"
             )
-            f.write("run 0\n")
-        return input_deck_path
+
+        self._work_dir = tempfile.TemporaryDirectory(prefix="bunkershot3d_liggghts_")
+        self._work_path = Path(self._work_dir.name)
+        self._input_deck_path = self._generate_input_deck(self._work_path)
 
     def run(self, output_path: Path | str) -> None:
-        """Run the simulation via subprocess and parse dump output into HDF5.
+        """Execute LIGGGHTS, parse dump files, and write HDF5 results.
+
+        If ``setup()`` was not called beforehand it will be called
+        automatically.
+
+        Args:
+            output_path: Path for the HDF5 result file.
 
         Raises:
-            NotImplementedError: LiggghtsDriver is not yet implemented.
-                Use the MPM backend instead.
+            BackendNotImplementedError: If LIGGGHTS binary is not on PATH.
+            subprocess.CalledProcessError: If LIGGGHTS exits with a non-zero
+                status (propagated as-is so failures are diagnosable).
         """
-        raise NotImplementedError(  # tracked: #5486
-            "LiggghtsDriver is not yet implemented. Use the MPM backend instead."
-        )
+        if self._input_deck_path is None:
+            self.setup()
+
+        assert self._input_deck_path is not None
+        assert self._work_path is not None
+
+        try:
+            subprocess.run(
+                ["liggghts", "-in", str(self._input_deck_path)],
+                capture_output=True,
+                check=True,
+                cwd=str(self._work_path),
+            )
+        except FileNotFoundError:
+            raise BackendNotImplementedError(
+                "LIGGGHTS not installed. Install from lammps.org"
+            )
+        # CalledProcessError is NOT caught — let it propagate for diagnosability.
+
+        self._parse_and_write(self._work_path, Path(output_path))
+
+    # ------------------------------------------------------------------
+    # Input-deck generation
+    # ------------------------------------------------------------------
+
+    def _generate_input_deck(self, work_dir: Path) -> Path:
+        """Generate a complete LIGGGHTS input script from *BunkerShotConfig*.
+
+        The deck uses Hertz-Mindlin contact, SI units, fixed boundary walls,
+        and dumps atom positions + velocities at the configured output rate.
+        """
+        cfg = self.config
+        domain = cfg.bunker_bed.domain
+        gp = cfg.grain_population
+        cm = cfg.contact_model
+        out = cfg.output
+
+        lx, ly, lz = domain.length_x, domain.width_y, domain.depth_z
+
+        # Lognormal: median diameter = mean in log space
+        r_mean = gp.diameter_mean / 2.0
+        # sigma of the underlying normal distribution for diameter
+        sigma_log = gp.diameter_sigma_log
+        # min/max radii spanning ~3σ in log-space to bound the polydispersity
+        r_min = r_mean * math.exp(-3.0 * sigma_log)
+        r_max = r_mean * math.exp(3.0 * sigma_log)
+
+        # Dump frequency: steps between dumps = 1 / (rate_hz * dt)
+        # We target dt = 1e-5 s (typical for LIGGGHTS granular sims)
+        dt = 1.0e-5
+        dump_every = max(1, round(1.0 / (out.rate_hz * dt)))
+
+        # Total steps: run long enough for ~0.5 s of simulation
+        total_steps = round(0.5 / dt)
+
+        input_deck_path = work_dir / "in.bunkershot"
+        with open(input_deck_path, "w") as f:
+            f.write(
+                f"""# LIGGGHTS input script generated by BunkerShot3D
+# Issue: #5552
+
+atom_style      granular
+atom_modify     map array
+boundary        f f f
+newton          off
+communicate     single vel yes
+units           si
+
+# ── Domain ──────────────────────────────────────────────────────────────────
+region          domain block 0.0 {lx:.6g} 0.0 {ly:.6g} 0.0 {lz:.6g} units box
+create_box      1 domain
+
+# ── Neighbour / communication ────────────────────────────────────────────────
+neighbor        {r_max * 0.5:.6g} bin
+neigh_modify    delay 0
+
+# ── Contact model: Hertz-Mindlin ─────────────────────────────────────────────
+pair_style      gran model hertz tangential history
+pair_coeff      * *
+
+# ── Material properties ──────────────────────────────────────────────────────
+fix             m1 all property/global youngsModulus peratomtype {cm.youngs_modulus:.6g}
+fix             m2 all property/global poissonsRatio peratomtype {cm.poisson_ratio:.6g}
+fix             m3 all property/global coefficientRestitution peratomtypepair 1 1 {cm.restitution_coefficient:.6g}
+fix             m4 all property/global coefficientFriction peratomtypepair 1 1 {cm.friction_coefficient:.6g}
+
+# ── Walls (fixed boundary) ───────────────────────────────────────────────────
+fix             wall_bot all wall/gran model hertz tangential history primitive type 1 zplane 0.0
+fix             wall_top all wall/gran model hertz tangential history primitive type 1 zplane {lz:.6g}
+fix             wall_xlo all wall/gran model hertz tangential history primitive type 1 xplane 0.0
+fix             wall_xhi all wall/gran model hertz tangential history primitive type 1 xplane {lx:.6g}
+fix             wall_ylo all wall/gran model hertz tangential history primitive type 1 yplane 0.0
+fix             wall_yhi all wall/gran model hertz tangential history primitive type 1 yplane {ly:.6g}
+
+# ── Particle insertion: lognormal diameter distribution ──────────────────────
+fix             pts1 all particletemplate/sphere 1 atom_type 1 \\
+                    density constant {gp.density:.6g} \\
+                    radius gaussian {r_mean:.6g} {sigma_log:.6g} {r_min:.6g} {r_max:.6g}
+
+fix             pdd1 all particledistribution/discrete 1 1 pts1 1.0
+
+fix             ins all insert/pack seed 5330 distributiontemplate pdd1 \\
+                    insert_every once overlapcheck yes all_in yes \\
+                    vel constant 0.0 0.0 -0.1 \\
+                    region domain ntry_mc 10000 \\
+                    particles_in_region {gp.count}
+
+# ── Gravity + integrator ─────────────────────────────────────────────────────
+fix             grav all gravity 9.81 vector 0.0 0.0 -1.0
+fix             integ all nve/sphere
+
+# ── Timestep ─────────────────────────────────────────────────────────────────
+timestep        {dt:.2e}
+
+# ── Thermo output ────────────────────────────────────────────────────────────
+thermo_style    custom step atoms ke vol
+thermo          {dump_every}
+
+# ── Dump: positions and velocities ──────────────────────────────────────────
+dump            dmp all custom {dump_every} dump.bunkershot id type x y z vx vy vz
+dump_modify     dmp sort id pad 8
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+run             {total_steps}
+"""
+            )
+
+        return input_deck_path
+
+    # ------------------------------------------------------------------
+    # Post-processing: parse dump → HDF5
+    # ------------------------------------------------------------------
+
+    def _parse_and_write(self, work_dir: Path, output_path: Path) -> None:
+        """Parse LIGGGHTS dump files and write results via *BunkerShotResultWriter*.
+
+        LIGGGHTS dump format (custom)::
+
+            ITEM: TIMESTEP
+            <step>
+            ITEM: NUMBER OF ATOMS
+            <n>
+            ITEM: BOX BOUNDS ...
+            ...
+            ITEM: ATOMS id type x y z vx vy vz
+            <id> <type> <x> <y> <z> <vx> <vy> <vz>
+            ...
+
+        Args:
+            work_dir: Directory containing ``dump.bunkershot``.
+            output_path: Destination HDF5 file.
+        """
+        cfg = self.config
+        dt = 1.0e-5
+        downsample = cfg.output.downsample_grains
+
+        dump_file = work_dir / "dump.bunkershot"
+
+        writer = BunkerShotResultWriter(output_path)
+        try:
+            for timestep, positions, velocities in _iter_dump_frames(dump_file):
+                time = timestep * dt
+
+                # Apply downsampling
+                if downsample > 1:
+                    positions = positions[::downsample]
+                    velocities = velocities[::downsample]
+
+                writer.write_grain_state(time, positions, velocities)
+        finally:
+            writer.close()
+
+
+# ---------------------------------------------------------------------------
+# Utility: dump-file parser
+# ---------------------------------------------------------------------------
+
+
+def _iter_dump_frames(
+    dump_path: Path,
+) -> "collections.abc.Generator[tuple[int, np.ndarray, np.ndarray], None, None]":
+    """Yield ``(timestep, positions, velocities)`` for each frame in a LIGGGHTS dump.
+
+    Args:
+        dump_path: Path to the LIGGGHTS dump file (custom per-atom format).
+
+    Yields:
+        Tuple of (timestep: int, positions: ndarray shape (N,3),
+        velocities: ndarray shape (N,3)).
+    """
+    import collections.abc  # noqa: PLC0415 — local import to satisfy yield type hint
+
+    with open(dump_path) as fh:
+        while True:
+            # ── ITEM: TIMESTEP ────────────────────────────────────────────
+            line = fh.readline()
+            if not line:
+                return
+            # Skip blank lines between frames
+            while line.strip() == "":
+                line = fh.readline()
+                if not line:
+                    return
+            if "TIMESTEP" not in line:
+                continue
+            timestep = int(fh.readline().strip())
+
+            # ── ITEM: NUMBER OF ATOMS ─────────────────────────────────────
+            fh.readline()  # "ITEM: NUMBER OF ATOMS"
+            n_atoms = int(fh.readline().strip())
+
+            # ── ITEM: BOX BOUNDS … (3 lines of header + 3 lines of data) ──
+            fh.readline()  # "ITEM: BOX BOUNDS ..."
+            fh.readline()
+            fh.readline()
+            fh.readline()
+
+            # ── ITEM: ATOMS … ─────────────────────────────────────────────
+            fh.readline()  # "ITEM: ATOMS id type x y z vx vy vz"
+
+            positions = np.empty((n_atoms, 3), dtype=np.float64)
+            velocities = np.empty((n_atoms, 3), dtype=np.float64)
+
+            for i in range(n_atoms):
+                parts = fh.readline().split()
+                # id type x y z vx vy vz
+                positions[i, 0] = float(parts[2])
+                positions[i, 1] = float(parts[3])
+                positions[i, 2] = float(parts[4])
+                velocities[i, 0] = float(parts[5])
+                velocities[i, 1] = float(parts[6])
+                velocities[i, 2] = float(parts[7])
+
+            yield timestep, positions, velocities

--- a/src/bunkershot3d/exceptions.py
+++ b/src/bunkershot3d/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Custom exceptions for BunkerShot3D.
+"""
+
+
+class BackendNotImplementedError(NotImplementedError):
+    """Raised when a simulation backend is not available or not installed.
+
+    This is a subclass of NotImplementedError so that legacy code catching
+    NotImplementedError continues to work.
+    """

--- a/tests/bunkershot3d/test_liggghts_driver.py
+++ b/tests/bunkershot3d/test_liggghts_driver.py
@@ -1,0 +1,313 @@
+"""
+Tests for the LIGGGHTS backend driver.
+
+Unit tests run without LIGGGHTS installed by mocking subprocess.
+Integration tests are skipped when the binary is absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from bunkershot3d.backends.liggghts.driver import LiggghtsDriver, _iter_dump_frames
+from bunkershot3d.exceptions import BackendNotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dummy_config(tmp_path: Path) -> Path:
+    yaml_content = textwrap.dedent(
+        """\
+        bunker_bed:
+          domain:
+            length_x: 2.0
+            width_y: 1.0
+            depth_z: 0.5
+          boundary: "fixed"
+        grain_population:
+          count: 500
+          diameter_mean: 0.002
+          diameter_sigma_log: 0.1
+          density: 2650.0
+          coarse_graining_factor: 1.0
+        contact_model:
+          friction_coefficient: 0.5
+          restitution_coefficient: 0.3
+          youngs_modulus: 1.0e7
+          poisson_ratio: 0.25
+        clubhead:
+          loft_deg: 56.0
+          bounce_deg: 10.0
+          width: 0.1
+          height: 0.05
+          mass: 0.3
+        trajectory:
+          file: "swing_data.csv"
+        output:
+          downsample_grains: 1
+          rate_hz: 500.0
+        """
+    )
+    config_path = tmp_path / "canonical.yaml"
+    config_path.write_text(yaml_content)
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no LIGGGHTS binary required
+# ---------------------------------------------------------------------------
+
+
+class TestLiggghtsDriverInit:
+    def test_init_loads_config(self, dummy_config: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        assert driver.config is not None
+        assert driver.config.bunker_bed.domain.length_x == 2.0
+
+    def test_init_stores_config_path(self, dummy_config: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        assert driver.config_path == dummy_config
+
+
+class TestSetupRaisesWhenBinaryMissing:
+    """setup() must raise BackendNotImplementedError (not FileNotFoundError)
+    when the liggghts binary is absent from PATH."""
+
+    def test_setup_raises_backend_not_implemented_error(
+        self, dummy_config: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(BackendNotImplementedError):
+                driver.setup()
+
+    def test_setup_error_message_mentions_install_location(
+        self, dummy_config: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(BackendNotImplementedError, match="lammps.org"):
+                driver.setup()
+
+    def test_setup_does_not_raise_file_not_found_error(
+        self, dummy_config: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(BackendNotImplementedError):
+                driver.setup()
+            # Verify it is NOT a bare FileNotFoundError
+            try:
+                driver.setup()
+            except BackendNotImplementedError:
+                pass  # expected
+            except FileNotFoundError:  # pragma: no cover
+                pytest.fail("setup() leaked a raw FileNotFoundError")
+
+
+class TestRunRaisesWhenBinaryMissing:
+    """run() must also raise BackendNotImplementedError when liggghts is absent."""
+
+    def test_run_raises_backend_not_implemented_error_on_file_not_found(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        # Patch shutil.which so setup() succeeds (thinks binary exists), but
+        # then patch subprocess.run to raise FileNotFoundError as the OS would.
+        with (
+            patch("shutil.which", return_value="/usr/bin/liggghts"),
+            patch(
+                "subprocess.run",
+                side_effect=FileNotFoundError("No such file or directory: liggghts"),
+            ),
+        ):
+            with pytest.raises(BackendNotImplementedError, match="lammps.org"):
+                driver.run(tmp_path / "out.h5")
+
+    def test_called_process_error_propagates(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        import subprocess
+
+        driver = LiggghtsDriver(dummy_config)
+        error = subprocess.CalledProcessError(1, "liggghts")
+        with (
+            patch("shutil.which", return_value="/usr/bin/liggghts"),
+            patch("subprocess.run", side_effect=error),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                driver.run(tmp_path / "out.h5")
+
+
+class TestInputDeckGeneration:
+    """_generate_input_deck() must produce a syntactically reasonable script."""
+
+    def test_deck_contains_hertz_mindlin(self, dummy_config: Path, tmp_path: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        deck = driver._generate_input_deck(tmp_path)
+        content = deck.read_text()
+        assert "hertz" in content
+
+    def test_deck_contains_domain_dimensions(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        deck = driver._generate_input_deck(tmp_path)
+        content = deck.read_text()
+        assert "2" in content  # length_x = 2.0
+        assert "region" in content
+
+    def test_deck_contains_gravity(self, dummy_config: Path, tmp_path: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        deck = driver._generate_input_deck(tmp_path)
+        content = deck.read_text()
+        assert "gravity" in content
+
+    def test_deck_contains_dump_command(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        deck = driver._generate_input_deck(tmp_path)
+        content = deck.read_text()
+        assert "dump" in content
+
+    def test_deck_is_written_to_work_dir(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        deck = driver._generate_input_deck(tmp_path)
+        assert deck.parent == tmp_path
+        assert deck.exists()
+
+
+class TestDumpParser:
+    """_iter_dump_frames() must parse the standard LIGGGHTS custom dump format."""
+
+    def _write_dump(self, path: Path, frames: list[tuple[int, list[list[float]]]]) -> None:
+        """Write a minimal LIGGGHTS custom dump file."""
+        with open(path, "w") as f:
+            for step, atoms in frames:
+                n = len(atoms)
+                f.write(f"ITEM: TIMESTEP\n{step}\n")
+                f.write(f"ITEM: NUMBER OF ATOMS\n{n}\n")
+                f.write("ITEM: BOX BOUNDS pp pp pp\n")
+                f.write("0.0 2.0\n0.0 1.0\n0.0 0.5\n")
+                f.write("ITEM: ATOMS id type x y z vx vy vz\n")
+                for i, row in enumerate(atoms, start=1):
+                    f.write(f"{i} 1 " + " ".join(f"{v:.4f}" for v in row) + "\n")
+
+    def test_parses_single_frame(self, tmp_path: Path) -> None:
+        dump = tmp_path / "dump.test"
+        atoms = [[0.1, 0.2, 0.3, 0.01, 0.02, 0.03]]
+        self._write_dump(dump, [(0, atoms)])
+        frames = list(_iter_dump_frames(dump))
+        assert len(frames) == 1
+        step, pos, vel = frames[0]
+        assert step == 0
+        np.testing.assert_allclose(pos[0], [0.1, 0.2, 0.3], atol=1e-4)
+        np.testing.assert_allclose(vel[0], [0.01, 0.02, 0.03], atol=1e-4)
+
+    def test_parses_multiple_frames(self, tmp_path: Path) -> None:
+        dump = tmp_path / "dump.test"
+        frame0 = [[0.1, 0.2, 0.3, 0.0, 0.0, 0.0], [0.4, 0.5, 0.1, 0.1, 0.0, 0.0]]
+        frame1 = [[0.2, 0.2, 0.3, 0.0, 0.0, -0.1], [0.4, 0.5, 0.15, 0.1, 0.0, -0.05]]
+        self._write_dump(dump, [(0, frame0), (100, frame1)])
+        frames = list(_iter_dump_frames(dump))
+        assert len(frames) == 2
+        assert frames[0][0] == 0
+        assert frames[1][0] == 100
+        assert frames[0][1].shape == (2, 3)
+        assert frames[1][2].shape == (2, 3)
+
+    def test_positions_shape_correct(self, tmp_path: Path) -> None:
+        dump = tmp_path / "dump.test"
+        atoms = [[float(i), 0.1, 0.2, 0.0, 0.0, 0.0] for i in range(5)]
+        self._write_dump(dump, [(0, atoms)])
+        _, pos, vel = list(_iter_dump_frames(dump))[0]
+        assert pos.shape == (5, 3)
+        assert vel.shape == (5, 3)
+
+
+class TestParseAndWrite:
+    """_parse_and_write() must produce a valid HDF5 file with grain states."""
+
+    def _write_dump(self, path: Path) -> None:
+        with open(path, "w") as f:
+            for step in [0, 200]:
+                atoms = [[0.1 * j, 0.05 * j, 0.02 * j, 0.0, 0.0, -0.01] for j in range(3)]
+                n = len(atoms)
+                f.write(f"ITEM: TIMESTEP\n{step}\n")
+                f.write(f"ITEM: NUMBER OF ATOMS\n{n}\n")
+                f.write("ITEM: BOX BOUNDS pp pp pp\n")
+                f.write("0.0 2.0\n0.0 1.0\n0.0 0.5\n")
+                f.write("ITEM: ATOMS id type x y z vx vy vz\n")
+                for i, row in enumerate(atoms, start=1):
+                    f.write(f"{i} 1 " + " ".join(f"{v:.4f}" for v in row) + "\n")
+
+    def test_creates_hdf5_output(self, dummy_config: Path, tmp_path: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        dump = tmp_path / "dump.bunkershot"
+        output = tmp_path / "result.h5"
+        self._write_dump(dump)
+        driver._parse_and_write(tmp_path, output)
+        assert output.exists()
+
+    def test_hdf5_contains_grain_group(self, dummy_config: Path, tmp_path: Path) -> None:
+        import h5py
+
+        driver = LiggghtsDriver(dummy_config)
+        dump = tmp_path / "dump.bunkershot"
+        output = tmp_path / "result.h5"
+        self._write_dump(dump)
+        driver._parse_and_write(tmp_path, output)
+
+        with h5py.File(output, "r") as f:
+            assert "grains" in f
+
+
+# ---------------------------------------------------------------------------
+# Integration test — skipped when LIGGGHTS binary is absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    shutil.which("liggghts") is None,
+    reason="liggghts not installed",
+)
+class TestLiggghtsIntegration:
+    """Full round-trip test: setup → run → HDF5 output.
+
+    Requires LIGGGHTS to be installed and on PATH.
+    """
+
+    def test_run_produces_output(self, dummy_config: Path, tmp_path: Path) -> None:
+        driver = LiggghtsDriver(dummy_config)
+        output = tmp_path / "result.h5"
+        driver.setup()
+        driver.run(output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_output_contains_grain_states(
+        self, dummy_config: Path, tmp_path: Path
+    ) -> None:
+        import h5py
+
+        driver = LiggghtsDriver(dummy_config)
+        output = tmp_path / "result.h5"
+        driver.run(output)
+
+        with h5py.File(output, "r") as f:
+            assert "grains" in f
+            assert len(f["grains"]) > 0

--- a/tests/unit/test_bunkershot3d_stubs.py
+++ b/tests/unit/test_bunkershot3d_stubs.py
@@ -2,6 +2,9 @@
 
 Verifies that unimplemented backends raise NotImplementedError rather than  # tracked: #5486
 silently returning mock data.
+
+Note: TestLiggghtsDriverStub has been removed because the LIGGGHTS backend
+is now implemented (#5552). See tests/bunkershot3d/test_liggghts_driver.py.
 """
 
 from __future__ import annotations
@@ -39,36 +42,6 @@ class TestChronoDriverStub:
         driver = self._make_driver()
         with pytest.raises(NotImplementedError):
             driver.run("output.h5")
-
-    def test_setup_error_message_mentions_mpm(self) -> None:
-        driver = self._make_driver()
-        with pytest.raises(NotImplementedError, match="MPM"):
-            driver.setup()
-
-
-# ---------------------------------------------------------------------------
-# LiggghtsDriver stub guard
-# ---------------------------------------------------------------------------
-
-
-class TestLiggghtsDriverStub:
-    """LiggghtsDriver must raise NotImplementedError on setup()."""  # tracked: #5486
-
-    def _make_driver(self) -> object:
-        """Create a LiggghtsDriver with a mocked config."""
-        from src.bunkershot3d.backends.liggghts.driver import LiggghtsDriver
-
-        mock_config = MagicMock()
-        with patch(
-            "src.bunkershot3d.backends.liggghts.driver.BunkerShotConfig.from_yaml",
-            return_value=mock_config,
-        ):
-            return LiggghtsDriver("fake_config.yaml")
-
-    def test_setup_raises_not_implemented(self) -> None:
-        driver = self._make_driver()
-        with pytest.raises(NotImplementedError):
-            driver.setup()
 
     def test_setup_error_message_mentions_mpm(self) -> None:
         driver = self._make_driver()


### PR DESCRIPTION
Closes #5552

Implements the LIGGGHTS backend:
- Generates complete LIGGGHTS input deck from BunkerShotConfig
- Invokes liggghts subprocess with proper error propagation
- Parses dump files and streams through BunkerShotResultWriter
- Raises BackendNotImplementedError when LIGGGHTS not installed
- Integration test (skip if not installed), unit test for missing-binary case