### PR TITLE
test(shared/python): cover remaining utilities

### DIFF
--- a/src/shared/python/assessment/analysis.py
+++ b/src/shared/python/assessment/analysis.py
@@ -124,7 +124,7 @@ def grep_count(
         raise ValueError("root must be provided")
     count = 0
     regex = re.compile(pattern)
-    excluded = {part for part in exclude_parts if part}
+    excluded = {part for part in (exclude_parts or []) if part}
     for p in root.glob(file_pattern):
         if not p.is_file():
             continue
@@ -144,9 +144,7 @@ def grep_count(
     return count
 
 
-def classify_assessment_category(
-    source_name: str, description: str = ""
-) -> str:  # noqa: C901
+def classify_assessment_category(source_name: str, description: str = "") -> str:  # noqa: C901
     """Classify an assessment finding into a standard category name.
 
     Args:

--- a/tests/shared/wave10_remaining/test_assessment_analysis.py
+++ b/tests/shared/wave10_remaining/test_assessment_analysis.py
@@ -1,0 +1,262 @@
+"""Tests for src.shared.python.assessment.analysis."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.assessment.analysis import (
+    assess_error_handling_content,
+    assess_logging_content,
+    calculate_complexity,
+    classify_assessment_category,
+    count_files,
+    get_detailed_function_metrics,
+    get_python_metrics,
+    grep_count,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_python_metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_python_metrics_counts(tmp_path):
+    src = tmp_path / "m.py"
+    src.write_text(
+        '"""Mod doc."""\n'
+        "def f(x: int) -> int:\n"
+        '    """fn doc."""\n'
+        "    if x > 0:\n"
+        "        return x\n"
+        "    return 0\n"
+        "class C:\n"
+        '    """class doc."""\n'
+        "    def m(self):\n"
+        "        for i in []: pass\n",
+        encoding="utf-8",
+    )
+    m = get_python_metrics(src)
+    assert m["functions"] == 2
+    assert m["classes"] == 1
+    assert m["docstrings"] >= 2
+    assert m["typed_returns"] == 1
+    assert m["branches"] >= 2
+
+
+@pytest.mark.unit
+def test_get_python_metrics_bad_syntax(tmp_path):
+    src = tmp_path / "bad.py"
+    src.write_text("def def def", encoding="utf-8")
+    m = get_python_metrics(src)
+    assert m == {
+        "functions": 0,
+        "classes": 0,
+        "docstrings": 0,
+        "typed_returns": 0,
+        "branches": 0,
+    }
+
+
+@pytest.mark.unit
+def test_get_python_metrics_missing_file(tmp_path):
+    m = get_python_metrics(tmp_path / "nope.py")
+    assert m["functions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# calculate_complexity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_calculate_complexity_zero_functions():
+    assert calculate_complexity({"functions": 0, "branches": 5}) == 0.0
+
+
+@pytest.mark.unit
+def test_calculate_complexity_normal():
+    assert calculate_complexity({"functions": 2, "branches": 10}) == 5.0
+
+
+@pytest.mark.unit
+def test_calculate_complexity_missing_keys():
+    assert calculate_complexity({}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# assess_error_handling_content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assess_error_handling_counts():
+    content = "try:\n    pass\nexcept:\n    pass\ntry:\n    pass\nexcept ValueError:\n    pass"
+    r = assess_error_handling_content(content)
+    assert r["try_count"] == 2
+    assert r["bare_except_count"] == 1
+
+
+@pytest.mark.unit
+def test_assess_error_handling_empty():
+    r = assess_error_handling_content("")
+    assert r == {"try_count": 0, "bare_except_count": 0}
+
+
+# ---------------------------------------------------------------------------
+# assess_logging_content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assess_logging_counts_logger_and_print():
+    content = (
+        "import logging\n"
+        "logger = logging.getLogger(__name__)\n"
+        "logger.info('hi')\n"
+        "print('debug')\n"
+        "print(1, 2)\n"
+    )
+    r = assess_logging_content(content)
+    assert r["print_usage"] == 2
+    assert r["logging_usage"] >= 2
+
+
+@pytest.mark.unit
+def test_assess_logging_falls_back_on_syntax_error():
+    content = "def def\nprint('x')\nprint(1)"
+    r = assess_logging_content(content)
+    assert r["print_usage"] == 2
+
+
+@pytest.mark.unit
+def test_assess_logging_ignores_print_attribute():
+    # `obj.print(...)` should not be counted by the AST path
+    content = "obj.print('x')\nprint('y')"
+    r = assess_logging_content(content)
+    assert r["print_usage"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_detailed_function_metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_detailed_function_metrics():
+    content = (
+        "def alpha(a, b):\n"
+        '    """alpha"""\n'
+        "    return a + b\n"
+        "async def beta():\n"
+        "    return 1\n"
+    )
+    out = get_detailed_function_metrics(content)
+    names = {f["name"] for f in out}
+    assert names == {"alpha", "beta"}
+    alpha = next(f for f in out if f["name"] == "alpha")
+    assert alpha["args"] == 2
+    assert alpha["has_docstring"] is True
+    beta = next(f for f in out if f["name"] == "beta")
+    assert beta["has_docstring"] is False
+
+
+@pytest.mark.unit
+def test_get_detailed_function_metrics_bad_syntax():
+    out = get_detailed_function_metrics("def def def")
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# count_files / grep_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_count_files(tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.py").write_text("b")
+    (tmp_path / "c.txt").write_text("c")
+    assert count_files(tmp_path, "*.py") == 2
+    assert count_files(tmp_path, "*.md") == 0
+
+
+@pytest.mark.unit
+def test_grep_count_finds_pattern(tmp_path):
+    (tmp_path / "a.py").write_text("hello world")
+    (tmp_path / "b.py").write_text("nothing here")
+    (tmp_path / "c.py").write_text("Hello there")
+    assert grep_count(tmp_path, r"hello") == 1
+    assert grep_count(tmp_path, r"(?i)hello") == 2
+
+
+@pytest.mark.unit
+def test_grep_count_default_exclude_parts_no_crash(tmp_path):
+    """Regression: ``exclude_parts=None`` (the default) used to raise TypeError."""
+    (tmp_path / "a.py").write_text("hello")
+    assert grep_count(tmp_path, r"hello") == 1
+
+
+@pytest.mark.unit
+def test_grep_count_with_excluded_dir(tmp_path):
+    (tmp_path / "a.py").write_text("needle")
+    sub = tmp_path / "skip_me"
+    sub.mkdir()
+    (sub / "b.py").write_text("needle")
+    n = grep_count(tmp_path, r"needle", exclude_parts=["skip_me"])
+    assert n == 1
+
+
+@pytest.mark.unit
+def test_grep_count_requires_root():
+    with pytest.raises(ValueError, match="root must be provided"):
+        grep_count(None, "x")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# classify_assessment_category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,desc,expected",
+    [
+        ("A", "", "Architecture"),
+        ("B", "", "Code Quality"),
+        ("C", "", "Documentation"),
+        ("D", "", "User Experience"),
+        ("E", "", "Performance"),
+        ("F", "", "Installation"),
+        ("G", "", "Testing"),
+        ("H", "", "Error Handling"),
+        ("I", "", "Security"),
+        ("J", "", "Extensibility"),
+        ("K", "", "Reproducibility"),
+        ("L", "", "Maintainability"),
+        ("N", "", "Visualization"),
+        ("O", "", "CI/CD"),
+        ("unknown", "", "General"),
+    ],
+)
+def test_classify_assessment_category_letter_codes(name, desc, expected):
+    assert classify_assessment_category(name, desc) == expected
+
+
+@pytest.mark.unit
+def test_classify_assessment_category_keyword_match():
+    assert (
+        classify_assessment_category("system", "implementation review")
+        == "Architecture"
+    )
+    assert classify_assessment_category("ux audit", "") == "User Experience"
+    assert (
+        classify_assessment_category("perf", "performance bottleneck") == "Performance"
+    )
+
+
+@pytest.mark.unit
+def test_classify_assessment_category_requires_source_name():
+    with pytest.raises(ValueError, match="source_name must be provided"):
+        classify_assessment_category(None)  # type: ignore[arg-type]

--- a/tests/shared/wave10_remaining/test_assessment_reporting.py
+++ b/tests/shared/wave10_remaining/test_assessment_reporting.py
@@ -1,0 +1,129 @@
+"""Tests for src.shared.python.assessment.reporting and constants."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.assessment.constants import (
+    CATEGORIES,
+    GROUP_MAPPING,
+    GROUP_WEIGHTS,
+    PRAGMATIC_PRINCIPLES,
+)
+from src.shared.python.assessment.reporting import (
+    generate_issue_document,
+    generate_markdown_report,
+)
+
+
+@pytest.mark.unit
+def test_generate_markdown_report_creates_file(tmp_path):
+    out = generate_markdown_report(
+        category_id="A",
+        category_name="Code Quality",
+        grade=7.5,
+        details="Some detail.",
+        recommendations=["Refactor", "Add tests"],
+        output_dir=tmp_path,
+    )
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "Code Quality" in text
+    assert "7.5/10" in text
+    assert "1. Refactor" in text
+    assert "2. Add tests" in text
+    # Filename contains category id + name with spaces replaced by underscores
+    assert out.name == "Assessment_A_Code_Quality.md"
+
+
+@pytest.mark.unit
+def test_generate_markdown_report_creates_parent_dir(tmp_path):
+    target = tmp_path / "nested" / "dir"
+    out = generate_markdown_report(
+        category_id="B",
+        category_name="X",
+        grade=5.0,
+        details="d",
+        recommendations=[],
+        output_dir=target,
+    )
+    assert out.exists()
+    assert out.parent == target
+
+
+@pytest.mark.unit
+def test_generate_markdown_report_requires_category_id(tmp_path):
+    with pytest.raises(ValueError, match="category_id must be provided"):
+        generate_markdown_report(
+            category_id=None,  # type: ignore[arg-type]
+            category_name="x",
+            grade=1.0,
+            details="d",
+            recommendations=[],
+            output_dir=tmp_path,
+        )
+
+
+@pytest.mark.unit
+def test_generate_issue_document(tmp_path):
+    out = generate_issue_document(
+        category_id="C",
+        category_name="Test Coverage",
+        grade=2.1,
+        details="Low coverage in module foo.",
+        output_dir=tmp_path,
+    )
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "Test Coverage" in text
+    assert "2.1/10" in text
+    assert "jules:assessment" in text
+    assert out.name == "ISSUE_Assessment_C_Test_Coverage.md"
+
+
+@pytest.mark.unit
+def test_generate_issue_document_requires_category_id(tmp_path):
+    with pytest.raises(ValueError, match="category_id must be provided"):
+        generate_issue_document(
+            category_id=None,  # type: ignore[arg-type]
+            category_name="x",
+            grade=1.0,
+            details="d",
+            output_dir=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_categories_are_complete():
+    # Sanity: a few well-known keys are present
+    assert CATEGORIES["A"]
+    assert "Documentation" in CATEGORIES.values()
+    assert len(CATEGORIES) == 15
+
+
+@pytest.mark.unit
+def test_group_weights_sum_to_one():
+    total = sum(GROUP_WEIGHTS.values())
+    assert total == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_group_mapping_targets_are_valid_groups():
+    valid_groups = set(GROUP_WEIGHTS.keys())
+    for cat, group in GROUP_MAPPING.items():
+        assert group in valid_groups, f"{cat} -> {group} not in {valid_groups}"
+
+
+@pytest.mark.unit
+def test_pragmatic_principles_have_required_fields():
+    for key, info in PRAGMATIC_PRINCIPLES.items():
+        assert "name" in info
+        assert "description" in info
+        assert "weight" in info
+        assert isinstance(info["weight"], (int, float))
+        assert info["weight"] > 0, key

--- a/tests/shared/wave10_remaining/test_contracts_exceptions.py
+++ b/tests/shared/wave10_remaining/test_contracts_exceptions.py
@@ -1,0 +1,156 @@
+"""Tests for src.shared.python._contracts_exceptions."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.shared.python._contracts_exceptions import (
+    _VIOLATION_CLASSES,
+    ContractEvaluationError,
+    ContractViolationError,
+    InvariantError,
+    PostconditionError,
+    PreconditionError,
+    _handle_violation,
+)
+from src.shared.python._contracts_level import (
+    ContractLevel,
+    _ContractState,
+    set_contract_level,
+)
+
+
+@pytest.fixture
+def restore_contract_level():
+    original = _ContractState.level
+    yield
+    set_contract_level(original)
+
+
+@pytest.mark.unit
+def test_violation_classes_mapping_complete():
+    assert _VIOLATION_CLASSES["pre-condition"] is PreconditionError
+    assert _VIOLATION_CLASSES["post-condition"] is PostconditionError
+    assert _VIOLATION_CLASSES["invariant"] is InvariantError
+    assert _VIOLATION_CLASSES["evaluation-error"] is ContractEvaluationError
+
+
+@pytest.mark.unit
+def test_contract_violation_error_message_includes_value():
+    err = ContractViolationError("pre-condition", "must be positive", value=-1)
+    text = str(err)
+    assert "pre-condition" in text
+    assert "must be positive" in text
+    assert "-1" in text
+
+
+@pytest.mark.unit
+def test_contract_violation_error_message_omits_none_value():
+    err = ContractViolationError("invariant", "x must hold")
+    assert "got:" not in str(err)
+
+
+@pytest.mark.unit
+def test_contract_violation_attributes():
+    err = ContractViolationError("invariant", "msg", value=42)
+    assert err.condition_type == "invariant"
+    assert err.message == "msg"
+    assert err.value == 42
+
+
+@pytest.mark.unit
+def test_contract_violation_is_assertion_and_value_error():
+    # Subclasses should inherit from both AssertionError and ValueError
+    err = ContractViolationError("pre-condition", "x")
+    assert isinstance(err, AssertionError)
+    assert isinstance(err, ValueError)
+
+
+@pytest.mark.unit
+def test_specific_subclasses_carry_correct_type():
+    pre = PreconditionError("p")
+    post = PostconditionError("po")
+    inv = InvariantError("inv")
+    ev = ContractEvaluationError("e")
+    assert pre.condition_type == "pre-condition"
+    assert post.condition_type == "post-condition"
+    assert inv.condition_type == "invariant"
+    assert ev.condition_type == "evaluation-error"
+
+
+@pytest.mark.unit
+def test_contract_violation_requires_condition_type():
+    with pytest.raises(ValueError, match="condition_type must be provided"):
+        ContractViolationError(None, "msg")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_precondition_error_requires_message():
+    with pytest.raises(ValueError, match="message must be provided"):
+        PreconditionError(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_postcondition_error_requires_message():
+    with pytest.raises(ValueError, match="message must be provided"):
+        PostconditionError(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_invariant_error_requires_message():
+    with pytest.raises(ValueError, match="message must be provided"):
+        InvariantError(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_evaluation_error_requires_message():
+    with pytest.raises(ValueError, match="message must be provided"):
+        ContractEvaluationError(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _handle_violation behaviour at the three enforcement levels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_handle_violation_enforce_raises_specific_error(restore_contract_level):
+    set_contract_level(ContractLevel.ENFORCE)
+    with pytest.raises(PreconditionError):
+        _handle_violation("pre-condition", "boom")
+    with pytest.raises(PostconditionError):
+        _handle_violation("post-condition", "boom")
+    with pytest.raises(InvariantError):
+        _handle_violation("invariant", "boom")
+    with pytest.raises(ContractEvaluationError):
+        _handle_violation("evaluation-error", "boom")
+
+
+@pytest.mark.unit
+def test_handle_violation_enforce_unknown_type_uses_base(restore_contract_level):
+    set_contract_level(ContractLevel.ENFORCE)
+    with pytest.raises(ContractViolationError):
+        _handle_violation("mystery-type", "boom")
+
+
+@pytest.mark.unit
+def test_handle_violation_warn_logs_only(restore_contract_level, caplog):
+    set_contract_level(ContractLevel.WARN)
+    with caplog.at_level(logging.WARNING):
+        # Must NOT raise.
+        _handle_violation("pre-condition", "soft warn", value=7)
+    joined = " ".join(rec.message for rec in caplog.records)
+    assert "pre-condition" in joined
+    assert "soft warn" in joined
+    assert "7" in joined
+
+
+@pytest.mark.unit
+def test_handle_violation_off_does_nothing(restore_contract_level, caplog):
+    set_contract_level(ContractLevel.OFF)
+    with caplog.at_level(logging.WARNING):
+        _handle_violation("pre-condition", "silent")
+    # Should not raise, should not log a warning for the violation.
+    assert all("silent" not in rec.message for rec in caplog.records)

--- a/tests/shared/wave10_remaining/test_launcher_factory.py
+++ b/tests/shared/wave10_remaining/test_launcher_factory.py
@@ -1,0 +1,96 @@
+"""Tests for src.shared.python.launcher_factory."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python import launcher_factory as lf
+
+
+@pytest.mark.unit
+def test_get_engine_module_known_engines():
+    # Every known engine maps to a non-empty module string.
+    for name in ("mujoco", "drake", "pinocchio", "opensim", "myosuite", "pendulum"):
+        path = lf.get_engine_module(name)
+        assert isinstance(path, str)
+        assert path  # non-empty
+
+
+@pytest.mark.unit
+def test_get_engine_module_unknown():
+    assert lf.get_engine_module("not_a_real_engine") is None
+
+
+@pytest.mark.unit
+def test_engine_modules_constant_shape():
+    # Map keys are lowercase identifiers, values are dotted Python paths.
+    for k, v in lf.ENGINE_MODULES.items():
+        assert k.islower()
+        assert "." in v
+
+
+@pytest.mark.unit
+def test_launch_engine_directly_unknown_engine_exits(caplog):
+    with pytest.raises(SystemExit) as exc_info:
+        lf.launch_engine_directly("does_not_exist")
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.unit
+def test_launch_engine_directly_invokes_main(monkeypatch):
+    fake_module = types.ModuleType("fake_engine_module")
+    main_calls: list[int] = []
+
+    def fake_main() -> None:
+        main_calls.append(1)
+
+    fake_module.main = fake_main  # type: ignore[attr-defined]
+
+    fake_path = "test.fake.engine.module"
+    monkeypatch.setitem(lf.ENGINE_MODULES, "fake_engine", fake_path)
+    monkeypatch.setitem(sys.modules, fake_path, fake_module)
+
+    lf.launch_engine_directly("fake_engine")
+    assert main_calls == [1]
+
+
+@pytest.mark.unit
+def test_launch_engine_directly_module_without_main_exits(monkeypatch):
+    fake_module = types.ModuleType("fake_no_main_module")
+    fake_path = "test.fake.no_main_module"
+    monkeypatch.setitem(lf.ENGINE_MODULES, "fake_no_main", fake_path)
+    monkeypatch.setitem(sys.modules, fake_path, fake_module)
+
+    with pytest.raises(SystemExit) as exc_info:
+        lf.launch_engine_directly("fake_no_main")
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.unit
+def test_launch_engine_directly_import_error_exits(monkeypatch):
+    monkeypatch.setitem(
+        lf.ENGINE_MODULES, "fake_missing", "definitely.not.an.importable.module.xyz"
+    )
+
+    def fake_import(name):
+        raise ImportError(f"cannot import {name}")
+
+    monkeypatch.setattr(lf.importlib, "import_module", fake_import)
+
+    with pytest.raises(SystemExit) as exc_info:
+        lf.launch_engine_directly("fake_missing")
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.unit
+def test_launch_engine_directly_uses_get_engine_module(monkeypatch):
+    """Verify the function consults ENGINE_MODULES via get_engine_module."""
+    called = MagicMock(return_value=None)
+    monkeypatch.setattr(lf, "get_engine_module", called)
+    with pytest.raises(SystemExit):
+        lf.launch_engine_directly("xx")
+    called.assert_called_once_with("xx")

--- a/tests/shared/wave10_remaining/test_notes_models.py
+++ b/tests/shared/wave10_remaining/test_notes_models.py
@@ -1,0 +1,61 @@
+"""Tests for src.shared.python.notes.models."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from src.shared.python.notes.models import RecycledNoteItem
+
+
+@pytest.mark.unit
+def test_recycled_note_item_constructs():
+    item = RecycledNoteItem(
+        item_id="abc",
+        reason="manual_delete",
+        path="/recycle/abc.json",
+        original_path="/notes/abc.md",
+        deleted_at="2024-01-01T00:00:00Z",
+    )
+    assert item.item_id == "abc"
+    assert item.reason == "manual_delete"
+    assert item.path == "/recycle/abc.json"
+    assert item.original_path == "/notes/abc.md"
+    assert item.deleted_at == "2024-01-01T00:00:00Z"
+
+
+@pytest.mark.unit
+def test_recycled_note_item_is_frozen():
+    item = RecycledNoteItem("a", "r", "p", "o", "d")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        item.item_id = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_recycled_note_item_equality():
+    a = RecycledNoteItem("a", "r", "p", "o", "d")
+    b = RecycledNoteItem("a", "r", "p", "o", "d")
+    c = RecycledNoteItem("a", "r", "p", "o", "DIFFERENT")
+    assert a == b
+    assert a != c
+
+
+@pytest.mark.unit
+def test_recycled_note_item_hashable():
+    a = RecycledNoteItem("a", "r", "p", "o", "d")
+    b = RecycledNoteItem("a", "r", "p", "o", "d")
+    assert hash(a) == hash(b)
+    assert {a, b} == {a}
+
+
+@pytest.mark.unit
+def test_recycled_note_item_fields():
+    field_names = {f.name for f in dataclasses.fields(RecycledNoteItem)}
+    assert field_names == {
+        "item_id",
+        "reason",
+        "path",
+        "original_path",
+        "deleted_at",
+    }


### PR DESCRIPTION
## Summary

Wave 10 — adds unit-test coverage for remaining `src/shared/python/`
utilities not addressed by prior waves.

**Modules covered** (~92.5% combined branch coverage):

- `assessment/analysis.py` (93.1%) — AST metrics, complexity, grep_count, category classifier
- `assessment/reporting.py` (88.9%) — markdown report + issue document generation
- `assessment/constants.py` (100%) — categories, group weights, pragmatic principles
- `launcher_factory.py` (100%) — engine module map + direct launch
- `notes/models.py` (100%) — `RecycledNoteItem` frozen dataclass
- `_contracts_exceptions.py` (88.8%) — DbC violation hierarchy + `_handle_violation`

**Bug fix**: `assessment.analysis.grep_count` previously crashed with
`TypeError` when invoked with the documented default `exclude_parts=None`
(set-comprehension iterated over `None`). Now treats `None` as empty.

**Stats**: 72 unit tests, suite runs in <3s, all marked `@pytest.mark.unit`.

## Test plan

- [x] `python3 -m pytest tests/shared/wave10_remaining -x --timeout=30` — 72/72 pass
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files
- [x] No changes under `vendor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)