### PR TITLE
fix(ci): use d-sorg-fleet runner in workflow lint and anti-phantom guard

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -44,7 +44,7 @@ jobs:
   guard:
     timeout-minutes: 30
     name: phantom-guard
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     if: github.event.pull_request.base.ref == 'main'
     steps:
       - name: Check out PR head with full history

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Restores Local-Only Workflow Runner Guard compliance. Two workflow files were added by the timeout-lint-campaign with `runs-on: ubuntu-latest`, failing the fleet runner guard. This switches them to `d-sorg-fleet` to match the rest of the fleet.