### PR TITLE
Fix docs governance tests and assertions

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate documentation governance files
         run: python3 scripts/check_docs_governance.py
 
+      - name: Test documentation governance files
+        run: python3 -m pytest tests/scripts/test_doc_governance_checks.py -q
+
       - name: Validate documentation catalog
         run: python3 scripts/check_doc_catalog.py
 

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -19,6 +19,10 @@ on:
       - "scripts/config/doc_size_budget.json"
       - ".github/workflows/docs-governance.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # -- Dispatcher: route to self-hosted if available --------------------------
   pick-runner:

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Validate documentation governance files
         run: python3 scripts/check_docs_governance.py
 
+      - name: Install test dependencies
+        run: python3 -m pip install pytest
+
       - name: Test documentation governance files
         run: python3 -m pytest tests/scripts/test_doc_governance_checks.py -q
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -783,3 +783,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
 ````
+
+<!-- Spec updated for PR #6065 (Docs Governance CI Fix) -->

--- a/SPEC.md
+++ b/SPEC.md
@@ -782,6 +782,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-13 | 1.0.166 | Moved the PyQt launcher close control into the top menu-bar row while keeping the custom title strip for drag/minimize/maximize behavior (#5374). |
 | 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
+| 2026-05-25 | 1.0.171 | Wire ADR numbering governance tests and strengthen duplicate numbering test assertions (#6065). |
 ````
-
-<!-- Spec updated for PR #6065 (Docs Governance CI Fix) -->

--- a/tests/scripts/test_doc_governance_checks.py
+++ b/tests/scripts/test_doc_governance_checks.py
@@ -182,7 +182,7 @@ def test_docs_governance_rejects_duplicate_source_of_truth_headings(
 
 
 def test_docs_governance_rejects_duplicate_adr_numbers(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, capsys
 ) -> None:
     _write(tmp_path / "docs" / "README.md", "# Docs\n")
     _write(tmp_path / "docs" / "assessments" / "README.md", "# Assessments\n")
@@ -209,6 +209,10 @@ def test_docs_governance_rejects_duplicate_adr_numbers(
     monkeypatch.setattr(check_docs_governance, "_git_changed_files", list)
 
     assert check_docs_governance.main() == 1
+
+    captured = capsys.readouterr()
+    assert "Duplicate ADR numbering detected:" in captured.err
+    assert "duplicate ADR number 0005: 0005-first.md, 0005-second.md" in captured.err
 
 
 def test_docs_governance_rejects_missing_examples_entries(


### PR DESCRIPTION
Wire ADR numbering governance tests and strengthen duplicate numbering test assertions.

Fixes #6065

---
*PR created automatically by Jules for task [579300098725252930](https://jules.google.com/task/579300098725252930) started by @dieterolson*