### PR TITLE
ci: fix final hosted-runner leak (Jules-Diff-Verifier to d-sorg-fleet)

### DIFF
--- a/.github/workflows/Jules-Diff-Verifier.yml
+++ b/.github/workflows/Jules-Diff-Verifier.yml
@@ -43,7 +43,7 @@ jobs:
   verify:
     timeout-minutes: 30
     name: Verify Diff Substance
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Only gate Jules-generated branches. Other PRs pass through automatically.
     if: >
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Summary

Fixes the last remaining hosted-runner routing leak in UpstreamDrift: Jules-Diff-Verifier.yml::verify was running on ubuntu-latest outside the allowed list. Changed to d-sorg-fleet so all workflow jobs in this repo now route exclusively to the self-hosted fleet.

## Changes
- .github/workflows/Jules-Diff-Verifier.yml: change runs-on: ubuntu-latest to runs-on: d-sorg-fleet

## Verification
- [x] Local guard scan: 0 violations after fix (was 1 before)
- [x] Allowlist confirmed: local-only-runner-guard.yml (canary on hosted) is the only permitted exception

## Out of scope
- No changes to guard logic, other workflows, or source code

Fixes #641 (final deferred item - UpstreamDrift leak)

---
Filed by address-issues skill, agent CONTROLTOWER-641-fix.
