### PR TITLE
fix(p1): restore embed adapter path + lazy api imports

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,25 +1,26 @@
-"""API package for Golf Modeling Suite."""
+"""API package for Golf Modeling Suite.
 
-from .auth import (
-    get_current_user,
-)
-from .middleware import (
-    add_security_headers,
-    handle_api_errors,
-)
-from .routes import (
-    launcher_router,
-    models_router,
-    physics_router,
-    simulation_router,
-)
-from .services import (
-    AnalysisService,
-    ChatService,
-    LauncherService,
-    SimulationService,
-    SimulationStats,
-)
+Heavy sub-packages (``auth``, ``routes``, ``services``) are imported lazily via
+``__getattr__`` so that lightweight consumers — such as ``from src.api import
+versioning`` or CLI scripts — can import this package without pulling in
+SQLAlchemy and the full web-framework stack.
+
+The public API is unchanged: names that used to be importable as
+``from src.api import AnalysisService`` (etc.) are still importable; they just
+resolve on first access rather than at module-load time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Eagerly-available names: versioning lives here and has no heavy dependencies.
+# Nothing else is imported eagerly.
+# ---------------------------------------------------------------------------
 
 __all__: list[str] = [
     # auth
@@ -39,3 +40,82 @@ __all__: list[str] = [
     "SimulationService",
     "SimulationStats",
 ]
+
+# ---------------------------------------------------------------------------
+# Mapping of attribute name -> (submodule, attribute_in_submodule)
+# for symbols that are re-exported at the package level.
+# ---------------------------------------------------------------------------
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # auth
+    "get_current_user": ("src.api.auth", "get_current_user"),
+    # middleware
+    "add_security_headers": ("src.api.middleware", "add_security_headers"),
+    "handle_api_errors": ("src.api.middleware", "handle_api_errors"),
+    # routes
+    "launcher_router": ("src.api.routes", "launcher_router"),
+    "models_router": ("src.api.routes", "models_router"),
+    "physics_router": ("src.api.routes", "physics_router"),
+    "simulation_router": ("src.api.routes", "simulation_router"),
+    # services
+    "AnalysisService": ("src.api.services", "AnalysisService"),
+    "ChatService": ("src.api.services", "ChatService"),
+    "LauncherService": ("src.api.services", "LauncherService"),
+    "SimulationService": ("src.api.services", "SimulationService"),
+    "SimulationStats": ("src.api.services", "SimulationStats"),
+}
+
+# Sub-packages that are exposed as sub-module attributes (``src.api.auth`` etc.)
+_LAZY_SUBPACKAGES: frozenset[str] = frozenset(
+    {"auth", "routes", "services", "middleware"}
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve heavy sub-package attributes on first access.
+
+    Preconditions:
+        name is a string attribute name on this module.
+
+    Raises:
+        ImportError: if the underlying sub-module cannot be imported (e.g.
+            SQLAlchemy is absent).
+        AttributeError: if *name* is not a known lazy attribute or sub-package.
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"attribute name must be a str, not {type(name)!r}")
+
+    # 1. Direct symbol re-exports (e.g. get_current_user, AnalysisService, …)
+    if name in _LAZY_ATTRS:
+        module_path, attr = _LAZY_ATTRS[name]
+        mod: ModuleType = importlib.import_module(module_path)
+        return getattr(mod, attr)
+
+    # 2. Sub-package attributes (e.g. src.api.auth, src.api.routes, …)
+    if name in _LAZY_SUBPACKAGES:
+        return importlib.import_module(f"src.api.{name}")
+
+    # 3. Versioning is a sibling module; expose it as an attribute too so that
+    #    ``import src.api; src.api.versioning`` works without SQLAlchemy.
+    if name == "versioning":
+        return importlib.import_module("src.api.versioning")
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Make ``sys.modules["src.api"].versioning`` work via the normal attribute
+# path without requiring the caller to explicitly import it.
+# ---------------------------------------------------------------------------
+def _preload_versioning() -> None:
+    """Pre-populate the versioning sub-module reference; it has no heavy deps."""
+    try:
+        versioning_mod = importlib.import_module("src.api.versioning")
+        # Attach to this module's namespace so attribute access is O(1) after
+        # the first call, and so ``import src.api.versioning`` succeeds without
+        # triggering __getattr__ again.
+        sys.modules[__name__].__dict__["versioning"] = versioning_mod
+    except ImportError:
+        pass  # tolerate missing versioning in minimal environments
+
+
+_preload_versioning()

--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -272,7 +272,7 @@ models:
     name: "Sidekick"
     description: "AI assistant chat panel — embed as a dock or tab"
     type: "special_app"
-    path: "src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py"
+    path: "src/tools/sidekick/_embed_adapter.py"
     launcher:
       category: "tool"
       logo: "assets/sidekick.svg"

--- a/tests/unit/api/test_api_lazy_imports.py
+++ b/tests/unit/api/test_api_lazy_imports.py
@@ -1,0 +1,180 @@
+"""Regression tests for issue #5739: src/api/__init__.py eager imports.
+
+PR #5681 added eager top-level imports of ``auth``, ``routes``, and
+``services`` to ``src/api/__init__.py``.  ``auth.models`` pulls in
+SQLAlchemy at import time.  Environments that only use the lightweight
+``versioning`` module (e.g. CLI tools, docs builds, test environments
+without the full API extras) now crash with::
+
+    ModuleNotFoundError: No module named 'sqlalchemy'
+
+Contract locked in by these tests:
+
+1. ``import src.api`` succeeds even when SQLAlchemy is absent.
+2. ``from src.api import versioning`` succeeds when SQLAlchemy is absent.
+3. Accessing ``src.api.routes``, ``src.api.auth``, or ``src.api.services``
+   while SQLAlchemy is absent raises ``ImportError`` (or
+   ``ModuleNotFoundError``), *not* silently returning ``None``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_API_MODULE = "src.api"
+# Sub-modules that transitively import SQLAlchemy
+_HEAVY_SUBMODULES = [
+    "src.api.auth",
+    "src.api.auth.models",
+    "src.api.auth.dependencies",
+    "src.api.auth.security",
+    "src.api.routes",
+    "src.api.routes.launcher",
+    "src.api.routes.models",
+    "src.api.routes.physics",
+    "src.api.routes.simulation",
+    "src.api.services",
+]
+
+# SQLAlchemy top-level packages/modules to stub out
+_SQLALCHEMY_NAMES = [
+    "sqlalchemy",
+    "sqlalchemy.orm",
+    "sqlalchemy.sql",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.declarative",
+]
+
+
+def _evict_api_modules() -> dict[str, ModuleType]:
+    """Remove src.api and all sub-modules from sys.modules, return snapshot."""
+    saved: dict[str, ModuleType] = {}
+    keys_to_remove = [
+        k for k in sys.modules if k == _API_MODULE or k.startswith(_API_MODULE + ".")
+    ]
+    for key in keys_to_remove:
+        saved[key] = sys.modules.pop(key)
+    return saved
+
+
+def _restore_api_modules(saved: dict[str, ModuleType]) -> None:
+    for key, mod in saved.items():
+        sys.modules[key] = mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportWithoutSQLAlchemy:
+    """src.api must import cleanly in lightweight / no-DB environments."""
+
+    def test_import_src_api_succeeds_without_sqlalchemy(self) -> None:
+        """``import src.api`` must not raise even when sqlalchemy is absent."""
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                # Should not raise
+                api_mod = importlib.import_module(_API_MODULE)
+                assert isinstance(api_mod, ModuleType)
+        finally:
+            _restore_api_modules(saved)
+
+    def test_versioning_importable_without_sqlalchemy(self) -> None:
+        """``from src.api import versioning`` must work without sqlalchemy."""
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                versioning = importlib.import_module("src.api.versioning")
+                assert isinstance(versioning, ModuleType)
+                # Sanity-check: versioning exposes at least one public symbol
+                assert hasattr(versioning, "__file__"), (
+                    "versioning module has no __file__"
+                )
+        finally:
+            _restore_api_modules(saved)
+
+    def test_versioning_accessible_via_attribute_without_sqlalchemy(self) -> None:
+        """``src.api.versioning`` attribute access must not trigger SQLAlchemy."""
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                api_mod = importlib.import_module(_API_MODULE)
+                versioning = api_mod.versioning  # type: ignore[attr-defined]
+                assert isinstance(versioning, ModuleType)
+        finally:
+            _restore_api_modules(saved)
+
+
+class TestHeavySubmodulesFailGracefullyWithoutSQLAlchemy:
+    """The lazy mechanism defers heavy imports; auth (which uses SQLAlchemy ORM
+    models) must raise ImportError when SQLAlchemy is absent.  ``routes`` and
+    ``services`` themselves do not import SQLAlchemy at their package level, so
+    they can be imported cleanly; only ``auth`` is the gating dependency."""
+
+    def test_accessing_auth_without_sqlalchemy_raises(self) -> None:
+        """``src.api.auth`` access must raise ImportError when sqlalchemy absent.
+
+        ``src.api.auth.models`` imports SQLAlchemy ORM types at module level,
+        so accessing the auth sub-package must propagate the ImportError.
+        """
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                api_mod = importlib.import_module(_API_MODULE)
+                with pytest.raises((ImportError, ModuleNotFoundError)):
+                    _ = api_mod.auth  # type: ignore[attr-defined]
+        finally:
+            _restore_api_modules(saved)
+
+    def test_accessing_routes_succeeds_without_sqlalchemy(self) -> None:
+        """``src.api.routes`` does not pull in SQLAlchemy at package level.
+
+        Only ``src.api.routes.auth`` (not imported by the routes __init__)
+        uses SQLAlchemy.  The main routes package must import cleanly.
+        """
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                api_mod = importlib.import_module(_API_MODULE)
+                routes = api_mod.routes  # type: ignore[attr-defined]
+                assert isinstance(routes, ModuleType)
+        finally:
+            _restore_api_modules(saved)
+
+    def test_accessing_services_succeeds_without_sqlalchemy(self) -> None:
+        """``src.api.services`` does not use SQLAlchemy directly.
+
+        Services rely on in-process Python objects, not ORM models.
+        The package must import cleanly when SQLAlchemy is absent.
+        """
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                api_mod = importlib.import_module(_API_MODULE)
+                services = api_mod.services  # type: ignore[attr-defined]
+                assert isinstance(services, ModuleType)
+        finally:
+            _restore_api_modules(saved)
+
+    def test_get_current_user_raises_without_sqlalchemy(self) -> None:
+        """``src.api.get_current_user`` is re-exported from auth; must raise."""
+        saved = _evict_api_modules()
+        try:
+            with mock.patch.dict(sys.modules, dict.fromkeys(_SQLALCHEMY_NAMES)):
+                api_mod = importlib.import_module(_API_MODULE)
+                with pytest.raises((ImportError, ModuleNotFoundError)):
+                    _ = api_mod.get_current_user  # type: ignore[attr-defined]
+        finally:
+            _restore_api_modules(saved)

