### PR TITLE
fix(concurrency): eliminate RealTimeController and DurableTaskManager race conditions (#6975–#6977, #6979)

### DIFF
--- a/src/api/task_manager_durable.py
+++ b/src/api/task_manager_durable.py
@@ -552,16 +552,26 @@ class DurableTaskManager:
         self.heartbeat_timeout = heartbeat_timeout
         self._closed = False
         self._cleanup_task: asyncio.Task[None] | None = None
+        self._cleanup_thread: threading.Thread | None = None
+        self._cleanup_stop = threading.Event()
+        self._cleanup_interval = cleanup_interval
 
         if auto_cleanup:
-            self._cleanup_interval = cleanup_interval
-            # Start background cleanup in asyncio context
             try:
                 loop = asyncio.get_running_loop()
                 self._cleanup_task = loop.create_task(self._cleanup_loop())
             except RuntimeError:
-                # No running loop, cleanup will be manual
-                pass
+                logger.warning(
+                    "DurableTaskManager: no running event loop at construction time; "
+                    "auto-cleanup falling back to a daemon thread. "
+                    "Call shutdown() to stop it cleanly."
+                )
+                self._cleanup_thread = threading.Thread(
+                    target=self._cleanup_loop_sync,
+                    daemon=True,
+                    name="durable-task-cleanup",
+                )
+                self._cleanup_thread.start()
 
     async def _cleanup_loop(self) -> None:
         """Background task to periodically clean up expired tasks."""
@@ -573,6 +583,18 @@ class DurableTaskManager:
                     logger.info("Cleaned up %d expired tasks", count)
             except Exception:  # noqa: BLE001
                 logger.exception("Cleanup error")
+
+    def _cleanup_loop_sync(self) -> None:
+        """Daemon-thread fallback for periodic cleanup when no event loop is present."""
+        while not self._cleanup_stop.wait(timeout=self._cleanup_interval):
+            if self._closed:
+                return
+            try:
+                count = self.backend.cleanup()
+                if count > 0:
+                    logger.info("Cleaned up %d expired tasks", count)
+            except Exception as e:  # noqa: BLE001
+                logger.error("Cleanup error: %s", e)
 
     def create_task(
         self,
@@ -792,4 +814,7 @@ class DurableTaskManager:
             self._cleanup_task.cancel()
             with suppress(asyncio.CancelledError):
                 await self._cleanup_task
+        if self._cleanup_thread is not None:
+            self._cleanup_stop.set()
+            self._cleanup_thread.join(timeout=5.0)
         logger.info("DurableTaskManager shutdown complete")

--- a/src/deployment/realtime/controller.py
+++ b/src/deployment/realtime/controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -146,8 +147,8 @@ class RealTimeController:
         # Control loop thread
         self._control_thread: threading.Thread | None = None
 
-        # Timing statistics
-        self._cycle_times: list[float] = []
+        # Timing statistics — bounded deque avoids unbounded memory growth (#6976)
+        self._cycle_times: deque[float] = deque(maxlen=10000)
         self._start_time: float = 0.0
         self._overruns = 0
 
@@ -158,12 +159,13 @@ class RealTimeController:
         # Loopback physics state
         self._sim_state: tuple[NDArray[np.floating], NDArray[np.floating]] | None = None
 
-        # Locks
-        self._state_lock = threading.Lock()
+        # Condition that notifies waiters whenever a new state is stored (#6975)
+        self._state_cond = threading.Condition()
         self._command_lock = threading.Lock()
-
-        # Event signalled whenever a new state reading is stored
-        self._state_event = threading.Event()
+        # Separate lock for timing counters so stats reads don't block the control loop
+        self._stats_lock = threading.Lock()
+        # Lock for _sim_state to prevent racy read-modify-write (#6977)
+        self._sim_state_lock = threading.Lock()
 
     @property
     def is_connected(self) -> bool:
@@ -191,6 +193,10 @@ class RealTimeController:
         """
         if not (robot_config is not None):
             raise ValueError("robot_config must be provided")
+        if self._is_running:
+            raise RuntimeError(
+                "Cannot call connect() while the control loop is running"
+            )
         self._config = robot_config
 
         try:
@@ -201,7 +207,8 @@ class RealTimeController:
                 # Simulated connection always succeeds
                 self._is_connected = True
                 # Reset simulation state on connect to ensure correct sizing
-                self._sim_state = None
+                with self._sim_state_lock:
+                    self._sim_state = None
             elif self.comm_type == CommunicationType.ROS2:
                 self._connect_ros2()
             elif self.comm_type == CommunicationType.UDP:
@@ -292,8 +299,9 @@ class RealTimeController:
         self._aborted_on_failure = False
         self._is_running = True
         self._start_time = time.perf_counter()
-        self._cycle_times = []
-        self._overruns = 0
+        with self._stats_lock:
+            self._cycle_times.clear()
+            self._overruns = 0
 
         self._control_thread = threading.Thread(
             target=self._control_loop,
@@ -348,10 +356,9 @@ class RealTimeController:
                 # Read state
                 state = self._read_state()
 
-                with self._state_lock:
+                with self._state_cond:
                     self._last_state = state
-                self._state_event.set()
-                self._state_event.clear()
+                    self._state_cond.notify_all()
 
                 # Compute control
                 if self._control_callback is not None:
@@ -390,11 +397,10 @@ class RealTimeController:
             # Record timing
             cycle_end = time.perf_counter()
             cycle_time = cycle_end - cycle_start
-            self._cycle_times.append(cycle_time)
-
-            # Check for overrun
-            if cycle_time > self.dt:
-                self._overruns += 1
+            with self._stats_lock:
+                self._cycle_times.append(cycle_time)
+                if cycle_time > self.dt:
+                    self._overruns += 1
 
             # Sleep until next cycle
             next_cycle_time += self.dt
@@ -443,11 +449,10 @@ class RealTimeController:
 
         if self.comm_type == CommunicationType.LOOPBACK:
             n_joints = self._config.n_joints if self._config else 7
-            if self._sim_state is None:
-                self._sim_state = (np.zeros(n_joints), np.zeros(n_joints))
-
-            # Atomic read of state tuple
-            current_sim_state = self._sim_state
+            with self._sim_state_lock:
+                if self._sim_state is None:
+                    self._sim_state = (np.zeros(n_joints), np.zeros(n_joints))
+                current_sim_state = self._sim_state
             return RobotState(
                 timestamp=timestamp,
                 joint_positions=current_sim_state[0],
@@ -474,52 +479,45 @@ class RealTimeController:
             return
 
         if self.comm_type == CommunicationType.LOOPBACK:
-            if self._sim_state is None:
-                # Initialize state if not present (should be handled in _read_state, but safety check)
-                n_joints = self._config.n_joints if self._config else 7
-                self._sim_state = (np.zeros(n_joints), np.zeros(n_joints))
+            with self._sim_state_lock:
+                if self._sim_state is None:
+                    n_joints = self._config.n_joints if self._config else 7
+                    self._sim_state = (np.zeros(n_joints), np.zeros(n_joints))
 
-            q, qd = self._sim_state
+                q, qd = self._sim_state
 
-            if command.mode == ControlMode.TORQUE:
-                if command.torque_commands is not None:
-                    # Simple double integrator: acc = torque (assuming unit mass)
-                    # Add damping to prevent instability
-                    damping = 0.1
-                    qdd = command.torque_commands - damping * qd
+                if command.mode == ControlMode.TORQUE:
+                    if command.torque_commands is not None:
+                        damping = 0.1
+                        qdd = command.torque_commands - damping * qd
+                        qd = qd + qdd * self.dt
+                        q = q + qd * self.dt
+
+                elif command.mode == ControlMode.POSITION:
+                    if command.position_targets is not None:
+                        q = command.position_targets
+                        qd = np.zeros_like(q)
+
+                elif command.mode == ControlMode.VELOCITY:
+                    if command.velocity_targets is not None:
+                        qd = command.velocity_targets
+                        q = q + qd * self.dt
+
+                elif (
+                    command.mode == ControlMode.IMPEDANCE
+                    and command.position_targets is not None
+                    and command.stiffness is not None
+                    and command.damping is not None
+                ):
+                    q_err = command.position_targets - q
+                    tau = command.stiffness * q_err - command.damping * qd
+                    if command.feedforward_torque is not None:
+                        tau += command.feedforward_torque
+                    qdd = tau
                     qd = qd + qdd * self.dt
                     q = q + qd * self.dt
 
-            elif command.mode == ControlMode.POSITION:
-                if command.position_targets is not None:
-                    # Instantaneous position control (infinite gain)
-                    q = command.position_targets
-                    # Reset velocity or leave it? Let's zero it to be safe as position jump implies infinite velocity
-                    qd = np.zeros_like(q)
-
-            elif command.mode == ControlMode.VELOCITY:
-                if command.velocity_targets is not None:
-                    qd = command.velocity_targets
-                    q = q + qd * self.dt
-
-            elif (
-                command.mode == ControlMode.IMPEDANCE
-                and command.position_targets is not None
-                and command.stiffness is not None
-                and command.damping is not None
-            ):
-                # Impedance control: tau = K(q_d - q) + D(0 - qd)
-                # acc = tau (unit mass)
-                q_err = command.position_targets - q
-                tau = command.stiffness * q_err - command.damping * qd
-                if command.feedforward_torque is not None:
-                    tau += command.feedforward_torque
-
-                qdd = tau
-                qd = qd + qdd * self.dt
-                q = q + qd * self.dt
-
-            self._sim_state = (q, qd)
+                self._sim_state = (q, qd)
             return
 
         # Hardware-specific protocols (ETHERCAT, ROS2, UDP) are not yet implemented.
@@ -534,20 +532,22 @@ class RealTimeController:
         Returns:
             Timing statistics.
         """
-        if not self._cycle_times:
-            return TimingStatistics()
+        with self._stats_lock:
+            if not self._cycle_times:
+                return TimingStatistics()
+            cycle_times = np.array(self._cycle_times)
+            overruns = self._overruns
+            total_cycles = len(self._cycle_times)
 
-        cycle_times = np.array(self._cycle_times)
         target_period = self.dt
-
         return TimingStatistics(
             mean_cycle_time=float(np.mean(cycle_times)),
             max_cycle_time=float(np.max(cycle_times)),
             min_cycle_time=float(np.min(cycle_times)),
             std_cycle_time=float(np.std(cycle_times)),
             jitter=float(np.max(np.abs(cycle_times - target_period))),
-            overruns=self._overruns,
-            total_cycles=len(self._cycle_times),
+            overruns=overruns,
+            total_cycles=total_cycles,
             uptime=time.perf_counter() - self._start_time if self._start_time else 0,
         )
 
@@ -557,7 +557,7 @@ class RealTimeController:
         Returns:
             Last received state or None.
         """
-        with self._state_lock:
+        with self._state_cond:
             return self._last_state
 
     def get_last_command(self) -> ControlCommand | None:
@@ -580,16 +580,12 @@ class RealTimeController:
         """
         if not (timeout is not None):
             raise ValueError("timeout must be provided")
-        start = time.perf_counter()
-        with self._state_lock:
+        with self._state_cond:
             initial_state = self._last_state
-
-        remaining = timeout
-        while remaining > 0:
-            self._state_event.wait(timeout=remaining)
-            with self._state_lock:
-                if self._last_state is not initial_state:
-                    return self._last_state
-            remaining = timeout - (time.perf_counter() - start)
-
-        return None
+            deadline = time.perf_counter() + timeout
+            while self._last_state is initial_state:
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    return None
+                self._state_cond.wait(timeout=remaining)
+            return self._last_state

--- a/tests/api/test_task_manager_durable.py
+++ b/tests/api/test_task_manager_durable.py
@@ -313,3 +313,68 @@ class TestDurableTaskManager:
 
         assert manager._closed is True
         assert manager._cleanup_task.cancelled() or manager._cleanup_task.done()
+
+
+class TestDurableTaskManagerAutoCleanupFallback:
+    """#6979: DurableTaskManager auto-cleanup fallback when no event loop."""
+
+    def test_warns_and_starts_daemon_thread_when_no_event_loop(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Auto-cleanup must log a warning and spawn a daemon thread outside async ctx."""
+        import logging
+
+        db_path = tmp_path / "tasks.db"
+        backend = SQLiteBackend(db_path=db_path)
+
+        with caplog.at_level(logging.WARNING):
+            manager = DurableTaskManager(
+                backend=backend, auto_cleanup=True, cleanup_interval=60
+            )
+
+        warning_text = " ".join(r.message for r in caplog.records).lower()
+        assert "no running event loop" in warning_text or "daemon" in warning_text, (
+            f"Expected warning about missing event loop, got: {caplog.text!r}"
+        )
+
+        assert manager._cleanup_thread is not None, "Expected daemon cleanup thread"
+        assert manager._cleanup_thread.is_alive()
+        assert manager._cleanup_thread.daemon
+
+    def test_daemon_thread_runs_cleanup(self, tmp_path: Path) -> None:
+        """Daemon cleanup thread must actually delete expired tasks."""
+        import time
+
+        db_path = tmp_path / "tasks.db"
+        backend = SQLiteBackend(db_path=db_path)
+
+        manager = DurableTaskManager(
+            backend=backend, auto_cleanup=True, cleanup_interval=1
+        )
+
+        # Insert an already-expired task
+        now = time.time()
+        expired_record = TaskRecord(
+            task_id="expired-task",
+            status=TaskStatus.PENDING.value,
+            created_at=now - 7200.0,
+            ttl_seconds=3600,
+        )
+        backend.create_task(expired_record)
+
+        assert backend.get_task("expired-task") is not None
+
+        # Wait up to 3 s for the daemon thread's first cleanup sweep
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            if backend.get_task("expired-task") is None:
+                break
+            time.sleep(0.1)
+
+        manager._closed = True
+        if manager._cleanup_stop is not None:
+            manager._cleanup_stop.set()
+
+        assert backend.get_task("expired-task") is None, (
+            "Daemon cleanup thread did not delete the expired task within 3 s"
+        )

--- a/tests/deployment/test_realtime.py
+++ b/tests/deployment/test_realtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 
 import numpy as np
@@ -234,6 +235,160 @@ class TestRealTimeController:
         q_pos, qd_pos = controller._sim_state  # type: ignore
         assert q_pos[0] == 10.0
         assert qd_pos[0] == 0.0
+
+    def test_wait_for_state_wakes_within_one_cycle(self) -> None:
+        """#6975: wait_for_state must return within one cycle, not block to full timeout."""
+        from src.deployment.realtime import (
+            ControlCommand,
+            ControlMode,
+            RealTimeController,
+            RobotConfig,
+            RobotState,
+        )
+
+        controller = RealTimeController(
+            control_frequency=100.0,
+            communication_type="simulation",
+        )
+        config = RobotConfig(name="test", n_joints=3)
+        controller.connect(config)
+
+        def cb(state: RobotState) -> ControlCommand:
+            return ControlCommand(
+                timestamp=state.timestamp,
+                mode=ControlMode.TORQUE,
+                torque_commands=np.zeros(3),
+            )
+
+        controller.set_control_callback(cb)
+        controller.start()
+
+        try:
+            t0 = time.perf_counter()
+            state = controller.wait_for_state(timeout=1.0)
+            elapsed = time.perf_counter() - t0
+            assert state is not None, "wait_for_state returned None (timed out)"
+            # At 100 Hz a cycle is 10 ms; allow 10× margin → 100 ms
+            assert elapsed < 0.1, (
+                f"wait_for_state blocked {elapsed:.3f}s, expected <0.1s"
+            )
+        finally:
+            controller.stop()
+            controller.disconnect()
+
+    def test_get_timing_stats_thread_safe(self) -> None:
+        """#6976: get_timing_stats must not raise when called concurrently."""
+        from src.deployment.realtime import (
+            ControlCommand,
+            ControlMode,
+            RealTimeController,
+            RobotConfig,
+            RobotState,
+        )
+
+        controller = RealTimeController(
+            control_frequency=200.0,
+            communication_type="simulation",
+        )
+        config = RobotConfig(name="test", n_joints=3)
+        controller.connect(config)
+
+        def cb(state: RobotState) -> ControlCommand:
+            return ControlCommand(
+                timestamp=state.timestamp,
+                mode=ControlMode.TORQUE,
+                torque_commands=np.zeros(3),
+            )
+
+        controller.set_control_callback(cb)
+        controller.start()
+
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            for _ in range(50):
+                try:
+                    controller.get_timing_stats()
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        controller.stop()
+        controller.disconnect()
+
+        assert not errors, f"Thread-safety errors in get_timing_stats: {errors}"
+
+    def test_cycle_times_bounded(self) -> None:
+        """#6976: cycle_times must not grow without bound."""
+        from src.deployment.realtime import (
+            ControlCommand,
+            ControlMode,
+            RealTimeController,
+            RobotConfig,
+            RobotState,
+        )
+
+        controller = RealTimeController(
+            control_frequency=500.0,
+            communication_type="simulation",
+        )
+        config = RobotConfig(name="test", n_joints=1)
+        controller.connect(config)
+
+        def cb(state: RobotState) -> ControlCommand:
+            return ControlCommand(
+                timestamp=state.timestamp,
+                mode=ControlMode.TORQUE,
+                torque_commands=np.zeros(1),
+            )
+
+        controller.set_control_callback(cb)
+        controller.start()
+        time.sleep(0.05)
+        controller.stop()
+
+        stats = controller.get_timing_stats()
+        assert stats.total_cycles <= 10000
+        controller.disconnect()
+
+    def test_connect_while_running_raises(self) -> None:
+        """#6977: connect() must raise RuntimeError while control loop is active."""
+        from src.deployment.realtime import (
+            ControlCommand,
+            ControlMode,
+            RealTimeController,
+            RobotConfig,
+            RobotState,
+        )
+
+        controller = RealTimeController(
+            control_frequency=100.0,
+            communication_type="simulation",
+        )
+        config = RobotConfig(name="test", n_joints=3)
+        controller.connect(config)
+
+        def cb(state: RobotState) -> ControlCommand:
+            return ControlCommand(
+                timestamp=state.timestamp,
+                mode=ControlMode.TORQUE,
+                torque_commands=np.zeros(3),
+            )
+
+        controller.set_control_callback(cb)
+        controller.start()
+
+        try:
+            with pytest.raises(RuntimeError, match="running"):
+                controller.connect(config)
+        finally:
+            controller.stop()
+            controller.disconnect()
 
 
 class TestControlLoopFailureEscalation:


### PR DESCRIPTION
Fixes four concurrency/async issues from the round-3 adversarial assessment.

## Per-issue

### #6975 — `wait_for_state` lost-wakeup
`_control_loop` used `Event.set(); Event.clear()` — a waiter arriving after `clear()` missed the notification and blocked until the next cycle (up to the full timeout at 1 kHz). Replaced `_state_lock + _state_event` with a single `threading.Condition(_state_cond)` and `notify_all()`. `wait_for_state` now uses `Condition.wait()` inside the lock, guaranteeing it wakes on every notification.

### #6976 — Unlocked `_cycle_times` / `_overruns` + unbounded growth
`_cycle_times` was appended and `_overruns` incremented in the control-loop thread while `get_timing_stats()` read them from a different thread without a lock, causing `list changed size during iteration` / torn reads. Added `_stats_lock` guarding all access. Changed `_cycle_times` from `list` to `deque(maxlen=10000)` to bound memory (~10 s at 1 kHz).

### #6977 — `_sim_state` racy read-modify-write + `connect()` reset race
`_read_state` and `_send_command` read-modify-wrote `_sim_state` without a lock; `connect()` could set it to `None` from the caller thread mid-cycle. Added `_sim_state_lock` protecting all accesses. Moved the `_is_running` guard in `connect()` before the `try/except` block so reconnecting while running raises `RuntimeError` to the caller (previously the error was caught and logged silently).

### #6979 — `DurableTaskManager` auto-cleanup silently disabled off event-loop
When constructed in a sync context `asyncio.get_running_loop()` raised `RuntimeError` and `auto_cleanup` was silently disabled — no warning, no fallback, expired tasks accumulated forever. Now logs a `WARNING` and starts a daemon thread (`_cleanup_loop_sync`) that runs the same cleanup logic. `shutdown()` stops the thread via `_cleanup_stop` Event.

## Testing

Six new unit tests (TDD — written before the fix):
- `test_wait_for_state_wakes_within_one_cycle` — wakes in <100 ms at 100 Hz
- `test_get_timing_stats_thread_safe` — 4 concurrent readers, no exceptions
- `test_cycle_times_bounded` — `total_cycles ≤ 10 000`
- `test_connect_while_running_raises` — `RuntimeError` propagates
- `test_warns_and_starts_daemon_thread_when_no_event_loop` — WARNING logged, daemon thread alive
- `test_daemon_thread_runs_cleanup` — expired task deleted within 3 s

All 31 tests in the affected suites pass. Ruff lint + format clean.

Closes #6975
Closes #6976
Closes #6977
Closes #6979

---
_Generated by [Claude Code](https://claude.ai/code/session_019hDmPbN3Hzjj3TD7KHqAPL)_