### PR TITLE
docs(sidekick): document Sidekick in AGENTS.md and tool embedding guide

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -159,7 +159,7 @@ UpstreamDrift/
 | Pendulum Models          | `src/engines/physics_engines/pendulum/`  | Educational simplified models for learning and quick prototyping                            |
 | FastAPI Backend          | `src/api/`                               | REST API exposing simulation, IK/ID, trajectory optimization, and control endpoints         |
 | PyQt6 GUI                | `src/launchers/golf_launcher.py`         | Professional interactive GUI with real-time 3D visualization                                |
-| Sidekick Sidebar         | `src/shared/python/upstream_drift_tools/ui/tools_sidebar/` | Unified collapsible dock providing Chat Assistant, Reporting, and context-aware utilities   |
+| Sidekick (AI assistant)  | PyQt: `src/shared/python/ai/gui/assistant_panel.py` · React: `ui/src/components/ui/ChatPanel.tsx` · Adapter: `src/tools/sidekick/_embed_adapter.py` | In-app AI chat surface with streaming, RAG, session history, and agentic tool dispatch. Design tokens: `src/shared/python/theme/sidekick_tokens.py`. See `docs/sidekick/README.md`. |
 | Tauri Desktop App        | `ui/`                                    | Cross-platform desktop application wrapper (Windows, macOS, Linux)                          |
 | Rust Physics Kernels     | `rust_core/upstream-physics/`            | High-performance compiled physics routines for critical paths, including initial flexible shaft FEM element primitives |
 | Configuration Manager    | `src/config/`                            | Centralized configuration loading, validation, and environment management                   |
@@ -198,6 +198,7 @@ Engine tier metadata is declared in each in-scope engine package with
 | F12 | Muscle dynamics analysis           | ✅     | IK, ID, and muscle dynamics computation with Hill-type and Millard muscle models                    |
 | F13 | Motion capture integration         | 🔄     | Import and track motion capture data (C3D, BVH, TRC formats) and compare with simulation            |
 | F14 | Reinforcement learning integration | 🔄     | Gym-compatible interface for RL-based controller learning and policy optimization                   |
+| F15 | Sidekick AI assistant              | 🔄     | In-app AI chat surface (PyQt + React/Tauri) with streaming, RAG, session history, and agentic tool dispatch. See `docs/sidekick/README.md`. |
 
 ### API / Interface Contract
 

