### PR TITLE
refactor(aerodynamics): extract magic numbers into named module-level constants

### DIFF
--- a/src/shared/python/physics/aerodynamics.py
+++ b/src/shared/python/physics/aerodynamics.py
@@ -55,38 +55,48 @@ from src.shared.python.physics.atmosphere import cd_dimpled_sphere
 
 MIN_AIR_DENSITY_KG_M3 = 0.01
 
+# Dynamic-pressure prefactor: F = 0.5 * rho * Cd * A * v**2
+_DRAG_FORMULA_PREFACTOR = 0.5
 
-_DEFAULT_FORCE_PREFACTOR = 0.5
-_DEFAULT_BASE_TEMPERATURE_C = 15.0
+# Floor for vector magnitude checks — below this a vector is treated as zero
+_VECTOR_MAGNITUDE_EPS = 1e-10
 
-# Drag constants
-_DEFAULT_REYNOLDS_MIN = 1.0e3
-_DEFAULT_REYNOLDS_MAX = 1.0e7
+# Default ambient temperature [°C]
+_DEFAULT_TEMPERATURE_C = 15.0
 
-# Lift constants
+# Reynolds number clamp for drag-crisis correlation [dimensionless]
+_REYNOLDS_MIN = 1.0e3
+_REYNOLDS_MAX = 1.0e7
+
+# Lift saturation: Cl saturates via 1 - exp(-spin_ratio / _LIFT_SPIN_RATIO_SCALE)
 _DEFAULT_MAX_LIFT_COEFFICIENT = 0.4
-_DEFAULT_SPIN_RATIO_SCALE = 0.1
+_LIFT_SPIN_RATIO_SCALE = 0.1  # dimensionless
 
-# Magnus constants
-_DEFAULT_SPIN_PARAM_SCALE = 0.2
+# Magnus saturation: linear up to spin_param / _MAGNUS_SPIN_RATIO_SATURATION, capped at 1
+_MAGNUS_SPIN_RATIO_SATURATION = 0.2  # dimensionless
 
 # Wind & Gust constants
-_DEFAULT_GUST_INTENSITY = 0.3
-_DEFAULT_GUST_FREQUENCY_HZ = 0.1
-_DEFAULT_GUST_DURATION_MEAN_S = 2.0
-_DEFAULT_GUST_MIN_DURATION_S = 0.5
-_DEFAULT_GUST_MAX_DURATION_S = 10.0
-_DEFAULT_GUST_SPEED_MIN_FACTOR = 0.5
-_DEFAULT_GUST_SPEED_MAX_FACTOR = 1.5
-_DEFAULT_GUST_DIR_PERTURB_SCALE = 0.3
-_DEFAULT_GUST_INITIAL_DT = 0.1
-_DEFAULT_WIND_ALTITUDE_SCALE = 10.0
+_DEFAULT_GUST_INTENSITY = 0.3  # fraction of base wind speed
+_DEFAULT_GUST_FREQUENCY_HZ = 0.1  # Hz — average gust arrival rate
+_DEFAULT_GUST_DURATION_MEAN_S = 2.0  # s — mean gust duration (exponential dist.)
+_GUST_DURATION_MIN_S = 0.5  # s — minimum clamped gust duration
+_GUST_DURATION_MAX_S = 10.0  # s — maximum clamped gust duration
+_GUST_SPEED_VARIABILITY_MIN = 0.5  # lower bound of gust speed multiplier
+_GUST_SPEED_VARIABILITY_MAX = 1.5  # upper bound of gust speed multiplier
+_GUST_DIRECTION_PERTURB_STD = 0.3  # std-dev of random direction perturbation [rad]
+_INITIAL_GUST_CHECK_DT_S = 0.1  # s — assumed dt on the very first gust check
+_GRADIENT_ALTITUDE_SCALE_M = (
+    10.0  # m — altitude divisor for wind gradient (altitude / 10)
+)
+
+# Wind shear default: 5 % speed increase per 10 m altitude gain
+_DEFAULT_GRADIENT_FACTOR = 0.05  # dimensionless fraction per 10 m
 
 # Turbulence constants
-_DEFAULT_TURBULENCE_INTENSITY = 0.5
-_DEFAULT_TURBULENCE_FREQ_MIN = 0.1
-_DEFAULT_TURBULENCE_FREQ_MAX = 2.0
-_DEFAULT_TURBULENCE_HARMONICS = 10
+_DEFAULT_TURBULENCE_INTENSITY = 0.5  # m/s scale factor
+_TURBULENCE_FREQ_MIN_HZ = 0.1  # Hz — minimum turbulence harmonic frequency
+_TURBULENCE_FREQ_MAX_HZ = 2.0  # Hz — maximum turbulence harmonic frequency
+_TURBULENCE_HARMONIC_COUNT = 10  # number of sinusoidal harmonics
 
 
 def _vector_magnitude(vector: np.ndarray) -> float:
@@ -199,7 +209,7 @@ class WindConfig:
     gust_duration_mean: float = _DEFAULT_GUST_DURATION_MEAN_S  # seconds
     turbulence_intensity: float = 0.0
     altitude_gradient: bool = False
