### PR TITLE
feat: add MyoSuite LiveKinematicsService + PoseConventionAdapter to pose_interchange

### DIFF
--- a/src/shared/python/pose_interchange/adapters/__init__.py
+++ b/src/shared/python/pose_interchange/adapters/__init__.py
@@ -6,14 +6,16 @@ uniformly.
 
 The :data:`ADAPTER_REGISTRY` mapping is the canonical lookup table —
 keys are stable engine identifiers (``"drake"``, ``"mujoco"``,
-``"pinocchio"``, ``"opensim"``, ``"simscape"``) and values are adapter
-**classes** (instantiate per-call to keep adapters cheap and stateless).
+``"myosuite"``, ``"pinocchio"``, ``"opensim"``, ``"simscape"``) and
+values are adapter **classes** (instantiate per-call to keep adapters
+cheap and stateless).
 """
 
 from __future__ import annotations
 
 from src.shared.python.pose_interchange.adapters.drake import DrakeAdapter
 from src.shared.python.pose_interchange.adapters.mujoco import MujocoAdapter
+from src.shared.python.pose_interchange.adapters.myosuite import MyosuiteAdapter
 from src.shared.python.pose_interchange.adapters.opensim import OpenSimAdapter
 from src.shared.python.pose_interchange.adapters.pinocchio import PinocchioAdapter
 from src.shared.python.pose_interchange.adapters.simscape import SimscapeAdapter
@@ -22,6 +24,7 @@ from src.shared.python.pose_interchange.protocol import PoseConventionAdapter
 ADAPTER_REGISTRY: dict[str, type[PoseConventionAdapter]] = {
     DrakeAdapter.engine_name: DrakeAdapter,
     MujocoAdapter.engine_name: MujocoAdapter,
+    MyosuiteAdapter.engine_name: MyosuiteAdapter,
     PinocchioAdapter.engine_name: PinocchioAdapter,
     OpenSimAdapter.engine_name: OpenSimAdapter,
     SimscapeAdapter.engine_name: SimscapeAdapter,
@@ -31,6 +34,7 @@ __all__ = [
     "ADAPTER_REGISTRY",
     "DrakeAdapter",
     "MujocoAdapter",
+    "MyosuiteAdapter",
     "OpenSimAdapter",
     "PinocchioAdapter",
     "SimscapeAdapter",

--- a/src/shared/python/pose_interchange/adapters/myosuite.py
+++ b/src/shared/python/pose_interchange/adapters/myosuite.py
@@ -1,0 +1,119 @@
+"""MyoSuite :class:`PoseConventionAdapter` implementation.
+
+MyoSuite is a muscle-driven reinforcement-learning environment built on
+top of MuJoCo.  Its models are MJCF files, so the underlying ``qpos``
+layout is **identical** to MuJoCo's:
+
+- Free-joint prefix: ``[x, y, z, qw, qx, qy, qz]`` (7 scalars, w-first).
+- Per-joint slots: radians for hinge joints, placed after the prefix.
+
+This adapter therefore shares ``_PELVIS_PREFIX = 7`` with
+:class:`~src.shared.python.pose_interchange.adapters.mujoco.MujocoAdapter`
+and delegates all quaternion/angle helpers to the same ``_base`` module.
+
+The adapter operates in mock mode by default; if a real MyoSuite
+``MjModel`` is supplied as ``model``, the per-joint layout must be
+passed alongside as a ``Mapping[str, JointSlot]`` (we do not introspect
+MyoSuite's qpos table here — the same restriction applies to the MuJoCo
+adapter).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from src.shared.python.pose_interchange.adapters._base import (
+    build_default_joint_layout,
+    decode_joint_angles,
+    encode_joint_angles,
+    euler_xyz_deg_to_quat_wxyz,
+    quat_wxyz_to_euler_xyz_deg,
+)
+from src.shared.python.pose_interchange.canonical import (
+    CONVENTION_TAG,
+    CanonicalPose,
+)
+from src.shared.python.pose_interchange.protocol import JointSlot
+
+# MyoSuite uses MuJoCo's coordinate convention: free-joint qpos prefix is
+# [x, y, z, qw, qx, qy, qz] — 7 scalars, quaternion w-first.
+_PELVIS_PREFIX = 7  # identical to MuJoCo free-joint prefix
+
+
+def _layout_from_model(model: Any | None) -> Mapping[str, JointSlot]:
+    if model is None:
+        return build_default_joint_layout(
+            base_offset=_PELVIS_PREFIX, units="rad", sign=1, name_prefix="myo_"
+        )
+    if hasattr(model, "joint_layout") and isinstance(model.joint_layout, Mapping):
+        return model.joint_layout
+    if isinstance(model, Mapping) and "joint_layout" in model:
+        return model["joint_layout"]
+    raise TypeError(
+        "MyosuiteAdapter: 'model' must be None, a Mapping with 'joint_layout', "
+        "or an object exposing a 'joint_layout' Mapping attribute"
+    )
+
+
+class MyosuiteAdapter:
+    """Adapter for MyoSuite MJCF (free-joint qpos is ``[xyz, quat_wxyz]``).
+
+    MyoSuite is backed by MuJoCo, so the qpos coordinate convention is
+    identical: position prefix ``[x, y, z]`` followed by a w-first unit
+    quaternion ``[qw, qx, qy, qz]``, then per-joint hinge angles in
+    radians.
+    """
+
+    engine_name: str = "myosuite"
+
+    def joint_layout(self, model: Any | None = None) -> Mapping[str, JointSlot]:
+        return _layout_from_model(model)
+
+    def from_canonical(
+        self,
+        pose: CanonicalPose,
+        *,
+        model: Any | None = None,
+    ) -> npt.NDArray[np.float64]:
+        if pose.convention_tag != CONVENTION_TAG:
+            raise ValueError(
+                f"MyosuiteAdapter.from_canonical: unsupported convention "
+                f"{pose.convention_tag!r}"
+            )
+        layout = _layout_from_model(model)
+        max_idx = max(
+            (slot.start_index + slot.length for slot in layout.values()),
+            default=_PELVIS_PREFIX,
+        )
+        size = max(_PELVIS_PREFIX, max_idx)
+        q = np.zeros(size, dtype=float)
+        q[0:3] = pose.pelvis_translation_m
+        q[3:7] = euler_xyz_deg_to_quat_wxyz(pose.pelvis_rotation_xyz_deg)
+        encode_joint_angles(pose.joint_angles_deg, layout, q)
+        return q
+
+    def to_canonical(
+        self,
+        engine_q: npt.ArrayLike,
+        *,
+        model: Any | None = None,
+    ) -> CanonicalPose:
+        q = np.asarray(engine_q, dtype=float)
+        if q.ndim != 1 or q.shape[0] < _PELVIS_PREFIX:
+            raise ValueError(
+                f"MyosuiteAdapter.to_canonical: expected 1-D q with at least "
+                f"{_PELVIS_PREFIX} entries, got shape {q.shape}"
+            )
+        layout = _layout_from_model(model)
+        translation = q[0:3].copy()
+        rotation_deg = quat_wxyz_to_euler_xyz_deg(q[3:7])
+        joint_angles = decode_joint_angles(q, layout)
+        return CanonicalPose(
+            pelvis_translation_m=translation,
+            pelvis_rotation_xyz_deg=rotation_deg,
+            joint_angles_deg=joint_angles,
+        )

