### PR TITLE
perf: vectorize np.array list comprehensions and use np.asarray in SignalImporter

### DIFF
--- a/src/shared/python/signal_toolkit/io.py
+++ b/src/shared/python/signal_toolkit/io.py
@@ -108,14 +108,14 @@ class SignalImporter:
             except ValueError:
                 continue  # Skip rows with non-numeric data
 
-        time_array = np.array(time_data)
+        time_array = np.asarray(time_data, dtype=float)
 
         # Create signals
         signals = []
         for idx, name in zip(value_indices, value_names, strict=False):
             sig = Signal(
                 time=time_array.copy(),
-                values=np.array(value_data[idx]),
+                values=np.asarray(value_data[idx], dtype=float),
                 name=name,
                 metadata={"source_file": str(file_path), "column": name},
             )
@@ -199,8 +199,8 @@ class SignalImporter:
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
 
-        time = np.array(data[time_key])
-        values = np.array(data[value_key])
+        time = np.asarray(data[time_key], dtype=float)
+        values = np.asarray(data[value_key], dtype=float)
 
         name = data.get("name", file_path.stem)
         units = data.get("units", "")
@@ -228,8 +228,8 @@ class SignalImporter:
             Signal object.
         """
         assert data is not None, "data must be provided"
-        time = np.array(data[time_key])
-        values = np.array(data[value_key])
+        time = np.asarray(data[time_key], dtype=float)
+        values = np.asarray(data[value_key], dtype=float)
 
         return Signal(
             time=time,

--- a/src/shared/python/signal_toolkit/polynomial_generator.py
+++ b/src/shared/python/signal_toolkit/polynomial_generator.py
@@ -513,8 +513,9 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         if len(points) < 2:
             return list(points)
 
-        xs = np.array([p[0] for p in points])
-        ys = np.array([p[1] for p in points])
+        pts = np.asarray(points)
+        xs = pts[:, 0]
+        ys = pts[:, 1]
 
         # Sort by x so interpolation is well-defined
         order = np.argsort(xs)


### PR DESCRIPTION
## Summary

- **polynomial_generator.py**: Replace `np.array([p[0] for p in points])` / `np.array([p[1] for p in points])` with `np.asarray(points)` + column slicing (`pts[:, 0]` / `pts[:, 1]`). Eliminates two full Python-level list iterations and two intermediate list allocations per call.
- **signal_toolkit/io.py**: Replace `np.array()` with `np.asarray(dtype=float)` in `SignalImporter.from_csv`, `from_json`, and `from_dict`. `np.asarray` avoids an unnecessary copy when the input is already an ndarray-backed buffer, and the explicit `dtype=float` documents intent.
- **ws_pubsub.py**: No change needed — the class-level `_http_client` reuse was already implemented (lines 286-289).

## Test plan

- [ ] `ruff check` passes (zero violations)
- [ ] `ruff format --check` passes (zero diffs)
- [ ] `python3 -m pytest tests/unit/signal_toolkit/ tests/unit/realtime/ -q --timeout=60` — 126+ pass, only pre-existing failures in `test_limits.py` / `test_signal_toolkit.py::TestFunctionFitting` / `test_signal_toolkit.py::TestCalculus::test_integral_of_constant` (confirmed pre-existing on `main` before this branch)

Partially addresses #5912

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_