### PR TITLE
test(pendulum_models): comprehensive coverage

### DIFF
--- a/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py
@@ -113,8 +113,6 @@ class ExpressionFunction:
     def __init__(self, expression: str) -> None:
         if not (expression is not None):
             raise ValueError("expression must be provided")
-        if not (expression is not None):
-            raise ValueError("expression must be provided")
         self.expression = expression.strip()
         # Validate the AST before accepting the expression
         self._validate_ast(self.expression)
@@ -125,8 +123,6 @@ class ExpressionFunction:
 
     def _validate_ast(self, expression: str) -> None:  # noqa: C901
         """Walk the AST and raise ValueError for any disallowed constructs."""
-        if not (expression is not None):
-            raise ValueError("expression must be provided")
         if not (expression is not None):
             raise ValueError("expression must be provided")
         try:
@@ -165,8 +161,6 @@ class ExpressionFunction:
                     raise ValueError(f"Use of unknown variable '{name}'")
 
     def __call__(self, t: float, state: DoublePendulumState) -> float:
-        if not (t is not None):
-            raise ValueError("t must be provided")
         if not (t is not None):
             raise ValueError("t must be provided")
         context: dict[str, float] = {
@@ -354,8 +348,6 @@ class DoublePendulumDynamics:
         # Use cached values
         if not (theta2 is not None):
             raise ValueError("theta2 must be provided")
-        if not (theta2 is not None):
-            raise ValueError("theta2 must be provided")
         m2 = self._m2
         l1 = self._l1
         lc2 = self._lc2
@@ -374,8 +366,6 @@ class DoublePendulumDynamics:
         """Compute Coriolis and centripetal force vector."""
         if not (theta2 is not None):
             raise ValueError("theta2 must be provided")
-        if not (theta2 is not None):
-            raise ValueError("theta2 must be provided")
         m2 = self._m2
         l1 = self._l1
         lc2 = self._lc2
@@ -387,8 +377,6 @@ class DoublePendulumDynamics:
 
     def gravity_vector(self, theta1: float, theta2: float) -> tuple[float, float]:
         """Compute gravitational torque vector for both joints."""
-        if not (theta1 is not None):
-            raise ValueError("theta1 must be provided")
         if not (theta1 is not None):
             raise ValueError("theta1 must be provided")
         m1 = self._m1
@@ -406,8 +394,6 @@ class DoublePendulumDynamics:
 
     def damping_vector(self, omega1: float, omega2: float) -> tuple[float, float]:
         """Compute viscous damping torques for both joints."""
-        if not (omega1 is not None):
-            raise ValueError("omega1 must be provided")
         if not (omega1 is not None):
             raise ValueError("omega1 must be provided")
         d1 = self._d1 * omega1
@@ -430,8 +416,6 @@ class DoublePendulumDynamics:
         self, state: DoublePendulumState
     ) -> tuple[tuple[float, ...], tuple[tuple[float, ...], ...]]:
         """Decompose dynamics into drift and control-input matrices."""
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         c1, c2 = self.coriolis_vector(state.theta2, state.omega1, state.omega2)
@@ -461,8 +445,6 @@ class DoublePendulumDynamics:
         """Evaluate user-defined forcing functions at the given state."""
         if not (t is not None):
             raise ValueError("t must be provided")
-        if not (t is not None):
-            raise ValueError("t must be provided")
         tau1 = self.forcing_functions[0](t, state)
         tau2 = self.forcing_functions[1](t, state)
         return tau1, tau2
@@ -472,8 +454,6 @@ class DoublePendulumDynamics:
     ) -> tuple[float, float]:
         """Compute joint torques required to realize the provided accelerations."""
 
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         c1, c2 = self.coriolis_vector(state.theta2, state.omega1, state.omega2)
@@ -492,8 +472,6 @@ class DoublePendulumDynamics:
         """Decompose joint torques into applied, gravity, damping, and Coriolis."""
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         c1, c2 = self.coriolis_vector(state.theta2, state.omega1, state.omega2)
         g1, g2 = self.gravity_vector(state.theta1, state.theta2)
         d1, d2 = self.damping_vector(state.omega1, state.omega2)
@@ -508,8 +486,6 @@ class DoublePendulumDynamics:
         self, t: float, state: DoublePendulumState
     ) -> tuple[float, float, float, float]:
         """Compute state derivatives (velocities and accelerations)."""
