### PR TITLE
ci: increase Trivy scan job timeout to 40 minutes

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   trivy-scan:
-    timeout-minutes: 20
+    timeout-minutes: 40
     name: Trivy Container Scan
     runs-on: d-sorg-fleet
     permissions:

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -18,6 +18,10 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: docker-security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trivy-scan:
     timeout-minutes: 40


### PR DESCRIPTION
This increases the job-level timeout-minutes for Trivy Container Scan to 40 minutes to prevent it from getting forcefully cancelled during longer runs.