### PR TITLE
test(scripts): batch B coverage

### DIFF
--- a/tests/scripts/wave9_scripts_b/test_check_file_size_budget.py
+++ b/tests/scripts/wave9_scripts_b/test_check_file_size_budget.py
@@ -1,0 +1,228 @@
+"""Tests for scripts/ci/check_file_size_budget.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import check_file_size_budget as mod
+
+
+def test_exception_is_active_no_expiry() -> None:
+    assert mod._exception_is_active({})
+
+
+def test_exception_is_active_future() -> None:
+    future = (date.today() + timedelta(days=10)).isoformat()
+    assert mod._exception_is_active({"expires_on": future})
+
+
+def test_exception_is_active_past() -> None:
+    past = (date.today() - timedelta(days=1)).isoformat()
+    assert not mod._exception_is_active({"expires_on": past})
+
+
+def test_line_count(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text("a\nb\nc\n", encoding="utf-8")
+    assert mod._line_count(p) == 3
+
+
+def test_load_config(tmp_path: Path) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    config_path = Path("scripts/config/budget.json")
+    (tmp_path / config_path).write_text(json.dumps({"max_lines": 100}))
+    out = mod._load_config(tmp_path, config_path)
+    assert out["max_lines"] == 100
+
+
+def test_get_owner_no_codeowners(tmp_path: Path) -> None:
+    assert mod._get_owner("src/x.py", tmp_path) == "Unknown"
+
+
+def test_get_owner_match(tmp_path: Path) -> None:
+    co = tmp_path / ".github" / "CODEOWNERS"
+    co.parent.mkdir()
+    co.write_text("# comment\n\nsrc/ @team-a\n")
+    assert mod._get_owner("src/x.py", tmp_path) == "@team-a"
+
+
+def test_get_owner_no_match(tmp_path: Path) -> None:
+    co = tmp_path / ".github" / "CODEOWNERS"
+    co.parent.mkdir()
+    co.write_text("docs/ @docs\n")
+    assert mod._get_owner("src/x.py", tmp_path) == "Unknown"
+
+
+def test_collect_active_exceptions_missing_fields() -> None:
+    cfg = {"exceptions": [{"path": "", "owner": "@x", "reason": "issue #1"}]}
+    _, invalid = mod._collect_active_exceptions(cfg)
+    assert any("Invalid exception" in m for m in invalid)
+
+
+def test_collect_active_exceptions_missing_issue_link() -> None:
+    cfg = {"exceptions": [{"path": "a.py", "owner": "@x", "reason": "just because"}]}
+    _, invalid = mod._collect_active_exceptions(cfg)
+    assert any("missing linked issue" in m for m in invalid)
+
+
+def test_collect_active_exceptions_expired() -> None:
+    past = (date.today() - timedelta(days=1)).isoformat()
+    cfg = {
+        "exceptions": [
+            {
+                "path": "a.py",
+                "owner": "@x",
+                "reason": "issue #5",
+                "expires_on": past,
+            }
+        ]
+    }
+    active, invalid = mod._collect_active_exceptions(cfg)
+    assert active == {}
+    assert any("Expired" in m for m in invalid)
+
+
+def test_collect_active_exceptions_bad_date() -> None:
+    cfg = {
+        "exceptions": [
+            {
+                "path": "a.py",
+                "owner": "@x",
+                "reason": "issue #5",
+                "expires_on": "garbage",
+            }
+        ]
+    }
+    _, invalid = mod._collect_active_exceptions(cfg)
+    assert any("Invalid expires_on" in m for m in invalid)
+
+
+def test_collect_active_exceptions_active() -> None:
+    cfg = {
+        "exceptions": [
+            {"path": "a.py", "owner": "@x", "reason": "issue #5"},
+            {
+                "path": "b.py",
+                "owner": "@y",
+                "reason": "decomposition pending",
+            },
+        ]
+    }
+    active, invalid = mod._collect_active_exceptions(cfg)
+    assert set(active.keys()) == {"a.py", "b.py"}
+    assert invalid == []
+
+
+def test_run_git_failure(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError):
+        mod._run_git(["this-is-not-a-real-git-cmd"], tmp_path)
+
+
+def test_main_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    cfg.write_text(json.dumps({"max_lines": 100, "exceptions": []}))
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", lambda r, b: [])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 0
+
+
+def test_main_violation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    cfg.write_text(json.dumps({"max_lines": 2, "exceptions": []}))
+    big = tmp_path / "big.py"
+    big.write_text("a\nb\nc\nd\ne\n")
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", lambda r, b: [big])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 1
+
+
+def test_main_skips_tests_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    cfg.write_text(json.dumps({"max_lines": 1, "exceptions": []}))
+    (tmp_path / "tests").mkdir()
+    big = tmp_path / "tests" / "big.py"
+    big.write_text("a\nb\nc\n")
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", lambda r, b: [big])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 0
+
+
+def test_main_watchlist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    cfg.write_text(json.dumps({"max_lines": 10, "exceptions": []}))
+    p = tmp_path / "warn.py"
+    p.write_text("\n".join(["x"] * 9) + "\n")
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", lambda r, b: [p])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 0
+
+
+def test_main_fallback_on_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    cfg.write_text(json.dumps({"max_lines": 100, "exceptions": []}))
+    calls = {"n": 0}
+
+    def fake(r, base):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("no origin/main")
+        return []
+
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", fake)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 0
+    assert calls["n"] == 2
+
+
+def test_main_too_many_exceptions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "scripts" / "config"
+    config_dir.mkdir(parents=True)
+    cfg = config_dir / "budget.json"
+    excs = [{"path": f"f{i}.py", "owner": "@x", "reason": "issue #1"} for i in range(6)]
+    cfg.write_text(json.dumps({"max_lines": 100, "exceptions": excs}))
+    monkeypatch.setattr(mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_changed_python_files", lambda r, b: [])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--config-path", "scripts/config/budget.json"],
+    )
+    assert mod.main() == 1

--- a/tests/scripts/wave9_scripts_b/test_check_lod.py
+++ b/tests/scripts/wave9_scripts_b/test_check_lod.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/ci/check_lod.py."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import check_lod as mod
+
+
+def test_attr_chain_basic() -> None:
+    tree = ast.parse("a.b.c.d", mode="eval")
+    assert mod._attr_chain(tree.body) == ["a", "b", "c", "d"]
+
+
+def test_attr_chain_returns_none_for_call_root() -> None:
+    tree = ast.parse("f().x.y", mode="eval")
+    assert mod._attr_chain(tree.body) is None
+
+
+def test_is_library_chain_leaf() -> None:
+    assert mod._is_library_chain(["self", "data", "tolist"])
+    assert mod._is_library_chain(["self", "btn", "clicked", "connect"])
+
+
+def test_is_library_chain_intermediate() -> None:
+    assert mod._is_library_chain(["self", "btn", "clicked", "x"])
+
+
+def test_is_library_chain_namespace_root() -> None:
+    assert mod._is_library_chain(["np", "linalg", "norm", "x"])
+    assert mod._is_library_chain(["QtCore", "Qt", "Orientation", "Horizontal"])
+
+
+def test_is_library_chain_navigation_not_library() -> None:
+    assert not mod._is_library_chain(["self", "a", "b", "c"])
+
+
+def test_is_library_chain_empty() -> None:
+    assert mod._is_library_chain([])
+
+
+def test_check_file_detects_violation(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text("self.a.b.c.d\n")
+    violations = mod.check_file(p)
+    assert violations
+    assert violations[0][1] == "self.a.b.c.d"
+
+
+def test_check_file_ignores_2_hops(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text("self.a.b\n")
+    assert mod.check_file(p) == []
+
+
+def test_check_file_ignores_library(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text("self.btn.clicked.connect(handler)\n")
+    assert mod.check_file(p) == []
+
+
+def test_check_file_syntax_error(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text("def f(:\n")
+    assert mod.check_file(p) == []
+
+
+def test_check_file_unicode_error(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_bytes(b"\xff\xfe\x00bogus")
+    assert mod.check_file(p) == []
+
+
+def test_iter_python_files_skips_tests_and_examples(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x=1\n")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "b.py").write_text("x=1\n")
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "c.py").write_text("x=1\n")
+    files = mod.iter_python_files(tmp_path)
+    names = {p.name for p in files}
+    assert "a.py" in names
+    assert "b.py" not in names
+    assert "c.py" not in names
+
+
+def test_main_missing_root(capsys: pytest.CaptureFixture[str]) -> None:
+    ret = mod.main(["/definitely/does/not/exist/xyz123"])
+    assert ret == 2
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_main_clean(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    assert mod.main([str(tmp_path)]) == 0
+    assert "clean" in capsys.readouterr().out
+
+
+def test_main_finds_violation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "a.py").write_text("self.a.b.c.d\n")
+    assert mod.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert "LOD chain" in captured.out
+
+
+def test_main_advisory_returns_zero(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("self.a.b.c.d\n")
+    assert mod.main([str(tmp_path), "--advisory"]) == 0

--- a/tests/scripts/wave9_scripts_b/test_check_pip_audit_waivers.py
+++ b/tests/scripts/wave9_scripts_b/test_check_pip_audit_waivers.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/ci/check_pip_audit_waivers.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import check_pip_audit_waivers as mod
+
+
+def _write_manifest(path: Path, *, waivers: list[dict] | None = None) -> Path:
+    body = {"schema_version": 1, "waivers": waivers or []}
+    path.write_text(json.dumps(body), encoding="utf-8")
+    return path
+
+
+def _waiver_dict(**over: object) -> dict:
+    base = {
+        "vuln": "GHSA-xxx",
+        "package": "requests",
+        "reason": "no fix yet",
+        "tracked_in": "#1234",
+        "expires_on": (date.today() + timedelta(days=30)).isoformat(),
+    }
+    base.update(over)
+    return base
+
+
+def test_load_waivers_success(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path / "w.json", waivers=[_waiver_dict()])
+    waivers = mod.load_waivers(manifest)
+    assert len(waivers) == 1
+    assert waivers[0].vuln == "GHSA-xxx"
+    assert waivers[0].package == "requests"
+
+
+def test_load_waivers_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        mod.load_waivers(tmp_path / "nope.json")
+
+
+def test_load_waivers_not_object(tmp_path: Path) -> None:
+    p = tmp_path / "w.json"
+    p.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_bad_schema(tmp_path: Path) -> None:
+    p = tmp_path / "w.json"
+    p.write_text(json.dumps({"schema_version": 99}), encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_missing_field(tmp_path: Path) -> None:
+    bad = _waiver_dict()
+    del bad["reason"]
+    p = _write_manifest(tmp_path / "w.json", waivers=[bad])
+    with pytest.raises(ValueError, match="missing waiver field"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_bad_date(tmp_path: Path) -> None:
+    p = _write_manifest(
+        tmp_path / "w.json", waivers=[_waiver_dict(expires_on="not-a-date")]
+    )
+    with pytest.raises(ValueError, match="ISO date"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_bad_tracked_in(tmp_path: Path) -> None:
+    p = _write_manifest(tmp_path / "w.json", waivers=[_waiver_dict(tracked_in="1234")])
+    with pytest.raises(ValueError, match="tracked_in"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_entry_not_dict(tmp_path: Path) -> None:
+    p = tmp_path / "w.json"
+    p.write_text(json.dumps({"schema_version": 1, "waivers": ["x"]}), encoding="utf-8")
+    with pytest.raises(ValueError, match="mapping"):
+        mod.load_waivers(p)
+
+
+def test_load_waivers_list_required(tmp_path: Path) -> None:
+    p = tmp_path / "w.json"
+    p.write_text(json.dumps({"schema_version": 1, "waivers": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        mod.load_waivers(p)
+
+
+def test_find_expired_waivers() -> None:
+    fresh = mod.Waiver("v1", "p", "r", "#1", date.today() + timedelta(days=1))
+    old = mod.Waiver("v2", "p", "r", "#1", date.today() - timedelta(days=1))
+    expired = mod.find_expired_waivers([fresh, old])
+    assert expired == [old]
+
+
+def test_load_reported_vulns(tmp_path: Path) -> None:
+    rpt = tmp_path / "rpt.json"
+    rpt.write_text(
+        json.dumps(
+            {
+                "dependencies": [
+                    {"name": "requests", "vulns": [{"id": "GHSA-xxx"}]},
+                    {"name": "Pkg", "vulns": [{"id": "GHSA-yyy"}, "bad"]},
+                    "not-a-dict",
+                    {"name": "", "vulns": []},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = mod.load_reported_vulns(rpt)
+    assert ("requests", "GHSA-xxx") in out
+    assert ("pkg", "GHSA-yyy") in out
+
+
+def test_load_reported_vulns_bad_shape(tmp_path: Path) -> None:
+    rpt = tmp_path / "rpt.json"
+    rpt.write_text(json.dumps({"dependencies": "no"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        mod.load_reported_vulns(rpt)
+
+
+def test_find_stale_waivers() -> None:
+    w = mod.Waiver("v1", "Pkg", "r", "#1", date.today())
+    reported: set[tuple[str, str]] = {("pkg", "v1")}
+    assert mod.find_stale_waivers([w], reported) == []
+    assert mod.find_stale_waivers([w], set()) == [w]
+
+
+def test_build_ignore_flags() -> None:
+    w1 = mod.Waiver("v1", "a", "r", "#1", date.today())
+    w2 = mod.Waiver("v2", "b", "r", "#2", date.today())
+    assert mod.build_ignore_flags([w1, w2]) == [
+        "--ignore-vuln",
+        "v1",
+        "--ignore-vuln",
+        "v2",
+    ]
+
+
+def test_main_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = _write_manifest(tmp_path / "w.json", waivers=[_waiver_dict()])
+    monkeypatch.setattr("sys.argv", ["x", "--waiver-file", str(p)])
+    assert mod.main() == 0
+    assert "--ignore-vuln" in capsys.readouterr().out
+
+
+def test_main_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = _waiver_dict(expires_on=(date.today() - timedelta(days=1)).isoformat())
+    p = _write_manifest(tmp_path / "w.json", waivers=[bad])
+    monkeypatch.setattr("sys.argv", ["x", "--waiver-file", str(p)])
+    assert mod.main() == 1
+    assert "Expired" in capsys.readouterr().err
+
+
+def test_main_stale_with_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = _write_manifest(tmp_path / "w.json", waivers=[_waiver_dict()])
+    rpt = tmp_path / "rpt.json"
+    rpt.write_text(json.dumps({"dependencies": []}), encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["x", "--waiver-file", str(p), "--audit-report", str(rpt)],
+    )
+    assert mod.main() == 1
+    assert "Stale" in capsys.readouterr().err

--- a/tests/scripts/wave9_scripts_b/test_check_subsystem_status.py
+++ b/tests/scripts/wave9_scripts_b/test_check_subsystem_status.py
@@ -1,0 +1,167 @@
+"""Tests for scripts/ci/check_subsystem_status.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ci import check_subsystem_status as mod
+
+
+def test_load_subsystem_registry(tmp_path: Path) -> None:
+    p = tmp_path / "reg.yaml"
+    p.write_text(
+        yaml.safe_dump({"subsystems": [{"name": "a", "status": "production"}]})
+    )
+    out = mod.load_subsystem_registry(str(p))
+    assert out == [{"name": "a", "status": "production"}]
+
+
+def test_load_subsystem_registry_missing(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        mod.load_subsystem_registry(str(tmp_path / "nope.yaml"))
+    assert exc.value.code == 2
+
+
+def test_run_tests_for_path_skips_missing(tmp_path: Path) -> None:
+    success, msg = mod.run_tests_for_path(str(tmp_path / "no.py"))
+    assert success
+    assert "SKIP" in msg
+
+
+def test_run_tests_for_path_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "t.py").write_text("x=1\n")
+
+    class FakeRes:
+        returncode = 0
+        stdout = "1 passed\n"
+        stderr = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: FakeRes())
+    ok, output = mod.run_tests_for_path(str(tmp_path / "t.py"))
+    assert ok
+    assert "passed" in output
+
+
+def test_run_tests_for_path_verbose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "t.py").write_text("x=1\n")
+
+    class FakeRes:
+        returncode = 1
+        stdout = "out"
+        stderr = "err"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: FakeRes())
+    ok, output = mod.run_tests_for_path(str(tmp_path / "t.py"), verbose=True)
+    assert not ok
+    assert "out" in output
+    assert "err" in output
+
+
+def test_run_tests_for_path_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "t.py").write_text("x=1\n")
+
+    def fake_run(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok, msg = mod.run_tests_for_path(str(tmp_path / "t.py"))
+    assert not ok
+    assert "TIMEOUT" in msg
+
+
+def test_run_tests_for_path_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "t.py").write_text("x=1\n")
+
+    def fake_run(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok, msg = mod.run_tests_for_path(str(tmp_path / "t.py"))
+    assert not ok
+    assert "ERROR" in msg
+
+
+def test_check_subsystem_status_all_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "t.py").write_text("x=1\n")
+    monkeypatch.setattr(mod, "run_tests_for_path", lambda p, v=False: (True, "ok"))
+    subs = [
+        {"name": "s1", "status": "production", "test_paths": [str(tmp_path / "t.py")]}
+    ]
+    assert mod.check_subsystem_status(subs) is True
+
+
+def test_check_subsystem_status_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "run_tests_for_path", lambda p, v=False: (False, "no"))
+    subs = [{"name": "s1", "status": "production", "test_paths": ["p"]}]
+    assert mod.check_subsystem_status(subs) is False
+
+
+def test_check_subsystem_status_skips_non_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "run_tests_for_path",
+        lambda p, v=False: pytest.fail("should not be called"),
+    )
+    subs = [{"name": "s1", "status": "alpha", "test_paths": ["p"]}]
+    assert mod.check_subsystem_status(subs, verbose=True) is True
+
+
+def test_check_subsystem_status_warns_no_test_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mod, "run_tests_for_path", lambda p, v=False: (True, ""))
+    subs = [{"name": "s1", "status": "production", "test_paths": []}]
+    assert mod.check_subsystem_status(subs) is True
+
+
+def test_check_subsystem_status_targets_specific(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        mod,
+        "run_tests_for_path",
+        lambda p, v=False: (calls.append(p), (True, "ok"))[1],
+    )
+    subs = [
+        {"name": "s1", "status": "production", "test_paths": ["a"]},
+        {"name": "s2", "status": "production", "test_paths": ["b"]},
+    ]
+    mod.check_subsystem_status(subs, target_subsystem="s2")
+    assert calls == ["b"]
+
+
+def test_main_no_subsystems(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = tmp_path / "r.yaml"
+    p.write_text(yaml.safe_dump({"subsystems": []}))
+    monkeypatch.setattr("sys.argv", ["x", "--registry", str(p)])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "load_subsystem_registry", lambda r: [])
+    assert mod.main() == 2
+
+
+def test_main_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["x"])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "load_subsystem_registry",
+        lambda r: [{"name": "s", "status": "alpha", "test_paths": []}],
+    )
+    assert mod.main() == 0

