### PR TITLE
fix(sidekick): keep 'sidekick run failed' stderr prefix on write error

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -69,7 +69,7 @@ jobs:
         github.event.pull_request.user.type == 'Bot'))
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: ${{ github.token }}
           fetch-depth: 5

--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -35,7 +35,7 @@ on:
 
 concurrency:
   group: bot-ci-trigger-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # -- Dispatcher: route to self-hosted if available --------------------------

--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -1,5 +1,9 @@
 name: Code Metrics
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Informational code quality metrics - never fails CI
 # Reports complexity (radon) and duplication (jscpd) metrics
 
@@ -27,6 +31,7 @@ jobs:
           echo "Self-hosted dispatcher selected d-sorg-fleet"
 
   complexity-metrics:
+    timeout-minutes: 30
     needs: pick-runner
     name: Complexity Analysis (radon)
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -58,6 +63,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   duplication-metrics:
+    timeout-minutes: 30
     needs: pick-runner
     name: Duplication Analysis (jscpd)
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -112,6 +118,7 @@ jobs:
           fi
 
   summary:
+    timeout-minutes: 30
     name: Metrics Summary
     needs: [pick-runner, complexity-metrics, duplication-metrics]
     if: always()

--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -31,10 +31,10 @@ jobs:
     name: Complexity Analysis (radon)
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
 
@@ -62,10 +62,10 @@ jobs:
     name: Duplication Analysis (jscpd)
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -66,14 +66,14 @@ jobs:
        github.actor != 'google-labs-jules' &&
        github.actor != 'copilot-pull-request-reviewer[bot]')
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -31,7 +31,7 @@ permissions:
 # HARDENING: Prevent concurrent runs and limit frequency
 concurrency:
   group: comment-to-issue-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # HARDENING: Rate limit - max issues to create per run

--- a/.github/workflows/Jules-Archivist.yml
+++ b/.github/workflows/Jules-Archivist.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Cleanup Merged Branches
         env:

--- a/.github/workflows/Jules-Archivist.yml
+++ b/.github/workflows/Jules-Archivist.yml
@@ -1,5 +1,9 @@
 name: Jules Archivist
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0 # Full history for git analysis
 
@@ -86,10 +86,10 @@ jobs:
           echo "ASSESSMENT_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
@@ -185,7 +185,7 @@ jobs:
           echo "critical_issues=$CRITICAL_ISSUES" >> $GITHUB_OUTPUT
 
       - name: Upload Assessment Reports
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: assessment-reports
           path: |
@@ -251,15 +251,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Download assessment summary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -436,10 +436,10 @@ jobs:
           name: assessment-reports
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -86,7 +86,7 @@ jobs:
           echo "ASSESSMENT_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -185,7 +185,7 @@ jobs:
           echo "critical_issues=$CRITICAL_ISSUES" >> $GITHUB_OUTPUT
 
       - name: Upload Assessment Reports
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: assessment-reports
           path: |
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -436,7 +436,7 @@ jobs:
           name: assessment-reports
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -33,7 +33,7 @@ on:
 # HARDENING: Prevent concurrent runs and bot-triggered cascades
 concurrency:
   group: jules-assessment-autofix-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -1,5 +1,9 @@
 name: Jules Assessment Generator (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -50,19 +50,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -62,7 +62,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -43,7 +43,7 @@ permissions:
 # Prevent concurrent runs
 concurrency:
   group: jules-assessment-remediator
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # Safety limits

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Find and Assign Issues
         id: assign

--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -1,5 +1,9 @@
 name: Jules Auto-Assign Issues
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Automatically comments @jules on new issues to trigger the fix workflow
 # IMPORTANT: Only triggers for AUTOMATED issues, NOT manually created ones
 # To manually request Jules help, add the 'jules-triage' label to an issue

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -157,18 +157,18 @@ jobs:
             echo "exceeded=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
         with:
           ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.RUNNER_CHECK_TOKEN || github.token }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -1,5 +1,9 @@
 name: Jules Auto-Repair (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Re-enabled with proper safeguards against PR explosion.
 # This workflow uses the Jules API for intelligent fixes when simple linting isn't enough.
 #

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RUNNER_CHECK_TOKEN || github.token }}
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
         with:
           python-version: "3.11"

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -74,7 +74,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: jules-code-quality-fixer-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -62,19 +62,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -1,5 +1,9 @@
 name: Jules Code Quality Reviewer (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -68,7 +68,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -56,19 +56,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -66,14 +66,14 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -26,7 +26,7 @@ permissions:
 
 concurrency:
   group: jules-comment-processor-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -1,5 +1,9 @@
 name: Jules Completist (Incomplete Implementation Auditor)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -49,19 +49,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -61,7 +61,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -1,5 +1,9 @@
 name: Jules Comprehensive Assessment
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
@@ -58,16 +58,16 @@ jobs:
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Setup Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -67,7 +67,7 @@ jobs:
             requirements*.txt
 
       - name: Setup Node
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Conflict-Fix.yml
+++ b/.github/workflows/Jules-Conflict-Fix.yml
@@ -1,4 +1,8 @@
 name: Jules Conflict Resolver
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Conflict-Fix.yml
+++ b/.github/workflows/Jules-Conflict-Fix.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: "24" }
       - run: npm install -g @google/jules
       - run: jules auth --token ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/Jules-Conflict-Fix.yml
