### PR TITLE
fix(security): refuse to start in production with default credentials

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -118,8 +118,14 @@ async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
         # env_validator checks GOLF_API_SECRET_KEY, DATABASE_URL, and the
         # production checklist; it raises on critical failures so misconfigured
         # deployments fail fast instead of silently using insecure defaults.
-        from src.shared.python.security.env_validator import validate_environment
+        # _assert_production_secrets() is a hard gate: it raises RuntimeError if
+        # production mode is active with .env.example placeholder credentials.
+        from src.shared.python.security.env_validator import (
+            _assert_production_secrets,
+            validate_environment,
+        )
 
+        _assert_production_secrets()
         validate_environment(raise_on_error=get_environment() == "production")
 
         # Initialize database (Issue #544)

--- a/src/shared/python/security/env_validator.py
+++ b/src/shared/python/security/env_validator.py
@@ -12,8 +12,10 @@ Usage:
     # Or validate specific components
     validate_api_security()
     validate_database_config()
+    _assert_production_secrets()  # hard-fail on .env.example placeholder values
 """
 
+import os
 import secrets
 from typing import TypedDict
 
@@ -103,6 +105,63 @@ def validate_secret_key_strength(key: str, min_length: int = 64) -> None:
                 f"Secret key contains weak pattern: '{pattern}'. "
                 f"Consider generating a stronger key."
             )
+
+
+# Exact placeholder strings shipped in .env.example — never acceptable in production.
+_DEFAULT_SECRET_KEY = "generate_a_random_string_here"
+_DEFAULT_ADMIN_PASSWORD = "change_me_in_production"
+
+
+def _assert_production_secrets() -> None:
+    """Raise RuntimeError if production mode is active with default credentials.
+
+    Checks whether the server is about to start in production with the exact
+    placeholder values that ship in .env.example.  These values are publicly
+    known and must never reach a production deployment.
+
+    This function is a hard gate: it calls ``logger.critical()`` and then
+    raises ``RuntimeError`` so the process aborts before accepting any traffic.
+
+    Preconditions:
+        - Called only after the environment variables have been loaded.
+
+    Postconditions:
+        - If not in production, returns without side-effects.
+        - If in production with safe credentials, returns without side-effects.
+        - If in production with default credentials, logs a CRITICAL message
+          and raises ``RuntimeError``.
+
+    Raises:
+        RuntimeError: When ``ENVIRONMENT`` indicates production and either
+            ``GOLF_API_SECRET_KEY`` or ``GOLF_ADMIN_PASSWORD`` still holds its
+            .env.example placeholder value.
+    """
+    if get_environment() != "production":
+        return
+
+    secret_key = os.getenv("GOLF_API_SECRET_KEY", "")
+    if secret_key == _DEFAULT_SECRET_KEY:
+        logger.critical(
+            "Production mode requires non-default GOLF_API_SECRET_KEY. "
+            "The current value matches the .env.example placeholder. "
+            "See .env.example for setup instructions."
+        )
+        raise RuntimeError(
+            "Production mode requires non-default GOLF_API_SECRET_KEY. "
+            "See .env.example for setup instructions."
+        )
+
+    admin_password = os.getenv("GOLF_ADMIN_PASSWORD", "")
+    if admin_password == _DEFAULT_ADMIN_PASSWORD:
+        logger.critical(
+            "Production mode requires non-default GOLF_ADMIN_PASSWORD. "
+            "The current value matches the .env.example placeholder. "
+            "See .env.example for setup instructions."
+        )
+        raise RuntimeError(
+            "Production mode requires non-default GOLF_ADMIN_PASSWORD. "
+            "See .env.example for setup instructions."
+        )
 
 
 def validate_api_security() -> APIKeyValidationResults:
@@ -299,6 +358,11 @@ def validate_environment(
         EnvironmentValidationError: If critical issues found and raise_on_error=True
     """
     logger.info("Validating environment configuration...")
