### PR TITLE
fix(launcher): resolve sidekick review, dialog mixin, and mypy list clash

### DIFF
--- a/src/launchers/custom_title_bar.py
+++ b/src/launchers/custom_title_bar.py
@@ -172,7 +172,7 @@ class CustomTitleBar(QWidget):
             tm = get_theme_manager()
             if tm is not None and hasattr(tm, "themeChanged"):
                 tm.themeChanged.connect(self._on_theme_changed)
-        except (ImportError, AttributeError):
+        except (ImportError, AttributeError, RuntimeError):
             pass
 
         layout.addWidget(self.title_label)

--- a/src/launchers/model_registry.py
+++ b/src/launchers/model_registry.py
@@ -1,6 +1,6 @@
 """Model registry for managing physics models and special applications."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 
 import yaml
@@ -50,7 +50,13 @@ class ModelRegistry:
             with open(full_config_path) as f:
                 data = yaml.safe_load(f)
 
-            self.models.extend([ModelSpec(**item) for item in data.get("models", [])])
+            allowed_fields = {f.name for f in fields(ModelSpec)}
+            loaded_models = []
+            for item in data.get("models", []):
+                filtered_item = {k: v for k, v in item.items() if k in allowed_fields}
+                loaded_models.append(ModelSpec(**filtered_item))
+
+            self.models.extend(loaded_models)
 
             self._loaded = True
             logger.info(f"Loaded {len(self.models)} models from registry")

--- a/src/shared/python/ai/cli_providers/registry.py
+++ b/src/shared/python/ai/cli_providers/registry.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from src.shared.python.ai.cli_providers.contracts import CliProviderDescriptor
 from src.shared.python.ai.cli_providers.discovery import discover_cli_providers
 
+_list = list  # Alias to avoid name clashes with class-level 'list' methods in mypy
+
 
 class CliProviderRegistry:
     """Maintains the set of CLI providers discovered on this host.
@@ -24,15 +26,15 @@ class CliProviderRegistry:
     """
 
     def __init__(self) -> None:
-        self._descriptors: list[CliProviderDescriptor] | None = None
+        self._descriptors: _list[CliProviderDescriptor] | None = None
 
-    def list(self) -> list[CliProviderDescriptor]:
+    def list(self) -> _list[CliProviderDescriptor]:
         """Return all known CLI provider descriptors."""
         if self._descriptors is None:
             self._descriptors = discover_cli_providers()
         return list(self._descriptors)
 
-    def refresh(self) -> list[CliProviderDescriptor]:
+    def refresh(self) -> _list[CliProviderDescriptor]:
         """Re-run discovery and return the updated list."""
         self._descriptors = discover_cli_providers()
         return list(self._descriptors)
@@ -89,7 +91,7 @@ class AllProviders:
     def __init__(
         self,
         cli_registry: CliProviderRegistry | None = None,
-        http_providers: list[tuple[str, str]] | None = None,
+        http_providers: _list[tuple[str, str]] | None = None,
     ) -> None:
         """Build a unified view over HTTP and CLI registries.
 
@@ -101,9 +103,9 @@ class AllProviders:
                 ``set_http_providers()``.
         """
         self._cli = cli_registry or CliProviderRegistry()
-        self._http: list[tuple[str, str]] = list(http_providers or ())
+        self._http: _list[tuple[str, str]] = list(http_providers or ())
 
-    def set_http_providers(self, providers: list[tuple[str, str]]) -> None:
+    def set_http_providers(self, providers: _list[tuple[str, str]]) -> None:
         """Replace the HTTP provider list shown in the dropdown.
 
         Args:
@@ -112,7 +114,7 @@ class AllProviders:
         """
         self._http = list(providers)
 
-    def list(self) -> list[ProviderEntry]:
+    def list(self) -> _list[ProviderEntry]:
         """Return the unified list of providers for the dropdown.
 
         Order: HTTP entries first (in input order), then CLI entries
@@ -142,6 +144,6 @@ class AllProviders:
             )
         return entries
 
-    def cli_entries(self) -> list[ProviderEntry]:
+    def cli_entries(self) -> _list[ProviderEntry]:
         """Return only the CLI portion of the unified list."""
         return [e for e in self.list() if e.category == self.CLI_CATEGORY]

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -134,7 +134,6 @@ class AIAssistantPanel(QWidget):
         # --- Session manager + history ----------------------------------
         self._session_manager = ChatSessionManager()
         self._session_manager.session_loaded.connect(self._on_session_loaded)
-        self._load_history()
 
         self._init_tools()
 
@@ -147,7 +146,7 @@ class AIAssistantPanel(QWidget):
 
         self._wire_controllers()
         self._setup_ui()
-        self._messages.restore_from_context(self._context)
+        self._load_history()
 
     # ------------------------------------------------------------------
     # Back-compat attribute proxies (read by external tests & code)
