### PR TITLE
Fix regex for log redaction to stop at common delimiters

### DIFF
--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -83,7 +83,12 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|access_token|auth_token|bearer"
         r"|private_key"
         r")"
-        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+        r"(['\"]?[\s]*[=:]\s*)"
+        r"("
+        r"['\"][^'\"]*['\"]"
+        r"|"
+        r"[^\s,{}&\])]+"
+        r")"
     ),
 ]
 
@@ -116,7 +121,7 @@ class SensitiveDataFilter(logging.Filter):
 def _redact_sensitive(text: str) -> str:
     """Replace sensitive values in *text* with a redaction placeholder."""
     for pattern in _SENSITIVE_PATTERNS:
-        text = pattern.sub(r"\1=***REDACTED***", text)
+        text = pattern.sub(r"\1\2***REDACTED***", text)
     return text
 
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -124,6 +124,24 @@ class TestSensitiveDataFilter:
         # args should be cleared after formatting
         assert record.args is None
 
+    def test_redacts_compact_json(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password":123,"user":"bob"}')
+        flt.filter(record)
+        assert record.msg == '{"password":***REDACTED***,"user":"bob"}'
+
+    def test_redacts_with_delimiters(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("password=123&user=bob")
+        flt.filter(record)
+        assert record.msg == "password=***REDACTED***&user=bob"
+
+    def test_redacts_braces(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("password:123 }")
+        flt.filter(record)
+        assert record.msg == "password:***REDACTED*** }"
+
     def test_case_insensitive_password(self) -> None:
         flt = SensitiveDataFilter()
         record = self._make_record("Password=MySuperSecret")


### PR DESCRIPTION
Fixes #6115

Stops the sensitive data redaction regex from aggressively consuming unrelated fields by adding explicit bounds for common delimiters like commas, braces, and ampersands.

---
*PR created automatically by Jules for task [9055272130809258672](https://jules.google.com/task/9055272130809258672) started by @dieterolson*