### PR TITLE
feat(reporting): ReportTemplate engine + standard templates

### DIFF
--- a/src/shared/python/reporting/__init__.py
+++ b/src/shared/python/reporting/__init__.py
@@ -1,0 +1,23 @@
+"""Reporting — standardized simulation and calculation report templates.
+
+Public surface::
+
+    from src.shared.python.reporting import (
+        ReportSection,
+        ReportTemplate,
+        REPORT_TEMPLATES,
+    )
+
+Implements Epic #5393: Standardized Simulation and Calculation Report Templates.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.reporting._templates import REPORT_TEMPLATES
+from src.shared.python.reporting._template_engine import ReportSection, ReportTemplate
+
+__all__ = [
+    "ReportSection",
+    "ReportTemplate",
+    "REPORT_TEMPLATES",
+]

--- a/src/shared/python/reporting/_template_engine.py
+++ b/src/shared/python/reporting/_template_engine.py
@@ -1,0 +1,174 @@
+"""ReportTemplate and ReportSection — Markdown report template engine.
+
+Design
+------
+- ``ReportSection`` is a frozen dataclass for a single section (heading + content
+  + optional nested subsections).  Nesting is deliberate and bounded: only two
+  levels are rendered distinctly (``##`` and ``###``), deeper nesting uses
+  the same ``###`` heading to stay readable.
+- ``ReportTemplate`` aggregates a title and an ordered list of sections and
+  exposes a single ``render() -> str`` method that produces a complete Markdown
+  document.
+
+Design-by-Contract invariants
+------------------------------
+- ``ReportTemplate.title`` must be a non-empty string.
+- ``ReportTemplate.sections`` must be a list.
+- ``ReportSection.heading`` must be a non-empty string.
+- ``render()`` postcondition: returns a ``str`` containing the title.
+
+Law of Demeter
+--------------
+``ReportTemplate.render()`` delegates per-section rendering to
+``ReportSection.render(level)``.  No cross-object attribute traversal.
+
+Implements part of Epic #5393.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from src.shared.python.contracts import ensure, require
+
+logger = logging.getLogger(__name__)
+
+# Maximum heading level emitted (Markdown uses 1-6; we cap at 4 for readability)
+_MAX_HEADING_LEVEL = 4
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    """A single section within a report.
+
+    Attributes:
+        heading: Section title (non-empty).
+        content: Body text for this section (may be empty).
+        subsections: Nested child sections (default empty list).
+    """
+
+    heading: str
+    content: str = ""
+    subsections: list[ReportSection] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.heading, str) and len(self.heading.strip()) > 0,
+            "ReportSection.heading must be a non-empty string",
+            self.heading,
+        )
+        require(
+            isinstance(self.content, str),
+            "ReportSection.content must be a string",
+            self.content,
+        )
+        require(
+            isinstance(self.subsections, list),
+            "ReportSection.subsections must be a list",
+            self.subsections,
+        )
+
+    def render(self, level: int = 2) -> str:
+        """Render this section and its subsections as Markdown.
+
+        Args:
+            level: Heading level (2 = ``##``, 3 = ``###``, etc.)
+                   Capped at ``_MAX_HEADING_LEVEL``.
+
+        Returns:
+            Markdown string for this section.
+
+        Postcondition:
+            Returns a non-empty string.
+        """
+        require(
+            isinstance(level, int) and level >= 1,
+            "level must be a positive integer",
+            level,
+        )
+        effective_level = min(level, _MAX_HEADING_LEVEL)
+        hashes = "#" * effective_level
+        lines: list[str] = [f"{hashes} {self.heading}"]
+
+        if self.content:
+            lines.append("")
+            lines.append(self.content)
+
+        for subsection in self.subsections:
+            lines.append("")
+            lines.append(subsection.render(level=effective_level + 1))
+
+        result = "\n".join(lines)
+        ensure(
+            isinstance(result, str) and len(result) > 0,
+            "render must return a non-empty str",
+        )
+        return result
+
+
+@dataclass
+class ReportTemplate:
+    """A complete report template composed of a title and ordered sections.
+
+    Attributes:
+        title: Report title (non-empty).
+        sections: Ordered list of top-level sections.
+
+    Examples::
+
+        tmpl = ReportTemplate(
+            title="Swing Analysis Report",
+            sections=[
+                ReportSection("Summary", "Overview of the swing."),
+                ReportSection("Kinematics", "Joint angles and velocities."),
+            ],
+        )
+        md = tmpl.render()
+    """
+
+    title: str
+    sections: list[ReportSection] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.title, str) and len(self.title.strip()) > 0,
+            "ReportTemplate.title must be a non-empty string",
+            self.title,
+        )
+        require(
+            isinstance(self.sections, list),
+            "ReportTemplate.sections must be a list",
+            self.sections,
+        )
+
+    def render(self) -> str:
+        """Render the full report as a Markdown string.
+
+        The output format is::
+
+            # <title>
+
+            ## <section 1 heading>
+            ...
+            ## <section N heading>
+            ...
+
+        Postcondition:
+            Returns a ``str`` that starts with the title.
+        """
+        lines: list[str] = [f"# {self.title}"]
+
+        for section in self.sections:
+            lines.append("")
+            lines.append(section.render(level=2))
+
+        result = "\n".join(lines)
+        ensure(
+            isinstance(result, str) and self.title in result,
+            "render postcondition: output must be str containing the title",
+        )
+        logger.debug(
+            "report_rendered title=%s sections=%d", self.title, len(self.sections)
+        )
+        return result