-        if not (t is not None):
-            raise ValueError("t must be provided")
         if not (t is not None):
             raise ValueError("t must be provided")
         tau1, tau2 = self.applied_torques(t, state)
@@ -528,15 +504,11 @@ class DoublePendulumDynamics:
 
         if not (t is not None):
             raise ValueError("t must be provided")
-        if not (t is not None):
-            raise ValueError("t must be provided")
 
         def rk4_increment(
             current_state: DoublePendulumState, scale: float, derivs: Iterable[float]
         ) -> DoublePendulumState:
             """Apply a scaled RK4 derivative increment to the state."""
-            if not (current_state is not None):
-                raise ValueError("current_state must be provided")
             if not (current_state is not None):
                 raise ValueError("current_state must be provided")
             dtheta1, dtheta2, domega1, domega2 = derivs

--- a/src/engines/pendulum_models/python/double_pendulum_model/physics/triple_pendulum.py
+++ b/src/engines/pendulum_models/python/double_pendulum_model/physics/triple_pendulum.py
@@ -101,15 +101,11 @@ class PolynomialProfile:
         """Evaluate angular velocity polynomial at time t."""
         if not (t is not None):
             raise ValueError("t must be provided")
-        if not (t is not None):
-            raise ValueError("t must be provided")
         poly = np.poly1d(self.coefficients)
         return float(poly(t))
 
     def alpha(self, t: float) -> float:
         """Evaluate angular acceleration polynomial at time t."""
-        if not (t is not None):
-            raise ValueError("t must be provided")
         if not (t is not None):
             raise ValueError("t must be provided")
         derivative = np.polyder(self.coefficients)
@@ -347,8 +343,6 @@ class TriplePendulumDynamics:
         """Compute the 3x3 mass matrix for the current state."""
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         params = self._parameter_vector()
         theta = (state.theta1, state.theta2, state.theta3)
         omega = (state.omega1, state.omega2, state.omega3)
@@ -357,8 +351,6 @@ class TriplePendulumDynamics:
 
     def bias_vector(self, state: TriplePendulumState) -> np.ndarray:
         """Compute bias vector including Coriolis, gravity, and damping."""
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         params = self._parameter_vector()
@@ -377,8 +369,6 @@ class TriplePendulumDynamics:
         """Solve for joint accelerations given applied torques."""
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         mass = self.mass_matrix(state)
         bias = self.bias_vector(state)
         accelerations = np.linalg.solve(mass, np.array(control, dtype=float) - bias)
@@ -392,8 +382,6 @@ class TriplePendulumDynamics:
         """Compute torques required to produce the given accelerations."""
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         mass = self.mass_matrix(state)
         bias = self.bias_vector(state)
         torques = mass @ np.array(accelerations, dtype=float) + bias
@@ -405,8 +393,6 @@ class TriplePendulumDynamics:
         self, state: TriplePendulumState, control: tuple[float, float, float]
     ) -> TripleJointTorques:
         """Decompose joint torques into applied, gravity, damping, and Coriolis."""
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         theta = (state.theta1, state.theta2, state.theta3)
@@ -448,8 +434,6 @@ class TriplePendulumDynamics:
 
         if not (_t is not None):
             raise ValueError("_t must be provided")
-        if not (_t is not None):
-            raise ValueError("_t must be provided")
 
         def rk4_increment(
             current_state: TriplePendulumState,
@@ -457,8 +441,6 @@ class TriplePendulumDynamics:
             derivs: tuple[float, float, float, float, float, float],
         ) -> TriplePendulumState:
             """Apply a scaled RK4 derivative increment to the state."""
-            if not (current_state is not None):
-                raise ValueError("current_state must be provided")
             if not (current_state is not None):
                 raise ValueError("current_state must be provided")
             dtheta1, dtheta2, dtheta3, domega1, domega2, domega3 = derivs

