### PR TITLE
chore: clarify canonical Dockerfile status, remove Dockerfile.modular if obsolete

### DIFF
--- a/Dockerfile.modular
+++ b/Dockerfile.modular
@@ -1,4 +1,5 @@
-# EXPERIMENTAL — not in the CI build path. See docker/README.md and ADR-0021.
+# See docker/README.md and ADR-0021 (docs/adr/0021-container-strategy.md) for container policy.
+# EXPERIMENTAL — profile-driven build vehicle. See docker/README.md and ADR-0021.
 # Modular UpstreamDrift Dockerfile.
 #
 # Selects features either by named profile or by explicit comma-separated

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,11 +6,11 @@ For the full rationale behind the three-Dockerfile policy, see
 
 ## Dockerfile Roles
 
-| Filename                            | Purpose                                                                                                                                                                                 | Used by CI                                                              | When to edit                                                            |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `Dockerfile` (repo root)            | **Canonical production build.** Multi-stage (builder / runtime / training). FastAPI on port 8001. Python 3.12-slim with pinned digest.                                                  | `docker-smoke.yml`, `docker-size-gates.yml`, `docker-security-scan.yml` | Production dependency changes, server config, security hardening        |
-| `Dockerfile.heavy_test` (repo root) | **Test environment** mirroring the `d-sorg-fleet-4core` custom runner. Bookworm base with X11/Xvfb, SDL2, and all physics/robotics engines (best-effort).                               | `heavy-tests-opt-in.yml` (runner, not this image)                       | When the runner's apt packages or test-suite requirements change        |
-| `Dockerfile.modular` (repo root)    | **Experimental / modular-build validation.** Selects features via `--build-arg PROFILE=<name>` or `--build-arg FEATURES=<list>`. Phase 2 validation vehicle — explicitly non-canonical. | None                                                                    | Local exploration of modular profiles only; see constraints in ADR-0021 |
+| Filename                            | Purpose                                                                                                                                                                                 | Used by CI                                                                                                                   | When to edit                                                            |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `Dockerfile` (repo root)            | **Canonical production build.** Multi-stage (builder / runtime / training). FastAPI on port 8001. Python 3.12-slim with pinned digest.                                                  | `docker-smoke.yml`, `docker-size-gates.yml`, `docker-security-scan.yml`                                                      | Production dependency changes, server config, security hardening        |
+| `Dockerfile.heavy_test` (repo root) | **Test environment** mirroring the `d-sorg-fleet-4core` custom runner. Bookworm base with X11/Xvfb, SDL2, and all physics/robotics engines (best-effort).                               | `heavy-tests-opt-in.yml` (runner, not this image)                                                                            | When the runner's apt packages or test-suite requirements change        |
+| `Dockerfile.modular` (repo root)    | **Experimental / modular-build validation.** Selects features via `--build-arg PROFILE=<name>` or `--build-arg FEATURES=<list>`. Phase 2 validation vehicle — explicitly non-canonical. | `docker-smoke.yml` (profile capability checks), `docker-size-gates.yml` (profile size matrix) — NOT covered by security scan | Local exploration of modular profiles only; see constraints in ADR-0021 |
 
 ## Docker Compose Variants
 
