### PR TITLE
feat(hygiene): no-shadow + clean-vendor enforcement tests (closes #5623)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,19 @@ maturin develop                                   # build Rust extensions locall
 - Breaking changes to Tools public API require a coordinated PR here.
 - Gasification_Model also depends on Tools — avoid transitive breakage.
 
+## Where to edit shared code
+
+Tools is the source of truth for: `shared/python/chat/`, `shared/python/ai/`,
+`shared/python/upstream_drift_tools/` (planned rename: `sidekick`).
+**Never edit these inside `vendor/ud-tools/`**; vendor changes are erased on the
+next `git submodule update` or vendor bump.
+
+Repository-hygiene tests at `tests/unit/repo_hygiene/` enforce this:
+- `test_no_shadow_of_tools_shared.py` — fails if a UD module shadows a Tools shared module without an allow-list entry
+- `test_vendor_submodule_clean.py` — fails if the vendor submodule has uncommitted edits in its working tree
+
+See issue #5623.
+
 ## Slash Commands
 
 - `/gaai-deliver` — Run Delivery Loop for next ready backlog item

--- a/scripts/config/shadow_modules.yaml
+++ b/scripts/config/shadow_modules.yaml
@@ -1,0 +1,66 @@
+# Shadow-module allow-list — see UpstreamDrift issue #5623.
+#
+# Every entry justifies a UD-side module that intentionally shadows a
+# same-named module in the vendored Tools tree. Each entry MUST include
+# a tracking issue and a sunset date. Once the sunset date passes, the
+# allow-list test fails and forces a refactor or removal.
+#
+# Default: EMPTY. Adding a shadow is a deliberate policy exception.
+#
+# The entries currently present capture the pre-existing shadows that
+# existed on `main` at the time issue #5623 was opened. They all point
+# at issue #5623 as the umbrella tracking issue for cleanup. Sunset
+# date enforces a deadline by which each shadow must be removed or
+# reassigned to a more specific tracking issue.
+shadows:
+  ai:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  chat:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  codemap:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  contracts.py:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  cors.py:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  data_processing:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  gui_launcher:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  humanoid_character_builder:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  model_generation:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  notes:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  plot_engine:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  plot_theme:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  safe_eval.py:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  signal_toolkit:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  theme:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  ui:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"
+  upstream_drift_tools:
+    tracking_issue: 5623
+    sunset_date: "2026-12-31"

--- a/tests/unit/repo_hygiene/__init__.py
+++ b/tests/unit/repo_hygiene/__init__.py
@@ -1,0 +1,5 @@
+"""Repository-hygiene enforcement tests.
+
+See UpstreamDrift issue #5623 — these tests prevent agents from shipping
+work into vendor copies or shadow shims of Tools-sourced shared modules.
+"""

--- a/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
+++ b/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
@@ -1,0 +1,142 @@
+"""Forbid UD-side modules from shadowing Tools-shared modules without an allow-list entry.
+
+See UpstreamDrift issue #5623. Tools is the source of truth for shared
+modules under ``shared/python/``. UD consumes them via the
+``vendor/ud-tools`` submodule. A UD-side module of the same name silently
+shadows the vendor copy and causes work to be lost on the next vendor bump.
+
+This test enumerates every top-level entry under
+``vendor/ud-tools/src/shared/python/`` and asserts that no same-named
+entry exists under ``src/shared/python/`` unless it is explicitly listed
+in ``scripts/config/shadow_modules.yaml``.
+
+Design-by-contract:
+
+- Every allow-list entry MUST carry a non-empty integer ``tracking_issue``
+  and a parseable ISO ``sunset_date``. Missing or malformed metadata fails
+  the test loudly — silent allow-list rot is the primary failure mode this
+  test exists to prevent.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# Repo root is three parents up: tests/unit/repo_hygiene/<this file>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VENDOR_SHARED = _REPO_ROOT / "vendor" / "ud-tools" / "src" / "shared" / "python"
+_UD_SHARED = _REPO_ROOT / "src" / "shared" / "python"
+_ALLOW_LIST_PATH = _REPO_ROOT / "scripts" / "config" / "shadow_modules.yaml"
+
+# Names that are not modules and must be ignored on either side.
+_IGNORED_NAMES = frozenset(
+    {
+        "__init__.py",
+        "__pycache__",
+        "README.md",
+        "README_PACKAGE.md",
+        "tests",
+    }
+)
+
+
+def _module_names(root: Path) -> set[str]:
+    """Return top-level module names (packages and .py modules) under ``root``.
+
+    Hidden entries and the items in :data:`_IGNORED_NAMES` are skipped.
+    """
+    if not root.is_dir():
+        return set()
+    names: set[str] = set()
+    for entry in root.iterdir():
+        if entry.name.startswith((".", "_")):
+            continue
+        if entry.name in _IGNORED_NAMES:
+            continue
+        if entry.is_dir() or (entry.is_file() and entry.suffix == ".py"):
+            names.add(entry.name)
+    return names
+
+
+def _load_allow_list() -> dict[str, dict[str, Any]]:
+    """Load and validate the shadow-module allow-list.
+
+    Returns an empty dict when the file declares ``shadows: {}`` or is
+    otherwise empty. Raises :class:`AssertionError` on malformed entries.
+    """
+    assert _ALLOW_LIST_PATH.is_file(), (
+        f"Allow-list config missing at {_ALLOW_LIST_PATH}. "
+        "See UpstreamDrift issue #5623."
+    )
+    raw = yaml.safe_load(_ALLOW_LIST_PATH.read_text(encoding="utf-8")) or {}
+    shadows = raw.get("shadows") or {}
+    assert isinstance(shadows, dict), (
+        f"shadow_modules.yaml: 'shadows' must be a mapping, got {type(shadows)!r}"
+    )
+
+    for name, entry in shadows.items():
+        assert isinstance(entry, dict), (
+            f"shadow_modules.yaml entry {name!r}: must be a mapping, got {type(entry)!r}"
+        )
+        issue = entry.get("tracking_issue")
+        sunset = entry.get("sunset_date")
+        assert isinstance(issue, int) and issue > 0, (
+            f"shadow_modules.yaml entry {name!r}: 'tracking_issue' must be a "
+            f"positive int, got {issue!r}"
+        )
+        assert isinstance(sunset, str) and sunset, (
+            f"shadow_modules.yaml entry {name!r}: 'sunset_date' must be a "
+            f"non-empty ISO date string, got {sunset!r}"
+        )
+        # date.fromisoformat raises ValueError on bad input — surface as
+        # AssertionError so the failure mode is uniform.
+        try:
+            date.fromisoformat(sunset)
+        except ValueError as exc:
+            raise AssertionError(
+                f"shadow_modules.yaml entry {name!r}: 'sunset_date' "
+                f"{sunset!r} is not a valid ISO date — {exc}"
+            ) from exc
+    return shadows
+
+
+@pytest.mark.unit
+def test_allow_list_is_well_formed() -> None:
+    """DbC: every allow-list entry has a tracking issue and a parseable sunset date."""
+    # Just calling the loader exercises every assertion above.
+    _load_allow_list()
+
+
+@pytest.mark.unit
+def test_no_unapproved_shadows_of_tools_shared() -> None:
+    """Fail if any UD module shadows a Tools-shared module without approval.
+
+    A "shadow" is a top-level entry (package directory or ``.py`` module)
+    that exists under both ``vendor/ud-tools/src/shared/python/`` and
+    ``src/shared/python/`` with the same name.
+    """
+    assert _VENDOR_SHARED.is_dir(), (
+        f"Expected vendored Tools tree at {_VENDOR_SHARED}. "
+        "Is the submodule initialised? Run `git submodule update --init`."
+    )
+
+    vendor_names = _module_names(_VENDOR_SHARED)
+    ud_names = _module_names(_UD_SHARED)
+    allowed = set(_load_allow_list().keys())
+
+    shadows = vendor_names & ud_names
+    unapproved = sorted(shadows - allowed)
+
+    assert not unapproved, (
+        "Unapproved shadow modules detected under src/shared/python/ — these "
+        "duplicate Tools-shared modules and will lose work on the next vendor "
+        "bump. Either remove the UD-side copy and import from "
+        "shared.python.<name> via the vendor tree, or add an entry to "
+        f"scripts/config/shadow_modules.yaml with a tracking issue and sunset "
+        f"date. See UpstreamDrift issue #5623.\n\nUnapproved shadows: {unapproved}"
+    )

--- a/tests/unit/repo_hygiene/test_vendor_submodule_clean.py
+++ b/tests/unit/repo_hygiene/test_vendor_submodule_clean.py
@@ -1,0 +1,89 @@
+"""Forbid uncommitted modifications inside the ``vendor/ud-tools`` submodule.
+
+See UpstreamDrift issue #5623. The vendor submodule is a downstream copy of
+Tools. Edits to its working tree are erased on the next
+``git submodule update`` or vendor bump, silently destroying work.
+
+This test runs ``git status --porcelain=v2 vendor/ud-tools`` from the repo
+root and asserts that no working-tree modifications exist *inside* the
+submodule. The submodule pointer itself moving (``M vendor/ud-tools`` at
+the parent level) is fine — that records a deliberate vendor bump.
+
+Design-by-contract:
+
+- The ``git`` invocation must not raise. If ``git`` is unavailable (e.g.
+  on a stripped-down CI runner) the test :func:`pytest.skip` s with a
+  clear reason rather than reporting a spurious failure.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404 - git invocation, no shell, fixed args
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VENDOR_PREFIX = "vendor/ud-tools/"
+
+
+@pytest.mark.unit
+def test_vendor_submodule_has_no_uncommitted_edits() -> None:
+    """Working tree inside ``vendor/ud-tools`` must be clean.
+
+    A dirty working tree inside the submodule means somebody edited
+    vendored Tools code in place. Those edits will be lost on the next
+    ``git submodule update`` or vendor bump — see issue #5623.
+    """
+    git_bin = shutil.which("git")
+    if git_bin is None:
+        pytest.skip("git executable not available on PATH")
+
+    try:
+        result = subprocess.run(  # nosec B603 - fixed args, no shell
+            [git_bin, "status", "--porcelain=v2", "vendor/ud-tools"],
+            cwd=str(_REPO_ROOT),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        pytest.skip(f"git status invocation failed: {exc}")
+
+    if result.returncode != 0:
+        pytest.skip(
+            "git status returned non-zero — likely not a git checkout "
+            f"(rc={result.returncode}, stderr={result.stderr.strip()!r})"
+        )
+
+    # porcelain=v2 format: each tracked change starts with "1 " (ordinary
+    # change), "2 " (rename/copy), "u " (unmerged), or "? " (untracked).
+    # Lines like "# branch.oid <sha>" start with "#" — ignore those.
+    #
+    # The submodule pointer change at the parent level appears as a single
+    # "1 .M ..." line whose final path field is exactly "vendor/ud-tools".
+    # We only flag entries that reference a path *inside* the submodule —
+    # i.e. paths starting with "vendor/ud-tools/".
+    offenders: list[str] = []
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.rstrip("\n")
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith(("1 ", "2 ", "u ")):
+            continue
+        # The path is the last whitespace-separated field for "1 ", and
+        # appears with a tab separator for "2 ". Checking simple substring
+        # containment of the prefix is sufficient and robust to either form.
+        if _VENDOR_PREFIX in line:
+            offenders.append(line)
+
+    assert not offenders, (
+        "vendor/ud-tools submodule has uncommitted modifications in its "
+        "working tree. Tools is the source of truth for these files — "
+        "changes here are erased on the next `git submodule update` or "
+        "vendor bump. Make the edit in the Tools repo, land it there, then "
+        "bump the submodule pointer. See UpstreamDrift issue #5623.\n\n"
+        "Offending entries:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

Implements UpstreamDrift issue #5623 — repo-hygiene enforcement so future agents cannot ship work into vendor copies or shadow shims of Tools-sourced shared modules.

## What's added

- **`tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py`** — for every top-level module under `vendor/ud-tools/src/shared/python/`, asserts no same-named module exists under `src/shared/python/` unless explicitly listed in `scripts/config/shadow_modules.yaml`. DbC: every allow-list entry must have a positive integer `tracking_issue` and a parseable ISO `sunset_date`.
- **`tests/unit/repo_hygiene/test_vendor_submodule_clean.py`** — runs `git status --porcelain=v2 vendor/ud-tools` and fails on any working-tree edits *inside* the submodule. The submodule pointer change at the parent level is intentionally ignored — only paths starting with `vendor/ud-tools/` are flagged. Skips cleanly if `git` is unavailable.
- **`scripts/config/shadow_modules.yaml`** — bootstrap allow-list. The 17 shadows that already exist on `main` (ai, chat, codemap, contracts.py, cors.py, data_processing, gui_launcher, humanoid_character_builder, model_generation, notes, plot_engine, plot_theme, safe_eval.py, signal_toolkit, theme, ui, upstream_drift_tools) are each tagged with tracking issue `#5623` and a `2026-12-31` sunset date. Once that date passes, the allow-list test fails and forces cleanup. The default for any future shadow is **EMPTY** — adding a new entry is a deliberate policy exception.
- **`CLAUDE.md`** — new "Where to edit shared code" section under "Cross-Repo Dependencies" pointing future agents at the enforcement tests.

## Why the allow-list isn't empty on day one

The issue text says "empty file by default", but the repo currently has 17 pre-existing shadows under `src/shared/python/`. The task explicitly forbids modifying source under `src/shared/python/` or `vendor/ud-tools/`, so the only ship-able state is: capture current shadows as allow-list entries pinned to a near-future sunset date. This converts the cleanup from invisible debt into a calendar-bounded checklist driven by a CI failure.

## Test plan

- [x] `python -m pytest tests/unit/repo_hygiene/ -p no:xdist -v` — 3 passed (allow-list well-formed, no unapproved shadows, vendor submodule clean)
- [x] `python -m ruff check tests/unit/repo_hygiene/ scripts/config/` — All checks passed
- [x] `python -m ruff format --check tests/unit/repo_hygiene/ scripts/config/` — 4 files already formatted

## Notes

- Commit used `--no-verify` per documented Windows constraint: `.git/hooks/pre-commit.legacy` has a `/bin/bash` shebang that does not resolve on Windows hosts. Pre-existing repo issue, not introduced here.
- Local working tree had a pre-existing modification on `tests/conftest.py` (CRLF line-ending normalization) and a submodule pointer move on `vendor/ud-tools` — neither was staged into this commit.

Closes #5623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)