### PR TITLE
⚡ Bolt: optimize constraint residual norm calculation in Drake cost wrapper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -86,3 +86,6 @@
 ## 2026-05-23 - trimesh ImportErrors
 **Learning:** Hard-coded imports of `trimesh` in files like `_mesh_decimation.py` and `_mesh_io.py` can cause tests or other modules that import them to fail if `trimesh` isn't installed.
 **Action:** Always wrap `import trimesh` with a `try...except ImportError` block and conditionally check if `trimesh is None` to safely handle environments where it is missing, or alternatively, make sure to add it to the test environment requirements.
+## 2026-05-18 - Optimize array operations in Drake constraint evaluation
+**Learning:** Drake's `AutoDiffXd` type lacks a `.conjugate()` method, so `np.vdot(arr, arr)` cannot be used directly for sum of squares reduction over arrays containing auto-diff variables. However, using element-wise multiplication `arr * arr` avoids the power evaluation overhead and intermediate memory allocations associated with `np.asarray(arr) ** 2`.
+**Action:** Replace `np.sum(np.asarray(arr) ** 2)` with `np.sum(np.asarray(arr) * np.asarray(arr))` (or `arr * arr` if safe) when computing squared residuals in Drake constraint optimization to improve performance during AutoDiff gradient evaluations while maintaining safety.

--- a/src/engines/physics_engines/drake/python/motion_matching/compute_cost_drake.py
+++ b/src/engines/physics_engines/drake/python/motion_matching/compute_cost_drake.py
@@ -82,12 +82,17 @@ def compute_cost_drake(
 
     j, breakdown = _shared_compute_cost(theta, target, _shared_sim_fn, cost_opts)
     if constraint_residuals:
-        penalty = float(sum(np.sum(np.asarray(r) ** 2) for r in constraint_residuals))
+        # ⚡ Bolt: np.asarray(r) ** 2 replaced by element-wise mult since it
+        # avoids evaluating the power function and creating a temporary matrix
+        penalty = float(
+            sum(np.sum(np.asarray(r) * np.asarray(r)) for r in constraint_residuals)
+        )
         j = j + penalty
         breakdown = CostBreakdown(
             position=breakdown.position,
             orientation=breakdown.orientation,
             impact_anchor=breakdown.impact_anchor,
+            body_marker=breakdown.body_marker,
             regularizer=breakdown.regularizer + penalty,
             total=j,
         )


### PR DESCRIPTION
💡 What: Replaced `np.sum(np.asarray(r) ** 2)` with `np.sum(np.asarray(r) * np.asarray(r))` and fixed the missing `body_marker` initialization in the `CostBreakdown` return.
🎯 Why: `np.asarray(r) ** 2` has high overhead from the power operator. Using elementwise multiplication is much faster, but we cannot use `np.vdot(r, r)` since Drake's `AutoDiffXd` type lacks a `.conjugate()` method. Restored `np.asarray` to prevent potential sequence multiplication errors.
📊 Impact: Faster gradient evaluations during swing optimization due to avoidance of power functions during constraint evaluation.
🔬 Measurement: Run `pytest tests/test_drake_fit_swing.py` to confirm correct breakdown mapping and functionality.

---
*PR created automatically by Jules for task [18075381990432827656](https://jules.google.com/task/18075381990432827656) started by @dieterolson*