### PR TITLE
test(motion_pipeline): add mock unit tests for OpenSim scale and TRC adapter

### DIFF
--- a/tests/unit/motion_pipeline/preprocessing/test_normalize.py
+++ b/tests/unit/motion_pipeline/preprocessing/test_normalize.py
@@ -6,7 +6,11 @@ import numpy as np
 import pytest
 
 from src.shared.python.motion_pipeline.contracts import (
+    Keypoint,
+    KeypointFrame,
     KeypointSequence,
+    Marker,
+    MarkerFrame,
     MarkerTrajectory,
 )
 from src.shared.python.motion_pipeline.preprocessing.normalize import (
@@ -70,9 +74,7 @@ def test_convert_units_mm_to_m_scales_by_1e_minus_3() -> None:
         frame_index=0,
     )
     traj = MarkerTrajectory(id="t", frames=[f])
-    out = convert_units(
-        traj, target_unit=UnitSystem.METERS, source_unit=UnitSystem.MILLIMETERS
-    )
+    out = convert_units(traj, target_unit=UnitSystem.METERS, source_unit=UnitSystem.MILLIMETERS)
     m = out.frames[0].markers["M"]
     assert m.x == pytest.approx(1.0)
     assert m.y == pytest.approx(2.0)
@@ -88,12 +90,8 @@ def test_convert_units_inches_round_trip() -> None:
         frame_index=0,
     )
     traj = MarkerTrajectory(id="t", frames=[f])
-    inch = convert_units(
-        traj, target_unit=UnitSystem.INCHES, source_unit=UnitSystem.METERS
-    )
-    back = convert_units(
-        inch, target_unit=UnitSystem.METERS, source_unit=UnitSystem.INCHES
-    )
+    inch = convert_units(traj, target_unit=UnitSystem.INCHES, source_unit=UnitSystem.METERS)
+    back = convert_units(inch, target_unit=UnitSystem.METERS, source_unit=UnitSystem.INCHES)
     m = back.frames[0].markers["M"]
     assert m.x == pytest.approx(1.0, rel=1e-3)
 
@@ -122,9 +120,7 @@ def test_normalize_keypoints_basic() -> None:
 
 def test_convert_units_keypoints_metadata() -> None:
     seq = make_keypoint_sequence(num_frames=3, num_kp=1)
-    out = convert_units(
-        seq, target_unit=UnitSystem.METERS, source_unit=UnitSystem.METERS
-    )
+    out = convert_units(seq, target_unit=UnitSystem.METERS, source_unit=UnitSystem.METERS)
     assert out.metadata.get("units_converted") is True
 
 
@@ -133,9 +129,7 @@ def test_get_unit_scale_meters_to_mm() -> None:
         _get_unit_scale,
     )
 
-    assert _get_unit_scale(UnitSystem.METERS, UnitSystem.MILLIMETERS) == pytest.approx(
-        1000.0
-    )
+    assert _get_unit_scale(UnitSystem.METERS, UnitSystem.MILLIMETERS) == pytest.approx(1000.0)
     assert _get_unit_scale(UnitSystem.METERS, UnitSystem.METERS) == pytest.approx(1.0)
 
 
@@ -144,9 +138,7 @@ def test_get_up_axis_transform_identity_for_same() -> None:
         _get_up_axis_transform,
     )
 
-    np.testing.assert_allclose(
-        _get_up_axis_transform(UpAxis.Y_UP, UpAxis.Y_UP), np.eye(3)
-    )
+    np.testing.assert_allclose(_get_up_axis_transform(UpAxis.Y_UP, UpAxis.Y_UP), np.eye(3))
 
 
 def test_get_up_axis_transform_z_to_y_inverse() -> None:
@@ -157,3 +149,373 @@ def test_get_up_axis_transform_z_to_y_inverse() -> None:
     fwd = _get_up_axis_transform(UpAxis.Y_UP, UpAxis.Z_UP)
     back = _get_up_axis_transform(UpAxis.Z_UP, UpAxis.Y_UP)
     np.testing.assert_allclose(fwd @ back, np.eye(3), atol=1e-9)
