### PR TITLE
Fix GitHub Issue #6065: test(docs): wire ADR numbering governance checks

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/check_doc_size_budget.py"
       - "scripts/config/doc_size_budget.json"
       - ".github/workflows/docs-governance.yml"
+      - "tests/scripts/test_doc_governance_checks.py"
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - "scripts/check_doc_size_budget.py"
       - "scripts/config/doc_size_budget.json"
       - ".github/workflows/docs-governance.yml"
+      - "tests/scripts/test_doc_governance_checks.py"
 
 jobs:
   # -- Dispatcher: route to self-hosted if available --------------------------
@@ -52,3 +54,6 @@ jobs:
 
       - name: Validate documentation size budget
         run: python3 scripts/check_doc_size_budget.py
+
+      - name: Test documentation governance checks
+        run: python3 -m pytest tests/scripts/test_doc_governance_checks.py -q

--- a/tests/scripts/test_doc_governance_checks.py
+++ b/tests/scripts/test_doc_governance_checks.py
@@ -182,7 +182,7 @@ def test_docs_governance_rejects_duplicate_source_of_truth_headings(
 
 
 def test_docs_governance_rejects_duplicate_adr_numbers(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, capsys
 ) -> None:
     _write(tmp_path / "docs" / "README.md", "# Docs\n")
     _write(tmp_path / "docs" / "assessments" / "README.md", "# Assessments\n")
@@ -209,6 +209,10 @@ def test_docs_governance_rejects_duplicate_adr_numbers(
     monkeypatch.setattr(check_docs_governance, "_git_changed_files", list)
 
     assert check_docs_governance.main() == 1
+
+    captured = capsys.readouterr()
+    assert "Duplicate ADR numbering detected" in captured.err
+    assert "duplicate ADR number 0005: 0005-first.md, 0005-second.md" in captured.err
 
 
 def test_docs_governance_rejects_missing_examples_entries(


### PR DESCRIPTION
This PR wires the existing docs governance test file into the Docs Governance workflow and strengthens the duplicate ADR-numbering test to assert the emitted conflict details.

Fixes #6065

---
*PR created automatically by Jules for task [3201067064938030622](https://jules.google.com/task/3201067064938030622) started by @dieterolson*