### PR TITLE
test(learning): comprehensive coverage

### DIFF
--- a/tests/learning/wave6_learning/__init__.py
+++ b/tests/learning/wave6_learning/__init__.py
@@ -1,0 +1,1 @@
+"""Wave 6 learning module coverage tests."""

--- a/tests/learning/wave6_learning/test_dataset.py
+++ b/tests/learning/wave6_learning/test_dataset.py
@@ -1,0 +1,207 @@
+"""Wave 6 coverage: src.learning.imitation.dataset."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.learning.imitation.dataset import Demonstration, DemonstrationDataset
+
+
+def _make_demo(
+    n_frames: int = 10,
+    n_joints: int = 3,
+    *,
+    with_actions: bool = True,
+    with_ee: bool = False,
+    with_contact: bool = False,
+    task_id: str | None = "t",
+    success: bool = True,
+) -> Demonstration:
+    return Demonstration(
+        timestamps=np.arange(n_frames, dtype=float) * 0.01,
+        joint_positions=np.arange(n_frames * n_joints, dtype=float).reshape(
+            n_frames, n_joints
+        ),
+        joint_velocities=np.ones((n_frames, n_joints)),
+        actions=np.full((n_frames, n_joints), 0.5) if with_actions else None,
+        end_effector_poses=np.zeros((n_frames, 7)) if with_ee else None,
+        contact_states=[[{"link": "f"}] for _ in range(n_frames)]
+        if with_contact
+        else None,
+        task_id=task_id,
+        success=success,
+    )
+
+
+class TestDemonstration:
+    def test_props(self) -> None:
+        d = _make_demo(20, 4)
+        assert d.n_frames == 20
+        assert d.n_joints == 4
+        assert d.duration == pytest.approx(0.19, rel=1e-6)
+
+    def test_validation_position_mismatch(self) -> None:
+        with pytest.raises(ValueError, match="joint_positions"):
+            Demonstration(
+                timestamps=np.zeros(5),
+                joint_positions=np.zeros((4, 3)),
+                joint_velocities=np.zeros((5, 3)),
+            )
+
+    def test_validation_velocity_mismatch(self) -> None:
+        with pytest.raises(ValueError, match="joint_velocities"):
+            Demonstration(
+                timestamps=np.zeros(5),
+                joint_positions=np.zeros((5, 3)),
+                joint_velocities=np.zeros((4, 3)),
+            )
+
+    def test_get_frame_basic(self) -> None:
+        d = _make_demo(5, 2)
+        frame = d.get_frame(2)
+        assert frame["timestamp"] == pytest.approx(0.02)
+        assert "action" in frame
+        assert "ee_pose" not in frame
+
+    def test_get_frame_with_ee(self) -> None:
+        d = _make_demo(5, 2, with_ee=True)
+        frame = d.get_frame(0)
+        assert "ee_pose" in frame
+
+    def test_subsample(self) -> None:
+        d = _make_demo(10, 2, with_ee=True, with_contact=True)
+        sub = d.subsample(2)
+        assert sub.n_frames == 5
+        assert sub.end_effector_poses is not None
+        assert sub.contact_states is not None
+        assert len(sub.contact_states) == 5
+
+    def test_subsample_no_optional(self) -> None:
+        d = _make_demo(10, 2, with_actions=False)
+        sub = d.subsample(3)
+        assert sub.actions is None
+        assert sub.end_effector_poses is None
+
+    def test_roundtrip_dict(self) -> None:
+        d = _make_demo(4, 2, with_ee=True, with_contact=True)
+        data = d.to_dict()
+        d2 = Demonstration.from_dict(data)
+        np.testing.assert_array_equal(d.joint_positions, d2.joint_positions)
+        assert d2.actions is not None
+        assert d2.end_effector_poses is not None
+        assert d2.contact_states == d.contact_states
+
+    def test_from_dict_minimal(self) -> None:
+        data = {
+            "timestamps": [0.0, 0.1],
+            "joint_positions": [[0.0], [1.0]],
+            "joint_velocities": [[0.0], [0.0]],
+        }
+        d = Demonstration.from_dict(data)
+        assert d.actions is None
+        assert d.success is True
+        assert d.source == "unknown"
+
+
+class TestDataset:
+    def test_basics(self) -> None:
+        ds = DemonstrationDataset()
+        assert len(ds) == 0
+        ds.add(_make_demo(5, 2))
+        ds.extend([_make_demo(3, 2), _make_demo(4, 2, success=False)])
+        assert len(ds) == 3
+        assert list(iter(ds))[0].n_frames == 5
+        assert ds[0].n_frames == 5
+
+    def test_totals(self) -> None:
+        ds = DemonstrationDataset([_make_demo(5, 2), _make_demo(3, 2)])
+        assert ds.total_frames == 8
+        assert ds.total_transitions == (5 - 1) + (3 - 1)
+
+    def test_filter_successful(self) -> None:
+        ds = DemonstrationDataset(
+            [_make_demo(3, 2, success=True), _make_demo(3, 2, success=False)]
+        )
+        ok = ds.filter_successful()
+        assert len(ok) == 1
+
+    def test_filter_by_task(self) -> None:
+        ds = DemonstrationDataset(
+            [_make_demo(3, 2, task_id="a"), _make_demo(3, 2, task_id="b")]
+        )
+        out = ds.filter_by_task("a")
+        assert len(out) == 1
+
+    def test_to_transitions(self) -> None:
+        ds = DemonstrationDataset([_make_demo(5, 2)])
+        s, a, ns = ds.to_transitions()
+        assert s.shape == (4, 4)
+        assert a.shape == (4, 2)
+        assert ns.shape == (4, 4)
+
+    def test_to_transitions_skips_no_actions(self) -> None:
+        ds = DemonstrationDataset([_make_demo(5, 2, with_actions=False)])
+        s, a, ns = ds.to_transitions()
+        assert s.size == 0
+
+    def test_state_action_pairs(self) -> None:
+        ds = DemonstrationDataset([_make_demo(4, 2)])
+        s, a = ds.to_state_action_pairs()
+        assert s.shape == (3, 4)
+        assert a.shape == (3, 2)
+
+    def test_augment(self) -> None:
+        ds = DemonstrationDataset([_make_demo(3, 2, with_ee=True)])
+        aug = ds.augment(
+            noise_std=0.01, num_augmentations=2, rng=np.random.default_rng(0)
+        )
+        # original + 2 augmented
+        assert len(aug) == 3
+        assert aug[1].metadata.get("augmented") is True
+        assert aug[1].source.endswith("_augmented")
+
+    def test_augment_default_rng(self) -> None:
+        ds = DemonstrationDataset([_make_demo(3, 2)])
+        aug = ds.augment(noise_std=0.0, num_augmentations=1)
+        assert len(aug) == 2
+
+    def test_save_load(self, tmp_path: Path) -> None:
+        ds = DemonstrationDataset([_make_demo(4, 2, with_ee=True)])
+        out = tmp_path / "ds.json"
+        ds.save(out)
+        loaded = DemonstrationDataset.load(out)
+        assert len(loaded) == 1
+        np.testing.assert_array_equal(loaded[0].joint_positions, ds[0].joint_positions)
+
+    def test_save_json_structure(self, tmp_path: Path) -> None:
+        ds = DemonstrationDataset([_make_demo(3, 1)])
+        out = tmp_path / "x.json"
+        ds.save(out)
+        data = json.loads(out.read_text())
+        assert data["version"] == "1.0"
+        assert data["n_demonstrations"] == 1
+
+    def test_sample(self) -> None:
+        ds = DemonstrationDataset([_make_demo(3, 2) for _ in range(5)])
+        sub = ds.sample(3, rng=np.random.default_rng(0))
+        assert len(sub) == 3
+        # n > len truncated
+        sub2 = ds.sample(99)
+        assert len(sub2) == 5
+
+    def test_statistics_empty(self) -> None:
+        assert DemonstrationDataset().get_statistics() == {"n_demonstrations": 0}
+
+    def test_statistics_full(self) -> None:
+        ds = DemonstrationDataset(
+            [_make_demo(4, 2, success=True), _make_demo(3, 2, success=False)]
+        )
+        stats = ds.get_statistics()
+        assert stats["n_demonstrations"] == 2
+        assert stats["total_frames"] == 7
+        assert stats["success_rate"] == pytest.approx(0.5)
+        assert len(stats["position_mean"]) == 2

--- a/tests/learning/wave6_learning/test_domain_randomization.py
+++ b/tests/learning/wave6_learning/test_domain_randomization.py
@@ -1,0 +1,168 @@
+"""Wave 6 coverage: src.learning.sim2real.domain_randomization."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.learning.sim2real.domain_randomization import (
+    DomainRandomizationConfig,
+    DomainRandomizer,
+)
+
+
+class FakeEngine:
+    """Minimal physics-engine stand-in implementing the optional accessors."""
+
+    def __init__(self, n: int = 3) -> None:
+        self.masses = np.ones(n)
+        self.damping = np.ones(n) * 0.1
+        self.friction = np.ones(n) * 0.5
+        self.motor_strength = np.ones(n) * 2.0
+        self.gravity = np.array([0.0, 0.0, -9.81])
+        self.actuator_gains = np.ones(n)
+
+    def get_link_masses(self) -> np.ndarray:
+        return self.masses
+
+    def set_link_masses(self, v: np.ndarray) -> None:
+        self.masses = v
+
+    def get_joint_damping(self) -> np.ndarray:
+        return self.damping
+
+    def set_joint_damping(self, v: np.ndarray) -> None:
+        self.damping = v
+
+    def get_friction_coefficients(self) -> np.ndarray:
+        return self.friction
+
+    def set_friction_coefficients(self, v: np.ndarray) -> None:
+        self.friction = v
+
+    def get_motor_strength(self) -> np.ndarray:
+        return self.motor_strength
+
+    def set_motor_strength(self, v: np.ndarray) -> None:
+        self.motor_strength = v
+
+    def get_gravity(self) -> np.ndarray:
+        return self.gravity
+
+    def set_gravity(self, v: np.ndarray) -> None:
+        self.gravity = v
+
+    def get_actuator_gains(self) -> np.ndarray:
+        return self.actuator_gains
+
+
+class TestConfig:
+    def test_defaults(self) -> None:
+        c = DomainRandomizationConfig()
+        assert c.mass_range == (0.8, 1.2)
+        assert c.randomize_mass is True
+
+
+class TestRandomizer:
+    def test_engine_none_raises(self) -> None:
+        with pytest.raises(ValueError):
+            DomainRandomizer(None)  # type: ignore[arg-type]
+
+    def test_store_nominal(self) -> None:
+        eng = FakeEngine()
+        r = DomainRandomizer(eng)
+        assert "masses" in r.nominal_params
+        assert "actuator_gains" in r.nominal_params
+
+    def test_randomize_with_seed_repeatable(self) -> None:
+        eng = FakeEngine()
+        r = DomainRandomizer(eng)
+        a = r.randomize(seed=42)
+        eng2 = FakeEngine()
+        r2 = DomainRandomizer(eng2)
+        b = r2.randomize(seed=42)
+        assert a["mass_scale"] == b["mass_scale"]
+
+    def test_randomize_populates_keys(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        rand = r.randomize(seed=1)
+        for key in (
+            "mass_scale",
+            "friction_scale",
+            "damping_scale",
+            "motor_scale",
+            "gravity",
+            "action_delay",
+            "observation_delay",
+        ):
+            assert key in rand
+
+    def test_reset_to_nominal(self) -> None:
+        eng = FakeEngine()
+        r = DomainRandomizer(eng)
+        r.randomize(seed=3)
+        r.reset_to_nominal()
+        np.testing.assert_array_equal(eng.masses, np.ones(3))
+        assert r.get_current_randomization() == {}
+
+    def test_apply_action_with_delay_zero(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        # delay disabled
+        r._action_delay = 0
+        action = np.array([1.0, 2.0])
+        out = r.apply_action_with_delay(action)
+        # noise applied with default std 0.01 -> shape preserved
+        assert out.shape == action.shape
+
+    def test_apply_action_with_delay_buffers(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        r.config.randomize_delays = True
+        r.config.randomize_noise = False
+        r._action_delay = 2
+        a1 = np.array([1.0])
+        a2 = np.array([2.0])
+        a3 = np.array([3.0])
+        # First two go into the buffer and return zeros
+        out1 = r.apply_action_with_delay(a1)
+        out2 = r.apply_action_with_delay(a2)
+        out3 = r.apply_action_with_delay(a3)
+        np.testing.assert_array_equal(out1, [0.0])
+        np.testing.assert_array_equal(out2, [0.0])
+        np.testing.assert_array_equal(out3, [1.0])
+
+    def test_apply_action_noise_disabled(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        r.config.randomize_noise = False
+        a = np.array([1.0])
+        out = r._apply_action_noise(a)
+        np.testing.assert_array_equal(out, a)
+
+    def test_apply_action_none_raises(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        with pytest.raises(ValueError):
+            r.apply_action_with_delay(None)  # type: ignore[arg-type]
+
+    def test_get_observation_with_delay(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        r.config.randomize_delays = True
+        r.config.randomize_noise = False
+        r._observation_delay = 1
+        first = np.array([1.0])
+        second = np.array([2.0])
+        out1 = r.get_observation_with_delay(first)
+        out2 = r.get_observation_with_delay(second)
+        # first call returns buffered first obs
+        np.testing.assert_array_equal(out1, first)
+        np.testing.assert_array_equal(out2, first)
+
+    def test_get_observation_no_delay(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        r.config.randomize_delays = False
+        r.config.randomize_noise = False
+        out = r.get_observation_with_delay(np.array([1.0]))
+        np.testing.assert_array_equal(out, [1.0])
+
+    def test_sample_batch(self) -> None:
+        r = DomainRandomizer(FakeEngine())
+        batch = r.sample_randomization_batch(3)
+        assert len(batch) == 3

--- a/tests/learning/wave6_learning/test_imitation_algorithms.py
+++ b/tests/learning/wave6_learning/test_imitation_algorithms.py
@@ -1,0 +1,192 @@
+"""Wave 6 coverage: src.learning.imitation BC / DAgger / GAIL pure-Python paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.learning.imitation._base import TrainingConfig
+from src.learning.imitation._bc import BehaviorCloning
+from src.learning.imitation._dagger import DAgger
+from src.learning.imitation._gail import GAIL
+from src.learning.imitation.dataset import Demonstration, DemonstrationDataset
+
+
+def _toy_dataset(
+    n_demos: int = 2, n_frames: int = 6, n_joints: int = 2
+) -> DemonstrationDataset:
+    demos = []
+    rng = np.random.default_rng(0)
+    for _ in range(n_demos):
+        demos.append(
+            Demonstration(
+                timestamps=np.arange(n_frames) * 0.01,
+                joint_positions=rng.standard_normal((n_frames, n_joints)),
+                joint_velocities=rng.standard_normal((n_frames, n_joints)),
+                actions=rng.standard_normal((n_frames, n_joints)),
+            )
+        )
+    return DemonstrationDataset(demos)
+
+
+def _tiny_cfg() -> TrainingConfig:
+    return TrainingConfig(epochs=2, batch_size=4, learning_rate=1e-3, hidden_sizes=[8])
+
+
+class TestBehaviorCloning:
+    def test_forward_shape(self) -> None:
+        bc = BehaviorCloning(observation_dim=4, action_dim=2, config=_tiny_cfg())
+        x = np.zeros((3, 4))
+        out = bc._forward(x)
+        assert out.shape == (3, 2)
+
+    def test_predict_1d(self) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        out = bc.predict(np.zeros(4))
+        assert out.shape == (2,)
+
+    def test_predict_batch(self) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        out = bc.predict(np.zeros((5, 4)))
+        assert out.shape == (5, 2)
+
+    def test_train_history(self) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        ds = _toy_dataset()
+        hist = bc.train(ds, validation_split=0.2)
+        assert "train_loss" in hist
+        assert len(hist["train_loss"]) == 2
+
+    def test_train_empty_raises(self) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        with pytest.raises(ValueError, match="no state-action pairs"):
+            bc.train(DemonstrationDataset())
+
+    def test_save_load_roundtrip(self, tmp_path: Path) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        out = tmp_path / "bc.npz"
+        bc.save(out)
+        # numpy appends .npz; handle both cases
+        path = out if out.exists() else out.with_suffix(".npz")
+        bc2 = BehaviorCloning(4, 2, _tiny_cfg())
+        bc2.load(path)
+        assert bc2.observation_dim == 4
+        assert bc2.action_dim == 2
+
+    def test_get_training_history(self) -> None:
+        bc = BehaviorCloning(4, 2, _tiny_cfg())
+        bc.train(_toy_dataset())
+        hist = bc.get_training_history()
+        assert "train_loss" in hist
+
+
+class TestDAgger:
+    def test_compute_beta_linear(self) -> None:
+        assert DAgger._compute_beta(0, 5, "linear") == pytest.approx(1.0)
+        assert DAgger._compute_beta(5, 5, "linear") == pytest.approx(0.0)
+
+    def test_compute_beta_exponential(self) -> None:
+        assert DAgger._compute_beta(2, 5, "exp") == pytest.approx(0.25)
+
+    def test_train_invokes_bc(self) -> None:
+        d = DAgger(4, 2, _tiny_cfg())
+        hist = d.train(_toy_dataset())
+        assert "train_loss" in hist
+
+    def test_train_online_without_initial_raises(self) -> None:
+        d = DAgger(4, 2, _tiny_cfg())
+        with pytest.raises(ValueError, match="train\\(\\) first"):
+            d.train_online(env=None, expert=lambda o: o, iterations=1)
+
+    def test_predict(self) -> None:
+        d = DAgger(4, 2, _tiny_cfg())
+        d.train(_toy_dataset())
+        out = d.predict(np.zeros(4))
+        assert out.shape == (2,)
+
+    def test_save_load(self, tmp_path: Path) -> None:
+        d = DAgger(4, 2, _tiny_cfg())
+        out = tmp_path / "dagger.npz"
+        d.save(out)
+        path = out if out.exists() else out.with_suffix(".npz")
+        d2 = DAgger(4, 2, _tiny_cfg())
+        d2.load(path)
+
+    def test_train_online_with_fake_env(self) -> None:
+        """Run train_online against a fake env to cover trajectory collection."""
+
+        class FakeEnv:
+            def __init__(self) -> None:
+                self.step_count = 0
+
+            def reset(self):
+                self.step_count = 0
+                return np.zeros(4), {}
+
+            def step(self, action):
+                self.step_count += 1
+                obs = np.zeros(4)
+                terminated = self.step_count >= 3
+                return obs, 1.0, terminated, False, {}
+
+        d = DAgger(4, 2, _tiny_cfg())
+        d.train(_toy_dataset())
+        results = d.train_online(
+            env=FakeEnv(),
+            expert=lambda obs: np.zeros(2),
+            iterations=2,
+            trajectories_per_iter=1,
+            max_steps=5,
+            beta_schedule="linear",
+        )
+        assert "iteration_rewards" in results
+        assert len(results["iteration_rewards"]) == 2
+
+
+class TestGAIL:
+    def test_forward_policy_and_disc(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        action = g._forward_policy(np.zeros((3, 4)))
+        assert action.shape == (3, 2)
+        out = g._forward_discriminator(np.zeros((3, 4)), np.zeros((3, 2)))
+        # sigmoid output in [0,1]
+        assert out.shape == (3, 1)
+        assert np.all((out >= 0) & (out <= 1))
+
+    def test_train_history(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        hist = g.train(_toy_dataset())
+        assert "discriminator_loss" in hist
+        assert "policy_loss" in hist
+        assert len(hist["discriminator_loss"]) == 2
+
+    def test_train_empty_raises(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        with pytest.raises(ValueError, match="no state-action pairs"):
+            g.train(DemonstrationDataset())
+
+    def test_predict_1d(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        out = g.predict(np.zeros(4))
+        assert out.shape == (2,)
+
+    def test_predict_stochastic(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        out = g.predict(np.zeros(4), deterministic=False)
+        assert out.shape == (2,)
+
+    def test_get_reward(self) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        r = g.get_reward(np.zeros(4), np.zeros(2))
+        assert isinstance(r, float)
+
+    def test_save_load(self, tmp_path: Path) -> None:
+        g = GAIL(4, 2, _tiny_cfg())
+        out = tmp_path / "gail.npz"
+        g.save(out)
+        path = out if out.exists() else out.with_suffix(".npz")
+        g2 = GAIL(4, 2, _tiny_cfg())
+        g2.load(path)
+        assert g2.observation_dim == 4

--- a/tests/learning/wave6_learning/test_retargeting.py
+++ b/tests/learning/wave6_learning/test_retargeting.py
@@ -1,0 +1,158 @@
+"""Wave 6 coverage: src.learning.retargeting.retargeter."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.learning.retargeting.retargeter import (
+    MotionRetargeter,
+    SkeletonConfig,
+)
+
+
+def _simple_skel(name: str = "s") -> SkeletonConfig:
+    return SkeletonConfig(
+        name=name,
+        joint_names=["root", "shoulder", "elbow", "hand"],
+        parent_indices=[-1, 0, 1, 2],
+        joint_offsets=np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.1, 0.0, 0.0],
+                [0.3, 0.0, 0.0],
+                [0.2, 0.0, 0.0],
+            ]
+        ),
+        semantic_labels={
+            "root": "root",
+            "left_shoulder": "shoulder",
+            "left_elbow": "elbow",
+            "left_hand": "hand",
+        },
+        end_effectors=["hand"],
+    )
+
+
+class TestSkeletonConfig:
+    def test_post_init_defaults(self) -> None:
+        s = _simple_skel()
+        assert s.joint_axes is not None
+        assert s.joint_axes.shape == (4, 3)
+        assert s.joint_limits is not None
+        assert s.joint_limits.shape == (4, 2)
+        assert s.n_joints == 4
+
+    def test_validation_parents(self) -> None:
+        with pytest.raises(ValueError, match="parent_indices"):
+            SkeletonConfig(
+                name="x",
+                joint_names=["a", "b"],
+                parent_indices=[-1],
+                joint_offsets=np.zeros((2, 3)),
+            )
+
+    def test_validation_offsets(self) -> None:
+        with pytest.raises(ValueError, match="joint_offsets"):
+            SkeletonConfig(
+                name="x",
+                joint_names=["a", "b"],
+                parent_indices=[-1, 0],
+                joint_offsets=np.zeros((1, 3)),
+            )
+
+    def test_get_joint_index(self) -> None:
+        s = _simple_skel()
+        assert s.get_joint_index("elbow") == 2
+        with pytest.raises(ValueError, match="not found"):
+            s.get_joint_index("nope")
+
+    def test_get_semantic_joint(self) -> None:
+        s = _simple_skel()
+        assert s.get_semantic_joint("left_shoulder") == "shoulder"
+        assert s.get_semantic_joint("missing") is None
+
+    def test_kinematic_chain(self) -> None:
+        s = _simple_skel()
+        chain = s.get_kinematic_chain("hand")
+        assert chain == ["root", "shoulder", "elbow", "hand"]
+
+    def test_create_humanoid(self) -> None:
+        h = SkeletonConfig.create_humanoid()
+        assert h.n_joints == 22
+        assert "head" in h.end_effectors
+        assert h.get_joint_index("pelvis") == 0
+
+
+class TestMotionRetargeter:
+    def test_init_and_mapping(self) -> None:
+        src = _simple_skel("src")
+        tgt = _simple_skel("tgt")
+        r = MotionRetargeter(src, tgt)
+        mapping = r.get_joint_mapping()
+        assert mapping["shoulder"] == "shoulder"
+        assert mapping["root"] == "root"
+
+    def test_retarget_direct(self) -> None:
+        src = _simple_skel("src")
+        tgt = _simple_skel("tgt")
+        r = MotionRetargeter(src, tgt)
+        motion = np.zeros((3, 4))
+        motion[:, 1] = 0.5
+        out = r.retarget(motion, method="direct")
+        assert out.shape == (3, 4)
+        np.testing.assert_allclose(out[:, 1], 0.5)
+
+    def test_retarget_direct_clipped_by_limits(self) -> None:
+        src = _simple_skel("src")
+        tgt = _simple_skel("tgt")
+        # narrow limits on the target
+        tgt.joint_limits = np.tile(np.array([-0.2, 0.2]), (4, 1))
+        r = MotionRetargeter(src, tgt)
+        motion = np.full((1, 4), 5.0)
+        out = r.retarget(motion, method="direct")
+        assert np.all(out <= 0.2)
+
+    def test_retarget_optimization_runs(self) -> None:
+        src = _simple_skel("src")
+        tgt = _simple_skel("tgt")
+        r = MotionRetargeter(src, tgt)
+        motion = np.zeros((2, 4))
+        out = r.retarget(motion, method="optimization")
+        assert out.shape == (2, 4)
+
+    def test_retarget_ik_runs(self) -> None:
+        src = _simple_skel("src")
+        tgt = _simple_skel("tgt")
+        r = MotionRetargeter(src, tgt)
+        out = r.retarget(np.zeros((1, 4)), method="ik")
+        assert out.shape == (1, 4)
+
+    def test_retarget_unknown_method(self) -> None:
+        r = MotionRetargeter(_simple_skel(), _simple_skel())
+        with pytest.raises(ValueError, match="Unknown"):
+            r.retarget(np.zeros((1, 4)), method="bogus")
+
+    def test_retarget_from_mocap_default_mapping(self) -> None:
+        # Use humanoid skeleton to align with marker name inference table.
+        h = SkeletonConfig.create_humanoid()
+        r = MotionRetargeter(h, h)
+        marker_names = ["LSHO", "RSHO", "LELB"]
+        marker_pos = np.zeros((2, 3, 3))
+        out = r.retarget_from_mocap(marker_pos, marker_names)
+        assert out.shape == (2, h.n_joints)
+
+    def test_retarget_from_mocap_explicit_mapping(self) -> None:
+        h = SkeletonConfig.create_humanoid()
+        r = MotionRetargeter(h, h)
+        marker_names = ["m1"]
+        mapping = {"m1": "left_shoulder"}
+        marker_pos = np.ones((1, 1, 3)) * 0.05
+        out = r.retarget_from_mocap(marker_pos, marker_names, mapping)
+        assert out.shape == (1, h.n_joints)
+
+    def test_visualize_mapping(self) -> None:
+        r = MotionRetargeter(_simple_skel("a"), _simple_skel("b"))
+        text = r.visualize_mapping()
+        assert "Motion Retargeting" in text
+        assert "Mapped joints" in text

--- a/tests/learning/wave6_learning/test_rl_configs.py
+++ b/tests/learning/wave6_learning/test_rl_configs.py
@@ -1,0 +1,99 @@
+"""Wave 6 coverage: src.learning.rl.configs."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.learning.rl.configs import (
+    ActionConfig,
+    ActionMode,
+    ObservationConfig,
+    RewardConfig,
+    TaskConfig,
+    TaskType,
+)
+
+
+class TestObservationConfig:
+    def test_default_dim(self) -> None:
+        c = ObservationConfig()
+        # joint_pos + joint_vel = 2 * n_joints
+        assert c.get_obs_dim(7) == 14
+
+    def test_all_flags(self) -> None:
+        c = ObservationConfig(
+            include_joint_pos=True,
+            include_joint_vel=True,
+            include_joint_torque=True,
+            include_ee_pos=True,
+            include_ee_vel=True,
+            include_imu=True,
+            history_length=2,
+        )
+        # 7 + 7 + 7 + 2*3 + 2*6 + 6 = 45, *2 = 90
+        assert c.get_obs_dim(7, n_ee=2) == 90
+
+    def test_none_joints_raises(self) -> None:
+        c = ObservationConfig()
+        with pytest.raises(ValueError):
+            c.get_obs_dim(None)  # type: ignore[arg-type]
+
+
+class TestActionConfig:
+    def test_process_action_clip_scale(self) -> None:
+        c = ActionConfig(mode=ActionMode.TORQUE, action_scale=2.0, action_clip=0.5)
+        result = c.process_action(np.array([2.0, -2.0, 0.1]), None)
+        # clipped to [-0.5, 0.5] then scaled by 2
+        np.testing.assert_allclose(result, [1.0, -1.0, 0.2])
+
+    def test_process_action_smoothing(self) -> None:
+        c = ActionConfig(smoothing_alpha=0.5, action_scale=1.0, action_clip=10.0)
+        prev = np.array([1.0])
+        cur = np.array([3.0])
+        out = c.process_action(cur, prev)
+        # 0.5*1 + 0.5*3 = 2
+        assert out[0] == pytest.approx(2.0)
+
+    def test_process_action_none_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ActionConfig().process_action(None, None)  # type: ignore[arg-type]
+
+    def test_action_mode_values(self) -> None:
+        assert ActionMode.TORQUE.value == "torque"
+        assert ActionMode.IMPEDANCE.value == "impedance"
+
+
+class TestRewardConfig:
+    def test_energy_penalty(self) -> None:
+        c = RewardConfig(energy_penalty_weight=0.5)
+        out = c.compute_energy_penalty(np.array([1.0, 2.0]))
+        assert out == pytest.approx(0.5 * 5.0)
+
+    def test_smoothness_penalty(self) -> None:
+        c = RewardConfig(smoothness_penalty_weight=1.0)
+        out = c.compute_smoothness_penalty(np.array([1.0, 1.0]), np.array([0.0, 0.0]))
+        assert out == pytest.approx(2.0)
+
+    def test_smoothness_no_prev(self) -> None:
+        c = RewardConfig()
+        assert c.compute_smoothness_penalty(np.array([1.0]), None) == 0.0
+
+    def test_smoothness_none_action_raises(self) -> None:
+        with pytest.raises(ValueError):
+            RewardConfig().compute_smoothness_penalty(None, None)  # type: ignore[arg-type]
+
+
+class TestTaskConfig:
+    def test_default_target_velocity(self) -> None:
+        c = TaskConfig()
+        np.testing.assert_array_equal(c.target_velocity, [1.0, 0.0, 0.0])
+
+    def test_is_success(self) -> None:
+        c = TaskConfig(success_threshold=0.1)
+        assert c.is_success(0.05)
+        assert not c.is_success(0.5)
+
+    def test_task_type_values(self) -> None:
+        assert TaskType.LOCOMOTION.value == "locomotion"
+        assert TaskType.MANIPULATION.value == "manipulation"

--- a/tests/learning/wave6_learning/test_simscape_compat.py
+++ b/tests/learning/wave6_learning/test_simscape_compat.py
@@ -1,0 +1,77 @@
+"""Wave 6 coverage: src.learning.sim2real._simscape_compat."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.learning.sim2real._simscape_compat import (
+    SimscapeSystemIdCompat,
+    wrap_for_system_identification,
+)
+
+
+class FakeAdapter:
+    """Lightweight stand-in for SimscapeAdapter."""
+
+    dof = 3
+
+    def __init__(self) -> None:
+        self.damping_set: list[np.ndarray] = []
+
+    def get_link_masses(self) -> np.ndarray:
+        return np.ones(self.dof)
+
+    def some_passthrough(self) -> str:
+        return "passed"
+
+
+class TestCompat:
+    def test_adapter_none_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SimscapeSystemIdCompat(None)  # type: ignore[arg-type]
+
+    def test_passthrough(self) -> None:
+        c = SimscapeSystemIdCompat(FakeAdapter())
+        assert c.some_passthrough() == "passed"
+        np.testing.assert_array_equal(c.get_link_masses(), np.ones(3))
+
+    def test_set_joint_damping_records(self) -> None:
+        c = SimscapeSystemIdCompat(FakeAdapter())
+        c.set_joint_damping(np.array([1.0, 2.0, 3.0]))
+        c.set_joint_damping(np.array([4.0, 5.0, 6.0]))
+        history = c.damping_history
+        assert len(history) == 2
+        np.testing.assert_array_equal(history[0], [1.0, 2.0, 3.0])
+
+    def test_compat_dispatch_getter_returns_zeros(self) -> None:
+        c = SimscapeSystemIdCompat(FakeAdapter())
+        out = c.get_friction_coefficients()
+        np.testing.assert_array_equal(out, np.zeros(3))
+
+    def test_compat_dispatch_setter_noop(self) -> None:
+        c = SimscapeSystemIdCompat(FakeAdapter())
+        # should not raise
+        assert c.set_motor_strength(np.zeros(3)) is None
+
+    def test_compat_dispatch_getter_no_dof(self) -> None:
+        class AdapterNoDof:
+            @property
+            def dof(self) -> int:
+                raise RuntimeError("no dof")
+
+        c = SimscapeSystemIdCompat(AdapterNoDof())
+        out = c.get_motor_strength()
+        # falls back to length-0 array
+        assert out.shape == (0,)
+
+    def test_warn_once(self) -> None:
+        c = SimscapeSystemIdCompat(FakeAdapter())
+        # Trigger twice; second call should not re-add to _warned
+        c.set_joint_damping(np.zeros(3))
+        c.set_joint_damping(np.zeros(3))
+        assert "set_joint_damping" in c._warned
+
+    def test_wrap_helper(self) -> None:
+        wrapped = wrap_for_system_identification(FakeAdapter())
+        assert isinstance(wrapped, SimscapeSystemIdCompat)

--- a/tests/learning/wave6_learning/test_system_identification.py
+++ b/tests/learning/wave6_learning/test_system_identification.py
@@ -1,0 +1,167 @@
+"""Wave 6 coverage: src.learning.sim2real.system_identification."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.learning.imitation.dataset import Demonstration
+from src.learning.sim2real.system_identification import (
+    IdentificationResult,
+    SystemIdentifier,
+)
+
+
+class FakeModel:
+    """Minimal physics model that emulates a passive integrator."""
+
+    def __init__(self, n: int = 2) -> None:
+        self.n = n
+        self.masses = np.ones(n)
+        self.damping = np.ones(n) * 0.1
+        self.friction = np.ones(n) * 0.5
+        self.motor = np.ones(n)
+        self._q = np.zeros(n)
+        self._v = np.zeros(n)
+        self._torques = np.zeros(n)
+
+    def get_link_masses(self) -> np.ndarray:
+        return self.masses
+
+    def set_link_masses(self, v: np.ndarray) -> None:
+        self.masses = v
+
+    def get_joint_damping(self) -> np.ndarray:
+        return self.damping
+
+    def set_joint_damping(self, v: np.ndarray) -> None:
+        self.damping = v
+
+    def get_friction_coefficients(self) -> np.ndarray:
+        return self.friction
+
+    def set_friction_coefficients(self, v: np.ndarray) -> None:
+        self.friction = v
+
+    def get_motor_strength(self) -> np.ndarray:
+        return self.motor
+
+    def set_motor_strength(self, v: np.ndarray) -> None:
+        self.motor = v
+
+    def set_joint_positions(self, q: np.ndarray) -> None:
+        self._q = q.copy()
+
+    def set_joint_velocities(self, v: np.ndarray) -> None:
+        self._v = v.copy()
+
+    def set_joint_torques(self, t: np.ndarray) -> None:
+        self._torques = t
+
+    def step(self, dt: float) -> None:
+        # Simple second-order integration with motor scaling.
+        a = self._torques / self.masses
+        self._v = self._v + a * dt
+        self._q = self._q + self._v * dt
+
+    def get_joint_positions(self) -> np.ndarray:
+        return self._q.copy()
+
+    def get_joint_velocities(self) -> np.ndarray:
+        return self._v.copy()
+
+
+def _make_demo(n_frames: int = 6, n_joints: int = 2) -> Demonstration:
+    return Demonstration(
+        timestamps=np.arange(n_frames, dtype=float) * 0.01,
+        joint_positions=np.linspace(0, 1, n_frames * n_joints).reshape(
+            n_frames, n_joints
+        ),
+        joint_velocities=np.ones((n_frames, n_joints)) * 0.1,
+        actions=np.zeros((n_frames, n_joints)),
+    )
+
+
+class TestSystemIdentifier:
+    def test_init_none_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SystemIdentifier(None)  # type: ignore[arg-type]
+
+    def test_default_bounds(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        bounds = ident.param_bounds
+        assert "mass_scale" in bounds
+        assert bounds["mass_scale"] == (0.5, 2.0)
+
+    def test_custom_bounds(self) -> None:
+        ident = SystemIdentifier(FakeModel(), param_bounds={"mass_scale": (0.9, 1.1)})
+        assert ident.param_bounds == {"mass_scale": (0.9, 1.1)}
+
+    def test_apply_params_modifies_model(self) -> None:
+        m = FakeModel()
+        ident = SystemIdentifier(m)
+        ident._apply_params(np.array([2.0, 1.0, 1.0, 1.0, 0, 0, 0]))
+        np.testing.assert_array_equal(m.masses, np.ones(2) * 2.0)
+
+    def test_apply_params_none_raises(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        with pytest.raises(ValueError):
+            ident._apply_params(None)  # type: ignore[arg-type]
+
+    def test_simulate_trajectory_shape(self) -> None:
+        m = FakeModel()
+        ident = SystemIdentifier(m)
+        state0 = np.zeros(4)
+        actions = np.zeros((3, 2))
+        traj = ident._simulate_trajectory(state0, actions, dt=0.01)
+        # initial + 3 steps
+        assert traj.shape == (4, 4)
+
+    def test_compute_error(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        sim = np.zeros((3, 4))
+        real = np.ones((3, 4))
+        err = ident._compute_trajectory_error(sim, real)
+        assert err == pytest.approx(1.0)
+
+    def test_compute_error_with_weights(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        sim = np.zeros((2, 4))
+        real = np.ones((2, 4))
+        weights = np.array([0.5, 0.5, 0.0, 0.0])
+        err = ident._compute_trajectory_error(sim, real, weights)
+        # weighted diff = 0.5 for half the entries, 0 for rest
+        assert err < 1.0
+
+    def test_identify_returns_result(self) -> None:
+        ident = SystemIdentifier(FakeModel(), param_bounds={"mass_scale": (0.5, 2.0)})
+        demos = [_make_demo()]
+        result = ident.identify_from_trajectories(
+            demos, params_to_identify=["mass_scale"], max_iterations=3
+        )
+        assert isinstance(result, IdentificationResult)
+        assert "mass_scale" in result.identified_params
+        assert result.iterations >= 1
+
+    def test_compute_reality_gap(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        sim = np.zeros((5, 4))
+        real = np.ones((5, 4))
+        gap = ident.compute_reality_gap(sim, real)
+        assert gap["total_mse"] == pytest.approx(1.0)
+        assert gap["max_position_error"] == pytest.approx(1.0)
+        assert gap["trajectory_length"] == 5
+        assert "joint_0_position_mse" in gap
+
+    def test_validate_identification(self) -> None:
+        ident = SystemIdentifier(FakeModel())
+        demos = [_make_demo(), _make_demo()]
+        params = {
+            "mass_scale": 1.0,
+            "friction_scale": 1.0,
+            "damping_scale": 1.0,
+            "motor_scale": 1.0,
+        }
+        metrics = ident.validate_identification(demos, params)
+        assert metrics["n_trajectories"] == 2
+        assert "mean_error" in metrics


### PR DESCRIPTION
## Summary
- Wave 6 coverage pass for `src/learning/` (imitation, retargeting, sim2real, rl/configs).
- 106 fast tests under `tests/learning/wave6_learning/`, full suite runs in under 1 second.
- All torch/sklearn-style training avoided; only pure-Python / numpy paths exercised, with lightweight fake engines / envs / adapters where needed.

## Coverage on in-scope (non-training-loop) modules
- `imitation/dataset.py`: 86%
- `imitation/_bc.py`: 83%, `_gail.py`: 81%, `_dagger.py`: 79%
- `retargeting/retargeter.py`: 81%
- `sim2real/domain_randomization.py`: 82%
- `sim2real/system_identification.py`: 79%
- `sim2real/_simscape_compat.py`: 100%
- `rl/configs.py`: 98%

RL Gymnasium environments (`base_env`, `humanoid_envs`, `manipulation_envs`) require real physics engines and live outside this wave's scope.

## Test plan
- [x] `python3 -m ruff check tests/learning/wave6_learning` passes
- [x] `python3 -m ruff format tests/learning/wave6_learning` clean
- [x] `python3 -m pytest tests/learning/wave6_learning -x --timeout=30` -> 106 passed in 0.86s