### PR TITLE
chore(tests): remove stale skip markers (audit batch 1)

### DIFF
--- a/tests/integration/motion_pipeline/adversarial/test_invariant_violations.py
+++ b/tests/integration/motion_pipeline/adversarial/test_invariant_violations.py
@@ -74,7 +74,6 @@ INVARIANT_CASES = [
 
 # Cases that surface real bugs in production — see filed issues.
 KNOWN_GAPS = {
-    "joint-empty-name": "GH #4720 — JointDef accepts empty name",
     "joint-bad-offset-length": "GH #4720 — JointDef accepts non-3D offset",
 }
 


### PR DESCRIPTION
## Summary

Result of the skip/xfail audit requested in #6095. Full triage report posted as a comment on that issue: https://github.com/D-sorganization/UpstreamDrift/issues/6095#issuecomment-4530070895

This PR is **the conservative removal slice** — one stale marker removed, with the underlying bug-fix verified locally.

## Change

Remove `joint-empty-name` from the `KNOWN_GAPS` dict in `tests/integration/motion_pipeline/adversarial/test_invariant_violations.py`. That entry referenced #4720 (closed-as-completed), and the bug fix is in `src/shared/python/motion_pipeline/contracts.py` — `JointDef.name` now has `Field(..., min_length=1)`. Before this PR the parametrised case was `XPASS(strict)`; after this PR it passes cleanly and now serves as a regression guard for the empty-name validator.

The companion `joint-bad-offset-length` entry stays in `KNOWN_GAPS` because that case still legitimately xfails (the parametrised input uses an old field name `offset` instead of `tpose_offset`, so the model silently ignores the bad input — a real follow-up, out of scope for this batch).

## Verification

```
$ python3 -m pytest tests/integration/motion_pipeline/adversarial/test_invariant_violations.py -v
8 passed, 1 xfailed
```

(The 1 xfail is the still-broken `joint-bad-offset-length` case, which is correct behaviour.)

`ruff check` and `ruff format --check` both clean on the touched file.

## What was *not* changed in this PR (deliberately)

The audit identified ~14 other markers worth a closer look (see the linked report) but only one met both bars of "clearly stale" + "verifiable from this sandbox without optional engine deps". The runner-up — a strict xfail for the C3D empty-file case (#4721) — looks XPASS-strict in CI but requires `ezc3d` to verify, so it's deferred to a follow-up PR.

Out of scope here per the task definition:
- Adding `xfail_strict = true` (could break currently-xpassing tests not yet identified)
- The marker-ratchet CI check (separate effort)
- Fixing underlying bugs in any still-xfailed test

## Test plan

- [x] `python3 -m pytest tests/integration/motion_pipeline/adversarial/test_invariant_violations.py -v` — 8 passed, 1 xfailed
- [x] `python3 -m ruff check tests/integration/motion_pipeline/adversarial/test_invariant_violations.py`
- [x] `python3 -m ruff format --check tests/integration/motion_pipeline/adversarial/test_invariant_violations.py`
- [ ] CI green on this branch

Refs #6095


---
_Generated by [Claude Code](https://claude.ai/code/session_01H82oFTHsdTs7J8xAsGAKCM)_