### PR TITLE
test(api): comprehensive coverage

### DIFF
--- a/src/api/utils/path_validation.py
+++ b/src/api/utils/path_validation.py
@@ -57,8 +57,15 @@ def validate_model_path(model_path: str) -> str:
             detail="Invalid path format",
         ) from exc
 
-    # Check both POSIX and Windows-style absolute paths
-    if user_path.is_absolute() or (len(model_path) >= 2 and model_path[1] == ":"):
+    # Check both POSIX and Windows-style absolute paths. Path.is_absolute()
+    # on Windows returns False for POSIX-style leading-slash paths such as
+    # "/etc/passwd", so we also reject any path that begins with "/" or "\\"
+    # to defend against path-traversal regardless of host OS.
+    if (
+        user_path.is_absolute()
+        or (len(model_path) >= 2 and model_path[1] == ":")
+        or model_path.startswith(("/", "\\"))
+    ):
         raise HTTPException(
             status_code=400,
             detail="Invalid path: absolute paths are not allowed",

--- a/src/api/versioning.py
+++ b/src/api/versioning.py
@@ -22,6 +22,10 @@ import re
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import APIRouter
 
 try:
     import tomllib
@@ -111,7 +115,7 @@ def make_versioned_router(
     *,
     deprecated: bool = False,
     sunset: str | None = None,
-):
+) -> APIRouter:
     """Create a versioned ``APIRouter`` with optional deprecation headers.
 
     Args:
@@ -155,6 +159,15 @@ def make_versioned_router(
         response.headers["Deprecation"] = "true"
         if normalized_sunset is not None:
             response.headers["Sunset"] = normalized_sunset
+
+    # The module uses ``from __future__ import annotations`` so the
+    # ``response: Response`` hint above is a string at runtime. FastAPI
+    # inspects ``__annotations__`` to recognise the special ``Response``
+    # parameter; without a live class object it would mis-classify the
+    # parameter as a query field and reject the request with HTTP 422.
+    # Pin the annotation to the actual class so the dependency injector
+    # passes the live ``Response`` instance.
+    _deprecation_headers.__annotations__ = {"response": Response, "return": None}
 
     dependencies: list = []
     if deprecated:

--- a/tests/api/wave5_api/__init__.py
+++ b/tests/api/wave5_api/__init__.py
@@ -1,0 +1,1 @@
+"""Wave 5 API surface coverage tests."""

--- a/tests/api/wave5_api/test_api_init_lazy.py
+++ b/tests/api/wave5_api/test_api_init_lazy.py
@@ -1,0 +1,34 @@
+"""Tests for src/api/__init__.py lazy-loading."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_versioning_pre_loaded() -> None:
+    api_mod = importlib.import_module("src.api")
+    # Pre-populated by _preload_versioning
+    assert hasattr(api_mod, "versioning")
+    assert api_mod.versioning.get_app_version
+
+
+def test_unknown_attribute_raises() -> None:
+    api_mod = importlib.import_module("src.api")
+    with pytest.raises(AttributeError):
+        _ = api_mod.does_not_exist  # type: ignore[attr-defined]
+
+
+def test_attribute_name_must_be_str() -> None:
+    api_mod = importlib.import_module("src.api")
+    with pytest.raises(TypeError):
+        api_mod.__getattr__(123)  # type: ignore[arg-type]
+
+
+def test_lazy_attrs_mapping_consistent() -> None:
+    api_mod = importlib.import_module("src.api")
+    for name in api_mod._LAZY_ATTRS:
+        assert name in api_mod.__all__

