### PR TITLE
docs(shared): refresh stale plot_style/body_part_viz init docstrings

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,11 +1,20 @@
-"""Body-part visualisation contracts and dataclasses.
+"""Body-part visualisation contracts, dataclasses, and implementations.
 
-This package defines the abstract surface (Protocols + frozen dataclasses)
-that every shape, fitter, and renderer implementation talks across.
+This package owns the canonical body-part visualisation stack used
+across UpstreamDrift:
 
-Implementations of shapes, fitters, and rendering backends live in the
-``shapes``, ``fitters``, and ``renderers`` sub-packages and are added in
-follow-up issues of EPIC #4755.
+- ``contracts`` — abstract surface (Protocols) that every shape,
+  fitter, and renderer implementation talks across.
+- ``bindings`` — marker bindings and configuration.
+- ``shapes`` — built-in body-part shape definitions.
+- ``fitters`` — shape fitting implementations.
+- ``renderers`` — rendering backend implementations.
+- ``asset_library`` — reusable visual assets.
+- ``persistence`` — segment visualisation schema and persistence.
+- ``theme`` — shape styling themes.
+- ``urdf_bridge`` — URDF export and bridging.
+
+Epic #4755 shipped the full stack.
 """
 
 from __future__ import annotations

--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -1,13 +1,31 @@
-"""Plot-style contracts and dataclasses.
+"""Plot-style contracts, dataclasses, and renderer implementations.
 
-This package defines the abstract surface (Protocols + frozen
-dataclasses) used by every marker / trace styling implementation in
-UpstreamDrift.
+This package owns the canonical marker-styling stack used across every
+plotting surface in UpstreamDrift (C3D Viewer, Motion-Match Preview,
+cross-engine dashboard, per-engine viz modules):
 
-Concrete implementations of color resolvers, renderers, Qt widgets, and
-marker-shape primitives live in the ``resolvers``, ``renderers``,
-``widgets``, and ``shapes`` sub-packages and are added in follow-up
-issues of EPIC #4796.
+- ``contracts`` — runtime-checkable Protocols (``ColorResolver``,
+  ``MarkerRenderer``, ``MarkerShapeRenderer``).
+- ``colors`` / ``colormaps`` / ``registry`` — color scales, semantic
+  colormap aliases, and the custom-colormap registry.
+- ``channels`` — ``DataChannel`` abstraction for per-frame scalar
+  sources (e.g. clubhead-velocity-magnitude) plus derivative / slice /
+  magnitude helpers.
+- ``markers`` / ``shapes`` — ``MarkerStyle``, ``MarkerShape``,
+  ``CustomMeshSpec`` and the built-in shape primitives.
+- ``renderers`` — ``MatplotlibMarkerRenderer`` (canonical 2D/3D
+  scatter backend) and ``PyQtGLMarkerRenderer`` (lazy-loaded via
+  ``__getattr__`` to keep PyQt6 optional).
+- ``resolvers`` — Static / Palette / DataDriven color resolvers
+  registered in ``RESOLVER_REGISTRY``.
+- ``widgets`` — optional Qt widgets (``MarkerStylePicker``,
+  ``ColorPicker``, ``ColormapPicker``, ``DataChannelEditor``) imported
+  only when PyQt6 is available; their names join ``__all__`` via the
+  UNION resolution from #4807.
+- ``persistence`` / ``preset_library`` — ``PlotStyleSet`` /
+  ``PlotStyleSpec`` JSON v1 schema and the built-in preset library.
+
+See ADR-0011 (Plot Style Toolkit). Epic #4796 shipped the full stack.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #6087.

Two shared package `__init__.py` docstrings still told readers that sub-packages were "added in follow-up issues" of an epic — but the sub-packages have been present, imported, and re-exported in the same file for some time. Both referenced epics are closed/completed.

This PR rewrites the two module docstrings to describe the current sub-package layout. Imports, `__all__`, the optional-widgets `try/except`, and all other code are unchanged.

Fixes #6103

---
*PR created automatically by Jules for task [10747792091127348936](https://jules.google.com/task/10747792091127348936) started by @dieterolson*