### PR TITLE
fix: guard zero-iteration differentiable optimization

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.203                                            |
+| **Spec Version**        | 1.0.204                                            |
 | **Last Spec Update**    | 2026-05-29                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-05-29** - Documented differentiable trajectory optimization behavior for zero-iteration runs: `optimize_trajectory()` now returns a valid `OptimizationResult` with the initial control sequence and an infinite gradient norm sentinel instead of reading an uninitialized gradient value.
 - **2026-05-29** - Updated CI hygiene contract for PR #6624: agent-doc literal path validation now skips glob/brace patterns, root-clutter allowlist documents `launch_upstream_drift.py` as a substantive launcher entry point, module-size baseline exceptions remain owner/expiry governed, and the canonical Sidekick embeddable adapter stays under `src/tools/sidekick/_embed_adapter.py` after removing the obsolete duplicate shared-chat adapter.
 - **2026-05-28** - Resolved python path resolution bug in `embedded_tool_bootstrap.py` and `upstream_drift_launcher.py` to fix launcher boot-time `ModuleNotFoundError` crashes and warnings.
 - **2026-05-28** - Added sg-optimizer Phase 2: GeoJSON I/O (`course_io.py` with `HoleGeometry`, `load_hole_geojson`, `save_hole_geojson`), UTM geometry utilities (`geometry.py` with `LatLonPoint`, `UTMPoint`, `project_to_utm`, `utm_to_latlon`, `haversine_m` via pyproj), classic-holes library (`library.py` with 5 GeoJSON data files for Sawgrass 17, Augusta 13, Pebble 7, Road Hole 17, Cypress 16), `StateFeatures` dataclass factory (`features.py`), and full `TreeModel` with `forced_punch_out_probability` distribution (`mdp/tree_model.py`); adds `pyproj>=3.6.0` optional dependency (closes #6271).

--- a/src/research/differentiable/engine.py
+++ b/src/research/differentiable/engine.py
@@ -47,6 +47,13 @@ class OptimizationResult:
     iterations: int
     gradient_norm: float
 
+    @property
+    def solver_status(self) -> str:
+        """Return a canonical solver status derived from the success flag."""
+        if self.success:
+            return "success"
+        return "failed"
+
 
 class DifferentiableEngine:
     """Differentiable physics simulation.
@@ -355,6 +362,8 @@ class DifferentiableEngine:
 
         best_loss = float("inf")
         best_controls = controls.copy()
+        grad_norm = float("inf")
+        iteration = -1
 
         for iteration in range(max_iterations):
             # Compute gradient

--- a/tests/research/wave6_research/test_differentiable.py
+++ b/tests/research/wave6_research/test_differentiable.py
@@ -97,6 +97,21 @@ class TestDifferentiableEngine:
         )
         assert isinstance(res, OptimizationResult)
 
+    def test_optimize_trajectory_zero_iterations_returns_result(
+        self, fake_engine
+    ) -> None:
+        de = DifferentiableEngine(fake_engine)
+        res = de.optimize_trajectory(
+            np.zeros(4),
+            np.array([0.5, 0.0, 0.0, 0.0]),
+            horizon=2,
+            max_iterations=0,
+        )
+        assert isinstance(res, OptimizationResult)
+        assert res.iterations == 0
+        assert np.isinf(res.gradient_norm)
+        assert res.optimal_controls.shape == (2, 2)
+
     def test_optimize_through_contact_nontrivial(self, fake_engine) -> None:
         cd = ContactDifferentiableEngine(
             fake_engine, contact_method="smoothed", smoothing_factor=0.01


### PR DESCRIPTION
## Summary
- initialize `grad_norm` and `iteration` before `DifferentiableEngine.optimize_trajectory` loops so `max_iterations=0` returns an `OptimizationResult` instead of raising `UnboundLocalError`
- add a regression test for the zero-iteration path
- restore the `OptimizationResult.solver_status` compatibility property expected by the adjacent differentiable-engine tests

Addresses #6644 (F3 only; does not close the rollup issue).

## Validation
- `python -m pytest tests\research\wave6_research\test_differentiable.py::TestDifferentiableEngine::test_optimize_trajectory_zero_iterations_returns_result -q` (fails before fix, passes after)
- `python -m pytest tests\research\wave6_research\test_differentiable.py tests\research\test_differentiable_engine.py -q`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python scripts\ci\check_file_size_budget.py`
- pre-push hooks: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, mypy, bandit, pytest

## Notes
- `python -m pytest -x --timeout=60 -q` still stops during collection on the existing duplicate basename import mismatch between `tests/api/test_rate_limiting.py` and `tests/security/test_rate_limiting.py`.
- `python -m pytest --import-mode=importlib -x --timeout=60 -q` proceeds past that but stops on an existing theme import path issue in `tests/shared/wave7_python_core/test_theme_colors.py`.