### PR TITLE
feat(ci): add pip caching to ci-standard.yml (gap missed by #5668)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -89,7 +89,12 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - name: Install Quality Tools
         run: |
           # Shared self-hosted runners can retain broken tool packages without
@@ -452,7 +457,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - name: Create isolated core install
         shell: bash
         run: |
@@ -491,7 +501,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with: { python-version: "3.12" }
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - name: Regenerate dependency artifacts
         shell: bash
         run: |
@@ -578,6 +593,10 @@ jobs:
         if: steps.core-test-changes.outputs.skip != 'true'
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
 
       - name: Create stub ui/dist for editable install
         if: steps.core-test-changes.outputs.skip != 'true'
@@ -832,6 +851,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - name: Create stub ui/dist for editable install
         run: mkdir -p ui/dist
       - name: Install migration test dependencies
@@ -926,6 +949,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - name: Create stub ui/dist for editable install
         run: mkdir -p ui/dist
       - name: Install Core Test Dependencies
@@ -1049,7 +1076,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
       - run: |
           python -m ensurepip --upgrade || true
           pip install platformio
@@ -1153,6 +1185,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
 
       - name: Enable long Cargo git dependency paths on Windows
         if: steps.rust-changes.outputs.has_changes == 'true' && matrix.os == 'windows-latest'
@@ -1319,6 +1355,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
 
       - name: Install Rust toolchain
         if: steps.rust-changes.outputs.has_changes == 'true'


### PR DESCRIPTION
Phase 6E caching effectiveness verification found that PR #5668 (comprehensive caching campaign) modified 29 workflow files but skipped ci-standard.yml — the workflow that produces the most runner-time per push. This PR adds cache: pip to every setup-python invocation in ci-standard.yml so the main CI pipeline benefits from pip cache (matching the GM and other-workflow patterns).