### PR TITLE
feat(diagnostics): DiagnosticsCollector + history ring-buffer

### DIFF
--- a/src/shared/python/diagnostics/__init__.py
+++ b/src/shared/python/diagnostics/__init__.py
@@ -1,0 +1,32 @@
+"""Diagnostics — system and simulation health monitoring.
+
+Public surface::
+
+    from src.shared.python.diagnostics import (
+        DiagnosticsCollector,
+        DiagnosticsSnapshot,
+        DiagnosticsHistory,
+        SystemMetrics,
+        SimulationMetrics,
+    )
+
+Implements Epic #5698 (first child): DiagnosticsCollector + history ring-buffer.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.diagnostics._collector import DiagnosticsCollector
+from src.shared.python.diagnostics._history import DiagnosticsHistory
+from src.shared.python.diagnostics._snapshot import (
+    DiagnosticsSnapshot,
+    SimulationMetrics,
+    SystemMetrics,
+)
+
+__all__ = [
+    "DiagnosticsCollector",
+    "DiagnosticsHistory",
+    "DiagnosticsSnapshot",
+    "SimulationMetrics",
+    "SystemMetrics",
+]

--- a/src/shared/python/diagnostics/_collector.py
+++ b/src/shared/python/diagnostics/_collector.py
@@ -1,0 +1,200 @@
+"""DiagnosticsCollector — collect a DiagnosticsSnapshot on demand.
+
+The collector attempts to gather system metrics via ``psutil`` (optional
+dependency) and GPU metrics via ``GPUtil`` (optional dependency).  When
+a dependency is absent the corresponding metric falls back to ``-1`` /
+``-1.0`` so callers can always rely on a valid ``DiagnosticsSnapshot``.
+
+Design-by-Contract invariants
+------------------------------
+- ``collect()`` postcondition: always returns a ``DiagnosticsSnapshot``.
+- ``active_simulations`` callback (if provided) must be callable and must
+  return an ``int``.
+
+Law of Demeter
+--------------
+``DiagnosticsCollector`` delegates system metric gathering to private
+helper functions (``_collect_system_metrics``, ``_collect_simulation_metrics``).
+It never reaches through ``psutil`` sub-objects more than one level.
+
+Implements part of Epic #5698.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from src.shared.python.contracts import ensure, require
+from src.shared.python.diagnostics._snapshot import (
+    DiagnosticsSnapshot,
+    SimulationMetrics,
+    SystemMetrics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers — LOD boundary
+# ---------------------------------------------------------------------------
+
+
+def _try_import_psutil() -> Any:
+    """Return the ``psutil`` module or ``None`` if not installed."""
+    try:
+        import psutil  # type: ignore[import-not-found]
+
+        return psutil
+    except ImportError:
+        return None
+
+
+def _try_import_gputil() -> Any:
+    """Return the ``GPUtil`` module or ``None`` if not installed."""
+    try:
+        import GPUtil  # type: ignore[import-not-found]
+
+        return GPUtil
+    except ImportError:
+        return None
+
+
+def _collect_system_metrics(psutil_mod: Any, gputil_mod: Any) -> SystemMetrics:
+    """Gather system resource metrics, returning safe defaults on failure."""
+    cpu_percent: float = -1.0
+    memory_used_mb: float = -1.0
+    memory_total_mb: float = -1.0
+    memory_percent: float = -1.0
+    gpu_percent: float = -1.0
+    open_file_handles: int = -1
+
+    if psutil_mod is not None:
+        try:
+            cpu_percent = float(psutil_mod.cpu_percent(interval=None))
+        except Exception:  # noqa: BLE001
+            logger.debug("diagnostics: cpu_percent unavailable")
+
+        try:
+            vm = psutil_mod.virtual_memory()
+            memory_used_mb = vm.used / (1024 * 1024)
+            memory_total_mb = vm.total / (1024 * 1024)
+            memory_percent = float(vm.percent)
+        except Exception:  # noqa: BLE001
+            logger.debug("diagnostics: virtual_memory unavailable")
+
+        try:
+            proc = psutil_mod.Process()
+            open_file_handles = proc.num_fds()
+        except AttributeError:
+            # Windows: num_fds() is not available; use num_handles() instead
+            try:
+                proc = psutil_mod.Process()
+                open_file_handles = proc.num_handles()
+            except Exception:  # noqa: BLE001
+                logger.debug("diagnostics: open_file_handles unavailable")
+        except Exception:  # noqa: BLE001
+            logger.debug("diagnostics: open_file_handles unavailable")
+
+    if gputil_mod is not None:
+        try:
+            gpus = gputil_mod.getGPUs()
+            if gpus:
+                gpu_percent = float(gpus[0].load * 100)
+        except Exception:  # noqa: BLE001
+            logger.debug("diagnostics: GPU metrics unavailable")
+
+    return SystemMetrics(
+        cpu_percent=cpu_percent,
+        memory_used_mb=memory_used_mb,
+        memory_total_mb=memory_total_mb,
+        memory_percent=memory_percent,
+        gpu_percent=gpu_percent,
+        open_file_handles=open_file_handles,
+    )
+
+
+def _collect_simulation_metrics(
+    active_simulations_fn: Callable[[], int] | None,
+) -> SimulationMetrics:
+    """Gather simulation subsystem metrics."""
+    active: int = -1
+
+    if active_simulations_fn is not None:
+        try:
+            active = int(active_simulations_fn())
+        except Exception:  # noqa: BLE001
+            logger.debug("diagnostics: active_simulations_fn raised")
+
+    return SimulationMetrics(active_simulations=active)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class DiagnosticsCollector:
+    """Collect a point-in-time ``DiagnosticsSnapshot``.
+
+    Args:
+        active_simulations_fn: Optional zero-argument callable that returns
+            the number of currently active simulations.  When ``None`` the
+            ``active_simulations`` field in the snapshot will be ``-1``.
+
+    Examples::
+
+        collector = DiagnosticsCollector()
+        snapshot = collector.collect()
+        print(snapshot.system_metrics.cpu_percent)
+    """
+
+    def __init__(
+        self,
+        active_simulations_fn: Callable[[], int] | None = None,
+    ) -> None:
+        if active_simulations_fn is not None:
+            require(
+                callable(active_simulations_fn),
+                "active_simulations_fn must be callable",
+                active_simulations_fn,
+            )
+        self._active_simulations_fn = active_simulations_fn
+        self._psutil = _try_import_psutil()
+        self._gputil = _try_import_gputil()
+        logger.debug(
+            "diagnostics_collector_created psutil=%s gputil=%s",
+            self._psutil is not None,
+            self._gputil is not None,
+        )
+
+    def collect(self) -> DiagnosticsSnapshot:
+        """Capture and return a diagnostics snapshot.
+
+        Postcondition:
+            Returns a ``DiagnosticsSnapshot`` instance.
+
+        Returns:
+            Immutable snapshot of current system and simulation state.
+        """
+        timestamp = datetime.now(tz=timezone.utc)
+        system_metrics = _collect_system_metrics(self._psutil, self._gputil)
+        simulation_metrics = _collect_simulation_metrics(self._active_simulations_fn)
+
+        snapshot = DiagnosticsSnapshot(
+            timestamp=timestamp,
+            system_metrics=system_metrics,
+            simulation_metrics=simulation_metrics,
+        )
+        ensure(
+            isinstance(snapshot, DiagnosticsSnapshot),
+            "collect postcondition: must return DiagnosticsSnapshot",
+        )
+        logger.debug(
+            "diagnostics_snapshot_collected ts=%s cpu=%.1f%%",
+            snapshot.timestamp.isoformat(),
+            snapshot.system_metrics.cpu_percent,
+        )
+        return snapshot

--- a/src/shared/python/diagnostics/_history.py
+++ b/src/shared/python/diagnostics/_history.py
@@ -1,0 +1,148 @@
+"""DiagnosticsHistory — ring-buffer of recent DiagnosticsSnapshot instances.
+
+The ring-buffer has a fixed capacity (default 100).  When full, the oldest
+snapshot is evicted automatically.  All operations are O(1) amortised thanks
+to ``collections.deque`` with ``maxlen``.
+
+Design-by-Contract invariants
+------------------------------
+- ``capacity`` must be a positive integer.
+- ``record(snapshot)`` precondition: ``snapshot`` must be a ``DiagnosticsSnapshot``.
+- ``get_recent(n)`` postcondition: returns a ``list`` of at most ``min(n, len)`` items.
+- ``len(history) <= capacity`` is always maintained.
+
+Implements part of Epic #5698.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+
+from src.shared.python.contracts import ensure, require
+from src.shared.python.diagnostics._snapshot import DiagnosticsSnapshot
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CAPACITY = 100
+
+
+class DiagnosticsHistory:
+    """Fixed-capacity ring-buffer of ``DiagnosticsSnapshot`` instances.
+
+    Args:
+        capacity: Maximum number of snapshots to retain.  Defaults to 100.
+            Older snapshots are silently evicted when capacity is exceeded.
+
+    Examples::
+
+        history = DiagnosticsHistory(capacity=10)
+        for snapshot in stream:
+            history.record(snapshot)
+        recent = history.get_recent(5)
+    """
+
+    def __init__(self, capacity: int = _DEFAULT_CAPACITY) -> None:
+        require(
+            isinstance(capacity, int) and capacity > 0,
+            "capacity must be a positive integer",
+            capacity,
+        )
+        self._capacity = capacity
+        self._buffer: deque[DiagnosticsSnapshot] = deque(maxlen=capacity)
+        logger.debug("diagnostics_history_created capacity=%d", capacity)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def capacity(self) -> int:
+        """Maximum number of snapshots retained."""
+        return self._capacity
+
+    def __len__(self) -> int:
+        """Return the number of snapshots currently stored."""
+        return len(self._buffer)
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def record(self, snapshot: DiagnosticsSnapshot) -> None:
+        """Append *snapshot* to the history, evicting the oldest if full.
+
+        Preconditions:
+            - ``snapshot`` must be a ``DiagnosticsSnapshot``.
+
+        Postcondition:
+            ``len(self) <= self.capacity``.
+
+        Args:
+            snapshot: The snapshot to record.
+        """
+        require(
+            isinstance(snapshot, DiagnosticsSnapshot),
+            "snapshot must be a DiagnosticsSnapshot",
+            snapshot,
+        )
+        self._buffer.append(snapshot)
+        ensure(
+            len(self._buffer) <= self._capacity,
+            "record postcondition: len must not exceed capacity",
+        )
+        logger.debug(
+            "diagnostics_recorded ts=%s size=%d",
+            snapshot.timestamp.isoformat(),
+            len(self._buffer),
+        )
+
+    def clear(self) -> None:
+        """Remove all snapshots from the history."""
+        self._buffer.clear()
+        logger.debug("diagnostics_history_cleared")
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_recent(self, n: int) -> list[DiagnosticsSnapshot]:
+        """Return up to the *n* most-recent snapshots, newest last.
+
+        Preconditions:
+            - ``n`` must be a non-negative integer.
+
+        Postcondition:
+            - Returns a ``list``.
+            - ``len(result) <= min(n, len(self))``.
+
+        Args:
+            n: Maximum number of snapshots to return.
+
+        Returns:
+            List of at most *n* snapshots in chronological order (oldest first).
+        """
+        require(
+            isinstance(n, int) and n >= 0,
+            "n must be a non-negative integer",
+            n,
+        )
+        items = list(self._buffer)
+        result = items[-n:] if n > 0 else []
+        ensure(
+            isinstance(result, list),
+            "get_recent postcondition: must return a list",
+        )
+        ensure(
+            len(result) <= min(n, len(self._buffer)),
+            "get_recent postcondition: len(result) must be <= min(n, len(history))",
+        )
+        return result
+
+    def get_all(self) -> list[DiagnosticsSnapshot]:
+        """Return all stored snapshots in chronological order (oldest first).
+
+        Returns:
+            List of all snapshots.
+        """
+        return list(self._buffer)

--- a/src/shared/python/diagnostics/_snapshot.py
+++ b/src/shared/python/diagnostics/_snapshot.py
@@ -1,0 +1,143 @@
+"""DiagnosticsSnapshot and constituent metrics dataclasses.
+
+All dataclasses are frozen so snapshots are immutable value objects — safe to
+store in ring-buffers and hand across thread boundaries without defensive
+copying.
+
+Implements part of Epic #5698.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any
+
+from src.shared.python.contracts import require
+
+
+@dataclass(frozen=True)
+class SystemMetrics:
+    """Point-in-time system resource measurements.
+
+    Attributes:
+        cpu_percent: Overall CPU utilisation 0–100.  ``-1.0`` when unavailable.
+        memory_used_mb: Resident set size in megabytes.  ``-1.0`` when unavailable.
+        memory_total_mb: Total physical RAM in megabytes.  ``-1.0`` when unavailable.
+        memory_percent: Percentage of RAM in use.  ``-1.0`` when unavailable.
+        gpu_percent: GPU utilisation 0–100.  ``-1.0`` when GPU is absent/unavailable.
+        open_file_handles: Number of open file descriptors for this process.  ``-1``
+            when unavailable (e.g. Windows with missing ``psutil``).
+    """
+
+    cpu_percent: float = -1.0
+    memory_used_mb: float = -1.0
+    memory_total_mb: float = -1.0
+    memory_percent: float = -1.0
+    gpu_percent: float = -1.0
+    open_file_handles: int = -1
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.cpu_percent, (int, float)),
+            "cpu_percent must be numeric",
+            self.cpu_percent,
+        )
+        require(
+            isinstance(self.memory_used_mb, (int, float)),
+            "memory_used_mb must be numeric",
+            self.memory_used_mb,
+        )
+        require(
+            isinstance(self.open_file_handles, int),
+            "open_file_handles must be int",
+            self.open_file_handles,
+        )
+
+
+@dataclass(frozen=True)
+class SimulationMetrics:
+    """Point-in-time simulation subsystem measurements.
+
+    Attributes:
+        active_simulations: Number of currently running simulations.  ``-1``
+            when the registry is unavailable.
+        registered_engines: Total number of registered physics engine instances.
+    """
+
+    active_simulations: int = -1
+    registered_engines: int = 0
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.active_simulations, int),
+            "active_simulations must be int",
+            self.active_simulations,
+        )
+        require(
+            isinstance(self.registered_engines, int) and self.registered_engines >= 0,
+            "registered_engines must be a non-negative int",
+            self.registered_engines,
+        )
+
+
+@dataclass(frozen=True)
+class DiagnosticsSnapshot:
+    """Immutable point-in-time diagnostics capture.
+
+    Attributes:
+        timestamp: UTC datetime when the snapshot was collected.
+        system_metrics: CPU, memory, GPU, and file-handle measurements.
+        simulation_metrics: Active simulation and engine counts.
+        extra: Optional free-form metadata dict for extension points.
+    """
+
+    timestamp: datetime
+    system_metrics: SystemMetrics
+    simulation_metrics: SimulationMetrics
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.timestamp, datetime),
+            "timestamp must be a datetime",
+            self.timestamp,
+        )
+        require(
+            isinstance(self.system_metrics, SystemMetrics),
+            "system_metrics must be a SystemMetrics instance",
+            self.system_metrics,
+        )
+        require(
+            isinstance(self.simulation_metrics, SimulationMetrics),
+            "simulation_metrics must be a SimulationMetrics instance",
+            self.simulation_metrics,
+        )
+        require(
+            isinstance(self.extra, dict),
+            "extra must be a dict",
+            self.extra,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise snapshot to a plain dictionary (JSON-compatible).
+
+        Returns:
+            Dict with all fields converted to primitives.
+
+        Postcondition:
+            Result is JSON-serialisable.
+        """
+        d = asdict(self)
+        # datetime is not JSON-serialisable by default — convert to ISO 8601
+        d["timestamp"] = self.timestamp.isoformat()
+        return d
+
+    def to_json(self) -> str:
+        """Serialise snapshot to a JSON string.
+
+        Returns:
+            JSON string representation of the snapshot.
+        """
+        return json.dumps(self.to_dict())

--- a/tests/unit/diagnostics/test_diagnostics_collector.py
+++ b/tests/unit/diagnostics/test_diagnostics_collector.py
@@ -1,0 +1,392 @@
+"""Tests for DiagnosticsCollector, DiagnosticsSnapshot, DiagnosticsHistory — Epic #5698.
+
+Covers:
+- DiagnosticsSnapshot structure and fields
+- SystemMetrics and SimulationMetrics construction
+- DiagnosticsCollector.collect() return type and structure
+- active_simulations_fn callback integration
+- DiagnosticsHistory ring-buffer: record, get_recent, capacity, overflow
+- History clear / len / get_all
+- JSON serialisation roundtrip
+- DbC precondition enforcement
+- Snapshot immutability (frozen dataclass)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.diagnostics import (
+    DiagnosticsCollector,
+    DiagnosticsHistory,
+    DiagnosticsSnapshot,
+    SimulationMetrics,
+    SystemMetrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(
+    cpu: float = 10.0,
+    mem_used: float = 512.0,
+    mem_total: float = 16384.0,
+    mem_pct: float = 3.1,
+    active: int = 2,
+) -> DiagnosticsSnapshot:
+    return DiagnosticsSnapshot(
+        timestamp=datetime.now(tz=timezone.utc),
+        system_metrics=SystemMetrics(
+            cpu_percent=cpu,
+            memory_used_mb=mem_used,
+            memory_total_mb=mem_total,
+            memory_percent=mem_pct,
+        ),
+        simulation_metrics=SimulationMetrics(active_simulations=active),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SystemMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestSystemMetrics:
+    def test_defaults(self) -> None:
+        sm = SystemMetrics()
+        assert sm.cpu_percent == -1.0
+        assert sm.memory_used_mb == -1.0
+        assert sm.open_file_handles == -1
+
+    def test_create_with_values(self) -> None:
+        sm = SystemMetrics(cpu_percent=42.0, memory_used_mb=1024.0)
+        assert sm.cpu_percent == 42.0
+        assert sm.memory_used_mb == 1024.0
+
+    def test_frozen_immutable(self) -> None:
+        sm = SystemMetrics(cpu_percent=10.0)
+        with pytest.raises((AttributeError, TypeError)):
+            sm.cpu_percent = 99.0  # type: ignore[misc]
+
+    def test_invalid_cpu_type_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            SystemMetrics(cpu_percent="high")  # type: ignore[arg-type]
+
+    def test_invalid_open_file_handles_type_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            SystemMetrics(open_file_handles=3.5)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# SimulationMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationMetrics:
+    def test_defaults(self) -> None:
+        sm = SimulationMetrics()
+        assert sm.active_simulations == -1
+        assert sm.registered_engines == 0
+
+    def test_create_with_values(self) -> None:
+        sm = SimulationMetrics(active_simulations=3, registered_engines=5)
+        assert sm.active_simulations == 3
+        assert sm.registered_engines == 5
+
+    def test_negative_registered_engines_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            SimulationMetrics(registered_engines=-1)
+
+    def test_frozen_immutable(self) -> None:
+        sm = SimulationMetrics(active_simulations=2)
+        with pytest.raises((AttributeError, TypeError)):
+            sm.active_simulations = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DiagnosticsSnapshot
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsSnapshot:
+    def test_create_snapshot(self) -> None:
+        snap = _make_snapshot()
+        assert isinstance(snap.timestamp, datetime)
+        assert isinstance(snap.system_metrics, SystemMetrics)
+        assert isinstance(snap.simulation_metrics, SimulationMetrics)
+
+    def test_snapshot_is_frozen(self) -> None:
+        snap = _make_snapshot()
+        with pytest.raises((AttributeError, TypeError)):
+            snap.system_metrics = SystemMetrics()  # type: ignore[misc]
+
+    def test_extra_defaults_to_empty_dict(self) -> None:
+        snap = _make_snapshot()
+        assert snap.extra == {}
+
+    def test_extra_custom_values(self) -> None:
+        snap = DiagnosticsSnapshot(
+            timestamp=datetime.now(tz=timezone.utc),
+            system_metrics=SystemMetrics(),
+            simulation_metrics=SimulationMetrics(),
+            extra={"foo": "bar"},
+        )
+        assert snap.extra["foo"] == "bar"
+
+    def test_to_dict_returns_dict(self) -> None:
+        snap = _make_snapshot()
+        d = snap.to_dict()
+        assert isinstance(d, dict)
+
+    def test_to_dict_timestamp_is_string(self) -> None:
+        snap = _make_snapshot()
+        d = snap.to_dict()
+        assert isinstance(d["timestamp"], str)
+
+    def test_to_dict_contains_system_metrics(self) -> None:
+        snap = _make_snapshot(cpu=55.5)
+        d = snap.to_dict()
+        assert "system_metrics" in d
+        assert d["system_metrics"]["cpu_percent"] == 55.5
+
+    def test_to_json_is_valid_json(self) -> None:
+        snap = _make_snapshot()
+        raw = snap.to_json()
+        parsed = json.loads(raw)
+        assert isinstance(parsed, dict)
+
+    def test_to_json_roundtrip_cpu(self) -> None:
+        snap = _make_snapshot(cpu=77.7)
+        parsed = json.loads(snap.to_json())
+        assert parsed["system_metrics"]["cpu_percent"] == pytest.approx(77.7)
+
+    def test_invalid_timestamp_type_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            DiagnosticsSnapshot(
+                timestamp="not-a-datetime",  # type: ignore[arg-type]
+                system_metrics=SystemMetrics(),
+                simulation_metrics=SimulationMetrics(),
+            )
+
+    def test_invalid_system_metrics_type_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError, Exception)):
+            DiagnosticsSnapshot(
+                timestamp=datetime.now(tz=timezone.utc),
+                system_metrics={"cpu": 10},  # type: ignore[arg-type]
+                simulation_metrics=SimulationMetrics(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# DiagnosticsCollector
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsCollector:
+    def test_collect_returns_snapshot(self) -> None:
+        collector = DiagnosticsCollector()
+        snap = collector.collect()
+        assert isinstance(snap, DiagnosticsSnapshot)
+
+    def test_collect_timestamp_is_utc(self) -> None:
+        collector = DiagnosticsCollector()
+        snap = collector.collect()
+        assert snap.timestamp.tzinfo is not None
+
+    def test_collect_system_metrics_populated(self) -> None:
+        collector = DiagnosticsCollector()
+        snap = collector.collect()
+        assert isinstance(snap.system_metrics, SystemMetrics)
+
+    def test_collect_simulation_metrics_populated(self) -> None:
+        collector = DiagnosticsCollector()
+        snap = collector.collect()
+        assert isinstance(snap.simulation_metrics, SimulationMetrics)
+
+    def test_active_simulations_fn_used(self) -> None:
+        collector = DiagnosticsCollector(active_simulations_fn=lambda: 7)
+        snap = collector.collect()
+        assert snap.simulation_metrics.active_simulations == 7
+
+    def test_active_simulations_fn_zero(self) -> None:
+        collector = DiagnosticsCollector(active_simulations_fn=lambda: 0)
+        snap = collector.collect()
+        assert snap.simulation_metrics.active_simulations == 0
+
+    def test_active_simulations_fn_none_yields_minus_one(self) -> None:
+        collector = DiagnosticsCollector(active_simulations_fn=None)
+        snap = collector.collect()
+        assert snap.simulation_metrics.active_simulations == -1
+
+    def test_active_simulations_fn_must_be_callable(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            DiagnosticsCollector(active_simulations_fn=42)  # type: ignore[arg-type]
+
+    def test_collect_multiple_times_returns_distinct_snapshots(self) -> None:
+        collector = DiagnosticsCollector()
+        s1 = collector.collect()
+        s2 = collector.collect()
+        assert s1 is not s2
+
+    def test_failing_active_simulations_fn_falls_back_gracefully(self) -> None:
+        def bad_fn() -> int:
+            raise RuntimeError("engine unavailable")
+
+        collector = DiagnosticsCollector(active_simulations_fn=bad_fn)
+        snap = collector.collect()  # Must not raise
+        assert snap.simulation_metrics.active_simulations == -1
+
+    def test_collect_without_psutil_still_returns_snapshot(self) -> None:
+        """When psutil is unavailable the collector should degrade gracefully."""
+        with patch(
+            "src.shared.python.diagnostics._collector._try_import_psutil",
+            return_value=None,
+        ):
+            collector = DiagnosticsCollector()
+            snap = collector.collect()
+        assert isinstance(snap, DiagnosticsSnapshot)
+        assert snap.system_metrics.cpu_percent == -1.0
+
+
+# ---------------------------------------------------------------------------
+# DiagnosticsHistory
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsHistory:
+    def test_initial_len_is_zero(self) -> None:
+        h = DiagnosticsHistory()
+        assert len(h) == 0
+
+    def test_default_capacity(self) -> None:
+        h = DiagnosticsHistory()
+        assert h.capacity == 100
+
+    def test_custom_capacity(self) -> None:
+        h = DiagnosticsHistory(capacity=10)
+        assert h.capacity == 10
+
+    def test_record_increases_len(self) -> None:
+        h = DiagnosticsHistory()
+        h.record(_make_snapshot())
+        assert len(h) == 1
+
+    def test_record_multiple(self) -> None:
+        h = DiagnosticsHistory()
+        for _ in range(5):
+            h.record(_make_snapshot())
+        assert len(h) == 5
+
+    def test_ring_buffer_overflow_evicts_oldest(self) -> None:
+        h = DiagnosticsHistory(capacity=3)
+        snaps = [_make_snapshot() for _ in range(5)]
+        for s in snaps:
+            h.record(s)
+        assert len(h) == 3
+        # The 3 most recent should be retained
+        retained = h.get_all()
+        assert retained == snaps[-3:]
+
+    def test_len_never_exceeds_capacity(self) -> None:
+        h = DiagnosticsHistory(capacity=5)
+        for _ in range(20):
+            h.record(_make_snapshot())
+        assert len(h) <= 5
+
+    def test_get_recent_returns_list(self) -> None:
+        h = DiagnosticsHistory()
+        h.record(_make_snapshot())
+        result = h.get_recent(1)
+        assert isinstance(result, list)
+
+    def test_get_recent_zero_returns_empty(self) -> None:
+        h = DiagnosticsHistory()
+        h.record(_make_snapshot())
+        assert h.get_recent(0) == []
+
+    def test_get_recent_one(self) -> None:
+        h = DiagnosticsHistory()
+        s = _make_snapshot()
+        h.record(s)
+        result = h.get_recent(1)
+        assert len(result) == 1
+        assert result[0] is s
+
+    def test_get_recent_n_larger_than_history(self) -> None:
+        h = DiagnosticsHistory()
+        h.record(_make_snapshot())
+        result = h.get_recent(1000)
+        assert len(result) == 1
+
+    def test_get_recent_preserves_order(self) -> None:
+        h = DiagnosticsHistory()
+        snaps = [_make_snapshot(cpu=float(i)) for i in range(5)]
+        for s in snaps:
+            h.record(s)
+        recent = h.get_recent(5)
+        assert [s.system_metrics.cpu_percent for s in recent] == [
+            0.0,
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+
+    def test_get_all_returns_all(self) -> None:
+        h = DiagnosticsHistory()
+        snaps = [_make_snapshot() for _ in range(4)]
+        for s in snaps:
+            h.record(s)
+        assert h.get_all() == snaps
+
+    def test_clear_empties_history(self) -> None:
+        h = DiagnosticsHistory()
+        for _ in range(5):
+            h.record(_make_snapshot())
+        h.clear()
+        assert len(h) == 0
+        assert h.get_all() == []
+
+    def test_record_after_clear(self) -> None:
+        h = DiagnosticsHistory()
+        for _ in range(3):
+            h.record(_make_snapshot())
+        h.clear()
+        s = _make_snapshot()
+        h.record(s)
+        assert len(h) == 1
+        assert h.get_all()[0] is s
+
+    def test_invalid_capacity_zero_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            DiagnosticsHistory(capacity=0)
+
+    def test_invalid_capacity_negative_raises(self) -> None:
+        with pytest.raises((ValueError, Exception)):
+            DiagnosticsHistory(capacity=-5)
+
+    def test_record_non_snapshot_raises(self) -> None:
+        h = DiagnosticsHistory()
+        with pytest.raises((ValueError, TypeError, Exception)):
+            h.record({"not": "a snapshot"})  # type: ignore[arg-type]
+
+    def test_get_recent_negative_n_raises(self) -> None:
+        h = DiagnosticsHistory()
+        with pytest.raises((ValueError, Exception)):
+            h.get_recent(-1)
+
+    def test_capacity_one_ring_buffer(self) -> None:
+        h = DiagnosticsHistory(capacity=1)
+        s1 = _make_snapshot(cpu=1.0)
+        s2 = _make_snapshot(cpu=2.0)
+        h.record(s1)
+        h.record(s2)
+        assert len(h) == 1
+        assert h.get_all()[0] is s2


### PR DESCRIPTION
Closes #5698 (partial — first child deliverable)\n\nAdd DiagnosticsSnapshot frozen dataclass, SystemMetrics, SimulationMetrics, DiagnosticsCollector (psutil/GPUtil optional, active_simulations_fn callback, graceful degradation), and DiagnosticsHistory deque ring-buffer. 51 unit tests cover snapshot structure, ring-buffer overflow, JSON serialisation, and DbC preconditions.