### PR TITLE
fix(launchers): address reviewer feedback - zoom callback, ViewMode import, fragment links

### DIFF
--- a/src/launchers/settings_dialog.py
+++ b/src/launchers/settings_dialog.py
@@ -146,7 +146,7 @@ class SettingsDialog(QDialog):
         self.combo_view_mode = QComboBox()
         # Ensure enums are imported correctly inside the method scope
         try:
-            from src.shared.python.gui_pkg.layout_manager import ViewMode
+            from src.launchers.launcher_constants import ViewMode
 
             self.combo_view_mode.addItem("Tile Small", ViewMode.SMALL)
             self.combo_view_mode.addItem("Tile Medium", ViewMode.MEDIUM)
@@ -217,8 +217,8 @@ class SettingsDialog(QDialog):
                         self.lbl_zoom_pct.setText(
                             f"{int(round(launcher._slider_to_scale(v) * 100))}%"
                         )
-                    if hasattr(launcher, "_zoom_slider_changed"):
-                        launcher._zoom_slider_changed(v)
+                    if hasattr(launcher, "_on_zoom_slider_changed"):
+                        launcher._on_zoom_slider_changed(v)
 
                 self.zoom_slider.valueChanged.connect(on_zoom)
 

--- a/src/shared/python/ui/qt/widgets/document_reader.py
+++ b/src/shared/python/ui/qt/widgets/document_reader.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal, QSize, pyqtSlot
+from PyQt6.QtCore import Qt, QUrl, pyqtSignal, QSize, pyqtSlot
 from PyQt6.QtGui import QImage, QPixmap, QFont
 from PyQt6.QtWidgets import (
     QWidget,
@@ -109,20 +109,38 @@ class DocumentReaderWidget(QWidget):
             logger.exception("Failed to load document")
             QMessageBox.critical(self, "Error", f"Could not load {path.name}: {e}")
 
-    @pyqtSlot(object)
-    def _handle_link_click(self, url) -> None:
+    @pyqtSlot(QUrl)
+    def _handle_link_click(self, url: QUrl) -> None:
+        """Handle a clicked hyperlink inside the document browser.
+
+        DbC precondition: url is a QUrl instance.
+
+        Fragment-link handling (fixes #5725):
+        - A bare fragment URL (e.g. ``#section``) scrolls within the current
+          document via :meth:`QTextBrowser.scrollToAnchor`.
+        - A file URL that contains a fragment (e.g. ``doc.md#step-1``) has the
+          fragment stripped before the file-existence check so that the path
+          resolves correctly.
+        """
+        assert isinstance(url, QUrl), f"Expected QUrl, got {type(url).__name__}"
+
+        fragment = url.fragment()
+
+        # Bare fragment — scroll to anchor within the current document
+        if not url.path() and fragment:
+            self.text_browser.scrollToAnchor(fragment)
+            return
+
         scheme = url.scheme()
         if scheme == "file" or not scheme:
-            # Local file - resolve relative to current doc if needed
-            path_str = url.toLocalFile()
-            if not path_str and url.toString():
-                path_str = url.toString()
+            # Strip the fragment so Path.exists() works correctly
+            path_str = url.toLocalFile() or url.toString().split("#")[0]
 
             p = Path(path_str)
             if not p.is_absolute() and self.current_file:
                 p = self.current_file.parent / p
             if p.exists():
-                # Open in a new document reader window
+                # Open in a new document reader window; pass anchor for future use
                 show_document(p)
                 return
 

--- a/tests/launchers/test_settings_dialog.py
+++ b/tests/launchers/test_settings_dialog.py
@@ -304,3 +304,42 @@ def test_timer_event_no_start_time(parent_launcher, qapp) -> None:
 
     # Should not raise any error
     dialog.timerEvent(None)
+
+
+# ── Issue #5730 / #5723: ViewMode import and zoom slider wiring ──────────────
+
+
+def test_layout_tab_view_mode_combo_populated(parent_launcher, qapp) -> None:
+    """#5730: ViewMode combo must be populated (import from correct module)."""
+    dialog = SettingsDialog(parent=parent_launcher, initial_tab=TAB_LAYOUT)
+    # If the import is broken the combo stays empty (count == 0)
+    assert dialog.combo_view_mode.count() > 0, (
+        "combo_view_mode has no items — ViewMode import failed (check #5730)"
+    )
+
+
+def test_layout_tab_zoom_slider_calls_on_zoom_slider_changed(
+    parent_launcher, qapp
+) -> None:
+    """#5723: Moving the zoom slider must call _on_zoom_slider_changed, not _zoom_slider_changed."""
+    from src.launchers.launcher_constants import ViewMode
+    from src.launchers.launcher_layout_manager import LayoutManager
+
+    layout_manager = MagicMock(spec=LayoutManager)
+    layout_manager.view_mode = ViewMode.LIST_LARGE
+    layout_manager.tile_scale = 1.0
+    parent_launcher.layout_manager = layout_manager
+    parent_launcher._scale_to_slider = MagicMock(return_value=50)
+    parent_launcher._slider_to_scale = MagicMock(return_value=0.75)
+    # The real method name is _on_zoom_slider_changed (not _zoom_slider_changed)
+    parent_launcher._on_zoom_slider_changed = MagicMock()
+    # Ensure the wrong name is not present (so hasattr check routes correctly)
+    if hasattr(parent_launcher, "_zoom_slider_changed"):
+        del parent_launcher._zoom_slider_changed
+
+    dialog = SettingsDialog(parent=parent_launcher, initial_tab=TAB_LAYOUT)
+
+    # Simulate slider movement
+    dialog.zoom_slider.setValue(75)
+
+    parent_launcher._on_zoom_slider_changed.assert_called_with(75)

--- a/tests/ui/test_document_reader.py
+++ b/tests/ui/test_document_reader.py
@@ -1,0 +1,95 @@
+"""Tests for DocumentReaderWidget — issue #5725: fragment link handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtCore import QUrl
+
+from src.shared.python.ui.qt.widgets.document_reader import DocumentReaderWidget
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reader(qapp) -> DocumentReaderWidget:
+    widget = DocumentReaderWidget()
+    return widget
+
+
+# ── Issue #5725: fragment links must not be treated as file paths ─────────────
+
+
+def test_same_doc_fragment_scrolls_to_anchor(reader) -> None:
+    """A bare '#section' URL must call scrollToAnchor, not open an external browser."""
+    reader.text_browser.scrollToAnchor = MagicMock()
+    with patch("PyQt6.QtGui.QDesktopServices") as mock_svc:
+        url = QUrl("#introduction")
+        reader._handle_link_click(url)
+
+    reader.text_browser.scrollToAnchor.assert_called_once_with("introduction")
+    mock_svc.openUrl.assert_not_called()
+
+
+def test_file_with_fragment_strips_fragment_before_existence_check(
+    reader, tmp_path
+) -> None:
+    """A link like 'quickstart.md#step-1' must open the file (without the fragment)."""
+    md_file = tmp_path / "quickstart.md"
+    md_file.write_text("# Quickstart\n## Step 1\nContent here.\n", encoding="utf-8")
+
+    reader.current_file = tmp_path / "index.md"
+
+    with patch(
+        "src.shared.python.ui.qt.widgets.document_reader.show_document"
+    ) as mock_show:
+        url = QUrl(f"file:///{md_file.as_posix()}#step-1")
+        reader._handle_link_click(url)
+
+    mock_show.assert_called_once()
+    called_path = Path(mock_show.call_args[0][0])
+    assert called_path == md_file
+
+
+def test_relative_file_with_fragment_resolves_correctly(reader, tmp_path) -> None:
+    """A relative link 'docs/arch.md#details' must resolve relative to current file."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    arch_file = docs_dir / "arch.md"
+    arch_file.write_text("# Architecture\n## Details\n", encoding="utf-8")
+
+    reader.current_file = tmp_path / "README.md"
+
+    with patch(
+        "src.shared.python.ui.qt.widgets.document_reader.show_document"
+    ) as mock_show:
+        url = QUrl("docs/arch.md#details")
+        reader._handle_link_click(url)
+
+    mock_show.assert_called_once()
+    called_path = Path(mock_show.call_args[0][0])
+    assert called_path == arch_file
+
+
+def test_external_http_link_opens_browser(reader) -> None:
+    """An http:// link must open in the external browser, not try file existence."""
+    with patch("PyQt6.QtGui.QDesktopServices") as mock_svc:
+        url = QUrl("https://example.com/page#section")
+        reader._handle_link_click(url)
+
+    mock_svc.openUrl.assert_called_once_with(url)
+
+
+def test_nonexistent_file_falls_back_to_browser(reader, tmp_path) -> None:
+    """A file:// link pointing to a nonexistent path falls back to QDesktopServices."""
+    reader.current_file = tmp_path / "README.md"
+    missing = tmp_path / "missing.md"
+
+    with patch("PyQt6.QtGui.QDesktopServices") as mock_svc:
+        url = QUrl(f"file:///{missing.as_posix()}")
+        reader._handle_link_click(url)
+
+    mock_svc.openUrl.assert_called_once()


### PR DESCRIPTION
## Summary

- **#5730** -- Fix broken ViewMode import in settings_dialog.py: was importing from nonexistent src.shared.python.gui_pkg.layout_manager; now imports from src.launchers.launcher_constants. The Layout tab view-mode combo box was silently empty (ImportError swallowed) -- now populates correctly.
- **#5723** -- Fix zoom slider callback name: on_zoom checked hasattr(launcher, _zoom_slider_changed) but the real method is _on_zoom_slider_changed. Moving the Settings zoom slider now propagates tile-scale changes to the launcher.
- **#5725** -- Handle Markdown fragment links in document_reader.py: bare #fragment URLs now call QTextBrowser.scrollToAnchor instead of falling through to the external browser. File links with fragments (e.g. doc.md#step-1) strip the fragment before Path.exists() so TOC links work. Also fix @pyqtSlot(object) to @pyqtSlot(QUrl) slot signature incompatibility.

## Test plan

- [x] TDD: 7 new tests written before implementation (red to green to refactor)
- [x] tests/launchers/test_settings_dialog.py::test_layout_tab_view_mode_combo_populated
- [x] tests/launchers/test_settings_dialog.py::test_layout_tab_zoom_slider_calls_on_zoom_slider_changed
- [x] tests/ui/test_document_reader.py -- 5 tests covering all fragment-link scenarios
- [x] All 25 settings dialog + document reader tests pass
- [x] ruff check and ruff format clean

## Closes

Closes #5723
Closes #5725
Closes #5730

Note: Issues #5689, #5690, #5714 were already resolved by PR #5688 (merged 2026-05-18) and have been closed.

Generated with Claude Code