### PR TITLE
fix(ui): wire AutoCompleteLineEdit into launcher search

### DIFF
--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -49,6 +49,8 @@ from src.launchers.custom_title_bar import create_window_control_button
 from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.theme.style_constants import Styles
 from src.shared.python.theme.typography import Weights, get_display_font
+from src.shared.python.ui.auto_complete import AutoCompleteLineEdit
+from src.shared.python.ui.completion_vocab import build_vocabulary
 
 if TYPE_CHECKING:
     pass
@@ -719,7 +721,7 @@ class LauncherUISetupMixin:
         top_bar.addStretch()
 
         # Search Bar
-        self.search_input = QLineEdit()
+        self.search_input = AutoCompleteLineEdit(words=build_vocabulary())
         self.search_input.setPlaceholderText("Search models...")
         try:
             from src.shared.python.theme.responsive import (

--- a/src/shared/python/ui/completion_vocab.py
+++ b/src/shared/python/ui/completion_vocab.py
@@ -1,0 +1,142 @@
+"""Centralized completion vocabulary service for AutoCompleteLineEdit.
+
+Provides a bootstrap function that seeds the global text-prediction
+dictionary from physics-engine names, common parameter identifiers,
+and constants declared in ``src/config/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Physics engine names surfaced throughout the launcher UI.
+_ENGINE_NAMES: list[str] = [
+    "mujoco",
+    "drake",
+    "pinocchio",
+    "myosuite",
+    "opensim",
+]
+
+# Common physics / simulation parameter names that appear in dialogs,
+# search queries, and the AI composer.
+_PHYSICS_TERMS: list[str] = [
+    # Kinematics / dynamics
+    "gravity",
+    "velocity",
+    "acceleration",
+    "angular_velocity",
+    "angular_acceleration",
+    "mass",
+    "inertia",
+    "torque",
+    "force",
+    "friction",
+    "damping",
+    "stiffness",
+    "compliance",
+    "restitution",
+    # Simulation controls
+    "timestep",
+    "duration",
+    "max_simulation_time",
+    "default_timestep",
+    "num_steps",
+    # Biomechanics / motion-capture terms
+    "joint",
+    "link",
+    "body",
+    "constraint",
+    "contact",
+    "tendon",
+    "actuator",
+    "muscle",
+    "pelvis",
+    "spine",
+    "femur",
+    "tibia",
+    "foot",
+    # Golf-specific
+    "swing",
+    "clubhead",
+    "ball_flight",
+    "launch_angle",
+    "spin_rate",
+    "carry_distance",
+    # Visualization
+    "live_viz",
+    "render",
+    "camera",
+    "fps",
+    # Runtime / infrastructure
+    "docker",
+    "wsl",
+    "native",
+    "gpu",
+    "cpu",
+    "cuda",
+]
+
+# Model-registry search shortcuts that users commonly type.
+_MODEL_SHORTCUTS: list[str] = [
+    "biomechanics",
+    "simulation",
+    "motion_capture",
+    "motion_matching",
+    "reinforcement_learning",
+    "research",
+    "tools",
+]
+
+
+def _load_engine_names_from_config() -> list[str]:
+    """Read the preferred engine list from ``interim_config.yaml`` if available.
+
+    Falls back to the hard-coded :data:`_ENGINE_NAMES` list on any error so
+    that the vocabulary service never raises at import time.
+    """
+    try:
+        config_path = (
+            Path(__file__).resolve().parents[4] / "config" / "interim_config.yaml"
+        )
+        if not config_path.exists():
+            return []
+        import re
+
+        text = config_path.read_text(encoding="utf-8")
+        in_section = False
+        found: list[str] = []
+        for line in text.splitlines():
+            if re.match(r"\s*preferred_order\s*:", line):
+                in_section = True
+                continue
+            if in_section:
+                item = re.match(r'\s*-\s*"?([a-zA-Z0-9_]+)"?', line)
+                if item:
+                    found.append(item.group(1))
+                elif re.match(r"\s{0,4}\S", line):
+                    break
+        return found
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def build_vocabulary() -> list[str]:
+    """Return the merged, deduplicated completion vocabulary.
+
+    The vocabulary is assembled from:
+
+    * Physics engine names (config-sourced, with a hard-coded fallback)
+    * Common physics / simulation parameter names
+    * Model-registry category shortcuts
+
+    Returns
+    -------
+    list[str]
+        Sorted, deduplicated list of completion terms.
+    """
+    config_engines = _load_engine_names_from_config()
+    engines = config_engines if config_engines else _ENGINE_NAMES
+
+    merged: set[str] = set(engines) | set(_PHYSICS_TERMS) | set(_MODEL_SHORTCUTS)
+    return sorted(merged)

--- a/tests/launchers/test_launcher_ui_setup.py
+++ b/tests/launchers/test_launcher_ui_setup.py
@@ -350,3 +350,48 @@ def test_on_sidebar_routed_existing_ids_still_work(launcher) -> None:
 
     launcher._on_sidebar_routed(1)
     assert launcher.layout_manager.current_category_filter == "Physics Engines"
+
+
+# ---------------------------------------------------------------------------
+# AutoCompleteLineEdit wiring (issue #5479)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_search_input_is_auto_complete_line_edit(launcher) -> None:
+    """The launcher search field must be an AutoCompleteLineEdit with a
+    non-empty vocabulary so that the Global Text Prediction feature is
+    actually wired globally rather than living only in the test file."""
+    from src.shared.python.ui.auto_complete import AutoCompleteLineEdit
+
+    with patch("src.launchers.launcher_constants.HELP_SYSTEM_AVAILABLE", False):
+        launcher._setup_top_bar()
+
+    assert isinstance(
+        launcher.search_input,
+        AutoCompleteLineEdit,
+    ), "search_input must be AutoCompleteLineEdit, not bare QLineEdit"
+    assert len(launcher.search_input.completer_words) > 0, (
+        "AutoCompleteLineEdit vocabulary must be non-empty after construction"
+    )
+
+
+@pytest.mark.unit
+def test_search_vocabulary_contains_engine_names(launcher) -> None:
+    """Engine names from the config (mujoco, drake, pinocchio …) must appear
+    in the completion vocabulary so users can type them into the search bar."""
+    from src.shared.python.ui.completion_vocab import build_vocabulary
+
+    vocab = build_vocabulary()
+    for engine in ("mujoco", "drake", "pinocchio"):
+        assert engine in vocab, f"Expected engine '{engine}' in vocabulary"
+
+
+@pytest.mark.unit
+def test_build_vocabulary_returns_nonempty_sorted_list() -> None:
+    """build_vocabulary() must always return a sorted, non-empty list."""
+    from src.shared.python.ui.completion_vocab import build_vocabulary
+
+    vocab = build_vocabulary()
+    assert len(vocab) > 0
+    assert vocab == sorted(vocab), "vocabulary must be returned in sorted order"


### PR DESCRIPTION
Closes #5479

## Summary

- Replaces the plain `QLineEdit` search bar in `launcher_ui_setup.py` with `AutoCompleteLineEdit` so global text prediction is actually active in the launcher
- Adds `src/shared/python/ui/completion_vocab.py`: a centralized vocabulary bootstrap that reads the preferred engine list from `src/config/interim_config.yaml` and merges physics/simulation parameter names (`gravity`, `timestep`, `damping`, …) with model-category shortcuts (`biomechanics`, `motion_capture`, …)
- Adds 3 tests to `tests/launchers/test_launcher_ui_setup.py` asserting that `search_input` is an `AutoCompleteLineEdit` with non-empty vocabulary, that engine names appear in it, and that `build_vocabulary()` returns a sorted non-empty list

## Test plan

- [ ] `pytest tests/launchers/test_launcher_ui_setup.py -k "auto_complete or vocabulary"` — all three new tests pass
- [ ] Existing `test_setup_top_bar` continues to pass (no regression)
- [ ] `pytest src/shared/python/tests/ui/test_auto_complete.py` — existing widget tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #5479
