### PR TITLE
api: add __version__ and SCHEMA_VERSION to cross-engine APIs

### DIFF
--- a/src/shared/python/launcher_embed/__init__.py
+++ b/src/shared/python/launcher_embed/__init__.py
@@ -30,7 +30,12 @@ from .registry import (
     unregister_embeddable_tool,
 )
 
+__version__ = "1.0.0"
+SCHEMA_VERSION = "1.0.0"
+
 __all__ = [
+    "SCHEMA_VERSION",
+    "__version__",
     "EMBEDDABLE_TOOL_REGISTRY",
     "EmbedCapabilities",
     "EmbeddableTool",

--- a/src/shared/python/pose_interchange/__init__.py
+++ b/src/shared/python/pose_interchange/__init__.py
@@ -45,7 +45,12 @@ from src.shared.python.pose_interchange.se3 import (
     se3_to_xyz_xyz_deg,
 )
 
+__version__ = "1.0.0"
+SCHEMA_VERSION = "1.0.0"
+
 __all__ = [
+    "SCHEMA_VERSION",
+    "__version__",
     "CONVENTION_TAG",
     "CanonicalPose",
     "CapabilityError",

--- a/src/shared/python/realtime/__init__.py
+++ b/src/shared/python/realtime/__init__.py
@@ -35,7 +35,12 @@ from .api import (
     subscribe,
 )
 
+__version__ = "1.0.0"
+SCHEMA_VERSION = "1.0.0"
+
 __all__ = [
+    "SCHEMA_VERSION",
+    "__version__",
     "CHANNEL_REGISTRY",
     "Subscription",
     "publish",

--- a/tests/unit/repo_hygiene/test_cross_engine_api_versions.py
+++ b/tests/unit/repo_hygiene/test_cross_engine_api_versions.py
@@ -1,0 +1,67 @@
+import re
+
+import pytest
+
+import src.shared.python.launcher_embed as launcher_embed
+import src.shared.python.pose_interchange as pose_interchange
+import src.shared.python.realtime as realtime
+
+# The three core cross-engine packages per ADR-0007 / ADR-0012 / ADR-0013.
+# These packages establish canonical representations and integration contracts
+# between engines and thus require strict semver discipline for schemas.
+CROSS_ENGINE_PACKAGES = [
+    launcher_embed,
+    pose_interchange,
+    realtime,
+]
+
+# Basic semantic versioning pattern (e.g., "1.0.0", "0.1.2-alpha", etc.)
+SEMVER_REGEX = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-zA-Z0-9-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-zA-Z0-9-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+
+@pytest.mark.parametrize("pkg", CROSS_ENGINE_PACKAGES)
+def test_cross_engine_api_has_version_attributes(pkg):
+    """
+    Assert that cross-engine packages expose __version__ and SCHEMA_VERSION.
+    """
+    assert hasattr(pkg, "__version__"), f"Package {pkg.__name__} missing __version__"
+    assert hasattr(
+        pkg, "SCHEMA_VERSION"
+    ), f"Package {pkg.__name__} missing SCHEMA_VERSION"
+
+
+@pytest.mark.parametrize("pkg", CROSS_ENGINE_PACKAGES)
+def test_cross_engine_api_versions_are_valid_semver(pkg):
+    """
+    Assert that the version attributes conform to semantic versioning.
+    """
+    version = getattr(pkg, "__version__", None)
+    schema_version = getattr(pkg, "SCHEMA_VERSION", None)
+
+    assert isinstance(version, str), f"{pkg.__name__}.__version__ must be a string"
+    assert SEMVER_REGEX.match(
+        version
+    ), f"{pkg.__name__}.__version__ ('{version}') is not valid semver"
+
+    assert isinstance(
+        schema_version, str
+    ), f"{pkg.__name__}.SCHEMA_VERSION must be a string"
+    assert SEMVER_REGEX.match(
+        schema_version
+    ), f"{pkg.__name__}.SCHEMA_VERSION ('{schema_version}') is not valid semver"
+
+
+@pytest.mark.parametrize("pkg", CROSS_ENGINE_PACKAGES)
+def test_cross_engine_api_versions_in_all(pkg):
+    """
+    Assert that __version__ and SCHEMA_VERSION are exported in __all__.
+    """
+    assert hasattr(pkg, "__all__"), f"Package {pkg.__name__} missing __all__"
+    assert (
+        "__version__" in pkg.__all__
+    ), f"'__version__' missing from {pkg.__name__}.__all__"
+    assert (
+        "SCHEMA_VERSION" in pkg.__all__
+    ), f"'SCHEMA_VERSION' missing from {pkg.__name__}.__all__"


### PR DESCRIPTION
api: add __version__ and SCHEMA_VERSION to cross-engine APIs

Adds semantic version fields `__version__` and `SCHEMA_VERSION` (both set to "1.0.0")
to the three canonical cross-engine API packages:
- `launcher_embed`
- `pose_interchange`
- `realtime`

Also adds repo hygiene tests to enforce this semantic versioning discipline across
these core integration surfaces.

Fixes #6066

---
*PR created automatically by Jules for task [2784451791454340236](https://jules.google.com/task/2784451791454340236) started by @dieterolson*