### PR TITLE
fix(security): refuse to start in production with dangerous default credentials

### DIFF
--- a/scripts/ci/check_gitignore_dotenv.py
+++ b/scripts/ci/check_gitignore_dotenv.py
@@ -1,0 +1,40 @@
+"""Verify .gitignore lists .env so secrets don't get committed."""
+
+import sys
+from pathlib import Path
+
+
+def check_gitignore_dotenv(gitignore_path: Path = Path(".gitignore")) -> bool:
+    """Check that .gitignore contains a pattern covering .env files.
+
+    Args:
+        gitignore_path: Path to the .gitignore file to check.
+
+    Returns:
+        True if an appropriate .env pattern is present, False otherwise.
+    """
+    if not gitignore_path.exists():
+        print(f"ERROR: {gitignore_path} not found", file=sys.stderr)
+        return False
+
+    gitignore_text = gitignore_path.read_text(encoding="utf-8")
+    patterns = [
+        line.strip()
+        for line in gitignore_text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    return bool(any(".env" in p for p in patterns))
+
+
+def main() -> None:
+    """Entry point for the CI check."""
+    if check_gitignore_dotenv():
+        print("OK: .gitignore includes .env pattern")
+    else:
+        print("ERROR: .gitignore does not list .env", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/python/security/env_validator.py
+++ b/src/shared/python/security/env_validator.py
@@ -85,6 +85,22 @@ def validate_secret_key_strength(key: str, min_length: int = 64) -> None:
             "Set GOLF_API_SECRET_KEY or SECRET_KEY environment variable."
         )
 
+    # Reject dangerous defaults that ship in .env.example
+    _DANGEROUS_SECRET_DEFAULTS = frozenset(
+        {
+            "generate_a_random_string_here",
+            "generate_another_random_string_here",
+            "changeme",
+            "change_me",
+        }
+    )
+    if key in _DANGEROUS_SECRET_DEFAULTS:
+        raise EnvironmentValidationError(
+            "GOLF_API_SECRET_KEY is still set to the example placeholder value. "
+            "Generate a real key with: "
+            'python3 -c "import secrets; print(secrets.token_hex(32))"'
+        )
+
     # Check for common weak patterns
     weak_patterns = [
         "password",
@@ -168,7 +184,30 @@ def validate_api_security() -> APIKeyValidationResults:
             )
         results["admin_password"] = False
     else:
-        if len(admin_password) < 12:
+        _DANGEROUS_ADMIN_DEFAULTS = frozenset(
+            {
+                "change_me_in_production",
+                "changeme",
+                "admin",
+                "password",
+                "password123",
+            }
+        )
+        if admin_password in _DANGEROUS_ADMIN_DEFAULTS:
+            if is_production():
+                results["issues"].append(
+                    "CRITICAL: GOLF_ADMIN_PASSWORD is still set to the dangerous "
+                    "default value from .env.example. Change it before deploying."
+                )
+                raise EnvironmentValidationError(
+                    "GOLF_ADMIN_PASSWORD",
+                    "GOLF_ADMIN_PASSWORD must be changed from the default in production.",
+                )
+            results["warnings"].append(
+                "GOLF_ADMIN_PASSWORD is using a known-dangerous default value. "
+                "Change it before deploying to production."
+            )
+        elif len(admin_password) < 12:
             results["warnings"].append(
                 f"Admin password is short ({len(admin_password)} chars). "
                 f"Recommend at least 12 characters."

--- a/tests/unit/scripts/test_check_gitignore_dotenv.py
+++ b/tests/unit/scripts/test_check_gitignore_dotenv.py
@@ -1,0 +1,78 @@
+"""Tests for scripts/ci/check_gitignore_dotenv.py."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.check_gitignore_dotenv import check_gitignore_dotenv
+
+
+@pytest.mark.unit
+class TestCheckGitignoreDotenv:
+    """Unit tests for the check_gitignore_dotenv helper."""
+
+    def test_returns_true_when_dotenv_listed(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text(".env\n*.pyc\n", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is True
+
+    def test_returns_true_for_glob_pattern(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.env\n", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is True
+
+    def test_returns_true_for_dotenv_star(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text(".env.*\n!.env.example\n", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is True
+
+    def test_returns_false_when_dotenv_missing(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.pyc\n__pycache__/\n", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is False
+
+    def test_ignores_comment_lines(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("# .env is important\n*.pyc\n", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is False
+
+    def test_returns_false_when_file_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / ".gitignore"
+        assert check_gitignore_dotenv(missing) is False
+
+    def test_empty_gitignore_returns_false(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("", encoding="utf-8")
+        assert check_gitignore_dotenv(gitignore) is False
+
+
+@pytest.mark.unit
+class TestCheckGitignoreDotenvScript:
+    """Integration tests: run the script as a subprocess."""
+
+    def test_script_exits_zero_on_real_repo(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "scripts/ci/check_gitignore_dotenv.py"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_script_exits_nonzero_when_env_missing(self, tmp_path: Path) -> None:
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.pyc\n", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.path.insert(0, '.'); "
+                "from scripts.ci.check_gitignore_dotenv import check_gitignore_dotenv; "
+                f"sys.exit(0 if check_gitignore_dotenv(__import__('pathlib').Path({str(gitignore)!r})) else 1)",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1


### PR DESCRIPTION
## Summary

- Extends `src/shared/python/security/env_validator.py` to explicitly reject the `.env.example` placeholder values (`generate_a_random_string_here`, `change_me_in_production`) as dangerous defaults — raises `EnvironmentValidationError` in production, logs a warning in development
- Adds `scripts/ci/check_gitignore_dotenv.py` — CI script that verifies `.gitignore` lists `.env` so secrets are never accidentally committed
- Adds `tests/unit/scripts/test_check_gitignore_dotenv.py` — 9 tests covering the gitignore checker (unit + subprocess integration)

The startup validation is already wired into the FastAPI lifespan via `validate_environment(raise_on_error=is_production())` in `server.py`, so the new checks take effect immediately on next deploy.

Partially addresses #5920

## Test plan

- [ ] `python3 scripts/ci/check_gitignore_dotenv.py` exits 0 (`.env` is in `.gitignore`)
- [ ] `pytest tests/unit/scripts/test_check_gitignore_dotenv.py -x` — 9 passed
- [ ] `pytest tests/unit/security/test_env_validator.py -x` — 10 passed (no regressions)
- [ ] `ruff check` and `ruff format --check` pass on all changed files

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_