### PR TITLE
policy(ci): migrate hosted-runner workflows to d-sorg-fleet (keep guard tripwire on hosted)

### DIFF
--- a/.github/workflows/Stub-Introduction-Guard.yml
+++ b/.github/workflows/Stub-Introduction-Guard.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   guard:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Check out PR head
         uses: actions/checkout@v4

--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -32,7 +32,7 @@ jobs:
     if: >-
       github.event.issue.state_reason != 'reopened' &&
       github.event.sender.login != 'github-actions[bot]'
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Check for closure evidence
         uses: actions/github-script@v7

--- a/.github/workflows/cross-engine-leaderboard-publish.yml
+++ b/.github/workflows/cross-engine-leaderboard-publish.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   publish:
     name: publish cross-engine leaderboard JSON
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 15
 
     env:

--- a/.github/workflows/cross-engine-leaderboard.yml
+++ b/.github/workflows/cross-engine-leaderboard.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   regenerate:
     name: regenerate cross-engine leaderboard
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/docs-currency-warning.yml
+++ b/.github/workflows/docs-currency-warning.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   warn:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Check for docs / tests / opt-out
         env:

--- a/.github/workflows/motion-matching-leaderboard.yml
+++ b/.github/workflows/motion-matching-leaderboard.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   check-leaderboard:
     name: check LEADERBOARD.md is committed
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/realtime-soak.yml
+++ b/.github/workflows/realtime-soak.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   soak:
     name: 24h realtime soak
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # 24 h + headroom for setup/teardown/artifact upload. GitHub-hosted
     # runners cap at 360 minutes; the nightly run uses the d-sorg-fleet
     # runner via a separate self-hosted dispatch when available. For


### PR DESCRIPTION
## Summary

Fleet-wide policy enforcement: no jobs may run on GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`). All work routes to the self-hosted `d-sorg-fleet` pool.

## Workflows / jobs migrated (ubuntu-latest -> d-sorg-fleet)

| Workflow | Job |
|----------|-----|
| `cross-engine-leaderboard-publish.yml` | `publish` |
| `cross-engine-leaderboard.yml` | `regenerate` |
| `docs-currency-warning.yml` | `warn` |
| `motion-matching-leaderboard.yml` | `check-leaderboard` |
| `realtime-soak.yml` | `soak` |
| `Stub-Introduction-Guard.yml` | `guard` |
| `Verify-Issue-Closure.yml` | `verify-closure` |

## Intentionally left on hosted (tripwire — must not be migrated)

- `ci-standard.yml` job `local-only-workflows` (name: `Reject hosted runner routing`) stays on `runs-on: ubuntu-latest`. It's the policy tripwire — its purpose is to RUN on hosted and exit 1 immediately, proving no real work landed on hosted. Migrating would defeat the guard mechanism.

## Intentionally left alone (already fleet-routed via matrix)

- `ci-standard.yml` cross-platform `tests-cross-platform` job uses `matrix.os = [ubuntu-latest, windows-latest, macos-latest]` — documented in the workflow comment as intentional cross-platform CI (Linux fleet-only label can't run Windows/macOS).
- `tauri-build.yml` `matrix.platform` — all entries already fleet (`d-sorg-fleet`, `[self-hosted, Windows]`, `[self-hosted, macOS]`).
- `release.yml` `matrix.runner` — all entries already `d-sorg-fleet`.

## Note on realtime-soak.yml

The workflow contains an inline comment about GitHub-hosted runners capping at 360 minutes and the `SOAK_DURATION_SEC` cap. With the migration to `d-sorg-fleet` the cap is no longer a hosted-runner limitation — the comment is left in place but is now informational only; if desired, follow-up PR can update SOAK_DURATION_SEC for the fleet.

## Verification

- Only `runs-on:` lines changed (verified via `git diff`)
- All edited files parse cleanly with `python -c "import yaml; yaml.safe_load(open(f, encoding='utf-8'))"`

## Test plan

- [ ] Migrated jobs pick up the `d-sorg-fleet` pool on next trigger
- [ ] Local-only-runner guard still trips on any new hosted-runner usage