### PR TITLE
fix(deps): add upper major-version bounds to engine optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ dependencies = [
 rust = ["upstream-physics>=0.1.0", "upstream-mocap-preproc>=0.1.0", "upstream-mocap-io>=0.1.0"]
 mocap-preproc = ["upstream-mocap-preproc>=0.1.0"]
 mocap-io = ["upstream-mocap-io>=0.1.0"]
-drake = ["drake>=1.22.0"]
-pinocchio = ["pin>=2.6.0", "meshcat>=0.3.0"]
+drake = ["drake>=1.22.0,<2.0.0"]
+pinocchio = ["pin>=2.6.0,<3.0.0", "meshcat>=0.3.0"]
 chrono = ["pychrono>=8.0"]
 
 all-engines = ["upstream-drift[drake,pinocchio]"]
@@ -69,8 +69,8 @@ analysis = ["opencv-python>=4.8.0", "scikit-learn>=1.3.0"]
 pose = ["mediapipe>=0.10.33", "opencv-python>=4.8.0", "imageio[ffmpeg]>=2.31.0"]
 
 # Biomechanics engines
-biomechanics = ["myosuite>=2.0.0", "opensim>=4.4.0", "gymnasium>=0.29.0"]
-experimental = ["myosuite>=2.0.0", "opensim>=4.4.0", "gymnasium>=0.29.0"]
+biomechanics = ["myosuite>=2.0.0", "opensim>=4.4.0,<5.0.0", "gymnasium>=0.29.0"]
+experimental = ["myosuite>=2.0.0", "opensim>=4.4.0,<5.0.0", "gymnasium>=0.29.0"]
 
 # Reinforcement learning (for MyoSuite muscle training)
 rl = ["stable-baselines3>=2.0.0", "gymnasium>=0.29.0"]

--- a/tests/test_opensim_fk_regression.py
+++ b/tests/test_opensim_fk_regression.py
@@ -146,6 +146,7 @@ def loaded_model_and_state():
 
     Module-scoped to amortise the SWIG load across all extractor tests.
     """
+    pytest.importorskip("opensim", reason="OpenSim Python bindings not installed")
     import opensim as osim
 
     assert MODEL_PATH.is_file(), (


### PR DESCRIPTION
## Summary

- Add `<2.0.0` upper bound to `drake` optional extra (`drake>=1.22.0,<2.0.0`)
- Add `<3.0.0` upper bound to `pin` (pinocchio) optional extra (`pin>=2.6.0,<3.0.0`)
- Add `<5.0.0` upper bound to `opensim` in `biomechanics` and `experimental` extras (`opensim>=4.4.0,<5.0.0`)
- `mujoco` already had `<4.0.0`; left unchanged
- Add `pytest.importorskip("opensim")` to the `loaded_model_and_state` fixture in `tests/test_opensim_fk_regression.py` so it skips gracefully instead of crashing when OpenSim bindings are absent

Without upper bounds, a breaking major release from any of these upstreams would silently break `[all-engines]` and `[biomechanics]` installs. All bounds are at the major version boundary only to avoid over-constraining patch/minor upgrades.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — valid TOML confirmed
- [x] `python3 -m pytest tests/test_opensim_fk_regression.py tests/test_opensim_fk.py --collect-only` — 22 tests collected cleanly
- [ ] CI ruff/lint passes (no Python source changes, only pyproject.toml and test guard)

Partially addresses #5914

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_