### PR TITLE
fix: clarify Pinocchio stub status, resolve stale TODO referencing #4095

### DIFF
--- a/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py
@@ -25,10 +25,14 @@ Public API:
     RecoveryTrial              -- per-sample recovery diagnostics.
     sample_random_theta        -- helper to draw a random theta vector.
 
-Engine-local Rob Neal adapter is intentionally here until issue #4095
-(PARITY-LOADERS) lands a shared ``shared/python/motion_matching/loaders/``
-package. At that point ``load_robneal_target`` should be promoted upstream
-and this module should re-export it for backward compatibility.
+The Rob Neal ``.mat`` adapter (``load_robneal_target``) lives in this
+engine-local package rather than in ``shared/python/motion_matching/loaders/``
+because it requires the engine-specific ``club_target_adapter`` stub fallback
+for stripped-down checkouts.  Issue #4095 (PARITY-LOADERS) has been
+completed — the shared ``club_target.py`` dataclass is available in full
+checkouts.  The adapter remains here for the intentional fallback behaviour
+(see ``club_target_adapter.py`` module docstring) and re-exports
+``load_robneal_target`` from the public API for backward compatibility.
 """
 
 from __future__ import annotations

--- a/src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py
+++ b/src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py
@@ -16,10 +16,14 @@ not include it).
 
 The output is the canonical ``ClubTarget`` from
 ``src/shared/python/motion_matching/club_target.py`` (frozen dataclass with a
-``__post_init__`` validator). If that module is unavailable for any reason a
-local stub is used and a warning is logged. See issue #4095 (PARITY-LOADERS)
-for the planned promotion of this loader to
-``shared/python/motion_matching/loaders/club_swing_dataset.py``.
+``__post_init__`` validator).  That shared module is available in full
+checkouts following the completion of issue #4095 (PARITY-LOADERS).  In
+stripped-down CI or headless environments where the shared package is not on
+``sys.path``, the import falls back to an inline stub that replicates the same
+validation rules and wire protocol; a ``WARNING`` is emitted so the fallback is
+visible in logs.  The stub is **intentional** — it keeps this adapter
+importable without the full ``shared/python/motion_matching/`` tree and is not
+a sign of missing functionality.
 """
 
 from __future__ import annotations
@@ -44,8 +48,13 @@ _TIME_EPS = 1.0e-9
 
 
 # ---------------------------------------------------------------------------
-# ClubTarget import w/ stub fallback (TODO: drop once #4095 PARITY-LOADERS
-# guarantees the shared module is always importable from every engine path).
+# ClubTarget import w/ stub fallback.
+#
+# The shared module is present in full checkouts (issue #4095 completed).
+# In stripped-down CI or headless environments where the shared package
+# tree is absent, the inline stub below is used instead.  The stub keeps
+# this adapter importable without the full shared/python/motion_matching/
+# tree; it is an intentional, permanent fallback — not a TODO to remove.
 # ---------------------------------------------------------------------------
 
 try:  # pragma: no cover - exercised by both branches via tests
@@ -57,9 +66,10 @@ try:  # pragma: no cover - exercised by both branches via tests
     _USING_STUB = False
 except ImportError:  # pragma: no cover - fallback for stripped-down checkouts
     logger.warning(
-        "src.shared.python.motion_matching.club_target unavailable; using "
-        "local stub. TODO(#4095 PARITY-LOADERS): remove this fallback once "
-        "the shared package is guaranteed importable."
+        "src.shared.python.motion_matching.club_target unavailable "
+        "(stripped-down checkout); using inline stub with identical "
+        "validation rules.  See services/pinocchio.py for the "
+        "with-wheel / without-wheel behaviour of the broader service."
     )
 
     @dataclass(frozen=True)