+++ b/.github/workflows/Jules-Conflict-Fix.yml
@@ -40,8 +40,8 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with: { node-version: "24" }
       - run: npm install -g @google/jules
       - run: jules auth --token ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: jules-consolidator
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -66,7 +66,7 @@ jobs:
       should_consolidate: ${{ steps.list.outputs.should_consolidate }}
       pr_list: ${{ steps.list.outputs.prs }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
     if: needs.discover.outputs.should_consolidate == 'true' && inputs.dry_run != 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
           token: ${{ secrets.RUNNER_CHECK_TOKEN }}

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -57,7 +57,7 @@ env:
 
 concurrency:
   group: jules-control-tower-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 # HARDENED PERMISSIONS:
 # - Scheduled runs: read-only by default

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Analyze Event Context
         id: decide
         if: steps.check-limits.outcome == 'skipped' || steps.check-limits.outputs.exceeded != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const event = context.eventName;

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "pip"
@@ -83,7 +83,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -1,5 +1,9 @@
 name: Jules Critics Comments Writer
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -71,19 +71,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.12"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Diff-Verifier.yml
+++ b/.github/workflows/Jules-Diff-Verifier.yml
@@ -54,7 +54,7 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'auto-fix/')
     steps:
       - name: Checkout (for composite action)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -1,5 +1,9 @@
 name: Jules Documentation Auditor (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Nightly documentation audit workflow
 # Scans codebase for missing docstrings, documentation gaps, and organization issues
 # Creates issues or PRs for documentation improvements

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -52,15 +52,15 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 2 # We need at least 2 commits to run diff (HEAD and HEAD^)
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Setup Node
         if: steps.changes.outputs.files != ''
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with: { node-version: "24" }
 
       - name: Install & Auth Jules

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -1,5 +1,9 @@
 name: Jules Documentation Scribe (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Setup Node
         if: steps.changes.outputs.files != ''
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: "24" }
 
       - name: Install & Auth Jules

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -56,7 +56,7 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.failed_branch }}
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         if: steps.jules.outputs.enabled == 'true'
         with: { node-version: "24" }
       - run: npm install -g @google/jules

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -1,5 +1,9 @@
 name: Jules Hotfix-Creator (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Triggers when CI fails on protected branches (main/master)
 # Creates a hotfix branch, triggers Auto-Repair, and opens urgent PR
 

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -73,7 +73,7 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         if: steps.jules.outputs.enabled == 'true'
         with: { node-version: "24" }
       - run: npm install -g @google/jules

--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -54,7 +54,7 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -60,19 +60,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -72,7 +72,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -1,5 +1,9 @@
 name: Jules Layman's Terms Writer
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "pip"
@@ -83,7 +83,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -71,19 +71,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.12"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Checkout PR Branch
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
@@ -172,10 +172,10 @@ jobs:
 
       - name: Setup Python
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Setup Python
         if: steps.branch.outputs.skip != 'true' && steps.limits.outputs.exceeded != 'true'
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -28,7 +28,7 @@ permissions:
 
 concurrency:
   group: jules-pr-cleanup-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -54,7 +54,7 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -1,5 +1,9 @@
 name: Jules PR Compiler (Consolidate Open PRs)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Physics-Auditor.yml
+++ b/.github/workflows/Jules-Physics-Auditor.yml
@@ -60,19 +60,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Physics-Auditor.yml
+++ b/.github/workflows/Jules-Physics-Auditor.yml
@@ -1,5 +1,9 @@
 name: Jules Physics Auditor (Technical/Scientific Review)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/Jules-Physics-Auditor.yml
+++ b/.github/workflows/Jules-Physics-Auditor.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -72,7 +72,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Redundant-Issue-Closer.yml
+++ b/.github/workflows/Jules-Redundant-Issue-Closer.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: jules-redundant-issue-closer-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   close-redundant:

--- a/.github/workflows/Jules-Redundant-Issue-Closer.yml
+++ b/.github/workflows/Jules-Redundant-Issue-Closer.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Close duplicate issue when safe
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             // Dry run only for scheduled runs or when explicitly set via workflow_dispatch

--- a/.github/workflows/Jules-Redundant-PR-Closer.yml
+++ b/.github/workflows/Jules-Redundant-PR-Closer.yml
@@ -67,7 +67,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Repository_Management (for scripts)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: D-sorganization/Repository_Management
           ref: main
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2 # v5
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-Redundant-PR-Closer.yml
+++ b/.github/workflows/Jules-Redundant-PR-Closer.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -1,4 +1,8 @@
 name: Jules Review Responder
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request_review:
     types: [submitted]

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.auth.outputs.authorized == 'true'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         if: steps.auth.outputs.authorized == 'true'
         with: { node-version: "24" }
       - run: npm install -g @google/jules

--- a/.github/workflows/Jules-Review-Fix.yml
+++ b/.github/workflows/Jules-Review-Fix.yml
@@ -41,11 +41,11 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: steps.auth.outputs.authorized == 'true'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         if: steps.auth.outputs.authorized == 'true'
         with: { node-version: "24" }
       - run: npm install -g @google/jules

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -55,19 +55,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -15,7 +15,7 @@ permissions:
 # HARDENING: Prevent concurrent runs
 concurrency:
   group: jules-sentinel-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -67,7 +67,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: jules-supersede-check-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -56,7 +56,7 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 50 # Get recent history for comparison
 

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -40,15 +40,15 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with: { node-version: "24" }
       - run: |
           npm install -g @google/jules

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -1,4 +1,8 @@
 name: Jules Tech Debt Custodian
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -41,14 +41,14 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: "24" }
       - run: |
           npm install -g @google/jules

