### PR TITLE
fix(security): require auth on /realtime/publish and /chat/sessions (audit)

### DIFF
--- a/src/api/route_registry.py
+++ b/src/api/route_registry.py
@@ -153,6 +153,44 @@ async def _global_auth_dependency(
     return await _current_user_from_bearer_header(request, db)
 
 
+async def _ws_compatible_auth_dependency(
+    request: Request = None,  # type: ignore[assignment]
+    db: Session = Depends(get_db),
+) -> User | None:
+    """Auth dependency safe to attach to routers that mix HTTP and WS routes.
+
+    The realtime and chat_ws routers are excluded from auto-discovery
+    (issues #6888, #6889) because they expose WebSocket endpoints that
+    authenticate themselves via ``resolve_ws_user`` before ``accept()``.
+    Their *HTTP* endpoints (``POST /realtime/publish``,
+    ``GET /chat/sessions``, ``GET /chat/sessions/{id}/history``) previously
+    had no auth at all, allowing unauthenticated broadcast injection and
+    session enumeration in cloud mode.
+
+    Attaching :func:`_global_auth_dependency` directly would break the WS
+    routes: it declares ``request: Request`` which FastAPI cannot inject into
+    a WebSocket scope, raising ``TypeError`` and dropping the connection. This
+    variant declares ``request`` as an optional special parameter: FastAPI
+    injects the HTTP ``Request`` and leaves it ``None`` in a WebSocket scope, so
+    the bearer header is enforced only on HTTP. WS connections fall through to
+    the route's own ``resolve_ws_user`` check.
+
+    In local/auth-disabled mode this is a no-op (returns ``None``).
+    """
+    if request is None:
+        # WebSocket scope: the route handler self-authenticates.
+        return None
+    if is_auth_disabled():
+        return None
+    return await _current_user_from_bearer_header(request, db)
+
+
+# Public alias for server.py: the chat_ws and realtime routers are mounted
+# explicitly there (they are excluded from auto-discovery) and need this
+# WS-safe auth dependency attached to close issues #6888 and #6889.
+ws_compatible_auth_dependency = _ws_compatible_auth_dependency
+
+
 _ROUTE_DEPENDENCIES: dict[str, tuple[Callable[..., object], ...]] = {
     "simulation": (_SIMULATION_QUOTA_DEPENDENCY,),
     "video": (_VIDEO_QUOTA_DEPENDENCY,),

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -25,7 +25,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import uvicorn
-from fastapi import FastAPI, Request, Response
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import JSONResponse
@@ -48,7 +48,7 @@ from .database import init_db
 from .middleware.security_headers import add_security_headers
 from .middleware.upload_limits import validate_upload_size
 from .rate_limit import limiter
-from .route_registry import register_routes
+from .route_registry import register_routes, ws_compatible_auth_dependency
 from .services.analysis_service import AnalysisService
 from .services.chat_service import ChatService
 from .services.simulation_service import SimulationService
@@ -296,19 +296,30 @@ logger.info("Registered %d route modules under /api", _legacy_api_count)
 _versioned_count = register_routes(app, prefix=API_PREFIX)
 logger.info("Registered %d route modules under %s", _versioned_count, API_PREFIX)
 
-# Register explicitly excluded WebSocket routes
-app.include_router(chat_ws.router, prefix=API_PREFIX)
+# Register explicitly excluded WebSocket routes.
+#
+# These routers mix WebSocket endpoints (which self-authenticate via
+# resolve_ws_user) with HTTP endpoints. The HTTP endpoints were previously
+# unauthenticated in cloud mode (issues #6888, #6889), allowing unauthenticated
+# broadcast injection (POST /realtime/publish) and chat-session enumeration
+# (GET /chat/sessions, /history). ws_compatible_auth_dependency enforces the
+# bearer header on HTTP requests only; WebSocket connections fall through to the
+# route handler's own auth check, and local/auth-disabled mode remains open.
+_excluded_ws_auth = [Depends(ws_compatible_auth_dependency)]
+app.include_router(chat_ws.router, prefix=API_PREFIX, dependencies=_excluded_ws_auth)
 app.include_router(simulation_ws.router, prefix=API_PREFIX)
-app.include_router(chat_ws.router, prefix="/api")
+app.include_router(chat_ws.router, prefix="/api", dependencies=_excluded_ws_auth)
 app.include_router(simulation_ws.router, prefix="/api")
-app.include_router(chat_ws.router, prefix="")
+app.include_router(chat_ws.router, prefix="", dependencies=_excluded_ws_auth)
 app.include_router(simulation_ws.router, prefix="")
 
 # Realtime IPC layer (issue #4997) — combined HTTP + WS endpoints under
 # /realtime; mounted at root so cross-process clients (WSPubSub) can use the
 # canonical "/realtime/publish" and "/realtime/subscribe" paths.
-app.include_router(realtime_route.router, prefix="")
-app.include_router(realtime_route.router, prefix=API_PREFIX)
+app.include_router(realtime_route.router, prefix="", dependencies=_excluded_ws_auth)
+app.include_router(
+    realtime_route.router, prefix=API_PREFIX, dependencies=_excluded_ws_auth
+)
 
 
 if __name__ == "__main__":

--- a/tests/unit/api/test_excluded_router_http_auth.py
+++ b/tests/unit/api/test_excluded_router_http_auth.py
@@ -1,0 +1,186 @@
+"""Auth coverage for the excluded HTTP routes on WS-mixed routers.
+
+Regression tests for issues #6888 and #6889.
+
+The ``realtime`` and ``chat_ws`` routers are excluded from auto-discovery
+(``route_registry._EXCLUDED_MODULES``) because they expose self-authenticating
+WebSocket endpoints. Before these fixes their *HTTP* endpoints carried no auth
+at all, so in cloud/remote mode an unauthenticated client could:
+
+* ``POST /realtime/publish`` — inject arbitrary JSON to every WS subscriber
+  (#6888, HIGH), and
+* ``GET /chat/sessions`` / ``GET /chat/sessions/{id}/history`` — enumerate
+  active sessions and read other users' history (#6889, MED).
+
+``server.py`` now attaches ``ws_compatible_auth_dependency`` to every mount of
+these routers. That dependency enforces the bearer header on HTTP requests only
+(respecting ``is_auth_disabled()``); WebSocket connections fall through to the
+route handler's own ``resolve_ws_user`` gate.
+
+These tests mount the *real* routers with the *real* dependency, mirroring the
+wiring in ``server.py``, and assert:
+
+(a) unauthenticated ``POST /realtime/publish`` → 401/403 in remote mode,
+(b) unauthenticated ``GET /chat/sessions`` + ``/history`` → 401/403 in remote
+    mode,
+(c) auth-disabled / local mode still allows all of the above, and
+(d) the WS ``subscribe`` / ``chat_stream`` routes still connect with a valid
+    user (the HTTP dependency does not break the socket handshake).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes import chat_ws as chat_ws_module
+from src.api.routes import realtime as realtime_module
+from src.api.route_registry import ws_compatible_auth_dependency
+
+_REMOTE_ENV = {"GOLF_SUITE_MODE": "remote", "GOLF_AUTH_DISABLED": "false"}
+_LOCAL_ENV = {"GOLF_SUITE_MODE": "local"}
+
+
+class _MockSession:
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+
+
+class _MockChatService:
+    def list_sessions(self) -> list[dict[str, str]]:
+        return [{"session_id": "session_1"}]
+
+    def get_session_history(self, session_id: str) -> list[dict[str, str]]:
+        return [{"role": "user", "content": "hello"}]
+
+    def get_or_create_session(self, session_id: str | None) -> _MockSession:
+        return _MockSession(session_id or "new_id")
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """App that mounts both excluded routers exactly as ``server.py`` does."""
+    deps = [Depends(ws_compatible_auth_dependency)]
+    test_app = FastAPI()
+    test_app.include_router(chat_ws_module.router, dependencies=deps)
+    test_app.include_router(realtime_module.router, dependencies=deps)
+    test_app.state.chat_service = _MockChatService()
+    return test_app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    # raise_server_exceptions=False so a rejected dependency surfaces as an
+    # HTTP status (401/403) rather than re-raising HTTPException in the test.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── (a) POST /realtime/publish unauthenticated in remote mode (#6888) ──
+
+
+def test_realtime_publish_unauthenticated_rejected_in_remote_mode(
+    client: TestClient,
+) -> None:
+    with patch.dict(os.environ, _REMOTE_ENV, clear=False):
+        response = client.post(
+            "/realtime/publish",
+            json={"channel": "pose/canonical", "payload": {"spoofed": True}},
+        )
+    assert response.status_code in (401, 403), response.text
+
+
+# ── (b) chat REST endpoints unauthenticated in remote mode (#6889) ──
+
+
+def test_chat_sessions_unauthenticated_rejected_in_remote_mode(
+    client: TestClient,
+) -> None:
+    with patch.dict(os.environ, _REMOTE_ENV, clear=False):
+        response = client.get("/chat/sessions")
+    assert response.status_code in (401, 403), response.text
+
+
+def test_chat_history_unauthenticated_rejected_in_remote_mode(
+    client: TestClient,
+) -> None:
+    with patch.dict(os.environ, _REMOTE_ENV, clear=False):
+        response = client.get("/chat/sessions/session_1/history")
+    assert response.status_code in (401, 403), response.text
+
+
+# ── (c) auth-disabled / local mode still allows the HTTP endpoints ──
+
+
+def test_local_mode_allows_chat_sessions(client: TestClient) -> None:
+    with patch.dict(os.environ, _LOCAL_ENV, clear=False):
+        response = client.get("/chat/sessions")
+    assert response.status_code == 200, response.text
+    assert response.json() == [{"session_id": "session_1"}]
+
+
+def test_local_mode_allows_chat_history(client: TestClient) -> None:
+    with patch.dict(os.environ, _LOCAL_ENV, clear=False):
+        response = client.get("/chat/sessions/session_1/history")
+    assert response.status_code == 200, response.text
+    assert response.json()["session_id"] == "session_1"
+
+
+def test_local_mode_allows_realtime_publish(client: TestClient) -> None:
+    with patch.dict(os.environ, _LOCAL_ENV, clear=False):
+        # No subscribers, but auth must not block the publish itself.
+        response = client.post(
+            "/realtime/publish",
+            json={"channel": "pose/canonical", "payload": {"ok": True}},
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["delivered"] == 0
+
+
+# ── (d) WS routes still connect with a valid user despite the HTTP dep ──
+
+
+def test_realtime_subscribe_ws_connects_with_valid_user(
+    client: TestClient,
+) -> None:
+    """A valid WS subscription must survive the router-level HTTP dependency.
+
+    The dependency declares ``request: Request``; if it were attached without
+    WS-scope handling FastAPI would raise ``TypeError`` for the WS scope and
+    drop the connection. We patch ``resolve_ws_user`` to stand in for a valid
+    token so the test does not need a real JWT or DB.
+    """
+    fake_user = object()
+    # Entering websocket_connect performs the handshake. If the router-level
+    # HTTP dependency mis-injected into the WS scope it would raise and the
+    # connect would fail with a 1008/close here.
+    with (
+        patch.dict(os.environ, _REMOTE_ENV, clear=False),
+        patch.object(
+            realtime_module,
+            "resolve_ws_user",
+            AsyncMock(return_value=fake_user),
+        ),
+        client.websocket_connect("/realtime/subscribe?channel=pose/canonical") as ws,
+    ):
+        ws.close()
+
+
+def test_chat_stream_ws_connects_with_valid_user(client: TestClient) -> None:
+    """The chat WebSocket must still connect through the HTTP auth dependency."""
+    fake_user = object()
+    with (
+        patch.dict(os.environ, _REMOTE_ENV, clear=False),
+        patch.object(
+            chat_ws_module,
+            "resolve_ws_user",
+            AsyncMock(return_value=fake_user),
+        ),
+        client.websocket_connect("/ws/chat/session_1") as ws,
+    ):
+        data = ws.receive_json()
+        assert data["type"] == "session_info"
+        assert data["session_id"] == "session_1"


### PR DESCRIPTION
Closes #6888
Closes #6889

The `realtime` and `chat_ws` routers are excluded from registry auto-auth because they expose self-authenticating WebSocket endpoints. Their **HTTP** endpoints (`POST /realtime/publish`, `GET /chat/sessions`, `GET /chat/sessions/{id}/history`) previously had **no auth**, allowing unauthenticated broadcast injection (#6888, HIGH) and chat-session enumeration/history read (#6889, MED) in cloud/remote mode.

## Fix
- Adds `ws_compatible_auth_dependency` in `route_registry.py`: declares `request` as an optional special param so FastAPI injects it for HTTP scopes (enforces bearer header) but leaves it `None` for WebSocket scopes (so the WS route's own `resolve_ws_user` gate still runs). No-op in local/auth-disabled mode.
- Attaches it via `dependencies=` to every `include_router` mount of `chat_ws` and `realtime` in `server.py`.

## Tests (`tests/unit/api/test_excluded_router_http_auth.py`, 8 passing)
- unauth `POST /realtime/publish` -> 401/403 in remote mode
- unauth `GET /chat/sessions` + `/history` -> 401/403 in remote mode
- local/auth-disabled mode still allows all three
- WS `/realtime/subscribe` and `/ws/chat/{id}` still connect with a valid user (HTTP dep does not break the socket handshake)