### PR TITLE
fix(logging): logger.exception, hide WS exception details from clients (#5919)

### DIFF
--- a/src/api/aip/methods.py
+++ b/src/api/aip/methods.py
@@ -8,12 +8,13 @@ See issue #763
 
 from __future__ import annotations
 
-import logging
 from typing import Any
+
+from src.shared.python.logging_pkg.logging_config import get_logger
 
 from .dispatcher import MethodRegistry
 
-_logger = logging.getLogger(__name__)
+_logger = get_logger(__name__)
 
 
 def create_registry() -> MethodRegistry:

--- a/src/api/database.py
+++ b/src/api/database.py
@@ -117,10 +117,11 @@ def get_db() -> Generator[Session, None, None]:
 
 def init_db() -> None:
     """Initialize database with tables and default data."""
-    import logging
     import secrets
 
-    logger = logging.getLogger(__name__)
+    from src.shared.python.logging_pkg.logging_config import get_logger
+
+    logger = get_logger(__name__)
 
     if _is_production_environment():
         _assert_alembic_head_applied()

--- a/src/api/middleware/error_handler.py
+++ b/src/api/middleware/error_handler.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import logging
 from collections.abc import Callable
 from typing import Any
 
 from fastapi import HTTPException
 
-logger = logging.getLogger(__name__)
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def _handle_common_exceptions(e: Exception, func_name: str) -> None:

--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import logging
 import math
 from typing import TYPE_CHECKING, Any
 
@@ -24,8 +23,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from src.shared.python.core.contracts import precondition
+from src.shared.python.logging_pkg.logging_config import get_logger
 
-from ..dependencies import get_engine_manager, get_logger
+from ..dependencies import get_engine_manager, get_logger as get_request_logger
 from ..models.requests import (
     BodyPositionUpdateRequest,
     DataExportRequest,
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 router = APIRouter()
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _check_position_support(engine: Any) -> None:
@@ -213,7 +213,7 @@ def _store_metric_snapshot(
 @router.get("/analysis/metrics")
 async def get_analysis_metrics(
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> dict[str, Any]:
     """Get current real-time analysis metrics.
 
@@ -248,7 +248,7 @@ async def get_analysis_metrics(
 @router.get("/analysis/statistics", response_model=AnalysisStatisticsResponse)
 async def get_analysis_statistics(  # noqa: C901
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> AnalysisStatisticsResponse:
     """Get statistical summary of analysis metrics over time.
 
@@ -336,7 +336,7 @@ async def get_analysis_statistics(  # noqa: C901
 async def export_analysis_data(  # noqa: C901
     request: DataExportRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> StreamingResponse:
     """Export analysis data as CSV or JSON download.
 
@@ -433,7 +433,7 @@ async def export_analysis_data(  # noqa: C901
 async def set_body_position(
     request: BodyPositionUpdateRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> BodyPositionResponse:
     """Set the position and/or rotation of a body in the simulation.
 
@@ -505,7 +505,7 @@ async def set_body_position(
 async def measure_distance(
     request: MeasurementRequest,
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> MeasurementResult:
     """Measure the distance between two bodies.
 
@@ -559,7 +559,7 @@ async def measure_distance(
 @router.get("/simulation/measurements", response_model=MeasurementToolsResponse)
 async def get_measurement_tools(
     engine_manager: EngineManager = Depends(get_engine_manager),
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> MeasurementToolsResponse:
     """Get all joint angles and active measurements.
 

--- a/src/api/routes/character_builder.py
+++ b/src/api/routes/character_builder.py
@@ -6,7 +6,6 @@ weight, and build type.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -14,11 +13,12 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from humanoid_character_builder.core.body_parameters import BodyParameters, BuildType
 from humanoid_character_builder.generators.urdf_generator import HumanoidURDFGenerator
 from src.api.middleware.error_handler import handle_api_errors
+from src.shared.python.logging_pkg.logging_config import get_logger
 
-from ..dependencies import get_logger
+from ..dependencies import get_logger as get_request_logger
 from ..models.requests import CharacterBuilderRequest
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 router = APIRouter()
 
 
@@ -35,7 +35,7 @@ router = APIRouter()
 @handle_api_errors
 async def generate_character_urdf(
     request: CharacterBuilderRequest,
-    logger: Any = Depends(get_logger),
+    logger: Any = Depends(get_request_logger),
 ) -> Response:
     """Generate a custom humanoid URDF model from body parameters.
 

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -178,8 +178,11 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                     chat_service.add_user_message(
                         session_id, user_message, engine_context
                     )
-                except ValueError as e:
-                    await websocket.send_json({"type": "error", "detail": str(e)})
+                except ValueError:
+                    logger.exception("Invalid user message for session %s", session_id)
+                    await websocket.send_json(
+                        {"type": "error", "detail": "invalid message"}
+                    )
                     continue
 
                 # Stream response chunks
@@ -195,9 +198,11 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                     await websocket.send_json(
                         {"type": "complete", "session_id": session_id}
                     )
-                except Exception as e:  # noqa: BLE001
-                    logger.error("Error during streaming response: %s", e)
-                    await websocket.send_json({"type": "error", "detail": str(e)})
+                except Exception:  # noqa: BLE001
+                    logger.exception("Error during streaming response")
+                    await websocket.send_json(
+                        {"type": "error", "detail": "internal error"}
+                    )
 
             elif action == "history":
                 messages = chat_service.get_session_history(session_id)
@@ -248,10 +253,10 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
 
     except WebSocketDisconnect:
         logger.debug("Chat WebSocket disconnected: session=%s", session_id)
-    except (ConnectionError, TimeoutError, OSError) as e:
-        logger.error("Chat WebSocket error: %s", e)
+    except (ConnectionError, TimeoutError, OSError):
+        logger.exception("Chat WebSocket error")
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
-            await websocket.send_json({"type": "error", "detail": str(e)})
+            await websocket.send_json({"type": "error", "detail": "internal error"})
 
 
 # ── REST fallback endpoints ──────────────────────────────────────────

--- a/src/api/routes/realtime.py
+++ b/src/api/routes/realtime.py
@@ -13,15 +13,15 @@ Subscriber bookkeeping is in-memory and protected by an :class:`asyncio.Lock`.
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
+from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.realtime.protocol import validate_channel
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(tags=["realtime"])
 

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel
 
 from src.shared.python.core.contracts import require
 from src.shared.python.engine_core.engine_registry import EngineType
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter()
 _DEFAULT_SPEED_FACTOR = 1.0
@@ -364,10 +367,10 @@ async def simulation_stream(
 
     except WebSocketDisconnect:
         pass  # Client disconnected
-    except (ValueError, RuntimeError, AttributeError) as e:
-        # Best effort error reporting
+    except (ValueError, RuntimeError, AttributeError):
+        logger.exception("Simulation WebSocket handler error")
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
-            await websocket.send_json({"error": str(e)})
+            await websocket.send_json({"type": "error", "detail": "internal error"})
     finally:
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
             await websocket.close()

--- a/src/api/routes/terrain.py
+++ b/src/api/routes/terrain.py
@@ -13,7 +13,6 @@ Fixes #1142
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import APIRouter
@@ -21,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from src.api.middleware.error_handler import handle_api_errors
 from src.shared.python.core.contracts import precondition
+from src.shared.python.logging_pkg.logging_config import get_logger
 from src.shared.python.physics.terrain import (
     MATERIALS,
     TERRAIN_MATERIAL_MAP,
@@ -34,7 +34,7 @@ from src.shared.python.physics.terrain_presets import (
     get_environment_preset_names,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/terrain", tags=["terrain"])
 

--- a/src/api/routes/theme.py
+++ b/src/api/routes/theme.py
@@ -4,13 +4,13 @@ Provides access to the fleet-wide ThemeManager so the React UI can synchronize
 its styling with the PyQt6 desktop launcher.
 """
 
-import logging
+from src.shared.python.logging_pkg.logging_config import get_logger
 
 
 from src.shared.python.theme.api import create_theme_router
 from src.shared.python.theme.theme_manager import ThemeManager
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Initialize the theme manager singleton
 # We use the standard D-sorganization FleetTheme settings path so it picks up

--- a/tests/unit/test_logging_discipline.py
+++ b/tests/unit/test_logging_discipline.py
@@ -1,0 +1,186 @@
+"""Logging discipline regression tests for WebSocket handlers.
+
+Issue #5919: Verify that:
+1. No ``str(e)`` appears in ``websocket.send_json`` error payloads in WS
+   handler modules (exception detail leakage prevention).
+2. All ``logger.error`` calls that caught exceptions are converted to
+   ``logger.exception`` so the traceback is always captured.
+
+Uses AST scanning so no imports of the production modules are needed and the
+tests remain dependency-free.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+
+_WS_HANDLER_FILES = [
+    _SRC_ROOT / "api" / "routes" / "simulation_ws.py",
+    _SRC_ROOT / "api" / "routes" / "chat_ws.py",
+]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _has_str_e_in_send_json(tree: ast.Module) -> list[tuple[int, str]]:
+    """Return (lineno, snippet) for any send_json call containing str(e).
+
+    Detects patterns such as::
+
+        await websocket.send_json({..., "detail": str(e), ...})
+
+    using AST traversal so string-encoding differences do not matter.
+    """
+    violations: list[tuple[int, str]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            # Match: <expr>.send_json(...)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "send_json":
+                # Inspect all values in any dict literal argument
+                for arg in node.args + [kw.value for kw in node.keywords]:
+                    for nested in ast.walk(arg):
+                        if _is_str_e_call(nested):
+                            snippet = ast.unparse(node)
+                            violations.append((node.lineno, snippet))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return violations
+
+
+def _is_str_e_call(node: ast.AST) -> bool:
+    """Return True if *node* is ``str(<name>)`` where <name> is a single char."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        # Single-character variable names used as exceptions (e, ex, exc, err)
+        # plus common multi-char names
+        and node.args[0].id in {"e", "ex", "exc", "err", "exception", "error", "error_"}
+        and not node.keywords
+    )
+
+
+def _find_logger_error_with_percent_e(tree: ast.Module) -> list[tuple[int, str]]:
+    """Find ``logger.error(msg, e)`` calls where *e* is a bare exception name.
+
+    These should be ``logger.exception(msg)`` instead, since the traceback is
+    not captured otherwise.
+    """
+    violations: list[tuple[int, str]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "error"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "logger"
+            ):
+                # Check positional args after the format string for bare exception names
+                for arg in node.args[1:]:
+                    if isinstance(arg, ast.Name) and arg.id in {
+                        "e",
+                        "ex",
+                        "exc",
+                        "err",
+                        "exception",
+                        "error",
+                    }:
+                        snippet = ast.unparse(node)
+                        violations.append((node.lineno, snippet))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return violations
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("ws_file", _WS_HANDLER_FILES)
+def test_no_str_e_in_websocket_send_json(ws_file: Path) -> None:
+    """Assert that no ``str(e)`` appears inside any ``send_json`` call.
+
+    Exposing raw exception text to WebSocket clients leaks internal details
+    (stack frames, file paths, library names) that can aid attackers.  All
+    error responses must use a generic static string instead.
+    """
+    assert ws_file.exists(), f"Expected WS handler at {ws_file}"
+    tree = _parse(ws_file)
+    violations = _has_str_e_in_send_json(tree)
+
+    if violations:
+        details = "\n".join(
+            f"  line {ln}: {textwrap.shorten(snippet, 120)}"
+            for ln, snippet in violations
+        )
+        pytest.fail(
+            f"Exception detail leakage in {ws_file.name}:\n{details}\n"
+            "Replace str(e) with a generic message and use logger.exception()."
+        )
+
+
+@pytest.mark.parametrize("ws_file", _WS_HANDLER_FILES)
+def test_no_logger_error_with_exception_arg(ws_file: Path) -> None:
+    """Assert that ``logger.error(msg, e)`` is not used when *e* is an exception.
+
+    ``logger.error`` does **not** capture the traceback; callers must use
+    ``logger.exception`` instead so the full stack trace is recorded in the
+    application logs.
+    """
+    assert ws_file.exists(), f"Expected WS handler at {ws_file}"
+    tree = _parse(ws_file)
+    violations = _find_logger_error_with_percent_e(tree)
+
+    if violations:
+        details = "\n".join(
+            f"  line {ln}: {textwrap.shorten(snippet, 120)}"
+            for ln, snippet in violations
+        )
+        pytest.fail(
+            f"logger.error with bare exception argument in {ws_file.name}:\n{details}\n"
+            "Replace logger.error('msg', e) with logger.exception('msg')."
+        )
+
+
+def test_simulation_ws_has_get_logger_import() -> None:
+    """Assert that simulation_ws.py imports get_logger from logging_pkg."""
+    ws_file = _WS_HANDLER_FILES[0]
+    assert ws_file.exists()
+    source = ws_file.read_text(encoding="utf-8")
+    assert "get_logger" in source, (
+        f"{ws_file.name} must import and use get_logger from logging_pkg"
+    )
+    assert "logging.getLogger" not in source, (
+        f"{ws_file.name} must not use logging.getLogger directly; use get_logger"
+    )
+
+
+def test_chat_ws_uses_get_logger() -> None:
+    """Assert that chat_ws.py uses get_logger from logging_pkg."""
+    ws_file = _WS_HANDLER_FILES[1]
+    assert ws_file.exists()
+    source = ws_file.read_text(encoding="utf-8")
+    assert "get_logger" in source, (
+        f"{ws_file.name} must import and use get_logger from logging_pkg"
+    )
+    assert "logging.getLogger" not in source, (
+        f"{ws_file.name} must not use logging.getLogger directly; use get_logger"
+    )


### PR DESCRIPTION
Closes #5919

- Convert logger.error(str(e)) to logger.exception() in all WS handlers and API routes (13 files)
- Replace str(e) detail in WebSocket JSON error responses with generic "internal error" message
- Standardize logger instantiation across api/ modules
- Add tests/unit/test_logging_discipline.py with AST-based regression checks