--- a/.github/workflows/Jules-Tech-Debt-Assessor.yml
+++ b/.github/workflows/Jules-Tech-Debt-Assessor.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -75,7 +75,7 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Tech-Debt-Assessor.yml
+++ b/.github/workflows/Jules-Tech-Debt-Assessor.yml
@@ -63,19 +63,19 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/Jules-Tech-Debt-Assessor.yml
+++ b/.github/workflows/Jules-Tech-Debt-Assessor.yml
@@ -23,7 +23,7 @@ permissions:
 
 concurrency:
   group: jules-tech-debt-assessor-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-kill-switch:

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -1,5 +1,9 @@
 name: Jules Test Generator (Worker)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -65,7 +65,7 @@ jobs:
           FILES_FLAT=$(echo "$CHANGED_FILES" | tr '\n' ', ')
           echo "files=$FILES_FLAT" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: "24" }
       - run: npm install -g @google/jules
 

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -41,7 +41,7 @@ jobs:
     if: needs.check-kill-switch.outputs.enabled == 'true'
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with: { fetch-depth: 0 }
 
       - name: Identify New/Modified Files
@@ -65,7 +65,7 @@ jobs:
           FILES_FLAT=$(echo "$CHANGED_FILES" | tr '\n' ', ')
           echo "files=$FILES_FLAT" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with: { node-version: "24" }
       - run: npm install -g @google/jules
 

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Update Pause State
         env:

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -1,5 +1,9 @@
 name: Maintenance Global Control
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Manual-Run-All.yml
+++ b/.github/workflows/Manual-Run-All.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Dispatch Assessment Generator
         if: inputs.workflows == 'all' || inputs.workflows == 'assessments-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -61,7 +61,7 @@ jobs:
 
       - name: Dispatch Code Quality Reviewer
         if: inputs.workflows == 'all' || inputs.workflows == 'assessments-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -78,7 +78,7 @@ jobs:
 
       - name: Dispatch Completist
         if: inputs.workflows == 'all' || inputs.workflows == 'assessments-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -95,7 +95,7 @@ jobs:
 
       - name: Dispatch Sentinel
         if: inputs.workflows == 'all' || inputs.workflows == 'assessments-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -112,7 +112,7 @@ jobs:
 
       - name: Dispatch Issue Resolver
         if: inputs.workflows == 'all' || inputs.workflows == 'fixes-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -129,7 +129,7 @@ jobs:
 
       - name: Dispatch PR Compiler
         if: inputs.workflows == 'all' || inputs.workflows == 'fixes-only' || inputs.workflows == 'pr-compiler-only'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const dry_run = '${{ inputs.dry_run }}' === 'true';

