### PR TITLE
docs(pose-interchange): clean stale NotImplementedError docstrings post-#4963

### DIFF
--- a/src/shared/python/pose_interchange/services/drake.py
+++ b/src/shared/python/pose_interchange/services/drake.py
@@ -1,15 +1,16 @@
-"""Drake :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""Drake :class:`LiveKinematicsService` implementation.
 
-The real implementation lazily imports :mod:`pydrake` and loads a URDF
-via the multibody plant's :class:`pydrake.multibody.parsing.Parser`.
-If :mod:`pydrake` is unavailable, :func:`create_drake_service` falls
-back to a :class:`MockKinematicsService` configured with
-``engine_name="drake"``.
+Loads a URDF via :class:`pydrake.multibody.parsing.Parser` into a
+:class:`MultibodyPlant` (with a :class:`SceneGraph`), maps
+:class:`CanonicalPose` to plant positions ``q`` using the Drake
+:class:`PoseConventionAdapter`, and returns world-frame transforms by
+iterating ``plant.GetBodyIndices`` and calling ``EvalBodyPoseInWorld``.
+``step()`` advances the Drake :class:`Simulator` by ``dt`` seconds;
+``reset()`` restores the cached default context and reinitialises the
+simulator.
 
-Method bodies that require non-trivial Drake plumbing currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up;
-this PR only commits the wiring scaffold so downstream code can target
-``LiveKinematicsService`` without waiting on the full Drake bridge.
+Falls back to :class:`MockKinematicsService` when the :mod:`pydrake`
+wheel is not installed.
 """
 
 from __future__ import annotations

--- a/src/shared/python/pose_interchange/services/opensim.py
+++ b/src/shared/python/pose_interchange/services/opensim.py
@@ -1,14 +1,17 @@
-"""OpenSim :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""OpenSim :class:`LiveKinematicsService` implementation.
 
-Lazily imports :mod:`opensim` and loads a ``.osim`` file via
-:class:`opensim.Model`.  If the wheel is unavailable,
-:func:`create_opensim_service` falls back to a
-:class:`MockKinematicsService` configured with
-``engine_name="opensim"``.
+Loads a ``.osim`` file via :class:`opensim.Model` and initialises a
+:class:`SimTK.State`. ``set_pose`` maps :class:`CanonicalPose` to
+coordinate values using the OpenSim :class:`PoseConventionAdapter`
+joint layout, writes them into the model's coordinate set, then calls
+``realizePosition`` so downstream queries see fresh body transforms.
+``get_link_transforms`` iterates the model's ``BodySet`` and returns
+each body's ``getTransformInGround`` as a 4x4 SE(3) matrix.
+``step()`` integrates an :class:`opensim.Manager` forward by ``dt``;
+``reset()`` re-initialises the system state.
 
-Method bodies that require non-trivial OpenSim wiring currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
+Falls back to :class:`MockKinematicsService` when the :mod:`opensim`
+wheel is not installed.
 """
 
 from __future__ import annotations

--- a/src/shared/python/pose_interchange/services/simscape.py
+++ b/src/shared/python/pose_interchange/services/simscape.py
@@ -1,15 +1,18 @@
-"""Simscape :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""Simscape :class:`LiveKinematicsService` implementation.
 
-Connects to the MATLAB engine via the existing
-:func:`load_matlab_3d_engine` machinery in :mod:`src.engines.loaders`.
-If MATLAB / the MATLAB engine API is unavailable,
-:func:`create_simscape_service` falls back to a
-:class:`MockKinematicsService` configured with
-``engine_name="simscape"``.
+Loads a Simscape Multibody model through
+:class:`src.engines.simscape.adapter.SimscapeAdapter`, which spins up
+the MATLAB engine. ``set_pose`` maps :class:`CanonicalPose` to joint
+values using the Simscape :class:`PoseConventionAdapter` joint layout
+and writes ``<joint>_q`` entries into the MATLAB workspace.
+``step()`` and ``reset()`` delegate to the underlying engine adapter.
 
-Method bodies that drive Simulink directly currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
+``get_link_transforms`` currently returns an empty dict: pulling
+body-frame transforms back out of the MATLAB engine is still pending
+and will land alongside the Pose Studio engine bridge.
+
+Falls back to :class:`MockKinematicsService` when MATLAB (and the
+MATLAB Engine API for Python) is not installed.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

#4963 (merged 2026-05-11) filled in the real-engine `LiveKinematicsService` bridges for Drake, MuJoCo, Pinocchio, OpenSim, and Simscape, but three module docstrings still described the pre-#4963 reality, claiming method bodies "raise `NotImplementedError` with a TODO: #4963 tied to follow-up". The actual implementations have been in place for two weeks (`grep "raise NotImplementedError" src/shared/python/pose_interchange/services/` returns zero matches).

This PR rewrites each affected module docstring to describe what the service actually does today.

## Files touched

- `src/shared/python/pose_interchange/services/drake.py` — describes URDF loading via `MultibodyPlant` + `Parser`, pose mapping via `DrakeAdapter`, world-frame transforms via `EvalBodyPoseInWorld`, and `step()`/`reset()` driven by the Drake `Simulator`.
- `src/shared/python/pose_interchange/services/opensim.py` — describes `.osim` loading via `opensim.Model`, coordinate-set writes from the `OpenSimAdapter` joint layout, `getTransformInGround` for link transforms, and integration via `opensim.Manager`.
- `src/shared/python/pose_interchange/services/simscape.py` — describes MATLAB-engine wiring through `src.engines.simscape.adapter.SimscapeAdapter` and per-joint workspace writes; explicitly notes that `get_link_transforms` still returns an empty dict (the only method that genuinely remains stubbed today).

`mujoco.py` and `pinocchio.py` were checked and already describe today's behavior accurately — no changes needed there.

## Out-of-scope follow-up noted

`simscape.py` line 139 still has an inline `# TODO: Implement actual transform queries from MATLAB engine #4963` comment in the body of `get_link_transforms`. This is a real gap (the method returns an empty dict). Per the issue's "docstrings only, do not change any code" constraint I left it as-is; tracking that gap should be a separate issue if it isn't already covered.

## Verification

- `ruff format src/shared/python/pose_interchange/services/` — 7 files left unchanged.
- `ruff check src/shared/python/pose_interchange/services/` — all checks passed.
- `grep -n "4963\|NotImplementedError" src/shared/python/pose_interchange/services/*.py` — only the intentional inline TODO above remains.
- `pytest tests/unit/pose_interchange/` was attempted but fails at collection time in this sandbox with `ModuleNotFoundError: No module named 'numpy'`. The failure is environmental (numpy missing), unrelated to these docstring-only changes; CI will run the full suite.

## Test plan

- [ ] CI: `ruff check` green
- [ ] CI: `ruff format --check` green
- [ ] CI: `pytest tests/unit/pose_interchange/` green (docstring-only diff, no behavior change expected)

Closes #6092

https://claude.ai/code/session_01H82oFTHsdTs7J8xAsGAKCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01H82oFTHsdTs7J8xAsGAKCM)_