### PR TITLE
fix(launcher): migrate config from .kiro/ to platform config dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "h5py>=3.0.0",
     "jinja2>=3.1.0",
 
+    # Platform-appropriate config/data directories (replaces .kiro/ — issue #5713)
+    "platformdirs>=4.2.0",
+
     # Runtime security floor constraints documented in issue #3838.
     "pillow>=12.2.0",
     "requests>=2.33.0",

--- a/src/launchers/launcher_constants.py
+++ b/src/launchers/launcher_constants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import subprocess
 import sys
 from enum import IntEnum
@@ -21,7 +22,57 @@ logger = get_logger(__name__)
 # Constants
 REPOS_ROOT = Path(__file__).parent.parent.parent.resolve()
 
-CONFIG_DIR = REPOS_ROOT / ".kiro" / "launcher"
+
+def _get_config_dir() -> Path:
+    """Return the platform-appropriate config directory for upstream-drift.
+
+    Migrates from the defunct .kiro/ path (issue #5713) to a proper location:
+    - Linux/macOS: ~/.config/upstream-drift/launcher  (via platformdirs)
+    - Windows:     %LOCALAPPDATA%/UpstreamDrift/launcher (via platformdirs)
+
+    Backward compatibility: if the old .kiro/launcher path exists and the new
+    path does not yet contain a layout.json, existing config is copied on first
+    run.
+
+    DbC postcondition: returned path does not contain '.kiro'.
+    """
+    try:
+        from platformdirs import user_config_dir
+
+        new_dir = Path(user_config_dir("upstream-drift")) / "launcher"
+    except ImportError:
+        # Graceful fallback if platformdirs is somehow unavailable at runtime
+        if sys.platform == "win32":
+            new_dir = Path.home() / "AppData" / "Local" / "UpstreamDrift" / "launcher"
+        else:
+            new_dir = Path.home() / ".config" / "upstream-drift" / "launcher"
+
+    # Backward-compatibility migration: copy config from old .kiro/ path on first run
+    old_dir = REPOS_ROOT / ".kiro" / "launcher"
+    if old_dir.exists() and not (new_dir / "layout.json").exists():
+        try:
+            new_dir.mkdir(parents=True, exist_ok=True)
+            for item in old_dir.iterdir():
+                dest = new_dir / item.name
+                if not dest.exists():
+                    if item.is_dir():
+                        shutil.copytree(str(item), str(dest))
+                    else:
+                        shutil.copy2(str(item), str(dest))
+            logger.info(
+                "Migrated launcher config from %s to %s (issue #5713)",
+                old_dir,
+                new_dir,
+            )
+        except OSError as exc:
+            logger.warning("Could not migrate old .kiro/ config: %s", exc)
+
+    # DbC postcondition
+    assert ".kiro" not in str(new_dir), f"Config dir must not be under .kiro/: {new_dir}"
+    return new_dir
+
+
+CONFIG_DIR = _get_config_dir()
 LAYOUT_CONFIG_FILE = CONFIG_DIR / "layout.json"
 GRID_COLUMNS = 4  # Changed to 3x4 grid (12 tiles total)
 

