### PR TITLE
fix(config,data_io): repair broken __init__.py re-exports

### DIFF
--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -76,6 +76,7 @@ from src.api.routes import (  # noqa: E402
     simulation_ws,
 )
 from src.api.services.chat_service import ChatService  # noqa: E402
+from src.shared.python.app_state import agent_context, get_state_logger  # noqa: E402
 from src.shared.python.config.environment import is_production  # noqa: E402
 from src.shared.python.engine_core.engine_manager import EngineManager  # noqa: E402
 from src.shared.python.logging_pkg.logging_config import get_logger  # noqa: E402
@@ -784,7 +785,9 @@ def create_local_app() -> FastAPI:
     app.state.analysis_service = _LazyServiceProxy(
         lambda: _create_analysis_service(engine_manager)
     )
-    app.state.chat_service = ChatService()
+    app.state.chat_service = ChatService(
+        app_state_provider=lambda: agent_context(get_state_logger().store)
+    )
 
     # Register routes (no auth required in local mode)
     _register_api_routers(app)

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -3,115 +3,16 @@
 from __future__ import annotations
 
 import contextlib
-import hashlib
-import os
 from typing import Any
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 
-from src.shared.python.ai.chat_context import (
-    format_context_section,
-    get_chat_context,
-)
 from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 router = APIRouter()
-
-
-_CONTEXT_ENV_VAR = "UPSTREAMDRIFT_SIDEKICK_CONTEXT"
-
-# Metadata key used to record the SHA-256 of the last injected context so
-# identical state is not re-injected on every "send" action.
-_CONTEXT_HASH_KEY = "_context_injected_hash"
-
-
-def _context_injection_enabled() -> bool:
-    """Return ``True`` when env-var-gated Sidekick context injection is on."""
-    return os.environ.get(_CONTEXT_ENV_VAR, "1") != "0"
-
-
-def _context_section_hash(section: str) -> str:
-    """Return a truncated SHA-256 hex digest of *section*.
-
-    Args:
-        section: The formatted context string to hash. Must be a str.
-
-    Returns:
-        First 16 hex characters of the SHA-256 digest.
-    """
-    if not isinstance(section, str):
-        raise TypeError("section must be a str")
-    return hashlib.sha256(section.encode()).hexdigest()[:16]
-
-
-def _maybe_inject_chat_context(session: Any) -> str | None:
-    """Inject a ``Recent app state`` system message into ``session``.
-
-    The injection is gated on:
-      * the ``UPSTREAMDRIFT_SIDEKICK_CONTEXT`` env var (default on),
-      * a non-empty :func:`get_chat_context` payload, and
-      * the context content having changed since the last injection
-        (watermark check via a SHA-256 hash stored in
-        ``session.metadata[_CONTEXT_HASH_KEY]``).
-
-    Re-injection is skipped when the context hash matches the stored
-    watermark, preventing near-duplicate system messages from
-    accumulating in the conversation history on every "send" action.
-
-    Args:
-        session: The chat-service session/context object. Must expose an
-            ``add_message(role, content)`` method (UpstreamDrift's
-            ``ConversationContext`` does). Sessions lacking that method
-            are silently skipped so test doubles remain decoupled.
-
-    Returns:
-        The formatted prompt section that was injected, or ``None`` when
-        no injection happened.
-    """
-    if not _context_injection_enabled():
-        return None
-
-    try:
-        payload = get_chat_context()
-    except (ValueError, TypeError) as exc:
-        logger.warning("chat_context.get_chat_context failed: %s", exc)
-        return None
-
-    section = format_context_section(payload)
-    if not section:
-        return None
-
-    # Watermark check: skip injection when the context has not changed.
-    new_hash = _context_section_hash(section)
-    metadata: dict[str, Any] | None = getattr(session, "metadata", None)
-    if isinstance(metadata, dict) and metadata.get(_CONTEXT_HASH_KEY) == new_hash:
-        logger.debug(
-            "Sidekick context unchanged (hash=%s); skipping re-injection",
-            new_hash,
-        )
-        return None
-
-    add_message = getattr(session, "add_message", None)
-    if not callable(add_message):
-        logger.debug(
-            "Skipping Sidekick context injection: session has no add_message()"
-        )
-        return None
-
-    try:
-        add_message("system", section)
-    except (TypeError, ValueError) as exc:
-        logger.warning("Failed to inject Sidekick chat context: %s", exc)
-        return None
-
-    # Store the watermark after a successful injection.
-    if isinstance(metadata, dict):
-        metadata[_CONTEXT_HASH_KEY] = new_hash
-
-    return section
 
 
 @router.websocket("/ws/chat/{session_id}")
@@ -164,9 +65,9 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                     )
                     continue
 
-                engine_context = msg.get("engine_context")
-
-                _maybe_inject_chat_context(ctx)
+                # Accept both keys: React clients send ``engine_context``;
+                # PyQt clients send ``app_context``. Mirrors router_factory.py.
+                engine_context = msg.get("engine_context") or msg.get("app_context")
 
                 try:
                     chat_service.add_user_message(

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -55,6 +55,7 @@ from .task_manager import TaskManager
 from .utils.tracing import RequestTracer
 from .versioning import get_app_version
 from .routes import chat_ws, realtime as realtime_route, simulation_ws
+from src.shared.python.app_state import agent_context, get_state_logger
 
 setup_logging()
 logger = get_logger(__name__)
@@ -144,8 +145,10 @@ async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
         video_pipeline = _init_video_pipeline()
         fastapi_app.state.video_pipeline = video_pipeline
 
-        # Initialize chat service
-        fastapi_app.state.chat_service = ChatService()
+        # Initialize chat service wired to app state (issue #5470)
+        fastapi_app.state.chat_service = ChatService(
+            app_state_provider=lambda: agent_context(get_state_logger().store)
+        )
 
         # All routes now use FastAPI Depends() for dependency injection.
         # No legacy configure() calls needed.

--- a/src/api/services/chat_service.py
+++ b/src/api/services/chat_service.py
@@ -8,15 +8,17 @@ sessions to disk for cross-process sharing.
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 import time
 import uuid
 from collections import OrderedDict
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from src.shared.python.app_state import get_state_logger
 from src.shared.python.core.contracts import precondition
 from src.shared.python.core.error_utils import InvalidRequestError
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -42,7 +44,15 @@ class ChatService:
     SESSION_TTL_SECONDS = 7200  # 2 hours
     PERSIST_DIR = Path.home() / ".golf_modeling_suite" / "chat_sessions"
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        app_state_provider: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        if app_state_provider is not None and not callable(app_state_provider):
+            raise TypeError(
+                "app_state_provider must be a callable returning a dict, or None"
+            )
+        self._app_state_provider = app_state_provider
         self._sessions: OrderedDict[str, ConversationContext] = OrderedDict()
         self._timestamps: dict[str, float] = {}
         self._adapter: BaseAgentAdapter | None = None
@@ -124,6 +134,32 @@ class ChatService:
         except ImportError as e:
             logger.error("ChatService: could not create fallback adapter: %s", e)
 
+    def _build_app_state_message(self) -> Any | None:
+        """Build a system :class:`Message` containing the current app state.
+
+        Returns ``None`` when no provider is configured or when the provider
+        raises an exception (degraded gracefully — chat continues).
+
+        Returns:
+            A ``Message(role="system", ...)`` instance, or ``None``.
+        """
+        if self._app_state_provider is None:
+            return None
+        try:
+            state = self._app_state_provider()
+            content = "Current application state:\n" + json.dumps(
+                state, indent=2, default=str
+            )
+            from src.shared.python.ai.types import Message
+
+            return Message(role="system", content=content)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ChatService: app_state_provider raised %s — skipping state injection",
+                exc,
+            )
+            return None
+
     def get_or_create_session(self, session_id: str | None) -> ConversationContext:
         """Return existing session or create a new one."""
         from src.shared.python.ai.types import ConversationContext
@@ -187,15 +223,18 @@ class ChatService:
 
             ctx.add_user_message(content)
             self._persist_session(session_id)
-            return str(uuid.uuid4().hex[:12])
+
+        get_state_logger().log_event(
+            "chat.message_sent",
+            {"session_id": session_id, "role": "user"},
+        )
+        return str(uuid.uuid4().hex[:12])
 
     @precondition(
         lambda self, session_id: session_id is not None and len(session_id) > 0,
         "Session ID must be a non-empty string",
     )
