### PR TITLE
fix(docs): correct CLAUDE.md path references for shared module directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,10 @@ maturin develop                                   # build Rust extensions locall
 
 ## Where to edit shared code
 
-Tools is the source of truth for: `shared/python/chat/`, `shared/python/ai/`,
-`shared/python/sidekick/` (canonical package name as of Stage 2, #5619).
+Tools is the source of truth for the shared utilities vendored here as
+`vendor/ud-tools/`. Within this repo those modules live at
+`src/shared/python/chat/`, `src/shared/python/ai/`, and the sidekick package
+(canonical name as of Stage 2, #5619) is provided by `vendor/ud-tools/`.
 **Never edit these inside `vendor/ud-tools/`**; vendor changes are erased on the
 next `git submodule update` or vendor bump.
 


### PR DESCRIPTION
## Summary

- The `check_agent_docs_consistency.py` script validates that all backtick-wrapped paths in `CLAUDE.md` exist relative to the repo root.
- The "Where to edit shared code" section referenced `shared/python/chat/`, `shared/python/ai/`, and `shared/python/sidekick/` which do NOT exist at the repo root (they live under `src/shared/python/` or in `vendor/ud-tools/`).
- This caused the `quality-gate` check to fail on every PR with: "CLAUDE.md references a missing path".

**Fix**: Updated the paths to use `src/shared/python/chat/` and `src/shared/python/ai/` (which exist), and clarified that sidekick is provided by `vendor/ud-tools/`.

This also unblocks bolt PRs #5685 and #5686 which have already had the fix cherry-picked onto them.

## Test plan
- [x] `python scripts/check_agent_docs_consistency.py` passes locally: "OK: README, CLAUDE, CONTRIBUTING, CHANGELOG, pyproject, and CI are aligned"
- [x] Verified `src/shared/python/chat/` and `src/shared/python/ai/` both exist
- [x] Verified `vendor/ud-tools/` exists

Generated with Claude Code