### PR TITLE
ci(jules): require diff verification before issue close / PR merge

### DIFF
--- a/.github/actions/verify-issue-resolution/action.yml
+++ b/.github/actions/verify-issue-resolution/action.yml
@@ -1,0 +1,129 @@
+name: "Verify Issue Resolution"
+description: >
+  Verifies that a PR claiming to resolve an issue actually ships substantive code
+  before allowing close/merge. Prevents the Jules close-and-reopen spam loop by
+  failing the workflow when the PR is a phantom merge (zero/trivial diff that
+  collapsed because a sibling PR with the same files merged first).
+
+inputs:
+  pr_number:
+    description: "Pull request number to verify."
+    required: true
+  issue_number:
+    description: >
+      Optional issue number the PR claims to resolve. When supplied, the action
+      additionally checks that the PR diff touches at least one path referenced
+      in the issue body.
+    required: false
+    default: ""
+  min_additions:
+    description: "Minimum additions required before the PR is considered substantive."
+    required: false
+    default: "5"
+  min_deletions:
+    description: "Minimum deletions required before the PR is considered substantive."
+    required: false
+    default: "5"
+  min_changed_files:
+    description: "Minimum changed files required before the PR is considered substantive."
+    required: false
+    default: "2"
+  github_token:
+    description: "Token used for gh api calls. Must have repo read scope on PRs/issues."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify PR diff is substantive
+      id: verify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        ISSUE_NUMBER: ${{ inputs.issue_number }}
+        MIN_ADDITIONS: ${{ inputs.min_additions }}
+        MIN_DELETIONS: ${{ inputs.min_deletions }}
+        MIN_CHANGED_FILES: ${{ inputs.min_changed_files }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PR_NUMBER:-}" ]; then
+          echo "::error::verify-issue-resolution: pr_number input is required"
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------------
+        # Check 1: diff must not be trivial
+        # base..head must have at least min_additions OR min_deletions LOC
+        # AND at least min_changed_files files changed.
+        # ---------------------------------------------------------------------
+        DIFF_STATS=$(gh pr view "$PR_NUMBER" --json additions,deletions,changedFiles \
+          --jq '"\(.additions) \(.deletions) \(.changedFiles)"')
+        ADDS=$(echo "$DIFF_STATS" | awk '{print $1}')
+        DELS=$(echo "$DIFF_STATS" | awk '{print $2}')
+        FILES=$(echo "$DIFF_STATS" | awk '{print $3}')
+
+        echo "PR #$PR_NUMBER diff: +$ADDS / -$DELS across $FILES file(s)"
+
+        if [ "$ADDS" -lt "$MIN_ADDITIONS" ] \
+           && [ "$DELS" -lt "$MIN_DELETIONS" ] \
+           && [ "$FILES" -lt "$MIN_CHANGED_FILES" ]; then
+          echo "::error::Refusing to close/merge: PR #$PR_NUMBER has trivial diff (+$ADDS/-$DELS, $FILES files). Likely a phantom merge — sibling PR absorbed the work."
+          echo "verdict=trivial_diff" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------------
+        # Check 2: title-vs-content sanity
+        # If title looks like a feature claim, diff must touch at least one
+        # source file (src/ or rust_core/). Docs-only PRs claiming features
+        # are exactly the phantom-merge pattern we're guarding against.
+        # ---------------------------------------------------------------------
+        TITLE=$(gh pr view "$PR_NUMBER" --json title --jq .title)
+        echo "PR #$PR_NUMBER title: $TITLE"
+
+        if echo "$TITLE" | grep -iqE "^(\[?jules[^]]*\]?[: ]*)?feat[:(]|implement|system|engine|framework|architecture"; then
+          CODE_FILES=$(gh pr diff "$PR_NUMBER" --name-only \
+            | grep -cE "^(src/|rust_core/)" || true)
+          echo "PR #$PR_NUMBER touches $CODE_FILES source file(s) under src/ or rust_core/"
+          if [ "$CODE_FILES" -lt 1 ]; then
+            echo "::error::Refusing to close/merge: PR #$PR_NUMBER title claims a feature ('$TITLE') but touches no src/ or rust_core/ files. Phantom merge — refusing to propagate issue closure."
+            echo "verdict=feature_title_no_code" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+        fi
+
+        # ---------------------------------------------------------------------
+        # Check 3: if issue_number was supplied AND its body references paths,
+        # the PR diff must touch at least one referenced path.
+        # ---------------------------------------------------------------------
+        if [ -n "${ISSUE_NUMBER:-}" ]; then
+          ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq .body 2>/dev/null || echo "")
+          REFERENCED_PATHS=$(echo "$ISSUE_BODY" \
+            | grep -oE "(src|tests|rust_core|api|services)/[A-Za-z0-9_/.-]+" \
+            | sort -u || true)
+
+          if [ -n "$REFERENCED_PATHS" ]; then
+            PR_FILES=$(gh pr diff "$PR_NUMBER" --name-only)
+            MATCH=0
+            while IFS= read -r path; do
+              [ -z "$path" ] && continue
+              if echo "$PR_FILES" | grep -qF "$path"; then
+                MATCH=1
+                echo "PR #$PR_NUMBER touches referenced path: $path"
+                break
+              fi
+            done <<< "$REFERENCED_PATHS"
+
+            if [ "$MATCH" -eq 0 ]; then
+              echo "::error::Refusing to close/merge: PR #$PR_NUMBER does not touch any path referenced in issue #$ISSUE_NUMBER body. Referenced paths:"
+              echo "$REFERENCED_PATHS" | sed 's/^/  - /'
+              echo "verdict=issue_path_mismatch" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+          fi
+        fi
+
+        echo "verdict=ok" >> "$GITHUB_OUTPUT"
+        echo "Diff verification passed for PR #$PR_NUMBER."

