### PR TITLE
test(research): comprehensive coverage

### DIFF
--- a/src/research/deformable/objects.py
+++ b/src/research/deformable/objects.py
@@ -71,9 +71,7 @@ class DeformableObject(ABC):
             mesh: Initial mesh node positions (N, 3).
             material: Material properties.
         """
-        if not (mesh is not None):
-            raise ValueError("mesh must be provided")
-        if not (mesh is not None):
+        if mesh is None:
             raise ValueError("mesh must be provided")
         self._mesh = mesh.copy()
         self._rest_mesh = mesh.copy()
@@ -132,9 +130,7 @@ class DeformableObject(ABC):
             node_indices: Indices of nodes to apply force to.
             forces: Force vectors (len(node_indices), 3) or (3,) for all.
         """
-        if not (node_indices is not None):
-            raise ValueError("node_indices must be provided")
-        if not (node_indices is not None):
+        if node_indices is None:
             raise ValueError("node_indices must be provided")
         if forces.ndim == 1:
             forces = np.tile(forces, (len(node_indices), 1))
@@ -207,9 +203,7 @@ class SoftBody(DeformableObject):
             tetrahedra: Tetrahedral connectivity (M, 4).
             material: Material properties.
         """
-        if not (mesh is not None):
-            raise ValueError("mesh must be provided")
-        if not (mesh is not None):
+        if mesh is None:
             raise ValueError("mesh must be provided")
         super().__init__(mesh, material)
         self._tetrahedra = tetrahedra
@@ -225,9 +219,7 @@ class SoftBody(DeformableObject):
         Returns:
             Volumes for each tetrahedron.
         """
-        if not (positions is not None):
-            raise ValueError("positions must be provided")
-        if not (positions is not None):
+        if positions is None:
             raise ValueError("positions must be provided")
         volumes = np.zeros(len(self._tetrahedra))
 
@@ -321,9 +313,7 @@ class SoftBody(DeformableObject):
             dt: Timestep.
         """
         # Compute forces
-        if not (dt is not None):
-            raise ValueError("dt must be provided")
-        if not (dt is not None):
+        if dt is None:
             raise ValueError("dt must be provided")
         internal_forces = self.compute_internal_forces()
         total_forces = internal_forces + self._external_forces
@@ -370,9 +360,7 @@ class Cable(DeformableObject):
             material: Material properties.
             rest_lengths: Rest lengths between nodes (optional).
         """
-        if not (mesh is not None):
-            raise ValueError("mesh must be provided")
-        if not (mesh is not None):
+        if mesh is None:
             raise ValueError("mesh must be provided")
         super().__init__(mesh, material)
 
@@ -468,9 +456,7 @@ class Cable(DeformableObject):
         Args:
             dt: Timestep.
         """
-        if not (dt is not None):
-            raise ValueError("dt must be provided")
-        if not (dt is not None):
+        if dt is None:
             raise ValueError("dt must be provided")
         internal_forces = self.compute_internal_forces()
         total_forces = internal_forces + self._external_forces
@@ -521,9 +507,7 @@ class Cloth(DeformableObject):
             height: Grid height.
             material: Material properties.
         """
-        if not (mesh is not None):
-            raise ValueError("mesh must be provided")
-        if not (mesh is not None):
+        if mesh is None:
             raise ValueError("mesh must be provided")
         super().__init__(mesh, material)
         self._width = width
@@ -648,9 +632,7 @@ class Cloth(DeformableObject):
         Args:
             dt: Timestep.
         """
-        if not (dt is not None):
-            raise ValueError("dt must be provided")
-        if not (dt is not None):
+        if dt is None:
             raise ValueError("dt must be provided")
         internal_forces = self.compute_internal_forces()
         total_forces = internal_forces + self._external_forces

--- a/src/research/differentiable/engine.py
+++ b/src/research/differentiable/engine.py
@@ -71,9 +71,7 @@ class DifferentiableEngine:
             engine: Physics engine to wrap.
             backend: Autodiff backend ("jax", "torch", "numpy").
         """
-        if not (engine is not None):
-            raise ValueError("engine must be provided")
-        if not (engine is not None):
+        if engine is None:
             raise ValueError("engine must be provided")
         self.engine = engine
         self._backend = AutodiffBackend(backend)
@@ -108,9 +106,7 @@ class DifferentiableEngine:
         Returns:
             State trajectory (T+1, n_x).
         """
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         T = len(controls)
         trajectory = np.zeros((T + 1, self._n_x))
@@ -169,9 +165,7 @@ class DifferentiableEngine:
         Returns:
             Gradient of loss w.r.t. controls (T, n_u).
         """
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         eps = 1e-5
         T, n_u = controls.shape
@@ -200,9 +194,7 @@ class DifferentiableEngine:
         v: NDArray[np.floating],
         torques: NDArray[np.floating],
     ) -> None:
-        if not (q is not None):
-            raise ValueError("q must be provided")
-        if not (q is not None):
+        if q is None:
             raise ValueError("q must be provided")
         if hasattr(self.engine, "set_joint_positions"):
             self.engine.set_joint_positions(q)
@@ -217,9 +209,7 @@ class DifferentiableEngine:
         v: NDArray[np.floating],
         dt: float,
     ) -> NDArray[np.floating]:
-        if not (q is not None):
-            raise ValueError("q must be provided")
-        if not (q is not None):
+        if q is None:
             raise ValueError("q must be provided")
         if hasattr(self.engine, "step"):
             self.engine.step(dt)
@@ -242,9 +232,7 @@ class DifferentiableEngine:
         control: NDArray[np.floating],
         dt: float,
     ) -> NDArray[np.floating]:
-        if not (state is not None):
-            raise ValueError("state must be provided")
-        if not (state is not None):
+        if state is None:
             raise ValueError("state must be provided")
         q = state[: self._n_q]
         v = state[self._n_q :]
@@ -259,9 +247,7 @@ class DifferentiableEngine:
         dt: float,
         eps: float,
     ) -> NDArray[np.floating]:
-        if not (state is not None):
-            raise ValueError("state must be provided")
-        if not (state is not None):
+        if state is None:
             raise ValueError("state must be provided")
         A = np.zeros((self._n_x, self._n_x))
         for i in range(self._n_x):
@@ -285,9 +271,7 @@ class DifferentiableEngine:
         dt: float,
         eps: float,
     ) -> NDArray[np.floating]:
-        if not (state is not None):
-            raise ValueError("state must be provided")
-        if not (state is not None):
+        if state is None:
             raise ValueError("state must be provided")
         q = state[: self._n_q]
         v = state[self._n_q :]
@@ -318,9 +302,7 @@ class DifferentiableEngine:
         Returns:
             Tuple of (df/dx, df/du) Jacobians.
         """
-        if not (state is not None):
-            raise ValueError("state must be provided")
-        if not (state is not None):
+        if state is None:
             raise ValueError("state must be provided")
         eps = 1e-5
         x_next = self._compute_nominal_next_state(state, control, dt)
@@ -353,9 +335,7 @@ class DifferentiableEngine:
             Optimization result.
         """
         # Initialize controls
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         controls = np.zeros((horizon, self._n_u))
 
@@ -441,9 +421,7 @@ class ContactDifferentiableEngine(DifferentiableEngine):
             contact_method: "smoothed", "randomized", or "stochastic".
             smoothing_factor: Smoothing parameter.
         """
-        if not (engine is not None):
-            raise ValueError("engine must be provided")
-        if not (engine is not None):
+        if engine is None:
             raise ValueError("engine must be provided")
         super().__init__(engine)
         self.contact_method = contact_method
@@ -467,9 +445,7 @@ class ContactDifferentiableEngine(DifferentiableEngine):
         Returns:
             Smoothed gradient.
         """
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         if self.contact_method == "randomized":
             # Randomized smoothing: average gradients with noise
@@ -535,9 +511,7 @@ class ContactDifferentiableEngine(DifferentiableEngine):
         Returns:
             Optimization result.
         """
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         original_smoothing = self.smoothing_factor
 
@@ -610,9 +584,7 @@ class ContactDifferentiableEngine(DifferentiableEngine):
         original_smoothing: float,
         contact_smoothing_multiplier: float,
     ) -> tuple[NDArray[np.floating], float, float, int]:
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         m = np.zeros_like(controls)
         v = np.zeros_like(controls)

--- a/src/research/mpc/controller.py
+++ b/src/research/mpc/controller.py
@@ -58,9 +58,7 @@ class CostFunction:
             Running cost value.
         """
         # State cost
-        if not (x is not None):
-            raise ValueError("x must be provided")
-        if not (x is not None):
+        if x is None:
             raise ValueError("x must be provided")
         x_err = x
         if self.x_ref is not None:
