### PR TITLE
fix(estimation): distortion threading, non-finite sentinel, GRF weight, eval-time span (#6892-#6895)

### DIFF
--- a/src/shared/python/estimation/map_estimator.py
+++ b/src/shared/python/estimation/map_estimator.py
@@ -19,6 +19,11 @@ from scipy.optimize import least_squares
 from src.shared.python.contracts import require
 from src.shared.python.simulation_backends.provenance import ProvenanceStamp
 
+# Large finite value substituted for non-finite residual entries so the
+# trust-region optimizer rejects an infeasible finite-difference step instead of
+# the callback raising and aborting the entire least_squares solve (issue #6893).
+NON_FINITE_RESIDUAL_SENTINEL = 1.0e12
+
 ParameterKind = Literal["length", "inertia", "generic"]
 ResidualFn = Callable[["SplineTrajectoryEvaluation", Mapping[str, float]], np.ndarray]
 JacobianFn = Callable[
@@ -509,6 +514,7 @@ def _validate_problem(problem: MapEstimatorProblem) -> None:
     eval_times = np.asarray(problem.evaluation_times, dtype=float)
     require(eval_times.ndim == 1, "evaluation_times must be a 1D array")
     require(bool(np.all(np.isfinite(eval_times))), "evaluation_times must be finite")
+    _require_times_within_knot_span(eval_times, problem.trajectory.knot_times)
     coeffs = np.asarray(problem.initial_coefficients, dtype=float)
     require(
         coeffs.shape == (problem.trajectory.coefficient_size,),
@@ -516,6 +522,27 @@ def _validate_problem(problem: MapEstimatorProblem) -> None:
     )
     require(bool(np.all(np.isfinite(coeffs))), "initial_coefficients must be finite")
     require(problem.options.max_iterations > 0, "max_iterations must be positive")
+
+
+def _require_times_within_knot_span(
+    eval_times: np.ndarray, knot_times: np.ndarray
+) -> None:
+    """Require evaluation times to lie within the spline knot span.
+
+    Out-of-range samples would otherwise be silently clamped to the first/last
+    segment and flat-extrapolated, fitting against the wrong instant with no
+    error (issue #6895). Extrapolation is not supported.
+    """
+    if eval_times.size == 0:
+        return
+    knots = np.asarray(knot_times, dtype=float)
+    lower = float(knots[0])
+    upper = float(knots[-1])
+    require(
+        float(eval_times.min()) >= lower and float(eval_times.max()) <= upper,
+        f"evaluation_times must lie within the knot span [{lower}, {upper}]; "
+        "extrapolation is not supported",
+    )
 
 
 def _pack_decision(
@@ -553,10 +580,28 @@ def _objective_residual(
     data_residual = np.asarray(problem.residual(evaluation, parameters), dtype=float)
     if data_residual.ndim != 1:
         raise ValueError("residual callable must return a 1D array")
-    if not np.all(np.isfinite(data_residual)):
-        raise ValueError("residual callable returned non-finite values")
+    data_residual = _sentinel_for_non_finite(data_residual)
     prior_residual = problem.shared_parameters.prior_residuals(parameter_values)
     return np.concatenate([data_residual, prior_residual])
+
+
+def _sentinel_for_non_finite(residual: np.ndarray) -> np.ndarray:
+    """Replace non-finite residual entries with a large finite sentinel.
+
+    SciPy's ``least_squares`` perturbs the decision vector for its 2-point
+    Jacobian; a probe into an infeasible region (e.g. RNEA at a singular config,
+    near-zero projection depth) can yield NaN/Inf. Returning a large finite value
+    lets the trust region reject the step instead of raising and aborting the
+    whole solve (issue #6893).
+    """
+    if np.all(np.isfinite(residual)):
+        return residual
+    return np.nan_to_num(
+        residual,
+        nan=NON_FINITE_RESIDUAL_SENTINEL,
+        posinf=NON_FINITE_RESIDUAL_SENTINEL,
+        neginf=-NON_FINITE_RESIDUAL_SENTINEL,
+    )
 
 
 def _objective_jacobian(

--- a/src/shared/python/estimation/multi_trial.py
+++ b/src/shared/python/estimation/multi_trial.py
@@ -19,6 +19,8 @@ from src.shared.python.estimation.map_estimator import (
     MapEstimatorOptions,
     SharedParameterBlock,
     SplineTrajectoryEvaluation,
+    _require_times_within_knot_span,
+    _sentinel_for_non_finite,
 )
 from src.shared.python.simulation_backends.provenance import ProvenanceStamp
 
@@ -236,6 +238,7 @@ def _validate_observation(observation: MultiTrialObservation) -> None:
     times = np.asarray(observation.evaluation_times, dtype=float)
     require(times.ndim == 1, "evaluation_times must be a 1D array")
     require(bool(np.all(np.isfinite(times))), "evaluation_times must be finite")
+    _require_times_within_knot_span(times, observation.trajectory.knot_times)
     coeffs = np.asarray(observation.initial_coefficients, dtype=float)
     require(
         coeffs.shape == (observation.trajectory.coefficient_size,),
@@ -297,8 +300,7 @@ def _objective_residual(
         )
         if residual.ndim != 1:
             raise ValueError("residual callable must return a 1D array")
-        if not np.all(np.isfinite(residual)):
-            raise ValueError("residual callable returned non-finite values")
+        residual = _sentinel_for_non_finite(residual)
         residuals.append(residual)
     residuals.append(problem.shared_parameters.prior_residuals(parameter_values))
     return np.concatenate(residuals)

--- a/src/shared/python/estimation/residuals.py
+++ b/src/shared/python/estimation/residuals.py
@@ -101,19 +101,48 @@ def _validate_confidence(confidence: object, keypoint_count: int) -> None:
         raise ValueError("confidence values must be in the inclusive range [0, 1]")
 
 
+DistortionLike: TypeAlias = "ArrayLike | None"
+
+
+def _apply_brown_conrady(
+    x_norm: Array, y_norm: Array, distortion: ArrayLike, xp: Any
+) -> tuple[Array, Array]:
+    """Apply the Brown-Conrady radial/tangential distortion model.
+
+    ``distortion`` is ordered ``(k1, k2, p1, p2)`` and operates on normalized
+    image coordinates (camera-frame coordinates divided by depth), matching the
+    synthetic rig in ``synthetic_ground_truth.project_world_point``.
+    """
+
+    _validate_numeric_array(distortion, "distortion", shape=(4,))
+    coeffs = _as_array(distortion, xp)
+    k1, k2, p1, p2 = coeffs[0], coeffs[1], coeffs[2], coeffs[3]
+    radius_2 = x_norm * x_norm + y_norm * y_norm
+    radial = 1.0 + k1 * radius_2 + k2 * radius_2 * radius_2
+    x_dist = x_norm * radial + 2.0 * p1 * x_norm * y_norm
+    x_dist = x_dist + p2 * (radius_2 + 2.0 * x_norm * x_norm)
+    y_dist = y_norm * radial + p1 * (radius_2 + 2.0 * y_norm * y_norm)
+    y_dist = y_dist + 2.0 * p2 * x_norm * y_norm
+    return x_dist, y_dist
+
+
 def project_pinhole(
     points_world: ArrayLike,
     camera_matrix: ArrayLike,
     *,
     rotation_world_to_camera: ArrayLike | None = None,
     translation_world_to_camera: ArrayLike | None = None,
+    distortion: DistortionLike = None,
     depth_epsilon: float = 1.0e-9,
 ) -> Array:
-    """Project world points with a pinhole camera.
+    """Project world points with a pinhole camera and optional lens distortion.
 
     Parameters use the usual computer-vision convention:
-    ``p_camera = R_world_to_camera @ p_world + t_world_to_camera`` and
-    ``uv_h = K @ p_camera``.
+    ``p_camera = R_world_to_camera @ p_world + t_world_to_camera``. Points are
+    normalized by depth, the optional Brown-Conrady ``distortion`` model
+    ``(k1, k2, p1, p2)`` is applied, and the intrinsics ``camera_matrix`` map the
+    distorted normalized coordinates to pixels. ``distortion=None`` (the default)
+    is the plain pinhole model.
     """
 
     _validate_numeric_array(points_world, "points_world", ndim=2, shape=(None, 3))
@@ -146,14 +175,20 @@ def project_pinhole(
         translation = _as_array(translation_world_to_camera, xp)
 
     points_camera = points @ rotation.T + translation
-    homogeneous = points_camera @ camera.T
-    depth = homogeneous[:, 2:3]
+    depth = points_camera[:, 2:3]
     safe_depth = xp.where(
         xp.abs(depth) < depth_epsilon,
         xp.where(depth < 0.0, -depth_epsilon, depth_epsilon),
         depth,
     )
-    return homogeneous[:, :2] / safe_depth
+    normalized = points_camera[:, :2] / safe_depth
+    if distortion is not None:
+        x_dist, y_dist = _apply_brown_conrady(
+            normalized[:, 0:1], normalized[:, 1:2], distortion, xp
+        )
+        normalized = xp.concatenate([x_dist, y_dist], axis=1)
+    homogeneous = xp.concatenate([normalized, xp.ones_like(normalized[:, :1])], axis=1)
+    return (homogeneous @ camera.T)[:, :2]
 
 
 def reprojection_residual_from_points(
@@ -165,13 +200,16 @@ def reprojection_residual_from_points(
     keypoint_offsets_m: ArrayLike | None = None,
     rotation_world_to_camera: ArrayLike | None = None,
     translation_world_to_camera: ArrayLike | None = None,
+    distortion: DistortionLike = None,
 ) -> Array:
     """Return weighted reprojection residuals for explicit 3-D keypoint points.
 
     Residuals are flattened as ``[u0, v0, u1, v1, ...]`` and weighted by
     ``sqrt(confidence)`` so missing keypoints with confidence 0 contribute zero.
     ``keypoint_offsets_m`` is the CC-15 local offset model evaluated in world
-    coordinates by the caller.
+    coordinates by the caller. ``distortion`` threads the Brown-Conrady
+    ``(k1, k2, p1, p2)`` coefficients into projection so a fit against a
+    calibrated camera with nonzero distortion is unbiased.
     """
 
     _validate_numeric_array(points_world, "points_world", ndim=2, shape=(None, 3))
@@ -201,6 +239,7 @@ def reprojection_residual_from_points(
         camera_matrix,
         rotation_world_to_camera=rotation_world_to_camera,
         translation_world_to_camera=translation_world_to_camera,
+        distortion=distortion,
     )
     weights = xp.sqrt(_as_array(confidence, xp))[:, None]
     return ((projected - observed) * weights).reshape(-1)
@@ -216,6 +255,7 @@ def reprojection_residual(
     keypoint_offsets_m: ArrayLike | None = None,
     rotation_world_to_camera: ArrayLike | None = None,
     translation_world_to_camera: ArrayLike | None = None,
+    distortion: DistortionLike = None,
 ) -> Array:
     """Return weighted reprojection residuals from a canonical-v2 ``q`` vector."""
 
@@ -231,6 +271,7 @@ def reprojection_residual(
         keypoint_offsets_m=keypoint_offsets_m,
         rotation_world_to_camera=rotation_world_to_camera,
         translation_world_to_camera=translation_world_to_camera,
+        distortion=distortion,
     )
 
 

--- a/src/shared/python/physics/ground_reaction_forces.py
+++ b/src/shared/python/physics/ground_reaction_forces.py
@@ -564,14 +564,14 @@ def extract_grf_from_contacts(  # noqa: C901
         # Known limitation: fallback calculation is inaccurate for dynamic movements.
         # It only accounts for static weight (W=mg) and ignores dynamic acceleration forces (F=m(g+a)).
         # Need to implement proper inverse dynamics or force estimation.
-        g = engine.compute_gravity_forces()
+        g = np.asarray(engine.compute_gravity_forces(), dtype=float).reshape(-1)
 
-        for body_name in contact_body_names:
-            jac_dict = engine.compute_jacobian(body_name)
-            if jac_dict is None:
-                continue
-            if len(g) > 0:
-                total_force[2] += abs(np.sum(g))
+        # Total support weight equals the magnitude of the generalized gravity
+        # force, computed ONCE for the whole body. Summing g (a generalized-force
+        # vector mixing unrelated joint terms) or re-adding it per contact body
+        # double-counts the weight (issue #6894).
+        if g.size > 0 and contact_body_names:
+            total_force[2] = float(np.linalg.norm(g))
 
         logger.debug("GRF estimated from gravity approximation (no contact data)")
 

--- a/tests/unit/estimation/test_map_estimator.py
+++ b/tests/unit/estimation/test_map_estimator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from src.shared.python.estimation import (
     CubicHermiteSplineTrajectory,
@@ -147,3 +148,83 @@ def test_inertia_parameter_is_shared_and_bound_limited() -> None:
     assert result.success
     assert result.parameters["club_inertia_kg_m2"] <= 1.05
     assert result.parameters["club_inertia_kg_m2"] > 1.0
+
+
+def test_non_finite_residual_step_is_rejected_not_crash() -> None:
+    """A finite-difference probe into a region where the engine residual is
+    non-finite must be turned into a large finite sentinel so the optimizer
+    rejects the step, instead of raising out of the callback and aborting the
+    whole least_squares solve (issue #6893)."""
+    from src.shared.python.estimation.map_estimator import _objective_residual
+
+    times = np.linspace(0.0, 1.0, 4)
+    trajectory = CubicHermiteSplineTrajectory(times, n_dof=1)
+    observations = times**2
+    initial_coefficients = trajectory.pack(
+        knot_q=(0.9 * times**2)[:, None],
+        knot_v=(1.8 * times)[:, None],
+    )
+    params = SharedParameterBlock.from_specs([])
+
+    def residual(
+        evaluation: SplineTrajectoryEvaluation,
+        _parameters: dict[str, float],
+    ) -> np.ndarray:
+        predicted = evaluation.q[:, 0]
+        # Emulate an engine that returns NaN/Inf in an infeasible region the
+        # finite-difference probe may step into (e.g. RNEA at a singular config).
+        if np.any(predicted > 5.0):
+            return np.full_like(predicted, np.inf)
+        return predicted - observations
+
+    problem = MapEstimatorProblem(
+        trajectory=trajectory,
+        evaluation_times=times,
+        initial_coefficients=initial_coefficients,
+        shared_parameters=params,
+        residual=residual,
+        options=MapEstimatorOptions(max_iterations=60),
+    )
+
+    # Probe directly into the infeasible region: residual must be finite and
+    # large (sentinel), not raise.
+    bad_coeffs = trajectory.pack(
+        knot_q=(100.0 * np.ones_like(times))[:, None],
+        knot_v=np.zeros_like(times)[:, None],
+    )
+    sentinel = _objective_residual(problem, bad_coeffs)
+    assert np.all(np.isfinite(sentinel))
+    assert np.max(np.abs(sentinel)) > 1.0e6
+
+    # And the full solve completes and recovers the truth.
+    result = solve_single_trial_map(problem)
+    assert result.success
+    fitted = trajectory.evaluate(result.coefficients, times)
+    np.testing.assert_allclose(fitted.q[:, 0], observations, atol=1e-6)
+
+
+def test_out_of_range_evaluation_time_is_rejected() -> None:
+    """Evaluation times outside the knot span must fail loudly rather than be
+    silently clamped/flat-extrapolated (issue #6895)."""
+    knot_times = np.linspace(0.0, 1.0, 4)
+    trajectory = CubicHermiteSplineTrajectory(knot_times, n_dof=1)
+    coefficients = trajectory.pack(
+        knot_q=np.zeros((knot_times.size, 1)),
+        knot_v=np.zeros((knot_times.size, 1)),
+    )
+    params = SharedParameterBlock.from_specs([])
+
+    def residual(_evaluation, _parameters):
+        return np.zeros(1)
+
+    problem = MapEstimatorProblem(
+        trajectory=trajectory,
+        evaluation_times=np.array([0.0, 0.5, 1.5]),  # 1.5 > knot span
+        initial_coefficients=coefficients,
+        shared_parameters=params,
+        residual=residual,
+        options=MapEstimatorOptions(max_iterations=10),
+    )
+
+    with pytest.raises(ValueError, match="knot"):
+        solve_single_trial_map(problem)

--- a/tests/unit/estimation/test_residuals.py
+++ b/tests/unit/estimation/test_residuals.py
@@ -9,6 +9,7 @@ from src.shared.python.estimation.residuals import (
     finite_difference_jacobian,
     project_pinhole,
     reprojection_residual,
+    reprojection_residual_from_points,
     residual_jacobian,
     smoothness_residual,
 )
@@ -202,6 +203,83 @@ def test_autodiff_jacobian_matches_finite_difference_when_jax_available() -> Non
     )
 
     np.testing.assert_allclose(auto, finite, rtol=1e-5, atol=1e-5)
+
+
+def test_project_pinhole_matches_brown_conrady_rig(monkeypatch=None) -> None:
+    """project_pinhole with distortion must match the synthetic rig's
+    Brown-Conrady projection (issue #6892)."""
+    from src.shared.python.estimation.synthetic_ground_truth import (
+        SyntheticCamera,
+        project_world_point,
+    )
+    from src.shared.python.motion_pipeline import (
+        CameraExtrinsics,
+        CameraIntrinsics,
+    )
+
+    intr = CameraIntrinsics(
+        fx=600.0,
+        fy=550.0,
+        cx=320.0,
+        cy=240.0,
+        k1=-0.21,
+        k2=0.08,
+        p1=0.001,
+        p2=-0.002,
+    )
+    rotation = np.array(
+        [[0.0, 0.0, 1.0], [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]], dtype=float
+    )
+    translation = np.array([0.1, -0.2, 4.0])
+    extr = CameraExtrinsics(
+        rotation=rotation.tolist(), translation=translation.tolist()
+    )
+    camera = SyntheticCamera("cam", intr, extr)
+
+    points = np.array([[0.3, 0.1, 0.2], [-0.4, 0.25, -0.1]])
+    camera_matrix = np.array(
+        [[intr.fx, 0.0, intr.cx], [0.0, intr.fy, intr.cy], [0.0, 0.0, 1.0]]
+    )
+
+    projected = project_pinhole(
+        points,
+        camera_matrix,
+        rotation_world_to_camera=rotation,
+        translation_world_to_camera=translation,
+        distortion=(intr.k1, intr.k2, intr.p1, intr.p2),
+    )
+
+    expected = np.array([project_world_point(camera, p)[:2] for p in points])
+    np.testing.assert_allclose(projected, expected, rtol=1e-9, atol=1e-9)
+
+
+def test_project_pinhole_zero_distortion_is_pinhole() -> None:
+    """Zero distortion must reproduce the plain pinhole projection."""
+    points = np.array([[2.0, 4.0, 2.0], [3.0, -6.0, 3.0]])
+    camera = np.eye(3)
+    plain = project_pinhole(points, camera)
+    with_zero = project_pinhole(points, camera, distortion=(0.0, 0.0, 0.0, 0.0))
+    np.testing.assert_allclose(plain, with_zero)
+
+
+def test_reprojection_residual_threads_distortion() -> None:
+    """A fit with nonzero distortion recovers truth when residual threads
+    the distortion coefficients (issue #6892)."""
+    points = np.array([[0.2, -0.1, 0.05]])
+    camera_matrix = np.array(
+        [[500.0, 0.0, 320.0], [0.0, 500.0, 240.0], [0.0, 0.0, 1.0]]
+    )
+    distortion = (-0.15, 0.05, 0.0, 0.0)
+    observed = project_pinhole(points, camera_matrix, distortion=distortion)
+
+    residual = reprojection_residual_from_points(
+        points,
+        observed,
+        camera_matrix,
+        np.array([1.0]),
+        distortion=distortion,
+    )
+    np.testing.assert_allclose(residual, np.zeros(2), atol=1e-9)
 
 
 def test_invalid_confidence_rejected() -> None:

--- a/tests/unit/test_ground_reaction_forces.py
+++ b/tests/unit/test_ground_reaction_forces.py
@@ -334,6 +334,20 @@ class TestExtractGRFFromContacts:
 
         np.testing.assert_allclose(grf.force, 0.0, atol=1e-10)
 
+    def test_gravity_fallback_not_doubled_for_two_bodies(self) -> None:
+        """Gravity fallback must report total weight once, not once per contact
+        body (issue #6894). Two feet must not double the vertical force."""
+        gravity = np.array([0.0, 0.0, -800.0])  # total weight magnitude 800 N
+
+        engine_one = self._make_engine(contact_force=np.zeros(3), gravity=gravity)
+        engine_two = self._make_engine(contact_force=np.zeros(3), gravity=gravity)
+
+        grf_one = extract_grf_from_contacts(engine_one, ["left_foot"])
+        grf_two = extract_grf_from_contacts(engine_two, ["left_foot", "right_foot"])
+
+        np.testing.assert_allclose(grf_one.force[2], 800.0, rtol=1e-9)
+        np.testing.assert_allclose(grf_two.force[2], 800.0, rtol=1e-9)
+
     def test_moment_computed_from_contact_data(self) -> None:
         """When contact data is available, moment should be computed from COP x force."""
         contact = np.array([0.0, 0.0, 1000.0])


### PR DESCRIPTION
Consolidated fixes for four adversarial-audit estimation issues.

Closes #6892
Closes #6893
Closes #6894
Closes #6895

### #6892 — Reprojection residual ignored lens distortion
`project_pinhole` now normalizes camera-frame points by depth, applies an optional Brown-Conrady `(k1, k2, p1, p2)` distortion model (identical to the synthetic rig's `project_world_point`), then applies intrinsics. `distortion` threads through `reprojection_residual_from_points` and `reprojection_residual`. `distortion=None` (default) is the plain pinhole model, so existing callers are unchanged.
Test: `project_pinhole` with nonzero distortion matches the rig's Brown-Conrady projection to 1e-9; zero distortion == plain pinhole; reprojection round-trip recovers truth.

### #6893 — `_objective_residual` raised on non-finite, aborting `least_squares`
Both `map_estimator._objective_residual` and `multi_trial._objective_residual` now route the data residual through a shared `_sentinel_for_non_finite` helper that replaces NaN/Inf entries with a large finite sentinel (`1e12`). SciPy's 2-point Jacobian probe into an infeasible region (RNEA at a singular config, near-zero projection depth) now makes the trust region reject the step instead of raising and killing the whole solve.
Test: a probe into the infeasible region yields a finite large sentinel (not a raise); the full solve completes and recovers truth.

### #6894 — GRF gravity fallback double-counted weight
The no-contact-data branch computed `abs(np.sum(g))` and added it **once per contact body** — 2x for two feet — while also collapsing a generalized-force vector with `np.sum`. Now total support weight is `norm(g)` computed **once** outside the loop.
Test: one foot and two feet both report the single correct vertical weight (800 N).

### #6895 — Out-of-range eval times silently clamped
`_validate_problem` and `_validate_observation` now share `_require_times_within_knot_span`, which requires `evaluation_times` to lie within the trajectory knot span. Out-of-range samples raise `ValueError` instead of being silently clamped and flat-extrapolated against the wrong instant. Extrapolation is explicitly unsupported.
Test: an evaluation time beyond the last knot raises.

TDD throughout (red → green). Ruff lint + format clean; mypy, bandit, unit pytest all passed in pre-push hooks. DRY: the sentinel and span-check helpers are defined once in `map_estimator` and imported by `multi_trial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)