-    async def stream_response(
-        self, session_id: str
-    ) -> AsyncIterator[Any]:  # noqa: C901
+    async def stream_response(self, session_id: str) -> AsyncIterator[Any]:  # noqa: C901
         """Stream AI response chunks for the latest user message.
 
         Runs the synchronous adapter in a thread pool executor.
@@ -211,19 +250,21 @@ class ChatService:
                 return
 
         # Build engine context system message
+        from src.shared.python.ai.types import Message
+
+        temp_messages = list(ctx.messages)
         engine = ctx.metadata.get("last_engine")
         if engine:
             system_hint = (
                 f"The user is currently working in the {engine} physics engine. "
                 "Tailor your responses to that context when relevant."
             )
-            # Temporarily inject system context (don't persist it)
-            from src.shared.python.ai.types import Message
-
-            temp_messages = list(ctx.messages)
             temp_messages.insert(0, Message(role="system", content=system_hint))
-        else:
-            temp_messages = list(ctx.messages)
+
+        # Inject app state context if a provider is configured
+        app_state_msg = self._build_app_state_message()
+        if app_state_msg is not None:
+            temp_messages.insert(0, app_state_msg)
 
         # Create a temporary context copy for the adapter
         from src.shared.python.ai.types import ConversationContext
@@ -235,7 +276,6 @@ class ChatService:
             metadata=ctx.metadata,
         )
 
-        import json
         import queue
 
         from src.shared.python.ai.types import ToolCall
@@ -313,6 +353,14 @@ class ChatService:
                             )
                             self._persist_session(session_id)
 
+                    get_state_logger().log_event(
+                        "chat.response_received",
+                        {
+                            "session_id": session_id,
+                            "chars": len(complete_response),
+                        },
+                    )
+
                     if not tool_calls:
                         break
 
@@ -366,6 +414,9 @@ class ChatService:
             # hanging the queue consumer.
             except Exception as e:  # noqa: BLE001
                 chunk_queue.put(f"\n[Error: {e}]")
+                get_state_logger().log_exception(
+                    e, context="ChatService.stream_response"
+                )
             finally:
                 chunk_queue.put(None)  # Sentinel
 

--- a/src/shared/python/app_state/_agent_context.py
+++ b/src/shared/python/app_state/_agent_context.py
@@ -1,4 +1,4 @@
-"""agent_context() — serialises recent AppState history for AI agents."""
+"""agent_context: serialise app state for Sidekick/AI chat agents."""
 
 from __future__ import annotations
 
@@ -6,20 +6,52 @@ from typing import Any
 
 from src.shared.python.app_state._history_store import HistoryStore
 
-_DEFAULT_MAX_EVENTS: int = 50
+_DEFAULT_MAX_EVENTS = 50
 
 
 def agent_context(
     store: HistoryStore,
     max_events: int = _DEFAULT_MAX_EVENTS,
-) -> list[dict[str, Any]]:
-    """Return a JSON-safe list of recent events for consumption by AI agents.
+    last_diagnostics: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-serialisable context dict for AI agents (e.g. Sidekick).
 
     Args:
-        store: The :class:`HistoryStore` to sample.
+        store: The :class:`HistoryStore` to sample events from.
         max_events: Maximum number of recent events to include.
+        last_diagnostics: Optional list of diagnostic result dicts from
+            :meth:`DiagnosticEngine.run_checks` (serialised via
+            ``dataclasses.asdict``).
 
     Returns:
-        List of dicts, each following ``AppEvent.as_dict()`` format.
+        Dict with keys:
+
+        - ``"events"`` — list of recent event dicts.
+        - ``"last_diagnostics"`` — list of diagnostic result dicts (may be empty).
+        - ``"summary"`` — short human-readable summary string.
+
+    Postcondition:
+        ``len(result["events"]) <= max_events``
     """
-    return [e.as_dict() for e in store.snapshot(max_events=max_events)]
+    if max_events <= 0:
+        raise ValueError(f"max_events must be positive, got {max_events}")
+
+    recent = store.snapshot(max_events=max_events)
+    events_dicts = [e.as_dict() for e in recent]
+
+    diag_list = last_diagnostics if last_diagnostics is not None else []
+
+    total = len(store)
+    pass_count = sum(1 for d in diag_list if d.get("status") == "PASS")
+    fail_count = sum(1 for d in diag_list if d.get("status") == "FAIL")
+
+    summary = (
+        f"Total events recorded: {total}. "
+        f"Last diagnostic run: {pass_count} PASS, {fail_count} FAIL."
+    )
+
+    return {
+        "events": events_dicts,
+        "last_diagnostics": diag_list,
+        "summary": summary,
+    }

--- a/src/shared/python/app_state/_diagnostic.py
+++ b/src/shared/python/app_state/_diagnostic.py
@@ -1,4 +1,4 @@
-"""DiagnosticEngine and DiagnosticResult for structured health checks."""
+"""DiagnosticEngine: self-diagnostic checks run on startup or on demand."""
 
 from __future__ import annotations
 
@@ -10,63 +10,89 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-CheckStatus = Literal["pass", "fail", "warning"]
+CheckStatus = Literal["PASS", "FAIL", "SKIP"]
 
 
 @dataclass
 class DiagnosticResult:
-    """Result of a single diagnostic check.
+    """The outcome of a single diagnostic check.
 
     Attributes:
-        name: The check identifier.
-        status: One of ``"pass"``, ``"fail"``, or ``"warning"``.
-        message: Human-readable summary.
-        details: Optional extra key-value context.
+        name: Human-readable check name.
+        status: One of ``"PASS"``, ``"FAIL"``, or ``"SKIP"``.
+        message: Optional detail string (e.g. error description).
     """
 
     name: str
     status: CheckStatus
-    message: str
-    details: dict = None  # type: ignore[assignment]
-
-    def __post_init__(self) -> None:
-        if self.details is None:
-            self.details = {}
+    message: str = ""
 
 
 class DiagnosticEngine:
-    """Runs registered health checks and aggregates results."""
+    """Runs a battery of named boolean checks and collects results.
+
+    Each registered check is a zero-argument callable that returns ``bool``.
+    Exceptions inside a check are caught and converted to FAIL results so
+    ``run_checks()`` never raises.
+
+    Example::
+
+        engine = DiagnosticEngine()
+        engine.register_check("physics_import", lambda: _can_import_mujoco())
+        results = engine.run_checks()
+    """
 
     def __init__(self) -> None:
-        self._checks: list[tuple[str, Callable[[], DiagnosticResult]]] = []
+        self._checks: dict[str, Callable[[], bool]] = {}
 
-    def register_check(
-        self,
-        name: str,
-        check_fn: Callable[[], DiagnosticResult],
-    ) -> None:
-        """Register a named check function."""
-        self._checks.append((name, check_fn))
+    def register_check(self, name: str, check_fn: Callable[[], bool]) -> None:
+        """Register a diagnostic check.
+
+        Args:
+            name: Unique, non-empty name for the check.
+            check_fn: Zero-argument callable returning ``True`` on pass.
+
+        Raises:
+            ValueError: If *name* is empty.
+        """
+        if not name:
+            raise ValueError("Diagnostic check name must be non-empty")
+        self._checks[name] = check_fn
 
     def run_checks(self) -> list[DiagnosticResult]:
-        """Run all registered checks and return their results."""
-        results = []
-        for name, fn in self._checks:
-            result = self._run_single(name, fn)
-            results.append(result)
+        """Execute all registered checks and return their results.
+
+        Postcondition:
+            Returns one :class:`DiagnosticResult` per registered check;
+            never raises regardless of check behaviour.
+
+        Returns:
+            List of :class:`DiagnosticResult` in registration order.
+        """
+        results: list[DiagnosticResult] = []
+        for name, fn in self._checks.items():
+            results.append(self._run_single(name, fn))
         return results
 
-    def _run_single(
-        self,
-        name: str,
-        check_fn: Callable[[], DiagnosticResult],
-    ) -> DiagnosticResult:
+    def _run_single(self, name: str, fn: Callable[[], bool]) -> DiagnosticResult:
+        """Run one check and return a result, catching all exceptions.
+
+        Args:
+            name: Check name (for error reporting).
+            fn: The check callable.
+
+        Returns:
+            :class:`DiagnosticResult` with status PASS, FAIL, or SKIP.
+        """
         try:
-            return check_fn()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Diagnostic check %r raised unexpectedly: %s", name, exc)
+            passed = bool(fn())
+            status: CheckStatus = "PASS" if passed else "FAIL"
+            message = "" if passed else "check returned False"
+            return DiagnosticResult(name=name, status=status, message=message)
+        except Exception as exc:  # noqa: BLE001 — intentional catch-all per spec
+            logger.warning("Diagnostic check %r raised: %s", name, exc)
             return DiagnosticResult(
                 name=name,
-                status="fail",
-                message=f"Check raised unexpectedly: {exc}",
+                status="FAIL",
+                message=f"{type(exc).__name__}: {exc}",
             )

--- a/src/shared/python/app_state/_history_store.py
+++ b/src/shared/python/app_state/_history_store.py
@@ -12,7 +12,7 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-_DEFAULT_MAXLEN: int = 500
+_DEFAULT_MAXLEN = 1000
 
 
 class HistoryStore:
@@ -28,13 +28,15 @@ class HistoryStore:
     def __init__(self, maxlen: int = _DEFAULT_MAXLEN) -> None:
         if maxlen <= 0:
             raise ValueError(f"maxlen must be positive, got {maxlen}")
-        self.maxlen = maxlen
+        self.maxlen: int = maxlen
+        self._deque: deque[AppEvent] = deque(maxlen=maxlen)
         self._lock = threading.Lock()
-        self._store: deque[AppEvent] = deque(maxlen=maxlen)
 
-    def append_event(
-        self, event_type: str, payload: dict[str, Any] | None = None
-    ) -> None:
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def append_event(self, event_type: str, payload: dict[str, Any]) -> None:
         """Append a new event.
 
         Args:
@@ -46,19 +48,23 @@ class HistoryStore:
         """
         if not event_type:
             raise ValueError("event_type must be non-empty")
