### PR TITLE
test(motion_capture): comprehensive coverage

### DIFF
--- a/src/motion_capture/freemocap_ingest/output_adapter.py
+++ b/src/motion_capture/freemocap_ingest/output_adapter.py
@@ -217,13 +217,19 @@ class FreeMoCapOutputAdapter:
 
                 points = []
                 for name, coords in landmark_data.items():
+                    if "x" not in coords or "y" not in coords or "z" not in coords:
+                        continue
                     try:
-                        x = float(row[coords.get("x", 0)])
-                        y = float(row[coords.get("y", 0)])
-                        z = float(row[coords.get("z", 0)])
-                        conf = float(row.get(coords.get("conf"), len(row) - 1))
+                        x = float(row[coords["x"]])
+                        y = float(row[coords["y"]])
+                        z = float(row[coords["z"]])
+                        conf_idx = coords.get("conf")
+                        if conf_idx is not None and conf_idx < len(row):
+                            conf = float(row[conf_idx])
+                        else:
+                            conf = 1.0
                         visible = conf > 0.5
-                    except (ValueError, IndexError):
+                    except (ValueError, IndexError, TypeError):
                         continue
 
                     points.append(

--- a/src/motion_capture/freemocap_ingest/output_adapter.py
+++ b/src/motion_capture/freemocap_ingest/output_adapter.py
@@ -198,7 +198,7 @@ class FreeMoCapOutputAdapter:
 
             # Parse header to find landmark columns
             # Format: frame_num, timestamp, nose_x, nose_y, nose_z, nose_conf, ...
-            landmark_data = {}
+            landmark_data: dict[str, dict[str, int]] = {}
             for i, col in enumerate(header[2:], start=2):
                 parts = col.rsplit("_", 1)
                 if len(parts) == 2:

--- a/tests/motion_capture/__init__.py
+++ b/tests/motion_capture/__init__.py
@@ -1,0 +1,1 @@
+"""Motion capture tests."""

--- a/tests/motion_capture/wave5_mocap/__init__.py
+++ b/tests/motion_capture/wave5_mocap/__init__.py
@@ -1,0 +1,1 @@
+"""Wave 5 fast tests for src/motion_capture."""

--- a/tests/motion_capture/wave5_mocap/test_launcher.py
+++ b/tests/motion_capture/wave5_mocap/test_launcher.py
@@ -1,0 +1,243 @@
+"""Fast tests for motion_capture.freemocap_ingest.launcher."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from motion_capture.freemocap_ingest.launcher import (
+    FreeMoCapLauncher,
+    LaunchConfig,
+    LaunchResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+def test_launch_config_defaults(tmp_path: Path) -> None:
+    cfg = LaunchConfig(session_dir=tmp_path)
+    assert cfg.freemocap_env is None
+    assert cfg.timeout_seconds == 3600
+    assert cfg.video_dir is None
+    assert cfg.output_dir is None
+    assert cfg.headless is True
+    assert cfg.extra_args is None
+
+
+def test_launcher_default_log_level() -> None:
+    launcher = FreeMoCapLauncher()
+    assert launcher.log_level == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# _find_freemocap_python
+# ---------------------------------------------------------------------------
+
+
+def test_find_python_with_env_path_existing(tmp_path: Path) -> None:
+    env = tmp_path / "freemocap-env"
+    (env / "bin").mkdir(parents=True)
+    py = env / "bin" / "python"
+    py.write_text("#!/bin/sh\n")
+    launcher = FreeMoCapLauncher()
+    found = launcher._find_freemocap_python(env)
+    assert found == str(py)
+
+
+def test_find_python_env_path_missing_falls_through(tmp_path: Path) -> None:
+    # env path provided but doesn't contain a python; should fall to search
+    env = tmp_path / "missing-env"
+    launcher = FreeMoCapLauncher()
+    with patch(
+        "motion_capture.freemocap_ingest.launcher.Path.home", return_value=tmp_path
+    ):
+        result = launcher._find_freemocap_python(env)
+    assert result is None
+
+
+def test_find_python_via_conda_default(tmp_path: Path) -> None:
+    conda_env = tmp_path / "miniconda3" / "envs" / "freemocap-env"
+    (conda_env / "bin").mkdir(parents=True)
+    py = conda_env / "bin" / "python"
+    py.write_text("")
+    launcher = FreeMoCapLauncher()
+    with patch(
+        "motion_capture.freemocap_ingest.launcher.Path.home", return_value=tmp_path
+    ):
+        assert launcher._find_freemocap_python(None) == str(py)
+
+
+def test_find_python_via_dot_venvs(tmp_path: Path) -> None:
+    venv = tmp_path / ".venvs" / "freemocap-env"
+    (venv / "bin").mkdir(parents=True)
+    py = venv / "bin" / "python"
+    py.write_text("")
+    launcher = FreeMoCapLauncher()
+    with patch(
+        "motion_capture.freemocap_ingest.launcher.Path.home", return_value=tmp_path
+    ):
+        assert launcher._find_freemocap_python(None) == str(py)
+
+
+def test_find_python_none_when_not_found(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    with (
+        patch(
+            "motion_capture.freemocap_ingest.launcher.Path.home", return_value=tmp_path
+        ),
+        patch.object(Path, "exists", return_value=False),
+    ):
+        assert launcher._find_freemocap_python(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_command
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_minimal(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    cfg = LaunchConfig(session_dir=tmp_path / "session_x")
+    cmd = launcher._build_command(cfg, "/usr/bin/python")
+    assert cmd[:3] == ["/usr/bin/python", "-m", "freemocap"]
+    assert "--headless" in cmd
+    assert "--session_id" in cmd
+    assert "session_x" in cmd
+    assert "--output_path" in cmd
+
+
+def test_build_command_with_all_options(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    cfg = LaunchConfig(
+        session_dir=tmp_path / "s",
+        video_dir=tmp_path / "videos",
+        output_dir=tmp_path / "out",
+        headless=False,
+        extra_args=["--gpu", "1"],
+    )
+    cmd = launcher._build_command(cfg, "python3")
+    assert "--headless" not in cmd
+    assert "--video_path" in cmd
+    assert str(tmp_path / "videos") in cmd
+    assert str(tmp_path / "out") in cmd
+    assert "--gpu" in cmd and "1" in cmd
+
+
+# ---------------------------------------------------------------------------
+# _setup_logging
+# ---------------------------------------------------------------------------
+
+
+def test_setup_logging_creates_log_dir(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    log_file = launcher._setup_logging(tmp_path)
+    assert log_file.parent.name == "logs"
+    assert log_file.parent.exists()
+    assert log_file.name.startswith("freemocap_")
+    assert log_file.suffix == ".log"
+
+
+# ---------------------------------------------------------------------------
+# launch()
+# ---------------------------------------------------------------------------
+
+
+def test_launch_session_dir_missing(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    cfg = LaunchConfig(session_dir=tmp_path / "absent")
+    result = launcher.launch(cfg)
+    assert isinstance(result, LaunchResult)
+    assert result.success is False
+    assert result.return_code == -1
+    assert "does not exist" in result.error_message
+
+
+def test_launch_env_not_found(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    with patch.object(launcher, "_find_freemocap_python", return_value=None):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path))
+    assert result.success is False
+    assert "FreeMoCap environment not found" in result.error_message
+
+
+def _make_popen(return_code: int = 0, timeout: bool = False) -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 4242
+    if timeout:
+        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="x", timeout=1), 0]
+    else:
+        proc.wait.return_value = return_code
+    return proc
+
+
+def test_launch_success(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    with (
+        patch.object(launcher, "_find_freemocap_python", return_value="/fake/python"),
+        patch("subprocess.Popen", return_value=_make_popen(0)) as popen,
+    ):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path))
+
+    assert result.success is True
+    assert result.return_code == 0
+    assert result.output_dir == tmp_path.resolve() / launcher.DEFAULT_OUTPUT_SUBDIR
+    assert result.log_file is not None and result.log_file.exists()
+    popen.assert_called_once()
+
+
+def test_launch_nonzero_exit(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    with (
+        patch.object(launcher, "_find_freemocap_python", return_value="/fake/python"),
+        patch("subprocess.Popen", return_value=_make_popen(3)),
+    ):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path))
+
+    assert result.success is False
+    assert result.return_code == 3
+    assert "exited with code 3" in result.error_message
+
+
+def test_launch_timeout(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    proc = _make_popen(timeout=True)
+    with (
+        patch.object(launcher, "_find_freemocap_python", return_value="/fake/python"),
+        patch("subprocess.Popen", return_value=proc),
+    ):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path, timeout_seconds=1))
+    assert result.success is False
+    assert "timed out" in result.error_message
+    proc.kill.assert_called_once()
+
+
+def test_launch_subprocess_exception(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    with (
+        patch.object(launcher, "_find_freemocap_python", return_value="/fake/python"),
+        patch("subprocess.Popen", side_effect=OSError("boom")),
+    ):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path))
+    assert result.success is False
+    assert "boom" in result.error_message
+
+
+def test_launch_respects_explicit_output_dir(tmp_path: Path) -> None:
+    launcher = FreeMoCapLauncher()
+    out = tmp_path / "custom_out"
+    with (
+        patch.object(launcher, "_find_freemocap_python", return_value="/fake/python"),
+        patch("subprocess.Popen", return_value=_make_popen(0)),
+    ):
+        result = launcher.launch(LaunchConfig(session_dir=tmp_path, output_dir=out))
+    assert result.success is True
+    assert result.output_dir == out

--- a/tests/motion_capture/wave5_mocap/test_main_cli.py
+++ b/tests/motion_capture/wave5_mocap/test_main_cli.py
@@ -1,0 +1,211 @@
+"""Fast tests for motion_capture.freemocap_ingest CLI entrypoints."""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from motion_capture.freemocap_ingest import __main__ as cli_main
+from motion_capture.freemocap_ingest import launcher as launcher_mod
+from motion_capture.freemocap_ingest import output_adapter as adapter_mod
+
+pytestmark = pytest.mark.unit
+
+
+def _make_csv(path: Path) -> None:
+    with open(path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(
+            ["frame_num", "timestamp", "nose_x", "nose_y", "nose_z", "nose_conf"]
+        )
+        for i in range(2):
+            w.writerow([i, i * 0.1, 0.0, 0.0, 0.0, 0.9])
+
+
+# ---------------------------------------------------------------------------
+# __main__.main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_errors() -> None:
+    with patch.object(sys, "argv", ["prog"]), pytest.raises(SystemExit):
+        cli_main.main()
+
+
+def test_main_parse_mode(tmp_path: Path) -> None:
+    out = tmp_path / "outdir"
+    out.mkdir()
+    _make_csv(out / "freemocap_3d_landmarks_x.csv")
+    (out / "camera_calibration.json").write_text('{"a": 1}')
+
+    npy = tmp_path / "out.npy"
+    csv_out = tmp_path / "out.csv"
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(out),
+            "--parse",
+            "--export-npy",
+            str(npy),
+            "--export-csv",
+            str(csv_out),
+            "-v",
+        ],
+    ):
+        rc = cli_main.main()
+    assert rc == 0
+    assert npy.exists()
+    assert csv_out.exists()
+
+
+def test_main_dry_run_capture(tmp_path: Path) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    with patch.object(sys, "argv", ["prog", str(session), "--dry-run"]):
+        rc = cli_main.main()
+    assert rc == 0
+
+
+def test_main_capture_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    fake_launcher = MagicMock()
+    fake_launcher.launch.return_value = launcher_mod.LaunchResult(
+        success=True,
+        return_code=0,
+        output_dir=session / "freemocap_output",
+        log_file=session / "logs" / "x.log",
+    )
+    monkeypatch.setattr(cli_main, "FreeMoCapLauncher", lambda: fake_launcher)
+
+    with patch.object(sys, "argv", ["prog", str(session)]):
+        rc = cli_main.main()
+    assert rc == 0
+
+
+def test_main_capture_failure_returns_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    fake_launcher = MagicMock()
+    fake_launcher.launch.return_value = launcher_mod.LaunchResult(
+        success=False,
+        return_code=2,
+        output_dir=None,
+        log_file=session / "x.log",
+        error_message="nope",
+    )
+    monkeypatch.setattr(cli_main, "FreeMoCapLauncher", lambda: fake_launcher)
+    with patch.object(sys, "argv", ["prog", str(session)]):
+        rc = cli_main.main()
+    assert rc == 1
+
+
+def test_main_capture_then_parse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    out = session / "freemocap_output"
+    out.mkdir()
+    _make_csv(out / "freemocap_3d_landmarks_y.csv")
+    fake_launcher = MagicMock()
+    fake_launcher.launch.return_value = launcher_mod.LaunchResult(
+        success=True,
+        return_code=0,
+        output_dir=out,
+        log_file=session / "x.log",
+    )
+    monkeypatch.setattr(cli_main, "FreeMoCapLauncher", lambda: fake_launcher)
+
+    npy = tmp_path / "data.npy"
+    csv_out = tmp_path / "data.csv"
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(session),
+            "--parse-output",
+            "--export-npy",
+            str(npy),
+            "--export-csv",
+            str(csv_out),
+        ],
+    ):
+        rc = cli_main.main()
+    assert rc == 0
+    assert npy.exists()
+    assert csv_out.exists()
+
+
+# ---------------------------------------------------------------------------
+# launcher.main and output_adapter.main
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_main_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    fake_launcher = MagicMock()
+    fake_launcher.launch.return_value = launcher_mod.LaunchResult(
+        success=True, return_code=0, output_dir=session, log_file=None
+    )
+    monkeypatch.setattr(launcher_mod, "FreeMoCapLauncher", lambda: fake_launcher)
+    with (
+        patch.object(sys, "argv", ["prog", str(session)]),
+        pytest.raises(SystemExit) as ei,
+    ):
+        launcher_mod.main()
+    assert ei.value.code == 0
+
+
+def test_launcher_main_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session = tmp_path / "session"
+    session.mkdir()
+    fake_launcher = MagicMock()
+    fake_launcher.launch.return_value = launcher_mod.LaunchResult(
+        success=False,
+        return_code=1,
+        output_dir=None,
+        log_file=session / "x.log",
+        error_message="bad",
+    )
+    monkeypatch.setattr(launcher_mod, "FreeMoCapLauncher", lambda: fake_launcher)
+    with (
+        patch.object(sys, "argv", ["prog", str(session), "--gui", "-v"]),
+        pytest.raises(SystemExit) as ei,
+    ):
+        launcher_mod.main()
+    assert ei.value.code == 1
+
+
+def test_output_adapter_main(tmp_path: Path) -> None:
+    out = tmp_path / "outdir"
+    out.mkdir()
+    _make_csv(out / "freemocap_3d_landmarks_a.csv")
+    npy = tmp_path / "x.npy"
+    csv_out = tmp_path / "x.csv"
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(out),
+            "--export-npy",
+            str(npy),
+            "--export-csv",
+            str(csv_out),
+            "-v",
+        ],
+    ):
+        adapter_mod.main()
+    assert npy.exists()
+    assert csv_out.exists()

--- a/tests/motion_capture/wave5_mocap/test_output_adapter.py
+++ b/tests/motion_capture/wave5_mocap/test_output_adapter.py
@@ -1,0 +1,273 @@
+"""Fast tests for motion_capture.freemocap_ingest.output_adapter."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from motion_capture.freemocap_ingest.output_adapter import (
+    MEDIAPIPE_LANDMARKS,
+    FreeMoCapOutputAdapter,
+    LandmarkFrame,
+    LandmarkPoint,
+    LandmarkSession,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Dataclass behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_landmark_point_defaults() -> None:
+    p = LandmarkPoint(name="nose", x=1.0, y=2.0, z=3.0)
+    assert p.confidence == 1.0
+    assert p.visible is True
+
+
+def test_landmark_frame_get_point_found_and_missing() -> None:
+    f = LandmarkFrame(
+        frame_number=1,
+        timestamp=0.5,
+        points=[LandmarkPoint("nose", 0.0, 0.0, 0.0)],
+    )
+    assert f.get_point("nose").name == "nose"
+    assert f.get_point("missing") is None
+
+
+def test_landmark_frame_to_array_with_points() -> None:
+    f = LandmarkFrame(
+        frame_number=0,
+        timestamp=0.0,
+        points=[
+            LandmarkPoint("a", 1.0, 2.0, 3.0, confidence=0.9),
+            LandmarkPoint("b", 4.0, 5.0, 6.0, confidence=0.8),
+        ],
+    )
+    arr = f.to_array()
+    assert arr.shape == (2, 4)
+    np.testing.assert_allclose(arr[0], [1.0, 2.0, 3.0, 0.9])
+    np.testing.assert_allclose(arr[1], [4.0, 5.0, 6.0, 0.8])
+
+
+def test_landmark_frame_to_array_empty() -> None:
+    f = LandmarkFrame(frame_number=0, timestamp=0.0)
+    arr = f.to_array()
+    assert arr.shape == (0, 4)
+
+
+def test_landmark_session_to_array_empty() -> None:
+    s = LandmarkSession(session_id="x")
+    arr = s.to_array()
+    assert arr.shape == (0, 0, 4)
+
+
+def test_landmark_session_to_array_stacks_frames() -> None:
+    points = [LandmarkPoint("a", 1.0, 2.0, 3.0)]
+    s = LandmarkSession(
+        session_id="x",
+        frames=[
+            LandmarkFrame(0, 0.0, points=points),
+            LandmarkFrame(1, 0.1, points=points),
+        ],
+    )
+    arr = s.to_array()
+    assert arr.shape == (2, 1, 4)
+
+
+def test_mediapipe_landmarks_list_nonempty() -> None:
+    assert len(MEDIAPIPE_LANDMARKS) > 0
+    assert "nose" in MEDIAPIPE_LANDMARKS
+
+
+# ---------------------------------------------------------------------------
+# Fixtures helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_landmarks_csv(
+    path: Path,
+    *,
+    landmarks: tuple[str, ...] = ("nose", "left_hip"),
+    rows: int = 3,
+    include_conf: bool = True,
+    bad_row: bool = False,
+) -> None:
+    header = ["frame_num", "timestamp"]
+    for name in landmarks:
+        header.extend([f"{name}_x", f"{name}_y", f"{name}_z"])
+        if include_conf:
+            header.append(f"{name}_conf")
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(header)
+        for i in range(rows):
+            row: list[object] = [i, i * 0.1]
+            for j, _ in enumerate(landmarks):
+                row.extend([j + 0.1, j + 0.2, j + 0.3])
+                if include_conf:
+                    row.append(0.9)
+            writer.writerow(row)
+        if bad_row:
+            # row that should be skipped (non-numeric coordinate)
+            row = [rows, rows * 0.1]
+            for _ in landmarks:
+                row.extend(["NaNbad", 0.0, 0.0])
+                if include_conf:
+                    row.append(0.0)
+            writer.writerow(row)
+        # Empty row should be tolerated (skipped)
+        writer.writerow([])
+
+
+# ---------------------------------------------------------------------------
+# Adapter behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_init_resolves_path(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    assert a.output_dir == tmp_path.expanduser().resolve()
+    assert a.get_session() is None
+
+
+def test_parse_missing_output_dir(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path / "nope")
+    with pytest.raises(FileNotFoundError, match="Output directory"):
+        a.parse()
+
+
+def test_parse_no_landmark_files(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    with pytest.raises(FileNotFoundError, match="No landmark CSV"):
+        a.parse()
+
+
+def test_parse_happy_path_with_conf(tmp_path: Path) -> None:
+    csv_path = tmp_path / "freemocap_3d_landmarks_main.csv"
+    _write_landmarks_csv(csv_path, rows=4)
+
+    # Calibration + metadata files
+    (tmp_path / "camera_calibration.json").write_text(
+        json.dumps({"cameras": ["c0", "c1"]})
+    )
+    (tmp_path / "recording_metadata.json").write_text(json.dumps({"fps": 30}))
+
+    adapter = FreeMoCapOutputAdapter(tmp_path)
+    session = adapter.parse(session_id="custom-id")
+
+    assert session.session_id == "custom-id"
+    assert len(session.frames) == 4
+    assert session.calibration == {"cameras": ["c0", "c1"]}
+    assert session.metadata == {"fps": 30}
+
+    first = session.frames[0]
+    assert first.frame_number == 0
+    assert first.timestamp == pytest.approx(0.0)
+    names = {p.name for p in first.points}
+    assert names == {"nose", "left_hip"}
+    # confidence preserved (0.9 → visible)
+    for p in first.points:
+        assert p.confidence == pytest.approx(0.9)
+        assert p.visible is True
+
+    assert adapter.get_session() is session
+
+
+def test_parse_default_session_id_from_parent(tmp_path: Path) -> None:
+    out = tmp_path / "session_42" / "freemocap_output"
+    out.mkdir(parents=True)
+    _write_landmarks_csv(out / "freemocap_3d_landmarks_a.csv")
+    adapter = FreeMoCapOutputAdapter(out)
+    session = adapter.parse()
+    assert session.session_id == "session_42"
+
+
+def test_parse_csv_without_conf_defaults_to_one(tmp_path: Path) -> None:
+    csv_path = tmp_path / "freemocap_3d_landmarks_x.csv"
+    _write_landmarks_csv(csv_path, include_conf=False, rows=2)
+    adapter = FreeMoCapOutputAdapter(tmp_path)
+    session = adapter.parse()
+    assert all(p.confidence == 1.0 for f in session.frames for p in f.points)
+    assert all(p.visible for f in session.frames for p in f.points)
+
+
+def test_parse_skips_bad_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "freemocap_3d_landmarks_b.csv"
+    _write_landmarks_csv(csv_path, rows=2, bad_row=True)
+    adapter = FreeMoCapOutputAdapter(tmp_path)
+    session = adapter.parse()
+    # 2 good rows; bad row's points were skipped so frame exists but with 0 points
+    # Empty trailing row dropped entirely
+    assert len(session.frames) == 3
+    assert session.frames[-1].points == []
+
+
+def test_export_to_numpy_requires_session(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    with pytest.raises(ValueError, match="No session"):
+        a.export_to_numpy(tmp_path / "out.npy")
+
+
+def test_export_to_csv_requires_session(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    with pytest.raises(ValueError, match="No session"):
+        a.export_to_csv(tmp_path / "out.csv")
+
+
+def test_export_to_numpy_roundtrip(tmp_path: Path) -> None:
+    csv_path = tmp_path / "freemocap_3d_landmarks_a.csv"
+    _write_landmarks_csv(csv_path, rows=3)
+    adapter = FreeMoCapOutputAdapter(tmp_path)
+    adapter.parse()
+    out = tmp_path / "out.npy"
+    arr = adapter.export_to_numpy(out)
+    assert out.exists()
+    reloaded = np.load(out)
+    np.testing.assert_array_equal(arr, reloaded)
+    assert arr.shape[0] == 3  # frames
+
+
+def test_export_to_csv_roundtrip(tmp_path: Path) -> None:
+    csv_path = tmp_path / "freemocap_3d_landmarks_a.csv"
+    _write_landmarks_csv(csv_path, rows=2)
+    adapter = FreeMoCapOutputAdapter(tmp_path)
+    adapter.parse()
+
+    out = tmp_path / "out.csv"
+    adapter.export_to_csv(out)
+    assert out.exists()
+
+    with open(out, newline="") as fh:
+        rows = list(csv.reader(fh))
+    header = rows[0]
+    assert header[0] == "frame_number"
+    assert header[1] == "timestamp"
+    # 4 columns per landmark
+    assert (len(header) - 2) % 4 == 0
+    assert len(rows) == 3  # header + 2 data rows
+
+
+def test_load_calibration_missing(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    assert a._load_calibration() is None
+
+
+def test_load_metadata_missing(tmp_path: Path) -> None:
+    a = FreeMoCapOutputAdapter(tmp_path)
+    assert a._load_metadata() == {}
+
+
+def test_find_landmarks_csv(tmp_path: Path) -> None:
+    (tmp_path / "freemocap_3d_landmarks_one.csv").write_text("x")
+    (tmp_path / "freemocap_3d_landmarks_two.csv").write_text("x")
+    (tmp_path / "unrelated.csv").write_text("x")
+    a = FreeMoCapOutputAdapter(tmp_path)
+    found = a._find_landmarks_csv()
+    assert len(found) == 2


### PR DESCRIPTION
## Summary

- Adds 47 fast unit tests under `tests/motion_capture/wave5_mocap/` for the FreeMoCap ingest module (launcher, output adapter, CLI entrypoints).
- Brings `src/motion_capture` coverage to ~95.3% (line + branch). Full suite runs in ~1s.
- Fixes a real bug in `FreeMoCapOutputAdapter._parse_landmark_csv`: confidence value was being read with `row.get(...)`, but rows from `csv.reader` are lists, not dicts — this would crash on any CSV containing `*_conf` columns. Replaced with safe index-based access and an explicit guard for missing x/y/z columns.

## Test plan

- [x] `python3 -m ruff check src/motion_capture tests/motion_capture/wave5_mocap` — clean
- [x] `python3 -m ruff format --check src/motion_capture tests/motion_capture/wave5_mocap` — clean
- [x] `python3 -m pytest tests/motion_capture/wave5_mocap -x --timeout=30` — 47 passed in 1.1s
- [x] Coverage: 95.3% over `src/motion_capture/`

Tests use synthetic CSV/JSON fixtures and mock `subprocess.Popen` — no FreeMoCap install required.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>