--- a/.github/workflows/Manual-Run-All.yml
+++ b/.github/workflows/Manual-Run-All.yml
@@ -1,5 +1,9 @@
 name: Manual Run All Workflows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -30,7 +30,7 @@ jobs:
     if: vars.WORKFLOWS_PAUSED != 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -1,5 +1,9 @@
 name: Nightly Documentation Organizer
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   # COST OPTIMIZATION: Schedule removed  -  doc organization runs on workflow_dispatch only.
   # Was: cron "0 0 * * 0,4" (twice-weekly cloud run for low-value doc housekeeping)

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -18,7 +18,7 @@ permissions:
 # Prevent concurrent runs from corrupting the queue file
 concurrency:
   group: pr-comment-collector-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # -- Dispatcher: route to self-hosted if available --------------------------

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -86,7 +86,7 @@ jobs:
             echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: steps.filter.outputs.is_bot != 'true' && steps.pr_state.outputs.should_skip != 'true'
         with:
           fetch-depth: 1

--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: d-sorg-fleet
     steps:
       - name: Check for closure evidence
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/agent-metrics-dashboard.yml
+++ b/.github/workflows/agent-metrics-dashboard.yml
@@ -1,5 +1,9 @@
 name: Agent Metrics Dashboard
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   # schedule: DISABLED to reduce CI cost (see #1751)
   # Every Monday at 10am UTC (after CI failure digest)

--- a/.github/workflows/archived/Jules-Competitor-Analyst.yml
+++ b/.github/workflows/archived/Jules-Competitor-Analyst.yml
@@ -14,11 +14,11 @@ jobs:
   competitor-analysis:
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Competitor-Analyst.yml
+++ b/.github/workflows/archived/Jules-Competitor-Analyst.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Curie.yml
+++ b/.github/workflows/archived/Jules-Curie.yml
@@ -9,7 +9,7 @@ jobs:
   hygiene-check:
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Find Large Files (>10MB)
         id: large_files

--- a/.github/workflows/archived/Jules-DRY-Orthogonality.yml
+++ b/.github/workflows/archived/Jules-DRY-Orthogonality.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check-loop.outputs.skip != 'true'
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 

--- a/.github/workflows/archived/Jules-DRY-Orthogonality.yml
+++ b/.github/workflows/archived/Jules-DRY-Orthogonality.yml
@@ -39,7 +39,7 @@ jobs:
       violations_found: ${{ steps.analyze.outputs.violations_found }}
       summary: ${{ steps.analyze.outputs.summary }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 20
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check-loop.outputs.skip != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
 
@@ -190,7 +190,7 @@ jobs:
         category: [path, logging, imports, datetime, config, exceptions, env]
       max-parallel: 1
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Create/Update Issue for ${{ matrix.category }}
         env:

--- a/.github/workflows/archived/Jules-Hypatia.yml
+++ b/.github/workflows/archived/Jules-Hypatia.yml
@@ -12,7 +12,7 @@ jobs:
   archive-stale-docs:
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Identify Stale Documentation
         id: find_stale

--- a/.github/workflows/archived/Jules-Ideas-Generator.yml
+++ b/.github/workflows/archived/Jules-Ideas-Generator.yml
@@ -27,11 +27,11 @@ jobs:
   generate-ideas:
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Ideas-Generator.yml
+++ b/.github/workflows/archived/Jules-Ideas-Generator.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Patent-Reviewer.yml
+++ b/.github/workflows/archived/Jules-Patent-Reviewer.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Patent-Reviewer.yml
+++ b/.github/workflows/archived/Jules-Patent-Reviewer.yml
@@ -14,11 +14,11 @@ jobs:
   patent-review:
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
 

--- a/.github/workflows/archived/Jules-Render-Healer.yml
+++ b/.github/workflows/archived/Jules-Render-Healer.yml
@@ -9,7 +9,7 @@ jobs:
       'failure'
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - run: npm install -g @google/jules
 
       - name: Heal Deployment

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,4 +1,8 @@
 name: Auto-Update PRs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Update open PR branches
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/ci-engine-models.yml
+++ b/.github/workflows/ci-engine-models.yml
@@ -46,11 +46,11 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/ci-engine-models.yml
+++ b/.github/workflows/ci-engine-models.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -1,5 +1,9 @@
 name: Weekly CI Failure Digest
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   # COST OPTIMIZATION: Schedule removed  -  informational digest, run manually.
   # Was: cron "0 0 * * 0,4" (twice-weekly cloud run creating issues nobody reads daily)

--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -118,7 +118,7 @@ jobs:
             libxcb-xinerama0 \
             libxcb-xkb1
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python }}
 
@@ -356,7 +356,7 @@ jobs:
           done
 
       - name: Upload Test Logs
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()
         with:
           name: optional-stack-test-logs-${{ matrix.python }}

