### PR TITLE
fix(ui): reconnect notice (#6642 F5); verify #6666/#6675/#6683 already landed

### DIFF
--- a/ui/src/pages/Simulation.test.tsx
+++ b/ui/src/pages/Simulation.test.tsx
@@ -375,4 +375,28 @@ describe('SimulationPage', () => {
       expect(mockSimulation.setSpeed).toHaveBeenCalledWith(2.5);
     });
   });
+
+  // F5 (#6642): a silent auto-reconnect restarts the sim from t=0 — the user
+  // must be notified rather than left thinking the app froze.
+  describe('connection status notifications', () => {
+    it('shows a reconnecting notice when the socket drops mid-run', async () => {
+      Object.assign(mockSimulation, { connectionStatus: 'reconnecting' });
+      render(<SimulationPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/reconnecting \(simulation will restart\)/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('surfaces a failure notice when reconnection gives up', async () => {
+      Object.assign(mockSimulation, { connectionStatus: 'failed' });
+      render(<SimulationPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText(/connection failed/i)).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/ui/src/pages/Simulation.tsx
+++ b/ui/src/pages/Simulation.tsx
@@ -120,10 +120,14 @@ export function SimulationPage() {
     prevConnectionStatusRef.current = connectionStatus;
     if (connectionStatus === 'connected') {
       showSuccess('Connected to simulation server');
+    } else if (connectionStatus === 'reconnecting') {
+      // F5: a transient drop re-runs connect() which restarts the sim from
+      // t=0; warn the user so a silent restart is not mistaken for a freeze.
+      showInfo('Connection lost — reconnecting (simulation will restart)');
     } else if (connectionStatus === 'failed') {
       showError('Connection failed. Please check the server.');
     }
-  }, [connectionStatus, showSuccess, showError]);
+  }, [connectionStatus, showSuccess, showError, showInfo]);
 
   // Surface WebSocket errors via toast (F2)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Wave-2 review sweep of four UpstreamDrift issues. Verify-before-build found that **#6666, #6675, and #6683 are already fully implemented in `main`** (landed via earlier consolidated PRs that never carried a `Closes` reference, so the issues stayed open). The only genuine gap was a single sub-item of **#6642**, fixed here.

## Changes in this PR

### #6642 F5 — auto-reconnect silently restarts the sim from t=0
`useSimulation` correctly sets `connectionStatus='reconnecting'` on a transient drop, but `Simulation.tsx`'s status-toast effect only notified on `connected`/`failed`. A mid-run reconnect therefore wiped progress with no user feedback.
- Added a `reconnecting` branch surfacing an info toast: *"Connection lost — reconnecting (simulation will restart)"*.
- Added `Simulation.test.tsx` coverage for the `reconnecting` and `failed` transitions (26/26 pass; eslint + `tsc -b` clean).

`Closes #6642` — all other findings were already in `main`:
- F1 export wired (`useDatasetGenerator.exportDataset`), F3 `serviceUnreachable` distinct error + retry in `DataExplorer.tsx`, F4 `Array.isArray` shape guards, F6 keyboard-sortable headers w/ `aria-sort`, F7 `catalogLoading`, F8 shared `api/fetch.ts apiFetch` + `selectEffectiveEngine` consumed from the store, F9 ref-gated connection toast, F2 `wsError`/speed-change error toasts.

## Verified-already-done (status comments posted; not closed by this PR)

- **#6666** — all 7 sub-items present & tested: unified embedded console, Undock/Redock tab actions, Clear Filters button + `_clear_all_filters`, C3D viewer tabs enabled at startup (`_update_ui_state(True)` in `c3d_viewer.py`), sibling model tiles (`MuJoCo/Drake/Pinocchio/OpenSim_Models` in `launcher_model_handlers.py`), Kill/Kill All processes panel, reduced runtime-label shadow (`RuntimeButton`, blur 2 / alpha 15). Tests: `test_launcher_ui_setup.py` (redock, shadow), `test_external_tools_adapter.py`.
- **#6675** — Data Processor tile in `launcher_manifest.json` (order 14) opens the shared Tools `DataProcessorWidget` in a dockable tab via `external_tools_adapter.get_data_processor_dockable_ui`, with graceful `_UnavailableToolWindow` degradation. No data-processing logic duplicated (DRY — consumes Tools single-source-of-truth). Test: `tests/launchers/wave8_misc/test_external_tools_adapter.py`.
- **#6683** — `HoverCopyTextBrowser` (overlapping-sheets SVG, hover overlay, "Copied!"/checkmark success state, 2 s revert) in `src/shared/python/ui/hover_copy_browser.py`, consumed across diagnostic/log/error screens. One clipboard helper (DRY). Test: `tests/unit/sidekick/test_hover_copy_browser.py` (cites #6683).

`Part of #6666`
`Part of #6675`
`Part of #6683`

🤖 Generated with [Claude Code](https://claude.com/claude-code)