--- a/tests/unit/launchers/test_launcher_constants_config_dir.py
+++ b/tests/unit/launchers/test_launcher_constants_config_dir.py
@@ -1,0 +1,97 @@
+"""
+Tests for launcher_constants.py CONFIG_DIR migration away from .kiro/.
+
+Fixes issue #5713: .kiro/ is a defunct IDE folder that confuses new contributors.
+
+DbC postconditions:
+- CONFIG_DIR must not use .kiro/ (defunct IDE folder)
+- CONFIG_DIR must end with "launcher" for compatibility with existing tests
+- CONFIG_DIR must be under user home or AppData
+- LAYOUT_CONFIG_FILE must be under CONFIG_DIR
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def test_config_dir_not_in_kiro() -> None:
+    """DbC postcondition: CONFIG_DIR must not use .kiro/ (defunct IDE folder)."""
+    from src.launchers.launcher_constants import CONFIG_DIR
+
+    assert ".kiro" not in str(CONFIG_DIR), (
+        f"CONFIG_DIR should not be in .kiro/: {CONFIG_DIR}\n"
+        "Fix: migrate to platformdirs user_config_dir or ~/.config/upstream-drift/"
+    )
+
+
+def test_config_dir_ends_with_launcher() -> None:
+    """CONFIG_DIR must end with 'launcher' for compatibility with existing code."""
+    from src.launchers.launcher_constants import CONFIG_DIR
+
+    assert str(CONFIG_DIR).endswith("launcher"), (
+        f"CONFIG_DIR should end with 'launcher', got: {CONFIG_DIR}"
+    )
+
+
+def test_config_dir_is_platform_appropriate() -> None:
+    """DbC postcondition: CONFIG_DIR should be under user home or AppData."""
+    from src.launchers.launcher_constants import CONFIG_DIR
+
+    config_str = str(CONFIG_DIR)
+    home_str = str(Path.home())
+
+    is_under_home = config_str.startswith(home_str)
+    is_under_appdata = "AppData" in config_str
+
+    assert is_under_home or is_under_appdata, (
+        f"CONFIG_DIR should be under user home ({home_str}) or AppData, "
+        f"but got: {config_str}"
+    )
+
+
+def test_layout_config_file_under_config_dir() -> None:
+    """DbC postcondition: LAYOUT_CONFIG_FILE must be under CONFIG_DIR."""
+    from src.launchers.launcher_constants import CONFIG_DIR, LAYOUT_CONFIG_FILE
+
+    assert str(LAYOUT_CONFIG_FILE).startswith(str(CONFIG_DIR)), (
+        f"LAYOUT_CONFIG_FILE ({LAYOUT_CONFIG_FILE}) must be under CONFIG_DIR ({CONFIG_DIR})"
+    )
+
+
+def test_config_dir_is_path_instance() -> None:
+    """CONFIG_DIR must be a pathlib.Path instance."""
+    from src.launchers.launcher_constants import CONFIG_DIR
+
+    assert isinstance(CONFIG_DIR, Path), f"CONFIG_DIR must be Path, got {type(CONFIG_DIR)}"
+
+
+def test_layout_config_file_is_path_instance() -> None:
+    """LAYOUT_CONFIG_FILE must be a pathlib.Path instance."""
+    from src.launchers.launcher_constants import LAYOUT_CONFIG_FILE
+
+    assert isinstance(LAYOUT_CONFIG_FILE, Path), (
+        f"LAYOUT_CONFIG_FILE must be Path, got {type(LAYOUT_CONFIG_FILE)}"
+    )
+
+
+def test_config_dir_uses_app_name_upstream_drift() -> None:
+    """CONFIG_DIR path should identify the upstream-drift application."""
+    from src.launchers.launcher_constants import CONFIG_DIR
+
+    config_str = str(CONFIG_DIR).lower().replace("-", "").replace("_", "")
+    assert "upstreamdrift" in config_str, (
+        f"CONFIG_DIR path should contain 'upstream-drift' or 'upstreamdrift', "
+        f"got: {CONFIG_DIR}"
+    )
+
+
+def test_repos_root_not_used_for_config_dir() -> None:
+    """Config state must not be stored under the repository root (REPOS_ROOT)."""
+    from src.launchers.launcher_constants import REPOS_ROOT, CONFIG_DIR
+
+    assert not str(CONFIG_DIR).startswith(str(REPOS_ROOT)), (
+        f"CONFIG_DIR ({CONFIG_DIR}) must not be under REPOS_ROOT ({REPOS_ROOT}). "
+        "Runtime state must not be stored in the repository tree."
+    )


### PR DESCRIPTION
## Summary

- Migrates CONFIG_DIR in src/launchers/launcher_constants.py from REPOS_ROOT/.kiro/launcher to a platform-appropriate location via platformdirs
  - Linux/macOS: ~/.config/upstream-drift/launcher
  - Windows: %LOCALAPPDATA%/UpstreamDrift/launcher
- Adds backward-compatibility migration: if old .kiro/launcher/ exists and the new path has no layout.json, config files are copied on first run
- Adds DbC postcondition assertion: CONFIG_DIR must not contain .kiro
- Adds platformdirs>=4.2.0 to core dependencies in pyproject.toml
- Adds tests/unit/launchers/test_launcher_constants_config_dir.py with 8 TDD tests

## Test plan

- test_config_dir_not_in_kiro: DbC postcondition passes
- test_config_dir_ends_with_launcher: backward compat with existing test
- test_config_dir_is_platform_appropriate: under home or AppData
- test_layout_config_file_under_config_dir: file is under dir
- test_config_dir_uses_app_name_upstream_drift: app identity
- test_repos_root_not_used_for_config_dir: not in repo tree

Fixes #5713

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>