### PR TITLE
feat(cc-25/cc-12): wrench extractor + canonical observation schema

### DIFF
--- a/src/shared/python/pose_estimation/__init__.py
+++ b/src/shared/python/pose_estimation/__init__.py
@@ -5,6 +5,24 @@ human pose / joint angles from video or mocap data.
 """
 
 from .interface import PoseEstimationResult, PoseEstimator
+from .observations import (
+    CanonicalObservations,
+    CameraCalibration,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    observations_from_dict,
+    observations_to_dict,
+)
 from .openpose_estimator import OpenPoseEstimator
 
-__all__ = ["PoseEstimator", "PoseEstimationResult", "OpenPoseEstimator"]
+__all__ = [
+    "CanonicalObservations",
+    "CameraCalibration",
+    "CameraExtrinsics",
+    "CameraIntrinsics",
+    "OpenPoseEstimator",
+    "PoseEstimationResult",
+    "PoseEstimator",
+    "observations_from_dict",
+    "observations_to_dict",
+]

--- a/src/shared/python/pose_estimation/observations.py
+++ b/src/shared/python/pose_estimation/observations.py
@@ -1,0 +1,309 @@
+"""Canonical observation schema for multi-camera markerless pose estimation.
+
+CC-12 (#6785) — input-side contract for the physics-matched estimator (CC-18).
+
+Observations capture per-camera 2D keypoints, camera calibration, per-keypoint
+confidence, and optionally triangulated 3D positions.  Confidence is preserved
+end-to-end so downstream estimators (CC-18) can weight residuals per keypoint.
+
+Typical usage::
+
+    obs = CanonicalObservations(
+        cameras=(cam0_calib, cam1_calib),
+        keypoints_2d=(kps_cam0, kps_cam1),   # each shape (N_kp, 2) [px]
+        confidences=(conf_cam0, conf_cam1),   # each shape (N_kp,) ∈ [0, 1]
+        detector_layout=("nose", "left_hip", ...),
+        timestamp=0.033,
+    )
+    d = observations_to_dict(obs)   # JSON-serialisable
+    obs2 = observations_from_dict(d)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "CanonicalObservations",
+    "CameraCalibration",
+    "CameraExtrinsics",
+    "CameraIntrinsics",
+    "observations_from_dict",
+    "observations_to_dict",
+]
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Pinhole camera intrinsic parameters.
+
+    Attributes:
+        fx: Horizontal focal length [px].
+        fy: Vertical focal length [px].
+        cx: Principal point x [px].
+        cy: Principal point y [px].
+        width: Image width [px].
+        height: Image height [px].
+    """
+
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    width: int
+    height: int
+
+    def __post_init__(self) -> None:
+        if self.fx <= 0 or self.fy <= 0:
+            raise ValueError(
+                f"focal lengths must be positive; got fx={self.fx}, fy={self.fy}"
+            )
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(
+                f"image dimensions must be positive; "
+                f"got width={self.width}, height={self.height}"
+            )
+
+    def as_matrix(self) -> np.ndarray:
+        """Return the 3×3 intrinsic matrix **K**.
+
+        Returns:
+            Array of shape ``(3, 3)``::
+
+                [[fx,  0, cx],
+                 [ 0, fy, cy],
+                 [ 0,  0,  1]]
+        """
+        return np.array(
+            [
+                [self.fx, 0.0, self.cx],
+                [0.0, self.fy, self.cy],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+
+
+@dataclass(frozen=True)
+class CameraExtrinsics:
+    """Camera extrinsic parameters (world-to-camera rigid transform).
+
+    Attributes:
+        rotation: 3×3 rotation matrix **R** (world-to-camera).
+        translation: 3-vector **t** (camera origin in world coordinates) [m].
+    """
+
+    rotation: np.ndarray  # (3, 3)
+    translation: np.ndarray  # (3,)
+
+    def __post_init__(self) -> None:
+        r = np.asarray(self.rotation, dtype=float)
+        t = np.asarray(self.translation, dtype=float)
+        if r.shape != (3, 3):
+            raise ValueError(f"rotation must have shape (3, 3), got {r.shape}")
+        if t.shape != (3,):
+            raise ValueError(f"translation must have shape (3,), got {t.shape}")
+        # Re-assign as float arrays (dataclass is frozen, so use __setattr__).
+        object.__setattr__(self, "rotation", r)
+        object.__setattr__(self, "translation", t)
+
+
+@dataclass(frozen=True)
+class CameraCalibration:
+    """Combined intrinsic and extrinsic calibration for one camera.
+
+    Attributes:
+        camera_id: Unique identifier string (e.g. ``"cam0"``, ``"left"``).
+        intrinsics: Pinhole intrinsic parameters.
+        extrinsics: World-to-camera rigid transform.
+    """
+
+    camera_id: str
+    intrinsics: CameraIntrinsics
+    extrinsics: CameraExtrinsics
+
+    def __post_init__(self) -> None:
+        if not self.camera_id:
+            raise ValueError("camera_id must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class CanonicalObservations:
+    """Canonical multi-camera observation for a single frame.
+
+    Captures the raw 2D keypoint observations from all cameras together with
+    per-keypoint confidence weights and camera calibration.  Optionally
+    includes triangulated 3D positions.
+
+    Preconditions (enforced in ``__post_init__``):
+
+    * ``len(cameras) == len(keypoints_2d) == len(confidences)``
+    * ``keypoints_2d[i].shape == (n_keypoints, 2)`` for every *i*
+    * ``confidences[i].shape == (n_keypoints,)`` with all values in ``[0, 1]``
+    * ``len(detector_layout) == n_keypoints > 0``
+    * ``keypoints_3d`` (if given) has shape ``(n_keypoints, 3)``
+
+    Attributes:
+        cameras: Per-camera calibration list.
+        keypoints_2d: Per-camera 2D keypoints, each shape ``(n_kp, 2)`` [px].
+        confidences: Per-camera per-keypoint confidence scores,
+            each shape ``(n_kp,)`` with values in ``[0, 1]``.
+        detector_layout: Ordered keypoint names matching the detector output.
+        timestamp: Frame timestamp [s].
+        keypoints_3d: Optional triangulated 3D positions,
+            shape ``(n_kp, 3)`` [m].
+    """
+
+    cameras: tuple[CameraCalibration, ...]
+    keypoints_2d: tuple[np.ndarray, ...]
+    confidences: tuple[np.ndarray, ...]
+    detector_layout: tuple[str, ...]
+    timestamp: float
+    keypoints_3d: np.ndarray | None = None
+
+    def __post_init__(self) -> None:  # noqa: C901
+        n_cams = len(self.cameras)
+        if len(self.keypoints_2d) != n_cams:
+            raise ValueError(
+                f"keypoints_2d length {len(self.keypoints_2d)} != "
+                f"number of cameras {n_cams}"
+            )
+        if len(self.confidences) != n_cams:
+            raise ValueError(
+                f"confidences length {len(self.confidences)} != "
+                f"number of cameras {n_cams}"
+            )
+        n_kp = len(self.detector_layout)
+        if n_kp == 0:
+            raise ValueError("detector_layout must be non-empty")
+        for i, kp in enumerate(self.keypoints_2d):
+            kp_arr = np.asarray(kp, dtype=float)
+            if kp_arr.shape != (n_kp, 2):
+                raise ValueError(
+                    f"keypoints_2d[{i}] must have shape ({n_kp}, 2), got {kp_arr.shape}"
+                )
+        for i, conf in enumerate(self.confidences):
+            c_arr = np.asarray(conf, dtype=float)
+            if c_arr.shape != (n_kp,):
+                raise ValueError(
+                    f"confidences[{i}] must have shape ({n_kp},), got {c_arr.shape}"
+                )
+            if not (np.all(c_arr >= 0.0) and np.all(c_arr <= 1.0)):
+                raise ValueError(
+                    f"confidence values must be in [0, 1]; "
+                    f"confidences[{i}] has min={float(c_arr.min()):.4f}, "
+                    f"max={float(c_arr.max()):.4f}"
+                )
+        if self.keypoints_3d is not None:
+            kp3 = np.asarray(self.keypoints_3d, dtype=float)
+            if kp3.shape != (n_kp, 3):
+                raise ValueError(
+                    f"keypoints_3d must have shape ({n_kp}, 3), got {kp3.shape}"
+                )
+            object.__setattr__(self, "keypoints_3d", kp3)
+
+    @property
+    def n_cameras(self) -> int:
+        """Number of cameras in this observation."""
+        return len(self.cameras)
+
+    @property
+    def n_keypoints(self) -> int:
+        """Number of keypoints declared in ``detector_layout``."""
+        return len(self.detector_layout)
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (JSON-compatible dict ↔ CanonicalObservations)
+# ---------------------------------------------------------------------------
+
+
+def observations_to_dict(obs: CanonicalObservations) -> dict[str, Any]:
+    """Serialise a :class:`CanonicalObservations` to a JSON-native dict.
+
+    All NumPy arrays are converted to nested Python lists so the result can
+    be passed to ``json.dumps`` or included in a CC-4 provenance record.
+
+    Args:
+        obs: Observation to serialise.
+
+    Returns:
+        A dict with only JSON-native scalars, lists, and strings.
+    """
+    cameras_out = []
+    for cal in obs.cameras:
+        cameras_out.append(
+            {
+                "camera_id": cal.camera_id,
+                "intrinsics": {
+                    "fx": cal.intrinsics.fx,
+                    "fy": cal.intrinsics.fy,
+                    "cx": cal.intrinsics.cx,
+                    "cy": cal.intrinsics.cy,
+                    "width": cal.intrinsics.width,
+                    "height": cal.intrinsics.height,
+                },
+                "extrinsics": {
+                    "rotation": cal.extrinsics.rotation.tolist(),
+                    "translation": cal.extrinsics.translation.tolist(),
+                },
+            }
+        )
+    return {
+        "cameras": cameras_out,
+        "keypoints_2d": [kp.tolist() for kp in obs.keypoints_2d],
+        "confidences": [c.tolist() for c in obs.confidences],
+        "detector_layout": list(obs.detector_layout),
+        "timestamp": float(obs.timestamp),
+        "keypoints_3d": (
+            obs.keypoints_3d.tolist() if obs.keypoints_3d is not None else None
+        ),
+    }
+
+
+def observations_from_dict(d: dict[str, Any]) -> CanonicalObservations:
+    """Deserialise a dict produced by :func:`observations_to_dict`.
+
+    Args:
+        d: Dict previously produced by :func:`observations_to_dict`.
+
+    Returns:
+        A :class:`CanonicalObservations` instance with all validation applied.
+
+    Raises:
+        KeyError: If a required key is missing from *d*.
+        ValueError: If the data violates the ``CanonicalObservations``
+            preconditions.
+    """
+    cameras = tuple(
+        CameraCalibration(
+            camera_id=c["camera_id"],
+            intrinsics=CameraIntrinsics(
+                fx=c["intrinsics"]["fx"],
+                fy=c["intrinsics"]["fy"],
+                cx=c["intrinsics"]["cx"],
+                cy=c["intrinsics"]["cy"],
+                width=int(c["intrinsics"]["width"]),
+                height=int(c["intrinsics"]["height"]),
+            ),
+            extrinsics=CameraExtrinsics(
+                rotation=np.array(c["extrinsics"]["rotation"]),
+                translation=np.array(c["extrinsics"]["translation"]),
+            ),
+        )
+        for c in d["cameras"]
+    )
+    keypoints_2d = tuple(np.array(kp) for kp in d["keypoints_2d"])
+    confidences = tuple(np.array(c) for c in d["confidences"])
+    kp3d_raw = d.get("keypoints_3d")
+    keypoints_3d = np.array(kp3d_raw) if kp3d_raw is not None else None
+    return CanonicalObservations(
+        cameras=cameras,
+        keypoints_2d=keypoints_2d,
+        confidences=confidences,
+        detector_layout=tuple(d["detector_layout"]),
+        timestamp=float(d["timestamp"]),
+        keypoints_3d=keypoints_3d,
+    )

--- a/src/shared/python/simulation_backends/__init__.py
+++ b/src/shared/python/simulation_backends/__init__.py
@@ -44,6 +44,13 @@ from .protocol import (
     SimulationBackend,
     Trace,
 )
+from .wrench_extractor import (
+    WrenchImpulses,
+    compute_wrench_impulses,
+    force_torque_from_wrench_array,
+    trace_wrench_impulses,
+    wrench_array_from_force_torque,
+)
 
 __all__ = [
     "SCHEMA_VERSION",
@@ -61,11 +68,16 @@ __all__ = [
     "Trace",
     "UnknownBackendError",
     "UpperSegmentParams",
+    "WrenchImpulses",
     "available_backends",
+    "compute_wrench_impulses",
+    "force_torque_from_wrench_array",
     "has_mujoco",
     "has_warp",
     "make_backend",
     "require_mujoco",
     "require_warp",
+    "trace_wrench_impulses",
     "warp_device_available",
+    "wrench_array_from_force_torque",
 ]

--- a/src/shared/python/simulation_backends/wrench_extractor.py
+++ b/src/shared/python/simulation_backends/wrench_extractor.py
@@ -1,0 +1,162 @@
+"""Engine-agnostic GRF/wrench extraction utilities (CC-25, #6798).
+
+Bridges the canonical ``Trace.wrench`` field (CC-4) with analysis primitives
+for ground-reaction force and contact-wrench data.
+
+The ``Trace.wrench`` field follows the CC-4 layout::
+
+    [fx, fy, fz, tx, ty, tz]   in N and N·m (world frame)
+
+Functions in this module let callers:
+
+* **Pack** separate force/torque arrays into the ``(T, 6)`` wrench field
+  understood by :class:`~simulation_backends.protocol.Trace`.
+* **Unpack** a wrench array back into force and torque components.
+* **Integrate** impulses from a wrench trace or directly from a
+  :class:`~simulation_backends.protocol.Trace`.
+
+No domain-specific (bunkershot3d) imports are used; the module operates
+purely on NumPy arrays so any engine can feed it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .protocol import Trace
+
+__all__ = [
+    "WrenchImpulses",
+    "compute_wrench_impulses",
+    "force_torque_from_wrench_array",
+    "trace_wrench_impulses",
+    "wrench_array_from_force_torque",
+]
+
+
+@dataclass(frozen=True)
+class WrenchImpulses:
+    """Linear and angular impulses integrated over a wrench trace.
+
+    Attributes:
+        linear_impulse: Time-integrated force, shape ``(3,)`` [N·s].
+        angular_impulse: Time-integrated torque, shape ``(3,)`` [N·m·s].
+    """
+
+    linear_impulse: np.ndarray
+    angular_impulse: np.ndarray
+
+
+def wrench_array_from_force_torque(
+    force: np.ndarray,
+    torque: np.ndarray,
+) -> np.ndarray:
+    """Pack separate force and torque arrays into a ``(T, 6)`` wrench array.
+
+    The layout matches the CC-4 ``Trace.wrench`` convention:
+    ``[fx, fy, fz, tx, ty, tz]``.
+
+    Args:
+        force: World-frame forces, shape ``(T, 3)`` [N].
+        torque: World-frame torques, shape ``(T, 3)`` [N·m].
+
+    Returns:
+        Combined wrench, shape ``(T, 6)``.
+
+    Raises:
+        ValueError: If *force* or *torque* do not have shape ``(T, 3)``,
+            or if their time dimensions disagree.
+    """
+    force = np.asarray(force, dtype=float)
+    torque = np.asarray(torque, dtype=float)
+    if force.ndim != 2 or force.shape[1] != 3:
+        raise ValueError(f"force must have shape (T, 3), got {force.shape}")
+    if torque.ndim != 2 or torque.shape[1] != 3:
+        raise ValueError(f"torque must have shape (T, 3), got {torque.shape}")
+    if force.shape[0] != torque.shape[0]:
+        raise ValueError(
+            "force and torque must have the same number of timesteps; "
+            f"got {force.shape[0]} vs {torque.shape[0]}"
+        )
+    return np.concatenate([force, torque], axis=1)
+
+
+def force_torque_from_wrench_array(
+    wrench: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Unpack a ``(T, 6)`` wrench array into separate force and torque arrays.
+
+    Args:
+        wrench: Combined wrench, shape ``(T, 6)``
+            ``[fx, fy, fz, tx, ty, tz]``.
+
+    Returns:
+        Tuple ``(force, torque)`` each of shape ``(T, 3)``.
+
+    Raises:
+        ValueError: If *wrench* does not have shape ``(T, 6)``.
+    """
+    wrench = np.asarray(wrench, dtype=float)
+    if wrench.ndim != 2 or wrench.shape[1] != 6:
+        raise ValueError(f"wrench must have shape (T, 6), got {wrench.shape}")
+    return wrench[:, :3], wrench[:, 3:]
+
+
+def compute_wrench_impulses(
+    time: np.ndarray,
+    wrench: np.ndarray,
+) -> WrenchImpulses:
+    """Integrate a wrench trace to compute linear and angular impulses.
+
+    Uses the trapezoidal rule for integration, matching the convention in
+    ``WrenchTrace.get_impulses`` (bunkershot3d).
+
+    Args:
+        time: Sample times, shape ``(T,)`` [s].  Should be strictly
+            increasing.
+        wrench: Wrench array, shape ``(T, 6)``
+            ``[fx, fy, fz, tx, ty, tz]``.
+
+    Returns:
+        :class:`WrenchImpulses` with ``linear_impulse`` (3,) [N·s]
+        and ``angular_impulse`` (3,) [N·m·s].
+
+    Raises:
+        ValueError: If *time* and *wrench* disagree in length, or if
+            *wrench* does not have shape ``(T, 6)``.
+    """
+    time = np.asarray(time, dtype=float).reshape(-1)
+    wrench = np.asarray(wrench, dtype=float)
+    if wrench.ndim != 2 or wrench.shape[1] != 6:
+        raise ValueError(f"wrench must have shape (T, 6), got {wrench.shape}")
+    if time.shape[0] != wrench.shape[0]:
+        raise ValueError(
+            f"time length {time.shape[0]} does not match wrench rows {wrench.shape[0]}"
+        )
+    force, torque = force_torque_from_wrench_array(wrench)
+    linear_impulse = np.trapezoid(force, x=time, axis=0)
+    angular_impulse = np.trapezoid(torque, x=time, axis=0)
+    return WrenchImpulses(
+        linear_impulse=linear_impulse,
+        angular_impulse=angular_impulse,
+    )
+
+
+def trace_wrench_impulses(trace: Trace) -> WrenchImpulses | None:
+    """Return wrench impulses from a :class:`~.protocol.Trace`, or ``None``.
+
+    Convenience wrapper that extracts the wrench field and delegates to
+    :func:`compute_wrench_impulses`.
+
+    Args:
+        trace: Simulation trace with optional wrench data.
+
+    Returns:
+        :class:`WrenchImpulses` if ``trace.wrench`` is not ``None``,
+        otherwise ``None``.
+    """
+    if trace.wrench is None:
+        return None
+    return compute_wrench_impulses(trace.t, trace.wrench)

--- a/tests/unit/simulation_backends/test_wrench_extractor.py
+++ b/tests/unit/simulation_backends/test_wrench_extractor.py
@@ -1,0 +1,177 @@
+"""Unit tests for simulation_backends.wrench_extractor (CC-25, #6798).
+
+TDD: these tests were written before the implementation and drove the design.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.simulation_backends.protocol import Trace
+from src.shared.python.simulation_backends.wrench_extractor import (
+    WrenchImpulses,
+    compute_wrench_impulses,
+    force_torque_from_wrench_array,
+    trace_wrench_impulses,
+    wrench_array_from_force_torque,
+)
+
+pytestmark = pytest.mark.unit
+
+_RNG = np.random.default_rng(0)
+_T = 10  # timesteps
+_DT = 0.01  # step [s]
+
+
+def _times() -> np.ndarray:
+    return np.arange(_T, dtype=float) * _DT
+
+
+def _base_trace(wrench: np.ndarray | None = None) -> Trace:
+    t = _times()
+    q = _RNG.standard_normal((_T, 2))
+    v = _RNG.standard_normal((_T, 2))
+    return Trace(t=t, q=q, v=v, dt=_DT, backend="ode", wrench=wrench)
+
+
+# ---------------------------------------------------------------------------
+# WrenchImpulses dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestWrenchImpulses:
+    def test_construction(self) -> None:
+        lin = np.array([1.0, 2.0, 3.0])
+        ang = np.array([0.1, 0.2, 0.3])
+        imp = WrenchImpulses(linear_impulse=lin, angular_impulse=ang)
+        assert np.array_equal(imp.linear_impulse, lin)
+        assert np.array_equal(imp.angular_impulse, ang)
+
+    def test_frozen(self) -> None:
+        imp = WrenchImpulses(linear_impulse=np.zeros(3), angular_impulse=np.zeros(3))
+        with pytest.raises((AttributeError, TypeError)):
+            imp.linear_impulse = np.ones(3)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# wrench_array_from_force_torque
+# ---------------------------------------------------------------------------
+
+
+class TestWrenchArrayFromForceTorque:
+    def test_packs_correctly(self) -> None:
+        force = np.ones((_T, 3)) * 10.0
+        torque = np.ones((_T, 3)) * 2.0
+        w = wrench_array_from_force_torque(force, torque)
+        assert w.shape == (_T, 6)
+        assert np.all(w[:, :3] == 10.0)
+        assert np.all(w[:, 3:] == 2.0)
+
+    def test_invalid_force_shape(self) -> None:
+        with pytest.raises(ValueError, match="force"):
+            wrench_array_from_force_torque(np.ones((_T,)), np.ones((_T, 3)))
+
+    def test_invalid_torque_shape(self) -> None:
+        with pytest.raises(ValueError, match="torque"):
+            wrench_array_from_force_torque(np.ones((_T, 3)), np.ones(3))
+
+    def test_mismatched_timesteps(self) -> None:
+        with pytest.raises(ValueError, match="same number of timesteps"):
+            wrench_array_from_force_torque(np.ones((_T, 3)), np.ones((_T + 1, 3)))
+
+
+# ---------------------------------------------------------------------------
+# force_torque_from_wrench_array
+# ---------------------------------------------------------------------------
+
+
+class TestForceTorqueFromWrenchArray:
+    def test_unpacks_correctly(self) -> None:
+        w = np.hstack([np.ones((_T, 3)) * 5.0, np.ones((_T, 3)) * 1.5])
+        force, torque = force_torque_from_wrench_array(w)
+        assert force.shape == (_T, 3)
+        assert torque.shape == (_T, 3)
+        assert np.all(force == 5.0)
+        assert np.all(torque == 1.5)
+
+    def test_round_trip(self) -> None:
+        force_orig = _RNG.standard_normal((_T, 3))
+        torque_orig = _RNG.standard_normal((_T, 3))
+        w = wrench_array_from_force_torque(force_orig, torque_orig)
+        force_rt, torque_rt = force_torque_from_wrench_array(w)
+        assert np.allclose(force_rt, force_orig)
+        assert np.allclose(torque_rt, torque_orig)
+
+    def test_invalid_shape(self) -> None:
+        with pytest.raises(ValueError, match="shape"):
+            force_torque_from_wrench_array(np.ones((_T, 3)))
+
+
+# ---------------------------------------------------------------------------
+# compute_wrench_impulses
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWrenchImpulses:
+    def test_constant_force_known_impulse(self) -> None:
+        """Constant 10 N force over 0.09 s → impulse = 0.9 N·s each component."""
+        force = np.ones((_T, 3)) * 10.0
+        torque = np.zeros((_T, 3))
+        w = wrench_array_from_force_torque(force, torque)
+        t = _times()
+        imp = compute_wrench_impulses(t, w)
+        expected = 10.0 * (t[-1] - t[0])
+        assert np.allclose(imp.linear_impulse, [expected] * 3, atol=1e-12)
+        assert np.allclose(imp.angular_impulse, [0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_constant_torque_known_impulse(self) -> None:
+        force = np.zeros((_T, 3))
+        torque = np.ones((_T, 3)) * 3.0
+        w = wrench_array_from_force_torque(force, torque)
+        t = _times()
+        imp = compute_wrench_impulses(t, w)
+        expected = 3.0 * (t[-1] - t[0])
+        assert np.allclose(imp.angular_impulse, [expected] * 3, atol=1e-12)
+        assert np.allclose(imp.linear_impulse, [0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_time_length_mismatch(self) -> None:
+        w = np.ones((_T, 6))
+        with pytest.raises(ValueError, match="time length"):
+            compute_wrench_impulses(np.arange(_T + 1, dtype=float) * _DT, w)
+
+    def test_invalid_wrench_shape(self) -> None:
+        with pytest.raises(ValueError, match="shape"):
+            compute_wrench_impulses(_times(), np.ones((_T, 3)))
+
+
+# ---------------------------------------------------------------------------
+# trace_wrench_impulses
+# ---------------------------------------------------------------------------
+
+
+class TestTraceWrenchImpulses:
+    def test_returns_none_when_no_wrench(self) -> None:
+        trace = _base_trace(wrench=None)
+        assert trace_wrench_impulses(trace) is None
+
+    def test_returns_impulses_when_wrench_present(self) -> None:
+        force = np.ones((_T, 3)) * 5.0
+        torque = np.ones((_T, 3)) * 1.0
+        w = wrench_array_from_force_torque(force, torque)
+        trace = _base_trace(wrench=w)
+        imp = trace_wrench_impulses(trace)
+        assert imp is not None
+        assert isinstance(imp, WrenchImpulses)
+        t = _times()
+        expected_lin = 5.0 * (t[-1] - t[0])
+        assert np.allclose(imp.linear_impulse, [expected_lin] * 3, atol=1e-12)
+
+    def test_impulses_match_direct_computation(self) -> None:
+        w = _RNG.standard_normal((_T, 6))
+        trace = _base_trace(wrench=w)
+        via_trace = trace_wrench_impulses(trace)
+        direct = compute_wrench_impulses(_times(), w)
+        assert via_trace is not None
+        assert np.allclose(via_trace.linear_impulse, direct.linear_impulse)
+        assert np.allclose(via_trace.angular_impulse, direct.angular_impulse)

--- a/tests/unit/test_canonical_observations.py
+++ b/tests/unit/test_canonical_observations.py
@@ -1,0 +1,297 @@
+"""Unit tests for pose_estimation.observations (CC-12, #6785).
+
+TDD: these tests were written before the implementation and drove the design.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.pose_estimation.observations import (
+    CanonicalObservations,
+    CameraCalibration,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    observations_from_dict,
+    observations_to_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+_N_KP = 5
+_LAYOUT = tuple(f"kp{i}" for i in range(_N_KP))
+_IMG_W, _IMG_H = 1920, 1080
+
+
+def _intrinsics(fx: float = 800.0, fy: float = 800.0) -> CameraIntrinsics:
+    return CameraIntrinsics(
+        fx=fx,
+        fy=fy,
+        cx=_IMG_W / 2,
+        cy=_IMG_H / 2,
+        width=_IMG_W,
+        height=_IMG_H,
+    )
+
+
+def _extrinsics(offset: float = 0.0) -> CameraExtrinsics:
+    return CameraExtrinsics(
+        rotation=np.eye(3),
+        translation=np.array([offset, 0.0, 5.0]),
+    )
+
+
+def _calib(cam_id: str = "cam0", offset: float = 0.0) -> CameraCalibration:
+    return CameraCalibration(
+        camera_id=cam_id,
+        intrinsics=_intrinsics(),
+        extrinsics=_extrinsics(offset),
+    )
+
+
+def _make_obs(
+    n_cams: int = 2,
+    include_3d: bool = False,
+) -> CanonicalObservations:
+    rng = np.random.default_rng(42)
+    cameras = tuple(_calib(f"cam{i}", float(i)) for i in range(n_cams))
+    kps = tuple(rng.uniform(0, 1920, size=(_N_KP, 2)) for _ in range(n_cams))
+    confs = tuple(rng.uniform(0.5, 1.0, size=(_N_KP,)) for _ in range(n_cams))
+    kp3d = rng.standard_normal((_N_KP, 3)) if include_3d else None
+    return CanonicalObservations(
+        cameras=cameras,
+        keypoints_2d=kps,
+        confidences=confs,
+        detector_layout=_LAYOUT,
+        timestamp=1.23,
+        keypoints_3d=kp3d,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CameraIntrinsics
+# ---------------------------------------------------------------------------
+
+
+class TestCameraIntrinsics:
+    def test_construction(self) -> None:
+        k = _intrinsics()
+        assert k.fx == 800.0
+        assert k.width == _IMG_W
+
+    def test_as_matrix(self) -> None:
+        k = _intrinsics(fx=600.0, fy=700.0)
+        mat = k.as_matrix()
+        assert mat.shape == (3, 3)
+        assert mat[0, 0] == pytest.approx(600.0)
+        assert mat[1, 1] == pytest.approx(700.0)
+        assert mat[2, 2] == pytest.approx(1.0)
+
+    def test_invalid_focal_length(self) -> None:
+        with pytest.raises(ValueError, match="focal"):
+            CameraIntrinsics(
+                fx=0.0, fy=800.0, cx=960.0, cy=540.0, width=_IMG_W, height=_IMG_H
+            )
+
+    def test_invalid_dimensions(self) -> None:
+        with pytest.raises(ValueError, match="dimensions"):
+            CameraIntrinsics(
+                fx=800.0, fy=800.0, cx=960.0, cy=540.0, width=0, height=_IMG_H
+            )
+
+
+# ---------------------------------------------------------------------------
+# CameraExtrinsics
+# ---------------------------------------------------------------------------
+
+
+class TestCameraExtrinsics:
+    def test_construction(self) -> None:
+        ext = _extrinsics()
+        assert ext.rotation.shape == (3, 3)
+        assert ext.translation.shape == (3,)
+
+    def test_invalid_rotation_shape(self) -> None:
+        with pytest.raises(ValueError, match="rotation"):
+            CameraExtrinsics(rotation=np.eye(4), translation=np.zeros(3))
+
+    def test_invalid_translation_shape(self) -> None:
+        with pytest.raises(ValueError, match="translation"):
+            CameraExtrinsics(rotation=np.eye(3), translation=np.zeros(4))
+
+
+# ---------------------------------------------------------------------------
+# CameraCalibration
+# ---------------------------------------------------------------------------
+
+
+class TestCameraCalibration:
+    def test_construction(self) -> None:
+        cal = _calib("left")
+        assert cal.camera_id == "left"
+
+    def test_empty_camera_id(self) -> None:
+        with pytest.raises(ValueError, match="camera_id"):
+            CameraCalibration(
+                camera_id="",
+                intrinsics=_intrinsics(),
+                extrinsics=_extrinsics(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# CanonicalObservations
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalObservations:
+    def test_construction_2cam(self) -> None:
+        obs = _make_obs(n_cams=2)
+        assert obs.n_cameras == 2
+        assert obs.n_keypoints == _N_KP
+        assert obs.timestamp == pytest.approx(1.23)
+        assert obs.keypoints_3d is None
+
+    def test_construction_with_3d(self) -> None:
+        obs = _make_obs(include_3d=True)
+        assert obs.keypoints_3d is not None
+        assert obs.keypoints_3d.shape == (_N_KP, 3)
+
+    def test_mismatched_camera_and_keypoints(self) -> None:
+        rng = np.random.default_rng(0)
+        cameras = tuple(_calib(f"cam{i}") for i in range(2))
+        kps = (rng.uniform(0, 1920, (_N_KP, 2)),)  # only 1, not 2
+        confs = tuple(np.ones(_N_KP) for _ in range(2))
+        with pytest.raises(ValueError, match="keypoints_2d"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=kps,
+                confidences=confs,
+                detector_layout=_LAYOUT,
+                timestamp=0.0,
+            )
+
+    def test_confidence_out_of_range(self) -> None:
+        rng = np.random.default_rng(0)
+        cameras = (_calib(),)
+        kps = (rng.uniform(0, 1920, (_N_KP, 2)),)
+        bad_conf = (np.full(_N_KP, 1.5),)  # > 1 → invalid
+        with pytest.raises(ValueError, match="confidence"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=kps,
+                confidences=bad_conf,
+                detector_layout=_LAYOUT,
+                timestamp=0.0,
+            )
+
+    def test_confidence_negative(self) -> None:
+        rng = np.random.default_rng(0)
+        cameras = (_calib(),)
+        kps = (rng.uniform(0, 1920, (_N_KP, 2)),)
+        bad_conf = (np.full(_N_KP, -0.1),)
+        with pytest.raises(ValueError, match="confidence"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=kps,
+                confidences=bad_conf,
+                detector_layout=_LAYOUT,
+                timestamp=0.0,
+            )
+
+    def test_keypoints_wrong_shape(self) -> None:
+        rng = np.random.default_rng(0)
+        cameras = (_calib(),)
+        # Wrong: (N_KP, 3) instead of (N_KP, 2)
+        kps = (rng.uniform(0, 1920, (_N_KP, 3)),)
+        confs = (np.ones(_N_KP),)
+        with pytest.raises(ValueError, match="keypoints_2d"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=kps,
+                confidences=confs,
+                detector_layout=_LAYOUT,
+                timestamp=0.0,
+            )
+
+    def test_3d_wrong_shape(self) -> None:
+        rng = np.random.default_rng(0)
+        cameras = (_calib(),)
+        kps = (rng.uniform(0, 1920, (_N_KP, 2)),)
+        confs = (np.ones(_N_KP),)
+        with pytest.raises(ValueError, match="keypoints_3d"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=kps,
+                confidences=confs,
+                detector_layout=_LAYOUT,
+                timestamp=0.0,
+                keypoints_3d=np.ones((_N_KP, 2)),  # should be (N_KP, 3)
+            )
+
+    def test_empty_detector_layout(self) -> None:
+        cameras = (_calib(),)
+        with pytest.raises(ValueError, match="detector_layout"):
+            CanonicalObservations(
+                cameras=cameras,
+                keypoints_2d=(np.zeros((0, 2)),),
+                confidences=(np.zeros(0),),
+                detector_layout=(),
+                timestamp=0.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestObservationsRoundTrip:
+    def test_round_trip_no_3d(self) -> None:
+        obs = _make_obs(n_cams=2, include_3d=False)
+        d = observations_to_dict(obs)
+        obs2 = observations_from_dict(d)
+
+        assert obs2.n_cameras == obs.n_cameras
+        assert obs2.n_keypoints == obs.n_keypoints
+        assert obs2.timestamp == pytest.approx(obs.timestamp)
+        assert obs2.detector_layout == obs.detector_layout
+        assert obs2.keypoints_3d is None
+
+        for i in range(obs.n_cameras):
+            assert np.allclose(obs2.keypoints_2d[i], obs.keypoints_2d[i])
+            assert np.allclose(obs2.confidences[i], obs.confidences[i])
+            assert obs2.cameras[i].camera_id == obs.cameras[i].camera_id
+
+    def test_round_trip_with_3d(self) -> None:
+        obs = _make_obs(n_cams=1, include_3d=True)
+        d = observations_to_dict(obs)
+        obs2 = observations_from_dict(d)
+        assert obs2.keypoints_3d is not None
+        assert np.allclose(obs2.keypoints_3d, obs.keypoints_3d)
+
+    def test_confidence_preserved(self) -> None:
+        """Confidence values must survive the round-trip exactly."""
+        rng = np.random.default_rng(7)
+        cameras = (_calib("c0"),)
+        kps = (rng.uniform(0, 1920, (_N_KP, 2)),)
+        confs = (rng.uniform(0.0, 1.0, _N_KP),)
+        obs = CanonicalObservations(
+            cameras=cameras,
+            keypoints_2d=kps,
+            confidences=confs,
+            detector_layout=_LAYOUT,
+            timestamp=0.5,
+        )
+        obs2 = observations_from_dict(observations_to_dict(obs))
+        assert np.allclose(obs2.confidences[0], obs.confidences[0])
+
+    def test_dict_is_json_serialisable(self) -> None:
+        """observations_to_dict must return only JSON-native types."""
+        import json
+
+        obs = _make_obs(n_cams=1)
+        d = observations_to_dict(obs)
+        # Should not raise
+        json.dumps(d)


### PR DESCRIPTION
## Summary

- **CC-25 (#6798):** Add `simulation_backends.wrench_extractor` — engine-agnostic utilities to pack/unpack the CC-4 `Trace.wrench` `(T, 6)` field and compute linear/angular impulses via trapezoid integration. No domain-specific (bunkershot3d) imports in the shared layer. Exports surfaced through `simulation_backends.__init__`.
- **CC-12 (#6785):** Add `pose_estimation.observations` — frozen `CanonicalObservations` schema with `CameraCalibration` (intrinsics + extrinsics), per-camera 2-D keypoints, per-keypoint confidence ∈ [0,1] (DbC-validated), optional triangulated 3-D positions, and JSON-serialisable round-trip helpers (`observations_to_dict` / `observations_from_dict`). Exports surfaced through `pose_estimation.__init__`.

## New files

| File | Purpose |
|------|---------|
| `src/shared/python/simulation_backends/wrench_extractor.py` | `WrenchImpulses`, `wrench_array_from_force_torque`, `force_torque_from_wrench_array`, `compute_wrench_impulses`, `trace_wrench_impulses` |
| `src/shared/python/pose_estimation/observations.py` | `CameraIntrinsics`, `CameraExtrinsics`, `CameraCalibration`, `CanonicalObservations`, `observations_to_dict`, `observations_from_dict` |
| `tests/unit/simulation_backends/test_wrench_extractor.py` | 16 unit tests (TDD) |
| `tests/unit/test_canonical_observations.py` | 21 unit tests (TDD) |

## Engineering notes

- **TDD:** Tests written first; all 37 pass green (`pytest` confirmed locally).
- **DbC:** `CanonicalObservations.__post_init__` enforces confidence ∈ [0,1], shape contracts, and non-empty `detector_layout`; `CameraIntrinsics` enforces positive focal lengths and image dimensions; all raise `ValueError` with descriptive messages.
- **DRY:** Wrench extractor reuses the same trapezoidal integration convention as `bunkershot3d.WrenchTrace.get_impulses` without duplicating the class. Observation schema reuses existing `PoseEstimationResult` interface conventions.
- **LOD:** No method chains >2 levels; no domain-specific imports in shared modules.
- **Format/lint:** `ruff check` and `ruff format --check` both pass on all changed files.

## Test plan

- [ ] `python3 -m pytest tests/unit/simulation_backends/test_wrench_extractor.py tests/unit/test_canonical_observations.py -v` — 37 passed
- [ ] `python3 -m ruff check src/shared/python/simulation_backends/wrench_extractor.py src/shared/python/pose_estimation/observations.py` — clean
- [ ] `python3 -m ruff format --check` — clean

Closes #6798
Closes #6785

https://claude.ai/code/session_01TMYNoaHFtnu4DAMqzuKFSh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMYNoaHFtnu4DAMqzuKFSh)_