### PR TITLE
fix(launcher,api): Windows cmd quoting, DRY, streaming preview, daemon timer

### DIFF
--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import mimetypes
 import os
 import secrets
+import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -899,11 +900,32 @@ def print_server_info(host: str, port: int) -> None:
         logger.info("    Press Ctrl+C to stop.\n")
 
 
+def _schedule_browser_open(host: str, port: int, delay: float = 1.5) -> threading.Timer:
+    """Schedule a one-shot browser open as a daemon timer.
+
+    Using a daemon thread ensures that if the server fails to bind (e.g. the
+    port is already in use), the process exits immediately instead of blocking
+    until the timer fires (issue #6924).
+
+    Returns:
+        The started, already-running daemon :class:`threading.Timer`.
+    """
+    import webbrowser
+
+    def open_browser() -> None:
+        from src.shared.python.config.environment import is_browser_suppressed
+
+        if not is_browser_suppressed():
+            webbrowser.open(f"http://{host}:{port}")
+
+    timer = threading.Timer(delay, open_browser)
+    timer.daemon = True
+    timer.start()
+    return timer
+
+
 def main() -> None:
     """Launch local server with auto-open browser."""
-    import webbrowser
-    from threading import Timer
-
     import uvicorn
 
     DIM = "\033[2m"
@@ -925,15 +947,8 @@ def main() -> None:
     print_matrix_status(f"Server ready on port {port}")
     logger.info("")
 
-    # Open browser after server starts
-    def open_browser() -> None:
-        """Open the default web browser to the local server URL."""
-        from src.shared.python.config.environment import is_browser_suppressed
-
-        if not is_browser_suppressed():
-            webbrowser.open(f"http://{host}:{port}")
-
-    Timer(1.5, open_browser).start()
+    # Open browser after server starts (daemon timer; see #6924)
+    _schedule_browser_open(host, port)
 
     # Print server info
     print_server_info(host, port)

--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -457,12 +457,71 @@ def _find_dataset_path(name: str) -> Path:
 
 
 def _load_dataset_from_path(filepath: Path) -> tuple[list[str], list[dict[str, Any]]]:
-    """Load previewable dataset rows from a resolved path."""
+    """Load previewable dataset rows from a resolved path.
+
+    Reads the entire file; only use for operations (stats, filtering) that
+    genuinely need every row. For previews use
+    :func:`_preview_dataset_from_path`, which streams a bounded window.
+    """
     content = filepath.read_text(encoding="utf-8")
     if filepath.suffix.lower() == ".csv":
         return _parse_csv_content(content)
     if filepath.suffix.lower() == ".json":
         return _parse_json_content(content)
+    raise HTTPException(
+        status_code=400,
+        detail=f"Preview not supported for {filepath.suffix} format",
+    )
+
+
+def _preview_csv_streaming(
+    filepath: Path, limit: int
+) -> tuple[list[str], list[dict[str, Any]], int]:
+    """Stream a CSV preview: header, first ``limit`` rows, and total count.
+
+    Reads the file incrementally via a single ``csv.reader`` pass so that
+    arbitrarily large files never materialize fully in memory (issue #6923).
+    """
+    rows: list[dict[str, Any]] = []
+    columns: list[str] = []
+    total = 0
+    with filepath.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            columns = next(reader)
+        except StopIteration:
+            return [], [], 0
+        for record in reader:
+            total += 1
+            if len(rows) < limit:
+                rows.append(dict(zip(columns, record, strict=False)))
+    return columns, rows, total
+
+
+def _preview_json_streaming(
+    filepath: Path, limit: int
+) -> tuple[list[str], list[dict[str, Any]], int]:
+    """Build a JSON preview, returning header, first ``limit`` rows, and total.
+
+    JSON has no line-oriented streaming guarantee, so the document is parsed
+    once and only the bounded preview window is retained for the response.
+    """
+    columns, all_rows = _parse_json_content(filepath.read_text(encoding="utf-8"))
+    return columns, all_rows[:limit], len(all_rows)
+
+
+def _preview_dataset_from_path(
+    filepath: Path, limit: int
+) -> tuple[list[str], list[dict[str, Any]], int]:
+    """Return (columns, preview_rows, total_rows) without holding large files.
+
+    Precondition: ``limit`` must be positive.
+    """
+    suffix = filepath.suffix.lower()
+    if suffix == ".csv":
+        return _preview_csv_streaming(filepath, limit)
+    if suffix == ".json":
+        return _preview_json_streaming(filepath, limit)
     raise HTTPException(
         status_code=400,
         detail=f"Preview not supported for {filepath.suffix} format",
@@ -611,13 +670,13 @@ async def preview_dataset(name: str, limit: int = 50) -> DatasetPreviewResponse:
         )
 
     filepath = _find_dataset_path(name)