--- a/tests/scripts/wave9_scripts_b/test_extract_dims.py
+++ b/tests/scripts/wave9_scripts_b/test_extract_dims.py
@@ -1,0 +1,73 @@
+"""Tests for scripts/_extract_dims.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import _extract_dims as mod
+
+
+def _write_csv(path: Path, header: list[str], row: list[str]) -> None:
+    text = ",".join(header) + "\n" + ",".join(row) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def test_main_keeps_model_prefixed_dimensions(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "data.csv"
+    _write_csv(
+        csv_path,
+        ["model_PelvisLength", "model_OtherThing", "model_TorsoMass", "junk"],
+        ["0.25", "999", "12.0", "x"],
+    )
+
+    mod.main(csv_path)
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"model_PelvisLength": "0.25", "model_TorsoMass": "12.0"}
+
+
+def test_main_keeps_explicit_names(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "data.csv"
+    _write_csv(
+        csv_path,
+        ["ClubLogs_ClubMass", "SegmentInertiaLogs_GolferMass", "noise"],
+        ["0.2", "75.0", "x"],
+    )
+    mod.main(csv_path)
+    out = json.loads(capsys.readouterr().out)
+    assert out == {
+        "ClubLogs_ClubMass": "0.2",
+        "SegmentInertiaLogs_GolferMass": "75.0",
+    }
+
+
+def test_main_keeps_segment_inertia_logs_inertia(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "data.csv"
+    _write_csv(
+        csv_path,
+        ["SegmentInertiaLogs_TorsoInertia", "SegmentInertiaLogs_FootCOM", "other"],
+        ["0.5", "0.1", "n"],
+    )
+    mod.main(csv_path)
+    out = json.loads(capsys.readouterr().out)
+    assert "SegmentInertiaLogs_TorsoInertia" in out
+    assert "SegmentInertiaLogs_FootCOM" in out
+    assert "other" not in out
+
+
+def test_main_drops_unmatched_keys(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "data.csv"
+    _write_csv(csv_path, ["random_col", "model_NoKeepSubstring"], ["1", "2"])
+    mod.main(csv_path)
+    out = json.loads(capsys.readouterr().out)
+    assert out == {}

--- a/tests/scripts/wave9_scripts_b/test_verify_installation.py
+++ b/tests/scripts/wave9_scripts_b/test_verify_installation.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/ci/verify_installation.py."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from scripts.ci import verify_installation as mod
+
+
+def test_check_python_version_ok() -> None:
+    ok, msg = mod.check_python_version()
+    # The test suite already runs on 3.10+, so this is always True
+    assert ok
+    assert "✓" in msg
+
+
+def test_check_virtualenv_returns_tuple() -> None:
+    ok, msg = mod.check_virtualenv()
+    assert isinstance(ok, bool)
+    assert isinstance(msg, str)
+
+
+def test_check_import_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_mod = types.ModuleType("fake_pkg_xyz")
+    fake_mod.__version__ = "1.2.3"
+    monkeypatch.setitem(sys.modules, "fake_pkg_xyz", fake_mod)
+    ok, msg = mod.check_import("fake_pkg_xyz")
+    assert ok
+    assert "1.2.3" in msg
+
+
+def test_check_import_uses_import_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_mod = types.ModuleType("real_path_abc")
+    fake_mod.PYQT_VERSION_STR = "6.5"
+    monkeypatch.setitem(sys.modules, "real_path_abc", fake_mod)
+    ok, msg = mod.check_import("Display", "real_path_abc", "PYQT_VERSION_STR")
+    assert ok
+    assert "6.5" in msg
+    assert "Display" in msg
+
+
+def test_check_import_unknown_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_mod = types.ModuleType("noversion_pkg")
+    monkeypatch.setitem(sys.modules, "noversion_pkg", fake_mod)
+    ok, msg = mod.check_import("noversion_pkg")
+    assert ok
+    assert "unknown" in msg
+
+
+def test_check_import_missing() -> None:
+    ok, msg = mod.check_import("definitely_not_a_real_module_xyz_12345")
+    assert not ok
+    assert "✗" in msg
+
+
+def test_check_import_rejects_non_string() -> None:
+    with pytest.raises(ValueError):
+        mod.check_import(123)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        mod.check_import("x", import_path=5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        mod.check_import("x", version_attr=5)  # type: ignore[arg-type]
+
+
+def test_main_runs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["verify"])
+    # Stub check_import to avoid heavy actual imports
+    monkeypatch.setattr(mod, "check_import", lambda *a, **k: (True, "ok"))
+    code = mod.main()
+    assert code == 0
+
+
+def test_main_json_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["verify", "--json"])
+    monkeypatch.setattr(mod, "check_import", lambda *a, **k: (True, "ok"))
+    code = mod.main()
+    assert code == 0
+    captured = capsys.readouterr()
+    assert '"python_ok"' in captured.out
+
+
+def test_main_failure_path(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["verify"])
+    monkeypatch.setattr(mod, "check_import", lambda *a, **k: (False, "x"))
+    assert mod.main() == 1


### PR DESCRIPTION
## Summary

Adds wave9 test suite for 6 scripts not yet covered by PR #5820 (wave 8):

- `scripts/_extract_dims.py` — 100%
- `scripts/ci/check_file_size_budget.py` — 94.0%
- `scripts/ci/check_lod.py` — 97.5%
- `scripts/ci/check_pip_audit_waivers.py` — 97.2%
- `scripts/ci/check_subsystem_status.py` — 95.7%
- `scripts/ci/verify_installation.py` — 92.6%

**Combined coverage: 95.6%** across 506 statements.

82 tests, ~1.7 s wall time. All FAST (no real subprocess; `tmp_path` +
synthetic data; `subprocess.run` mocked for `check_subsystem_status`).
No source changes — pure test additions.

## Test plan

- [x] `python3 -m pytest tests/scripts/wave9_scripts_b -x --timeout=30` — 82 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Pre-commit hooks pass

Generated with Claude Code