### PR TITLE
Fix GitHub Issue #6071

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-05-15
+  LAST UPDATED: 2026-05-25
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.

--- a/src/shared/python/security/env_validator.py
+++ b/src/shared/python/security/env_validator.py
@@ -32,6 +32,28 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+# Sentinel placeholder values shipped in `.env.example`.  If a user copies
+# `.env.example` -> `.env` without editing, these defaults would silently
+# become real credentials -- refuse to accept them.  See issue #5920.
+KNOWN_SECRET_KEY_PLACEHOLDERS: frozenset[str] = frozenset(
+    {
+        "UNSAFE-NO-SECRET-KEY-SET-AUTHENTICATION-WILL-FAIL",
+        "generate_a_random_string_here",
+        "generate_another_random_string_here",
+    }
+)
+
+KNOWN_ADMIN_PASSWORD_PLACEHOLDERS: frozenset[str] = frozenset(
+    {
+        "change_me_in_production",
+        "changeme",
+        "change_me",
+        "password",
+        "admin",
+    }
+)
+
+
 class APIKeyValidationResults(TypedDict):
     secret_key: bool
     environment: str | None
@@ -73,16 +95,21 @@ def validate_secret_key_strength(key: str, min_length: int = 64) -> None:
     if not key:
         raise EnvironmentValidationError("Secret key is empty")
 
+    # Check it's not a placeholder shipped in `.env.example` BEFORE the length
+    # check -- the shipped placeholders are shorter than ``min_length`` and we
+    # want the user to see the clearer "you forgot to edit .env" message
+    # rather than the generic "too short" error (issue #5920).
+    if key in KNOWN_SECRET_KEY_PLACEHOLDERS:
+        raise EnvironmentValidationError(
+            f"Secret key is using a known placeholder value ({key!r}). "
+            "It looks like `.env.example` was copied to `.env` without "
+            "editing.  Set GOLF_API_SECRET_KEY (or SECRET_KEY) to a "
+            "freshly generated random string."
+        )
+
     if len(key) < min_length:
         raise EnvironmentValidationError(
             f"Secret key is too short: {len(key)} chars (minimum: {min_length})"
-        )
-
-    # Check it's not a placeholder
-    if key == "UNSAFE-NO-SECRET-KEY-SET-AUTHENTICATION-WILL-FAIL":
-        raise EnvironmentValidationError(
-            "Secret key is using unsafe placeholder. "
-            "Set GOLF_API_SECRET_KEY or SECRET_KEY environment variable."
         )
 
     # Check for common weak patterns
@@ -103,6 +130,39 @@ def validate_secret_key_strength(key: str, min_length: int = 64) -> None:
                 f"Secret key contains weak pattern: '{pattern}'. "
                 f"Consider generating a stronger key."
             )
+
+
+def validate_admin_password_strength(password: str, min_length: int = 12) -> None:
+    """Validate that the admin password meets minimum security requirements.
+
+    Rejects empty values, values shorter than ``min_length``, and any value
+    that matches a known placeholder shipped in ``.env.example`` (e.g.
+    ``change_me_in_production``).  See issue #5920.
+
+    Args:
+        password: Admin password to validate.
+        min_length: Minimum acceptable length (default: 12).
+
+    Raises:
+        EnvironmentValidationError: If the password is empty, too short, or
+            matches a known placeholder.
+    """
+    if not password:
+        raise EnvironmentValidationError("Admin password is empty")
+
+    if password in KNOWN_ADMIN_PASSWORD_PLACEHOLDERS:
+        raise EnvironmentValidationError(
+            f"Admin password is using a known placeholder value "
+            f"({password!r}).  It looks like `.env.example` was copied to "
+            "`.env` without editing.  Set GOLF_ADMIN_PASSWORD to a strong, "
+            "unique value."
+        )
+
+    if len(password) < min_length:
+        raise EnvironmentValidationError(
+            f"Admin password is too short: {len(password)} chars "
+            f"(minimum: {min_length})"
+        )
 
 
 def validate_api_security() -> APIKeyValidationResults:
@@ -168,12 +228,26 @@ def validate_api_security() -> APIKeyValidationResults:
             )
         results["admin_password"] = False
     else:
