### PR TITLE
docs(urdf): resolve ADR-0020 status drift — record Option B decision

### DIFF
--- a/docs/adr/0020-canonical-urdf-subsystem.md
+++ b/docs/adr/0020-canonical-urdf-subsystem.md
@@ -1,6 +1,6 @@
 # ADR 0020: Canonical URDF subsystem (humanoid_character_builder vs model_generation)
 
-- **Status:** Proposed (awaiting decision)
+- **Status:** Accepted
 - **Date:** 2026-05-08
 - **Tracking issue:** [#4521](https://github.com/D-sorganization/UpstreamDrift/issues/4521)
 - **Campaign:** [URDF Hardening Campaign #4520](https://github.com/D-sorganization/UpstreamDrift/issues/4520)
@@ -55,7 +55,35 @@ Fold `humanoid_character_builder` into `model_generation` as a domain-specific b
 - Duplication remains but is intentional
 - Risk: future features have to be implemented twice or the line drifts again
 
-## Recommendation: Option B (Layer)
+## Decision
+
+Option **B (Layer)** was accepted by the repo owner on 2026-05-08 and
+recorded in the closing comment on [#4521](https://github.com/D-sorganization/UpstreamDrift/issues/4521).
+
+`model_generation` is the canonical low-level URDF / mesh / inertia
+toolkit. `humanoid_character_builder` remains the anthropometric domain
+layer that composes those lower-level primitives for humanoid workflows.
+
+## Decision in practice
+
+The implementation is transitional but the dependency direction now
+matches Option B:
+
+- `humanoid_character_builder.mesh.inertia_calculator` imports
+  `model_generation.inertia.calculator`
+- `humanoid_character_builder.mesh.primitive_inertia` imports
+  `model_generation.inertia.primitives`
+- `humanoid_character_builder.generators.urdf_xml_builder` imports
+  `model_generation.builders.urdf_writer`
+- `model_generation.humanoid` exists as a compatibility facade that
+  re-exports the humanoid-domain public API without making
+  `model_generation` the owner of anthropometric workflows
+
+The migration tracked under #4600-#4603 was only partially completed, so
+some legacy humanoid-specific wrappers still exist. That is an
+implementation gap, not an unresolved architecture decision.
+
+## Rationale
 
 Reasoning:
 
@@ -65,7 +93,7 @@ Reasoning:
 4. **Option A loses domain clarity.** Folding anthropometry into `model_generation/humanoid/` makes the "generic toolkit" claim weaker — `model_generation` would now contain humanoid-specific code that has nothing to do with URDF emission. Option B keeps the toolkit truly generic.
 5. **Option C is the do-nothing-much option.** It documents the current mess as the intended state, leaves duplication, and lets the next refactor be even bigger.
 
-Estimated migration effort: 3–4 PRs over the campaign:
+Estimated migration effort at acceptance time: 3–4 PRs over the campaign:
 
 1. Extract `model_generation/inertia/` as the canonical inertia computation module; route `humanoid_character_builder` callers through it.
 2. Extract `model_generation/builders/urdf_writer.py` as the canonical XML emitter; route `humanoid_character_builder.generators.urdf_generator` through it.
@@ -89,10 +117,13 @@ Estimated migration effort: 3–4 PRs over the campaign:
 
 - If Option B is adopted but enforcement is weak, the code can drift back into duplication. Mitigation: add a CI check that `humanoid_character_builder/` does not import its own URDF XML writer (#4523 acceptance criteria).
 
-## Acceptance criteria for closing this ADR
+## Validation notes
 
-- [ ] User picks A, B, or C (or amends with rationale)
-- [ ] If B is picked: migration tracked as 4 sub-issues under #4521
-- [ ] `docs/architecture/URDF_SUBSYSTEM_BOUNDARY.md` written (closes #4523)
-- [ ] `src/shared/python/__init__.py` re-exports updated to match
-- [ ] No file imports from both subsystems (CI check)
+- [x] Decision recorded on #4521 as Option B (Layer)
+- [x] `docs/architecture/URDF_SUBSYSTEM_BOUNDARY.md` documents the
+      current layering and compatibility facade
+- [x] `src/shared/python/__init__.py` describes
+      `model_generation` as the canonical generic toolkit and
+      `humanoid_character_builder` as the anthropometric domain layer
+- [ ] Complete the remaining migration tasks tracked under #4600-#4603
+      so the implementation fully matches the accepted boundary

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 | [0017](0017-sidekick-agentic-action-layer.md)      | Sidekick agentic action layer                                   | Accepted | 2026-05-22 |
 | [0018](0018-standalone-sidekick.md)                | Standalone Sidekick Application                                 | Accepted | 2026-05-23 |
 | [0019](0019-mission-drift-calculators.md)          | Mission-Drift Calculators                                       | Accepted | 2026-04-25 |
-| [0020](0020-canonical-urdf-subsystem.md)           | Canonical URDF subsystem                                        | Proposed | 2026-05-08 |
+| [0020](0020-canonical-urdf-subsystem.md)           | Canonical URDF subsystem                                        | Accepted | 2026-05-08 |
 
 ## ADR Backlog
 

--- a/docs/architecture/URDF_SUBSYSTEM_BOUNDARY.md
+++ b/docs/architecture/URDF_SUBSYSTEM_BOUNDARY.md
@@ -1,55 +1,35 @@
 # URDF Subsystem Boundary: humanoid_character_builder vs model_generation
 
-This document clarifies the architectural boundary between two URDF generation subsystems in the UpstreamDrift repository:
+This document clarifies the accepted architectural boundary between the
+two URDF-related packages in UpstreamDrift. It reflects ADR-0020
+(`Option B: Layer`) rather than the earlier "pick one stack" framing.
 
-1. **`humanoid_character_builder`** - Character-focused URDF generation
-2. **`model_generation`** - General-purpose model generation
+1. **`model_generation`** is the canonical low-level URDF / mesh /
+   inertia toolkit.
+2. **`humanoid_character_builder`** is the anthropometric domain layer
+   that builds humanoid-specific workflows on top of that toolkit.
+3. **`model_generation.humanoid`** is a compatibility facade that
+   re-exports the humanoid-domain public API for callers already rooted
+   in the `model_generation` namespace.
 
-## Decision Tree
+## Current layering
 
-Use this flowchart to determine which subsystem to use:
+The boundary is about abstraction level, not "humanoid vs non-humanoid"
+ownership of all code:
 
-```
-                                    ┌─────────────────────────────────────┐
-                                    │  What type of model do you need?    │
-                                    └─────────────────┬───────────────────┘
-                                                      │
-                    ┌─────────────────────────────────┴──────────────────────────────────┐
-                    │                                                                    │
-                    ▼                                                                    ▼
-        ┌───────────────────────┐                                          ┌───────────────────────┐
-        │  Humanoid character   │                                          │  Non-humanoid or      │
-        │  (biped, anthropo-    │                                          │  specialized model    │
-        │   metric proportions) │                                          │  (quadruped, robot,   │
-        │                       │                                          │   custom geometry)    │
-        └───────────┬───────────┘                                          └───────────┬───────────┘
-                    │                                                                    │
-                    ▼                                                                    ▼
-        ┌───────────────────────┐                                          ┌───────────────────────┐
-        │  Need SMPL-X or       │                                          │  Use model_generation │
-        │  MakeHuman mesh       │                                          │  with custom URDF     │
-        │  generation?          │                                          │  templates            │
-        └───────────┬───────────┘                                          └───────────────────────┘
-                    │
-        ┌───────────┴───────────┐
-        │          Yes          │          No
-        │                       │
-        ▼                       ▼
-┌───────────────────┐   ┌───────────────────┐
-│ Use SMPLXMesh     │   │ Use               │
-│ Generator or      │   │ PrimitiveMesh     │
-│ MakeHumanMesh     │   │ Generator         │
-│ Generator         │   │                   │
-└─────────┬─────────┘   └─────────┬─────────┘
-          │                       │
-          └───────────┬───────────┘
-                      │
-                      ▼
-          ┌───────────────────────┐
-          │ humanoid_character_   │
-          │ builder               │
-          └───────────────────────┘
-```
+- `model_generation`
+  - owns generic URDF XML writing, inertia primitives, conversion, and
+    reusable model-building infrastructure
+  - is the package new low-level URDF helpers should target
+- `humanoid_character_builder`
+  - owns anthropometry, body presets, humanoid segment definitions, and
+    the `CharacterBuilder` user workflow
+  - may compose `model_generation` but should not reintroduce duplicate
+    low-level URDF or inertia implementations
+- `model_generation.humanoid`
+  - is a compatibility facade for callers that want the humanoid-domain
+    API from inside the `model_generation` namespace
+  - should stay thin; it is not the home for new anthropometric logic
 
 ## When to Use humanoid_character_builder
 
@@ -97,7 +77,7 @@ result.export_urdf("./output/my_character")
 
 Use `model_generation` when:
 
-1. **Building non-humanoid models** (quadrupeds, robots, manipulators)
+1. **Building low-level URDF/MJCF helpers** or reusable exporter logic
 2. **Need custom geometry** not based on human anthropometry
 3. **Working with CAD imports** or external mesh sources
 4. **Building specialized mechanisms** (grippers, legs, arms)
@@ -107,102 +87,40 @@ Use `model_generation` when:
 ### Example Use Cases
 
 ```python
-from model_generation import ModelBuilder
+from model_generation import ManualBuilder, Link, Joint, Inertia
 
 # Custom robot model
-builder = ModelBuilder()
-builder.add_link("base", geometry=BoxGeometry(0.5, 0.3, 0.2))
-builder.add_joint("joint1", parent="base", child="link1", joint_type="revolute")
-model = builder.build()
-model.export_urdf("./output/my_robot.urdf")
-model.export_simscape("./output/my_robot.smdb")
+builder = ManualBuilder("robot")
+builder.add_link(Link(name="base", inertia=Inertia.from_box(10, 1, 1, 0.5)))
+urdf = builder.build().urdf_xml
 ```
 
-## Module Dependencies
+## Code-level evidence
 
-```
-humanoid_character_builder
-├── core/
-│   ├── body_parameters.py      # BodyParameters dataclass
-│   ├── anthropometry.py        # Mass/length estimation from CDC/NHANES data
-│   └── segment_definitions.py  # HUMANOID_SEGMENTS constant
-├── generators/
-│   ├── urdf_generator.py       # URDF generation for humanoids
-│   ├── mesh_generator.py       # Mesh generation backends
-│   ├── _mesh_smplx.py          # SMPL-X body model integration
-│   └── _mesh_makehuman.py      # MakeHuman integration
-├── presets/
-│   └── loader.py               # Body type presets with citations
-└── interfaces/
-    └── api.py                  # CharacterBuilder public API
+Current source code already points in the accepted direction:
 
-model_generation
-├── builders/
-│   ├── model_builder.py        # General model construction
-│   └── link_builder.py         # Link/joint definitions
-├── exporters/
-│   ├── urdf_exporter.py        # URDF export (general purpose)
-│   └── simscape_exporter.py    # Simscape Multibody export
-├── converters/
-│   └── urdf_to_simscape.py     # Format conversion
-└── library/
-    └── model_library.py        # Pre-built model repository
-```
-
-## Shared Dependencies
-
-Both subsystems share:
-
-- `BodyParameters` - Defined in `humanoid_character_builder.core.body_parameters`
-- Standard URDF schema (ROS/URDF specification)
-- Mesh processing utilities (trimesh, numpy)
-
-## Migration Guide
-
-### From model_generation to humanoid_character_builder
-
-If you're building humanoids and currently using `model_generation`:
-
-```python
-# Old (model_generation)
-from model_generation import create_humanoid
-model = create_humanoid(height=1.75, mass=75.0)
-
-# New (humanoid_character_builder)
-from humanoid_character_builder import CharacterBuilder, BodyParameters
-builder = CharacterBuilder()
-params = BodyParameters(height_m=1.75, mass_kg=75.0)
-result = builder.build(params)
-```
-
-### From humanoid_character_builder to model_generation
-
-If you need Simscape export for a humanoid:
-
-```python
-# humanoid_character_builder doesn't directly support Simscape export
-# Use the URDF output and convert:
-
-from model_generation.converters import urdf_to_simscape
-urdf_to_simscape("my_humanoid.urdf", "my_humanoid.smdb")
-```
+- `humanoid_character_builder.mesh.inertia_calculator` imports
+  `model_generation.inertia.calculator`
+- `humanoid_character_builder.mesh.primitive_inertia` imports
+  `model_generation.inertia.primitives`
+- `humanoid_character_builder.generators.urdf_xml_builder` imports
+  `model_generation.builders.urdf_writer`
+- `model_generation.humanoid.__init__` re-exports the public humanoid
+  API as a compatibility facade
 
 ## Summary Table
 
-| Feature                | humanoid_character_builder | model_generation |
-| ---------------------- | -------------------------- | ---------------- |
-| Humanoid presets       | ✅ Yes (16 presets)        | ❌ No            |
-| SMPL-X integration     | ✅ Yes                     | ❌ No            |
-| MakeHuman integration  | ✅ Yes                     | ❌ No            |
-| Anthropometric scaling | ✅ CDC/NHANES based        | ❌ Manual        |
-| Gender-specific models | ✅ Yes                     | ❌ Manual        |
-| Simscape export        | ❌ Via converter           | ✅ Native        |
-| Custom robots          | ❌ No                      | ✅ Yes           |
-| Quadrupeds             | ❌ No                      | ✅ Yes           |
-| CAD import             | ❌ No                      | ✅ Yes           |
+| Concern                         | Canonical owner                 | Notes |
+| ------------------------------- | ------------------------------- | ----- |
+| URDF XML writer                 | `model_generation`              | Composed by `humanoid_character_builder` |
+| Inertia primitives/calculators  | `model_generation`              | Reused by `humanoid_character_builder.mesh.*` |
+| Anthropometry + body presets    | `humanoid_character_builder`    | Domain-specific human modeling |
+| CharacterBuilder user workflow  | `humanoid_character_builder`    | Public humanoid entry point |
+| Humanoid namespace compatibility| `model_generation.humanoid`     | Compatibility facade only |
 
 ## References
 
+- [ADR-0020](../adr/0020-canonical-urdf-subsystem.md)
 - [Character Builder Quickstart](../user_guide/character_builder_quickstart.md)
 - [Character Presets Reference](../user_guide/character_presets.md)
 - [Model Generation API](../../src/shared/python/model_generation/README.md)

--- a/src/shared/python/__init__.py
+++ b/src/shared/python/__init__.py
@@ -8,8 +8,8 @@ Available packages:
     - theme: Fleet-wide color theme management for PyQt6 applications
     - sidekick: Process engineering calculators
     - signal_toolkit: Signal processing and analysis
-    - humanoid_character_builder: URDF humanoid model generation
-    - model_generation: URDF/MJCF model building and conversion
+    - humanoid_character_builder: anthropometric domain layer for humanoid generation
+    - model_generation: canonical generic URDF/MJCF toolkit and conversion surface
 
 Preferred imports (direct from package, since src/shared/python is on sys.path):
     from shared.python.theme import ThemeManager, get_theme_manager  # theme: keep prefix

--- a/src/shared/python/humanoid_character_builder/__init__.py
+++ b/src/shared/python/humanoid_character_builder/__init__.py
@@ -1,14 +1,18 @@
 """
-Humanoid Character Builder - Standalone URDF Generation Module.
+Humanoid Character Builder - anthropometric domain layer.
 
-A self-contained, decoupled module for generating humanoid URDF models
-with video game-style character customization.
+This package owns the humanoid-specific workflow for generating body
+parameter-driven character models with video game-style customization.
+It composes the generic URDF / mesh / inertia primitives from
+``model_generation`` rather than acting as a second low-level toolkit.
 
 This module is designed to:
-- Be completely standalone with no dependencies on other Golf Modeling Suite modules
-- Provide clean, well-defined interfaces for integration
-- Support parallel development without merge conflicts
-- Be easily relocatable to shared tool repositories
+- expose the anthropometric public API (`CharacterBuilder`,
+  `BodyParameters`, presets, humanoid segment definitions)
+- keep humanoid-domain concerns discoverable and separate from the
+  generic `model_generation` infrastructure
+- preserve stable user-facing entry points while the low-level
+  migration tracked from ADR-0020 continues
 
 Usage:
     from humanoid_character_builder import (

--- a/tests/unit/repo_hygiene/test_urdf_governance_docs.py
+++ b/tests/unit/repo_hygiene/test_urdf_governance_docs.py
@@ -1,0 +1,87 @@
+"""Regression guards for URDF subsystem governance docs.
+
+Issue #6094 found ADR-0020 stuck in ``Proposed`` even though #4521 was
+closed with Option B (Layer) recorded as the repo decision. These tests keep
+the ADR, boundary doc, and package-level documentation aligned.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(*parts: str) -> str:
+    path = _REPO_ROOT.joinpath(*parts)
+    assert path.exists(), f"{path} must exist"
+    return path.read_text(encoding="utf-8")
+
+
+class TestUrdfAdr0020:
+    """ADR-0020 must reflect the accepted URDF layering decision."""
+
+    def test_status_is_accepted(self) -> None:
+        text = _read("docs", "adr", "0020-canonical-urdf-subsystem.md")
+        assert "Status:** Accepted" in text or "Status: Accepted" in text
+
+    def test_records_option_b_layering(self) -> None:
+        text = _read("docs", "adr", "0020-canonical-urdf-subsystem.md")
+        assert "Option B" in text
+        assert "Layer" in text
+        assert "#4521" in text
+
+    def test_has_decision_in_practice_section(self) -> None:
+        text = _read("docs", "adr", "0020-canonical-urdf-subsystem.md")
+        assert "## Decision in practice" in text
+        assert "model_generation.humanoid" in text
+
+
+class TestUrdfBoundaryDoc:
+    """The boundary doc must describe the accepted layering, not a split stack."""
+
+    def test_boundary_doc_exists(self) -> None:
+        assert (
+            _REPO_ROOT / "docs" / "architecture" / "URDF_SUBSYSTEM_BOUNDARY.md"
+        ).exists()
+
+    def test_boundary_doc_marks_model_generation_as_canonical_toolkit(self) -> None:
+        text = _read("docs", "architecture", "URDF_SUBSYSTEM_BOUNDARY.md")
+        assert "canonical low-level URDF / mesh /" in text
+        assert "inertia toolkit" in text
+        assert "humanoid_character_builder" in text
+        assert "anthropometric domain layer" in text
+
+    def test_boundary_doc_mentions_compatibility_facade(self) -> None:
+        text = _read("docs", "architecture", "URDF_SUBSYSTEM_BOUNDARY.md")
+        assert "model_generation.humanoid" in text
+        assert "compatibility facade" in text
+
+
+class TestUrdfPackageDocs:
+    """Package docstrings must match the accepted layering decision."""
+
+    def test_humanoid_character_builder_docstring_describes_domain_layer(self) -> None:
+        text = _read(
+            "src", "shared", "python", "humanoid_character_builder", "__init__.py"
+        )
+        assert "anthropometric domain layer" in text
+        assert "model_generation" in text
+
+    def test_shared_python_index_describes_canonical_toolkit(self) -> None:
+        text = _read("src", "shared", "python", "__init__.py")
+        assert "canonical generic URDF/MJCF toolkit" in text
+
+
+class TestAdrIndex:
+    """The ADR index must reflect ADR-0020's accepted status."""
+
+    def test_adr_index_marks_0020_accepted(self) -> None:
+        text = _read("docs", "adr", "README.md")
+        assert "[0020](0020-canonical-urdf-subsystem.md)" in text
+        assert "Canonical URDF subsystem" in text
+        assert "Accepted | 2026-05-08" in text


### PR DESCRIPTION
## Summary

- ADR-0020 (`docs/adr/0020-canonical-urdf-subsystem.md`) was stuck in `Proposed (awaiting decision)` since 2026-05-08, despite issue #4521 being closed with **Option B (Layer)** as the accepted decision and the codebase already reflecting that layering.
- Updates the ADR status to `Accepted`, adds `## Decision`, `## Decision in practice`, and `## Rationale` sections.
- Rewrites `docs/architecture/URDF_SUBSYSTEM_BOUNDARY.md` to reflect the accepted layering rather than the outdated "pick one stack" framing.
- Updates package docstrings in `src/shared/python/__init__.py` and `humanoid_character_builder/__init__.py` to match.
- Adds 9 regression tests in `tests/unit/repo_hygiene/test_urdf_governance_docs.py` to lock these documentation contracts in place.

## Evidence of Option B being in practice

The codebase already implements the layering:
- `humanoid_character_builder.mesh.inertia_calculator` imports `model_generation.inertia.calculator`
- `humanoid_character_builder.mesh.primitive_inertia` imports `model_generation.inertia.primitives`
- `humanoid_character_builder.generators.urdf_xml_builder` imports `model_generation.builders.urdf_writer`
- `model_generation.humanoid` re-exports the humanoid-domain public API as a compatibility facade

No code behaviour was changed — only documentation and tests.

## Test plan

- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [x] `pytest tests/unit/repo_hygiene/test_urdf_governance_docs.py` — 9/9 pass

Closes #6094

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_