### PR TITLE
fix(sidekick): catch validate_inputs exceptions in protocol calculator path

### DIFF
--- a/src/shared/python/sidekick/standalone/runner.py
+++ b/src/shared/python/sidekick/standalone/runner.py
@@ -207,7 +207,12 @@ def run_calculator(
     fn = _REGISTRY[calculator]
 
     if hasattr(fn, "validate_inputs") and hasattr(fn, "calculate"):
-        vr = fn.validate_inputs(inputs)
+        try:
+            vr = fn.validate_inputs(inputs)
+        except (ValueError, AssertionError) as exc:
+            logger.error("Validation failed: %s", exc)
+            sys.stderr.write(json.dumps({"errors": [str(exc)]}) + "\n")
+            return 3
         if not vr.valid:
             sys.stderr.write(json.dumps({"errors": vr.errors}) + "\n")
             return 3

--- a/tests/unit/sidekick/standalone/test_run.py
+++ b/tests/unit/sidekick/standalone/test_run.py
@@ -255,6 +255,53 @@ def test_protocol_calculator_exception_exits_3(tmp_path: Path) -> None:
         del runner._REGISTRY["_test_proto_exc"]
 
 
+def test_protocol_validate_inputs_exception_exits_3(tmp_path: Path) -> None:
+    """Regression for #6532.
+
+    If a protocol calculator raises ``ValueError``/``AssertionError`` from
+    ``validate_inputs`` (instead of returning ``valid=False``), the runner
+    must exit with code 3 — not crash with an uncaught traceback.
+    """
+    from sidekick.standalone import runner
+
+    class _BadValidator:
+        def validate_inputs(self, inputs: dict) -> Any:
+            raise ValueError("validation rejected input")
+
+        def calculate(self, inputs: dict) -> Any:  # pragma: no cover - unreached
+            return _FakeCalculationResult(values={}, units={}, warnings=[])
+
+    runner._REGISTRY["_test_proto_validate_exc"] = _BadValidator()
+    try:
+        code, _, err = _invoke("_test_proto_validate_exc", {}, tmp_path)
+        assert code == 3
+        payload = json.loads(err)
+        assert "validation rejected input" in payload["errors"][0]
+    finally:
+        del runner._REGISTRY["_test_proto_validate_exc"]
+
+
+def test_protocol_validate_inputs_assertion_error_exits_3(tmp_path: Path) -> None:
+    """Same as #6532 but for ``AssertionError`` from ``validate_inputs``."""
+    from sidekick.standalone import runner
+
+    class _AssertingValidator:
+        def validate_inputs(self, inputs: dict) -> Any:
+            assert False, "assert in validate"  # noqa: B011, PT015
+
+        def calculate(self, inputs: dict) -> Any:  # pragma: no cover - unreached
+            return _FakeCalculationResult(values={}, units={}, warnings=[])
+
+    runner._REGISTRY["_test_proto_validate_assert"] = _AssertingValidator()
+    try:
+        code, _, err = _invoke("_test_proto_validate_assert", {}, tmp_path)
+        assert code == 3
+        payload = json.loads(err)
+        assert "assert in validate" in payload["errors"][0]
+    finally:
+        del runner._REGISTRY["_test_proto_validate_assert"]
+
+
 # ---------------------------------------------------------------------------
 # No PyQt6 on headless path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #6532.

The protocol-style calculator branch in `sidekick run` did not wrap `validate_inputs()` in a try/except, so a calculator that signals invalid input by raising `ValueError`/`AssertionError` (instead of returning `valid=False`) caused the runner to crash with a traceback instead of returning the documented exit code 3. The `calculate()` branch and the legacy callable path both already catch these — this brings `validate_inputs` into line.

## Test plan

- [x] `test_protocol_validate_inputs_exception_exits_3` — covers `ValueError`
- [x] `test_protocol_validate_inputs_assertion_error_exits_3` — covers `AssertionError`
- [x] All 15 tests in `tests/unit/sidekick/standalone/test_run.py` pass locally
- [x] `ruff check` + `ruff format --check` clean