### PR TITLE
test(sidekick): regression guard for python-repl tab wiring (UD #5649)

### DIFF
--- a/tests/unit/sidekick/test_python_repl_tab_wiring.py
+++ b/tests/unit/sidekick/test_python_repl_tab_wiring.py
@@ -1,0 +1,91 @@
+"""Regression guard for UD #5649 — python-repl tab must wire a real REPL.
+
+Codex review feedback on PR #5639 flagged that the original ``sidebar.py``
+factory ``_make_python_repl_widget`` returned a ``QLabel`` placeholder.
+PR #5613 subsequently removed that ``sidebar.py`` and migrated the
+workspace-tab plumbing into ``default_tabs.build_workspace_tab``. The
+risk the Codex comment identified — a non-interactive placeholder
+shipping in production — is still worth guarding against, so this test
+inspects the current builder and asserts it instantiates
+:class:`PythonReplWidget` rather than a stub label.
+
+Approach: AST-level inspection of ``default_tabs.build_workspace_tab``
+(not a Qt invocation) so the test runs cleanly in headless CI.
+
+Design-by-contract:
+
+- Postcondition: ``build_workspace_tab`` must reference
+  ``PythonReplWidget`` and must contain a ``Call`` whose callee is the
+  ``PythonReplWidget`` name — a bare reference or annotation is not
+  enough.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from src.shared.python.upstream_drift_tools.ui.tools_sidebar import default_tabs
+
+
+def _walk_names(tree: ast.AST) -> set[str]:
+    """Return every ``Name``/``Attribute`` identifier in ``tree``."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+@pytest.mark.unit
+def test_build_workspace_tab_uses_python_repl_widget() -> None:
+    """The workspace-tab builder must instantiate the real REPL widget.
+
+    See UD #5649. The original sidebar.py factory shipped a placeholder
+    label; this test pins the fix so a future refactor cannot silently
+    regress the python-repl tab back into a no-op.
+    """
+    source = inspect.getsource(default_tabs.build_workspace_tab)
+    tree = ast.parse(source)
+    names = _walk_names(tree)
+
+    assert "PythonReplWidget" in names, (
+        "default_tabs.build_workspace_tab must construct PythonReplWidget "
+        "so the python-repl tab actually runs Python. A QLabel placeholder "
+        "is not acceptable — see UD #5649."
+    )
+
+
+@pytest.mark.unit
+def test_build_workspace_tab_calls_python_repl_widget() -> None:
+    """Builder must actually *call* PythonReplWidget, not just reference it.
+
+    A defensive check beyond the name-presence guard above: the AST must
+    contain at least one ``Call`` node whose callee is ``PythonReplWidget``.
+    This catches a regression where somebody imports the class but only
+    uses it for an ``isinstance`` check or annotation while reverting to
+    a placeholder for the actual construction. See UD #5649.
+    """
+    source = inspect.getsource(default_tabs.build_workspace_tab)
+    tree = ast.parse(source)
+
+    has_call = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            callee = node.func
+            if isinstance(callee, ast.Name) and callee.id == "PythonReplWidget":
+                has_call = True
+                break
+            if isinstance(callee, ast.Attribute) and callee.attr == "PythonReplWidget":
+                has_call = True
+                break
+
+    assert has_call, (
+        "build_workspace_tab must contain a call to PythonReplWidget(...). "
+        "A bare reference or annotation is not enough — the tab must "
+        "actually run Python. See UD #5649."
+    )


### PR DESCRIPTION
## Summary

This PR addresses the third Codex review finding from the original task: UD #5649 (the python-repl tab placeholder). The other two findings (5626 and 5627) were independently fixed by PR #5652 (merged 2026-05-16) while this work was in progress — both source-test fixes shipped there, so this PR is the residual portion that #5652 did not cover.

### UD #5649 — Python REPL placeholder

Codex flagged `_make_python_repl_widget` in `src/shared/python/upstream_drift_tools/ui/tools_sidebar/sidebar.py` returning a `QLabel` placeholder. That file was already removed from `main` by PR #5613 ("drop shadow shim") — the python-repl tab is now wired via `default_tabs.build_workspace_tab` which constructs `PythonReplWidget` directly.

The risk Codex identified is therefore handled on main, but a regression guard is still valuable: a future refactor could silently revert the tab back to a label.

**Fix:** No source change required.
**Regression guard:** `tests/unit/sidekick/test_python_repl_tab_wiring.py` inspects `default_tabs.build_workspace_tab` via AST and asserts (a) the `PythonReplWidget` name is referenced and (b) it is actually called. AST-level only — runs cleanly headless.

## DbC / LOD / DRY

- DbC: Postcondition on `build_workspace_tab` — it must instantiate a real REPL, not a placeholder.
- LOD: Test reads only `default_tabs.build_workspace_tab` source; no deep traversal.
- DRY: Helper `_walk_names` localised to the one file using it.

## Verification

- `python -m ruff check tests/unit/sidekick/test_python_repl_tab_wiring.py` — All checks passed
- `python -m ruff format --check` — already formatted
- `python -m pytest tests/unit/sidekick/test_python_repl_tab_wiring.py -p no:xdist` — 2 passed

## Cross-references

- Source PR the feedback came from: #5639
- Sibling PR that handled the other findings: #5652 (merged)
- Superseded prior attempt at #5649: #5654 (closed in favour of this PR)

Implements (regression guard for) #5649 — the source bug is already fixed on main by PR #5613; this PR adds an AST-level test that pins the wiring against future regression.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
