### PR TITLE
fix(anti-phantom): retry loop for API propagation race (mirror Tools #2941)

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -144,6 +144,37 @@ jobs:
           echo "changed files:"
           echo "$CHANGED_FILES"
 
+          # If git diff reports 0 changed files, cross-check via the GitHub API
+          # and retry up to 3 times. This handles a race condition where the
+          # workflow fires before the PR's push has fully propagated to the
+          # GitHub API / git database (see false-positives on #2898, #2907).
+          RETRIES=0
+          while [ "$NUM_CHANGED" -eq 0 ] && [ $RETRIES -lt 3 ]; do
+            echo "::notice::0 changed files reported; waiting 10s and retrying (attempt $((RETRIES+1))/3)"
+            sleep 10
+            # Re-fetch base + head in case refs propagated since the initial fetch.
+            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50 || true
+            git fetch origin "$BASE_SHA" || true
+            git fetch origin "$HEAD_SHA" || true
+            # Cross-check via the API as well.
+            API_STATS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json additions,deletions,changedFiles 2>/dev/null || echo '{}')
+            API_FILES=$(echo "$API_STATS" | jq -r '.changedFiles // 0')
+            API_ADDS=$(echo "$API_STATS" | jq -r '.additions // 0')
+            API_DELS=$(echo "$API_STATS" | jq -r '.deletions // 0')
+            echo "api_changed_files=$API_FILES api_additions=$API_ADDS api_deletions=$API_DELS"
+            MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+            CHANGED_FILES=$(git diff --name-only "$MERGE_BASE...$HEAD_SHA" || true)
+            NUM_CHANGED=$(echo "$CHANGED_FILES" | sed '/^$/d' | wc -l)
+            # If the API sees changes but local git still doesn't, trust the API
+            # count to avoid a false-positive rule-1 failure on a racey push.
+            if [ "$NUM_CHANGED" -eq 0 ] && [ "$API_FILES" -gt 0 ]; then
+              echo "::notice::API reports $API_FILES changed files; deferring to API count to avoid race-induced false positive"
+              NUM_CHANGED="$API_FILES"
+            fi
+            RETRIES=$((RETRIES + 1))
+          done
+          echo "post-retry num_changed=$NUM_CHANGED"
+
           # -------- Rule 1 — empty diff --------
           if [ "$NUM_CHANGED" -eq 0 ]; then
             if [ "$PR_TITLE" = "chore: empty PR" ]; then


### PR DESCRIPTION
Mirrors Tools PR #2941 which fixed the anti-phantom-merge guard timing race. The original guard fires immediately on PR push events but the GitHub API sometimes hasn't propagated the diff yet, producing false 0-changed-files reports.

Adds: retry loop that re-fetches diff stats up to 3 times with 10s sleeps before treating 0-changed-files as a genuine empty PR.

Identified by Phase 4A audit (false-positive comments on Tools PRs #2898, #2907).