### PR TITLE
fix(ui): remove inline style overrides from ChatPanel bubbles

### DIFF
--- a/ui/src/components/ui/ChatPanel.test.tsx
+++ b/ui/src/components/ui/ChatPanel.test.tsx
@@ -197,4 +197,45 @@ describe('ChatPanel', () => {
     const payload = JSON.parse(socket.sent[0].data) as Record<string, unknown>;
     expect(payload.engine_context).toBe('mujoco');
   });
+
+  it('renders message bubbles with data-role but no inline style overrides (CSS should own colors)', async () => {
+    render(<ChatPanel />);
+    const socket = await waitForSocket();
+
+    // User message
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'hi' } });
+    fireEvent.click(screen.getByTestId('chat-send'));
+
+    await waitFor(() => {
+      expect(screen.getByText('hi')).toBeInTheDocument();
+    });
+
+    // System error message
+    act(() => {
+      socket.emit({ type: 'error', detail: 'err' });
+    });
+    await waitFor(() => {
+      expect(screen.getByText('err')).toBeInTheDocument();
+    });
+
+    // Assistant streaming chunk
+    act(() => {
+      socket.emit({ type: 'chunk', content: 'reply' });
+    });
+    await waitFor(() => {
+      expect(screen.getByText('reply')).toBeInTheDocument();
+    });
+
+    // Every bubble must have data-role and must NOT have inline backgroundColor/borderColor/color
+    const allBubbles = document.querySelectorAll('.sidekick-chat-bubble');
+    expect(allBubbles.length).toBeGreaterThan(0);
+
+    allBubbles.forEach((bubble) => {
+      const el = bubble as HTMLElement;
+      expect(el.dataset.role).toBeTruthy();
+      expect(el.style.backgroundColor).toBe('');
+      expect(el.style.borderColor).toBe('');
+      expect(el.style.color).toBe('');
+    });
+  });
 });

--- a/ui/src/components/ui/ChatPanel.tsx
+++ b/ui/src/components/ui/ChatPanel.tsx
@@ -404,19 +404,6 @@ export function ChatPanel({ engineContext, url }: ChatPanelProps = {}) {
           >
             <div
               className="sidekick-chat-bubble max-w-[80%] rounded-lg px-3 py-2 whitespace-pre-wrap break-words border"
-              style={{
-                backgroundColor:
-                  m.role === 'user'
-                    ? 'var(--sidekick-color-accent)'
-                    : m.role === 'assistant'
-                      ? 'var(--sidekick-color-surface-raised)'
-                      : 'var(--sidekick-color-warning)',
-                borderColor:
-                  m.role === 'system'
-                    ? 'var(--sidekick-color-warning)'
-                    : 'var(--sidekick-color-border)',
-                color: 'var(--sidekick-color-text)',
-              }}
               data-role={m.role}
             >
               {m.content}


### PR DESCRIPTION
## Summary

Removes the inline \style={{ backgroundColor, borderColor, color }}\ block from chat bubble divs in \ChatPanel.tsx\, deferring to the existing \[data-role]\ CSS selectors in \index.css\ which already handle all three message roles correctly.

### Problem
- Inline styles on chat bubble divs always win over CSS, making the \[data-role]\ selectors dead code.
- User-message bubbles rendered fully-saturated accent (\ar(--sidekick-color-accent)\) instead of the muted accent the CSS intends via \color-mix()\.
- System-message bubbles used solid \#d29922\ yellow with light gray text, failing WCAG AA contrast. The CSS uses \color-mix(in srgb, warning 22%, transparent)\ which passes.
- Theme switching had no effect on bubble appearance since inline styles override everything.

### Fix
- Removed the inline \style\ prop from the bubble \<div>\.
- The \data-role\ attribute on both the outer wrapper and inner bubble div drives all styling via CSS.
- Added a regression test asserting every \.sidekick-chat-bubble\ has \data-role\ set and has **no** inline \ackgroundColor\, \orderColor\, or \color\.

### Testing
- All 9 ChatPanel tests pass (8 existing + 1 new regression test).
- Rebased onto current main (includes a11y attributes from \526c0a9\).

Closes #5482