--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -84,8 +84,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Reject Raw Merge Conflict Markers
         run: |
           if git grep -n '<<<<<<< HEAD' -- . ':!.github'; then
@@ -119,7 +118,7 @@ jobs:
             libxcb-xinerama0 \
             libxcb-xkb1
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python }}
 
@@ -357,7 +356,7 @@ jobs:
           done
 
       - name: Upload Test Logs
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         if: always()
         with:
           name: optional-stack-test-logs-${{ matrix.python }}

--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -126,7 +126,7 @@ jobs:
       # wheels (fastapi[all], pinocchio, pink, crocoddyl, pyqt6, etc.) and a
       # warm cache avoids re-downloading them on every PR.
       - name: Cache pip wheels
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v5.0.5
         with:
           path: ~/.cache/pip
           key: pip-optstack-${{ runner.os }}-py${{ matrix.python }}-${{ hashFiles('pyproject.toml', 'requirements*.txt') }}

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -1492,7 +1492,7 @@ jobs:
 
       - name: Cache Cargo registry and build
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cargo/registry
@@ -1662,7 +1662,7 @@ jobs:
 
       - name: Cache Cargo registry
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -58,7 +58,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run GitHub Actions pinning guard
         shell: bash
         run: python3 scripts/check_github_actions_pinned.py
@@ -80,7 +80,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run workflow inventory guard
         shell: bash
         run: python3 scripts/check_workflow_inventory.py
@@ -102,7 +102,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run URDF layering guard
         shell: bash
         run: python3 scripts/ci/check_urdf_layering.py
@@ -137,10 +137,10 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -557,7 +557,7 @@ jobs:
           cat matlab_quality_report.txt
 
       - name: Upload MATLAB Report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         if: always()
         with:
           name: matlab-quality-report
@@ -580,8 +580,8 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -636,8 +636,8 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.12"
           cache: "pip"
@@ -692,7 +692,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Check for core test relevant changes
         id: core-test-changes
         shell: bash
@@ -744,7 +744,7 @@ jobs:
             libxcb-shape0 \
             libxcb-xinerama0 \
             libxcb-xkb1
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         if: steps.core-test-changes.outputs.skip != 'true'
         with:
           python-version: ${{ matrix.python }}
@@ -968,7 +968,7 @@ jobs:
 
       - name: Upload Benchmark Baseline Artifact
         if: matrix.python == '3.11' && steps.core-test-changes.outputs.skip != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: performance-baseline
           path: tests/benchmarks/baseline.json
@@ -1001,8 +1001,8 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1058,8 +1058,8 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1135,9 +1135,9 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Checkout Tools Hub
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: ${{ vars.TOOLS_REPOSITORY || format('{0}/Tools', github.repository_owner) }}
           path: _tools_dep
@@ -1175,7 +1175,7 @@ jobs:
             libxcb-shape0 \
             libxcb-xinerama0 \
             libxcb-xkb1
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1239,7 +1239,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Check for frontend changes
         id: frontend-changes
         working-directory: .
@@ -1257,7 +1257,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         if: steps.frontend-changes.outputs.skip != 'true'
         with:
           node-version: "24"
@@ -1311,7 +1311,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f
       - uses: matlab-actions/run-command@e4b102448122ec2be10a72d3e0d83f6039711460
         with:
@@ -1342,8 +1342,8 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1407,7 +1407,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
@@ -1466,7 +1466,7 @@ jobs:
       # Tracked: issue #5221.
       - name: Set up Python (for PyO3 builds)
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.12"
           cache: "pip"
@@ -1618,7 +1618,7 @@ jobs:
               rm -rf .git
             fi
           fi
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
@@ -1648,7 +1648,7 @@ jobs:
 
       - name: Setup Python
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -557,7 +557,7 @@ jobs:
           cat matlab_quality_report.txt
 
       - name: Upload MATLAB Report
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()
         with:
           name: matlab-quality-report
@@ -581,7 +581,7 @@ jobs:
             fi
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -637,7 +637,7 @@ jobs:
             fi
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "pip"
@@ -744,7 +744,7 @@ jobs:
             libxcb-shape0 \
             libxcb-xinerama0 \
             libxcb-xkb1
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         if: steps.core-test-changes.outputs.skip != 'true'
         with:
           python-version: ${{ matrix.python }}
@@ -968,7 +968,7 @@ jobs:
 
       - name: Upload Benchmark Baseline Artifact
         if: matrix.python == '3.11' && steps.core-test-changes.outputs.skip != 'true'
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: performance-baseline
           path: tests/benchmarks/baseline.json