-    columns, rows = _load_dataset_from_path(filepath)
+    columns, rows, total_rows = _preview_dataset_from_path(filepath, limit)
 
     return DatasetPreviewResponse(
         name=name,
         columns=columns,
-        rows=rows[:limit],
-        total_rows=len(rows),
+        rows=rows,
+        total_rows=total_rows,
         format=filepath.suffix.lstrip("."),
     )
 

--- a/src/launchers/launcher_process_manager.py
+++ b/src/launchers/launcher_process_manager.py
@@ -123,6 +123,31 @@ VCXSRV_PATHS = [
 _MODULE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
 
 
+def _build_windows_console_cmd(args: list[str], *, keep_terminal_open: bool) -> str:
+    """Build a cmd.exe command string for a new-console subprocess launch.
+
+    ``subprocess.list2cmdline`` applies Windows (cmd.exe) quoting rules,
+    wrapping arguments that contain spaces in double quotes. POSIX
+    ``shlex.quote`` uses single quotes, which cmd.exe does not recognize,
+    so interpreter or script paths containing spaces fail to launch
+    (issue #6921).
+
+    Args:
+        args: The program and its arguments, e.g. ``[exe, script]`` or
+            ``[exe, "-m", module]``. All entries must already be validated.
+        keep_terminal_open: When ``True`` use ``cmd /k ... & pause`` so the
+            console stays open after the process exits; otherwise ``cmd /c``.
+
+    Returns:
+        A command string suitable for ``subprocess.Popen`` with
+        ``creationflags=CREATE_NEW_CONSOLE``.
+    """
+    inner = subprocess.list2cmdline(args)
+    if keep_terminal_open:
+        return f'cmd /k "{inner} & pause"'
+    return f'cmd /c "{inner}"'
+
+
 class ProcessManager:
     """Manages subprocess lifecycle for the Golf Launcher.
 
@@ -476,31 +501,16 @@ class ProcessManager:
                 process_env.get("PYTHONPATH", "<unset>")[:300],
             )
 
-            # Validate script path to prevent path-traversal / injection.
-            validate_script_path(script_path, self.repo_root)
-
-            # Diagnostic: log full launch details for debugging silent failures
-            logger.info(
-                "Launching script %s: cmd=[%s, %s], cwd=%s, PYTHONPATH=%s",
-                name,
-                sys.executable,
-                script_path,
-                cwd,
-                process_env.get("PYTHONPATH", "<unset>")[:300],
-            )
-
             if self.use_separate_terminals:
                 # Legacy: each engine gets its own console window.
                 # On Windows we must pass a string to open a new console but
                 # quote both the interpreter and script paths so that spaces
                 # and other shell-significant characters cannot inject commands.
                 if os.name == "nt":
-                    exe_q = shlex.quote(sys.executable)
-                    script_q = shlex.quote(str(script_path))
-                    if keep_terminal_open:
-                        cmd_str = f'cmd /k "{exe_q} {script_q} & pause"'
-                    else:
-                        cmd_str = f'cmd /c "{exe_q} {script_q}"'
+                    cmd_str = _build_windows_console_cmd(
+                        [sys.executable, str(script_path)],
+                        keep_terminal_open=keep_terminal_open,
+                    )
                     process = subprocess.Popen(
                         cmd_str,
                         cwd=str(cwd),
@@ -588,12 +598,6 @@ class ProcessManager:
                     f"Invalid module name (potential injection): {module_name!r}"
                 )
 
-            # Validate module name: must be a dotted Python identifier.
-            if not _MODULE_NAME_RE.match(module_name):
-                raise SecureSubprocessError(
-                    f"Invalid module name (potential injection): {module_name!r}"
-                )
-
             if os.name == "nt":
                 current_pythonpath = process_env.get("PYTHONPATH", "")
                 repo_root_str = str(self.repo_root)
@@ -630,13 +634,12 @@ class ProcessManager:
                 # On Windows we must pass a string to open a new console but
                 # quote the interpreter path so spaces cannot inject commands.
                 # module_name has already been validated against the allowlist
-                # regex so it is safe to interpolate directly.
+                # regex so it is safe to pass through.
                 if os.name == "nt":
-                    exe_q = shlex.quote(sys.executable)
-                    if keep_terminal_open:
-                        cmd_str = f'cmd /k "{exe_q} -m {module_name} & pause"'
-                    else:
-                        cmd_str = f'cmd /c "{exe_q} -m {module_name}"'
+                    cmd_str = _build_windows_console_cmd(
+                        [sys.executable, "-m", module_name],
+                        keep_terminal_open=keep_terminal_open,
+                    )
                     process = subprocess.Popen(
                         cmd_str,
                         cwd=str(cwd),

--- a/tests/launchers/test_launcher_process_manager.py
+++ b/tests/launchers/test_launcher_process_manager.py
@@ -398,6 +398,71 @@ def test_launch_module_keep_terminal(mock_popen, manager) -> None:
         assert "& pause" in mock_popen.call_args[0][0]
 
 
+@patch(_VALIDATE_SCRIPT)
+@patch("subprocess.Popen")
+@patch(_SECURE_POPEN)
+def test_launch_script_separate_term_quotes_spaces_for_cmd(
+    mock_secure_popen, mock_popen, mock_validate, manager
+) -> None:
+    """Windows console launch must use cmd-compatible double-quote quoting.
+
+    Regression for #6921: shlex.quote uses POSIX single quotes, which
+    cmd.exe does not honor, breaking paths that contain spaces.
+    """
+    manager.use_separate_terminals = True
+    script_path = Path("/fake/dir with spaces/script.py")
+    cwd_path = Path("/fake/cwd")
+    fake_exe = r"C:\Program Files\Python\python.exe"
+
+    with (
+        patch("src.launchers.launcher_process_manager.os.name", "nt"),
+        patch("src.launchers.launcher_process_manager.sys.executable", fake_exe),
+    ):
+        manager.launch_script("Test", script_path, cwd_path)
+        cmd_str = mock_popen.call_args[0][0]
+
+    # cmd.exe quoting uses double quotes around the spaced executable path.
+    assert '"C:\\Program Files\\Python\\python.exe"' in cmd_str
+    # POSIX single-quote quoting must never appear.
+    assert "'" not in cmd_str
+    assert "cmd /c" in cmd_str
+
+
+@patch("subprocess.Popen")
+def test_launch_module_separate_term_quotes_spaces_for_cmd(mock_popen, manager) -> None:
+    """Windows module launch must double-quote the spaced interpreter path."""
+    manager.use_separate_terminals = True
+    fake_exe = r"C:\Program Files\Python\python.exe"
+
+    with (
+        patch("src.launchers.launcher_process_manager.os.name", "nt"),
+        patch("src.launchers.launcher_process_manager.sys.executable", fake_exe),
+        patch.dict("os.environ", {}),
+    ):
+        manager.launch_module("Test", "my_module", PureWindowsPath("."))
+        cmd_str = mock_popen.call_args[0][0]
+
+    assert '"C:\\Program Files\\Python\\python.exe"' in cmd_str
+    assert "'" not in cmd_str
+    assert "-m my_module" in cmd_str
+
+
+def test_build_windows_console_cmd_helper() -> None:
+    """The shared cmd-builder helper quotes args and toggles pause (DRY #6922)."""
+    from src.launchers.launcher_process_manager import _build_windows_console_cmd
+
+    args = [r"C:\Program Files\Python\python.exe", r"C:\my scripts\a.py"]
+    plain = _build_windows_console_cmd(args, keep_terminal_open=False)
+    paused = _build_windows_console_cmd(args, keep_terminal_open=True)
+
+    assert plain.startswith('cmd /c "')
+    assert '"C:\\Program Files\\Python\\python.exe"' in plain
+    assert "& pause" not in plain
+
+    assert paused.startswith('cmd /k "')
+    assert "& pause" in paused
+
+
 @patch("subprocess.Popen")
 def test_launch_in_wsl_posix(mock_popen, manager) -> None:
     with patch("os.name", "posix"):

--- a/tests/unit/api/test_routes_data_explorer.py
+++ b/tests/unit/api/test_routes_data_explorer.py
@@ -125,3 +125,61 @@ def test_list_datasets_no_absolute_paths(client: TestClient, temp_dataset_dir) -
         ds = next(d for d in data["datasets"] if d["name"] == "dummy_dataset.csv")
         assert not Path(ds["path"]).is_absolute()
         assert ds["path"] == "dummy_dataset.csv"
+
+
+def test_preview_streams_only_limit_rows_for_large_csv(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """Issue #6923: preview must not read an entire large CSV into memory.
+
+    It streams only the header plus ``limit`` rows from a file handle while
+    still reporting the true total row count.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    big_csv = output_dir / "big.csv"
+    total = 5000
+    lines = ["a,b"]
+    lines.extend(f"{i},{i * 2}" for i in range(total))
+    big_csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    with (
+        patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir),
+        patch.object(
+            Path, "read_text", side_effect=AssertionError("must not read whole file")
+        ),
+    ):
+        response = client.get("/tools/data-explorer/datasets/big.csv/preview?limit=10")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["columns"] == ["a", "b"]
+    assert len(data["rows"]) == 10
+    assert data["total_rows"] == total
+    assert data["rows"][0] == {"a": "0", "b": "0"}
+
+
+def test_preview_streams_only_limit_rows_for_large_json(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """Issue #6923: JSON preview returns at most ``limit`` rows."""
+    import json
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    big_json = output_dir / "big.json"
+    total = 2000
+    records = [{"x": i, "y": i * 2} for i in range(total)]
+    big_json.write_text(json.dumps(records), encoding="utf-8")
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        response = client.get("/tools/data-explorer/datasets/big.json/preview?limit=5")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["columns"] == ["x", "y"]
+    assert len(data["rows"]) == 5
+    assert data["total_rows"] == total

--- a/tests/unit/test_local_server_browser_timer.py
+++ b/tests/unit/test_local_server_browser_timer.py
@@ -1,0 +1,56 @@
+"""Tests for the auto-open-browser timer in the local server (#6924)."""
+
+from __future__ import annotations
+
+import pytest
+
+local_server = pytest.importorskip("src.api.local_server")
+
+
+def test_schedule_browser_open_returns_daemon_timer() -> None:
+    """The browser-open timer must be a daemon so a failed bind exits cleanly.
+
+    Regression for #6924: a non-daemon Timer kept the process alive for the
+    full delay when the server failed to start.
+    """
+    timer = local_server._schedule_browser_open("127.0.0.1", 8000, delay=0.0)
+    try:
+        assert timer.daemon is True
+    finally:
+        timer.cancel()
+
+
+def test_schedule_browser_open_respects_suppression(monkeypatch) -> None:
+    """When the browser is suppressed, the scheduled callback opens nothing."""
+    opened: list[str] = []
+
+    monkeypatch.setattr(
+        "src.shared.python.config.environment.is_browser_suppressed",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "webbrowser.open",
+        lambda url: opened.append(url),
+    )
+
+    timer = local_server._schedule_browser_open("127.0.0.1", 8000, delay=0.0)
+    timer.join(timeout=2.0)
+    assert opened == []
+
+
+def test_schedule_browser_open_opens_when_not_suppressed(monkeypatch) -> None:
+    """When not suppressed, the timer opens the local server URL."""
+    opened: list[str] = []
+
+    monkeypatch.setattr(
+        "src.shared.python.config.environment.is_browser_suppressed",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "webbrowser.open",
+        lambda url: opened.append(url),
+    )
+
+    timer = local_server._schedule_browser_open("127.0.0.1", 8123, delay=0.0)
+    timer.join(timeout=2.0)
+    assert opened == ["http://127.0.0.1:8123"]


### PR DESCRIPTION
Consolidated fix for four concrete open review issues. TDD throughout (failing test added first), DRY/DbC/LoD respected, Ruff clean, error-handling ratchet OK.

## Closes #6921 — launcher POSIX quoting on Windows
`launch_script`/`launch_module` built cmd.exe console strings with `shlex.quote`, which emits POSIX single quotes that cmd.exe does not honor — so interpreter or script paths containing spaces (e.g. `C:\Program Files\...`) failed to launch. New `_build_windows_console_cmd()` uses `subprocess.list2cmdline` for correct Windows double-quote quoting.

## Closes #6922 — duplicated launcher code (DRY)
Removed the duplicated script-validation/logging block in `launch_script` and the duplicated module-name validation in `launch_module`. Console-command construction is now centralized in the shared `_build_windows_console_cmd` helper.

## Closes #6923 — data explorer reads entire file into memory (OOM)
`preview_dataset` read whole files via `read_text`. New `_preview_dataset_from_path` streams CSV through a single `csv.reader` pass, retaining only `limit` rows while still counting true `total_rows`; JSON preview is bounded to `limit`. Full-file `_load_dataset_from_path` is retained only for stats/filter operations that genuinely need every row.

## Closes #6924 — non-daemon auto-open-browser Timer
The `threading.Timer` was non-daemon, so a failed uvicorn bind kept the process alive for the full delay. Extracted `_schedule_browser_open()` which returns a daemon Timer.

### Tests
- `tests/launchers/test_launcher_process_manager.py`: Windows double-quote quoting for spaced paths (script + module), `_build_windows_console_cmd` helper.
- `tests/unit/api/test_routes_data_explorer.py`: large CSV/JSON preview streams only `limit` rows, reports true total (CSV test asserts `read_text` is never called).
- `tests/unit/test_local_server_browser_timer.py`: timer is daemon; respects/ignores browser suppression.

Note: source-only bug fixes (no top-level package or version/CI-gate changes per SPEC update triggers) → `spec-exempt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)