--- a/tests/api/wave5_api/test_config_and_guards.py
+++ b/tests/api/wave5_api/test_config_and_guards.py
@@ -1,0 +1,133 @@
+"""Tests for src/api/config.py, debug_guard.py, rate_limit.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api import config, debug_guard, rate_limit
+
+pytestmark = pytest.mark.unit
+
+
+# ----- config.py -----
+
+
+def test_default_allowed_hosts_unmodified(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
+    hosts = config.get_allowed_hosts()
+    assert hosts == config.DEFAULT_ALLOWED_HOSTS
+    hosts.append("evil")
+    # Should return a copy, not the canonical list
+    assert "evil" not in config.DEFAULT_ALLOWED_HOSTS
+
+
+def test_allowed_hosts_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALLOWED_HOSTS", "a.com, b.com ,  ,c.com")
+    assert config.get_allowed_hosts() == ["a.com", "b.com", "c.com"]
+
+
+def test_allowed_hosts_empty_env_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALLOWED_HOSTS", "")
+    assert config.get_allowed_hosts() == config.DEFAULT_ALLOWED_HOSTS
+
+
+def test_cors_origins_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORS_ORIGINS", "http://x , http://y")
+    assert config.get_cors_origins() == ["http://x", "http://y"]
+
+
+def test_cors_origins_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    assert config.get_cors_origins() == config.DEFAULT_CORS_ORIGINS
+
+
+def test_server_host_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_HOST", raising=False)
+    assert config.get_server_host() == config.DEFAULT_SERVER_HOST
+
+
+def test_server_host_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_HOST", "0.0.0.0")
+    assert config.get_server_host() == "0.0.0.0"
+
+
+def test_server_port_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_PORT", raising=False)
+    assert config.get_server_port() == config.DEFAULT_SERVER_PORT
+
+
+def test_server_port_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_PORT", "9000")
+    assert config.get_server_port() == 9000
+
+
+@pytest.mark.parametrize("bad", ["0", "70000", "-1", "notanumber"])
+def test_server_port_invalid_raises(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setenv("API_PORT", bad)
+    with pytest.raises(ValueError):
+        config.get_server_port()
+
+
+def test_constants_sane() -> None:
+    assert config.MAX_UPLOAD_SIZE_BYTES > 0
+    assert config.MAX_UPLOAD_SIZE_MB == config.MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)
+    assert (
+        0 <= config.MIN_CONFIDENCE <= config.DEFAULT_CONFIDENCE <= config.MAX_CONFIDENCE
+    )
+    assert "mediapipe" in config.VALID_ESTIMATOR_TYPES
+
+
+# ----- debug_guard.py -----
+
+
+def test_debug_default_non_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UPSTREAM_DRIFT_ENV", "development")
+    monkeypatch.delenv("UPSTREAM_DRIFT_DEBUG_ENDPOINTS", raising=False)
+    assert debug_guard.debug_endpoints_enabled() is True
+
+
+def test_debug_production_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UPSTREAM_DRIFT_ENV", "production")
+    monkeypatch.delenv("UPSTREAM_DRIFT_DEBUG_ENDPOINTS", raising=False)
+    assert debug_guard.debug_endpoints_enabled() is False
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "TRUE", "yes", "on"])
+def test_debug_production_truthy_overrides(
+    monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    monkeypatch.setenv("UPSTREAM_DRIFT_ENV", "production")
+    monkeypatch.setenv("UPSTREAM_DRIFT_DEBUG_ENDPOINTS", flag)
+    assert debug_guard.debug_endpoints_enabled() is True
+
+
+@pytest.mark.parametrize("flag", ["0", "false", "no", "off", "", "maybe"])
+def test_debug_production_falsy_stays_off(
+    monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    monkeypatch.setenv("UPSTREAM_DRIFT_ENV", "production")
+    monkeypatch.setenv("UPSTREAM_DRIFT_DEBUG_ENDPOINTS", flag)
+    assert debug_guard.debug_endpoints_enabled() is False
+
+
+# ----- rate_limit.py -----
+
+
+def test_rate_limit_default_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UD_TEST_LIMIT", raising=False)
+    assert rate_limit.get_limit("UD_TEST_LIMIT", "5/minute") == "5/minute"
+
+
+def test_rate_limit_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UD_TEST_LIMIT", "10/second")
+    assert rate_limit.get_limit("UD_TEST_LIMIT", "5/minute") == "10/second"
+
+
+def test_rate_limit_blank_env_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UD_TEST_LIMIT", "   ")
+    assert rate_limit.get_limit("UD_TEST_LIMIT", "5/minute") == "5/minute"
+
+
+def test_limiter_exists() -> None:
+    assert rate_limit.limiter is not None
+    assert callable(rate_limit.limiter.limit)

--- a/tests/api/wave5_api/test_dependencies.py
+++ b/tests/api/wave5_api/test_dependencies.py
@@ -1,0 +1,95 @@
+"""Tests for src/api/dependencies.py and src/api/routes/_route_utils.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from src.api import dependencies as deps
+from src.api.routes import _route_utils
+
+pytestmark = pytest.mark.unit
+
+
+def _make_request(**state: object) -> SimpleNamespace:
+    app = SimpleNamespace(state=SimpleNamespace(**state))
+    return SimpleNamespace(app=app)
+
+
+def test_get_engine_manager_missing() -> None:
+    req = _make_request()
+    with pytest.raises(HTTPException) as exc:
+        deps.get_engine_manager(req)  # type: ignore[arg-type]
+    assert exc.value.status_code == 503
+
+
+def test_get_engine_manager_present() -> None:
+    sentinel = object()
+    req = _make_request(engine_manager=sentinel)
+    assert deps.get_engine_manager(req) is sentinel  # type: ignore[arg-type]
+
+
+def test_get_simulation_service_missing() -> None:
+    with pytest.raises(HTTPException) as exc:
+        deps.get_simulation_service(_make_request())  # type: ignore[arg-type]
+    assert exc.value.status_code == 503
+
+
+def test_get_simulation_service_present() -> None:
+    sentinel = object()
+    assert (
+        deps.get_simulation_service(_make_request(simulation_service=sentinel))  # type: ignore[arg-type]
+        is sentinel
+    )
+
+
+def test_get_analysis_service_missing_and_present() -> None:
+    with pytest.raises(HTTPException):
+        deps.get_analysis_service(_make_request())  # type: ignore[arg-type]
+    s = object()
+    assert (
+        deps.get_analysis_service(_make_request(analysis_service=s))  # type: ignore[arg-type]
+        is s
+    )
+
+
+def test_get_video_pipeline_missing_message() -> None:
+    with pytest.raises(HTTPException) as exc:
+        deps.get_video_pipeline(_make_request())  # type: ignore[arg-type]
+    assert "Video pipeline" in exc.value.detail
+
+
+def test_get_video_pipeline_present() -> None:
+    s = object()
+    assert deps.get_video_pipeline(_make_request(video_pipeline=s)) is s  # type: ignore[arg-type]
+
+
+def test_get_task_manager_missing_and_present() -> None:
+    with pytest.raises(HTTPException):
+        deps.get_task_manager(_make_request())  # type: ignore[arg-type]
+    s = object()
+    assert deps.get_task_manager(_make_request(task_manager=s)) is s  # type: ignore[arg-type]
+
+
+def test_get_logger_none_when_missing() -> None:
+    assert deps.get_logger(_make_request()) is None  # type: ignore[arg-type]
+
+
+def test_get_logger_returns_state() -> None:
+    s = object()
+    assert deps.get_logger(_make_request(logger=s)) is s  # type: ignore[arg-type]
+
+
+def test_find_project_root_returns_directory() -> None:
+    root = _route_utils.find_project_root()
+    assert isinstance(root, Path)
+    assert root.exists()
+    # pyproject.toml or src/shared/urdf marker should be in result tree
+    assert (
+        (root / "pyproject.toml").exists()
+        or (root / "src" / "shared" / "urdf").exists()
+        or root == Path.cwd()
+    )

