### PR TITLE
fix: properly redact secrets containing commas or json encoding

### DIFF
--- a/patch_logging.py
+++ b/patch_logging.py
@@ -1,0 +1,63 @@
+import re
+
+with open("src/shared/python/logging_pkg/logging_config.py", "r") as f:
+    content = f.read()
+
+old_pattern = r'''_SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"(?i)"
+        r"("
+        r"password|passwd|pwd"
+        r"|api_key|apikey|api[-_]?secret"
+        r"|secret_key|secret[-_]?token"
+        r"|access_token|auth_token|bearer"
+        r"|private_key"
+        r")"
+        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+    ),
+]'''
+
+new_pattern = r'''_SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"(?i)"
+        r"(['\"]?)"
+        r"("
+        r"password|passwd|pwd"
+        r"|api_key|apikey|api[-_]?secret"
+        r"|secret_key|secret[-_]?token"
+        r"|access_token|auth_token|bearer"
+        r"|private_key"
+        r")"
+        r"\1"
+        r"([\s]*[=:]\s*)"
+        r"(?:"
+        r"(['\"])(.*?)\4"
+        r"|"
+        r"([^\s'\",]+)"
+        r")"
+    ),
+]'''
+
+content = content.replace(old_pattern, new_pattern)
+
+old_redact = r'''def _redact_sensitive(text: str) -> str:
+    """Replace sensitive values in *text* with a redaction placeholder."""
+    for pattern in _SENSITIVE_PATTERNS:
+        text = pattern.sub(r"\1=***REDACTED***", text)
+    return text'''
+
+new_redact = r'''def _redact_sensitive(text: str) -> str:
+    """Replace sensitive values in *text* with a redaction placeholder."""
+    for pattern in _SENSITIVE_PATTERNS:
+
+        def repl(m: re.Match[str]) -> str:
+            quote = m.group(4) if m.group(4) else ""
+            return f"{m.group(1)}{m.group(2)}{m.group(1)}{m.group(3)}{quote}***REDACTED***{quote}"
+
+        text = pattern.sub(repl, text)
+    return text'''
+
+content = content.replace(old_redact, new_redact)
+
+with open("src/shared/python/logging_pkg/logging_config.py", "w") as f:
+    f.write(content)

--- a/patch_test.py
+++ b/patch_test.py
@@ -1,0 +1,67 @@
+import re
+
+with open("tests/unit/test_logging_config.py", "r") as f:
+    content = f.read()
+
+old_test = r'''    def test_handles_percent_formatting(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("connecting to %s", ("db.example.com",))
+        flt.filter(record)
+        assert "db.example.com" in record.msg
+        # args should be cleared after formatting
+        assert record.args is None'''
+
+new_test = r'''    def test_handles_percent_formatting(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("connecting to %s", ("db.example.com",))
+        flt.filter(record)
+        assert "db.example.com" in record.msg
+        # args should be cleared after formatting
+        assert record.args is None
+
+    def test_json_quoted_keys(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "secret123"}')
+        flt.filter(record)
+        assert "secret123" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+    def test_json_quoted_keys_multiple(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"api_key": "abc123xyz", "other": "value"}')
+        flt.filter(record)
+        assert "abc123xyz" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"api_key": "***REDACTED***", "other": "value"}'
+
+    def test_comma_suffix(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('api_key=abc123xyz, other=value')
+        flt.filter(record)
+        assert "abc123xyz" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == 'api_key=***REDACTED***, other=value'
+
+    def test_space_in_secret(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "my secret password"}')
+        flt.filter(record)
+        assert "my secret password" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+    def test_comma_in_secret(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "my,secret,password"}')
+        flt.filter(record)
+        assert "my,secret,password" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+'''
+
+content = content.replace(old_test, new_test)
+
+with open("tests/unit/test_logging_config.py", "w") as f:
+    f.write(content)

--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -76,6 +76,7 @@ DEFAULT_BACKUP_COUNT = 5
 _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(
         r"(?i)"
+        r"(['\"]?)"
         r"("
         r"password|passwd|pwd"
         r"|api_key|apikey|api[-_]?secret"
@@ -83,7 +84,13 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|access_token|auth_token|bearer"
         r"|private_key"
         r")"
-        r"[\s]*[=:]\s*['\"]?([^\s'\"]{1,})['\"]?"
+        r"\1"
+        r"([\s]*[=:]\s*)"
+        r"(?:"
+        r"(['\"])(.*?)\4"
+        r"|"
+        r"([^\s'\",]+)"
+        r")"
     ),
 ]
 
@@ -115,8 +122,13 @@ class SensitiveDataFilter(logging.Filter):
 
 def _redact_sensitive(text: str) -> str:
     """Replace sensitive values in *text* with a redaction placeholder."""
+
+    def repl(m: re.Match[str]) -> str:
+        quote = m.group(4) or ""
+        return f"{m.group(1)}{m.group(2)}{m.group(1)}{m.group(3)}{quote}***REDACTED***{quote}"
+
     for pattern in _SENSITIVE_PATTERNS:
-        text = pattern.sub(r"\1=***REDACTED***", text)
+        text = pattern.sub(repl, text)
     return text
 
 

