### PR TITLE
Fix Sidekick profile layout switch

### DIFF
--- a/src/shared/python/sidekick/standalone/window.py
+++ b/src/shared/python/sidekick/standalone/window.py
@@ -235,9 +235,37 @@ class StandaloneSidekickWindow(QMainWindow):
         logger.info("Load profile triggered (UI not yet implemented — T8)")
 
     def _switch_profile(self, profile: str) -> None:
-        logger.info(
-            "Switch profile to %r (re-layout not yet implemented — T8)", profile
+        if profile not in _VALID_PROFILES:
+            raise ValueError(f"Unknown profile: {profile!r}")
+
+        if profile == self._config.profile:
+            return
+
+        logger.info("Switching profile to %r", profile)
+
+        # Determine logical order based on profile
+        if profile == "chat-first":
+            primary = self._chat_panel
+            secondary = self._sidebar_panel
+        else:
+            primary = self._sidebar_panel
+            secondary = self._chat_panel
+
+        # Reorder widgets in the splitter
+        # QSplitter.insertWidget will move an existing widget to the new index
+        self._splitter.insertWidget(0, primary)
+        self._splitter.insertWidget(1, secondary)
+
+        # Re-apply the config to store new profile
+        self._config = StandaloneSidekickConfig(
+            profile=profile,
+            theme_name=self._config.theme_name,
+            session_store=self._config.session_store,
+            host_action_port=self._config.host_action_port,
         )
+
+        # Update layout sizes based on new ratio logic
+        self._apply_ratio()
 
     def _toggle_sidebar(self) -> None:
         self._sidebar_panel.setVisible(not self._sidebar_panel.isVisible())

--- a/tests/unit/sidekick/standalone/test_window.py
+++ b/tests/unit/sidekick/standalone/test_window.py
@@ -142,9 +142,9 @@ class TestSplitterRatio:
         total = sum(sizes)
         assert total > 0
         chat_ratio = sizes[0] / total
-        assert abs(chat_ratio - 0.6) < 0.05, (
-            f"chat-first: expected ~0.60 left ratio, got {chat_ratio:.3f}"
-        )
+        assert (
+            abs(chat_ratio - 0.6) < 0.05
+        ), f"chat-first: expected ~0.60 left ratio, got {chat_ratio:.3f}"
         win.close()
 
     def test_calc_first_ratio(self, app: Any, session_store: Any) -> None:
@@ -158,9 +158,9 @@ class TestSplitterRatio:
         total = sum(sizes)
         assert total > 0
         sidebar_ratio = sizes[0] / total
-        assert abs(sidebar_ratio - 0.6) < 0.05, (
-            f"calc-first: expected ~0.60 left ratio, got {sidebar_ratio:.3f}"
-        )
+        assert (
+            abs(sidebar_ratio - 0.6) < 0.05
+        ), f"calc-first: expected ~0.60 left ratio, got {sidebar_ratio:.3f}"
         win.close()
 
 
@@ -206,6 +206,43 @@ class TestPublicAccessors:
 # ---------------------------------------------------------------------------
 # Hygiene: no src.launchers.* imports
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Profile switching
+# ---------------------------------------------------------------------------
+
+
+class TestProfileSwitch:
+    def test_switch_profile_reorders_and_reflows(
+        self, app: Any, session_store: Any
+    ) -> None:
+        from sidekick.standalone.window import StandaloneSidekickWindow
+
+        win = StandaloneSidekickWindow(_make_config(session_store, "chat-first"))
+        win.resize(1280, 800)
+        win.show()
+
+        # Check initial state
+        sizes_chat_first = win.splitter_handle_positions()
+        chat_ratio = sizes_chat_first[0] / sum(sizes_chat_first)
+        assert abs(chat_ratio - 0.6) < 0.05
+
+        # Access internal layout to check widget order without breaking encapsulation too badly
+        assert win._splitter.widget(0) is win._chat_panel
+        assert win._splitter.widget(1) is win._sidebar_panel
+
+        # Switch to calc-first
+        win._switch_profile("calc-first")
+
+        # Check new state
+        sizes_calc_first = win.splitter_handle_positions()
+        calc_ratio = sizes_calc_first[0] / sum(sizes_calc_first)
+        assert abs(calc_ratio - 0.6) < 0.05
+        assert win._splitter.widget(0) is win._sidebar_panel
+        assert win._splitter.widget(1) is win._chat_panel
+
+        win.close()
 
 
 class TestNoLaunchersImport:


### PR DESCRIPTION
Implemented the missing live re-layout logic for standalone sidekick window profile switching, allowing seamless transition between chat-first and calc-first layouts.

Fixes #6102

---
*PR created automatically by Jules for task [4103443565402762082](https://jules.google.com/task/4103443565402762082) started by @dieterolson*