### PR TITLE
test(wave10): cover lowest-coverage modules

### DIFF
--- a/tests/wave10_gap_audit/conftest.py
+++ b/tests/wave10_gap_audit/conftest.py
@@ -1,0 +1,8 @@
+"""Local conftest for wave10 gap audit tests.
+
+Isolated from the repo-wide conftest because the global conftest pulls in
+heavy deps (tensorflow, PyQt6) that are broken/slow on this machine. Each
+test only imports the small, pure-Python module it covers.
+"""
+
+from __future__ import annotations

--- a/tests/wave10_gap_audit/test_cli_utils.py
+++ b/tests/wave10_gap_audit/test_cli_utils.py
@@ -1,0 +1,344 @@
+"""Coverage for src/shared/python/cli_utils.py.
+
+Covers parser builders, argparse type helpers, and main runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python import cli_utils
+
+
+# ── Parser builders ─────────────────────────────────────────────────────
+
+
+def test_create_base_parser() -> None:
+    parser = cli_utils.create_base_parser("test program")
+    assert isinstance(parser, argparse.ArgumentParser)
+    assert parser.description == "test program"
+
+
+def test_add_logging_args_no_file() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser, include_file=False)
+    args = parser.parse_args(["-v"])
+    assert args.verbose is True
+    assert args.quiet is False
+    assert args.log_level == "INFO"
+
+
+def test_add_logging_args_with_file() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser, include_file=True)
+    args = parser.parse_args(["--log-file", "/tmp/x.log", "--log-level", "DEBUG"])
+    assert args.log_file == Path("/tmp/x.log")
+    assert args.log_level == "DEBUG"
+
+
+def test_add_output_args() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_output_args(parser, include_format=True)
+    args = parser.parse_args(["-o", "out.json", "--overwrite", "--format", "yaml"])
+    assert args.output == Path("out.json")
+    assert args.overwrite is True
+    assert args.format == "yaml"
+
+
+def test_add_config_args() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_config_args(parser, default_config="default.yaml")
+    args = parser.parse_args([])
+    assert args.config == Path("default.yaml")
+    args2 = parser.parse_args(["--no-config"])
+    assert args2.no_config is True
+
+
+def test_add_simulation_args() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_simulation_args(parser)
+    args = parser.parse_args(
+        ["--time-step", "0.01", "--duration", "5", "--engine", "mujoco"]
+    )
+    assert args.time_step == 0.01
+    assert args.duration == 5
+    assert args.engine == "mujoco"
+
+
+def test_add_dry_run_and_force() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_dry_run_arg(parser)
+    cli_utils.add_force_arg(parser)
+    args = parser.parse_args(["-n", "-f"])
+    assert args.dry_run is True
+    assert args.force is True
+
+
+def test_add_parallel_args() -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_parallel_args(parser, default_workers=4)
+    args = parser.parse_args(["--sequential"])
+    assert args.sequential is True
+    assert args.jobs == 4
+
+
+# ── setup_from_args ─────────────────────────────────────────────────────
+
+
+def test_setup_from_args_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_setup_logging(*, level, filename=None):  # type: ignore[no-untyped-def]
+        captured["level"] = level
+        captured["filename"] = filename
+
+    monkeypatch.setattr(cli_utils, "setup_logging", fake_setup_logging)
+    ns = argparse.Namespace(verbose=True, quiet=False, log_level="INFO", log_file=None)
+    cli_utils.setup_from_args(ns)
+    assert captured["level"] == cli_utils.LogLevel.DEBUG
+
+
+def test_setup_from_args_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        cli_utils,
+        "setup_logging",
+        lambda **kw: captured.update(kw),
+    )
+    ns = argparse.Namespace(verbose=False, quiet=True, log_level="INFO", log_file=None)
+    cli_utils.setup_from_args(ns)
+    assert captured["level"] == cli_utils.LogLevel.WARNING
+
+
+def test_setup_from_args_explicit_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        cli_utils,
+        "setup_logging",
+        lambda **kw: captured.update(kw),
+    )
+    ns = argparse.Namespace(
+        verbose=False, quiet=False, log_level="ERROR", log_file=None
+    )
+    cli_utils.setup_from_args(ns)
+    assert captured["level"] == cli_utils.LogLevel.ERROR
+
+
+# ── get_effective_log_level ─────────────────────────────────────────────
+
+
+def test_get_effective_log_level_verbose() -> None:
+    ns = argparse.Namespace(verbose=True)
+    assert cli_utils.get_effective_log_level(ns) == "DEBUG"
+
+
+def test_get_effective_log_level_quiet() -> None:
+    ns = argparse.Namespace(verbose=False, quiet=True)
+    assert cli_utils.get_effective_log_level(ns) == "WARNING"
+
+
+def test_get_effective_log_level_explicit() -> None:
+    ns = argparse.Namespace(verbose=False, quiet=False, log_level="ERROR")
+    assert cli_utils.get_effective_log_level(ns) == "ERROR"
+
+
+def test_get_effective_log_level_default() -> None:
+    ns = argparse.Namespace()
+    assert cli_utils.get_effective_log_level(ns) == "INFO"
+
+
+# ── resolve_output_path ─────────────────────────────────────────────────
+
+
+def test_resolve_output_path_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    ns = argparse.Namespace(output=None)
+    result = cli_utils.resolve_output_path(ns, default_name="report", extension=".json")
+    assert result.name == "report.json"
+
+
+def test_resolve_output_path_directory(tmp_path: Path) -> None:
+    target_dir = tmp_path / "results"
+    target_dir.mkdir()
+    ns = argparse.Namespace(output=target_dir)
+    result = cli_utils.resolve_output_path(ns, default_name="data", extension=".csv")
+    assert result == target_dir / "data.csv"
+
+
+def test_resolve_output_path_with_suffix(tmp_path: Path) -> None:
+    ns = argparse.Namespace(output=tmp_path / "result.json")
+    result = cli_utils.resolve_output_path(ns, extension=".json")
+    assert result.suffix == ".json"
+
+
+def test_resolve_output_path_no_suffix_adds_extension(tmp_path: Path) -> None:
+    ns = argparse.Namespace(output=tmp_path / "no_ext_path_that_does_not_exist")
+    # treated as dir-like since no suffix and doesn't exist
+    result = cli_utils.resolve_output_path(ns, default_name="x", extension=".txt")
+    assert result.name.endswith(".txt")
+
+
+# ── validate_input_files ────────────────────────────────────────────────
+
+
+def test_validate_input_files_must_exist(tmp_path: Path) -> None:
+    f = tmp_path / "a.txt"
+    f.write_text("hello")
+    result = cli_utils.validate_input_files([f])
+    assert result == [f]
+
+
+def test_validate_input_files_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
+        cli_utils.validate_input_files([tmp_path / "missing.txt"])
+
+
+def test_validate_input_files_extension_filter(tmp_path: Path) -> None:
+    f = tmp_path / "a.txt"
+    f.write_text("hi")
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid file type"):
+        cli_utils.validate_input_files([f], extensions=[".csv"])
+
+
+def test_validate_input_files_skip_existence(tmp_path: Path) -> None:
+    paths = [tmp_path / "missing.txt"]
+    result = cli_utils.validate_input_files(paths, must_exist=False)
+    assert result == paths
+
+
+# ── path_type ───────────────────────────────────────────────────────────
+
+
+def test_path_type_exists(tmp_path: Path) -> None:
+    fn = cli_utils.path_type(must_exist=True)
+    assert fn(str(tmp_path)) == tmp_path  # type: ignore[operator]
+
+
+def test_path_type_missing_raises(tmp_path: Path) -> None:
+    fn = cli_utils.path_type(must_exist=True)
+    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
+        fn(str(tmp_path / "nope"))  # type: ignore[operator]
+
+
+def test_path_type_not_file(tmp_path: Path) -> None:
+    fn = cli_utils.path_type(must_be_file=True)
+    with pytest.raises(argparse.ArgumentTypeError, match="not a file"):
+        fn(str(tmp_path))  # type: ignore[operator]
+
+
+def test_path_type_not_dir(tmp_path: Path) -> None:
+    f = tmp_path / "a.txt"
+    f.write_text("hi")
+    fn = cli_utils.path_type(must_be_dir=True)
+    with pytest.raises(argparse.ArgumentTypeError, match="not a directory"):
+        fn(str(f))  # type: ignore[operator]
+
+
+# ── numeric types ──────────────────────────────────────────────────────
+
+
+def test_positive_int_ok() -> None:
+    assert cli_utils.positive_int("5") == 5
+
+
+def test_positive_int_zero_rejected() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Must be positive"):
+        cli_utils.positive_int("0")
+
+
+def test_positive_int_invalid() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid integer"):
+        cli_utils.positive_int("abc")
+
+
+def test_non_negative_int_ok() -> None:
+    assert cli_utils.non_negative_int("0") == 0
+    assert cli_utils.non_negative_int("3") == 3
+
+
+def test_non_negative_int_negative() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="non-negative"):
+        cli_utils.non_negative_int("-1")
+
+
+def test_non_negative_int_invalid() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid integer"):
+        cli_utils.non_negative_int("x")
+
+
+def test_positive_float_ok() -> None:
+    assert cli_utils.positive_float("1.5") == 1.5
+
+
+def test_positive_float_zero() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Must be positive"):
+        cli_utils.positive_float("0")
+
+
+def test_positive_float_invalid() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid float"):
+        cli_utils.positive_float("nope")
+
+
+# ── run_main ───────────────────────────────────────────────────────────
+
+
+def test_run_main_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser)
+    monkeypatch.setattr(cli_utils, "setup_from_args", MagicMock())
+    monkeypatch.setattr("sys.argv", ["prog"])
+    rc = cli_utils.run_main(lambda _ns: 0, parser)
+    assert rc == 0
+
+
+def test_run_main_none_return(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser)
+    monkeypatch.setattr(cli_utils, "setup_from_args", MagicMock())
+    monkeypatch.setattr("sys.argv", ["prog"])
+    rc = cli_utils.run_main(lambda _ns: None, parser)
+    assert rc == 0
+
+
+def test_run_main_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser)
+    monkeypatch.setattr(cli_utils, "setup_from_args", MagicMock())
+    monkeypatch.setattr("sys.argv", ["prog"])
+
+    def boom(_ns: argparse.Namespace) -> int:
+        raise KeyboardInterrupt
+
+    rc = cli_utils.run_main(boom, parser)
+    assert rc == 130
+
+
+def test_run_main_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser)
+    monkeypatch.setattr(cli_utils, "setup_from_args", MagicMock())
+    monkeypatch.setattr("sys.argv", ["prog"])
+
+    def boom(_ns: argparse.Namespace) -> int:
+        raise RuntimeError("nope")
+
+    rc = cli_utils.run_main(boom, parser)
+    assert rc == 1
+
+
+def test_run_main_no_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = cli_utils.create_base_parser("x")
+    cli_utils.add_logging_args(parser)
+    setup_mock = MagicMock()
+    monkeypatch.setattr(cli_utils, "setup_from_args", setup_mock)
+    monkeypatch.setattr("sys.argv", ["prog"])
+    rc = cli_utils.run_main(lambda _ns: 7, parser, setup_logging_from_args=False)
+    assert rc == 7
+    setup_mock.assert_not_called()

--- a/tests/wave10_gap_audit/test_cors.py
+++ b/tests/wave10_gap_audit/test_cors.py
@@ -1,0 +1,84 @@
+"""Coverage for src/shared/python/cors.py."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.shared.python.cors import DEFAULT_ORIGINS, add_cors_middleware  # noqa: E402
+
+
+def _make_app(**kwargs: object) -> fastapi.FastAPI:
+    app = fastapi.FastAPI()
+    add_cors_middleware(app, **kwargs)  # type: ignore[arg-type]
+
+    @app.get("/ping")
+    def ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    return app
+
+
+def test_default_origins_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    app = _make_app()
+    client = TestClient(app)
+    r = client.options(
+        "/ping",
+        headers={
+            "Origin": DEFAULT_ORIGINS[0],
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == DEFAULT_ORIGINS[0]
+
+
+def test_explicit_origins_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    app = _make_app(origins=["http://example.com"])
+    client = TestClient(app)
+    r = client.options(
+        "/ping",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "http://example.com"
+
+
+def test_env_var_takes_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORS_ORIGINS", "http://from-env.com, http://other.com ,")
+    # origins arg should be ignored when env var is set
+    app = _make_app(origins=["http://ignored.com"])
+    client = TestClient(app)
+    r = client.options(
+        "/ping",
+        headers={
+            "Origin": "http://from-env.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "http://from-env.com"
+
+
+def test_disallowed_origin_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    app = _make_app(origins=["http://allowed.com"])
+    client = TestClient(app)
+    r = client.options(
+        "/ping",
+        headers={
+            "Origin": "http://blocked.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    # CORS middleware does not echo origin back when origin isn't allowed
+    assert r.headers.get("access-control-allow-origin") != "http://blocked.com"
+
+
+def test_default_origins_contains_localhost() -> None:
+    assert any("localhost" in o for o in DEFAULT_ORIGINS)

--- a/tests/wave10_gap_audit/test_docker_config.py
+++ b/tests/wave10_gap_audit/test_docker_config.py
@@ -1,0 +1,111 @@
+"""Coverage for src/shared/python/docker_config.py."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python import docker_config
+
+
+def test_constants_have_image_family_prefix() -> None:
+    assert docker_config.DOCKER_IMAGE_ENGINE.endswith(":engine")
+    assert docker_config.DOCKER_IMAGE_RUNTIME.endswith(":runtime")
+    assert docker_config.DOCKER_IMAGE_DEV.endswith(":dev")
+    assert docker_config.DOCKER_IMAGE_TRAINING.endswith(":training")
+    for img in (
+        docker_config.DOCKER_IMAGE_ENGINE,
+        docker_config.DOCKER_IMAGE_RUNTIME,
+        docker_config.DOCKER_IMAGE_DEV,
+        docker_config.DOCKER_IMAGE_TRAINING,
+    ):
+        assert img.startswith(docker_config.DOCKER_IMAGE_FAMILY)
+
+
+def test_legacy_aliases_present() -> None:
+    assert "robotics_env:latest" in docker_config.LEGACY_DOCKER_ALIASES
+
+
+def test_detect_gpu_no_nvidia_smi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_config.shutil, "which", lambda _name: None)
+    result = docker_config.detect_gpu_support()
+    assert result["available"] is False
+    assert result["device_name"] == ""
+    assert result["driver_version"] == ""
+    assert result["container_toolkit"] is False
+
+
+def test_detect_gpu_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(name: str) -> str | None:
+        if name == "nvidia-smi":
+            return "/usr/bin/nvidia-smi"
+        if name == "nvidia-container-cli":
+            return "/usr/bin/nvidia-container-cli"
+        return None
+
+    monkeypatch.setattr(docker_config.shutil, "which", fake_which)
+
+    calls = {"n": 0}
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="NVIDIA RTX 4090, 535.86.10\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="8.9\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(docker_config.subprocess, "run", fake_run)
+    result = docker_config.detect_gpu_support()
+    assert result["available"] is True
+    assert result["device_name"] == "NVIDIA RTX 4090"
+    assert result["driver_version"] == "535.86.10"
+    assert result["cuda_version"] == "8.9"
+    assert result["container_toolkit"] is True
+
+
+def test_detect_gpu_subprocess_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_config.shutil, "which", lambda name: "/usr/bin/" + name)
+
+    def raise_timeout(*_a: Any, **_k: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd="nvidia-smi", timeout=10)
+
+    monkeypatch.setattr(docker_config.subprocess, "run", raise_timeout)
+    result = docker_config.detect_gpu_support()
+    assert result["available"] is False
+
+
+def test_detect_gpu_smi_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_config.shutil, "which", lambda name: "/usr/bin/" + name)
+
+    def fake_run(*_a: Any, **_k: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="err"
+        )
+
+    monkeypatch.setattr(docker_config.subprocess, "run", fake_run)
+    result = docker_config.detect_gpu_support()
+    assert result["available"] is False
+    assert result["container_toolkit"] is True  # which() still returns a path
+
+
+def test_detect_gpu_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_config.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(
+        docker_config.subprocess,
+        "run",
+        MagicMock(side_effect=OSError("boom")),
+    )
+    result = docker_config.detect_gpu_support()
+    assert result["available"] is False

--- a/tests/wave10_gap_audit/test_launcher_factory.py
+++ b/tests/wave10_gap_audit/test_launcher_factory.py
@@ -1,0 +1,67 @@
+"""Coverage for src/shared/python/launcher_factory.py."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python import launcher_factory
+
+
+def test_get_engine_module_known() -> None:
+    assert launcher_factory.get_engine_module("mujoco") is not None
+    assert launcher_factory.get_engine_module("drake") is not None
+    assert launcher_factory.get_engine_module("pinocchio") is not None
+    assert launcher_factory.get_engine_module("opensim") is not None
+    assert launcher_factory.get_engine_module("myosuite") is not None
+    assert launcher_factory.get_engine_module("pendulum") is not None
+
+
+def test_get_engine_module_unknown() -> None:
+    assert launcher_factory.get_engine_module("nonexistent_engine") is None
+
+
+def test_launch_engine_unknown_exits(caplog: pytest.LogCaptureFixture) -> None:
+    with pytest.raises(SystemExit) as exc:
+        launcher_factory.launch_engine_directly("bogus_engine")
+    assert exc.value.code == 1
+
+
+def test_launch_engine_calls_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_module = types.ModuleType("fake_module")
+    fake_main = MagicMock()
+    fake_module.main = fake_main  # type: ignore[attr-defined]
+
+    def fake_import(_name: str) -> types.ModuleType:
+        return fake_module
+
+    monkeypatch.setattr(launcher_factory.importlib, "import_module", fake_import)
+    launcher_factory.launch_engine_directly("mujoco")
+    fake_main.assert_called_once()
+
+
+def test_launch_engine_missing_main_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_module = types.ModuleType("fake_module_no_main")
+
+    monkeypatch.setattr(
+        launcher_factory.importlib,
+        "import_module",
+        lambda _name: fake_module,
+    )
+    with pytest.raises(SystemExit) as exc:
+        launcher_factory.launch_engine_directly("mujoco")
+    assert exc.value.code == 1
+
+
+def test_launch_engine_import_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(_name: str) -> Any:
+        raise ImportError("missing dep")
+
+    monkeypatch.setattr(launcher_factory.importlib, "import_module", fake_import)
+    with pytest.raises(SystemExit) as exc:
+        launcher_factory.launch_engine_directly("mujoco")
+    assert exc.value.code == 1

--- a/tests/wave10_gap_audit/test_safe_eval.py
+++ b/tests/wave10_gap_audit/test_safe_eval.py
@@ -1,0 +1,183 @@
+"""Coverage for src/shared/python/safe_eval.py.
+
+The safe expression evaluator is security-critical — exercise both the
+happy path and every rejection path of the AST validator.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.safe_eval import (
+    NUMPY_MATH_NAMESPACE,
+    SCALAR_MATH_NAMESPACE,
+    safe_eval,
+    safe_eval_math,
+    validate_expression,
+)
+
+
+class TestValidateExpression:
+    def test_empty_expression_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_expression("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_expression("   \t\n")
+
+    def test_syntax_error_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid syntax"):
+            validate_expression("1 +")
+
+    def test_disallowed_node_lambda(self) -> None:
+        with pytest.raises(ValueError):
+            validate_expression("(lambda: 1)()")
+
+    def test_disallowed_attribute_access(self) -> None:
+        with pytest.raises(ValueError, match="Unsafe operation"):
+            validate_expression("a.b")
+
+    def test_disallowed_dict_literal(self) -> None:
+        with pytest.raises(ValueError, match="Unsafe operation"):
+            validate_expression("{1: 2}")
+
+    def test_disallowed_setcomp(self) -> None:
+        with pytest.raises(ValueError, match="Unsafe operation"):
+            validate_expression("[x for x in [1, 2]]")
+
+    def test_unknown_name_with_allowlist(self) -> None:
+        with pytest.raises(ValueError, match="Unknown variable"):
+            validate_expression("x + y", allowed_names={"x"})
+
+    def test_unknown_function_with_allowlist(self) -> None:
+        with pytest.raises(ValueError, match="Unknown function"):
+            validate_expression("f(1)", allowed_names={"x"})
+
+    def test_attribute_function_call_rejected(self) -> None:
+        # ast.parse permits the syntax but our validator must reject it
+        # because the attribute access is the disallowed step.
+        with pytest.raises(ValueError):
+            validate_expression("os.system('ls')")
+
+    def test_allowed_name_passes(self) -> None:
+        tree = validate_expression("x + 1", allowed_names={"x"})
+        assert tree is not None
+
+
+class TestSafeEval:
+    def test_basic_arithmetic(self) -> None:
+        assert safe_eval("1 + 2 * 3", {}) == 7
+        assert safe_eval("(1 + 2) * 3", {}) == 9
+        assert safe_eval("10 / 4", {}) == 2.5
+        assert safe_eval("10 // 4", {}) == 2
+        assert safe_eval("10 % 3", {}) == 1
+        assert safe_eval("2 ** 10", {}) == 1024
+
+    def test_unary(self) -> None:
+        assert safe_eval("-5", {}) == -5
+        assert safe_eval("+5", {}) == 5
+        assert safe_eval("not True", {"True": True}) is False
+        assert safe_eval("~0", {}) == -1
+
+    def test_compare_chain(self) -> None:
+        assert safe_eval("1 < 2 < 3", {}) is True
+        assert safe_eval("1 < 2 > 5", {}) is False
+        assert safe_eval("1 == 1", {}) is True
+        assert safe_eval("1 != 2", {}) is True
+
+    def test_bool_ops(self) -> None:
+        assert safe_eval("True and False", {"True": True, "False": False}) is False
+        assert safe_eval("True or False", {"True": True, "False": False}) is True
+
+    def test_namespace_lookup(self) -> None:
+        assert safe_eval("x * y", {"x": 3, "y": 4}) == 12
+
+    def test_name_allowed_but_missing_from_namespace(self) -> None:
+        # When validation accepts a name but execution can't find it.
+        with pytest.raises(NameError):
+            safe_eval("x", {}, allowed_names={"x"})
+
+    def test_undefined_name_with_default_allowlist(self) -> None:
+        # Default behavior: allowed_names defaults to namespace.keys(), so
+        # undefined names are rejected at validation as ValueError.
+        with pytest.raises(ValueError, match="Unknown variable"):
+            safe_eval("undefined_var", {})
+
+    def test_function_call(self) -> None:
+        assert safe_eval("add(2, 3)", {"add": lambda a, b: a + b}) == 5
+
+    def test_call_with_keywords(self) -> None:
+        def f(*, x: int, y: int) -> int:
+            return x - y
+
+        assert safe_eval("f(x=10, y=3)", {"f": f}) == 7
+
+    def test_call_with_starred(self) -> None:
+        def f(a: int, b: int, c: int) -> int:
+            return a + b + c
+
+        assert safe_eval("f(*args)", {"f": f, "args": [1, 2, 3]}) == 6
+
+    def test_list_tuple_literals(self) -> None:
+        assert safe_eval("[1, 2, 3]", {}) == [1, 2, 3]
+        assert safe_eval("(1, 2)", {}) == (1, 2)
+
+    def test_subscript_and_slice(self) -> None:
+        assert safe_eval("xs[1]", {"xs": [10, 20, 30]}) == 20
+        assert safe_eval("xs[0:2]", {"xs": [10, 20, 30]}) == [10, 20]
+        assert safe_eval("xs[::-1]", {"xs": [1, 2, 3]}) == [3, 2, 1]
+
+    def test_ifexp(self) -> None:
+        assert safe_eval("1 if cond else 2", {"cond": True}) == 1
+        assert safe_eval("1 if cond else 2", {"cond": False}) == 2
+
+    def test_none_expression_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be provided"):
+            safe_eval(None, {})  # type: ignore[arg-type]
+
+    def test_non_dict_namespace_raises(self) -> None:
+        with pytest.raises(TypeError, match="must be a dict"):
+            safe_eval("1", "not a dict")  # type: ignore[arg-type]
+
+    def test_default_allowed_names_uses_namespace(self) -> None:
+        # When allowed_names is None it defaults to namespace.keys()
+        assert safe_eval("x", {"x": 42}) == 42
+        with pytest.raises(ValueError, match="Unknown variable"):
+            safe_eval("y", {"x": 42})
+
+
+class TestSafeEvalMath:
+    def test_numpy_namespace_default(self) -> None:
+        result = safe_eval_math("sqrt(16)")
+        assert np.isclose(result, 4.0)
+
+    def test_scalar_namespace(self) -> None:
+        result = safe_eval_math("sqrt(9)", use_numpy=False)
+        assert math.isclose(result, 3.0)
+
+    def test_variables_merged(self) -> None:
+        result = safe_eval_math("sin(0) + offset", {"offset": 5})
+        assert np.isclose(result, 5.0)
+
+    def test_constants(self) -> None:
+        assert np.isclose(safe_eval_math("pi"), np.pi)
+        assert np.isclose(safe_eval_math("e", use_numpy=False), math.e)
+
+    def test_none_expression(self) -> None:
+        with pytest.raises(ValueError, match="must be provided"):
+            safe_eval_math(None)  # type: ignore[arg-type]
+
+    def test_array_operations(self) -> None:
+        arr = np.array([1.0, 4.0, 9.0])
+        result = safe_eval_math("sqrt(x)", {"x": arr})
+        np.testing.assert_allclose(result, [1.0, 2.0, 3.0])
+
+
+def test_namespaces_have_expected_keys() -> None:
+    for key in ("sin", "cos", "sqrt", "pi", "e"):
+        assert key in NUMPY_MATH_NAMESPACE
+        assert key in SCALAR_MATH_NAMESPACE


### PR DESCRIPTION
## Summary
Adds focused unit tests for 5 previously-low-coverage pure-Python modules in `src/shared/python/`. All tests run in under 5 seconds and avoid heavy engine dependencies.

| Module | Coverage |
|---|---|
| `safe_eval.py` | 93.4% |
| `cors.py` | 100% |
| `docker_config.py` | 100% |
| `launcher_factory.py` | 100% |
| `cli_utils.py` | 93.3% |
| **Combined** | **94.5%** (335 stmts) |

93 tests, no slow markers, fully isolated (each test imports only the small module it covers).

## Test plan
- [x] `python -m pytest tests/wave10_gap_audit -x --timeout=30` → 93 passed
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] Pre-commit hooks pass

No production code modified; no behavioral changes.

Generated with Claude Code.