### PR TITLE
fix: resolve partial redaction of valid secrets

### DIFF
--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -83,7 +83,8 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|access_token|auth_token|bearer"
         r"|private_key"
         r")"
-        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+        r"(['\"]?\s*[=:]\s*)"
+        r"(?:(['\"])(.*?)\3|([^\s'\"<>]+))"
     ),
 ]
 
@@ -115,8 +116,15 @@ class SensitiveDataFilter(logging.Filter):
 
 def _redact_sensitive(text: str) -> str:
     """Replace sensitive values in *text* with a redaction placeholder."""
+
+    def _replace(m: re.Match[str]) -> str:
+        key = m.group(1)
+        sep = m.group(2)
+        quote = m.group(3) or ""
+        return f"{key}{sep}{quote}***REDACTED***{quote}"
+
     for pattern in _SENSITIVE_PATTERNS:
-        text = pattern.sub(r"\1=***REDACTED***", text)
+        text = pattern.sub(_replace, text)
     return text
 
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -190,3 +190,30 @@ class TestSetupLogging:
     def test_custom_level_does_not_raise(self) -> None:
         # Just verifying no exception — root level can be affected by other workers
         setup_logging(level=LogLevel.ERROR)  # should not raise
+
+
+class TestRedactionCommas:
+    def _make_record(self, msg: str, args: tuple = ()) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=args,
+            exc_info=None,
+        )
+
+    def test_json_payloads_redact_commas(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password":"abc,def"}')
+        flt.filter(record)
+        assert "abc,def" not in record.msg
+        assert '{"password":"***REDACTED***"}' in record.msg
+
+    def test_unquoted_payloads_redact_commas(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("password=abc,def")
+        flt.filter(record)
+        assert "abc,def" not in record.msg
+        assert "password=***REDACTED***" in record.msg


### PR DESCRIPTION
Fixes #6052\n\nThis PR fixes the regex pattern in the logging config that stopped at commas or braces when redacting sensitive data. It correctly handles quoted and unquoted secrets to prevent security regressions.

---
*PR created automatically by Jules for task [14876560415428475186](https://jules.google.com/task/14876560415428475186) started by @dieterolson*