### PR TITLE
fix(launchers): guard non-mapping docker profile YAML against AttributeError

### DIFF
--- a/src/launchers/docker_profile_info.py
+++ b/src/launchers/docker_profile_info.py
@@ -101,6 +101,15 @@ def load_docker_profiles() -> dict[str, ProfileInfo]:
         logger.warning("Could not parse %s: %s", _PROFILES_PATH, exc)
         return {}
 
+    if not isinstance(data, dict):
+        logger.warning(
+            "Expected mapping at top level of %s; got %s. "
+            "Falling back to empty profiles.",
+            _PROFILES_PATH,
+            type(data).__name__,
+        )
+        return {}
+
     raw_profiles: dict[str, Any] = data.get("profiles", {})
     out: dict[str, ProfileInfo] = {}
 

--- a/tests/launchers/test_docker_profile_info.py
+++ b/tests/launchers/test_docker_profile_info.py
@@ -105,6 +105,26 @@ def test_load_docker_profiles_malformed_yaml_returns_empty(
     assert load_docker_profiles() == {}
 
 
+def test_load_docker_profiles_non_mapping_top_level_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A YAML whose top-level is a list/string must not crash startup.
+
+    Regression for #6538: removing the ``isinstance(data, dict)`` guard
+    let a malformed profiles.yaml propagate ``AttributeError`` through
+    ``data.get(...)`` and take down the launcher dialog.
+    """
+    # Top-level list.
+    p = _write_yaml(tmp_path, "- not\n- a\n- mapping\n")
+    monkeypatch.setattr(dpi, "_PROFILES_PATH", p)
+    assert load_docker_profiles() == {}
+
+    # Top-level scalar string.
+    p2 = _write_yaml(tmp_path, "just a string\n")
+    monkeypatch.setattr(dpi, "_PROFILES_PATH", p2)
+    assert load_docker_profiles() == {}
+
+
 def test_load_docker_profiles_unknown_feature_is_skipped(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #6538.

When `docker/profiles.yaml` is syntactically valid YAML but not a top-level mapping (e.g. a list or a scalar string from a partially-edited or malformed file), `load_docker_profiles()` previously reached `data.get('profiles', {})` and raised `AttributeError`, taking down launcher / dialog initialization.

Restores the `isinstance(data, dict)` guard so non-mapping top-levels fall back to `{}` with a warning, preserving the documented graceful-degradation contract on the surrounding error handlers (file-missing, YAMLError).

## Test plan

- [x] New regression test `test_load_docker_profiles_non_mapping_top_level_returns_empty` covers top-level list and top-level scalar inputs
- [x] All 16 tests in `tests/launchers/test_docker_profile_info.py` pass locally
- [x] `ruff check` + `ruff format --check` clean