### PR TITLE
test(deployment): comprehensive coverage

### DIFF
--- a/src/deployment/digital_twin/estimator.py
+++ b/src/deployment/digital_twin/estimator.py
@@ -56,8 +56,6 @@ class StateEstimator:
         """
         if not (n_dof is not None):
             raise ValueError("n_dof must be provided")
-        if not (n_dof is not None):
-            raise ValueError("n_dof must be provided")
         self.config = config or EstimatorConfig()
         self.n_dof = n_dof
 
@@ -104,8 +102,6 @@ class StateEstimator:
         Returns:
             Dictionary with estimated position, velocity, acceleration.
         """
-        if not (robot_state is not None):
-            raise ValueError("robot_state must be provided")
         if not (robot_state is not None):
             raise ValueError("robot_state must be provided")
         if dt is None:
@@ -175,8 +171,6 @@ class StateEstimator:
         Returns:
             Filtered measurement with outliers replaced.
         """
-        if not (measurement is not None):
-            raise ValueError("measurement must be provided")
         if not (measurement is not None):
             raise ValueError("measurement must be provided")
         predicted = self._H @ self._state
@@ -280,8 +274,6 @@ class StateEstimator:
         Returns:
             Predicted state.
         """
-        if not (dt is not None):
-            raise ValueError("dt must be provided")
         if not (dt is not None):
             raise ValueError("dt must be provided")
         n = self.n_dof

--- a/src/deployment/digital_twin/twin.py
+++ b/src/deployment/digital_twin/twin.py
@@ -90,8 +90,6 @@ class DigitalTwin:
         """
         if not (sim_engine is not None):
             raise ValueError("sim_engine must be provided")
-        if not (sim_engine is not None):
-            raise ValueError("sim_engine must be provided")
         self.sim = sim_engine
         self.real = real_interface
         self._sync_error = 0.0
@@ -161,8 +159,6 @@ class DigitalTwin:
         Returns:
             Predicted state trajectory (n_steps+1, n_states).
         """
-        if not (horizon is not None):
-            raise ValueError("horizon must be provided")
         if not (horizon is not None):
             raise ValueError("horizon must be provided")
         n_steps = int(horizon / dt)

--- a/src/deployment/realtime/controller.py
+++ b/src/deployment/realtime/controller.py
@@ -120,8 +120,6 @@ class RealTimeController:
         """
         if not (control_frequency is not None):
             raise ValueError("control_frequency must be provided")
-        if not (control_frequency is not None):
-            raise ValueError("control_frequency must be provided")
         self.control_frequency = control_frequency
         self.dt = 1.0 / control_frequency
         self.comm_type = CommunicationType(communication_type)
@@ -173,8 +171,6 @@ class RealTimeController:
         Returns:
             True if connection successful.
         """
-        if not (robot_config is not None):
-            raise ValueError("robot_config must be provided")
         if not (robot_config is not None):
             raise ValueError("robot_config must be provided")
         self._config = robot_config
@@ -403,8 +399,6 @@ class RealTimeController:
         Args:
             command: Control command to send.
         """
-        if not (command is not None):
-            raise ValueError("command must be provided")
         if not (command is not None):
             raise ValueError("command must be provided")
         if self.comm_type == CommunicationType.SIMULATION:

--- a/src/deployment/realtime/state.py
+++ b/src/deployment/realtime/state.py
@@ -100,8 +100,6 @@ class RobotState:
         """
         if not (sensor_name is not None):
             raise ValueError("sensor_name must be provided")
-        if not (sensor_name is not None):
-            raise ValueError("sensor_name must be provided")
         if self.ft_wrenches is None:
             return None
         return self.ft_wrenches.get(sensor_name)
@@ -151,8 +149,6 @@ class ControlCommand:
         Raises:
             ValueError: If command is invalid.
         """
-        if not (n_joints is not None):
-            raise ValueError("n_joints must be provided")
         if not (n_joints is not None):
             raise ValueError("n_joints must be provided")
         if self.mode == ControlMode.POSITION:

--- a/src/deployment/safety/collision.py
+++ b/src/deployment/safety/collision.py
@@ -57,8 +57,6 @@ class Obstacle:
         """
         if not (point is not None):
             raise ValueError("point must be provided")