-    gradient_factor: float = 0.05  # 5% per 10m
+    gradient_factor: float = _DEFAULT_GRADIENT_FACTOR  # 5% per 10 m
 
     @property
     def speed(self) -> float:
@@ -210,7 +220,7 @@ class WindConfig:
     def direction(self) -> np.ndarray:
         """Get normalized wind direction."""
         speed = self.speed
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.array([1.0, 0.0, 0.0])
         return self.base_velocity / speed
 
@@ -291,12 +301,12 @@ class DragModel:
         velocity_vec = np.asarray(velocity, dtype=float).reshape(-1)
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity_vec)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         cd = self.get_effective_coefficient(velocity_vec, air_density)
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cd * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cd * self.ball_area * speed**2
         )
 
         # Drag opposes velocity
@@ -328,7 +338,7 @@ class DragModel:
 
         # ⚡ Bolt: math.hypot(*vec) is ~5x faster than np.linalg.norm(vec) for 3D magnitudes
         speed = _vector_magnitude(velocity)
-        if speed < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS:
             return self.base_coefficient
 
         # Reynolds number
@@ -338,7 +348,7 @@ class DragModel:
         # Delegate to the smoothed drag-crisis correlation (Bearman & Harvey
         # 1976, Mehta 1985); clamp to the model's validated range so the
         # integrator never sees a discontinuity. See issue #3504.
-        re_clamped = max(_DEFAULT_REYNOLDS_MIN, min(_DEFAULT_REYNOLDS_MAX, re))
+        re_clamped = max(_REYNOLDS_MIN, min(_REYNOLDS_MAX, re))
         return cd_dimpled_sphere(re_clamped, base_cd=self.base_coefficient)
 
 
@@ -401,7 +411,7 @@ class LiftModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Lift direction: perpendicular to velocity, in spin plane
@@ -409,7 +419,7 @@ class LiftModel:
         lift_dir = np.cross(spin_axis, velocity_vec)
         lift_norm = float(math.hypot(*lift_dir))
 
-        if lift_norm < 1e-10:
+        if lift_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         lift_dir = lift_dir / lift_norm
@@ -420,7 +430,7 @@ class LiftModel:
 
         # Lift magnitude
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cl * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cl * self.ball_area * speed**2
         )
 
         return force_magnitude * lift_dir
@@ -437,9 +447,7 @@ class LiftModel:
         # Empirical relationship: Cl saturates at high spin
         if spin_ratio is None:
             raise ValueError("spin_ratio must be provided")
-        cl = self.max_coefficient * (
-            1 - math.exp(-spin_ratio / _DEFAULT_SPIN_RATIO_SCALE)
-        )
+        cl = self.max_coefficient * (1 - math.exp(-spin_ratio / _LIFT_SPIN_RATIO_SCALE))
         return min(cl, self.max_coefficient)
 
 
@@ -497,14 +505,14 @@ class MagnusModel:
         # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm for small arrays
         spin_magnitude = _vector_magnitude(spin_vec)
 
-        if speed < 1e-10 or spin_magnitude < 1e-10:
+        if speed < _VECTOR_MAGNITUDE_EPS or spin_magnitude < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         # Magnus direction: spin x velocity
         magnus_dir = np.cross(spin_vec, velocity_vec)
         magnus_norm = float(math.hypot(*magnus_dir))
 
-        if magnus_norm < 1e-10:
+        if magnus_norm < _VECTOR_MAGNITUDE_EPS:
             return np.zeros_like(velocity_vec)
 
         magnus_dir = magnus_dir / magnus_norm
@@ -515,7 +523,7 @@ class MagnusModel:
 
         # Force magnitude
         force_magnitude = (
-            _DEFAULT_FORCE_PREFACTOR * air_density * cm * self.ball_area * speed**2
+            _DRAG_FORMULA_PREFACTOR * air_density * cm * self.ball_area * speed**2
         )
 
         return force_magnitude * magnus_dir
@@ -530,7 +538,7 @@ class MagnusModel:
             Magnus coefficient
         """
         # Approximately linear for small spin_param, saturates for large
-        return self.coefficient * min(spin_param / _DEFAULT_SPIN_PARAM_SCALE, 1.0)
+        return self.coefficient * min(spin_param / _MAGNUS_SPIN_RATIO_SATURATION, 1.0)
 
 
 # =============================================================================
@@ -616,14 +624,12 @@ class TurbulenceModel:
         self.intensity = intensity
         self._rng = np.random.default_rng(seed)
         # Pre-generate noise coefficients for smooth interpolation
-        self._coeffs = self._rng.standard_normal((3, _DEFAULT_TURBULENCE_HARMONICS))
-        self._phases = self._rng.uniform(
-            0, 2 * np.pi, (3, _DEFAULT_TURBULENCE_HARMONICS)
-        )
+        self._coeffs = self._rng.standard_normal((3, _TURBULENCE_HARMONIC_COUNT))
+        self._phases = self._rng.uniform(0, 2 * np.pi, (3, _TURBULENCE_HARMONIC_COUNT))
         self._freqs = self._rng.uniform(
-            _DEFAULT_TURBULENCE_FREQ_MIN,
-            _DEFAULT_TURBULENCE_FREQ_MAX,
-            _DEFAULT_TURBULENCE_HARMONICS,
+            _TURBULENCE_FREQ_MIN_HZ,
+            _TURBULENCE_FREQ_MAX_HZ,
+            _TURBULENCE_HARMONIC_COUNT,
         )
 
     def get_perturbation(
@@ -642,7 +648,7 @@ class TurbulenceModel:
         """
         if t is None:
             raise ValueError("t must be provided")