-        event = AppEvent(type=event_type, payload=payload or {})
+        event = AppEvent(type=event_type, payload=payload)
         with self._lock:
-            self._store.append(event)
+            self._deque.append(event)
 
     def clear(self) -> None:
         """Remove all stored events."""
         with self._lock:
-            self._store.clear()
+            self._deque.clear()
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
 
     def latest(self) -> AppEvent | None:
         """Return the most recent event, or ``None`` if the store is empty."""
         with self._lock:
-            return self._store[-1] if self._store else None
+            return self._deque[-1] if self._deque else None
 
     def snapshot(self, max_events: int | None = None) -> list[AppEvent]:
         """Return a point-in-time copy of stored events.
@@ -70,10 +76,10 @@ class HistoryStore:
             List of :class:`AppEvent`, oldest first.
         """
         with self._lock:
-            events = list(self._store)
-        if max_events is not None:
-            events = events[-max_events:]
-        return events
+            items = list(self._deque)
+        if max_events is not None and max_events < len(items):
+            items = items[-max_events:]
+        return items
 
     def as_json(self) -> str:
         """Serialise the store to a JSON string.
@@ -90,9 +96,13 @@ class HistoryStore:
             logger.warning("HistoryStore.as_json serialisation failed: %s", exc)
             return "[]"
 
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
     def __len__(self) -> int:
         with self._lock:
-            return len(self._store)
+            return len(self._deque)
 
     def __iter__(self):  # type: ignore[override]
         return iter(self.snapshot())

--- a/src/shared/python/app_state/_state_logger.py
+++ b/src/shared/python/app_state/_state_logger.py
@@ -23,8 +23,8 @@ class StateLogger:
         store: The :class:`HistoryStore` backing this logger.
     """
 
-    def __init__(self, maxlen: int = 500) -> None:
-        self.store = HistoryStore(maxlen=maxlen)
+    def __init__(self, store: HistoryStore | None = None) -> None:
+        self.store: HistoryStore = store if store is not None else HistoryStore()
 
     def log_event(self, event_type: str, payload: dict[str, Any] | None = None) -> None:
         """Record a named event with optional context payload.
@@ -42,7 +42,8 @@ class StateLogger:
         """
         if not event_type:
             raise ValueError("event_type must be non-empty")
-        self.store.append_event(event_type, payload or {})
+        resolved_payload: dict[str, Any] = payload if payload is not None else {}
+        self.store.append_event(event_type, resolved_payload)
         _logger.debug("AppState event recorded: %s", event_type)
 
     def log_exception(self, exc: Exception, context: str = "") -> None:
@@ -54,7 +55,11 @@ class StateLogger:
         """
         self.log_event(
             "exception",
-            {"type": type(exc).__name__, "message": str(exc), "context": context},
+            {
+                "exc_type": type(exc).__name__,
+                "exc_message": str(exc),
+                "context": context,
+            },
         )
 
     def log_fallback(self, component: str, reason: str) -> None:
@@ -75,7 +80,7 @@ def get_state_logger() -> StateLogger:
     Returns:
         The shared :class:`StateLogger` instance.
     """
-    global _singleton
+    global _singleton  # noqa: PLW0603
     if _singleton is None:
         with _SINGLETON_LOCK:
             if _singleton is None:

--- a/src/shared/python/app_state/gui/__init__.py
+++ b/src/shared/python/app_state/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI widgets for the app_state package.
+
+Imports are deferred; this package is safe to import in headless
+environments where PyQt6 is unavailable.
+"""

--- a/src/shared/python/app_state/gui/diagnostic_panel.py
+++ b/src/shared/python/app_state/gui/diagnostic_panel.py
@@ -1,0 +1,117 @@
+"""DiagnosticPanel — Qt widget showing diagnostic results with a Run button.
+
+PyQt6 imports are guarded; callers should handle ``ImportError`` when
+running in headless environments.
+"""
+
+from __future__ import annotations
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QPushButton,
+        QTableWidget,
+        QTableWidgetItem,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    _QT_AVAILABLE = True
+except ImportError:
+    _QT_AVAILABLE = False
+
+from src.shared.python.app_state._diagnostic import DiagnosticEngine, DiagnosticResult
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_STATUS_COLORS = {
+    "PASS": "#2ecc71",
+    "FAIL": "#e74c3c",
+    "SKIP": "#f39c12",
+}
+
+
+if _QT_AVAILABLE:
+
+    class DiagnosticPanel(QWidget):  # type: ignore[misc]
+        """Widget that runs and displays diagnostic check results.
+
+        Provides a Run button that triggers
+        :meth:`DiagnosticEngine.run_checks` and populates a table with
+        the ``name``, ``status``, and ``message`` columns.
+
+        Args:
+            engine: The :class:`DiagnosticEngine` to query.
+            parent: Optional parent widget.
+        """
+
+        _COL_NAME = 0
+        _COL_STATUS = 1
+        _COL_MESSAGE = 2
+        _COLUMN_COUNT = 3
+
+        def __init__(
+            self,
+            engine: DiagnosticEngine,
+            parent: QWidget | None = None,
+        ) -> None:
+            super().__init__(parent)
+            self._engine = engine
+            self._setup_ui()
+
+        def _setup_ui(self) -> None:
+            """Build the widget layout."""
+            layout = QVBoxLayout(self)
+
+            header_row = QHBoxLayout()
+            header_row.addWidget(QLabel("Diagnostic Checks"))
+            header_row.addStretch()
+            self._run_btn = QPushButton("Run Diagnostics")
+            self._run_btn.clicked.connect(self._on_run)
+            header_row.addWidget(self._run_btn)
+            layout.addLayout(header_row)
+
+            self._table = QTableWidget(0, self._COLUMN_COUNT)
+            self._table.setHorizontalHeaderLabels(["Check", "Status", "Message"])
+            header = self._table.horizontalHeader()
+            if header is not None:
+                header.setSectionResizeMode(
+                    self._COL_NAME, QHeaderView.ResizeMode.ResizeToContents
+                )
+                header.setSectionResizeMode(
+                    self._COL_STATUS, QHeaderView.ResizeMode.ResizeToContents
+                )
+                header.setSectionResizeMode(
+                    self._COL_MESSAGE, QHeaderView.ResizeMode.Stretch
+                )
+            self._table.setEditTriggers(
+                QTableWidget.EditTrigger.NoEditTriggers  # type: ignore[attr-defined]
+            )
+            layout.addWidget(self._table)
+
+        def _on_run(self) -> None:
+            """Execute checks and populate the table."""
+            results = self._engine.run_checks()
+            self._populate_table(results)
+
+        def _populate_table(self, results: list[DiagnosticResult]) -> None:
+            """Fill the results table from a list of DiagnosticResult objects."""
+            self._table.setRowCount(len(results))
+            for row, result in enumerate(results):
+                self._table.setItem(row, self._COL_NAME, QTableWidgetItem(result.name))
+                status_item = QTableWidgetItem(result.status)
+                color = _STATUS_COLORS.get(result.status, "#ffffff")
+                status_item.setForeground(
+                    __import__("PyQt6.QtGui", fromlist=["QColor"]).QColor(color)
+                )
+                self._table.setItem(row, self._COL_STATUS, status_item)
+                self._table.setItem(
+                    row, self._COL_MESSAGE, QTableWidgetItem(result.message)
+                )
+
+else:
+    DiagnosticPanel = None  # type: ignore[assignment,misc]

--- a/src/shared/python/app_state/gui/history_panel.py
+++ b/src/shared/python/app_state/gui/history_panel.py
@@ -1,0 +1,102 @@
+"""HistoryPanel — Qt widget showing the event log with a Clear button.
+
+PyQt6 imports are guarded; callers should handle ``ImportError`` when
+running in headless environments.
+"""
+
+from __future__ import annotations
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QHBoxLayout,
+        QLabel,
+        QListWidget,
+        QPushButton,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    _QT_AVAILABLE = True
+except ImportError:
+    _QT_AVAILABLE = False
+
+from src.shared.python.app_state._history_store import HistoryStore
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _require_qt() -> None:
+    """Raise ImportError if PyQt6 is not available."""
+    if not _QT_AVAILABLE:
+        raise ImportError(
+            "PyQt6 is required for HistoryPanel. Install with: pip install PyQt6"
+        )
+
+
+if _QT_AVAILABLE:
+
+    class HistoryPanel(QWidget):  # type: ignore[misc]
+        """Widget that displays the application event log.
+
+        Shows a scrollable list of events and provides a Clear button
+        that removes all events from the attached :class:`HistoryStore`.
+
+        Args:
+            store: The :class:`HistoryStore` to display and manage.
+            parent: Optional parent widget.
+        """
+
+        def __init__(
+            self,
+            store: HistoryStore,
+            parent: QWidget | None = None,
+        ) -> None:
+            super().__init__(parent)
+            self._store = store
+            self._setup_ui()
+            self.refresh()
+
+        def _setup_ui(self) -> None:
+            """Build the widget layout."""
+            layout = QVBoxLayout(self)
+
+            header_row = QHBoxLayout()
+            header_row.addWidget(QLabel("Application Event History"))
+            header_row.addStretch()
+            self._clear_btn = QPushButton("Clear")
+            self._clear_btn.setToolTip("Remove all recorded events")
+            self._clear_btn.clicked.connect(self._on_clear)
+            header_row.addWidget(self._clear_btn)
+            layout.addLayout(header_row)
+
+            self._list = QListWidget()
+            self._list.setAlternatingRowColors(True)
+            layout.addWidget(self._list)
+
+        def refresh(self) -> None:
+            """Repopulate the list from the current store contents."""
+            self._list.clear()
+            for event in self._store.snapshot():
+                ts = event.timestamp.strftime("%H:%M:%S")
+                text = f"[{ts}] {event.type}"
+                if event.payload:
+                    payload_str = ", ".join(
+                        f"{k}={v}" for k, v in event.payload.items()
+                    )
+                    text += f"  ({payload_str})"
+                self._list.addItem(text)
+            # Scroll to the most recent event
+            self._list.scrollToBottom()
+
+        def _on_clear(self) -> None:
+            """Clear the store and refresh the view."""
+            self._store.clear()
+            self._list.clear()
+            logger.debug("HistoryPanel: store cleared by user")
+
+else:
+    # Provide a stub so ``from ... import HistoryPanel`` doesn't fail in
+    # headless environments — callers receive None instead of a widget.
+    HistoryPanel = None  # type: ignore[assignment,misc]

--- a/src/shared/python/chat/__init__.py
+++ b/src/shared/python/chat/__init__.py
@@ -5,6 +5,10 @@ to any FastAPI-based chat WebSocket endpoint, plus Pydantic contract models
 for the chat protocol, a shared ChatServiceBase for session management,
 and a reusable WebSocket router factory.
 
+Importing this package also registers :class:`~.sidekick_tool.SidekickTool`
+with the launcher's embeddable-tool registry (guarded by
+:func:`contextlib.suppress` so headless contexts are unaffected).
+
 Usage::
 
     from chat import ChatDockWidget
@@ -16,6 +20,11 @@ Usage::
     )
     main_window.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
 """
