### PR TITLE
fix(ci): add concurrency group and timeout to Docker Size workflow

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -3,7 +3,18 @@ name: Docker Size and Health Check
 on:
   push:
     branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "docker-compose*.yml"
+      - "pyproject.toml"
+      - "requirements*.txt"
+      - "src/**"
+      - ".github/workflows/docker-size-gates.yml"
   workflow_dispatch:
+
+concurrency:
+  group: docker-size-gates-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # -- Dispatcher: route to self-hosted if available --------------------------
@@ -22,6 +33,7 @@ jobs:
   docker-smoke-and-size:
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
+    timeout-minutes: 90
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
## Summary

- **Root cause**: `docker-size-gates.yml` had no `concurrency` group, causing every push to `main` to queue a new Docker build even while previous builds were still running. Right now (at time of filing) there are 4 concurrent Docker runs blocking 4 runners — the 3 oldest were stuck for 90+ minutes before being manually cancelled.
- Docker builds with mujoco/pinocchio/scipy take ~1h per run, so stacking is very expensive.

## Changes

- Add `concurrency.group: docker-size-gates-${{ github.ref }}` with `cancel-in-progress: true` so superseded builds are cancelled when a new push arrives
- Add `paths:` filter so the workflow only triggers when Docker-relevant files change (`Dockerfile`, `requirements*.txt`, `src/**`, `pyproject.toml`, the workflow itself)
- Add `timeout-minutes: 90` on `docker-smoke-and-size` as a hard safety net

## Verification

- [ ] CI Standard passes
- [ ] No `docker-size-gates` runs stack on subsequent pushes to main

## Impact

Frees ~4 runner-hours immediately (3 runs cancelled), and prevents future stacking.

---
Filed by address-issues skill, agent claude, runner saturation investigation 2026-05-16.