+
+
+def test_normalize_empty_keypoint_sequence_returns_unchanged() -> None:
+    seq = KeypointSequence.model_construct(id="empty", frames=[])
+    out = normalize_coordinates(seq, target_up=UpAxis.Y_UP, source_up=UpAxis.Y_UP)
+    assert out is seq
+    assert len(out.frames) == 0
+
+
+def test_normalize_empty_marker_trajectory_returns_unchanged() -> None:
+    traj = MarkerTrajectory.model_construct(id="empty", frames=[])
+    out = normalize_coordinates(traj, target_up=UpAxis.Y_UP, source_up=UpAxis.Y_UP)
+    assert out is traj
+    assert len(out.frames) == 0
+
+
+def test_convert_units_empty_keypoint_sequence_returns_unchanged() -> None:
+    seq = KeypointSequence.model_construct(id="empty", frames=[])
+    out = convert_units(seq, target_unit=UnitSystem.METERS, source_unit=UnitSystem.METERS)
+    assert out is seq
+    assert len(out.frames) == 0
+
+
+def test_convert_units_empty_marker_trajectory_returns_unchanged() -> None:
+    traj = MarkerTrajectory.model_construct(id="empty", frames=[])
+    out = convert_units(traj, target_unit=UnitSystem.METERS, source_unit=UnitSystem.METERS)
+    assert out is traj
+    assert len(out.frames) == 0
+
+
+def test_detect_up_axis_keypoints() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.normalize import (
+        _detect_up_axis_keypoints,
+    )
+
+    # 1. Y_UP detection (y has largest variance)
+    frames_y = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=1.0, y=10.0, z=1.0, confidence=1.0),
+                Keypoint(name="kp", x=1.1, y=0.0, z=1.1, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_keypoints(frames_y) == UpAxis.Y_UP
+
+    # 2. Z_UP detection (z has largest variance)
+    frames_z = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=1.0, y=1.0, z=10.0, confidence=1.0),
+                Keypoint(name="kp", x=1.1, y=1.1, z=0.0, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_keypoints(frames_z) == UpAxis.Z_UP
+
+    # 3. X_UP detection (x has largest variance)
+    frames_x = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=10.0, y=1.0, z=1.0, confidence=1.0),
+                Keypoint(name="kp", x=0.0, y=1.1, z=1.1, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_keypoints(frames_x) == UpAxis.X_UP
+
+    # 4. Empty frames fallback
+    assert _detect_up_axis_keypoints([]) == UpAxis.Y_UP
+
+
+def test_detect_up_axis_markers() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.normalize import (
+        _detect_up_axis_markers,
+    )
+
+    # 1. Y_UP detection
+    frames_y = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=1.0, y=10.0, z=1.0),
+                "M2": Marker(name="M2", x=1.1, y=0.0, z=1.1),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_markers(frames_y) == UpAxis.Y_UP
+
+    # 2. Z_UP detection
+    frames_z = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=1.0, y=1.0, z=10.0),
+                "M2": Marker(name="M2", x=1.1, y=1.1, z=0.0),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_markers(frames_z) == UpAxis.Z_UP
+
+    # 3. X_UP detection
+    frames_x = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=10.0, y=1.0, z=1.0),
+                "M2": Marker(name="M2", x=0.0, y=1.1, z=1.1),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_up_axis_markers(frames_x) == UpAxis.X_UP
+
+    # 4. Empty frames fallback
+    assert _detect_up_axis_markers([]) == UpAxis.Y_UP
+
+
+def test_detect_unit_keypoints() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.normalize import (
+        _detect_unit_keypoints,
+    )
+
+    # 1. Millimeters (extent > 100)
+    frames_mm = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=0.0, y=1000.0, z=0.0, confidence=1.0),
+                Keypoint(name="kp", x=0.0, y=0.0, z=0.0, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_keypoints(frames_mm) == UnitSystem.MILLIMETERS
+
+    # 2. Centimeters (10 < extent <= 100)
+    frames_cm = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=0.0, y=50.0, z=0.0, confidence=1.0),
+                Keypoint(name="kp", x=0.0, y=0.0, z=0.0, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_keypoints(frames_cm) == UnitSystem.CENTIMETERS
+
+    # 3. Meters (extent <= 10)
+    frames_m = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[
+                Keypoint(name="kp", x=0.0, y=1.8, z=0.0, confidence=1.0),
+                Keypoint(name="kp", x=0.0, y=0.0, z=0.0, confidence=1.0),
+            ],
+            schema_name="custom",
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_keypoints(frames_m) == UnitSystem.METERS
+
+    # 4. Empty frames fallback
+    assert _detect_unit_keypoints([]) == UnitSystem.METERS
+
+
+def test_detect_unit_markers() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.normalize import (
+        _detect_unit_markers,
+    )
+
+    # 1. Millimeters (extent > 100)
+    frames_mm = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=0.0, y=1000.0, z=0.0),
+                "M2": Marker(name="M2", x=0.0, y=0.0, z=0.0),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_markers(frames_mm) == UnitSystem.MILLIMETERS
+
+    # 2. Centimeters (10 < extent <= 100)
+    frames_cm = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=0.0, y=50.0, z=0.0),
+                "M2": Marker(name="M2", x=0.0, y=0.0, z=0.0),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_markers(frames_cm) == UnitSystem.CENTIMETERS
+
+    # 3. Meters (extent <= 10)
+    frames_m = [
+        MarkerFrame(
+            timestamp=0.0,
+            markers={
+                "M1": Marker(name="M1", x=0.0, y=1.8, z=0.0),
+                "M2": Marker(name="M2", x=0.0, y=0.0, z=0.0),
+            },
+            frame_index=0,
+        )
+    ]
+    assert _detect_unit_markers(frames_m) == UnitSystem.METERS
+
+    # 4. Empty frames fallback
+    assert _detect_unit_markers([]) == UnitSystem.METERS
+
+
+def test_normalize_auto_detection_and_centering_keypoints() -> None:
+    # y-up, in meters, shifted centroid
+    seq = KeypointSequence(
+        id="seq",
+        frames=[
+            KeypointFrame(
+                timestamp=0.0,
+                keypoints=[
+                    Keypoint(name="kp1", x=2.0, y=10.0, z=2.0, confidence=1.0),
+                    Keypoint(name="kp2", x=4.0, y=0.0, z=4.0, confidence=1.0),
+                ],
+                schema_name="custom",
+                frame_index=0,
+            )
+        ],
+    )
+    # y-up should be detected since y variance (25) is larger than x/z variance (1)
+    # center_origin = True should center the coordinates (centroid at x=3.0, y=5.0, z=3.0)
+    out = normalize_coordinates(seq, target_up=UpAxis.Y_UP, source_up=None, center_origin=True)
+    assert out.metadata["source_up"] == UpAxis.Y_UP.value
+
+    # Centroid should be 0,0,0
+    kp1 = out.frames[0].keypoints[0]
+    kp2 = out.frames[0].keypoints[1]
+    assert kp1.x == pytest.approx(-1.0)
+    assert kp1.y == pytest.approx(5.0)
+    assert kp1.z == pytest.approx(-1.0)
+    assert kp2.x == pytest.approx(1.0)
+    assert kp2.y == pytest.approx(-5.0)
+    assert kp2.z == pytest.approx(1.0)
+
+
+def test_normalize_auto_detection_markers() -> None:
+    traj = MarkerTrajectory(
+        id="traj",
+        frames=[
+            MarkerFrame(
+                timestamp=0.0,
+                markers={
+                    "M1": Marker(name="M1", x=2.0, y=10.0, z=2.0),
+                    "M2": Marker(name="M2", x=4.0, y=0.0, z=4.0),
+                },
+                frame_index=0,
+            )
+        ],
+    )
+    # Auto detect Y_UP and center it
+    out = normalize_coordinates(traj, target_up=UpAxis.Y_UP, source_up=None, center_origin=True)
+    assert out.metadata["source_up"] == UpAxis.Y_UP.value
+    m1 = out.frames[0].markers["M1"]
+    m2 = out.frames[0].markers["M2"]
+    assert m1.x == pytest.approx(-1.0)
+    assert m1.y == pytest.approx(5.0)
+    assert m1.z == pytest.approx(-1.0)
+    assert m2.x == pytest.approx(1.0)
+    assert m2.y == pytest.approx(-5.0)
+    assert m2.z == pytest.approx(1.0)
+
+
+def test_convert_units_auto_detection_keypoints() -> None:
+    # mm data (extent y is 1000)
+    seq = KeypointSequence(
+        id="seq",
+        frames=[
+            KeypointFrame(
+                timestamp=0.0,
+                keypoints=[
+                    Keypoint(name="kp1", x=0.0, y=1000.0, z=0.0, confidence=1.0),
+                    Keypoint(name="kp2", x=0.0, y=0.0, z=0.0, confidence=1.0),
+                ],
+                schema_name="custom",
+                frame_index=0,
+            )
+        ],
+    )
+    # Convert to meters with auto-detected mm
+    out = convert_units(seq, target_unit=UnitSystem.METERS, source_unit=None)
+    assert out.metadata["source_unit"] == UnitSystem.MILLIMETERS.value
+    assert out.frames[0].keypoints[0].y == pytest.approx(1.0)
+
+
+def test_convert_units_auto_detection_markers() -> None:
+    # mm data
+    traj = MarkerTrajectory(
+        id="traj",
+        frames=[
+            MarkerFrame(
+                timestamp=0.0,
+                markers={
+                    "M1": Marker(name="M1", x=0.0, y=1000.0, z=0.0),
+                    "M2": Marker(name="M2", x=0.0, y=0.0, z=0.0),
+                },
+                frame_index=0,
+            )
+        ],
+    )
+    out = convert_units(traj, target_unit=UnitSystem.METERS, source_unit=None)
+    assert out.metadata["source_unit"] == UnitSystem.MILLIMETERS.value
+    assert out.frames[0].markers["M1"].y == pytest.approx(1.0)
+
+
+def test_center_functions_empty_returns() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.normalize import (
+        _center_keypoints_origin,
+        _center_markers_origin,
+    )
+
+    assert _center_keypoints_origin([]) == []
+    assert _center_markers_origin([]) == []
+
+
+def test_normalize_keypoints_without_z() -> None:
+    seq = KeypointSequence(
+        id="seq2d",
+        frames=[
+            KeypointFrame(
+                timestamp=0.0,
+                keypoints=[
+                    Keypoint(name="kp1", x=1.0, y=2.0, z=None, confidence=1.0),
+                ],
+                schema_name="custom",
+                frame_index=0,
+            )
+        ],
+    )
+    # Convert Y_UP to Z_UP. Since Z is None, it should remain None.
+    out = normalize_coordinates(
+        seq, target_up=UpAxis.Z_UP, source_up=UpAxis.Y_UP, center_origin=False
+    )
+    assert out.frames[0].keypoints[0].z is None
+
+    # Check convert units preserves None Z
+    out_units = convert_units(
+        seq, target_unit=UnitSystem.MILLIMETERS, source_unit=UnitSystem.METERS
+    )
+    assert out_units.frames[0].keypoints[0].z is None
+
+    # Check center origin preserves None Z
+    out_centered = normalize_coordinates(
+        seq, target_up=UpAxis.Y_UP, source_up=UpAxis.Y_UP, center_origin=True
+    )
+    assert out_centered.frames[0].keypoints[0].z is None

