### PR TITLE
fix(workflows): repair 3 pre-existing broken workflow YAMLs

### DIFF
--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -39,8 +39,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install Radon
-        python -m ensurepip --upgrade || true
-        run: pip install radon
+        run: |
+          python -m ensurepip --upgrade || true
+          pip install radon
 
       - name: Run Complexity Analysis
         run: |

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -136,12 +136,14 @@ jobs:
             ruff format --check .
           fi
 
-      python -m ensurepip --upgrade || true
-      - run: python -m pip install --ignore-installed "mypy==1.20.1" types-PyYAML types-requests
+      - run: |
+          python -m ensurepip --upgrade || true
+          python -m pip install --ignore-installed "mypy==1.20.1" types-PyYAML types-requests
       - name: Create stub ui/dist for editable install (quality checks only)
         run: mkdir -p ui/dist
-      python -m ensurepip --upgrade || true
-      - run: python -m pip install --ignore-installed -e ".[dev]"
+      - run: |
+          python -m ensurepip --upgrade || true
+          python -m pip install --ignore-installed -e ".[dev]"
 
       - name: Pin Type Toolchain
         run: |
@@ -1048,8 +1050,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: { python-version: "3.11" }
-      python -m ensurepip --upgrade || true
-      - run: pip install platformio
+      - run: |
+          python -m ensurepip --upgrade || true
+          pip install platformio
       - name: Verify Build
         working-directory: ./arduino
         run: pio run -e uno

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
             exit 1
           fi
       - name: Install build tools
-        python -m ensurepip --upgrade || true
-        run: python3 -m pip install build twine pip-audit
+        run: |
+          python -m ensurepip --upgrade || true
+          python3 -m pip install build twine pip-audit
       - name: Build package
         run: python3 -m build
       - name: Generate SBOM
@@ -103,8 +104,9 @@ jobs:
           name: dist
           path: dist/
       - name: Install smoke dependencies
-        python -m ensurepip --upgrade || true
-        run: python -m pip install pytest
+        run: |
+          python -m ensurepip --upgrade || true
+          python -m pip install pytest
       - name: Run Python wheel smoke tests
         run: python -m pytest tests/smoke/python_wheel
 


### PR DESCRIPTION
## Problem

Three UpstreamDrift workflow files had stray `python -m ensurepip --upgrade || true` lines sitting between `- name:` and `run:` on a step. The YAML parser tried to interpret these as map keys, hit "could not find expected ':'", and the entire workflow failed to parse — every run.

## Fix

Moved each stray `ensurepip` line inside the appropriate `run:` block, combining adjacent steps into multi-line scripts where needed.

### Files repaired

| File | Bug location(s) | Fix |
|---|---|---|
| `.github/workflows/ci-standard.yml` | lines 139, 143, 1053 | Merged stray lines into adjacent `- run:` steps |
| `.github/workflows/Code-Metrics.yml` | line 42 | Wrapped step body in `run: |` block |
| `.github/workflows/release.yml` | lines 57, 106 | Wrapped step body in `run: |` block |

### Validation

All 76 workflow files in `.github/workflows/` now parse as valid YAML with `jobs:` and `steps:` keys (checked via `yaml.safe_load` + structural assertions). No workflow logic was changed; only the misplaced bash lines were moved.

This unblocks UpstreamDrift CI which has been failing to even start these workflows.