-        if not (point is not None):
-            raise ValueError("point must be provided")
         if self.obstacle_type == ObstacleType.SPHERE:
             return float(
                 # Avoid NumPy dispatch overhead for fixed-size 3D vectors.
@@ -100,8 +98,6 @@ class Obstacle:
         Returns:
             Gradient vector (points away from obstacle).
         """
-        if not (point is not None):
-            raise ValueError("point must be provided")
         if not (point is not None):
             raise ValueError("point must be provided")
         eps = 1e-6
@@ -186,8 +182,6 @@ class CollisionAvoidance:
         """
         if not (robot_model is not None):
             raise ValueError("robot_model must be provided")
-        if not (robot_model is not None):
-            raise ValueError("robot_model must be provided")
         self.model = robot_model
         self.safety_distance = safety_distance
         self._obstacles: list[Obstacle] = []
@@ -215,8 +209,6 @@ class CollisionAvoidance:
         Returns:
             True if obstacle was found and removed.
         """
-        if not (name is not None):
-            raise ValueError("name must be provided")
         if not (name is not None):
             raise ValueError("name must be provided")
         for i, obs in enumerate(self._obstacles):
@@ -251,8 +243,6 @@ class CollisionAvoidance:
         """
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         positions = {}
 
         # Set robot state
@@ -285,8 +275,6 @@ class CollisionAvoidance:
         Returns:
             Repulsive force in joint space (n_joints,).
         """
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         n_joints = len(state.joint_positions)
@@ -353,8 +341,6 @@ class CollisionAvoidance:
         """
         if not (trajectory is not None):
             raise ValueError("trajectory must be provided")
-        if not (trajectory is not None):
-            raise ValueError("trajectory must be provided")
         if min_distance is None:
             min_distance = self.safety_distance
 
@@ -406,8 +392,6 @@ class CollisionAvoidance:
         """
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         link_positions = self.get_link_positions(state)
 
         # Get all obstacles including human
@@ -446,8 +430,6 @@ class CollisionAvoidance:
         Returns:
             Minimum distance in meters.
         """
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         link_positions = self.get_link_positions(state)

--- a/src/deployment/safety/monitor.py
+++ b/src/deployment/safety/monitor.py
@@ -85,8 +85,6 @@ class SafetyLimits:
         """
         if not (robot_config is not None):
             raise ValueError("robot_config must be provided")
-        if not (robot_config is not None):
-            raise ValueError("robot_config must be provided")
         n_joints = robot_config.n_joints
 
         # Default limits
@@ -134,8 +132,6 @@ class SafetyMonitor:
         """
         if not (robot_config is not None):
             raise ValueError("robot_config must be provided")
-        if not (robot_config is not None):
-            raise ValueError("robot_config must be provided")
         self.config = robot_config
         self.limits = limits or SafetyLimits.from_config(robot_config)
         self._speed_override = 1.0
@@ -151,8 +147,6 @@ class SafetyMonitor:
         Returns:
             Safety status.
         """
-        if not (state is not None):
-            raise ValueError("state must be provided")
         if not (state is not None):
             raise ValueError("state must be provided")
         violations = []
@@ -225,8 +219,6 @@ class SafetyMonitor:
         """
         if not (command is not None):
             raise ValueError("command must be provided")
-        if not (command is not None):
-            raise ValueError("command must be provided")
         violations: list[str] = []
         warnings: list[str] = []
 
@@ -290,8 +282,6 @@ class SafetyMonitor:
         Returns:
             Safe control command.
         """
-        if not (desired is not None):
-            raise ValueError("desired must be provided")
         if not (desired is not None):
             raise ValueError("desired must be provided")
         from src.deployment.realtime import ControlCommand
@@ -381,8 +371,6 @@ class SafetyMonitor:
         # Full implementation would use dynamics model
         if not (state is not None):
             raise ValueError("state must be provided")
-        if not (state is not None):
-            raise ValueError("state must be provided")
         max_vel = float(np.max(np.abs(state.joint_velocities)))
         max_decel = 2.0  # m/s² typical deceleration
 
@@ -405,8 +393,6 @@ class SafetyMonitor:
         Args:
             nearby: True if human is within safety distance.
         """
-        if not (nearby is not None):
-            raise ValueError("nearby must be provided")
         if not (nearby is not None):
             raise ValueError("nearby must be provided")
         self._human_nearby = nearby

--- a/src/deployment/teleoperation/devices.py
+++ b/src/deployment/teleoperation/devices.py
@@ -127,8 +127,6 @@ class SpaceMouseInput(BaseInputDevice):
         """
         if not (device_index is not None):
             raise ValueError("device_index must be provided")
-        if not (device_index is not None):
-            raise ValueError("device_index must be provided")
         super().__init__()
         self._device_index = device_index
         self._sensitivity = 1.0
@@ -177,8 +175,6 @@ class VRControllerInput(BaseInputDevice):
             hand: "left" or "right" hand.
             tracking_system: VR tracking system.
         """
-        if not (hand is not None):
-            raise ValueError("hand must be provided")
         if not (hand is not None):
             raise ValueError("hand must be provided")
         super().__init__()
@@ -242,8 +238,6 @@ class HapticDeviceInput(BaseInputDevice):
         """
         if not (device_name is not None):
             raise ValueError("device_name must be provided")
-        if not (device_name is not None):
-            raise ValueError("device_name must be provided")
         super().__init__()
         self._device_name = device_name
         self._workspace_scale = 0.001  # mm to m
@@ -273,8 +267,6 @@ class HapticDeviceInput(BaseInputDevice):
         Args:
             wrench: Desired force/torque.
         """
-        if not (wrench is not None):
-            raise ValueError("wrench must be provided")
         if not (wrench is not None):
             raise ValueError("wrench must be provided")
         if not self._is_connected:

--- a/src/deployment/teleoperation/interface.py
+++ b/src/deployment/teleoperation/interface.py
@@ -77,8 +77,6 @@ class TeleoperationInterface:
         """
         if not (robot is not None):
             raise ValueError("robot must be provided")
-        if not (robot is not None):
-            raise ValueError("robot must be provided")
         self.robot = robot
         self.input = input_device
         self._mode = TeleoperationMode.POSITION
@@ -131,8 +129,6 @@ class TeleoperationInterface:
             follower_frame: Follower reference frame (4x4).
             scaling: Position scaling factor.
         """
-        if not (leader_frame is not None):
-            raise ValueError("leader_frame must be provided")
         if not (leader_frame is not None):
             raise ValueError("leader_frame must be provided")
         self._workspace.leader_frame = leader_frame
@@ -228,8 +224,6 @@ class TeleoperationInterface:
         """
         if not (device_pose is not None):
             raise ValueError("device_pose must be provided")
-        if not (device_pose is not None):
-            raise ValueError("device_pose must be provided")
         from src.deployment.realtime import ControlCommand, ControlMode
 
         # Compute position delta from reference
@@ -296,8 +290,6 @@ class TeleoperationInterface:
         """
         if not (device_twist is not None):
             raise ValueError("device_twist must be provided")
-        if not (device_twist is not None):
-            raise ValueError("device_twist must be provided")
         from src.deployment.realtime import ControlCommand, ControlMode
 
         # Scale twist
@@ -343,8 +335,6 @@ class TeleoperationInterface:
         """
         if not (device_twist is not None):
             raise ValueError("device_twist must be provided")
-        if not (device_twist is not None):
-            raise ValueError("device_twist must be provided")
         from src.deployment.realtime import ControlCommand, ControlMode
 
         # Interpret twist as desired wrench
@@ -381,8 +371,6 @@ class TeleoperationInterface:
         Returns:
             Impedance control command.
         """
-        if not (device_pose is not None):
-            raise ValueError("device_pose must be provided")
         if not (device_pose is not None):
             raise ValueError("device_pose must be provided")
         from src.deployment.realtime import ControlCommand, ControlMode
@@ -476,8 +464,6 @@ class TeleoperationInterface:
             joint_velocities: Current joint velocities.
             action: Applied action/torque.
         """
-        if not (joint_positions is not None):
-            raise ValueError("joint_positions must be provided")
         if not (joint_positions is not None):
             raise ValueError("joint_positions must be provided")
         if not self._recording:

--- a/tests/deployment/wave5_deployment/__init__.py
+++ b/tests/deployment/wave5_deployment/__init__.py
@@ -1,0 +1,1 @@
+"""Wave 5 deployment coverage tests."""

--- a/tests/deployment/wave5_deployment/test_collision.py
+++ b/tests/deployment/wave5_deployment/test_collision.py
@@ -1,0 +1,275 @@
+"""Comprehensive tests for deployment.safety.collision."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from src.deployment.realtime import RobotState
+from src.deployment.safety.collision import (
+    CollisionAvoidance,
+    HumanState,
+    Obstacle,
+    ObstacleType,
+)
+
+
+def _state(n: int = 3) -> RobotState:
+    return RobotState(
+        timestamp=0.0,
+        joint_positions=np.zeros(n),
+        joint_velocities=np.zeros(n),
+        joint_torques=np.zeros(n),
+    )
+
+
+class TestObstacle:
+    def test_sphere_distance(self) -> None:
+        ob = Obstacle(
+            name="s",
+            obstacle_type=ObstacleType.SPHERE,
+            position=np.zeros(3),
+            dimensions=np.array([1.0]),
+            inflation=0.0,
+        )
+        assert ob.get_distance(np.array([2.0, 0, 0])) == pytest.approx(1.0)
+
+    def test_box_distance(self) -> None:
+        ob = Obstacle(
+            name="b",
+            obstacle_type=ObstacleType.BOX,
+            position=np.zeros(3),
+            dimensions=np.array([2.0, 2.0, 2.0]),
+            inflation=0.0,
+        )
+        assert ob.get_distance(np.array([2.0, 0.0, 0.0])) == pytest.approx(1.0)
+        assert ob.get_distance(np.zeros(3)) <= 0  # inside
+
+    def test_human_obstacle_uses_box_math(self) -> None:
+        ob = Obstacle(
+            name="h",
+            obstacle_type=ObstacleType.HUMAN,
+            position=np.zeros(3),
+            dimensions=np.array([1.0, 1.0, 1.0]),
+            inflation=0.0,
+        )
+        assert ob.get_distance(np.array([1.0, 0, 0])) == pytest.approx(0.5)
+
+    def test_cylinder_distance(self) -> None:
+        ob = Obstacle(
+            name="c",
+            obstacle_type=ObstacleType.CYLINDER,
+            position=np.zeros(3),
+            dimensions=np.array([1.0, 2.0]),
+            inflation=0.0,
+        )
+        # Outside along radial
+        assert ob.get_distance(np.array([2.0, 0, 0])) == pytest.approx(1.0)
+        # Outside along z
+        assert ob.get_distance(np.array([0.0, 0, 2.0])) == pytest.approx(1.0)
+        # Corner case
+        d = ob.get_distance(np.array([2.0, 0, 2.0]))
+        assert d > 0
+
+    def test_dynamic_returns_zero(self) -> None:
+        ob = Obstacle(
+            name="d",
+            obstacle_type=ObstacleType.DYNAMIC,
+            position=np.zeros(3),
+            dimensions=np.array([1.0]),
+        )
+        assert ob.get_distance(np.array([5.0, 0, 0])) == 0.0
+
+    def test_gradient_points_outward(self) -> None:
+        ob = Obstacle(
+            name="s",
+            obstacle_type=ObstacleType.SPHERE,
+            position=np.zeros(3),
+            dimensions=np.array([1.0]),
+            inflation=0.0,
+        )
+        g = ob.get_gradient(np.array([2.0, 0.0, 0.0]))
+        assert g[0] > 0.9
+        np.testing.assert_array_almost_equal(g[1:], [0.0, 0.0], decimal=3)
+
+
+class TestHumanState:
+    def test_to_obstacle(self) -> None:
+        h = HumanState(position=np.array([1.0, 2.0, 3.0]))
+        ob = h.to_obstacle()
+        assert ob.obstacle_type == ObstacleType.HUMAN
+        assert ob.inflation == 0.3
+
+
+class TestCollisionAvoidance:
+    def _ca(self) -> CollisionAvoidance:
+        model = MagicMock()
+        del model.get_link_positions  # force fallback
+        del model.set_joint_positions
+        return CollisionAvoidance(model, safety_distance=0.1)
+
+    def test_add_remove_obstacle(self) -> None:
+        ca = self._ca()
+        ob = Obstacle(
+            name="x",
+            obstacle_type=ObstacleType.SPHERE,
+            position=np.zeros(3),
+            dimensions=np.array([0.1]),
+        )
+        ca.add_obstacle(ob)
+        assert ca.remove_obstacle("x") is True
+        assert ca.remove_obstacle("x") is False
+
+    def test_clear_obstacles(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle("a", ObstacleType.SPHERE, np.zeros(3), np.array([0.1]))
+        )
+        ca.clear_obstacles()
+        assert ca._obstacles == []
+
+    def test_update_human(self) -> None:
+        ca = self._ca()
+        h = HumanState(position=np.array([1.0, 0, 0]))
+        ca.update_human_position(h)
+        assert ca._human_state is h
+
+    def test_get_link_positions_fallback(self) -> None:
+        ca = self._ca()
+        pos = ca.get_link_positions(_state(n=3))
+        assert len(pos) == 3
+        assert "link_0" in pos
+
+    def test_get_link_positions_via_model(self) -> None:
+        model = MagicMock()
+        model.get_link_positions.return_value = {"link_0": np.zeros(3)}
+        ca = CollisionAvoidance(model)
+        result = ca.get_link_positions(_state())
+        assert "link_0" in result
+
+    def test_repulsive_field_no_obstacles(self) -> None:
+        ca = self._ca()
+        r = ca.compute_repulsive_field(_state())
+        assert np.all(r == 0)
+
+    def test_repulsive_field_with_close_obstacle(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([0.0, 0.0, 0.15]),
+                dimensions=np.array([0.05]),
+                inflation=0.0,
+            )
+        )
+        r = ca.compute_repulsive_field(_state(n=3))
+        assert r.shape == (3,)
+
+    def test_repulsive_field_inside_obstacle(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([0.0, 0.0, 0.1]),
+                dimensions=np.array([1.0]),
+                inflation=0.0,
+            )
+        )
+        r = ca.compute_repulsive_field(_state(n=3))
+        assert r.shape == (3,)
+
+    def test_path_clearance_clear(self) -> None:
+        ca = self._ca()
+        traj = np.zeros((5, 3))
+        clear, dist = ca.check_path_clearance(traj)
+        assert clear is True
+
+    def test_path_clearance_blocked(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([0.0, 0.0, 0.2]),
+                dimensions=np.array([1.0]),
+                inflation=0.0,
+            )
+        )
+        traj = np.zeros((3, 3))
+        clear, _ = ca.check_path_clearance(traj, min_distance=0.5)
+        assert clear is False
+
+    def test_safe_velocity_no_obstacle(self) -> None:
+        ca = self._ca()
+        assert ca.get_safe_velocity_scaling(_state()) == 1.0
+
+    def test_safe_velocity_inside(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([0, 0, 0.1]),
+                dimensions=np.array([1.0]),
+                inflation=0.0,
+            )
+        )
+        assert ca.get_safe_velocity_scaling(_state(n=3)) == 0.0
+
+    def test_safe_velocity_far(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([10.0, 0, 0]),
+                dimensions=np.array([0.01]),
+                inflation=0.0,
+            )
+        )
+        assert ca.get_safe_velocity_scaling(_state(n=3)) == 1.0
+
+    def test_safe_velocity_mid_range(self) -> None:
+        ca = self._ca()
+        # Fallback link_0 at z=0.1; obstacle far enough that
+        # safety_distance < dist < repulsion_distance.
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([0.5, 0.0, 0.1]),
+                dimensions=np.array([0.05]),
+                inflation=0.0,
+            )
+        )
+        v = ca.get_safe_velocity_scaling(_state(n=1))
+        assert 0.0 < v < 1.0
+
+    def test_min_distance_no_obstacle(self) -> None:
+        ca = self._ca()
+        assert ca.get_minimum_distance(_state()) == float("inf")
+
+    def test_min_distance_with_obstacle(self) -> None:
+        ca = self._ca()
+        ca.add_obstacle(
+            Obstacle(
+                "s",
+                ObstacleType.SPHERE,
+                position=np.array([1.0, 0, 0]),
+                dimensions=np.array([0.1]),
+                inflation=0.0,
+            )
+        )
+        d = ca.get_minimum_distance(_state(n=3))
+        assert d > 0
+        assert d < float("inf")
+
+    def test_with_human(self) -> None:
+        ca = self._ca()
+        ca.update_human_position(HumanState(position=np.array([0.5, 0.0, 0.0])))
+        d = ca.get_minimum_distance(_state(n=3))
+        assert d < float("inf")

