### PR TITLE
fix: resolve partial redaction of valid secrets

### DIFF
--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -83,7 +83,15 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|access_token|auth_token|bearer"
         r"|private_key"
         r")"
-        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+        r"(['\"]?)"  # optional quote around key
+        r"([\s]*[=:]\s*)"  # separator
+        r"(?:"
+        r"(?:(['\"])(.*?)\4)"  # quoted value
+        r"|"
+        r"(?:(['\"])([^'\",\s}]+))"  # unterminated quoted value fallback
+        r"|"
+        r"([^'\",\s}]+)"  # unquoted value
+        r")"
     ),
 ]
 
@@ -116,7 +124,21 @@ class SensitiveDataFilter(logging.Filter):
 def _redact_sensitive(text: str) -> str:
     """Replace sensitive values in *text* with a redaction placeholder."""
     for pattern in _SENSITIVE_PATTERNS:
-        text = pattern.sub(r"\1=***REDACTED***", text)
+
+        def repl(m: re.Match[str]) -> str:
+            key = m.group(1)
+            key_quote = m.group(2)
+            sep = m.group(3)
+            val_quote = m.group(4)
+            unterminated_quote = m.group(6)
+
+            if val_quote:
+                return f"{key}{key_quote}{sep}{val_quote}***REDACTED***{val_quote}"
+            if unterminated_quote:
+                return f"{key}{key_quote}{sep}{unterminated_quote}***REDACTED***"
+            return f"{key}{key_quote}{sep}***REDACTED***"
+
+        text = pattern.sub(repl, text)
     return text
 
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -137,6 +137,37 @@ class TestSensitiveDataFilter:
         assert "key1" not in record.msg
         assert "pass1" not in record.msg
 
+    def test_redacts_with_comma(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("api_key=mysecret, other_var=1")
+        flt.filter(record)
+        assert "mysecret" not in record.msg
+        assert "REDACTED" in record.msg
+        assert "other_var=1" in record.msg
+
+    def test_redacts_json_format(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"api_key": "mysecret"}')
+        flt.filter(record)
+        assert "mysecret" not in record.msg
+        assert "REDACTED" in record.msg
+        assert '{"api_key": "***REDACTED***"}' in record.msg
+
+    def test_redacts_quoted_with_comma(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('api_key="my_secret_with_comma,and_stuff"')
+        flt.filter(record)
+        assert "my_secret_with_comma" not in record.msg
+        assert 'api_key="***REDACTED***"' in record.msg
+
+    def test_redacts_unterminated_quoted_json(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"api_key": "mysecret}')
+        flt.filter(record)
+        assert "mysecret" not in record.msg
+        assert "REDACTED" in record.msg
+        assert '{"api_key": "***REDACTED***}' in record.msg
+
 
 # ---------------------------------------------------------------------------
 # get_logger


### PR DESCRIPTION
This commit introduces a new fallback regex to handle unterminated quoted values (like `api_key="abc123`), which prevents sensitive values from leaking into logs during truncation or malformed serialization. We also introduced a new unit test for this case.

Fixes #6133

---
*PR created automatically by Jules for task [17635203845533905755](https://jules.google.com/task/17635203845533905755) started by @dieterolson*