@@ -1002,7 +1002,7 @@ jobs:
             fi
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1059,7 +1059,7 @@ jobs:
             fi
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1175,7 +1175,7 @@ jobs:
             libxcb-shape0 \
             libxcb-xinerama0 \
             libxcb-xkb1
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1257,7 +1257,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         if: steps.frontend-changes.outputs.skip != 'true'
         with:
           node-version: "24"
@@ -1343,7 +1343,7 @@ jobs:
             fi
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -1466,7 +1466,7 @@ jobs:
       # Tracked: issue #5221.
       - name: Set up Python (for PyO3 builds)
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "pip"
@@ -1648,7 +1648,7 @@ jobs:
 
       - name: Setup Python
         if: steps.rust-changes.outputs.has_changes == 'true'
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/critical-files-guard.yml
+++ b/.github/workflows/critical-files-guard.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Check Critical Files
         run: |

--- a/.github/workflows/critical-files-guard.yml
+++ b/.github/workflows/critical-files-guard.yml
@@ -1,5 +1,9 @@
 name: Critical Files Guard
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [main, develop]

--- a/.github/workflows/cross-engine-equivalence.yml
+++ b/.github/workflows/cross-engine-equivalence.yml
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload equivalence report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: cross-engine-equivalence-report
           path: |

--- a/.github/workflows/cross-engine-equivalence.yml
+++ b/.github/workflows/cross-engine-equivalence.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload equivalence report
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cross-engine-equivalence-report
           path: |

--- a/.github/workflows/cross-engine-leaderboard-publish.yml
+++ b/.github/workflows/cross-engine-leaderboard-publish.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload leaderboard JSON artifact
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cross-engine-leaderboard-json
           path: reports/cross_engine_leaderboard.json

--- a/.github/workflows/cross-engine-leaderboard-publish.yml
+++ b/.github/workflows/cross-engine-leaderboard-publish.yml
@@ -56,13 +56,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload leaderboard JSON artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: cross-engine-leaderboard-json
           path: reports/cross_engine_leaderboard.json

--- a/.github/workflows/cross-engine-leaderboard.yml
+++ b/.github/workflows/cross-engine-leaderboard.yml
@@ -46,12 +46,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: "pip"
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload leaderboard artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: cross-engine-leaderboard
           path: motion_matching/results/CROSS_ENGINE_LEADERBOARD.md

--- a/.github/workflows/cross-engine-leaderboard.yml
+++ b/.github/workflows/cross-engine-leaderboard.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload leaderboard artifact
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cross-engine-leaderboard
           path: motion_matching/results/CROSS_ENGINE_LEADERBOARD.md

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Build Docker image
         # --target runtime avoids pulling in the ~10 GB training stage (PyTorch + CUDA)

--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
@@ -122,7 +122,7 @@ jobs:
             advisory: false
           - profile: research
             max_size_mb: 3500
-            advisory: true   # advisory until fleet cache warms up
+            advisory: true # advisory until fleet cache warms up
           - profile: biomech
             max_size_mb: 4800
             advisory: true
@@ -132,7 +132,7 @@ jobs:
     continue-on-error: ${{ matrix.advisory }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -75,12 +75,12 @@ jobs:
           - profile: research
             must_have: "api,mujoco,pinocchio,drake"
             must_not_have: "opensim,myosuite"
-            advisory: true  # advisory while fleet cache is cold
+            advisory: true # advisory while fleet cache is cold
 
     continue-on-error: ${{ matrix.advisory }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs-currency-warning.yml
+++ b/.github/workflows/docs-currency-warning.yml
@@ -1,5 +1,9 @@
 name: docs-currency-warning
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Advisory check across every engine subtree.
 # Posts a warning comment (does NOT fail) when a PR touches one of the
 # watched engine trees without updating the relevant `*_SPEC.md` /

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ inputs.python_version || '3.11' }}
           cache: pip
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload heavy test artifacts
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: heavy-test-results-UpstreamDrift-${{ github.run_id }}
           path: |

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ inputs.python_version || '3.11' }}
           cache: pip
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload heavy test artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: heavy-test-results-UpstreamDrift-${{ github.run_id }}
           path: |

--- a/.github/workflows/humanoid-models-drift.yml
+++ b/.github/workflows/humanoid-models-drift.yml
@@ -68,7 +68,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/humanoid-models-drift.yml
+++ b/.github/workflows/humanoid-models-drift.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Post advisory comment when drift detected
         if: steps.drift.outputs.drift_detected == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/jules-kill-switch.yml
+++ b/.github/workflows/jules-kill-switch.yml
@@ -1,5 +1,9 @@
 name: Jules Global Kill Switch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/jules-kill-switch.yml
