### PR TITLE
docs(README): add Quick Start with explicit entry-point hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ For a focused reviewer walkthrough, start with the
 
 ## Quick Start
 
+The recommended entry point is the **web UI**:
+
+```bash
+python3 launch_golf_suite.py
+```
+
+This starts the local API server (default port `8000`) and opens the React UI
+in your default browser.
+
+### Other entry points
+
+| Command | What it launches |
+|---------|------------------|
+| `python3 launch_golf_suite.py` | Web UI (recommended) |
+| `python3 launch_golf_suite.py --classic` | Classic PyQt6 desktop launcher |
+| `python3 launch_golf_suite.py --api-only` | API server without auto-opening a UI |
+| `python3 launch_golf_suite.py --engine <name>` | Direct engine launch (legacy) |
+| `python3 -m src.tools.pose_studio` | Pose Studio standalone |
+
+Additional flags: `--port <N>` to override the API port, `--no-browser` to skip
+auto-opening the browser. The classic PyQt6 launcher remains supported as a
+fallback.
+
 **Hiring Manager or Reviewer?** See the [Golf Modeling Portfolio Demo](docs/portfolio/golf_modeling_demo.md) for a focused, reproducible showcase of the physics capabilities.
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

Adds an entry-point block at the top of the `Quick Start` section in the root `README.md` so a new contributor can see, at a glance, which command to run.

- Web UI (`python3 launch_golf_suite.py`) is presented as the recommended path.
- Classic PyQt6 launcher remains documented as a fallback via `--classic`.
- Each row in the entry-points table maps to a flag that actually exists in `launch_golf_suite.py` (verified against `launch_golf_suite.py` and `src/api/local_server.py`; default port is `8000`).
- No other content in `README.md` was reformatted or rewritten. There is no `launch.bat` reference in this file, so nothing was removed on that front (the sibling PR #6086 removes the file itself).

Refs #6096.

> **Note on the `Closes` keyword:** intentionally `Refs` rather than `Closes` because the Anti-Phantom-Merge guard pattern-matches paths cited in the issue body (`src/api/local_server.py`, `src/launchers/upstream_drift_launcher.py`) and expects the diff to touch them. In this issue those paths are the *entry points being documented*, not the fix location — the fix is to update `README.md` to describe them. Issue #6096 should be closed manually on merge.

## Note for the maintainer

The "web UI primary, classic PyQt6 fallback" framing comes from the issue audit, not from a unilateral product decision on my part. If you'd rather lead with the classic launcher (or present them as equal-weight peers), this section is intentionally easy to flip — the wording is factual ("this command launches X") rather than promotional, and the table rows can be reordered without rewriting prose.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the Quick Start block reads cleanly
- [ ] Confirm `python3 launch_golf_suite.py` opens the web UI as documented
- [ ] Confirm `python3 launch_golf_suite.py --classic` launches the PyQt6 launcher

https://claude.ai/code/session_01H82oFTHsdTs7J8xAsGAKCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01H82oFTHsdTs7J8xAsGAKCM)_