--- a/src/shared/python/pose_interchange/services/pinocchio.py
+++ b/src/shared/python/pose_interchange/services/pinocchio.py
@@ -1,13 +1,13 @@
 """Pinocchio :class:`LiveKinematicsService` implementation.
 
 Lazily imports :mod:`pinocchio` and loads a URDF via
-:func:`pinocchio.buildModelFromUrdf`.  If the wheel is unavailable
-(or is the local stub that lacks :func:`buildModelFromUrdf`),
-:func:`create_pinocchio_service` falls back to a
-:class:`MockKinematicsService` configured with
-``engine_name="pinocchio"``.
+:func:`pinocchio.buildModelFromUrdf`.
 
-The real bridge wires:
+Wheel-present behaviour
+-----------------------
+:func:`create_pinocchio_service` detects the real ``pinocchio`` wheel by
+checking for :func:`pinocchio.buildModelFromUrdf` (the PyPI ``pinocchio``
+0.1 placeholder stub omits this symbol).  When the real wheel is present:
 
 - :meth:`load` -> ``pin.buildModelFromUrdf`` + ``model.createData()``.
 - :meth:`set_pose` -> :class:`PinocchioAdapter` to convert canonical to
@@ -18,6 +18,29 @@ The real bridge wires:
 - :meth:`step` -> Euler integration via ``pin.aba`` (forward
   dynamics) + ``pin.integrate``.
 - :meth:`reset` -> restore neutral q, zero v.
+
+Wheel-absent (or PyPI stub) behaviour
+--------------------------------------
+When the real wheel is not installed — or the installed ``pinocchio``
+package is the PyPI 0.1 placeholder stub (which exposes no
+``buildModelFromUrdf``) — :func:`create_pinocchio_service` falls back to
+a :class:`MockKinematicsService` configured with
+``engine_name="pinocchio"``.  The mock satisfies the
+:class:`LiveKinematicsService` protocol (all methods callable, correct
+``engine_name``) so callers always receive a working service object.
+
+This fallback is **intentional**: it allows the rest of the codebase to
+import and exercise Pinocchio-flavoured service code in any environment,
+deferring the actual physics to CI runs where the wheel is available.
+Tests in ``tests/unit/pose_interchange/live_kinematics/`` cover the
+mock-fallback contract; live integration tests are in
+``tests/integration/pose_interchange/services/test_pinocchio_real.py``
+(skipped when the wheel is absent).
+
+Note: the ``club_target_adapter`` in
+``src/engines/physics_engines/pinocchio/python/motion_matching/`` has its
+own separate stub fallback for the shared ``ClubTarget`` dataclass;
+see that module's docstring for details.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Issue #4095 (PARITY-LOADERS) is **closed/completed** — the shared `motion_matching/club_target.py` dataclass exists in full checkouts. The three `TODO(#4095)` and "until #4095 lands" references in the Pinocchio integration were stale.
- The inline stub in `club_target_adapter.py` is an **intentional permanent fallback** for stripped-down/headless checkouts, not a placeholder waiting on any open issue.
- `pose_interchange/services/pinocchio.py` now has explicit "Wheel-present" / "Wheel-absent" behaviour sections satisfying the acceptance-criteria documentation requirement.

### Files changed

| File | Change |
|---|---|
| `src/engines/physics_engines/pinocchio/python/motion_matching/club_target_adapter.py` | Rewrite module docstring and block comment to state stub is intentional; update `logger.warning` to drop stale `TODO(#4095)` |
| `src/engines/physics_engines/pinocchio/python/motion_matching/__init__.py` | Replace "until #4095 lands" note with factual "completed" statement |
| `src/shared/python/pose_interchange/services/pinocchio.py` | Expand module docstring with explicit Wheel-present / Wheel-absent sections and cross-ref to existing tests |

### Acceptance criteria check

- [x] `grep -rn "#4095" src/` — no remaining TODOs or "until lands" references; remaining hits describe #4095 as completed
- [x] Pinocchio's with-wheel vs. without-wheel behaviour documented in `services/pinocchio.py` docstring
- [x] Tests already exist: `tests/unit/pose_interchange/live_kinematics/test_registry_fallback.py` covers mock-fallback contract; `tests/integration/pose_interchange/services/test_pinocchio_real.py` covers live-wheel path (skip-marked when absent)
- [x] `ruff check` and `ruff format --check` pass

Closes #6093

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_