### PR TITLE
fix(gui): annotate engine comparison conventions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,8 +38,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.202                                            |
-| **Last Spec Update**    | 2026-05-28                                         |
+| **Spec Version**        | 1.0.203                                            |
+| **Last Spec Update**    | 2026-05-29                                         |
 
 ## 2. Purpose & Mission
 
@@ -70,6 +70,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-05-29** - Annotated cross-engine dashboard comparison results with per-engine velocity convention and units metadata in GUI result labels and headless logs so learners can see which native representation each engine result uses before normalized comparison (closes #6659).
 - **2026-05-28** - Resolved python path resolution bug in `embedded_tool_bootstrap.py` and `upstream_drift_launcher.py` to fix launcher boot-time `ModuleNotFoundError` crashes and warnings.
 - **2026-05-28** - Added sg-optimizer Phase 2: GeoJSON I/O (`course_io.py` with `HoleGeometry`, `load_hole_geojson`, `save_hole_geojson`), UTM geometry utilities (`geometry.py` with `LatLonPoint`, `UTMPoint`, `project_to_utm`, `utm_to_latlon`, `haversine_m` via pyproj), classic-holes library (`library.py` with 5 GeoJSON data files for Sawgrass 17, Augusta 13, Pebble 7, Road Hole 17, Cypress 16), `StateFeatures` dataclass factory (`features.py`), and full `TreeModel` with `forced_punch_out_probability` distribution (`mdp/tree_model.py`); adds `pyproj>=3.6.0` optional dependency (closes #6271).
 - **2026-05-28** - Restored production symbols deleted by Bolt commit #6501: `_resolve_default_server` in `chat_dock_widget`, full 60-token `ThemeColors` derivation pipeline in `theme/api.py`, `ThemeColorsCompat` and `_derive_full_palette` in `theme/__init__.py`, `_tool_declarations_to_ollama` + `keep_alive`/`num_ctx` latency optimizations in `ollama_adapter.py`, and `_EmbedAdapter` + `_register()` in all 5 tool GUI modules; closes #6527, #6528, #6529. Also fixes sg_optimizer longitudinal dispersion applying wrong modifier column (closes #6343).
@@ -625,6 +626,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-29 | 1.0.203 | fix(gui): annotate cross-engine dashboard comparison results with per-engine velocity convention and units metadata in headless logs and GUI chart labels; closes #6659. |
 | 2026-05-28 | 1.0.198 | fix(mujoco): `get_dockable_ui()` returns a `QWidget` container wrapping `HumanoidLauncher` (not `QMainWindow`) for tab embedding; `_apply_styling` now calls `apply_theme_to_window` for consistent theming (issue #6509). |
 | 2026-05-27 | 1.0.201 | chore(sidekick): confirm T2 (`StandaloneSidekickWindow` profile switching) and T5 (schema-version persisted in round-trip JSON) acceptance criteria with targeted tests; closes issues #5980 and #5983. |
 | 2026-05-27 | 1.0.202 | feat(sidekick): complete T4 headless calculator invoker — `sidekick run` validates inputs via Calculator Protocol, surfaces structured errors (exit 3 validation/calc, exit 4 unknown-calculator + fuzzy suggestions, exit 1 I/O), supports `--format json` and `--format csv`, with full TDD coverage (issue #5982). |

--- a/src/launchers/cross_engine_dashboard.py
+++ b/src/launchers/cross_engine_dashboard.py
@@ -114,6 +114,58 @@ class _StubEngine:
 
 _ENGINE_NAMES = ("mujoco", "drake", "pinocchio", "pendulum_stub")
 
+_DEFAULT_ENGINE_CONVENTION = {
+    "velocity": "engine-native",
+    "units": "reported SI",
+}
+
+_ENGINE_CONVENTIONS: dict[str, dict[str, str]] = {
+    "drake": {
+        "velocity": "v generalized velocity",
+        "units": "SI; joint angles rad",
+    },
+    "mujoco": {
+        "velocity": "qvel tangent-space",
+        "units": "SI; joint angles rad",
+    },
+    "opensim": {
+        "velocity": "coordinate speeds",
+        "units": "SI; rotational coordinates deg",
+    },
+    "pendulum_stub": {
+        "velocity": "qdot state",
+        "units": "SI; angles rad",
+    },
+    "pinocchio": {
+        "velocity": "tangent vector",
+        "units": "SI; joint angles rad",
+    },
+    "simscape": {
+        "velocity": "Simscape logged derivatives",
+        "units": "SI; angular channels rad",
+    },
+}
+
+
+def _engine_convention(name: str) -> dict[str, str]:
+    """Return user-facing convention metadata for an engine result."""
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"name must be a non-empty string; got {name!r}")
+    return _ENGINE_CONVENTIONS.get(name, _DEFAULT_ENGINE_CONVENTION)
+
+
+def _format_engine_result_label(name: str) -> str:
+    """Return the comparison label with velocity convention and units."""
+    convention = _engine_convention(name)
+    return f"{name}\nvelocity: {convention['velocity']}; units: {convention['units']}"
+
+
+def _format_engine_result_log_label(name: str) -> str:
+    """Return a single-line result label for logs and status text."""
+    convention = _engine_convention(name)
+    return f"{name} [velocity: {convention['velocity']}; units: {convention['units']}]"
+
+
 # ---------------------------------------------------------------------------
 # Plot-style integration (issue #4810)
 # ---------------------------------------------------------------------------
@@ -449,7 +501,7 @@ def _run_headless(
     for eng_name, result in results.items():
         logger.info(
             "  %s: mean_energy=%.4f, mean_speed=%.4f, mean_peak=%.4f",
-            eng_name,
+            _format_engine_result_log_label(eng_name),
             result.mean_total_energy_final,
             result.mean_end_effector_speed_final,
             result.mean_peak_end_effector_speed,
@@ -909,7 +961,10 @@ def _create_dashboard_window_class() -> type:  # noqa: C901
                 width=0.5,
             )
             ax.set_xticks(x)
-            ax.set_xticklabels(engine_names, fontsize=9)
+            ax.set_xticklabels(
+                [_format_engine_result_label(name) for name in engine_names],
+                fontsize=8,
+            )
             ax.set_ylim(0.0, 1.0)
             ax.set_ylabel("Robustness Score", fontsize=9)
             ax.axhline(0.5, color="#ff6060", linewidth=0.8, linestyle="--")

--- a/tests/launchers/wave8_dashboards/test_cross_engine_dashboard_logic.py
+++ b/tests/launchers/wave8_dashboards/test_cross_engine_dashboard_logic.py
@@ -197,6 +197,33 @@ def test_build_dashboard_style_set_default_engine_names() -> None:
     assert "pendulum_stub" in names
 
 
+class TestEngineConventionLabels:
+    def test_known_engine_label_includes_convention_and_units(self) -> None:
+        label = ced._format_engine_result_label("mujoco")
+
+        assert "mujoco" in label
+        assert "velocity: qvel tangent-space" in label
+        assert "units: SI; joint angles rad" in label
+
+    def test_unknown_engine_label_uses_explicit_fallback(self) -> None:
+        label = ced._format_engine_result_label("custom_engine")
+
+        assert label == "custom_engine\nvelocity: engine-native; units: reported SI"
+
+    def test_headless_log_includes_engine_convention(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO, logger=ced.logger.name)
+
+        ced._run_headless(["pendulum_stub"], _fast_config())
+
+        assert any(
+            "pendulum_stub [velocity: qdot state; units: SI; angles rad]"
+            in record.message
+            for record in caplog.records
+        )
+
+
 # ---------------------------------------------------------------------------
 # _render_trajectory_overlay
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add per-engine velocity convention and units metadata for comparison results
- annotate headless comparison logs with convention metadata
- show convention/unit annotations in engine comparison chart labels
- update SPEC.md for the functionality change

## Validation
- python -m pytest -q tests\\launchers\\wave8_dashboards\\test_cross_engine_dashboard_logic.py tests\\launchers\\test_cross_engine_dashboard.py
- python -m ruff check src\\launchers\\cross_engine_dashboard.py tests\\launchers\\wave8_dashboards\\test_cross_engine_dashboard_logic.py
- python -m ruff format --check src\\launchers\\cross_engine_dashboard.py tests\\launchers\\wave8_dashboards\\test_cross_engine_dashboard_logic.py
- push hooks: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print() in src, prettier, bandit, pytest

Closes #6659