--- a/tests/engines/pendulum_models/python/double_pendulum_model/test_double_pendulum_edges.py
+++ b/tests/engines/pendulum_models/python/double_pendulum_model/test_double_pendulum_edges.py
@@ -1,0 +1,199 @@
+"""Edge-case and precondition tests for DoublePendulumDynamics."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pendulum import (
+    DoublePendulumDynamics,
+    DoublePendulumParameters,
+    DoublePendulumState,
+    JointTorques,
+    LowerSegmentProperties,
+    SegmentProperties,
+)
+
+
+@pytest.fixture()
+def state() -> DoublePendulumState:
+    return DoublePendulumState(theta1=0.5, theta2=0.3, omega1=0.2, omega2=-0.1)
+
+
+@pytest.fixture()
+def dyn() -> DoublePendulumDynamics:
+    return DoublePendulumDynamics()
+
+
+class TestParametersProperties:
+    def test_projected_gravity_disabled(self) -> None:
+        params = DoublePendulumParameters.default()
+        params.gravity_enabled = False
+        assert params.projected_gravity == 0.0
+
+    def test_projected_gravity_unconstrained(self) -> None:
+        params = DoublePendulumParameters.default()
+        params.constrained_to_plane = False
+        assert params.projected_gravity == pytest.approx(params.gravity_m_s2)
+
+    def test_projected_gravity_inclined(self) -> None:
+        params = DoublePendulumParameters.default()
+        expected = params.gravity_m_s2 * math.cos(
+            math.radians(params.plane_inclination_deg)
+        )
+        assert params.projected_gravity == pytest.approx(expected)
+
+    def test_plane_inclination_rad(self) -> None:
+        params = DoublePendulumParameters.default()
+        assert params.plane_inclination_rad == pytest.approx(
+            math.radians(params.plane_inclination_deg)
+        )
+
+
+class TestSegmentProperties:
+    def test_center_of_mass_distance(self) -> None:
+        seg = SegmentProperties(
+            length_m=2.0, mass_kg=1.0, center_of_mass_ratio=0.5, inertia_about_com=1.0
+        )
+        assert seg.center_of_mass_distance == pytest.approx(1.0)
+
+    def test_inertia_about_proximal_joint(self) -> None:
+        seg = SegmentProperties(
+            length_m=2.0, mass_kg=3.0, center_of_mass_ratio=0.5, inertia_about_com=1.0
+        )
+        # 1.0 + 3.0 * 1.0**2 = 4.0
+        assert seg.inertia_about_proximal_joint == pytest.approx(4.0)
+
+
+class TestLowerSegmentProperties:
+    def test_total_mass(self) -> None:
+        seg = LowerSegmentProperties(
+            length_m=1.0, shaft_mass_kg=0.2, clubhead_mass_kg=0.3, shaft_com_ratio=0.5
+        )
+        assert seg.total_mass == pytest.approx(0.5)
+
+    def test_center_of_mass_distance(self) -> None:
+        seg = LowerSegmentProperties(
+            length_m=1.0, shaft_mass_kg=0.2, clubhead_mass_kg=0.3, shaft_com_ratio=0.5
+        )
+        # (0.5*0.2 + 1.0*0.3)/0.5 = 0.4/0.5 = 0.8
+        assert seg.center_of_mass_distance == pytest.approx(0.8)
+
+    def test_inertia_about_com_positive(self) -> None:
+        seg = LowerSegmentProperties(
+            length_m=1.0,
+            shaft_mass_kg=0.15,
+            clubhead_mass_kg=0.20,
+            shaft_com_ratio=0.43,
+        )
+        assert seg.inertia_about_com > 0
+
+    def test_inertia_about_proximal_joint_uses_parallel_axis(self) -> None:
+        seg = LowerSegmentProperties(
+            length_m=1.0,
+            shaft_mass_kg=0.15,
+            clubhead_mass_kg=0.20,
+            shaft_com_ratio=0.43,
+        )
+        expected = (
+            seg.inertia_about_com + seg.total_mass * seg.center_of_mass_distance**2
+        )
+        assert seg.inertia_about_proximal_joint == pytest.approx(expected)
+
+
+class TestSingularMassMatrix:
+    def test_zero_mass_lower_segment_singular(self) -> None:
+        upper = SegmentProperties(
+            length_m=1.0, mass_kg=1.0, center_of_mass_ratio=0.5, inertia_about_com=0.1
+        )
+        # Zero-mass, zero-inertia lower segment => det(M)=0
+        lower = LowerSegmentProperties(
+            length_m=1.0, shaft_mass_kg=0.0, clubhead_mass_kg=0.0, shaft_com_ratio=0.5
+        )
+        # total_mass=0 will divide-by-zero in center_of_mass_distance;
+        # instead, force tiny but vanishing parameters via direct override.
+        params = DoublePendulumParameters(
+            upper_segment=upper,
+            lower_segment=LowerSegmentProperties(
+                length_m=1.0,
+                shaft_mass_kg=1e-30,
+                clubhead_mass_kg=1e-30,
+                shaft_com_ratio=0.5,
+            ),
+        )
+        dyn = DoublePendulumDynamics(params)
+        with pytest.raises(ZeroDivisionError, match="singular|determinant"):
+            dyn.control_affine(
+                DoublePendulumState(theta1=0.0, theta2=0.0, omega1=0.0, omega2=0.0)
+            )
+
+
+class TestDynamicsComputations:
+    def test_damping_vector(self, dyn: DoublePendulumDynamics) -> None:
+        d1, d2 = dyn.damping_vector(1.0, -2.0)
+        assert d1 == pytest.approx(dyn._d1 * 1.0)
+        assert d2 == pytest.approx(dyn._d2 * -2.0)
+
+    def test_gravity_vector_zero_at_zero_angles(
+        self, dyn: DoublePendulumDynamics
+    ) -> None:
+        g1, g2 = dyn.gravity_vector(0.0, 0.0)
+        assert g1 == pytest.approx(0.0)
+        assert g2 == pytest.approx(0.0)
+
+    def test_inverse_dynamics_identity(
+        self, dyn: DoublePendulumDynamics, state: DoublePendulumState
+    ) -> None:
+        """Apply torques -> get accelerations -> invert -> recover torques."""
+        # forward: compute accelerations from zero applied torque
+        from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pendulum import (  # noqa: E501
+            DoublePendulumDynamics as DPD,
+        )
+
+        # Use forward via derivatives
+        _, _, acc1, acc2 = dyn.derivatives(0.0, state)
+        # Inverse dynamics returns torque needed
+        tau1, tau2 = dyn.inverse_dynamics(state, (acc1, acc2))
+        # Default forcing is zero -> recovered torques should be ~0
+        assert tau1 == pytest.approx(0.0, abs=1e-9)
+        assert tau2 == pytest.approx(0.0, abs=1e-9)
+        # Re-construct the type to silence unused-import warning
+        assert DPD is dyn.__class__
+
+    def test_joint_torque_breakdown_returns_named_components(
+        self, dyn: DoublePendulumDynamics, state: DoublePendulumState
+    ) -> None:
+        breakdown = dyn.joint_torque_breakdown(state, control=(0.7, -0.4))
+        assert isinstance(breakdown, JointTorques)
+        assert breakdown.applied == (0.7, -0.4)
+        assert len(breakdown.gravitational) == 2
+        assert len(breakdown.damping) == 2
+        assert len(breakdown.coriolis_centripetal) == 2
+
+    def test_applied_torques_with_default_zero_input(
+        self, dyn: DoublePendulumDynamics, state: DoublePendulumState
+    ) -> None:
+        t1, t2 = dyn.applied_torques(0.0, state)
+        assert t1 == 0.0
+        assert t2 == 0.0
+
+    def test_control_affine_returns_drift_and_input(
+        self, dyn: DoublePendulumDynamics, state: DoublePendulumState
+    ) -> None:
+        f, g = dyn.control_affine(state)
+        assert len(f) == 4
+        assert f[0] == state.omega1
+        assert f[1] == state.omega2
+        # Control matrix: top two rows are zeros, bottom two are mass-inverse
+        assert g[0] == (0.0, 0.0)
+        assert g[1] == (0.0, 0.0)
+        assert len(g[2]) == 2
+        assert len(g[3]) == 2
+
+    def test_step_preserves_phi(self, dyn: DoublePendulumDynamics) -> None:
+        state = DoublePendulumState(
+            theta1=0.1, theta2=0.2, omega1=0.0, omega2=0.0, phi=0.5, omega_phi=0.3
+        )
+        new_state = dyn.step(0.0, state, dt=0.001)
+        assert new_state.phi == pytest.approx(0.5)
+        assert new_state.omega_phi == pytest.approx(0.3)

--- a/tests/engines/pendulum_models/python/double_pendulum_model/test_expression_function.py
+++ b/tests/engines/pendulum_models/python/double_pendulum_model/test_expression_function.py
@@ -1,0 +1,97 @@
+"""Tests for ExpressionFunction safe expression evaluator.
+
+Covers AST validation rejection paths, allowed-name handling, and runtime
+evaluation against ``DoublePendulumState`` context.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from src.engines.pendulum_models.python.double_pendulum_model.physics.double_pendulum import (
+    DoublePendulumState,
+    ExpressionFunction,
+    compile_forcing_functions,
+)
+
+
+@pytest.fixture()
+def zero_state() -> DoublePendulumState:
+    return DoublePendulumState(theta1=0.0, theta2=0.0, omega1=0.0, omega2=0.0)
+
+
+class TestExpressionFunctionEvaluation:
+    def test_constant_expression(self, zero_state: DoublePendulumState) -> None:
+        fn = ExpressionFunction("1.5")
+        assert fn(0.0, zero_state) == pytest.approx(1.5)
+
+    def test_uses_state_variables(self) -> None:
+        fn = ExpressionFunction("theta1 + 2 * omega2")
+        state = DoublePendulumState(theta1=1.0, theta2=0.0, omega1=0.0, omega2=2.0)
+        assert fn(0.0, state) == pytest.approx(5.0)
+
+    def test_uses_time(self, zero_state: DoublePendulumState) -> None:
+        fn = ExpressionFunction("sin(t)")
+        assert fn(math.pi / 2, zero_state) == pytest.approx(1.0)
+
+    def test_uses_pi_and_tau(self, zero_state: DoublePendulumState) -> None:
+        fn = ExpressionFunction("pi + tau")
+        assert fn(0.0, zero_state) == pytest.approx(math.pi + math.tau)
+
+    def test_strips_whitespace(self, zero_state: DoublePendulumState) -> None:
+        fn = ExpressionFunction("  2 + 3  ")
+        assert fn(0.0, zero_state) == pytest.approx(5.0)
+
+    def test_allowed_math_functions(self, zero_state: DoublePendulumState) -> None:
+        fn = ExpressionFunction("sqrt(fabs(log(exp(2.0))))")
+        assert fn(0.0, zero_state) == pytest.approx(math.sqrt(2.0))
+
+
+class TestExpressionFunctionValidation:
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "[1, 2]",  # List
+            "{1: 2}",  # Dict
+            "{1, 2}",  # Set
+            "[x for x in [1]]",  # ListComp
+            "(x for x in [1])",  # GeneratorExp
+            "lambda x: x",  # Lambda
+            "1 if True else 2",  # IfExp
+        ],
+    )
+    def test_rejects_disallowed_nodes(self, expr: str) -> None:
+        with pytest.raises(ValueError, match="Disallowed syntax"):
+            ExpressionFunction(expr)
+
+    def test_rejects_attribute_access(self) -> None:
+        with pytest.raises(ValueError, match="Attribute"):
+            ExpressionFunction("sin.__doc__")
+
+    def test_rejects_syntax_error(self) -> None:
+        with pytest.raises(ValueError, match="Syntax error"):
+            ExpressionFunction("1 + ")
+
+    def test_rejects_unknown_function(self) -> None:
+        with pytest.raises(ValueError, match="not permitted"):
+            ExpressionFunction("eval('1')")
+
+    def test_rejects_unknown_variable(self) -> None:
+        with pytest.raises(ValueError, match="unknown variable"):
+            ExpressionFunction("foobar + 1")
+
+    def test_rejects_indirect_call(self) -> None:
+        # A call where func is not a direct Name (e.g. via subscript) — synthesize one
+        # via attribute since attribute itself is blocked first; use call on call result:
+        with pytest.raises(ValueError):
+            # "sin(1)(2)" - func is a Call, not a Name
+            ExpressionFunction("sin(1)(2)")
+
+
+class TestCompileForcingFunctions:
+    def test_returns_two_callables(self) -> None:
+        shoulder, wrist = compile_forcing_functions("1.0", "2.0")
+        state = DoublePendulumState(theta1=0.0, theta2=0.0, omega1=0.0, omega2=0.0)
+        assert shoulder(0.0, state) == pytest.approx(1.0)
+        assert wrist(0.0, state) == pytest.approx(2.0)