-        if len(admin_password) < 12:
-            results["warnings"].append(
-                f"Admin password is short ({len(admin_password)} chars). "
-                f"Recommend at least 12 characters."
+        # Reject known `.env.example` placeholders outright (issue #5920) --
+        # in production these are a critical issue, in dev a loud warning.
+        if admin_password in KNOWN_ADMIN_PASSWORD_PLACEHOLDERS:
+            message = (
+                f"Admin password is using a known placeholder value "
+                f"({admin_password!r}).  Set GOLF_ADMIN_PASSWORD to a "
+                "strong, unique value."
             )
-        results["admin_password"] = True
+            if is_production():
+                results["issues"].append(f"CRITICAL: {message}")
+                raise EnvironmentValidationError("GOLF_ADMIN_PASSWORD", message)
+            results["warnings"].append(message)
+            results["admin_password"] = False
+        else:
+            if len(admin_password) < 12:
+                results["warnings"].append(
+                    f"Admin password is short ({len(admin_password)} chars). "
+                    f"Recommend at least 12 characters."
+                )
+            results["admin_password"] = True
 
     return results
 

--- a/tests/unit/security/test_env_validator.py
+++ b/tests/unit/security/test_env_validator.py
@@ -9,7 +9,10 @@ from src.shared.python.core.error_utils import (
     EnvironmentError as EnvironmentValidationError,
 )
 from src.shared.python.security.env_validator import (
+    KNOWN_ADMIN_PASSWORD_PLACEHOLDERS,
+    KNOWN_SECRET_KEY_PLACEHOLDERS,
     generate_secure_key_command,
+    validate_admin_password_strength,
     validate_secret_key_strength,
 )
 
@@ -72,3 +75,55 @@ class TestGenerateSecureKeyCommand:
         assert any(
             word in lower for word in ["python", "token", "secret", "key", "openssl"]
         )
+
+
+# ---------------------------------------------------------------------------
+# Placeholder rejection (issue #5920)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretKeyPlaceholderRejection:
+    """Refuse the literal placeholders shipped in `.env.example`."""
+
+    @pytest.mark.parametrize(
+        "placeholder",
+        sorted(KNOWN_SECRET_KEY_PLACEHOLDERS),
+    )
+    def test_known_secret_key_placeholder_raises(self, placeholder: str) -> None:
+        with pytest.raises(EnvironmentValidationError):
+            validate_secret_key_strength(placeholder)
+
+    def test_dotenv_example_secret_key_placeholder_is_recognised(self) -> None:
+        # Sanity-check the literal string from `.env.example` is covered.
+        assert "generate_a_random_string_here" in KNOWN_SECRET_KEY_PLACEHOLDERS
+
+    def test_dotenv_example_x_api_key_placeholder_is_recognised(self) -> None:
+        assert "generate_another_random_string_here" in KNOWN_SECRET_KEY_PLACEHOLDERS
+
+
+class TestValidateAdminPasswordStrength:
+    def test_strong_password_passes(self) -> None:
+        validate_admin_password_strength(secrets.token_urlsafe(16))
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(EnvironmentValidationError):
+            validate_admin_password_strength("")
+
+    def test_short_raises(self) -> None:
+        with pytest.raises(EnvironmentValidationError, match="too short"):
+            validate_admin_password_strength("short")
+
+    @pytest.mark.parametrize(
+        "placeholder",
+        sorted(KNOWN_ADMIN_PASSWORD_PLACEHOLDERS),
+    )
+    def test_known_admin_password_placeholder_raises(self, placeholder: str) -> None:
+        with pytest.raises(EnvironmentValidationError):
+            validate_admin_password_strength(placeholder)
+
+    def test_dotenv_example_admin_password_is_recognised(self) -> None:
+        # The literal default shipped in `.env.example` must be rejected.
+        assert "change_me_in_production" in KNOWN_ADMIN_PASSWORD_PLACEHOLDERS
+
+    def test_custom_min_length(self) -> None:
+        validate_admin_password_strength("a" * 8, min_length=8)


### PR DESCRIPTION
Extract fix from consolidate-prs-v3 for rejecting default shipped placeholder values from .env.example so that they cannot be accidentally used as live secrets/passwords.

Fixes #6071

---
*PR created automatically by Jules for task [3338413085497509374](https://jules.google.com/task/3338413085497509374) started by @dieterolson*