### PR TITLE
fix(ws): validate initial_state q/v and isolate JSON parse errors

### DIFF
--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import json
 import logging
 import math
 import time
@@ -60,6 +61,18 @@ def _engine_type_from_str(name: str) -> EngineType:
     return EngineType(name.lower())
 
 
+def _is_numeric_sequence(value: object) -> bool:
+    """Return True iff value is a list/tuple of int/float values (no bools).
+
+    Precondition: value is any Python object.
+    Postcondition: returns True only when value is a non-string sequence whose
+    every element is a finite numeric scalar (int or float, not bool).
+    """
+    if not isinstance(value, (list, tuple)):
+        return False
+    return all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in value)
+
+
 def _apply_initial_state(engine: object, state_dict: dict[str, Any]) -> None:
     """Apply an initial state dict to the engine using the (q, v) contract.
 
@@ -67,14 +80,31 @@ def _apply_initial_state(engine: object, state_dict: dict[str, Any]) -> None:
     client sends ``{"q": [...], "v": [...]}``; this helper converts and
     dispatches correctly.
 
+    Preconditions:
+        - state_dict must be a dict
+        - state_dict.get("q"), if present, must be a list/tuple of numbers
+        - state_dict.get("v"), if present, must be a list/tuple of numbers
+
     Args:
         engine: The active physics engine instance.
         state_dict: Dict with optional 'q' and 'v' lists.
     """
     if not hasattr(engine, "set_state"):
         return
-    q = np.array(state_dict.get("q", []), dtype=float)
-    v = np.array(state_dict.get("v", []), dtype=float)
+    q_raw = state_dict.get("q", [])
+    v_raw = state_dict.get("v", [])
+    if not _is_numeric_sequence(q_raw):
+        logger.warning(
+            "initial_state.q must be a list of numbers; ignoring initial state"
+        )
+        return
+    if not _is_numeric_sequence(v_raw):
+        logger.warning(
+            "initial_state.v must be a list of numbers; ignoring initial state"
+        )
+        return
+    q = np.array(q_raw, dtype=float)
+    v = np.array(v_raw, dtype=float)
     engine.set_state(q, v)
 
 
