### PR TITLE
Refactor aerodynamics magic constants to module level

### DIFF
--- a/src/shared/python/physics/aerodynamics.py
+++ b/src/shared/python/physics/aerodynamics.py
@@ -55,38 +55,61 @@ from src.shared.python.physics.atmosphere import cd_dimpled_sphere
 
 MIN_AIR_DENSITY_KG_M3 = 0.01
 
+# ---------------------------------------------------------------------------
+# Module-level constants (extracted from inline magic numbers — issue #5916)
+# ---------------------------------------------------------------------------
 
-_DEFAULT_FORCE_PREFACTOR = 0.5
-_DEFAULT_BASE_TEMPERATURE_C = 15.0
+# Dynamic-pressure prefactor in F = 0.5 * rho * Cd * A * v^2 (Bernoulli).
+# Used by drag, lift, and Magnus force formulas.
+_DRAG_FORMULA_PREFACTOR = 0.5
 
-# Drag constants
-_DEFAULT_REYNOLDS_MIN = 1.0e3
-_DEFAULT_REYNOLDS_MAX = 1.0e7
+# Floor below which a vector magnitude is treated as zero (avoids division
+# by ~0 in unit-vector normalizations).
+_VECTOR_MAGNITUDE_EPS = 1e-10
 
-# Lift constants
+# Reynolds-number clamp range for cd_dimpled_sphere; outside this band the
+# Bearman & Harvey / Mehta correlation is not validated (issue #3504).
+_REYNOLDS_MIN = 1.0e3
+_REYNOLDS_MAX = 1.0e7
+
+# Spin-ratio scale in lift coefficient saturation:
+# Cl = Cl_max * (1 - exp(-S/scale)).
+_LIFT_SPIN_RATIO_SCALE = 0.1
+
+# Spin parameter at which the Magnus coefficient saturates to its full value.
+_MAGNUS_SPIN_RATIO_SATURATION = 0.2
+
+# WindConfig defaults
+_DEFAULT_GUST_INTENSITY = 0.3  # fraction of base wind speed
+_DEFAULT_GUST_FREQUENCY_HZ = 0.1  # Hz
+_DEFAULT_GUST_DURATION_MEAN_S = 2.0  # seconds
+_DEFAULT_GRADIENT_FACTOR = 0.05  # 5% wind-speed increase per scale height
+
+# Altitude scale [m] used in the linear wind-speed gradient model:
+# multiplier = 1 + gradient_factor * (altitude / scale).
+_GRADIENT_ALTITUDE_SCALE_M = 10.0
+
+# Gust spawn bounds
+_GUST_DURATION_MIN_S = 0.5
+_GUST_DURATION_MAX_S = 10.0
+_GUST_SPEED_VARIABILITY_MIN = 0.5
+_GUST_SPEED_VARIABILITY_MAX = 1.5
+_GUST_DIRECTION_PERTURB_STD = 0.3
+
+# Default temperature used when no atmospheric snapshot is supplied [degC].
+_DEFAULT_TEMPERATURE_C = 15.0
+
+# Initial dt assumption for the first gust-spawn poll, before real dt is known.
+_INITIAL_GUST_CHECK_DT_S = 0.1
+
+# Maximum lift coefficient (saturation cap) for the LiftModel.
 _DEFAULT_MAX_LIFT_COEFFICIENT = 0.4
-_DEFAULT_SPIN_RATIO_SCALE = 0.1
 
-# Magnus constants
-_DEFAULT_SPIN_PARAM_SCALE = 0.2
-
-# Wind & Gust constants
-_DEFAULT_GUST_INTENSITY = 0.3
-_DEFAULT_GUST_FREQUENCY_HZ = 0.1
-_DEFAULT_GUST_DURATION_MEAN_S = 2.0
-_DEFAULT_GUST_MIN_DURATION_S = 0.5
-_DEFAULT_GUST_MAX_DURATION_S = 10.0
-_DEFAULT_GUST_SPEED_MIN_FACTOR = 0.5
-_DEFAULT_GUST_SPEED_MAX_FACTOR = 1.5
-_DEFAULT_GUST_DIR_PERTURB_SCALE = 0.3
-_DEFAULT_GUST_INITIAL_DT = 0.1
-_DEFAULT_WIND_ALTITUDE_SCALE = 10.0
-
-# Turbulence constants
+# TurbulenceModel defaults
 _DEFAULT_TURBULENCE_INTENSITY = 0.5
-_DEFAULT_TURBULENCE_FREQ_MIN = 0.1
-_DEFAULT_TURBULENCE_FREQ_MAX = 2.0
-_DEFAULT_TURBULENCE_HARMONICS = 10
+_TURBULENCE_HARMONIC_COUNT = 10
+_TURBULENCE_FREQ_MIN_HZ = 0.1
+_TURBULENCE_FREQ_MAX_HZ = 2.0
 
 
 def _vector_magnitude(vector: np.ndarray) -> float:
