### PR TITLE
feat(simulation_backends): unified results schema v2 — torques/wrench/markers/contacts + v1 migration (CC-4)

### DIFF
--- a/docs/simulation_backends/results_schema_v2.md
+++ b/docs/simulation_backends/results_schema_v2.md
@@ -1,0 +1,150 @@
+# Unified Results Schema v2
+
+**Implemented by:** CC-4 (#6776)  
+**Canonical module:** `src/shared/python/simulation_backends/trace_io.py`  
+**Schema version constant:** `SCHEMA_VERSION = "2.0.0"` (in `protocol.py`)
+
+This document is the authoritative reference for the unified HDF5 result
+format that covers every simulation backend (ODE, MuJoCo, MuJoCo Warp) and
+the BunkerShot3D sand-interaction results. Every file written by `write_trace`
+is self-describing and versioned.
+
+---
+
+## Scope
+
+Two formats existed before CC-4:
+
+| Format | Owner | Groups |
+|---|---|---|
+| `Trace` v1.x | `simulation_backends` | `/t`, `/q`, `/v`, `/u` |
+| BunkerShot3D | `bunkershot3d.io.schema` | `/clubhead/<t>/`, `/wrench/<t>/`, `/grains/<t>/` |
+
+**v2 unifies them** by extending `Trace` with optional trajectory and
+wrench groups. BunkerShot3D files can be imported via
+`read_bunkershot3d_result` and are never used as an internal intermediate.
+
+---
+
+## HDF5 Layout
+
+### Root attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `schema_version` | str | `"MAJOR.MINOR.PATCH"` stamped at write time |
+| `backend` | str | Backend name, e.g. `"ode"`, `"mujoco"`, `"bunkershot3d"` |
+| `dt` | float | Integration step [s] |
+| `kind` | str | `"single"` (Trace) or `"batch"` (BatchTrace) |
+| `meta_<key>` | scalar | One attribute per scalar provenance entry |
+
+### Required datasets
+
+| Dataset | Shape | dtype | Description |
+|---|---|---|---|
+| `t` | `(T,)` | float64 | Sample times [s] |
+| `q` | `(T, nq)` or `(N, T, nq)` | float64 | Generalised positions [rad] |
+| `v` | `(T, nv)` or `(N, T, nv)` | float64 | Generalised velocities [rad/s] |
+
+### Optional datasets (v2+, single Trace only)
+
+| Dataset | Shape | dtype | Description |
+|---|---|---|---|
+| `u` | `(T, nu)` | float64 | Applied controls [N·m]; omitted if passive |
+| `torques` | `(T, nu)` | float64 | Joint torques / generalised forces [N·m] |
+| `wrench` | `(T, 6)` | float64 | Contact wrench `[fx, fy, fz, tx, ty, tz]` [N, N·m] |
+| `markers` | `(T, n_markers, 3)` | float64 | Predicted marker positions [m] |
+| `contacts` | `(T, n_contacts, 3)` | float64 | Contact point positions [m] |
+
+Datasets that are `None` are **omitted** from the file; the reader returns
+`None` for absent datasets.
+
+---
+
+## BunkerShot3D Profile
+
+BunkerShot3D files use a legacy time-keyed sub-group layout under
+`/clubhead/`, `/wrench/`, and `/grains/`. They are **import-only**:
+`read_bunkershot3d_result` maps them to the unified schema as follows:
+
+| BunkerShot3D | Trace v2 field |
+|---|---|
+| `/clubhead/t_<t>/position` (3,) | `markers[:, 0, :]` shape `(T, 1, 3)` |
+| `/wrench/t_<t>/force` + `torque` (3,) each | `wrench` columns `[:3]` + `[3:]` |
+| `/grains/…` | dropped (not mapped) |
+| — | `q`, `v` → empty `(T, 0)` arrays |
+
+BunkerShot3D results are **never** written back in the BunkerShot3D format
+by the analysis layer; all downstream analysis reads `Trace` objects.
+
+---
+
+## Versioning Policy
+
+| File major | Accepted | Notes |
+|---|---|---|
+| `1` | ✓ (auto-migrated) | v1.x files lack optional datasets; all default to `None` |
+| `2` | ✓ (current) | Full v2 support |
+| other | ✗ | `ValueError` raised |
+
+Minor and patch differences within an accepted major are always accepted
+(additive changes only).
+
+---
+
+## Migration API
+
+```python
+from src.shared.python.simulation_backends.trace_io import (
+    read_trace,             # reads v1 or v2; auto-migrates v1
+    migrate_from_v1,        # explicitly reads a v1 file
+    read_bunkershot3d_result,  # imports a BunkerShot3D HDF5 file
+    write_trace,            # always writes v2
+)
+```
+
+### Auto-migration example
+
+```python
+# Works transparently for both v1 and v2 files:
+trace = read_trace("old_v1_file.h5")
+assert trace.torques is None   # new fields default to None
+```
+
+### Explicit v1 migration
+
+```python
+trace = migrate_from_v1("old_v1_file.h5")
+# trace.schema_version == "1.0.0" (preserved from file)
+```
+
+### BunkerShot3D import
+
+```python
+trace = read_bunkershot3d_result("bunker_sim.h5")
+# trace.markers: clubhead positions, shape (T, 1, 3)
+# trace.wrench:  contact wrench,    shape (T, 6)
+# trace.q / v:   empty (T, 0) arrays — no joint states
+```
+
+---
+
+## Provenance (pending CC-6)
+
+The `meta_` attribute namespace carries scalar provenance today. When
+CC-6 (#6778, `ProvenanceStamp`) merges, a dedicated `/provenance` group
+will be written by every `write_trace` call. The flat `meta_` attributes
+will remain for backward compatibility.
+
+---
+
+## See also
+
+- `src/shared/python/simulation_backends/protocol.py` — `Trace` dataclass
+- `src/shared/python/simulation_backends/trace_io.py` — read/write/migrate
+- `src/bunkershot3d/io/schema.py` — legacy BunkerShot3D reader (for direct
+  BunkerShot3D access; prefer `read_bunkershot3d_result` for cross-engine
+  analysis)
+- ADR-0023 — `simulation_backends` architecture
+- CC-6 (#6778) — ProvenanceStamp (pending)
+- CC-25 (#6798) — WrenchTrace into unified schema (pending)

--- a/src/shared/python/simulation_backends/protocol.py
+++ b/src/shared/python/simulation_backends/protocol.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
 
 #: Versioned schema stamped into every serialised trace. Bump on any breaking
 #: change to the on-disk layout (see :mod:`simulation_backends.trace`).
-SCHEMA_VERSION = "1.0.0"
+#: v2.0.0 adds optional /torques, /wrench, /markers, /contacts groups.
+#: v1.x files are auto-migrated by :func:`simulation_backends.trace_io.read_trace`.
+SCHEMA_VERSION = "2.0.0"
 
 
 @dataclass(frozen=True)
@@ -103,6 +105,12 @@ class Trace:
         dt: Integration step [s].
         backend: Name of the backend that produced the trace.
         meta: Free-form provenance metadata (scalars/strings only).
+        torques: Generalised joint forces, shape ``(T, nu)`` [N*m], or ``None``.
+        wrench: Contact wrench [fx,fy,fz,tx,ty,tz], shape ``(T, 6)``, or ``None``.
+        markers: Predicted marker positions, shape ``(T, n_markers, 3)`` [m], or
+            ``None``.
+        contacts: Contact point positions, shape ``(T, n_contacts, 3)`` [m], or
+            ``None``.
     """
 
     t: np.ndarray
@@ -113,6 +121,10 @@ class Trace:
     backend: str = "unknown"
     meta: Mapping[str, object] = field(default_factory=dict)
     schema_version: str = SCHEMA_VERSION
+    torques: np.ndarray | None = None
+    wrench: np.ndarray | None = None
+    markers: np.ndarray | None = None
+    contacts: np.ndarray | None = None
 
     def __post_init__(self) -> None:
         """Validate array shapes are mutually consistent (postcondition guard)."""
@@ -130,6 +142,40 @@ class Trace:
             if self.u.shape[0] != n:
                 raise ValueError(
                     f"control history has {self.u.shape[0]} rows, expected {n}"
+                )
+        if self.torques is not None:
+            self.torques = np.atleast_2d(np.asarray(self.torques, dtype=float))
+            if self.torques.shape[0] != n:
+                raise ValueError(
+                    f"torques has {self.torques.shape[0]} rows, expected {n}"
+                )
+        if self.wrench is not None:
+            self.wrench = np.asarray(self.wrench, dtype=float)
+            if self.wrench.ndim != 2 or self.wrench.shape != (n, 6):
+                raise ValueError(
+                    f"wrench must have shape ({n}, 6), got {self.wrench.shape}"
+                )
+        if self.markers is not None:
+            self.markers = np.asarray(self.markers, dtype=float)
+            if (
+                self.markers.ndim != 3
+                or self.markers.shape[0] != n
+                or self.markers.shape[2] != 3
+            ):
+                raise ValueError(
+                    f"markers must have shape ({n}, n_markers, 3), "
+                    f"got {self.markers.shape}"
+                )
+        if self.contacts is not None:
+            self.contacts = np.asarray(self.contacts, dtype=float)
+            if (
+                self.contacts.ndim != 3
+                or self.contacts.shape[0] != n
+                or self.contacts.shape[2] != 3
+            ):
+                raise ValueError(
+                    f"contacts must have shape ({n}, n_contacts, 3), "
+                    f"got {self.contacts.shape}"
                 )
 
     @property

--- a/src/shared/python/simulation_backends/trace_io.py
+++ b/src/shared/python/simulation_backends/trace_io.py
@@ -1,7 +1,7 @@
 """Versioned HDF5 (de)serialisation for :class:`Trace` and :class:`BatchTrace`.
 
-This is the M3.3 *shared schema*: a single on-disk format every backend writes
-and the analysis layer reads, so a rollout produced on the GPU can be replayed,
+This is the *shared schema*: a single on-disk format every backend writes and
+the analysis layer reads, so a rollout produced on the GPU can be replayed,
 diffed, or cross-validated on CPU. The format is self-describing and versioned
 via :data:`~simulation_backends.protocol.SCHEMA_VERSION`.
 
@@ -18,19 +18,32 @@ Root group attributes:
   ``int`` / ``float`` / ``bool`` values are persisted; richer objects are
   skipped silently (the attribute namespace only round-trips scalars).
 
-Datasets:
+Datasets (all single traces):
 
 * ``t`` -- sample times, shape ``(T,)``.
 * ``q`` -- positions, shape ``(T, nq)`` (single) or ``(N, T, nq)`` (batch).
 * ``v`` -- velocities, matching ``q``.
 * ``u`` -- controls, written **only** when present (``None`` is omitted).
+* ``torques`` -- joint torques ``(T, nu)``; written only when present (v2+).
+* ``wrench`` -- contact wrench ``(T, 6)``; written only when present (v2+).
+* ``markers`` -- marker positions ``(T, n_markers, 3)``; written only when
+  present (v2+).
+* ``contacts`` -- contact points ``(T, n_contacts, 3)``; written only when
+  present (v2+).
 
 Versioning policy
 -----------------
-The reader requires the file's schema *MAJOR* component to equal the running
-:data:`SCHEMA_VERSION` major; a mismatch raises :class:`ValueError` rather than
-silently misinterpreting an incompatible layout. Minor/patch differences are
-accepted (additive, backward-compatible changes).
+The reader accepts schema **major 1** (v1.x legacy) and **major 2** (current).
+A v1 file is auto-migrated: new optional datasets default to ``None``. Any
+other major raises :class:`ValueError`. Minor/patch differences within an
+accepted major are always accepted.
+
+Migration helpers
+-----------------
+:func:`migrate_from_v1` reads a v1.x file explicitly and returns a :class:`Trace`.
+:func:`read_bunkershot3d_result` converts a BunkerShot3D HDF5 file into a
+:class:`Trace` (clubhead positions → ``markers``; wrenches → ``wrench``).
+See ``docs/simulation_backends/results_schema_v2.md`` for the full schema.
 """
 
 from __future__ import annotations
@@ -46,7 +59,7 @@ from .protocol import SCHEMA_VERSION, BatchTrace, Trace
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-__all__ = ["read_trace", "write_trace"]
+__all__ = ["migrate_from_v1", "read_bunkershot3d_result", "read_trace", "write_trace"]
 
 #: Prefix applied to every metadata entry stored as a root HDF5 attribute.
 _META_PREFIX = "meta_"
@@ -97,6 +110,21 @@ def _meta_scalars(meta: Mapping[str, object]) -> dict[str, str | bool | int | fl
     }
 
 
+def _write_optional_dataset(
+    root: h5py.Group, name: str, data: np.ndarray | None
+) -> None:
+    """Write ``data`` as dataset ``name`` under ``root`` iff it is not None."""
+    if data is not None:
+        root.create_dataset(name, data=np.asarray(data, dtype=float))
+
+
+def _read_optional_dataset(root: h5py.Group, name: str) -> np.ndarray | None:
+    """Return dataset ``name`` from ``root`` as a float array, or None if absent."""
+    if name not in root:
+        return None
+    return np.asarray(root[name][()], dtype=float)
+
+
 def _write_common(
     root: h5py.Group,
     *,
@@ -109,6 +137,10 @@ def _write_common(
     q: np.ndarray,
     v: np.ndarray,
     u: np.ndarray | None,
+    torques: np.ndarray | None = None,
+    wrench: np.ndarray | None = None,
+    markers: np.ndarray | None = None,
+    contacts: np.ndarray | None = None,
 ) -> None:
     """Write the shared attribute/dataset payload for either trace kind.
 
@@ -126,10 +158,14 @@ def _write_common(
         q: Position array.
         v: Velocity array.
         u: Control array, or ``None`` to omit the dataset.
+        torques: Optional joint-torque array ``(T, nu)``.
+        wrench: Optional contact wrench ``(T, 6)``.
+        markers: Optional marker-position array ``(T, n_markers, 3)``.
+        contacts: Optional contact-point array ``(T, n_contacts, 3)``.
 
     Postconditions:
         ``root`` has ``schema_version``/``backend``/``dt``/``kind`` attrs, the
-        ``t``/``q``/``v`` datasets, and a ``u`` dataset iff ``u is not None``.
+        ``t``/``q``/``v`` datasets, optional datasets written iff not None.
     """
     root.attrs["schema_version"] = schema_version
     root.attrs["backend"] = backend
@@ -141,8 +177,11 @@ def _write_common(
     root.create_dataset("t", data=np.asarray(t, dtype=float))
     root.create_dataset("q", data=np.asarray(q, dtype=float))
     root.create_dataset("v", data=np.asarray(v, dtype=float))
-    if u is not None:
-        root.create_dataset("u", data=np.asarray(u, dtype=float))
+    _write_optional_dataset(root, "u", u)
+    _write_optional_dataset(root, "torques", torques)
+    _write_optional_dataset(root, "wrench", wrench)
+    _write_optional_dataset(root, "markers", markers)
+    _write_optional_dataset(root, "contacts", contacts)
 
 
 def write_trace(trace: Trace | BatchTrace, path: str | os.PathLike[str]) -> None:
@@ -173,6 +212,10 @@ def write_trace(trace: Trace | BatchTrace, path: str | os.PathLike[str]) -> None
         )
 
     with h5py.File(os.fspath(path), "w") as handle:
+        torques = getattr(trace, "torques", None)
+        wrench = getattr(trace, "wrench", None)
+        markers = getattr(trace, "markers", None)
+        contacts = getattr(trace, "contacts", None)
         _write_common(
             handle,
             kind=kind,
@@ -184,27 +227,34 @@ def write_trace(trace: Trace | BatchTrace, path: str | os.PathLike[str]) -> None
             q=trace.q,
             v=trace.v,
             u=trace.u,
+            torques=torques,
+            wrench=wrench,
+            markers=markers,
+            contacts=contacts,
         )
 
 
 def _check_schema_compatible(file_version: str, path: str) -> None:
-    """Validate that the file's schema major matches the running schema.
+    """Validate that the file's schema major is accepted by the reader.
+
+    Accepted majors: ``"1"`` (v1.x legacy, auto-migrated) and ``"2"``
+    (current). Any other major raises :class:`ValueError`.
 
     Args:
         file_version: ``schema_version`` attribute read from the file.
         path: Source path, included in error messages for diagnostics.
 
     Raises:
-        ValueError: If the major components differ (incompatible layout).
+        ValueError: If the major is not ``"1"`` or ``"2"``.
     """
     file_major = _major(file_version)
     current_major = _major(SCHEMA_VERSION)
-    if file_major != current_major:
+    accepted = {current_major, "1"}
+    if file_major not in accepted:
         raise ValueError(
             f"incompatible trace schema in {path!r}: file major version "
-            f"{file_major} (schema {file_version!r}) does not match the "
-            f"supported major version {current_major} (schema "
-            f"{SCHEMA_VERSION!r})"
+            f"{file_major} (schema {file_version!r}) is not in the "
+            f"supported set {sorted(accepted)}"
         )
 
 
@@ -312,7 +362,12 @@ def read_trace(path: str | os.PathLike[str]) -> Trace | BatchTrace:
         t = np.asarray(handle["t"][()], dtype=float)
         q = np.asarray(handle["q"][()], dtype=float)
         v = np.asarray(handle["v"][()], dtype=float)
-        u = np.asarray(handle["u"][()], dtype=float) if "u" in handle else None
+        u = _read_optional_dataset(handle, "u")
+
+        torques = _read_optional_dataset(handle, "torques")
+        wrench = _read_optional_dataset(handle, "wrench")
+        markers = _read_optional_dataset(handle, "markers")
+        contacts = _read_optional_dataset(handle, "contacts")
 
     if kind == _KIND_SINGLE:
         return Trace(
@@ -324,6 +379,10 @@ def read_trace(path: str | os.PathLike[str]) -> Trace | BatchTrace:
             backend=backend,
             meta=meta,
             schema_version=schema_version,
+            torques=torques,
+            wrench=wrench,
+            markers=markers,
+            contacts=contacts,
         )
     if kind == _KIND_BATCH:
         return BatchTrace(
@@ -339,4 +398,117 @@ def read_trace(path: str | os.PathLike[str]) -> Trace | BatchTrace:
     raise ValueError(
         f"unrecognised trace kind {kind!r} in {spath!r}; "
         f"expected {_KIND_SINGLE!r} or {_KIND_BATCH!r}"
+    )
+
+
+def migrate_from_v1(path: str | os.PathLike[str]) -> Trace:
+    """Read a v1.x :class:`Trace` file and return a :class:`Trace`.
+
+    Unlike :func:`read_trace`, this function explicitly requires the file to
+    be major version 1 and raises if it is not. New optional fields
+    (``torques``, ``wrench``, ``markers``, ``contacts``) default to ``None``.
+
+    Args:
+        path: Source filesystem path of a v1.x trace file.
+
+    Returns:
+        A :class:`Trace` with ``schema_version`` preserved from the file.
+
+    Raises:
+        TypeError: If ``path`` is not a str or :class:`os.PathLike`.
+        ValueError: If ``path`` is empty or the file is not major version 1.
+    """
+    _validate_path(path)
+    spath = os.fspath(path)
+    with h5py.File(spath, "r") as handle:
+        schema_version = str(_read_attr(handle, "schema_version"))
+        file_major = _major(schema_version)
+        if file_major != "1":
+            raise ValueError(
+                f"migrate_from_v1 requires a version 1 file; "
+                f"got schema {schema_version!r} in {spath!r}"
+            )
+        kind = str(_read_attr(handle, "kind"))
+        backend = str(_read_attr(handle, "backend"))
+        dt = float(_read_attr(handle, "dt"))  # type: ignore[arg-type]
+        meta = _read_meta(handle)
+        t = np.asarray(handle["t"][()], dtype=float)
+        q = np.asarray(handle["q"][()], dtype=float)
+        v = np.asarray(handle["v"][()], dtype=float)
+        u = _read_optional_dataset(handle, "u")
+
+    if kind != _KIND_SINGLE:
+        raise ValueError(
+            f"migrate_from_v1 only supports single-trace files; "
+            f"got kind={kind!r} in {spath!r}"
+        )
+    return Trace(
+        t=t,
+        q=q,
+        v=v,
+        u=u,
+        dt=dt,
+        backend=backend,
+        meta=meta,
+        schema_version=schema_version,
+    )
+
+
+def read_bunkershot3d_result(path: str | os.PathLike[str]) -> Trace:
+    """Convert a BunkerShot3D HDF5 result file into a :class:`Trace`.
+
+    BunkerShot3D stores clubhead states and contact wrenches in per-timestep
+    sub-groups (``/clubhead/t_<t>/`` and ``/wrench/t_<t>/``). This function
+    reads those groups and maps them to the unified v2 schema:
+
+    * Clubhead positions → ``Trace.markers`` shape ``(T, 1, 3)`` [m].
+    * Contact wrenches → ``Trace.wrench`` shape ``(T, 6)`` [N, N, N, N·m, …].
+    * ``Trace.q`` / ``Trace.v`` are empty ``(T, 0)`` arrays (no joint states).
+    * ``Trace.backend`` is set to ``"bunkershot3d"``.
+
+    Args:
+        path: Source filesystem path of a BunkerShot3D HDF5 result file.
+
+    Returns:
+        A :class:`Trace` with schema_version equal to :data:`SCHEMA_VERSION`.
+
+    Raises:
+        TypeError: If ``path`` is not a str or :class:`os.PathLike`.
+        ValueError: If ``path`` is empty or the file lacks a ``/clubhead``
+            group.
+    """
+    _validate_path(path)
+    spath = os.fspath(path)
+    with h5py.File(spath, "r") as f:
+        if "clubhead" not in f:
+            raise ValueError(
+                f"not a BunkerShot3D file: missing /clubhead group in {spath!r}"
+            )
+        clubhead_grp = f["clubhead"]
+        keys = sorted(clubhead_grp.keys())
+        times = np.array([clubhead_grp[k].attrs["time"] for k in keys], dtype=float)
+        positions = np.array(
+            [clubhead_grp[k]["position"][:] for k in keys], dtype=float
+        )
+
+        if "wrench" in f:
+            wrench_grp = f["wrench"]
+            wkeys = sorted(wrench_grp.keys())
+            forces = np.array([wrench_grp[k]["force"][:] for k in wkeys], dtype=float)
+            torques = np.array([wrench_grp[k]["torque"][:] for k in wkeys], dtype=float)
+            wrench = np.concatenate([forces, torques], axis=1)
+        else:
+            wrench = None
+
+    n = len(times)
+    markers = positions.reshape(n, 1, 3)
+    empty = np.empty((n, 0), dtype=float)
+    return Trace(
+        t=times,
+        q=empty,
+        v=empty,
+        dt=float(np.mean(np.diff(times))) if n > 1 else 0.0,
+        backend="bunkershot3d",
+        markers=markers,
+        wrench=wrench,
     )

--- a/tests/unit/simulation_backends/test_trace_v2_schema.py
+++ b/tests/unit/simulation_backends/test_trace_v2_schema.py
@@ -1,0 +1,344 @@
+"""Tests for the v2 Trace schema extension (CC-4).
+
+Covers:
+* Trace v2 optional groups: torques, wrench, markers, contacts.
+* Round-trip identity for all optional groups.
+* Backward compatibility: v1 HDF5 files auto-migrate through read_trace.
+* Migration helper: migrate_from_v1.
+* BunkerShot3D import helper: read_bunkershot3d_result.
+* Shape validation for the new optional arrays.
+"""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from src.shared.python.simulation_backends.protocol import (
+    SCHEMA_VERSION,
+    Trace,
+)
+from src.shared.python.simulation_backends.trace_io import (
+    migrate_from_v1,
+    read_bunkershot3d_result,
+    read_trace,
+    write_trace,
+)
+
+pytestmark = pytest.mark.unit
+
+_RNG = np.random.default_rng(42)
+_T = 11
+_NQ = 2
+_NU = 2
+_N_MARKERS = 4
+_N_CONTACTS = 3
+
+
+def _base_trace(**kwargs) -> Trace:
+    t = np.arange(_T, dtype=float) * 0.01
+    q = _RNG.standard_normal((_T, _NQ))
+    v = _RNG.standard_normal((_T, _NQ))
+    return Trace(t=t, q=q, v=v, dt=0.01, backend="ode", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# SCHEMA_VERSION
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_2() -> None:
+    """SCHEMA_VERSION must be 2.x after the CC-4 bump."""
+    major = SCHEMA_VERSION.split(".", 1)[0]
+    assert major == "2", f"Expected major 2, got {SCHEMA_VERSION!r}"
+
+
+# ---------------------------------------------------------------------------
+# Optional group write/read round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_trace_v2_round_trip_with_torques(tmp_path) -> None:
+    """A Trace with torques round-trips losslessly."""
+    torques = _RNG.standard_normal((_T, _NU))
+    trace = _base_trace(torques=torques)
+    path = tmp_path / "torques.h5"
+
+    write_trace(trace, path)
+    loaded = read_trace(path)
+
+    assert isinstance(loaded, Trace)
+    assert loaded.torques is not None
+    np.testing.assert_allclose(loaded.torques, torques)
+
+
+def test_trace_v2_round_trip_with_wrench(tmp_path) -> None:
+    """A Trace with wrench (T, 6) round-trips losslessly."""
+    wrench = _RNG.standard_normal((_T, 6))
+    trace = _base_trace(wrench=wrench)
+    path = tmp_path / "wrench.h5"
+
+    write_trace(trace, path)
+    loaded = read_trace(path)
+
+    assert loaded.wrench is not None
+    np.testing.assert_allclose(loaded.wrench, wrench)
+
+
+def test_trace_v2_round_trip_with_markers(tmp_path) -> None:
+    """A Trace with markers (T, n_markers, 3) round-trips losslessly."""
+    markers = _RNG.standard_normal((_T, _N_MARKERS, 3))
+    trace = _base_trace(markers=markers)
+    path = tmp_path / "markers.h5"
+
+    write_trace(trace, path)
+    loaded = read_trace(path)
+
+    assert loaded.markers is not None
+    np.testing.assert_allclose(loaded.markers, markers)
+
+
+def test_trace_v2_round_trip_with_contacts(tmp_path) -> None:
+    """A Trace with contacts (T, n_contacts, 3) round-trips losslessly."""
+    contacts = _RNG.standard_normal((_T, _N_CONTACTS, 3))
+    trace = _base_trace(contacts=contacts)
+    path = tmp_path / "contacts.h5"
+
+    write_trace(trace, path)
+    loaded = read_trace(path)
+
+    assert loaded.contacts is not None
+    np.testing.assert_allclose(loaded.contacts, contacts)
+
+
+def test_trace_v2_round_trip_all_optional_groups(tmp_path) -> None:
+    """A Trace with all optional groups set round-trips completely."""
+    torques = _RNG.standard_normal((_T, _NU))
+    wrench = _RNG.standard_normal((_T, 6))
+    markers = _RNG.standard_normal((_T, _N_MARKERS, 3))
+    contacts = _RNG.standard_normal((_T, _N_CONTACTS, 3))
+
+    trace = _base_trace(
+        torques=torques, wrench=wrench, markers=markers, contacts=contacts
+    )
+    path = tmp_path / "all_groups.h5"
+
+    write_trace(trace, path)
+    loaded = read_trace(path)
+
+    np.testing.assert_allclose(loaded.torques, torques)
+    np.testing.assert_allclose(loaded.wrench, wrench)
+    np.testing.assert_allclose(loaded.markers, markers)
+    np.testing.assert_allclose(loaded.contacts, contacts)
+
+
+def test_trace_v2_optional_groups_absent_when_none(tmp_path) -> None:
+    """When optional arrays are None the HDF5 file has no corresponding dataset."""
+    trace = _base_trace()
+    path = tmp_path / "no_optional.h5"
+
+    write_trace(trace, path)
+
+    with h5py.File(path, "r") as f:
+        assert "torques" not in f
+        assert "wrench" not in f
+        assert "markers" not in f
+        assert "contacts" not in f
+
+    loaded = read_trace(path)
+    assert loaded.torques is None
+    assert loaded.wrench is None
+    assert loaded.markers is None
+    assert loaded.contacts is None
+
+
+def test_trace_v2_schema_version_stamped(tmp_path) -> None:
+    """Written file carries the current SCHEMA_VERSION."""
+    trace = _base_trace()
+    path = tmp_path / "version.h5"
+    write_trace(trace, path)
+
+    with h5py.File(path, "r") as f:
+        sv = f.attrs["schema_version"]
+        if isinstance(sv, bytes):
+            sv = sv.decode()
+    assert sv == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: v1 file auto-migrates
+# ---------------------------------------------------------------------------
+
+
+def _write_v1_file(path, *, with_controls: bool = False) -> None:
+    """Write a minimal v1.0.0 trace file directly via h5py."""
+    t = np.arange(_T, dtype=float) * 0.01
+    q = _RNG.standard_normal((_T, _NQ))
+    v = _RNG.standard_normal((_T, _NQ))
+    with h5py.File(path, "w") as f:
+        f.attrs["schema_version"] = "1.0.0"
+        f.attrs["backend"] = "ode"
+        f.attrs["dt"] = 0.01
+        f.attrs["kind"] = "single"
+        f.create_dataset("t", data=t)
+        f.create_dataset("q", data=q)
+        f.create_dataset("v", data=v)
+        if with_controls:
+            f.create_dataset("u", data=_RNG.standard_normal((_T, _NU)))
+
+
+def test_read_trace_auto_migrates_v1_file(tmp_path) -> None:
+    """read_trace accepts a v1 file and returns a valid Trace."""
+    path = tmp_path / "v1.h5"
+    _write_v1_file(path)
+
+    loaded = read_trace(path)
+    assert isinstance(loaded, Trace)
+    assert loaded.t.shape == (_T,)
+    assert loaded.torques is None
+    assert loaded.wrench is None
+
+
+def test_read_trace_v1_with_controls_auto_migrates(tmp_path) -> None:
+    """v1 file with controls round-trips controls through auto-migration."""
+    path = tmp_path / "v1_u.h5"
+    _write_v1_file(path, with_controls=True)
+
+    loaded = read_trace(path)
+    assert loaded.u is not None
+    assert loaded.u.shape == (_T, _NU)
+
+
+def test_migrate_from_v1_returns_trace(tmp_path) -> None:
+    """migrate_from_v1 reads a v1 file and returns a Trace."""
+    path = tmp_path / "v1_mig.h5"
+    _write_v1_file(path)
+
+    trace = migrate_from_v1(path)
+    assert isinstance(trace, Trace)
+    assert trace.schema_version == "1.0.0"
+    assert trace.torques is None
+    assert trace.wrench is None
+    assert trace.markers is None
+    assert trace.contacts is None
+
+
+def test_migrate_from_v1_rejects_non_v1_file(tmp_path) -> None:
+    """migrate_from_v1 raises ValueError when the file is not major version 1."""
+    trace = _base_trace()
+    path = tmp_path / "v2.h5"
+    write_trace(trace, path)
+
+    with pytest.raises(ValueError, match="version 1"):
+        migrate_from_v1(path)
+
+
+# ---------------------------------------------------------------------------
+# BunkerShot3D import
+# ---------------------------------------------------------------------------
+
+
+def _write_bunkershot_file(path) -> dict:
+    """Write a minimal BunkerShot3D HDF5 file; return the data for assertion."""
+    n = 5
+    times = np.arange(n, dtype=float) * 0.01
+    positions = _RNG.standard_normal((n, 3))
+    quats = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))
+    forces = _RNG.standard_normal((n, 3))
+    torques = _RNG.standard_normal((n, 3))
+
+    with h5py.File(path, "w") as f:
+        cg = f.create_group("clubhead")
+        wg = f.create_group("wrench")
+        f.create_group("grains")
+
+        for i, t in enumerate(times):
+            key = f"t_{t:.6f}"
+            sg = cg.create_group(key)
+            sg.attrs["time"] = t
+            sg.create_dataset("position", data=positions[i])
+            sg.create_dataset("orientation", data=quats[i])
+
+            wsg = wg.create_group(key)
+            wsg.attrs["time"] = t
+            wsg.create_dataset("force", data=forces[i])
+            wsg.create_dataset("torque", data=torques[i])
+
+    return {
+        "n": n,
+        "times": times,
+        "positions": positions,
+        "forces": forces,
+        "torques": torques,
+    }
+
+
+def test_read_bunkershot3d_result_returns_trace(tmp_path) -> None:
+    """read_bunkershot3d_result converts a BunkerShot3D HDF5 file into a Trace."""
+    path = tmp_path / "bunker.h5"
+    ref = _write_bunkershot_file(path)
+
+    trace = read_bunkershot3d_result(path)
+
+    assert isinstance(trace, Trace)
+    assert trace.t.shape == (ref["n"],)
+    np.testing.assert_allclose(trace.t, ref["times"])
+
+
+def test_read_bunkershot3d_result_populates_markers(tmp_path) -> None:
+    """Clubhead positions become the markers array."""
+    path = tmp_path / "bunker_markers.h5"
+    ref = _write_bunkershot_file(path)
+
+    trace = read_bunkershot3d_result(path)
+
+    assert trace.markers is not None
+    assert trace.markers.shape == (ref["n"], 1, 3)
+    np.testing.assert_allclose(trace.markers[:, 0, :], ref["positions"])
+
+
+def test_read_bunkershot3d_result_populates_wrench(tmp_path) -> None:
+    """Contact wrenches become the wrench (T, 6) array."""
+    path = tmp_path / "bunker_wrench.h5"
+    ref = _write_bunkershot_file(path)
+
+    trace = read_bunkershot3d_result(path)
+
+    assert trace.wrench is not None
+    assert trace.wrench.shape == (ref["n"], 6)
+    np.testing.assert_allclose(trace.wrench[:, :3], ref["forces"])
+    np.testing.assert_allclose(trace.wrench[:, 3:], ref["torques"])
+
+
+# ---------------------------------------------------------------------------
+# Shape validation
+# ---------------------------------------------------------------------------
+
+
+def test_trace_v2_torques_wrong_first_dim_raises() -> None:
+    """torques with wrong time dimension raises ValueError."""
+    torques = _RNG.standard_normal((_T + 1, _NU))
+    with pytest.raises(ValueError, match="torques"):
+        _base_trace(torques=torques)
+
+
+def test_trace_v2_wrench_wrong_second_dim_raises() -> None:
+    """wrench with shape other than (T, 6) raises ValueError."""
+    wrench = _RNG.standard_normal((_T, 3))
+    with pytest.raises(ValueError, match="wrench"):
+        _base_trace(wrench=wrench)
+
+
+def test_trace_v2_markers_wrong_last_dim_raises() -> None:
+    """markers with shape other than (T, n, 3) raises ValueError."""
+    markers = _RNG.standard_normal((_T, _N_MARKERS, 2))
+    with pytest.raises(ValueError, match="markers"):
+        _base_trace(markers=markers)
+
+
+def test_trace_v2_contacts_wrong_first_dim_raises() -> None:
+    """contacts with wrong time dimension raises ValueError."""
+    contacts = _RNG.standard_normal((_T + 2, _N_CONTACTS, 3))
+    with pytest.raises(ValueError, match="contacts"):
+        _base_trace(contacts=contacts)


### PR DESCRIPTION
## Summary

Implements **CC-4** ([#6776](https://github.com/D-sorganization/UpstreamDrift/issues/6776)) — Unified results schema v2 extending `Trace`/`trace_io` with optional data groups and v1 backward compatibility.

- **`protocol.py`**: `SCHEMA_VERSION` → `"2.0.0"`; `Trace` gains four optional fields — `torques (T, nu)`, `wrench (T, 6)`, `markers (T, n_markers, 3)`, `contacts (T, n_contacts, 3)` — each validated in `__post_init__` (DbC shape preconditions).
- **`trace_io.py`**: `_write_common` writes optional datasets iff not None; `read_trace` reads optional datasets and accepts major-1 legacy files (auto-migration); `_check_schema_compatible` accepts majors `{1, 2}`; two new public helpers: `migrate_from_v1()` (explicit v1 reader) and `read_bunkershot3d_result()` (clubhead positions → `markers`, wrenches → `wrench`, empty joint arrays).
- **`tests/unit/simulation_backends/test_trace_v2_schema.py`** (new): 19 unit tests — round-trips for every optional group, backward compat with v1 files, both migration helpers, shape validation. All 26 trace tests pass (7 pre-existing + 19 new).
- **`docs/simulation_backends/results_schema_v2.md`** (new): authoritative schema reference — HDF5 layout, BunkerShot3D profile, versioning policy, migration API.

### Not in scope (deferred per issue)
- `/provenance` group (CC-6 / #6778 ProvenanceStamp not yet merged)
- `WrenchTrace` wrapping (CC-25 / #6798)

## Test plan

- [x] `python3 -m pytest tests/unit/simulation_backends/test_trace_io.py tests/unit/simulation_backends/test_trace_v2_schema.py` → **26 passed**
- [x] `python3 -m ruff check` → zero violations
- [x] `python3 -m ruff format --check` → zero diffs
- [x] All files under 1200 lines (`trace_io.py`: 514, `protocol.py`: 358, test file: 344)
- [x] TDD: tests written first (red), then implementation (green), then formatted (refactor)
- [x] DbC: `Trace.__post_init__` validates shape of every new optional array
- [x] DRY: `_write_optional_dataset` / `_read_optional_dataset` centralise optional I/O
- [x] LOD: no method chains >2 levels

Closes #6776

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_0136eyxpF9HQj2CywF81JdM4)_