--- a/tests/api/wave5_api/test_models_chat.py
+++ b/tests/api/wave5_api/test_models_chat.py
@@ -1,0 +1,105 @@
+"""Tests for src/api/models/chat.py."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models import chat
+
+pytestmark = pytest.mark.unit
+
+
+def test_style_prompt_known_styles() -> None:
+    for s in ("concise", "standard", "detailed"):
+        out = chat.style_prompt(s)
+        assert isinstance(out, str)
+        assert out
+
+
+def test_style_prompt_unknown_falls_back_to_default() -> None:
+    out = chat.style_prompt("nonsense")
+    assert out == chat.RESPONSE_STYLE_PROMPTS[chat.DEFAULT_RESPONSE_STYLE]
+
+
+def test_style_prompt_none_falls_back() -> None:
+    assert chat.style_prompt(None) == chat.RESPONSE_STYLE_PROMPTS["standard"]
+
+
+def test_chat_message_request_default_style() -> None:
+    req = chat.ChatMessageRequest(message="hello")
+    assert req.response_style == "standard"
+
+
+def test_chat_message_request_explicit_response_style_wins() -> None:
+    req = chat.ChatMessageRequest(
+        message="hi", response_style="concise", expertise_level="beginner"
+    )
+    assert req.response_style == "concise"
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        ("beginner", "detailed"),
+        ("INTERMEDIATE", "standard"),
+        ("advanced", "concise"),
+        ("Expert", "concise"),
+    ],
+)
+def test_chat_message_legacy_expertise_back_fill(level: str, expected: str) -> None:
+    req = chat.ChatMessageRequest(message="hi", expertise_level=level)
+    assert req.response_style == expected
+
+
+def test_chat_message_unknown_legacy_keeps_default() -> None:
+    req = chat.ChatMessageRequest(message="hi", expertise_level="alien")
+    # Unknown mapping should leave default in place
+    assert req.response_style == "standard"
+
+
+def test_chat_message_requires_min_length() -> None:
+    with pytest.raises(ValidationError):
+        chat.ChatMessageRequest(message="")
+
+
+def test_chat_message_max_length_enforced() -> None:
+    with pytest.raises(ValidationError):
+        chat.ChatMessageRequest(message="x" * 10001)
+
+
+def test_chat_model_info_round_trip() -> None:
+    info = chat.ChatModelInfo(name="llama3", provider="ollama", display_name="L3")
+    assert info.model_dump()["name"] == "llama3"
+
+
+def test_chat_model_list_response_default_models() -> None:
+    resp = chat.ChatModelListResponse(refreshed_at="2024-01-01T00:00:00Z")
+    assert resp.models == []
+
+
+def test_chat_chunk_defaults() -> None:
+    c = chat.ChatChunkResponse(content="x")
+    assert c.is_final is False
+    assert c.index == 0
+
+
+def test_chat_session_info_default_contexts() -> None:
+    s = chat.ChatSessionInfo(
+        session_id="s", message_count=0, created_at="a", last_active="b"
+    )
+    assert s.engine_contexts == []
+
+
+def test_chat_history_response_messages_required() -> None:
+    h = chat.ChatHistoryResponse(session_id="s", messages=[{"role": "user"}])
+    assert h.messages[0]["role"] == "user"
+
+
+def test_chat_index_status_states() -> None:
+    s = chat.ChatIndexStatusResponse(state="running")
+    assert s.files_parsed == 0
+    s2 = chat.ChatIndexStatusResponse(
+        state="complete", files_parsed=5, symbols_inserted=10, duration_seconds=1.5
+    )
+    assert s2.duration_seconds == 1.5

--- a/tests/api/wave5_api/test_models_requests.py
+++ b/tests/api/wave5_api/test_models_requests.py
@@ -1,0 +1,287 @@
+"""Tests for src/api/models/requests.py."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models import requests as r
+
+pytestmark = pytest.mark.unit
+
+
+# ----- SimulationRequest -----
+
+
+def test_simulation_request_minimum_valid() -> None:
+    sim = r.SimulationRequest(engine_type="MuJoCo")
+    assert sim.engine_type == "mujoco"
+    assert sim.duration == 1.0
+    assert sim.timestep is None
+
+
+def test_simulation_request_unknown_engine() -> None:
+    with pytest.raises(ValidationError):
+        r.SimulationRequest(engine_type="nope")
+
+
+def test_simulation_request_duration_bounds() -> None:
+    with pytest.raises(ValidationError):
+        r.SimulationRequest(engine_type="mujoco", duration=0)
+    with pytest.raises(ValidationError):
+        r.SimulationRequest(
+            engine_type="mujoco", duration=r.MAX_SIMULATION_DURATION + 1
+        )
+
+
+def test_simulation_request_timestep_too_small() -> None:
+    with pytest.raises(ValidationError):
+        r.SimulationRequest(engine_type="mujoco", timestep=r.MIN_TIMESTEP / 10)
+
+
+def test_simulation_request_timestep_too_large() -> None:
+    with pytest.raises(ValidationError):
+        r.SimulationRequest(engine_type="mujoco", timestep=r.MAX_TIMESTEP * 2)
+
+
+# ----- AnalysisRequest -----
+
+
+def test_analysis_request_normalizes() -> None:
+    a = r.AnalysisRequest(
+        analysis_type=" Kinematics ", data_source="sim", export_format="JSON"
+    )
+    assert a.analysis_type == "kinematics"
+    assert a.export_format == "json"
+
+
+def test_analysis_request_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        r.AnalysisRequest(analysis_type="nope", data_source="sim")
+
+
+def test_analysis_request_unknown_format() -> None:
+    with pytest.raises(ValidationError):
+        r.AnalysisRequest(
+            analysis_type="kinematics", data_source="sim", export_format="xml"
+        )
+
+
+# ----- VideoAnalysisRequest -----
+
+
+def test_video_request_defaults() -> None:
+    v = r.VideoAnalysisRequest()
+    assert v.estimator_type == "mediapipe"
+    assert 0 <= v.min_confidence <= 1
+
+
+def test_video_request_confidence_bounds() -> None:
+    with pytest.raises(ValidationError):
+        r.VideoAnalysisRequest(min_confidence=-0.1)
+    with pytest.raises(ValidationError):
+        r.VideoAnalysisRequest(min_confidence=1.1)
+
+
+# ----- ActuatorUpdateRequest -----
+
+
+def test_actuator_update_strategy_normalized() -> None:
+    a = r.ActuatorUpdateRequest(strategy=" PD ")
+    assert a.strategy == "pd"
+
+
+def test_actuator_update_unknown_strategy() -> None:
+    with pytest.raises(ValidationError):
+        r.ActuatorUpdateRequest(strategy="quantum")
+
+
+def test_actuator_update_strategy_none_ok() -> None:
+    a = r.ActuatorUpdateRequest(strategy=None)
+    assert a.strategy is None
+
+
+def test_actuator_update_kp_must_be_positive() -> None:
+    with pytest.raises(ValidationError):
+        r.ActuatorUpdateRequest(kp=0)
+
+
+def test_actuator_update_ki_zero_ok() -> None:
+    a = r.ActuatorUpdateRequest(ki=0)
+    assert a.ki == 0
+
+
+# ----- SpeedControlRequest -----
+
+
+def test_speed_control_bounds() -> None:
+    assert r.SpeedControlRequest().speed_factor == 1.0
+    with pytest.raises(ValidationError):
+        r.SpeedControlRequest(speed_factor=0.0)
+    with pytest.raises(ValidationError):
+        r.SpeedControlRequest(speed_factor=11.0)
+
+
+# ----- CameraPresetRequest -----
+
+
+def test_camera_preset_valid() -> None:
+    assert r.CameraPresetRequest(preset="SIDE").preset == "side"
+
+
+def test_camera_preset_invalid() -> None:
+    with pytest.raises(ValidationError):
+        r.CameraPresetRequest(preset="behind")
+
+
+# ----- TrajectoryRecordRequest -----
+
+
+def test_trajectory_record_actions() -> None:
+    for action in ["start", "STOP", " export "]:
+        req = r.TrajectoryRecordRequest(action=action)
+        assert req.action in {"start", "stop", "export"}
+
+
+def test_trajectory_record_invalid_action() -> None:
+    with pytest.raises(ValidationError):
+        r.TrajectoryRecordRequest(action="pause")
+
+
+# ----- DataExportRequest -----
+
+
+def test_data_export_format_normalized() -> None:
+    assert r.DataExportRequest(format="JSON").format == "json"
+
+
+def test_data_export_invalid() -> None:
+    with pytest.raises(ValidationError):
+        r.DataExportRequest(format="xml")
+
+
+# ----- BodyPositionUpdateRequest -----
+
+
+def test_body_position_valid() -> None:
+    req = r.BodyPositionUpdateRequest(
+        body_name="club", position=[0.0, 1.0, 2.0], rotation=[0.0, 0.0, 0.0]
+    )
+    assert req.position == [0.0, 1.0, 2.0]
+
+
+@pytest.mark.parametrize("bad", [[0.0, 1.0], [0.0, 1.0, 2.0, 3.0]])
+def test_body_position_wrong_size(bad: list[float]) -> None:
+    with pytest.raises(ValidationError):
+        r.BodyPositionUpdateRequest(body_name="club", position=bad)
+
+
+@pytest.mark.parametrize("bad", [[0.0, 1.0], [0.0, 1.0, 2.0, 3.0]])
+def test_body_rotation_wrong_size(bad: list[float]) -> None:
+    with pytest.raises(ValidationError):
+        r.BodyPositionUpdateRequest(body_name="club", rotation=bad)
+
+
+# ----- MeasurementRequest -----
+
+
+def test_measurement_request_valid() -> None:
+    m = r.MeasurementRequest(body_a="A", body_b="B")
+    assert m.body_a == "A"
+
+
+# ----- ForceOverlayRequest -----
+
+
+def test_force_overlay_defaults() -> None:
+    fo = r.ForceOverlayRequest()
+    assert fo.force_types == ["applied"]
+
+
+def test_force_overlay_normalizes_force_types() -> None:
+    fo = r.ForceOverlayRequest(force_types=["APPLIED", " gravity "])
+    assert fo.force_types == ["applied", "gravity"]
+
+
+def test_force_overlay_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        r.ForceOverlayRequest(force_types=["magic"])
+
+
+def test_force_overlay_scale_must_be_positive() -> None:
+    with pytest.raises(ValidationError):
+        r.ForceOverlayRequest(scale_factor=0)
+
+
+# ----- ActuatorCommandRequest -----
+
+
+def test_actuator_command_valid() -> None:
+    c = r.ActuatorCommandRequest(actuator_index=2, value=1.0, control_type="PD_GAINS")
+    assert c.control_type == "pd_gains"
+
+
+def test_actuator_command_negative_index() -> None:
+    with pytest.raises(ValidationError):
+        r.ActuatorCommandRequest(actuator_index=-1, value=0.0)
+
+
+def test_actuator_command_unknown_control() -> None:
+    with pytest.raises(ValidationError):
+        r.ActuatorCommandRequest(actuator_index=0, value=0.0, control_type="nope")
+
+
+# ----- ActuatorBatchCommandRequest -----
+
+
+def test_actuator_batch_requires_one_command() -> None:
+    with pytest.raises(ValidationError):
+        r.ActuatorBatchCommandRequest(commands=[])
+
+
+def test_actuator_batch_valid() -> None:
+    batch = r.ActuatorBatchCommandRequest(
+        commands=[r.ActuatorCommandRequest(actuator_index=0, value=1.0)]
+    )
+    assert len(batch.commands) == 1
+
+
+# ----- ModelExplorerRequest / ModelCompareRequest -----
+
+
+def test_model_explorer_request_minimal() -> None:
+    m = r.ModelExplorerRequest(model_path="x.urdf")
+    assert m.model_path == "x.urdf"
+    assert m.joint_values is None
+
+
+def test_model_compare_request_minimal() -> None:
+    mc = r.ModelCompareRequest(model_a_path="a", model_b_path="b")
+    assert mc.model_a_path == "a"
+
+
+# ----- AIPJsonRpcRequest -----
+
+
+def test_aip_request_default_version() -> None:
+    req = r.AIPJsonRpcRequest(method="ping")
+    assert req.jsonrpc == "2.0"
+    assert req.id is None
+
+
+def test_aip_request_bad_version() -> None:
+    with pytest.raises(ValidationError):
+        r.AIPJsonRpcRequest(jsonrpc="1.0", method="ping")
+
+
+def test_aip_request_with_params_and_id() -> None:
+    req = r.AIPJsonRpcRequest(method="x", params={"a": 1}, id=7)
+    assert req.id == 7
+
+
+# ----- ModelFittingRequest -----
+
+
+def test_model_fitting_minimal() -> None:
+    f = r.ModelFittingRequest(model_path="m", data_path="d")
+    assert f.fitting_method == "least_squares"

