### PR TITLE
⚡ Bolt: Optimize Drake constraint residual penalty computation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -86,3 +86,6 @@
 ## 2026-05-23 - trimesh ImportErrors
 **Learning:** Hard-coded imports of `trimesh` in files like `_mesh_decimation.py` and `_mesh_io.py` can cause tests or other modules that import them to fail if `trimesh` isn't installed.
 **Action:** Always wrap `import trimesh` with a `try...except ImportError` block and conditionally check if `trimesh is None` to safely handle environments where it is missing, or alternatively, make sure to add it to the test environment requirements.
+## 2026-05-25 - Optimize constraint residual penalties in Drake
+**Learning:** Using `sum(np.sum(np.asarray(r) ** 2) for r in constraint_residuals)` creates intermediate array allocations for `** 2`. Since this calculation is part of the cost function inner loop, it creates unnecessary overhead.
+**Action:** Replace `np.sum(np.asarray(r) ** 2)` with `np.vdot(arr := np.asarray(r), arr)` to avoid the intermediate allocation and calculate the squared sum directly at the C level, improving inner loop performance.

--- a/src/engines/physics_engines/drake/python/motion_matching/compute_cost_drake.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/compute_cost_drake.py
@@ -82,7 +82,9 @@ def compute_cost_drake(
 
     j, breakdown = _shared_compute_cost(theta, target, _shared_sim_fn, cost_opts)
     if constraint_residuals:
-        penalty = float(sum(np.sum(np.asarray(r) ** 2) for r in constraint_residuals))
+        penalty = float(
+            sum(np.vdot(arr := np.asarray(r), arr) for r in constraint_residuals)
+        )
         j = j + penalty
         breakdown = CostBreakdown(
             position=breakdown.position,


### PR DESCRIPTION
💡 What: Replaced `np.sum(np.asarray(r) ** 2)` with `np.vdot(arr := np.asarray(r), arr)` in `compute_cost_drake.py`.
🎯 Why: The `** 2` operation creates an intermediate array allocation in memory. Using `np.vdot` avoids this allocation and computes the sum of squares directly at the C level, speeding up the cost function evaluation.
📊 Impact: Eliminates temporary memory allocations in the constraint residual penalty calculation within the cost function inner loop.
🔬 Measurement: Verified locally using a custom scratch test demonstrating mathematically identical results and full passing of the `test_cost.py` unit test suite.

---
*PR created automatically by Jules for task [12153863017046666466](https://jules.google.com/task/12153863017046666466) started by @dieterolson*