@@ -244,6 +274,11 @@ async def _handle_client_commands(
                 stats.speed_factor = speed_factor
     except TimeoutError:
         pass  # No message, continue simulation
+    except json.JSONDecodeError:
+        logger.warning("Received invalid JSON from WebSocket client; ignoring message")
+        await websocket.send_json(
+            {"error": "invalid_json", "message": "Message must be valid JSON"}
+        )
     return "continue"
 
 

--- a/tests/unit/api/test_simulation_ws.py
+++ b/tests/unit/api/test_simulation_ws.py
@@ -31,6 +31,7 @@ from src.api.routes.simulation_ws import (
     _engine_type_from_str,
     _get_simulation_speed_factor,
     _handle_client_commands,
+    _is_numeric_sequence,
     _wait_for_resume_or_stop,
 )
 from src.shared.python.engine_core.engine_registry import EngineType
@@ -457,3 +458,154 @@ async def test_simulation_stream_rejects_malformed_initial_state(
     assert websocket.closed is True
     assert websocket.sent == [{"error": "Invalid simulation config"}]
     load_engine.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. _is_numeric_sequence — pure unit tests (issue #5918)
+# ---------------------------------------------------------------------------
+
+
+class TestIsNumericSequence:
+    """_is_numeric_sequence guards np.array() against non-numeric inputs."""
+
+    def test_valid_float_list(self) -> None:
+        """A list of floats must be accepted."""
+        assert _is_numeric_sequence([1.0, 2.5, 3.14]) is True
+
+    def test_valid_int_list(self) -> None:
+        """A list of ints must be accepted."""
+        assert _is_numeric_sequence([0, 1, 2]) is True
+
+    def test_empty_list_is_valid(self) -> None:
+        """An empty list is a valid (zero-length) numeric sequence."""
+        assert _is_numeric_sequence([]) is True
+
+    def test_string_is_rejected(self) -> None:
+        """A bare string must be rejected."""
+        assert _is_numeric_sequence("not-a-list") is False
+
+    def test_none_is_rejected(self) -> None:
+        """None must be rejected (would produce NaN array)."""
+        assert _is_numeric_sequence(None) is False
+
+    def test_list_with_string_element_is_rejected(self) -> None:
+        """A list containing a non-numeric element must be rejected."""
+        assert _is_numeric_sequence([1.0, "bad"]) is False
+
+    def test_bool_elements_are_rejected(self) -> None:
+        """Lists of booleans must be rejected (bool is a subclass of int)."""
+        assert _is_numeric_sequence([True, False]) is False
+
+    def test_tuple_of_numbers_is_valid(self) -> None:
+        """A tuple of numbers is also accepted."""
+        assert _is_numeric_sequence((1.0, 2.0)) is True
+
+    def test_nested_list_is_rejected(self) -> None:
+        """A nested list must be rejected."""
+        assert _is_numeric_sequence([[1.0], [2.0]]) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. _apply_initial_state validation — issue #5918
+# ---------------------------------------------------------------------------
+
+
+class TestApplyInitialStateValidation:
+    """_apply_initial_state must guard set_state() against non-numeric q/v."""
+
+    def _make_engine(self) -> MagicMock:
+        engine = MagicMock()
+        engine.set_state.return_value = None
+        return engine
+
+    def test_string_q_is_ignored_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-numeric q must produce a warning and skip set_state."""
+        engine = self._make_engine()
+        with caplog.at_level("WARNING"):
+            _apply_initial_state(engine, {"q": "bad-state", "v": []})
+        engine.set_state.assert_not_called()
+        assert any("initial_state.q" in r.message for r in caplog.records)
+
+    def test_none_q_is_ignored_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """None q must produce a warning and skip set_state."""
+        engine = self._make_engine()
+        with caplog.at_level("WARNING"):
+            _apply_initial_state(engine, {"q": None, "v": []})
+        engine.set_state.assert_not_called()
+        assert any("initial_state.q" in r.message for r in caplog.records)
+
+    def test_string_v_is_ignored_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-numeric v must produce a warning and skip set_state."""
+        engine = self._make_engine()
+        with caplog.at_level("WARNING"):
+            _apply_initial_state(engine, {"q": [1.0], "v": "bad-v"})
+        engine.set_state.assert_not_called()
+        assert any("initial_state.v" in r.message for r in caplog.records)
+
+    def test_valid_q_and_v_calls_set_state(self) -> None:
+        """Valid numeric q and v must still invoke set_state."""
+        engine = self._make_engine()
+        _apply_initial_state(engine, {"q": [0.1, 0.2], "v": [0.3, 0.4]})
+        engine.set_state.assert_called_once()
+
+    def test_missing_q_and_v_defaults_to_empty_arrays(self) -> None:
+        """Missing q/v keys must default to empty arrays (existing contract)."""
+        engine = self._make_engine()
+        _apply_initial_state(engine, {})
+        engine.set_state.assert_called_once()
+        args = engine.set_state.call_args.args
+        assert len(args[0]) == 0
+        assert len(args[1]) == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. _handle_client_commands JSON parse error isolation — issue #5918
+# ---------------------------------------------------------------------------
+
+
+class TestHandleClientCommandsJsonError:
+    """_handle_client_commands must handle invalid JSON from the client."""
+
+    @pytest.mark.anyio
+    async def test_invalid_json_sends_error_and_continues(self) -> None:
+        """A json.JSONDecodeError must trigger an error response, not a crash."""
+        websocket: Any = _WebSocket(speed_factor=1.0)
+
+        async def mock_receive_json() -> dict[str, Any]:
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+        sent_messages: list[dict[str, Any]] = []
+
+        async def mock_send_json(data: dict[str, Any]) -> None:
+            sent_messages.append(data)
+
+        websocket.receive_json = mock_receive_json
+        websocket.send_json = mock_send_json
+
+        config: dict[str, Any] = {}
+        result = await _handle_client_commands(websocket, config)
+
+        assert result == "continue"
+        assert sent_messages == [
+            {"error": "invalid_json", "message": "Message must be valid JSON"}
+        ]
+
+    @pytest.mark.anyio
+    async def test_timeout_still_returns_continue(self) -> None:
+        """TimeoutError (no message yet) must still return 'continue' cleanly."""
+        websocket: Any = _WebSocket(speed_factor=1.0)
+
+        async def mock_receive_json() -> dict[str, Any]:
+            raise TimeoutError
+
+        websocket.receive_json = mock_receive_json
+
+        config: dict[str, Any] = {}
+        result = await _handle_client_commands(websocket, config)
+        assert result == "continue"


### PR DESCRIPTION
## Summary

- Add `_is_numeric_sequence()` guard that rejects strings, `None`, booleans, and mixed-type inputs before passing to `np.array()` — prevents silent NaN arrays and unexpected `ValueError`s in `_apply_initial_state()`
- Update `_apply_initial_state()` with upfront validation of `q` and `v`, logging a warning and returning early on invalid input instead of crashing
- Catch `json.JSONDecodeError` in `_handle_client_commands()` and respond with `{"error": "invalid_json", "message": "Message must be valid JSON"}` instead of propagating an unhandled exception

## Test plan

- [x] 16 new unit tests added covering `TestIsNumericSequence`, `TestApplyInitialStateValidation`, and `TestHandleClientCommandsJsonError`
- [x] All 41 tests in `tests/unit/api/test_simulation_ws.py` pass
- [x] `ruff check` — zero violations
- [x] `ruff format --check` — zero diffs
- [x] File size: `simulation_ws.py` 480 lines, `test_simulation_ws.py` 611 lines (both within 1200-line limit)

Partially addresses #5918

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_