@@ -98,9 +96,7 @@ class CostFunction:
         Returns:
             Terminal cost value.
         """
-        if not (x is not None):
-            raise ValueError("x must be provided")
-        if not (x is not None):
+        if x is None:
             raise ValueError("x must be provided")
         if self.P is None:
             return 0.0
@@ -188,9 +184,7 @@ class ModelPredictiveController:
             horizon: Number of prediction steps.
             dt: Timestep in seconds.
         """
-        if not (model is not None):
-            raise ValueError("model must be provided")
-        if not (model is not None):
+        if model is None:
             raise ValueError("model must be provided")
         self.model = model
         self.horizon = horizon
@@ -268,9 +262,7 @@ class ModelPredictiveController:
         Returns:
             Next state.
         """
-        if not (x is not None):
-            raise ValueError("x must be provided")
-        if not (x is not None):
+        if x is None:
             raise ValueError("x must be provided")
         n_q = self._n_x // 2
         q = x[:n_q]
@@ -315,9 +307,7 @@ class ModelPredictiveController:
         Returns:
             Tuple of (A, B) matrices.
         """
-        if not (x is not None):
-            raise ValueError("x must be provided")
-        if not (x is not None):
+        if x is None:
             raise ValueError("x must be provided")
         eps = 1e-5
         A = np.zeros((self._n_x, self._n_x))
@@ -429,9 +419,7 @@ class ModelPredictiveController:
         Returns:
             Tuple of (gains K, feedforward d).
         """
-        if not (X is not None):
-            raise ValueError("X must be provided")
-        if not (X is not None):
+        if X is None:
             raise ValueError("X must be provided")
         K: list[NDArray[np.floating]] = []
         d: list[NDArray[np.floating]] = []
@@ -505,9 +493,7 @@ class ModelPredictiveController:
         Returns:
             Tuple of (new states, new controls, cost).
         """
-        if not (X is not None):
-            raise ValueError("X must be provided")
-        if not (X is not None):
+        if X is None:
             raise ValueError("X must be provided")
         alpha = 1.0
         best_cost = float("inf")
@@ -553,9 +539,7 @@ class ModelPredictiveController:
         Returns:
             Maximum violation.
         """
-        if not (X is not None):
-            raise ValueError("X must be provided")
-        if not (X is not None):
+        if X is None:
             raise ValueError("X must be provided")
         max_violation = 0.0
 
@@ -587,9 +571,7 @@ class ModelPredictiveController:
         Returns:
             First control input u_0.
         """
-        if not (result is not None):
-            raise ValueError("result must be provided")
-        if not (result is not None):
+        if result is None:
             raise ValueError("result must be provided")
         if result.optimal_controls is None:
             return np.zeros(self._n_u)

--- a/src/research/mpc/specialized.py
+++ b/src/research/mpc/specialized.py
@@ -63,9 +63,7 @@ class CentroidalMPC(ModelPredictiveController):
             dt: Timestep.
             n_contacts: Number of contact points (feet).
         """
-        if not (model is not None):
-            raise ValueError("model must be provided")
-        if not (model is not None):
+        if model is None:
             raise ValueError("model must be provided")
         super().__init__(model, horizon, dt)
 
@@ -150,9 +148,7 @@ class CentroidalMPC(ModelPredictiveController):
         Returns:
             Next state.
         """
-        if not (x is not None):
-            raise ValueError("x must be provided")
-        if not (x is not None):
+        if x is None:
             raise ValueError("x must be provided")
         com = x[:3]
         com_vel = x[3:6]
@@ -264,9 +260,7 @@ class WholeBodyMPC(ModelPredictiveController):
             horizon: Prediction horizon.
             dt: Timestep.
         """
-        if not (model is not None):
-            raise ValueError("model must be provided")
-        if not (model is not None):
+        if model is None:
             raise ValueError("model must be provided")
         super().__init__(model, horizon, dt)
 
@@ -341,9 +335,7 @@ class WholeBodyMPC(ModelPredictiveController):
             lower_limits: Lower joint limits.
             upper_limits: Upper joint limits.
         """
-        if not (lower_limits is not None):
-            raise ValueError("lower_limits must be provided")
-        if not (lower_limits is not None):
+        if lower_limits is None:
             raise ValueError("lower_limits must be provided")
         from src.research.mpc.controller import Constraint
 
@@ -370,9 +362,7 @@ class WholeBodyMPC(ModelPredictiveController):
         Args:
             torque_limits: Maximum torque magnitudes.
         """
-        if not (torque_limits is not None):
-            raise ValueError("torque_limits must be provided")
-        if not (torque_limits is not None):
+        if torque_limits is None:
             raise ValueError("torque_limits must be provided")
         from src.research.mpc.controller import Constraint
 
@@ -399,9 +389,7 @@ class WholeBodyMPC(ModelPredictiveController):
             MPC solution result.
         """
         # Convert EE targets to joint targets via IK
-        if not (initial_state is not None):
-            raise ValueError("initial_state must be provided")
-        if not (initial_state is not None):
+        if initial_state is None:
             raise ValueError("initial_state must be provided")
         if self._end_effector_targets and hasattr(self.model, "solve_ik"):
             # Use first EE target

--- a/src/research/multi_robot/coordination.py
+++ b/src/research/multi_robot/coordination.py
@@ -48,9 +48,7 @@ class FormationConfig:
         Returns:
             Line formation config.
         """
-        if not (n_robots is not None):
-            raise ValueError("n_robots must be provided")
-        if not (n_robots is not None):
+        if n_robots is None:
             raise ValueError("n_robots must be provided")
         positions = np.zeros((n_robots, 3))
         for i in range(n_robots):
@@ -73,9 +71,7 @@ class FormationConfig:
         Returns:
             Circle formation config.
         """
-        if not (n_robots is not None):
-            raise ValueError("n_robots must be provided")
-        if not (n_robots is not None):
+        if n_robots is None:
             raise ValueError("n_robots must be provided")
         positions = np.zeros((n_robots, 3))
         for i in range(n_robots):
@@ -102,9 +98,7 @@ class FormationConfig:
         Returns:
             Wedge formation config.
         """
-        if not (n_robots is not None):
-            raise ValueError("n_robots must be provided")
-        if not (n_robots is not None):
+        if n_robots is None:
             raise ValueError("n_robots must be provided")
         positions = np.zeros((n_robots, 3))
         positions[0] = [0, 0, 0]  # Leader at front
@@ -141,9 +135,7 @@ class FormationController:
             robots: List of robot IDs.
             formation: Formation configuration.
         """
-        if not (robots is not None):
-            raise ValueError("robots must be provided")
-        if not (robots is not None):
+        if robots is None:
             raise ValueError("robots must be provided")
         self.robots = robots
         self.formation = formation
@@ -188,9 +180,7 @@ class FormationController:
         Returns:
             Dictionary mapping robot IDs to velocity commands.
         """
-        if not (leader_pose is not None):
-            raise ValueError("leader_pose must be provided")
-        if not (leader_pose is not None):
+        if leader_pose is None:
             raise ValueError("leader_pose must be provided")
         commands = {}
 
@@ -244,9 +234,7 @@ class FormationController:
         Returns:
             3x3 rotation matrix.
         """
