### PR TITLE
fix(review-feedback): jaxsim.api probe, blank CSV rows, public MultiSourceTarget, token dir perms

### DIFF
--- a/src/api/cloud_client.py
+++ b/src/api/cloud_client.py
@@ -70,10 +70,12 @@ class CloudClient:
             return
 
         config_dir = Path.home() / ".golf-suite"
-        config_dir.mkdir(exist_ok=True)
+        config_dir.mkdir(mode=0o700, exist_ok=True)
+        config_dir.chmod(0o700)  # tighten pre-existing dirs (#6971)
 
         token_file = config_dir / "cloud_token"
         token_file.write_text(self.token)
+        token_file.chmod(0o600)
 
     def logout(self) -> None:
         """Logout and clear local token."""

--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -492,6 +492,8 @@ def _preview_csv_streaming(
         except StopIteration:
             return [], [], 0
         for record in reader:
+            if not record:
+                continue
             total += 1
             if len(rows) < limit:
                 rows.append(dict(zip(columns, record, strict=False)))

--- a/src/shared/python/engine_core/engine_manager.py
+++ b/src/shared/python/engine_core/engine_manager.py
@@ -44,7 +44,7 @@ _RUNTIME_DEPENDENCY_NAMES: dict[EngineType, str] = {
     EngineType.MUJOCO: "mujoco",
     EngineType.DRAKE: "drake",
     EngineType.PINOCCHIO: "pinocchio",
-    EngineType.JAXSIM: "jaxsim",
+    EngineType.JAXSIM: "jaxsim.api",
     EngineType.OPENSIM: "opensim",
     EngineType.MYOSIM: "myosuite",
 }

--- a/src/shared/python/motion_matching/provider.py
+++ b/src/shared/python/motion_matching/provider.py
@@ -31,6 +31,7 @@ from typing import Any, Protocol, runtime_checkable
 from .club_ball_target import ClubBallTarget
 from .club_target import ClubTarget
 from .fit_result import CanonicalFitResult
+from .multi_source_target import MultiSourceTarget as _PublicMultiSourceTarget
 
 __all__ = [
     "FitOptions",
@@ -268,7 +269,7 @@ def resolve_club_target(target: Any) -> ClubTarget:
         return target
     if isinstance(target, ClubBallTarget):
         return target.club
-    if isinstance(target, MultiSourceTarget):
+    if isinstance(target, (MultiSourceTarget, _PublicMultiSourceTarget)):
         if target.club is None:
             raise ValueError(
                 "resolve_club_target requires target.club to be set; "

--- a/tests/api/test_cloud_client.py
+++ b/tests/api/test_cloud_client.py
@@ -1,5 +1,7 @@
 """Tests for the optional cloud client."""
 
+import os
+import sys
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -49,6 +51,63 @@ def test_logout(temp_cache_dir: Path) -> None:
     assert not client.is_logged_in
     assert client.token is None
     assert not token_file.exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions only")
+def test_save_token_sets_private_file_permissions(temp_cache_dir: Path) -> None:
+    """#6971: token file and its parent dir must be owner-only (0600 / 0700)."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"access_token": "secret-token"}
+
+    import asyncio
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.post.return_value = mock_response
+    mock_client_class = MagicMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+    with patch("src.api.cloud_client.httpx.AsyncClient", mock_client_class):
+        client = CloudClient()
+        asyncio.run(client.login("test@example.com", "password"))
+
+    config_dir = temp_cache_dir / ".golf-suite"
+    token_file = config_dir / "cloud_token"
+
+    assert token_file.exists()
+    dir_mode = oct(os.stat(config_dir).st_mode)[-3:]
+    file_mode = oct(os.stat(token_file).st_mode)[-3:]
+    assert dir_mode == "700", f"config dir mode should be 700, got {dir_mode}"
+    assert file_mode == "600", f"token file mode should be 600, got {file_mode}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions only")
+def test_save_token_fixes_permissions_on_existing_dir(temp_cache_dir: Path) -> None:
+    """#6971: pre-existing config dir with loose permissions must be tightened."""
+    # Simulate an old install that left the dir world-readable (0755)
+    config_dir = temp_cache_dir / ".golf-suite"
+    config_dir.mkdir(parents=True)
+    config_dir.chmod(0o755)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"access_token": "secret-token"}
+
+    import asyncio
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.post.return_value = mock_response
+    mock_client_class = MagicMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+    with patch("src.api.cloud_client.httpx.AsyncClient", mock_client_class):
+        client = CloudClient()
+        asyncio.run(client.login("test@example.com", "password"))
+
+    dir_mode = oct(os.stat(config_dir).st_mode)[-3:]
+    assert dir_mode == "700", (
+        f"pre-existing dir should be tightened to 700, got {dir_mode}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_routes_data_explorer.py
+++ b/tests/unit/api/test_routes_data_explorer.py
@@ -161,6 +161,37 @@ def test_preview_streams_only_limit_rows_for_large_csv(
     assert data["rows"][0] == {"a": "0", "b": "0"}
 
 
+def test_preview_csv_skips_blank_lines(client: TestClient, temp_dataset_dir) -> None:
+    """Issue #6956: blank lines in a CSV must not inflate total_rows or add empty rows.
+
+    csv.reader yields an empty list for blank lines; the streaming path must
+    skip them so the row count and preview match what csv.DictReader (used for
+    stats/filtering) reports for the same file.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    csv_file = output_dir / "blanks.csv"
+    # 3 real data rows, 2 blank lines interspersed
+    csv_file.write_text("a,b\n1,2\n\n3,4\n\n5,6\n", encoding="utf-8")
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        response = client.get(
+            "/tools/data-explorer/datasets/blanks.csv/preview?limit=10"
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["columns"] == ["a", "b"]
+    assert data["total_rows"] == 3
+    assert len(data["rows"]) == 3
+    assert {"a": "1", "b": "2"} in data["rows"]
+    assert {"a": "3", "b": "4"} in data["rows"]
+    assert {"a": "5", "b": "6"} in data["rows"]
+    assert {} not in data["rows"]
+
+
 def test_preview_streams_only_limit_rows_for_large_json(
     client: TestClient, temp_dataset_dir
 ) -> None:

--- a/tests/unit/motion_matching/test_shared_provider_helpers.py
+++ b/tests/unit/motion_matching/test_shared_provider_helpers.py
@@ -86,6 +86,20 @@ def test_resolve_club_target_unwraps_uniformly(
     assert resolved is club
 
 
+def test_resolve_club_target_accepts_public_multi_source_target(
+    club: ClubTarget,
+) -> None:
+    """#6961: resolve_club_target must accept the public MultiSourceTarget from
+    multi_source_target.py (the package-level export used by the data-sources
+    panel), not only the provider-local class."""
+    from src.shared.python.motion_matching.multi_source_target import (
+        MultiSourceTarget as PublicMultiSourceTarget,
+    )
+
+    target = PublicMultiSourceTarget(club=club, body=None)
+    assert resolve_club_target(target) is club
+
+
 def test_resolve_club_target_rejects_empty_multi_source() -> None:
     bad = MultiSourceTarget(body={"present": True})  # club is None
     with pytest.raises(ValueError, match="club"):

--- a/tests/unit/test_engine_manager_availability_guard.py
+++ b/tests/unit/test_engine_manager_availability_guard.py
@@ -74,7 +74,7 @@ def test_jaxsim_not_available_when_package_absent(
     """#6880: JaxSim adapter dir present but jaxsim package absent => not available."""
 
     def _status(name: str) -> AvailabilityStatus:
-        if name == "jaxsim":
+        if name == "jaxsim.api":
             return AvailabilityStatus.NOT_INSTALLED
         return AvailabilityStatus.AVAILABLE
 
@@ -130,7 +130,31 @@ def test_runtime_status_helper_maps_engine_types() -> None:
     # Pure-rigid engines without a dedicated importable package map to None and
     # are treated as path-gated (no runtime requirement).
     assert engine_manager.runtime_dependency_name(EngineType.MUJOCO) == "mujoco"
-    assert engine_manager.runtime_dependency_name(EngineType.JAXSIM) == "jaxsim"
+    assert engine_manager.runtime_dependency_name(EngineType.JAXSIM) == "jaxsim.api"
     assert engine_manager.runtime_dependency_name(EngineType.PENDULUM) is None
     # Sanity: the resolved names are accepted by the availability layer.
     assert engine_availability.get_engine_status("mujoco") in AvailabilityStatus
+
+
+def test_jaxsim_not_available_when_api_submodule_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#6887: partial jaxsim install (jaxsim ok, jaxsim.api missing) => not available.
+
+    Discovery must probe the same surface the loader requires (jaxsim.api),
+    so an incomplete install is caught before switch_engine, not during.
+    """
+
+    def _status(name: str) -> AvailabilityStatus:
+        # jaxsim top-level importable; jaxsim.api is not
+        if name == "jaxsim.api":
+            return AvailabilityStatus.NOT_INSTALLED
+        return AvailabilityStatus.AVAILABLE
+
+    monkeypatch.setattr(engine_manager, "get_runtime_engine_status", _status)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _make_engine_dirs(root, "jaxsim")
+        manager = EngineManager(suite_root=root)
+        assert EngineType.JAXSIM not in manager.get_available_engines()
+        assert manager.get_engine_status(EngineType.JAXSIM) == EngineStatus.UNAVAILABLE


### PR DESCRIPTION
Consolidated fixes for four follow-up review issues.

## Per-issue

### #6887 — Probe `jaxsim.api` in engine availability guard
`engine_manager._RUNTIME_DEPENDENCY_NAMES` mapped `EngineType.JAXSIM` to `"jaxsim"`, but `load_jaxsim_engine` requires `jaxsim.api`. With a partial install where `import jaxsim` succeeds but `import jaxsim.api` fails, `get_available_engines()` advertised JaxSim as selectable and only failed during `switch_engine`. Changed the mapping to `"jaxsim.api"` so `_runtime_ready` probes the same surface as the loader.

### #6956 — Skip blank CSV records in streaming preview
`_preview_csv_streaming` used `csv.reader` which yields `[]` for blank lines. Each blank incremented `total_rows` and could append `{}` to the preview rows, diverging from the `csv.DictReader`-based stats/filtering path. Added `if not record: continue` to skip them.

### #6961 — Accept public `MultiSourceTarget` in `resolve_club_target` (also closes #6964, #6967)
`resolve_club_target` checked `isinstance(target, MultiSourceTarget)` against the provider-local class, not the package-level `multi_source_target.MultiSourceTarget` used by the data-sources panel and starting-pose matcher. Changed the check to `isinstance(target, (MultiSourceTarget, _PublicMultiSourceTarget))`.

### #6971 — Tighten pre-existing token dir permissions
`config_dir.mkdir(mode=0o700, exist_ok=True)` only applies the mode when the directory is newly created. Added `config_dir.chmod(0o700)` after mkdir to tighten pre-existing loose-permission directories, and `token_file.chmod(0o600)` after write.

## Test plan
- `tests/unit/test_engine_manager_availability_guard.py` — updated existing `test_jaxsim_not_available_when_package_absent` mock to use `"jaxsim.api"` key; added `test_jaxsim_not_available_when_api_submodule_absent` for partial-install scenario; updated `test_runtime_status_helper_maps_engine_types` assertion.
- `tests/unit/api/test_routes_data_explorer.py` — `test_preview_csv_skips_blank_lines` verifies `total_rows==3` and no empty rows for a CSV with interspersed blank lines.
- `tests/unit/motion_matching/test_shared_provider_helpers.py` — `test_resolve_club_target_accepts_public_multi_source_target` passes a `multi_source_target.MultiSourceTarget` to `resolve_club_target` and verifies it resolves correctly.
- `tests/api/test_cloud_client.py` — `test_save_token_sets_private_file_permissions` and `test_save_token_fixes_permissions_on_existing_dir` verify 0700/0600 on POSIX.

Ruff lint + format: clean. File size budget: all files well under 1200 lines.

Closes #6887
Closes #6956
Closes #6961
Closes #6964
Closes #6967
Closes #6971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437prfhrJdAJTGbSDNCQMS)_