--- a/test_regex7.py
+++ b/test_regex7.py
@@ -1,0 +1,54 @@
+import re
+
+pattern = re.compile(
+    r"(?i)"
+    r"(['\"]?)"
+    r"("
+    r"password|passwd|pwd"
+    r"|api_key|apikey|api[-_]?secret"
+    r"|secret_key|secret[-_]?token"
+    r"|access_token|auth_token|bearer"
+    r"|private_key"
+    r")"
+    r"\1"
+    r"([\s]*[=:]\s*)"
+    r"("
+    r"(['\"])(.*?)\5"
+    r"|"
+    r"([^\s'\",]+)"
+    r")"
+)
+
+text1 = '{"password": "secret123"}'
+text2 = '{"api_key": "abc123xyz", "other": "value"}'
+text3 = 'api_key=abc123xyz, other=value'
+text4 = 'api_key="abc123xyz"'
+text5 = "api_key='abc123xyz'"
+text6 = "password=secret123"
+text7 = "password = secret123"
+text8 = '{"password": "my secret password"}'
+text9 = '{"password": "my,secret,password"}'
+text10 = 'password="my secret password"'
+
+def repl(m):
+    # m.group(1): quote around key
+    # m.group(2): key
+    # m.group(3): separator
+    # m.group(4): entire matched value
+    # m.group(5): quote around value (if quoted)
+    # m.group(6): value string (if quoted)
+    # m.group(7): value string (if unquoted)
+
+    quote = m.group(5) if m.group(5) else ''
+    return f"{m.group(1)}{m.group(2)}{m.group(1)}{m.group(3)}{quote}***REDACTED***{quote}"
+
+print(pattern.sub(repl, text1))
+print(pattern.sub(repl, text2))
+print(pattern.sub(repl, text3))
+print(pattern.sub(repl, text4))
+print(pattern.sub(repl, text5))
+print(pattern.sub(repl, text6))
+print(pattern.sub(repl, text7))
+print(pattern.sub(repl, text8))
+print(pattern.sub(repl, text9))
+print(pattern.sub(repl, text10))

--- a/test_regex8.py
+++ b/test_regex8.py
@@ -1,0 +1,53 @@
+import re
+
+pattern = re.compile(
+    r"(?i)"
+    r"(['\"]?)"
+    r"("
+    r"password|passwd|pwd"
+    r"|api_key|apikey|api[-_]?secret"
+    r"|secret_key|secret[-_]?token"
+    r"|access_token|auth_token|bearer"
+    r"|private_key"
+    r")"
+    r"\1"
+    r"([\s]*[=:]\s*)"
+    r"(?:"
+    r"(['\"])(.*?)\4"
+    r"|"
+    r"([^\s'\",]+)"
+    r")"
+)
+
+text1 = '{"password": "secret123"}'
+text2 = '{"api_key": "abc123xyz", "other": "value"}'
+text3 = 'api_key=abc123xyz, other=value'
+text4 = 'api_key="abc123xyz"'
+text5 = "api_key='abc123xyz'"
+text6 = "password=secret123"
+text7 = "password = secret123"
+text8 = '{"password": "my secret password"}'
+text9 = '{"password": "my,secret,password"}'
+text10 = 'password="my secret password"'
+
+def repl(m):
+    # m.group(1): quote around key
+    # m.group(2): key
+    # m.group(3): separator
+    # m.group(4): quote around value (if quoted)
+    # m.group(5): value string (if quoted)
+    # m.group(6): value string (if unquoted)
+
+    quote = m.group(4) if m.group(4) else ''
+    return f"{m.group(1)}{m.group(2)}{m.group(1)}{m.group(3)}{quote}***REDACTED***{quote}"
+
+print(pattern.sub(repl, text1))
+print(pattern.sub(repl, text2))
+print(pattern.sub(repl, text3))
+print(pattern.sub(repl, text4))
+print(pattern.sub(repl, text5))
+print(pattern.sub(repl, text6))
+print(pattern.sub(repl, text7))
+print(pattern.sub(repl, text8))
+print(pattern.sub(repl, text9))
+print(pattern.sub(repl, text10))

--- a/test_regression.py
+++ b/test_regression.py
@@ -1,0 +1,5 @@
+from src.shared.python.logging_pkg.logging_config import _redact_sensitive
+
+print(_redact_sensitive('{"password": "my secret password"}'))
+print(_redact_sensitive('{"password": "my,secret,password"}'))
+print(_redact_sensitive('password="my secret password"'))

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -124,6 +124,46 @@ class TestSensitiveDataFilter:
         # args should be cleared after formatting
         assert record.args is None
 
+    def test_space_in_secret(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "my secret password"}')
+        flt.filter(record)
+        assert "my secret password" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+    def test_comma_in_secret(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "my,secret,password"}')
+        flt.filter(record)
+        assert "my,secret,password" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+    def test_json_quoted_keys(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"password": "secret123"}')
+        flt.filter(record)
+        assert "secret123" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"password": "***REDACTED***"}'
+
+    def test_json_quoted_keys_multiple(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record('{"api_key": "abc123xyz", "other": "value"}')
+        flt.filter(record)
+        assert "abc123xyz" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == '{"api_key": "***REDACTED***", "other": "value"}'
+
+    def test_comma_suffix(self) -> None:
+        flt = SensitiveDataFilter()
+        record = self._make_record("api_key=abc123xyz, other=value")
+        flt.filter(record)
+        assert "abc123xyz" not in record.msg
+        assert "REDACTED" in record.msg
+        assert record.msg == "api_key=***REDACTED***, other=value"
+
     def test_case_insensitive_password(self) -> None:
         flt = SensitiveDataFilter()
         record = self._make_record("Password=MySuperSecret")


### PR DESCRIPTION
Updates the regex in SensitiveDataFilter to properly match quoted boundaries so it won't leak secrets via suffix characters like commas and won't fail to match when the JSON-like keys have quotes around them. Fixes #6059

Fixes #6121

---
*PR created automatically by Jules for task [15561470831662673680](https://jules.google.com/task/15561470831662673680) started by @dieterolson*