### PR TITLE
⚡ Bolt: Optimize hypot computation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,6 @@
 ## 2026-05-18 - Optimize norm calculations in UI/Viz adapters
 **Learning:** `np.linalg.norm(..., axis=1)` creates an intermediate memory allocation and has significant internal overhead when used on multi-dimensional numpy arrays inside tight loops, leading to suboptimal performance, particularly when parsing and calculating distances in data visualizers.
 **Action:** Replace `np.linalg.norm(diff, axis=1)` with `np.sqrt(np.einsum("ij,ij->i", diff, diff))` for all generic vector distance calculations that map down dimensions. Remember to retain any shape alterations such as `[:, np.newaxis]` when performing element-wise broadcasting on multi-dimensional arrays, so the shapes do not mismatch.
+## 2026-05-19 - Optimize generic element-wise norm for small vectors
+**Learning:** Element-wise norm computation or generic `np.linalg.norm(..., axis=None)` creates temporary arrays and runs via python layer handling. For very small native tuples or 1D arrays like normal vectors, standard `math.hypot(*v)` is substantially faster than `math.hypot(*np.ravel(v))` and extremely faster than `np.linalg.norm`.
+**Action:** Always prefer `math.hypot(*v)` directly rather than applying `np.ravel()` first on 1D flat structures when optimizing tiny vectors for normalisations.

--- a/src/robotics/planning/collision/collision_types.py
+++ b/src/robotics/planning/collision/collision_types.py
@@ -118,9 +118,8 @@ class DistanceResult:
                 raise ValueError("normal must be shape (3,)")
             # Normalize the normal vector
             # ⚡ Bolt: Element-wise norm computation is faster than np.linalg.norm(..., axis=None) for tiny vectors
-            # using math.hypot equivalent
-            arr = np.ravel(self.normal)
-            norm = 0.0 if arr.size == 0 else math.hypot(*arr)
+            # using math.hypot directly (avoiding ravel)
+            norm = math.hypot(*self.normal)
             if norm > 1e-10:
                 object.__setattr__(self, "normal", self.normal / norm)
 


### PR DESCRIPTION
💡 What: Removed unnecessary np.ravel before calling math.hypot
🎯 Why: math.hypot directly on small tuples is faster than calling np.ravel + math.hypot
📊 Impact: Reduces overhead on generic norm implementations for small vectors
🔬 Measurement: Validated performance increase with standard python timeit benchmarks

---
*PR created automatically by Jules for task [14023178111549824992](https://jules.google.com/task/14023178111549824992) started by @dieterolson*