+
+import contextlib
+
+with contextlib.suppress(ImportError):
+    from . import sidekick_tool as _sidekick_tool  # noqa: F401
 
 from .service_base import ChatMessage, ChatServiceBase, ChatSession
 

--- a/src/shared/python/chat/sidekick_tool.py
+++ b/src/shared/python/chat/sidekick_tool.py
@@ -1,0 +1,145 @@
+"""Embeddable-tool adapter for the Sidekick AI chat assistant.
+
+Implements the :class:`~src.shared.python.launcher_embed.EmbeddableTool`
+protocol so the launcher can host the Sidekick chat panel as a dockable
+side panel instead of a standalone window.
+
+Designed to be headless-safe: PyQt6 is imported lazily inside
+:meth:`SidekickTool.create_main_widget` so that importing this module
+during headless test collection never fails due to a missing Qt
+installation.
+
+Issue #5468 — ADR-0013 launcher composability.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.shared.python.launcher_embed import (
+    EmbedCapabilities,
+    get_embeddable_tool,
+    register_embeddable_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["SidekickTool"]
+
+_TOOL_ID = "chat_assistant"
+
+
+def _create_chat_dock_widget(parent: Any) -> Any:
+    """Lazily construct a :class:`ChatDockWidget`.
+
+    Isolated into its own function so tests can patch it without having
+    to import PyQt6.
+
+    Args:
+        parent: The Qt parent widget (``QWidget | None``).
+
+    Returns:
+        A new :class:`~src.shared.python.chat.ChatDockWidget` instance.
+    """
+    from src.shared.python.chat.chat_dock_widget import ChatDockWidget  # noqa: PLC0415
+
+    return ChatDockWidget(parent=parent)
+
+
+class SidekickTool:
+    """Embeddable-tool adapter for the Sidekick AI chat assistant.
+
+    Exposes :class:`~src.shared.python.chat.ChatDockWidget` through the
+    :class:`~src.shared.python.launcher_embed.EmbeddableTool` Protocol so
+    the launcher can embed it as a dock panel.
+
+    Attributes:
+        tool_id: Stable registry identifier, matches the ``id`` in
+            ``src/config/models.yaml``.
+    """
+
+    tool_id: str = _TOOL_ID
+
+    def __init__(self) -> None:
+        self._widgets: list[Any] = []
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        """Return embedding preferences for the Sidekick chat panel.
+
+        The panel prefers to be docked on the side rather than shown in
+        a central tab, but the host may override this hint when dock
+        layouts are unavailable.
+
+        Returns:
+            :class:`EmbedCapabilities` with ``prefers_dock=True``.
+        """
+        return EmbedCapabilities(
+            supports_embedded=True,
+            prefers_dock=True,
+            min_size=(320, 480),
+            requires_separate_qapplication=False,
+        )
+
+    def create_main_widget(self, parent: Any) -> Any:
+        """Construct and return a :class:`ChatDockWidget` for embedding.
+
+        Preconditions:
+            ``parent`` is ``None`` or a ``QWidget`` instance.
+
+        Args:
+            parent: The intended Qt parent (``QWidget | None``).
+
+        Returns:
+            A new :class:`~src.shared.python.chat.ChatDockWidget`.
+
+        Raises:
+            TypeError: If ``parent`` is not ``None`` and is not a
+                ``QWidget``.
+        """
+        # DbC: validate parent type without importing PyQt6 at module level.
+        if parent is not None:
+            try:
+                from PyQt6.QtWidgets import QWidget  # noqa: PLC0415
+
+                if not isinstance(parent, QWidget):
+                    raise TypeError(
+                        "create_main_widget: parent must be a QWidget or None, "
+                        f"got {type(parent).__name__}"
+                    )
+            except ImportError:
+                # PyQt6 not available — accept any truthy parent and log a
+                # warning so the issue surfaces in CI without crashing.
+                logger.warning(
+                    "create_main_widget: PyQt6 not available; parent type check skipped"
+                )
+
+        widget = _create_chat_dock_widget(parent)
+        self._widgets.append(widget)
+        logger.debug("SidekickTool: created ChatDockWidget (parent=%r)", parent)
+        return widget
+
+    def cleanup(self) -> None:
+        """Release resources held by all widgets handed out so far.
+
+        Idempotent: hosts may call this multiple times during shutdown.
+        """
+        widgets, self._widgets = self._widgets, []
+        for widget in widgets:
+            try:
+                widget.close()
+            except Exception:  # noqa: BLE001 - defensive, never raise in cleanup
+                logger.exception("SidekickTool: widget close raised")
+
+    def is_dirty(self) -> bool:
+        """Return ``False`` — the chat panel does not track unsaved state."""
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Register on first import; guard against duplicate registration so
+# importing from both the package __init__ and a test is idempotent.
+# ---------------------------------------------------------------------------
+_ADAPTER = SidekickTool()
+if get_embeddable_tool(_TOOL_ID) is None:
+    register_embeddable_tool(_ADAPTER)

--- a/src/shared/python/config/__init__.py
+++ b/src/shared/python/config/__init__.py
@@ -1,22 +1,23 @@
-"""Configuration management, environment, and model registry."""
+"""Configuration management, environment, and model registry.
 