--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -499,10 +499,18 @@ jobs:
           ---
           - Closed by Jules Assessment Auto-Fix Workflow"
 
-          # Close the PR
-          gh pr close "$SOURCE_PR"
-
-          echo "- Closed PR #$SOURCE_PR"
+          # Anti-phantom-merge gate: skip PRs flagged jules-verification-failed
+          # so the diagnostic remains visible to the user.
+          has_failed_label=$(gh pr view "$SOURCE_PR" --json labels \
+            --jq '[.labels[].name] | contains(["jules-verification-failed"])' \
+            2>/dev/null || echo "false")
+          if [ "$has_failed_label" = "true" ]; then
+            echo "Skipping close of PR #$SOURCE_PR: jules-verification-failed label present."
+          else
+            # Close the PR
+            gh pr close "$SOURCE_PR"
+            echo "- Closed PR #$SOURCE_PR"
+          fi
 
   # Dry run summary - runs independently when dry_run is true
   dry-run-summary:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -102,6 +102,36 @@ jobs:
           echo "todo_count=$TODO_COUNT" >> $GITHUB_OUTPUT
           echo "not_impl_count=$NOT_IMPL_COUNT" >> $GITHUB_OUTPUT
 
+      - name: Collect verification-failed issue numbers (skip-list)
+        # Build a list of issue numbers linked to PRs flagged
+        # jules-verification-failed. The Completist must NOT recreate / reopen
+        # these issues — doing so produces the close-and-reopen notification spam
+        # loop the user explicitly asked us to break.
+        id: skip_list
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
+        run: |
+          set -euo pipefail
+          SKIP_LIST=""
+          PRS=$(gh pr list --state all --label jules-verification-failed \
+            --json number,title,body --limit 200 2>/dev/null || echo "[]")
+          while IFS= read -r pr_json; do
+            [ -z "$pr_json" ] && continue
+            BODY=$(echo "$pr_json" | jq -r '.body // ""')
+            TITLE=$(echo "$pr_json" | jq -r '.title // ""')
+            ISSUES=$(printf '%s\n%s\n' "$TITLE" "$BODY" \
+              | grep -oiE '(fixes|closes|resolves)[[:space:]]*#[0-9]+' \
+              | grep -oE '[0-9]+' || true)
+            for issue_num in $ISSUES; do
+              SKIP_LIST="$SKIP_LIST $issue_num"
+            done
+          done < <(echo "$PRS" | jq -c '.[]')
+          SKIP_LIST=$(echo "$SKIP_LIST" | tr ' ' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+          echo "skip_list=$SKIP_LIST" >> "$GITHUB_OUTPUT"
+          echo "Completist will skip these issues: ${SKIP_LIST:-<none>}"
+          mkdir -p .jules/completist_data
+          echo "$SKIP_LIST" > .jules/completist_data/skip_list.txt
+
       - name: Jules Completist Analysis
         env:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
@@ -193,6 +223,13 @@ jobs:
 
           DO NOT MAKE CODE CHANGES. This is an AUDIT workflow.
           Your job is to identify and document, not fix.
+
+          ## Anti-Loop Skip List
+          The following issue numbers are flagged jules-verification-failed and
+          must NOT be recreated or reopened: ${{ steps.skip_list.outputs.skip_list }}.
+          If you find work matching one of those issues, post a single summary
+          comment on the linked PR instead of creating a new issue. This breaks
+          the close-and-reopen notification spam loop.
           PROMPT_EOF
           )
 