--- a/tests/engines/pendulum_models/python/double_pendulum_model/test_triple_pendulum_dynamics.py
+++ b/tests/engines/pendulum_models/python/double_pendulum_model/test_triple_pendulum_dynamics.py
@@ -1,0 +1,235 @@
+"""Tests for TriplePendulumDynamics — mass matrix, bias, forward/inverse, step."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from src.engines.pendulum_models.python.double_pendulum_model.physics.triple_pendulum import (
+    DAMPING_DEFAULT,
+    GRAVITATIONAL_ACCELERATION,
+    PolynomialProfile,
+    TripleJointTorques,
+    TriplePendulumDynamics,
+    TriplePendulumParameters,
+    TriplePendulumState,
+    TripleSegmentProperties,
+)
+
+
+@pytest.fixture()
+def dyn() -> TriplePendulumDynamics:
+    return TriplePendulumDynamics()
+
+
+@pytest.fixture()
+def zero_state() -> TriplePendulumState:
+    return TriplePendulumState(
+        theta1=0.0, theta2=0.0, theta3=0.0, omega1=0.0, omega2=0.0, omega3=0.0
+    )
+
+
+@pytest.fixture()
+def nonzero_state() -> TriplePendulumState:
+    return TriplePendulumState(
+        theta1=0.4, theta2=-0.3, theta3=0.2, omega1=0.5, omega2=-0.2, omega3=0.1
+    )
+
+
+class TestTripleSegmentProperties:
+    def test_center_of_mass_distance(self) -> None:
+        seg = TripleSegmentProperties(
+            length_m=2.0, mass_kg=1.0, center_of_mass_ratio=0.5, inertia_about_com=0.1
+        )
+        assert seg.center_of_mass_distance == pytest.approx(1.0)
+
+    def test_inertia_about_proximal_joint(self) -> None:
+        seg = TripleSegmentProperties(
+            length_m=2.0, mass_kg=3.0, center_of_mass_ratio=0.5, inertia_about_com=0.1
+        )
+        assert seg.inertia_about_proximal_joint == pytest.approx(0.1 + 3.0 * 1.0)
+
+
+class TestTriplePendulumParameters:
+    def test_default_constructs(self) -> None:
+        params = TriplePendulumParameters.default()
+        assert len(params.segments) == 3
+        assert params.damping == DAMPING_DEFAULT
+        assert params.gravity_enabled is True
+
+    def test_gravity_enabled_true(self) -> None:
+        params = TriplePendulumParameters.default()
+        assert params.gravity == GRAVITATIONAL_ACCELERATION
+
+    def test_gravity_disabled(self) -> None:
+        params = TriplePendulumParameters.default()
+        params.gravity_enabled = False
+        assert params.gravity == 0.0
+
+
+class TestPolynomialProfile:
+    def test_omega_evaluates_polynomial(self) -> None:
+        # coefficients are in numpy poly1d order (highest power first)
+        prof = PolynomialProfile(coefficients=(2.0, 1.0, 3.0))  # 2t^2 + t + 3
+        assert prof.omega(0.0) == pytest.approx(3.0)
+        assert prof.omega(1.0) == pytest.approx(6.0)
+
+    def test_alpha_is_derivative(self) -> None:
+        prof = PolynomialProfile(coefficients=(2.0, 1.0, 3.0))  # d/dt = 4t + 1
+        assert prof.alpha(0.0) == pytest.approx(1.0)
+        assert prof.alpha(1.0) == pytest.approx(5.0)
+
+
+class TestTriplePendulumMassMatrix:
+    def test_mass_matrix_shape(
+        self, dyn: TriplePendulumDynamics, zero_state: TriplePendulumState
+    ) -> None:
+        M = dyn.mass_matrix(zero_state)
+        assert M.shape == (3, 3)
+
+    def test_mass_matrix_symmetric(
+        self, dyn: TriplePendulumDynamics, nonzero_state: TriplePendulumState
+    ) -> None:
+        M = dyn.mass_matrix(nonzero_state)
+        np.testing.assert_allclose(M, M.T, atol=1e-12)
+
+    def test_mass_matrix_positive_definite(
+        self, dyn: TriplePendulumDynamics, nonzero_state: TriplePendulumState
+    ) -> None:
+        M = dyn.mass_matrix(nonzero_state)
+        eigs = np.linalg.eigvalsh(M)
+        assert np.all(eigs > 0)
+
+    def test_mass_matrix_positive_definite_random(
+        self, dyn: TriplePendulumDynamics
+    ) -> None:
+        rng = np.random.default_rng(42)
+        for _ in range(10):
+            t = rng.uniform(-math.pi, math.pi, 3)
+            o = rng.uniform(-2.0, 2.0, 3)
+            state = TriplePendulumState(
+                theta1=t[0],
+                theta2=t[1],
+                theta3=t[2],
+                omega1=o[0],
+                omega2=o[1],
+                omega3=o[2],
+            )
+            M = dyn.mass_matrix(state)
+            eigs = np.linalg.eigvalsh(M)
+            assert np.all(eigs > 0)
+
+
+class TestTriplePendulumBias:
+    def test_bias_zero_at_rest_no_gravity(self) -> None:
+        params = TriplePendulumParameters.default()
+        params.gravity_enabled = False
+        dyn = TriplePendulumDynamics(params)
+        state = TriplePendulumState(
+            theta1=0.0, theta2=0.0, theta3=0.0, omega1=0.0, omega2=0.0, omega3=0.0
+        )
+        bias = dyn.bias_vector(state)
+        np.testing.assert_allclose(bias, np.zeros(3), atol=1e-12)
+
+    def test_bias_includes_damping(self, dyn: TriplePendulumDynamics) -> None:
+        # State with zero angles and gravity off but nonzero omegas -> only damping
+        params = TriplePendulumParameters.default()
+        params.gravity_enabled = False
+        d = TriplePendulumDynamics(params)
+        state = TriplePendulumState(
+            theta1=0.0, theta2=0.0, theta3=0.0, omega1=1.0, omega2=2.0, omega3=3.0
+        )
+        bias = d.bias_vector(state)
+        expected_damping = np.array(d.parameters.damping) * np.array([1.0, 2.0, 3.0])
+        # Coriolis terms vanish at theta=0 (all sin terms are 0)
+        np.testing.assert_allclose(bias, expected_damping, atol=1e-10)
+
+
+class TestTriplePendulumDynamicsAlgorithms:
+    def test_inverse_then_forward_identity(
+        self, dyn: TriplePendulumDynamics, nonzero_state: TriplePendulumState
+    ) -> None:
+        target_acc = (0.1, -0.2, 0.05)
+        torques = dyn.inverse_dynamics(nonzero_state, target_acc)
+        recovered = dyn.forward_dynamics(nonzero_state, torques)
+        for r, t in zip(recovered, target_acc, strict=True):
+            assert r == pytest.approx(t, abs=1e-9)
+
+    def test_forward_dynamics_returns_three_floats(
+        self, dyn: TriplePendulumDynamics, zero_state: TriplePendulumState
+    ) -> None:
+        accs = dyn.forward_dynamics(zero_state, (0.0, 0.0, 0.0))
+        assert len(accs) == 3
+        for a in accs:
+            assert isinstance(a, float)
+            assert math.isfinite(a)
+
+    def test_joint_torque_breakdown(
+        self, dyn: TriplePendulumDynamics, nonzero_state: TriplePendulumState
+    ) -> None:
+        breakdown = dyn.joint_torque_breakdown(nonzero_state, control=(0.1, 0.2, 0.3))
+        assert isinstance(breakdown, TripleJointTorques)
+        assert breakdown.applied == (0.1, 0.2, 0.3)
+        assert len(breakdown.gravitational) == 3
+        assert len(breakdown.damping) == 3
+        assert len(breakdown.coriolis_centripetal) == 3
+
+    def test_damping_breakdown_proportional_to_omega(
+        self, dyn: TriplePendulumDynamics
+    ) -> None:
+        state = TriplePendulumState(
+            theta1=0.0, theta2=0.0, theta3=0.0, omega1=2.0, omega2=-1.0, omega3=0.5
+        )
+        breakdown = dyn.joint_torque_breakdown(state, control=(0.0, 0.0, 0.0))
+        expected = tuple(DAMPING_DEFAULT[i] * o for i, o in enumerate([2.0, -1.0, 0.5]))
+        for got, exp in zip(breakdown.damping, expected, strict=True):
+            assert got == pytest.approx(exp)
+
+
+class TestTriplePendulumStep:
+    def test_step_at_rest_with_zero_control_stays_at_rest_no_gravity(self) -> None:
+        params = TriplePendulumParameters.default()
+        params.gravity_enabled = False
+        params.damping = (0.0, 0.0, 0.0)
+        dyn = TriplePendulumDynamics(params)
+        state = TriplePendulumState(
+            theta1=0.0, theta2=0.0, theta3=0.0, omega1=0.0, omega2=0.0, omega3=0.0
+        )
+        new_state = dyn.step(0.0, state, dt=0.01, control=(0.0, 0.0, 0.0))
+        assert new_state.theta1 == pytest.approx(0.0, abs=1e-12)
+        assert new_state.theta2 == pytest.approx(0.0, abs=1e-12)
+        assert new_state.theta3 == pytest.approx(0.0, abs=1e-12)
+        assert new_state.omega1 == pytest.approx(0.0, abs=1e-12)
+        assert new_state.omega2 == pytest.approx(0.0, abs=1e-12)
+        assert new_state.omega3 == pytest.approx(0.0, abs=1e-12)
+
+    def test_step_returns_new_state(
+        self, dyn: TriplePendulumDynamics, nonzero_state: TriplePendulumState
+    ) -> None:
+        new_state = dyn.step(0.0, nonzero_state, dt=0.001, control=(0.0, 0.0, 0.0))
+        assert isinstance(new_state, TriplePendulumState)
+        # State must have moved due to nonzero omegas
+        assert new_state.theta1 != nonzero_state.theta1
+
+    def test_step_energy_approximately_conserved_no_damping_no_gravity(self) -> None:
+        params = TriplePendulumParameters.default()
+        params.gravity_enabled = False
+        params.damping = (0.0, 0.0, 0.0)
+        dyn = TriplePendulumDynamics(params)
+        state = TriplePendulumState(
+            theta1=0.1, theta2=0.0, theta3=0.0, omega1=1.0, omega2=0.0, omega3=0.0
+        )
+
+        def kinetic(s: TriplePendulumState) -> float:
+            M = dyn.mass_matrix(s)
+            omega = np.array([s.omega1, s.omega2, s.omega3])
+            return float(0.5 * omega @ M @ omega)
+
+        e0 = kinetic(state)
+        s = state
+        for _ in range(20):
+            s = dyn.step(0.0, s, dt=0.005, control=(0.0, 0.0, 0.0))
+        e1 = kinetic(s)
+        # Allow generous tolerance — RK4 with short horizon
+        assert abs(e1 - e0) / max(abs(e0), 1e-9) < 0.05

--- a/tests/engines/pendulum_models/python/double_pendulum_model/test_validation.py
+++ b/tests/engines/pendulum_models/python/double_pendulum_model/test_validation.py
@@ -1,0 +1,47 @@
+"""Tests for UI input validation helpers."""
+
+from __future__ import annotations
+
+from src.engines.pendulum_models.python.double_pendulum_model.ui.validation import (
+    validate_polynomial_text,
+    validate_torque_text,
+)
+
+
+class TestValidatePolynomialText:
+    def test_empty_string_valid(self) -> None:
+        assert validate_polynomial_text("") is None
+
+    def test_whitespace_only_valid(self) -> None:
+        assert validate_polynomial_text("   ") is None
+
+    def test_single_number_valid(self) -> None:
+        assert validate_polynomial_text("1.5") is None
+
+    def test_sum_of_numbers_valid(self) -> None:
+        assert validate_polynomial_text("1.0 + 2.5 + 3") is None
+
+    def test_invalid_text_returns_error(self) -> None:
+        result = validate_polynomial_text("abc")
+        assert result is not None
+        assert "Invalid polynomial" in result
+
+    def test_garbage_token_returns_error(self) -> None:
+        result = validate_polynomial_text("1+foo")
+        assert result is not None
+
+
+class TestValidateTorqueText:
+    def test_empty_string_valid(self) -> None:
+        assert validate_torque_text("") is None
+
+    def test_whitespace_only_valid(self) -> None:
+        assert validate_torque_text("   ") is None
+
+    def test_valid_expression(self) -> None:
+        assert validate_torque_text("sin(t) + theta1") is None
+
+    def test_invalid_syntax_returns_error(self) -> None:
+        result = validate_torque_text("1 + ")
+        assert result is not None
+        assert "Invalid syntax" in result


### PR DESCRIPTION
## Summary

- Added comprehensive unit tests for double and triple pendulum dynamics under `tests/engines/pendulum_models/`.
- Coverage on the physics + validation modules rose from ~50% to **88.5%** (double_pendulum.py: **91%**).
- Tests are deterministic, mock-free (pure math), and complete in **<1s** total (108 passed).

## Bug fix

Each public method in `physics/double_pendulum.py` and `physics/triple_pendulum.py` had its DbC precondition block duplicated back-to-back, e.g.

```python
if not (state is not None):
    raise ValueError("state must be provided")
if not (state is not None):
    raise ValueError("state must be provided")
```

The second clause was unreachable dead code (and triggered coverage misses). Deduplicated ~21 such pairs.

## Test plan

- [x] `python3 -m ruff check` passes
- [x] `python3 -m ruff format` clean
- [x] `python3 -m pytest tests/engines/pendulum_models -x --timeout=30` — 108 passed, <1s