@@ -195,11 +218,11 @@ class WindConfig:
     base_velocity: np.ndarray = field(default_factory=lambda: np.array([0.0, 0.0, 0.0]))
     gusts_enabled: bool = False
     gust_intensity: float = _DEFAULT_GUST_INTENSITY
-    gust_frequency: float = _DEFAULT_GUST_FREQUENCY_HZ  # Hz
-    gust_duration_mean: float = _DEFAULT_GUST_DURATION_MEAN_S  # seconds
+    gust_frequency: float = _DEFAULT_GUST_FREQUENCY_HZ
+    gust_duration_mean: float = _DEFAULT_GUST_DURATION_MEAN_S
     turbulence_intensity: float = 0.0
     altitude_gradient: bool = False
-    gradient_factor: float = 0.05  # 5% per 10m
+    gradient_factor: float = _DEFAULT_GRADIENT_FACTOR
 
     @property
     def speed(self) -> float:
@@ -210,7 +233,7 @@ class WindConfig:
     def direction(self) -> np.ndarray:
         """Get normalized wind direction."""
         speed = self.speed
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.array([1.0, 0.0, 0.0])
         return self.base_velocity / speed
 
@@ -291,12 +314,12 @@ class DragModel:
         velocity_vec = np.asarray(velocity, dtype=float).reshape(-1)
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity_vec)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         cd = self.get_effective_coefficient(velocity_vec, air_density)
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cd * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cd * self.ball_area * speed**2
         )
 
         # Drag opposes velocity
@@ -328,7 +351,7 @@ class DragModel:
 
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return self.base_coefficient
 
         # Reynolds number
@@ -338,7 +361,7 @@ class DragModel:
         # Delegate to the smoothed drag-crisis correlation (Bearman & Harvey
         # 1976, Mehta 1985); clamp to the model's validated range so the
         # integrator never sees a discontinuity. See issue #3504.
-        re_clamped = max(_DEFAULT_REYNOLDS_MIN, min(_DEFAULT_REYNOLDS_MAX, re))
+        re_clamped = max(_REYNOLDS_MIN, min(_REYNOLDS_MAX, re))
         return cd_dimpled_sphere(re_clamped, base_cd=self.base_coefficient)
 
 
@@ -401,7 +424,7 @@ class LiftModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Lift direction: perpendicular to velocity, in spin plane
@@ -409,7 +432,7 @@ class LiftModel:
         lift_dir = np.cross(spin_axis, velocity_vec)
         lift_norm = float(math.hypot(*lift_dir))
 
-        if lift_norm < 1e-10:
+        if lift_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         lift_dir = lift_dir / lift_norm
@@ -420,7 +443,7 @@ class LiftModel:
 
         # Lift magnitude
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cl * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cl * self.ball_area * speed**2
         )
 
         return force_magnitude * lift_dir
@@ -437,9 +460,7 @@ class LiftModel:
         # Empirical relationship: Cl saturates at high spin
         if spin_ratio is None:
             raise ValueError("spin_ratio must be provided")
-        cl = self.max_coefficient * (
-            1 - math.exp(-spin_ratio / _DEFAULT_SPIN_RATIO_SCALE)
-        )
+        cl = self.max_coefficient * (1 - math.exp(-spin_ratio / _LIFT_SPIN_RATIO_SCALE))
         return min(cl, self.max_coefficient)
 
 
@@ -497,14 +518,14 @@ class MagnusModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Magnus direction: spin x velocity
         magnus_dir = np.cross(spin_vec, velocity_vec)
         magnus_norm = float(math.hypot(*magnus_dir))
 
-        if magnus_norm < 1e-10:
+        if magnus_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         magnus_dir = magnus_dir / magnus_norm
@@ -515,7 +536,7 @@ class MagnusModel:
 
         # Force magnitude
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cm * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cm * self.ball_area * speed**2
         )
 
         return force_magnitude * magnus_dir