-        if self.intensity < 1e-10:
+        if self.intensity < _VECTOR_MAGNITUDE_EPS:
             return np.zeros(3)
 
         # Sum of sinusoids at different frequencies (vectorized)
@@ -712,7 +718,7 @@ class WindModel:
         if self.config.altitude_gradient:
             altitude = max(0.0, position[2])
             gradient_multiplier = 1.0 + self.config.gradient_factor * (
-                altitude / _DEFAULT_WIND_ALTITUDE_SCALE
+                altitude / _GRADIENT_ALTITUDE_SCALE_M
             )
             wind = wind * gradient_multiplier
 
@@ -763,7 +769,7 @@ class WindModel:
             raise ValueError("t must be provided")
         if self._last_check_time < 0:
             self._last_check_time = t
-            dt = _DEFAULT_GUST_INITIAL_DT  # Initial time step assumption
+            dt = _INITIAL_GUST_CHECK_DT_S  # Initial time step assumption
         else:
             dt = t - self._last_check_time
             self._last_check_time = t
@@ -785,8 +791,8 @@ class WindModel:
             # Generate random gust
             duration = self._rng.exponential(self.config.gust_duration_mean)
             duration = max(
-                _DEFAULT_GUST_MIN_DURATION_S,
-                min(duration, _DEFAULT_GUST_MAX_DURATION_S),
+                _GUST_DURATION_MIN_S,
+                min(duration, _GUST_DURATION_MAX_S),
             )  # Clamp
 
             # Random direction perturbation
@@ -795,17 +801,15 @@ class WindModel:
                 base_speed
                 * self.config.gust_intensity
                 * self._rng.uniform(
-                    _DEFAULT_GUST_SPEED_MIN_FACTOR, _DEFAULT_GUST_SPEED_MAX_FACTOR
+                    _GUST_SPEED_VARIABILITY_MIN, _GUST_SPEED_VARIABILITY_MAX
                 )
             )
 
             # Gust direction: mostly aligned with base wind, some random deviation
             base_dir = self.config.direction
-            random_perturb = (
-                self._rng.standard_normal(3) * _DEFAULT_GUST_DIR_PERTURB_SCALE
-            )
+            random_perturb = self._rng.standard_normal(3) * _GUST_DIRECTION_PERTURB_STD
             gust_dir = base_dir + random_perturb
-            gust_dir = gust_dir / (math.hypot(*gust_dir) + 1e-10)
+            gust_dir = gust_dir / (math.hypot(*gust_dir) + _VECTOR_MAGNITUDE_EPS)
 
             gust = WindGust(
                 start_time=t,
@@ -956,7 +960,7 @@ class EnvironmentRandomizer:
     def create_snapshot(
         self,
         base_air_density: float = float(AIR_DENSITY_SEA_LEVEL_KG_M3),
-        base_temperature: float = _DEFAULT_BASE_TEMPERATURE_C,
+        base_temperature: float = _DEFAULT_TEMPERATURE_C,
         base_wind_config: WindConfig | None = None,
     ) -> EnvironmentSnapshot:
         """Create a consistent randomized environment snapshot.


### PR DESCRIPTION
## Summary

- Extracts all inline numeric literals in `src/shared/python/physics/aerodynamics.py` into descriptive module-level constants with unit/rationale comments
- Renames existing `_DEFAULT_*` constants to match the canonical names specified in issue #5916 (e.g. `_DRAG_FORMULA_PREFACTOR`, `_VECTOR_MAGNITUDE_EPS`, `_REYNOLDS_MIN/MAX`, etc.)
- Adds two new constants that were previously inline: `_VECTOR_MAGNITUDE_EPS = 1e-10` (used in 8 magnitude-floor checks) and `_DEFAULT_GRADIENT_FACTOR = 0.05` (was hardcoded default in `WindConfig`)
- Zero behavioral change — same logic, same values, just named

## Test plan

- [x] `ruff check src/shared/python/physics/aerodynamics.py` — zero violations
- [x] `ruff format --check src/shared/python/physics/aerodynamics.py` — no diffs
- [x] `pytest tests/unit/test_aerodynamics.py tests/unit/test_aerodynamics_package_2506.py tests/unit/physics/` — 261 passed, 4 failed (all 4 failures are pre-existing on main, confirmed by running against HEAD before the change)
- [x] File stays within 1200-line limit (1175 lines)

Partially addresses #5916

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_