### PR TITLE
Fixes #6087

### DIFF
--- a/src/shared/python/body_part_viz/__init__.py
+++ b/src/shared/python/body_part_viz/__init__.py
@@ -1,11 +1,12 @@
-"""Body-part visualisation contracts and dataclasses.
+"""Body-part visualisation contracts, dataclasses, and implementations.
 
-This package defines the abstract surface (Protocols + frozen dataclasses)
-that every shape, fitter, and renderer implementation talks across.
+This package owns the canonical body-part visualisation stack:
 
-Implementations of shapes, fitters, and rendering backends live in the
-``shapes``, ``fitters``, and ``renderers`` sub-packages and are added in
-follow-up issues of EPIC #4755.
+- ``contracts`` — runtime-checkable Protocols (``BodyPartShape``,
+  ``ShapeFitter``, ``ShapeRenderer``).
+- ``shapes`` — primitive shapes (capsule, ellipsoid, cylinder, mesh).
+- ``fitters`` — fitting strategies (Kabsch, Procrustes, cluster).
+- ``renderers`` — rendering backends (Matplotlib, PyQtGL).
 """
 
 from __future__ import annotations

--- a/src/shared/python/plot_style/__init__.py
+++ b/src/shared/python/plot_style/__init__.py
@@ -1,13 +1,16 @@
-"""Plot-style contracts and dataclasses.
+"""Plot-style contracts, dataclasses, and renderer implementations.
 
-This package defines the abstract surface (Protocols + frozen
-dataclasses) used by every marker / trace styling implementation in
-UpstreamDrift.
+This package owns the canonical marker-styling stack:
 
-Concrete implementations of color resolvers, renderers, Qt widgets, and
-marker-shape primitives live in the ``resolvers``, ``renderers``,
-``widgets``, and ``shapes`` sub-packages and are added in follow-up
-issues of EPIC #4796.
+- ``contracts`` — runtime-checkable Protocols (``ColorResolver``,
+  ``MarkerRenderer``, ``MarkerShapeRenderer``).
+- ``colors`` / ``colormaps`` — color scales and registries.
+- ``markers`` — ``MarkerStyle``, ``MarkerShape``, ``CustomMeshSpec``.
+- ``renderers`` — ``MatplotlibMarkerRenderer`` (canonical), ``PyQtGLMarkerRenderer``.
+- ``resolvers`` — static / palette / data-driven color resolvers.
+- ``widgets`` — optional Qt widgets (imported only if PyQt6 is available).
+
+See ADR-0011 for the design.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Updates plot_style and body_part_viz __init__.py docstrings to claim completeness for shipped sub-packages. The Epics #4796 and #4755 have been addressed in their respective implementations, and any specific pending items can be tracked directly if needed, but these modules are now complete enough to remove the 'added in follow-up issues' language.

Fixes #6087

---
*PR created automatically by Jules for task [13403268341923625187](https://jules.google.com/task/13403268341923625187) started by @dieterolson*