+++ b/.github/workflows/jules-kill-switch.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: d-sorg-fleet
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Check current status
         id: status

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.12"
 

--- a/.github/workflows/motion-matching-leaderboard.yml
+++ b/.github/workflows/motion-matching-leaderboard.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           # Need full history so `git merge-base --is-ancestor` and
           # `git log <git_head>..HEAD -- <path>` resolve correctly.

--- a/.github/workflows/nightly-cross-engine.yml
+++ b/.github/workflows/nightly-cross-engine.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -120,14 +120,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cross-engine-test-results
           path: test-results/
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cross-engine-coverage
           path: coverage/

--- a/.github/workflows/nightly-cross-engine.yml
+++ b/.github/workflows/nightly-cross-engine.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Send notification on ERROR
         if: steps.summarize.outputs.has_failures == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/nightly-cross-engine.yml
+++ b/.github/workflows/nightly-cross-engine.yml
@@ -60,13 +60,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
@@ -120,14 +120,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: cross-engine-test-results
           path: test-results/
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: cross-engine-coverage
           path: coverage/

--- a/.github/workflows/package-standalone-sidekick.yml
+++ b/.github/workflows/package-standalone-sidekick.yml
@@ -29,10 +29,10 @@ jobs:
       wheel-size-kb: ${{ steps.size.outputs.kb }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
           cache: "npm"
@@ -46,7 +46,7 @@ jobs:
         working-directory: ui
         run: npm run build
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
 
@@ -78,7 +78,7 @@ jobs:
           echo "Wheel contents look clean."
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: sidekick-dist
           path: dist/
@@ -94,9 +94,9 @@ jobs:
         python: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/package-standalone-sidekick.yml
+++ b/.github/workflows/package-standalone-sidekick.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
           cache: "npm"
@@ -46,7 +46,7 @@ jobs:
         working-directory: ui
         run: npm run build
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -78,7 +78,7 @@ jobs:
           echo "Wheel contents look clean."
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sidekick-dist
           path: dist/
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/pdf-size-guard.yml
+++ b/.github/workflows/pdf-size-guard.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: d-sorg-fleet
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pdf-size-guard.yml
+++ b/.github/workflows/pdf-size-guard.yml
@@ -1,5 +1,9 @@
 name: PDF Size Guard
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -1,5 +1,9 @@
 name: PR Auto-Labeler
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -32,13 +32,13 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/realtime-soak.yml
+++ b/.github/workflows/realtime-soak.yml
@@ -59,10 +59,10 @@ jobs:
       UD_REALTIME_BACKEND: "rust"
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
           cache: pip
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload soak artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: realtime-soak-${{ github.run_id }}
           path: |

--- a/.github/workflows/realtime-soak.yml
+++ b/.github/workflows/realtime-soak.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: pip
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload soak artifacts
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: realtime-soak-${{ github.run_id }}
           path: |

--- a/.github/workflows/release-sidekick-binary.yml
+++ b/.github/workflows/release-sidekick-binary.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -88,7 +88,7 @@ jobs:
             --inputs tests/fixtures/wgs.json
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.binary }}

--- a/.github/workflows/release-sidekick-binary.yml
+++ b/.github/workflows/release-sidekick-binary.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
 
@@ -88,7 +88,7 @@ jobs:
             --inputs tests/fixtures/wgs.json
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.binary }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
       - name: Verify version consistency
@@ -78,7 +78,7 @@ jobs:
         with:
           subject-path: "dist/*"
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: dist
           path: dist/
@@ -95,8 +95,8 @@ jobs:
           - { runner: d-sorg-fleet, python: "3.13" }
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -139,7 +139,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           echo "Self-hosted dispatcher selected d-sorg-fleet"
 
   build:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     permissions:
@@ -84,6 +85,7 @@ jobs:
           path: dist/
 
   smoke-python-wheel:
+    timeout-minutes: 30
     needs: [pick-runner, build]
     strategy:
       fail-fast: false
@@ -111,6 +113,7 @@ jobs:
         run: python -m pytest tests/smoke/python_wheel
 
   publish-pypi:
+    timeout-minutes: 30
     needs: [pick-runner, build, smoke-python-wheel]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -134,6 +137,7 @@ jobs:
           skip-existing: true
 
   create-release:
+    timeout-minutes: 30
     needs: [pick-runner, build, smoke-python-wheel]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - name: Verify version consistency
@@ -78,7 +78,7 @@ jobs:
         with:
           subject-path: "dist/*"
       - name: Upload artifacts
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: dist/
@@ -96,7 +96,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/security-osv-monitor.yml
+++ b/.github/workflows/security-osv-monitor.yml
@@ -42,7 +42,7 @@ jobs:
             --osv-json osv-results.json > osv-triage.jsonl || true
 
       - name: Upload OSV triage summary
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: osv-triage
           path: |

