### PR TITLE
feat(launcher): connect Model Explorer widget.destroyed to tool.cleanup

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 ### Recent Spec Updates
 
 - **2026-05-28** - Enabled dynamic MuJoCo GUI docking and styling in the launcher via DraggableTabWidget and dynamic ThemeManager palette application to resolve issue #6509.
+- **2026-05-28** - Connected Model Explorer widget destroyed signal to cleanup method to ensure proper tool lifecycle in launcher simulation.
 - **2026-05-28** - Registered the shared.python.config subpackage in lazy loading to prevent mock-patching AttributeError during launcher diagnostics unit testing.
 - **2026-05-27** - Resolved mypy type-checking errors by excluding Jython/OpenSim scripts from the pre-commit mypy hook and replaced print statements with logging.info/logging.warning in computeMomentArm.py and AGENT_INSTRUCTIONS.md to satisfy the no-print-in-src hook.
 - **2026-05-26** - Folded remaining API/security/realtime/logging PR scope into the post-#6181 consolidation branch: `FitResult` now exposes explicit `fit_succeeded` and `solver_status` fields, the `.gitignore` secrets guard has an importable CI helper plus tests, and logging redaction preserves delimiters while redacting quoted, JSON, and comma-containing secret values.

--- a/src/launchers/launcher_simulation.py
+++ b/src/launchers/launcher_simulation.py
@@ -705,6 +705,7 @@ except (RuntimeError, TypeError, AttributeError) as e:
 
                 ui_widget = tool.create_main_widget(self.launcher)
                 if ui_widget:
+                    ui_widget.destroyed.connect(tool.cleanup)
                     self.dock_widget_as_tab(ui_widget, "Model Explorer")
                     self.show_toast("Model Explorer loaded as tab.", "success")
                     self.lbl_status.setText("> Model Explorer Running")

--- a/tests/launchers/test_launcher_simulation.py
+++ b/tests/launchers/test_launcher_simulation.py
@@ -366,6 +366,25 @@ def test_launch_module_process(launcher) -> None:
         mock_crit.assert_called_once()
 
 
+def test_launch_urdf_generator_embedded_wires_cleanup_signal(launcher) -> None:
+    """Issue #6510: destroyed signal must be connected to tool.cleanup."""
+    mock_widget = MagicMock()
+    mock_tool = MagicMock()
+    mock_tool.create_main_widget.return_value = mock_widget
+    launcher.workspace_tabs = MagicMock()
+    launcher.workspace_tabs.count.return_value = 0
+    launcher.dock_widget_as_tab = MagicMock()
+
+    with patch(
+        "src.shared.python.launcher_embed.get_embeddable_tool", return_value=mock_tool
+    ):
+        launcher._launch_urdf_generator()
+
+    mock_widget.destroyed.connect.assert_called_once_with(mock_tool.cleanup)
+    launcher.dock_widget_as_tab.assert_called_once_with(mock_widget, "Model Explorer")
+    launcher.show_toast.assert_called_with("Model Explorer loaded as tab.", "success")
+
+
 def test_launch_urdf_generator(launcher) -> None:
     with patch("src.launchers.launcher_simulation.Path.exists", return_value=True):
         launcher.process_manager.launch_script.return_value = MagicMock()


### PR DESCRIPTION
## Summary

- When the embedded Model Explorer tab is closed, Qt destroys the widget but the embed adapter's `cleanup()` was never called, leaking internal widget references tracked in `_embed_adapter._widgets`
- Added `ui_widget.destroyed.connect(tool.cleanup)` before docking the widget so the adapter cleans up automatically when the tab closes

## Test plan

- [ ] `test_launch_urdf_generator_embedded_wires_cleanup_signal` — new test verifying the signal is connected and `dock_widget_as_tab` is called

Closes #6510

🤖 Generated with [Claude Code](https://claude.com/claude-code)