--- a/tests/unit/motion_pipeline/preprocessing/test_resample.py
+++ b/tests/unit/motion_pipeline/preprocessing/test_resample.py
@@ -84,3 +84,59 @@ def test_resample_marker_trajectory_id_preserved() -> None:
     traj = make_marker_trajectory(num_frames=10, fps=30.0)
     out = resample(traj, target_fps=60.0)
     assert out.id == traj.id
+
+
+def test_pure_python_resample_parity() -> None:
+    from src.shared.python.motion_pipeline.preprocessing._resample_pure_python import (
+        resample as pure_resample,
+    )
+
+    # Test standard parity
+    seq = make_keypoint_sequence(num_frames=30, num_kp=1, fps=30.0)
+    out = pure_resample(seq, target_fps=120.0, source_fps=30.0)
+    assert out.num_frames > 30
+    assert out.metadata.get("resampled") is True
+
+    traj = make_marker_trajectory(num_frames=30, fps=60.0)
+    out_traj = pure_resample(traj, target_fps=120.0, source_fps=60.0)
+    assert out_traj.num_frames > 30
+
+    # Test error condition
+    with pytest.raises(ValueError, match="Unsupported"):
+        pure_resample("invalid", target_fps=60.0)  # type: ignore[arg-type]
+
+    # Test short inputs (len < 2)
+    short_seq = make_keypoint_sequence(num_frames=1, num_kp=1, fps=30.0)
+    assert pure_resample(short_seq, target_fps=120.0) is short_seq
+
+    short_traj = make_marker_trajectory(num_frames=1, fps=60.0)
+    assert pure_resample(short_traj, target_fps=120.0) is short_traj
+
+
+def test_resample_estimate_fps_edge_cases() -> None:
+    from src.shared.python.motion_pipeline.preprocessing.resample import _estimate_fps
+    from src.shared.python.motion_pipeline.preprocessing._resample_pure_python import (
+        _estimate_fps as pure_estimate_fps,
+    )
+    from src.shared.python.motion_pipeline.contracts import KeypointFrame
+
+    # dt <= 0
+    frames_bad = [
+        KeypointFrame.model_construct(
+            timestamp=1.0, keypoints=[], schema_name="custom", frame_index=0
+        ),
+        KeypointFrame.model_construct(
+            timestamp=0.5, keypoints=[], schema_name="custom", frame_index=1
+        ),
+    ]
+    assert _estimate_fps(frames_bad) == 30.0
+    assert pure_estimate_fps(frames_bad) == 30.0
+
+    # len < 2
+    frames_short = [
+        KeypointFrame.model_construct(
+            timestamp=1.0, keypoints=[], schema_name="custom", frame_index=0
+        ),
+    ]
+    assert _estimate_fps(frames_short) == 30.0
+    assert pure_estimate_fps(frames_short) == 30.0

