### PR TITLE
fix(workflow): add duplicate label before closing to prevent Verify-Issue-Closure reopen-loop

### DIFF
--- a/.github/workflows/Jules-Redundant-Issue-Closer.yml
+++ b/.github/workflows/Jules-Redundant-Issue-Closer.yml
@@ -112,6 +112,19 @@ jobs:
               return;
             }
 
+            // Add 'duplicate' label BEFORE closing so Verify-Issue-Closure
+            // recognises the exempt label and does not reopen-close-loop.
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: ['duplicate'],
+              });
+            } catch (labelErr) {
+              core.warning(`Could not add duplicate label to #${issue.number}: ${labelErr.message}`);
+            }
+
             await github.rest.issues.update({
               owner,
               repo,


### PR DESCRIPTION
## Root cause

`Jules-Redundant-Issue-Closer` closes duplicate issues with `state_reason: 'not_planned'` but never adds a `duplicate` label. `Verify-Issue-Closure` checks only for **exempt labels** (`wontfix`, `roadmap`, `duplicate`, `invalid`, `not-planned`) — not `state_reason` — so it sees no evidence and reopens the issue. This re-triggers Jules (on the `reopened` event), which closes it again. Loop repeats every 6 hours.

## Fix

Add `addLabels(['duplicate'])` **before** `issues.update(state:'closed')`. Now Verify-Issue-Closure finds the exempt label on the first check and allows the closure.

The `addLabels` call is wrapped in try/catch so a pre-existing label or missing label permission doesn't block the close.

## Same fix applied to

- `Repository_Management` (pushed directly to main — the source-of-truth copy)
- This PR for `UpstreamDrift` (the only other repo that has this workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)