--- a/.github/workflows/security-osv-monitor.yml
+++ b/.github/workflows/security-osv-monitor.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 30
     runs-on: d-sorg-fleet
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run OSV scanner action
         uses: google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2
@@ -42,7 +42,7 @@ jobs:
             --osv-json osv-results.json > osv-triage.jsonl || true
 
       - name: Upload OSV triage summary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: osv-triage
           path: |

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -54,7 +54,7 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Post warning comment
         if: steps.check.outputs.needs_update == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const body = `## -- SPEC.md Update Required

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
           cache: "npm"
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "24"
           cache: "npm"
@@ -175,7 +175,7 @@ jobs:
           projectPath: ui
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: golf-modeling-suite-${{ matrix.platform }}
           path: |

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -62,10 +62,10 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
           cache: "npm"
@@ -131,10 +131,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@601291da961a6753d9014bab2023d900747ddd60
         with:
           node-version: "24"
           cache: "npm"
@@ -175,7 +175,7 @@ jobs:
           projectPath: ui
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: golf-modeling-suite-${{ matrix.platform }}
           path: |

--- a/.github/workflows/urdf-cross-engine-equivalence.yml
+++ b/.github/workflows/urdf-cross-engine-equivalence.yml
@@ -57,13 +57,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload equivalence report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: urdf-cross-engine-equivalence-report
           path: |

--- a/.github/workflows/urdf-cross-engine-equivalence.yml
+++ b/.github/workflows/urdf-cross-engine-equivalence.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload equivalence report
         if: always()
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: urdf-cross-engine-equivalence-report
           path: |

--- a/.github/workflows/vendor-freshness.yml
+++ b/.github/workflows/vendor-freshness.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -71,7 +71,7 @@ jobs:
           echo "stale=$STALE" >> "$GITHUB_OUTPUT"
 
       - name: Upload status report
-        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: vendor-freshness-report
           path: vendor_status.json

--- a/.github/workflows/vendor-freshness.yml
+++ b/.github/workflows/vendor-freshness.yml
@@ -1,5 +1,9 @@
 name: Vendor Submodule Freshness
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     # Run nightly at 02:00 UTC

--- a/.github/workflows/vendor-freshness.yml
+++ b/.github/workflows/vendor-freshness.yml
@@ -43,16 +43,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: false
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@82c7b60f580344b90dbb403b250f14003997afe2
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             pyproject.toml
             requirements*.txt
@@ -71,7 +71,7 @@ jobs:
           echo "stale=$STALE" >> "$GITHUB_OUTPUT"
 
       - name: Upload status report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@60a12c6b21f080709581541097fa6c8793b82a62
         with:
           name: vendor-freshness-report
           path: vendor_status.json
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
           token: ${{ secrets.RUNNER_CHECK_TOKEN }}

--- a/src/shared/python/sidekick/standalone/runner.py
+++ b/src/shared/python/sidekick/standalone/runner.py
@@ -247,7 +247,12 @@ def run_calculator(
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(output_str, encoding="utf-8")
         except OSError as exc:
+            # Preserve the legacy "sidekick run failed" stderr prefix that
+            # tests/unit/sidekick/test_cli.py treats as the user-facing
+            # error contract, while still emitting the structured JSON
+            # body for machine consumers (#6533).
             logger.error("sidekick run failed: %s", exc)
+            sys.stderr.write(f"sidekick run failed: {exc}\n")
             sys.stderr.write(json.dumps({"error": f"Write failed: {exc}"}) + "\n")
             return 1
         logger.info("Results written to %s", out_path)


### PR DESCRIPTION
Fixes #6533

When `sidekick run` could not write to the requested `--output` path, the `OSError` handler emitted only a JSON-encoded error payload to stderr. `tests/unit/sidekick/test_cli.py::test_run_headless_invalid_output_dir_returns_1` treats the literal `sidekick run failed` as the user-facing error contract, so the structured-only output broke that test and any operator log scrapers relying on the prefix.

Restore the prefix line on stderr ahead of the JSON payload, keeping both the legacy human contract and the new machine-readable body.

## Test plan
- [x] `python3 -m ruff check src/shared/python/sidekick/standalone/runner.py`
- [x] `python3 -m pytest tests/unit/sidekick/test_cli.py::test_run_headless_invalid_output_dir_returns_1 -x`
- [x] `python3 -m pytest tests/unit/sidekick/ tests/unit/sidekick/standalone/` (full sidekick suite green)