### PR TITLE
feat(sidekick): MATLAB-style workspace tab — live variable table, shared REPL, command history

### DIFF
--- a/src/launchers/golf_launcher.py
+++ b/src/launchers/golf_launcher.py
@@ -463,10 +463,53 @@ class GolfLauncher(
         self._initialize_model_order()
         self._apply_docker_status(results.docker_available)
         self._load_layout()
+        self._seed_sidekick_workspace()
 
         from PyQt6.QtCore import QTimer as _QTimer
 
         _QTimer.singleShot(100, self._show_onboarding_if_needed)
+
+    def _seed_sidekick_workspace(self) -> None:
+        """Push launcher state into any active Sidekick workspace registry.
+
+        Called after startup results are applied so the Sidekick workspace
+        tab shows live state (engine manager, model registry, current scenario)
+        rather than an empty inspector.
+
+        Issue #5616 — seed the registry from the launcher.
+
+        Postcondition: if a sidebar with a WorkspaceRegistry is reachable,
+        its registry contains 'engine_manager' and 'model_registry' keys.
+        LOD: reaches only one level deep (sidebar.registry).
+        """
+        sidebar = getattr(self, "sidekick_sidebar", None)
+        if sidebar is None:
+            # Try the tools-sidebar integration hook if present
+            try:
+                from src.shared.python.gui_launcher.tools_sidebar_integration import (
+                    get_active_sidebar,
+                )
+
+                sidebar = get_active_sidebar()
+            except (ImportError, AttributeError):
+                pass
+
+        if sidebar is None:
+            logger.debug("No sidekick sidebar found; workspace seed skipped")
+            return
+
+        registry = getattr(sidebar, "registry", None)
+        if not hasattr(registry, "set_variable"):
+            logger.debug(
+                "sidebar.registry has no set_variable method; workspace seed skipped"
+            )
+            return
+
+        if self.engine_manager is not None:
+            registry.set_variable("engine_manager", self.engine_manager)
+        if self.registry is not None:
+            registry.set_variable("model_registry", self.registry)
+        logger.info("Sidekick workspace seeded with engine_manager and model_registry")
 
     def create_model_card(self, model: Any) -> None:
         """Create a clickable card widget for *model*.

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/__init__.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/__init__.py
@@ -1,20 +1,32 @@
 """UnifiedToolsSidebar package.
 
 Provides the tab-based sidebar widget and its factory API.
+Issue #5616: adds WorkspaceRegistry, LayoutMode, WorkspaceTableModel,
+PythonReplWidget, and build_workspace_tab.
 """
 
 from __future__ import annotations
 
-from sidekick.ui.tools_sidebar.api import (
+from .api import (
     create_tools_sidebar,
 )
-from sidekick.ui.tools_sidebar.sidebar import (
+from .registry import (
+    Subscription,
+    WorkspaceRegistry,
+    WorkspaceVariable,
+)
+from .sidebar import (
+    LayoutMode,
     SidebarTabDefinition,
     UnifiedToolsSidebar,
 )
 
 __all__ = [
-    "create_tools_sidebar",
+    "LayoutMode",
+    "Subscription",
     "SidebarTabDefinition",
     "UnifiedToolsSidebar",
+    "WorkspaceRegistry",
+    "WorkspaceVariable",
+    "create_tools_sidebar",
 ]

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py
@@ -11,7 +11,7 @@ from src.shared.python.launcher_embed import (
     EmbedCapabilities,
     register_embeddable_tool,
 )
-from sidekick.ui.tools_sidebar.api import (
+from .api import (
     create_tools_sidebar,
 )
 

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/api.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/api.py
@@ -18,7 +18,7 @@ def create_tools_sidebar(parent: Any = None) -> Any:
     Returns:
         A UnifiedToolsSidebar widget.
     """
-    from sidekick.ui.tools_sidebar.sidebar import (
+    from .sidebar import (
         UnifiedToolsSidebar,
     )
 

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
@@ -1,0 +1,170 @@
+"""Default tab builder functions for the Sidekick/UnifiedToolsSidebar.
+
+Provides ``build_workspace_tab()`` — the MATLAB-style workspace panel that
+replaces the blank QListWidget placeholder with a live variable table,
+a Python REPL command window, and a command-history list.
+
+Layout (70/30 horizontal splitter):
+    Left pane  (~70%): PythonReplWidget — shared REPL tied to workspace namespace
+    Right pane (~30%):
+        Top half:    WorkspaceTableView — auto-refreshing variable table
+        Bottom half: Command history QListWidget — double-click to re-run
+
+Design-by-Contract:
+- build_workspace_tab(sidebar): precondition sidebar.registry is a
+  WorkspaceRegistry; postcondition returns a QWidget.
+- LOD: accesses only sidebar.registry and sidebar.set_context_variable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["build_workspace_tab"]
+
+
+def build_workspace_tab(sidebar: Any) -> Any:
+    """Build the MATLAB-style workspace panel.
+
+    Creates a two-pane QSplitter layout:
+    - Left (~70%): Python REPL sharing the workspace namespace
+    - Right (~30%): live variable table (top) + command history list (bottom)
+
+    Precondition: sidebar.registry is a WorkspaceRegistry instance.
+    Postcondition: returns a QWidget.
+
+    Args:
+        sidebar: The UnifiedToolsSidebar (or compatible host) instance.
+
+    Returns:
+        QWidget containing the workspace layout.
+    """
+    try:
+        from PyQt6.QtWidgets import QListWidget, QSplitter, QVBoxLayout, QWidget
+        from PyQt6.QtCore import Qt
+
+        from .python_repl import PythonReplWidget
+        from .registry import WorkspaceRegistry
+        from .workspace_table import WorkspaceTableView
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("build_workspace_tab: Qt unavailable — %s", exc)
+        return _fallback_workspace_tab(sidebar, str(exc))
+
+    registry: WorkspaceRegistry | None = getattr(sidebar, "registry", None)
+    if registry is None or not isinstance(registry, WorkspaceRegistry):
+        logger.warning(
+            "build_workspace_tab: sidebar.registry is not a WorkspaceRegistry; "
+            "falling back to empty panel"
+        )
+        return _fallback_workspace_tab(sidebar, "registry not initialised")
+
+    set_variable = getattr(sidebar, "set_context_variable", registry.set_variable)
+
+    # Shared globals namespace initialised from the registry
+    namespace: dict[str, Any] = {
+        name: registry.get(name) for name in registry.list_names()
+    }
+
+    # -----------------------------------------------------------------------
+    # Build top-level horizontal splitter (left repl / right inspector)
+    # -----------------------------------------------------------------------
+    outer_splitter = QSplitter(Qt.Orientation.Horizontal, sidebar)
+    outer_splitter.setObjectName("WorkspaceOuterSplitter")
+
+    # -----------------------------------------------------------------------
+    # Left pane: Python REPL
+    # -----------------------------------------------------------------------
+    repl = PythonReplWidget(
+        namespace=namespace, registry=registry, parent=outer_splitter
+    )
+    repl_widget = (
+        repl.widget
+        if repl.widget is not None
+        else _label_placeholder(outer_splitter, "Python REPL (Qt unavailable)")
+    )
+    outer_splitter.addWidget(repl_widget)
+
+    # -----------------------------------------------------------------------
+    # Right pane: variable table (top) + history list (bottom)
+    # -----------------------------------------------------------------------
+    right_pane = QSplitter(Qt.Orientation.Vertical, outer_splitter)
+    right_pane.setObjectName("WorkspaceRightPane")
+
+    workspace_view = WorkspaceTableView(registry, parent=right_pane)
+    workspace_view.setObjectName("WorkspaceTableView")
+    right_pane.addWidget(workspace_view)
+
+    history_list = QListWidget(right_pane)
+    history_list.setObjectName("WorkspaceHistoryList")
+    history_list.setToolTip(
+        "Command history — double-click to re-run an entry in the REPL"
+    )
+
+    def _on_repl_run(code: str) -> None:
+        """Update history list when code is evaluated."""
+        history_list.addItem(code)
+
+    # Wire history: the REPL widget updates history internally; we mirror it
+    # into the QListWidget by hooking into a signal if available, else polling.
+    # For now, we expose a simple mechanism: the right-side list updates after
+    # each evaluate. Since PythonReplWidget does not yet emit a signal, we
+    # wrap the evaluate method.
+    _original_evaluate = repl.evaluate
+
+    def _evaluate_and_record(code: str) -> str:
+        result = _original_evaluate(code)
+        if code.strip():
+            history_list.addItem(code.strip())
+        return result
+
+    repl.evaluate = _evaluate_and_record  # type: ignore[method-assign]
+
+    # Double-click history item to re-run
+    def _on_history_double_clicked(item: Any) -> None:
+        repl.evaluate(item.text())
+
+    history_list.itemDoubleClicked.connect(_on_history_double_clicked)
+    right_pane.addWidget(history_list)
+    right_pane.setSizes([300, 150])
+
+    outer_splitter.addWidget(right_pane)
+    # 70/30 split
+    outer_splitter.setSizes([700, 300])
+
+    return outer_splitter
+
+
+def _fallback_workspace_tab(sidebar: Any, reason: str) -> Any:
+    """Return a minimal placeholder when Qt is unavailable.
+
+    Args:
+        sidebar: Parent sidebar widget.
+        reason: Human-readable reason for the fallback.
+
+    Returns:
+        A simple QWidget (or bare object) with the reason text.
+    """
+    try:
+        from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+        widget = QWidget(sidebar)
+        layout = QVBoxLayout(widget)
+        label = QLabel(f"Workspace tab unavailable: {reason}", widget)
+        label.setWordWrap(True)
+        layout.addWidget(label)
+        return widget
+    except Exception:  # noqa: BLE001
+        # Absolute last resort
+        return None
+
+
+def _label_placeholder(parent: Any, text: str) -> Any:
+    try:
+        from PyQt6.QtWidgets import QLabel
+
+        return QLabel(text, parent)
+    except Exception:  # noqa: BLE001
+        return None

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/python_repl.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/python_repl.py
@@ -1,0 +1,225 @@
+"""PythonReplWidget — shared REPL widget for Sidekick sidebar.
+
+Provides a PyQt6 widget that evaluates Python expressions in a shared
+namespace, records command history, and optionally syncs assignments to a
+WorkspaceRegistry.
+
+Design-by-Contract:
+- evaluate(code): postcondition returns a non-None string; never raises.
+- Assignments in code are written to the registry via set_variable().
+- LOD: the widget receives the registry directly; does not reach into sidebar.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import types
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PythonReplWidget", "_evaluate_in_namespace"]
+
+_RESERVED_NAMES: frozenset[str] = frozenset(
+    {
+        "__builtins__",
+        "__name__",
+        "__doc__",
+        "__package__",
+        "__loader__",
+        "__spec__",
+        "np",
+        "numpy",
+        "pd",
+        "pandas",
+    }
+)
+
+
+def _evaluate_in_namespace(code: str, namespace: dict[str, Any]) -> str:
+    """Execute *code* in *namespace* and return captured output.
+
+    Postcondition: always returns a string; never raises.  Exceptions are
+    formatted and included in the return value.
+
+    For expressions (single-line, no assignment), the repr of the result is
+    also included when non-None.
+
+    Args:
+        code: Python source code (expression or statement block).
+        namespace: Mutable namespace dict used for execution.
+
+    Returns:
+        String containing stdout, stderr, and any exception message.
+    """
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    try:
+        compiled = compile(code, "<sidekick-repl>", "exec")
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exec(compiled, namespace, namespace)  # noqa: S102  # nosec B102
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("REPL execution error: %s", exc)
+        parts = [s for s in (stdout.getvalue(), stderr.getvalue()) if s]
+        parts.append(f"{type(exc).__name__}: {exc}")
+        return "".join(parts).strip()
+
+    # Try to also capture the repr of the last expression if the code is a
+    # single line that looks like an expression (not an assignment).
+    result_repr: str | None = None
+    stripped = code.strip()
+    if "\n" not in stripped and "=" not in stripped and stripped:
+        with contextlib.suppress(Exception):
+            val = eval(stripped, namespace)  # noqa: S307  # nosec B307
+            if val is not None:
+                result_repr = repr(val)
+
+    parts = [s for s in (stdout.getvalue(), stderr.getvalue()) if s]
+    if result_repr:
+        parts.append(result_repr)
+    return "".join(parts).strip() if parts else "Executed."
+
+
+def _exportable_items(namespace: dict[str, Any]) -> dict[str, Any]:
+    """Return namespace items that can be exported to the registry."""
+    return {
+        name: value
+        for name, value in namespace.items()
+        if _is_exportable_name(name) and _is_exportable_value(value)
+    }
+
+
+def _is_exportable_name(name: str) -> bool:
+    return bool(name) and not name.startswith("_") and name not in _RESERVED_NAMES
+
+
+def _is_exportable_value(value: Any) -> bool:
+    return not isinstance(value, types.ModuleType) and not callable(value)
+
+
+# ---------------------------------------------------------------------------
+# Widget
+# ---------------------------------------------------------------------------
+
+
+class PythonReplWidget:
+    """Shared Python REPL widget (PyQt6 or fallback shim).
+
+    Evaluates Python code, records history, and optionally syncs variable
+    assignments to a WorkspaceRegistry.
+
+    Usage::
+
+        registry = WorkspaceRegistry()
+        repl = PythonReplWidget(namespace={}, registry=registry)
+        output = repl.evaluate("x = 3.14")
+
+    Args:
+        namespace: Initial globals dict for the REPL.
+        registry: Optional WorkspaceRegistry to receive variable assignments.
+        parent: Optional Qt parent widget.
+    """
+
+    def __init__(
+        self,
+        namespace: dict[str, Any],
+        registry: Any = None,
+        parent: Any = None,
+    ) -> None:
+        self._namespace: dict[str, Any] = dict(namespace)
+        self._registry = registry
+        self._history: list[str] = []
+        self._qt_widget: Any = None
+        self._try_build_qt_widget(parent)
+
+    def _try_build_qt_widget(self, parent: Any) -> None:
+        """Attempt to build the PyQt6 widget; silently skip if unavailable."""
+        try:
+            from PyQt6.QtWidgets import (
+                QPlainTextEdit,
+                QPushButton,
+                QVBoxLayout,
+                QWidget,
+            )
+            from PyQt6.QtCore import QAbstractTableModel
+
+            if not hasattr(QAbstractTableModel, "rowCount"):
+                # We got a MagicMock; skip widget construction
+                return
+
+            widget = QWidget(parent)
+            layout = QVBoxLayout(widget)
+            layout.setContentsMargins(8, 8, 8, 8)
+            layout.setSpacing(4)
+
+            self._input_edit = QPlainTextEdit(widget)
+            self._input_edit.setObjectName("PythonReplInput")
+            self._input_edit.setPlaceholderText("Type Python code here…")
+            layout.addWidget(self._input_edit, stretch=2)
+
+            run_button = QPushButton("Run", widget)
+            run_button.setObjectName("PythonReplRun")
+            run_button.clicked.connect(self._on_run_clicked)
+            layout.addWidget(run_button)
+
+            self._output_edit = QPlainTextEdit(widget)
+            self._output_edit.setObjectName("PythonReplOutput")
+            self._output_edit.setReadOnly(True)
+            layout.addWidget(self._output_edit, stretch=3)
+
+            self._qt_widget = widget
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _on_run_clicked(self) -> None:
+        """Handler for the Run button in the Qt widget."""
+        code = self._input_edit.toPlainText()
+        result = self.evaluate(code)
+        self._output_edit.setPlainText(result)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def widget(self) -> Any:
+        """Return the underlying Qt widget (may be None in headless mode)."""
+        return self._qt_widget
+
+    @property
+    def history(self) -> list[str]:
+        """Return the ordered list of evaluated code strings."""
+        return list(self._history)
+
+    def evaluate(self, code: str) -> str:
+        """Execute *code* in the shared namespace.
+
+        Postcondition: returns a non-None string; never raises.
+        Assignments detected in the namespace after execution are propagated
+        to the WorkspaceRegistry if one was provided.
+
+        Args:
+            code: Python source code.
+
+        Returns:
+            Captured stdout/stderr and/or exception text.
+        """
+        if not code.strip():
+            return "No code to run."
+        self._history.append(code)
+        before_keys = set(self._namespace.keys())
+        result = _evaluate_in_namespace(code, self._namespace)
+        self._sync_new_variables(before_keys)
+        return result
+
+    def _sync_new_variables(self, before_keys: set[str]) -> None:
+        """Push newly assigned variables to the registry."""
+        if self._registry is None:
+            return
+        new_exports = _exportable_items(self._namespace)
+        for name, value in new_exports.items():
+            if name not in before_keys or self._namespace.get(name) != value:
+                with contextlib.suppress(Exception):
+                    self._registry.set_variable(name, value)

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/registry.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/registry.py
@@ -1,0 +1,328 @@
+"""WorkspaceRegistry — workspace variable registry with pub-sub notifications.
+
+This module provides a complete WorkspaceRegistry implementation that
+shadows the vendor version (vendor/ud-tools/.../registry.py) and adds
+a subscribe/unsubscribe pub-sub layer so UI components (e.g.
+WorkspaceTableModel) can react to variable changes without polling.
+
+The core WorkspaceRegistry data model (set/get/remove/list/describe/
+save_json/load_json) is reproduced from the vendor implementation
+verbatim to ensure API compatibility. UpstreamDrift issue #5616 extends
+it with the notification surface.
+
+Design-by-Contract:
+- subscribe(callback): precondition callable(callback); postcondition returns
+  a Subscription whose .dispose() removes the callback.
+- set_variable / delete_variable: fire all current subscribers.
+- Invariant: re-entrancy is safe — a callback that calls set_variable will
+  not cause infinite recursion.
+"""
+
+from __future__ import annotations
+
+import builtins
+import contextlib
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+JSONScalar = str | int | float | bool | None
+JSONValue = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+__all__ = ["Subscription", "WorkspaceRegistry", "WorkspaceVariable"]
+
+
+@dataclass(frozen=True)
+class WorkspaceVariable:
+    """Metadata snapshot for one workspace variable."""
+
+    name: str
+    value: Any
+    type_name: str
+    summary: str
+    json_safe: bool
+    repr_value: str | None = None
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return JSON-safe metadata for UI lists and persisted state."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type_name,
+            "summary": self.summary,
+            "json_safe": self.json_safe,
+        }
+        if self.json_safe:
+            data["value"] = self.value
+        else:
+            data["repr"] = self.repr_value or repr(self.value)
+        return data
+
+
+class Subscription:
+    """Disposable handle returned by WorkspaceRegistry.subscribe().
+
+    Calling :meth:`dispose` removes the callback from the registry.
+    Subsequent dispose() calls are no-ops.
+    """
+
+    def __init__(self, registry: WorkspaceRegistry, callback: Callable) -> None:
+        self._registry = registry
+        self._callback: Callable | None = callback
+
+    def dispose(self) -> None:
+        """Remove this subscription from the registry; idempotent."""
+        if self._callback is not None:
+            self._registry._unsubscribe(self._callback)
+            self._callback = None
+
+
+class WorkspaceRegistry:
+    """In-memory registry for workspace variables, with pub-sub notifications.
+
+    Implements the same interface as the vendor WorkspaceRegistry and adds:
+    - subscribe(callback) -> Subscription
+    - set_variable(name, value) — fire subscribers after storing
+    - delete_variable(name) — fire subscribers with value=None after removing
+    - get_variable(name, default=None) — alias for get()
+
+    Invariant: subscriber dispatch is re-entrancy-safe via a snapshot of the
+    subscriber list; inner set_variable calls dispatch independently.
+    """
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self._values: dict[str, Any] = {}
+        self._repr_values: dict[str, str] = {}
+        self._subscribers: list[Callable] = []
+        if initial:
+            for name, value in initial.items():
+                self.set(name, value)
+
+    # ------------------------------------------------------------------
+    # Core data store (vendor-compatible API)
+    # ------------------------------------------------------------------
+
+    def set(self, name: str, value: Any) -> WorkspaceVariable:
+        """Set a workspace variable and return its metadata snapshot."""
+        self._validate_name(name)
+        self._values[name] = value
+        if _is_json_safe(value):
+            self._repr_values.pop(name, None)
+        else:
+            self._repr_values[name] = repr(value)
+        return self.describe(name)
+
+    def get(self, name: str, default: Any = None) -> Any:
+        """Return a variable value or ``default`` when absent."""
+        return self._values.get(name, default)
+
+    def remove(self, name: str) -> bool:
+        """Remove a variable. Returns ``True`` when it existed."""
+        existed = name in self._values
+        self._values.pop(name, None)
+        self._repr_values.pop(name, None)
+        return existed
+
+    def clear(self) -> None:
+        """Remove all variables."""
+        self._values.clear()
+        self._repr_values.clear()
+
+    def list(self) -> builtins.list[str]:
+        """Return registered variable names in stable sorted order."""
+        return sorted(self._values)
+
+    def list_names(self) -> builtins.list[str]:
+        """Alias for callers that avoid shadowing the built-in ``list``."""
+        return self.list()
+
+    def describe(self, name: str) -> WorkspaceVariable:
+        """Return a metadata snapshot for one variable."""
+        if name not in self._values:
+            raise KeyError(name)
+        value = self._values[name]
+        json_safe = name not in self._repr_values and _is_json_safe(value)
+        return WorkspaceVariable(
+            name=name,
+            value=value,
+            type_name=type(value).__name__,
+            summary=_summarize_dimensions(value),
+            json_safe=json_safe,
+            repr_value=(
+                None if json_safe else self._repr_values.get(name, repr(value))
+            ),
+        )
+
+    def variables(self) -> builtins.list[WorkspaceVariable]:
+        """Return metadata snapshots for all variables."""
+        return [self.describe(name) for name in self.list()]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe payload suitable for persistence."""
+        return {
+            "version": 1,
+            "variables": [variable.to_metadata() for variable in self.variables()],
+        }
+
+    def save_json(self, path: str | Path) -> None:
+        """Persist registry metadata and JSON-safe values to ``path``."""
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+    @classmethod
+    def load_json(cls, path: str | Path) -> WorkspaceRegistry:
+        """Load a registry saved by :meth:`save_json`."""
+        source = Path(path)
+        payload = json.loads(source.read_text(encoding="utf-8"))
+        registry = cls()
+        for entry in payload.get("variables", []):
+            name = str(entry["name"])
+            if entry.get("json_safe", False):
+                registry.set(name, entry.get("value"))
+            else:
+                repr_value = str(entry.get("repr", ""))
+                registry._values[name] = repr_value
+                registry._repr_values[name] = repr_value
+        return registry
+
+    def export_environment(self, prefix: str = "UD_VAR_") -> dict[str, str]:
+        """Return stringified variables for terminal/process environments."""
+        env: dict[str, str] = {}
+        for name, variable in ((name, self.describe(name)) for name in self.list()):
+            key = f"{prefix}{_env_key(name)}"
+            if variable.json_safe:
+                env[key] = json.dumps(variable.value)
+            else:
+                env[key] = variable.repr_value or repr(variable.value)
+        return env
+
+    def export_all(self) -> dict[str, Any]:
+        """Return a dict of all variable names → values (for context export)."""
+        return dict(self._values)
+
+    @staticmethod
+    def _validate_name(name: str) -> None:
+        if not name or not name.strip():
+            raise ValueError("Workspace variable name must be non-empty")
+
+    # ------------------------------------------------------------------
+    # Pub-sub extension (Issue #5616)
+    # ------------------------------------------------------------------
+
+    def subscribe(self, callback: Callable) -> Subscription:
+        """Register *callback* to fire on every variable change.
+
+        Precondition: callable(callback).
+        Postcondition: returns a Subscription whose .dispose() removes callback.
+
+        Args:
+            callback: Callable receiving (name: str, value: Any).
+                      For delete_variable, value is None.
+
+        Returns:
+            Subscription handle.
+
+        Raises:
+            TypeError: If callback is not callable.
+        """
+        if not callable(callback):
+            raise TypeError(
+                f"subscribe() requires a callable, got {type(callback).__name__!r}"
+            )
+        self._subscribers.append(callback)
+        return Subscription(self, callback)
+
+    def _unsubscribe(self, callback: Callable) -> None:
+        """Remove *callback* from the subscriber list (called by Subscription)."""
+        with contextlib.suppress(ValueError):
+            self._subscribers.remove(callback)
+
+    def set_variable(self, name: str, value: Any) -> None:
+        """Set a workspace variable and notify all subscribers.
+
+        Postcondition: value is stored and subscribers have been invoked.
+
+        Args:
+            name: Variable name. Must be non-empty.
+            value: Any Python value.
+        """
+        self.set(name, value)
+        self._notify(name, value)
+
+    def delete_variable(self, name: str) -> None:
+        """Remove a variable and notify subscribers with value=None.
+
+        Args:
+            name: Variable name to remove.
+        """
+        self.remove(name)
+        self._notify(name, None)
+
+    def get_variable(self, name: str, default: Any = None) -> Any:
+        """Return the value for *name*, or *default* when absent.
+
+        Args:
+            name: Variable name.
+            default: Fallback value (default None).
+
+        Returns:
+            Stored value or *default*.
+        """
+        return self.get(name, default)
+
+    def _notify(self, name: str, value: Any) -> None:
+        """Invoke all subscribers with (name, value).
+
+        Takes a snapshot of the subscriber list to be re-entrancy-safe:
+        if a callback calls set_variable/delete_variable, those nested
+        calls will dispatch their own _notify without affecting this one.
+        """
+        for callback in list(self._subscribers):
+            try:
+                callback(name, value)
+            except Exception:  # noqa: BLE001 — subscribers must not crash the registry
+                logger.exception(
+                    "WorkspaceRegistry subscriber %r raised an exception", callback
+                )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reproduced from vendor for API parity)
+# ---------------------------------------------------------------------------
+
+
+def _is_json_safe(value: Any) -> bool:
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(value, str | int | float | bool | type(None) | list | dict)
+
+
+def _summarize_dimensions(value: Any) -> str:
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        try:
+            return "shape=" + "x".join(str(part) for part in shape)
+        except TypeError:
+            return "shape=unknown"
+    if isinstance(value, dict):
+        return f"keys={len(value)}"
+    if isinstance(value, str):
+        return f"length={len(value)}"
+    if isinstance(value, list | tuple):
+        if value and all(isinstance(row, list | tuple) for row in value):
+            row_lengths = {len(row) for row in value}
+            if len(row_lengths) == 1:
+                return f"{len(value)}x{row_lengths.pop()}"
+        return f"length={len(value)}"
+    return "scalar"
+
+
+def _env_key(name: str) -> str:
+    return "".join(char.upper() if char.isalnum() else "_" for char in name)

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/sidebar.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/sidebar.py
@@ -5,10 +5,12 @@ tab uses ChatDockWidget from src.shared.python.chat rather than a placeholder.
 
 Issue #5490: replace the placeholder QLabel in the Chat tab with the real
 ChatDockWidget implementation.
+Issue #5616: add LayoutMode enum + Workspace tab with MATLAB-style layout.
 """
 
 from __future__ import annotations
 
+import enum
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -16,7 +18,26 @@ from collections.abc import Callable
 
 from PyQt6.QtWidgets import QWidget
 
+from .registry import WorkspaceRegistry
+
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# LayoutMode enum (Issue #5616)
+# ---------------------------------------------------------------------------
+
+
+class LayoutMode(enum.Enum):
+    """Sidebar layout mode selector.
+
+    SIDEBAR (default): conventional right-edge dock with tab icons.
+    MATLAB_HOME: replaces the dock with a full 70/30 horizontal split
+        (command window left, workspace inspector + history right).
+    """
+
+    SIDEBAR = "sidebar"
+    MATLAB_HOME = "matlab_home"
 
 
 # ---------------------------------------------------------------------------
@@ -53,15 +74,24 @@ class UnifiedToolsSidebar(QWidget):
     lazily instantiates panel widgets via their ``factory`` callable on first
     activation so startup cost is minimised.
 
+    Attributes:
+        registry: WorkspaceRegistry shared between the workspace tab and
+            the Python REPL. Seed variables here after construction so they
+            appear in the variable inspector.
+        layout_mode: Active LayoutMode (SIDEBAR or MATLAB_HOME).
+
     Usage::
 
         sidebar = UnifiedToolsSidebar(parent=main_window)
+        sidebar.registry.set_variable('engine_manager', engine_manager)
         main_layout.addWidget(sidebar)
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._parent = parent
+        self.registry: WorkspaceRegistry = WorkspaceRegistry()
+        self.layout_mode: LayoutMode = LayoutMode.SIDEBAR
         self._tab_definitions: list[SidebarTabDefinition] = (
             self._default_tab_definitions()
         )
@@ -79,8 +109,10 @@ class UnifiedToolsSidebar(QWidget):
         1. chat      — AI chat assistant (Issue #5490)
         2. terminal  — Real OS shell with PTY backend (Issue #5617)
         3. python-repl — Python REPL sharing workspace variables (Issue #5617)
+        4. workspace — MATLAB-style variable inspector (Issue #5616)
 
-        Postcondition: returned list contains 'terminal' and 'python-repl' tabs.
+        Postcondition: returned list contains 'terminal', 'python-repl', and
+        'workspace' tabs.
         """
         return [
             SidebarTabDefinition(
@@ -106,6 +138,12 @@ class UnifiedToolsSidebar(QWidget):
                     "workspace registry."
                 ),
                 factory=self._make_python_repl_widget,
+            ),
+            SidebarTabDefinition(
+                tab_id="workspace",
+                label="Workspace",
+                tooltip="Variable inspector + Python REPL (MATLAB-style)",
+                factory=self._make_workspace_widget,
             ),
         ]
 
@@ -178,6 +216,37 @@ class UnifiedToolsSidebar(QWidget):
         """
         logger.debug("Python REPL tab: created placeholder")
         return self._placeholder("Python REPL")
+
+    def _make_workspace_widget(self, _sidebar: Any) -> QWidget:
+        """Build the MATLAB-style workspace tab (Issue #5616).
+
+        Delegates to :func:`default_tabs.build_workspace_tab`, injecting
+        this sidebar as the host so the widget shares ``self.registry``.
+
+        Args:
+            _sidebar: Unused; matches factory signature.
+
+        Returns:
+            QWidget with command-window / variable-inspector layout.
+        """
+        from .default_tabs import build_workspace_tab
+
+        widget = build_workspace_tab(self)
+        logger.debug("Workspace tab: created MATLAB-style layout")
+        return widget
+
+    def set_context_variable(self, name: str, value: Any) -> None:
+        """Set a variable in the shared workspace registry.
+
+        Convenience method that lets REPL widgets call
+        ``sidebar.set_context_variable(name, value)`` without reaching
+        directly into the registry internals.
+
+        Args:
+            name: Variable name.
+            value: Variable value.
+        """
+        self.registry.set_variable(name, value)
 
     def _placeholder(self, label: str) -> QWidget:
         """Return a simple placeholder label widget.

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/workspace_table.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/workspace_table.py
@@ -1,0 +1,226 @@
+"""WorkspaceTableModel — sortable QAbstractTableModel backed by WorkspaceRegistry.
+
+Columns: Name | Type | Size | Preview
+
+The model subscribes to WorkspaceRegistry change events and refreshes
+itself automatically when variables are added, updated, or removed.
+Double-clicking a row emits the ``inspect_requested`` signal.
+
+Design-by-Contract:
+- Precondition: __init__ requires a WorkspaceRegistry instance.
+- Postcondition: after set_variable on the registry, rowCount() reflects
+  the new state within the same Qt event loop tick (synchronous update).
+- LOD: The model receives only a WorkspaceRegistry reference; it does not
+  reach into sidebar internals or theme tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PyQt6.QtCore import (
+    QAbstractTableModel,
+    QModelIndex,
+    Qt,
+    pyqtSignal,
+)
+from PyQt6.QtWidgets import QTableView
+
+from .registry import WorkspaceRegistry, WorkspaceVariable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["WorkspaceTableModel", "WorkspaceTableView"]
+
+_COLUMNS = ["Name", "Type", "Size", "Preview"]
+_COL_NAME = 0
+_COL_TYPE = 1
+_COL_SIZE = 2
+_COL_PREVIEW = 3
+_MAX_PREVIEW_LEN = 64
+
+
+class WorkspaceTableModel(QAbstractTableModel):
+    """Sortable table model mirroring WorkspaceRegistry contents.
+
+    Each row represents one workspace variable. The model subscribes to
+    the registry so it refreshes automatically on every change.
+
+    Usage::
+
+        registry = WorkspaceRegistry()
+        model = WorkspaceTableModel(registry)
+        view = QTableView()
+        view.setModel(model)
+    """
+
+    def __init__(self, registry: WorkspaceRegistry, parent: Any = None) -> None:
+        """Initialise the model.
+
+        Args:
+            registry: The WorkspaceRegistry to mirror.
+            parent: Optional QObject parent.
+
+        Raises:
+            TypeError: If registry is not a WorkspaceRegistry.
+        """
+        if not isinstance(registry, WorkspaceRegistry):
+            raise TypeError(
+                f"registry must be a WorkspaceRegistry, got {type(registry).__name__!r}"
+            )
+        super().__init__(parent)
+        self._registry = registry
+        self._rows: list[WorkspaceVariable] = []
+        self._sort_column = _COL_NAME
+        self._sort_order = Qt.SortOrder.AscendingOrder
+        self._subscription = registry.subscribe(self._on_registry_change)
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    # QAbstractTableModel interface
+    # ------------------------------------------------------------------
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N803
+        """Return the number of rows (one per variable)."""
+        return len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N803
+        """Return the number of columns (always 4)."""
+        return len(_COLUMNS)
+
+    def data(
+        self,
+        index: QModelIndex,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        """Return data for the given *index* and *role*.
+
+        Only DisplayRole is handled; other roles return None.
+        """
+        if not index.isValid() or role != Qt.ItemDataRole.DisplayRole:
+            return None
+        row = index.row()
+        col = index.column()
+        if row >= len(self._rows) or col >= len(_COLUMNS):
+            return None
+        var = self._rows[row]
+        return self._cell_text(var, col)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        """Return column header labels for horizontal orientation."""
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal and 0 <= section < len(_COLUMNS):
+            return _COLUMNS[section]
+        return None
+
+    def sort(
+        self,
+        column: int,
+        order: Qt.SortOrder = Qt.SortOrder.AscendingOrder,
+    ) -> None:
+        """Sort rows by the given *column* in *order*.
+
+        Args:
+            column: Column index (0 = Name, 1 = Type, 2 = Size, 3 = Preview).
+            order: Qt.SortOrder.AscendingOrder or DescendingOrder.
+        """
+        self.layoutAboutToBeChanged.emit()
+        self._sort_column = column
+        self._sort_order = order
+        self._sort_rows()
+        self.layoutChanged.emit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _refresh(self) -> None:
+        """Reload rows from the registry and notify views."""
+        self.beginResetModel()
+        self._rows = self._registry.variables()
+        self._sort_rows()
+        self.endResetModel()
+
+    def _sort_rows(self) -> None:
+        reverse = self._sort_order == Qt.SortOrder.DescendingOrder
+        self._rows.sort(
+            key=lambda var: self._sort_key(var, self._sort_column),
+            reverse=reverse,
+        )
+
+    @staticmethod
+    def _sort_key(var: WorkspaceVariable, column: int) -> str:
+        if column == _COL_NAME:
+            return var.name.lower()
+        if column == _COL_TYPE:
+            return var.type_name.lower()
+        if column == _COL_SIZE:
+            return var.summary.lower()
+        return repr(var.value)[:_MAX_PREVIEW_LEN].lower()
+
+    @staticmethod
+    def _cell_text(var: WorkspaceVariable, col: int) -> str:
+        if col == _COL_NAME:
+            return var.name
+        if col == _COL_TYPE:
+            return var.type_name
+        if col == _COL_SIZE:
+            return var.summary
+        # Preview column
+        if var.json_safe:
+            preview = repr(var.value)
+        else:
+            preview = var.repr_value or repr(var.value)
+        return preview[:_MAX_PREVIEW_LEN]
+
+    def _on_registry_change(self, name: str, value: Any) -> None:  # noqa: ARG002
+        """Subscriber callback — refresh the model when registry changes."""
+        self._refresh()
+
+
+class WorkspaceTableView(QTableView):
+    """QTableView wired to a WorkspaceTableModel.
+
+    Emits ``inspect_requested(name)`` on double-click.
+
+    Usage::
+
+        registry = WorkspaceRegistry()
+        view = WorkspaceTableView(registry)
+        view.inspect_requested.connect(my_inspector)
+    """
+
+    inspect_requested = pyqtSignal(str)
+
+    def __init__(
+        self,
+        registry: WorkspaceRegistry,
+        parent: Any = None,
+    ) -> None:
+        """Initialise the view.
+
+        Args:
+            registry: WorkspaceRegistry to display.
+            parent: Optional parent widget.
+        """
+        super().__init__(parent)
+        self._model = WorkspaceTableModel(registry, parent=self)
+        self.setModel(self._model)
+        self.setSortingEnabled(True)
+        self.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
+        self.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
+        self.doubleClicked.connect(self._on_double_click)
+
+    def _on_double_click(self, index: QModelIndex) -> None:
+        row = index.row()
+        name_index = self._model.index(row, _COL_NAME)
+        name = self._model.data(name_index, Qt.ItemDataRole.DisplayRole)
+        if name:
+            self.inspect_requested.emit(name)

--- a/tests/unit/sidekick/__init__.py
+++ b/tests/unit/sidekick/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sidekick workspace tab and related widgets."""

--- a/tests/unit/sidekick/test_python_repl_widget.py
+++ b/tests/unit/sidekick/test_python_repl_widget.py
@@ -1,0 +1,136 @@
+"""Tests for PythonReplWidget (Issue #5616).
+
+TDD: written before implementation. Tests the shared REPL widget that
+evaluates expressions, records history, and syncs assignments to a
+WorkspaceRegistry.
+
+Note: The conftest mocks PyQt6 when it is not pre-loaded. These tests detect
+the mock and skip Qt-dependent assertions accordingly.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from upstream_drift_tools.ui.tools_sidebar.registry import WorkspaceRegistry
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Detect whether we have real PyQt6 or a conftest-injected mock.
+# MagicMock has all attributes, so check isinstance(..., type).
+# ---------------------------------------------------------------------------
+_pyqt6_module = sys.modules.get("PyQt6")
+try:
+    _qtcore = getattr(_pyqt6_module, "QtCore", None)
+    _qabt = getattr(_qtcore, "QAbstractTableModel", None)
+    _HAVE_REAL_QT = (
+        _qabt is not None
+        and isinstance(_qabt, type)
+        and not getattr(_qabt, "_mock_name", None)
+    )
+except Exception:
+    _HAVE_REAL_QT = False
+
+_skip_qt = pytest.mark.skipif(
+    not _HAVE_REAL_QT,
+    reason="PyQt6 not available or mocked by conftest",
+)
+
+
+def _make_repl(namespace: dict, registry: WorkspaceRegistry | None = None) -> Any:
+    """Construct PythonReplWidget lazily."""
+    from upstream_drift_tools.ui.tools_sidebar.python_repl import PythonReplWidget
+
+    return PythonReplWidget(namespace=namespace, registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# Qt-dependent tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_qt
+def test_repl_evaluates_expression() -> None:
+    """evaluate('2 + 2') returns a string containing '4'."""
+    repl = _make_repl(namespace={})
+    result = repl.evaluate("2 + 2")
+    assert "4" in result
+
+
+@_skip_qt
+def test_repl_assignment_updates_registry() -> None:
+    """Assignment in REPL propagates value to the WorkspaceRegistry."""
+    registry = WorkspaceRegistry()
+    repl = _make_repl(namespace={}, registry=registry)
+    repl.evaluate("x = 3")
+    assert registry.get_variable("x") == 3  # noqa: PLR2004
+
+
+@_skip_qt
+def test_repl_history_is_recorded() -> None:
+    """Each evaluated expression is appended to history."""
+    repl = _make_repl(namespace={})
+    repl.evaluate("1 + 1")
+    assert "1 + 1" in repl.history
+
+
+@_skip_qt
+def test_repl_exception_does_not_crash() -> None:
+    """Exceptions in user code are caught and returned as a string."""
+    repl = _make_repl(namespace={})
+    result = repl.evaluate("1 / 0")
+    assert "ZeroDivisionError" in result
+
+
+@_skip_qt
+def test_repl_multiple_assignments() -> None:
+    """Multiple assignments update the registry correctly."""
+    registry = WorkspaceRegistry()
+    repl = _make_repl(namespace={}, registry=registry)
+    repl.evaluate("a = 10\nb = 20")
+    assert registry.get_variable("a") == 10  # noqa: PLR2004
+    assert registry.get_variable("b") == 20  # noqa: PLR2004
+
+
+@_skip_qt
+def test_repl_no_registry_still_evaluates() -> None:
+    """Widget works without a registry."""
+    repl = _make_repl(namespace={})
+    result = repl.evaluate("3 * 7")
+    assert "21" in result
+
+
+# ---------------------------------------------------------------------------
+# Non-Qt behaviour tests (evaluate logic can be tested on the logic layer)
+# ---------------------------------------------------------------------------
+
+
+def test_repl_evaluate_logic_expression() -> None:
+    """Standalone test: evaluate helper produces correct output."""
+    from upstream_drift_tools.ui.tools_sidebar.python_repl import _evaluate_in_namespace
+
+    ns: dict = {}
+    result = _evaluate_in_namespace("2 + 2", ns)
+    assert "4" in result
+
+
+def test_repl_evaluate_logic_assignment() -> None:
+    """Assignment via eval helper populates the namespace."""
+    from upstream_drift_tools.ui.tools_sidebar.python_repl import _evaluate_in_namespace
+
+    ns: dict = {}
+    _evaluate_in_namespace("x = 42", ns)
+    assert ns.get("x") == 42  # noqa: PLR2004
+
+
+def test_repl_evaluate_logic_exception() -> None:
+    """Exceptions are returned as formatted strings, not raised."""
+    from upstream_drift_tools.ui.tools_sidebar.python_repl import _evaluate_in_namespace
+
+    ns: dict = {}
+    result = _evaluate_in_namespace("1 / 0", ns)
+    assert "ZeroDivisionError" in result

--- a/tests/unit/sidekick/test_workspace_registry.py
+++ b/tests/unit/sidekick/test_workspace_registry.py
@@ -1,0 +1,97 @@
+"""Tests for WorkspaceRegistry.subscribe / unsubscribe (Issue #5616).
+
+TDD: these tests are written first, before the implementation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from upstream_drift_tools.ui.tools_sidebar.registry import WorkspaceRegistry
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_subscribe_fires_on_set_variable() -> None:
+    """Precondition: subscribe returns Subscription; fires on set_variable."""
+    registry = WorkspaceRegistry()
+    fired: list[tuple[str, object]] = []
+    registry.subscribe(lambda name, value: fired.append((name, value)))
+    registry.set_variable("x", 42)
+    assert fired == [("x", 42)]
+
+
+def test_registry_subscribe_fires_on_delete_variable() -> None:
+    """Subscriber fires on delete_variable with value=None."""
+    registry = WorkspaceRegistry()
+    registry.set_variable("x", 10)
+    events: list[tuple[str, object]] = []
+    registry.subscribe(lambda name, value: events.append((name, value)))
+    registry.delete_variable("x")
+    assert ("x", None) in events
+
+
+def test_registry_unsubscribe_stops_firing() -> None:
+    """Postcondition: Subscription.dispose() removes the callback."""
+    registry = WorkspaceRegistry()
+    fired: list[str] = []
+    sub = registry.subscribe(lambda n, v: fired.append(n))
+    sub.dispose()
+    registry.set_variable("x", 1)
+    assert fired == []
+
+
+def test_registry_subscribe_multiple_callbacks() -> None:
+    """Both subscribers fire independently."""
+    registry = WorkspaceRegistry()
+    a: list[str] = []
+    b: list[str] = []
+    registry.subscribe(lambda n, v: a.append(n))
+    registry.subscribe(lambda n, v: b.append(n))
+    registry.set_variable("y", 2)
+    assert a == ["y"]
+    assert b == ["y"]
+
+
+def test_subscribe_none_raises_type_error() -> None:
+    """DbC: subscribe(None) raises TypeError."""
+    with pytest.raises(TypeError, match="callable"):
+        WorkspaceRegistry().subscribe(None)  # type: ignore[arg-type]
+
+
+def test_subscribe_non_callable_raises_type_error() -> None:
+    """DbC: subscribe with a non-callable raises TypeError."""
+    with pytest.raises(TypeError, match="callable"):
+        WorkspaceRegistry().subscribe("not_callable")  # type: ignore[arg-type]
+
+
+def test_set_variable_forwards_to_registry_set() -> None:
+    """set_variable stores the value in the registry."""
+    registry = WorkspaceRegistry()
+    registry.set_variable("z", 99)
+    assert registry.get_variable("z") == 99
+
+
+def test_get_variable_returns_default_when_absent() -> None:
+    """get_variable returns None when name not set."""
+    registry = WorkspaceRegistry()
+    assert registry.get_variable("missing") is None
+
+
+def test_no_reentrancy_loop_on_subscribe_firing() -> None:
+    """Invariant: set_variable from inside a callback does not loop infinitely."""
+    registry = WorkspaceRegistry()
+    call_count = 0
+
+    def callback(name: str, value: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Second set_variable from within callback
+            registry.set_variable("inner", 0)
+
+    registry.subscribe(callback)
+    registry.set_variable("outer", 1)
+    # callback fires for "outer" (count=1) then for "inner" (count=2)
+    # it must not recurse indefinitely
+    assert call_count == 2  # noqa: PLR2004

--- a/tests/unit/sidekick/test_workspace_tab_table.py
+++ b/tests/unit/sidekick/test_workspace_tab_table.py
@@ -1,0 +1,139 @@
+"""Tests for WorkspaceTableModel (Issue #5616).
+
+TDD: written before implementation. Tests the sortable table model that mirrors
+WorkspaceRegistry contents and auto-refreshes on change.
+
+Note: The conftest mocks PyQt6 when it is not pre-loaded. These tests detect
+the mock and skip Qt-dependent assertions when running in a headless CI that
+does not load real PyQt6 before the conftest runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from upstream_drift_tools.ui.tools_sidebar.registry import WorkspaceRegistry
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Detect whether we have real PyQt6 or a conftest-injected mock.
+# MagicMock has all attributes and passes hasattr/isinstance checks, so we
+# must check whether QAbstractTableModel is an actual class (not a MagicMock).
+# ---------------------------------------------------------------------------
+_pyqt6_module = sys.modules.get("PyQt6")
+try:
+    _qtcore = getattr(_pyqt6_module, "QtCore", None)
+    _qabt = getattr(_qtcore, "QAbstractTableModel", None)
+    _HAVE_REAL_QT = (
+        _qabt is not None
+        and isinstance(_qabt, type)
+        and not getattr(_qabt, "_mock_name", None)
+    )
+except Exception:
+    _HAVE_REAL_QT = False
+
+_skip_qt = pytest.mark.skipif(
+    not _HAVE_REAL_QT,
+    reason="PyQt6 not available or mocked by conftest",
+)
+
+
+def _make_model(registry: WorkspaceRegistry) -> Any:
+    """Import and construct WorkspaceTableModel (lazy to avoid collection errors)."""
+    from upstream_drift_tools.ui.tools_sidebar.workspace_table import (
+        WorkspaceTableModel,
+    )
+
+    return WorkspaceTableModel(registry)
+
+
+# ---------------------------------------------------------------------------
+# Registry-only tests (no Qt dependency)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_change_triggers_model_refresh_via_subscription() -> None:
+    """WorkspaceTableModel subscribes to the registry; we verify subscription exists."""
+    registry = WorkspaceRegistry()
+    # Verify subscription mechanism works even without Qt
+    fires: list[str] = []
+    sub = registry.subscribe(lambda n, v: fires.append(n))
+    registry.set_variable("ping", 1)
+    assert "ping" in fires
+    sub.dispose()
+    registry.set_variable("gone", 2)
+    assert "gone" not in fires
+
+
+# ---------------------------------------------------------------------------
+# Qt-dependent model tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_qt
+def test_workspace_table_has_four_columns() -> None:
+    """Columns are Name, Type, Size, Preview."""
+    from PyQt6.QtCore import Qt
+
+    registry = WorkspaceRegistry()
+    model = _make_model(registry)
+    assert model.columnCount() == 4  # noqa: PLR2004
+    headers = [
+        model.headerData(i, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        for i in range(4)
+    ]
+    assert headers == ["Name", "Type", "Size", "Preview"]
+
+
+@_skip_qt
+def test_workspace_table_updates_when_registry_changes() -> None:
+    """Row count increases when a variable is added to the registry."""
+    from PyQt6.QtCore import Qt
+
+    registry = WorkspaceRegistry()
+    model = _make_model(registry)
+    assert model.rowCount() == 0
+    registry.set_variable("x", 3.14)
+    assert model.rowCount() == 1
+    assert model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole) == "x"
+
+
+@_skip_qt
+def test_workspace_table_sorts_by_name() -> None:
+    """sort(0, AscendingOrder) orders rows alphabetically by name."""
+    from PyQt6.QtCore import Qt
+
+    registry = WorkspaceRegistry()
+    model = _make_model(registry)
+    registry.set_variable("z", 1)
+    registry.set_variable("a", 2)
+    model.sort(0, Qt.SortOrder.AscendingOrder)
+    assert model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole) == "a"
+
+
+@_skip_qt
+def test_workspace_table_type_column() -> None:
+    """Column 1 shows the Python type name."""
+    from PyQt6.QtCore import Qt
+
+    registry = WorkspaceRegistry()
+    model = _make_model(registry)
+    registry.set_variable("val", 42)
+    assert model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole) == "int"
+
+
+@_skip_qt
+def test_workspace_table_preview_column() -> None:
+    """Column 3 shows a repr preview."""
+    from PyQt6.QtCore import Qt
+
+    registry = WorkspaceRegistry()
+    model = _make_model(registry)
+    registry.set_variable("val", 99)
+    preview = model.data(model.index(0, 3), Qt.ItemDataRole.DisplayRole)
+    assert preview is not None
+    assert "99" in str(preview)


### PR DESCRIPTION
## Summary

Closes #5616

Implements the MATLAB-style Sidekick workspace tab that was rendering blank. Replaces the empty `QListWidget` placeholder with a full live variable inspector, Python REPL command window, and command history panel.

### What changed

- **`registry.py`** (new in UD source): `WorkspaceRegistry` with `subscribe()` / `Subscription.dispose()` pub-sub layer — auto-notifies table model on variable change; re-entrancy-safe
- **`workspace_table.py`** (new): `WorkspaceTableModel` (sortable QAbstractTableModel, Name/Type/Size/Preview columns) + `WorkspaceTableView` with `inspect_requested` double-click signal
- **`python_repl.py`** (new): `PythonReplWidget` — shared REPL widget; assignments propagated to `WorkspaceRegistry.set_variable()` automatically; headless `_evaluate_in_namespace()` helper
- **`default_tabs.py`** (new): `build_workspace_tab(sidebar)` — 70/30 QSplitter layout (REPL left, variable table + history right)
- **`sidebar.py`** (updated): `LayoutMode` enum (SIDEBAR / MATLAB_HOME), `registry: WorkspaceRegistry` attribute, `set_context_variable()` delegate, Workspace tab in default definitions
- **`golf_launcher.py`** (updated): `_seed_sidekick_workspace()` seeds `engine_manager` + `model_registry` into sidebar registry after startup

### TDD (red → green)

- `tests/unit/sidekick/test_workspace_registry.py` — 9 tests
- `tests/unit/sidekick/test_workspace_tab_table.py` — subscription + Qt model tests
- `tests/unit/sidekick/test_python_repl_widget.py` — REPL logic + Qt widget tests

All 13 active tests pass; 11 skipped (conftest mocks PyQt6 in unit lane — Qt-heavy tests run when real Qt is pre-loaded).

## Test plan

- [x] `python3 -m pytest tests/unit/sidekick/ --timeout=30` → 13 passed, 11 skipped
- [x] `python3 -m ruff check src/shared/python/upstream_drift_tools/ui/tools_sidebar/` → All checks passed
- [x] `python3 -m ruff format --check ...` → All files formatted
- [x] `python3 scripts/ci/check_file_size_budget.py` → OK
- [x] `python3 -m pytest tests/unit/repo_hygiene/` → 3 passed (shadow test + vendor clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)