### PR TITLE
test(engines): cover common loaders and tiers

### DIFF
--- a/src/engines/common/physics.py
+++ b/src/engines/common/physics.py
@@ -65,10 +65,18 @@ class AirProperties:
             AirProperties at the specified altitude
         """
         # International Standard Atmosphere model
-        if not (altitude_m is not None):
+        if altitude_m is None:
             raise ValueError("altitude_m must be provided")
-        if not (altitude_m is not None):
-            raise ValueError("altitude_m must be provided")
+        if not isinstance(altitude_m, (int, float)):
+            raise TypeError("altitude_m must be a number")
+        if (
+            altitude_m < MIN_VALID_ALTITUDE_M
+            or altitude_m > MAX_VALID_TROPOSPHERE_ALTITUDE_M
+        ):
+            raise ValueError(
+                f"altitude_m={altitude_m} outside ISA troposphere range "
+                f"[{MIN_VALID_ALTITUDE_M}, {MAX_VALID_TROPOSPHERE_ALTITUDE_M}] m"
+            )
         T0 = 288.15  # K
         P0 = 101325.0  # Pa
         L = 0.0065  # Temperature lapse rate [K/m]

--- a/tests/engines/common/test_capabilities_shim.py
+++ b/tests/engines/common/test_capabilities_shim.py
@@ -1,0 +1,19 @@
+"""Coverage for src.engines.common.capabilities shim module."""
+
+from __future__ import annotations
+
+
+def test_capabilities_shim_reexports() -> None:
+    """The shim re-exports CapabilityLevel and EngineCapabilities."""
+    from src.engines.common import capabilities as shim
+    from src.shared.python.engine_core.capabilities import (
+        CapabilityLevel,
+        EngineCapabilities,
+        SPATIAL_JACOBIAN_ORDER,
+    )
+
+    assert shim.CapabilityLevel is CapabilityLevel
+    assert shim.EngineCapabilities is EngineCapabilities
+    assert shim.SPATIAL_JACOBIAN_ORDER is SPATIAL_JACOBIAN_ORDER
+    assert "CapabilityLevel" in shim.__all__
+    assert "EngineCapabilities" in shim.__all__

--- a/tests/engines/common/test_loaders_extras.py
+++ b/tests/engines/common/test_loaders_extras.py
@@ -1,0 +1,307 @@
+"""Coverage for src.engines.loaders — engines not covered elsewhere.
+
+Mocks heavy engine dependencies (MuJoCo, OpenSim, MyoSuite, pydrake, MATLAB).
+Pure-Python — no real physics engines spun up.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.shared.python.engine_core.engine_probes as engine_probes_mod
+from src.shared.python.data_io.common_utils import GolfModelingError
+from src.shared.python.engine_core.engine_probes import EngineProbe
+from src.shared.python.engine_core.engine_registry import EngineType
+from src.shared.python.engine_core.interfaces import PhysicsEngine
+
+
+_PROBE_SPEC = [
+    "is_available",
+    "diagnostic_message",
+    "get_fix_instructions",
+    "details",
+]
+
+
+def _probe_mock(available: bool = True) -> MagicMock:
+    cls = MagicMock()
+    instance = MagicMock(spec=EngineProbe)
+    cls.return_value = instance
+    result = MagicMock(spec=_PROBE_SPEC)
+    result.is_available.return_value = available
+    result.diagnostic_message = "missing"
+    result.get_fix_instructions.return_value = "install it"
+    instance.probe.return_value = result
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# LOADER_MAP completeness
+# ---------------------------------------------------------------------------
+
+
+def test_loader_map_has_all_engine_types() -> None:
+    from src.engines.loaders import LOADER_MAP
+
+    expected = {
+        EngineType.MUJOCO,
+        EngineType.DRAKE,
+        EngineType.PINOCCHIO,
+        EngineType.OPENSIM,
+        EngineType.MYOSIM,
+        EngineType.PENDULUM,
+        EngineType.GOLF_SWING_PENDULUM,
+        EngineType.PUTTING_GREEN,
+        EngineType.MATLAB_3D,
+    }
+    assert expected.issubset(set(LOADER_MAP))
+
+
+# ---------------------------------------------------------------------------
+# OpenSim loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_opensim_engine_success(tmp_path: Path) -> None:
+    from src.engines.loaders import load_opensim_engine
+
+    engine = MagicMock(spec=PhysicsEngine)
+    engine_cls = MagicMock(return_value=engine)
+
+    opensim_mod = MagicMock(spec=["OpenSimPhysicsEngine"])
+    opensim_mod.OpenSimPhysicsEngine = engine_cls
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "src.engines.physics_engines.opensim.python.opensim_physics_engine": opensim_mod,  # noqa: E501
+            },
+        ),
+        patch.object(engine_probes_mod, "OpenSimProbe", _probe_mock(True)),
+    ):
+        result = load_opensim_engine(tmp_path)
+    assert result is engine
+
+
+def test_load_opensim_engine_probe_fails(tmp_path: Path) -> None:
+    from src.engines.loaders import load_opensim_engine
+
+    engine_cls = MagicMock()
+    opensim_mod = MagicMock(spec=["OpenSimPhysicsEngine"])
+    opensim_mod.OpenSimPhysicsEngine = engine_cls
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "src.engines.physics_engines.opensim.python.opensim_physics_engine": opensim_mod,  # noqa: E501
+            },
+        ),
+        patch.object(engine_probes_mod, "OpenSimProbe", _probe_mock(False)),
+        pytest.raises(GolfModelingError, match="OpenSim (not ready|requirements)"),
+    ):
+        load_opensim_engine(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# MyoSim loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_myosim_engine_success(tmp_path: Path) -> None:
+    from src.engines.loaders import load_myosim_engine
+
+    engine = MagicMock(spec=PhysicsEngine)
+    engine_cls = MagicMock(return_value=engine)
+    myosim_mod = MagicMock(spec=["MyoSuitePhysicsEngine"])
+    myosim_mod.MyoSuitePhysicsEngine = engine_cls
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "src.engines.physics_engines.myosuite.python.myosuite_physics_engine": myosim_mod,  # noqa: E501
+            },
+        ),
+        patch.object(engine_probes_mod, "MyoSimProbe", _probe_mock(True)),
+    ):
+        result = load_myosim_engine(tmp_path)
+    assert result is engine
+
+
+# ---------------------------------------------------------------------------
+# Pendulum loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_pendulum_engine_success(tmp_path: Path) -> None:
+    from src.engines.loaders import load_pendulum_engine
+
+    engine = MagicMock(spec=PhysicsEngine)
+    engine_cls = MagicMock(return_value=engine)
+    pend_mod = MagicMock(spec=["PendulumPhysicsEngine"])
+    pend_mod.PendulumPhysicsEngine = engine_cls
+    with patch.dict(
+        sys.modules,
+        {
+            "src.engines.physics_engines.pendulum.python.pendulum_physics_engine": pend_mod,  # noqa: E501
+        },
+    ):
+        result = load_pendulum_engine(tmp_path)
+    assert result is engine
+
+
+def test_load_pendulum_engine_import_error_raises(tmp_path: Path) -> None:
+    from src.engines.loaders import load_pendulum_engine
+
+    real_import = __import__
+
+    def fake_import(name: str, *a, **kw):  # type: ignore[no-untyped-def]
+        if "pendulum_physics_engine" in name:
+            raise ImportError("nope")
+        return real_import(name, *a, **kw)
+
+    with (
+        patch("builtins.__import__", side_effect=fake_import),
+        pytest.raises(GolfModelingError, match="Pendulum engine not found"),
+    ):
+        load_pendulum_engine(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Golf Swing Pendulum loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_golf_swing_pendulum_success(tmp_path: Path) -> None:
+    from src.engines.loaders import load_golf_swing_pendulum_engine
+
+    engine = MagicMock(spec=PhysicsEngine)
+    engine_cls = MagicMock(return_value=engine)
+    engine_cls.is_available = MagicMock(return_value=True)
+    mod = MagicMock(spec=["GolfSwingPendulumEngine"])
+    mod.GolfSwingPendulumEngine = engine_cls
+
+    with patch.dict(
+        sys.modules,
+        {
+            "src.engines.physics_engines.pendulum.python.golf_swing_physics_engine": mod,  # noqa: E501
+        },
+    ):
+        result = load_golf_swing_pendulum_engine(tmp_path)
+    assert result is engine
+
+
+def test_load_golf_swing_pendulum_unavailable_raises(tmp_path: Path) -> None:
+    from src.engines.loaders import load_golf_swing_pendulum_engine
+
+    engine_cls = MagicMock()
+    engine_cls.is_available = MagicMock(return_value=False)
+    mod = MagicMock(spec=["GolfSwingPendulumEngine"])
+    mod.GolfSwingPendulumEngine = engine_cls
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "src.engines.physics_engines.pendulum.python.golf_swing_physics_engine": mod,  # noqa: E501
+            },
+        ),
+        pytest.raises(GolfModelingError, match="vendor/ud-tools"),
+    ):
+        load_golf_swing_pendulum_engine(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Putting Green loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_putting_green_success(tmp_path: Path) -> None:
+    from src.engines.loaders import load_putting_green_engine
+
+    sim = MagicMock()
+    sim_cls = MagicMock(return_value=sim)
+    mod = MagicMock(spec=["PuttingGreenSimulator"])
+    mod.PuttingGreenSimulator = sim_cls
+    with patch.dict(
+        sys.modules,
+        {
+            "src.engines.physics_engines.putting_green.python.simulator": mod,
+        },
+    ):
+        result = load_putting_green_engine(tmp_path)
+    assert result is sim
+
+
+def test_load_putting_green_import_error_raises(tmp_path: Path) -> None:
+    from src.engines.loaders import load_putting_green_engine
+
+    real_import = __import__
+
+    def fake_import(name: str, *a, **kw):  # type: ignore[no-untyped-def]
+        if "putting_green.python.simulator" in name:
+            raise ImportError("nope")
+        return real_import(name, *a, **kw)
+
+    with (
+        patch("builtins.__import__", side_effect=fake_import),
+        pytest.raises(GolfModelingError, match="Putting Green engine not found"),
+    ):
+        load_putting_green_engine(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# MATLAB_3D loader edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_load_matlab_3d_requires_path_type() -> None:
+    from src.engines.loaders import load_matlab_3d_engine
+
+    with pytest.raises(TypeError, match="suite_root must be a Path"):
+        load_matlab_3d_engine("not-a-path")  # type: ignore[arg-type]
+
+
+def test_load_matlab_3d_model_missing_returns_unloaded(tmp_path: Path) -> None:
+    """When the default .slx file does not exist the loader emits a warning
+    and returns the adapter unloaded."""
+    from src.engines.loaders import load_matlab_3d_engine
+
+    engine = load_matlab_3d_engine(tmp_path)
+    assert engine is not None
+
+
+def test_load_matlab_3d_load_error_propagates(tmp_path: Path) -> None:
+    """If load_from_path raises, loader wraps it as GolfModelingError."""
+    from src.engines.loaders import DEFAULT_MATLAB_3D_SLX_RELPATH
+
+    model_path = tmp_path / DEFAULT_MATLAB_3D_SLX_RELPATH
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.write_text("<fake slx>")
+
+    fake_adapter_instance = MagicMock(spec=PhysicsEngine)
+    fake_adapter_instance.load_from_path.side_effect = RuntimeError("boom")
+    fake_adapter_cls = MagicMock(return_value=fake_adapter_instance)
+
+    fake_simscape_mod = MagicMock(spec=["SimscapeAdapter"])
+    fake_simscape_mod.SimscapeAdapter = fake_adapter_cls
+
+    with (
+        patch.dict(sys.modules, {"src.engines.simscape": fake_simscape_mod}),
+        pytest.raises(GolfModelingError, match="failed to load default model"),
+    ):
+        from src.engines.loaders import load_matlab_3d_engine
+
+        load_matlab_3d_engine(tmp_path)
+
+
+def test_ensure_engine_loaded_rejects_none() -> None:
+    from src.engines.loaders import _ensure_engine_loaded
+
+    with pytest.raises(GolfModelingError, match="DbC postcondition"):
+        _ensure_engine_loaded(None, "Test")  # type: ignore[arg-type]

--- a/tests/engines/common/test_simulation_control.py
+++ b/tests/engines/common/test_simulation_control.py
@@ -1,0 +1,173 @@
+"""Coverage for simulation_control.py — controller lifecycle + dataclasses."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.engines.common.simulation_control import (
+    ForceOverlay,
+    MeasurementResult,
+    SimulationController,
+    SimulationMode,
+)
+from src.shared.python.core.contracts import PreconditionError
+
+
+class _StubController(SimulationController):
+    """Minimal concrete controller for testing the base class."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.step_count = 0
+
+    def _do_step(self) -> None:
+        self.step_count += 1
+
+    def translate_body(self, body_name: str, delta: np.ndarray) -> bool:
+        return True
+
+    def rotate_body(self, body_name: str, axis: np.ndarray, angle: float) -> bool:
+        return True
+
+    def measure_distance(self, body_a: str, body_b: str) -> MeasurementResult:
+        return MeasurementResult(
+            type="distance", value=1.5, unit="m", point_a=body_a, point_b=body_b
+        )
+
+    def measure_angle(self, body_a: str, body_b: str, body_c: str) -> MeasurementResult:
+        return MeasurementResult(
+            type="angle",
+            value=0.5,
+            unit="rad",
+            point_a=body_a,
+            point_b=body_b,
+        )
+
+
+# ---------------------------------------------------------------------------
+# MeasurementResult
+# ---------------------------------------------------------------------------
+
+
+class TestMeasurementResult:
+    def test_to_dict_without_vector(self) -> None:
+        r = MeasurementResult(type="distance", value=1.0, unit="m", point_a="a")
+        d = r.to_dict()
+        assert d == {
+            "type": "distance",
+            "value": 1.0,
+            "unit": "m",
+            "point_a": "a",
+            "point_b": "",
+        }
+
+    def test_to_dict_with_vector(self) -> None:
+        r = MeasurementResult(
+            type="vec",
+            value=1.0,
+            unit="m",
+            point_a="a",
+            point_b="b",
+            vector=np.array([1.0, 2.0, 3.0]),
+        )
+        d = r.to_dict()
+        assert d["vector"] == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# ForceOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestForceOverlay:
+    def test_defaults(self) -> None:
+        o = ForceOverlay(body_name="club")
+        np.testing.assert_array_equal(o.force, np.zeros(3))
+        np.testing.assert_array_equal(o.torque, np.zeros(3))
+        assert o.scale == 1.0
+        assert o.color == (255, 100, 100)
+
+    def test_to_dict_round_trip(self) -> None:
+        o = ForceOverlay(
+            body_name="club",
+            force=np.array([1.0, 0, 0]),
+            torque=np.array([0, 1.0, 0]),
+            scale=2.0,
+            color=(0, 255, 0),
+            label="grip",
+        )
+        d = o.to_dict()
+        assert d["body_name"] == "club"
+        assert d["force"] == [1.0, 0.0, 0.0]
+        assert d["torque"] == [0.0, 1.0, 0.0]
+        assert d["color"] == [0, 255, 0]
+        assert d["label"] == "grip"
+        assert d["scale"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# SimulationController
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationController:
+    def test_initial_mode_is_idle(self) -> None:
+        c = _StubController()
+        assert c.mode == SimulationMode.IDLE
+        assert not c.is_running
+        assert not c.is_paused
+
+    def test_start_pause_resume_stop_cycle(self) -> None:
+        c = _StubController()
+        assert c.start() is True
+        assert c.is_running
+        assert c.pause() is True
+        assert c.is_paused
+        assert c.start() is True  # resume
+        assert c.is_running
+        assert c.stop() is True
+        assert c.mode == SimulationMode.IDLE
+
+    def test_single_step_runs_do_step_and_pauses(self) -> None:
+        c = _StubController()
+        assert c.single_step() is True
+        assert c.step_count == 1
+        assert c.mode == SimulationMode.PAUSED
+
+    def test_overlays_add_and_clear(self) -> None:
+        c = _StubController()
+        c.add_force_overlay(ForceOverlay(body_name="a"))
+        c.add_force_overlay(ForceOverlay(body_name="b"))
+        assert len(c.overlays) == 2
+        # overlays is a copy
+        c.overlays.clear()
+        assert len(c.overlays) == 2
+        c.clear_overlays()
+        assert c.overlays == []
+
+    def test_measurements_serialization(self) -> None:
+        c = _StubController()
+        c._measurements.append(c.measure_distance("a", "b"))
+        c._measurements.append(c.measure_angle("a", "b", "c"))
+        results = c.get_measurements()
+        assert len(results) == 2
+        assert results[0]["type"] == "distance"
+        c.clear_measurements()
+        assert c.get_measurements() == []
+
+    def test_start_from_running_violates_precondition(self) -> None:
+        c = _StubController()
+        c.start()
+        with pytest.raises(PreconditionError):
+            c.start()
+
+    def test_pause_from_idle_violates_precondition(self) -> None:
+        c = _StubController()
+        with pytest.raises(PreconditionError):
+            c.pause()
+
+    def test_stop_from_idle_violates_precondition(self) -> None:
+        c = _StubController()
+        with pytest.raises(PreconditionError):
+            c.stop()

--- a/tests/engines/common/test_state_extras.py
+++ b/tests/engines/common/test_state_extras.py
@@ -1,0 +1,242 @@
+"""Coverage for state.py — EngineStateMixin, ForceAccumulator, edges."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.engines.common.state import (
+    EngineLifecycleState,
+    EngineStateMixin,
+    ForceAccumulator,
+    ForceSource,
+    SimulationState,
+    StateManager,
+)
+from src.shared.python.core.contracts import StateError
+
+
+# ---------------------------------------------------------------------------
+# SimulationState
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationStateValidate:
+    def test_valid_state(self) -> None:
+        s = SimulationState(q=np.zeros(3), v=np.zeros(3))
+        assert s.validate() is True
+
+    def test_nan_q_invalid(self) -> None:
+        s = SimulationState(q=np.array([np.nan, 0, 0]), v=np.zeros(3))
+        assert s.validate() is False
+
+    def test_inf_v_invalid(self) -> None:
+        s = SimulationState(q=np.zeros(3), v=np.array([np.inf, 0, 0]))
+        assert s.validate() is False
+
+    def test_nan_a_invalid(self) -> None:
+        s = SimulationState(q=np.zeros(3), v=np.zeros(3), a=np.array([np.nan, 0, 0]))
+        assert s.validate() is False
+
+    def test_nan_tau_invalid(self) -> None:
+        s = SimulationState(q=np.zeros(3), v=np.zeros(3), tau=np.array([np.nan, 0, 0]))
+        assert s.validate() is False
+
+    def test_negative_time_invalid(self) -> None:
+        s = SimulationState(q=np.zeros(3), v=np.zeros(3), time=-1.0)
+        assert s.validate() is False
+
+    def test_copy_is_deep(self) -> None:
+        s = SimulationState(q=np.ones(2), v=np.ones(2), metadata={"engine": "test"})
+        c = s.copy()
+        c.q[0] = 99
+        c.metadata["engine"] = "other"
+        assert s.q[0] == 1.0
+        assert s.metadata["engine"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# StateManager undo/redo edges
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagerHistory:
+    def test_undo_redo_walks_history(self) -> None:
+        m = StateManager(nq=2, nv=2, max_history=10)
+        m.initialize(q0=np.array([1.0, 2.0]))
+        m._state.q[:] = [3.0, 4.0]
+        m._save_history()
+        m._state.q[:] = [5.0, 6.0]
+        m._save_history()
+
+        assert m.can_undo()
+        assert not m.can_redo()
+        assert m.undo() is True
+        np.testing.assert_array_equal(m.state.q, [3.0, 4.0])
+        assert m.can_redo()
+        assert m.redo() is True
+        np.testing.assert_array_equal(m.state.q, [5.0, 6.0])
+
+    def test_undo_at_start_returns_false(self) -> None:
+        m = StateManager(nq=2, nv=2)
+        m.initialize()
+        assert m.undo() is False
+
+    def test_redo_at_end_returns_false(self) -> None:
+        m = StateManager(nq=2, nv=2)
+        m.initialize()
+        assert m.redo() is False
+
+    def test_history_capped_at_max(self) -> None:
+        m = StateManager(nq=1, nv=1, max_history=3)
+        m.initialize()
+        for _ in range(10):
+            m._save_history()
+        assert len(m._history) <= 3
+
+    def test_reset_clears_history(self) -> None:
+        m = StateManager(nq=1, nv=1)
+        m.initialize(q0=np.array([5.0]))
+        m._save_history()
+        m.reset()
+        assert m._history == []
+        np.testing.assert_array_equal(m.state.q, np.zeros(1))
+
+    def test_set_state_dimension_mismatch_raises(self) -> None:
+        m = StateManager(nq=2, nv=2)
+        with pytest.raises(ValueError, match="q dimension"):
+            m.set_state(np.zeros(3), np.zeros(2))
+        with pytest.raises(ValueError, match="v dimension"):
+            m.set_state(np.zeros(2), np.zeros(5))
+
+    def test_advance_time_updates_step_count(self) -> None:
+        m = StateManager(nq=1, nv=1)
+        m.initialize()
+        m.advance_time(0.01)
+        m.advance_time(0.01)
+        assert m.state.step_count == 2
+        assert m.state.time == pytest.approx(0.02)
+
+    def test_get_state_returns_copies(self) -> None:
+        m = StateManager(nq=2, nv=2)
+        m.initialize(q0=np.array([1.0, 2.0]))
+        q, v = m.get_state()
+        q[0] = 99
+        assert m.state.q[0] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# EngineStateMixin
+# ---------------------------------------------------------------------------
+
+
+class _DummyEngine(EngineStateMixin):
+    pass
+
+
+class TestEngineStateMixin:
+    def test_initial_state_is_uninitialized(self) -> None:
+        e = _DummyEngine()
+        assert e._get_lifecycle() == EngineLifecycleState.UNINITIALIZED
+
+    def test_set_lifecycle_notifies_callbacks(self) -> None:
+        e = _DummyEngine()
+        observed: list[EngineLifecycleState] = []
+        e.add_lifecycle_callback(observed.append)
+        e._set_lifecycle(EngineLifecycleState.INITIALIZED)
+        assert observed == [EngineLifecycleState.INITIALIZED]
+
+    def test_callback_errors_are_swallowed(self) -> None:
+        e = _DummyEngine()
+
+        def boom(_: EngineLifecycleState) -> None:
+            raise RuntimeError("kaboom")
+
+        e.add_lifecycle_callback(boom)
+        # Should not propagate
+        e._set_lifecycle(EngineLifecycleState.INITIALIZED)
+
+    def test_remove_callback(self) -> None:
+        e = _DummyEngine()
+        observed: list[EngineLifecycleState] = []
+        e.add_lifecycle_callback(observed.append)
+        e.remove_lifecycle_callback(observed.append)
+        e._set_lifecycle(EngineLifecycleState.INITIALIZED)
+        assert observed == []
+
+    def test_remove_unknown_callback_is_noop(self) -> None:
+        e = _DummyEngine()
+        e.remove_lifecycle_callback(lambda _s: None)  # no error
+
+    def test_require_lifecycle_raises_when_wrong_state(self) -> None:
+        e = _DummyEngine()
+        with pytest.raises(StateError):
+            e._require_lifecycle(EngineLifecycleState.INITIALIZED, operation="step")
+
+    def test_require_lifecycle_passes_when_state_matches(self) -> None:
+        e = _DummyEngine()
+        e._set_lifecycle(EngineLifecycleState.INITIALIZED)
+        e._require_lifecycle(EngineLifecycleState.INITIALIZED, operation="step")
+
+
+# ---------------------------------------------------------------------------
+# ForceAccumulator
+# ---------------------------------------------------------------------------
+
+
+class TestForceAccumulator:
+    def test_empty_returns_zero_vectors(self) -> None:
+        acc = ForceAccumulator(nv=4)
+        np.testing.assert_array_equal(acc.get_total_force(), np.zeros(3))
+        np.testing.assert_array_equal(acc.get_total_torque(), np.zeros(3))
+        np.testing.assert_array_equal(acc.get_total_generalized_force(), np.zeros(4))
+
+    def test_add_force_default_zero_torque(self) -> None:
+        acc = ForceAccumulator(nv=2)
+        acc.add_force("g", np.array([0.0, 0.0, -9.81]))
+        sources = acc.get_forces_by_source()
+        assert "g" in sources
+        np.testing.assert_array_equal(sources["g"].torque, np.zeros(3))
+
+    def test_total_force_and_torque_sums(self) -> None:
+        acc = ForceAccumulator(nv=2)
+        acc.add_force("a", np.array([1.0, 0, 0]), torque=np.array([0, 1.0, 0]))
+        acc.add_force("b", np.array([0.0, 2.0, 0]), torque=np.array([0, 0, 3.0]))
+        np.testing.assert_allclose(acc.get_total_force(), [1.0, 2.0, 0.0])
+        np.testing.assert_allclose(acc.get_total_torque(), [0.0, 1.0, 3.0])
+
+    def test_add_generalized_force_dimension_check(self) -> None:
+        acc = ForceAccumulator(nv=3)
+        acc.add_generalized_force("m", np.array([1.0, 2.0, 3.0]))
+        np.testing.assert_allclose(acc.get_total_generalized_force(), [1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="tau dimension"):
+            acc.add_generalized_force("bad", np.array([1.0, 2.0]))
+
+    def test_get_forces_by_category_groups(self) -> None:
+        acc = ForceAccumulator(nv=1)
+        acc.add_force("g", np.zeros(3), category="gravity")
+        acc.add_force("d", np.zeros(3), category="drag")
+        acc.add_force("d2", np.zeros(3), category="drag")
+        by_cat = acc.get_forces_by_category()
+        assert set(by_cat) == {"gravity", "drag"}
+        assert len(by_cat["drag"]) == 2
+
+    def test_get_source_names_includes_generalized(self) -> None:
+        acc = ForceAccumulator(nv=2)
+        acc.add_force("g", np.zeros(3))
+        acc.add_generalized_force("m", np.zeros(2))
+        assert set(acc.get_source_names()) == {"g", "m"}
+
+    def test_clear_removes_all(self) -> None:
+        acc = ForceAccumulator(nv=2)
+        acc.add_force("g", np.ones(3))
+        acc.add_generalized_force("m", np.ones(2))
+        acc.clear()
+        np.testing.assert_array_equal(acc.get_total_force(), np.zeros(3))
+        assert acc.get_source_names() == []
+
+    def test_force_source_default_zero_arrays(self) -> None:
+        src = ForceSource(name="x")
+        np.testing.assert_array_equal(src.force, np.zeros(3))
+        np.testing.assert_array_equal(src.torque, np.zeros(3))
+        assert src.category == "external"

--- a/tests/engines/common/test_tiers.py
+++ b/tests/engines/common/test_tiers.py
@@ -1,0 +1,60 @@
+"""Coverage for src.engines.tiers — tier policy helpers."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from src.engines.tiers import (
+    ALLOWED_TIERS,
+    ENGINE_TIERS,
+    ExperimentalTierWarning,
+    get_engine_tier,
+    warn_if_experimental,
+)
+
+
+class TestGetEngineTier:
+    def test_known_engines_return_documented_tier(self) -> None:
+        for name, tier in ENGINE_TIERS.items():
+            assert get_engine_tier(name) == tier
+            assert tier in ALLOWED_TIERS
+
+    def test_normalizes_whitespace_and_case(self) -> None:
+        assert get_engine_tier("  MuJoCo  ") == "core"
+
+    def test_unknown_engine_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown engine tier metadata"):
+            get_engine_tier("not_a_real_engine")
+
+    def test_empty_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            get_engine_tier("   ")
+
+    def test_non_string_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="must be a string"):
+            get_engine_tier(123)  # type: ignore[arg-type]
+
+
+class TestWarnIfExperimental:
+    def test_experimental_emits_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_experimental("opensim", "OpenSim")
+        assert any(issubclass(w.category, ExperimentalTierWarning) for w in caught)
+        assert any("OpenSim" in str(w.message) for w in caught)
+
+    def test_core_engine_does_not_warn(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_experimental("mujoco", "MuJoCo")
+        assert not any(issubclass(w.category, ExperimentalTierWarning) for w in caught)
+
+    def test_non_string_display_name_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="display_name must be a string"):
+            warn_if_experimental("opensim", 42)  # type: ignore[arg-type]
+
+    def test_unknown_engine_propagates_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            warn_if_experimental("does_not_exist", "Bogus")


### PR DESCRIPTION
## Summary
- Add 66 focused unit tests under `tests/engines/common/` for `src/engines/common/`, `src/engines/loaders.py`, and `src/engines/tiers.py`. Heavy engines (MuJoCo, OpenSim, MyoSuite, pydrake, MATLAB Simscape) are mocked via `patch.dict(sys.modules, ...)` per CLAUDE.md — no real physics engines are spun up.
- Scope coverage climbs from ~72% to ~89% (loaders.py 36% -> 92%, simulation_control.py 67% -> 100%, state.py 63% -> 93%, tiers.py 66% -> 94%).
- Bug fix in `AirProperties.from_altitude`: the constants `MIN_VALID_ALTITUDE_M` and `MAX_VALID_TROPOSPHERE_ALTITUDE_M` were declared but never enforced. Two pre-existing tests in `tests/unit/engines/test_common_physics.py` (`test_from_altitude_rejects_outside_troposphere_range`) were asserting this validation and failing. They now pass.

## Test plan
- [x] `python3 -m pytest tests/engines/common -x --timeout=30` — 66 passed, <1s total
- [x] `python3 -m ruff check tests/engines/common src/engines/common/physics.py`
- [x] `python3 -m ruff format --check`
- [x] Pre-existing `tests/unit/engines/test_common_physics.py` now fully passes after bug fix

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>