### PR TITLE
cleanup: extract aerodynamics magic numbers to named constants (#5916)

### DIFF
--- a/src/shared/python/physics/aerodynamics.py
+++ b/src/shared/python/physics/aerodynamics.py
@@ -55,6 +55,62 @@ from src.shared.python.physics.atmosphere import cd_dimpled_sphere
 
 MIN_AIR_DENSITY_KG_M3 = 0.01
 
+# ---------------------------------------------------------------------------
+# Module-level constants (extracted from inline magic numbers — issue #5916)
+# ---------------------------------------------------------------------------
+
+# Dynamic-pressure prefactor in F = 0.5 * rho * Cd * A * v^2 (Bernoulli).
+# Used by drag, lift, and Magnus force formulas.
+_DRAG_FORMULA_PREFACTOR = 0.5
+
+# Floor below which a vector magnitude is treated as zero (avoids division
+# by ~0 in unit-vector normalizations).
+_VECTOR_MAGNITUDE_EPS = 1e-10
+
+# Reynolds-number clamp range for cd_dimpled_sphere; outside this band the
+# Bearman & Harvey / Mehta correlation is not validated (issue #3504).
+_REYNOLDS_MIN = 1.0e3
+_REYNOLDS_MAX = 1.0e7
+
+# Spin-ratio scale in lift coefficient saturation:
+# Cl = Cl_max * (1 - exp(-S/scale)).
+_LIFT_SPIN_RATIO_SCALE = 0.1
+
+# Spin parameter at which the Magnus coefficient saturates to its full value.
+_MAGNUS_SPIN_RATIO_SATURATION = 0.2
+
+# WindConfig defaults
+_DEFAULT_GUST_INTENSITY = 0.3  # fraction of base wind speed
+_DEFAULT_GUST_FREQUENCY_HZ = 0.1  # Hz
+_DEFAULT_GUST_DURATION_MEAN_S = 2.0  # seconds
+_DEFAULT_GRADIENT_FACTOR = 0.05  # 5% wind-speed increase per scale height
+
+# Altitude scale [m] used in the linear wind-speed gradient model:
+# multiplier = 1 + gradient_factor * (altitude / scale).
+_GRADIENT_ALTITUDE_SCALE_M = 10.0
+
+# Gust spawn bounds
+_GUST_DURATION_MIN_S = 0.5
+_GUST_DURATION_MAX_S = 10.0
+_GUST_SPEED_VARIABILITY_MIN = 0.5
+_GUST_SPEED_VARIABILITY_MAX = 1.5
+_GUST_DIRECTION_PERTURB_STD = 0.3
+
+# Default temperature used when no atmospheric snapshot is supplied [degC].
+_DEFAULT_TEMPERATURE_C = 15.0
+
+# Initial dt assumption for the first gust-spawn poll, before real dt is known.
+_INITIAL_GUST_CHECK_DT_S = 0.1
+
+# Maximum lift coefficient (saturation cap) for the LiftModel.
+_DEFAULT_MAX_LIFT_COEFFICIENT = 0.4
+
+# TurbulenceModel defaults
+_DEFAULT_TURBULENCE_INTENSITY = 0.5
+_TURBULENCE_HARMONIC_COUNT = 10
+_TURBULENCE_FREQ_MIN_HZ = 0.1
+_TURBULENCE_FREQ_MAX_HZ = 2.0
+
 
 def _vector_magnitude(vector: np.ndarray) -> float:
     """Return the Euclidean magnitude of any vector-shaped array."""
@@ -161,12 +217,12 @@ class WindConfig:
 
     base_velocity: np.ndarray = field(default_factory=lambda: np.array([0.0, 0.0, 0.0]))
     gusts_enabled: bool = False
-    gust_intensity: float = 0.3
-    gust_frequency: float = 0.1  # Hz
-    gust_duration_mean: float = 2.0  # seconds
+    gust_intensity: float = _DEFAULT_GUST_INTENSITY
+    gust_frequency: float = _DEFAULT_GUST_FREQUENCY_HZ
+    gust_duration_mean: float = _DEFAULT_GUST_DURATION_MEAN_S
     turbulence_intensity: float = 0.0
     altitude_gradient: bool = False
-    gradient_factor: float = 0.05  # 5% per 10m
+    gradient_factor: float = _DEFAULT_GRADIENT_FACTOR
 
     @property
     def speed(self) -> float:
@@ -177,7 +233,7 @@ class WindConfig:
     def direction(self) -> np.ndarray:
         """Get normalized wind direction."""
         speed = self.speed
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.array([1.0, 0.0, 0.0])
         return self.base_velocity / speed
 
@@ -258,11 +314,13 @@ class DragModel:
         velocity_vec = np.asarray(velocity, dtype=float).reshape(-1)
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity_vec)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         cd = self.get_effective_coefficient(velocity_vec, air_density)
-        force_magnitude = 0.5 * air_density * cd * self.ball_area * speed**2
+        force_magnitude = (
+            _DRAG_FORMULA_PREFACTOR * air_density * cd * self.ball_area * speed**2
+        )
 
         # Drag opposes velocity
         return -force_magnitude * velocity_vec / speed
