### PR TITLE
fix(logging): redact entire unquoted secret value past commas

### DIFF
--- a/src/shared/python/logging_pkg/logging_config.py
+++ b/src/shared/python/logging_pkg/logging_config.py
@@ -90,7 +90,12 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
         r"|"
         r"(?:(['\"])([^'\"\s}]+))"  # unterminated quoted value fallback
         r"|"
-        r"([^'\"\s,{}&;:\])]+)"  # unquoted value
+        # Unquoted value: fail-closed — consume past commas so credentials
+        # containing literal commas are not leaked beyond the first one
+        # (#6494). The closing-quote / brace / ampersand / semicolon /
+        # colon stops still apply so JSON and form-encoded boundaries are
+        # respected when present.
+        r"([^'\"\s{}&;:\])]+)"
         r")"
     ),
 ]

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -146,17 +146,27 @@ class TestSensitiveDataFilter:
         assert "other_var=1" in record.msg
 
     def test_redacts_unquoted_value_containing_comma(self) -> None:
+        # Fail-closed (#6494): secrets can legitimately contain commas, so
+        # the unquoted branch must over-redact past the first comma rather
+        # than leak the suffix.
         flt = SensitiveDataFilter()
         record = self._make_record("password=abc,def")
         flt.filter(record)
         assert "abc" not in record.msg
-        assert record.msg == "password=***REDACTED***,def"
+        assert "def" not in record.msg
+        assert "***REDACTED***" in record.msg
 
     def test_redacts_compact_json_without_consuming_next_key(self) -> None:
+        # In compact JSON with an unquoted (numeric) secret value, the
+        # fail-closed unquoted branch (#6494) consumes the comma before the
+        # next key. The secret is fully redacted; downstream JSON parsers
+        # already could not reliably parse a logged-and-redacted message,
+        # so over-redaction is acceptable here.
         flt = SensitiveDataFilter()
         record = self._make_record('{"password":123,"user":"bob"}')
         flt.filter(record)
-        assert record.msg == '{"password":***REDACTED***,"user":"bob"}'
+        assert "123" not in record.msg
+        assert "***REDACTED***" in record.msg
 
     def test_redacts_quoted_json_value_containing_comma_and_brace(self) -> None:
         flt = SensitiveDataFilter()


### PR DESCRIPTION
Fixes #6494

The unquoted-value branch of the sensitive-data redaction regex previously excluded commas, so `password=abc,def` was rewritten to `password=***REDACTED***,def` leaking the credential suffix. Per the fail-closed principle for security redaction, the filter should over-redact rather than expose ambiguous suffixes.

Remove `,` from the unquoted-value negative character class so the whole secret (including any embedded commas) is consumed before the redaction marker. The closing-quote / brace / ampersand / semicolon / colon stops still apply so JSON and form-encoded boundaries are respected when present.

Existing tests that documented the leak-on-comma behaviour are updated to assert the new fail-closed contract:
- `test_redacts_unquoted_value_containing_comma` — now asserts `def` is also redacted
- `test_redacts_compact_json_without_consuming_next_key` — accepts over-redaction for the unrealistic unquoted-JSON-secret case (passwords in JSON should be quoted)

## Test plan
- [x] `python3 -m ruff check src/shared/python/logging_pkg/logging_config.py tests/unit/test_logging_config.py`
- [x] `python3 -m pytest tests/unit/test_logging_config.py -x` (34 passed)