@@ -273,6 +272,58 @@ class AIAssistantPanel(QWidget):
         register_file_tools(self._tools_registry)
         register_codemap_tools(self._tools_registry)
         register_panel_tools(self._tools_registry, self._rag_store)
+
+    def _populate_cli_provider_entries(self, combo: Any) -> None:
+        """Append a 'CLI Agents' section to the provider combo.
+
+        Reads only through ``AllProviders`` so the populator stays
+        decoupled from subprocess introspection (Law of Demeter).
+        Entries are appended only when at least one CLI provider was
+        discovered; otherwise the combo is left untouched.
+
+        Args:
+            combo: The provider QComboBox to extend.
+
+        Raises:
+            ValueError: If ``combo`` is None.
+        """
+        if combo is None:
+            raise ValueError("combo must be provided")
+
+        try:
+            from src.shared.python.ai.cli_providers import AllProviders
+        except ImportError:
+            return
+
+        try:
+            all_providers = AllProviders()
+            cli_entries = all_providers.cli_entries()
+        except OSError:
+            return
+
+        if not cli_entries:
+            return
+
+        # Visual separator between HTTP and CLI sections.
+        combo.insertSeparator(combo.count())
+        # Section header item — disabled so users can't pick it.
+        combo.addItem("— CLI Agents —")
+        try:
+            from PyQt6.QtGui import QStandardItemModel
+
+            model = combo.model()
+            if isinstance(model, QStandardItemModel):
+                item = model.item(combo.count() - 1)
+                if item is not None:
+                    item.setEnabled(False)
+                    item.setSelectable(False)
+        except (ImportError, AttributeError, TypeError):
+            pass
+
+        self._cli_provider_entries = {}
+        for entry in cli_entries:
+            combo.addItem(entry.name, entry.id)
+            self._cli_provider_entries[entry.name] = entry
 
     # ------------------------------------------------------------------
     # UI assembly

--- a/src/shared/python/ai/gui/session_manager.py
+++ b/src/shared/python/ai/gui/session_manager.py
@@ -122,11 +122,14 @@ class ChatSessionManager(QObject):
                     timestamp_str = messages[-1].get("timestamp", "")
 
                 try:
-                    dt = (
-                        datetime.fromisoformat(timestamp_str)
-                        if timestamp_str
-                        else datetime.min
-                    )
+                    if timestamp_str:
+                        dt = datetime.fromisoformat(timestamp_str)
+                        if dt.tzinfo is not None:
+                            from datetime import timezone
+
+                            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+                    else:
+                        dt = datetime.min
                 except ValueError:
                     dt = datetime.min
 

--- a/tests/unit/launcher/conftest.py
+++ b/tests/unit/launcher/conftest.py
@@ -82,6 +82,9 @@ def ui_setup(qapp):
 
         _install_sidekick_sidebar = _RealLauncher._install_sidekick_sidebar
         _apply_sidekick_splitter_sizes = _RealLauncher._apply_sidekick_splitter_sizes
+        _get_sidekick_module = _RealLauncher._get_sidekick_module
+        _create_sidekick_sidebar_widget = _RealLauncher._create_sidekick_sidebar_widget
+        _embed_sidekick_sidebar_widget = _RealLauncher._embed_sidekick_sidebar_widget
 
         def _show_preferences(self, *_a, **_k) -> None: ...
         def _toggle_layout_mode_from_menu(self, *_a, **_k) -> None: ...

--- a/tests/unit/launcher/test_sidekick_tab_dispatch.py
+++ b/tests/unit/launcher/test_sidekick_tab_dispatch.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
-from src.launchers.launcher_dialogs import LauncherDialogsMixin
+from src.launchers.launcher_dialogs import DialogsManager
 
 
-class _LauncherHarness(LauncherDialogsMixin):
+class _LauncherHarness:
     def __init__(self, sidebar=None, embedded_host=None) -> None:
         self.sidekick_sidebar = sidebar
         self.embedded_host = embedded_host
         self.toasts: list[tuple[str, str]] = []
+        self.dialogs_manager = DialogsManager(self)
+        self.dialogs_manager.show_toast = self.show_toast
 
     def show_toast(self, message: str, toast_type: str = "info") -> None:
         self.toasts.append((message, toast_type))
+
+    def open_sidekick_tab(self, tool_id: str) -> None:
+        self.dialogs_manager.open_sidekick_tab(tool_id)
 
 
 class _Sidebar:


### PR DESCRIPTION
This PR aggregates the fixes from the sidekick review worktree: 1. Fixes registry instantiation, timezone compare, and sidekick setup. 2. Fixes sidekick tab dispatch test composition refactor. 3. Fixes mypy type clashing on list method in registry.