### PR TITLE
docs(docker): record container strategy as ADR-0021, add docker/README.md

### DIFF
--- a/Dockerfile.modular
+++ b/Dockerfile.modular
@@ -1,3 +1,4 @@
+# EXPERIMENTAL — not in the CI build path. See docker/README.md and ADR-0021.
 # Modular UpstreamDrift Dockerfile.
 #
 # Selects features either by named profile or by explicit comma-separated

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,47 @@
+# Docker — Quick Reference
+
+This directory contains Docker-related configuration used by the build system.
+For the full rationale behind the three-Dockerfile policy, see
+[ADR-0021](../docs/adr/0021-container-strategy.md).
+
+## Dockerfile Roles
+
+| Filename | Purpose | Used by CI | When to edit |
+|---|---|---|---|
+| `Dockerfile` (repo root) | **Canonical production build.** Multi-stage (builder / runtime / training). FastAPI on port 8001. Python 3.12-slim with pinned digest. | `docker-smoke.yml`, `docker-size-gates.yml`, `docker-security-scan.yml` | Production dependency changes, server config, security hardening |
+| `Dockerfile.heavy_test` (repo root) | **Test environment** mirroring the `d-sorg-fleet-4core` custom runner. Bookworm base with X11/Xvfb, SDL2, and all physics/robotics engines (best-effort). | `heavy-tests-opt-in.yml` (runner, not this image) | When the runner's apt packages or test-suite requirements change |
+| `Dockerfile.modular` (repo root) | **Experimental / modular-build validation.** Selects features via `--build-arg PROFILE=<name>` or `--build-arg FEATURES=<list>`. Phase 2 validation vehicle — explicitly non-canonical. | None | Local exploration of modular profiles only; see constraints in ADR-0021 |
+
+## Docker Compose Variants
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | Standard local development stack |
+| `docker-compose.gpu.yml` | GPU-enabled override (mounts NVIDIA device) |
+| `docker-compose.profiles.yml` | Per-profile services driven by `docker/profiles.yaml` |
+
+## Modular Profiles
+
+Feature profiles and their size budgets are defined in `docker/profiles.yaml`.
+The resolver lives in `scripts/docker/install_features.py`.
+
+## Quick-start
+
+```bash
+# Production image (canonical)
+docker build -t upstream-drift:latest .
+
+# Heavy-test image (local runner parity)
+docker build -f Dockerfile.heavy_test -t upstream-drift:heavy-test .
+
+# Modular image with a named profile (experimental)
+docker build --build-arg PROFILE=research -f Dockerfile.modular -t upstream-drift:research .
+
+# Modular image with an explicit feature list (experimental)
+docker build --build-arg FEATURES=mujoco,drake,pose-mediapipe -f Dockerfile.modular -t upstream-drift:custom .
+```
+
+> **Note:** Only `Dockerfile` is monitored by CI security scans and size gates.
+> Changes to `Dockerfile.modular` may silently diverge from production.
+> See [ADR-0021](../docs/adr/0021-container-strategy.md) before promoting
+> `Dockerfile.modular` to production use.