@@ -530,7 +551,7 @@ class MagnusModel:
             Magnus coefficient
         """
         # Approximately linear for small spin_param, saturates for large
-        return self.coefficient * min(spin_param / _DEFAULT_SPIN_PARAM_SCALE, 1.0)
+        return self.coefficient * min(spin_param / _MAGNUS_SPIN_RATIO_SATURATION, 1.0)
 
 
 # =============================================================================
@@ -616,14 +637,12 @@ class TurbulenceModel:
         self.intensity = intensity
         self._rng = np.random.default_rng(seed)
         # Pre-generate noise coefficients for smooth interpolation
-        self._coeffs = self._rng.standard_normal((3, _DEFAULT_TURBULENCE_HARMONICS))
-        self._phases = self._rng.uniform(
-            0, 2 * np.pi, (3, _DEFAULT_TURBULENCE_HARMONICS)
-        )
+        self._coeffs = self._rng.standard_normal((3, _TURBULENCE_HARMONIC_COUNT))
+        self._phases = self._rng.uniform(0, 2 * np.pi, (3, _TURBULENCE_HARMONIC_COUNT))
         self._freqs = self._rng.uniform(
-            _DEFAULT_TURBULENCE_FREQ_MIN,
-            _DEFAULT_TURBULENCE_FREQ_MAX,
-            _DEFAULT_TURBULENCE_HARMONICS,
+            _TURBULENCE_FREQ_MIN_HZ,
+            _TURBULENCE_FREQ_MAX_HZ,
+            _TURBULENCE_HARMONIC_COUNT,
         )
 
     def get_perturbation(
@@ -642,7 +661,7 @@ class TurbulenceModel:
         """
         if t is None:
             raise ValueError("t must be provided")
-        if self.intensity < 1e-10:
+        if self.intensity < _VECTOR_MAGNITUDE_EPS:
             return np.zeros(3)
 
         # Sum of sinusoids at different frequencies (vectorized)
@@ -712,7 +731,7 @@ class WindModel:
         if self.config.altitude_gradient:
             altitude = max(0.0, position[2])
             gradient_multiplier = 1.0 + self.config.gradient_factor * (
-                altitude / _DEFAULT_WIND_ALTITUDE_SCALE
+                altitude / _GRADIENT_ALTITUDE_SCALE_M
             )
             wind = wind * gradient_multiplier
 
@@ -763,7 +782,7 @@ class WindModel:
             raise ValueError("t must be provided")
         if self._last_check_time < 0:
             self._last_check_time = t
-            dt = _DEFAULT_GUST_INITIAL_DT  # Initial time step assumption
+            dt = _INITIAL_GUST_CHECK_DT_S  # Initial time step assumption
         else:
             dt = t - self._last_check_time
             self._last_check_time = t
@@ -785,8 +804,7 @@ class WindModel:
             # Generate random gust
             duration = self._rng.exponential(self.config.gust_duration_mean)
             duration = max(
-                _DEFAULT_GUST_MIN_DURATION_S,
-                min(duration, _DEFAULT_GUST_MAX_DURATION_S),
+                _GUST_DURATION_MIN_S, min(duration, _GUST_DURATION_MAX_S)
             )  # Clamp
 
             # Random direction perturbation
@@ -795,17 +813,15 @@ class WindModel:
                 base_speed
                 * self.config.gust_intensity
                 * self._rng.uniform(
-                    _DEFAULT_GUST_SPEED_MIN_FACTOR, _DEFAULT_GUST_SPEED_MAX_FACTOR
+                    _GUST_SPEED_VARIABILITY_MIN, _GUST_SPEED_VARIABILITY_MAX
                 )
             )
 
             # Gust direction: mostly aligned with base wind, some random deviation
             base_dir = self.config.direction
-            random_perturb = (
-                self._rng.standard_normal(3) * _DEFAULT_GUST_DIR_PERTURB_SCALE
-            )
+            random_perturb = self._rng.standard_normal(3) * _GUST_DIRECTION_PERTURB_STD
             gust_dir = base_dir + random_perturb
-            gust_dir = gust_dir / (math.hypot(*gust_dir) + 1e-10)
+            gust_dir = gust_dir / (math.hypot(*gust_dir) + _VECTOR_MAGNITUDE_EPS)
 
             gust = WindGust(
                 start_time=t,
@@ -956,7 +972,7 @@ class EnvironmentRandomizer:
     def create_snapshot(
         self,
         base_air_density: float = float(AIR_DENSITY_SEA_LEVEL_KG_M3),
-        base_temperature: float = _DEFAULT_BASE_TEMPERATURE_C,
+        base_temperature: float = _DEFAULT_TEMPERATURE_C,
         base_wind_config: WindConfig | None = None,
     ) -> EnvironmentSnapshot:
         """Create a consistent randomized environment snapshot.


### PR DESCRIPTION
Extracts inline magic numbers (e.g., drag formula prefactors, reynolds number limits, spin ratio scales, gust configurations, turbulence harmonics) into named `_DEFAULT_...` or module-level constants at the top of `src/shared/python/physics/aerodynamics.py`, as requested by Issue #5916. No behavioral or logic changes were made.

Fixes #6076

---
*PR created automatically by Jules for task [7997906756579879503](https://jules.google.com/task/7997906756579879503) started by @dieterolson*