### PR TITLE
test: coverage for terrain, inertia, auth, collision modules (#6994-#6997)

### DIFF
--- a/src/shared/python/model_generation/inertia/calculator.py
+++ b/src/shared/python/model_generation/inertia/calculator.py
@@ -171,9 +171,18 @@ class InertiaResult:
         return abs(self.ixx - self.izz) <= self.iyy <= self.ixx + self.izz
 
     def validate_positive_definite(self) -> bool:
-        """Check if inertia matrix is positive definite."""
+        """Check if inertia matrix is positive definite.
+
+        A matrix containing NaN/inf is never positive definite. Some BLAS
+        backends do not raise ``LinAlgError`` for a NaN-laden matrix in the
+        Cholesky factorization, so non-finite entries are rejected explicitly
+        before the decomposition is attempted.
+        """
+        matrix = self.as_matrix()
+        if not np.all(np.isfinite(matrix)):
+            return False
         try:
-            np.linalg.cholesky(self.as_matrix())
+            np.linalg.cholesky(matrix)
             return True
         except np.linalg.LinAlgError:
             return False
@@ -310,7 +319,14 @@ class InertiaCalculator:
 
         Returns:
             InertiaResult
+
+        Raises:
+            ValueError: If mass is not strictly positive. A non-positive mass
+                would yield a physically meaningless (zero or negative) inertia
+                tensor, so it is rejected rather than silently propagated.
         """
+        if mass <= 0:
+            raise ValueError(f"mass must be positive, got {mass}")
         return self.compute(geometry, mass=mass, mode=InertiaMode.PRIMITIVE)
 
     def compute_from_mesh(

--- a/tests/unit/physics/test_terrain_representation.py
+++ b/tests/unit/physics/test_terrain_representation.py
@@ -1,0 +1,439 @@
+"""Value-asserting tests for terrain geometry + physics (issue #6994).
+
+Covers ``terrain_representation.py`` (ElevationMap flat/sloped/from_array,
+gradient/normal/slope-angle vs analytic, ``_check_bounds`` OOB, TerrainRegion
+point-in-polygon edges, to_dict/from_dict round-trips, material/contact-param
+precedence) and ``_terrain_physics.py`` (penetration, monotonic contact force,
+capped Coulomb friction, lie quality).
+
+All assertions are against closed-form analytic expectations; nothing here
+requires Qt/GL.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from src.shared.python.physics import terrain_representation as tr
+from src.shared.python.physics._terrain_physics import (
+    CompressibleTurfModel,
+    TerrainContactModel,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# ElevationMap constructors
+# --------------------------------------------------------------------------- #
+
+
+class TestElevationMapFlat:
+    def test_flat_constant_elevation(self) -> None:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0, base_elevation=2.5)
+        assert em.get_elevation(0.0, 0.0) == pytest.approx(2.5)
+        assert em.get_elevation(5.0, 7.0) == pytest.approx(2.5)
+
+    def test_flat_zero_gradient_and_vertical_normal(self) -> None:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        assert em.get_gradient(3.0, 3.0) == (pytest.approx(0.0), pytest.approx(0.0))
+        assert np.allclose(em.get_normal(3.0, 3.0), [0.0, 0.0, 1.0])
+        assert em.get_slope_angle(3.0, 3.0) == pytest.approx(0.0)
+
+    def test_flat_rejects_nonpositive_dims(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            tr.ElevationMap.flat(0.0, 10.0, 1.0)
+        with pytest.raises(ValueError, match="Resolution"):
+            tr.ElevationMap.flat(10.0, 10.0, 0.0)
+
+
+class TestElevationMapSloped:
+    def test_sloped_gradient_matches_tan(self) -> None:
+        # 10 deg uphill toward +X => dz/dx = tan(10 deg), dz/dy = 0.
+        em = tr.ElevationMap.sloped(
+            10.0, 10.0, 1.0, slope_angle_deg=10.0, slope_direction_deg=0.0
+        )
+        dzdx, dzdy = em.get_gradient(5.0, 5.0)
+        assert dzdx == pytest.approx(math.tan(math.radians(10.0)), rel=1e-6)
+        assert dzdy == pytest.approx(0.0, abs=1e-9)
+
+    def test_sloped_slope_angle_recovered(self) -> None:
+        em = tr.ElevationMap.sloped(
+            10.0, 10.0, 1.0, slope_angle_deg=15.0, slope_direction_deg=90.0
+        )
+        assert em.get_slope_angle(5.0, 5.0) == pytest.approx(15.0, rel=1e-6)
+
+    def test_sloped_normal_is_unit_vector(self) -> None:
+        em = tr.ElevationMap.sloped(
+            10.0, 10.0, 1.0, slope_angle_deg=20.0, slope_direction_deg=45.0
+        )
+        normal = em.get_normal(5.0, 5.0)
+        assert np.linalg.norm(normal) == pytest.approx(1.0)
+        assert normal[2] > 0.0  # points upward
+
+    def test_sloped_direction_y(self) -> None:
+        # Uphill toward +Y => gradient only in y.
+        em = tr.ElevationMap.sloped(
+            10.0, 10.0, 1.0, slope_angle_deg=10.0, slope_direction_deg=90.0
+        )
+        dzdx, dzdy = em.get_gradient(5.0, 5.0)
+        assert dzdx == pytest.approx(0.0, abs=1e-9)
+        assert dzdy == pytest.approx(math.tan(math.radians(10.0)), rel=1e-6)
+
+
+class TestElevationMapFromArray:
+    def test_from_array_bilinear_interpolation(self) -> None:
+        # 2x2 grid, resolution 1.0. Plane z = x (cols are X).
+        data = np.array([[0.0, 1.0], [0.0, 1.0]])
+        em = tr.ElevationMap.from_array(data, resolution=1.0)
+        assert em.get_elevation(0.0, 0.0) == pytest.approx(0.0)
+        assert em.get_elevation(1.0, 0.0) == pytest.approx(1.0)
+        assert em.get_elevation(0.5, 0.0) == pytest.approx(0.5)
+
+    def test_from_array_dimensions(self) -> None:
+        data = np.zeros((3, 4))
+        em = tr.ElevationMap.from_array(data, resolution=2.0)
+        assert em.width == pytest.approx(8.0)  # 4 cols * 2
+        assert em.length == pytest.approx(6.0)  # 3 rows * 2
+
+
+# --------------------------------------------------------------------------- #
+# _check_bounds OOB
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckBounds:
+    def test_out_of_bounds_x_raises(self) -> None:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        with pytest.raises(ValueError, match="X coordinate"):
+            em.get_elevation(100.0, 5.0)
+
+    def test_out_of_bounds_y_raises(self) -> None:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        with pytest.raises(ValueError, match="Y coordinate"):
+            em.get_elevation(5.0, -1.0)
+
+    def test_coordinate_beyond_last_node_rejected(self) -> None:
+        # 10x10 at res 1.0 => 10 cols => last node at x=9.0; x=10 is OOB.
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        with pytest.raises(ValueError):
+            em.get_elevation(10.0, 5.0)
+        # Last valid node is fine.
+        assert em.get_elevation(9.0, 9.0) == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------- #
+# TerrainRegion point-in-polygon
+# --------------------------------------------------------------------------- #
+
+
+class TestPointInPolygon:
+    SQUARE = [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]
+
+    def test_interior_point_inside(self) -> None:
+        region = tr.TerrainRegion.polygon(tr.TerrainType.GREEN, self.SQUARE)
+        assert region.contains(2.0, 2.0) is True
+
+    def test_exterior_point_outside(self) -> None:
+        region = tr.TerrainRegion.polygon(tr.TerrainType.GREEN, self.SQUARE)
+        assert region.contains(5.0, 2.0) is False
+        assert region.contains(-1.0, 2.0) is False
+
+    def test_triangle_membership(self) -> None:
+        tri = tr.TerrainRegion.polygon(
+            tr.TerrainType.BUNKER, [(0.0, 0.0), (4.0, 0.0), (0.0, 4.0)]
+        )
+        assert tri.contains(0.5, 0.5) is True  # near right-angle corner
+        assert tri.contains(3.0, 3.0) is False  # beyond hypotenuse
+
+    def test_circle_region_membership(self) -> None:
+        circ = tr.TerrainRegion.circle(tr.TerrainType.GREEN, 5.0, 5.0, 2.0)
+        assert circ.contains(5.0, 5.0) is True
+        assert circ.contains(6.0, 5.0) is True  # distance 1 < radius 2
+        assert circ.contains(8.0, 5.0) is False  # distance 3 > radius 2
+        # On-boundary point (distance exactly radius) counts as inside.
+        assert circ.contains(7.0, 5.0) is True
+
+
+# --------------------------------------------------------------------------- #
+# to_dict / from_dict round-trips
+# --------------------------------------------------------------------------- #
+
+
+class TestRoundTrips:
+    def test_elevation_map_round_trip(self) -> None:
+        em = tr.ElevationMap.sloped(
+            6.0, 6.0, 1.0, slope_angle_deg=5.0, slope_direction_deg=30.0
+        )
+        restored = tr.ElevationMap.from_dict(em.to_dict())
+        assert restored.resolution == em.resolution
+        assert restored.width == em.width
+        assert np.allclose(restored.data, em.data)
+        assert restored.get_elevation(3.0, 3.0) == pytest.approx(
+            em.get_elevation(3.0, 3.0)
+        )
+
+    def test_region_round_trip_preserves_material(self) -> None:
+        mat = tr.SurfaceMaterial(
+            name="custom",
+            friction_coefficient=0.9,
+            compressibility=0.5,
+            moisture_content=0.6,
+        )
+        region = tr.TerrainRegion.circle(
+            tr.TerrainType.BUNKER, 1.0, 2.0, 3.0, material=mat
+        )
+        restored = tr.TerrainRegion.from_dict(region.to_dict())
+        assert restored.terrain_type == tr.TerrainType.BUNKER
+        assert restored.shape_type == "circle"
+        assert restored.material is not None
+        assert restored.material.friction_coefficient == pytest.approx(0.9)
+        assert restored.material.compressibility == pytest.approx(0.5)
+        assert restored.material.moisture_content == pytest.approx(0.6)
+
+    def test_patch_round_trip(self) -> None:
+        patch = tr.TerrainPatch(tr.TerrainType.FAIRWAY, 0.0, 5.0, 0.0, 5.0)
+        restored = tr.TerrainPatch.from_dict(patch.to_dict())
+        assert restored.terrain_type == tr.TerrainType.FAIRWAY
+        assert restored.x_max == pytest.approx(5.0)
+
+    def test_terrain_config_round_trip(self) -> None:
+        terrain = tr.create_sloped_terrain(
+            "course", 8.0, 8.0, slope_angle_deg=3.0, slope_direction_deg=0.0
+        )
+        cfg = tr.TerrainConfig.from_terrain(terrain)
+        rebuilt = tr.TerrainConfig.from_dict(cfg.to_dict()).to_terrain()
+        assert rebuilt.name == "course"
+        assert rebuilt.get_elevation(4.0, 4.0) == pytest.approx(
+            terrain.get_elevation(4.0, 4.0)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Material & contact-param precedence
+# --------------------------------------------------------------------------- #
+
+
+class TestMaterialPrecedence:
+    def _terrain(self) -> tr.Terrain:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        # Patch covers everything as FAIRWAY; region overrides a circle as GREEN.
+        patch = tr.TerrainPatch(tr.TerrainType.FAIRWAY, 0.0, 10.0, 0.0, 10.0)
+        region = tr.TerrainRegion.circle(tr.TerrainType.GREEN, 5.0, 5.0, 2.0)
+        return tr.Terrain(name="t", elevation=em, patches=[patch], regions=[region])
+
+    def test_region_overrides_patch(self) -> None:
+        terrain = self._terrain()
+        # Inside the green circle => green material.
+        assert terrain.get_material(5.0, 5.0).name == "green"
+        # Outside the circle but inside the patch => fairway.
+        assert terrain.get_material(0.5, 0.5).name == "fairway"
+
+    def test_terrain_type_resolution(self) -> None:
+        terrain = self._terrain()
+        assert terrain.get_terrain_type(5.0, 5.0) == tr.TerrainType.GREEN
+        assert terrain.get_terrain_type(0.5, 0.5) == tr.TerrainType.FAIRWAY
+
+    def test_contact_params_reflect_material(self) -> None:
+        terrain = self._terrain()
+        params = terrain.get_contact_params(5.0, 5.0)
+        green = tr.MATERIALS["green"]
+        assert params["friction"] == pytest.approx(green.friction_coefficient)
+        assert params["restitution"] == pytest.approx(green.restitution)
+        # Stiffness scales with hardness; harder green > softer default rough.
+        assert params["stiffness"] == pytest.approx(1e5 * green.hardness)
+        assert params["damping"] > 0.0
+
+    def test_default_material_when_uncovered(self) -> None:
+        em = tr.ElevationMap.flat(10.0, 10.0, 1.0)
+        terrain = tr.Terrain(
+            name="bare", elevation=em, default_type=tr.TerrainType.ROUGH
+        )
+        assert terrain.get_material(1.0, 1.0).name == "rough"
+
+
+class TestSurfaceMaterialValidation:
+    def test_negative_friction_rejected(self) -> None:
+        with pytest.raises(ValueError, match="friction_coefficient"):
+            tr.SurfaceMaterial(name="bad", friction_coefficient=-0.1)
+
+    def test_restitution_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="restitution"):
+            tr.SurfaceMaterial(name="bad", restitution=1.5)
+
+
+# --------------------------------------------------------------------------- #
+# compute_gravity_on_slope
+# --------------------------------------------------------------------------- #
+
+
+class TestGravityOnSlope:
+    def test_flat_slope_all_perpendicular(self) -> None:
+        g_par, g_perp = tr.compute_gravity_on_slope(0.0, gravity=9.81)
+        assert g_par == pytest.approx(0.0, abs=1e-9)
+        assert g_perp == pytest.approx(9.81)
+
+    def test_thirty_degree_components(self) -> None:
+        g_par, g_perp = tr.compute_gravity_on_slope(30.0, gravity=10.0)
+        assert g_par == pytest.approx(10.0 * 0.5)  # sin 30 = 0.5
+        assert g_perp == pytest.approx(10.0 * math.cos(math.radians(30.0)))
+
+
+# =========================================================================== #
+# _terrain_physics.py
+# =========================================================================== #
+
+
+def _green_terrain() -> tr.Terrain:
+    return tr.create_flat_terrain(
+        "green", 10.0, 10.0, terrain_type=tr.TerrainType.GREEN, resolution=1.0
+    )
+
+
+class TestContactModelPenetration:
+    def test_penetration_zero_above_ground(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        assert model.compute_penetration(5.0, 5.0, z=1.0, radius=0.0) == 0.0
+
+    def test_penetration_positive_below_ground(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        # ground at z=0, object centre at -0.3 => penetration 0.3.
+        assert model.compute_penetration(5.0, 5.0, z=-0.3) == pytest.approx(0.3)
+
+    def test_penetration_accounts_for_radius(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        # contact point = z - radius = 0.1 - 0.3 = -0.2 => penetration 0.2.
+        assert model.compute_penetration(5.0, 5.0, z=0.1, radius=0.3) == pytest.approx(
+            0.2
+        )
+
+    def test_is_in_contact(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        assert model.is_in_contact(5.0, 5.0, z=-0.1) is True
+        assert model.is_in_contact(5.0, 5.0, z=0.5) is False
+
+
+class TestContactForce:
+    def test_no_force_without_penetration(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        force = model.compute_contact_force(5.0, 5.0, z=1.0)
+        assert np.allclose(force, np.zeros(3))
+
+    def test_force_monotonic_with_penetration(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        shallow = np.linalg.norm(model.compute_contact_force(5.0, 5.0, z=-0.1))
+        deep = np.linalg.norm(model.compute_contact_force(5.0, 5.0, z=-0.3))
+        assert deep > shallow > 0.0
+
+    def test_force_acts_along_normal_on_flat(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        force = model.compute_contact_force(5.0, 5.0, z=-0.2)
+        # On flat ground the normal is +Z, so force is purely vertical.
+        assert force[0] == pytest.approx(0.0, abs=1e-6)
+        assert force[1] == pytest.approx(0.0, abs=1e-6)
+        assert force[2] > 0.0
+
+
+class TestFrictionForce:
+    def test_friction_capped_at_mu_times_normal(self) -> None:
+        terrain = _green_terrain()
+        model = TerrainContactModel(terrain=terrain)
+        velocity = np.array([2.0, 0.0, 0.0])
+        normal_force = np.array([0.0, 0.0, 100.0])
+        friction = model.compute_friction_force(
+            5.0,
+            5.0,
+            z=-0.1,
+            radius=0.0,
+            velocity=velocity,
+            normal_force=normal_force,
+        )
+        mu = terrain.get_material(5.0, 5.0).friction_coefficient
+        assert np.linalg.norm(friction) == pytest.approx(mu * 100.0)
+
+    def test_friction_opposes_motion(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        velocity = np.array([3.0, 0.0, 0.0])
+        friction = model.compute_friction_force(
+            5.0,
+            5.0,
+            z=-0.1,
+            radius=0.0,
+            velocity=velocity,
+            normal_force=np.array([0.0, 0.0, 50.0]),
+        )
+        assert friction[0] < 0.0  # opposes +X motion
+
+    def test_zero_friction_when_stationary(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        friction = model.compute_friction_force(
+            5.0,
+            5.0,
+            z=-0.1,
+            radius=0.0,
+            velocity=np.zeros(3),
+            normal_force=np.array([0.0, 0.0, 50.0]),
+        )
+        assert np.allclose(friction, np.zeros(3))
+
+    def test_zero_friction_without_normal_force(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        # No penetration => derived normal force ~0 => no friction.
+        friction = model.compute_friction_force(
+            5.0, 5.0, z=1.0, radius=0.0, velocity=np.array([2.0, 0.0, 0.0])
+        )
+        assert np.allclose(friction, np.zeros(3))
+
+
+class TestCompressibleTurf:
+    def test_lie_quality_keys_and_ranges(self) -> None:
+        model = CompressibleTurfModel(terrain=_green_terrain())
+        lie = model.compute_lie_quality(5.0, 5.0)
+        assert set(lie) >= {
+            "lie_type",
+            "sitting_depth",
+            "grass_interference",
+            "playability_factor",
+            "grass_height",
+            "terrain_type",
+        }
+        assert 0.0 <= lie["playability_factor"] <= 1.0
+        assert lie["sitting_depth"] >= 0.0
+
+    def test_firm_green_gives_tight_lie(self) -> None:
+        model = CompressibleTurfModel(terrain=_green_terrain())
+        lie = model.compute_lie_quality(5.0, 5.0)
+        # A firm green barely compresses => shallow sitting depth => tight lie.
+        assert lie["lie_type"] == "tight"
+        # Near-perfect playability: ball sits almost entirely above the grass.
+        assert lie["playability_factor"] > 0.99
+
+    def test_soft_turf_sits_deeper_than_green(self) -> None:
+        green = CompressibleTurfModel(terrain=_green_terrain())
+        soft_terrain = tr.Terrain(
+            name="soft",
+            elevation=tr.ElevationMap.flat(10.0, 10.0, 1.0),
+            patches=[
+                tr.TerrainPatch(
+                    tr.TerrainType.ROUGH,
+                    0.0,
+                    10.0,
+                    0.0,
+                    10.0,
+                    material=tr.MATERIALS["soft_turf"],
+                )
+            ],
+        )
+        soft = CompressibleTurfModel(terrain=soft_terrain)
+        deep = soft.compute_lie_quality(5.0, 5.0)["sitting_depth"]
+        shallow = green.compute_lie_quality(5.0, 5.0)["sitting_depth"]
+        assert deep >= shallow
+
+    def test_compression_state_clamped_to_max(self) -> None:
+        model = CompressibleTurfModel(terrain=_green_terrain())
+        state = model.get_compression_state(5.0, 5.0, z=-1.0, radius=0.0)
+        # Huge penetration is clamped to the material's max compression depth.
+        assert state["compression_depth"] <= state["max_compression"] + 1e-9
+        assert 0.0 <= state["compression_ratio"] <= 1.0

--- a/tests/unit/robotics/test_real_collision_checker.py
+++ b/tests/unit/robotics/test_real_collision_checker.py
@@ -1,0 +1,295 @@
+"""Value-asserting tests for the real ``CollisionChecker`` (issue #6997).
+
+The pre-existing ``test_planning_collision.py`` only exercises the checker
+through a mock engine that hands back ``Sphere`` geometry. These tests use a
+tiny *real* ``CollisionCapable`` stub and assert concrete numeric outcomes of
+``_aabb_overlap``, ``check_collision`` (body-body and body-environment),
+``compute_distance`` (sign + zero-at-contact), ``check_path_collision``, the
+environment-primitive mutators, and pair enable/disable.
+
+All geometry here is real (``Sphere``), so the narrow-phase
+``compute_primitive_distance`` actually runs -- nothing is mocked.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from src.robotics.planning.collision.collision_checker import (
+    CollisionChecker,
+    CollisionCheckerConfig,
+)
+from src.robotics.planning.collision.collision_types import (
+    CollisionPair,
+    CollisionQuery,
+    CollisionQueryType,
+)
+from src.robotics.planning.collision.geometric_primitives import Sphere
+
+pytestmark = pytest.mark.unit
+
+
+class StubEngine:
+    """Minimal real ``CollisionCapable`` implementation.
+
+    Two unit-radius spheres whose centres are driven directly by the first two
+    DOF of ``q`` (metres). No mocking: ``get_body_collision_geometry`` returns
+    genuine ``Sphere`` primitives.
+    """
+
+    def __init__(self) -> None:
+        self._q = np.zeros(2)
+        self._v = np.zeros(2)
+        self._radius = 1.0
+        # Far apart by default so the default checker reports no collision.
+        self._positions = {
+            "a": np.array([0.0, 0.0, 0.0]),
+            "b": np.array([10.0, 0.0, 0.0]),
+        }
+
+    def get_state(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._q.copy(), self._v.copy()
+
+    def set_state(self, q: np.ndarray, v: np.ndarray) -> None:
+        self._q = np.asarray(q, dtype=float).copy()
+        self._v = np.asarray(v, dtype=float).copy()
+        # Body "a" slides along x by q[0]; body "b" by q[1] from its base.
+        self._positions["a"] = np.array([self._q[0], 0.0, 0.0])
+        self._positions["b"] = np.array([10.0 + self._q[1], 0.0, 0.0])
+
+    def get_body_names(self) -> list[str]:
+        return list(self._positions.keys())
+
+    def get_body_position(self, body_name: str) -> np.ndarray | None:
+        pos = self._positions.get(body_name)
+        return None if pos is None else pos.copy()
+
+    def get_body_collision_geometry(self, body_name: str) -> Sphere | None:
+        if body_name not in self._positions:
+            return None
+        return Sphere(center=self._positions[body_name].copy(), radius=self._radius)
+
+
+@pytest.fixture
+def checker() -> CollisionChecker:
+    # Broad phase on, zero margin so contact is exact for assertions.
+    cfg = CollisionCheckerConfig(default_margin=0.0)
+    return CollisionChecker(StubEngine(), cfg)
+
+
+# --------------------------------------------------------------------------- #
+# Construction / protocol enforcement
+# --------------------------------------------------------------------------- #
+
+
+def test_rejects_non_collision_capable_engine() -> None:
+    with pytest.raises(TypeError, match="CollisionCapable"):
+        CollisionChecker(object())
+
+
+def test_default_pairs_are_all_unordered_body_pairs(checker: CollisionChecker) -> None:
+    pairs = checker.get_collision_pairs()
+    assert len(pairs) == 1
+    assert pairs[0] == CollisionPair("a", "b")
+
+
+# --------------------------------------------------------------------------- #
+# _aabb_overlap: overlap / touch / disjoint
+# --------------------------------------------------------------------------- #
+
+
+class TestAabbOverlap:
+    def test_overlapping(self, checker: CollisionChecker) -> None:
+        a = Sphere(center=np.zeros(3), radius=1.0)
+        b = Sphere(center=np.array([1.0, 0.0, 0.0]), radius=1.0)
+        assert checker._aabb_overlap(a, b, margin=0.0) is True
+
+    def test_touching_counts_as_overlap(self, checker: CollisionChecker) -> None:
+        # AABBs share a face exactly at x=1 (>= comparison => overlap).
+        a = Sphere(center=np.zeros(3), radius=1.0)
+        b = Sphere(center=np.array([2.0, 0.0, 0.0]), radius=1.0)
+        assert checker._aabb_overlap(a, b, margin=0.0) is True
+
+    def test_disjoint(self, checker: CollisionChecker) -> None:
+        a = Sphere(center=np.zeros(3), radius=1.0)
+        b = Sphere(center=np.array([5.0, 0.0, 0.0]), radius=1.0)
+        assert checker._aabb_overlap(a, b, margin=0.0) is False
+
+    def test_margin_bridges_a_gap(self, checker: CollisionChecker) -> None:
+        a = Sphere(center=np.zeros(3), radius=1.0)
+        b = Sphere(center=np.array([2.5, 0.0, 0.0]), radius=1.0)
+        # Gap between AABB faces is 0.5; margin 0.6 closes it.
+        assert checker._aabb_overlap(a, b, margin=0.0) is False
+        assert checker._aabb_overlap(a, b, margin=0.6) is True
+
+
+# --------------------------------------------------------------------------- #
+# check_collision: body-body
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckCollisionBodyBody:
+    def test_no_collision_when_far_apart(self, checker: CollisionChecker) -> None:
+        result = checker.check_collision(np.zeros(2))
+        assert result.in_collision is False
+        assert result.collision_pairs == []
+        assert result.num_contacts == 0
+
+    def test_collision_when_spheres_overlap(self, checker: CollisionChecker) -> None:
+        # Move "a" to x=8.5: centres 8.5 vs 10.0 => gap 1.5 < r_a+r_b=2 => overlap.
+        result = checker.check_collision(np.array([8.5, 0.0]))
+        assert result.in_collision is True
+        assert CollisionPair("a", "b") in result.collision_pairs
+        assert result.num_contacts == 1
+
+    def test_state_restored_after_check(self, checker: CollisionChecker) -> None:
+        checker.check_collision(np.array([8.5, 0.0]))
+        q_after, v_after = checker._engine.get_state()
+        assert np.allclose(q_after, np.zeros(2))
+        assert np.allclose(v_after, np.zeros(2))
+
+    def test_non_finite_configuration_rejected(self, checker: CollisionChecker) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            checker.check_collision(np.array([np.inf, 0.0]))
+
+
+# --------------------------------------------------------------------------- #
+# check_collision: body-environment
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckCollisionEnvironment:
+    def test_environment_primitive_triggers_collision(
+        self, checker: CollisionChecker
+    ) -> None:
+        # Sphere obstacle overlapping body "a" (centre 0, r=1): obstacle centre
+        # 1.5 away with r=1 => surface gap 1.5 - 1 - 1 = -0.5 (penetrating).
+        obstacle = Sphere(center=np.array([1.5, 0.0, 0.0]), radius=1.0)
+        checker.add_environment_primitive("obstacle", obstacle)
+        result = checker.check_collision(np.zeros(2))
+        assert result.in_collision is True
+        assert CollisionPair("a", "obstacle") in result.collision_pairs
+
+    def test_clearing_environment_removes_collision(
+        self, checker: CollisionChecker
+    ) -> None:
+        obstacle = Sphere(center=np.array([1.5, 0.0, 0.0]), radius=1.0)
+        checker.add_environment_primitive("obstacle", obstacle)
+        assert checker.check_collision(np.zeros(2)).in_collision is True
+        checker.clear_environment()
+        assert checker.check_collision(np.zeros(2)).in_collision is False
+
+
+# --------------------------------------------------------------------------- #
+# compute_distance: sign + zero-at-contact
+# --------------------------------------------------------------------------- #
+
+
+class TestComputeDistance:
+    def test_positive_distance_when_separated(self, checker: CollisionChecker) -> None:
+        # a@0, b@10, r=1 each => surface gap = 10 - 1 - 1 = 8.
+        result = checker.compute_distance(np.zeros(2))
+        assert result.distance == pytest.approx(8.0)
+        assert result.in_collision is False
+        assert result.closest_pair == CollisionPair("a", "b")
+
+    def test_zero_distance_at_contact(self, checker: CollisionChecker) -> None:
+        # Centres exactly 2 apart (r+r) => touching => distance 0.
+        result = checker.compute_distance(np.array([8.0, 0.0]))
+        assert result.distance == pytest.approx(0.0, abs=1e-9)
+
+    def test_negative_distance_when_penetrating(
+        self, checker: CollisionChecker
+    ) -> None:
+        # Centres 1.5 apart => penetration of 0.5 => signed distance -0.5.
+        result = checker.compute_distance(np.array([8.5, 0.0]))
+        assert result.distance == pytest.approx(-0.5)
+        assert result.in_collision is True
+        assert result.penetration_depth == pytest.approx(0.5)
+
+    def test_state_restored_after_distance(self, checker: CollisionChecker) -> None:
+        checker.compute_distance(np.array([8.5, 0.0]))
+        q_after, _ = checker._engine.get_state()
+        assert np.allclose(q_after, np.zeros(2))
+
+
+# --------------------------------------------------------------------------- #
+# check_path_collision
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckPathCollision:
+    def test_clear_path_is_collision_free(self, checker: CollisionChecker) -> None:
+        # Both endpoints leave the spheres far apart.
+        free, t = checker.check_path_collision(
+            np.zeros(2), np.array([1.0, 0.0]), num_samples=10
+        )
+        assert free is True
+        assert t is None
+
+    def test_path_flags_interpolated_waypoint(self, checker: CollisionChecker) -> None:
+        # Endpoints are collision-free but the midpoint drives "a" into "b".
+        free, t = checker.check_path_collision(
+            np.array([0.0, 0.0]), np.array([17.0, 0.0]), num_samples=11
+        )
+        assert free is False
+        assert t is not None
+        assert 0.0 < t < 1.0
+
+    def test_too_few_samples_rejected(self, checker: CollisionChecker) -> None:
+        with pytest.raises(ValueError, match="at least 2"):
+            checker.check_path_collision(np.zeros(2), np.zeros(2), num_samples=1)
+
+
+# --------------------------------------------------------------------------- #
+# environment primitive add/remove/clear
+# --------------------------------------------------------------------------- #
+
+
+class TestEnvironmentPrimitiveMutators:
+    def test_add_then_remove(self, checker: CollisionChecker) -> None:
+        prim = Sphere(center=np.zeros(3), radius=0.5)
+        checker.add_environment_primitive("obs", prim)
+        assert checker.remove_environment_primitive("obs") is True
+
+    def test_remove_missing_returns_false(self, checker: CollisionChecker) -> None:
+        assert checker.remove_environment_primitive("nope") is False
+
+    def test_empty_name_rejected(self, checker: CollisionChecker) -> None:
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            checker.add_environment_primitive("", Sphere())
+
+    def test_clear_empties_environment(self, checker: CollisionChecker) -> None:
+        checker.add_environment_primitive("o1", Sphere(radius=0.5))
+        checker.add_environment_primitive("o2", Sphere(radius=0.5))
+        checker.clear_environment()
+        assert checker.remove_environment_primitive("o1") is False
+
+
+# --------------------------------------------------------------------------- #
+# enable / disable collision pair
+# --------------------------------------------------------------------------- #
+
+
+class TestEnableDisablePair:
+    def test_disable_removes_pair_from_checks(self, checker: CollisionChecker) -> None:
+        checker.disable_collision_pair("a", "b")
+        assert CollisionPair("a", "b") not in checker.get_collision_pairs()
+        # With the only pair disabled, an otherwise-colliding config is clear.
+        result = checker.check_collision(np.array([8.5, 0.0]))
+        assert result.in_collision is False
+
+    def test_enable_restores_pair(self, checker: CollisionChecker) -> None:
+        checker.disable_collision_pair("a", "b")
+        checker.enable_collision_pair("a", "b")
+        assert CollisionPair("a", "b") in checker.get_collision_pairs()
+        result = checker.check_collision(np.array([8.5, 0.0]))
+        assert result.in_collision is True
+
+    def test_query_exclude_pairs_skips_check(self, checker: CollisionChecker) -> None:
+        query = CollisionQuery(
+            query_type=CollisionQueryType.BOOLEAN,
+            exclude_pairs=[CollisionPair("a", "b")],
+        )
+        result = checker.check_collision(np.array([8.5, 0.0]), query=query)
+        assert result.in_collision is False

--- a/tests/unit/shared_python/ai/test_authentication.py
+++ b/tests/unit/shared_python/ai/test_authentication.py
@@ -1,0 +1,250 @@
+"""Security-focused tests for the AI auth module (issue #6996).
+
+Covers credential save/load round-trips (with the credentials file redirected
+to ``tmp_path``), POSIX ``0o600`` permissions, corrupt-JSON tolerance,
+``AuthToken.is_valid`` expiry, ``UserProfile`` tier/feature gating, API-key
+login success/failure, logout clearing, and ``FeatureGate`` blocking.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+
+import pytest
+from src.shared.python.ai.auth.authentication import (
+    AuthManager,
+    AuthToken,
+    FeatureGate,
+    SubscriptionTier,
+    UserProfile,
+)
+
+pytestmark = pytest.mark.unit
+
+IS_POSIX = os.name == "posix"
+
+
+@pytest.fixture
+def cred_file(tmp_path, monkeypatch):
+    """Redirect ``AuthManager.CREDENTIALS_FILE`` into a temp dir."""
+    path = tmp_path / "auth_credentials.json"
+    monkeypatch.setattr(AuthManager, "CREDENTIALS_FILE", path)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# AuthToken.is_valid
+# --------------------------------------------------------------------------- #
+
+
+class TestAuthToken:
+    def test_future_expiry_is_valid(self) -> None:
+        token = AuthToken(token="x", expires_at=datetime.now() + timedelta(hours=1))
+        assert token.is_valid() is True
+
+    def test_past_expiry_is_invalid(self) -> None:
+        token = AuthToken(token="x", expires_at=datetime.now() - timedelta(seconds=1))
+        assert token.is_valid() is False
+
+
+# --------------------------------------------------------------------------- #
+# UserProfile tier / feature logic
+# --------------------------------------------------------------------------- #
+
+
+class TestUserProfile:
+    def test_free_tier_always_active(self) -> None:
+        profile = UserProfile(user_id="u", subscription_tier=SubscriptionTier.FREE)
+        assert profile.is_active() is True
+
+    def test_pro_tier_expired_is_inactive(self) -> None:
+        profile = UserProfile(
+            user_id="u",
+            subscription_tier=SubscriptionTier.PRO,
+            subscription_expires=datetime.now() - timedelta(days=1),
+        )
+        assert profile.is_active() is False
+
+    def test_pro_tier_future_expiry_is_active(self) -> None:
+        profile = UserProfile(
+            user_id="u",
+            subscription_tier=SubscriptionTier.PRO,
+            subscription_expires=datetime.now() + timedelta(days=1),
+        )
+        assert profile.is_active() is True
+
+    def test_free_tier_includes_basic_feature(self) -> None:
+        profile = UserProfile(user_id="u", subscription_tier=SubscriptionTier.FREE)
+        assert profile.has_feature("ollama_chat") is True
+
+    def test_free_tier_excludes_pro_feature(self) -> None:
+        profile = UserProfile(user_id="u", subscription_tier=SubscriptionTier.FREE)
+        assert profile.has_feature("claude_code") is False
+
+    def test_pro_tier_includes_pro_feature(self) -> None:
+        profile = UserProfile(user_id="u", subscription_tier=SubscriptionTier.PRO)
+        assert profile.has_feature("claude_code") is True
+
+    def test_enterprise_only_feature_gated_below_enterprise(self) -> None:
+        pro = UserProfile(user_id="u", subscription_tier=SubscriptionTier.PRO)
+        ent = UserProfile(user_id="u", subscription_tier=SubscriptionTier.ENTERPRISE)
+        assert pro.has_feature("sso_auth") is False
+        assert ent.has_feature("sso_auth") is True
+
+    def test_expired_profile_has_no_features(self) -> None:
+        profile = UserProfile(
+            user_id="u",
+            subscription_tier=SubscriptionTier.PRO,
+            subscription_expires=datetime.now() - timedelta(days=1),
+        )
+        # Inactive subscription => has_feature short-circuits to False.
+        assert profile.has_feature("claude_code") is False
+
+    def test_explicitly_enabled_feature_honored(self) -> None:
+        profile = UserProfile(
+            user_id="u",
+            subscription_tier=SubscriptionTier.FREE,
+            features_enabled=["claude_code"],
+        )
+        assert profile.has_feature("claude_code") is True
+
+
+# --------------------------------------------------------------------------- #
+# API-key login
+# --------------------------------------------------------------------------- #
+
+
+class TestApiKeyLogin:
+    def test_empty_key_fails(self, cred_file) -> None:
+        auth = AuthManager()
+        assert auth.login_with_api_key("") is False
+        assert auth.is_authenticated is False
+
+    def test_valid_key_logs_in_as_pro(self, cred_file) -> None:
+        auth = AuthManager()
+        assert auth.login_with_api_key("secret-key") is True
+        assert auth.is_authenticated is True
+        assert auth.subscription_tier == SubscriptionTier.PRO
+        assert auth.has_feature("claude_code") is True
+        assert auth.get_api_key() == "secret-key"
+
+    def test_oauth_login_not_implemented(self, cred_file) -> None:
+        auth = AuthManager()
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "code")
+
+    def test_email_password_login_not_implemented(self, cred_file) -> None:
+        auth = AuthManager()
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("a@b.com", "pw")
+
+
+# --------------------------------------------------------------------------- #
+# Credential persistence round-trip + permissions
+# --------------------------------------------------------------------------- #
+
+
+class TestCredentialPersistence:
+    def test_save_load_round_trip(self, cred_file) -> None:
+        auth = AuthManager()
+        assert auth.login_with_api_key("round-trip-key") is True
+        assert cred_file.exists()
+        user_id = auth.current_user.user_id
+
+        # Fresh manager reads back the persisted profile.
+        reloaded = AuthManager()
+        assert reloaded.current_user is not None
+        assert reloaded.current_user.user_id == user_id
+        assert reloaded.current_user.api_key == "round-trip-key"
+        assert reloaded.subscription_tier == SubscriptionTier.PRO
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX file modes only")
+    def test_credentials_file_is_chmod_600(self, cred_file) -> None:
+        auth = AuthManager()
+        auth.login_with_api_key("perm-key")
+        mode = cred_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_corrupt_json_tolerated(self, cred_file) -> None:
+        cred_file.parent.mkdir(parents=True, exist_ok=True)
+        cred_file.write_text("{ this is not valid json", encoding="utf-8")
+        # Should not raise; just logs and leaves no user.
+        auth = AuthManager()
+        assert auth.current_user is None
+        assert auth.is_authenticated is False
+
+    def test_missing_keys_tolerated(self, cred_file) -> None:
+        cred_file.parent.mkdir(parents=True, exist_ok=True)
+        cred_file.write_text(json.dumps({"unrelated": 1}), encoding="utf-8")
+        auth = AuthManager()
+        assert auth.current_user is None
+
+
+# --------------------------------------------------------------------------- #
+# logout
+# --------------------------------------------------------------------------- #
+
+
+class TestLogout:
+    def test_logout_clears_user_and_file(self, cred_file) -> None:
+        auth = AuthManager()
+        auth.login_with_api_key("k")
+        assert cred_file.exists()
+        auth.logout()
+        assert auth.current_user is None
+        assert auth.is_authenticated is False
+        assert not cred_file.exists()
+
+
+# --------------------------------------------------------------------------- #
+# FeatureGate
+# --------------------------------------------------------------------------- #
+
+
+class TestFeatureGate:
+    @pytest.fixture(autouse=True)
+    def _reset_gate(self, cred_file, monkeypatch):
+        # Force FeatureGate to build a fresh AuthManager bound to tmp creds.
+        monkeypatch.setattr(FeatureGate, "_auth", None)
+        yield
+        monkeypatch.setattr(FeatureGate, "_auth", None)
+
+    def test_require_blocks_unauthorized(self) -> None:
+        @FeatureGate.require("claude_code")
+        def gated() -> str:
+            return "ok"
+
+        # Default (no login) AuthManager => FREE tier, no claude_code.
+        with pytest.raises(PermissionError, match="claude_code"):
+            gated()
+
+    def test_require_allows_authorized(self) -> None:
+        auth = FeatureGate._get_auth()
+        auth.login_with_api_key("pro-key")  # PRO tier => claude_code allowed
+
+        @FeatureGate.require("claude_code")
+        def gated() -> str:
+            return "ok"
+
+        assert gated() == "ok"
+
+    def test_require_tier_blocks_below_minimum(self) -> None:
+        # FREE manager cannot satisfy an ENTERPRISE requirement.
+        @FeatureGate.require_tier(SubscriptionTier.ENTERPRISE)
+        def gated() -> str:
+            return "ok"
+
+        with pytest.raises(PermissionError, match="enterprise"):
+            gated()
+
+    def test_require_tier_allows_at_or_above(self) -> None:
+        auth = FeatureGate._get_auth()
+        auth.login_with_api_key("pro-key")  # PRO tier
+
+        @FeatureGate.require_tier(SubscriptionTier.PRO)
+        def gated() -> str:
+            return "ok"
+
+        assert gated() == "ok"

--- a/tests/unit/shared_python/model_generation/test_inertia_calculator.py
+++ b/tests/unit/shared_python/model_generation/test_inertia_calculator.py
@@ -1,0 +1,245 @@
+"""Value-asserting tests for the unified inertia calculator (issue #6995).
+
+Covers ``InertiaCalculator.compute_from_geometry`` against closed-form analytic
+tensors for box/cylinder/sphere, ``InertiaResult`` validity/positive-definite
+checks, ``scale_to_mass`` linearity, serialization round-trips
+(``as_matrix``/``as_urdf_dict``/``to_dict``/``as_dict``), ``_detect_mode``
+dispatch, ``create_default``, and rejection of non-positive mass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from model_generation.core.types import Geometry
+from model_generation.inertia.calculator import (
+    InertiaCalculator,
+    InertiaMode,
+    InertiaResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def calc() -> InertiaCalculator:
+    return InertiaCalculator()
+
+
+# --------------------------------------------------------------------------- #
+# compute_from_geometry vs analytic tensors
+# --------------------------------------------------------------------------- #
+
+
+class TestComputeFromGeometryAnalytic:
+    def test_box_matches_analytic(self, calc: InertiaCalculator) -> None:
+        # Solid box: I = (m/12) * (sum of squares of the *other* two sides).
+        # m=12, sides 2x4x6 => ixx=(1)*(16+36)=52, iyy=(4+36)=40, izz=(4+16)=20.
+        result = calc.compute_from_geometry(Geometry.box(2.0, 4.0, 6.0), mass=12.0)
+        assert result.ixx == pytest.approx(52.0)
+        assert result.iyy == pytest.approx(40.0)
+        assert result.izz == pytest.approx(20.0)
+        assert result.ixy == 0.0 and result.ixz == 0.0 and result.iyz == 0.0
+        assert result.mode == InertiaMode.PRIMITIVE
+
+    def test_sphere_matches_analytic(self, calc: InertiaCalculator) -> None:
+        # Solid sphere: I = (2/5) m r^2. m=10, r=0.5 => 0.4*10*0.25 = 1.0.
+        result = calc.compute_from_geometry(Geometry.sphere(0.5), mass=10.0)
+        assert result.ixx == pytest.approx(1.0)
+        assert result.iyy == pytest.approx(1.0)
+        assert result.izz == pytest.approx(1.0)
+
+    def test_cylinder_matches_analytic(self, calc: InertiaCalculator) -> None:
+        # Solid cylinder (axis z): izz = 0.5 m r^2;
+        # ixx = iyy = (m/12)(3 r^2 + L^2). m=12, r=2, L=6.
+        result = calc.compute_from_geometry(Geometry.cylinder(2.0, 6.0), mass=12.0)
+        assert result.izz == pytest.approx(0.5 * 12.0 * 4.0)  # 24
+        expected_perp = (12.0 / 12.0) * (3.0 * 4.0 + 36.0)  # 48
+        assert result.ixx == pytest.approx(expected_perp)
+        assert result.iyy == pytest.approx(expected_perp)
+
+    def test_inertia_scales_linearly_with_mass(self, calc: InertiaCalculator) -> None:
+        small = calc.compute_from_geometry(Geometry.sphere(0.3), mass=1.0)
+        big = calc.compute_from_geometry(Geometry.sphere(0.3), mass=3.0)
+        assert big.ixx == pytest.approx(3.0 * small.ixx)
+
+
+# --------------------------------------------------------------------------- #
+# Non-positive mass rejected (DbC) -- regression for the #6995 fix
+# --------------------------------------------------------------------------- #
+
+
+class TestMassValidation:
+    def test_negative_mass_raises(self, calc: InertiaCalculator) -> None:
+        with pytest.raises(ValueError, match="mass must be positive"):
+            calc.compute_from_geometry(Geometry.box(1.0, 1.0, 1.0), mass=-2.0)
+
+    def test_zero_mass_raises(self, calc: InertiaCalculator) -> None:
+        with pytest.raises(ValueError, match="mass must be positive"):
+            calc.compute_from_geometry(Geometry.sphere(0.5), mass=0.0)
+
+    def test_scale_to_zero_or_negative_mass_raises(self) -> None:
+        result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, mass=2.0)
+        with pytest.raises(ValueError):
+            result.scale_to_mass(0.0)
+        with pytest.raises(ValueError):
+            result.scale_to_mass(-1.0)
+
+
+# --------------------------------------------------------------------------- #
+# scale_to_mass linearity
+# --------------------------------------------------------------------------- #
+
+
+class TestScaleToMass:
+    def test_scales_components_and_mass(self) -> None:
+        result = InertiaResult(
+            ixx=2.0, iyy=4.0, izz=6.0, ixy=0.1, ixz=0.2, iyz=0.3, mass=2.0
+        )
+        scaled = result.scale_to_mass(6.0)  # 3x
+        assert scaled.mass == pytest.approx(6.0)
+        assert scaled.ixx == pytest.approx(6.0)
+        assert scaled.iyy == pytest.approx(12.0)
+        assert scaled.izz == pytest.approx(18.0)
+        assert scaled.ixy == pytest.approx(0.3)
+        assert scaled.ixz == pytest.approx(0.6)
+        assert scaled.iyz == pytest.approx(0.9)
+        # Original is untouched (returns a new instance).
+        assert result.mass == pytest.approx(2.0)
+
+    def test_scale_from_nonpositive_mass_raises(self) -> None:
+        result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, mass=0.0)
+        with pytest.raises(ValueError, match="Cannot scale from zero or negative"):
+            result.scale_to_mass(5.0)
+
+
+# --------------------------------------------------------------------------- #
+# Validity / positive-definite checks
+# --------------------------------------------------------------------------- #
+
+
+class TestValidity:
+    def test_valid_diagonal_inertia(self) -> None:
+        # Equal principal moments satisfy the triangle inequalities.
+        result = InertiaResult(ixx=2.0, iyy=2.0, izz=2.0, mass=1.0)
+        assert result.is_valid() is True
+        assert result.validate_positive_definite() is True
+
+    def test_nonpositive_diagonal_is_invalid(self) -> None:
+        assert InertiaResult(ixx=0.0, iyy=1.0, izz=1.0, mass=1.0).is_valid() is False
+        assert InertiaResult(ixx=-1.0, iyy=1.0, izz=1.0, mass=1.0).is_valid() is False
+
+    def test_triangle_inequality_violation_is_invalid(self) -> None:
+        # izz must be >= |ixx - iyy| and <= ixx + iyy. izz=100 breaks the upper.
+        result = InertiaResult(ixx=1.0, iyy=1.0, izz=100.0, mass=1.0)
+        assert result.is_valid() is False
+
+    def test_nan_breaks_positive_definite(self) -> None:
+        result = InertiaResult(ixx=float("nan"), iyy=1.0, izz=1.0, mass=1.0)
+        assert result.validate_positive_definite() is False
+
+    def test_indefinite_matrix_not_positive_definite(self) -> None:
+        # Large off-diagonal term makes the matrix indefinite.
+        result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, ixy=5.0, mass=1.0)
+        assert result.validate_positive_definite() is False
+
+
+# --------------------------------------------------------------------------- #
+# Serialization round-trips
+# --------------------------------------------------------------------------- #
+
+
+class TestSerialization:
+    def test_as_matrix_symmetric(self) -> None:
+        result = InertiaResult(
+            ixx=1.0, iyy=2.0, izz=3.0, ixy=0.1, ixz=0.2, iyz=0.3, mass=1.0
+        )
+        mat = result.as_matrix()
+        assert mat.shape == (3, 3)
+        assert np.allclose(mat, mat.T)
+        assert mat[0, 0] == 1.0 and mat[1, 1] == 2.0 and mat[2, 2] == 3.0
+        assert mat[0, 1] == 0.1 and mat[0, 2] == 0.2 and mat[1, 2] == 0.3
+
+    def test_as_urdf_dict_keys_and_values(self) -> None:
+        result = InertiaResult(
+            ixx=1.0, iyy=2.0, izz=3.0, ixy=0.1, ixz=0.2, iyz=0.3, mass=1.0
+        )
+        urdf = result.as_urdf_dict()
+        assert set(urdf) == {"ixx", "ixy", "ixz", "iyy", "iyz", "izz"}
+        assert urdf["ixx"] == 1.0 and urdf["iyz"] == 0.3
+
+    def test_to_dict_preserves_all_fields(self) -> None:
+        result = InertiaResult(
+            ixx=1.0,
+            iyy=2.0,
+            izz=3.0,
+            mass=4.0,
+            center_of_mass=(0.1, 0.2, 0.3),
+            volume=0.5,
+            mode=InertiaMode.MANUAL,
+            is_watertight=True,
+            source="unit-test",
+        )
+        d = result.to_dict()
+        assert d["ixx"] == 1.0
+        assert d["mass"] == 4.0
+        assert d["center_of_mass"] == [0.1, 0.2, 0.3]
+        assert d["volume"] == 0.5
+        assert d["mode"] == "manual"
+        assert d["is_watertight"] is True
+        assert d["source"] == "unit-test"
+
+    def test_as_dict_humanoid_format(self) -> None:
+        result = InertiaResult(ixx=1.0, iyy=1.0, izz=1.0, mass=2.0, volume=0.3)
+        d = result.as_dict()
+        assert d["was_watertight"] is None
+        assert d["center_of_mass"] == [0.0, 0.0, 0.0]
+        assert d["mode"] == "primitive"
+
+
+# --------------------------------------------------------------------------- #
+# _detect_mode dispatch
+# --------------------------------------------------------------------------- #
+
+
+class TestDetectMode:
+    def test_dict_with_ixx_is_manual(self, calc: InertiaCalculator) -> None:
+        assert calc._detect_mode({"ixx": 1.0}) == InertiaMode.MANUAL
+
+    def test_dict_without_inertia_is_primitive(self, calc: InertiaCalculator) -> None:
+        assert calc._detect_mode({"radius": 0.1}) == InertiaMode.PRIMITIVE
+
+    def test_mesh_path_is_mesh_uniform(self, calc: InertiaCalculator) -> None:
+        assert calc._detect_mode("arm.STL") == InertiaMode.MESH_UNIFORM_DENSITY
+        assert calc._detect_mode(Path("part.obj")) == InertiaMode.MESH_UNIFORM_DENSITY
+
+    def test_non_mesh_path_is_primitive(self, calc: InertiaCalculator) -> None:
+        assert calc._detect_mode("config.yaml") == InertiaMode.PRIMITIVE
+
+    def test_geometry_primitive_is_primitive(self, calc: InertiaCalculator) -> None:
+        assert calc._detect_mode(Geometry.box(1, 1, 1)) == InertiaMode.PRIMITIVE
+
+
+# --------------------------------------------------------------------------- #
+# create_default & manual
+# --------------------------------------------------------------------------- #
+
+
+class TestDefaults:
+    def test_create_default_uses_one_tenth_mass(self) -> None:
+        result = InertiaResult.create_default(mass=5.0)
+        assert result.mass == pytest.approx(5.0)
+        assert result.ixx == pytest.approx(0.5)
+        assert result.iyy == pytest.approx(0.5)
+        assert result.izz == pytest.approx(0.5)
+        assert result.is_valid() is True
+
+    def test_compute_manual_round_trip(self, calc: InertiaCalculator) -> None:
+        result = calc.compute_from_manual(
+            ixx=0.1, iyy=0.2, izz=0.3, mass=2.0, center_of_mass=(1.0, 0.0, 0.0)
+        )
+        assert result.mode == InertiaMode.MANUAL
+        assert result.ixx == 0.1 and result.izz == 0.3
+        assert result.center_of_mass == (1.0, 0.0, 0.0)


### PR DESCRIPTION
## Summary

Adds value-asserting (non-smoke), TDD-style unit tests for four previously untested modules, raising coverage. Two real bugs surfaced by the tests were fixed inline.

## Bugs found & fixed (TDD)

In `model_generation/inertia/calculator.py`:
1. **`compute_from_geometry` accepted non-positive mass**, silently producing a zero/negative (physically meaningless) inertia tensor. Now raises `ValueError` (DbC precondition), per #6995's "negatives→ValueError".
2. **`validate_positive_definite` returned `True` for a NaN-laden tensor** on BLAS backends where `np.linalg.cholesky` does not raise on NaN. Now rejects non-finite matrices explicitly before factorization.

## Tests added

- **`tests/unit/physics/test_terrain_representation.py`** (#6994, 43 tests): `ElevationMap` flat/sloped/from_array vs analytic gradient/normal/slope-angle; `_check_bounds` OOB + beyond-last-node; `TerrainRegion` point-in-polygon (square/triangle) + circle edges; `to_dict`/`from_dict` round-trips (elevation, patch, region-with-material, `TerrainConfig`); material & contact-param precedence (region overrides patch); `SurfaceMaterial` validation; `compute_gravity_on_slope`; and `_terrain_physics` penetration, monotonic contact force, capped Coulomb friction (= μ·N), lie quality.
- **`tests/unit/shared_python/model_generation/test_inertia_calculator.py`** (#6995, 25 tests): box/cylinder/sphere analytic tensors; `scale_to_mass` linearity; `is_valid`/`validate_positive_definite` (reject non-PD/NaN/neg/triangle-violation); `as_matrix`/`as_urdf_dict`/`to_dict`/`as_dict`; `_detect_mode` dispatch; `create_default`; non-positive-mass rejection.
- **`tests/unit/shared_python/ai/test_authentication.py`** (#6996, 24 tests, 1 POSIX-only skipped on Win): `tmp_path`-redirected `CREDENTIALS_FILE` save/load round-trip; chmod `0o600` (POSIX); corrupt-JSON & missing-keys tolerance; `AuthToken.is_valid`; `UserProfile` tier/feature gating; API-key login success/empty-key failure; OAuth/email NotImplemented; logout clears file; `FeatureGate.require`/`require_tier` block + allow.
- **`tests/unit/robotics/test_real_collision_checker.py`** (#6997, 26 tests): a tiny **real** `CollisionCapable` stub (returns genuine `Sphere` geometry, no mocks) exercising `_aabb_overlap` overlap/touch/disjoint/margin; body-body + body-environment `check_collision` with state restoration; `compute_distance` positive/zero-at-contact/negative-penetration; `check_path_collision` flagging an interpolated midpoint; add/remove/clear environment primitive; enable/disable pair + query exclude.

All 117 added tests pass locally (1 skipped on Windows); ruff lint + format clean; pre-push mypy/bandit/pytest all green.

Closes #6994
Closes #6995
Closes #6996
Closes #6997

🤖 Generated with [Claude Code](https://claude.com/claude-code)