### PR TITLE
docs(pose-interchange): clean stale NotImplementedError docstrings post-#4963

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-05-15
+  LAST UPDATED: 2026-05-25
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.

--- a/src/shared/python/pose_interchange/services/drake.py
+++ b/src/shared/python/pose_interchange/services/drake.py
@@ -2,14 +2,13 @@
 
 The real implementation lazily imports :mod:`pydrake` and loads a URDF
 via the multibody plant's :class:`pydrake.multibody.parsing.Parser`.
+Pose mapping is handled via :class:`DrakeAdapter`, world-frame transforms
+via :meth:`EvalBodyPoseInWorld`, and ``step()``/``reset()`` driven by the
+Drake :class:`Simulator`.
+
 If :mod:`pydrake` is unavailable, :func:`create_drake_service` falls
 back to a :class:`MockKinematicsService` configured with
 ``engine_name="drake"``.
-
-Method bodies that require non-trivial Drake plumbing currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up;
-this PR only commits the wiring scaffold so downstream code can target
-``LiveKinematicsService`` without waiting on the full Drake bridge.
 """
 
 from __future__ import annotations

--- a/src/shared/python/pose_interchange/services/opensim.py
+++ b/src/shared/python/pose_interchange/services/opensim.py
@@ -1,14 +1,13 @@
 """OpenSim :class:`LiveKinematicsService` implementation (Subtask 3 of #4895).
 
 Lazily imports :mod:`opensim` and loads a ``.osim`` file via
-:class:`opensim.Model`.  If the wheel is unavailable,
-:func:`create_opensim_service` falls back to a
-:class:`MockKinematicsService` configured with
-``engine_name="opensim"``.
+:class:`opensim.Model`. Coordinate-set writes are handled from the
+:class:`OpenSimAdapter` joint layout, link transforms via
+:meth:`getTransformInGround`, and integration via :class:`opensim.Manager`.
 
-Method bodies that require non-trivial OpenSim wiring currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
+If the wheel is unavailable, :func:`create_opensim_service` falls
+back to a :class:`MockKinematicsService` configured with
+``engine_name="opensim"``.
 """
 
 from __future__ import annotations

--- a/src/shared/python/pose_interchange/services/simscape.py
+++ b/src/shared/python/pose_interchange/services/simscape.py
@@ -2,14 +2,14 @@
 
 Connects to the MATLAB engine via the existing
 :func:`load_matlab_3d_engine` machinery in :mod:`src.engines.loaders`.
+MATLAB-engine wiring is handled through :class:`src.engines.simscape.adapter.SimscapeAdapter`
+and per-joint workspace writes. Note that ``get_link_transforms`` currently
+returns an empty dict.
+
 If MATLAB / the MATLAB engine API is unavailable,
 :func:`create_simscape_service` falls back to a
 :class:`MockKinematicsService` configured with
 ``engine_name="simscape"``.
-
-Method bodies that drive Simulink directly currently raise
-:class:`NotImplementedError` with a TODO: #4963 tied to follow-up
-against the EPIC #4895 Pose Studio engine bridge.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Rewrites the module docstrings in `drake.py`, `opensim.py`, and `simscape.py` to accurately reflect their true implementations and capabilities as of #4963. Removes outdated paragraphs claiming that methods raise `NotImplementedError`.

Fixes #6107

---
*PR created automatically by Jules for task [3020559916253435219](https://jules.google.com/task/3020559916253435219) started by @dieterolson*