### PR TITLE
deps: add upper bounds to drake/pinocchio/chrono extras (#5914)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,11 @@ dependencies = [
 rust = ["upstream-physics>=0.1.0", "upstream-mocap-preproc>=0.1.0", "upstream-mocap-io>=0.1.0"]
 mocap-preproc = ["upstream-mocap-preproc>=0.1.0"]
 mocap-io = ["upstream-mocap-io>=0.1.0"]
-drake = ["drake>=1.22.0"]
-pinocchio = ["pin>=2.6.0", "meshcat>=0.3.0"]
-chrono = ["pychrono>=8.0"]
+# Upper bounds added per issue #5914 to prevent silent breakage on
+# upstream major releases of these physics engines.
+drake = ["drake>=1.22.0,<2.0.0"]
+pinocchio = ["pin>=2.6.0,<3.0.0", "meshcat>=0.3.0,<1.0.0"]
+chrono = ["pychrono>=8.0,<10.0"]
 
 all-engines = ["upstream-drift[drake,pinocchio]"]
 


### PR DESCRIPTION
Partial progress on #5914.

Adds upper version bounds to drake/pinocchio/chrono optional extras to prevent silent breakage from major-version bumps.