### PR TITLE
test(mujoco): hold QApplication reference in humanoid launcher tests

### DIFF
--- a/tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py
+++ b/tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py
@@ -59,7 +59,12 @@ def test_remote_recorder():
 )
 def test_humanoid_launcher_init(mock_config_manager):
     """Test HumanoidLauncher initialization."""
-    QApplication.instance() or QApplication(sys.argv)
+    # Keep a live reference to the QApplication for the duration of the test;
+    # PyQt will garbage-collect a temporary QApplication and destroy it before
+    # the QWidget is constructed, causing "Must construct a QApplication
+    # before a QWidget" (#6515).
+    _qapp = QApplication.instance() or QApplication(sys.argv)
+    assert _qapp is not None
     mock_cm_instance = MagicMock()
     mock_config = MagicMock()
     mock_cm_instance.load.return_value = mock_config
@@ -78,7 +83,10 @@ def test_humanoid_launcher_init(mock_config_manager):
 )
 def test_humanoid_launcher_sim_mixin(mock_config_manager):
     """Test SimulationMixin methods."""
-    QApplication.instance() or QApplication(sys.argv)
+    # See test_humanoid_launcher_init for why the QApplication must be held
+    # in a local reference (#6515).
+    _qapp = QApplication.instance() or QApplication(sys.argv)
+    assert _qapp is not None
     mock_cm_instance = MagicMock()
     mock_config = MagicMock()
     mock_config.live_view = False
@@ -125,7 +133,10 @@ def test_humanoid_launcher_sim_mixin(mock_config_manager):
 )
 def test_humanoid_launcher_analysis_mixin(mock_config_manager):
     """Test AnalysisMixin methods."""
-    QApplication.instance() or QApplication(sys.argv)
+    # See test_humanoid_launcher_init for why the QApplication must be held
+    # in a local reference (#6515).
+    _qapp = QApplication.instance() or QApplication(sys.argv)
+    assert _qapp is not None
     mock_cm_instance = MagicMock()
     mock_config = MagicMock()
     mock_cm_instance.load.return_value = mock_config


### PR DESCRIPTION
Fixes #6515

Three humanoid launcher tests created a QApplication via the expression `QApplication.instance() or QApplication(sys.argv)` but immediately dropped the only Python reference. When the suite is run without a pre-existing QApplication, PyQt can garbage-collect the application before the QMainWindow is constructed, producing "Must construct a QApplication before a QWidget".

Bind the QApplication to a local `_qapp` for the lifetime of each test so the test process keeps a live owner. No behaviour change for runs that already have a QApplication.

## Test plan
- [x] `python3 -m ruff check tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py`
- [x] `python3 -m pytest tests/unit/engines/physics_engines/mujoco/test_humanoid_launchers.py -x`