### PR TITLE
fix(sidekick): wire ring-buffer producers and tool declarations

### DIFF
--- a/src/launchers/launcher_diagnostics.py
+++ b/src/launchers/launcher_diagnostics.py
@@ -134,6 +134,53 @@ class LauncherDiagnostics:
         self.results: list[DiagnosticResult] = []
         self._start_time = time.time()
 
+    @staticmethod
+    def _push_to_ring_buffer(results: list[DiagnosticResult]) -> None:
+        """Emit diagnostic results into the app-state ring buffer (issue #5474).
+
+                Called at the end of :meth:
+        un_all_checks after all checks complete.
+                Uses a lazy import so the ring buffer is only required at call-time.
+                Best-effort: any import or record error is silently swallowed.
+        """
+        try:
+            from src.shared.python.ai.chat_context import record_event
+
+            for r in results:
+                record_event(
+                    "diagnostic",
+                    {
+                        "check": r.name,
+                        "status": r.status,
+                        "message": r.message,
+                        "duration_ms": r.duration_ms,
+                    },
+                )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _record_result(self, result: DiagnosticResult) -> None:
+        """Append *result* to ``self.results`` and push it to the ring buffer.
+
+        Best-effort ring-buffer write: any failure from `record_event` is
+        silently swallowed so a buffer outage never breaks the diagnostic run.
+        """
+        self.results.append(result)
+        try:
+            from src.shared.python.ai.chat_context import record_event
+
+            record_event(
+                "diagnostic",
+                {
+                    "check": result.name,
+                    "status": result.status,
+                    "message": result.message,
+                    "duration_ms": result.duration_ms,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     def run_all_checks(self) -> dict[str, Any]:
         """Run all diagnostic checks and return comprehensive report.
 
@@ -154,6 +201,9 @@ class LauncherDiagnostics:
         self.check_biomech_siblings()
         self.check_tools_sidebar()
 
+        # Feed all results into the app-state ring buffer so the Sidekick
+        # chat assistant can include them via get_chat_context() (issue #5474).
+        self._push_to_ring_buffer(self.results)
         # Calculate summary
         passed = sum(1 for r in self.results if r.status == "pass")
         failed = sum(1 for r in self.results if r.status == "fail")
@@ -192,7 +242,7 @@ class LauncherDiagnostics:
             details=details,
             duration_ms=(time.time() - start) * 1000,
         )
-        self.results.append(result)
+        self._record_result(result)
         return result
 
     def _validate_models_yaml_content(

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -925,12 +925,25 @@ class AIAssistantPanel(QWidget):
         self._set_status("Thinking...")
         self._send_btn.setEnabled(False)
 
+        # Build tool declarations from the registry (issue #5475).
+        from src.shared.python.ai.adapters.base import ToolDeclaration
+
+        tool_declarations = [
+            ToolDeclaration(
+                name=t.name,
+                description=t.description,
+                parameters={p.name: p.to_json_schema() for p in t.parameters},
+                required=[p.name for p in t.parameters if p.required],
+            )
+            for t in self._tools_registry.list_tools()
+        ]
+
         # Create streaming worker
         self._current_worker = StreamWorker(
             self._adapter,
             message,
             self._context,
-            [],  # Tools will be added later
+            tool_declarations,
         )
         self._current_worker.chunk_received.connect(self._on_stream_chunk)
         self._current_worker.finished.connect(self._on_stream_finished)

--- a/tests/unit/test_sidekick_ring_buffer_wiring.py
+++ b/tests/unit/test_sidekick_ring_buffer_wiring.py
@@ -1,0 +1,282 @@
+"""Tests for issues #5474 and #5475 — ring-buffer producers and tool wiring.
+
+Issue #5474: LauncherDiagnostics must call record_event so the ring buffer
+has events after a diagnostic pass.
+
+Issue #5475: AIAssistantPanel must pass a non-empty tools list to StreamWorker
+so analytics and other registered tools are reachable by the adapter.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.shared.python.ai.chat_context as chat_context
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_ring_buffer() -> None:
+    """Reset the module-level ring buffer before each test."""
+    chat_context.reset_buffer()
+
+
+# ── Issue #5474: LauncherDiagnostics populates the ring buffer ────────
+
+
+class TestDiagnosticsRingBufferIntegration:
+    """LauncherDiagnostics must emit at least one event to the ring buffer."""
+
+    def test_run_all_checks_populates_ring_buffer(self) -> None:
+        """After run_all_checks, the ring buffer has at least one event."""
+        try:
+            from src.launchers.launcher_diagnostics import LauncherDiagnostics
+        except ImportError as exc:
+            pytest.skip(f"launcher_diagnostics unavailable: {exc}")
+
+        diag = LauncherDiagnostics()
+        diag.run_all_checks()
+
+        ctx = chat_context.get_chat_context()
+        assert ctx["count"] > 0, (
+            "Ring buffer must have at least one event after run_all_checks(). "
+            "Add record_event() calls in launcher_diagnostics.py (issue #5474)."
+        )
+
+    def test_run_all_checks_emits_diagnostic_category(self) -> None:
+        """Events emitted by LauncherDiagnostics have the 'diagnostic' category."""
+        try:
+            from src.launchers.launcher_diagnostics import LauncherDiagnostics
+        except ImportError as exc:
+            pytest.skip(f"launcher_diagnostics unavailable: {exc}")
+
+        diag = LauncherDiagnostics()
+        diag.run_all_checks()
+
+        ctx = chat_context.get_chat_context()
+        categories = {ev["payload"].get("category") for ev in ctx["events"]}
+        check_names = {
+            ev["payload"].get("check")
+            for ev in ctx["events"]
+            if isinstance(ev.get("payload"), dict)
+        }
+        # Events should contain check names
+        assert check_names, (
+            "Ring-buffer events should contain 'check' fields with check names."
+        )
+
+    def test_single_check_populates_ring_buffer(self) -> None:
+        """A single check (check_python_environment) emits one ring-buffer event."""
+        try:
+            from src.launchers.launcher_diagnostics import LauncherDiagnostics
+        except ImportError as exc:
+            pytest.skip(f"launcher_diagnostics unavailable: {exc}")
+
+        diag = LauncherDiagnostics()
+        diag.check_python_environment()
+
+        ctx = chat_context.get_chat_context()
+        assert ctx["count"] >= 1, (
+            "check_python_environment() must emit at least one ring-buffer event."
+        )
+        first_event = ctx["events"][0]
+        assert first_event.get("category") == "diagnostic"
+        payload = first_event.get("payload", {})
+        assert payload.get("check") == "python_environment"
+        assert payload.get("status") in {"pass", "fail", "warning"}
+
+    def test_record_result_tolerates_buffer_failure(self) -> None:
+        """_record_result must not raise even if record_event fails."""
+        try:
+            from src.launchers.launcher_diagnostics import (
+                DiagnosticResult,
+                LauncherDiagnostics,
+            )
+        except ImportError as exc:
+            pytest.skip(f"launcher_diagnostics unavailable: {exc}")
+
+        diag = LauncherDiagnostics()
+        result = DiagnosticResult(
+            name="test",
+            status="pass",
+            message="ok",
+        )
+
+        with patch(
+            "src.shared.python.ai.chat_context.record_event",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Should not raise
+            diag._record_result(result)
+
+
+# ── Issue #5475: AIAssistantPanel passes non-empty tools to StreamWorker ──
+
+
+class TestAssistantPanelToolsWiring:
+    """AIAssistantPanel must pass registered tools to StreamWorker."""
+
+    def _make_panel_stub(self) -> Any:
+        """Build a minimal stub that exercises _process_message tool wiring.
+
+        We avoid actually creating a QApplication / QWidget by stubbing out
+        the PyQt6 layer. The goal is to verify that the list passed to
+        StreamWorker is non-empty.
+        """
+        try:
+            import src.shared.python.ai.gui.assistant_panel as ap_mod
+        except ImportError as exc:
+            pytest.skip(f"assistant_panel unavailable (PyQt6 not installed?): {exc}")
+            return None  # unreachable but satisfies type checker
+
+        return ap_mod
+
+    def test_process_message_passes_non_empty_tools(self) -> None:
+        """_process_message must pass non-empty tool declarations to StreamWorker."""
+        try:
+            import src.shared.python.ai.gui.assistant_panel as ap_mod
+        except ImportError as exc:
+            pytest.skip(f"assistant_panel unavailable: {exc}")
+
+        from src.shared.python.ai.tool_registry import ToolCategory, ToolRegistry
+
+        # Build a fresh registry with at least one tool so we get a non-empty list.
+        registry = ToolRegistry()
+
+        @registry.register(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.ANALYSIS,
+        )
+        def test_tool() -> str:
+            return "ok"
+
+        captured_tools: list[Any] = []
+
+        class _WorkerStub:
+            def __init__(
+                self,
+                adapter: Any,
+                message: str,
+                context: Any,
+                tools: list[Any],
+            ) -> None:
+                captured_tools.extend(tools)
+
+            def start(self) -> None:
+                pass
+
+            chunk_received = MagicMock()
+            finished = MagicMock()
+            error = MagicMock()
+
+        _adapter_stub = MagicMock()
+
+        # Patch StreamWorker, get_global_registry, and all Qt widget constructors
+        with (
+            patch.object(ap_mod, "StreamWorker", _WorkerStub),
+            patch.object(ap_mod, "get_global_registry", return_value=registry),
+            patch.object(ap_mod.AIAssistantPanel, "_setup_ui", lambda self: None),
+            patch.object(ap_mod.AIAssistantPanel, "_load_history", lambda self: None),
+            patch.object(
+                ap_mod.AIAssistantPanel, "_restore_ui_messages", lambda self: None
+            ),
+            patch.object(ap_mod.AIAssistantPanel, "_init_tools", lambda self: None),
+            patch("src.shared.python.ai.rag.simple_rag.SimpleRAGStore"),
+            patch.object(ap_mod.AIAssistantPanel, "_add_message", return_value=None),
+            patch.object(ap_mod.AIAssistantPanel, "_set_status", lambda self, s: None),
+        ):
+            from src.shared.python.ai.types import ConversationContext
+
+            panel = ap_mod.AIAssistantPanel.__new__(ap_mod.AIAssistantPanel)
+            panel._adapter = _adapter_stub
+            panel._tools_registry = registry
+            panel._context = ConversationContext()
+            panel._current_worker = None
+            panel._current_assistant_message = None
+            panel._is_first_chunk = True
+            panel._send_btn = MagicMock()
+
+            panel._process_message("hello")
+
+        assert len(captured_tools) > 0, (
+            "StreamWorker must receive non-empty tools list (issue #5475). "
+            "Fix the tools=[] placeholder in _process_message."
+        )
+
+    def test_tool_declarations_have_name_and_description(self) -> None:
+        """Tool declarations passed to StreamWorker have name and description."""
+        try:
+            import src.shared.python.ai.gui.assistant_panel as ap_mod
+        except ImportError as exc:
+            pytest.skip(f"assistant_panel unavailable: {exc}")
+
+        from src.shared.python.ai.adapters.base import ToolDeclaration
+        from src.shared.python.ai.tool_registry import ToolCategory, ToolRegistry
+
+        registry = ToolRegistry()
+
+        @registry.register(
+            name="analytics_tool",
+            description="Retrieve simulation analytics",
+            category=ToolCategory.ANALYSIS,
+        )
+        def analytics_tool(run_id: str) -> str:
+            return run_id
+
+        captured_tools: list[Any] = []
+
+        class _WorkerStub:
+            def __init__(
+                self,
+                adapter: Any,
+                message: str,
+                context: Any,
+                tools: list[Any],
+            ) -> None:
+                captured_tools.extend(tools)
+
+            def start(self) -> None:
+                pass
+
+            chunk_received = MagicMock()
+            finished = MagicMock()
+            error = MagicMock()
+
+        with (
+            patch.object(ap_mod, "StreamWorker", _WorkerStub),
+            patch.object(ap_mod, "get_global_registry", return_value=registry),
+            patch.object(ap_mod.AIAssistantPanel, "_setup_ui", lambda self: None),
+            patch.object(ap_mod.AIAssistantPanel, "_load_history", lambda self: None),
+            patch.object(
+                ap_mod.AIAssistantPanel, "_restore_ui_messages", lambda self: None
+            ),
+            patch.object(ap_mod.AIAssistantPanel, "_init_tools", lambda self: None),
+            patch("src.shared.python.ai.rag.simple_rag.SimpleRAGStore"),
+            patch.object(ap_mod.AIAssistantPanel, "_add_message", return_value=None),
+            patch.object(ap_mod.AIAssistantPanel, "_set_status", lambda self, s: None),
+        ):
+            from src.shared.python.ai.types import ConversationContext
+
+            panel = ap_mod.AIAssistantPanel.__new__(ap_mod.AIAssistantPanel)
+            panel._adapter = MagicMock()
+            panel._tools_registry = registry
+            panel._context = ConversationContext()
+            panel._current_worker = None
+            panel._current_assistant_message = None
+            panel._is_first_chunk = True
+            panel._send_btn = MagicMock()
+
+            panel._process_message("analyse this")
+
+        assert len(captured_tools) >= 1
+        for tool in captured_tools:
+            assert isinstance(tool, ToolDeclaration)
+            assert tool.name
+            assert tool.description


### PR DESCRIPTION
## Summary

- **Issue #5474**: `LauncherDiagnostics` now emits `record_event("diagnostic", ...)` for every check result. Added `_push_to_ring_buffer(results)` (batch emit after `run_all_checks`) and `_record_result(result)` (per-check emit so individual check calls also populate the buffer). Both use lazy imports to avoid circular dependencies and are silently best-effort so a buffer failure never breaks diagnostics.
- **Issue #5475**: `AIAssistantPanel._process_message` now builds `ToolDeclaration` objects from `self._tools_registry.list_tools()` and passes them to `StreamWorker` instead of the previous hard-coded empty list `[]`.

## Test plan

- [ ] `tests/unit/test_sidekick_ring_buffer_wiring.py` — 6 new tests:
  - `test_run_all_checks_populates_ring_buffer` — ring buffer has >0 events after `run_all_checks()`
  - `test_run_all_checks_emits_diagnostic_category` — events have `check` fields
  - `test_single_check_populates_ring_buffer` — `check_python_environment()` alone writes to buffer
  - `test_record_result_tolerates_buffer_failure` — `_record_result` doesn't raise when `record_event` throws
  - `test_process_message_passes_non_empty_tools` — `StreamWorker` receives non-empty tools list
  - `test_tool_declarations_have_name_and_description` — tool items are `ToolDeclaration` with name/description
- [ ] `tests/unit/test_launcher_diagnostics.py` — all 23 pre-existing tests still pass

Closes #5474
Closes #5475

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #5474
Closes #5475
