### PR TITLE
feat(motion_capture): canonical-state → C3D exporter, output-only (CC-16)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.219                                            |
+| **Spec Version**        | 1.0.220                                            |
 | **Last Spec Update**    | 2026-05-31                                         |
 
 ## 2. Purpose & Mission
@@ -69,6 +69,8 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 ## 4. Architecture Overview
 
 ### Recent Spec Updates
+
+- **2026-05-31** - Added the CC-16 output-only canonical C3D exporter (#6789): motion capture can now export marker trajectories from canonical state arrays to terminal C3D files with unit, label, sample-rate, and architecture guards that prevent C3D from becoming an internal intermediate.
 
 - **2026-05-31** - Added the canonical run `ProvenanceStamp` primitive for issue #6778: simulation traces, batch traces, and state checkpoints can now carry deterministic run metadata covering engine/model identifiers, timestamp, adapter version, units, feature flags, and dependency versions without changing the existing trace/checkpoint schemas.
 - **2026-05-31** - Added a third-party license ledger for issue #6781 under `docs/legal/licenses.md`, with a CI-sized advisory checker that covers direct dependency declarations, keeps OpenPose visibly fenced as non-commercial opt-in, supports Python 3.10 via `tomli`, and avoids false core-install optional-engine findings from the local `scripts/jaxsim` helper directory.
@@ -843,5 +845,6 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 | 2026-05-22 | 1.0.170 | Hardened the shared BitNet subprocess adapter by rejecting non-UTF-8 and oversize prompts before `llama-cli` launch, and added focused regression coverage for the synchronous and streaming guard paths (issue #5913). |
 | 2026-05-25 | 1.0.171 | Removed stale "raises NotImplementedError" and scaffold-era caveats from the module and class docstrings of the Drake, OpenSim, and Simscape `LiveKinematicsService` implementations; updated the Simscape transform-query TODO to reference the current tracking issue #6093 instead of closed epic #4963 (issue #6092). |
 | 2026-05-29 | 1.0.172 | Bolt: Optimized `np.linalg.norm(np.array(...))` to `math.hypot(...)` in `anthropometric.py` to avoid temporary array allocation and speed up calculation. |
+| 2026-05-31 | 1.0.220 | Added the CC-16 output-only canonical C3D exporter (#6789), including marker trajectory export to terminal C3D files, unit/label/sample-rate preservation, and architecture guards preventing C3D as an internal intermediate. |
 | 2026-05-31 | 1.0.219 | Added the canonical-v2 pose interchange contract export surface, ADR, and conventions guide for durable cross-engine state exchange (#6773). |
 ````

--- a/src/motion_capture/canonical_c3d_exporter.py
+++ b/src/motion_capture/canonical_c3d_exporter.py
@@ -1,0 +1,136 @@
+"""Canonical-state → C3D exporter (CC-16).
+
+**OUTPUT-ONLY** — this module is a terminal export for downstream
+biomechanical tools (e.g. Visual3D, OpenSim, Mokka).  C3D must never
+be used as a lossy intermediate format inside the pipeline.
+
+Architecture invariant: ``canonical_c3d_exporter`` must not be imported
+by simulation-pipeline internals (``trace_io``, ``protocol``,
+``pose_interchange``, etc.).  This constraint is asserted by the
+architecture test in
+``tests/unit/motion_capture/test_canonical_c3d_exporter.py``.
+
+Typical usage::
+
+    from src.motion_capture.canonical_c3d_exporter import export_markers_to_c3d
+
+    # markers from Trace.markers or from FK on canonical sites
+    export_markers_to_c3d(
+        markers=trace.markers,   # shape (T, n_markers, 3) [m]
+        marker_names=site_names,
+        sample_rate=200.0,
+        output_path="results/swing_export.c3d",
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+__all__ = ["export_markers_to_c3d"]
+
+logger = logging.getLogger(__name__)
+
+
+def export_markers_to_c3d(
+    markers: np.ndarray,
+    marker_names: list[str],
+    sample_rate: float,
+    output_path: str | Path,
+) -> Path:
+    """Export marker position data to a C3D file.
+
+    This is a **one-way, output-only** export.  The resulting file is
+    intended for external biomechanical tools and must never be read back
+    into the pipeline as a canonical data source.
+
+    Preconditions:
+        - ``markers`` is a ``numpy.ndarray`` with shape ``(T, n_markers, 3)``
+          where T >= 1 and n_markers >= 1.
+        - ``len(marker_names) == markers.shape[1]``
+        - ``sample_rate > 0.0``
+        - Parent directory of ``output_path`` must exist.
+        - ``ezc3d >= 1.5.0`` must be installed.
+
+    Postconditions:
+        - A valid C3D file is written to ``output_path``.
+        - The returned path is absolute (resolved).
+        - Marker labels, positions, units (``"m"``), and sample rate are
+          preserved across a write / read round-trip.
+
+    Args:
+        markers: Marker positions in metres, shape ``(T, n_markers, 3)``.
+        marker_names: Ordered list of marker label strings.
+            ``len(marker_names)`` must equal ``markers.shape[1]``.
+        sample_rate: Acquisition rate in Hz.  Must be strictly positive.
+        output_path: Destination file path.  Parent directory must exist.
+
+    Returns:
+        Resolved :class:`~pathlib.Path` of the written C3D file.
+
+    Raises:
+        TypeError: When ``markers`` is not a :class:`numpy.ndarray`.
+        ValueError: When shape, rate, or name-count constraints are violated.
+        FileNotFoundError: When the parent directory of ``output_path`` does
+            not exist.
+        ImportError: When ``ezc3d`` is not installed.
+    """
+    # --- DbC preconditions (validated before the optional ezc3d import) ---
+    if not isinstance(markers, np.ndarray):
+        raise TypeError(
+            f"markers must be a numpy.ndarray, got {type(markers).__name__!r}"
+        )
+    if markers.ndim != 3 or markers.shape[2] != 3:
+        raise ValueError(
+            f"markers must have shape (T, n_markers, 3), got {markers.shape!r}"
+        )
+    n_frames, n_markers, _ = markers.shape
+    if n_frames < 1:
+        raise ValueError(
+            f"markers must contain at least one frame (T >= 1), got T={n_frames}"
+        )
+    if n_markers < 1:
+        raise ValueError(
+            f"markers must contain at least one marker (n_markers >= 1), "
+            f"got n_markers={n_markers}"
+        )
+    if len(marker_names) != n_markers:
+        raise ValueError(
+            f"len(marker_names)={len(marker_names)!r} does not match "
+            f"markers.shape[1]={n_markers!r}"
+        )
+    if not isinstance(sample_rate, (int, float)) or sample_rate <= 0.0:
+        raise ValueError(f"sample_rate must be a positive number, got {sample_rate!r}")
+
+    dest = Path(output_path)
+    if not dest.parent.exists():
+        raise FileNotFoundError(f"Output directory does not exist: {dest.parent}")
+
+    # --- Optional dependency: ezc3d ---
+    try:
+        import ezc3d  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(
+            "ezc3d is required for C3D export. "
+            "Install it with: pip install 'ezc3d>=1.5.0'"
+        ) from exc
+
+    # Build the C3D object
+    c = ezc3d.c3d()
+    c["parameters"]["POINT"]["RATE"]["value"] = [float(sample_rate)]
+    c["parameters"]["POINT"]["LABELS"]["value"] = list(marker_names)
+    c["parameters"]["POINT"]["UNITS"]["value"] = ["m"]
+
+    # ezc3d stores data as (4, n_markers, T): rows are [X, Y, Z, residual].
+    # Transpose from (T, n_markers, 3) → (3, n_markers, T), then append
+    # a zero-residual row to make it (4, n_markers, T).
+    data_xyz = np.transpose(markers.astype(np.float64), (2, 1, 0))  # (3, n_markers, T)
+    residuals = np.zeros((1, n_markers, n_frames), dtype=np.float64)
+    c["data"]["points"] = np.concatenate([data_xyz, residuals], axis=0)
+
+    c.write(str(dest))
+    logger.info("Exported %d-frame C3D (%d markers) → %s", n_frames, n_markers, dest)
+    return dest.resolve()

--- a/tests/unit/motion_capture/test_canonical_c3d_exporter.py
+++ b/tests/unit/motion_capture/test_canonical_c3d_exporter.py
@@ -1,0 +1,216 @@
+"""Unit tests for the canonical-state → C3D exporter (CC-16).
+
+TDD: tests were written first (red → green → refactor).
+
+Architecture invariant asserted by :class:`TestArchitectureOutputOnly`:
+``canonical_c3d_exporter`` is OUTPUT-ONLY.  It must never be imported by
+simulation-pipeline internals (trace_io, protocol, pose_interchange).
+"""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.motion_capture.canonical_c3d_exporter import export_markers_to_c3d
+
+_ezc3d_available = importlib.util.find_spec("ezc3d") is not None
+
+
+# ---------------------------------------------------------------------------
+# DbC precondition tests (no ezc3d required)
+# ---------------------------------------------------------------------------
+
+
+class TestExportPreconditions:
+    """Validate DbC preconditions; these run with or without ezc3d."""
+
+    def test_raises_type_error_on_non_array(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(TypeError, match="numpy.ndarray"):
+            export_markers_to_c3d([[1, 2, 3]], ["M1"], 100.0, out)
+
+    def test_raises_on_2d_array(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="shape"):
+            export_markers_to_c3d(np.zeros((10, 3)), ["M1"], 100.0, out)
+
+    def test_raises_on_wrong_last_dim(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="shape"):
+            export_markers_to_c3d(np.zeros((10, 2, 4)), ["M1", "M2"], 100.0, out)
+
+    def test_raises_on_zero_frames(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="frame"):
+            export_markers_to_c3d(np.zeros((0, 1, 3)), ["M1"], 100.0, out)
+
+    def test_raises_on_zero_markers(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="marker"):
+            export_markers_to_c3d(np.zeros((10, 0, 3)), [], 100.0, out)
+
+    def test_raises_on_mismatched_name_count(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="marker_names"):
+            export_markers_to_c3d(np.zeros((10, 2, 3)), ["M1"], 100.0, out)
+
+    def test_raises_on_zero_sample_rate(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="sample_rate"):
+            export_markers_to_c3d(np.zeros((10, 1, 3)), ["M1"], 0.0, out)
+
+    def test_raises_on_negative_sample_rate(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ValueError, match="sample_rate"):
+            export_markers_to_c3d(np.zeros((10, 1, 3)), ["M1"], -5.0, out)
+
+    def test_raises_when_output_dir_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent" / "out.c3d"
+        with pytest.raises(FileNotFoundError):
+            export_markers_to_c3d(np.zeros((10, 1, 3)), ["M1"], 100.0, missing)
+
+    @pytest.mark.skipif(
+        _ezc3d_available, reason="ezc3d installed; ImportError won't fire"
+    )
+    def test_raises_import_error_without_ezc3d(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.c3d"
+        with pytest.raises(ImportError, match="ezc3d"):
+            export_markers_to_c3d(np.zeros((10, 1, 3)), ["M1"], 100.0, out)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests (require ezc3d)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _ezc3d_available, reason="ezc3d not installed")
+class TestExportRoundTrip:
+    """Round-trip correctness; skipped when ezc3d is not installed."""
+
+    def test_creates_file(self, tmp_path: Path) -> None:
+        markers = np.zeros((5, 2, 3))
+        out = export_markers_to_c3d(markers, ["A", "B"], 100.0, tmp_path / "out.c3d")
+        assert out.exists()
+
+    def test_returns_resolved_path(self, tmp_path: Path) -> None:
+        markers = np.zeros((5, 1, 3))
+        out = export_markers_to_c3d(markers, ["M1"], 100.0, tmp_path / "out.c3d")
+        assert out.is_absolute()
+
+    def test_marker_labels_preserved(self, tmp_path: Path) -> None:
+        import ezc3d  # noqa: PLC0415
+
+        markers = np.zeros((5, 2, 3))
+        out = export_markers_to_c3d(
+            markers, ["LHEE", "RHEE"], 100.0, tmp_path / "out.c3d"
+        )
+        c = ezc3d.c3d(str(out))
+        assert c["parameters"]["POINT"]["LABELS"]["value"] == ["LHEE", "RHEE"]
+
+    def test_round_trip_marker_data(self, tmp_path: Path) -> None:
+        import ezc3d  # noqa: PLC0415
+
+        rng = np.random.default_rng(42)
+        markers = rng.uniform(-1.0, 1.0, (10, 3, 3))
+        names = ["A", "B", "C"]
+        out = export_markers_to_c3d(markers, names, 200.0, tmp_path / "out.c3d")
+
+        c = ezc3d.c3d(str(out))
+        # ezc3d stores (4, n_markers, T); first 3 rows are X, Y, Z
+        data_xyz = c["data"]["points"][:3, :, :]  # (3, n_markers, T)
+        recovered = np.transpose(data_xyz, (2, 1, 0))  # → (T, n_markers, 3)
+        np.testing.assert_allclose(recovered, markers, rtol=1e-5)
+
+    def test_units_written_as_metres(self, tmp_path: Path) -> None:
+        import ezc3d  # noqa: PLC0415
+
+        markers = np.ones((3, 1, 3))
+        out = export_markers_to_c3d(markers, ["X"], 100.0, tmp_path / "out.c3d")
+        c = ezc3d.c3d(str(out))
+        assert c["parameters"]["POINT"]["UNITS"]["value"] == ["m"]
+
+    def test_sample_rate_written(self, tmp_path: Path) -> None:
+        import ezc3d  # noqa: PLC0415
+
+        markers = np.zeros((4, 1, 3))
+        out = export_markers_to_c3d(markers, ["X"], 250.0, tmp_path / "out.c3d")
+        c = ezc3d.c3d(str(out))
+        rate = c["parameters"]["POINT"]["RATE"]["value"][0]
+        assert abs(rate - 250.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Architecture test — output-only invariant
+# ---------------------------------------------------------------------------
+
+
+class TestArchitectureOutputOnly:
+    """The exporter must never be imported by simulation-pipeline internals.
+
+    c3d is a terminal output format for external biomechanical tools.
+    Importing ``canonical_c3d_exporter`` from the trace/pose stack would
+    violate the output-only contract.
+
+    Implementation note: we scan source files directly (not via importlib)
+    to avoid triggering transitive import chains that require optional
+    heavy dependencies (pydantic, mujoco, etc.).
+    """
+
+    _REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+    # Paths relative to the repo root that must not import canonical_c3d_exporter
+    _GUARDED_PATHS = [
+        "src/shared/python/simulation_backends/trace_io.py",
+        "src/shared/python/simulation_backends/protocol.py",
+        "src/shared/python/pose_interchange/canonical.py",
+        "src/shared/python/pose_interchange/protocol.py",
+    ]
+
+    def _scan_source_for_exporter_import(self, rel_path: str) -> bool:
+        """Return True if the source file imports canonical_c3d_exporter."""
+        src_path = self._REPO_ROOT / rel_path
+        if not src_path.exists():
+            return False  # file absent — nothing to guard
+        source = src_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(src_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module and "canonical_c3d_exporter" in node.module:
+                    return True
+                for alias in node.names:
+                    if "canonical_c3d_exporter" in alias.name:
+                        return True
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if "canonical_c3d_exporter" in alias.name:
+                        return True
+        return False
+
+    def test_trace_io_does_not_import_exporter(self) -> None:
+        found = self._scan_source_for_exporter_import(
+            "src/shared/python/simulation_backends/trace_io.py"
+        )
+        assert not found, (
+            "trace_io imports canonical_c3d_exporter — "
+            "c3d must remain OUTPUT-ONLY and never flow back into the pipeline"
+        )
+
+    def test_protocol_does_not_import_exporter(self) -> None:
+        found = self._scan_source_for_exporter_import(
+            "src/shared/python/simulation_backends/protocol.py"
+        )
+        assert not found, (
+            "protocol imports canonical_c3d_exporter — c3d must remain OUTPUT-ONLY"
+        )
+
+    def test_pose_interchange_canonical_does_not_import_exporter(self) -> None:
+        found = self._scan_source_for_exporter_import(
+            "src/shared/python/pose_interchange/canonical.py"
+        )
+        assert not found, (
+            "pose_interchange.canonical imports canonical_c3d_exporter — "
+            "c3d must remain OUTPUT-ONLY"
+        )


### PR DESCRIPTION
## Summary

Implements **CC-16** ([#6789](https://github.com/D-sorganization/UpstreamDrift/issues/6789)): a canonical-state → C3D exporter for downstream biomechanical tools (Visual3D, OpenSim, Mokka, etc.).

- `src/motion_capture/canonical_c3d_exporter.py` — `export_markers_to_c3d(markers, marker_names, sample_rate, output_path)` reads a `(T, n_markers, 3)` numpy array (metres) and writes a valid C3D file via `ezc3d`.  Units, labels, and sample rate are preserved round-trip.
- **OUTPUT-ONLY invariant**: C3D is a terminal export format; it must never flow back into the pipeline as a lossy intermediate.  The architecture tests in `TestArchitectureOutputOnly` assert this by AST-scanning `trace_io.py`, `protocol.py`, and `pose_interchange/canonical.py`.

## Engineering

| Principle | How met |
|-----------|---------|
| **TDD** | Tests written first (red → green).  13 pass locally; 6 round-trip tests skipped (ezc3d not in dev env) and will run in CI. |
| **DbC** | Full precondition validation: type, ndim/shape, frame/marker count, name-count, positive rate, parent-dir existence — all before the optional `ezc3d` import. |
| **DRY** | Extends existing `src/motion_capture/` c3d layer; no logic duplicated. |
| **LOD** | No method chains >2 levels. |
| **File size** | Exporter: 136 lines; test file: 216 lines — well under budget. |
| **No print in src/** | Uses `logging`. |
| **Lint / format** | `ruff check` + `ruff format --check`: both clean. |

## Test plan

- [x] `python3 -m pytest tests/unit/motion_capture/test_canonical_c3d_exporter.py -v` — 13 passed, 6 skipped (ezc3d absent locally)
- [x] `python3 -m ruff check src/motion_capture/canonical_c3d_exporter.py tests/unit/motion_capture/test_canonical_c3d_exporter.py` — clean
- [x] `python3 -m ruff format --check ...` — clean
- [ ] CI: round-trip tests (`TestExportRoundTrip`) will run with `ezc3d>=1.5.0` installed

## Notes

Agent-lease protocol: `Repository_Management` clone not available in this environment; proceeding fail-open per CLAUDE.md § "Fail-open".

Closes #6789


---
_Generated by [Claude Code](https://claude.ai/code/session_01G6T27wXLtHqg4TVPFXK9BU)_