### PR TITLE
fix(license-ledger): validate OpenPose row status cell, not whole-file text (#6816)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.219                                            |
+| **Spec Version**        | 1.0.220                                            |
 | **Last Spec Update**    | 2026-05-31                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,7 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-05-31** - Tightened the OpenPose license-ledger gate for review issue #6816: `scripts/legal/check_license_ledger.py` now parses the `openpose` row's Status cell directly instead of accepting legend text elsewhere in `docs/legal/licenses.md`, with regression coverage proving a tampered row fails validation even when the legend still contains the expected non-commercial wording.
 - **2026-05-31** - Added the canonical run `ProvenanceStamp` primitive for issue #6778: simulation traces, batch traces, and state checkpoints can now carry deterministic run metadata covering engine/model identifiers, timestamp, adapter version, units, feature flags, and dependency versions without changing the existing trace/checkpoint schemas.
 - **2026-05-31** - Added a third-party license ledger for issue #6781 under `docs/legal/licenses.md`, with a CI-sized advisory checker that covers direct dependency declarations, keeps OpenPose visibly fenced as non-commercial opt-in, supports Python 3.10 via `tomli`, and avoids false core-install optional-engine findings from the local `scripts/jaxsim` helper directory.
 - **2026-05-31** - Added the canonical-v2 pose interchange contract (#6773) with public exports from `src/shared/python/pose_interchange/__init__.py`, a conventions guide under `docs/conventions/canonical-v2.md`, and ADR coverage in `docs/adr/0026-canonical-dynamic-state-v2.md`.

--- a/scripts/legal/check_license_ledger.py
+++ b/scripts/legal/check_license_ledger.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 CI
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+")
 _LEDGER_PACKAGE_RE = re.compile(r"^\|\s*`([^`]+)`\s*\|")
+_OPENPOSE_ROW_RE = re.compile(r"^\|\s*`openpose`\s*\|", re.IGNORECASE)
 
 
 def normalize_package_name(name: str) -> str:
@@ -63,6 +64,22 @@ def ledger_package_names(ledger_path: Path) -> set[str]:
     return rows
 
 
+def _openpose_row_status(ledger_text: str) -> str | None:
+    """Return the stripped Status column of the openpose table row, or None.
+
+    Parses the specific openpose row rather than searching the whole file, so
+    legend text that contains 'Non-commercial' / 'Opt-in' as definition prose
+    does not produce a false-positive gate result.
+    """
+    for line in ledger_text.splitlines():
+        if _OPENPOSE_ROW_RE.match(line):
+            # Pipe-split yields: ['', package, scope, version, license, status, notes, '']
+            cols = [c.strip() for c in line.split("|")]
+            if len(cols) >= 7:  # noqa: PLR2004
+                return cols[5]
+    return None
+
+
 def validate_license_ledger(pyproject_path: Path, ledger_path: Path) -> list[str]:
     """Return validation errors for the dependency ledger."""
     declared = declared_dependency_names(pyproject_path)
@@ -75,8 +92,10 @@ def validate_license_ledger(pyproject_path: Path, ledger_path: Path) -> list[str
     ledger_text = ledger_path.read_text(encoding="utf-8")
     if "`openpose`" not in ledger_text:
         errors.append("missing OpenPose commercialization-gate row")
-    if "Non-commercial" not in ledger_text or "Opt-in" not in ledger_text:
-        errors.append("OpenPose row must state Non-commercial and Opt-in")
+    else:
+        status = _openpose_row_status(ledger_text)
+        if status is None or "Non-commercial" not in status or "Opt-in" not in status:
+            errors.append("OpenPose row must state Non-commercial and Opt-in")
 
     return errors
 

--- a/tests/unit/third_party_integration_audit/test_license_ledger.py
+++ b/tests/unit/third_party_integration_audit/test_license_ledger.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -19,6 +21,7 @@ _spec.loader.exec_module(_ledger_module)
 declared_dependency_names = _ledger_module.declared_dependency_names
 ledger_package_names = _ledger_module.ledger_package_names
 validate_license_ledger = _ledger_module.validate_license_ledger
+_openpose_row_status = _ledger_module._openpose_row_status
 
 
 def test_license_ledger_covers_declared_dependencies() -> None:
@@ -31,11 +34,48 @@ def test_license_ledger_covers_declared_dependencies() -> None:
 
 def test_license_ledger_flags_openpose_as_non_commercial_opt_in() -> None:
     """OpenPose must stay visibly fenced for commercial builds."""
-    ledger = (ROOT / "docs" / "legal" / "licenses.md").read_text(encoding="utf-8")
+    ledger_text = (ROOT / "docs" / "legal" / "licenses.md").read_text(encoding="utf-8")
 
-    assert "`openpose`" in ledger
-    assert "Non-commercial" in ledger
-    assert "Opt-in" in ledger
+    status = _openpose_row_status(ledger_text)
+    assert status is not None, "openpose row not found in ledger"
+    assert "Non-commercial" in status, (
+        f"openpose status missing 'Non-commercial': {status!r}"
+    )
+    assert "Opt-in" in status, f"openpose status missing 'Opt-in': {status!r}"
+
+
+def test_openpose_gate_validates_row_not_legend() -> None:
+    """validate_license_ledger must catch a downgraded openpose row status.
+
+    The legend section always contains 'Non-commercial' and 'Opt-in' as definition
+    text. If the check searches the whole file instead of the specific row, it
+    passes even when the openpose Status cell is changed to 'Commercial-OK'.
+    """
+    ledger_path = ROOT / "docs" / "legal" / "licenses.md"
+    real_text = ledger_path.read_text(encoding="utf-8")
+
+    # Tamper: replace the openpose row's status cell with "Commercial-OK"
+    tampered = re.sub(
+        r"(?m)^(\|\s*`openpose`(?:[^|]*\|){4})\s*Non-commercial, Opt-in\s*(\|)",
+        r"\1 Commercial-OK \2",
+        real_text,
+    )
+    assert tampered != real_text, "tamper regex did not match — test fixture is broken"
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as tmp_file:
+        tmp_file.write(tampered)
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        errors = validate_license_ledger(ROOT / "pyproject.toml", tmp_path)
+        assert errors, (
+            "expected an error when openpose row status is 'Commercial-OK' "
+            "but 'Non-commercial'/'Opt-in' still appear in the legend"
+        )
+    finally:
+        tmp_path.unlink()
 
 
 def test_license_ledger_script_reports_clean() -> None:


### PR DESCRIPTION
## Summary

Fixes the commercialization gate for OpenPose in `scripts/legal/check_license_ledger.py`.

**Root cause:** The previous check searched for `"Non-commercial"` and `"Opt-in"` anywhere in the ledger file. Both strings appear in the legend/definition section, so an incorrect OpenPose Status cell (e.g. `Commercial-OK`) would still pass CI — the gate was not actually enforced on the row itself.

**Fix:** Added `_openpose_row_status()` which locates the `openpose` table row by regex and extracts its Status column (column index 5 in the pipe-split). `validate_license_ledger()` now calls this helper instead of doing a whole-file string search.

**Tests updated (`TDD`):**
- `test_license_ledger_flags_openpose_as_non_commercial_opt_in` — updated to use `_openpose_row_status()` directly on the row, not whole-file text search
- `test_openpose_gate_validates_row_not_legend` (**new**) — proves the fix: tampers the openpose row's status to `Commercial-OK` while leaving legend text intact, asserts `validate_license_ledger` returns an error

## Test plan

- [x] `ruff check scripts/legal/check_license_ledger.py tests/unit/third_party_integration_audit/test_license_ledger.py` — passes
- [x] `ruff format --check` — passes
- [x] `pytest tests/unit/third_party_integration_audit/test_license_ledger.py -v` — 4/4 pass

Closes #6816


---
_Generated by [Claude Code](https://claude.ai/code/session_017h59rxBCEw1APuPNZBuyUE)_