+
+    # Hard-fail immediately if production credentials are still at default values.
+    # This runs before any other check so a misconfigured deployment is caught
+    # before the application starts accepting traffic.
+    _assert_production_secrets()
 
     results: EnvironmentValidationResults = {
         "environment": get_environment(),

--- a/tests/unit/api/test_production_safety.py
+++ b/tests/unit/api/test_production_safety.py
@@ -1,0 +1,275 @@
+"""Unit tests for production-credential safety check (issue #5920).
+
+Verifies that ``_assert_production_secrets`` hard-fails when the server would
+start in production mode with the exact placeholder values from .env.example.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROD_ENV = {"ENVIRONMENT": "production"}
+_DEV_ENV = {"ENVIRONMENT": "development"}
+
+_DEFAULT_SECRET_KEY = "generate_a_random_string_here"
+_DEFAULT_ADMIN_PASSWORD = "change_me_in_production"
+_SAFE_SECRET_KEY = "a-sufficiently-long-and-random-production-secret-key-xyz-12345"
+_SAFE_ADMIN_PASSWORD = "S3cur3P@ssw0rd!XYZ"
+
+
+def _call(env: dict[str, str]) -> None:
+    """Import and call _assert_production_secrets with a clean env patch."""
+    # Clear the functools.cache on get_environment so env patches take effect.
+    from src.shared.python.config import environment as env_mod
+
+    env_mod.get_environment.cache_clear()
+    try:
+        from src.shared.python.security import env_validator
+
+        importlib.reload(env_validator)
+        with patch.dict(os.environ, env, clear=True):
+            env_mod.get_environment.cache_clear()
+            env_validator._assert_production_secrets()
+    finally:
+        env_mod.get_environment.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests: production mode with default credentials — must raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssertProductionSecretsRaises:
+    """_assert_production_secrets must RuntimeError in production with defaults."""
+
+    def test_raises_with_default_secret_key_in_production(self) -> None:
+        """RuntimeError when GOLF_API_SECRET_KEY is the .env.example placeholder."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _SAFE_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            with pytest.raises(RuntimeError, match="GOLF_API_SECRET_KEY"):
+                _assert_production_secrets()
+
+    def test_raises_with_default_admin_password_in_production(self) -> None:
+        """RuntimeError when GOLF_ADMIN_PASSWORD is the .env.example placeholder."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _SAFE_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _DEFAULT_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            with pytest.raises(RuntimeError, match="GOLF_ADMIN_PASSWORD"):
+                _assert_production_secrets()
+
+    def test_error_message_references_env_example(self) -> None:
+        """Error message should mention .env.example so ops can find docs."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _SAFE_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            with pytest.raises(RuntimeError, match=".env.example"):
+                _assert_production_secrets()
+
+
+# ---------------------------------------------------------------------------
+# Tests: development mode — must NOT raise even with default credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssertProductionSecretsDevMode:
+    """_assert_production_secrets must be a no-op outside of production."""
+
+    def test_no_raise_in_development_with_default_secret_key(self) -> None:
+        """Development mode: default GOLF_API_SECRET_KEY does not raise."""
+        env = {
+            **_DEV_ENV,
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _DEFAULT_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise
+
+    def test_no_raise_in_development_with_default_admin_password(self) -> None:
+        """Development mode: default GOLF_ADMIN_PASSWORD does not raise."""
+        env = {
+            **_DEV_ENV,
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _DEFAULT_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise
+
+    def test_no_raise_when_environment_unset(self) -> None:
+        """Unset ENVIRONMENT defaults to development — must not raise."""
+        env = {
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _DEFAULT_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests: production mode with proper credentials — must NOT raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssertProductionSecretsPassesWithSafeCredentials:
+    """_assert_production_secrets must pass silently in production with real creds."""
+
+    def test_no_raise_in_production_with_safe_credentials(self) -> None:
+        """Production mode with proper credentials: no exception raised."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _SAFE_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _SAFE_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise
+
+    def test_no_raise_in_production_with_no_admin_password_set(self) -> None:
+        """Production mode: unset GOLF_ADMIN_PASSWORD does not trigger default check."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _SAFE_SECRET_KEY,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise (password not set != default)
+
+    def test_no_raise_in_production_with_no_secret_key_set(self) -> None:
+        """Production mode: unset GOLF_API_SECRET_KEY does not trigger default check.
+
+        The default-credential guard only fires when the key is *exactly* the
+        placeholder string; an absent key is handled separately by other validators.
+        """
+        env = {
+            **_PROD_ENV,
+            "GOLF_ADMIN_PASSWORD": _SAFE_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            from src.shared.python.security.env_validator import (
+                _assert_production_secrets,
+            )
+
+            _assert_production_secrets()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests: logger.critical is called before RuntimeError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssertProductionSecretsLogging:
+    """Verify logger.critical() is called before RuntimeError is raised."""
+
+    def test_critical_logged_for_default_secret_key(self) -> None:
+        """logger.critical() must be called when secret key is the default."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _DEFAULT_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _SAFE_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            import src.shared.python.security.env_validator as ev_module
+
+            with patch.object(ev_module.logger, "critical") as mock_critical:
+                with pytest.raises(RuntimeError):
+                    ev_module._assert_production_secrets()
+                mock_critical.assert_called_once()
+
+    def test_critical_logged_for_default_admin_password(self) -> None:
+        """logger.critical() must be called when admin password is the default."""
+        env = {
+            **_PROD_ENV,
+            "GOLF_API_SECRET_KEY": _SAFE_SECRET_KEY,
+            "GOLF_ADMIN_PASSWORD": _DEFAULT_ADMIN_PASSWORD,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from src.shared.python.config.environment import get_environment
+
+            get_environment.cache_clear()
+            import src.shared.python.security.env_validator as ev_module
+
+            with patch.object(ev_module.logger, "critical") as mock_critical:
+                with pytest.raises(RuntimeError):
+                    ev_module._assert_production_secrets()
+                mock_critical.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `_assert_production_secrets()` to `src/shared/python/security/env_validator.py` that hard-fails when `ENVIRONMENT=production` and either `GOLF_API_SECRET_KEY` or `GOLF_ADMIN_PASSWORD` matches the exact `.env.example` placeholder value (`generate_a_random_string_here` / `change_me_in_production`)
- Calls `logger.critical()` before raising `RuntimeError` so the failure is visible in log aggregators
- Call `_assert_production_secrets()` explicitly in `src/api/server.py` lifespan startup (before `validate_environment`) so the guard runs as early as possible
- Add 11 unit tests in `tests/unit/api/test_production_safety.py`

## Test plan

- [ ] `_assert_production_secrets()` raises `RuntimeError` with default `GOLF_API_SECRET_KEY` in production mode
- [ ] `_assert_production_secrets()` raises `RuntimeError` with default `GOLF_ADMIN_PASSWORD` in production mode
- [ ] Error message references `.env.example` for operator guidance
- [ ] `_assert_production_secrets()` is a no-op in development mode even with default values
- [ ] `_assert_production_secrets()` is a no-op in production mode with proper non-default credentials
- [ ] `logger.critical()` is called before `RuntimeError` is raised (verified by mock assertion)
- [ ] All 11 tests pass: `python3 -m pytest tests/unit/api/test_production_safety.py -x --timeout=30`
- [ ] `ruff check` and `ruff format --check` pass on changed files

Partially addresses #5920

https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R

---
_Generated by [Claude Code](https://claude.ai/code/session_012QCeYsqi8H7HZF6NPSSq7R)_