--- a/tests/deployment/wave5_deployment/test_controller.py
+++ b/tests/deployment/wave5_deployment/test_controller.py
@@ -1,0 +1,224 @@
+"""Comprehensive tests for deployment.realtime.controller."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from src.deployment.realtime.controller import (
+    CommunicationType,
+    RealTimeController,
+    RobotConfig,
+    TimingStatistics,
+)
+from src.deployment.realtime.state import (
+    ControlCommand,
+    ControlMode,
+    RobotState,
+)
+
+
+def _config(n: int = 3) -> RobotConfig:
+    return RobotConfig(name="bot", n_joints=n)
+
+
+def _callback_zero(state: RobotState) -> ControlCommand:
+    return ControlCommand.torque_command(
+        state.timestamp, np.zeros(len(state.joint_positions))
+    )
+
+
+class TestRobotConfig:
+    def test_default_joint_names(self) -> None:
+        c = RobotConfig(name="bot", n_joints=3)
+        assert c.joint_names == ["joint_0", "joint_1", "joint_2"]
+
+    def test_explicit_joint_names_kept(self) -> None:
+        c = RobotConfig(name="bot", n_joints=2, joint_names=["a", "b"])
+        assert c.joint_names == ["a", "b"]
+
+
+class TestTimingStatisticsDefaults:
+    def test_defaults(self) -> None:
+        s = TimingStatistics()
+        assert s.total_cycles == 0
+        assert s.min_cycle_time == float("inf")
+
+
+class TestConnect:
+    def test_connect_simulation(self) -> None:
+        c = RealTimeController(communication_type="simulation")
+        assert c.connect(_config()) is True
+        assert c.is_connected
+
+    def test_connect_loopback(self) -> None:
+        c = RealTimeController(communication_type="loopback")
+        assert c.connect(_config()) is True
+
+    def test_connect_ros2_fails(self) -> None:
+        c = RealTimeController(communication_type="ros2")
+        assert c.connect(_config()) is False
+        assert not c.is_connected
+
+    def test_connect_udp_fails(self) -> None:
+        c = RealTimeController(communication_type="udp")
+        assert c.connect(_config()) is False
+
+    def test_connect_ethercat_fails(self) -> None:
+        c = RealTimeController(communication_type="ethercat")
+        assert c.connect(_config()) is False
+
+    def test_disconnect_clears(self) -> None:
+        c = RealTimeController()
+        c.connect(_config())
+        c.disconnect()
+        assert not c.is_connected
+        assert c._config is None
+
+
+class TestStartStop:
+    def test_start_without_connect_raises(self) -> None:
+        c = RealTimeController()
+        c.set_control_callback(_callback_zero)
+        with pytest.raises(RuntimeError, match="connect"):
+            c.start()
+
+    def test_start_without_callback_raises(self) -> None:
+        c = RealTimeController()
+        c.connect(_config())
+        with pytest.raises(RuntimeError, match="callback"):
+            c.start()
+
+    def test_start_twice_noop(self) -> None:
+        c = RealTimeController(control_frequency=100.0)
+        c.connect(_config())
+        c.set_control_callback(_callback_zero)
+        c.start()
+        try:
+            c.start()  # second start should be no-op
+            assert c.is_running
+        finally:
+            c.stop()
+
+    def test_full_cycle_simulation(self) -> None:
+        c = RealTimeController(control_frequency=200.0)
+        c.connect(_config())
+        c.set_control_callback(_callback_zero)
+        c.start()
+        time.sleep(0.05)
+        c.stop()
+        assert not c.is_running
+        stats = c.get_timing_stats()
+        assert stats.total_cycles > 0
+
+    def test_get_timing_stats_no_data(self) -> None:
+        c = RealTimeController()
+        stats = c.get_timing_stats()
+        assert stats.total_cycles == 0
+
+    def test_disconnect_while_running(self) -> None:
+        c = RealTimeController(control_frequency=200.0)
+        c.connect(_config())
+        c.set_control_callback(_callback_zero)
+        c.start()
+        time.sleep(0.02)
+        c.disconnect()
+        assert not c.is_connected
+
+
+class TestLoopback:
+    def test_loopback_torque(self) -> None:
+        c = RealTimeController(control_frequency=100.0, communication_type="loopback")
+        c.connect(_config(n=3))
+        c._sim_state = (np.zeros(3), np.zeros(3))
+        cmd = ControlCommand.torque_command(0.0, np.ones(3))
+        c._send_command(cmd)
+        q, qd = c._sim_state
+        assert qd[0] > 0
+
+    def test_loopback_position(self) -> None:
+        c = RealTimeController(communication_type="loopback")
+        c.connect(_config(n=3))
+        c._sim_state = (np.zeros(3), np.ones(3))
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.POSITION,
+            position_targets=np.array([1.0, 2.0, 3.0]),
+        )
+        c._send_command(cmd)
+        q, qd = c._sim_state
+        np.testing.assert_array_equal(q, [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(qd, np.zeros(3))
+
+    def test_loopback_velocity(self) -> None:
+        c = RealTimeController(control_frequency=100.0, communication_type="loopback")
+        c.connect(_config(n=3))
+        c._sim_state = (np.zeros(3), np.zeros(3))
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.VELOCITY,
+            velocity_targets=np.array([1.0, 0.0, 0.0]),
+        )
+        c._send_command(cmd)
+        q, qd = c._sim_state
+        assert qd[0] == 1.0
+
+    def test_loopback_impedance(self) -> None:
+        c = RealTimeController(control_frequency=100.0, communication_type="loopback")
+        c.connect(_config(n=3))
+        c._sim_state = (np.zeros(3), np.zeros(3))
+        cmd = ControlCommand.impedance_command(
+            0.0,
+            np.ones(3),
+            np.ones(3) * 10,
+            np.ones(3),
+            feedforward=np.zeros(3),
+        )
+        c._send_command(cmd)
+        q, qd = c._sim_state
+        assert qd[0] > 0
+
+    def test_loopback_init_when_none(self) -> None:
+        c = RealTimeController(communication_type="loopback")
+        c.connect(_config(n=3))
+        c._sim_state = None
+        cmd = ControlCommand.torque_command(0.0, np.zeros(3))
+        c._send_command(cmd)
+        assert c._sim_state is not None
+
+    def test_loopback_read_state(self) -> None:
+        c = RealTimeController(communication_type="loopback")
+        c.connect(_config(n=3))
+        s = c._read_state()
+        assert s.joint_positions.shape == (3,)
+
+    def test_simulation_read_state(self) -> None:
+        c = RealTimeController(communication_type="simulation")
+        c.connect(_config(n=4))
+        s = c._read_state()
+        assert s.joint_positions.shape == (4,)
+
+
+class TestWaitForState:
+    def test_wait_for_state_timeout(self) -> None:
+        c = RealTimeController()
+        s = c.wait_for_state(timeout=0.01)
+        assert s is None
+
+    def test_get_last_state_none(self) -> None:
+        c = RealTimeController()
+        assert c.get_last_state() is None
+        assert c.get_last_command() is None
+
+    def test_wait_for_state_returns_when_set(self) -> None:
+        c = RealTimeController(control_frequency=200.0, communication_type="loopback")
+        c.connect(_config(n=3))
+        c.set_control_callback(_callback_zero)
+        c.start()
+        try:
+            s = c.wait_for_state(timeout=0.5)
+            assert s is not None
+        finally:
+            c.stop()

--- a/tests/deployment/wave5_deployment/test_digital_twin.py
+++ b/tests/deployment/wave5_deployment/test_digital_twin.py
@@ -1,0 +1,314 @@
+"""Comprehensive tests for deployment.digital_twin."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from src.deployment.digital_twin.estimator import (
+    EstimatorConfig,
+    StateEstimator,
+)
+from src.deployment.digital_twin.twin import (
+    AnomalyReport,
+    AnomalyType,
+    DigitalTwin,
+)
+from src.deployment.realtime import RobotState
+
+
+def _state(n: int = 3, **kw) -> RobotState:
+    d = {
+        "timestamp": 0.0,
+        "joint_positions": np.zeros(n),
+        "joint_velocities": np.zeros(n),
+        "joint_torques": np.zeros(n),
+    }
+    d.update(kw)
+    return RobotState(**d)
+
+
+class TestAnomalyReport:
+    def test_valid(self) -> None:
+        r = AnomalyReport(
+            timestamp=0.0,
+            anomaly_type=AnomalyType.COLLISION,
+            severity=0.5,
+            affected_joints=[0],
+            description="x",
+            recommended_action="stop",
+        )
+        assert r.confidence == 0.9
+
+    def test_bad_severity(self) -> None:
+        with pytest.raises(ValueError, match="severity"):
+            AnomalyReport(
+                timestamp=0.0,
+                anomaly_type=AnomalyType.COLLISION,
+                severity=2.0,
+                affected_joints=[],
+                description="x",
+                recommended_action="y",
+            )
+
+    def test_bad_confidence(self) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            AnomalyReport(
+                timestamp=0.0,
+                anomaly_type=AnomalyType.COLLISION,
+                severity=0.5,
+                affected_joints=[],
+                description="x",
+                recommended_action="y",
+                confidence=2.0,
+            )
+
+
+class TestStateEstimator:
+    def test_update_and_estimates(self) -> None:
+        est = StateEstimator(n_dof=3)
+        s = _state(n=3, timestamp=0.01)
+        out = est.update(s, dt=0.01)
+        assert "position" in out
+        assert out["position"].shape == (3,)
+
+    def test_update_auto_dt(self) -> None:
+        est = StateEstimator(n_dof=3)
+        # First call: dt computed as timestamp - 0
+        est.update(_state(n=3, timestamp=0.01))
+        # Second call same timestamp -> dt<=0 fallback
+        est.update(_state(n=3, timestamp=0.01))
+
+    def test_get_velocity_with_filter(self) -> None:
+        est = StateEstimator(n_dof=3, config=EstimatorConfig(use_velocity_filter=True))
+        v = est.get_velocity()
+        assert v.shape == (3,)
+
+    def test_get_velocity_no_filter(self) -> None:
+        est = StateEstimator(n_dof=3, config=EstimatorConfig(use_velocity_filter=False))
+        est.update(_state(n=3, joint_velocities=np.ones(3), timestamp=0.01), dt=0.01)
+        v = est.get_velocity()
+        assert v.shape == (3,)
+
+    def test_get_acceleration(self) -> None:
+        est = StateEstimator(n_dof=3)
+        assert est.get_acceleration().shape == (3,)
+
+    def test_get_covariance(self) -> None:
+        est = StateEstimator(n_dof=3)
+        cov = est.get_covariance()
+        assert cov.shape == (9, 9)
+
+    def test_get_uncertainties(self) -> None:
+        est = StateEstimator(n_dof=3)
+        assert est.get_position_uncertainty().shape == (3,)
+        assert est.get_velocity_uncertainty().shape == (3,)
+
+    def test_reset(self) -> None:
+        est = StateEstimator(n_dof=3)
+        est.reset(position=np.ones(3), velocity=np.ones(3) * 2)
+        np.testing.assert_array_equal(est.get_position(), np.ones(3))
+
+    def test_reset_defaults(self) -> None:
+        est = StateEstimator(n_dof=3)
+        est.reset()
+        assert np.all(est.get_position() == 0)
+
+    def test_predict_no_control(self) -> None:
+        est = StateEstimator(n_dof=3)
+        out = est.predict(0.1)
+        assert out["position"].shape == (3,)
+
+    def test_predict_with_control(self) -> None:
+        est = StateEstimator(n_dof=3)
+        out = est.predict(0.1, control=np.ones(3))
+        np.testing.assert_array_equal(out["acceleration"], np.ones(3))
+
+
+class TestDigitalTwin:
+    def _twin(
+        self, has_methods: bool = True
+    ) -> tuple[DigitalTwin, MagicMock, MagicMock]:
+        sim = MagicMock()
+        if has_methods:
+            sim.get_joint_positions.return_value = np.zeros(3)
+            sim.get_joint_velocities.return_value = np.zeros(3)
+            sim.get_joint_torques.return_value = np.zeros(3)
+        else:
+            del sim.get_joint_positions
+            del sim.get_joint_velocities
+            del sim.get_joint_torques
+            del sim.set_joint_positions
+            del sim.set_joint_velocities
+            del sim.set_joint_torques
+            del sim.step
+        real = MagicMock()
+        return DigitalTwin(sim, real), sim, real
+
+    def test_sync_error_property(self) -> None:
+        t, _, _ = self._twin()
+        assert t.sync_error == 0.0
+
+    def test_synchronize_no_state(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = None
+        assert t.synchronize() == 0.0
+
+    def test_synchronize_with_state(self) -> None:
+        t, sim, real = self._twin()
+        real.get_last_state.return_value = _state(
+            n=3, joint_positions=np.ones(3), joint_velocities=np.ones(3) * 0.5
+        )
+        err = t.synchronize()
+        assert err > 0
+
+    def test_synchronize_without_sim_methods(self) -> None:
+        t, _, real = self._twin(has_methods=False)
+        real.get_last_state.return_value = _state(n=3)
+        err = t.synchronize()
+        assert err >= 0
+
+    def test_predict(self) -> None:
+        t, sim, _ = self._twin()
+        sim.get_joint_positions.return_value = np.zeros(3)
+        sim.get_joint_velocities.return_value = np.zeros(3)
+        controls = np.zeros((10, 3))
+        traj = t.predict(0.01, controls, dt=0.001)
+        assert traj.shape == (11, 6)
+
+    def test_predict_without_methods(self) -> None:
+        t, _, _ = self._twin(has_methods=False)
+        traj = t.predict(0.005, np.zeros((5, 7)), dt=0.001)
+        assert traj.shape[0] == 6
+
+    def test_detect_anomaly_no_state(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = None
+        assert t.detect_anomaly() is None
+
+    def test_detect_position_mismatch(self) -> None:
+        t, sim, real = self._twin()
+        sim.get_joint_positions.return_value = np.zeros(3)
+        sim.get_joint_velocities.return_value = np.zeros(3)
+        sim.get_joint_torques.return_value = np.zeros(3)
+        real.get_last_state.return_value = _state(
+            n=3, joint_positions=np.array([0.5, 0.0, 0.0])
+        )
+        anomaly = t.detect_anomaly()
+        assert anomaly is not None
+        assert anomaly.anomaly_type in (
+            AnomalyType.MODEL_MISMATCH,
+            AnomalyType.COLLISION,
+        )
+
+    def test_detect_torque_spike(self) -> None:
+        t, sim, real = self._twin()
+        sim.get_joint_positions.return_value = np.zeros(3)
+        sim.get_joint_velocities.return_value = np.zeros(3)
+        sim.get_joint_torques.return_value = np.zeros(3)
+        real.get_last_state.return_value = _state(
+            n=3, joint_torques=np.array([20.0, 0.0, 0.0])
+        )
+        anomaly = t.detect_anomaly()
+        assert anomaly is not None
+        assert anomaly.anomaly_type == AnomalyType.COLLISION
+
+    def test_detect_no_sim_methods(self) -> None:
+        sim = MagicMock()
+        del sim.get_joint_positions
+        real = MagicMock()
+        real.get_last_state.return_value = _state(n=3)
+        t = DigitalTwin(sim, real)
+        assert t.detect_anomaly() is None
+
+    def test_detect_no_velocity_method(self) -> None:
+        sim = MagicMock()
+        sim.get_joint_positions.return_value = np.zeros(3)
+        del sim.get_joint_velocities
+        real = MagicMock()
+        real.get_last_state.return_value = _state(n=3)
+        t = DigitalTwin(sim, real)
+        assert t.detect_anomaly() is None
+
+    def test_get_estimated_contacts_no_state(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = None
+        assert t.get_estimated_contacts() == []
+
+    def test_get_estimated_contacts_ft(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = _state(
+            n=3, ft_wrenches={"wrist": np.array([5.0, 0, 0, 0, 0, 0])}
+        )
+        contacts = t.get_estimated_contacts()
+        assert len(contacts) == 1
+        assert contacts[0]["sensor"] == "wrist"
+
+    def test_get_estimated_contacts_below_threshold(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = _state(
+            n=3, ft_wrenches={"wrist": np.array([0.1, 0, 0, 0, 0, 0])}
+        )
+        assert t.get_estimated_contacts() == []
+
+    def test_get_estimated_contacts_states(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = _state(n=3, contact_states=[True, False])
+        contacts = t.get_estimated_contacts()
+        assert len(contacts) == 1
+
+    def test_compute_virtual_forces_no_state(self) -> None:
+        t, _, real = self._twin()
+        real.get_last_state.return_value = None
+        assert np.all(t.compute_virtual_forces() == 0)
+
+    def test_compute_virtual_forces_with_torques(self) -> None:
+        t, sim, real = self._twin()
+        sim.get_joint_torques.return_value = np.zeros(7)
+        real.get_last_state.return_value = _state(n=7, joint_torques=np.ones(7) * 2.0)
+        f = t.compute_virtual_forces()
+        assert f.shape == (6,)
+        assert f[0] == 2.0
+
+    def test_compute_virtual_forces_short(self) -> None:
+        t, sim, real = self._twin()
+        sim.get_joint_torques.return_value = np.zeros(3)
+        real.get_last_state.return_value = _state(n=3)
+        f = t.compute_virtual_forces()
+        assert np.all(f == 0)
+
+    def test_compute_virtual_forces_no_method(self) -> None:
+        sim = MagicMock()
+        del sim.get_joint_torques
+        real = MagicMock()
+        real.get_last_state.return_value = _state(n=3)
+        t = DigitalTwin(sim, real)
+        assert np.all(t.compute_virtual_forces() == 0)
+
+    def test_anomaly_history(self) -> None:
+        t, sim, real = self._twin()
+        sim.get_joint_positions.return_value = np.zeros(3)
+        sim.get_joint_velocities.return_value = np.zeros(3)
+        sim.get_joint_torques.return_value = np.zeros(3)
+        real.get_last_state.return_value = _state(
+            n=3, joint_positions=np.array([0.5, 0, 0]), timestamp=10.0
+        )
+        t.detect_anomaly()
+        assert len(t.get_anomaly_history()) >= 1
+        # max_age filter
+        real.get_last_state.return_value = _state(n=3, timestamp=10.0)
+        h = t.get_anomaly_history(max_age=100.0)
+        assert len(h) >= 1
+        # No state
+        real.get_last_state.return_value = None
+        h = t.get_anomaly_history(max_age=1.0)
+        assert isinstance(h, list)
+        t.clear_anomaly_history()
+        assert t.get_anomaly_history() == []
+
+    def test_set_anomaly_threshold(self) -> None:
+        t, _, _ = self._twin()
+        t.set_anomaly_threshold(0.5)
+        assert t._anomaly_threshold == 0.5

--- a/tests/deployment/wave5_deployment/test_safety.py
+++ b/tests/deployment/wave5_deployment/test_safety.py
@@ -1,0 +1,204 @@
+"""Comprehensive tests for deployment.safety.monitor."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.deployment.realtime import (
+    ControlCommand,
+    ControlMode,
+    RobotConfig,
+    RobotState,
+)
+from src.deployment.safety.monitor import (
+    SafetyLimits,
+    SafetyMonitor,
+    SafetyStatusLevel,
+)
+
+
+def _cfg(n: int = 3) -> RobotConfig:
+    return RobotConfig(
+        name="bot",
+        n_joints=n,
+        joint_limits_lower=np.full(n, -1.0),
+        joint_limits_upper=np.full(n, 1.0),
+        velocity_limits=np.full(n, 2.0),
+        torque_limits=np.full(n, 50.0),
+    )
+
+
+def _state(n: int = 3, **kwargs) -> RobotState:
+    defaults = {
+        "timestamp": 0.0,
+        "joint_positions": np.zeros(n),
+        "joint_velocities": np.zeros(n),
+        "joint_torques": np.zeros(n),
+    }
+    defaults.update(kwargs)
+    return RobotState(**defaults)
+
+
+class TestSafetyLimits:
+    def test_from_config(self) -> None:
+        lim = SafetyLimits.from_config(_cfg())
+        assert lim.max_joint_velocity.shape == (3,)
+        assert lim.max_joint_torque.shape == (3,)
+
+    def test_from_config_defaults(self) -> None:
+        cfg = RobotConfig(name="b", n_joints=3)
+        lim = SafetyLimits.from_config(cfg)
+        assert np.all(lim.max_joint_velocity == 2.0)
+        assert np.all(lim.max_joint_torque == 50.0)
+
+
+class TestSafetyMonitorCheckState:
+    def test_ok(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state())
+        assert st.is_safe
+        assert st.level == SafetyStatusLevel.OK
+
+    def test_velocity_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state(joint_velocities=np.array([10.0, 0, 0])))
+        assert not st.is_safe
+        assert any("velocity" in v for v in st.violations)
+
+    def test_torque_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state(joint_torques=np.array([100.0, 0, 0])))
+        assert not st.is_safe
+        assert any("torque" in v for v in st.violations)
+
+    def test_lower_limit_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state(joint_positions=np.array([-2.0, 0, 0])))
+        assert not st.is_safe
+        assert any("Lower" in v for v in st.violations)
+
+    def test_upper_limit_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state(joint_positions=np.array([2.0, 0, 0])))
+        assert not st.is_safe
+        assert any("Upper" in v for v in st.violations)
+
+    def test_warning_approaching_limit(self) -> None:
+        m = SafetyMonitor(_cfg())
+        st = m.check_state(_state(joint_positions=np.array([0.95, 0, 0])))
+        assert st.is_safe
+        assert st.level == SafetyStatusLevel.WARNING
+
+    def test_emergency_stop_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        m.trigger_emergency_stop()
+        st = m.check_state(_state())
+        assert not st.is_safe
+        assert any("Emergency" in v for v in st.violations)
+
+
+class TestSafetyMonitorCheckCommand:
+    def test_ok(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.torque_command(0.0, np.zeros(3))
+        st = m.check_command(cmd)
+        assert st.is_safe
+
+    def test_torque_command_violation(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.torque_command(0.0, np.array([100.0, 0, 0]))
+        st = m.check_command(cmd)
+        assert not st.is_safe
+
+    def test_position_below_limit(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.position_command(0.0, np.array([-2.0, 0, 0]))
+        st = m.check_command(cmd)
+        assert not st.is_safe
+        assert any("below" in v for v in st.violations)
+
+    def test_position_above_limit(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.position_command(0.0, np.array([2.0, 0, 0]))
+        st = m.check_command(cmd)
+        assert not st.is_safe
+        assert any("above" in v for v in st.violations)
+
+
+class TestSafetyMonitorComputeSafe:
+    def test_clip_torque(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.torque_command(0.0, np.array([100.0, -100.0, 0.0]))
+        safe = m.compute_safe_command(cmd, _state())
+        assert safe.torque_commands is not None
+        assert np.all(np.abs(safe.torque_commands) <= 50.0)
+
+    def test_clip_position(self) -> None:
+        m = SafetyMonitor(_cfg())
+        cmd = ControlCommand.position_command(0.0, np.array([2.0, -2.0, 0.5]))
+        safe = m.compute_safe_command(cmd, _state())
+        assert safe.position_targets is not None
+        assert safe.position_targets[0] <= 1.0
+        assert safe.position_targets[1] >= -1.0
+
+    def test_estop_freezes_position(self) -> None:
+        m = SafetyMonitor(_cfg())
+        m.trigger_emergency_stop()
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.IMPEDANCE,
+            position_targets=np.array([0.5, 0.5, 0.5]),
+            stiffness=np.ones(3),
+            damping=np.ones(3),
+            feedforward_torque=np.ones(3),
+        )
+        state = _state(joint_positions=np.array([0.1, 0.1, 0.1]))
+        safe = m.compute_safe_command(cmd, state)
+        np.testing.assert_array_equal(safe.position_targets, state.joint_positions)
+        assert np.all(safe.feedforward_torque == 0)
+
+    def test_speed_override_scales(self) -> None:
+        m = SafetyMonitor(_cfg())
+        m.set_speed_override(0.5)
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.VELOCITY,
+            velocity_targets=np.ones(3),
+            torque_commands=np.ones(3),
+        )
+        safe = m.compute_safe_command(cmd, _state())
+        np.testing.assert_array_almost_equal(safe.velocity_targets, np.ones(3) * 0.5)
+        np.testing.assert_array_almost_equal(safe.torque_commands, np.ones(3) * 0.5)
+
+
+class TestSafetyMonitorMisc:
+    def test_stopping_distance(self) -> None:
+        m = SafetyMonitor(_cfg())
+        d = m.get_stopping_distance(
+            _state(joint_velocities=np.array([2.0, 0, 0])), "ee"
+        )
+        assert d == pytest.approx(1.0, rel=1e-3)
+
+    def test_set_speed_override_clamps(self) -> None:
+        m = SafetyMonitor(_cfg())
+        m.set_speed_override(2.0)
+        assert m._speed_override == 1.0
+        m.set_speed_override(-1.0)
+        assert m._speed_override == 0.0
+
+    def test_set_human_nearby(self) -> None:
+        m = SafetyMonitor(_cfg())
+        m.set_human_nearby(True)
+        assert m._human_nearby
+        assert m._speed_override <= 0.5
+
+    def test_emergency_stop_cycle(self) -> None:
+        m = SafetyMonitor(_cfg())
+        assert not m.is_emergency_stopped()
+        m.trigger_emergency_stop()
+        assert m.is_emergency_stopped()
+        assert m._speed_override == 0.0
+        m.clear_emergency_stop()
+        assert not m.is_emergency_stopped()
+        assert m._speed_override == 1.0

--- a/tests/deployment/wave5_deployment/test_state.py
+++ b/tests/deployment/wave5_deployment/test_state.py
@@ -1,0 +1,191 @@
+"""Comprehensive tests for deployment.realtime.state."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.deployment.realtime.state import (
+    ControlCommand,
+    ControlMode,
+    IMUReading,
+    RobotState,
+)
+
+
+class TestIMUReading:
+    def test_valid_imu(self) -> None:
+        imu = IMUReading(
+            timestamp=1.0,
+            linear_acceleration=np.zeros(3),
+            angular_velocity=np.zeros(3),
+            orientation=np.array([1.0, 0.0, 0.0, 0.0]),
+        )
+        assert imu.timestamp == 1.0
+
+    def test_imu_no_orientation(self) -> None:
+        imu = IMUReading(
+            timestamp=0.0,
+            linear_acceleration=np.zeros(3),
+            angular_velocity=np.zeros(3),
+        )
+        assert imu.orientation is None
+
+    def test_imu_bad_linear_acc(self) -> None:
+        with pytest.raises(ValueError, match="linear_acceleration"):
+            IMUReading(
+                timestamp=0.0,
+                linear_acceleration=np.zeros(4),
+                angular_velocity=np.zeros(3),
+            )
+
+    def test_imu_bad_angular_vel(self) -> None:
+        with pytest.raises(ValueError, match="angular_velocity"):
+            IMUReading(
+                timestamp=0.0,
+                linear_acceleration=np.zeros(3),
+                angular_velocity=np.zeros(2),
+            )
+
+    def test_imu_bad_orientation(self) -> None:
+        with pytest.raises(ValueError, match="orientation"):
+            IMUReading(
+                timestamp=0.0,
+                linear_acceleration=np.zeros(3),
+                angular_velocity=np.zeros(3),
+                orientation=np.zeros(3),
+            )
+
+
+class TestRobotState:
+    def _make(self) -> RobotState:
+        return RobotState(
+            timestamp=0.5,
+            joint_positions=np.arange(7.0),
+            joint_velocities=np.ones(7),
+            joint_torques=np.zeros(7),
+            ft_wrenches={"wrist": np.arange(6.0)},
+        )
+
+    def test_get_ft_wrench_present(self) -> None:
+        s = self._make()
+        w = s.get_ft_wrench("wrist")
+        assert w is not None
+        np.testing.assert_array_equal(w, np.arange(6.0))
+
+    def test_get_ft_wrench_missing(self) -> None:
+        s = self._make()
+        assert s.get_ft_wrench("ankle") is None
+
+    def test_get_ft_wrench_no_dict(self) -> None:
+        s = RobotState(
+            timestamp=0.0,
+            joint_positions=np.zeros(7),
+            joint_velocities=np.zeros(7),
+            joint_torques=np.zeros(7),
+        )
+        assert s.get_ft_wrench("wrist") is None
+
+    def test_get_ft_wrench_none_name(self) -> None:
+        s = self._make()
+        with pytest.raises(ValueError, match="sensor_name"):
+            s.get_ft_wrench(None)  # type: ignore[arg-type]
+
+
+class TestControlCommandFactories:
+    def test_position_command(self) -> None:
+        cmd = ControlCommand.position_command(0.0, np.zeros(7), np.ones(7))
+        assert cmd.mode == ControlMode.POSITION
+        assert cmd.position_targets is not None
+        assert cmd.feedforward_torque is not None
+
+    def test_torque_command(self) -> None:
+        cmd = ControlCommand.torque_command(0.0, np.zeros(7))
+        assert cmd.mode == ControlMode.TORQUE
+
+    def test_impedance_command(self) -> None:
+        cmd = ControlCommand.impedance_command(
+            0.0, np.zeros(7), np.ones(7) * 100, np.ones(7) * 10
+        )
+        assert cmd.mode == ControlMode.IMPEDANCE
+        assert cmd.stiffness is not None
+        assert cmd.damping is not None
+
+
+class TestControlCommandValidate:
+    def test_validate_position_ok(self) -> None:
+        cmd = ControlCommand.position_command(0.0, np.zeros(7))
+        assert cmd.validate(7) is True
+
+    def test_validate_position_missing(self) -> None:
+        cmd = ControlCommand(timestamp=0.0, mode=ControlMode.POSITION)
+        with pytest.raises(ValueError, match="position_targets"):
+            cmd.validate(7)
+
+    def test_validate_position_wrong_len(self) -> None:
+        cmd = ControlCommand.position_command(0.0, np.zeros(5))
+        with pytest.raises(ValueError, match="position_targets length"):
+            cmd.validate(7)
+
+    def test_validate_velocity_ok(self) -> None:
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.VELOCITY,
+            velocity_targets=np.zeros(7),
+        )
+        assert cmd.validate(7) is True
+
+    def test_validate_velocity_missing(self) -> None:
+        cmd = ControlCommand(timestamp=0.0, mode=ControlMode.VELOCITY)
+        with pytest.raises(ValueError, match="velocity_targets"):
+            cmd.validate(7)
+
+    def test_validate_velocity_wrong_len(self) -> None:
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.VELOCITY,
+            velocity_targets=np.zeros(3),
+        )
+        with pytest.raises(ValueError, match="velocity_targets length"):
+            cmd.validate(7)
+
+    def test_validate_torque_ok(self) -> None:
+        cmd = ControlCommand.torque_command(0.0, np.zeros(7))
+        assert cmd.validate(7) is True
+
+    def test_validate_torque_missing(self) -> None:
+        cmd = ControlCommand(timestamp=0.0, mode=ControlMode.TORQUE)
+        with pytest.raises(ValueError, match="torque_commands"):
+            cmd.validate(7)
+
+    def test_validate_torque_wrong_len(self) -> None:
+        cmd = ControlCommand.torque_command(0.0, np.zeros(2))
+        with pytest.raises(ValueError, match="torque_commands length"):
+            cmd.validate(7)
+
+    def test_validate_impedance_ok(self) -> None:
+        cmd = ControlCommand.impedance_command(0.0, np.zeros(7), np.ones(7), np.ones(7))
+        assert cmd.validate(7) is True
+
+    def test_validate_impedance_missing_positions(self) -> None:
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.IMPEDANCE,
+            stiffness=np.ones(7),
+            damping=np.ones(7),
+        )
+        with pytest.raises(ValueError, match="position_targets"):
+            cmd.validate(7)
+
+    def test_validate_impedance_missing_stiffness(self) -> None:
+        cmd = ControlCommand(
+            timestamp=0.0,
+            mode=ControlMode.IMPEDANCE,
+            position_targets=np.zeros(7),
+        )
+        with pytest.raises(ValueError, match="stiffness and damping"):
+            cmd.validate(7)
+
+    def test_validate_hybrid_passes(self) -> None:
+        cmd = ControlCommand(timestamp=0.0, mode=ControlMode.HYBRID)
+        assert cmd.validate(7) is True

--- a/tests/deployment/wave5_deployment/test_teleoperation.py
+++ b/tests/deployment/wave5_deployment/test_teleoperation.py
@@ -1,0 +1,245 @@
+"""Comprehensive tests for deployment.teleoperation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from src.deployment.realtime import ControlMode
+from src.deployment.teleoperation.devices import (
+    HapticDeviceInput,
+    KeyboardMouseInput,
+    SpaceMouseInput,
+    VRControllerInput,
+)
+from src.deployment.teleoperation.interface import (
+    TeleoperationInterface,
+    TeleoperationMode,
+    WorkspaceMapping,
+)
+
+
+class FakeDevice:
+    def __init__(self):
+        self._pose = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        self._twist = np.zeros(6)
+        self._gripper = 0.5
+        self._buttons: dict[str, bool] = {}
+
+    def get_pose(self):
+        return self._pose.copy()
+
+    def get_twist(self):
+        return self._twist.copy()
+
+    def get_gripper_state(self):
+        return self._gripper
+
+    def set_force_feedback(self, w):
+        pass
+
+    def get_buttons(self):
+        return dict(self._buttons)
+
+    def update(self):
+        pass
+
+
+def _make_robot(n_q: int = 3, with_ik: bool = True, with_jac: bool = True):
+    robot = MagicMock()
+    robot.n_q = n_q
+    if with_ik:
+        robot.solve_ik.return_value = (np.ones(n_q), True)
+    else:
+        del robot.solve_ik
+    if with_jac:
+        robot.compute_jacobian.return_value = np.eye(6, n_q)
+    else:
+        del robot.compute_jacobian
+    robot.get_ee_position.return_value = np.zeros(3)
+    return robot
+
+
+class TestWorkspaceMapping:
+    def test_defaults(self) -> None:
+        m = WorkspaceMapping()
+        assert m.position_scale == 1.0
+
+
+class TestTeleoperationInterface:
+    def test_init(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        assert ti.mode == TeleoperationMode.POSITION
+        assert ti.is_clutch_engaged is True
+        assert ti.is_recording is False
+
+    def test_set_control_mode(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.set_control_mode(TeleoperationMode.VELOCITY)
+        assert ti.mode == TeleoperationMode.VELOCITY
+
+    def test_set_workspace_mapping(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.set_workspace_mapping(np.eye(4), np.eye(4), scaling=2.0)
+        assert ti._scaling == 2.0
+
+    def test_clutch_cycle(self) -> None:
+        dev = FakeDevice()
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.disengage_clutch()
+        assert not ti.is_clutch_engaged
+        ti.engage_clutch()
+        assert ti.is_clutch_engaged
+        assert ti._reference_pose is not None
+
+    def test_update_clutch_disengaged_returns_zero(self) -> None:
+        dev = FakeDevice()
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.disengage_clutch()
+        cmd = ti.update()
+        assert cmd.mode == ControlMode.TORQUE
+        assert np.all(cmd.torque_commands == 0)
+
+    def test_update_button_engages_clutch(self) -> None:
+        dev = FakeDevice()
+        dev._buttons = {"button_1": True}
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.disengage_clutch()
+        ti.update()
+        assert ti.is_clutch_engaged
+
+    def test_update_button2_disengages(self) -> None:
+        dev = FakeDevice()
+        dev._buttons = {"button_2": True}
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.update()
+        assert not ti.is_clutch_engaged
+
+    def test_update_position_mode(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        cmd = ti.update()
+        assert cmd.mode == ControlMode.POSITION
+
+    def test_update_velocity_mode(self) -> None:
+        dev = FakeDevice()
+        dev._twist = np.array([0.1, 0, 0, 0, 0, 0])
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.set_control_mode(TeleoperationMode.VELOCITY)
+        cmd = ti.update()
+        assert cmd.mode == ControlMode.VELOCITY
+
+    def test_update_velocity_rate_limited(self) -> None:
+        dev = FakeDevice()
+        dev._twist = np.array([10.0, 0, 0, 0, 0, 0])
+        ti = TeleoperationInterface(_make_robot(), dev)
+        ti.set_control_mode(TeleoperationMode.VELOCITY)
+        cmd = ti.update()
+        assert cmd.velocity_targets is not None
+
+    def test_update_velocity_no_jacobian(self) -> None:
+        ti = TeleoperationInterface(_make_robot(with_jac=False), FakeDevice())
+        ti.set_control_mode(TeleoperationMode.VELOCITY)
+        cmd = ti.update()
+        assert cmd.velocity_targets is not None
+
+    def test_update_wrench_mode(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.set_control_mode(TeleoperationMode.WRENCH)
+        cmd = ti.update()
+        assert cmd.mode == ControlMode.TORQUE
+
+    def test_update_wrench_no_jacobian(self) -> None:
+        ti = TeleoperationInterface(_make_robot(with_jac=False), FakeDevice())
+        ti.set_control_mode(TeleoperationMode.WRENCH)
+        cmd = ti.update()
+        assert cmd.torque_commands is not None
+
+    def test_update_impedance_mode(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.set_control_mode(TeleoperationMode.IMPEDANCE)
+        cmd = ti.update()
+        assert cmd.mode == ControlMode.IMPEDANCE
+        assert cmd.stiffness is not None
+
+    def test_update_position_no_ik(self) -> None:
+        ti = TeleoperationInterface(_make_robot(with_ik=False), FakeDevice())
+        cmd = ti.update()
+        assert cmd.position_targets is not None
+
+    def test_haptic_feedback_default(self) -> None:
+        robot = MagicMock()
+        del robot.get_contact_forces
+        ti = TeleoperationInterface(robot, FakeDevice())
+        assert np.all(ti.get_haptic_feedback() == 0)
+
+    def test_haptic_feedback_with_contact(self) -> None:
+        robot = _make_robot()
+        robot.get_contact_forces.return_value = np.array([10.0, 0, 0, 0, 0, 0])
+        ti = TeleoperationInterface(robot, FakeDevice())
+        fb = ti.get_haptic_feedback()
+        assert fb[0] == pytest.approx(1.0)
+
+    def test_haptic_feedback_none(self) -> None:
+        robot = _make_robot()
+        robot.get_contact_forces.return_value = None
+        ti = TeleoperationInterface(robot, FakeDevice())
+        assert np.all(ti.get_haptic_feedback() == 0)
+
+    def test_recording_cycle(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.start_demonstration_recording()
+        assert ti.is_recording
+        ti.record_state(np.zeros(3), np.zeros(3), np.zeros(3))
+        ti.record_state(np.ones(3), np.ones(3))
+        demo = ti.stop_demonstration_recording()
+        assert not ti.is_recording
+        assert demo.source == "teleoperation"
+        assert len(demo.timestamps) == 2
+
+    def test_record_state_when_not_recording(self) -> None:
+        ti = TeleoperationInterface(_make_robot(), FakeDevice())
+        ti.record_state(np.zeros(3), np.zeros(3))
+        # No exception, nothing recorded
+
+
+class TestInputDevices:
+    def test_spacemouse(self) -> None:
+        d = SpaceMouseInput(0)
+        d.connect()
+        d.update()
+        d.set_sensitivity(0.5)
+        assert "button_1" in d.get_buttons()
+
+    def test_vr_controller(self) -> None:
+        d = VRControllerInput("right", "steamvr")
+        d.connect()
+        d.update()
+        assert d.get_trigger_value() == 0.0
+        assert d.get_grip_value() == 0.0
+
+    def test_haptic(self) -> None:
+        d = HapticDeviceInput("phantom")
+        d.connect()
+        d.update()
+        d.set_force_feedback(np.array([1, 2, 3, 0, 0, 0], dtype=float))
+        d.set_workspace_scale(0.002)
+        d.disconnect()
+        # set_force_feedback when disconnected is no-op
+        d.set_force_feedback(np.zeros(6))
+
+    def test_keyboard(self) -> None:
+        d = KeyboardMouseInput()
+        d.connect()
+        d.set_key_state("forward", True)
+        d.set_key_state("close_gripper", True)
+        d.update()
+        twist = d.get_twist()
+        assert twist[0] > 0
+        d.set_key_state("open_gripper", True)
+        d.update()
+        assert d.get_gripper_state() == 1.0
+        d.set_key_state("unknown_key", True)  # noop
+        d.disconnect()
+        d.update()


### PR DESCRIPTION
## Summary

- Adds 155 fast tests under `tests/deployment/wave5_deployment/` covering realtime state/controller, safety monitor/collision, digital twin estimator/twin, and teleoperation interface/devices.
- New tests alone reach **91.0%** line+branch coverage on `src/deployment` in ~1.3s.
- Real bug fix: removed 38 instances of a DRY-violating duplicate `if not (X is not None): raise ValueError(...)` guard pair across 8 deployment modules. Each public method previously executed the identical guard twice in a row.

## Test plan

- [x] `ruff check src/deployment tests/deployment/wave5_deployment` — clean
- [x] `ruff format --check` — clean
- [x] `pytest tests/deployment/wave5_deployment -x --timeout=30` — 155 passed in 1.26s
- [x] Existing `tests/deployment/` + `tests/unit/deployment/` suites still pass (untouched)

Coverage by module (new tests only):
- `realtime/state.py` 96.8%, `realtime/controller.py` 90.8%
- `safety/monitor.py` 88.8%, `safety/collision.py` 88.3%
- `digital_twin/estimator.py` 93.9%, `digital_twin/twin.py` 97.6%
- `teleoperation/interface.py` 88.9%, `teleoperation/devices.py` 83.4%

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>