--- a/tests/api/wave5_api/test_models_responses.py
+++ b/tests/api/wave5_api/test_models_responses.py
@@ -1,0 +1,200 @@
+"""Tests for src/api/models/responses.py."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models import responses as m
+
+pytestmark = pytest.mark.unit
+
+
+def test_engine_status_minimal() -> None:
+    e = m.EngineStatusResponse(
+        name="mujoco",
+        available=True,
+        engine_type="mujoco",
+        status="ok",
+        is_available=True,
+    )
+    assert e.loaded is False
+    assert e.capabilities == []
+
+
+def test_simulation_response_success_must_have_data() -> None:
+    with pytest.raises(ValidationError):
+        m.SimulationResponse(success=True, duration=1.0, frames=10, data={})
+
+
+def test_simulation_response_success_with_data_ok() -> None:
+    r = m.SimulationResponse(
+        success=True, duration=1.0, frames=10, data={"states": [0]}
+    )
+    assert r.success is True
+
+
+def test_simulation_response_failure_empty_data_ok() -> None:
+    r = m.SimulationResponse(success=False, duration=0.0, frames=0, data={})
+    assert r.success is False
+
+
+def test_simulation_response_negative_duration_rejected() -> None:
+    with pytest.raises(ValidationError):
+        m.SimulationResponse(
+            success=True, duration=-1.0, frames=10, data={"states": [0]}
+        )
+
+
+def test_analysis_response_success_requires_results() -> None:
+    with pytest.raises(ValidationError):
+        m.AnalysisResponse(analysis_type="kinematics", success=True, results={})
+
+
+def test_analysis_response_failure_empty_ok() -> None:
+    r = m.AnalysisResponse(analysis_type="kinematics", success=False, results={})
+    assert r.success is False
+
+
+def test_task_status_response_minimal() -> None:
+    t = m.TaskStatusResponse(task_id="t1", status="pending")
+    assert t.progress is None
+
+
+def test_joint_info_response_required_fields() -> None:
+    j = m.JointInfoResponse(
+        index=0,
+        name="shoulder",
+        torque_limit=10.0,
+        position_limit_lower=-1.0,
+        position_limit_upper=1.0,
+        velocity_limit=5.0,
+        current_torque=0.0,
+    )
+    assert j.name == "shoulder"
+
+
+def test_actuator_state_response_minimal() -> None:
+    a = m.ActuatorStateResponse(
+        strategy="pd",
+        n_joints=0,
+        joint_names=[],
+        torques=[],
+        kp=[],
+        kd=[],
+        ki=[],
+        joints=[],
+        available_strategies=[],
+    )
+    assert a.n_joints == 0
+
+
+def test_force_vector_response_required() -> None:
+    f = m.ForceVectorResponse(sim_time=0.0, applied_torques=[1.0, 2.0])
+    assert f.applied_torques == [1.0, 2.0]
+
+
+def test_biomechanics_metrics_response_minimal() -> None:
+    b = m.BiomechanicsMetricsResponse(
+        sim_time=0.0,
+        joint_positions=[0.0],
+        joint_velocities=[0.0],
+    )
+    assert b.club_head_speed is None
+
+
+def test_capability_level_and_engine_capabilities() -> None:
+    lvl = m.CapabilityLevelResponse(name="dyn", level="full", supported=True)
+    e = m.EngineCapabilitiesResponse(
+        engine_name="mujoco",
+        engine_type="mujoco",
+        capabilities=[lvl],
+        summary={"full": 1, "partial": 0, "none": 0},
+    )
+    assert e.capabilities[0].level == "full"
+
+
+def test_urdf_response_defaults() -> None:
+    link = m.URDFLinkGeometry(link_name="root", geometry_type="box")
+    assert link.origin == [0.0, 0.0, 0.0]
+    assert link.color == [0.5, 0.5, 0.5, 1.0]
+
+
+def test_urdf_joint_descriptor_defaults() -> None:
+    j = m.URDFJointDescriptor(
+        name="j1", joint_type="revolute", parent_link="a", child_link="b"
+    )
+    assert j.axis == [0.0, 0.0, 1.0]
+
+
+def test_urdf_model_and_model_list_response() -> None:
+    model = m.URDFModelResponse(model_name="foo", links=[], joints=[], root_link="root")
+    assert model.urdf_raw is None
+    lr = m.ModelListResponse(models=[{"name": "a", "format": "urdf"}])
+    assert lr.models[0]["name"] == "a"
+
+
+def test_analysis_metrics_summary_default_std() -> None:
+    s = m.AnalysisMetricsSummary(
+        metric_name="x", current=1.0, minimum=0.0, maximum=2.0, mean=1.0
+    )
+    assert s.std_dev == 0.0
+
+
+def test_data_export_response_required_fields() -> None:
+    r = m.DataExportResponse(
+        format="csv",
+        filename="x.csv",
+        size_bytes=10,
+        download_url="/dl",
+        record_count=1,
+    )
+    assert r.format == "csv"
+
+
+def test_measurement_result_required() -> None:
+    res = m.MeasurementResult(
+        body_a="a",
+        body_b="b",
+        distance=1.0,
+        position_a=[0.0, 0.0, 0.0],
+        position_b=[1.0, 0.0, 0.0],
+        delta=[1.0, 0.0, 0.0],
+    )
+    assert res.distance == 1.0
+
+
+def test_force_vector3d_defaults() -> None:
+    fv = m.ForceVector3D(
+        body_name="a",
+        force_type="applied",
+        origin=[0, 0, 0],
+        direction=[1, 0, 0],
+        magnitude=1.0,
+    )
+    assert fv.color == [1.0, 0.0, 0.0, 1.0]
+
+
+def test_force_overlay_response_defaults() -> None:
+    r = m.ForceOverlayResponse(sim_time=0.0)
+    assert r.vectors == []
+    assert r.total_force_magnitude == 0.0
+
+
+def test_actuator_info_defaults() -> None:
+    info = m.ActuatorInfo(index=0, name="j")
+    assert info.units == "N*m"
+    assert info.min_value < info.max_value
+
+
+def test_aip_handshake_response_defaults() -> None:
+    cap = m.AIPCapability(name="x", methods=["m"])
+    h = m.AIPHandshakeResponse(capabilities=[cap], supported_methods=["m"])
+    assert h.server_name.startswith("UpstreamDrift")
+
+
+def test_aip_jsonrpc_response_defaults() -> None:
+    r = m.AIPJsonRpcResponse()
+    assert r.jsonrpc == "2.0"
+    assert r.result is None
+    assert r.error is None

--- a/tests/api/wave5_api/test_utils_datetime_compat.py
+++ b/tests/api/wave5_api/test_utils_datetime_compat.py
@@ -1,0 +1,46 @@
+"""Tests for src/api/utils/datetime_compat.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.api.utils import datetime_compat as dc
+
+pytestmark = pytest.mark.unit
+
+
+def test_utc_now_is_timezone_aware() -> None:
+    now = dc.utc_now()
+    assert now.tzinfo is not None
+    # Should be very close to "now"
+    delta = abs((datetime.now(timezone.utc) - now).total_seconds())
+    assert delta < 5.0
+
+
+def test_add_minutes_positive_and_negative() -> None:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=dc.UTC)
+    assert dc.add_minutes(base, 30) == base + timedelta(minutes=30)
+    assert dc.add_minutes(base, -15) == base - timedelta(minutes=15)
+    assert dc.add_minutes(base, 0) == base
+
+
+def test_add_days_positive_and_negative() -> None:
+    base = datetime(2024, 1, 1, tzinfo=dc.UTC)
+    assert dc.add_days(base, 7) == base + timedelta(days=7)
+    assert dc.add_days(base, -1) == base - timedelta(days=1)
+
+
+def test_iso_format_round_trip() -> None:
+    base = datetime(2024, 6, 15, 8, 30, 45, tzinfo=dc.UTC)
+    iso = dc.iso_format(base)
+    assert isinstance(iso, str)
+    assert "2024-06-15" in iso
+    parsed = datetime.fromisoformat(iso)
+    assert parsed == base
+
+
+def test_utc_constant_is_utc() -> None:
+    now = datetime.now(dc.UTC)
+    assert now.utcoffset() == timedelta(0)

