### PR TITLE
docs: update stale __init__ docstrings in plot_style and body_part_viz

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,11 +1,24 @@
-"""Body-part visualisation contracts and dataclasses.
+"""Body-part visualisation contracts, dataclasses, and implementations.
 
-This package defines the abstract surface (Protocols + frozen dataclasses)
-that every shape, fitter, and renderer implementation talks across.
+This package provides the full body-part visualisation stack:
 
-Implementations of shapes, fitters, and rendering backends live in the
-``shapes``, ``fitters``, and ``renderers`` sub-packages and are added in
-follow-up issues of EPIC #4755.
+- ``contracts`` — runtime-checkable Protocols (``BodyPartShape``,
+  ``ShapeFitter``, ``ShapeRenderer``).
+- ``_types`` — ``FittedShape`` dataclass.
+- ``shapes`` — capsule, ellipsoid, cylinder, mesh, composite, and line
+  shape implementations.
+- ``fitters`` — Kabsch (pairwise and cluster) and anisotropic Procrustes
+  fitters.
+- ``renderers`` — Matplotlib and PyQtGL rendering backends.
+- ``bindings`` — ``MarkerBinding`` / ``BindingKind`` for attaching
+  markers to body-part shapes.
+- ``persistence`` — ``SegmentVizSpec`` / ``SegmentVizSet`` serialisation
+  and v1→v2 migration.
+- ``theme`` — ``ShapeTheme`` for unified visual styling.
+- ``asset_library`` — built-in shape asset registry.
+- ``urdf_bridge`` — helpers for importing shapes from URDF descriptions.
+
+See ADR-0011 for the shared-style design rationale.
 """
 
 from __future__ import annotations

--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -1,13 +1,24 @@
-"""Plot-style contracts and dataclasses.
+"""Plot-style contracts, dataclasses, and renderer implementations.
 
-This package defines the abstract surface (Protocols + frozen
-dataclasses) used by every marker / trace styling implementation in
-UpstreamDrift.
+This package owns the canonical marker-styling stack:
 
-Concrete implementations of color resolvers, renderers, Qt widgets, and
-marker-shape primitives live in the ``resolvers``, ``renderers``,
-``widgets``, and ``shapes`` sub-packages and are added in follow-up
-issues of EPIC #4796.
+- ``contracts`` — runtime-checkable Protocols (``ColorResolver``,
+  ``MarkerRenderer``, ``MarkerShapeRenderer``).
+- ``colors`` / ``colormaps`` — color scales, colormaps, and registries.
+- ``channels`` — ``DataChannel`` and channel-combinator helpers.
+- ``markers`` — ``MarkerStyle``, ``MarkerShape``, ``CustomMeshSpec``.
+- ``shapes`` — built-in marker-shape primitives (sphere, cube, diamond,
+  star, cross, custom mesh).
+- ``renderers`` — ``MatplotlibMarkerRenderer`` (canonical);
+  ``PyQtGLMarkerRenderer`` available via lazy import when PyQtGL is present.
+- ``resolvers`` — static, palette, and data-driven color resolvers.
+- ``widgets`` — optional Qt widgets (imported only when PyQt6 is available):
+  ``ColorPicker``, ``ColormapPicker``, ``DataChannelEditor``,
+  ``MarkerStylePicker``.
+- ``persistence`` — ``PlotStyleSpec`` / ``PlotStyleSet`` serialisation.
+- ``preset_library`` — built-in named presets.
+
+See ADR-0011 for the design rationale.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Removes the false "added in follow-up issues of EPIC #4796/#4755" language from both `__init__.py` docstrings, which misled readers into thinking the packages were incomplete skeletons.
- Replaces each docstring with an accurate, structured sub-package inventory reflecting what is actually shipped today (all shape, fitter, renderer, resolver, widget, persistence, and preset sub-packages are present and functional).

## Files changed

- `src/shared/python/plot_style/__init__.py` — new docstring enumerates `contracts`, `colors`/`colormaps`, `channels`, `markers`, `shapes`, `renderers`, `resolvers`, `widgets`, `persistence`, `preset_library`.
- `src/shared/python/body_part_viz/__init__.py` — new docstring enumerates `contracts`, `_types`, `shapes`, `fitters`, `renderers`, `bindings`, `persistence`, `theme`, `asset_library`, `urdf_bridge`.

## Test plan

- [x] `ruff check` passes with zero violations
- [x] `ruff format --check` passes with zero diffs
- No logic changes; docstring-only update requires no new tests.

Closes #6087

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_