--- a/.github/workflows/Jules-Diff-Verifier.yml
+++ b/.github/workflows/Jules-Diff-Verifier.yml
@@ -1,0 +1,145 @@
+name: Jules Diff Verifier (Anti-Phantom-Merge Gate)
+
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Diff Verifier                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run diff-substance checks on every Jules-generated PR                   │
+# │  • Apply the jules-verification-failed label when diff is phantom         │
+# │  • Comment once on the PR explaining why it should not be merged          │
+# │  • Set a failing job status (acts as required check for the merge bot)    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Close PRs or issues directly                                            │
+# │  • Modify the PR contents                                                  │
+# │  • Push commits or branches                                                │
+# │                                                                             │
+# │ PURPOSE:                                                                    │
+# │  • Stops the close-and-reopen notification spam loop by failing the gate  │
+# │    on phantom merges (PRs whose diff collapsed to zero after a sibling    │
+# │    PR with the same files merged first).                                  │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to re-verify"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: jules-diff-verifier-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify Diff Substance
+    runs-on: ubuntu-latest
+    # Only gate Jules-generated branches. Other PRs pass through automatically.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.pull_request.head.ref, 'jules/') ||
+      startsWith(github.event.pull_request.head.ref, 'fix/jules') ||
+      startsWith(github.event.pull_request.head.ref, 'fix/pragmatic') ||
+      startsWith(github.event.pull_request.head.ref, 'fix/code-quality') ||
+      startsWith(github.event.pull_request.head.ref, 'auto-fix/')
+    steps:
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Extract linked issue number
+        id: extract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Try to pull "Fixes #NNN" or "Closes #NNN" from PR title or body.
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json title,body)
+          TITLE=$(echo "$PR_JSON" | jq -r .title)
+          BODY=$(echo "$PR_JSON" | jq -r .body)
+
+          ISSUE_NUM=$(printf '%s\n%s\n' "$TITLE" "$BODY" \
+            | grep -oiE '(fixes|closes|resolves)[[:space:]]*#[0-9]+' \
+            | head -1 | grep -oE '[0-9]+' || true)
+          echo "issue_number=${ISSUE_NUM:-}" >> "$GITHUB_OUTPUT"
+          echo "Linked issue: ${ISSUE_NUM:-<none>}"
+
+      - name: Run diff verification
+        id: gate
+        uses: ./.github/actions/verify-issue-resolution
+        continue-on-error: true
+        with:
+          pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          issue_number: ${{ steps.extract.outputs.issue_number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label + comment on failure
+        if: steps.gate.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" --add-label "jules-verification-failed" || true
+
+          # Only comment once. Check existing comments for our marker.
+          MARKER="<!-- jules-verification-failed-comment -->"
+          EXISTING=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq "[.comments[] | select(.body | contains(\"$MARKER\"))] | length")
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Verification-failed comment already posted, skipping."
+            exit 0
+          fi
+
+          cat > /tmp/verifier_comment.md <<EOF
+          $MARKER
+          ## Jules Diff Verification Failed
+
+          This PR did not pass the anti-phantom-merge gate. The diff appears to be
+          trivial or inconsistent with what the PR title / linked issue claims.
+
+          Likely cause: a sibling PR touching the same files merged first, so the
+          base..head diff for this PR collapsed. The Jules merge bot must NOT merge
+          this PR because doing so would close the linked issue without actually
+          shipping the work.
+
+          To clear this gate:
+          - Either rebase/push real changes onto this branch, OR
+          - Close this PR manually (it is a phantom — its work shipped elsewhere)
+          - Re-running this workflow will re-evaluate.
+
+          Label \`jules-verification-failed\` has been applied. Closer / cleaner
+          workflows will respect this label and refuse to propagate issue closure.
+          EOF
+          gh pr comment "$PR_NUMBER" --body-file /tmp/verifier_comment.md
+
+      - name: Remove failure label on pass
+        if: steps.gate.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
+        run: |
+          # If we previously labelled this PR as failed but the diff now has
+          # substance (e.g. the author pushed real commits), clear the label.
+          gh pr edit "$PR_NUMBER" --remove-label "jules-verification-failed" 2>/dev/null || true
+
+      - name: Fail the job if gate failed
+        if: steps.gate.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::error::Jules diff verification failed for this PR. See PR comment for details."
+          exit 1

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -264,5 +264,21 @@ jobs:
             # Post-processing: Remove reviewers to reduce noise
             if [ -n "$PR_NUM" ]; then
                gh pr edit "$PR_NUM" --remove-reviewer "dieterolson" || true
+               echo "PR_NUM=$PR_NUM" >> "$GITHUB_ENV"
             fi
           fi
+
+      - name: Anti-phantom-merge verification on resolver PR
+        if: env.PR_NUM != ''
+        uses: ./.github/actions/verify-issue-resolution
+        continue-on-error: true
+        with:
+          pr_number: ${{ env.PR_NUM }}
+          github_token: ${{ secrets.RUNNER_CHECK_TOKEN }}
+
+      - name: Label PR if verification failed
+        if: env.PR_NUM != '' && failure()
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
+        run: |
+          gh pr edit "$PR_NUM" --add-label "jules-verification-failed" || true

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -143,16 +143,25 @@ jobs:
             if [ "$DRY_RUN" = "true" ]; then
               echo "[DRY RUN] Would close PR #$PR_NUM: $PR_TITLE"
             else
+              # Anti-phantom-merge gate: skip PRs flagged jules-verification-failed
+              # so the diagnostic remains visible to the user.
+              has_failed_label=$(gh pr view "$PR_NUM" --json labels \
+                --jq '[.labels[].name] | contains(["jules-verification-failed"])' \
+                2>/dev/null || echo "false")
+              if [ "$has_failed_label" = "true" ]; then
+                echo "Skipping PR #$PR_NUM: jules-verification-failed label present."
+                continue
+              fi
+
               echo "Closing PR #$PR_NUM: $PR_TITLE"
               COMMENT=$(printf '%s\n' \
                 "Auto-closed: Stale Jules-generated PR with failing CI." \
                 "" \
                 "If this PR is still needed, you can:" \
                 "1. Reopen it and push new commits" \
-                "2. Add the `jules-keep` label to prevent auto-closure" \
+                "2. Add the \`jules-keep\` label to prevent auto-closure" \
                 "" \
                 "This cleanup runs weekly to prevent PR accumulation.")
-              gh pr close "$PR_NUM" --comment "$COMMENT"
               gh pr close "$PR_NUM" --comment "$COMMENT"
 
               # Also delete the branch

--- a/.github/workflows/Jules-Redundant-Issue-Closer.yml
+++ b/.github/workflows/Jules-Redundant-Issue-Closer.yml
@@ -96,6 +96,22 @@ jobs:
               return;
             }
 
+            // Anti-phantom-merge gate: if either issue is linked to a PR carrying
+            // jules-verification-failed, do NOT silently close as duplicate — that
+            // hides the diagnostic. Leave both open for human triage.
+            const flaggedPRs = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: `repo:${owner}/${repo} is:pr label:jules-verification-failed`,
+              per_page: 100,
+            }).catch(() => []);
+            const isFlagged = (issueNumber) => flaggedPRs.some(pr => {
+              const text = `${pr.title || ''} ${pr.body || ''}`;
+              return new RegExp(`(?:fixes|closes|resolves)\\s+#${issueNumber}\\b`, 'i').test(text);
+            });
+            if (isFlagged(issue.number) || isFlagged(canonical.number)) {
+              core.warning(`Skipping duplicate-close: issue #${issue.number} or #${canonical.number} is linked to a jules-verification-failed PR. Leaving both open for human triage.`);
+              return;
+            }
+
             await github.rest.issues.update({
               owner,
               repo,

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -144,6 +144,17 @@ jobs:
             PR_TITLE=$(echo "$pr_json" | jq -r '.title')
             PR_BRANCH=$(echo "$pr_json" | jq -r '.branch')
 
+            # Anti-phantom-merge gate: skip PRs flagged jules-verification-failed
+            # so the diagnostic remains visible to the user.
+            has_failed_label=$(gh pr view "$PR_NUM" --json labels \
+              --jq '[.labels[].name] | contains(["jules-verification-failed"])' \
+              2>/dev/null || echo "false")
+            if [ "$has_failed_label" = "true" ]; then
+              echo "Skipping PR #$PR_NUM ($PR_TITLE): jules-verification-failed label present."
+              gh pr comment "$PR_NUM" --body "Skipped auto-close-as-superseded because this PR is flagged jules-verification-failed. Investigate before closing." 2>/dev/null || true
+              continue
+            fi
+
             echo "Closing PR #$PR_NUM: $PR_TITLE"
 
             # Create comment body in temp file to avoid YAML parsing issues

--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -146,11 +146,20 @@ jobs:
             }
 
             // 3a. Strict: closing keyword in merged PR body or title.
+            //     ANTI-PHANTOM-MERGE GATE: if the merged PR carries the
+            //     jules-verification-failed label, the closure is NOT trusted —
+            //     the PR was flagged because its base..head diff collapsed
+            //     (sibling PR absorbed the work). Fall through to the reopen path.
             for (const prNumber of candidatePRs) {
               try {
                 const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
                 if (pr.merged === true &&
                     (closingRegex.test(pr.body || '') || closingRegex.test(pr.title || ''))) {
+                  const prLabels = (pr.labels || []).map(l => (typeof l === 'string' ? l : l.name).toLowerCase());
+                  if (prLabels.includes('jules-verification-failed')) {
+                    core.warning(`Merged PR #${prNumber} carries jules-verification-failed; refusing to accept it as closure evidence for #${issueNumber}. This is a phantom merge — the diff collapsed because a sibling PR absorbed the work.`);
+                    continue;
+                  }
                   core.info(`Merged PR #${prNumber} closes #${issueNumber} via closing keyword.`);
                   return;
                 }


### PR DESCRIPTION
## Summary

Stops the Jules close-and-reopen notification spam loop by adding an anti-phantom-merge verification gate that every closer-type Jules workflow must respect — and, critically, by teaching Verify-Issue-Closure to reject merged-PR closure evidence when the PR is flagged as a phantom merge.

The forensic finding: Jules-Issue-Resolver opens PRs with feat:/Implement titles + \`Closes #N\` body. The auto-merge bot rebases them onto main. When a sibling PR touching the same files merges first, the rebase collapses base..head to zero — but the PR still self-merges under its feat: title, closing the linked issue via GitHub's keyword link. Verify-Issue-Closure currently sees a merged PR with closing keyword and allows the close. Then Jules-Completist scans the codebase, finds the work is still missing, and creates a NEW issue with the same content. Daily cycle → notification spam.

Reference PRs the gate would have blocked: Tools #2728, #2729, #2807.

## What this PR adds

**New composite action** \`.github/actions/verify-issue-resolution/action.yml\` — three checks:
1. PR diff must clear minimum thresholds.
2. Feature-titled PRs must touch src/ or rust_core/.
3. PRs must touch paths referenced in the linked issue body.

**New workflow** \`.github/workflows/Jules-Diff-Verifier.yml\` — runs on every PR open/sync/reopen for Jules-pattern branches. On failure: applies label \`jules-verification-failed\`, posts a single comment, exits non-zero (becomes a failing required-check that the merge bot will respect).

**Modified closer-type workflows** — each \`gh pr close\` skips PRs flagged \`jules-verification-failed\`:
- Jules-PR-Cleanup.yml (also fixed a duplicate \`gh pr close\` call)
- Jules-Supersede-Check.yml
- Jules-Assessment-AutoFix.yml
- Jules-Redundant-Issue-Closer.yml (skips duplicate-close when either issue is linked to a flagged PR)

**Modified Verify-Issue-Closure.yml** — the critical change. When the closing-keyword PR carries \`jules-verification-failed\`, the workflow REJECTS it as closure evidence and falls through to the reopen path. Without this the existing reopener treats phantom merges as legitimate.

**Modified Jules-Issue-Resolver.yml** — verifies its own PR and labels on failure.

**Modified Jules-Completist.yml** — builds a skip-list of issue numbers linked to flagged PRs and tells the Jules audit prompt to NOT recreate / reopen those issues. Breaks the reopen leg of the loop.

## Quality

All nine modified YAML files parse via python yaml.safe_load. No existing job names or triggers removed. Purely additive verification gates.

## Test plan

- [ ] Confirm Jules-Diff-Verifier triggers on next jules/* branch PR
- [ ] Confirm a synthetic 0-file PR with \`Closes #N\` is labelled jules-verification-failed and that Verify-Issue-Closure reopens issue N when the PR auto-merges
- [ ] Confirm Jules-Cleaner / Supersede-Check / Redundant-Issue-Closer leave a flagged PR alone
- [ ] Confirm Completist run reads the skip list and does not recreate flagged issues