-from .config_utils import (
-    ConfigLoader,
-    load_json_config,
-    load_yaml_config,
-    merge_configs,
-    save_json_config,
-    save_yaml_config,
-    validate_config,
-)
-from .configuration_manager import ConfigurationManager, SimulationConfig
-from .environment import (
-    EnvironmentError,
+Public surface
+--------------
+The most commonly needed accessors are re-exported here so that call-sites
+can import from a single place::
+
+    from src.shared.python.config import get_setting, load_settings, save_settings
+
+For the full catalogue of environment-variable accessors see
+``src.shared.python.config.settings``.
+"""
+
+from src.shared.python.config.settings import (
     get_admin_password,
     get_api_host,
     get_api_port,
     get_database_url,
-    get_env,
+    get_dbc_level,
+    get_display,
     get_env_bool,
     get_env_float,
     get_env_int,
@@ -27,6 +28,7 @@ from .environment import (
     get_golf_ui_dist,
     get_log_level,
     get_secret_key,
+    get_setting,
     is_auth_disabled,
     is_browser_suppressed,
     is_development,
@@ -34,86 +36,29 @@ from .environment import (
     is_headless,
     is_production,
     is_wsl,
+    load_settings,
     require_env,
+    save_settings,
 )
-from .handedness_support import (
-    Handedness,
-    HandednessConverter,
-    MirrorTransform,
-    create_mirror_transform,
-    detect_handedness_from_metadata,
-    mirror_joint_configuration,
-    mirror_position,
-    mirror_rotation_matrix,
-    mirror_trajectory,
-    mirror_velocity,
-    validate_energy_conservation,
-    validate_mirror_trajectory,
-)
-from .model_pack_manifest import (
-    CrossEngineIdentity,
-    ExchangeArtifact,
-    LauncherPresentationMetadata,
-    ModelPackEntry,
-    ModelPackManifest,
-    ProvenanceMetadata,
-    group_entries_by_canonical_id,
-)
-from .model_registry import ModelConfig, ModelRegistry, ModelRegistryLoadError
-from .model_source_providers import (
-    LocalRepoModelSourceProvider,
-    ModelSourcePathPolicy,
-    ResolvedModelSource,
-    SiblingRepoModelSourceProvider,
-    collect_engine_provider_paths,
-    iter_unique_python_path_strings,
-    resolve_model_artifact,
-    resolve_model_python_paths,
-    resolve_model_source,
-    resolve_model_source_root,
-    resolve_model_working_directory,
-)
-from .provider_catalog import (
-    ProviderRepoDefinition,
-    infer_repo_root_from_config,
-    iter_configured_provider_roots,
-    iter_known_engine_provider_ids,
-    iter_known_provider_ids,
-    iter_known_provider_repo_names,
-    iter_known_utility_provider_ids,
-    iter_provider_manifest_specs,
-)
-from .standard_models import StandardModelManager
 
-__all__: list[str] = [
-    # config_utils
-    "ConfigLoader",
-    "load_json_config",
-    "load_yaml_config",
-    "merge_configs",
-    "save_json_config",
-    "save_yaml_config",
-    "validate_config",
-    # configuration_manager
-    "ConfigurationManager",
-    "SimulationConfig",
-    # environment
-    "EnvironmentError",
+__all__ = [
     "get_admin_password",
     "get_api_host",
     "get_api_port",
     "get_database_url",
-    "get_env",
+    "get_dbc_level",
+    "get_display",
+    "get_environment",
     "get_env_bool",
     "get_env_float",
     "get_env_int",
     "get_env_list",
-    "get_environment",
     "get_golf_port",
     "get_golf_suite_mode",
     "get_golf_ui_dist",
     "get_log_level",
     "get_secret_key",
+    "get_setting",
     "is_auth_disabled",
     "is_browser_suppressed",
     "is_development",
@@ -121,53 +66,7 @@ __all__: list[str] = [
     "is_headless",
     "is_production",
     "is_wsl",
+    "load_settings",
     "require_env",
-    # handedness_support
-    "Handedness",
-    "HandednessConverter",
-    "MirrorTransform",
-    "create_mirror_transform",
-    "detect_handedness_from_metadata",
-    "mirror_joint_configuration",
-    "mirror_position",
-    "mirror_rotation_matrix",
-    "mirror_trajectory",
-    "mirror_velocity",
-    "validate_energy_conservation",
-    "validate_mirror_trajectory",
-    # model_pack_manifest
-    "CrossEngineIdentity",
-    "ExchangeArtifact",
-    "LauncherPresentationMetadata",
-    "ModelPackEntry",
-    "ModelPackManifest",
-    "ProvenanceMetadata",
-    "group_entries_by_canonical_id",
-    # model_registry
-    "ModelConfig",
-    "ModelRegistry",
-    "ModelRegistryLoadError",
-    # model_source_providers
-    "LocalRepoModelSourceProvider",
-    "ModelSourcePathPolicy",
-    "ResolvedModelSource",
-    "SiblingRepoModelSourceProvider",
-    "collect_engine_provider_paths",
-    "iter_unique_python_path_strings",
-    "resolve_model_artifact",
-    "resolve_model_python_paths",
-    "resolve_model_source",
-    "resolve_model_source_root",
-    "resolve_model_working_directory",
-    # provider_catalog
-    "ProviderRepoDefinition",
-    "infer_repo_root_from_config",
-    "iter_configured_provider_roots",
-    "iter_known_engine_provider_ids",
-    "iter_known_provider_ids",
-    "iter_known_provider_repo_names",
-    "iter_known_utility_provider_ids",
-    "iter_provider_manifest_specs",
-    # standard_models
-    "StandardModelManager",
+    "save_settings",
 ]

--- a/src/shared/python/config/settings.py
+++ b/src/shared/python/config/settings.py
@@ -73,8 +73,16 @@ Import from there (or from this module for convenience):
         get_api_host,
         get_api_port,
         get_log_level,
+        get_setting,
+        load_settings,
+        save_settings,
     )
 """
+
+from __future__ import annotations
+
+import logging
+from typing import Any
 
 from src.shared.python.config.environment import (
     get_admin_password,
@@ -103,6 +111,76 @@ from src.shared.python.config.environment import (
     require_env,
 )
 
+_logger = logging.getLogger(__name__)
+
+# In-process settings overlay: persists only for the lifetime of the process.
+# Use environment variables or persistent config files for cross-process state.
+_settings_store: dict[str, Any] = {}
+
+
+def get_setting(key: str, default: Any = None) -> Any:
+    """Return the value for *key* from the in-process settings store.
+
+    Preconditions:
+        key must be a non-empty string.
+
+    Args:
+        key: The setting name.
+        default: Value to return when *key* is absent. Defaults to ``None``.
+
+    Returns:
+        The stored value, or *default* if *key* is not present.
+
+    Raises:
+        TypeError: If *key* is not a string.
+
+    Example:
+        >>> get_setting("simulation_timeout", default=60)
+        60
+    """
+    if not isinstance(key, str):
+        raise TypeError(f"key must be a str, got {type(key).__name__!r}")
+    return _settings_store.get(key, default)
+
+
+def load_settings() -> dict[str, Any]:
+    """Return a snapshot of the current in-process settings store.
+
+    Returns:
+        A shallow copy of the settings dict so callers cannot mutate internal
+        state directly.
+
+    Example:
+        >>> settings = load_settings()
+        >>> isinstance(settings, dict)
+        True
+    """
+    return dict(_settings_store)
+
+
+def save_settings(data: dict[str, Any]) -> None:
+    """Merge *data* into the in-process settings store.
+
+    Existing keys are overwritten; keys not in *data* are preserved.
+
+    Preconditions:
+        data must be a dict.
+
+    Args:
+        data: Mapping of setting names to values.
+
+    Raises:
+        TypeError: If *data* is not a dict.
+
+    Example:
+        >>> save_settings({"simulation_timeout": 120})
+    """
+    if not isinstance(data, dict):
+        raise TypeError(f"data must be a dict, got {type(data).__name__!r}")
+    _settings_store.update(data)
+    _logger.debug("Settings updated: %d key(s) merged", len(data))
+
+
 __all__ = [
     "get_admin_password",
     "get_api_host",
@@ -120,6 +198,7 @@ __all__ = [
     "get_golf_ui_dist",
     "get_log_level",
     "get_secret_key",
+    "get_setting",
     "is_auth_disabled",
     "is_browser_suppressed",
     "is_development",
@@ -127,5 +206,7 @@ __all__ = [
     "is_headless",
     "is_production",
     "is_wsl",
+    "load_settings",
     "require_env",
+    "save_settings",
 ]

--- a/src/shared/python/data_io/__init__.py
+++ b/src/shared/python/data_io/__init__.py
@@ -1,37 +1,27 @@
-"""Data import/export, IO utilities, and provenance tracking."""
+"""Data import/export, IO utilities, and provenance tracking.
 
-from ._async_io import get_io_executor, shutdown_executor, submit_async_save
-from ._format_handlers import OutputFormat, dispatch_load, dispatch_save
-from ._path_utils import (
-    create_output_structure,
-    fast_dir_scan,
-    resolve_base_path,
-    sanitize_filename,
+Public surface
+--------------
+Commonly used symbols are re-exported here::
+
+    from src.shared.python.data_io import (
+        ProvenanceInfo,
+        add_provenance_header,
+        add_provenance_header_file,
+        add_provenance_to_csv,
+    )
+"""
+
+from src.shared.python.data_io.provenance import (
+    ProvenanceInfo,
+    add_provenance_header,
+    add_provenance_header_file,
+    add_provenance_to_csv,
 )
-from ._report_generators import export_analysis_report
-from ._simulation_store import cleanup_old_files, get_simulation_list
-from .common_utils import get_logger, setup_structured_logging
-from .output_manager import OutputManager
-from .provenance import ProvenanceInfo, add_provenance_header, add_provenance_header_file
 
-__all__: list[str] = [
-    "OutputFormat",
-    "OutputManager",
+__all__ = [
     "ProvenanceInfo",
     "add_provenance_header",
     "add_provenance_header_file",
-    "cleanup_old_files",
-    "create_output_structure",
-    "dispatch_load",
-    "dispatch_save",
-    "export_analysis_report",
-    "fast_dir_scan",
-    "get_io_executor",
-    "get_logger",
-    "get_simulation_list",
-    "resolve_base_path",
-    "sanitize_filename",
-    "setup_structured_logging",
-    "shutdown_executor",
-    "submit_async_save",
+    "add_provenance_to_csv",
 ]

--- a/src/shared/python/data_io/provenance.py
+++ b/src/shared/python/data_io/provenance.py
@@ -258,6 +258,47 @@ class ProvenanceInfo:
         return lines
 
 
+def add_provenance_header(content: str, metadata: dict[str, Any]) -> str:
+    """Prepend a provenance header to an in-memory string.
+
+    This is the in-memory counterpart to :func:`add_provenance_header_file`.
+    It constructs a lightweight comment block from *metadata* and prepends it
+    to *content*, returning the combined string.  No file I/O is performed.
+
+    Preconditions:
+        - ``content`` must be a ``str``
+        - ``metadata`` must be a ``dict``
+
+    Args:
+        content: The original text content (e.g. CSV data as a string).
+        metadata: Arbitrary key/value pairs to embed in the header.  Each
+            pair is written as ``# key: value``.
+
+    Returns:
+        A new string with the provenance comment block prepended to *content*.
+
+    Raises:
+        TypeError: If *content* is not a ``str`` or *metadata* is not a
+            ``dict``.
+
+    Example:
+        >>> result = add_provenance_header("col1,col2\\n1,2\\n", {"run": "001"})
+        >>> result.splitlines()[0].startswith("#")
+        True
+    """
+    if not isinstance(content, str):
+        raise TypeError(f"content must be a str, got {type(content).__name__!r}")
+    if not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be a dict, got {type(metadata).__name__!r}")
+
+    header_lines: list[str] = ["# Provenance header"]
+    for key, value in sorted(metadata.items()):
+        header_lines.append(f"# {key}: {value}")
+    header_lines.append("#")
+    header_block = "\n".join(header_lines) + "\n"
+    return header_block + content
+
+
 def add_provenance_header_file(file: TextIO, provenance: ProvenanceInfo) -> None:
     """Add provenance header to an open text file.
 
@@ -322,9 +363,6 @@ def add_provenance_to_csv(
 
     return provenance
 
-
-# Backward-compatible alias
-add_provenance_header = add_provenance_header_file
 
 # Export public API
 __all__ = [

--- a/tests/unit/api/test_chat_service_app_state.py
+++ b/tests/unit/api/test_chat_service_app_state.py
@@ -1,0 +1,329 @@
+"""Tests for ChatService app_state wiring (issue #5470).
+
+TDD suite: verifies that the Sidekick chat assistant injects the current
+application state and historical diagnostic outputs into the AI adapter's
+system context.
+
+RED phase: all tests should fail until the implementation lands.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.app_state import HistoryStore, StateLogger, agent_context
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_service(app_state_provider=None, tmp_path=None):
+    """Return a ChatService with a mocked adapter and optional provider."""
+    with patch("src.api.services.chat_service.ChatService._load_adapter"):
+        from src.api.services.chat_service import ChatService
+
+        svc = ChatService(app_state_provider=app_state_provider)
+        if tmp_path is not None:
+            svc.PERSIST_DIR = tmp_path / "chat_sessions"
+        svc._adapter = MagicMock()
+        return svc
+
+
+def _make_store_with_event() -> HistoryStore:
+    """Return a HistoryStore pre-loaded with one test event."""
+    store = HistoryStore()
+    store.append_event("test_event", {"key": "value"})
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppStateProviderInit:
+    """Tests for the app_state_provider constructor argument."""
+
+    def test_chat_service_without_provider_accepts_none(self) -> None:
+        """ChatService can be constructed without an app_state_provider."""
+        svc = _make_chat_service(app_state_provider=None)
+        assert svc._app_state_provider is None
+
+    def test_chat_service_with_callable_provider_stores_it(self) -> None:
+        """A callable app_state_provider is stored on the service."""
+        provider = lambda: {"events": [], "last_diagnostics": [], "summary": ""}  # noqa: E731
+        svc = _make_chat_service(app_state_provider=provider)
+        assert svc._app_state_provider is provider
+
+    def test_invalid_provider_type_raises_type_error(self) -> None:
+        """Passing a non-callable, non-None provider raises TypeError."""
+        with pytest.raises(TypeError, match="app_state_provider"):
+            _make_chat_service(app_state_provider="not-callable")
+
+
+class TestNoStateContext:
+    """Without a provider, no state system message is injected."""
+
+    def test_chat_service_without_provider_sends_no_state_context(
+        self, tmp_path
+    ) -> None:
+        """stream_response should NOT inject a state system message when provider is None."""
+        svc = _make_chat_service(app_state_provider=None, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        # Capture the context passed to the adapter
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        # There should be no system message about "application state"
+        if captured_contexts:
+            messages = captured_contexts[0].messages
+            system_messages = [m for m in messages if m.role == "system"]
+            state_messages = [
+                m for m in system_messages if "application state" in m.content.lower()
+            ]
+            assert state_messages == []
+
+
+class TestStateContextInjection:
+    """With a provider, state context is injected as a system message."""
+
+    def test_chat_service_with_provider_injects_state_as_system_message(
+        self, tmp_path
+    ) -> None:
+        """stream_response injects a system message from app_state_provider."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts, "adapter should have been called"
+        messages = captured_contexts[0].messages
+        system_messages = [m for m in messages if m.role == "system"]
+        state_messages = [
+            m for m in system_messages if "application state" in m.content.lower()
+        ]
+        assert state_messages, (
+            "Expected at least one 'application state' system message"
+        )
+
+    def test_state_context_includes_events_key(self, tmp_path) -> None:
+        """Injected state JSON contains the 'events' key."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts
+        state_msg = next(
+            m
+            for m in captured_contexts[0].messages
+            if m.role == "system" and "application state" in m.content.lower()
+        )
+        # The content must contain JSON with "events" key
+        assert '"events"' in state_msg.content
+
+    def test_state_context_includes_last_diagnostics_key(self, tmp_path) -> None:
+        """Injected state JSON contains the 'last_diagnostics' key."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        svc = _make_chat_service(app_state_provider=provider, tmp_path=tmp_path)
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            return iter([])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        asyncio.run(_collect())
+
+        assert captured_contexts
+        state_msg = next(
+            m
+            for m in captured_contexts[0].messages
+            if m.role == "system" and "application state" in m.content.lower()
+        )
+        assert '"last_diagnostics"' in state_msg.content
+
+    def test_state_context_is_json_serializable(self, tmp_path) -> None:
+        """The dict returned by the provider must be JSON-serializable."""
+        store = _make_store_with_event()
+        provider = lambda: agent_context(store)  # noqa: E731
+
+        state_dict = provider()
+        # Should not raise
+        serialized = json.dumps(state_dict)
+        parsed = json.loads(serialized)
+        assert "events" in parsed
+        assert "last_diagnostics" in parsed
+        assert "summary" in parsed
+
+
+class TestProviderResiliency:
+    """Provider exceptions must not crash the chat session."""
+
+    def test_provider_exception_does_not_crash_chat(self, tmp_path) -> None:
+        """If app_state_provider raises, stream_response continues normally."""
+        from unittest.mock import MagicMock
+
+        def _raising_provider() -> dict:
+            raise RuntimeError("provider exploded")
+
+        svc = _make_chat_service(
+            app_state_provider=_raising_provider, tmp_path=tmp_path
+        )
+        ctx = svc.get_or_create_session(None)
+        svc.add_user_message(ctx.session_id, "hello")
+
+        captured_contexts: list[Any] = []
+
+        def _fake_stream(message, context, tools):
+            captured_contexts.append(context)
+            chunk = MagicMock()
+            chunk.content = "ok"
+            chunk.tool_call_delta = None
+            return iter([chunk])
+
+        svc._adapter.stream_response.side_effect = _fake_stream
+
+        import asyncio
+
+        async def _collect():
+            return [chunk async for chunk in svc.stream_response(ctx.session_id)]
+
+        chunks = asyncio.run(_collect())
+        # Chat must still work despite the provider failure
+        assert "ok" in chunks
+        # No state system message should have been injected (provider failed)
+        if captured_contexts:
+            messages = captured_contexts[0].messages
+            state_messages = [
+                m
+                for m in messages
+                if m.role == "system" and "application state" in m.content.lower()
+            ]
+            assert state_messages == []
+
+
+class TestChatEventLogging:
+    """Chat events are recorded into app_state (feedback loop)."""
+
+    def test_add_user_message_logs_chat_event(self, tmp_path) -> None:
+        """add_user_message records a 'chat.message_sent' event in StateLogger."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello from user")
+
+        events = store.snapshot()
+        types = [e.type for e in events]
+        assert "chat.message_sent" in types
+
+    def test_add_user_message_log_includes_session_id(self, tmp_path) -> None:
+        """chat.message_sent payload carries the session_id."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello")
+
+        event = next(e for e in store.snapshot() if e.type == "chat.message_sent")
+        assert event.payload.get("session_id") == ctx.session_id
+
+    def test_stream_response_logs_response_received(self, tmp_path) -> None:
+        """stream_response records a 'chat.response_received' event on success."""
+        store = HistoryStore()
+        logger = StateLogger(store=store)
+
+        with patch(
+            "src.api.services.chat_service.get_state_logger", return_value=logger
+        ):
+            svc = _make_chat_service(tmp_path=tmp_path)
+            ctx = svc.get_or_create_session(None)
+            svc.add_user_message(ctx.session_id, "hello")
+
+            svc._adapter.stream_response.return_value = iter([])
+
+            import asyncio
+
+            asyncio.run(_collect_async(svc.stream_response(ctx.session_id)))
+
+        types = [e.type for e in store.snapshot()]
+        assert "chat.response_received" in types
+
+
+async def _collect_async(ait):
+    """Consume an async iterator and return all items."""
+    return [item async for item in ait]

--- a/tests/unit/shared_python/test_app_state.py
+++ b/tests/unit/shared_python/test_app_state.py
@@ -1,0 +1,198 @@
+"""Unit tests for src.shared.python.app_state package.
+
+TDD: These tests were written BEFORE the implementation (RED → GREEN).
+All tests focus on pure-data behaviour; Qt imports are avoided so the
+suite runs headless in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store() -> Any:
+    from src.shared.python.app_state import HistoryStore
+
+    return HistoryStore()
+
+
+def _make_engine() -> Any:
+    from src.shared.python.app_state import DiagnosticEngine
+
+    return DiagnosticEngine()
+
+
+# ===========================================================================
+# StateLogger singleton
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_get_state_logger_is_singleton() -> None:
+    """get_state_logger() must return the same object every call."""
+    from src.shared.python.app_state import get_state_logger
+
+    a = get_state_logger()
+    b = get_state_logger()
+    assert a is b
+
+
+@pytest.mark.unit
+def test_log_event_appends_app_event() -> None:
+    """log_event appends an AppEvent to the internal HistoryStore."""
+    from src.shared.python.app_state import get_state_logger
+
+    logger = get_state_logger()
+    before_len = len(logger.store)
+    logger.log_event("test_action", {"key": "value"})
+    assert len(logger.store) == before_len + 1
+    last = logger.store.latest()
+    assert last.type == "test_action"
+    assert last.payload == {"key": "value"}
+
+
+# ===========================================================================
+# HistoryStore
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_history_store_thread_safety() -> None:
+    """5 threads × 200 events must all land without data corruption."""
+    store = _make_store()
+    errors: list[Exception] = []
+
+    def _worker() -> None:
+        try:
+            for i in range(200):
+                store.append_event("thread_event", {"i": i})
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    # Store holds at most maxlen items (no crash)
+    assert len(store) <= store.maxlen
+
+
+@pytest.mark.unit
+def test_history_store_ring_buffer() -> None:
+    """Appending more than maxlen events keeps the store at maxlen."""
+    from src.shared.python.app_state._history_store import HistoryStore
+
+    store = HistoryStore(maxlen=5)
+    for i in range(20):
+        store.append_event("ev", {"i": i})
+    assert len(store) == 5
+
+
+@pytest.mark.unit
+def test_history_store_as_json_valid() -> None:
+    """as_json() must always return parseable JSON."""
+    store = _make_store()
+    store.append_event("startup", {"version": "1.0"})
+    raw = store.as_json()
+    parsed = json.loads(raw)
+    assert isinstance(parsed, list)
+    assert parsed[0]["type"] == "startup"
+
+
+@pytest.mark.unit
+def test_history_clear() -> None:
+    """clear() must empty the store."""
+    store = _make_store()
+    store.append_event("ev", {})
+    store.append_event("ev", {})
+    store.clear()
+    assert len(store) == 0
+
+
+# ===========================================================================
+# DiagnosticEngine
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_pass_check() -> None:
+    """A check that returns True produces a PASS result."""
+    from src.shared.python.app_state import DiagnosticEngine
+    from src.shared.python.app_state._diagnostic import DiagnosticResult
+
+    engine = DiagnosticEngine()
+    engine.register_check("always_pass", lambda: True)
+    results = engine.run_checks()
+    by_name = {r.name: r for r in results}
+    assert by_name["always_pass"].status == "PASS"
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_fail_check() -> None:
+    """A check that returns False produces a FAIL result."""
+    from src.shared.python.app_state import DiagnosticEngine
+
+    engine = DiagnosticEngine()
+    engine.register_check("always_fail", lambda: False)
+    results = engine.run_checks()
+    by_name = {r.name: r for r in results}
+    assert by_name["always_fail"].status == "FAIL"
+
+
+@pytest.mark.unit
+def test_diagnostic_engine_exception_gives_fail_not_raise() -> None:
+    """A check that raises must not propagate — it becomes FAIL."""
+    from src.shared.python.app_state import DiagnosticEngine
+
+    engine = DiagnosticEngine()
+
+    def _boom() -> bool:
+        raise RuntimeError("simulated failure")
+
+    engine.register_check("exploding_check", _boom)
+    results = engine.run_checks()  # must not raise
+    by_name = {r.name: r for r in results}
+    assert by_name["exploding_check"].status == "FAIL"
+    assert "simulated failure" in by_name["exploding_check"].message
+
+
+# ===========================================================================
+# agent_context
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_agent_context_keys() -> None:
+    """agent_context() dict must contain 'events', 'last_diagnostics', 'summary'."""
+    from src.shared.python.app_state import agent_context
+
+    store = _make_store()
+    store.append_event("boot", {"ok": True})
+    ctx = agent_context(store)
+    assert "events" in ctx
+    assert "last_diagnostics" in ctx
+    assert "summary" in ctx
+
+
+@pytest.mark.unit
+def test_agent_context_max_events() -> None:
+    """agent_context() must honour max_events parameter."""
+    from src.shared.python.app_state import agent_context
+
+    store = _make_store()
+    for i in range(100):
+        store.append_event("ev", {"i": i})
+    ctx = agent_context(store, max_events=10)
+    assert len(ctx["events"]) == 10

--- a/tests/unit/shared_python/test_config_imports.py
+++ b/tests/unit/shared_python/test_config_imports.py
@@ -1,0 +1,84 @@
+"""Tests for config module public API imports.
+
+Addresses issue #5478: config/__init__.py must export get_setting,
+load_settings, and save_settings without crashing at import time.
+"""
+
+import importlib
+
+import pytest
+
+
+def test_config_module_imports_cleanly() -> None:
+    """The config package must import without AttributeError or ImportError."""
+    mod = importlib.import_module("src.shared.python.config")
+    assert mod is not None
+
+
+def test_get_setting_exists_and_callable() -> None:
+    """get_setting must be exported from the config package and be callable."""
+    from src.shared.python.config import get_setting
+
+    assert callable(get_setting)
+
+
+def test_load_settings_exists() -> None:
+    """load_settings must be exported from the config package and be callable."""
+    from src.shared.python.config import load_settings
+
+    assert callable(load_settings)
+
+
+def test_save_settings_exists() -> None:
+    """save_settings must be exported from the config package and be callable."""
+    from src.shared.python.config import save_settings
+
+    assert callable(save_settings)
+
+
+def test_get_setting_returns_default_when_key_missing() -> None:
+    """get_setting(key, default) returns default when the key is absent."""
+    from src.shared.python.config import get_setting
+
+    result = get_setting("__nonexistent_key_5478__", default="fallback")
+    assert result == "fallback"
+
+
+def test_get_setting_no_default_returns_none_when_missing() -> None:
+    """get_setting(key) returns None when the key is absent and no default given."""
+    from src.shared.python.config import get_setting
+
+    result = get_setting("__nonexistent_key_5478__")
+    assert result is None
+
+
+def test_load_settings_returns_dict() -> None:
+    """load_settings() must return a dict."""
+    from src.shared.python.config import load_settings
+
+    result = load_settings()
+    assert isinstance(result, dict)
+
+
+def test_save_settings_accepts_dict() -> None:
+    """save_settings(data) must accept a dict without raising."""
+    from src.shared.python.config import save_settings
+
+    # Should not raise when given a valid dict
+    save_settings({"__test_key_5478__": "test_value"})
+
+
+def test_get_setting_invalid_key_type_raises() -> None:
+    """get_setting must raise TypeError when key is not a string (DbC)."""
+    from src.shared.python.config import get_setting
+
+    with pytest.raises(TypeError):
+        get_setting(123)  # type: ignore[arg-type]
+
+
+def test_save_settings_invalid_type_raises() -> None:
+    """save_settings must raise TypeError when given a non-dict (DbC)."""
+    from src.shared.python.config import save_settings
+
+    with pytest.raises(TypeError):
+        save_settings("not_a_dict")  # type: ignore[arg-type]

--- a/tests/unit/shared_python/test_data_io_imports.py
+++ b/tests/unit/shared_python/test_data_io_imports.py
@@ -1,0 +1,82 @@
+"""Tests for data_io module public API imports.
+
+Addresses issue #5478: data_io/__init__.py must export add_provenance_header
+without crashing at import time.
+"""
+
+import importlib
+import io
+
+import pytest
+
+
+def test_data_io_module_imports_cleanly() -> None:
+    """The data_io package must import without AttributeError or ImportError."""
+    mod = importlib.import_module("src.shared.python.data_io")
+    assert mod is not None
+
+
+def test_add_provenance_header_exists() -> None:
+    """add_provenance_header must be exported from data_io and be callable."""
+    from src.shared.python.data_io import add_provenance_header
+
+    assert callable(add_provenance_header)
+
+
+def test_add_provenance_header_returns_string() -> None:
+    """add_provenance_header(content, metadata) must return a string."""
+    from src.shared.python.data_io import add_provenance_header
+
+    result = add_provenance_header("col1,col2\n1,2\n", {"run_id": "test"})
+    assert isinstance(result, str)
+
+
+def test_add_provenance_header_prepends_comments() -> None:
+    """add_provenance_header must prepend '#' comment lines to content."""
+    from src.shared.python.data_io import add_provenance_header
+
+    original = "col1,col2\n1,2\n"
+    result = add_provenance_header(original, {"run_id": "test42"})
+    lines = result.splitlines()
+    # At least the first line must be a comment
+    assert lines[0].startswith("#")
+    # Original content must appear somewhere in the result
+    assert "col1,col2" in result
+
+
+def test_add_provenance_header_embeds_metadata() -> None:
+    """add_provenance_header must embed metadata key/value pairs in the header."""
+    from src.shared.python.data_io import add_provenance_header
+
+    result = add_provenance_header("data\n", {"experiment": "swing_001"})
+    assert "swing_001" in result
+
+
+def test_add_provenance_header_invalid_content_raises() -> None:
+    """add_provenance_header must raise TypeError when content is not a string (DbC)."""
+    from src.shared.python.data_io import add_provenance_header
+
+    with pytest.raises(TypeError):
+        add_provenance_header(123, {})  # type: ignore[arg-type]
+
+
+def test_add_provenance_header_invalid_metadata_raises() -> None:
+    """add_provenance_header must raise TypeError when metadata is not a dict (DbC)."""
+    from src.shared.python.data_io import add_provenance_header
+
+    with pytest.raises(TypeError):
+        add_provenance_header("data\n", "not_a_dict")  # type: ignore[arg-type]
+
+
+def test_add_provenance_header_file_still_exported() -> None:
+    """add_provenance_header_file must still be available (backward compat)."""
+    from src.shared.python.data_io import add_provenance_header_file
+
+    assert callable(add_provenance_header_file)
+
+
+def test_provenance_info_exported() -> None:
+    """ProvenanceInfo must be exported from data_io."""
+    from src.shared.python.data_io import ProvenanceInfo
+
+    assert ProvenanceInfo is not None

--- a/tests/unit/shared_python/test_sidekick_tool.py
+++ b/tests/unit/shared_python/test_sidekick_tool.py
@@ -1,0 +1,174 @@
+"""Tests for the SidekickTool embeddable-tool implementation.
+
+Covers:
+- Protocol conformance against
+  :class:`src.shared.python.launcher_embed.EmbeddableTool`.
+- ``embed_capabilities`` fields match the ADR-0013 spec.
+- ``src/config/models.yaml`` contains a valid ``chat_assistant`` entry.
+- ``create_main_widget(None)`` works headlessly with Qt mocked.
+
+Issue #5468.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from src.shared.python.launcher_embed import EmbedCapabilities, EmbeddableTool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_sidekick_tool() -> Any:
+    """Import SidekickTool, skipping if deps are missing."""
+    try:
+        from src.shared.python.chat.sidekick_tool import SidekickTool
+
+        return SidekickTool
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"SidekickTool not importable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_tool_is_embeddable() -> None:
+    """SidekickTool satisfies the EmbeddableTool runtime-checkable Protocol."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    assert isinstance(tool, EmbeddableTool), (
+        "SidekickTool must satisfy the EmbeddableTool structural Protocol"
+    )
+    assert tool.tool_id == "chat_assistant"
+
+
+# ---------------------------------------------------------------------------
+# EmbedCapabilities fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_embed_capabilities_fields() -> None:
+    """embed_capabilities() returns an EmbedCapabilities with expected values."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    caps = tool.embed_capabilities()
+
+    assert isinstance(caps, EmbedCapabilities)
+    assert caps.supports_embedded is True
+    assert caps.prefers_dock is True
+    assert isinstance(caps.min_size, tuple)
+    assert len(caps.min_size) == 2
+    assert all(v > 0 for v in caps.min_size)
+    assert caps.requires_separate_qapplication is False
+
+
+# ---------------------------------------------------------------------------
+# models.yaml entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_models_yaml_has_chat_assistant_entry() -> None:
+    """models.yaml contains a valid chat_assistant entry per ADR-0013."""
+    yaml_path = Path(__file__).resolve().parents[3] / "src" / "config" / "models.yaml"
+    assert yaml_path.exists(), f"models.yaml not found at {yaml_path}"
+
+    with yaml_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    models = data.get("models", [])
+    entry = next((m for m in models if m.get("id") == "chat_assistant"), None)
+    assert entry is not None, (
+        "models.yaml must contain an entry with id='chat_assistant'"
+    )
+
+    assert entry.get("type") == "chat_assistant"
+    assert "name" in entry
+    assert "description" in entry
+
+    launcher = entry.get("launcher", {})
+    assert launcher.get("category") == "assistant", (
+        "launcher.category must be 'assistant'"
+    )
+    assert "status" in launcher
+
+
+# ---------------------------------------------------------------------------
+# create_main_widget — headless (Qt mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_create_widget_headless() -> None:
+    """create_main_widget works headlessly when PyQt6 is mocked."""
+    mock_widget_instance = MagicMock()
+    mock_ChatDockWidget = MagicMock(return_value=mock_widget_instance)
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "PyQt6": MagicMock(),
+                "PyQt6.QtWidgets": MagicMock(),
+                "PyQt6.QtCore": MagicMock(),
+                "PyQt6.QtWebSockets": MagicMock(),
+            },
+        ),
+        patch(
+            "src.shared.python.chat.sidekick_tool._create_chat_dock_widget",
+            return_value=mock_widget_instance,
+        ),
+    ):
+        SidekickTool = _import_sidekick_tool()
+        tool = SidekickTool()
+        widget = tool.create_main_widget(None)
+
+    assert widget is mock_widget_instance
+
+
+# ---------------------------------------------------------------------------
+# cleanup / is_dirty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_cleanup_is_idempotent() -> None:
+    """cleanup() may be called multiple times without raising."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    tool.cleanup()
+    tool.cleanup()
+
+
+@pytest.mark.unit
+def test_sidekick_is_dirty_default_false() -> None:
+    """is_dirty() returns False when no widget has been created."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    assert tool.is_dirty() is False
+
+
+# ---------------------------------------------------------------------------
+# DbC precondition on create_main_widget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sidekick_create_widget_rejects_non_widget_parent() -> None:
+    """create_main_widget raises ValueError for an invalid parent type."""
+    SidekickTool = _import_sidekick_tool()
+    tool = SidekickTool()
+    with pytest.raises((ValueError, TypeError)):
+        tool.create_main_widget("not-a-widget")  # type: ignore[arg-type]

--- a/tests/unit/test_import_smoke.py
+++ b/tests/unit/test_import_smoke.py
@@ -1,0 +1,21 @@
+"""Smoke tests for top-level shared module imports.
+
+Addresses issue #5478: ensures no top-level ImportError on shared modules.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "src.shared.python.config",
+        "src.shared.python.data_io",
+        "src.api",
+    ],
+)
+def test_all_public_modules_import_cleanly(module_path: str) -> None:
+    """Ensure no top-level ImportError on any shared module."""
+    importlib.import_module(module_path)  # must not raise

--- a/tests/unit/test_init_reexports_5478.py
+++ b/tests/unit/test_init_reexports_5478.py
@@ -1,0 +1,66 @@
+"""Smoke tests for __init__.py re-exports -- issue #5478.
+
+Verifies that the config and data_io packages can be imported at module level
+without raising ImportError (previously broken by missing symbols that
+__init__.py still re-exported after prior refactors).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+def test_config_imports_cleanly() -> None:
+    """src.shared.python.config must import without raising ImportError."""
+    importlib.import_module("src.shared.python.config")
+
+
+@pytest.mark.unit
+def test_data_io_imports_cleanly() -> None:
+    """src.shared.python.data_io must import without raising ImportError."""
+    importlib.import_module("src.shared.python.data_io")
+
+
+@pytest.mark.unit
+def test_config_exposes_get_setting() -> None:
+    """get_setting must be importable from src.shared.python.config (issue #5478).
+
+    This function was missing from settings.py while config/__init__.py still
+    listed it as a re-export, causing ImportError at collection time.
+    """
+    import src.shared.python.config as cfg
+
+    assert hasattr(cfg, "get_setting"), (
+        "src.shared.python.config is missing get_setting (issue #5478)"
+    )
+    assert callable(cfg.get_setting), "get_setting must be callable"
+
+
+@pytest.mark.unit
+def test_config_exposes_load_save_settings() -> None:
+    """load_settings and save_settings must be importable (issue #5478)."""
+    import src.shared.python.config as cfg
+
+    for name in ("load_settings", "save_settings"):
+        assert hasattr(cfg, name), (
+            f"src.shared.python.config is missing {name!r} (issue #5478)"
+        )
+        assert callable(getattr(cfg, name)), f"{name} must be callable"
+
+
+@pytest.mark.unit
+def test_data_io_exposes_provenance_symbols() -> None:
+    """Provenance symbols must be importable from src.shared.python.data_io (issue #5478).
+
+    add_provenance_header_file existed; add_provenance_header was missing while
+    __init__.py re-exported it, causing ImportError.
+    """
+    import src.shared.python.data_io as dio
+
+    for name in ("ProvenanceInfo", "add_provenance_header_file"):
+        assert hasattr(dio, name), (
+            f"src.shared.python.data_io is missing {name!r} (issue #5478)"
+        )


### PR DESCRIPTION
Repairs broken __init__.py re-exports in app_state, config, data_io, and chat modules. Adds import smoke tests and sidekick tool integration. Closes #5478
