### PR TITLE
fix(deps): declare pyarrow so Parquet IO tests stop crashing CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN python -m pip install --upgrade --no-cache-dir pip==26.1
 # MuJoCo headless rendering + health check
 # X11/XCB/PyQt6 libs removed — not needed in a headless API server
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcap2 \
     libgl1 \
     libosmesa6 \
     libglew2.2 \

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.205                                            |
+| **Spec Version**        | 1.0.206                                            |
 | **Last Spec Update**    | 2026-05-30                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-05-30** - Declared `pyarrow>=14.0.0` in the data/dev dependency surfaces and regenerated dependency artifacts so Parquet compactor/loader tests can collect in CI; `tests/unit/test_build_install_contracts.py` now falls back to `tomli` on Python 3.10.
 - **2026-05-30** - Widen pinocchio version limit from `<3.0.0` to `<5.0.0` in `pyproject.toml` to resolve numpy 2.0 version compatibility conflict.
 - **2026-05-29** - API security hardening (issue #6643): introduced `_assert_type` guard in `src/api/auth/dependencies.py` to narrow SQLAlchemy query-result types for MyPy strict mode, replaced the previous `type: ignore[return-value]` workarounds with explicit runtime assertions, and added `_lookup_cached_api_key`, `_lookup_api_key_by_prefix`, and `_get_active_user_for_api_key` helper functions for testability. Added `src/api/auth/dependencies.py` prefix-hash API-key lookup regression coverage in `tests/unit/api/test_api_hardening_6643.py`. Sim GUI honest messaging (issue #6641): updated `src/tools/bunker_shot_gui/gui.py` and `src/tools/putting_green_gui/gui.py` to surface explicit error and loading states instead of silently showing stale data; regression tests added in `tests/unit/test_sim_gui_honest_messaging_6641.py`.
 - **2026-05-29** - Documented differentiable trajectory optimization behavior for zero-iteration runs: `optimize_trajectory()` now returns a valid `OptimizationResult` with the initial control sequence and an infinite gradient norm sentinel instead of reading an uninitialized gradient value.
@@ -537,6 +538,7 @@ Beyond standard tools, CI enforces custom checks:
 | mediapipe    | 0.9+    | Motion capture integration (pose detection) |
 | scikit-learn | 1.0+    | RL policy learning and clustering           |
 | sympy        | 1.11+   | Symbolic trajectory optimization            |
+| pyarrow      | 14.0+   | Parquet IO for compact swing dataset paths  |
 
 ### Development Dependencies
 
@@ -546,6 +548,7 @@ Beyond standard tools, CI enforces custom checks:
 | pytest-cov | 4.0+    | Coverage measurement                                                               |
 | hypothesis | 6.0+    | Property-based testing                                                             |
 | pip-tools  | 7.4+    | Regenerate Python dependency lockfiles from `pyproject.toml`                       |
+| pyarrow    | 14.0+   | Parquet IO test coverage for compact swing dataset paths                           |
 | ruff       | latest  | Linting and formatting                                                             |
 | mypy       | 1.7+    | Type checking                                                                      |
 | bandit     | 1.7+    | Security scanning                                                                  |

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.206                                            |
+| **Spec Version**        | 1.0.207                                            |
 | **Last Spec Update**    | 2026-05-30                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-05-30** - Hardened the runtime Docker image against the current Debian 13 `libcap2` high-severity CVE by explicitly upgrading/installing `libcap2` during the runtime apt layer while preserving the pinned `python:3.12-slim` base digest.
 - **2026-05-30** - Declared `pyarrow>=14.0.0` in the data/dev dependency surfaces and regenerated dependency artifacts so Parquet compactor/loader tests can collect in CI; `tests/unit/test_build_install_contracts.py` now falls back to `tomli` on Python 3.10.
 - **2026-05-30** - Widen pinocchio version limit from `<3.0.0` to `<5.0.0` in `pyproject.toml` to resolve numpy 2.0 version compatibility conflict.
 - **2026-05-29** - API security hardening (issue #6643): introduced `_assert_type` guard in `src/api/auth/dependencies.py` to narrow SQLAlchemy query-result types for MyPy strict mode, replaced the previous `type: ignore[return-value]` workarounds with explicit runtime assertions, and added `_lookup_cached_api_key`, `_lookup_api_key_by_prefix`, and `_get_active_user_for_api_key` helper functions for testability. Added `src/api/auth/dependencies.py` prefix-hash API-key lookup regression coverage in `tests/unit/api/test_api_hardening_6643.py`. Sim GUI honest messaging (issue #6641): updated `src/tools/bunker_shot_gui/gui.py` and `src/tools/putting_green_gui/gui.py` to surface explicit error and loading states instead of silently showing stale data; regression tests added in `tests/unit/test_sim_gui_honest_messaging_6641.py`.

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,7 @@ dependencies:
       - tomli>=2.0.0; python_version<'3.11'
       - build
       - pandas>=2.0.0
+      - pyarrow>=14.0.0
       - defusedxml>=0.7.0
       - matplotlib>=3.10.8
       - sqlalchemy>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ sg-optimizer = ["pyproj>=3.6.0"]
 # additive schema checks in src/shared/python/data_io/_schemas.py. These are
 # optional: the loaders import pandera lazily and degrade to structural-only
 # checks when it is absent, so this stays out of the hard core dependencies.
-data = ["pandas>=2.0.0", "pandera>=0.20.0"]
+# pyarrow powers the Parquet IO in scripts/compact_swing_dataset.py and the
+# dataset_tools loaders (hard top-level imports, not lazy), so it ships with
+# the data extra rather than being treated as optional.
+data = ["pandas>=2.0.0", "pandera>=0.20.0", "pyarrow>=14.0.0"]
 
 # Analysis extras
 analysis = ["opencv-python>=4.8.0", "scikit-learn>=1.3.0"]
@@ -122,6 +125,8 @@ dev = [
     "build",
     # Required for tests that import common_utils and model_explorer
     "pandas>=2.0.0",
+    # Required for Parquet IO tests (compact_swing_dataset compactor/loader suites)
+    "pyarrow>=14.0.0",
     "defusedxml>=0.7.0",
     # Required for plotting tests
     "matplotlib>=3.10.8",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -182,6 +182,8 @@ pluggy==1.6.0
     #   pytest-cov
 py-cpuinfo==9.0.0
     # via pytest-benchmark
+pyarrow==24.0.0
+    # via upstream-drift (pyproject.toml)
 pycparser==3.0
     # via cffi
 pydantic==2.12.5

--- a/tests/unit/test_build_install_contracts.py
+++ b/tests/unit/test_build_install_contracts.py
@@ -11,8 +11,12 @@ Two bugs:
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
 
 class TestUIBuildHookMissingDist:


### PR DESCRIPTION
## Problem
The Core Test Suite (`tests (3.10/3.11/3.12)`) on `main` aborts at collection when Parquet compactor tests import `pyarrow`, because the package was not declared in the install extras used by CI.

## Fix
- declare `pyarrow>=14.0.0` in the data and dev extras
- sync the generated dependency artifacts that CI enforces (`requirements-dev.lock`, `environment.yml`)
- make the build/install contract test use `tomli` on Python 3.10, matching the project dependency marker
- document the dependency contract in `SPEC.md`
- refresh runtime-image `libcap2` during the apt layer so the Docker security scan picks up the fixed Debian package

Fixes #6748.

## Verification
- `py -3.10 -m pytest tests/unit/test_build_install_contracts.py -q`
- `git diff --check`
- pre-push hooks: ruff, format guidance, prettier, bandit, pytest
- attempted `docker build --target runtime -t upstreamdrift:ci-local .`; local Docker daemon was not reachable, so PR Docker scan is authoritative