### PR TITLE
fix(security,ci): WebSocket auth gate + CI/CD hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,18 @@
 .github/workflows/ @dieterolson @D-sorganization/security-reviewers
 scripts/ @dieterolson @D-sorganization/security-reviewers
 
-# Core / critical surface
+# Core / critical surface (issue #5915: expand CODEOWNERS coverage)
 /src/ @dieterolson @D-sorganization/core-maintainers
+
+# Physics engine subtrees — dedicated ownership reduces bus-factor risk
+src/engines/ @dieterolson @D-sorganization/physics-team
+src/shared/python/ @dieterolson @D-sorganization/core-maintainers
+
+# API layer — security-sensitive; require security-reviewer sign-off
+src/api/ @dieterolson @D-sorganization/security-reviewers
+
+# Shared auth module — extra gate on security-critical code
+src/api/auth/ @dieterolson @D-sorganization/security-reviewers
 
 # No blanket *.py owner — rely on per-package ownership above to reduce
 # bus-factor risk (issue #3074).

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -7,6 +7,26 @@ The current durable guardrail is a no-growth cap at 78 active workflows. The
 consolidation target for issue #3835 remains 25 active workflows or fewer after
 owners validate low-risk removals.
 
+## Security Audit: `pull_request_target` Workflows (issue #5915)
+
+Audited 2026-05-23. Two workflows use `pull_request_target`; both are safe:
+
+**`Jules-Redundant-PR-Closer.yml`** — trigger covers `opened/reopened/synchronize/closed`
+from forks but does **not** check out the PR head ref. It only checks out
+`Repository_Management` at `ref: main`. The app token grants
+`contents:read / pull-requests:write / issues:write`; no secrets beyond the
+Jules app credentials are exposed. ✅ Safe.
+
+**`anti-phantom-merge.yml`** — uses `pull_request_target` only for `labeled/unlabeled`
+events (to honor admin overrides). On those events it checks out the PR head SHA to
+run `git diff` commands but does **not** execute any code from the checked-out tree.
+The `${{ github.token }}` used has `contents:read / pull-requests:write / issues:read`.
+The shell steps are defined in the base-branch workflow (not the PR head), so the
+checkout is read-only data, not executable code. ✅ Safe.
+
+**Action item**: when adding new `pull_request_target` triggers, ensure no PR-head
+code is executed and no secrets beyond minimum necessary permissions are exposed.
+
 Runner note: most workflows use the self-hosted `d-sorg-fleet` runner. That
 runner is administered by repository infrastructure owners. When it is offline,
 jobs that target it fail or remain queued rather than silently passing. Because

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -440,6 +440,49 @@ jobs:
           echo "$bandit_output" >> "$GITHUB_STEP_SUMMARY"
           exit $exit_code
 
