### PR TITLE
Fix: Update plot_style and body_part_viz __init__ docstrings

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -783,3 +783,7 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
 ````
+
+## 2026-05-25: Epics #4796 and #4755 Audit
+
+Epics #4796 (plot_style implementations) and #4755 (body_part_viz implementations) have been fully audited and closed. The `plot_style` module has shipped the canonical `MatplotlibMarkerRenderer` and `PyQtGLMarkerRenderer`, along with its colors, colormaps, markers, resolvers, and widgets sub-packages. The `body_part_viz` module has shipped the canonical matplotlib and PyQtGL renderers, capsule/ellipsoid/cylinder/mesh shapes, and Kabsch/Procrustes/cluster fitters. Both epics are fully implemented and can be closed as completed.

--- a/docs/issues/ROADMAP_ISSUES.md
+++ b/docs/issues/ROADMAP_ISSUES.md
@@ -83,3 +83,11 @@ These issues are already tracked in GitHub and represent planned improvements.
 - **GitHub Issue**: #130
 - **Status**: Open
 - **Description**: Implement lazy imports to improve startup time
+
+## Phase 5: Documentation & Audits
+
+### Phase 5.1: Audit Epics #4796 and #4755
+
+- **GitHub Issue**: #6087
+- **Status**: Closed
+- **Description**: Epics #4796 (plot_style implementations) and #4755 (body_part_viz implementations) have been audited. The `plot_style` module has shipped the canonical `MatplotlibMarkerRenderer` and `PyQtGLMarkerRenderer`, along with its colors, colormaps, markers, resolvers, and widgets sub-packages. The `body_part_viz` module has shipped the canonical matplotlib and PyQtGL renderers, capsule/ellipsoid/cylinder/mesh shapes, and Kabsch/Procrustes/cluster fitters. Both epics are fully implemented and can be closed as completed.

--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,11 +1,12 @@
-"""Body-part visualisation contracts and dataclasses.
+"""Body-part visualisation contracts, dataclasses, and implementations.
 
 This package defines the abstract surface (Protocols + frozen dataclasses)
-that every shape, fitter, and renderer implementation talks across.
+that every shape, fitter, and renderer implementation talks across, and
+provides their canonical implementations:
 
-Implementations of shapes, fitters, and rendering backends live in the
-``shapes``, ``fitters``, and ``renderers`` sub-packages and are added in
-follow-up issues of EPIC #4755.
+- ``shapes`` — capsule, ellipsoid, cylinder, and mesh shapes.
+- ``fitters`` — Kabsch, Procrustes, and cluster fitters.
+- ``renderers`` — matplotlib and PyQtGL rendering backends.
 """
 
 from __future__ import annotations

--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -1,13 +1,16 @@
-"""Plot-style contracts and dataclasses.
+"""Plot-style contracts, dataclasses, and renderer implementations.
 
-This package defines the abstract surface (Protocols + frozen
-dataclasses) used by every marker / trace styling implementation in
-UpstreamDrift.
+This package owns the canonical marker-styling stack:
 
-Concrete implementations of color resolvers, renderers, Qt widgets, and
-marker-shape primitives live in the ``resolvers``, ``renderers``,
-``widgets``, and ``shapes`` sub-packages and are added in follow-up
-issues of EPIC #4796.
+- ``contracts`` — runtime-checkable Protocols (``ColorResolver``,
+  ``MarkerRenderer``, ``MarkerShapeRenderer``).
+- ``colors`` / ``colormaps`` — color scales and registries.
+- ``markers`` — ``MarkerStyle``, ``MarkerShape``, ``CustomMeshSpec``.
+- ``renderers`` — ``MatplotlibMarkerRenderer`` (canonical), ``PyQtGLMarkerRenderer``.
+- ``resolvers`` — static / palette / data-driven color resolvers.
+- ``widgets`` — optional Qt widgets (imported only if PyQt6 is available).
+
+See ADR-0011 for the design.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #6087

Removes misleading "added in follow-up issues" language from `plot_style` and `body_part_viz` package __init__.py files, correctly detailing their shipped complete set of sub-packages, renderers, and implementations. Also documents the closure of Epics #4796 and #4755 within the ROADMAP_ISSUES.md tracking file.

---
*PR created automatically by Jules for task [6803376846037649949](https://jules.google.com/task/6803376846037649949) started by @dieterolson*