### PR TITLE
feat(ui): Phase 3 install-prompt UX — PyQt6 dialog + hot-refresh

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core UpstreamDrift modules."""

--- a/src/core/capability_registry.py
+++ b/src/core/capability_registry.py
@@ -1,0 +1,34 @@
+"""Thin re-export shim for the capability/feature registry.
+
+The canonical implementation lives in
+:mod:`src.shared.python.feature_registry`.  This module provides the
+``src.core.capability_registry`` import path referenced in the Phase 3
+install-prompt UX spec (issue #5768) without duplicating any logic.
+
+Usage::
+
+    from src.core.capability_registry import get_registry, refresh
+
+    registry = get_registry()
+    registry.refresh()
+"""
+
+from __future__ import annotations
+
+from src.shared.python.feature_registry import (  # noqa: F401
+    CapabilityRegistry,
+    FeatureReport,
+    InstallResult,
+    get_registry,
+    install_feature,
+    refresh,
+)
+
+__all__ = [
+    "CapabilityRegistry",
+    "FeatureReport",
+    "InstallResult",
+    "get_registry",
+    "install_feature",
+    "refresh",
+]

--- a/src/shared/python/ui/dialogs/__init__.py
+++ b/src/shared/python/ui/dialogs/__init__.py
@@ -1,0 +1,8 @@
+"""UI dialog components."""
+
+from src.shared.python.ui.dialogs.install_prompt import (  # noqa: F401
+    InstallPromptDialog,
+    InstallPromptResult,
+)
+
+__all__ = ["InstallPromptDialog", "InstallPromptResult"]

--- a/src/shared/python/ui/dialogs/install_prompt.py
+++ b/src/shared/python/ui/dialogs/install_prompt.py
@@ -1,0 +1,418 @@
+"""Install-prompt dialog for missing optional dependencies.
+
+When a user requests a feature that requires an optional package that is
+not currently installed, this dialog offers to install it in the
+background, skip this time, or permanently suppress the prompt.
+
+Architecture
+------------
+* :class:`InstallPromptDialog` — PyQt6 modal dialog with three actions.
+* :class:`_InstallWorker` — ``QThread`` subclass that runs the pip
+  install in a background thread so the UI stays responsive.
+* :data:`PREFS_FILE` — ``~/.upstreamdrift/prefs.json`` stores
+  ``dont_ask_again`` feature flags across sessions.
+
+Design by Contract
+------------------
+Preconditions:
+    * ``feature_name`` must be a non-empty string registered in the
+      feature registry.
+    * ``package_name`` must be a non-empty string (the human-readable
+      package label shown in the dialog body).
+Postconditions:
+    * If the user clicks **Yes**, the install runs to completion (or
+      fails) in a background thread; ``registry.refresh()`` is called
+      regardless of success so the registry reflects the post-install
+      state.
+    * If the user clicks **Don't ask again**, the suppression preference
+      is written to :data:`PREFS_FILE` before the dialog closes.
+
+Law of Demeter
+--------------
+The dialog does not reach into the registry internals.  It calls
+:func:`src.shared.python.feature_registry.install_feature` and
+:func:`src.shared.python.feature_registry.refresh` via the public API
+only.
+
+No ``print()`` — all diagnostic output goes through ``logging``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import Enum, auto
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PyQt6.QtCore import QThread, pyqtSignal
+from PyQt6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.feature_registry import install_feature, refresh  # noqa: F401
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# User prefs file
+# ---------------------------------------------------------------------------
+
+PREFS_DIR: Path = Path.home() / ".upstreamdrift"
+PREFS_FILE: Path = PREFS_DIR / "prefs.json"
+
+_DONT_ASK_KEY = "dont_ask_again_features"
+
+
+def _load_prefs() -> dict:
+    """Load prefs from :data:`PREFS_FILE`, returning an empty dict on failure."""
+    if PREFS_FILE.exists():
+        try:
+            return json.loads(PREFS_FILE.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            logger.warning("Failed to read prefs file %s: %s", PREFS_FILE, exc)
+    return {}
+
+
+def _save_prefs(data: dict) -> None:
+    """Persist *data* to :data:`PREFS_FILE`.
+
+    Preconditions:
+        * ``data`` is a JSON-serialisable dict.
+    """
+    try:
+        PREFS_DIR.mkdir(parents=True, exist_ok=True)
+        PREFS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except (OSError, TypeError, ValueError) as exc:
+        logger.error("Failed to save prefs to %s: %s", PREFS_FILE, exc)
+
+
+def is_suppressed(feature_name: str) -> bool:
+    """Return ``True`` if the user has chosen *Don't ask again* for this feature.
+
+    Preconditions:
+        * ``feature_name`` is a non-empty string.
+    """
+    if not isinstance(feature_name, str) or not feature_name:
+        raise ValueError("feature_name must be a non-empty string")
+    prefs = _load_prefs()
+    return feature_name in prefs.get(_DONT_ASK_KEY, [])
+
+
+def suppress_feature(feature_name: str) -> None:
+    """Persist a *Don't ask again* entry for ``feature_name``.
+
+    Preconditions:
+        * ``feature_name`` is a non-empty string.
+    """
+    if not isinstance(feature_name, str) or not feature_name:
+        raise ValueError("feature_name must be a non-empty string")
+    prefs = _load_prefs()
+    suppressed: list[str] = prefs.setdefault(_DONT_ASK_KEY, [])
+    if feature_name not in suppressed:
+        suppressed.append(feature_name)
+        _save_prefs(prefs)
+        logger.info("Install prompt suppressed for feature %r", feature_name)
+
+
+# ---------------------------------------------------------------------------
+# Result enum
+# ---------------------------------------------------------------------------
+
+
+class InstallPromptResult(Enum):
+    """Outcome of :class:`InstallPromptDialog`.
+
+    Attributes:
+        YES: User clicked **Yes**; install was attempted.
+        NO: User clicked **No**; install was skipped this session.
+        DONT_ASK: User clicked **Don't ask again**; suppression persisted.
+        SUPPRESSED: Dialog was not shown because the user had previously
+            chosen *Don't ask again*.
+    """
+
+    YES = auto()
+    NO = auto()
+    DONT_ASK = auto()
+    SUPPRESSED = auto()
+
+
+# ---------------------------------------------------------------------------
+# Background install worker
+# ---------------------------------------------------------------------------
+
+
+class _InstallWorker(QThread):
+    """Run :func:`install_feature` in a background thread.
+
+    Signals:
+        finished(success: bool, reason: str): Emitted when the install
+            subprocess exits (or is rejected by a safety rail).
+        progress(message: str): Emitted periodically while the install
+            is running (currently only at start/end; a richer
+            implementation could tail the subprocess stdout).
+    """
+
+    finished = pyqtSignal(bool, str)
+    progress = pyqtSignal(str)
+
+    def __init__(self, feature_name: str, parent: QWidget | None = None) -> None:
+        """Initialise the worker.
+
+        Preconditions:
+            * ``feature_name`` is a non-empty string.
+        """
+        if not isinstance(feature_name, str) or not feature_name:
+            raise ValueError("feature_name must be a non-empty string")
+        super().__init__(parent)
+        self._feature_name = feature_name
+
+    def run(self) -> None:
+        """Execute the install and emit :attr:`finished`."""
+        from src.shared.python.ui.dialogs import install_prompt as _mod
+
+        self.progress.emit(f"Installing {self._feature_name}…")
+        logger.info("Background install started for feature %r", self._feature_name)
+        try:
+            result = _mod.install_feature(self._feature_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "Unexpected error during install of %r", self._feature_name
+            )
+            self.finished.emit(False, str(exc))
+            return
+        logger.info(
+            "Background install finished for %r: success=%s reason=%s",
+            self._feature_name,
+            result.success,
+            result.reason,
+        )
+        self.finished.emit(result.success, result.reason)
+
+
+# ---------------------------------------------------------------------------
+# Dialog
+# ---------------------------------------------------------------------------
+
+
+class InstallPromptDialog(QDialog):
+    """Modal dialog prompting the user to install a missing optional package.
+
+    The dialog presents three choices:
+
+    * **Yes** — trigger an async pip install and show a progress bar.
+    * **No** — close without installing (ask again next time).
+    * **Don't ask again** — close and persist a suppression flag.
+
+    On completion of the background install (success *or* failure) the
+    dialog calls :func:`src.shared.python.feature_registry.refresh` so
+    the registry reflects the post-install state.
+
+    Usage::
+
+        dialog = InstallPromptDialog(
+            feature_name="drake",
+            package_name="Drake",
+            parent=main_window,
+        )
+        result = dialog.prompt()
+        if result == InstallPromptResult.YES:
+            ...
+
+    Args:
+        feature_name: Registry key (e.g. ``"drake"``).
+        package_name: Human-readable label shown in the dialog body
+            (e.g. ``"Drake"``).
+        parent: Optional parent widget.
+    """
+
+    #: Emitted after the background install finishes (success, reason).
+    install_finished = pyqtSignal(bool, str)
+
+    def __init__(
+        self,
+        feature_name: str,
+        package_name: str,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Create the dialog.
+
+        Preconditions:
+            * ``feature_name`` is a non-empty string.
+            * ``package_name`` is a non-empty string.
+        """
+        if not isinstance(feature_name, str) or not feature_name:
+            raise ValueError("feature_name must be a non-empty string")
+        if not isinstance(package_name, str) or not package_name:
+            raise ValueError("package_name must be a non-empty string")
+        super().__init__(parent)
+
+        self._feature_name = feature_name
+        self._package_name = package_name
+        self._result: InstallPromptResult | None = None
+        self._worker: _InstallWorker | None = None
+
+        self.setWindowTitle("Missing Optional Dependency")
+        self.setMinimumWidth(420)
+        self._setup_ui()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def prompt(self) -> InstallPromptResult:
+        """Show the dialog if not suppressed; return the user's choice.
+
+        If the feature is already suppressed via *Don't ask again*, this
+        method returns :attr:`InstallPromptResult.SUPPRESSED` immediately
+        without showing a dialog.
+
+        Postconditions:
+            * Returns a member of :class:`InstallPromptResult`.
+        """
+        if is_suppressed(self._feature_name):
+            logger.debug(
+                "Install prompt suppressed for %r; skipping display",
+                self._feature_name,
+            )
+            return InstallPromptResult.SUPPRESSED
+        self.exec()
+        return self._result if self._result is not None else InstallPromptResult.NO
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        """Build the dialog widgets."""
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        # Body text
+        body_text = (
+            f"Feature <b>{self._feature_name}</b> requires installing "
+            f"<b>{self._package_name}</b>.<br/><br/>"
+            "Install now?"
+        )
+        self._label = QLabel(body_text)
+        self._label.setWordWrap(True)
+        layout.addWidget(self._label)
+
+        # Progress bar (hidden until install starts)
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 0)  # indeterminate
+        self._progress.hide()
+        layout.addWidget(self._progress)
+
+        # Status label (hidden until install starts)
+        self._status_label = QLabel("")
+        self._status_label.hide()
+        layout.addWidget(self._status_label)
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+
+        self._yes_btn = QPushButton("Yes")
+        self._yes_btn.setDefault(True)
+        self._yes_btn.clicked.connect(self._on_yes)
+        btn_layout.addWidget(self._yes_btn)
+
+        self._no_btn = QPushButton("No")
+        self._no_btn.clicked.connect(self._on_no)
+        btn_layout.addWidget(self._no_btn)
+
+        self._dont_ask_btn = QPushButton("Don't ask again")
+        self._dont_ask_btn.clicked.connect(self._on_dont_ask)
+        btn_layout.addWidget(self._dont_ask_btn)
+
+        layout.addLayout(btn_layout)
+
+    # ------------------------------------------------------------------
+    # Button handlers
+    # ------------------------------------------------------------------
+
+    def _on_yes(self) -> None:
+        """Start background install and show progress bar."""
+        self._result = InstallPromptResult.YES
+        self._yes_btn.setEnabled(False)
+        self._no_btn.setEnabled(False)
+        self._dont_ask_btn.setEnabled(False)
+        self._progress.show()
+        self._status_label.show()
+        self._status_label.setText(f"Installing {self._package_name}…")
+
+        self._worker = _InstallWorker(self._feature_name, parent=self)
+        self._worker.progress.connect(self._on_worker_progress)
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _on_no(self) -> None:
+        """Close without installing."""
+        self._result = InstallPromptResult.NO
+        self.reject()
+
+    def _on_dont_ask(self) -> None:
+        """Persist suppression and close."""
+        suppress_feature(self._feature_name)
+        self._result = InstallPromptResult.DONT_ASK
+        self.reject()
+
+    # ------------------------------------------------------------------
+    # Worker callbacks
+    # ------------------------------------------------------------------
+
+    def _on_worker_progress(self, message: str) -> None:
+        """Update status label with progress text."""
+        self._status_label.setText(message)
+
+    def _on_worker_finished(self, success: bool, reason: str) -> None:
+        """Handle install completion: refresh registry and close.
+
+        Postconditions:
+            * :func:`src.shared.python.feature_registry.refresh` has been
+              called before this method returns.
+            * :attr:`install_finished` signal has been emitted.
+        """
+        self._progress.hide()
+        status = "installed successfully" if success else f"install failed: {reason}"
+        self._status_label.setText(f"{self._package_name} {status}.")
+        logger.info(
+            "InstallPromptDialog: install of %r finished — success=%s",
+            self._feature_name,
+            success,
+        )
+
+        # Hot-refresh the capability registry regardless of success/failure
+        # so the registry reflects the true post-install state.
+        try:
+            from src.shared.python.ui.dialogs import install_prompt as _mod
+
+            _mod.refresh()
+            logger.debug(
+                "Capability registry refreshed after install of %r",
+                self._feature_name,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Registry refresh failed after install: %s", exc)
+
+        self.install_finished.emit(success, reason)
+        self.accept()
+
+
+__all__ = [
+    "PREFS_DIR",
+    "PREFS_FILE",
+    "InstallPromptDialog",
+    "InstallPromptResult",
+    "is_suppressed",
+    "suppress_feature",
+]

--- a/tests/unit/ui/dialogs/test_install_prompt.py
+++ b/tests/unit/ui/dialogs/test_install_prompt.py
@@ -1,0 +1,525 @@
+"""Unit tests for InstallPromptDialog (Phase 3 install-prompt UX).
+
+All tests are headless-safe: PyQt6 widgets are instantiated but never
+shown on screen.  The background ``_InstallWorker`` thread is always
+patched out so no real subprocess runs.
+
+Coverage requirements (see issue #5768):
+    * Dialog is shown when feature is missing (not suppressed).
+    * Yes path: worker starts, progress bar appears, registry refresh called.
+    * No path: dialog rejected, no install, no suppression.
+    * Don't-ask-again path: suppression written to prefs file.
+    * Async install callback: ``install_finished`` signal emitted with
+      correct (success, reason) values.
+    * Hot-refresh: ``registry.refresh()`` is called on install completion.
+    * Suppressed feature: ``prompt()`` returns SUPPRESSED without exec.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Use offscreen Qt platform for headless test environments.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+# Skip entire module if PyQt6 is unavailable.
+pytest.importorskip("PyQt6")
+
+if TYPE_CHECKING:
+    from src.shared.python.ui.dialogs.install_prompt import InstallPromptDialog
+
+
+# ---------------------------------------------------------------------------
+# Module-level Qt app (created once per test session)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    """Provide a module-scoped QApplication for all dialog tests."""
+    try:
+        from PyQt6.QtWidgets import QApplication
+    except (ImportError, OSError) as exc:
+        pytest.skip(f"PyQt6 runtime unavailable: {exc}")
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_prefs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the prefs file to a temporary directory."""
+    import src.shared.python.ui.dialogs.install_prompt as mod
+
+    fake_dir = tmp_path / ".upstreamdrift"
+    fake_file = fake_dir / "prefs.json"
+    monkeypatch.setattr(mod, "PREFS_DIR", fake_dir)
+    monkeypatch.setattr(mod, "PREFS_FILE", fake_file)
+    return fake_file
+
+
+@pytest.fixture()
+def dialog(qt_app, tmp_prefs: Path) -> InstallPromptDialog:
+    """Return a fresh dialog instance with prefs in a temp location."""
+    from src.shared.python.ui.dialogs.install_prompt import InstallPromptDialog
+
+    dlg = InstallPromptDialog(feature_name="mujoco", package_name="MuJoCo")
+    # Prevent exec() from blocking the event loop.
+    dlg.exec = lambda: None  # type: ignore[method-assign]
+    return dlg
+
+
+# ---------------------------------------------------------------------------
+# Prefs helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPrefsHelpers:
+    def test_is_suppressed_false_when_no_prefs_file(self, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import is_suppressed
+
+        assert is_suppressed("mujoco") is False
+
+    def test_suppress_feature_writes_prefs(self, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import (
+            is_suppressed,
+            suppress_feature,
+        )
+
+        suppress_feature("drake")
+
+        assert tmp_prefs.exists()
+        data = json.loads(tmp_prefs.read_text())
+        assert "drake" in data.get("dont_ask_again_features", [])
+        assert is_suppressed("drake") is True
+
+    def test_suppress_feature_idempotent(self, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import suppress_feature
+
+        suppress_feature("drake")
+        suppress_feature("drake")  # second call must not duplicate
+
+        data = json.loads(tmp_prefs.read_text())
+        assert data["dont_ask_again_features"].count("drake") == 1
+
+    def test_suppress_feature_raises_on_empty_name(self, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import suppress_feature
+
+        with pytest.raises(ValueError):
+            suppress_feature("")
+
+    def test_is_suppressed_raises_on_empty_name(self, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import is_suppressed
+
+        with pytest.raises(ValueError):
+            is_suppressed("")
+
+
+# ---------------------------------------------------------------------------
+# InstallPromptResult enum
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPromptResult:
+    def test_all_members_present(self) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptResult
+
+        names = {m.name for m in InstallPromptResult}
+        assert names == {"YES", "NO", "DONT_ASK", "SUPPRESSED"}
+
+
+# ---------------------------------------------------------------------------
+# Dialog construction
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPromptDialogConstruction:
+    def test_valid_construction(self, qt_app, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptDialog
+
+        dlg = InstallPromptDialog(feature_name="drake", package_name="Drake")
+        assert dlg is not None
+
+    def test_raises_on_empty_feature_name(self, qt_app, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptDialog
+
+        with pytest.raises(ValueError, match="feature_name"):
+            InstallPromptDialog(feature_name="", package_name="Drake")
+
+    def test_raises_on_empty_package_name(self, qt_app, tmp_prefs: Path) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptDialog
+
+        with pytest.raises(ValueError, match="package_name"):
+            InstallPromptDialog(feature_name="drake", package_name="")
+
+    def test_dialog_title(self, dialog: InstallPromptDialog) -> None:
+        title = dialog.windowTitle()
+        assert "Missing" in title or "Dependency" in title
+
+    def test_label_contains_feature_and_package(
+        self, dialog: InstallPromptDialog
+    ) -> None:
+        label_text = dialog._label.text()
+        assert "mujoco" in label_text
+        assert "MuJoCo" in label_text
+
+    def test_progress_bar_initially_hidden(self, dialog: InstallPromptDialog) -> None:
+        assert dialog._progress.isHidden()
+
+
+# ---------------------------------------------------------------------------
+# Yes path
+# ---------------------------------------------------------------------------
+
+
+class TestYesPath:
+    def _make_fake_worker(self) -> MagicMock:
+        fake_worker = MagicMock()
+        fake_worker.progress = MagicMock()
+        fake_worker.progress.connect = MagicMock()
+        fake_worker.finished = MagicMock()
+        fake_worker.finished.connect = MagicMock()
+        fake_worker.start = MagicMock()
+        return fake_worker
+
+    def test_yes_sets_result(
+        self, dialog: InstallPromptDialog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.ui.dialogs import install_prompt as mod
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptResult
+
+        monkeypatch.setattr(
+            mod, "_InstallWorker", lambda *a, **kw: self._make_fake_worker()
+        )
+        dialog._on_yes()
+        assert dialog._result == InstallPromptResult.YES
+
+    def test_yes_shows_progress_bar(
+        self, dialog: InstallPromptDialog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.ui.dialogs import install_prompt as mod
+
+        monkeypatch.setattr(
+            mod, "_InstallWorker", lambda *a, **kw: self._make_fake_worker()
+        )
+        dialog._on_yes()
+        # isHidden() is used here because isVisible() returns False for widgets
+        # whose parent (the dialog) is not shown on screen in headless tests.
+        assert not dialog._progress.isHidden()
+
+    def test_yes_disables_buttons(
+        self, dialog: InstallPromptDialog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.ui.dialogs import install_prompt as mod
+
+        monkeypatch.setattr(
+            mod, "_InstallWorker", lambda *a, **kw: self._make_fake_worker()
+        )
+        dialog._on_yes()
+
+        assert not dialog._yes_btn.isEnabled()
+        assert not dialog._no_btn.isEnabled()
+        assert not dialog._dont_ask_btn.isEnabled()
+
+    def test_yes_starts_worker(
+        self, dialog: InstallPromptDialog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.ui.dialogs import install_prompt as mod
+
+        fake = self._make_fake_worker()
+        monkeypatch.setattr(mod, "_InstallWorker", lambda *a, **kw: fake)
+        dialog._on_yes()
+        fake.start.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# No path
+# ---------------------------------------------------------------------------
+
+
+class TestNoPath:
+    def test_no_sets_result(self, dialog: InstallPromptDialog) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptResult
+
+        with patch.object(dialog, "reject"):
+            dialog._on_no()
+
+        assert dialog._result == InstallPromptResult.NO
+
+    def test_no_does_not_suppress(
+        self, dialog: InstallPromptDialog, tmp_prefs: Path
+    ) -> None:
+        with patch.object(dialog, "reject"):
+            dialog._on_no()
+
+        assert not tmp_prefs.exists()
+
+
+# ---------------------------------------------------------------------------
+# Don't-ask-again path
+# ---------------------------------------------------------------------------
+
+
+class TestDontAskPath:
+    def test_dont_ask_sets_result(
+        self, dialog: InstallPromptDialog, tmp_prefs: Path
+    ) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import InstallPromptResult
+
+        with patch.object(dialog, "reject"):
+            dialog._on_dont_ask()
+
+        assert dialog._result == InstallPromptResult.DONT_ASK
+
+    def test_dont_ask_writes_suppression(
+        self, dialog: InstallPromptDialog, tmp_prefs: Path
+    ) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import is_suppressed
+
+        with patch.object(dialog, "reject"):
+            dialog._on_dont_ask()
+
+        assert is_suppressed("mujoco")
+
+    def test_dont_ask_rejects_dialog(
+        self, dialog: InstallPromptDialog, tmp_prefs: Path
+    ) -> None:
+        with patch.object(dialog, "reject") as mock_reject:
+            dialog._on_dont_ask()
+
+        mock_reject.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Suppressed feature — prompt() short-circuits
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressedFeature:
+    def test_prompt_returns_suppressed_without_exec(
+        self, qt_app, tmp_prefs: Path
+    ) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import (
+            InstallPromptDialog,
+            InstallPromptResult,
+            suppress_feature,
+        )
+
+        suppress_feature("mujoco")
+        dlg = InstallPromptDialog(feature_name="mujoco", package_name="MuJoCo")
+
+        exec_called: list[bool] = []
+        dlg.exec = lambda: exec_called.append(True)  # type: ignore[method-assign]
+
+        result = dlg.prompt()
+
+        assert result == InstallPromptResult.SUPPRESSED
+        assert not exec_called
+
+
+# ---------------------------------------------------------------------------
+# Async install callback + hot-refresh
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncInstallCallback:
+    def test_worker_finished_emits_signal(self, dialog: InstallPromptDialog) -> None:
+        emitted: list[tuple[bool, str]] = []
+        dialog.install_finished.connect(lambda s, r: emitted.append((s, r)))
+
+        with (
+            patch.object(dialog, "accept"),
+            patch(
+                "src.shared.python.ui.dialogs.install_prompt.refresh"
+            ) as mock_refresh,
+        ):
+            dialog._on_worker_finished(True, "installed mujoco")
+            mock_refresh.assert_called_once()
+
+        assert emitted == [(True, "installed mujoco")]
+
+    def test_worker_finished_calls_refresh_on_success(
+        self, dialog: InstallPromptDialog
+    ) -> None:
+        with (
+            patch.object(dialog, "accept"),
+            patch(
+                "src.shared.python.ui.dialogs.install_prompt.refresh"
+            ) as mock_refresh,
+        ):
+            dialog._on_worker_finished(True, "installed mujoco")
+
+        mock_refresh.assert_called_once()
+
+    def test_worker_finished_calls_refresh_on_failure(
+        self, dialog: InstallPromptDialog
+    ) -> None:
+        """refresh() must be called even when the install fails."""
+        with (
+            patch.object(dialog, "accept"),
+            patch(
+                "src.shared.python.ui.dialogs.install_prompt.refresh"
+            ) as mock_refresh,
+        ):
+            dialog._on_worker_finished(False, "exit 1")
+
+        mock_refresh.assert_called_once()
+
+    def test_worker_finished_accepts_dialog(self, dialog: InstallPromptDialog) -> None:
+        with (
+            patch.object(dialog, "accept") as mock_accept,
+            patch("src.shared.python.ui.dialogs.install_prompt.refresh"),
+        ):
+            dialog._on_worker_finished(True, "ok")
+
+        mock_accept.assert_called_once()
+
+    def test_worker_finished_hides_progress(self, dialog: InstallPromptDialog) -> None:
+        dialog._progress.show()
+        with (
+            patch.object(dialog, "accept"),
+            patch("src.shared.python.ui.dialogs.install_prompt.refresh"),
+        ):
+            dialog._on_worker_finished(True, "ok")
+
+        assert dialog._progress.isHidden()
+
+    def test_refresh_exception_does_not_crash_dialog(
+        self, dialog: InstallPromptDialog
+    ) -> None:
+        emitted: list[tuple[bool, str]] = []
+        dialog.install_finished.connect(lambda s, r: emitted.append((s, r)))
+
+        with (
+            patch.object(dialog, "accept"),
+            patch(
+                "src.shared.python.ui.dialogs.install_prompt.refresh",
+                side_effect=RuntimeError("registry boom"),
+            ),
+        ):
+            dialog._on_worker_finished(True, "installed")
+
+        assert emitted == [(True, "installed")]
+
+
+# ---------------------------------------------------------------------------
+# _InstallWorker
+# ---------------------------------------------------------------------------
+
+
+class TestInstallWorker:
+    def test_raises_on_empty_feature_name(self, qt_app) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import _InstallWorker
+
+        with pytest.raises(ValueError, match="feature_name"):
+            _InstallWorker("")
+
+    def test_worker_emits_finished_on_success(
+        self, qt_app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.feature_registry import InstallResult
+        from src.shared.python.ui.dialogs.install_prompt import _InstallWorker
+
+        fake_result = InstallResult(
+            feature="mujoco",
+            success=True,
+            command="pip install mujoco",
+            stdout="",
+            stderr="",
+            returncode=0,
+            reason="installed mujoco",
+        )
+        monkeypatch.setattr(
+            "src.shared.python.ui.dialogs.install_prompt.install_feature",
+            lambda name: fake_result,
+        )
+
+        worker = _InstallWorker("mujoco")
+        received: list[tuple[bool, str]] = []
+        worker.finished.connect(lambda s, r: received.append((s, r)))
+        worker.run()  # call run() directly — no real thread
+
+        assert received == [(True, "installed mujoco")]
+
+    def test_worker_emits_finished_on_failure(
+        self, qt_app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.feature_registry import InstallResult
+        from src.shared.python.ui.dialogs.install_prompt import _InstallWorker
+
+        fake_result = InstallResult(
+            feature="mujoco",
+            success=False,
+            command="pip install mujoco",
+            stdout="",
+            stderr="error output",
+            returncode=1,
+            reason="install failed for mujoco (exit 1)",
+        )
+        monkeypatch.setattr(
+            "src.shared.python.ui.dialogs.install_prompt.install_feature",
+            lambda name: fake_result,
+        )
+
+        worker = _InstallWorker("mujoco")
+        received: list[tuple[bool, str]] = []
+        worker.finished.connect(lambda s, r: received.append((s, r)))
+        worker.run()
+
+        assert received == [(False, "install failed for mujoco (exit 1)")]
+
+    def test_worker_handles_unexpected_exception(
+        self, qt_app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.shared.python.ui.dialogs.install_prompt import _InstallWorker
+
+        monkeypatch.setattr(
+            "src.shared.python.ui.dialogs.install_prompt.install_feature",
+            MagicMock(side_effect=RuntimeError("unexpected")),
+        )
+
+        worker = _InstallWorker("mujoco")
+        received: list[tuple[bool, str]] = []
+        worker.finished.connect(lambda s, r: received.append((s, r)))
+        worker.run()
+
+        assert len(received) == 1
+        assert received[0][0] is False
+        assert "unexpected" in received[0][1]
+
+
+# ---------------------------------------------------------------------------
+# src.core.capability_registry shim
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityRegistryShim:
+    def test_shim_exports_get_registry(self) -> None:
+        from src.core.capability_registry import get_registry
+
+        assert callable(get_registry)
+
+    def test_shim_exports_refresh(self) -> None:
+        from src.core.capability_registry import refresh
+
+        assert callable(refresh)
+
+    def test_shim_get_registry_returns_same_instance(self) -> None:
+        from src.core import capability_registry as shim
+        from src.shared.python.feature_registry import get_registry as canonical
+
+        assert shim.get_registry() is canonical()


### PR DESCRIPTION
## Summary

- Adds `src/shared/python/ui/dialogs/install_prompt.py` with `InstallPromptDialog`: a PyQt6 modal dialog shown when a user requests a feature with a missing optional dependency. Presents **Yes / No / Don't ask again** buttons with an indeterminate progress bar during background install.
- Background install runs in `_InstallWorker` (QThread) via the existing `install_feature()` API; on completion (success or failure) calls `registry.refresh()` for hot-refresh of the capability registry.
- `~/.upstreamdrift/prefs.json` stores per-feature `dont_ask_again` flags; `prompt()` short-circuits to `SUPPRESSED` without showing a dialog when already suppressed.
- Adds `src/core/capability_registry.py` as a thin re-export shim (no logic duplication) so callers can use `from src.core.capability_registry import get_registry, refresh`.
- 35 unit tests covering all paths: yes/no/dont-ask, async install callback, hot-refresh triggered on success and failure, refresh exception resilience, worker exception handling, suppression short-circuit, and the shim.

## Test plan

- [x] `python3 -m pytest tests/unit/ui/dialogs/test_install_prompt.py` — 35 passed locally
- [x] `python3 -m ruff check src/shared/python/ui/dialogs/ src/core/ tests/unit/ui/dialogs/` — no violations
- [x] `python3 -m ruff format --check ...` — no diffs
- [ ] CI: ruff check, ruff format, file size budget, full pytest suite

Closes #5768

🤖 Generated with [Claude Code](https://claude.com/claude-code)