-        if not (quat is not None):
-            raise ValueError("quat must be provided")
-        if not (quat is not None):
+        if quat is None:
             raise ValueError("quat must be provided")
         w, x, y, z = quat
         return np.array(
@@ -291,9 +279,7 @@ class FormationController:
         Returns:
             Sum of position errors.
         """
-        if not (leader_pose is not None):
-            raise ValueError("leader_pose must be provided")
-        if not (leader_pose is not None):
+        if leader_pose is None:
             raise ValueError("leader_pose must be provided")
         total_error = 0.0
 
@@ -336,9 +322,7 @@ class CooperativeManipulation:
             robots: List of robot physics engines.
             object_model: Object model identifier.
         """
-        if not (robots is not None):
-            raise ValueError("robots must be provided")
-        if not (robots is not None):
+        if robots is None:
             raise ValueError("robots must be provided")
         self.robots = robots
         self._object_model = object_model
@@ -361,9 +345,7 @@ class CooperativeManipulation:
             grasp_points: Contact points in object frame.
             grasp_normals: Contact normals (optional).
         """
-        if not (grasp_points is not None):
-            raise ValueError("grasp_points must be provided")
-        if not (grasp_points is not None):
+        if grasp_points is None:
             raise ValueError("grasp_points must be provided")
         self._grasp_points = grasp_points
 
@@ -390,9 +372,7 @@ class CooperativeManipulation:
         Returns:
             Grasp matrix (6, 3*n_contacts).
         """
-        if not (object_pose is not None):
-            raise ValueError("object_pose must be provided")
-        if not (object_pose is not None):
+        if object_pose is None:
             raise ValueError("object_pose must be provided")
         n_contacts = len(self._grasp_points)
         G = np.zeros((6, 3 * n_contacts))
@@ -459,9 +439,7 @@ class CooperativeManipulation:
         Returns:
             List of force vectors for each contact.
         """
-        if not (desired_object_wrench is not None):
-            raise ValueError("desired_object_wrench must be provided")
-        if not (desired_object_wrench is not None):
+        if desired_object_wrench is None:
             raise ValueError("desired_object_wrench must be provided")
         G = self.compute_grasp_matrix(object_pose)
         n_contacts = len(self._grasp_points)
@@ -500,9 +478,7 @@ class CooperativeManipulation:
         Returns:
             List of end-effector trajectories, one per robot.
         """
-        if not (object_goal_pose is not None):
-            raise ValueError("object_goal_pose must be provided")
-        if not (object_goal_pose is not None):
+        if object_goal_pose is None:
             raise ValueError("object_goal_pose must be provided")
         n_steps = int(duration / dt)
         n_contacts = len(self._grasp_points)
@@ -561,9 +537,7 @@ class CooperativeManipulation:
         Returns:
             Interpolated quaternion.
         """
-        if not (q0 is not None):
-            raise ValueError("q0 must be provided")
-        if not (q0 is not None):
+        if q0 is None:
             raise ValueError("q0 must be provided")
         dot = np.dot(q0, q1)
 
@@ -590,9 +564,7 @@ class CooperativeManipulation:
         quat: NDArray[np.floating],
     ) -> NDArray[np.floating]:
         """Convert quaternion to rotation matrix."""
-        if not (quat is not None):
-            raise ValueError("quat must be provided")
-        if not (quat is not None):
+        if quat is None:
             raise ValueError("quat must be provided")
         w, x, y, z = quat
         return np.array(
@@ -629,9 +601,7 @@ class CooperativeManipulation:
         Returns:
             Tuple of (has_closure, quality_metric).
         """
-        if not (object_pose is not None):
-            raise ValueError("object_pose must be provided")
-        if not (object_pose is not None):
+        if object_pose is None:
             raise ValueError("object_pose must be provided")
         G = self.compute_grasp_matrix(object_pose)
 

--- a/src/research/multi_robot/system.py
+++ b/src/research/multi_robot/system.py
@@ -107,9 +107,7 @@ class TaskCoordinator:
         Returns:
             True if task was found and removed.
         """
-        if not (task_id is not None):
-            raise ValueError("task_id must be provided")
-        if not (task_id is not None):
+        if task_id is None:
             raise ValueError("task_id must be provided")
         if task_id in self._tasks:
             del self._tasks[task_id]
@@ -140,9 +138,7 @@ class TaskCoordinator:
         Returns:
             True if assignment was successful.
         """
-        if not (task_id is not None):
-            raise ValueError("task_id must be provided")
-        if not (task_id is not None):
+        if task_id is None:
             raise ValueError("task_id must be provided")
         if task_id not in self._tasks:
             return False
@@ -165,9 +161,7 @@ class TaskCoordinator:
         Returns:
             True if status was updated.
         """
-        if not (task_id is not None):
-            raise ValueError("task_id must be provided")
-        if not (task_id is not None):
+        if task_id is None:
             raise ValueError("task_id must be provided")
         if task_id not in self._tasks:
             return False
@@ -188,9 +182,7 @@ class TaskCoordinator:
         Returns:
             True if status was updated.
         """
-        if not (task_id is not None):
-            raise ValueError("task_id must be provided")
-        if not (task_id is not None):
+        if task_id is None:
             raise ValueError("task_id must be provided")
         if task_id not in self._tasks:
             return False
@@ -213,9 +205,7 @@ class TaskCoordinator:
         Returns:
             True if status was updated.
         """
-        if not (task_id is not None):
-            raise ValueError("task_id must be provided")
-        if not (task_id is not None):
+        if task_id is None:
             raise ValueError("task_id must be provided")
         if task_id not in self._tasks:
             return False
@@ -237,9 +227,7 @@ class TaskCoordinator:
         Returns:
             Assigned task or None.
         """
-        if not (robot_id is not None):
-            raise ValueError("robot_id must be provided")
-        if not (robot_id is not None):
+        if robot_id is None:
             raise ValueError("robot_id must be provided")
         task_id = self._robot_tasks.get(robot_id)
         if task_id:
@@ -297,9 +285,7 @@ class MultiRobotSystem:
             engine: Physics engine for this robot.
             base_pose: Initial base pose (7D: xyz + quaternion).
         """
-        if not (robot_id is not None):
-            raise ValueError("robot_id must be provided")
-        if not (robot_id is not None):
+        if robot_id is None:
             raise ValueError("robot_id must be provided")
         self._robots[robot_id] = engine
         self._robot_poses[robot_id] = base_pose.copy()
@@ -313,9 +299,7 @@ class MultiRobotSystem:
         Returns:
             True if robot was found and removed.
         """
-        if not (robot_id is not None):
-            raise ValueError("robot_id must be provided")
-        if not (robot_id is not None):
+        if robot_id is None:
             raise ValueError("robot_id must be provided")
         if robot_id in self._robots:
             del self._robots[robot_id]
@@ -383,9 +367,7 @@ class MultiRobotSystem:
         Returns:
             List of colliding robot pairs.
         """
-        if not (safety_distance is not None):
-            raise ValueError("safety_distance must be provided")
-        if not (safety_distance is not None):
+        if safety_distance is None:
             raise ValueError("safety_distance must be provided")
         collisions = []
         robot_ids = list(self._robots.keys())
@@ -415,9 +397,7 @@ class MultiRobotSystem:
         Returns:
             Dictionary mapping robot IDs to assigned tasks.
         """
-        if not (tasks is not None):
-            raise ValueError("tasks must be provided")
-        if not (tasks is not None):
+        if tasks is None:
             raise ValueError("tasks must be provided")
         allocation: dict[str, list[Task]] = {robot_id: [] for robot_id in self._robots}
 

--- a/tests/research/wave6_research/conftest.py
+++ b/tests/research/wave6_research/conftest.py
@@ -1,0 +1,47 @@
+"""Shared fixtures for wave6 research tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+class FakeEngine:
+    """Minimal physics engine stub for MPC/diff tests."""
+
+    def __init__(self, n_q: int = 2, n_v: int | None = None) -> None:
+        self.n_q = n_q
+        self.n_v = n_v if n_v is not None else n_q
+        self._q = np.zeros(self.n_q)
+        self._v = np.zeros(self.n_v)
+        self._tau = np.zeros(self.n_v)
+
+    def set_joint_positions(self, q):  # noqa: ANN001
+        self._q = np.asarray(q, dtype=float).copy()
+
+    def set_joint_velocities(self, v):  # noqa: ANN001
+        self._v = np.asarray(v, dtype=float).copy()
+
+    def set_joint_torques(self, tau):  # noqa: ANN001
+        self._tau = np.asarray(tau, dtype=float).copy()
+
+    def get_joint_positions(self):
+        return self._q.copy()
+
+    def get_joint_velocities(self):
+        return self._v.copy()
+
+    def step(self, dt: float) -> None:
+        # Linear: v += tau*dt (unit mass), q += v*dt
+        self._v = self._v + self._tau * dt
+        self._q = self._q + self._v * dt
+
+
+@pytest.fixture
+def fake_engine() -> FakeEngine:
+    return FakeEngine(n_q=2, n_v=2)
+
+
+@pytest.fixture
+def small_engine() -> FakeEngine:
+    return FakeEngine(n_q=1, n_v=1)

--- a/tests/research/wave6_research/test_deformable_objects.py
+++ b/tests/research/wave6_research/test_deformable_objects.py
@@ -1,0 +1,242 @@
+"""Tests for src/research/deformable/objects.py."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.research.deformable.objects import (
+    Cable,
+    Cloth,
+    MaterialProperties,
+    SoftBody,
+)
+
+
+class TestGuards:
+    def test_soft_body_none_mesh(self) -> None:
+        with pytest.raises(ValueError, match="mesh"):
+            SoftBody(None, np.array([[0, 1, 2, 3]]), MaterialProperties())  # type: ignore[arg-type]
+
+    def test_cable_none_mesh(self) -> None:
+        with pytest.raises(ValueError, match="mesh"):
+            Cable(None, MaterialProperties())  # type: ignore[arg-type]
+
+    def test_cloth_none_mesh(self) -> None:
+        with pytest.raises(ValueError, match="mesh"):
+            Cloth(None, 2, 2, MaterialProperties())  # type: ignore[arg-type]
+
+
+class TestMaterialProperties:
+    def test_defaults(self) -> None:
+        mp = MaterialProperties()
+        assert mp.youngs_modulus == 1e6
+        assert mp.poisson_ratio == 0.3
+        assert mp.density == 1000.0
+        assert mp.bending_stiffness is None
+
+    def test_shear_modulus(self) -> None:
+        mp = MaterialProperties(youngs_modulus=2.6e6, poisson_ratio=0.3)
+        assert mp.shear_modulus == pytest.approx(2.6e6 / (2 * 1.3))
+
+    def test_bulk_modulus(self) -> None:
+        mp = MaterialProperties(youngs_modulus=3e6, poisson_ratio=0.2)
+        assert mp.bulk_modulus == pytest.approx(3e6 / (3 * 0.6))
+
+
+@pytest.fixture
+def tet_mesh() -> tuple[np.ndarray, np.ndarray]:
+    # Single tetrahedron
+    mesh = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    tets = np.array([[0, 1, 2, 3]])
+    return mesh, tets
+
+
+class TestSoftBody:
+    def test_construction(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        assert sb.n_nodes == 4
+        np.testing.assert_allclose(sb.mesh, mesh)
+        assert sb.material.density == 1000.0
+        # rest volume = 1/6 for unit tet
+        assert sb._rest_volumes[0] == pytest.approx(1 / 6)
+
+    def test_get_set_positions(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        pos = sb.get_node_positions()
+        assert pos.shape == (4, 3)
+        new_pos = pos + 0.5
+        sb.set_node_positions(new_pos)
+        np.testing.assert_allclose(sb.get_node_positions(), new_pos)
+
+    def test_velocities_start_zero(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        np.testing.assert_allclose(sb.get_node_velocities(), 0.0)
+
+    def test_apply_external_force_array(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        sb.apply_external_force([0, 1], np.array([[1.0, 0, 0], [0, 1, 0]]))
+        assert sb._external_forces[0, 0] == 1.0
+        assert sb._external_forces[1, 1] == 1.0
+
+    def test_apply_external_force_broadcast(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        sb.apply_external_force([0, 1, 2], np.array([0.0, 0, -1.0]))
+        assert sb._external_forces[0, 2] == -1.0
+        assert sb._external_forces[2, 2] == -1.0
+
+    def test_clear_external_forces(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        sb.apply_external_force([0], np.array([1.0, 1, 1]))
+        sb.clear_external_forces()
+        np.testing.assert_allclose(sb._external_forces, 0.0)
+
+    def test_fix_unfix_nodes(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        sb.fix_nodes([0, 1])
+        assert sb._fixed_nodes == {0, 1}
+        sb.unfix_nodes([0])
+        assert sb._fixed_nodes == {1}
+
+    def test_compute_internal_forces_at_rest(self, tet_mesh) -> None:
+        # At rest, F=I -> P=0 -> forces approximately zero
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        forces = sb.compute_internal_forces()
+        assert forces.shape == (4, 3)
+        # neo-hookean at F=I gives mu*(I - I^-T) + lam*log(1)*I^-T = 0
+        np.testing.assert_allclose(forces, 0.0, atol=1e-8)
+
+    def test_step_stable(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties(damping=0.5))
+        sb.fix_nodes([0])
+        sb.step(1e-4)
+        # node 0 stays fixed
+        np.testing.assert_allclose(sb.mesh[0], mesh[0])
+
+    def test_reset(self, tet_mesh) -> None:
+        mesh, tets = tet_mesh
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        sb.set_node_positions(mesh + 5)
+        sb._velocities += 2.0
+        sb.reset()
+        np.testing.assert_allclose(sb.mesh, mesh)
+        np.testing.assert_allclose(sb.get_node_velocities(), 0.0)
+
+    def test_degenerate_shape_matrix(self) -> None:
+        # Degenerate tet (coplanar) should not crash
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]], dtype=float)
+        tets = np.array([[0, 1, 2, 3]])
+        sb = SoftBody(mesh, tets, MaterialProperties())
+        assert sb._B_matrices[0].shape == (3, 3)
+
+
+class TestCable:
+    def test_construction(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+        c = Cable(mesh, MaterialProperties())
+        assert c.n_nodes == 3
+        assert c.rest_length == pytest.approx(2.0)
+
+    def test_custom_rest_lengths(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+        rest = np.array([0.5, 0.5])
+        c = Cable(mesh, MaterialProperties(), rest_lengths=rest)
+        assert c.rest_length == pytest.approx(1.0)
+
+    def test_get_length_at_rest(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+        c = Cable(mesh, MaterialProperties())
+        assert c.get_length() == pytest.approx(2.0)
+
+    def test_get_tension(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+        c = Cable(mesh, MaterialProperties())
+        # No stretch -> tension ~0
+        assert c.get_tension() == pytest.approx(0.0)
+
+    def test_compute_internal_forces_when_stretched(self) -> None:
+        mesh = np.array([[0, 0, 0], [2.0, 0, 0]], dtype=float)
+        rest = np.array([1.0])
+        c = Cable(mesh, MaterialProperties(youngs_modulus=100.0), rest_lengths=rest)
+        f = c.compute_internal_forces()
+        # Pulls inward
+        assert f[0, 0] > 0
+        assert f[1, 0] < 0
+
+    def test_step_with_fixed(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+        c = Cable(mesh, MaterialProperties(damping=0.1))
+        c.fix_nodes([0])
+        c.step(1e-3)
+        np.testing.assert_allclose(c.mesh[0], mesh[0])
+
+    def test_bending_forces_in_straight_cable(self) -> None:
+        mesh = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+        c = Cable(mesh, MaterialProperties())
+        f = c.compute_internal_forces()
+        # Straight cable: cos_angle == 1, so bending contribution is zero
+        assert np.allclose(f, 0.0)
+
+
+class TestCloth:
+    def _grid_mesh(self, w: int = 3, h: int = 3) -> np.ndarray:
+        pts = []
+        for y in range(h):
+            for x in range(w):
+                pts.append([float(x), float(y), 0.0])
+        return np.array(pts)
+
+    def test_construction(self) -> None:
+        mesh = self._grid_mesh(3, 3)
+        cl = Cloth(mesh, 3, 3, MaterialProperties())
+        assert cl.width == 3
+        assert cl.height == 3
+        assert cl.n_nodes == 9
+        # springs: stretch (12) + shear (8) + bend (6) = 26
+        types = {t for _, _, _, t in cl._springs}
+        assert types == {"stretch", "shear", "bend"}
+
+    def test_compute_internal_forces_at_rest(self) -> None:
+        mesh = self._grid_mesh(3, 3)
+        cl = Cloth(mesh, 3, 3, MaterialProperties())
+        f = cl.compute_internal_forces()
+        np.testing.assert_allclose(f, 0.0, atol=1e-10)
+
+    def test_step(self) -> None:
+        mesh = self._grid_mesh(3, 3)
+        cl = Cloth(mesh, 3, 3, MaterialProperties(damping=0.05))
+        cl.fix_nodes([0])
+        cl.step(1e-4)
+        np.testing.assert_allclose(cl.mesh[0], mesh[0])
+
+    def test_attach_to_body(self) -> None:
+        mesh = self._grid_mesh(2, 2)
+        cl = Cloth(mesh, 2, 2, MaterialProperties())
+        new_pos = np.array([[5, 5, 5], [6, 5, 5]], dtype=float)
+        cl.attach_to_body("b1", [0, 1], new_pos)
+        np.testing.assert_allclose(cl.mesh[0], [5, 5, 5])
+        assert 0 in cl._fixed_nodes
+        assert 1 in cl._fixed_nodes
+
+    def test_degenerate_spring_skipped(self) -> None:
+        # Coincident nodes -> length<1e-10 -> skipped
+        mesh = np.zeros((4, 3))
+        cl = Cloth(mesh, 2, 2, MaterialProperties())
+        f = cl.compute_internal_forces()
+        np.testing.assert_allclose(f, 0.0)

--- a/tests/research/wave6_research/test_differentiable.py
+++ b/tests/research/wave6_research/test_differentiable.py
@@ -1,0 +1,203 @@
+"""Tests for src/research/differentiable/engine.py."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.research.differentiable.engine import (
+    AutodiffBackend,
+    ContactDifferentiableEngine,
+    DifferentiableEngine,
+    OptimizationResult,
+)
+
+
+class TestAutodiffBackend:
+    def test_values(self) -> None:
+        assert AutodiffBackend("numpy") is AutodiffBackend.NUMPY
+        assert AutodiffBackend("jax") is AutodiffBackend.JAX
+        assert AutodiffBackend("torch") is AutodiffBackend.TORCH
+
+
+class TestOptimizationResult:
+    def test_fields(self) -> None:
+        r = OptimizationResult(
+            success=True,
+            optimal_states=np.zeros((3, 4)),
+            optimal_controls=np.zeros((2, 2)),
+            final_cost=0.5,
+            iterations=3,
+            gradient_norm=0.01,
+        )
+        assert r.success is True
+        assert r.iterations == 3
+
+
+class TestDifferentiableEngine:
+    def test_construction(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine, backend="numpy")
+        assert de._n_q == 2
+        assert de._n_v == 2
+        assert de._n_x == 4
+        assert de._n_u == 2
+
+    def test_no_n_q(self) -> None:
+        class Bare:
+            pass
+
+        de = DifferentiableEngine(Bare())
+        assert de._n_q == 7
+        assert de._n_v == 7
+
+    def test_simulate_trajectory(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine)
+        x0 = np.zeros(4)
+        u = np.zeros((3, 2))
+        traj = de.simulate_trajectory(x0, u, dt=0.01)
+        assert traj.shape == (4, 4)
+        np.testing.assert_allclose(traj[0], x0)
+
+    def test_compute_gradient_shape(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine)
+        x0 = np.zeros(4)
+        u = np.zeros((2, 2))
+
+        def loss(traj):  # noqa: ANN001
+            return float(np.sum(traj**2))
+
+        g = de.compute_gradient(x0, u, loss, dt=0.01)
+        assert g.shape == (2, 2)
+
+    def test_compute_jacobian(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine)
+        A, B = de.compute_jacobian(np.zeros(4), np.zeros(2), dt=0.01)
+        assert A.shape == (4, 4)
+        assert B.shape == (4, 2)
+
+    def test_optimize_trajectory_adam(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine)
+        x0 = np.zeros(4)
+        # Nonzero goal so gradient is nontrivial and Adam update path runs
+        goal = np.array([0.5, 0.5, 0.0, 0.0])
+        res = de.optimize_trajectory(
+            x0, goal, horizon=2, dt=0.01, method="adam", max_iterations=2
+        )
+        assert isinstance(res, OptimizationResult)
+        assert res.optimal_controls.shape == (2, 2)
+
+    def test_optimize_trajectory_sgd(self, fake_engine) -> None:
+        de = DifferentiableEngine(fake_engine)
+        res = de.optimize_trajectory(
+            np.zeros(4),
+            np.array([0.5, 0.0, 0.0, 0.0]),
+            horizon=2,
+            method="sgd",
+            max_iterations=2,
+        )
+        assert isinstance(res, OptimizationResult)
+
+    def test_optimize_through_contact_nontrivial(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(
+            fake_engine, contact_method="smoothed", smoothing_factor=0.01
+        )
+        # Pass nonzero goal so adam update path executes
+        res = cd.optimize_through_contact(
+            initial_state=np.zeros(4),
+            goal_state=np.array([0.3, 0.0, 0.0, 0.0]),
+            contact_schedule=[True, False],
+            horizon=2,
+            dt=0.01,
+        )
+        assert isinstance(res, OptimizationResult)
+
+
+class TestContactDifferentiableEngine:
+    def test_construction(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(
+            fake_engine, contact_method="smoothed", smoothing_factor=0.02
+        )
+        assert cd.contact_method == "smoothed"
+        assert cd.smoothing_factor == 0.02
+
+    def test_compute_gradient_smoothed(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine, contact_method="smoothed")
+        u = np.zeros((2, 2))
+
+        def loss(traj):  # noqa: ANN001
+            return float(np.sum(traj**2))
+
+        g = cd.compute_gradient(np.zeros(4), u, loss, dt=0.01)
+        assert g.shape == (2, 2)
+
+    def test_compute_gradient_stochastic(self, fake_engine) -> None:
+        np.random.seed(0)
+        cd = ContactDifferentiableEngine(fake_engine, contact_method="stochastic")
+        u = np.zeros((2, 2))
+
+        def loss(traj):  # noqa: ANN001
+            return float(np.sum(traj**2))
+
+        g = cd.compute_gradient(np.zeros(4), u, loss, dt=0.01)
+        assert g.shape == (2, 2)
+
+    def test_compute_gradient_randomized(self, fake_engine, monkeypatch) -> None:
+        np.random.seed(0)
+        cd = ContactDifferentiableEngine(fake_engine, contact_method="randomized")
+        u = np.zeros((1, 2))
+
+        def loss(traj):  # noqa: ANN001
+            return float(np.sum(traj**2))
+
+        # Reduce n_samples by monkeypatching the parent compute_gradient call indirectly:
+        # we just run with default 10 samples but only horizon=1 so it's fast.
+        g = cd.compute_gradient(np.zeros(4), u, loss, dt=0.01)
+        assert g.shape == (1, 2)
+
+    def test_pad_contact_schedule_truncate(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine)
+        assert cd._pad_contact_schedule([True, False, True], 2) == [True, False]
+
+    def test_pad_contact_schedule_extend(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine)
+        assert cd._pad_contact_schedule([True], 3) == [True, False, False]
+
+    def test_build_contact_loss_no_transitions(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine)
+        loss = cd._build_contact_loss(np.zeros(4), [False, False, False], 1.0)
+        traj = np.zeros((4, 4))
+        traj[-1] = [1, 0, 0, 0]
+        # No transitions; just goal error = 1
+        assert loss(traj) == pytest.approx(1.0)
+
+    def test_build_contact_loss_with_transition(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine)
+        loss = cd._build_contact_loss(np.zeros(4), [True, False, False], 0.5)
+        traj = np.zeros((4, 4))
+        traj[2, 2:] = [1.0, 0.0]  # v_curr
+        traj[3, 2:] = [2.0, 0.0]  # v_next
+        # transition at t=0; v diff = [1,0] -> penalty = 0.5
+        # final goal error = ||traj[-1] - 0||^2 = 4
+        assert loss(traj) == pytest.approx(4.5)
+
+    def test_apply_phase_smoothing(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(fake_engine, smoothing_factor=0.01)
+        cd._apply_phase_smoothing([True, False], 0.01, 5.0)
+        assert cd.smoothing_factor == 0.05
+        cd._apply_phase_smoothing([False, False], 0.01, 5.0)
+        assert cd.smoothing_factor == 0.01
+
+    def test_optimize_through_contact(self, fake_engine) -> None:
+        cd = ContactDifferentiableEngine(
+            fake_engine, contact_method="smoothed", smoothing_factor=0.01
+        )
+        res = cd.optimize_through_contact(
+            initial_state=np.zeros(4),
+            goal_state=np.zeros(4),
+            contact_schedule=[False, True],
+            horizon=2,
+            dt=0.01,
+        )
+        assert isinstance(res, OptimizationResult)
+        # smoothing reset
+        assert cd.smoothing_factor == 0.01

--- a/tests/research/wave6_research/test_mpc.py
+++ b/tests/research/wave6_research/test_mpc.py
@@ -1,0 +1,318 @@
+"""Tests for src/research/mpc/*."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.research.mpc.controller import (
+    Constraint,
+    CostFunction,
+    ModelPredictiveController,
+    MPCResult,
+)
+from src.research.mpc.specialized import (
+    CentroidalMPC,
+    CentroidalState,
+    WholeBodyMPC,
+)
+
+
+class TestCostFunction:
+    def test_running_cost_no_ref(self) -> None:
+        cf = CostFunction(Q=np.eye(2), R=np.eye(1))
+        c = cf.evaluate_running_cost(np.array([1.0, 0.0]), np.array([2.0]))
+        assert c == pytest.approx(1.0 + 4.0)
+
+    def test_running_cost_with_ref_1d(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            x_ref=np.array([1.0, 1.0]),
+            u_ref=np.array([0.5]),
+        )
+        c = cf.evaluate_running_cost(np.array([2.0, 1.0]), np.array([0.5]))
+        assert c == pytest.approx(1.0)
+
+    def test_running_cost_with_traj_ref(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            x_ref=np.array([[0.0, 0.0], [1.0, 1.0]]),
+            u_ref=np.array([[0.0], [1.0]]),
+        )
+        c = cf.evaluate_running_cost(np.array([1.0, 1.0]), np.array([1.0]), k=1)
+        assert c == pytest.approx(0.0)
+
+    def test_running_cost_ref_past_horizon(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            x_ref=np.array([[1.0, 1.0]]),
+            u_ref=np.array([[0.0]]),
+        )
+        # k beyond, uses last
+        c = cf.evaluate_running_cost(np.array([1.0, 1.0]), np.array([0.0]), k=5)
+        assert c == pytest.approx(0.0)
+
+    def test_running_cost_linear_terms(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            q=np.array([1.0, 0.0]),
+            r=np.array([2.0]),
+        )
+        c = cf.evaluate_running_cost(np.array([1.0, 0.0]), np.array([1.0]))
+        # x^T Q x = 1; q.x = 1; u^T R u = 1; r.u = 2 -> total 5
+        assert c == pytest.approx(5.0)
+
+    def test_terminal_cost_zero_when_no_P(self) -> None:
+        cf = CostFunction(Q=np.eye(2), R=np.eye(1))
+        assert cf.evaluate_terminal_cost(np.array([3.0, 4.0])) == 0.0
+
+    def test_terminal_cost_with_P_and_ref(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            P=2 * np.eye(2),
+            x_ref=np.array([1.0, 1.0]),
+            p=np.array([1.0, 0.0]),
+        )
+        c = cf.evaluate_terminal_cost(np.array([2.0, 1.0]))
+        # x_err = [1,0]; x.P.x = 2; p.x_err = 1 -> 3
+        assert c == pytest.approx(3.0)
+
+    def test_terminal_cost_traj_ref(self) -> None:
+        cf = CostFunction(
+            Q=np.eye(2),
+            R=np.eye(1),
+            P=np.eye(2),
+            x_ref=np.array([[0.0, 0.0], [1.0, 1.0]]),
+        )
+        c = cf.evaluate_terminal_cost(np.array([1.0, 1.0]))
+        assert c == pytest.approx(0.0)
+
+
+class TestConstraint:
+    def test_default(self) -> None:
+        c = Constraint()
+        assert c.constraint_type == "mixed"
+        assert c.A is None and c.B is None
+
+
+class TestMPCResult:
+    def test_defaults(self) -> None:
+        r = MPCResult(
+            success=True, optimal_states=None, optimal_controls=None, cost=0.0
+        )
+        assert r.solve_time == 0.0
+        assert r.iterations == 0
+
+
+class TestModelPredictiveController:
+    def test_construction(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=5, dt=0.05)
+        assert mpc.n_states == 4
+        assert mpc.n_controls == 2
+        assert mpc.horizon == 5
+
+    def test_no_n_q_attr(self) -> None:
+        class Bare:
+            pass
+
+        mpc = ModelPredictiveController(Bare(), horizon=2)
+        assert mpc.n_states == 14
+        assert mpc.n_controls == 7
+
+    def test_set_cost_and_constraints(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=3)
+        cf = CostFunction(Q=np.eye(4), R=np.eye(2), P=np.eye(4))
+        mpc.set_cost_function(cf)
+        assert mpc._cost is cf
+
+        c1 = Constraint(B=np.eye(2), ub=np.ones(2))
+        mpc.add_constraint(c1)
+        assert len(mpc._constraints) == 1
+        mpc.set_constraints([c1, c1])
+        assert len(mpc._constraints) == 2
+        mpc.clear_constraints()
+        assert mpc._constraints == []
+
+    def test_solve_raises_without_cost(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=3)
+        with pytest.raises(ValueError, match="Cost function not set"):
+            mpc.solve(np.zeros(4))
+
+    def test_solve_runs(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=3, dt=0.05)
+        mpc._max_iterations = 2  # speed
+        cf = CostFunction(
+            Q=np.eye(4),
+            R=np.eye(2) * 0.01,
+            P=np.eye(4),
+        )
+        mpc.set_cost_function(cf)
+        result = mpc.solve(np.array([1.0, 0.0, 0.0, 0.0]))
+        assert isinstance(result, MPCResult)
+        assert result.optimal_states.shape == (4, 4)
+        assert result.optimal_controls.shape == (3, 2)
+        assert result.solve_time >= 0
+
+    def test_solve_with_reference(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=2, dt=0.05)
+        mpc._max_iterations = 1
+        cf = CostFunction(Q=np.eye(4), R=np.eye(2) * 0.01)
+        mpc.set_cost_function(cf)
+        ref = np.zeros((3, 4))
+        res = mpc.solve(np.zeros(4), reference_trajectory=ref)
+        assert res.optimal_states is not None
+
+    def test_get_first_control(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine)
+        r = MPCResult(
+            success=True,
+            optimal_states=None,
+            optimal_controls=np.array([[1.0, 2.0], [3.0, 4.0]]),
+            cost=0.0,
+        )
+        u = mpc.get_first_control(r)
+        np.testing.assert_allclose(u, [1.0, 2.0])
+
+    def test_get_first_control_empty(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine)
+        r = MPCResult(success=False, optimal_states=None, optimal_controls=None, cost=0)
+        u = mpc.get_first_control(r)
+        assert u.shape == (2,)
+        np.testing.assert_allclose(u, 0.0)
+
+    def test_constraint_violation_bounds(self, fake_engine) -> None:
+        mpc = ModelPredictiveController(fake_engine, horizon=2, dt=0.05)
+        mpc._max_iterations = 1
+        cf = CostFunction(Q=np.eye(4), R=np.eye(2) * 0.01)
+        mpc.set_cost_function(cf)
+        # Constraint that will be violated: u <= -100
+        mpc.add_constraint(Constraint(B=np.eye(2)[:1, :], ub=np.array([-100.0])))
+        res = mpc.solve(np.zeros(4))
+        assert res.constraint_violations >= 0
+
+    def test_dynamics_fallback_no_attrs(self) -> None:
+        class Bare:
+            n_q = 2
+            n_v = 2
+
+        mpc = ModelPredictiveController(Bare(), horizon=1, dt=0.1)
+        # _dynamics on a bare engine uses fallback q+v*dt
+        x_next = mpc._dynamics(np.array([0, 0, 1.0, 1.0]), np.zeros(2))
+        np.testing.assert_allclose(x_next[:2], [0.1, 0.1])
+        np.testing.assert_allclose(x_next[2:], [1.0, 1.0])
+
+
+class TestCentroidalState:
+    def test_construction(self) -> None:
+        s = CentroidalState(
+            com_position=np.zeros(3),
+            com_velocity=np.zeros(3),
+            angular_momentum=np.zeros(3),
+            contact_forces={"l": np.zeros(3)},
+        )
+        assert s.com_position.shape == (3,)
+        assert "l" in s.contact_forces
+
+
+class TestCentroidalMPC:
+    def test_construction(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=4, dt=0.05, n_contacts=2)
+        assert cmpc.n_states == 9
+        assert cmpc.n_controls == 6
+        assert cmpc._cost is not None
+        assert cmpc._mass == 50.0
+
+    def test_set_mass(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=2)
+        cmpc.set_mass(80.0)
+        assert cmpc._mass == 80.0
+
+    def test_update_contact_positions(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=2)
+        new_pos = [np.array([1, 0, 0.0]), np.array([0, 1, 0.0])]
+        cmpc.update_contact_positions(new_pos)
+        assert cmpc._contact_positions[0][0] == 1
+
+    def test_dynamics(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=2, dt=0.01, n_contacts=2)
+        x = np.zeros(9)
+        x[2] = 1.0  # com z
+        u = np.zeros(6)
+        u[2] = 50.0 * 9.81  # gravity-cancelling normal force
+        x_next = cmpc._dynamics(x, u)
+        assert x_next.shape == (9,)
+        # acceleration ~ 0 -> velocity ~0
+        np.testing.assert_allclose(x_next[3:6], 0.0, atol=1e-6)
+
+    def test_friction_cone_constraints(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=2, n_contacts=2)
+        cmpc.add_friction_cone_constraints()
+        # 2 contacts * (1 normal + 2 axes * 1 constraint pair) = 6 constraints
+        assert len(cmpc._constraints) == 6
+
+    def test_set_gait_reference(self, fake_engine) -> None:
+        cmpc = CentroidalMPC(fake_engine, horizon=5)
+        cmpc.set_gait_reference(np.array([0.5, 0.0]), target_height=1.0)
+        assert cmpc._cost.x_ref is not None
+        assert cmpc._cost.x_ref.shape == (6, 9)
+        assert cmpc._cost.x_ref[0, 2] == 1.0
+        # CoM moves
+        assert cmpc._cost.x_ref[-1, 0] > cmpc._cost.x_ref[0, 0]
+
+
+class TestWholeBodyMPC:
+    def test_construction(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine, horizon=3, dt=0.01)
+        assert wb._cost is not None
+        assert wb.n_states == 4
+
+    def test_set_end_effector_target(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine)
+        target = np.array([0.5, 0, 0.5, 1, 0, 0, 0.0])
+        wb.set_end_effector_target("ee", target)
+        assert "ee" in wb._end_effector_targets
+
+    def test_set_joint_targets_with_vel(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine)
+        wb.set_joint_targets(np.array([0.1, 0.2]), np.array([0.0, 0.0]))
+        assert wb._cost.x_ref.shape == (4,)
+
+    def test_set_joint_targets_default_vel(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine)
+        wb.set_joint_targets(np.array([0.5, 0.5]))
+        assert wb._cost.x_ref[2] == 0.0
+
+    def test_joint_limit_constraints(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine)
+        wb.add_joint_limit_constraints(np.array([-1.0, -1.0]), np.array([1.0, 1.0]))
+        assert len(wb._constraints) == 1
+
+    def test_torque_limit_constraints(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine)
+        wb.add_torque_limit_constraints(np.array([5.0, 5.0]))
+        assert len(wb._constraints) == 1
+
+    def test_solve_with_ee_tracking_no_ik(self, fake_engine) -> None:
+        wb = WholeBodyMPC(fake_engine, horizon=2, dt=0.05)
+        wb._max_iterations = 1
+        res = wb.solve_with_ee_tracking(np.zeros(4))
+        assert isinstance(res, MPCResult)
+
+    def test_solve_with_ee_tracking_with_ik(self, fake_engine) -> None:
+        class IkEngine:
+            n_q = 2
+            n_v = 2
+
+            def solve_ik(self, name, target):  # noqa: ANN001
+                return np.array([0.3, 0.3]), True
+
+        wb = WholeBodyMPC(IkEngine(), horizon=2, dt=0.05)
+        wb._max_iterations = 1
+        wb.set_end_effector_target("ee", np.array([0.0, 0, 0, 1, 0, 0, 0.0]))
+        res = wb.solve_with_ee_tracking(np.zeros(4))
+        assert isinstance(res, MPCResult)

--- a/tests/research/wave6_research/test_multi_robot.py
+++ b/tests/research/wave6_research/test_multi_robot.py
@@ -1,0 +1,349 @@
+"""Tests for src/research/multi_robot/*."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.research.multi_robot.coordination import (
+    CooperativeManipulation,
+    FormationConfig,
+    FormationController,
+)
+from src.research.multi_robot.system import (
+    MultiRobotSystem,
+    Task,
+    TaskCoordinator,
+    TaskStatus,
+    TaskType,
+)
+
+
+class TestFormationConfig:
+    def test_line_formation(self) -> None:
+        c = FormationConfig.line_formation(3, spacing=2.0)
+        assert c.name == "line"
+        assert c.positions.shape == (3, 3)
+        assert c.positions[2, 1] == 4.0
+
+    def test_circle_formation(self) -> None:
+        c = FormationConfig.circle_formation(4, radius=1.0)
+        assert c.name == "circle"
+        # each robot at distance ~1 from origin
+        dists = np.linalg.norm(c.positions[:, :2], axis=1)
+        np.testing.assert_allclose(dists, 1.0)
+
+    def test_wedge_formation(self) -> None:
+        c = FormationConfig.wedge_formation(5, spacing=1.0, angle=0.5)
+        assert c.name == "wedge"
+        np.testing.assert_allclose(c.positions[0], 0.0)
+        # second/third robots symmetric on y
+        assert c.positions[1, 1] == -c.positions[2, 1]
+
+
+class TestFormationController:
+    def test_construction(self) -> None:
+        f = FormationConfig.line_formation(2)
+        fc = FormationController(["a", "b"], f)
+        assert fc.robots == ["a", "b"]
+        assert fc.formation is f
+
+    def test_set_gains(self) -> None:
+        f = FormationConfig.line_formation(1)
+        fc = FormationController(["a"], f)
+        fc.set_gains(position=5.0, velocity=2.0, heading=3.0)
+        assert fc._gains["position"] == 5.0
+
+    def test_compute_formation_control(self) -> None:
+        f = FormationConfig.line_formation(2, spacing=1.0)
+        fc = FormationController(["a", "b"], f)
+        leader_pose = np.array([0.0, 0, 0, 1, 0, 0, 0])
+        positions = {"a": np.array([0.0, 0, 0]), "b": np.array([0.0, 0.5, 0])}
+        cmds = fc.compute_formation_control(leader_pose, positions)
+        # b should be commanded to move further along +y to reach desired
+        assert cmds["b"][1] > 0
+
+    def test_compute_formation_with_velocities(self) -> None:
+        f = FormationConfig.line_formation(1)
+        fc = FormationController(["a"], f)
+        cmds = fc.compute_formation_control(
+            np.array([0.0, 0, 0]),
+            {"a": np.zeros(3)},
+            {"a": np.array([1.0, 0, 0])},
+        )
+        # velocity damping subtracts
+        assert cmds["a"][0] < 0
+
+    def test_compute_formation_missing_robot(self) -> None:
+        f = FormationConfig.line_formation(2)
+        fc = FormationController(["a", "b"], f)
+        cmds = fc.compute_formation_control(np.zeros(3), {"a": np.zeros(3)})
+        assert "b" not in cmds
+
+    def test_quat_to_rotation_identity(self) -> None:
+        f = FormationConfig.line_formation(1)
+        fc = FormationController(["a"], f)
+        R = fc._quat_to_rotation(np.array([1.0, 0, 0, 0]))
+        np.testing.assert_allclose(R, np.eye(3))
+
+    def test_set_formation(self) -> None:
+        f1 = FormationConfig.line_formation(2)
+        f2 = FormationConfig.circle_formation(2)
+        fc = FormationController(["a", "b"], f1)
+        fc.set_formation(f2)
+        assert fc.formation is f2
+
+    def test_get_formation_error(self) -> None:
+        f = FormationConfig.line_formation(2, spacing=1.0)
+        fc = FormationController(["a", "b"], f)
+        # perfect formation
+        leader = np.array([0.0, 0, 0])
+        positions = {
+            "a": np.array([0.0, 0, 0]),
+            "b": np.array([0.0, 1.0, 0]),
+        }
+        err = fc.get_formation_error(leader, positions)
+        assert err == pytest.approx(0.0, abs=1e-9)
+
+    def test_get_formation_error_missing(self) -> None:
+        f = FormationConfig.line_formation(2)
+        fc = FormationController(["a", "b"], f)
+        err = fc.get_formation_error(np.zeros(7), {"a": np.zeros(3)})
+        assert err == 0.0
+
+
+class TestCooperativeManipulation:
+    def test_construction(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        assert cm.n_robots == 2
+
+    def test_set_grasp_points_default_normals(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        cm.set_grasp_points([np.array([1.0, 0, 0]), np.array([-1.0, 0, 0])])
+        assert len(cm._grasp_normals) == 2
+        # normals point toward each other
+        assert cm._grasp_normals[0][0] < 0
+        assert cm._grasp_normals[1][0] > 0
+
+    def test_set_grasp_points_explicit_normals(self) -> None:
+        cm = CooperativeManipulation(["r1"])
+        normals = [np.array([0.0, 0, 1.0])]
+        cm.set_grasp_points([np.zeros(3)], grasp_normals=normals)
+        assert cm._grasp_normals[0][2] == 1.0
+
+    def test_compute_grasp_matrix(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        cm.set_grasp_points([np.array([1.0, 0, 0]), np.array([-1.0, 0, 0])])
+        G = cm.compute_grasp_matrix(np.array([0.0, 0, 0, 1, 0, 0, 0]))
+        assert G.shape == (6, 6)
+
+    def test_compute_load_sharing(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        cm.set_grasp_points([np.array([1.0, 0, 0]), np.array([-1.0, 0, 0])])
+        forces = cm.compute_load_sharing(
+            np.array([0.0, 0, 10, 0, 0, 0]),
+            np.array([0.0, 0, 0, 1, 0, 0, 0]),
+        )
+        assert len(forces) == 2
+        # total z force ~ 10
+        z_total = forces[0][2] + forces[1][2]
+        assert z_total == pytest.approx(10.0, rel=1e-3)
+
+    def test_plan_cooperative_motion(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        cm.set_grasp_points([np.array([1.0, 0, 0]), np.array([-1.0, 0, 0])])
+        trajs = cm.plan_cooperative_motion(
+            object_goal_pose=np.array([1.0, 0, 0, 1, 0, 0, 0]),
+            object_current_pose=np.array([0.0, 0, 0, 1, 0, 0, 0]),
+            dt=0.1,
+            duration=0.5,
+        )
+        assert len(trajs) == 2
+        assert trajs[0].shape[1] == 7
+        assert trajs[0].shape[0] >= 2
+
+    def test_slerp_identical(self) -> None:
+        cm = CooperativeManipulation(["r1"])
+        q = np.array([1.0, 0, 0, 0])
+        out = cm._slerp(q, q, 0.5)
+        np.testing.assert_allclose(out, q, atol=1e-9)
+
+    def test_slerp_negative_dot(self) -> None:
+        cm = CooperativeManipulation(["r1"])
+        q0 = np.array([1.0, 0, 0, 0])
+        q1 = np.array([-1.0, 0, 0, 0])  # negative dot -> negate
+        out = cm._slerp(q0, q1, 0.5)
+        assert np.linalg.norm(out) == pytest.approx(1.0, rel=1e-6)
+
+    def test_slerp_orthogonal(self) -> None:
+        cm = CooperativeManipulation(["r1"])
+        q0 = np.array([1.0, 0, 0, 0])
+        q1 = np.array([0.0, 1, 0, 0])
+        out = cm._slerp(q0, q1, 0.5)
+        # midway, magnitude one
+        assert np.linalg.norm(out) == pytest.approx(1.0, rel=1e-6)
+
+    def test_check_force_closure(self) -> None:
+        cm = CooperativeManipulation(["r1", "r2"])
+        cm.set_grasp_points([np.array([1.0, 0, 0]), np.array([-1.0, 0, 0])])
+        has, qual = cm.check_force_closure(np.array([0.0, 0, 0, 1, 0, 0, 0]))
+        assert bool(has) in (True, False)
+        assert qual >= 0
+
+
+class TestTask:
+    def test_is_ready_no_deps(self) -> None:
+        t = Task("t1", TaskType.MOVE_TO)
+        assert t.is_ready(set())
+
+    def test_is_ready_with_deps(self) -> None:
+        t = Task("t2", TaskType.PICK, dependencies=["t1"])
+        assert not t.is_ready(set())
+        assert t.is_ready({"t1"})
+
+
+class TestTaskCoordinator:
+    def test_add_remove(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.MOVE_TO))
+        assert c.remove_task("t1")
+        assert not c.remove_task("missing")
+
+    def test_get_ready_priority_sorted(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("a", TaskType.WAIT, priority=1))
+        c.add_task(Task("b", TaskType.WAIT, priority=5))
+        ready = c.get_ready_tasks()
+        assert ready[0].task_id == "b"
+
+    def test_assign_start_complete(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.WAIT))
+        assert c.assign_task("t1", "r1")
+        assert c._tasks["t1"].status == TaskStatus.ASSIGNED
+        assert c.start_task("t1")
+        assert c._tasks["t1"].status == TaskStatus.IN_PROGRESS
+        assert c.complete_task("t1")
+        assert "t1" in c._completed_tasks
+        # robot freed
+        assert "r1" not in c._robot_tasks
+
+    def test_assign_unknown(self) -> None:
+        c = TaskCoordinator()
+        assert not c.assign_task("x", "r1")
+
+    def test_assign_already_assigned_fails(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.WAIT))
+        c.assign_task("t1", "r1")
+        assert not c.assign_task("t1", "r2")
+
+    def test_start_invalid(self) -> None:
+        c = TaskCoordinator()
+        assert not c.start_task("missing")
+        c.add_task(Task("t1", TaskType.WAIT))
+        assert not c.start_task("t1")  # not assigned yet
+
+    def test_fail_task(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.WAIT))
+        c.assign_task("t1", "r1")
+        assert c.fail_task("t1")
+        assert c._tasks["t1"].status == TaskStatus.FAILED
+        assert "r1" not in c._robot_tasks
+        assert not c.fail_task("missing")
+
+    def test_complete_missing(self) -> None:
+        c = TaskCoordinator()
+        assert not c.complete_task("missing")
+
+    def test_get_robot_task(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.WAIT))
+        c.assign_task("t1", "r1")
+        t = c.get_robot_task("r1")
+        assert t.task_id == "t1"
+        assert c.get_robot_task("nobody") is None
+
+    def test_available_robots(self) -> None:
+        c = TaskCoordinator()
+        c.add_task(Task("t1", TaskType.WAIT))
+        c.assign_task("t1", "r1")
+        avail = c.get_available_robots(["r1", "r2", "r3"])
+        assert avail == ["r2", "r3"]
+
+
+class TestMultiRobotSystem:
+    def test_add_remove(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.array([1.0, 0, 0, 1, 0, 0, 0]))
+        assert s.n_robots == 1
+        assert s.get_robot("r1") is fake_engine
+        assert s.remove_robot("r1")
+        assert s.n_robots == 0
+        assert not s.remove_robot("missing")
+
+    def test_get_robot_missing(self) -> None:
+        s = MultiRobotSystem()
+        assert s.get_robot("x") is None
+        assert s.get_robot_pose("x") is None
+
+    def test_set_robot_pose(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.zeros(7))
+        s.set_robot_pose("r1", np.array([5.0, 0, 0, 1, 0, 0, 0]))
+        assert s.get_robot_pose("r1")[0] == 5.0
+        # silently ignored for missing
+        s.set_robot_pose("missing", np.zeros(7))
+
+    def test_step_all(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.zeros(7))
+        s.step_all(0.01)  # just verify no errors
+
+    def test_check_inter_robot_collision(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.array([0.0, 0, 0, 1, 0, 0, 0]))
+        s.add_robot("r2", fake_engine, np.array([0.1, 0, 0, 1, 0, 0, 0]))
+        s.add_robot("r3", fake_engine, np.array([5.0, 0, 0, 1, 0, 0, 0]))
+        col = s.check_inter_robot_collision(safety_distance=0.5)
+        assert ("r1", "r2") in col
+        assert ("r1", "r3") not in col
+
+    def test_allocate_tasks(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.array([0.0, 0, 0, 1, 0, 0, 0]))
+        s.add_robot("r2", fake_engine, np.array([10.0, 0, 0, 1, 0, 0, 0]))
+        tasks = [
+            Task(
+                "t1",
+                TaskType.MOVE_TO,
+                target_position=np.array([0.0, 0, 0]),
+                priority=1,
+            ),
+            Task(
+                "t2",
+                TaskType.MOVE_TO,
+                target_position=np.array([10.0, 0, 0]),
+                priority=1,
+            ),
+        ]
+        alloc = s.allocate_tasks(tasks)
+        # r1 gets the task near origin
+        r1_ids = [t.task_id for t in alloc["r1"]]
+        assert "t1" in r1_ids
+
+    def test_allocate_tasks_no_target(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.zeros(7))
+        tasks = [Task("t1", TaskType.WAIT)]
+        alloc = s.allocate_tasks(tasks)
+        assert any(t.task_id == "t1" for t in alloc["r1"])
+
+    def test_system_state(self, fake_engine) -> None:
+        s = MultiRobotSystem()
+        s.add_robot("r1", fake_engine, np.zeros(7))
+        state = s.get_system_state()
+        assert state["n_robots"] == 1
+        assert "r1" in state["robot_states"]
+        assert "joint_positions" in state["robot_states"]["r1"]


### PR DESCRIPTION
## Summary

- 126 fast unit tests under `tests/research/wave6_research/` (~1.5s total)
- Coverage of `src/research/` rises from ~31% to ~90%
- Fixed 63 duplicate defensive guard checks (real bug: back-to-back identical `if not (x is not None): raise ValueError(...)` blocks; the second was unreachable)
- Simplified surviving guards from `if not (x is not None):` to idiomatic `if x is None:`

## Coverage per module
| Module | Before | After |
|---|---|---|
| `deformable/objects.py` | 15.3% | 95.1% |
| `differentiable/engine.py` | 40.8% | 86.3% |
| `mpc/controller.py` | 30.5% | 92.1% |
| `mpc/specialized.py` | 15.6% | 89.0% |
| `multi_robot/coordination.py` | 55.3% | 87.1% |
| `multi_robot/system.py` | 18.9% | 89.5% |
| **TOTAL** | **31.0%** | **90.3%** |

## Test plan
- [x] `python3 -m pytest tests/research/wave6_research -x --timeout=30` (126 passed in 1.45s)
- [x] `python3 -m ruff check src/research tests/research/wave6_research`
- [x] `python3 -m ruff format --check src/research tests/research/wave6_research`

A pre-existing failure in `tests/research/test_differentiable_engine.py::TestOptimizationResult::test_differentiable_engine_construction` (asserts a `solver_status` attribute that does not exist on `OptimizationResult`) is unrelated to this PR and out of scope.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)