### PR TITLE
fix: resolve partial redaction of valid secrets

### DIFF
--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -83,7 +83,7 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|access_token|auth_token|bearer"
         r"|private_key"
         r")"
-        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+        r"[\s]*[=:]\s*(?:([\"']).*?\2|[^\s,{}]+)"
     ),
 ]
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -137,6 +137,29 @@ class TestSensitiveDataFilter:
         assert "key1" not in record.msg
         assert "pass1" not in record.msg
 
+    def test_redacts_stops_at_comma(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("api_key=secret123, other_key=val")
+        flt.filter(record)
+        assert "secret123" not in record.msg
+        assert "other_key=val" in record.msg
+        assert "api_key=***REDACTED***, other_key=val" in record.msg
+
+    def test_redacts_stops_at_brace(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("api_key=secret123} other=val")
+        flt.filter(record)
+        assert "secret123" not in record.msg
+        assert "} other=val" in record.msg
+        assert "api_key=***REDACTED***} other=val" in record.msg
+
+    def test_redacts_quoted_secrets(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('api_key="secret, 123" other=val')
+        flt.filter(record)
+        assert "secret, 123" not in record.msg
+        assert "api_key=***REDACTED*** other=val" in record.msg
+
 
 # ---------------------------------------------------------------------------
 # get_logger


### PR DESCRIPTION
This PR fixes the regex pattern in the logging config that stopped at commas or braces when redacting sensitive data. It correctly handles quoted and unquoted secrets to prevent security regressions.

Fixes #6061

---
*PR created automatically by Jules for task [14308285257218982322](https://jules.google.com/task/14308285257218982322) started by @dieterolson*