--- a/docs/sidekick/README.md
+++ b/docs/sidekick/README.md
@@ -1,0 +1,187 @@
+# Sidekick — AI Chat / Agentic Assistant
+
+Sidekick is UpstreamDrift's in-app AI assistant. It runs in two host shells
+that share a single design-token contract and a single AI tool registry, so
+adding a capability once makes it available in both places.
+
+---
+
+## Surfaces
+
+| Shell | Entry point | Notes |
+|-------|-------------|-------|
+| **PyQt launcher panel** | [`src/shared/python/ai/gui/assistant_panel.py`](../../src/shared/python/ai/gui/assistant_panel.py) (`AIAssistantPanel`, window title "Sidekick") | Embedded as a splitter pane in `src/launchers/launcher_ui_setup.py` and as a registered `EmbeddableTool` tile so users can open it via right-click → "Launch in Dock" |
+| **React/Tauri shell** | [`ui/src/pages/Chat.tsx`](../../ui/src/pages/Chat.tsx) (route `/chat`) renders [`ui/src/components/ui/ChatPanel.tsx`](../../ui/src/components/ui/ChatPanel.tsx) | Styled with `var(--sidekick-color-*)` CSS variables; communicates over the FastAPI WebSocket at `src/api/routes/chat_ws.py` |
+
+Both surfaces display the brand name "Sidekick" in their window / header text
+and route messages through the same FastAPI chat service.
+
+---
+
+## Layout (ASCII)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  PyQt launcher                   React / Tauri (web)     │
+│  ┌──────────────────────────┐   ┌──────────────────────┐ │
+│  │ AIAssistantPanel         │   │ ChatPanel.tsx         │ │
+│  │  ┌─── sidebar ──────┐    │   │  (route /chat)        │ │
+│  │  │ Sessions         │    │   └──────────┬───────────┘ │
+│  │  │ History          │    │              │              │
+│  │  │ Memory           │    │     var(--sidekick-*)       │
+│  │  └──────────────────┘    │                            │
+│  │  ┌─── transcript ───┐    │                            │
+│  │  │ MessageWidget    │    │     sidekick_tokens.py     │
+│  │  └──────────────────┘    │     (Python tokens)        │
+│  │  ┌─── composer ─────┐    │                            │
+│  │  │ ChatInput        │    │                            │
+│  │  │ Send button      │    │                            │
+│  │  └──────────────────┘    │                            │
+│  └──────────────────────────┘                            │
+│                    │  WebSocket (both shells)             │
+│          ┌─────────▼────────────────────────────────┐    │
+│          │  src/api/routes/chat_ws.py  (FastAPI)     │    │
+│          │  └── _maybe_inject_chat_context()         │    │
+│          └─────────┬────────────────────────────────┘    │
+│                    │  tool calls                          │
+│          ┌─────────▼────────────────────────────────┐    │
+│          │  AI Tool Registry                         │    │
+│          │  src/shared/python/ai/tools/              │    │
+│          │  e.g. sidekick_analytics.py               │    │
+│          └──────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Design tokens
+
+`src/shared/python/theme/sidekick_tokens.py` (Python) and
+`ui/src/api/themeClient.ts` (TypeScript) export matching maps:
+
+- **`COLOR_TOKEN_MAP`** — 21 canonical `sidekick.color.*` keys
+  mapped onto active launcher theme color keys.
+- **`DEFAULT_SIDEKICK_TOKENS`** — hex fallbacks for environments
+  without a running launcher theme.
+- **Spacing / radius / font** tokens follow the same pattern.
+
+The two maps are pinned together by
+[`tests/unit/theme/test_sidekick_parity.py`](../../tests/unit/theme/test_sidekick_parity.py).
+If you add a token in one language, add it in the other in the same PR —
+the parity test will fail otherwise.
+
+When styling a new chat-adjacent surface, always prefer:
+```css
+var(--sidekick-color-surface)
+var(--sidekick-color-text)
+var(--sidekick-color-accent)
+```
+over raw hex or Tailwind grays.
+
+---
+
+## Embedding Sidekick as a launcher tile
+
+Sidekick is registered as an `EmbeddableTool` via
+[`src/tools/sidekick/_embed_adapter.py`](../../src/tools/sidekick/_embed_adapter.py).
+The tile entry in `src/config/models.yaml`:
+
+```yaml
+- id: "sidekick"
+  name: "Sidekick"
+  description: "AI chat / agentic assistant"
+  launcher:
+    category: "tool"
+    default_launch: "dock"
+    status: "beta"
+```
+
+Key points about the adapter:
+- Sets `prefers_dock=True` — Sidekick is a sidebar tool, not a primary
+  workspace, so it docks rather than opening in a new tab.
+- `create_main_widget` is **idempotent**: opening Sidekick twice reuses
+  the same widget instance.
+- `cleanup()` is **idempotent**: safe to call on tab close, window close,
+  or test fixture teardown.
+- PyQt6 imports are **lazy** (inside `create_main_widget`), so the adapter
+  module can be introspected on headless CI without a display server.
+
+For a full walkthrough of the `EmbeddableTool` protocol, see
+[`docs/development/embedding_a_tool.md`](../development/embedding_a_tool.md).
+
+---
+
+## Chat context bridge
+
+`src/shared/python/ai/chat_context.py` exposes a thread-safe ring buffer
+the rest of the app can push events to:
+
+```python
+from src.shared.python.ai.chat_context import record_event
+
+record_event("diagnostic", {"name": "engine_check", "status": "ok"})
+record_event("simulation", {"engine": "mujoco", "duration_s": 4.2})
+```
+
+`chat_ws.py` calls `_maybe_inject_chat_context(session)` at the start of
+each `send` action; when the buffer is non-empty the formatted payload is
+injected as a `system` message before the user prompt reaches the model.
+
+**Safety nets applied to every dump:**
+
+| Protection | Behavior |
+|------------|----------|
+| Redaction | Keys matching `password`, `token`, `secret`, `api_key` and values matching `/home/` or `C:\` are replaced with `"<redacted>"` |
+| Size cap | Payload is truncated to ≤ 4 KB; oldest events dropped first |
+
+Disable injection for deterministic test runs:
+```bash
+export UPSTREAMDRIFT_SIDEKICK_CONTEXT=0
+```
+
+---
+
+## Adding an agentic tool
+
+New analytical surfaces register through the AI tool registry. The
+canonical cross-engine example:
+
+```python
+# src/shared/python/ai/tools/sidekick_analytics.py
+from src.shared.python.ai.tool_registry import ToolCategory, get_global_registry
+
+registry = get_global_registry()
+
+@registry.register(
+    name="summarize_simulation_run",
+    description="Summarize a completed simulation run by run_id.",
+    category=ToolCategory.ANALYSIS,
+)
+def summarize_simulation_run(run_id: str) -> dict:
+    """Return a summary dict for the given simulation run."""
+    ...
+```
+
+After defining the function, register it in
+`src/shared/python/ai/sample_tools.register_golf_suite_tools` so the
+default `ChatService` picks it up on startup.
+
+The system prompt in `src/shared/python/ai/system_prompts.py` advertises
+registered tools to the assistant automatically — no prompt edits needed.
+
+---
+
+## See also
+
+- [AGENTS.md §B "Sidekick"](../../AGENTS.md) — contributor quick-reference
+  with all file pointers.
+- [`docs/development/embedding_a_tool.md`](../development/embedding_a_tool.md)
+  — `EmbeddableTool` protocol and tile registration guide.
+- [`docs/development/sidekick.md`](../development/sidekick.md) — deeper
+  architecture and design-token notes.
+- [`docs/development/realtime_ipc.md`](../development/realtime_ipc.md)
+  — pub-sub IPC for tools that publish live state.
+- [`src/tools/sidekick/_embed_adapter.py`](../../src/tools/sidekick/_embed_adapter.py)
+  — minimal `EmbeddableTool` adapter for the PyQt panel.
+- [`tests/unit/theme/test_sidekick_parity.py`](../../tests/unit/theme/test_sidekick_parity.py)
+  — design-token parity test (Python ↔ TypeScript).

--- a/tests/unit/repo_hygiene/test_sidekick_docs.py
+++ b/tests/unit/repo_hygiene/test_sidekick_docs.py
@@ -1,0 +1,160 @@
+"""TDD tests for Sidekick documentation presence (issue #5465).
+
+Verifies that the key Sidekick documentation files exist and mention
+the required entry points so they cannot be accidentally deleted or
+left empty.
+
+These are import-free, read-only path checks — suitable for headless CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---------------------------------------------------------------------------
+# AGENTS.md — must mention Sidekick with key entry points
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsMdSidekick:
+    """AGENTS.md must document Sidekick with the required file pointers."""
+
+    def _read(self) -> str:
+        path = _REPO_ROOT / "AGENTS.md"
+        assert path.exists(), "AGENTS.md must exist at the repo root"
+        return path.read_text(encoding="utf-8")
+
+    def test_mentions_sidekick(self) -> None:
+        """AGENTS.md must contain the word 'Sidekick'."""
+        assert "Sidekick" in self._read()
+
+    def test_mentions_sidekick_tokens(self) -> None:
+        """AGENTS.md must reference sidekick_tokens.py (design-token source)."""
+        assert "sidekick_tokens" in self._read()
+
+    def test_mentions_assistant_panel(self) -> None:
+        """AGENTS.md must reference the PyQt panel entry point."""
+        assert "assistant_panel" in self._read()
+
+    def test_mentions_chat_panel(self) -> None:
+        """AGENTS.md must reference the React/Tauri ChatPanel surface."""
+        assert "ChatPanel" in self._read()
+
+    def test_has_sidekick_section_heading(self) -> None:
+        """AGENTS.md must have a dedicated Sidekick section."""
+        content = self._read()
+        # Accept either a Markdown heading or a bold label inside an existing section
+        assert "Sidekick" in content and ("##" in content or "**Sidekick" in content)
+
+
+# ---------------------------------------------------------------------------
+# docs/development/embedding_a_tool.md — must reference Sidekick
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingAToolSidekick:
+    """embedding_a_tool.md must reference Sidekick as a worked example."""
+
+    def _read(self) -> str:
+        path = _REPO_ROOT / "docs" / "development" / "embedding_a_tool.md"
+        assert path.exists(), "docs/development/embedding_a_tool.md must exist"
+        return path.read_text(encoding="utf-8")
+
+    def test_mentions_sidekick(self) -> None:
+        """embedding_a_tool.md must mention 'Sidekick'."""
+        assert "Sidekick" in self._read()
+
+    def test_mentions_sidekick_adapter(self) -> None:
+        """embedding_a_tool.md must reference the Sidekick embed adapter."""
+        assert "_embed_adapter" in self._read()
+
+    def test_mentions_prefers_dock(self) -> None:
+        """embedding_a_tool.md must document prefers_dock for Sidekick tools."""
+        assert "prefers_dock" in self._read()
+
+
+# ---------------------------------------------------------------------------
+# SPEC.md — must have a Sidekick entry in the tool inventory
+# ---------------------------------------------------------------------------
+
+
+class TestSpecMdSidekick:
+    """SPEC.md must have a Sidekick row in the Key Components table."""
+
+    def _read(self) -> str:
+        path = _REPO_ROOT / "SPEC.md"
+        assert path.exists(), "SPEC.md must exist at the repo root"
+        return path.read_text(encoding="utf-8")
+
+    def test_has_sidekick_row(self) -> None:
+        """SPEC.md Key Components table must contain a 'Sidekick' row."""
+        assert "Sidekick" in self._read()
+
+    def test_sidekick_row_has_correct_paths(self) -> None:
+        """SPEC.md Sidekick row must reference the PyQt panel path."""
+        content = self._read()
+        assert "ai/gui/assistant" in content or "assistant_panel" in content
+
+    def test_spec_mentions_sidekick_feature(self) -> None:
+        """SPEC.md Feature Status table must mention Sidekick."""
+        content = self._read()
+        # Either as a feature row (Fxx) or as part of the component table
+        assert content.count("Sidekick") >= 2
+
+
+# ---------------------------------------------------------------------------
+# docs/sidekick/README.md — must exist with required content
+# ---------------------------------------------------------------------------
+
+
+class TestSidekickReadme:
+    """docs/sidekick/README.md must exist and contain the key sections."""
+
+    def _read(self) -> str:
+        path = _REPO_ROOT / "docs" / "sidekick" / "README.md"
+        assert path.exists(), (
+            "docs/sidekick/README.md must exist; "
+            "create it per the acceptance criteria in issue #5465"
+        )
+        return path.read_text(encoding="utf-8")
+
+    def test_readme_exists(self) -> None:
+        """docs/sidekick/README.md must exist."""
+        path = _REPO_ROOT / "docs" / "sidekick" / "README.md"
+        assert path.exists()
+
+    def test_mentions_sidekick(self) -> None:
+        """README.md must mention 'Sidekick'."""
+        assert "Sidekick" in self._read()
+
+    def test_describes_pyqt_surface(self) -> None:
+        """README.md must describe the PyQt launcher panel."""
+        content = self._read()
+        assert "AIAssistantPanel" in content or "PyQt" in content
+
+    def test_describes_react_surface(self) -> None:
+        """README.md must describe the React/Tauri chat surface."""
+        content = self._read()
+        assert "ChatPanel" in content or "React" in content or "Tauri" in content
+
+    def test_describes_design_tokens(self) -> None:
+        """README.md must document the design-token contract."""
+        content = self._read()
+        assert "sidekick_tokens" in content or "design token" in content.lower()
+
+    def test_describes_agentic_tools(self) -> None:
+        """README.md must explain how to add agentic tools."""
+        content = self._read()
+        assert "tool" in content.lower()
+
+    def test_describes_embedding_path(self) -> None:
+        """README.md must describe how to embed Sidekick as a launcher tile."""
+        content = self._read()
+        assert "embed" in content.lower() or "_embed_adapter" in content


### PR DESCRIPTION
## Summary

- Creates `docs/sidekick/README.md` — user-facing one-pager covering both chat surfaces (PyQt `AIAssistantPanel` + React `ChatPanel`), design-token contract, chat context bridge, adding agentic tools, and the `EmbeddableTool` embedding path with ASCII layout diagram
- Updates `SPEC.md` Key Components row for Sidekick with correct canonical paths and adds F15 Sidekick entry to the Feature Status table
- Adds 18 TDD tests in `tests/unit/repo_hygiene/test_sidekick_docs.py` that guard against accidental deletion of Sidekick docs in AGENTS.md, embedding_a_tool.md, SPEC.md, and docs/sidekick/README.md
- `AGENTS.md` and `docs/development/embedding_a_tool.md` already contain the required Sidekick sections (added in prior fleet work) — no further changes needed

## Test plan

- [x] `python -m pytest tests/unit/repo_hygiene/test_sidekick_docs.py -v` — 18 passed
- [x] `ruff check` and `ruff format` — clean

Closes #5465

🤖 Generated with [Claude Code](https://claude.com/claude-code)