### PR TITLE
Clean stale NotImplementedError docstrings in pose_interchange services

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -783,3 +783,6 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
 ````
+
+## Changelog
+- Cleaned up stale `NotImplementedError` docstrings in `pose_interchange` services post-#4963.

--- a/src/shared/python/pose_interchange/services/drake.py
+++ b/src/shared/python/pose_interchange/services/drake.py
@@ -1,15 +1,11 @@
-"""Drake :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""Drake LiveKinematicsService.
 
-The real implementation lazily imports :mod:`pydrake` and loads a URDF
-via the multibody plant's :class:`pydrake.multibody.parsing.Parser`.
-If :mod:`pydrake` is unavailable, :func:`create_drake_service` falls
-back to a :class:`MockKinematicsService` configured with
-``engine_name="drake"``.
+Loads a MultibodyPlant via `Parser`, maps :class:`CanonicalPose` to ``q`` using
+the Drake :class:`PoseConventionAdapter`, and returns world-frame transforms
+from ``plant.EvalBodyPoseInWorld``. ``step()`` advances a Drake :class:`Simulator`;
+``reset()`` restores a stored default :class:`Context`.
 
-Method bodies that require non-trivial Drake plumbing currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up;
-this PR only commits the wiring scaffold so downstream code can target
-``LiveKinematicsService`` without waiting on the full Drake bridge.
+Falls back to :class:`MockKinematicsService` when the Drake wheel is not installed.
 """
 
 from __future__ import annotations
@@ -57,11 +53,7 @@ def _drake_is_importable() -> bool:
 
 
 class DrakeKinematicsService:
-    """Real-engine :class:`LiveKinematicsService` backed by :mod:`pydrake`.
-
-    Skeletal: full body-transform queries are wired up but require a
-    follow-up issue to land alongside the Pose Studio engine bridge.
-    """
+    """Real-engine :class:`LiveKinematicsService` backed by :mod:`pydrake`."""
 
     engine_name: str = ENGINE_NAME
 

--- a/src/shared/python/pose_interchange/services/opensim.py
+++ b/src/shared/python/pose_interchange/services/opensim.py
@@ -1,14 +1,13 @@
-"""OpenSim :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""OpenSim LiveKinematicsService.
 
 Lazily imports :mod:`opensim` and loads a ``.osim`` file via
-:class:`opensim.Model`.  If the wheel is unavailable,
-:func:`create_opensim_service` falls back to a
-:class:`MockKinematicsService` configured with
-``engine_name="opensim"``.
+:class:`opensim.Model`. Maps :class:`CanonicalPose` to coordinate values
+using the OpenSim :class:`PoseConventionAdapter`, and returns body transforms
+via ``getTransformInGround``. ``step()`` integrates forward in time;
+``reset()`` restores the default initialized state.
 
-Method bodies that require non-trivial OpenSim wiring currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
+If the wheel is unavailable, :func:`create_opensim_service` falls back to a
+:class:`MockKinematicsService` configured with ``engine_name="opensim"``.
 """
 
 from __future__ import annotations

--- a/src/shared/python/pose_interchange/services/simscape.py
+++ b/src/shared/python/pose_interchange/services/simscape.py
@@ -1,15 +1,14 @@
-"""Simscape :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
+"""Simscape LiveKinematicsService.
 
-Connects to the MATLAB engine via the existing
-:func:`load_matlab_3d_engine` machinery in :mod:`src.engines.loaders`.
+Connects to the MATLAB engine via the existing SimscapeAdapter.
+Loads a model, maps :class:`CanonicalPose` to MATLAB workspace variables,
+and can advance simulation via ``step()``. The ``get_link_transforms()``
+method is currently stubbed and requires a follow-up implementation.
+
 If MATLAB / the MATLAB engine API is unavailable,
 :func:`create_simscape_service` falls back to a
 :class:`MockKinematicsService` configured with
 ``engine_name="simscape"``.
-
-Method bodies that drive Simulink directly currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
 """
 
 from __future__ import annotations
@@ -60,9 +59,8 @@ def _matlab_engine_is_importable() -> bool:
 class SimscapeKinematicsService:
     """Real-engine :class:`LiveKinematicsService` backed by Simscape Multibody.
 
-    Connects via :mod:`src.engines.loaders.load_matlab_3d_engine`; the
-    actual body-transform queries land in a follow-up issue alongside
-    the Pose Studio engine bridge.
+    Connects via the SimscapeAdapter. Note that ``get_link_transforms()`` is
+    currently stubbed (see #6093).
     """
 
     engine_name: str = ENGINE_NAME
@@ -133,7 +131,7 @@ class SimscapeKinematicsService:
         if getattr(self, "_engine", None) is None:
             return transforms
 
-        # TODO: Implement actual transform queries from MATLAB engine #4963
+        # TODO: Implement actual transform queries from MATLAB engine #6093
         return transforms
 
     def step(self, dt: float) -> None:


### PR DESCRIPTION
Cleaned up stale NotImplementedError docstrings in pose_interchange services (drake, opensim, simscape) post-#4963.

Fixes #6092

---
*PR created automatically by Jules for task [7104633001167941207](https://jules.google.com/task/7104633001167941207) started by @dieterolson*