### PR TITLE
fix(#5917): add fit_succeeded/solver_status to FitResult; document channel regex

### DIFF
--- a/src/shared/python/realtime/protocol.py
+++ b/src/shared/python/realtime/protocol.py
@@ -23,13 +23,33 @@ _CHANNEL_RE = re.compile(r"^[a-z][a-z0-9_]*(/[a-z0-9_]+)+$")
 def validate_channel(name: str) -> None:
     """Validate a channel name against the ``scope/topic`` pattern.
 
+    Channel names must follow the ``scope/topic`` convention:
+
+    - Composed of at least two segments separated by ``/``.
+    - The first segment must begin with a **lowercase ASCII letter**
+      (``a``–``z``) and may continue with lowercase letters, digits
+      (``0``–``9``), or underscores (``_``).
+    - Every subsequent segment may contain lowercase letters, digits, or
+      underscores, but **must not** be empty.
+    - Uppercase letters, hyphens, dots, leading/trailing slashes, and
+      consecutive slashes are all forbidden.
+
+    Formally the name must match ``^[a-z][a-z0-9_]*(/[a-z0-9_]+)+$``.
+
+    Examples of valid names: ``"pose/canonical"``,
+    ``"engine/mujoco/state"``, ``"session/marker_42"``.
+
+    Examples of invalid names: ``"Pose/canonical"`` (uppercase),
+    ``"pose"`` (no slash), ``"/leading"`` (leading slash),
+    ``"pose/Topic"`` (uppercase segment), ``"pose/bad-name"`` (hyphen).
+
     Args:
         name: Channel name to validate.
 
     Raises:
         TypeError: If ``name`` is not a string.
-        ValueError: If ``name`` does not match
-            ``^[a-z][a-z0-9_]*(/[a-z0-9_]+)+$``.
+        ValueError: If ``name`` does not match the channel naming rule
+            described above.
     """
     if not isinstance(name, str):
         raise TypeError(f"channel name must be a string, got {type(name).__name__}")

--- a/src/shared/python/signal_toolkit/fitting.py
+++ b/src/shared/python/signal_toolkit/fitting.py
@@ -28,13 +28,26 @@ class FitResult:
 
     Attributes:
         parameters: Dictionary of fitted parameter names and values.
-        covariance: Covariance matrix of the fit (if available).
+        covariance: Covariance matrix of the fit (if available).  A ``None``
+            value is ambiguous on its own: use ``fit_succeeded`` (or
+            ``solver_status``) to distinguish "fit failed" from "covariance
+            not computed".
         r_squared: Coefficient of determination (R^2).
         rmse: Root mean square error.
         fitted_signal: Signal with fitted values.
         residuals: Residuals (original - fitted).
         success: Whether the fit converged successfully.
         message: Fit status message.
+        fit_succeeded: Explicit boolean indicator — ``True`` when the
+            optimiser converged, ``False`` when it failed or diverged.
+            Derived from ``success`` in ``__post_init__`` if not set
+            explicitly.
+        solver_status: Canonical status string (``"success"`` or
+            ``"failure"``).  Mirrors the vocabulary used by
+            ``CanonicalFitResult`` and ``BuildResult`` across the platform
+            so that downstream consumers can apply uniform filtering.
+            Derived from ``success`` in ``__post_init__`` if not set
+            explicitly.
     """
 
     parameters: dict[str, float]
@@ -45,6 +58,21 @@ class FitResult:
     residuals: np.ndarray
     success: bool = True
     message: str = ""
+    fit_succeeded: bool = True
+    solver_status: str = "success"
+
+    def __post_init__(self) -> None:
+        """Derive ``fit_succeeded`` and ``solver_status`` from ``success``.
+
+        If the caller did not explicitly override ``fit_succeeded`` or
+        ``solver_status`` but did pass ``success=False``, this method
+        propagates the failure state so all three fields remain consistent.
+        """
+        if not self.success:
+            if self.fit_succeeded:
+                self.fit_succeeded = False
+            if self.solver_status == "success":
+                self.solver_status = "failure"
 
     def get_function_string(self) -> str:
         """Get a string representation of the fitted function."""


### PR DESCRIPTION
## Summary

- **`FitResult` success discriminator** (`src/shared/python/signal_toolkit/fitting.py`): adds `fit_succeeded: bool` and `solver_status: str` fields to `FitResult`. A `__post_init__` hook derives both from the existing `success: bool` field, so callers can now unambiguously distinguish "fit failed" from "covariance not computed" without inspecting `covariance is None`. The new fields follow the same `"success"` / `"failure"` vocabulary as `CanonicalFitResult` and `BuildResult` elsewhere in the platform. Existing `success` field is unchanged.

- **`validate_channel()` docstring** (`src/shared/python/realtime/protocol.py`): expands the docstring with a plain-English description of the `scope/topic` naming rule, concrete valid/invalid examples, and a formal regex reference. Previously the rule was only implicit in the regex literal.

## Test plan

- [ ] `ruff check` passes on both changed files
- [ ] `ruff format --check` passes on both changed files
- [ ] `tests/unit/signal_toolkit/test_signal_toolkit.py::TestFunctionFitting` — all 5 tests pass (previously failing with `AttributeError: 'FitResult' object has no attribute 'solver_status'`)
- [ ] `tests/unit/realtime/test_protocol.py` — all 7 tests pass (no behaviour change, docstring only)

Partially addresses #5917

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_