### PR TITLE
fix(dbc): deduplicate precondition guard pairs in AIAssistantPanel

### DIFF
--- a/src/shared/python/ai/gui/assistant/_guards.py
+++ b/src/shared/python/ai/gui/assistant/_guards.py
@@ -1,0 +1,19 @@
+"""Shared Design-by-Contract precondition helpers for the assistant package."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def require_not_none(value: Any, name: str) -> None:
+    """Raise ValueError if *value* is None.
+
+    Args:
+        value: The value to check.
+        name: Argument name used in the error message.
+
+    Raises:
+        ValueError: When *value* is ``None``.
+    """
+    if value is None:
+        raise ValueError(f"{name} must be provided")

--- a/src/shared/python/ai/gui/assistant/panel.py
+++ b/src/shared/python/ai/gui/assistant/panel.py
@@ -6,6 +6,8 @@ history sidebar, and settings dialog into a single coherent QWidget.
 
 from __future__ import annotations
 
+from src.shared.python.ai.gui.assistant._guards import require_not_none
+
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -456,8 +458,7 @@ class AIAssistantPanel(QWidget):
         return header
 
     def _add_header_title_widgets(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
+        require_not_none(layout, "layout")
         self._provider_icon = QLabel("\U0001f916")
         layout.addWidget(self._provider_icon)
 
@@ -467,8 +468,7 @@ class AIAssistantPanel(QWidget):
         layout.addSpacing(10)
 
     def _add_header_mode_and_status(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
+        require_not_none(layout, "layout")
         self._mode_combo = QComboBox()
         self._mode_combo.addItems(["Ask", "Plan", "Agent"])
         self._mode_combo.setToolTip(
@@ -480,8 +480,7 @@ class AIAssistantPanel(QWidget):
         layout.addWidget(self._status_label)
 
     def _add_header_action_buttons(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
+        require_not_none(layout, "layout")
 
         from PyQt6.QtWidgets import QCheckBox
 
@@ -524,8 +523,7 @@ class AIAssistantPanel(QWidget):
         Args:
             message: User's message.
         """
-        if message is None:
-            raise ValueError("message must be provided")
+        require_not_none(message, "message")
         if not self._adapter:
             self._add_system_message(
                 "No AI provider configured — open Settings to add one."
@@ -584,8 +582,7 @@ class AIAssistantPanel(QWidget):
 
     def _on_stream_error(self, error: str) -> None:
         """Handle stream error."""
-        if error is None:
-            raise ValueError("error must be provided")
+        require_not_none(error, "error")
         self._set_status("Error")
         self._send_btn.setEnabled(True)
 
@@ -627,8 +624,7 @@ class AIAssistantPanel(QWidget):
         Returns:
             The created MessageWidget.
         """
-        if role is None:
-            raise ValueError("role must be provided")
+        require_not_none(role, "role")
         idx = self._message_layout.count() - 1
         widget = MessageWidget(role, content, timestamp)
         self._message_layout.insertWidget(idx, widget)
@@ -674,15 +670,13 @@ class AIAssistantPanel(QWidget):
 
     def set_adapter(self, adapter: BaseAgentAdapter) -> None:
         """Set the AI adapter to use."""
-        if adapter is None:
-            raise ValueError("adapter must be provided")
+        require_not_none(adapter, "adapter")
         self._adapter = adapter
         self._set_status("Ready")
 
     def set_expertise_level(self, level: ExpertiseLevel) -> None:
         """Set the user's expertise level."""
-        if level is None:
-            raise ValueError("level must be provided")
+        require_not_none(level, "level")
         self._context.user_expertise = level
         level_names = {
             ExpertiseLevel.BEGINNER: "Verbose",
@@ -694,8 +688,7 @@ class AIAssistantPanel(QWidget):
 
     def apply_settings(self, settings: AISettings) -> None:  # noqa: C901
         """Apply settings from dialog."""
-        if settings is None:
-            raise ValueError("settings must be provided")
+        require_not_none(settings, "settings")
         from src.shared.python.ai.gui.settings_dialog import AIProvider, get_api_key
         from src.shared.python.ai.types import ExpertiseLevel
 

--- a/src/shared/python/ai/gui/assistant/streaming.py
+++ b/src/shared/python/ai/gui/assistant/streaming.py
@@ -6,6 +6,8 @@ selected AI adapter and emits chunk_received / finished / error signals.
 
 from __future__ import annotations
 
+from src.shared.python.ai.gui.assistant._guards import require_not_none
+
 from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import QThread, pyqtSignal
@@ -42,8 +44,7 @@ class StreamWorker(QThread):
             context: Conversation context.
             tools: Available tools.
         """
-        if adapter is None:
-            raise ValueError("adapter must be provided")
+        require_not_none(adapter, "adapter")
         super().__init__()
         self._adapter = adapter
         self._message = message

--- a/src/shared/python/ai/gui/assistant/transcript.py
+++ b/src/shared/python/ai/gui/assistant/transcript.py
@@ -6,6 +6,8 @@ build_message_area() for constructing the scrollable conversation history.
 
 from __future__ import annotations
 
+from src.shared.python.ai.gui.assistant._guards import require_not_none
+
 from datetime import datetime, timezone
 
 from PyQt6.QtCore import Qt
@@ -41,8 +43,7 @@ class MessageWidget(QFrame):
             timestamp: When the message was created.
             parent: Parent widget.
         """
-        if role is None:
-            raise ValueError("role must be provided")
+        require_not_none(role, "role")
         super().__init__(parent)
         self._role = role
         self._content = content
@@ -148,8 +149,7 @@ class MessageWidget(QFrame):
         Args:
             text: Text to append.
         """
-        if text is None:
-            raise ValueError("text must be provided")
+        require_not_none(text, "text")
         self._content += text
         self._content_label.setMarkdown(self._content)
 
@@ -159,8 +159,7 @@ class MessageWidget(QFrame):
         Args:
             text: New content.
         """
-        if text is None:
-            raise ValueError("text must be provided")
+        require_not_none(text, "text")
         self._content = text
         self._content_label.setMarkdown(self._content)
 


### PR DESCRIPTION
Consolidates 14 duplicated precondition check pairs into single guards.

## Changes

- Adds `src/shared/python/ai/gui/assistant/_guards.py` with a shared `require_not_none(value, name)` helper
- Replaces all inline `if x is None: raise ValueError(...)` two-liners in `panel.py` (10 guards), `streaming.py` (1 guard), and `transcript.py` (3 guards) with single calls to `require_not_none()`
- The `layout` guard that was copy-pasted identically into three header-builder methods is now a single canonical form
- All files pass `ruff check` and `ruff format` with no changes needed

Closes #5481