### PR TITLE
feat(launcher): close tabs into background (keep running) + restore (#6013)

### DIFF
--- a/src/launchers/launcher_ui_setup.py
+++ b/src/launchers/launcher_ui_setup.py
@@ -530,12 +530,16 @@ class UISetupManager:
         self._setup_search_shortcuts()
 
     def dock_widget_as_tab(self, widget: QWidget, title: str) -> None:
-        """Dock a submodule widget as a new tab in the workspace."""
-        if not True:
-            logger.error("Workspace tabs not initialized; cannot dock widget.")
-            return
+        """Dock a submodule/tool widget as a new tab in the workspace.
 
-        index = self.workspace_tabs.addTab(widget, title)
+        Tool tabs are background-eligible (#6013): closing one keeps the
+        widget running hidden and restorable via the View > Background Tabs
+        menu, rather than destroying it.
+        """
+        if widget is None:
+            raise ValueError("widget must be provided")
+
+        index = self.workspace_tabs.add_background_tab(widget, title)
         self.workspace_tabs.setCurrentIndex(index)
 
     def _open_library_tab(self) -> None:
@@ -1083,9 +1087,46 @@ class UISetupManager:
         view_menu.addAction(action_redock_tabs)
         self.action_redock_tabs = action_redock_tabs
 
+        background_menu = view_menu.addMenu("&Background Tabs")
+        self._background_tabs_menu = background_menu
+        background_menu.aboutToShow.connect(self._refresh_background_tabs_menu)
+
         view_menu.addSeparator()
         theme_menu = view_menu.addMenu("&Theme")
         self._setup_theme_menu(theme_menu)
+
+    def _refresh_background_tabs_menu(self) -> None:
+        """Populate the Background Tabs menu with restore actions (#6013).
+
+        Lists tool tabs that were closed but kept running hidden, so the
+        user can bring them back. Rebuilt each time the menu opens.
+        """
+        menu = getattr(self, "_background_tabs_menu", None)
+        if menu is None:
+            return
+        menu.clear()
+
+        tabs = getattr(self, "workspace_tabs", None)
+        titles = tabs.list_background_tabs() if tabs is not None else []
+
+        if not titles:
+            empty = QAction("(no background tabs)", self.launcher)
+            empty.setEnabled(False)
+            menu.addAction(empty)
+            return
+
+        for title in titles:
+            act = QAction(f"Restore: {title}", self.launcher)
+            act.setToolTip(f"Bring the hidden '{title}' tab back into view")
+            act.triggered.connect(
+                lambda _checked=False, t=title: tabs.restore_background_tab(t)
+            )
+            menu.addAction(act)
+
+        menu.addSeparator()
+        restore_all = QAction("Restore All", self.launcher)
+        restore_all.triggered.connect(tabs.restore_all_background_tabs)
+        menu.addAction(restore_all)
 
     def _popout_active_tab(self) -> None:
         """Undock the currently active workspace tab into a floating window."""

--- a/src/shared/python/gui_pkg/draggable_tabs.py
+++ b/src/shared/python/gui_pkg/draggable_tabs.py
@@ -92,6 +92,8 @@ class DraggableTabWidget(QTabWidget):
 
     tab_detached = pyqtSignal(int, QPoint)
     tab_moved = pyqtSignal(int, int)
+    tab_backgrounded = pyqtSignal(str)
+    tab_restored = pyqtSignal(str)
 
     def __init__(
         self,
@@ -109,6 +111,11 @@ class DraggableTabWidget(QTabWidget):
         # Track closed tabs for "Open Tab" functionality
         self.closed_tabs: dict[str, Callable[[], QWidget | None]] = {}
         self.tab_factories: dict[str, Callable[[], QWidget | None]] = {}
+
+        # Background tabs: closing a background-eligible tab hides it and
+        # retains the live widget + its state instead of deleting it, so it
+        # keeps running and can be restored. Keyed by tab title.
+        self.background_tabs: dict[str, tuple[QWidget, QIcon]] = {}
 
         # Core tabs cannot be closed
         self.core_tabs: set[str] = core_tabs if core_tabs is not None else set()
@@ -129,6 +136,7 @@ class DraggableTabWidget(QTabWidget):
         if isinstance(widget, QMainWindow) and not isinstance(widget, DockedTabWrapper):
             widget = DockedTabWrapper(widget)
         index = super().addTab(widget, *args)
+        self._drop_background_entry(widget)
         self._update_tab_ux(index)
         return index
 
@@ -139,8 +147,20 @@ class DraggableTabWidget(QTabWidget):
         if isinstance(widget, QMainWindow) and not isinstance(widget, DockedTabWrapper):
             widget = DockedTabWrapper(widget)
         ret_index = super().insertTab(index, widget, *args)
+        self._drop_background_entry(widget)
         self._update_tab_ux(ret_index)
         return ret_index
+
+    def _drop_background_entry(self, widget: QWidget) -> None:
+        """Forget any background record for ``widget`` once it is shown again.
+
+        Keeps the background registry consistent when a widget is re-added
+        through a side channel (e.g. the console toggle) rather than via
+        ``restore_background_tab``.
+        """
+        for title, (bg_widget, _icon) in list(self.background_tabs.items()):
+            if bg_widget is widget:
+                del self.background_tabs[title]
 
     def _update_tab_ux(self, index: int) -> None:
         """Hide close button for core tabs and add tooltip hints."""
@@ -252,16 +272,80 @@ class DraggableTabWidget(QTabWidget):
             if reply != QMessageBox.StandardButton.Yes:
                 return
 
+        # Background-eligible tabs keep running hidden instead of being
+        # destroyed. This subsumes the legacy ``prevent_deletion_on_close``
+        # flag into a single, generic lifecycle (DRY).
+        if widget is not None and self._is_background_eligible(widget):
+            self._background_tab(index, tab_text, widget)
+            return
+
         if tab_text in self.tab_factories:
             self.closed_tabs[tab_text] = self.tab_factories[tab_text]
 
-        prevent_delete = getattr(widget, "prevent_deletion_on_close", False)
         self.removeTab(index)
         if widget:
-            if prevent_delete:
-                widget.setParent(None)
-            else:
-                widget.deleteLater()
+            widget.deleteLater()
+
+    # ── Background (keep-running-hidden) lifecycle ──────────────────
+
+    @staticmethod
+    def _is_background_eligible(widget: QWidget) -> bool:
+        """Return True if closing ``widget`` should background it, not delete.
+
+        Opt-in is generic: any widget carrying a truthy ``background_eligible``
+        attribute qualifies. The legacy ``prevent_deletion_on_close`` flag is
+        honoured as an alias so existing call sites keep working.
+        """
+        return bool(
+            getattr(widget, "background_eligible", False)
+            or getattr(widget, "prevent_deletion_on_close", False)
+        )
+
+    def add_background_tab(self, widget: QWidget, *args) -> int:
+        """Add a tab whose widget keeps running when its tab is closed.
+
+        Marks ``widget`` background-eligible and adds it like ``addTab``.
+        Returns the new tab index.
+        """
+        if widget is None:
+            raise ValueError("widget must be provided")
+        widget.background_eligible = True
+        return self.addTab(widget, *args)
+
+    def _background_tab(self, index: int, title: str, widget: QWidget) -> None:
+        """Remove ``widget``'s tab but retain the live widget + state."""
+        if not title:
+            raise ValueError("title must be provided for a background tab")
+        icon = self.tabIcon(index)
+        self.removeTab(index)
+        widget.setParent(None)
+        widget.hide()
+        self.background_tabs[title] = (widget, icon)
+        self.tab_backgrounded.emit(title)
+
+    def list_background_tabs(self) -> list[str]:
+        """Return titles of tabs currently running hidden in the background."""
+        return sorted(self.background_tabs)
+
+    def restore_background_tab(self, title: str) -> None:
+        """Restore a backgrounded tab back into the tab bar by title."""
+        if title is None:
+            raise ValueError("title must be provided")
+        entry = self.background_tabs.pop(title, None)
+        if entry is None:
+            return
+        widget, icon = entry
+        if widget.parent():
+            widget.setParent(None)
+        idx = self.addTab(widget, icon, title)
+        widget.show()
+        self.setCurrentIndex(idx)
+        self.tab_restored.emit(title)
+
+    def restore_all_background_tabs(self) -> None:
+        """Restore every backgrounded tab."""
+        for title in list(self.background_tabs):
+            self.restore_background_tab(title)
 
     def reopen_closed_tab(self, tab_name: str) -> None:
         """Reopen a previously closed tab by name."""
@@ -612,15 +696,21 @@ class DetachedTabWindow(QMainWindow):
             # Remove from parent's detached tabs registry
             if self.parent_tab_widget and self in self.parent_tab_widget.detached_tabs:
                 del self.parent_tab_widget.detached_tabs[self]
-            # Delete/clean up the widget, respecting prevent_deletion_on_close
+            # Background-eligible widgets keep running hidden; others are
+            # destroyed. Mirrors DraggableTabWidget.close_tab (DRY intent).
             if self.widget:
-                prevent_delete = getattr(
-                    self.widget, "prevent_deletion_on_close", False
-                )
-                if prevent_delete:
+                parent_tabs = self.parent_tab_widget
+                background = DraggableTabWidget._is_background_eligible(self.widget)
+                if background and parent_tabs is not None:
                     if isinstance(self.widget, DockedTabWrapper):
                         self.widget.main_window.setParent(None)
                     self.widget.setParent(None)
+                    self.widget.hide()
+                    parent_tabs.background_tabs[self.original_title] = (
+                        self.widget,
+                        self.windowIcon(),
+                    )
+                    parent_tabs.tab_backgrounded.emit(self.original_title)
                 else:
                     if isinstance(self.widget, DockedTabWrapper):
                         self.widget.main_window.deleteLater()

--- a/tests/launchers/test_workspace_tabs.py
+++ b/tests/launchers/test_workspace_tabs.py
@@ -428,3 +428,85 @@ def test_docked_tab_menu_bar_preservation(launcher, qtbot):
     assert re_wrapped_widget.layout().count() == 2
     assert re_wrapped_widget.layout().itemAt(0).widget() == menu_bar
     assert re_wrapped_widget.layout().itemAt(1).widget() == win
+
+
+# ── Epic #6013: close-in-background (keep running hidden) ──────────────
+
+
+def _add_background_tab(launcher, monkeypatch, title="BG Tool"):
+    """Add a background-eligible tab and return (widget, index).
+
+    Forces 'never' confirmation so close_tab does not prompt.
+    """
+    from src.shared.python.ui.preferences_dialog import UserPreferences
+
+    monkeypatch.setattr(
+        UserPreferences,
+        "load",
+        classmethod(lambda cls: UserPreferences(confirm_close_tabs="never")),
+    )
+    tabs = launcher.workspace_tabs
+    widget = QWidget()
+    idx = tabs.add_background_tab(widget, title)
+    return widget, idx
+
+
+def test_close_keeps_widget_alive_when_background(launcher, monkeypatch):
+    """Closing a background-eligible tab hides it but keeps the widget alive."""
+    widget, idx = _add_background_tab(launcher, monkeypatch)
+    tabs = launcher.workspace_tabs
+    assert tabs.indexOf(widget) == idx
+
+    tabs.close_tab(idx)
+
+    # Tab removed from the bar...
+    assert tabs.indexOf(widget) == -1
+    # ...but the widget itself is still a live, retained object.
+    assert "BG Tool" in tabs.list_background_tabs()
+    # Widget not deleted: attribute access must still work (no RuntimeError).
+    assert widget.objectName() == ""
+
+
+def test_restore_background_tab(launcher, monkeypatch):
+    """A backgrounded tab can be restored back into the tab bar."""
+    widget, idx = _add_background_tab(launcher, monkeypatch)
+    tabs = launcher.workspace_tabs
+
+    tabs.close_tab(idx)
+    assert tabs.indexOf(widget) == -1
+
+    tabs.restore_background_tab("BG Tool")
+
+    restored_idx = tabs.indexOf(widget)
+    assert restored_idx != -1
+    assert tabs.tabText(restored_idx) == "BG Tool"
+    assert "BG Tool" not in tabs.list_background_tabs()
+
+
+def test_background_tab_state_preserved(launcher, monkeypatch):
+    """State set on a background tab's widget survives close + restore."""
+    from src.shared.python.ui.preferences_dialog import UserPreferences
+
+    monkeypatch.setattr(
+        UserPreferences,
+        "load",
+        classmethod(lambda cls: UserPreferences(confirm_close_tabs="never")),
+    )
+
+    class StatefulWidget(QWidget):
+        def __init__(self) -> None:
+            super().__init__()
+            self.counter = 0
+
+    tabs = launcher.workspace_tabs
+    widget = StatefulWidget()
+    idx = tabs.add_background_tab(widget, "Stateful")
+    widget.counter = 42
+
+    tabs.close_tab(idx)
+    assert widget.counter == 42  # retained while hidden
+
+    tabs.restore_background_tab("Stateful")
+    restored = tabs.widget(tabs.indexOf(widget))
+    assert restored is widget
+    assert restored.counter == 42


### PR DESCRIPTION
## Summary

Completes epic **#6013** (launcher tabs closeable-in-background + pop-out-able). Pop-out / drag-to-detach was already implemented in `DraggableTabWidget`; this PR adds the missing half: **"close in background = keep running"**, implemented as *keep-running-hidden* (retain the live widget + its state instead of `deleteLater`) plus a restore affordance.

## What changed

`src/shared/python/gui_pkg/draggable_tabs.py` — one DRY background lifecycle:
- `background_tabs` registry + `tab_backgrounded` / `tab_restored` signals.
- `add_background_tab()`, `restore_background_tab()`, `restore_all_background_tabs()`, `list_background_tabs()`.
- `_is_background_eligible()` — generic opt-in via a `background_eligible` widget attribute; honours the legacy `prevent_deletion_on_close` flag as an alias, so the console keeps working and there is a single mechanism.
- `close_tab()` and the `DetachedTabWindow` close-event "Close Tab" path now route eligible widgets into the background instead of deleting them.
- `addTab` / `insertTab` drop stale background entries when a widget reappears (keeps the registry consistent with the console toggle).

`src/launchers/launcher_ui_setup.py`:
- Tool tabs (`dock_widget_as_tab`) are now background-eligible (generic opt-in, not just the console).
- New **View > Background Tabs** menu listing hidden tabs with per-tab Restore + Restore All, rebuilt on `aboutToShow`.

## Tests (TDD: red → green)

Added to `tests/launchers/test_workspace_tabs.py` (offscreen Qt, one launcher per test to respect the multi-widget segfault constraint):
- `test_close_keeps_widget_alive_when_background`
- `test_restore_background_tab`
- `test_background_tab_state_preserved`

All three were verified failing before implementation, passing after. Full file: the 3 new + existing background-adjacent tests pass. (`test_tab_right_click_undock_menu` fails identically on clean `origin/main` — pre-existing, unrelated.)

ruff check/format clean, mypy + bandit + full pytest passed in the pre-push hook. File sizes within budget (`draggable_tabs.py` 723 lines).

Closes #6013

🤖 Generated with [Claude Code](https://claude.com/claude-code)