### PR TITLE
fix: isolate GOLF_API_PORT + restore cam1 −15° yaw (#7087, #7071)

### DIFF
--- a/src/shared/python/config/typed_settings.py
+++ b/src/shared/python/config/typed_settings.py
@@ -99,18 +99,6 @@ class Settings(BaseSettings):
         default=DEFAULT_SERVER_PORT,
         validation_alias="API_PORT",
     )
-    # --- Canonical API host/port cluster ---------------------------------
-    # Reads ``GOLF_API_HOST`` / ``GOLF_API_PORT`` with defaults identical to
-    # ``config.environment.get_api_host`` / ``get_api_port``.  New code should
-    # prefer these over the scattered ``os.environ.get("GOLF_API_*")`` sites.
-    api_host: str = Field(
-        default=DEFAULT_API_HOST,
-        validation_alias="GOLF_API_HOST",
-    )
-    api_port: int = Field(
-        default=DEFAULT_API_PORT,
-        validation_alias="GOLF_API_PORT",
-    )
     allowed_hosts_raw: str | None = Field(
         default=None,
         validation_alias="ALLOWED_HOSTS",
@@ -120,7 +108,7 @@ class Settings(BaseSettings):
         validation_alias="CORS_ORIGINS",
     )
 
-    @field_validator("server_port", "api_port")
+    @field_validator("server_port")
     @classmethod
     def _validate_port(cls, value: int) -> int:
         """Enforce the 1..65535 range the legacy accessors required."""
@@ -144,6 +132,54 @@ class Settings(BaseSettings):
         return DEFAULT_CORS_ORIGINS.copy()
 
 
+class CanonicalApiSettings(BaseSettings):
+    """Isolated settings for the canonical GOLF_API_HOST / GOLF_API_PORT cluster.
+
+    Kept separate from :class:`Settings` so that a malformed ``GOLF_API_PORT``
+    in the environment does not cause callers of :func:`get_settings` (which
+    only need the legacy ``API_*`` / ``ALLOWED_HOSTS`` / ``CORS_ORIGINS``
+    cluster) to fail on construction.  Construct only when the canonical API
+    host/port values are actually needed.
+    """
+
+    model_config = SettingsConfigDict(
+        extra="ignore",
+        case_sensitive=True,
+    )
+
+    # Reads ``GOLF_API_HOST`` / ``GOLF_API_PORT`` — distinct from the legacy
+    # ``API_HOST`` / ``API_PORT`` cluster in ``Settings``.  Divergence is
+    # documented in ``src/api/config.py`` (issue #2068).
+    api_host: str = Field(
+        default=DEFAULT_API_HOST,
+        validation_alias="GOLF_API_HOST",
+    )
+    api_port: int = Field(
+        default=DEFAULT_API_PORT,
+        validation_alias="GOLF_API_PORT",
+    )
+
+    @field_validator("api_port")
+    @classmethod
+    def _validate_api_port(cls, value: int) -> int:
+        """Enforce the 1..65535 range."""
+        if not (1 <= value <= 65535):
+            raise ValueError(f"Invalid port value: {value!r}")
+        return value
+
+
+def get_canonical_api_settings() -> CanonicalApiSettings:
+    """Construct a fresh :class:`CanonicalApiSettings` from the environment.
+
+    Returns a new instance on every call (no caching) so that tests and
+    runtime code that mutate ``os.environ`` observe the change.
+
+    Returns:
+        A freshly constructed :class:`CanonicalApiSettings`.
+    """
+    return CanonicalApiSettings()
+
+
 def get_settings() -> Settings:
     """Construct a fresh :class:`Settings` from the current environment.
 
@@ -163,6 +199,7 @@ def get_settings() -> Settings:
 
 
 __all__ = [
+    "CanonicalApiSettings",
     "DEFAULT_ALLOWED_HOSTS",
     "DEFAULT_API_HOST",
     "DEFAULT_API_PORT",
@@ -170,5 +207,6 @@ __all__ = [
     "DEFAULT_SERVER_HOST",
     "DEFAULT_SERVER_PORT",
     "Settings",
+    "get_canonical_api_settings",
     "get_settings",
 ]

--- a/src/shared/python/estimation/synthetic_fixtures.py
+++ b/src/shared/python/estimation/synthetic_fixtures.py
@@ -72,12 +72,18 @@ def make_fixture_cameras() -> tuple[
 ]:
     """Return two calibrated pinhole cameras looking along positive depth.
 
