### PR TITLE
⚡ Bolt: Use math.hypot for wiffle distance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-06-02
+  LAST UPDATED: 2026-06-03
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
@@ -9,8 +9,8 @@ Enhanced main application with Excel data loading and advanced visualization
 """
 
 import logging
-import sys
 import math
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -612,19 +612,23 @@ class WiffleGolfMainWindow(QMainWindow):
 
         # Calculate frame-specific metrics
         try:
+            # ⚡ Bolt: Extract rows once to avoid expensive repeated pandas .iloc lookups  # noqa: E501
+            baseq_row = self.baseq_data.iloc[frame_idx]
+            ztcfq_row = self.ztcfq_data.iloc[frame_idx]
+
             prov1_pos = np.array(
                 [
-                    self.baseq_data.iloc[frame_idx]["CHx"],
-                    self.baseq_data.iloc[frame_idx]["CHy"],
-                    self.baseq_data.iloc[frame_idx]["CHz"],
+                    baseq_row["CHx"],
+                    baseq_row["CHy"],
+                    baseq_row["CHz"],
                 ]
             )
 
             wiffle_pos = np.array(
                 [
-                    self.ztcfq_data.iloc[frame_idx]["CHx"],
-                    self.ztcfq_data.iloc[frame_idx]["CHy"],
-                    self.ztcfq_data.iloc[frame_idx]["CHz"],
+                    ztcfq_row["CHx"],
+                    ztcfq_row["CHy"],
+                    ztcfq_row["CHz"],
                 ]
             )
 
@@ -633,7 +637,7 @@ class WiffleGolfMainWindow(QMainWindow):
             distance = math.hypot(diff[0], diff[1], diff[2])
 
             # Update status bar with frame info
-            time_val = self.baseq_data.iloc[frame_idx]["Time"]
+            time_val = baseq_row["Time"]
             self.statusBar().showMessage(
                 f"Frame {frame_idx + 1}, Time: {time_val:.3f}s, "
                 f"Distance: {distance:.3f}m"  # noqa: E501

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/matlab/src/apps/golf_gui/Simscape Multibody Data Plotters/Python Version/integrated_golf_gui_r0/golf_wiffle_main.py
@@ -10,6 +10,7 @@ Enhanced main application with Excel data loading and advanced visualization
 
 import logging
 import sys
+import math
 from pathlib import Path
 from typing import Any
 
@@ -627,7 +628,9 @@ class WiffleGolfMainWindow(QMainWindow):
                 ]
             )
 
-            distance = np.linalg.norm(prov1_pos - wiffle_pos)
+            # ⚡ Bolt: math.hypot is faster than np.linalg.norm for small 1D arrays
+            diff = prov1_pos - wiffle_pos
+            distance = math.hypot(diff[0], diff[1], diff[2])
 
             # Update status bar with frame info
             time_val = self.baseq_data.iloc[frame_idx]["Time"]


### PR DESCRIPTION
## ⚡ Bolt: Use math.hypot for wiffle distance

💡 What: Replaced `np.linalg.norm(prov1_pos - wiffle_pos)` with `math.hypot(diff[0], diff[1], diff[2])`.
🎯 Why: Calculating the Euclidean distance of small 3D vectors via `math.hypot` circumvents NumPy's function dispatch overhead, array creation, and argument parsing.
📊 Impact: Considerably faster computation in loop bodies when computing lengths of small 1D vectors.
🔬 Measurement: Run unit tests and performance benchmarks.

---
*PR created automatically by Jules for task [12361612321876870327](https://jules.google.com/task/12361612321876870327) started by @dieterolson*