### PR TITLE
ci: cache optimizations for long-running workflows

### DIFF
--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -110,6 +110,18 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      # Cache pip download cache. The optional-stack lane installs ~1.5GB of
+      # wheels (fastapi[all], pinocchio, pink, crocoddyl, pyqt6, etc.) and a
+      # warm cache avoids re-downloading them on every PR.
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-optstack-${{ runner.os }}-py${{ matrix.python }}-${{ hashFiles('pyproject.toml', 'requirements*.txt') }}
+          restore-keys: |
+            pip-optstack-${{ runner.os }}-py${{ matrix.python }}-
+            pip-optstack-${{ runner.os }}-
+
       - name: Prepare Optional-Stack Venv
         # The shared self-hosted runner can expose partially installed ambient
         # site-packages (for example matplotlib without a RECORD file), which

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -64,6 +64,14 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Cache cargo registry, git deps, and ui/src-tauri/target/. Cold Tauri
+      # builds compile ~400 crates; warm cache typically cuts time by 60-70%.
+      - name: Cache Rust target (check)
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ui/src-tauri -> target
+          key: ud-tauri-check
+
       - name: Install Linux dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=300 update
@@ -123,6 +131,14 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: ${{ matrix.target }}
+
+      # Per-target Rust cache for release builds. Each platform gets its own
+      # cache so the Linux/Windows/macOS matrix legs don't trash each other.
+      - name: Cache Rust target (build)
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ui/src-tauri -> target
+          key: ud-tauri-build-${{ matrix.target }}
 
       - name: Install Linux dependencies
         if: matrix.platform == 'd-sorg-fleet'


### PR DESCRIPTION
## Summary

Targets workflows in UpstreamDrift that consistently ran >30 min in the last 7 days based on a survey of recent action runs. User authorized a cache+schedule campaign across the fleet.

## Workflows touched

| Workflow | Recent runtime | Expected after | Change |
|---|---|---|---|
| `tauri-build.yml` | ~44 min | ~15-20 min (warm cache) | Added `Swatinem/rust-cache@v2` on both `check` and `build` jobs, with per-target keys for the build matrix. Existing npm cache preserved. |
| `ci-optional-stack.yml` | ~65 min (avg ~57) | ~25-30 min (warm cache) | Added `actions/cache@v4` for pip wheels. This lane installs ~1.5GB of wheels (`fastapi[all]`, `pinocchio`, `pink`, `crocoddyl`, `pyqt6`) into an isolated venv. Wheel cache is reused across venvs since pip's download cache lives at `~/.cache/pip` regardless. |

## What was NOT changed

- All existing path filters preserved.
- Existing `cache: "npm"` on `setup-node` preserved.
- `concurrency:` blocks untouched (separate campaign).
- No step removal — only cache steps added.
- No trigger changes — both workflows are useful as PR feedback.

## Workflows surveyed but NOT touched

- `Docker Size and Health Check` (~69 min): already uses `cache-from: type=gha, cache-to: type=gha, mode=max` for the Docker build. Long runtime is the physics-stack Docker layer (mujoco, pinocchio, drake) — no further easy optimization without restructuring the Dockerfile.
- `Spec Check` (~60 min): 5-min timeout job; long wall time is queue wait on the self-hosted fleet, not cacheable work.
- Bot orchestration workflows (`Jules-*`, `Auto-Update PRs`, `Comment Collector`): intentional long-pollers, not bottlenecks.

## Cache strategy notes

- Pip cache: `~/.cache/pip` keyed on `hashFiles('pyproject.toml', 'requirements*.txt')` with `restore-keys` fallback.
- Rust cache: `Swatinem/rust-cache@v2` workspace-scoped to `ui/src-tauri -> target` with per-target key to keep the matrix legs isolated.

## Test plan

- [ ] First merged run populates caches; second run shows reduced install/compile time.
- [ ] Tauri build artifacts unchanged.
- [ ] Optional stack tests still run (no skip regression).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>