### PR TITLE
fix(ws): validate speed_factor finiteness and timestep/duration bounds

### DIFF
--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -45,6 +45,63 @@ def _clamp_speed_factor(raw: object) -> float:
     return value
 
 
+_MAX_WS_DURATION = 3600.0  # 1 hour hard cap for WebSocket sessions
+_MAX_WS_TIMESTEP = 1.0  # 1 second upper bound
+_MIN_WS_TIMESTEP = 1e-6  # 1 microsecond lower bound
+
+
+def _validate_ws_numeric_fields(config_input: dict[str, Any]) -> str | None:
+    """Validate speed_factor finiteness and timestep/duration bounds for WS start.
+
+    Performs WebSocket-specific checks that must reject bad values with an error
+    frame rather than silently clamping, complementing the Pydantic layer.
+
+    Args:
+        config_input: The raw config dict from the ``start`` message.
+
+    Returns:
+        An error message string if validation fails, or ``None`` if valid.
+
+    Postcondition:
+        Returns ``None`` only when all present numeric fields are finite and
+        within their respective WS limits.
+    """
+    if "speed_factor" in config_input:
+        raw_sf = config_input["speed_factor"]
+        try:
+            sf_value = float(raw_sf)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return "speed_factor must be a finite number"
+        if not math.isfinite(sf_value):
+            return "speed_factor must be a finite number"
+
+    if "duration" in config_input:
+        raw_dur = config_input["duration"]
+        try:
+            dur_value = float(raw_dur)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return "duration must be a positive finite number"
+        if not math.isfinite(dur_value) or dur_value <= 0:
+            return "duration must be a positive finite number"
+        if dur_value >= _MAX_WS_DURATION:
+            return f"duration must be less than {_MAX_WS_DURATION}s"
+
+    if "timestep" in config_input:
+        raw_ts = config_input["timestep"]
+        try:
+            ts_value = float(raw_ts)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return "timestep must be a positive finite number"
+        if not math.isfinite(ts_value) or ts_value <= 0:
+            return "timestep must be a positive finite number"
+        if ts_value >= _MAX_WS_TIMESTEP:
+            return f"timestep must be less than {_MAX_WS_TIMESTEP}s"
+        if ts_value < _MIN_WS_TIMESTEP:
+            return f"timestep must be at least {_MIN_WS_TIMESTEP}s"
+
+    return None
+
+
 def _engine_type_from_str(name: str) -> EngineType:
     """Resolve an engine type string to EngineType, accepting any case.
 
@@ -403,8 +460,16 @@ async def simulation_stream(
             await websocket.send_json({"error": "Expected 'start' action"})
             return
 
+        raw_config = start_msg.get("config", {}) or {}
+        ws_error = _validate_ws_numeric_fields(
+            raw_config if isinstance(raw_config, dict) else {}
+        )
+        if ws_error is not None:
+            await websocket.send_json({"error": ws_error})
+            return
+
         try:
-            config = _validate_start_config(engine_type, start_msg.get("config", {}))
+            config = _validate_start_config(engine_type, raw_config)
         except (ValidationError, ValueError):
             await websocket.send_json({"error": "Invalid simulation config"})
             return

--- a/tests/unit/api/test_simulation_ws.py
+++ b/tests/unit/api/test_simulation_ws.py
@@ -430,7 +430,8 @@ async def test_simulation_stream_rejects_invalid_duration(
 
     assert websocket.accepted is True
     assert websocket.closed is True
-    assert websocket.sent == [{"error": "Invalid simulation config"}]
+    # The WS numeric-field guard fires before Pydantic and emits a specific message.
+    assert websocket.sent == [{"error": "duration must be a positive finite number"}]
     load_engine.assert_not_called()
 
 
@@ -456,4 +457,206 @@ async def test_simulation_stream_rejects_malformed_initial_state(
     assert websocket.accepted is True
     assert websocket.closed is True
     assert websocket.sent == [{"error": "Invalid simulation config"}]
+    load_engine.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _validate_ws_numeric_fields — unit tests for issue #5918
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWsNumericFields:
+    """_validate_ws_numeric_fields must reject non-finite and out-of-bounds values."""
+
+    def _call(self, config: dict[str, Any]) -> str | None:
+        return simulation_ws_module._validate_ws_numeric_fields(config)
+
+    # speed_factor checks
+    def test_nan_speed_factor_rejected(self) -> None:
+        assert self._call({"speed_factor": float("nan")}) is not None
+
+    def test_inf_speed_factor_rejected(self) -> None:
+        assert self._call({"speed_factor": float("inf")}) is not None
+
+    def test_neg_inf_speed_factor_rejected(self) -> None:
+        assert self._call({"speed_factor": float("-inf")}) is not None
+
+    def test_string_nan_speed_factor_rejected(self) -> None:
+        assert self._call({"speed_factor": "NaN"}) is not None
+
+    def test_valid_speed_factor_accepted(self) -> None:
+        assert self._call({"speed_factor": 2.0}) is None
+
+    # duration checks
+    def test_nan_duration_rejected(self) -> None:
+        assert self._call({"duration": float("nan")}) is not None
+
+    def test_inf_duration_rejected(self) -> None:
+        assert self._call({"duration": float("inf")}) is not None
+
+    def test_zero_duration_rejected(self) -> None:
+        assert self._call({"duration": 0.0}) is not None
+
+    def test_negative_duration_rejected(self) -> None:
+        assert self._call({"duration": -1.0}) is not None
+
+    def test_duration_at_cap_rejected(self) -> None:
+        """duration >= 3600s must be rejected."""
+        assert self._call({"duration": 3600.0}) is not None
+
+    def test_duration_just_below_cap_accepted(self) -> None:
+        assert self._call({"duration": 3599.9}) is None
+
+    def test_valid_duration_accepted(self) -> None:
+        assert self._call({"duration": 10.0}) is None
+
+    # timestep checks
+    def test_nan_timestep_rejected(self) -> None:
+        assert self._call({"timestep": float("nan")}) is not None
+
+    def test_inf_timestep_rejected(self) -> None:
+        assert self._call({"timestep": float("inf")}) is not None
+
+    def test_zero_timestep_rejected(self) -> None:
+        assert self._call({"timestep": 0.0}) is not None
+
+    def test_negative_timestep_rejected(self) -> None:
+        assert self._call({"timestep": -0.001}) is not None
+
+    def test_timestep_at_max_rejected(self) -> None:
+        """timestep >= 1.0s must be rejected."""
+        assert self._call({"timestep": 1.0}) is not None
+
+    def test_timestep_too_small_rejected(self) -> None:
+        """timestep < 1e-6 must be rejected."""
+        assert self._call({"timestep": 1e-7}) is not None
+
+    def test_valid_timestep_accepted(self) -> None:
+        assert self._call({"timestep": 0.002}) is None
+
+    def test_empty_config_accepted(self) -> None:
+        """No numeric fields supplied should not raise."""
+        assert self._call({}) is None
+
+
+# ---------------------------------------------------------------------------
+# WS handler integration: non-finite speed_factor/timestep/duration error frames
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_nan_speed_factor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-finite speed_factor must send an error frame and not load an engine."""
+    websocket = _RouteWebSocket(
+        [{"action": "start", "config": {"speed_factor": float("nan")}}]
+    )
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
+    load_engine.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_inf_speed_factor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Infinite speed_factor must send an error frame and not load an engine."""
+    websocket = _RouteWebSocket(
+        [{"action": "start", "config": {"speed_factor": float("inf")}}]
+    )
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
+    load_engine.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_duration_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """duration >= 3600s must send a specific error frame and not load an engine."""
+    websocket = _RouteWebSocket([{"action": "start", "config": {"duration": 3600.0}}])
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
+    load_engine.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_timestep_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """timestep >= 1.0s must send a specific error frame and not load an engine."""
+    websocket = _RouteWebSocket(
+        [{"action": "start", "config": {"duration": 1.0, "timestep": 1.5}}]
+    )
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
+    load_engine.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_timestep_too_small(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """timestep < 1e-6s must send a specific error frame and not load an engine."""
+    websocket = _RouteWebSocket(
+        [{"action": "start", "config": {"duration": 1.0, "timestep": 1e-9}}]
+    )
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
     load_engine.assert_not_called()


### PR DESCRIPTION
## Summary

- Add `_validate_ws_numeric_fields()` helper that runs **before** `_validate_start_config` / Pydantic in the WS `start` handler
- Non-finite `speed_factor` (NaN, ±inf) now sends a WS error frame and returns early instead of silently clamping to the default
- `duration` is checked: must be a positive finite number and `< 3600s`
- `timestep` is checked: must be a positive finite number in `[1e-6, 1.0)` seconds
- Updated the existing `test_simulation_stream_rejects_invalid_duration` assertion to match the new more-specific error message
- Added 25 new tests: `TestValidateWsNumericFields` (unit) + 5 integration-style async tests covering all rejection paths

Does **not** touch `_apply_initial_state()` q/v validation or `json.JSONDecodeError` isolation (those are covered by PR #6195 on branch `fix/issue-6071`).

Partially addresses #5918.

## Test plan

- [x] `ruff check src/api/routes/simulation_ws.py` — zero violations
- [x] `ruff format --check src/api/routes/simulation_ws.py` — no diffs
- [x] `ruff check tests/unit/api/test_simulation_ws.py` — zero violations
- [x] `ruff format --check tests/unit/api/test_simulation_ws.py` — no diffs
- [x] `pytest tests/unit/api/test_simulation_ws.py` — 50 passed

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_