@@ -41,7 +41,9 @@ docker build --build-arg PROFILE=research -f Dockerfile.modular -t upstream-drif
 docker build --build-arg FEATURES=mujoco,drake,pose-mediapipe -f Dockerfile.modular -t upstream-drift:custom .
 ```
 
-> **Note:** Only `Dockerfile` is monitored by CI security scans and size gates.
-> Changes to `Dockerfile.modular` may silently diverge from production.
+> **Note:** Only `Dockerfile` is covered by the CI security scan and the canonical
+> size gate. `Dockerfile.modular` is covered by the profile smoke tests and the
+> per-profile size budget matrix, but NOT the security scan. Changes to it may
+> silently diverge from production configuration.
 > See [ADR-0021](../docs/adr/0021-container-strategy.md) before promoting
 > `Dockerfile.modular` to production use.

--- a/docs/adr/0021-container-strategy.md
+++ b/docs/adr/0021-container-strategy.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-05-25
+Issue: #6097
 
 ## Context
 
@@ -27,9 +28,10 @@ test suite under `xvfb-run`. Built and used locally via
 via named `--build-arg PROFILE=<name>` or `--build-arg FEATURES=<list>`
 arguments. Feature resolution is delegated to
 `scripts/docker/install_features.py` and
-`src/shared/python/feature_registry/features.py`. Described in
-`docs/plans/DOCKER_MODULAR_BUILDS_EPIC.md` as the "Phase 2 validation vehicle"
-and is explicitly non-canonical during Phase 2. Not wired into any CI workflow.
+`src/shared/python/feature_registry/features.py`. Explicitly non-canonical
+during Phase 2. Targeted by `docker-smoke.yml` (profile capability checks)
+and `docker-size-gates.yml` (profile size budget matrix) — but NOT by the
+security scan or the canonical size gate that uses `Dockerfile` directly.
 
 The three options considered were:
 
@@ -44,11 +46,11 @@ The three options considered were:
 
 We adopt **Option 3**: keep all three Dockerfiles with explicit, documented roles.
 
-| File                    | Role                                    | CI scope                                              | When to edit                                                       |
-| ----------------------- | --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
-| `Dockerfile`            | Canonical production build              | docker-smoke, docker-size-gates, docker-security-scan | Production dependency changes, server config, hardening            |
-| `Dockerfile.heavy_test` | Test environment mirroring fleet runner | heavy-tests-opt-in (uses runner directly)             | When runner apt packages or test-suite requirements change         |
-| `Dockerfile.modular`    | Experimental / modular-build validation | None                                                  | Local exploration of modular profiles only — see constraints below |
+| File                    | Role                                    | CI scope                                                                          | When to edit                                                       |
+| ----------------------- | --------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `Dockerfile`            | Canonical production build              | docker-smoke, docker-size-gates, docker-security-scan                             | Production dependency changes, server config, hardening            |
+| `Dockerfile.heavy_test` | Test environment mirroring fleet runner | heavy-tests-opt-in (uses runner directly)                                         | When runner apt packages or test-suite requirements change         |
+| `Dockerfile.modular`    | Experimental / modular-build validation | docker-smoke (profile capability checks), docker-size-gates (profile size matrix) | Local exploration of modular profiles only — see constraints below |
 
 Rationale:
 
@@ -66,9 +68,10 @@ Rationale:
   patches, dependency upgrades, and server configuration changes go here first.
 - **`Dockerfile.heavy_test` must stay in sync with the fleet runner.** Changes
   to the runner's apt packages or Python tool versions should be reflected here.
-- **`Dockerfile.modular` is frozen from CI scope.** It may drift from production
-  without alerting CI. Developers using it for local experiments should not
-  assume it reflects the current production dependency set.
+- **`Dockerfile.modular` is in limited CI scope** (profile smoke and size-budget
+  matrix only). It is NOT covered by the security scan or the canonical size
+  gate. Developers using it for local experiments should not assume it reflects
+  the current production dependency set.
 - **Any future modularization effort that promotes `Dockerfile.modular` to
   production must file a new ADR** (superseding this one) rather than silently
   modifying the file or wiring it into CI without governance review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 | [0018](0018-standalone-sidekick.md)                | Standalone Sidekick Application                                 | Accepted | 2026-05-23 |
 | [0019](0019-mission-drift-calculators.md)          | Mission-Drift Calculators                                       | Accepted | 2026-04-25 |
 | [0020](0020-canonical-urdf-subsystem.md)           | Canonical URDF subsystem                                        | Accepted | 2026-05-08 |
+| [0021](0021-container-strategy.md)                 | Container Strategy — Three-Dockerfile Policy                    | Accepted | 2026-05-25 |
 
 ## ADR Backlog
 


### PR DESCRIPTION
## Summary

- **Decision: keep all three Dockerfiles.** `Dockerfile.modular` is not obsolete — it is actively used by `docker-compose.profiles.yml` (all 6 profile services) and IS wired into CI (`docker-smoke.yml` profile capability checks, `docker-size-gates.yml` profile size budget matrix).
- Add policy header to `Dockerfile.modular` referencing `docker/README.md` and `ADR-0021`, fixing the hygiene test (`test_docker_docs.py`) which requires all three root Dockerfiles to have this header.
- Correct `ADR-0021` and `docker/README.md`: both incorrectly stated Dockerfile.modular has "None" / "not wired into any CI workflow". Corrected to accurately describe the limited-but-real CI scope.
- Add `#6097` reference to ADR-0021 as required by `test_cross_links_issue` hygiene check.

## What was found

| File | Problem | Fix |
|------|---------|-----|
| `Dockerfile.modular` | Missing `docker/README.md` and `0021-container-strategy` header (hygiene test would fail) | Added policy header |
| `docs/adr/0021-container-strategy.md` | Said "Not wired into any CI workflow" — wrong, two workflows target it | Corrected CI scope description; added `#6097` reference |
| `docker/README.md` | Listed CI scope as "None" for Dockerfile.modular — wrong | Corrected to show docker-smoke and docker-size-gates coverage |

## Test plan

- [ ] `pytest tests/unit/repo_hygiene/test_docker_docs.py` — all hygiene checks pass
- [ ] CI quality-gate passes (no Python/lint changes, only docs + Dockerfile comment)

Closes #6097