--- a/tests/unit/launchers/test_special_app_embed_adapter.py
+++ b/tests/unit/launchers/test_special_app_embed_adapter.py
@@ -1,0 +1,111 @@
+"""Regression tests for issue #5738: Sidekick embed adapter path in models.yaml.
+
+PR #5681 deleted src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py
+and moved the sidekick adapter to src/tools/sidekick/_embed_adapter.py.  The
+Sidekick tile in src/config/models.yaml was not updated, so SpecialAppHandler.launch()
+fails with "script not found".
+
+Contract these tests lock in:
+
+1. Every ``special_app`` entry in models.yaml whose ``path`` ends with a known
+   .py extension must resolve to a file that actually exists on disk.
+2. The Sidekick tile in particular must resolve to an existing file (regression
+   guard for #5738).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODELS_YAML = REPO_ROOT / "src" / "config" / "models.yaml"
+
+
+def _load_models() -> list[dict]:
+    with MODELS_YAML.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return data.get("models", [])
+
+
+def _special_app_script_entries() -> list[tuple[str, str]]:
+    """Return (model_id, path) pairs for local special_app entries with .py paths.
+
+    Entries with ``provider`` set are served from a sibling repository and are
+    only resolvable at runtime when that repo is present; they are excluded from
+    this static existence check.  Entries with a ``source_root`` that resolves
+    to a path outside the current repo are similarly excluded.
+    """
+    result = []
+    for model in _load_models():
+        if model.get("type") != "special_app":
+            continue
+        # Skip entries served by an external provider (e.g. Tools repo)
+        if model.get("provider"):
+            continue
+        # Skip entries with a source_root that is an external/sibling directory
+        source_root = model.get("source_root", "")
+        if source_root and not (REPO_ROOT / source_root).exists():
+            continue
+        path = model.get("path", "")
+        if path.endswith(".py"):
+            result.append((model["id"], path))
+    return result
+
+
+# -----------------------------------------------------------------------
+# Tests
+# -----------------------------------------------------------------------
+
+
+def test_models_yaml_exists() -> None:
+    """Precondition: the config file must be present."""
+    assert MODELS_YAML.exists(), f"models.yaml not found at {MODELS_YAML}"
+
+
+def test_sidekick_entry_present() -> None:
+    """models.yaml must contain a 'sidekick' entry (regression guard)."""
+    ids = {m["id"] for m in _load_models()}
+    assert "sidekick" in ids, "Sidekick tile missing from models.yaml"
+
+
+def test_sidekick_path_exists_on_disk() -> None:
+    """Bug #5738: the sidekick path in models.yaml must resolve to a real file.
+
+    This is the primary regression guard.  After the fix models.yaml should
+    point to src/tools/sidekick/_embed_adapter.py (which exists), not to
+    the deleted src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py.
+    """
+    models = _load_models()
+    sidekick = next((m for m in models if m["id"] == "sidekick"), None)
+    assert sidekick is not None, "Sidekick tile missing from models.yaml"
+
+    declared_path: str = sidekick.get("path", "")
+    assert declared_path, "Sidekick entry has no 'path' key"
+
+    resolved = REPO_ROOT / declared_path
+    assert resolved.exists(), (
+        f"Sidekick path declared in models.yaml does not exist on disk.\n"
+        f"  Declared : {declared_path}\n"
+        f"  Resolved : {resolved}\n"
+        f"  Hint     : update models.yaml to point to src/tools/sidekick/_embed_adapter.py"
+    )
+
+
+@pytest.mark.parametrize("model_id,rel_path", _special_app_script_entries())
+def test_special_app_script_paths_exist(model_id: str, rel_path: str) -> None:
+    """Every special_app .py path referenced in models.yaml must exist.
+
+    DbC precondition enforced by SpecialAppHandler.launch(): if the script is
+    missing it logs a warning and returns False, silently breaking the tile.
+    This test surfaces the breakage at CI time instead.
+    """
+    resolved = REPO_ROOT / rel_path
+    assert resolved.exists(), (
+        f"special_app '{model_id}' references a missing script.\n"
+        f"  Declared : {rel_path}\n"
+        f"  Resolved : {resolved}"
+    )


### PR DESCRIPTION
Closes #5738
Closes #5739

Fixes two P1 regressions from PR #5681:

## Bug #5738 — Sidekick embed adapter path missing

PR #5681 deleted \src/shared/python/upstream_drift_tools/ui/tools_sidebar/_embed_adapter.py\ and moved the sidekick adapter to \src/tools/sidekick/_embed_adapter.py\, but \src/config/models.yaml\ still referenced the deleted path.  \SpecialAppHandler.launch()\ was logging *script not found* and returning \False\, silently breaking the Sidekick tile.

**Fix**: update the \sidekick\ entry in \models.yaml\ to point at \src/tools/sidekick/_embed_adapter.py\.

**Test**: \	ests/unit/launchers/test_special_app_embed_adapter.py\ — asserts the declared path exists on disk, parametrized over all local \special_app\ entries.

## Bug #5739 — Eager imports in src/api/__init__.py

\src/api/__init__.py\ eagerly imported \uth\, \outes\, and \services\, pulling SQLAlchemy in at import time.  Lightweight consumers (\rom src.api import versioning\, CLI tools, docs builds) crashed with \ModuleNotFoundError: No module named 'sqlalchemy'\.

**Fix**: replace eager imports with a \__getattr__\-based lazy loading scheme.  \ersioning\ is pre-loaded eagerly (no heavy deps).  All previously exported names remain importable; they just resolve on first access.  \uth\ (and symbols re-exported from it) correctly propagate \ImportError\ when SQLAlchemy is absent.

**Test**: \	ests/unit/api/test_api_lazy_imports.py\ — mocks SQLAlchemy as absent and verifies the import / access contracts.