--- a/tests/api/wave5_api/test_utils_error_codes.py
+++ b/tests/api/wave5_api/test_utils_error_codes.py
@@ -1,0 +1,124 @@
+"""Tests for src/api/utils/error_codes.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.api.utils import error_codes as ec
+from src.api.utils import tracing
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_error_code_has_metadata() -> None:
+    for code in ec.ErrorCode:
+        assert code in ec.ERROR_METADATA, f"missing metadata for {code}"
+        meta = ec.ERROR_METADATA[code]
+        assert "status_code" in meta
+        assert "message" in meta
+        assert "category" in meta
+        assert isinstance(meta["category"], ec.ErrorCategory)
+
+
+def test_error_code_format() -> None:
+    for code in ec.ErrorCode:
+        assert code.value.startswith("GMS-")
+        parts = code.value.split("-")
+        assert len(parts) == 3
+        assert parts[1] in {cat.value for cat in ec.ErrorCategory}
+
+
+def test_apierror_from_code_defaults() -> None:
+    err = ec.APIError.from_code(ec.ErrorCode.ENGINE_NOT_LOADED)
+    assert err.code is ec.ErrorCode.ENGINE_NOT_LOADED
+    assert err.message  # default
+    assert err.details == {}
+
+
+def test_apierror_from_code_custom_message_and_details() -> None:
+    err = ec.APIError.from_code(
+        ec.ErrorCode.SIMULATION_FAILED,
+        message="custom",
+        details={"reason": "timeout"},
+    )
+    assert err.message == "custom"
+    assert err.details == {"reason": "timeout"}
+
+
+def test_apierror_from_code_requires_code() -> None:
+    with pytest.raises(ValueError):
+        ec.APIError.from_code(None)  # type: ignore[arg-type]
+
+
+def test_apierror_to_dict_minimal() -> None:
+    err = ec.APIError.from_code(ec.ErrorCode.INVALID_REQUEST)
+    d = err.to_dict()
+    assert d["error"]["code"] == ec.ErrorCode.INVALID_REQUEST.value
+    assert "message" in d["error"]
+    assert "details" not in d["error"]
+
+
+def test_apierror_to_dict_with_details_and_request_id() -> None:
+    token = tracing.set_request_id("req_abc")
+    ctx_token = tracing.set_trace_context(
+        tracing.TraceContext(request_id="req_abc", correlation_id="cor_abc")
+    )
+    try:
+        err = ec.APIError.from_code(
+            ec.ErrorCode.VALIDATION_FAILED, details={"field": "x"}
+        )
+        d = err.to_dict()
+        assert d["error"]["details"] == {"field": "x"}
+        assert d["error"]["request_id"] == "req_abc"
+        assert d["error"]["correlation_id"] == "cor_abc"
+    finally:
+        tracing._request_id_var.reset(token)
+        tracing._trace_context_var.reset(ctx_token)
+
+
+def test_apierror_to_response_uses_status_code() -> None:
+    err = ec.APIError.from_code(ec.ErrorCode.RATE_LIMITED)
+    resp = err.to_response()
+    assert resp.status_code == 429
+    body = json.loads(resp.body)
+    assert body["error"]["code"] == "GMS-GEN-003"
+
+
+def test_apierror_to_response_unknown_code_defaults_to_500() -> None:
+    err = ec.APIError(code=ec.ErrorCode.INTERNAL_ERROR, message="x")
+    # Force an unknown code path by simulating missing metadata.
+    err.code = ec.ErrorCode.INTERNAL_ERROR  # known; assert that path works
+    resp = err.to_response()
+    assert resp.status_code == 500
+
+
+def test_api_exception_carries_status_and_detail() -> None:
+    exc = ec.APIException(ec.ErrorCode.ENGINE_NOT_FOUND, details={"engine": "mujoco"})
+    assert exc.status_code == 404
+    assert exc.detail["error"]["code"] == "GMS-ENG-001"
+    assert exc.detail["error"]["details"] == {"engine": "mujoco"}
+
+
+def test_api_exception_requires_code() -> None:
+    with pytest.raises(ValueError):
+        ec.APIException(None)  # type: ignore[arg-type]
+
+
+def test_raise_api_error_raises_apiexception() -> None:
+    with pytest.raises(ec.APIException) as exc:
+        ec.raise_api_error(ec.ErrorCode.VALIDATION_FAILED, message="bad", field="x")
+    assert exc.value.status_code == 422
+    assert exc.value.detail["error"]["details"] == {"field": "x"}
+
+
+def test_raise_api_error_no_details() -> None:
+    with pytest.raises(ec.APIException) as exc:
+        ec.raise_api_error(ec.ErrorCode.RESOURCE_NOT_FOUND)
+    assert exc.value.status_code == 404
+
+
+def test_error_category_values() -> None:
+    expected = {"GEN", "ENG", "SIM", "VID", "ANL", "AUT", "VAL", "RES", "SYS"}
+    assert {c.value for c in ec.ErrorCategory} == expected

--- a/tests/api/wave5_api/test_utils_path_validation.py
+++ b/tests/api/wave5_api/test_utils_path_validation.py
@@ -1,0 +1,86 @@
+"""Tests for src/api/utils/path_validation.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.utils import path_validation as pv
+
+pytestmark = pytest.mark.unit
+
+
+def test_absolute_posix_path_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        pv.validate_model_path("/etc/passwd")
+    assert exc.value.status_code == 400
+    assert "absolute" in exc.value.detail.lower()
+
+
+def test_absolute_windows_path_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        pv.validate_model_path("C:/Windows/system32")
+    assert exc.value.status_code == 400
+
+
+def test_parent_traversal_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        pv.validate_model_path("../../../etc/passwd")
+    assert exc.value.status_code == 400
+    assert "parent" in exc.value.detail.lower()
+
+
+def test_parent_traversal_in_parts_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        pv.validate_model_path("foo/../bar")
+    assert exc.value.status_code == 400
+
+
+def test_nonexistent_path_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc:
+        pv.validate_model_path("definitely_not_a_real_file_xyz.urdf")
+    assert exc.value.status_code == 404
+
+
+def test_resolve_contained_path_outside_raises_404(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    candidate = other / "file.txt"
+    candidate.write_text("x")
+    with pytest.raises(HTTPException) as exc:
+        pv.resolve_contained_path(candidate, [allowed])
+    assert exc.value.status_code == 404
+
+
+def test_resolve_contained_path_inside_returns_resolved(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    f = allowed / "model.urdf"
+    f.write_text("<robot/>")
+    result = pv.resolve_contained_path(f, [allowed])
+    assert result == f.resolve()
+
+
+def test_resolve_contained_path_not_exists_skips(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    candidate = allowed / "missing.urdf"  # exists() returns False
+    with pytest.raises(HTTPException) as exc:
+        pv.resolve_contained_path(candidate, [allowed])
+    assert exc.value.status_code == 404
+
+
+def test_validate_model_path_finds_existing_in_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_root = tmp_path / "models"
+    fake_root.mkdir()
+    target = fake_root / "swing.urdf"
+    target.write_text("<robot/>")
+    monkeypatch.setattr(pv, "ALLOWED_MODEL_DIRS", [fake_root.resolve()])
+    out = pv.validate_model_path("swing.urdf")
+    assert "swing.urdf" in out

--- a/tests/api/wave5_api/test_utils_tracing.py
+++ b/tests/api/wave5_api/test_utils_tracing.py
@@ -1,0 +1,184 @@
+"""Tests for src/api/utils/tracing.py."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.api.utils import tracing
+
+pytestmark = pytest.mark.unit
+
+
+def test_generate_request_id_has_prefix_and_uniqueness() -> None:
+    a = tracing.generate_request_id()
+    b = tracing.generate_request_id()
+    assert a.startswith("req_")
+    assert b.startswith("req_")
+    assert a != b
+    assert len(a) == len("req_") + 16
+
+
+def test_generate_correlation_id_has_prefix_and_uniqueness() -> None:
+    a = tracing.generate_correlation_id()
+    b = tracing.generate_correlation_id()
+    assert a.startswith("cor_")
+    assert a != b
+
+
+def test_get_set_reset_request_id() -> None:
+    assert tracing.get_request_id() == ""
+    token = tracing.set_request_id("req_abc")
+    try:
+        assert tracing.get_request_id() == "req_abc"
+    finally:
+        tracing._request_id_var.reset(token)
+    assert tracing.get_request_id() == ""
+
+
+def test_trace_context_to_dict_round_trip() -> None:
+    ctx = tracing.TraceContext(
+        request_id="req_1",
+        correlation_id="cor_1",
+        operation="GET /x",
+        start_time=1.5,
+        metadata={"k": "v"},
+    )
+    d = ctx.to_dict()
+    assert d["request_id"] == "req_1"
+    assert d["correlation_id"] == "cor_1"
+    assert d["operation"] == "GET /x"
+    assert d["metadata"] == {"k": "v"}
+
+
+def test_get_set_trace_context() -> None:
+    assert tracing.get_trace_context() is None
+    ctx = tracing.TraceContext(request_id="r", correlation_id="c")
+    token = tracing.set_trace_context(ctx)
+    try:
+        got = tracing.get_trace_context()
+        assert got is ctx
+    finally:
+        tracing._trace_context_var.reset(token)
+    assert tracing.get_trace_context() is None
+
+
+def test_traced_log_requires_level() -> None:
+    with pytest.raises(ValueError):
+        tracing.traced_log(None, "msg")  # type: ignore[arg-type]
+
+
+def test_traced_log_injects_context() -> None:
+    # Should not raise; we verify by spying on logger via patching.
+    logs: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_info(msg: str, extra: dict[str, Any] | None = None, **_: Any) -> None:
+        logs.append((msg, extra or {}))
+
+    orig = tracing.logger.info
+    tracing.logger.info = fake_info  # type: ignore[assignment]
+    rid_token = tracing.set_request_id("req_xyz")
+    ctx_token = tracing.set_trace_context(
+        tracing.TraceContext(request_id="req_xyz", correlation_id="cor_xyz")
+    )
+    try:
+        tracing.traced_log("info", "hello", extra_key="ek")
+    finally:
+        tracing.logger.info = orig  # type: ignore[assignment]
+        tracing._request_id_var.reset(rid_token)
+        tracing._trace_context_var.reset(ctx_token)
+
+    assert logs
+    _msg, extra = logs[0]
+    assert extra["request_id"] == "req_xyz"
+    assert extra["correlation_id"] == "cor_xyz"
+    assert extra["extra_key"] == "ek"
+
+
+def test_traced_log_unknown_level_falls_back_to_info() -> None:
+    # Just ensure no crash for unknown level.
+    tracing.traced_log("noplevel", "msg")
+
+
+class _FakeReq:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+        self.method = "GET"
+
+        class _U:
+            path = "/x"
+
+        self.url = _U()
+
+        class _C:
+            host = "1.2.3.4"
+
+        self.client = _C()
+
+
+def test_request_tracer_requires_request() -> None:
+    tracer = tracing.RequestTracer()
+
+    async def go() -> None:
+        with pytest.raises(ValueError):
+            await tracer.trace_request(None, lambda r: r)  # type: ignore[arg-type]
+
+    asyncio.run(go())
+
+
+def test_request_tracer_happy_path_sets_headers() -> None:
+    tracer = tracing.RequestTracer()
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers: dict[str, str] = {}
+
+    async def call_next(_req: Any) -> _Resp:
+        return _Resp()
+
+    req = _FakeReq(headers={"X-Correlation-ID": "cor_existing"})
+
+    async def go() -> _Resp:
+        return await tracer.trace_request(req, call_next)
+
+    resp = asyncio.run(go())
+    assert resp.headers[tracing.CORRELATION_ID_HEADER] == "cor_existing"
+    assert resp.headers[tracing.REQUEST_ID_HEADER].startswith("req_")
+    assert "X-Response-Time-Ms" in resp.headers
+
+
+def test_request_tracer_generates_correlation_if_missing() -> None:
+    tracer = tracing.RequestTracer()
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers: dict[str, str] = {}
+
+    async def call_next(_req: Any) -> _Resp:
+        return _Resp()
+
+    async def go() -> _Resp:
+        return await tracer.trace_request(_FakeReq(), call_next)
+
+    resp = asyncio.run(go())
+    assert resp.headers[tracing.CORRELATION_ID_HEADER].startswith("cor_")
+
+
+def test_request_tracer_propagates_errors_and_resets_context() -> None:
+    tracer = tracing.RequestTracer()
+
+    async def call_next(_req: Any) -> Any:
+        raise RuntimeError("boom")
+
+    async def go() -> None:
+        with pytest.raises(RuntimeError):
+            await tracer.trace_request(_FakeReq(), call_next)
+
+    asyncio.run(go())
+    # Context must be cleared
+    assert tracing.get_request_id() == ""
+    assert tracing.get_trace_context() is None

--- a/tests/api/wave5_api/test_versioning.py
+++ b/tests/api/wave5_api/test_versioning.py
@@ -1,0 +1,102 @@
+"""Tests for src/api/versioning.py."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api import versioning
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_app_version_returns_string() -> None:
+    versioning.get_app_version.cache_clear()
+    v = versioning.get_app_version()
+    assert isinstance(v, str)
+    assert v  # non-empty
+    versioning.get_app_version.cache_clear()
+
+
+def test_get_app_version_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(_name: str) -> str:
+        from importlib.metadata import PackageNotFoundError
+
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(versioning, "version", _raise)
+    monkeypatch.setattr(
+        versioning.Path, "open", lambda self, *a, **kw: (_ for _ in ()).throw(OSError())
+    )
+    versioning.get_app_version.cache_clear()
+    assert versioning.get_app_version() == "0.0.0"
+    versioning.get_app_version.cache_clear()
+
+
+def test_make_versioned_router_prefix() -> None:
+    r = versioning.make_versioned_router("v1")
+    assert r.prefix == "/v1"
+    assert r.deprecated is False
+
+
+def test_make_versioned_router_v2() -> None:
+    r = versioning.make_versioned_router("v2")
+    assert r.prefix == "/v2"
+
+
+def test_make_versioned_router_invalid_value() -> None:
+    with pytest.raises(ValueError):
+        versioning.make_versioned_router("1")
+    with pytest.raises(ValueError):
+        versioning.make_versioned_router("vX")
+    with pytest.raises(ValueError):
+        versioning.make_versioned_router("v")
+
+
+def test_make_versioned_router_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        versioning.make_versioned_router(1)  # type: ignore[arg-type]
+
+
+def test_make_versioned_router_invalid_sunset_type() -> None:
+    with pytest.raises(TypeError):
+        versioning.make_versioned_router("v1", deprecated=True, sunset=123)  # type: ignore[arg-type]
+
+
+def test_make_versioned_router_empty_sunset() -> None:
+    with pytest.raises(ValueError):
+        versioning.make_versioned_router("v1", deprecated=True, sunset="   ")
+
+
+def test_deprecated_router_injects_headers() -> None:
+    app = FastAPI()
+    r = versioning.make_versioned_router(
+        "v1", deprecated=True, sunset="Wed, 11 Nov 2026 23:59:59 GMT"
+    )
+
+    @r.get("/ping")
+    def _ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    app.include_router(r)
+    client = TestClient(app)
+    resp = client.get("/v1/ping")
+    assert resp.status_code == 200
+    assert resp.headers.get("Deprecation") == "true"
+    assert resp.headers.get("Sunset") == "Wed, 11 Nov 2026 23:59:59 GMT"
+
+
+def test_non_deprecated_router_omits_headers() -> None:
+    app = FastAPI()
+    r = versioning.make_versioned_router("v1")
+
+    @r.get("/ping")
+    def _ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    app.include_router(r)
+    resp = TestClient(app).get("/v1/ping")
+    assert resp.status_code == 200
+    assert "Deprecation" not in resp.headers
+    assert "Sunset" not in resp.headers


### PR DESCRIPTION
## Summary

Adds 181 fast unit tests under `tests/api/wave5_api/` covering the
`src/api/` surface — schemas, validators, error codes, tracing, path
validation, versioning router, config helpers, dependency providers,
lazy package init, and debug/rate-limit guards. Total runtime ~2.6s on
Windows. Coverage on the targeted modules: **98%**.

Two real bugs were uncovered by the new tests and fixed in this PR:

- **`src/api/utils/path_validation.py`** — on Windows, `Path('/etc/passwd').is_absolute()` returns `False`, so a POSIX-style leading-slash path bypassed the absolute-path check entirely and only the 404 fallback caught it. Now reject any path starting with `/` or `\` for consistent cross-platform behaviour.
- **`src/api/versioning.py`** — `from __future__ import annotations` left the `Response` parameter of the deprecated-router dependency as a string at runtime, so FastAPI mis-classified it as a query field and returned HTTP 422 for every request to a deprecated router. Pinned `__annotations__` to the live class so the dependency injector resolves correctly. Also added the missing `-> APIRouter` return annotation that mypy flagged on the pre-push hook.

## Test plan

- [x] `python3 -m ruff check tests/api/wave5_api src/api/utils/path_validation.py src/api/versioning.py`
- [x] `python3 -m ruff format --check`
- [x] `python3 -m pytest tests/api/wave5_api -x --timeout=30` — 181 passed in 2.6s