### PR TITLE
fix(workflows): broaden spec-check + docker-size paths filters (Closes #5666, #5658)

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -8,6 +8,8 @@ on:
       - "docker-compose*.yml"
       - "pyproject.toml"
       - "requirements*.txt"
+      - "requirements.lock"
+      - "requirements*.lock"
       - "src/**"
       - ".github/workflows/docker-size-gates.yml"
   workflow_dispatch:

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -23,6 +23,8 @@ on:
       - "docs/**"
       - "specs/**"
       - "**/*.md"
+      - "src/**"
+      - "tests/**"
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Addresses two Codex review-feedback issues:

- **#5666**: spec-check.yml paths filter was too restrictive (docs/specs/md only). Adds src/** and tests/** so inline specs embedded in source code get validated.
- **#5658**: docker-size-gates.yml paths filter missing requirements.lock. Adds lockfile patterns so lockfile-only changes trigger size validation.

Also closes #5661 (exact duplicate of #5666 — Codex bot fired twice on same comment).

Closes #5666
Closes #5658