### PR TITLE
perf: single asarray + slicing in polynomial _resample_drawn_points (#5912)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -782,4 +782,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-13 | 1.0.166 | Moved the PyQt launcher close control into the top menu-bar row while keeping the custom title strip for drag/minimize/maximize behavior (#5374). |
 | 2026-05-16 | 1.0.169 | Added 14 remaining launcher tiles covering engine-specific dashboards (Drake, MuJoCo, Pinocchio), Analysis Tools API, Motion Pipeline, capability surfaces (perturbation analysis, force overlays, realtime WebSocket, AIP, actuator controls), and feature tiles (Unreal integration, robotics module, Tools calculator hub, P&ID generator); closed 12 issues resolved by prior #5556 merge and 2 by-design closures (#5515, #5521, #5523–#5524, #5527–#5535). |
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
+| 2026-05-25 | 1.0.171 | Optimized `_resample_drawn_points` using `np.asarray` and slicing to avoid redundant Python allocations (#5912). |
 ````

--- a/src/shared/python/signal_toolkit/polynomial_generator.py
+++ b/src/shared/python/signal_toolkit/polynomial_generator.py
@@ -513,8 +513,9 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         if len(points) < 2:
             return list(points)
 
-        xs = np.array([p[0] for p in points])
-        ys = np.array([p[1] for p in points])
+        points_arr = np.asarray(points)
+        xs = points_arr[:, 0]
+        ys = points_arr[:, 1]
 
         # Sort by x so interpolation is well-defined
         order = np.argsort(xs)


### PR DESCRIPTION
Avoids one redundant copy when input is already array-like. Eliminates two pure-Python list comprehensions over the input.

Fixes #6063

---
*PR created automatically by Jules for task [10468158539185783238](https://jules.google.com/task/10468158539185783238) started by @dieterolson*