@@ -293,7 +351,7 @@ class DragModel:
 
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return self.base_coefficient
 
         # Reynolds number
@@ -303,7 +361,7 @@ class DragModel:
         # Delegate to the smoothed drag-crisis correlation (Bearman & Harvey
         # 1976, Mehta 1985); clamp to the model's validated range so the
         # integrator never sees a discontinuity. See issue #3504.
-        re_clamped = max(1.0e3, min(1.0e7, re))
+        re_clamped = max(_REYNOLDS_MIN, min(_REYNOLDS_MAX, re))
         return cd_dimpled_sphere(re_clamped, base_cd=self.base_coefficient)
 
 
@@ -323,7 +381,7 @@ class LiftModel:
         base_coefficient: float = float(GOLF_BALL_LIFT_COEFFICIENT),
         ball_area: float = float(GOLF_BALL_CROSS_SECTIONAL_AREA_M2),
         ball_radius: float = float(GOLF_BALL_RADIUS_M),
-        max_coefficient: float = 0.4,
+        max_coefficient: float = _DEFAULT_MAX_LIFT_COEFFICIENT,
     ) -> None:
         """Initialize lift model.
 
@@ -366,7 +424,7 @@ class LiftModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Lift direction: perpendicular to velocity, in spin plane
@@ -374,7 +432,7 @@ class LiftModel:
         lift_dir = np.cross(spin_axis, velocity_vec)
         lift_norm = float(math.hypot(*lift_dir))
 
-        if lift_norm < 1e-10:
+        if lift_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         lift_dir = lift_dir / lift_norm
@@ -384,7 +442,9 @@ class LiftModel:
         cl = self._compute_lift_coefficient(spin_ratio)
 
         # Lift magnitude
-        force_magnitude = 0.5 * air_density * cl * self.ball_area * speed**2
+        force_magnitude = (
+            _DRAG_FORMULA_PREFACTOR * air_density * cl * self.ball_area * speed**2
+        )
 
         return force_magnitude * lift_dir
 
@@ -400,7 +460,7 @@ class LiftModel:
         # Empirical relationship: Cl saturates at high spin
         if spin_ratio is None:
             raise ValueError("spin_ratio must be provided")
-        cl = self.max_coefficient * (1 - math.exp(-spin_ratio / 0.1))
+        cl = self.max_coefficient * (1 - math.exp(-spin_ratio / _LIFT_SPIN_RATIO_SCALE))
         return min(cl, self.max_coefficient)
 
 
@@ -458,14 +518,14 @@ class MagnusModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Magnus direction: spin x velocity
         magnus_dir = np.cross(spin_vec, velocity_vec)
         magnus_norm = float(math.hypot(*magnus_dir))
 
-        if magnus_norm < 1e-10:
+        if magnus_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         magnus_dir = magnus_dir / magnus_norm
@@ -475,7 +535,9 @@ class MagnusModel:
         cm = self._compute_magnus_coefficient(spin_param)
 
         # Force magnitude
-        force_magnitude = 0.5 * air_density * cm * self.ball_area * speed**2
+        force_magnitude = (
+            _DRAG_FORMULA_PREFACTOR * air_density * cm * self.ball_area * speed**2
+        )
 
         return force_magnitude * magnus_dir
 
@@ -489,7 +551,7 @@ class MagnusModel:
             Magnus coefficient
         """
         # Approximately linear for small spin_param, saturates for large
-        return self.coefficient * min(spin_param / 0.2, 1.0)
+        return self.coefficient * min(spin_param / _MAGNUS_SPIN_RATIO_SATURATION, 1.0)
 
 
 # =============================================================================
@@ -561,7 +623,7 @@ class TurbulenceModel:
 
     def __init__(
         self,
-        intensity: float = 0.5,
+        intensity: float = _DEFAULT_TURBULENCE_INTENSITY,
         seed: int | None = None,
     ) -> None:
         """Initialize turbulence model.
@@ -575,9 +637,13 @@ class TurbulenceModel:
         self.intensity = intensity
         self._rng = np.random.default_rng(seed)
         # Pre-generate noise coefficients for smooth interpolation
-        self._coeffs = self._rng.standard_normal((3, 10))
-        self._phases = self._rng.uniform(0, 2 * np.pi, (3, 10))
-        self._freqs = self._rng.uniform(0.1, 2.0, 10)
+        self._coeffs = self._rng.standard_normal((3, _TURBULENCE_HARMONIC_COUNT))
+        self._phases = self._rng.uniform(0, 2 * np.pi, (3, _TURBULENCE_HARMONIC_COUNT))
+        self._freqs = self._rng.uniform(
+            _TURBULENCE_FREQ_MIN_HZ,
+            _TURBULENCE_FREQ_MAX_HZ,
+            _TURBULENCE_HARMONIC_COUNT,
+        )
 
     def get_perturbation(
         self,
@@ -595,7 +661,7 @@ class TurbulenceModel:
         """
         if t is None:
             raise ValueError("t must be provided")