-    ``cam1`` is rotated by a proper 15-degree rotation about the Y axis, built
-    from ``cos``/``sin`` so the matrix is guaranteed orthonormal with
-    ``det == +1`` (the ``CameraExtrinsics`` validator rejects anything else).
+    ``cam1`` is rotated by a proper −15-degree rotation about the Y axis
+    (R_y(−15°): ``[cos, 0, -sin] / [0,1,0] / [sin, 0, cos]``), built from
+    ``cos``/``sin`` so the matrix is guaranteed orthonormal with ``det == +1``
+    (the ``CameraExtrinsics`` validator rejects anything else).  The sign
+    matches the original fixture geometry: a negative yaw places the camera to
+    the right of centre so projected observations land left-of-centre on the
+    image plane, consistent with all multi-camera baselines that consume this
+    fixture.
     """
     intrinsics = CameraIntrinsics(fx=800.0, fy=800.0, cx=640.0, cy=480.0)
-    theta = np.deg2rad(15.0)
+    # Negative angle: R_y(-15°) matches the original fixture orientation.
+    theta = np.deg2rad(-15.0)
     cos_t = float(np.cos(theta))
     sin_t = float(np.sin(theta))
     rotation_about_y = [

--- a/tests/unit/config/test_typed_settings.py
+++ b/tests/unit/config/test_typed_settings.py
@@ -17,7 +17,9 @@ from src.shared.python.config.typed_settings import (
     DEFAULT_CORS_ORIGINS,
     DEFAULT_SERVER_HOST,
     DEFAULT_SERVER_PORT,
+    CanonicalApiSettings,
     Settings,
+    get_canonical_api_settings,
     get_settings,
 )
 
@@ -30,35 +32,52 @@ def test_defaults_match_documented_values() -> None:
         assert settings.server_port == DEFAULT_SERVER_PORT == 8000
         assert settings.allowed_hosts == DEFAULT_ALLOWED_HOSTS
         assert settings.cors_origins == DEFAULT_CORS_ORIGINS
-        assert settings.api_host == DEFAULT_API_HOST == "127.0.0.1"
-        assert settings.api_port == DEFAULT_API_PORT == 8000
+    with patch.dict(os.environ, {}, clear=True):
+        api_settings = get_canonical_api_settings()
+        assert api_settings.api_host == DEFAULT_API_HOST == "127.0.0.1"
+        assert api_settings.api_port == DEFAULT_API_PORT == 8000
 
 
 def test_api_host_reads_golf_api_host_env() -> None:
     """``api_host`` mirrors ``config.environment.get_api_host`` (GOLF_API_HOST)."""
     with patch.dict(os.environ, {"GOLF_API_HOST": "0.0.0.0"}):
-        assert get_settings().api_host == "0.0.0.0"
+        assert get_canonical_api_settings().api_host == "0.0.0.0"
 
 
 def test_api_port_reads_golf_api_port_env() -> None:
     """``api_port`` mirrors ``config.environment.get_api_port`` (GOLF_API_PORT)."""
     with patch.dict(os.environ, {"GOLF_API_PORT": "7654"}):
-        assert get_settings().api_port == 7654
+        assert get_canonical_api_settings().api_port == 7654
 
 
 def test_api_port_out_of_range_raises() -> None:
     with patch.dict(os.environ, {"GOLF_API_PORT": "0"}), pytest.raises(ValueError):
-        Settings()
+        CanonicalApiSettings()
     with patch.dict(os.environ, {"GOLF_API_PORT": "70000"}), pytest.raises(ValueError):
-        Settings()
+        CanonicalApiSettings()
 
 
 def test_api_and_legacy_clusters_are_independent() -> None:
     """``GOLF_API_*`` and the legacy ``API_*`` cluster do not cross-contaminate."""
     with patch.dict(os.environ, {"GOLF_API_HOST": "10.0.0.1", "API_HOST": "1.2.3.4"}):
+        api_settings = get_canonical_api_settings()
         settings = get_settings()
-        assert settings.api_host == "10.0.0.1"
+        assert api_settings.api_host == "10.0.0.1"
         assert settings.server_host == "1.2.3.4"
+
+
+def test_bad_golf_api_port_does_not_affect_get_settings() -> None:
+    """A malformed GOLF_API_PORT must not break callers that only need Settings.
+
+    ``get_settings()`` reads API_HOST / API_PORT / ALLOWED_HOSTS / CORS_ORIGINS.
+    It must not raise when GOLF_API_PORT is malformed, because that variable
+    belongs to the canonical API cluster (now in CanonicalApiSettings), not to
+    the legacy API server cluster.  Regression guard for review feedback on
+    merged PR #7086 (issue #7087).
+    """
+    with patch.dict(os.environ, {"GOLF_API_PORT": "not-a-port"}):
+        settings = get_settings()
+        assert settings.server_port == DEFAULT_SERVER_PORT
 
 
 def test_server_host_reads_api_host_env() -> None:

--- a/tests/unit/estimation/test_synthetic_ground_truth.py
+++ b/tests/unit/estimation/test_synthetic_ground_truth.py
@@ -30,6 +30,29 @@ def test_fixture_cameras_are_proper_rotations() -> None:
         assert np.isclose(np.linalg.det(rotation), 1.0, atol=1e-9)
 
 
+def test_cam1_uses_negative_fifteen_degree_yaw() -> None:
+    """cam1 must encode a −15° rotation about Y (R_y(-15°)), not +15°.
+
+    Regression guard for review feedback on merged PR #7069 (issue #7071):
+    the original non-orthonormal fixture used a −15° world-to-camera rotation
+    ([cos, 0, -sin] / [0,1,0] / [sin, 0, cos]).  The fix must preserve the
+    same geometric orientation, not mirror it.
+
+    For R_y(-15°):  R[0][2] = sin(-15°) < 0  and  R[2][0] = -sin(-15°) > 0.
+    """
+    cameras = make_fixture_cameras()
+    _cam_id, _intrinsics, cam1_extrinsics = cameras[1]
+    rotation = np.asarray(cam1_extrinsics.rotation, dtype=np.float64)
+    assert rotation[0][2] < 0, (
+        f"cam1 R[0][2]={rotation[0][2]:.6f}: expected negative (−sin 15°). "
+        "The fixture must use −15° yaw, not +15°."
+    )
+    assert rotation[2][0] > 0, (
+        f"cam1 R[2][0]={rotation[2][0]:.6f}: expected positive (+sin 15°). "
+        "The fixture must use −15° yaw, not +15°."
+    )
+
+
 def test_camera_extrinsics_rejects_non_orthonormal_rotation() -> None:
     """Negative: the legacy non-orthonormal fixture matrix is rejected."""
     with pytest.raises(ValueError, match="orthonormal"):


### PR DESCRIPTION
Closes #7071
Closes #7087

## Summary

Two post-merge regressions from the 2026-06-02 backlog run, both flagged by the codex-connector bot review.

### #7087 — isolate `GOLF_API_PORT` from `Settings`

`api_host`/`api_port` (reading `GOLF_API_HOST`/`GOLF_API_PORT`) were added to the monolithic `Settings` class in PR #7086. Because `BaseSettings` validates every field on construction, a malformed `GOLF_API_PORT` crashes **all** callers of `get_settings()` — including `get_allowed_hosts()` and `get_server_port()` in `src/api/config.py` — even though those callers never touch the canonical API cluster.

**Fix:** Move `api_host` + `api_port` to a new `CanonicalApiSettings(BaseSettings)` class with a dedicated `get_canonical_api_settings()` constructor. `Settings` now only parses `API_HOST` / `API_PORT` / `ALLOWED_HOSTS` / `CORS_ORIGINS`. New test `test_bad_golf_api_port_does_not_affect_get_settings` pins the isolation contract.

### #7071 — restore cam1 −15° yaw in `synthetic_fixtures`

PR #7069 corrected the non-orthonormal camera fixture but changed `theta` from the original −15° to +15°, mirroring every `cam1` observation (root projected at ~910 px instead of ~481 px). The sign is restored to `np.deg2rad(-15.0)` so `R_y(−15°)` matches the original `[cos, 0, −sin] / [0,1,0] / [sin, 0, cos]` geometry and all multi-camera baselines remain valid.  New test `test_cam1_uses_negative_fifteen_degree_yaw` guards the invariant.

## Test plan

- [x] `test_bad_golf_api_port_does_not_affect_get_settings` — asserts `get_settings()` succeeds with a malformed `GOLF_API_PORT`
- [x] `test_cam1_uses_negative_fifteen_degree_yaw` — asserts `R[0][2] < 0` and `R[2][0] > 0` for cam1 (−15° yaw)
- [x] All 13 `tests/unit/config/test_typed_settings.py` tests pass locally
- [x] All 10 `tests/unit/estimation/test_synthetic_ground_truth.py` tests pass locally
- [x] `ruff check` and `ruff format --check` clean on all 4 changed files
- [x] File size budget check passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB1UCWRvzJBq17Q8sQBs8i)_