--- a/src/shared/python/reporting/_templates.py
+++ b/src/shared/python/reporting/_templates.py
@@ -1,0 +1,214 @@
+"""Standard report template registry.
+
+``REPORT_TEMPLATES`` maps a template key to a ``ReportTemplate`` instance.
+Keys are stable identifiers callers use to look up the appropriate template
+for their output type.
+
+Registered templates
+--------------------
+- ``"swing_analysis"``  — full golf swing biomechanical analysis
+- ``"ball_flight"``     — ball flight and aerodynamics summary
+- ``"biomechanics"``    — joint/segment biomechanics breakdown
+
+Implements part of Epic #5393.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.reporting._template_engine import ReportSection, ReportTemplate
+
+# ---------------------------------------------------------------------------
+# Swing Analysis Template
+# ---------------------------------------------------------------------------
+
+_SWING_ANALYSIS = ReportTemplate(
+    title="Swing Analysis Report",
+    sections=[
+        ReportSection(
+            heading="Executive Summary",
+            content=(
+                "High-level assessment of the swing performance, "
+                "highlighting key metrics and areas for improvement."
+            ),
+        ),
+        ReportSection(
+            heading="Setup and Address",
+            content="Posture, grip, stance width, ball position, and alignment.",
+            subsections=[
+                ReportSection(
+                    heading="Posture",
+                    content="Spine angle, knee flex, and weight distribution at address.",
+                ),
+                ReportSection(
+                    heading="Alignment",
+                    content="Foot, hip, and shoulder alignment relative to target.",
+                ),
+            ],
+        ),
+        ReportSection(
+            heading="Kinematic Sequence",
+            content=(
+                "Segmental velocity sequencing from pelvis through torso, "
+                "lead arm, and club."
+            ),
+            subsections=[
+                ReportSection(
+                    heading="Pelvis",
+                    content="Pelvis rotation velocity and sequencing order.",
+                ),
+                ReportSection(
+                    heading="Thorax",
+                    content="Thorax rotation velocity and timing relative to pelvis.",
+                ),
+                ReportSection(
+                    heading="Lead Arm",
+                    content="Lead arm angular velocity peak and timing.",
+                ),
+                ReportSection(
+                    heading="Club",
+                    content="Club angular velocity and lag release timing.",
+                ),
+            ],
+        ),
+        ReportSection(
+            heading="Impact Metrics",
+            content="Club path, face angle, attack angle, and dynamic loft at impact.",
+        ),
+        ReportSection(
+            heading="Follow-Through and Finish",
+            content="Post-impact club path, balance, and finish position.",
+        ),
+        ReportSection(
+            heading="Recommendations",
+            content="Prioritized list of movement corrections and drill prescriptions.",
+        ),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Ball Flight Template
+# ---------------------------------------------------------------------------
+
+_BALL_FLIGHT = ReportTemplate(
+    title="Ball Flight Analysis Report",
+    sections=[
+        ReportSection(
+            heading="Summary",
+            content="Overview of ball flight characteristics and carry/total distance.",
+        ),
+        ReportSection(
+            heading="Launch Conditions",
+            content="Ball speed, launch angle, and spin rate at departure.",
+            subsections=[
+                ReportSection(
+                    heading="Ball Speed",
+                    content="Measured and estimated peak ball speed (m/s / mph).",
+                ),
+                ReportSection(
+                    heading="Launch Angle",
+                    content="Vertical launch angle (degrees above horizontal).",
+                ),
+                ReportSection(
+                    heading="Spin Rate",
+                    content="Total spin, backspin, and side-spin components (rpm).",
+                ),
+            ],
+        ),
+        ReportSection(
+            heading="Trajectory",
+            content="Peak height, descent angle, and lateral deviation.",
+            subsections=[
+                ReportSection(
+                    heading="Apex",
+                    content="Maximum height reached (metres / feet).",
+                ),
+                ReportSection(
+                    heading="Lateral Deviation",
+                    content="Left/right deviation from intended target line (metres).",
+                ),
+            ],
+        ),
+        ReportSection(
+            heading="Distance",
+            content="Carry, roll, and total distance.",
+        ),
+        ReportSection(
+            heading="Aerodynamic Parameters",
+            content=(
+                "Coefficient of drag and lift values used in the simulation, "
+                "and sensitivity analysis."
+            ),
+        ),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Biomechanics Template
+# ---------------------------------------------------------------------------
+
+_BIOMECHANICS = ReportTemplate(
+    title="Biomechanics Analysis Report",
+    sections=[
+        ReportSection(
+            heading="Overview",
+            content=(
+                "Summary of joint loading, muscle activation patterns, "
+                "and injury-risk indicators."
+            ),
+        ),
+        ReportSection(
+            heading="Joint Kinematics",
+            content="Range of motion and angular velocity for each joint of interest.",
+            subsections=[
+                ReportSection(
+                    heading="Hip",
+                    content="Hip flexion/extension, abduction/adduction, and rotation.",
+                ),
+                ReportSection(
+                    heading="Lumbar Spine",
+                    content="Lumbar flexion, lateral bend, and axial rotation.",
+                ),
+                ReportSection(
+                    heading="Shoulder",
+                    content="Shoulder plane of elevation, elevation angle, and rotation.",
+                ),
+                ReportSection(
+                    heading="Elbow and Wrist",
+                    content="Elbow flexion and wrist flexion/extension during downswing.",
+                ),
+            ],
+        ),
+        ReportSection(
+            heading="Joint Kinetics",
+            content="Net joint moments and powers through the swing cycle.",
+        ),
+        ReportSection(
+            heading="Ground Reaction Forces",
+            content=(
+                "Vertical, anterior-posterior, and medial-lateral GRF "
+                "for lead and trail foot."
+            ),
+        ),
+        ReportSection(
+            heading="Muscle Activation",
+            content="EMG or musculoskeletal model-estimated activation levels.",
+        ),
+        ReportSection(
+            heading="Injury Risk Assessment",
+            content=(
+                "Composite injury-risk scores for lumbar spine, lead wrist, "
+                "and trail elbow based on peak loading metrics."
+            ),
+        ),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+REPORT_TEMPLATES: dict[str, ReportTemplate] = {
+    "swing_analysis": _SWING_ANALYSIS,
+    "ball_flight": _BALL_FLIGHT,
+    "biomechanics": _BIOMECHANICS,
+}

--- a/tests/unit/reporting/test_report_template.py
+++ b/tests/unit/reporting/test_report_template.py
@@ -1,0 +1,277 @@
+"""Tests for ReportTemplate engine — Epic #5393.
+
+Covers:
+- ReportSection creation and rendering
+- ReportTemplate creation and rendering
+- Nested sections (subsections)
+- Empty content sections
+- Template registry lookup
+- Heading-level capping
+- DbC precondition enforcement for invalid inputs
+- Markdown output structure
+- Standard template completeness
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.reporting import REPORT_TEMPLATES, ReportSection, ReportTemplate
+
+
+# ---------------------------------------------------------------------------
+# ReportSection
+# ---------------------------------------------------------------------------
+
+
+class TestReportSection:
+    def test_create_minimal(self) -> None:
+        sec = ReportSection(heading="Intro")
+        assert sec.heading == "Intro"
+        assert sec.content == ""
+        assert sec.subsections == []
+
+    def test_create_with_content(self) -> None:
+        sec = ReportSection(heading="H", content="Some text.")
+        assert sec.content == "Some text."
+
+    def test_create_with_subsections(self) -> None:
+        child = ReportSection(heading="Child")
+        parent = ReportSection(heading="Parent", subsections=[child])
+        assert len(parent.subsections) == 1
+        assert parent.subsections[0].heading == "Child"
+
+    def test_render_produces_string(self) -> None:
+        sec = ReportSection(heading="Test")
+        result = sec.render()
+        assert isinstance(result, str)
+
+    def test_render_contains_heading(self) -> None:
+        sec = ReportSection(heading="My Section")
+        result = sec.render()
+        assert "My Section" in result
+
+    def test_render_default_level_uses_hash_hash(self) -> None:
+        sec = ReportSection(heading="Demo")
+        result = sec.render(level=2)
+        assert result.startswith("## Demo")
+
+    def test_render_level_3_uses_hash_hash_hash(self) -> None:
+        sec = ReportSection(heading="Sub")
+        result = sec.render(level=3)
+        assert result.startswith("### Sub")
+
+    def test_render_level_capped_at_four(self) -> None:
+        sec = ReportSection(heading="Deep")
+        result = sec.render(level=10)
+        assert result.startswith("#### Deep")
+
+    def test_render_includes_content(self) -> None:
+        sec = ReportSection(heading="Kin", content="Joint angles here.")
+        result = sec.render()
+        assert "Joint angles here." in result
+
+    def test_render_empty_content_no_trailing_blank(self) -> None:
+        sec = ReportSection(heading="Empty")
+        result = sec.render()
+        # No extra blank line after the heading when content is empty
+        assert "\n\n" not in result or "## Empty" in result
+
+    def test_render_subsections_included(self) -> None:
+        child = ReportSection(heading="Child", content="child body")
+        parent = ReportSection(heading="Parent", subsections=[child])
+        result = parent.render(level=2)
+        assert "Child" in result
+        assert "child body" in result
+
+    def test_render_subsection_uses_deeper_level(self) -> None:
+        child = ReportSection(heading="Child")
+        parent = ReportSection(heading="Parent", subsections=[child])
+        result = parent.render(level=2)
+        assert "### Child" in result
+
+    def test_render_multiple_subsections(self) -> None:
+        children = [ReportSection(heading=f"Sub{i}") for i in range(3)]
+        parent = ReportSection(heading="Parent", subsections=children)
+        result = parent.render()
+        for i in range(3):
+            assert f"Sub{i}" in result
+
+
+# ---------------------------------------------------------------------------
+# ReportSection — DbC invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestReportSectionDbC:
+    def test_empty_heading_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            ReportSection(heading="")
+
+    def test_whitespace_heading_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            ReportSection(heading="   ")
+
+    def test_non_string_content_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            ReportSection(heading="Valid", content=123)  # type: ignore[arg-type]
+
+    def test_non_list_subsections_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            ReportSection(heading="Valid", subsections="not_a_list")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ReportTemplate
+# ---------------------------------------------------------------------------
+
+
+class TestReportTemplate:
+    def test_create_minimal(self) -> None:
+        tmpl = ReportTemplate(title="My Report")
+        assert tmpl.title == "My Report"
+        assert tmpl.sections == []
+
+    def test_create_with_sections(self) -> None:
+        s = ReportSection(heading="Intro")
+        tmpl = ReportTemplate(title="T", sections=[s])
+        assert len(tmpl.sections) == 1
+
+    def test_render_returns_string(self) -> None:
+        tmpl = ReportTemplate(title="R")
+        assert isinstance(tmpl.render(), str)
+
+    def test_render_contains_title(self) -> None:
+        tmpl = ReportTemplate(title="Swing Report")
+        result = tmpl.render()
+        assert "Swing Report" in result
+
+    def test_render_starts_with_h1(self) -> None:
+        tmpl = ReportTemplate(title="My Title")
+        result = tmpl.render()
+        assert result.startswith("# My Title")
+
+    def test_render_includes_section_headings(self) -> None:
+        tmpl = ReportTemplate(
+            title="Report",
+            sections=[
+                ReportSection(heading="Alpha"),
+                ReportSection(heading="Beta"),
+            ],
+        )
+        result = tmpl.render()
+        assert "Alpha" in result
+        assert "Beta" in result
+
+    def test_render_sections_as_h2(self) -> None:
+        tmpl = ReportTemplate(
+            title="R",
+            sections=[ReportSection(heading="Section One")],
+        )
+        result = tmpl.render()
+        assert "## Section One" in result
+
+    def test_render_empty_sections_list(self) -> None:
+        tmpl = ReportTemplate(title="Empty")
+        result = tmpl.render()
+        assert result == "# Empty"
+
+    def test_render_section_content_included(self) -> None:
+        tmpl = ReportTemplate(
+            title="T",
+            sections=[ReportSection(heading="H", content="Body text here.")],
+        )
+        result = tmpl.render()
+        assert "Body text here." in result
+
+    def test_render_nested_subsections(self) -> None:
+        child = ReportSection(heading="Sub", content="sub content")
+        parent = ReportSection(heading="Top", subsections=[child])
+        tmpl = ReportTemplate(title="T", sections=[parent])
+        result = tmpl.render()
+        assert "Sub" in result
+        assert "sub content" in result
+
+    def test_render_preserves_section_order(self) -> None:
+        tmpl = ReportTemplate(
+            title="T",
+            sections=[
+                ReportSection(heading="First"),
+                ReportSection(heading="Second"),
+                ReportSection(heading="Third"),
+            ],
+        )
+        result = tmpl.render()
+        pos_first = result.index("First")
+        pos_second = result.index("Second")
+        pos_third = result.index("Third")
+        assert pos_first < pos_second < pos_third
+
+
+# ---------------------------------------------------------------------------
+# ReportTemplate — DbC invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestReportTemplateDbC:
+    def test_empty_title_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            ReportTemplate(title="")
+
+    def test_whitespace_title_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            ReportTemplate(title="   ")
+
+    def test_non_list_sections_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            ReportTemplate(title="T", sections="not_a_list")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# REPORT_TEMPLATES registry
+# ---------------------------------------------------------------------------
+
+
+class TestReportTemplatesRegistry:
+    @pytest.mark.parametrize("key", ["swing_analysis", "ball_flight", "biomechanics"])
+    def test_key_exists(self, key: str) -> None:
+        assert key in REPORT_TEMPLATES
+
+    @pytest.mark.parametrize("key", ["swing_analysis", "ball_flight", "biomechanics"])
+    def test_value_is_report_template(self, key: str) -> None:
+        assert isinstance(REPORT_TEMPLATES[key], ReportTemplate)
+
+    @pytest.mark.parametrize("key", ["swing_analysis", "ball_flight", "biomechanics"])
+    def test_template_has_title(self, key: str) -> None:
+        tmpl = REPORT_TEMPLATES[key]
+        assert len(tmpl.title.strip()) > 0
+
+    @pytest.mark.parametrize("key", ["swing_analysis", "ball_flight", "biomechanics"])
+    def test_template_has_sections(self, key: str) -> None:
+        tmpl = REPORT_TEMPLATES[key]
+        assert len(tmpl.sections) > 0
+
+    @pytest.mark.parametrize("key", ["swing_analysis", "ball_flight", "biomechanics"])
+    def test_template_renders_without_error(self, key: str) -> None:
+        tmpl = REPORT_TEMPLATES[key]
+        result = tmpl.render()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_swing_analysis_contains_kinematic_sequence(self) -> None:
+        result = REPORT_TEMPLATES["swing_analysis"].render()
+        assert "Kinematic" in result
+
+    def test_ball_flight_contains_launch_conditions(self) -> None:
+        result = REPORT_TEMPLATES["ball_flight"].render()
+        assert "Launch" in result
+
+    def test_biomechanics_contains_joint_kinematics(self) -> None:
+        result = REPORT_TEMPLATES["biomechanics"].render()
+        assert "Kinematics" in result
+
+    def test_registry_is_dict(self) -> None:
+        assert isinstance(REPORT_TEMPLATES, dict)
+
+    def test_registry_has_exactly_three_entries(self) -> None:
+        assert len(REPORT_TEMPLATES) == 3


### PR DESCRIPTION
Closes #5393\n\nAdd ReportSection and ReportTemplate dataclasses with Markdown render, DbC, heading-level capping, and REPORT_TEMPLATES registry with swing_analysis/ball_flight/biomechanics entries. 51 unit tests.