--- a/docs/adr/0021-container-strategy.md
+++ b/docs/adr/0021-container-strategy.md
@@ -1,0 +1,76 @@
+# ADR-0021: Container Strategy — Three-Dockerfile Policy
+
+Status: Accepted
+Date: 2026-05-25
+
+## Context
+
+The repository contains three Dockerfiles, each serving a distinct purpose, but
+their roles were not formally documented, creating ambiguity about which file CI
+targets and which files developers should edit for particular use-cases.
+
+**`Dockerfile`** — multi-stage build (builder → runtime → training). Uses a
+pinned `python:3.12-slim` digest for reproducible production images. Runs the
+FastAPI server on port 8001. Contains a full dependency stack (Pinocchio, MuJoCo
+headless, PyTorch/CUDA training stage). This is the file targeted by
+`docker-smoke.yml`, `docker-size-gates.yml`, and `docker-security-scan.yml`.
+
+**`Dockerfile.heavy_test`** — single-stage `python:3.11-bookworm` image
+designed to mirror the `d-sorg-fleet-4core` custom GitHub Actions runner. Installs
+X11/Xvfb, SDL2, and the full physics/robotics engine stack (Pinocchio, MuJoCo,
+Drake, OpenSim, MyoSuite — best-effort). Default CMD runs the heavy integration
+test suite under `xvfb-run`. Built and used locally via
+`wsl bash run_local_heavy_tests.sh`; kept in sync with
+`.github/workflows/heavy-tests-opt-in.yml`.
+
+**`Dockerfile.modular`** — experimental two-stage build that selects features
+via named `--build-arg PROFILE=<name>` or `--build-arg FEATURES=<list>`
+arguments. Feature resolution is delegated to
+`scripts/docker/install_features.py` and
+`src/shared/python/feature_registry/features.py`. Described in
+`docs/plans/DOCKER_MODULAR_BUILDS_EPIC.md` as the "Phase 2 validation vehicle"
+and is explicitly non-canonical during Phase 2. Not wired into any CI workflow.
+
+The three options considered were:
+
+1. **Consolidate** — merge all functionality into a single Dockerfile using
+   multi-stage targets and build-args.
+2. **Promote** `Dockerfile.modular` — retire the legacy `Dockerfile` and make
+   the modular one canonical.
+3. **Keep all three with explicit documented roles** — formalise the status quo
+   with clear per-file policy.
+
+## Decision
+
+We adopt **Option 3**: keep all three Dockerfiles with explicit, documented roles.
+
+| File | Role | CI scope | When to edit |
+|---|---|---|---|
+| `Dockerfile` | Canonical production build | docker-smoke, docker-size-gates, docker-security-scan | Production dependency changes, server config, hardening |
+| `Dockerfile.heavy_test` | Test environment mirroring fleet runner | heavy-tests-opt-in (uses runner directly) | When runner apt packages or test-suite requirements change |
+| `Dockerfile.modular` | Experimental / modular-build validation | None | Local exploration of modular profiles only — see constraints below |
+
+Rationale:
+
+- Consolidation (Option 1) would couple three very different concerns into one
+  complex Dockerfile with many `--target` arguments, increasing cognitive load
+  and the risk of production regressions from test-env changes.
+- Promoting `Dockerfile.modular` (Option 2) is premature while Phase 2
+  validation is still in progress. The feature registry is not yet stable enough
+  to be the sole production build path.
+- Option 3 preserves CI stability while keeping each file focused and readable.
+
+## Consequences
+
+- **`Dockerfile` is the authoritative file for production changes.** Security
+  patches, dependency upgrades, and server configuration changes go here first.
+- **`Dockerfile.heavy_test` must stay in sync with the fleet runner.** Changes
+  to the runner's apt packages or Python tool versions should be reflected here.
+- **`Dockerfile.modular` is frozen from CI scope.** It may drift from production
+  without alerting CI. Developers using it for local experiments should not
+  assume it reflects the current production dependency set.
+- **Any future modularization effort that promotes `Dockerfile.modular` to
+  production must file a new ADR** (superseding this one) rather than silently
+  modifying the file or wiring it into CI without governance review.
+- Operators should consult `docker/README.md` for a quick-reference table before
+  choosing which Dockerfile to build.


### PR DESCRIPTION
## Summary

- Implements **Option 3** from issue #6097: keep all three Dockerfiles with explicit documented roles rather than consolidating or promoting `Dockerfile.modular`.
- Creates `docs/adr/0021-container-strategy.md` with full context, decision rationale, and consequences table.
- Creates `docker/README.md` with a quick-reference table (filename / purpose / CI scope / when to edit) and quick-start build commands.
- Adds `# EXPERIMENTAL — not in the CI build path. See docker/README.md and ADR-0021.` banner to the top of `Dockerfile.modular`.

## Test plan

- [ ] No Python files changed — ruff check/format not applicable to these changes.
- [ ] Verify `docs/adr/0021-container-strategy.md` renders correctly on GitHub.
- [ ] Verify `docker/README.md` table displays correctly.
- [ ] Confirm `Dockerfile.modular` comment is the first line of the file.

Closes #6097

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_