### PR TITLE
perf(series): replace per-call factorial loop with precomputed lookup table

### DIFF
--- a/src/shared/python/signal_toolkit/series.py
+++ b/src/shared/python/signal_toolkit/series.py
@@ -14,11 +14,19 @@ Following pragmatic programming and Design by Contract principles.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+
+# Precomputed factorial lookup table for orders 0..170 (math.factorial(171) overflows
+# float64, but SeriesExpansion.max_terms defaults to 50 and is capped there).
+_MAX_FACTORIAL_ORDER = 170
+_FACTORIAL_TABLE: list[int] = [
+    math.factorial(i) for i in range(_MAX_FACTORIAL_ORDER + 1)
+]
 
 
 @dataclass
@@ -434,15 +442,21 @@ class SeriesExpansion:
 
     @staticmethod
     def _factorial(n: int) -> int:
-        """Compute factorial of n."""
+        """Return n! using a precomputed lookup table for speed.
+
+        Args:
+            n: Non-negative integer.
+
+        Raises:
+            ValueError: If *n* is negative or exceeds the table size.
+        """
         if n < 0:
             raise ValueError(f"Factorial undefined for negative numbers: {n}")
-        if n <= 1:
-            return 1
-        result = 1
-        for i in range(2, n + 1):
-            result *= i
-        return result
+        if n > _MAX_FACTORIAL_ORDER:
+            raise ValueError(
+                f"n={n} exceeds precomputed factorial table size ({_MAX_FACTORIAL_ORDER})"
+            )
+        return _FACTORIAL_TABLE[n]
 
     @staticmethod
     def _binomial(n: int, k: int) -> int:


### PR DESCRIPTION
## Summary

- Replaced the `O(n)` per-call `_factorial` loop in `SeriesExpansion` with a module-level precomputed lookup table (`_FACTORIAL_TABLE`, orders 0–170), making each factorial call `O(1)`.
- The table is built once at import time using `math.factorial`; the existing `_factorial` method now does a single list index.
- Orders above 170 raise `ValueError` (float64 overflow boundary; `max_terms` defaults to 50 so this is never reached in normal use).
- `fitting.py` already uses `np.asarray` throughout — no changes needed there.

Partially addresses #5912

## Test plan

- [x] `ruff check src/shared/python/signal_toolkit/series.py` — passes
- [x] `ruff format --check src/shared/python/signal_toolkit/series.py` — passes
- [x] `python3 -m pytest tests/unit/signal_toolkit/ -q --timeout=60` — all pre-existing failures are unrelated to this change (FitResult.solver_status, limits bounds, noise amplitude); no new failures introduced

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_