--- a/src/shared/python/pose_interchange/services/__init__.py
+++ b/src/shared/python/pose_interchange/services/__init__.py
@@ -30,6 +30,9 @@ from src.shared.python.pose_interchange.services.drake import (
 from src.shared.python.pose_interchange.services.mujoco import (
     create_mujoco_service,
 )
+from src.shared.python.pose_interchange.services.myosuite import (
+    create_myosuite_service,
+)
 from src.shared.python.pose_interchange.services.opensim import (
     create_opensim_service,
 )
@@ -43,6 +46,7 @@ from src.shared.python.pose_interchange.services.simscape import (
 KINEMATICS_SERVICE_REGISTRY: dict[str, Callable[[], LiveKinematicsService]] = {
     "drake": create_drake_service,
     "mujoco": create_mujoco_service,
+    "myosuite": create_myosuite_service,
     "pinocchio": create_pinocchio_service,
     "opensim": create_opensim_service,
     "simscape": create_simscape_service,

--- a/src/shared/python/pose_interchange/services/myosuite.py
+++ b/src/shared/python/pose_interchange/services/myosuite.py
@@ -1,0 +1,304 @@
+"""MyoSuite :class:`LiveKinematicsService` implementation.
+
+MyoSuite is a muscle-driven RL environment built on top of MuJoCo; its
+models are MJCF files and the underlying physics solver is
+:mod:`mujoco`.  Consequently the qpos layout, joint-address table, and
+simulation calls (``mj_forward``, ``mj_step``, ``mj_resetData``) are
+identical to the MuJoCo service — the only difference is the
+``engine_name`` tag that labels data at the interchange boundary.
+
+Lazily imports :mod:`myosuite` and falls back to a
+:class:`MockKinematicsService` configured with ``engine_name="myosuite"``
+when the wheel is unavailable.
+
+The real bridge wires:
+
+- :meth:`load` -> ``myosuite.MjModel.from_xml_path`` + ``MjData(model)``.
+- :meth:`set_pose` -> build a model-aware ``qpos`` from the canonical
+  pose using the MuJoCo joint-address table, then ``mj_forward`` to
+  update derived quantities (``xpos`` / ``xmat``).
+- :meth:`get_link_transforms` -> iterate ``model.nbody`` and read
+  ``data.xpos[i]`` / ``data.xmat[i].reshape(3, 3)`` into 4x4 SE(3).
+- :meth:`step` -> set ``model.opt.timestep`` and call ``mj_step``.
+- :meth:`reset` -> ``mj_resetData`` then forget the last pose.
+
+Note: MyoSuite uses MuJoCo's coordinate convention for ``qpos``:
+free-joint prefix is ``[x, y, z, qw, qx, qy, qz]`` (7 scalars,
+quaternion w-first), followed by per-joint hinge angles in radians.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.pose_interchange.adapters._base import (
+    build_default_joint_layout,
+    encode_joint_angles,
+    euler_xyz_deg_to_quat_wxyz,
+)
+from src.shared.python.pose_interchange.canonical import CanonicalPose
+from src.shared.python.pose_interchange.live_kinematics import (
+    LiveKinematicsService,
+    ServiceCapabilities,
+)
+from src.shared.python.pose_interchange.protocol import JointSlot
+from src.shared.python.pose_interchange.services._mock import (
+    MockKinematicsService,
+)
+
+logger = get_logger(__name__)
+
+ENGINE_NAME = "myosuite"
+
+
+_MYOSUITE_CAPABILITIES = ServiceCapabilities(
+    supports_dynamics_step=True,
+    supports_collision_query=True,
+    supports_realtime=True,
+)
+
+
+def _myosuite_is_importable() -> bool:
+    """Return ``True`` if :mod:`myosuite` can be imported.
+
+    Resilient to test conftests that stub the module without setting
+    ``__spec__`` (``find_spec`` raises ``ValueError`` in that case).
+    """
+    try:
+        return importlib.util.find_spec("myosuite") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _configured_joint_layout(model: Any) -> Mapping[str, JointSlot] | None:
+    if hasattr(model, "joint_layout") and isinstance(model.joint_layout, Mapping):
+        return model.joint_layout
+    if isinstance(model, Mapping) and isinstance(model.get("joint_layout"), Mapping):
+        return model["joint_layout"]
+    return None
+
+
+def _discover_joint_layout(
+    model: Any,
+    mujoco_module: Any,
+) -> Mapping[str, JointSlot]:
+    """Discover the per-joint layout from a MyoSuite/MuJoCo model.
+
+    MyoSuite is backed by MuJoCo, so joint discovery uses the same
+    ``mjtObj`` / ``mjtJoint`` introspection as the MuJoCo service.
+    """
+    configured_layout = _configured_joint_layout(model)
+    if configured_layout is not None:
+        return configured_layout
+
+    layout_by_engine_name = {
+        slot.engine_name: canonical_name
+        for canonical_name, slot in build_default_joint_layout(
+            base_offset=0, units="rad", sign=1, name_prefix="myo_"
+        ).items()
+    }
+    layout_by_engine_name.update(
+        {
+            canonical_name: canonical_name
+            for canonical_name in layout_by_engine_name.values()
+        }
+    )
+
+    discovered: dict[str, JointSlot] = {}
+    njnt = int(getattr(model, "njnt", 0))
+    jnt_qposadr = getattr(model, "jnt_qposadr", ())
+    jnt_type = getattr(model, "jnt_type", ())
+    free_joint_kind = int(mujoco_module.mjtJoint.mjJNT_FREE)
+    for joint_index in range(njnt):
+        joint_name = mujoco_module.mj_id2name(
+            model,
+            mujoco_module.mjtObj.mjOBJ_JOINT,
+            joint_index,
+        )
+        if not joint_name:
+            continue
+        canonical_name = layout_by_engine_name.get(str(joint_name))
+        if canonical_name is None:
+            continue
+        if int(jnt_type[joint_index]) == free_joint_kind:
+            continue
+        discovered[canonical_name] = JointSlot(
+            canonical_name=canonical_name,
+            engine_name=str(joint_name),
+            start_index=int(jnt_qposadr[joint_index]),
+            length=1,
+            units="rad",
+            sign=1,
+        )
+    return discovered
+
+
+def _free_joint_qpos_address(model: Any, mujoco_module: Any) -> int | None:
+    njnt = int(getattr(model, "njnt", 0))
+    jnt_qposadr = getattr(model, "jnt_qposadr", ())
+    jnt_type = getattr(model, "jnt_type", ())
+    free_joint_kind = int(mujoco_module.mjtJoint.mjJNT_FREE)
+    for joint_index in range(njnt):
+        if int(jnt_type[joint_index]) == free_joint_kind:
+            return int(jnt_qposadr[joint_index])
+    return None
+
+
+def _canonical_pose_to_qpos(
+    model: Any,
+    pose: CanonicalPose,
+    mujoco_module: Any,
+) -> npt.NDArray[np.float64]:
+    """Convert a :class:`CanonicalPose` to a MyoSuite/MuJoCo ``qpos`` array.
+
+    MyoSuite uses MuJoCo's qpos convention; this helper is structurally
+    identical to the MuJoCo service helper of the same name.
+    """
+    nq = int(model.nq)
+    qpos = np.zeros(nq, dtype=np.float64)
+
+    free_joint_qpos_address = _free_joint_qpos_address(model, mujoco_module)
+    if free_joint_qpos_address is not None:
+        free_joint_stop = free_joint_qpos_address + 7
+        if free_joint_stop > nq:
+            raise RuntimeError(
+                "MyosuiteKinematicsService.set_pose: free joint overruns qpos "
+                f"(start={free_joint_qpos_address}, nq={nq})."
+            )
+        qpos[free_joint_qpos_address : free_joint_qpos_address + 3] = (
+            pose.pelvis_translation_m
+        )
+        qpos[free_joint_qpos_address + 3 : free_joint_stop] = (
+            euler_xyz_deg_to_quat_wxyz(pose.pelvis_rotation_xyz_deg)
+        )
+    elif np.any(pose.pelvis_translation_m) or np.any(pose.pelvis_rotation_xyz_deg):
+        logger.debug(
+            "MyosuiteKinematicsService.set_pose: model has no free joint; "
+            "ignoring canonical pelvis pose."
+        )
+
+    joint_layout = _discover_joint_layout(model, mujoco_module)
+    if joint_layout:
+        encode_joint_angles(pose.joint_angles_deg, joint_layout, qpos)
+    return qpos
+
+
+class MyosuiteKinematicsService:
+    """Real-engine :class:`LiveKinematicsService` backed by :mod:`myosuite`.
+
+    MyoSuite is built on MuJoCo, so all MuJoCo C-API calls (``mj_forward``,
+    ``mj_step``, ``mj_resetData``) are used directly via the bundled
+    :mod:`mujoco` module that MyoSuite depends on.
+    """
+
+    engine_name: str = ENGINE_NAME
+
+    def __init__(self) -> None:
+        self._model: Any = None
+        self._data: Any = None
+        self._pose: CanonicalPose | None = None
+
+    def _require_loaded(self, op: str) -> None:
+        if self._model is None or self._data is None:
+            raise RuntimeError(
+                f"MyosuiteKinematicsService.{op}: model not loaded; call load() first."
+            )
+
+    def load(self, model_path: Path) -> None:
+        if not isinstance(model_path, Path):
+            raise TypeError(
+                f"model_path must be a pathlib.Path, got {type(model_path).__name__}"
+            )
+        import mujoco  # type: ignore[import-not-found]
+
+        self._model = mujoco.MjModel.from_xml_path(str(model_path))
+        self._data = mujoco.MjData(self._model)
+        logger.debug(
+            "MyosuiteKinematicsService loaded model_path=%s nq=%d nbody=%d",
+            model_path,
+            getattr(self._model, "nq", -1),
+            getattr(self._model, "nbody", -1),
+        )
+
+    def set_pose(self, pose: CanonicalPose) -> None:
+        if not isinstance(pose, CanonicalPose):
+            raise TypeError(f"pose must be a CanonicalPose, got {type(pose).__name__}")
+        self._require_loaded("set_pose")
+        self._pose = pose
+        import mujoco  # type: ignore[import-not-found]
+
+        qpos = _canonical_pose_to_qpos(self._model, pose, mujoco)
+        self._data.qpos[:] = qpos  # type: ignore[union-attr]
+        mujoco.mj_forward(self._model, self._data)
+
+    def get_link_transforms(self) -> dict[str, npt.NDArray[np.float64]]:
+        self._require_loaded("get_link_transforms")
+        import mujoco  # type: ignore[import-not-found]
+
+        transforms: dict[str, npt.NDArray[np.float64]] = {}
+        nbody = int(self._model.nbody)  # type: ignore[union-attr]
+        for i in range(nbody):
+            name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_BODY, i)
+            if name is None or name == "":
+                name = f"body_{i}"
+            transform = np.eye(4, dtype=np.float64)
+            transform[:3, :3] = np.asarray(
+                self._data.xmat[i],  # type: ignore[union-attr]
+                dtype=np.float64,
+            ).reshape(3, 3)
+            transform[:3, 3] = np.asarray(
+                self._data.xpos[i],  # type: ignore[union-attr]
+                dtype=np.float64,
+            )
+            transforms[name] = transform
+        return transforms
+
+    def step(self, dt: float) -> None:
+        if dt <= 0:
+            raise ValueError(f"dt must be positive, got {dt!r}")
+        self._require_loaded("step")
+        import mujoco  # type: ignore[import-not-found]
+
+        self._model.opt.timestep = float(dt)  # type: ignore[union-attr]
+        mujoco.mj_step(self._model, self._data)
+
+    def reset(self) -> None:
+        self._pose = None
+        if self._model is None or self._data is None:
+            return
+        import mujoco  # type: ignore[import-not-found]
+
+        mujoco.mj_resetData(self._model, self._data)
+
+    def capabilities(self) -> ServiceCapabilities:
+        return _MYOSUITE_CAPABILITIES
+
+
+def create_myosuite_service() -> LiveKinematicsService:
+    """Return a MyoSuite service if :mod:`myosuite` is installed, else mock."""
+    if _myosuite_is_importable():
+        logger.debug(
+            "create_myosuite_service: myosuite importable, returning real service."
+        )
+        return MyosuiteKinematicsService()
+    logger.info(
+        "create_myosuite_service: myosuite not importable, "
+        "falling back to MockKinematicsService(engine_name=%r).",
+        ENGINE_NAME,
+    )
+    mock: LiveKinematicsService = MockKinematicsService(engine_name=ENGINE_NAME)
+    return mock
+
+
+__all__ = [
+    "ENGINE_NAME",
+    "MyosuiteKinematicsService",
+    "create_myosuite_service",
+]

--- a/tests/shared/pose_interchange/test_coverage_gaps.py
+++ b/tests/shared/pose_interchange/test_coverage_gaps.py
@@ -29,7 +29,6 @@ from src.shared.python.motion_matching.diagnostics.reference_pose import (
     REFERENCE_GOLFER_FIELDS,
 )
 from src.shared.python.pose_interchange import (
-    CONVENTION_TAG,
     CanonicalPose,
     CapabilityError,
     JointSlot,
@@ -41,6 +40,7 @@ from src.shared.python.pose_interchange.adapters import (
     ADAPTER_REGISTRY,
     DrakeAdapter,
     MujocoAdapter,
+    MyosuiteAdapter,
     OpenSimAdapter,
     PinocchioAdapter,
     SimscapeAdapter,
@@ -82,6 +82,10 @@ from src.shared.python.pose_interchange.services.opensim import (
 from src.shared.python.pose_interchange.services.pinocchio import (
     PinocchioKinematicsService,
     _pinocchio_is_importable,
+)
+from src.shared.python.pose_interchange.services.myosuite import (
+    MyosuiteKinematicsService,
+    _myosuite_is_importable,
 )
 from src.shared.python.pose_interchange.services.simscape import (
     SimscapeKinematicsService,
@@ -249,6 +253,7 @@ class TestCanonicalPoseExtras:
 _ADAPTERS = [
     ("drake", DrakeAdapter),
     ("mujoco", MujocoAdapter),
+    ("myosuite", MyosuiteAdapter),
     ("opensim", OpenSimAdapter),
     ("pinocchio", PinocchioAdapter),
     ("simscape", SimscapeAdapter),
@@ -434,6 +439,9 @@ class TestPoseIO:
             frozenset({"drake", "mujoco", "pinocchio", "opensim", "simscape"})
             == SUPPORTED_ENGINES
         )
+        # MyoSuite is registered in the adapter/service registries but is
+        # not a pose_io SUPPORTED_ENGINE (it serialises via the MuJoCo
+        # qpos path rather than its own file format).
 
     def test_list_saved_reference_poses_returns_list(self) -> None:
         # The library may or may not exist; either way the function
@@ -504,6 +512,7 @@ class TestServiceCapabilities:
         [
             (DrakeKinematicsService, "drake"),
             (MuJoCoKinematicsService, "mujoco"),
+            (MyosuiteKinematicsService, "myosuite"),
             (OpenSimKinematicsService, "opensim"),
             (PinocchioKinematicsService, "pinocchio"),
             (SimscapeKinematicsService, "simscape"),
@@ -517,6 +526,7 @@ class TestServiceCapabilities:
         [
             DrakeKinematicsService,
             MuJoCoKinematicsService,
+            MyosuiteKinematicsService,
             OpenSimKinematicsService,
             PinocchioKinematicsService,
             SimscapeKinematicsService,
@@ -533,6 +543,7 @@ class TestServiceCapabilities:
         [
             DrakeKinematicsService,
             MuJoCoKinematicsService,
+            MyosuiteKinematicsService,
             OpenSimKinematicsService,
             PinocchioKinematicsService,
         ],
@@ -547,6 +558,7 @@ class TestServiceCapabilities:
         [
             DrakeKinematicsService,
             MuJoCoKinematicsService,
+            MyosuiteKinematicsService,
             OpenSimKinematicsService,
             PinocchioKinematicsService,
         ],
@@ -560,6 +572,7 @@ class TestServiceCapabilities:
         "cls",
         [
             MuJoCoKinematicsService,
+            MyosuiteKinematicsService,
             OpenSimKinematicsService,
             PinocchioKinematicsService,
         ],
@@ -603,6 +616,9 @@ class TestServiceCapabilities:
             (MuJoCoKinematicsService, "set_pose"),
             (MuJoCoKinematicsService, "get_link_transforms"),
             (MuJoCoKinematicsService, "step"),
+            (MyosuiteKinematicsService, "set_pose"),
+            (MyosuiteKinematicsService, "get_link_transforms"),
+            (MyosuiteKinematicsService, "step"),
             (OpenSimKinematicsService, "set_pose"),
             (OpenSimKinematicsService, "get_link_transforms"),
             (PinocchioKinematicsService, "set_pose"),
@@ -651,6 +667,10 @@ class TestServiceCapabilities:
         svc = MuJoCoKinematicsService()
         svc.reset()
 
+    def test_myosuite_reset_noop_without_load(self) -> None:
+        svc = MyosuiteKinematicsService()
+        svc.reset()
+
     def test_opensim_reset_noop_without_load(self) -> None:
         svc = OpenSimKinematicsService()
         svc.reset()
@@ -671,6 +691,9 @@ class TestImportableProbes:
 
     def test_mujoco_probe_returns_bool(self) -> None:
         assert isinstance(_mujoco_is_importable(), bool)
+
+    def test_myosuite_probe_returns_bool(self) -> None:
+        assert isinstance(_myosuite_is_importable(), bool)
 
     def test_opensim_probe_returns_bool(self) -> None:
         assert isinstance(_opensim_is_importable(), bool)
@@ -765,7 +788,6 @@ class TestMujocoQposBuilder:
         assert qpos[0] == pytest.approx(np.pi / 2)
 
     def test_configured_layout_via_mapping(self) -> None:
-        fake = self._fake_mujoco()
         slot = JointSlot(
             canonical_name="LEStartPosition",
             engine_name="le",
@@ -781,18 +803,8 @@ class TestMujocoQposBuilder:
             "joint_layout": {"LEStartPosition": slot},
         }
 
-        # _canonical_pose_to_qpos uses attribute access for nq, so wrap it.
-        class _ModelView:
-            def __init__(self, payload: dict) -> None:
-                self._payload = payload
-
-            def __getattr__(self, key: str):
-                return self._payload[key]
-
-        # Use dict directly: _configured_joint_layout supports Mapping branch.
-        pose = canonical_zero_pose()
-        # Direct call would fail (nq via attr); use the view to exercise the
-        # Mapping branch on the joint_layout helper alone:
+        # Use dict directly: _configured_joint_layout supports the Mapping
+        # branch without needing a real MuJoCo model or fake module.
         from src.shared.python.pose_interchange.services.mujoco import (
             _configured_joint_layout,
         )

--- a/tests/unit/pose_interchange/adapters/test_myosuite_layout.py
+++ b/tests/unit/pose_interchange/adapters/test_myosuite_layout.py
@@ -1,0 +1,26 @@
+"""Layout test for :class:`MyosuiteAdapter`."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from src.shared.python.motion_matching.diagnostics.reference_pose import (
+    REFERENCE_GOLFER_FIELDS,
+)
+from src.shared.python.pose_interchange.adapters.myosuite import MyosuiteAdapter
+from src.shared.python.pose_interchange.protocol import JointSlot
+
+pytestmark = pytest.mark.unit
+
+
+def test_myosuite_layout_jointslots() -> None:
+    layout = MyosuiteAdapter().joint_layout()
+    assert isinstance(layout, Mapping)
+    canonical_set = set(REFERENCE_GOLFER_FIELDS)
+    assert set(layout.keys()) <= canonical_set
+    for name, slot in layout.items():
+        assert isinstance(slot, JointSlot)
+        assert slot.canonical_name == name
+        assert slot.units == "rad"

--- a/tests/unit/pose_interchange/adapters/test_myosuite_protocol.py
+++ b/tests/unit/pose_interchange/adapters/test_myosuite_protocol.py
@@ -1,0 +1,16 @@
+"""Protocol conformance for :class:`MyosuiteAdapter`."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.pose_interchange.adapters.myosuite import MyosuiteAdapter
+from src.shared.python.pose_interchange.protocol import PoseConventionAdapter
+
+pytestmark = pytest.mark.unit
+
+
+def test_myosuite_is_pose_convention_adapter() -> None:
+    adapter = MyosuiteAdapter()
+    assert isinstance(adapter, PoseConventionAdapter)
+    assert adapter.engine_name == "myosuite"

--- a/tests/unit/pose_interchange/adapters/test_myosuite_roundtrip.py
+++ b/tests/unit/pose_interchange/adapters/test_myosuite_roundtrip.py
@@ -1,0 +1,64 @@
+"""Round-trip parity tests for :class:`MyosuiteAdapter`.
+
+MyoSuite is MJCF-backed (MuJoCo), so the qpos convention is identical to
+MuJoCo: free-joint prefix ``[x, y, z, qw, qx, qy, qz]`` followed by
+per-joint hinge angles in radians.  The round-trip properties should
+therefore match the MuJoCo adapter exactly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.pose_interchange.adapters.myosuite import MyosuiteAdapter
+from src.shared.python.pose_interchange.canonical import CanonicalPose
+
+pytestmark = pytest.mark.unit
+
+
+def _assert_pose_close(a: CanonicalPose, b: CanonicalPose, *, tol: float) -> None:
+    np.testing.assert_allclose(a.pelvis_translation_m, b.pelvis_translation_m, atol=tol)
+    np.testing.assert_allclose(
+        a.pelvis_rotation_xyz_deg, b.pelvis_rotation_xyz_deg, atol=tol
+    )
+    full_a = a.angles_full_dict_deg()
+    full_b = b.angles_full_dict_deg()
+    assert set(full_a) == set(full_b)
+    for key, val in full_a.items():
+        assert val == pytest.approx(full_b[key], abs=tol)
+
+
+def test_myosuite_roundtrip_100_random(random_poses: list[CanonicalPose]) -> None:
+    adapter = MyosuiteAdapter()
+    for pose in random_poses:
+        q = adapter.from_canonical(pose)
+        recovered = adapter.to_canonical(q)
+        _assert_pose_close(pose, recovered, tol=1e-9)
+
+
+def test_myosuite_q_roundtrip_identity(random_poses: list[CanonicalPose]) -> None:
+    adapter = MyosuiteAdapter()
+    for pose in random_poses:
+        q1 = adapter.from_canonical(pose)
+        q2 = adapter.from_canonical(adapter.to_canonical(q1))
+        np.testing.assert_allclose(q1, q2, atol=1e-9)
+
+
+def test_myosuite_quaternion_is_w_first(random_poses: list[CanonicalPose]) -> None:
+    """Sanity-check: q[3] is the scalar component (w-first MJCF convention).
+
+    MyoSuite uses MuJoCo's coordinate convention; the quaternion slice is
+    q[3:7] and its Euclidean norm must equal 1.
+    """
+    adapter = MyosuiteAdapter()
+    for pose in random_poses:
+        q = adapter.from_canonical(pose)
+        # Quaternion slice is q[3:7]; norm should be 1.
+        assert abs(np.linalg.norm(q[3:7]) - 1.0) < 1e-9
+
+
+def test_myosuite_rejects_short_q() -> None:
+    adapter = MyosuiteAdapter()
+    with pytest.raises(ValueError, match="at least 7 entries"):
+        adapter.to_canonical(np.zeros(4))

--- a/tests/unit/pose_interchange/adapters/test_registry.py
+++ b/tests/unit/pose_interchange/adapters/test_registry.py
@@ -9,7 +9,7 @@ from src.shared.python.pose_interchange.protocol import PoseConventionAdapter
 
 pytestmark = pytest.mark.unit
 
-EXPECTED_ENGINES = {"drake", "mujoco", "pinocchio", "opensim", "simscape"}
+EXPECTED_ENGINES = {"drake", "mujoco", "myosuite", "pinocchio", "opensim", "simscape"}
 
 
 def test_registry_has_all_engines() -> None:

--- a/tests/unit/pose_interchange/live_kinematics/test_myosuite_service.py
+++ b/tests/unit/pose_interchange/live_kinematics/test_myosuite_service.py
@@ -1,0 +1,175 @@
+"""Regression tests for MyoSuite live-kinematics pose application.
+
+MyoSuite is backed by MuJoCo, so the qpos layout, joint-address
+introspection, and simulation calls are identical to the MuJoCo service.
+These tests mirror the MuJoCo service tests, exercising
+:class:`MyosuiteKinematicsService` with the same fake-mujoco stubs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _install_reference_pose_stub(monkeypatch: pytest.MonkeyPatch) -> str:
+    canonical_joint = "trail_elbow"
+
+    motion_matching_package = types.ModuleType("src.shared.python.motion_matching")
+    motion_matching_package.__path__ = []
+    diagnostics_package = types.ModuleType(
+        "src.shared.python.motion_matching.diagnostics"
+    )
+    diagnostics_package.__path__ = []
+    reference_pose_module = types.ModuleType(
+        "src.shared.python.motion_matching.diagnostics.reference_pose"
+    )
+    forward_kinematics_module = types.ModuleType(
+        "src.shared.python.motion_matching.diagnostics.forward_kinematics"
+    )
+    reference_pose_module.REFERENCE_GOLFER_FIELDS = (canonical_joint,)
+    reference_pose_module.reference_golfer_setup = lambda: {canonical_joint: 0.0}
+    forward_kinematics_module.forward_kinematics = lambda angles: {}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.shared.python.motion_matching",
+        motion_matching_package,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.shared.python.motion_matching.diagnostics",
+        diagnostics_package,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.shared.python.motion_matching.diagnostics.reference_pose",
+        reference_pose_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.shared.python.motion_matching.diagnostics.forward_kinematics",
+        forward_kinematics_module,
+    )
+    return canonical_joint
+
+
+def _import_service_module(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_mujoco: types.ModuleType,
+):
+    canonical_joint = _install_reference_pose_stub(monkeypatch)
+    monkeypatch.setitem(sys.modules, "mujoco", fake_mujoco)
+    monkeypatch.setitem(sys.modules, "myosuite", types.ModuleType("myosuite"))
+
+    for module_name in (
+        "src.shared.python.pose_interchange.adapters._base",
+        "src.shared.python.pose_interchange.canonical",
+        "src.shared.python.pose_interchange.services.myosuite",
+    ):
+        sys.modules.pop(module_name, None)
+
+    module = importlib.import_module(
+        "src.shared.python.pose_interchange.services.myosuite"
+    )
+    return module, canonical_joint
+
+
+def _build_fake_mujoco(joint_names: list[str]) -> types.ModuleType:
+    module = types.ModuleType("mujoco")
+    module.mjtObj = SimpleNamespace(mjOBJ_JOINT=1)
+    module.mjtJoint = SimpleNamespace(mjJNT_FREE=0, mjJNT_HINGE=3)
+    module.forward_calls: list[np.ndarray] = []
+
+    def mj_id2name(model, object_type, joint_index):
+        if object_type != module.mjtObj.mjOBJ_JOINT:
+            return None
+        return joint_names[joint_index]
+
+    def mj_forward(model, data) -> None:
+        module.forward_calls.append(np.asarray(data.qpos, dtype=float).copy())
+
+    module.mj_id2name = mj_id2name
+    module.mj_forward = mj_forward
+    return module
+
+
+def test_set_pose_uses_joint_addresses_for_fixed_base_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mujoco = _build_fake_mujoco(["myo_trail_elbow"])
+    service_module, canonical_joint = _import_service_module(
+        monkeypatch,
+        fake_mujoco,
+    )
+
+    pose = service_module.CanonicalPose(
+        pelvis_translation_m=np.array([1.0, 2.0, 3.0]),
+        pelvis_rotation_xyz_deg=np.array([15.0, 25.0, 35.0]),
+        joint_angles_deg={canonical_joint: 90.0},
+    )
+    model = SimpleNamespace(
+        nq=1,
+        njnt=1,
+        jnt_qposadr=np.array([0]),
+        jnt_type=np.array([fake_mujoco.mjtJoint.mjJNT_HINGE]),
+    )
+    data = SimpleNamespace(qpos=np.full(1, np.nan))
+
+    service = service_module.MyosuiteKinematicsService()
+    service._model = model
+    service._data = data
+
+    service.set_pose(pose)
+
+    np.testing.assert_allclose(data.qpos, [np.pi / 2])
+    assert len(fake_mujoco.forward_calls) == 1
+
+
+def test_set_pose_respects_nonzero_free_joint_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mujoco = _build_fake_mujoco(["myo_trail_elbow", "root_free"])
+    service_module, canonical_joint = _import_service_module(
+        monkeypatch,
+        fake_mujoco,
+    )
+
+    pose = service_module.CanonicalPose(
+        pelvis_translation_m=np.array([1.0, 2.0, 3.0]),
+        pelvis_rotation_xyz_deg=np.array([90.0, 0.0, 0.0]),
+        joint_angles_deg={canonical_joint: 45.0},
+    )
+    model = SimpleNamespace(
+        nq=8,
+        njnt=2,
+        jnt_qposadr=np.array([0, 1]),
+        jnt_type=np.array(
+            [
+                fake_mujoco.mjtJoint.mjJNT_HINGE,
+                fake_mujoco.mjtJoint.mjJNT_FREE,
+            ]
+        ),
+    )
+    data = SimpleNamespace(qpos=np.full(8, np.nan))
+
+    service = service_module.MyosuiteKinematicsService()
+    service._model = model
+    service._data = data
+
+    service.set_pose(pose)
+
+    np.testing.assert_allclose(data.qpos[0], np.pi / 4)
+    np.testing.assert_allclose(data.qpos[1:4], [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(
+        data.qpos[4:8],
+        [np.sqrt(0.5), np.sqrt(0.5), 0.0, 0.0],
+    )
+    assert len(fake_mujoco.forward_calls) == 1

--- a/tests/unit/pose_interchange/live_kinematics/test_protocol_compliance.py
+++ b/tests/unit/pose_interchange/live_kinematics/test_protocol_compliance.py
@@ -38,5 +38,5 @@ def test_registry_factory_returns_protocol_compliant_service(
 
 def test_registry_covers_all_first_class_engines() -> None:
     """Every first-class engine (per CROSS_ENGINE_PARITY_SPEC) is registered."""
-    expected = {"drake", "mujoco", "pinocchio", "opensim", "simscape"}
+    expected = {"drake", "mujoco", "myosuite", "pinocchio", "opensim", "simscape"}
     assert set(KINEMATICS_SERVICE_REGISTRY) == expected

--- a/tests/unit/pose_interchange/live_kinematics/test_registry_fallback.py
+++ b/tests/unit/pose_interchange/live_kinematics/test_registry_fallback.py
@@ -38,6 +38,11 @@ _FALLBACK_PROBES: Iterable[tuple[str, str, str]] = (
         "_mujoco_is_importable",
     ),
     (
+        "myosuite",
+        "src.shared.python.pose_interchange.services.myosuite",
+        "_myosuite_is_importable",
+    ),
+    (
         "pinocchio",
         "src.shared.python.pose_interchange.services.pinocchio",
         "_pinocchio_is_importable",


### PR DESCRIPTION
## Summary

- Adds `MyosuiteAdapter` (`adapters/myosuite.py`) implementing `PoseConventionAdapter` — mirrors `MujocoAdapter` exactly since MyoSuite is MJCF-backed with identical qpos convention (`[x, y, z, qw, qx, qy, qz]` free-joint prefix, radians for hinge joints)
- Adds `MyosuiteKinematicsService` + `create_myosuite_service()` factory (`services/myosuite.py`) with mock fallback when `myosuite` wheel is unavailable
- Registers `"myosuite"` in both `ADAPTER_REGISTRY` and `KINEMATICS_SERVICE_REGISTRY`
- Adds 4 new test files: `test_myosuite_protocol`, `test_myosuite_layout`, `test_myosuite_roundtrip`, `test_myosuite_service`
- Updates existing engine-set assertions in `test_registry`, `test_protocol_compliance`, `test_registry_fallback`, and `test_coverage_gaps` to include `"myosuite"`
- Fixes 3 pre-existing ruff violations in `test_coverage_gaps.py` (unused import, unused variables)

## Test plan

- [x] `ruff check src/shared/python/pose_interchange/ tests/unit/pose_interchange/ tests/shared/pose_interchange/` — zero violations
- [x] `ruff format --check` on all modified files — zero diffs
- [x] `pytest tests/unit/pose_interchange/ tests/shared/pose_interchange/` — 284 passed

Closes #6091

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_