### PR TITLE
fix(tools): load training_controller at runtime and wire 6 unregistered tools

### DIFF
--- a/src/launchers/embedded_tool_bootstrap.py
+++ b/src/launchers/embedded_tool_bootstrap.py
@@ -71,6 +71,12 @@ def bootstrap_embeddable_tools() -> list[str]:
         "src.tools.sidekick._embed_adapter",
         "src.tools.pose_studio.gui",
         "src.tools.video_analyzer._embed_adapter",
+        "src.tools.ball_flight_gui._embed_adapter",
+        "src.tools.bunker_shot_gui._embed_adapter",
+        "src.tools.putting_green_gui._embed_adapter",
+        "src.tools.golf_environment._embed_adapter",
+        "src.tools.terrain_engine._embed_adapter",
+        "src.tools.golf_simulation_suite._embed_adapter",
     ]
 
     registered = []

--- a/src/tools/training_controller/controller.py
+++ b/src/tools/training_controller/controller.py
@@ -26,7 +26,7 @@ import time
 from collections.abc import Callable, Iterable
 
 from src.shared.python.logging_pkg.logging_config import get_logger
-from training import (
+from src.shared.python.training import (
     CompatibilityChecker,
     CompatibilityReport,
     DatasetRegistry,
@@ -37,9 +37,9 @@ from training import (
     TrainingJob,
     summarize_by_kind,
 )
-from training.metric_summary import RollingMean
-from training.metrics import MetricKind, TrainingMetric
-from training.resource_monitor import ResourceSample
+from src.shared.python.training.metric_summary import RollingMean
+from src.shared.python.training.metrics import MetricKind, TrainingMetric
+from src.shared.python.training.resource_monitor import ResourceSample
 
 from .view_model import (
     DashboardModel,
@@ -384,7 +384,9 @@ class TrainingDashboardController:
     def _compat_error(report: CompatibilityReport, engine: str):
         # Local import keeps the public import block tidy; the error
         # type lives next to the rest of the training errors.
-        from training.errors import CompatibilityError  # noqa: PLC0415
+        from src.shared.python.training.errors import (  # noqa: PLC0415
+            CompatibilityError,
+        )
 
         msgs = "; ".join(i.message for i in report.errors)
         return CompatibilityError(

--- a/src/tools/training_controller/gui.py
+++ b/src/tools/training_controller/gui.py
@@ -34,7 +34,13 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from training import Dataset, DatasetRegistry, JobId, TrainingConfig, TrainingFramework
+from src.shared.python.training import (
+    Dataset,
+    DatasetRegistry,
+    JobId,
+    TrainingConfig,
+    TrainingFramework,
+)
 
 from .controller import TrainingDashboardController
 from .view_model import DashboardModel, MetricSeries, ResourceSnapshot
@@ -583,7 +589,7 @@ class MainWidget(QWidget):
     def _on_cancel_clicked(self) -> None:
         selected_id = self.controller.selected_job_id
         if selected_id is not None:
-            from training import TrainingError
+            from src.shared.python.training import TrainingError
 
             try:
                 self.controller.cancel_job(selected_id)
@@ -593,7 +599,7 @@ class MainWidget(QWidget):
     def _on_pause_clicked(self) -> None:
         selected_id = self.controller.selected_job_id
         if selected_id is not None:
-            from training import TrainingError
+            from src.shared.python.training import TrainingError
 
             try:
                 self.controller.pause_job(selected_id)
@@ -603,7 +609,7 @@ class MainWidget(QWidget):
     def _on_resume_clicked(self) -> None:
         selected_id = self.controller.selected_job_id
         if selected_id is not None:
-            from training import TrainingError
+            from src.shared.python.training import TrainingError
 
             try:
                 self.controller.resume_job(selected_id)
@@ -709,8 +715,12 @@ class SubmitDialog(QDialog):
 
 def build_default_controller() -> TrainingDashboardController:
     """Construct headless controller using a default Scheduler configuration."""
-    from training import CompatibilityChecker, JobRegistry, Scheduler
-    from training.runtime import InProcessDriver, RunnerRegistry
+    from src.shared.python.training import (
+        CompatibilityChecker,
+        JobRegistry,
+        Scheduler,
+    )
+    from src.shared.python.training.runtime import InProcessDriver, RunnerRegistry
 
     runners = RunnerRegistry()
     scheduler = Scheduler(

--- a/src/tools/training_controller/live_subscriber.py
+++ b/src/tools/training_controller/live_subscriber.py
@@ -20,10 +20,10 @@ from collections.abc import Callable
 from typing import Any
 
 from src.shared.python.logging_pkg.logging_config import get_logger
-from training import TrainingStatus
-from training.persistence import training_metric_from_dict
-from training.metrics import TrainingMetric
-from training.runtime.progress_sinks import training_channel_for
+from src.shared.python.training import TrainingStatus
+from src.shared.python.training.persistence import training_metric_from_dict
+from src.shared.python.training.metrics import TrainingMetric
+from src.shared.python.training.runtime.progress_sinks import training_channel_for
 
 
 __all__ = [

--- a/src/tools/training_controller/view_model.py
+++ b/src/tools/training_controller/view_model.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from training import JobId, TrainingJob
-from training.metrics import MetricKind
+from src.shared.python.training import JobId, TrainingJob
+from src.shared.python.training.metrics import MetricKind
 
 
 __all__ = [

--- a/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
+++ b/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
@@ -139,3 +139,41 @@ def test_bootstrap_records_successfully_imported_tools() -> None:
     with patch.object(_builtins, "__import__", _make_filtered_import(_selective)):
         result = bootstrap.bootstrap_embeddable_tools()
     assert "model_explorer" in result
+
+
+# Tools whose adapters live in this repo (not the vendored Tools submodule) and
+# have no heavy/optional runtime dependencies, so they must register on a bare
+# bootstrap run. Regression guard for #6560 (training_controller import bug) and
+# #6561 (six adapters that existed but were never added to adapter_modules).
+_FIRST_PARTY_TOOL_IDS = {
+    "ball_flight_gui",
+    "bunker_shot_gui",
+    "putting_green_gui",
+    "golf_environment",
+    "terrain_engine",
+    "golf_simulation_suite",
+    "training_controller",
+    "video_analyzer",
+}
+
+
+def test_first_party_tools_are_listed_in_adapter_modules() -> None:
+    """Static guard: every first-party tool has an adapter_modules entry."""
+    import inspect
+
+    source = inspect.getsource(bootstrap.bootstrap_embeddable_tools)
+    for tool_id in _FIRST_PARTY_TOOL_IDS:
+        assert f"src.tools.{tool_id}." in source, (
+            f"{tool_id} missing from adapter_modules in bootstrap"
+        )
+
+
+def test_bootstrap_registers_all_first_party_tools(monkeypatch) -> None:
+    """Functional guard: a real bootstrap run registers every first-party tool.
+
+    Runs offscreen so PyQt6 widgets can be constructed headlessly.
+    """
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    registered = set(bootstrap.bootstrap_embeddable_tools())
+    missing = _FIRST_PARTY_TOOL_IDS - registered
+    assert not missing, f"first-party tools failed to bootstrap: {sorted(missing)}"

--- a/tests/tools/training_controller/test_controller.py
+++ b/tests/tools/training_controller/test_controller.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from training import (
+from src.shared.python.training import (
     CompatibilityChecker,
     CompatibilityError,
     Dataset,
@@ -26,10 +26,10 @@ from training import (
     TrainingStatus,
     new_run_id,
 )
-from training.contracts import CancelToken, ProgressSink
-from training.metrics import MetricKind, TrainingMetric
-from training.resource_monitor import GpuSample, ResourceSample
-from training.runtime import InProcessDriver, RunnerRegistry
+from src.shared.python.training.contracts import CancelToken, ProgressSink
+from src.shared.python.training.metrics import MetricKind, TrainingMetric
+from src.shared.python.training.resource_monitor import GpuSample, ResourceSample
+from src.shared.python.training.runtime import InProcessDriver, RunnerRegistry
 from src.tools.training_controller.controller import (
     DEFAULT_ROLLING_WINDOW,
     TrainingDashboardController,
@@ -356,7 +356,7 @@ class TestSelection:
     def test_select_unknown_job_raises(self) -> None:
         controller, scheduler = _make_controller()
         try:
-            from training import JobId  # local import for readability
+            from src.shared.python.training import JobId  # local import for readability
 
             with pytest.raises(KeyError):
                 controller.select_job(JobId("unknown"))
@@ -585,7 +585,7 @@ class TestMetricIngest:
     def test_metrics_for_unknown_returns_empty(self) -> None:
         controller, scheduler = _make_controller()
         try:
-            from training import JobId
+            from src.shared.python.training import JobId
 
             assert controller.metrics_for(JobId("never-seen")) == ()
         finally:

--- a/tests/tools/training_controller/test_embed_adapter.py
+++ b/tests/tools/training_controller/test_embed_adapter.py
@@ -2,13 +2,46 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.shared.python.launcher_embed import (
     get_embeddable_tool,
     unregister_embeddable_tool,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_adapter_imports_without_shared_python_on_path() -> None:
+    """Regression for #6560.
+
+    At launcher runtime the bootstrap does NOT add ``src/shared/python`` to
+    ``sys.path`` (only ``vendor/ud-tools/src/shared/python``). The test suite
+    masked the bug because ``tests/conftest.py`` injects ``src/shared/python``.
+    Import the adapter in a subprocess whose path contains only the repo root
+    so the backend must resolve as ``src.shared.python.training`` — a bare
+    ``from training import`` would raise ``ModuleNotFoundError`` here.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import src.tools.training_controller._embed_adapter"],
+        cwd=str(_REPO_ROOT),
+        env={
+            **os.environ,
+            "PYTHONPATH": str(_REPO_ROOT),
+            "QT_QPA_PLATFORM": "offscreen",
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        "training_controller adapter failed to import at simulated runtime:\n"
+        f"{result.stderr}"
+    )
 
 
 def test_embed_adapter_tool_id_and_capabilities() -> None:

--- a/tests/tools/training_controller/test_gui_smoke.py
+++ b/tests/tools/training_controller/test_gui_smoke.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.unit
 
 
 def _make_controller():
-    from training import (
+    from src.shared.python.training import (
         CompatibilityChecker,
         Dataset,
         DatasetRegistry,
@@ -35,8 +35,8 @@ def _make_controller():
         TrainingStatus,
         new_run_id,
     )
-    from training.contracts import CancelToken, ProgressSink
-    from training.runtime import InProcessDriver, RunnerRegistry
+    from src.shared.python.training.contracts import CancelToken, ProgressSink
+    from src.shared.python.training.runtime import InProcessDriver, RunnerRegistry
     from src.tools.training_controller import TrainingDashboardController
 
     class _Runner:
@@ -135,15 +135,19 @@ def test_lifecycle_buttons_call_controller_methods(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     QTest, Qt, _ = _load_qt()
-    from training import JobId
+    from src.shared.python.training import (
+        JobId,
+        TrainingConfig,
+        TrainingFramework,
+    )
     from src.tools.training_controller import TrainingDashboardController
     from src.tools.training_controller.gui import MainWindow
 
     del qapp
     controller, scheduler = _make_controller()
     job = controller.submit_job(
-        __import__("training").TrainingConfig(
-            framework=__import__("training").TrainingFramework.PYTORCH,
+        TrainingConfig(
+            framework=TrainingFramework.PYTORCH,
             entry_point="module:train",
             output_dir=Path("/tmp/training-controller-gui"),
             dataset_id="dataset-1",

--- a/tests/tools/training_controller/test_live_subscriber.py
+++ b/tests/tools/training_controller/test_live_subscriber.py
@@ -13,10 +13,10 @@ from typing import Any
 
 import pytest
 
-from training import TrainingStatus
-from training.metrics import MetricKind, TrainingMetric
-from training.persistence import training_metric_to_dict
-from training.runtime.progress_sinks import training_channel_for
+from src.shared.python.training import TrainingStatus
+from src.shared.python.training.metrics import MetricKind, TrainingMetric
+from src.shared.python.training.persistence import training_metric_to_dict
+from src.shared.python.training.runtime.progress_sinks import training_channel_for
 from src.tools.training_controller.live_subscriber import (
     TrainingJobLiveSubscriber,
 )

--- a/tests/tools/training_controller/test_view_model.py
+++ b/tests/tools/training_controller/test_view_model.py
@@ -6,14 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from training import (
+from src.shared.python.training import (
     JobId,
     TrainingConfig,
     TrainingFramework,
     TrainingJob,
     TrainingStatus,
 )
-from training.metrics import MetricKind
+from src.shared.python.training.metrics import MetricKind
 from src.tools.training_controller.view_model import (
     DashboardModel,
     GpuSnapshot,


### PR DESCRIPTION
## Summary

Two tool-surface fixes surfaced while advancing the Epic B audit (#6083 / #6089):

- **`training_controller` tile crashed on load (Fixes #6560).** It was registered in `embedded_tool_bootstrap.py` but imported its backend via the bare `training` package, which is only on `sys.path` in tests (via `conftest`), not at launcher runtime — so it failed with `ModuleNotFoundError: No module named 'training'`, silently swallowed by the bootstrap's `except ImportError`. Rewrote those imports to the canonical `src.shared.python.training` form used by every other tool adapter, and updated the matching tests so the package loads under a single module identity (avoids the dual-import class-identity hazard `conftest` documents for `contracts`).
- **6 tools had adapters but were never wired (Fixes #6561).** `ball_flight_gui`, `bunker_shot_gui`, `putting_green_gui`, `golf_environment`, `terrain_engine`, `golf_simulation_suite` each ship a valid `_embed_adapter.py` that registers an `EmbeddableTool`, but were missing from the bootstrap's `adapter_modules` list. Added all six.

## Tests

- New subprocess regression test imports the `training_controller` adapter with only the repo root on `sys.path` (simulating launcher runtime) — would fail on the old bare imports.
- New bootstrap test asserts all eight first-party tools register (static list guard + functional offscreen run).
- `tests/tools/training_controller/` + `tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py`: **99 passed**.
- `ruff check` / `ruff format --check`: clean. Pre-push mypy/bandit/pytest-unit: passed.

## Notes

- This updates the stale premise of #6089: those tools were "unwired with no adapters" when the audit was filed; they have since gained adapters, so only bootstrap registration / the import bug remained.
- The 3 `sidekick`/`data_explorer` bootstrap warnings in a bare checkout are pre-existing (vendored submodule not populated) and unrelated.

## Test plan

- [ ] CI quality-gate green
- [ ] Launch the launcher and confirm the 6 newly-wired tiles appear and the training-controller tile opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)