### PR TITLE
ci(standard): parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -529,10 +529,11 @@ jobs:
           pip-audit -r <(pip freeze)
 
   tests:
-    needs: [pick-runner, quality-gate, dependency-consistency]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20 # Prevent runaway tests - hard cutoff
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.10", "3.11", "3.12"]
     steps:
@@ -902,7 +903,7 @@ jobs:
             -vv --tb=short
 
   shared-tools-consumer-contracts:
-    needs: [pick-runner, quality-gate]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
     steps:
@@ -989,7 +990,7 @@ jobs:
             -v --tb=short
 
   frontend-tests:
-    needs: [pick-runner, quality-gate]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     defaults:
       run:
@@ -1050,7 +1051,7 @@ jobs:
   # Users with local MATLAB can run: matlab/run_all.m for equivalent tests.
   # =============================================================================
   matlab-tests:
-    needs: [pick-runner, quality-gate]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     if: false # DISABLED - Requires MATLAB license not available in CI
     continue-on-error: true
@@ -1070,7 +1071,7 @@ jobs:
   # No Arduino components in this project - disabled.
   # =============================================================================
   arduino-build:
-    needs: [pick-runner, quality-gate]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     if: false # DISABLED - No Arduino components in this project
     steps:


### PR DESCRIPTION
## Why

On a saturated runner pool, jobs chained behind `quality-gate` via `needs:` pay queue-wait twice. Worse, when `quality-gate` fails, **every downstream job is SKIPPED** (default `needs:` behavior in GitHub Actions). A PR-remediation agent then only sees one class of failure per CI cycle — fix, push, wait 30 min, discover the next failure, repeat.

After this change, every job that doesn't genuinely depend on `quality-gate` starts in parallel after `pick-runner`. All failure classes surface on the first run, so the remediation agent can fix everything in one push.

## What

Verified via `grep -nE "needs\.(quality-gate|dependency-consistency)\." .github/workflows/ci-standard.yml` — **zero matches**. Neither `quality-gate` nor `dependency-consistency` exposes any `outputs:` block, and no downstream job consumes their outputs. The `needs:` edges were pure ordering, not data dependencies.

Jobs flattened (`needs:` reduced to just `pick-runner`):

| Job | Before | After |
|---|---|---|
| `tests` (line 531) | `[pick-runner, quality-gate, dependency-consistency]` | `pick-runner` |
| `shared-tools-consumer-contracts` (line 904) | `[pick-runner, quality-gate]` | `pick-runner` |
| `frontend-tests` (line 991) | `[pick-runner, quality-gate]` | `pick-runner` |
| `matlab-tests` (line 1052, `if: false`) | `[pick-runner, quality-gate]` | `pick-runner` |
| `arduino-build` (line 1072, `if: false`) | `[pick-runner, quality-gate]` | `pick-runner` |

Plus `strategy.fail-fast: false` added to the `tests` matrix (Python 3.10 / 3.11 / 3.12) so one interpreter's failure no longer cancels its siblings — the agent sees all version-specific failures at once. `rust-quality-gate` already had `fail-fast: false`; no other matrix block exists.

## What this does NOT touch

- No `steps:`, `runs-on:`, `timeout-minutes:`, or `concurrency:` keys changed.
- No other workflow files modified.
- `quality-gate`, `dependency-consistency`, `core-only-install`, `alembic-postgres-round-trip`, and `rust-quality-gate` already only depended on `pick-runner` — left as-is.

## Verification

- `grep -nE "needs\.(quality-gate|dependency-consistency)\." .github/workflows/ci-standard.yml` -> 0 matches (no data deps broken)
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-standard.yml'))"` -> parses
- `git diff` -> only `needs:` lines and one `fail-fast: false` insertion (6 insertions, 5 deletions, 1 file)

This PR is a pure topology + matrix-policy edit. It cannot break tests. Pre-existing CI failures on `main` (Tauri lockfile, etc.) are unrelated.