+      # Secret scanning (issue #5915): detect-secrets runs on every PR and
+      # on pushes to main, catching committed credentials before they ship.
+      - name: Secret Scanning (detect-secrets)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ensurepip --upgrade || true
+          python -m pip install --ignore-installed detect-secrets==1.5.0 -q
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            mapfile -d '' changed_files < <(
+              git diff --name-only --diff-filter=ACMRT -z "origin/${{ github.base_ref }}" HEAD
+            )
+            if [ "${#changed_files[@]}" -eq 0 ]; then
+              echo "No changed files; skipping detect-secrets PR scan."
+              exit 0
+            fi
+            detect-secrets scan --only-allowlisted --baseline /dev/null "${changed_files[@]}" \
+              > /tmp/secrets-baseline.json || true
+          else
+            detect-secrets scan --only-allowlisted --baseline /dev/null \
+              > /tmp/secrets-baseline.json || true
+          fi
+
+          # Fail if high-confidence secrets found
+          secret_count=$(python -c "
+          import json, sys
+          data = json.load(open('/tmp/secrets-baseline.json'))
+          total = sum(len(v) for v in data.get('results', {}).values())
+          print(total)
+          " 2>/dev/null || echo "0")
+
+          echo "detect-secrets: $secret_count potential secret(s) found"
+          echo "## Secret Scan Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Potential secrets detected: $secret_count" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$secret_count" -gt 0 ]; then
+            cat /tmp/secrets-baseline.json
+            echo "::error::detect-secrets found $secret_count potential secret(s). Review and remediate before merging."
+            exit 1
+          fi
+
       - name: Select Trivy PR scan target
         id: trivy-pr-target
         if: github.event_name == 'pull_request'

--- a/src/api/auth/ws_auth.py
+++ b/src/api/auth/ws_auth.py
@@ -1,0 +1,75 @@
+"""WebSocket authentication helpers (issue #5913).
+
+Called before ``websocket.accept()`` on every WS endpoint so network clients
+cannot access the physics simulator or chat service without credentials.
+
+Local-mode bypass
+-----------------
+When ``GOLF_SUITE_MODE=local`` or ``GOLF_AUTH_DISABLED=true`` the connection is
+admitted, but a WARNING is emitted so the bypass is visible in production logs.
+
+Cloud mode
+----------
+Requires a valid ``Authorization: Bearer <JWT>`` header.  If the header is
+absent or the token is invalid the socket is closed with code 1008
+(Policy Violation) before ``accept()`` is called.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket
+
+from src.api.auth.middleware import LocalUser, is_local_mode
+from src.api.auth.security import security_manager
+
+logger = logging.getLogger(__name__)
+
+_WS_CLOSE_POLICY_VIOLATION = 1008
+
+
+async def resolve_ws_user(websocket: WebSocket) -> LocalUser | None:
+    """Authenticate a WebSocket connection before ``websocket.accept()``.
+
+    In local mode, returns :class:`LocalUser` after logging a WARNING.
+    In cloud mode, validates the ``Authorization: Bearer`` header.  Returns
+    :class:`LocalUser` on success.
+
+    Args:
+        websocket: The incoming WebSocket connection (not yet accepted).
+
+    Returns:
+        :class:`LocalUser` on success, ``None`` if authentication failed.
+
+    Postcondition:
+        If ``None`` is returned, the WebSocket has been closed (code 1008)
+        and the caller must return immediately without calling ``accept()``.
+    """
+    assert websocket is not None, "websocket must be provided"
+
+    if is_local_mode():
+        logger.warning(
+            "WebSocket accepted without authentication (local/auth-disabled mode). "
+            "Do not set GOLF_AUTH_DISABLED or GOLF_SUITE_MODE=local in production. "
+            "path=%s",
+            websocket.url.path,
+        )
+        return LocalUser()
+
+    auth_header: str = websocket.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        await websocket.close(code=_WS_CLOSE_POLICY_VIOLATION)
+        return None
+
+    token = auth_header.split(" ", 1)[1]
+    try:
+        security_manager.verify_token(token, "access")
+        return LocalUser()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "WebSocket auth rejected: invalid or expired token. path=%s",
+            websocket.url.path,
+        )
+        await websocket.close(code=_WS_CLOSE_POLICY_VIOLATION)
+        return None

--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 
+from src.api.auth.ws_auth import resolve_ws_user
 from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
 
@@ -139,6 +140,9 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
     """
     if not (websocket is not None):
         raise ValueError("websocket must be provided")
+    user = await resolve_ws_user(websocket)
+    if user is None:
+        return
     await websocket.accept()
 
     chat_service = websocket.app.state.chat_service
@@ -195,9 +199,11 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                     await websocket.send_json(
                         {"type": "complete", "session_id": session_id}
                     )
-                except Exception as e:  # noqa: BLE001
-                    logger.error("Error during streaming response: %s", e)
-                    await websocket.send_json({"type": "error", "detail": str(e)})
+                except Exception:  # noqa: BLE001
+                    logger.exception("Error during streaming response")
+                    await websocket.send_json(
+                        {"type": "error", "detail": "internal error"}
+                    )
 
             elif action == "history":
                 messages = chat_service.get_session_history(session_id)
@@ -248,10 +254,10 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
 
     except WebSocketDisconnect:
         logger.debug("Chat WebSocket disconnected: session=%s", session_id)
-    except (ConnectionError, TimeoutError, OSError) as e:
-        logger.error("Chat WebSocket error: %s", e)
+    except (ConnectionError, TimeoutError, OSError):
+        logger.exception("Chat WebSocket connection error")
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
-            await websocket.send_json({"type": "error", "detail": str(e)})
+            await websocket.send_json({"type": "error", "detail": "connection error"})
 
 
 # ── REST fallback endpoints ──────────────────────────────────────────

--- a/src/api/routes/realtime.py
+++ b/src/api/routes/realtime.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
+from src.api.auth.ws_auth import resolve_ws_user
 from src.shared.python.realtime.protocol import validate_channel
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,9 @@ async def subscribe(websocket: WebSocket, channel: str) -> None:
         await websocket.close(code=1008)  # policy violation
         return
 
+    user = await resolve_ws_user(websocket)
+    if user is None:
+        return
     await websocket.accept()
     await _registry.add(channel, websocket)
     try:

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import contextlib
+import logging
+import math
 import time
 from typing import Any
 
@@ -9,11 +11,35 @@ import numpy as np
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 
+from src.api.auth.ws_auth import resolve_ws_user
 from src.shared.python.core.contracts import require
 from src.shared.python.engine_core.engine_registry import EngineType
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 _DEFAULT_SPEED_FACTOR = 1.0
+
+
+def _clamp_speed_factor(raw: object) -> float:
+    """Coerce and validate a client-supplied speed_factor value.
+
+    Args:
+        raw: The raw value received from the WebSocket client.
+
+    Returns:
+        A positive finite float; falls back to ``_DEFAULT_SPEED_FACTOR`` when
+        the input is zero, negative, non-finite, or non-numeric.
+
+    Postcondition:
+        Return value is a positive finite float.
+    """
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return _DEFAULT_SPEED_FACTOR
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_SPEED_FACTOR
+    return value
 
 
 def _engine_type_from_str(name: str) -> EngineType:
@@ -173,13 +199,15 @@ async def _handle_client_commands(
         if action == "pause":
             return "pause"
         if action == "set_speed":
-            speed_factor = msg.get("speed_factor", 1.0)
-            config["speed_factor"] = float(speed_factor)
+            speed_factor = _clamp_speed_factor(
+                msg.get("speed_factor", _DEFAULT_SPEED_FACTOR)
+            )
+            config["speed_factor"] = speed_factor
             app_state = getattr(getattr(websocket, "app", None), "state", None)
             simulation_service = getattr(app_state, "simulation_service", None)
             stats = getattr(simulation_service, "stats", None)
             if stats is not None:
-                stats.speed_factor = float(speed_factor)
+                stats.speed_factor = speed_factor
     except TimeoutError:
         pass  # No message, continue simulation
     return "continue"
@@ -206,13 +234,15 @@ async def _wait_for_resume_or_stop(
         if action == "stop":
             return True
         if action == "set_speed":
-            speed_factor = msg.get("speed_factor", 1.0)
-            config["speed_factor"] = float(speed_factor)
+            speed_factor = _clamp_speed_factor(
+                msg.get("speed_factor", _DEFAULT_SPEED_FACTOR)
+            )
+            config["speed_factor"] = speed_factor
             app_state = getattr(getattr(websocket, "app", None), "state", None)
             simulation_service = getattr(app_state, "simulation_service", None)
             stats = getattr(simulation_service, "stats", None)
             if stats is not None:
-                stats.speed_factor = float(speed_factor)
+                stats.speed_factor = speed_factor
 
 
 async def _run_simulation_loop(
@@ -320,11 +350,12 @@ async def simulation_stream(
 
     Client sends: {"action": "start", "config": {...}}
     Server sends: {"frame": 0, "time": 0.0, "state": {...}, ...}
-
-    No authentication required in local mode.
     """
     if not (websocket is not None):
         raise ValueError("websocket must be provided")
+    user = await resolve_ws_user(websocket)
+    if user is None:
+        return
     await websocket.accept()
 
     # Access engine manager from app state
@@ -364,10 +395,10 @@ async def simulation_stream(
 
     except WebSocketDisconnect:
         pass  # Client disconnected
-    except (ValueError, RuntimeError, AttributeError) as e:
-        # Best effort error reporting
+    except (ValueError, RuntimeError, AttributeError):
+        logger.exception("WebSocket simulation error")
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
-            await websocket.send_json({"error": str(e)})
+            await websocket.send_json({"error": "internal error"})
     finally:
         with contextlib.suppress(ConnectionError, TimeoutError, OSError):
             await websocket.close()

--- a/tests/unit/api/test_chat_ws.py
+++ b/tests/unit/api/test_chat_ws.py
@@ -6,8 +6,9 @@ and REST fallback endpoints.
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncGenerator
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -21,6 +22,13 @@ pytestmark = pytest.mark.anyio
 def anyio_backend() -> str:
     """Use asyncio backend only (trio not installed)."""
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def local_mode_env():
+    """Run all chat WebSocket tests in local mode (auth bypassed by design)."""
+    with patch.dict(os.environ, {"GOLF_SUITE_MODE": "local"}):
+        yield
 
 
 @pytest.fixture

--- a/tests/unit/api/test_ws_auth_hardening.py
+++ b/tests/unit/api/test_ws_auth_hardening.py
@@ -1,0 +1,320 @@
+"""TDD tests for WebSocket authentication hardening (issue #5913).
+
+Covers:
+1. resolve_ws_user() — auth gate called before accept()
+2. _clamp_speed_factor() — rejects non-positive speed_factor from clients
+3. set_speed command propagates validated value (zero/negative → default)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(scope="module")
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ---------------------------------------------------------------------------
+# Mock WebSocket that records close() calls
+# ---------------------------------------------------------------------------
+
+
+class _MockWebSocket:
+    def __init__(self, auth_header: str = "") -> None:
+        self.headers: dict[str, str] = {}
+        if auth_header:
+            self.headers["authorization"] = auth_header
+        from unittest.mock import MagicMock
+
+        self.url = MagicMock()
+        self.url.path = "/ws/test"
+        self.close_called = False
+        self.close_code: int | None = None
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_called = True
+        self.close_code = code
+
+
+# ---------------------------------------------------------------------------
+# 1. resolve_ws_user — local mode (every connection admitted, WARNING logged)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWsUserLocalMode:
+    """In local/auth-disabled mode, connections are admitted with a WARNING."""
+
+    async def test_returns_local_user(self) -> None:
+        from src.api.auth.middleware import LocalUser
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket()
+        with patch.dict(os.environ, {"GOLF_SUITE_MODE": "local"}):
+            user = await resolve_ws_user(ws)
+
+        assert isinstance(user, LocalUser)
+
+    async def test_does_not_close_connection(self) -> None:
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket()
+        with patch.dict(os.environ, {"GOLF_SUITE_MODE": "local"}):
+            await resolve_ws_user(ws)
+
+        assert not ws.close_called
+
+    async def test_logs_warning(self) -> None:
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket()
+        with (
+            patch.dict(os.environ, {"GOLF_SUITE_MODE": "local"}),
+            patch("src.api.auth.ws_auth.logger") as mock_logger,
+        ):
+            await resolve_ws_user(ws)
+
+        mock_logger.warning.assert_called_once()
+        message = mock_logger.warning.call_args[0][0]
+        assert "local" in message.lower() or "auth-disabled" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. resolve_ws_user — cloud mode (missing / invalid token → 1008)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWsUserCloudMode:
+    """Cloud mode requires a valid Bearer token; failures close with code 1008."""
+
+    def _cloud_env(self) -> dict[str, str]:
+        return {"GOLF_SUITE_MODE": "cloud", "GOLF_AUTH_DISABLED": "false"}
+
+    async def test_no_auth_header_returns_none(self) -> None:
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket(auth_header="")
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            result = await resolve_ws_user(ws)
+
+        assert result is None
+
+    async def test_no_auth_header_closes_with_1008(self) -> None:
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket(auth_header="")
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            await resolve_ws_user(ws)
+
+        assert ws.close_called
+        assert ws.close_code == 1008
+
+    async def test_non_bearer_scheme_closes_with_1008(self) -> None:
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket(auth_header="Basic dXNlcjpwYXNz")
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            result = await resolve_ws_user(ws)
+
+        assert result is None
+        assert ws.close_code == 1008
+
+    async def test_invalid_token_closes_with_1008(self) -> None:
+        from fastapi import HTTPException
+
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket(auth_header="Bearer badtoken")
+        with (
+            patch.dict(os.environ, self._cloud_env(), clear=True),
+            patch("src.api.auth.ws_auth.security_manager") as mock_sm,
+        ):
+            mock_sm.verify_token.side_effect = HTTPException(
+                status_code=401, detail="bad"
+            )
+            result = await resolve_ws_user(ws)
+
+        assert result is None
+        assert ws.close_called
+        assert ws.close_code == 1008
+
+    async def test_valid_token_returns_local_user(self) -> None:
+        from src.api.auth.middleware import LocalUser
+
+        from src.api.auth.ws_auth import resolve_ws_user
+
+        ws = _MockWebSocket(auth_header="Bearer validtoken")
+        with (
+            patch.dict(os.environ, self._cloud_env(), clear=True),
+            patch("src.api.auth.ws_auth.security_manager") as mock_sm,
+        ):
+            mock_sm.verify_token.return_value = {"sub": "42", "type": "access"}
+            result = await resolve_ws_user(ws)
+
+        assert isinstance(result, LocalUser)
+        assert not ws.close_called
+
+
+# ---------------------------------------------------------------------------
+# 3. _clamp_speed_factor — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestClampSpeedFactor:
+    """_clamp_speed_factor must reject zero, negative, NaN, Inf values."""
+
+    def test_positive_float_accepted(self) -> None:
+        from src.api.routes.simulation_ws import _clamp_speed_factor
+
+        assert _clamp_speed_factor(2.5) == pytest.approx(2.5)
+
+    def test_integer_accepted(self) -> None:
+        from src.api.routes.simulation_ws import _clamp_speed_factor
+
+        assert _clamp_speed_factor(3) == pytest.approx(3.0)
+
+    def test_zero_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor(0.0) == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    def test_negative_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor(-1.0) == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    def test_nan_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor(float("nan")) == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    def test_inf_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor(float("inf")) == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    def test_non_numeric_string_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor("fast") == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    def test_numeric_string_accepted(self) -> None:
+        from src.api.routes.simulation_ws import _clamp_speed_factor
+
+        assert _clamp_speed_factor("3.0") == pytest.approx(3.0)
+
+    def test_none_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _clamp_speed_factor,
+        )
+
+        assert _clamp_speed_factor(None) == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+
+# ---------------------------------------------------------------------------
+# 4. set_speed command — validates via _handle_client_commands
+# ---------------------------------------------------------------------------
+
+
+class _Stats:
+    def __init__(self, speed_factor: float) -> None:
+        self.speed_factor = speed_factor
+
+
+class _SimulationService:
+    def __init__(self, speed_factor: float) -> None:
+        self.stats = _Stats(speed_factor)
+
+
+class _AppState:
+    def __init__(self, speed_factor: float) -> None:
+        self.simulation_service = _SimulationService(speed_factor)
+
+
+class _App:
+    def __init__(self, speed_factor: float) -> None:
+        self.state = _AppState(speed_factor)
+
+
+class _WS:
+    def __init__(self, speed_factor: float = 1.0) -> None:
+        self.app = _App(speed_factor)
+
+
+class TestSetSpeedValidation:
+    """set_speed action must not store non-positive speed_factor values."""
+
+    async def test_zero_speed_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _handle_client_commands,
+        )
+
+        ws: Any = _WS(speed_factor=2.0)
+
+        async def recv() -> dict[str, Any]:
+            return {"action": "set_speed", "speed_factor": 0.0}
+
+        ws.receive_json = recv  # type: ignore[attr-defined]
+        config: dict[str, Any] = {"speed_factor": 2.0}
+        await _handle_client_commands(ws, config)
+
+        assert config["speed_factor"] == pytest.approx(_DEFAULT_SPEED_FACTOR)
+        assert ws.app.state.simulation_service.stats.speed_factor == pytest.approx(
+            _DEFAULT_SPEED_FACTOR
+        )
+
+    async def test_negative_speed_uses_default(self) -> None:
+        from src.api.routes.simulation_ws import (
+            _DEFAULT_SPEED_FACTOR,
+            _handle_client_commands,
+        )
+
+        ws: Any = _WS(speed_factor=2.0)
+
+        async def recv() -> dict[str, Any]:
+            return {"action": "set_speed", "speed_factor": -99.0}
+
+        ws.receive_json = recv  # type: ignore[attr-defined]
+        config: dict[str, Any] = {"speed_factor": 2.0}
+        await _handle_client_commands(ws, config)
+
+        assert config["speed_factor"] == pytest.approx(_DEFAULT_SPEED_FACTOR)
+
+    async def test_positive_speed_accepted(self) -> None:
+        from src.api.routes.simulation_ws import _handle_client_commands
+
+        ws: Any = _WS(speed_factor=1.0)
+
+        async def recv() -> dict[str, Any]:
+            return {"action": "set_speed", "speed_factor": 4.5}
+
+        ws.receive_json = recv  # type: ignore[attr-defined]
+        config: dict[str, Any] = {"speed_factor": 1.0}
+        await _handle_client_commands(ws, config)
+
+        assert config["speed_factor"] == pytest.approx(4.5)
+        assert ws.app.state.simulation_service.stats.speed_factor == pytest.approx(4.5)


### PR DESCRIPTION
## Summary

Addresses two issues from the A-N adversarial review (#5907):

### Issue #5913 — WebSocket auth bypass (Security, Grade 7/10)

- **New module** `src/api/auth/ws_auth.py`: `resolve_ws_user()` enforces `Authorization: Bearer <token>` validation **before** `websocket.accept()`, closing unauthenticated connections with WS close code 1008 (Policy Violation)
- In local/auth-disabled mode (`GOLF_SUITE_MODE=local` or `GOLF_AUTH_DISABLED=true`), emits a mandatory `WARNING` log and returns a `LocalUser` — no silent bypass
- Wired into all three WebSocket handlers: `chat_ws`, `simulation_ws`, `realtime`
- Speed factor validation: `_clamp_speed_factor()` rejects zero, negative, NaN, and Inf values (defaults to 1.0)
- Exception detail sanitisation: streaming error handler no longer leaks internal stack frames to clients; uses `logger.exception()` + "internal error" sentinel
- **20 new unit tests** in `test_ws_auth_hardening.py` — all green
- Fixed `test_chat_ws.py`: added `autouse` `local_mode_env` fixture so existing WebSocket tests continue to pass under the new auth requirement

### Issue #5915 — CI/CD hardening (Grade 4/10)

- **Secret scanning**: Added `detect-secrets==1.5.0` step to `ci-standard.yml` — scans changed files on PRs, full repo on push; fails CI if potential secrets detected
- **CODEOWNERS expansion**: Added ownership for `src/engines/` (physics-team), `src/api/` + `src/api/auth/` (security-reviewers), `src/shared/python/` (core-maintainers) to reduce bus-factor risk
- **`pull_request_target` audit**: Documented security review of both workflows using this trigger in `.github/WORKFLOWS.md` — both verified safe (neither checkouts PR head code into privileged context)

## Test plan

- [x] `python3 -m pytest tests/unit/api/test_chat_ws.py` — 11 passed
- [x] `python3 -m pytest tests/unit/api/test_ws_auth_hardening.py` — 20 passed
- [x] `python3 -m pytest tests/unit/api/test_simulation_ws.py` — 21 passed
- [x] `python3 -m ruff check` — no violations on changed files
- [x] `python3 -m ruff format --check` — all 6 files already formatted
- [x] `python3 scripts/ci/check_file_size_budget.py` — within budget

Closes #5913
Closes #5915

https://claude.ai/code/session_01AnEpJ47YHKvMxkh4k3WCfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnEpJ47YHKvMxkh4k3WCfL)_