### PR TITLE
logging: use logger.exception in HTTP route except blocks (#5919)

### DIFF
--- a/src/api/routes/actuator_controls.py
+++ b/src/api/routes/actuator_controls.py
@@ -189,7 +189,7 @@ async def get_actuator_panel(
         )
     except (RuntimeError, TypeError, AttributeError) as exc:
         if logger:
-            logger.error("Error getting actuator panel: %s", exc)
+            logger.exception("Error getting actuator panel")
         raise HTTPException(
             status_code=500, detail=f"Actuator panel error: {str(exc)}"
         ) from exc
@@ -268,7 +268,7 @@ async def send_actuator_command(  # noqa: C901
         raise
     except (ValueError, RuntimeError, AttributeError) as exc:
         if logger:
-            logger.error("Error sending actuator command: %s", exc)
+            logger.exception("Error sending actuator command")
         raise HTTPException(
             status_code=500, detail=f"Actuator command error: {str(exc)}"
         ) from exc

--- a/src/api/routes/analysis.py
+++ b/src/api/routes/analysis.py
@@ -51,7 +51,7 @@ async def analyze_biomechanics(
         return result
     except (RuntimeError, TypeError, AttributeError) as exc:
         if logger:
-            logger.error("Analysis error: %s", exc)
+            logger.exception("Analysis error")
         raise HTTPException(
             status_code=500, detail=f"Analysis failed: {str(exc)}"
         ) from exc

--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -239,7 +239,7 @@ async def get_analysis_metrics(
         return {"status": "ok", "metrics": metrics}
     except (RuntimeError, TypeError, AttributeError) as exc:
         if logger:
-            logger.error("Metrics collection error: %s", exc)
+            logger.exception("Metrics collection error")
         raise HTTPException(
             status_code=500, detail=f"Metrics collection failed: {str(exc)}"
         ) from exc
@@ -317,7 +317,7 @@ async def get_analysis_statistics(  # noqa: C901
         )
     except ImportError as exc:
         if logger:
-            logger.error("Statistics computation error: %s", exc)
+            logger.exception("Statistics computation error")
         raise HTTPException(
             status_code=500, detail=f"Statistics computation failed: {str(exc)}"
         ) from exc
@@ -412,7 +412,7 @@ async def export_analysis_data(  # noqa: C901
         )
     except ImportError as exc:
         if logger:
-            logger.error("Export error: %s", exc)
+            logger.exception("Export error")
         raise HTTPException(
             status_code=500, detail=f"Export failed: {str(exc)}"
         ) from exc
@@ -481,7 +481,7 @@ async def set_body_position(
         ) from exc
     except ImportError as exc:
         if logger:
-            logger.error("Body positioning error: %s", exc)
+            logger.exception("Body positioning error")
         raise HTTPException(
             status_code=500, detail=f"Positioning failed: {str(exc)}"
         ) from exc
@@ -550,7 +550,7 @@ async def measure_distance(
         raise
     except (ValueError, RuntimeError, AttributeError) as exc:
         if logger:
-            logger.error("Measurement error: %s", exc)
+            logger.exception("Measurement error")
         raise HTTPException(
             status_code=500, detail=f"Measurement failed: {str(exc)}"
         ) from exc
@@ -620,7 +620,7 @@ async def get_measurement_tools(
         )
     except (ValueError, RuntimeError, AttributeError) as exc:
         if logger:
-            logger.error("Measurement tools error: %s", exc)
+            logger.exception("Measurement tools error")
         raise HTTPException(
             status_code=500, detail=f"Measurement tools failed: {str(exc)}"
         ) from exc

--- a/src/api/routes/launcher.py
+++ b/src/api/routes/launcher.py
@@ -35,7 +35,7 @@ def _get_manifest() -> LauncherManifest:
         try:
             _launcher_state["manifest"] = LauncherManifest.load()
         except (FileNotFoundError, ValueError) as e:
-            logger.error("Failed to load launcher manifest: %s", e)
+            logger.exception("Failed to load launcher manifest")
             raise HTTPException(
                 status_code=500,
                 detail=f"Launcher manifest error: {e}",

--- a/src/api/routes/model_explorer.py
+++ b/src/api/routes/model_explorer.py
@@ -338,7 +338,7 @@ async def get_model_explorer(
         ) from exc
     except ImportError as exc:
         if logger:
-            logger.error("Error in model explorer for %s: %s", model_name, exc)
+            logger.exception("Error in model explorer for %s", model_name)
         raise HTTPException(
             status_code=500, detail=f"Model explorer error: {str(exc)}"
         ) from exc

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -381,7 +381,7 @@ async def list_models(
         return ModelListResponse(models=models)
     except (RuntimeError, TypeError, AttributeError) as exc:
         if logger:
-            logger.error("Error listing models: %s", exc)
+            logger.exception("Error listing models")
         raise HTTPException(
             status_code=500, detail=f"Failed to list models: {str(exc)}"
         ) from exc
@@ -461,7 +461,7 @@ async def get_model_urdf(  # noqa: C901
         ) from exc
     except ImportError as exc:
         if logger:
-            logger.error("Error loading model %s: %s", model_name, exc)
+            logger.exception("Error loading model %s", model_name)
         raise HTTPException(
             status_code=500, detail=f"Failed to load model: {str(exc)}"
         ) from exc

--- a/src/api/routes/physics.py
+++ b/src/api/routes/physics.py
@@ -222,7 +222,7 @@ async def update_actuators(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except ImportError as exc:
         if logger:
-            logger.error("Actuator update error: %s", exc)
+            logger.exception("Actuator update error")
         raise HTTPException(
             status_code=500, detail=f"Actuator update failed: {str(exc)}"
         ) from exc
@@ -324,7 +324,7 @@ async def get_forces(
         )
     except ImportError as exc:
         if logger:
-            logger.error("Force query error: %s", exc)
+            logger.exception("Force query error")
         raise HTTPException(
             status_code=500, detail=f"Force query failed: {str(exc)}"
         ) from exc
@@ -408,7 +408,7 @@ async def get_metrics(
         )
     except ImportError as exc:
         if logger:
-            logger.error("Metrics query error: %s", exc)
+            logger.exception("Metrics query error")
         raise HTTPException(
             status_code=500, detail=f"Metrics query failed: {str(exc)}"
         ) from exc

--- a/src/api/routes/simulation.py
+++ b/src/api/routes/simulation.py
@@ -68,7 +68,7 @@ async def run_simulation(
         ) from exc
     except RuntimeError as exc:
         if logger:
-            logger.error("Simulation runtime error: %s", exc)
+            logger.exception("Simulation runtime error")
         raise HTTPException(
             status_code=500, detail=f"Simulation failed: {str(exc)}"
         ) from exc

--- a/src/api/routes/video.py
+++ b/src/api/routes/video.py
@@ -109,12 +109,7 @@ async def _validate_video_upload(file: UploadFile) -> None:
 
 @router.post("/analyze/video", response_model=VideoAnalysisResponse)
 @precondition(  # fmt: skip
-    lambda file=None,
-    estimator_type="mediapipe",
-    min_confidence=0.5,
-    enable_smoothing=True,
-    video_pipeline=None,
-    logger=None: (
+    lambda file=None, estimator_type="mediapipe", min_confidence=0.5, enable_smoothing=True, video_pipeline=None, logger=None: (
         estimator_type is not None
         and len(estimator_type.strip()) > 0
         and 0.0 <= min_confidence <= 1.0
@@ -203,7 +198,7 @@ async def analyze_video(
         raise
     except (FileNotFoundError, OSError) as e:
         if logger:
-            logger.error("Video analysis error: %s", e)
+            logger.exception("Video analysis error")
         raise HTTPException(
             status_code=500, detail=f"Video analysis failed: {str(e)}"
         ) from e
@@ -222,12 +217,7 @@ async def analyze_video(
 
 @router.post("/analyze/video/async")
 @precondition(  # fmt: skip
-    lambda background_tasks=None,
-    file=None,
-    estimator_type="mediapipe",
-    min_confidence=0.5,
-    video_pipeline=None,
-    task_manager=None: (
+    lambda background_tasks=None, file=None, estimator_type="mediapipe", min_confidence=0.5, video_pipeline=None, task_manager=None: (
         estimator_type is not None
         and len(estimator_type.strip()) > 0
         and 0.0 <= min_confidence <= 1.0


### PR DESCRIPTION
Partial progress on #5919 (Category L: Logging, grade 7/10).

## Scope

Converts `logger.error(\"...: %s\", exc)` to `logger.exception(\"...\")` in 9 FastAPI route modules. The `exception` call preserves the active traceback at the exact moment it matters (the `except` branch). CLAUDE.md already flags this as an anti-pattern.

## Changes

18 instances retired across:
- `src/api/routes/analysis.py`
- `src/api/routes/analysis_tools.py` (6)
- `src/api/routes/actuator_controls.py` (2)
- `src/api/routes/launcher.py`
- `src/api/routes/model_explorer.py`
- `src/api/routes/models.py` (2)
- `src/api/routes/physics.py` (3)
- `src/api/routes/simulation.py`
- `src/api/routes/video.py`

For messages that templated extra context (`model_name`), the dynamic context is retained and only the exception interpolation is dropped (since `logger.exception` already appends the traceback).

## Why this slice

WebSocket handlers were already addressed by merged PR #6023 and closed PRs #5994 / #5996. This PR completes the same anti-pattern cleanup on the regular HTTP route surface. Redaction-regex (closed PR #6035) and structured-context middleware remain as separate follow-ups on #5919.

## Test plan
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files
- Existing route tests exercise the success paths; the changed lines are only reached on exception (traceback now preserved instead of formatted away)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>