-        if self.intensity < 1e-10:
+        if self.intensity < _VECTOR_MAGNITUDE_EPS:
             return np.zeros(3)
 
         # Sum of sinusoids at different frequencies (vectorized)
@@ -664,7 +730,9 @@ class WindModel:
         # Apply altitude gradient
         if self.config.altitude_gradient:
             altitude = max(0.0, position[2])
-            gradient_multiplier = 1.0 + self.config.gradient_factor * (altitude / 10.0)
+            gradient_multiplier = 1.0 + self.config.gradient_factor * (
+                altitude / _GRADIENT_ALTITUDE_SCALE_M
+            )
             wind = wind * gradient_multiplier
 
         # Add gusts
@@ -714,7 +782,7 @@ class WindModel:
             raise ValueError("t must be provided")
         if self._last_check_time < 0:
             self._last_check_time = t
-            dt = 0.1  # Initial time step assumption
+            dt = _INITIAL_GUST_CHECK_DT_S  # Initial time step assumption
         else:
             dt = t - self._last_check_time
             self._last_check_time = t
@@ -735,19 +803,25 @@ class WindModel:
 
             # Generate random gust
             duration = self._rng.exponential(self.config.gust_duration_mean)
-            duration = max(0.5, min(duration, 10.0))  # Clamp
+            duration = max(
+                _GUST_DURATION_MIN_S, min(duration, _GUST_DURATION_MAX_S)
+            )  # Clamp
 
             # Random direction perturbation
             base_speed = self.config.speed
             gust_speed = (
-                base_speed * self.config.gust_intensity * self._rng.uniform(0.5, 1.5)
+                base_speed
+                * self.config.gust_intensity
+                * self._rng.uniform(
+                    _GUST_SPEED_VARIABILITY_MIN, _GUST_SPEED_VARIABILITY_MAX
+                )
             )
 
             # Gust direction: mostly aligned with base wind, some random deviation
             base_dir = self.config.direction
-            random_perturb = self._rng.standard_normal(3) * 0.3
+            random_perturb = self._rng.standard_normal(3) * _GUST_DIRECTION_PERTURB_STD
             gust_dir = base_dir + random_perturb
-            gust_dir = gust_dir / (math.hypot(*gust_dir) + 1e-10)
+            gust_dir = gust_dir / (math.hypot(*gust_dir) + _VECTOR_MAGNITUDE_EPS)
 
             gust = WindGust(
                 start_time=t,
@@ -898,7 +972,7 @@ class EnvironmentRandomizer:
     def create_snapshot(
         self,
         base_air_density: float = float(AIR_DENSITY_SEA_LEVEL_KG_M3),
-        base_temperature: float = 15.0,
+        base_temperature: float = _DEFAULT_TEMPERATURE_C,
         base_wind_config: WindConfig | None = None,
     ) -> EnvironmentSnapshot:
         """Create a consistent randomized environment snapshot.


### PR DESCRIPTION
Partial progress on #5916.

Extracts ~15 inline magic numbers in `src/shared/python/physics/aerodynamics.py` to named module-level constants per the triage comment: https://github.com/D-sorganization/UpstreamDrift/issues/5916#issuecomment-4529067266

## Constants introduced (underscore-prefixed, module-private)
- `_DRAG_FORMULA_PREFACTOR` — 0.5 Bernoulli dynamic-pressure prefactor (drag, lift, Magnus)
- `_VECTOR_MAGNITUDE_EPS` — 1e-10 vector-magnitude floor
- `_REYNOLDS_MIN` / `_REYNOLDS_MAX` — 1e3 / 1e7 Bearman & Harvey / Mehta clamp
- `_LIFT_SPIN_RATIO_SCALE`, `_MAGNUS_SPIN_RATIO_SATURATION`
- `_DEFAULT_GUST_INTENSITY`, `_DEFAULT_GUST_FREQUENCY_HZ`, `_DEFAULT_GUST_DURATION_MEAN_S`, `_DEFAULT_GRADIENT_FACTOR`
- `_GRADIENT_ALTITUDE_SCALE_M`
- `_GUST_DURATION_MIN_S`/`_GUST_DURATION_MAX_S`, `_GUST_SPEED_VARIABILITY_MIN/MAX`, `_GUST_DIRECTION_PERTURB_STD`
- `_DEFAULT_TEMPERATURE_C`, `_INITIAL_GUST_CHECK_DT_S`
- `_DEFAULT_MAX_LIFT_COEFFICIENT`
- `_DEFAULT_TURBULENCE_INTENSITY`, `_TURBULENCE_HARMONIC_COUNT`, `_TURBULENCE_FREQ_MIN_HZ`, `_TURBULENCE_FREQ_MAX_HZ`

## Verification
- `python -m ruff check src/shared/python/physics/aerodynamics.py` — clean
- `python -m ruff format --check src/shared/python/physics/aerodynamics.py` — clean

No behavior change. Diff: +104 / -30 lines, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)