--- a/tests/unit/motion_pipeline/scaling/test_opensim_scale_mocked.py
+++ b/tests/unit/motion_pipeline/scaling/test_opensim_scale_mocked.py
@@ -1,0 +1,263 @@
+"""Tests for the OpenSim ScaleTool wrapper using mocks to avoid skipping."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import numpy as np
+import pytest
+
+from src.shared.python.motion_pipeline.contracts import (
+    JointDef,
+    Marker,
+    MarkerFrame,
+    SkeletonRig,
+)
+from src.shared.python.motion_pipeline.scaling.opensim_scale import (
+    OpenSimScaleBackend,
+)
+
+
+def _rig() -> SkeletonRig:
+    return SkeletonRig(
+        id="generic",
+        joints={
+            "pelvis": JointDef(
+                name="pelvis",
+                parent=None,
+                children=["femur"],
+                tpose_offset=[0.0, 0.0, 0.0],
+                axes=["X"],
+            ),
+            "femur": JointDef(
+                name="femur",
+                parent="pelvis",
+                children=[],
+                tpose_offset=[0.0, -0.4, 0.0],
+                axes=["X"],
+            ),
+        },
+        root_joint="pelvis",
+    )
+
+
+def _markers() -> MarkerFrame:
+    return MarkerFrame(
+        timestamp=0.0,
+        markers={
+            "femur_prox": Marker(name="femur_prox", x=0.0, y=0.0, z=0.0),
+            "femur_dist": Marker(name="femur_dist", x=0.0, y=-0.45, z=0.0),
+            "pelvis_l": Marker(name="pelvis_l", x=-0.1, y=0.0, z=0.0),
+            "pelvis_r": Marker(name="pelvis_r", x=0.1, y=0.0, z=0.0),
+        },
+    )
+
+
+def test_opensim_scale_backend_initialization_validation():
+    # Test valid initializations
+    backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75, generic_model_path="model.osim")
+    assert backend.mass_kg == 70.0
+    assert backend.height_m == 1.75
+    assert backend.generic_model_path == Path("model.osim")
+
+    # Test invalid mass
+    with pytest.raises(ValueError, match="mass_kg must be a positive finite number"):
+        OpenSimScaleBackend(mass_kg=0)
+    with pytest.raises(ValueError, match="mass_kg must be a positive finite number"):
+        OpenSimScaleBackend(mass_kg=-10.0)
+    with pytest.raises(ValueError, match="mass_kg must be a positive finite number"):
+        OpenSimScaleBackend(mass_kg=float("inf"))
+
+    # Test invalid height
+    with pytest.raises(ValueError, match="height_m must be a positive finite number"):
+        OpenSimScaleBackend(height_m=0)
+    with pytest.raises(ValueError, match="height_m must be a positive finite number"):
+        OpenSimScaleBackend(height_m=-1.80)
+    with pytest.raises(ValueError, match="height_m must be a positive finite number"):
+        OpenSimScaleBackend(height_m=float("nan"))
+
+
+def test_scale_without_opensim_installed():
+    """Verify that scale() raises RuntimeError if opensim is not installed/importable."""
+    rig = _rig()
+    markers = _markers()
+    backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75)
+
+    with (
+        patch.dict(sys.modules, {"opensim": None}),
+        pytest.raises(RuntimeError, match="opensim not installed"),
+    ):
+        # In python, setting a module to None in sys.modules triggers an ImportError when importing it
+        backend.scale(rig, markers, {"femur_prox": "femur"})
+
+
+def test_scale_success_with_mocked_opensim():
+    """Test successful scaling using a mocked opensim module."""
+    rig = _rig()
+    markers = _markers()
+    marker_to_segment = {
+        "femur_prox": "femur",
+        "femur_dist": "femur",
+        "pelvis_l": "pelvis",
+        "pelvis_r": "pelvis",
+    }
+
+    mock_opensim = MagicMock()
+    mock_scale_tool = MagicMock()
+    mock_opensim.ScaleTool.return_value = mock_scale_tool
+
+    with patch.dict(sys.modules, {"opensim": mock_opensim}):
+        backend = OpenSimScaleBackend(
+            mass_kg=70.0, height_m=1.75, generic_model_path="generic.osim"
+        )
+        scaled = backend.scale(rig, markers, marker_to_segment)
+
+        # Verify calls to ScaleTool
+        mock_opensim.ScaleTool.assert_called_once()
+        mock_scale_tool.setName.assert_called_once_with("generic-scale")
+        mock_scale_tool.setSubjectMass.assert_called_once_with(70.0)
+        mock_scale_tool.setSubjectHeight.assert_called_once_with(1750.0)
+
+        # Verify scaled rig properties
+        assert scaled.id == "generic-scaled"
+        assert scaled.metadata["scaled_by"] == "opensim"
+
+        # pelvis is root so it doesn't change from 0.0 offset. femur should have a scaled offset based on markers.
+        # femur_prox = [0,0,0], femur_dist = [0,-0.45,0], so distance is 0.45
+        femur_offset = scaled.joints["femur"].tpose_offset
+        assert np.linalg.norm(femur_offset) == pytest.approx(0.45)
+
+
+def test_scale_validation_parameters():
+    """Test input parameter validation in scale()."""
+    backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75)
+    rig = _rig()
+    markers = _markers()
+    marker_to_segment = {"femur_prox": "femur"}
+
+    with pytest.raises(ValueError, match="rig must be provided"):
+        backend.scale(None, markers, marker_to_segment)
+
+    with pytest.raises(ValueError, match="calibration_markers must contain markers"):
+        backend.scale(rig, MarkerFrame(timestamp=0.0, markers={}), marker_to_segment)
+
+    with pytest.raises(ValueError, match="marker_to_segment must be provided"):
+        backend.scale(rig, markers, None)
+
+
+def test_scale_zero_or_nan_length_fallback():
+    """Test fallback when current offset is zero or length is non-finite/negative."""
+    # A rig where the femur tpose_offset is zero.
+    rig = SkeletonRig(
+        id="zero_offset",
+        joints={
+            "pelvis": JointDef(
+                name="pelvis",
+                parent=None,
+                children=["femur"],
+                tpose_offset=[0.0, 0.0, 0.0],
+                axes=["X"],
+            ),
+            "femur": JointDef(
+                name="femur", parent="pelvis", children=[], tpose_offset=[0.0, 0.0, 0.0], axes=["X"]
+            ),
+        },
+        root_joint="pelvis",
+    )
+    markers = _markers()
+    # Marker to segment has no valid pairings for femur, so segment length defaults to 1.0 (or current if valid)
+    marker_to_segment = {}
+
+    mock_opensim = MagicMock()
+    with patch.dict(sys.modules, {"opensim": mock_opensim}):
+        backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75)
+        scaled = backend.scale(rig, markers, marker_to_segment)
+
+        # For femur, current offset norm is 0.0, target is default 1.0.
+        # Since scale is 0.0 (current <= 1e-9), it falls back to new_offset = [target, 0.0, 0.0] = [1.0, 0.0, 0.0]
+        assert scaled.joints["femur"].tpose_offset == [1.0, 0.0, 0.0]
+
+
+def test_scale_nan_coordinates_fallback():
+    """Test that nan/infinite marker coordinates fallback gracefully to default/previous lengths."""
+    rig = _rig()
+    markers = MarkerFrame(
+        timestamp=0.0,
+        markers={
+            "femur_prox": Marker.model_construct(name="femur_prox", x=float("nan"), y=0.0, z=0.0),
+            "femur_dist": Marker(name="femur_dist", x=0.0, y=-0.45, z=0.0),
+        },
+    )
+    marker_to_segment = {"femur_prox": "femur", "femur_dist": "femur"}
+
+    mock_opensim = MagicMock()
+    with patch.dict(sys.modules, {"opensim": mock_opensim}):
+        backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75)
+        scaled = backend.scale(rig, markers, marker_to_segment)
+        # target becomes NaN, fallback uses current offset (0.4)
+        assert np.linalg.norm(scaled.joints["femur"].tpose_offset) == pytest.approx(0.4)
+
+
+def test_scale_non_positive_postcondition_raises():
+    """Verify that scale() raises RuntimeError if a non-root joint has non-positive length in postcondition check."""
+    rig = _rig()
+    markers = _markers()
+    mock_opensim = MagicMock()
+    bad_rig = SkeletonRig(
+        id="bad",
+        joints={
+            "pelvis": JointDef(
+                name="pelvis",
+                parent=None,
+                children=["femur"],
+                tpose_offset=[0.0, 0.0, 0.0],
+                axes=["X"],
+            ),
+            "femur": JointDef(
+                name="femur", parent="pelvis", children=[], tpose_offset=[0.0, 0.0, 0.0], axes=["X"]
+            ),
+        },
+        root_joint="pelvis",
+    )
+    with patch.dict(sys.modules, {"opensim": mock_opensim}):
+        backend = OpenSimScaleBackend(mass_kg=70.0, height_m=1.75)
+        # Patch _apply_lengths_to_rig to return a rig with zero offset for femur
+        with (
+            patch.object(OpenSimScaleBackend, "_apply_lengths_to_rig") as mock_apply,
+            pytest.raises(
+                RuntimeError, match="Scaled rig has non-positive segment length for femur"
+            ),
+        ):
+            mock_apply.return_value = bad_rig
+            backend.scale(rig, markers, {})
+
+
+def test_scale_additional_branches():
+    """Test remaining branch coverage in opensim_scale.py."""
+    rig = _rig()
+    markers = _markers()
+    marker_to_segment = {
+        "femur_prox": "single_marker_seg",  # segment with 1 marker (line 118->117)
+        "femur_dist": "femur",
+        "pelvis_l": "pelvis",
+        "pelvis_r": "pelvis",
+        "missing_marker": "femur",  # missing marker key (line 113->112)
+    }
+
+    mock_opensim = MagicMock()
+    mock_scale_tool = MagicMock()
+    mock_opensim.ScaleTool.return_value = mock_scale_tool
+
+    # Mock Path.exists to return True for out_osim
+    with (
+        patch.dict(sys.modules, {"opensim": mock_opensim}),
+        patch(
+            "src.shared.python.motion_pipeline.scaling.opensim_scale.Path.exists", return_value=True
+        ),
+    ):
+        backend = OpenSimScaleBackend(
+            mass_kg=70.0, height_m=1.75, generic_model_path="generic.osim"
+        )
+        scaled = backend.scale(rig, markers, marker_to_segment)
+        assert scaled.joints["femur"].tpose_offset is not None

--- a/tests/unit/motion_pipeline/sources/test_trc_adapter.py
+++ b/tests/unit/motion_pipeline/sources/test_trc_adapter.py
@@ -57,3 +57,222 @@ def test_trc_truncated_raises(tmp_path: Path) -> None:
     p.write_text("PathFileType\t4\nfoo\n")
     with pytest.raises(ValueError):
         TRCAdapter().load(p)
+
+
+def test_trc_supports_os_error() -> None:
+    from unittest.mock import patch
+
+    with patch("builtins.open", side_effect=OSError):
+        assert TRCAdapter.supports(Path("dummy.trc")) is False
+
+
+def test_trc_parse_header_missing_values(tmp_path: Path) -> None:
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames",
+            "100.0\t100.0",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+            "1\t0.0\t1.0\t2.0\t3.0",
+        ]
+    )
+    p = tmp_path / "test.trc"
+    p.write_text(content)
+    md = TRCAdapter().metadata(p)
+    assert md.frame_count == 0
+
+
+def test_trc_metadata_fps_fallbacks(tmp_path: Path) -> None:
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "invalid_fps\t60.0\t10\tmm",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+            "1\t0.0\t1.0\t2.0\t3.0",
+        ]
+    )
+    p = tmp_path / "test1.trc"
+    p.write_text(content)
+    md = TRCAdapter().metadata(p)
+    assert md.fps == 60.0
+    assert md.frame_count == 10
+
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "invalid_fps\tinvalid_cam\tinvalid_frames\tmm",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+            "1\t0.0\t1.0\t2.0\t3.0",
+        ]
+    )
+    p = tmp_path / "test2.trc"
+    p.write_text(content)
+    md = TRCAdapter().metadata(p)
+    assert md.fps == 30.0
+    assert md.frame_count == 0
+
+
+def test_trc_load_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        TRCAdapter().load(Path("non_existent_file.trc"))
+
+
+def test_trc_load_invalid_lines(tmp_path: Path) -> None:
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t3\tmm",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+            "",
+            "only_one_token",
+            "1\t0.0\t1000\t2000\t3000",
+        ]
+    )
+    p = tmp_path / "invalid1.trc"
+    p.write_text(content)
+    traj = TRCAdapter().load(p)
+    assert traj.num_frames == 1
+
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t3\tmm",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+            "invalid_frame\t0.0\t1000\t2000\t3000",
+        ]
+    )
+    p = tmp_path / "invalid2.trc"
+    p.write_text(content)
+    with pytest.raises(ValueError, match="has invalid frame/time"):
+        TRCAdapter().load(p)
+
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t3\tmm",
+            "Frame#\tTime\tHEAD\tHIP",
+            "\t\tX1\tY1\tZ1\tX2\tY2\tZ2",
+            "1\t0.0\t1000\t2000\t3000\t100",
+        ]
+    )
+    p = tmp_path / "invalid3.trc"
+    p.write_text(content)
+    traj = TRCAdapter().load(p)
+    assert "HEAD" in traj.frames[0].markers
+    assert "HIP" not in traj.frames[0].markers
+
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t3\tmm",
+            "Frame#\tTime\tHEAD\tHIP",
+            "\t\tX1\tY1\tZ1\tX2\tY2\tZ2",
+            "1\t0.0\t1000\t2000\t3000\t100\tinvalid\t300",
+        ]
+    )
+    p = tmp_path / "invalid4.trc"
+    p.write_text(content)
+    traj = TRCAdapter().load(p)
+    assert "HEAD" in traj.frames[0].markers
+    assert "HIP" not in traj.frames[0].markers
+
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t3\tmm",
+            "Frame#\tTime\tHEAD",
+            "\t\tX1\tY1\tZ1",
+        ]
+    )
+    p = tmp_path / "invalid5.trc"
+    p.write_text(content)
+    with pytest.raises(ValueError, match="has no data rows"):
+        TRCAdapter().load(p)
+
+
+def test_trc_load_via_rust(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+
+    p = tmp_path / "tiny.trc"
+    p.write_text(
+        "\n".join(
+            [
+                "PathFileType\t4\t(X/Y/Z)\ttiny.trc",
+                "DataRate\tCameraRate\tNumFrames\tNumMarkers\tUnits\tOrigDataRate\tOrigDataStartFrame\tOrigNumFrames",
+                "100.0\t100.0\t3\t2\tmm\t100.0\t1\t3",
+                "Frame#\tTime\tHEAD\t\t\tHIP\t\t\t",
+                "\t\tX1\tY1\tZ1\tX2\tY2\tZ2",
+                "1\t0.0\t1000\t2000\t3000\t100\t200\t300",
+            ]
+        )
+    )
+
+    mock_rust_io = MagicMock()
+    mock_rust_io.parse_trc.return_value = {
+        "positions": np.array([[1.0, 2.0, 3.0, 0.1, 0.2, 0.3]], dtype=np.float32),
+        "labels": ["HEAD", "HIP"],
+        "n_frames": 1,
+        "fps": 100.0,
+        "units": "mm",
+    }
+    with (
+        patch("src.shared.python.motion_pipeline.sources.trc_adapter._rust_io", mock_rust_io),
+        patch("src.shared.python.motion_pipeline.sources.trc_adapter._HAS_RUST", True),
+    ):
+        traj = TRCAdapter().load(p)
+        assert traj.num_frames == 1
+        assert traj.frames[0].markers["HEAD"].x == pytest.approx(1.0)
+        assert traj.frames[0].markers["HIP"].x == pytest.approx(0.1)
+
+
+def test_trc_load_via_rust_edge_cases(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+
+    mock_rust_io = MagicMock()
+    mock_rust_io.parse_trc.return_value = {
+        "positions": np.array([[float("nan"), 2.0, 3.0, 0.1, 0.2, 0.3]], dtype=np.float32),
+        "labels": ["HEAD", "HIP"],
+        "n_frames": 1,
+        "fps": 100.0,
+        "units": "mm",
+    }
+    content = "\n".join(
+        [
+            "PathFileType\t4\t(X/Y/Z)\tfile.trc",
+            "DataRate\tCameraRate\tNumFrames\tUnits",
+            "100.0\t100.0\t1\tmm",
+            "Frame#\tTime\tHEAD\tHIP",
+            "\t\tX1\tY1\tZ1\tX2\tY2\tZ2",
+        ]
+    )
+    p = tmp_path / "edge.trc"
+    p.write_text(content)
+    with (
+        patch("src.shared.python.motion_pipeline.sources.trc_adapter._rust_io", mock_rust_io),
+        patch("src.shared.python.motion_pipeline.sources.trc_adapter._HAS_RUST", True),
+    ):
+        traj = TRCAdapter().load(p)
+        assert traj.num_frames == 1
+        assert "HEAD" not in traj.frames[0].markers
+        assert traj.frames[0].markers["HIP"].x == pytest.approx(0.1)
+        assert traj.frames[0].frame_index == 0
+        assert traj.frames[0].timestamp == 0.0
+
+        mock_rust_io.parse_trc.return_value["n_frames"] = 0
+        mock_rust_io.parse_trc.return_value["positions"] = np.empty((0, 6), dtype=np.float32)
+        with pytest.raises(ValueError, match="has no data rows"):
+            TRCAdapter().load(p)


### PR DESCRIPTION
This PR adds comprehensive unit and mock tests for opensim_scale.py and trc_adapter.py under motion_pipeline.