### PR TITLE
feat(launcher): sidekick subtab port, pop-out lifecycle hooks, manifest coverage validation

### DIFF
--- a/src/launchers/embedded_host.py
+++ b/src/launchers/embedded_host.py
@@ -570,6 +570,11 @@ class EmbeddedHostWidget(QWidget):
             logger.info("pop_out_tab: %s is pin-only; ignoring", tool_id)
             return False
 
+        # Bracket the re-parent with pause/resume so tools holding
+        # re-parent-sensitive resources (GL contexts, timers, IPC) get a
+        # chance to quiesce before the widget changes top-level windows.
+        _safe_pause(record.tool, record.widget)
+
         index = self._tab_widget.indexOf(record.widget)
         if index != -1:
             self._tab_widget.removeTab(index)
@@ -585,6 +590,7 @@ class EmbeddedHostWidget(QWidget):
         )
         window.show()
         window.raise_()
+        _safe_resume(record.tool, record.widget)
         return True
 
     def dock_back(self, tool_id: str) -> int:
@@ -604,6 +610,10 @@ class EmbeddedHostWidget(QWidget):
         if record is None:
             return -1
 
+        # Same pause/resume bracket as pop_out_tab: the widget is about
+        # to migrate between top-level windows.
+        _safe_pause(record.tool, record.widget)
+
         widget = record.widget
         widget.setParent(self._tab_widget)
         widget.show()
@@ -617,6 +627,7 @@ class EmbeddedHostWidget(QWidget):
         record.window.setCentralWidget(None)
         record.window.close()
         record.window.deleteLater()
+        _safe_resume(record.tool, widget)
         return index
 
     def backgrounded_tools(self) -> set[str]:
@@ -626,6 +637,50 @@ class EmbeddedHostWidget(QWidget):
         need to know which tools are alive-but-hidden.
         """
         return set(self._backgrounded.keys())
+
+    def popped_out_tools(self) -> set[str]:
+        """Return the set of tool ids currently in their own windows."""
+        return set(self._popped_out.keys())
+
+    def open_tool_ids(self) -> list[str]:
+        """Return the tool ids of open tabs in current display order.
+
+        Display order reflects user drag-reordering of the movable tab
+        bar, so indices are computed live rather than from cached
+        bookkeeping.
+        """
+        by_index: list[tuple[int, str]] = []
+        for tool_id, record in self._active_tabs.items():
+            index = self._tab_widget.indexOf(record.widget)
+            if index != -1:
+                by_index.append((index, tool_id))
+        return [tool_id for _, tool_id in sorted(by_index)]
+
+    def active_tool_id(self) -> str | None:
+        """Return the tool id of the currently focused tab, or ``None``."""
+        current = self._tab_widget.currentIndex()
+        if current < 0:
+            return None
+        record = self._lookup_tab(current)
+        return record.tool.tool_id if record is not None else None
+
+    def focus_tab(self, tool_id: str) -> None:
+        """Bring ``tool_id``'s tab to the front.
+
+        Backgrounded and popped-out tools are re-surfaced via
+        :meth:`open_tab` (which re-docks / resumes them).
+
+        Raises:
+            KeyError: If ``tool_id`` is not an open, backgrounded, or
+                popped-out tool.
+        """
+        if (
+            tool_id not in self._active_tabs
+            and tool_id not in self._backgrounded
+            and tool_id not in self._popped_out
+        ):
+            raise KeyError(tool_id)
+        self.open_tab(tool_id)
 
     # ------------------------------------------------------------------
     # Dock API

--- a/src/launchers/embedded_tool_bootstrap.py
+++ b/src/launchers/embedded_tool_bootstrap.py
@@ -95,45 +95,87 @@ def bootstrap_embeddable_tools() -> list[str]:
         "engines.Simscape_Multibody_Models.3D_Golf_Model.python.src.apps._embed_adapter",
     ]
 
+    from src.shared.python.launcher_embed import EMBEDDABLE_TOOL_REGISTRY
+
     registered = []
     for module_path in adapter_modules:
+        # Diff the registry around the import so we record the tool ids
+        # the adapter actually registered (an adapter may register zero,
+        # one, or several tools; ids need not match the module name).
+        before = set(EMBEDDABLE_TOOL_REGISTRY)
         try:
             # Import the module - it self-registers at module level
             __import__(module_path)
-            # Extract tool_id from module name for tracking
-            if module_path == "src.tools.canonical_core._embed_adapter":
-                registered.extend(
-                    ["canonical_core_estimation", "canonical_core_comparison"]
-                )
-                logger.debug("Bootstrapped canonical-core embeddable tools")
-                continue
-            if (
-                module_path
-                == "engines.Simscape_Multibody_Models.3D_Golf_Model.python.src.apps._embed_adapter"
-            ):
-                tool_id = "c3d_viewer"
-            else:
-                tool_id = (
-                    module_path.split(".")[-2]
-                    if "_embed_adapter" in module_path
-                    else module_path.split(".")[-1]
-                )
-
-            registered.append(tool_id)
-            logger.debug(f"Bootstrapped embeddable tool: {tool_id}")
         except ImportError as e:
             # Tools may have optional dependencies (PyQt6, etc.)
             # Log but don't fail - the tool just won't be embeddable
             logger.warning(f"Failed to bootstrap {module_path}: {e}")
+            continue
         except Exception as e:  # noqa: BLE001
             # Catch any other unexpected errors during registration
             logger.warning(f"Error bootstrapping {module_path}: {e}")
+            continue
+        new_ids = sorted(set(EMBEDDABLE_TOOL_REGISTRY) - before)
+        if new_ids:
+            registered.extend(new_ids)
+            logger.debug(f"Bootstrapped embeddable tools: {new_ids}")
+        else:
+            logger.debug(
+                "Adapter module %s imported but registered no new tools "
+                "(already imported, or registration is conditional)",
+                module_path,
+            )
 
     _registered_tools = registered
     _bootstrap_complete = True
 
     logger.info(f"Bootstrapped {len(registered)} embeddable tools: {registered}")
+    _warn_on_manifest_gaps()
     return registered
+
+
+def missing_embeddable_manifest_tools(manifest: object | None = None) -> list[str]:
+    """Return tool-like manifest tile ids with no registered embeddable tool.
+
+    A tile in the launcher manifest whose category is tool-like is
+    expected to be openable inside the launcher; if no embeddable tool
+    is registered under its id, clicking the tile can only fall back to
+    a subprocess launch (or fail). Surfacing the delta makes "I added a
+    tile but forgot the adapter" loud instead of a silent dead tile.
+
+    Args:
+        manifest: Optional pre-loaded ``LauncherManifest`` (mainly for
+            tests). Loaded from disk when omitted.
+
+    Returns:
+        Sorted list of tile ids that are tool-like but unregistered.
+    """
+    from src.shared.python.launcher_embed import EMBEDDABLE_TOOL_REGISTRY
+
+    if manifest is None:
+        from src.config.launcher_manifest_loader import LauncherManifest
+
+        manifest = LauncherManifest.load()
+    return sorted(
+        tile.id
+        for tile in manifest.tiles  # type: ignore[attr-defined]
+        if getattr(tile, "is_tool", False) and tile.id not in EMBEDDABLE_TOOL_REGISTRY
+    )
+
+
+def _warn_on_manifest_gaps() -> None:
+    """Log a warning for manifest tool tiles without embeddable adapters."""
+    try:
+        missing = missing_embeddable_manifest_tools()
+    except (FileNotFoundError, ValueError):
+        logger.exception("Could not validate launcher manifest coverage")
+        return
+    if missing:
+        logger.warning(
+            "Manifest tool tiles without embeddable adapters (these tiles "
+            "fall back to subprocess launch or fail): %s",
+            missing,
+        )
 
 
 def get_bootstrapped_tools() -> list[str]:

--- a/src/launchers/sidekick_host_port.py
+++ b/src/launchers/sidekick_host_port.py
@@ -1,0 +1,275 @@
+"""Launcher-side ``SubtabActionPort`` implementation (epic #5967 follow-up).
+
+The Sidekick agent layer (``sidekick.agent``) ships a fully tested
+``SubtabAdapter`` whose only dependency is the narrow
+:class:`~sidekick.agent.subtab_adapter.SubtabActionPort` Protocol. Until
+now no host implemented that port, so chat agents could not see or
+control launcher tabs. This module closes that gap for the PyQt6
+launcher: :class:`LauncherSubtabPort` bridges the port onto
+:class:`~src.launchers.embedded_host.EmbeddedHostWidget` plus an
+injected workspace registry, calculator table, and state-profile store.
+
+Design notes:
+
+* **No PyQt6 imports.** The port only calls duck-typed host methods
+  (``open_tool_ids``, ``focus_tab``, ``open_tab``, ``close_tab``,
+  ``backgrounded_tools``, ``popped_out_tools``), so it can be unit
+  tested headlessly against a fake host.
+* **LOD.** The port never reaches into host internals; everything goes
+  through the host's public tab API.
+* **DbC.** Construction validates the host exposes the required
+  surface; tab methods raise ``KeyError`` for unknown tabs as the
+  Protocol requires.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from sidekick.agent.subtab_adapter import (
+    CalculatorRun,
+    StateProfile,
+    SubtabAdapter,
+    WorkspaceSnapshot,
+)
+
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "LauncherSubtabPort",
+    "TabHost",
+    "create_launcher_subtab_adapter",
+]
+
+
+@runtime_checkable
+class TabHost(Protocol):
+    """The slice of ``EmbeddedHostWidget`` the port needs.
+
+    Kept as a Protocol so tests can pass a fake and so the port stays
+    importable in headless environments where PyQt6 is unavailable.
+    """
+
+    def open_tool_ids(self) -> list[str]: ...
+
+    def active_tool_id(self) -> str | None: ...
+
+    def focus_tab(self, tool_id: str) -> None: ...
+
+    def open_tab(self, tool_id: str) -> int: ...
+
+    def close_tab(self, target: int | str, *, destroy: bool = True) -> bool: ...
+
+    def backgrounded_tools(self) -> set[str]: ...
+
+    def popped_out_tools(self) -> set[str]: ...
+
+
+class _DictWorkspace:
+    """Minimal in-memory workspace used when no registry is injected."""
+
+    def __init__(self) -> None:
+        self._values: dict[str, Any] = {}
+
+    def list(self) -> list[str]:
+        return sorted(self._values)
+
+    def get(self, name: str, default: Any = None) -> Any:
+        return self._values.get(name, default)
+
+    def set(self, name: str, value: Any) -> None:
+        self._values[name] = value
+
+
+class LauncherSubtabPort:
+    """``SubtabActionPort`` backed by the launcher's embedded tool host.
+
+    Args:
+        host: The tab host (normally an ``EmbeddedHostWidget``).
+        workspace: Optional workspace registry exposing ``list()``,
+            ``get(name, default)``, and ``set(name, value)`` (the
+            ``sidekick.ui.tools_sidebar.registry.WorkspaceRegistry``
+            surface). Defaults to an in-memory store.
+        calculators: Optional mapping of calculator id to a callable
+            ``(inputs) -> CalculatorRun``.
+        profile_path: Optional JSON file used to persist state profiles
+            across sessions. Profiles stay in memory when omitted.
+
+    Raises:
+        TypeError: If ``host`` does not satisfy :class:`TabHost`.
+    """
+
+    def __init__(
+        self,
+        host: TabHost,
+        *,
+        workspace: Any | None = None,
+        calculators: Mapping[str, Callable[[Mapping[str, Any]], CalculatorRun]]
+        | None = None,
+        profile_path: str | Path | None = None,
+    ) -> None:
+        if not isinstance(host, TabHost):
+            raise TypeError(f"host must satisfy TabHost, got {type(host).__name__}")
+        self._host = host
+        self._workspace = workspace if workspace is not None else _DictWorkspace()
+        self._calculators = dict(calculators or {})
+        self._profile_path = Path(profile_path) if profile_path else None
+        self._profiles: dict[str, dict[str, Any]] = self._load_profiles()
+
+    # ---- Tabs ------------------------------------------------------------
+
+    def list_tabs(self) -> Sequence[str]:
+        """Open tabs in display order, then backgrounded and popped-out."""
+        open_ids = self._host.open_tool_ids()
+        seen = set(open_ids)
+        extras = sorted(
+            (self._host.backgrounded_tools() | self._host.popped_out_tools()) - seen
+        )
+        return [*open_ids, *extras]
+
+    def active_tab(self) -> str | None:
+        return self._host.active_tool_id()
+
+    def focus(self, tab_id: str) -> None:
+        self._host.focus_tab(tab_id)
+
+    def set_visible(self, tab_id: str, visible: bool) -> None:
+        if visible:
+            if (
+                tab_id
+                in self._host.backgrounded_tools()
+                | set(self._host.open_tool_ids())
+                | self._host.popped_out_tools()
+            ):
+                self._host.open_tab(tab_id)
+                return
+            try:
+                self._host.open_tab(tab_id)
+            except ValueError as exc:
+                # The Protocol promises KeyError for unknown tabs.
+                raise KeyError(tab_id) from exc
+            return
+        if tab_id in self._host.backgrounded_tools():
+            return  # already hidden — idempotent
+        if not self._host.close_tab(tab_id, destroy=False):
+            raise KeyError(tab_id)
+
+    # ---- Workspace --------------------------------------------------------
+
+    def workspace_snapshot(self) -> WorkspaceSnapshot:
+        values = {name: self._workspace.get(name) for name in self._workspace.list()}
+        return WorkspaceSnapshot(values=values)
+
+    def workspace_set_variable(self, name: str, value: Any) -> Any:
+        prior = self._workspace.get(name)
+        self._workspace.set(name, value)
+        return prior
+
+    # ---- Calculators -------------------------------------------------------
+
+    def register_calculator(
+        self, calculator_id: str, fn: Callable[[Mapping[str, Any]], CalculatorRun]
+    ) -> None:
+        """Expose a named calculator to chat agents.
+
+        Raises:
+            ValueError: If ``calculator_id`` is empty or already registered.
+        """
+        if not calculator_id or not calculator_id.strip():
+            raise ValueError("calculator_id must be a non-empty string")
+        if calculator_id in self._calculators:
+            raise ValueError(f"calculator {calculator_id!r} is already registered")
+        self._calculators[calculator_id] = fn
+
+    def calculator_run(
+        self, calculator_id: str, inputs: Mapping[str, Any]
+    ) -> CalculatorRun:
+        fn = self._calculators.get(calculator_id)
+        if fn is None:
+            raise KeyError(calculator_id)
+        return fn(inputs)
+
+    # ---- State profiles -----------------------------------------------------
+
+    def state_profile_save(self, name: str, payload: Mapping[str, Any]) -> None:
+        self._profiles[name] = dict(payload)
+        self._persist_profiles()
+
+    def state_profile_load(self, name: str) -> StateProfile:
+        if name not in self._profiles:
+            raise KeyError(name)
+        return StateProfile(name=name, payload=dict(self._profiles[name]))
+
+    def state_profile_delete(self, name: str) -> None:
+        self._profiles.pop(name, None)
+        self._persist_profiles()
+
+    # ---- Persistence (internal) ---------------------------------------------
+
+    def _load_profiles(self) -> dict[str, dict[str, Any]]:
+        if self._profile_path is None or not self._profile_path.exists():
+            return {}
+        try:
+            raw = json.loads(self._profile_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.exception(
+                "Failed to load sidekick state profiles from %s", self._profile_path
+            )
+            return {}
+        if not isinstance(raw, dict):
+            logger.warning(
+                "Ignoring malformed profile store %s (not an object)",
+                self._profile_path,
+            )
+            return {}
+        return {
+            str(name): dict(payload)
+            for name, payload in raw.items()
+            if isinstance(payload, dict)
+        }
+
+    def _persist_profiles(self) -> None:
+        if self._profile_path is None:
+            return
+        try:
+            self._profile_path.parent.mkdir(parents=True, exist_ok=True)
+            self._profile_path.write_text(
+                json.dumps(self._profiles, indent=2, default=repr),
+                encoding="utf-8",
+            )
+        except OSError:
+            logger.exception(
+                "Failed to persist sidekick state profiles to %s", self._profile_path
+            )
+
+
+def create_launcher_subtab_adapter(
+    host: TabHost,
+    *,
+    workspace: Any | None = None,
+    calculators: Mapping[str, Callable[[Mapping[str, Any]], CalculatorRun]]
+    | None = None,
+    profile_path: str | Path | None = None,
+) -> SubtabAdapter:
+    """Build the ready-to-register ``SidekickActionHandler`` for a host.
+
+    Convenience factory so launcher wiring is one line::
+
+        service.register(create_launcher_subtab_adapter(embedded_host))
+
+    Returns:
+        A :class:`SubtabAdapter` whose port is a
+        :class:`LauncherSubtabPort` over ``host``.
+    """
+    port = LauncherSubtabPort(
+        host,
+        workspace=workspace,
+        calculators=calculators,
+        profile_path=profile_path,
+    )
+    return SubtabAdapter(port=port)

--- a/src/tools/swing_flight_pipeline/gui.py
+++ b/src/tools/swing_flight_pipeline/gui.py
@@ -244,8 +244,8 @@ class SwingFlightWidget(QWidget):
         except ImportError as e:
             self._results_text.setPlainText(
                 f"Pipeline not available: {e}\n\n"
-                "The SwingBallFlightPipeline module may not be merged yet.\n"
-                "Check branch: feat/5337-swing-ball-flight-pipeline"
+                "A required dependency for the swing-to-flight pipeline "
+                "failed to import. Check the log for details."
             )
         except Exception as e:
             logger.exception("Pipeline execution failed")

--- a/tests/launchers/launcher_embed/test_popout_hooks.py
+++ b/tests/launchers/launcher_embed/test_popout_hooks.py
@@ -1,0 +1,131 @@
+"""Pop-out / dock-back lifecycle hooks and tab introspection.
+
+Covers the pause/resume bracket around tab re-parenting
+(:meth:`EmbeddedHostWidget.pop_out_tab` / :meth:`dock_back`) and the
+public tab-introspection API (``open_tool_ids``, ``active_tool_id``,
+``focus_tab``) added for the Sidekick subtab port.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+from PyQt6.QtWidgets import QApplication, QLabel  # noqa: E402
+
+from src.launchers.embedded_host import EmbeddedHostWidget  # noqa: E402
+from src.shared.python.launcher_embed import (  # noqa: E402
+    EmbedCapabilities,
+    EMBEDDABLE_TOOL_REGISTRY,
+    register_embeddable_tool,
+)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(scope="module")
+def _qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+class _HookTool:
+    """EmbeddableTool that records pause/resume calls."""
+
+    def __init__(self, tool_id: str) -> None:
+        self.tool_id = tool_id
+        self.pause_calls = 0
+        self.resume_calls = 0
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities(supports_embedded=True)
+
+    def create_main_widget(self, parent: Any) -> Any:
+        return QLabel(self.tool_id, parent)
+
+    def cleanup(self) -> None:
+        pass
+
+    def is_dirty(self) -> bool:
+        return False
+
+    def pause(self) -> None:
+        self.pause_calls += 1
+
+    def resume(self) -> None:
+        self.resume_calls += 1
+
+
+@pytest.fixture
+def host(_qapp):  # noqa: ANN001
+    w = EmbeddedHostWidget()
+    yield w
+    w.close()
+    w.deleteLater()
+
+
+@pytest.fixture
+def tool(request):  # noqa: ANN001
+    tool_id = f"hooktool::{request.node.name}"
+    t = _HookTool(tool_id)
+    register_embeddable_tool(t)
+    yield t
+    EMBEDDABLE_TOOL_REGISTRY.pop(tool_id, None)
+
+
+class TestPopOutHooks:
+    def test_pop_out_brackets_with_pause_and_resume(self, host, tool) -> None:
+        host.open_tab(tool.tool_id)
+        assert host.pop_out_tab(tool.tool_id) is True
+        assert tool.pause_calls == 1
+        assert tool.resume_calls == 1
+        assert tool.tool_id in host.popped_out_tools()
+
+    def test_dock_back_brackets_with_pause_and_resume(self, host, tool) -> None:
+        host.open_tab(tool.tool_id)
+        host.pop_out_tab(tool.tool_id)
+        index = host.dock_back(tool.tool_id)
+        assert index >= 0
+        assert tool.pause_calls == 2
+        assert tool.resume_calls == 2
+        assert tool.tool_id in host.open_tool_ids()
+
+    def test_pop_out_unknown_tool_is_noop(self, host, tool) -> None:
+        assert host.pop_out_tab("missing") is False
+
+
+class TestTabIntrospection:
+    def test_open_tool_ids_in_display_order(self, host, tool) -> None:
+        other = _HookTool(f"{tool.tool_id}::other")
+        register_embeddable_tool(other)
+        try:
+            host.open_tab(tool.tool_id)
+            host.open_tab(other.tool_id)
+            assert host.open_tool_ids() == [tool.tool_id, other.tool_id]
+        finally:
+            EMBEDDABLE_TOOL_REGISTRY.pop(other.tool_id, None)
+
+    def test_active_tool_id_tracks_current_tab(self, host, tool) -> None:
+        assert host.active_tool_id() is None
+        host.open_tab(tool.tool_id)
+        assert host.active_tool_id() == tool.tool_id
+
+    def test_focus_tab_unknown_raises_keyerror(self, host, tool) -> None:
+        with pytest.raises(KeyError):
+            host.focus_tab("missing")
+
+    def test_focus_tab_resurfaces_backgrounded_tool(self, host, tool) -> None:
+        host.open_tab(tool.tool_id)
+        assert host.close_tab(tool.tool_id, destroy=False) is True
+        assert tool.tool_id in host.backgrounded_tools()
+        host.focus_tab(tool.tool_id)
+        assert tool.tool_id in host.open_tool_ids()
+        assert host.active_tool_id() == tool.tool_id

--- a/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
+++ b/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
@@ -132,16 +132,43 @@ def test_bootstrap_adds_vendor_path_to_sys_path() -> None:
 
 
 def test_bootstrap_records_successfully_imported_tools() -> None:
-    """Successful imports get their tool_id extracted and recorded."""
+    """Tool ids actually registered during an adapter import are recorded.
+
+    Recording diffs the registry around each import, so the recorded ids
+    are the ones the adapter registered — not ids guessed from the
+    module name.
+    """
+    from src.shared.python.launcher_embed import EMBEDDABLE_TOOL_REGISTRY
+    from src.shared.python.launcher_embed.contract import EmbedCapabilities
+
+    class _FakeTool:
+        tool_id = "model_explorer"
+
+        def embed_capabilities(self) -> EmbedCapabilities:
+            return EmbedCapabilities(supports_embedded=True)
+
+        def create_main_widget(self, parent: object) -> object:
+            return object()
+
+        def cleanup(self) -> None:
+            pass
+
+        def is_dirty(self) -> bool:
+            return False
 
     def _selective(name):
         if name == "src.tools.model_explorer._embed_adapter":
-            return object()  # success
+            # Simulate the adapter's import-time self-registration.
+            EMBEDDABLE_TOOL_REGISTRY.setdefault("model_explorer", _FakeTool())
+            return object()
         raise ImportError(f"forced for {name}")
 
-    with patch.object(_builtins, "__import__", _make_filtered_import(_selective)):
-        result = bootstrap.bootstrap_embeddable_tools()
-    assert "model_explorer" in result
+    try:
+        with patch.object(_builtins, "__import__", _make_filtered_import(_selective)):
+            result = bootstrap.bootstrap_embeddable_tools()
+        assert "model_explorer" in result
+    finally:
+        EMBEDDABLE_TOOL_REGISTRY.pop("model_explorer", None)
 
 
 # Tools whose adapters live in this repo (not the vendored Tools submodule) and

--- a/tests/unit/launcher/test_bootstrap_manifest_coverage.py
+++ b/tests/unit/launcher/test_bootstrap_manifest_coverage.py
@@ -1,0 +1,71 @@
+"""Tests for launcher-manifest coverage validation in the tool bootstrap."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from src.launchers.embedded_tool_bootstrap import missing_embeddable_manifest_tools
+from src.shared.python.launcher_embed import (
+    EMBEDDABLE_TOOL_REGISTRY,
+    EmbedCapabilities,
+    register_embeddable_tool,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+@dataclass
+class _Tile:
+    id: str
+    is_tool: bool
+
+
+@dataclass
+class _Manifest:
+    tiles: tuple[_Tile, ...]
+
+
+class _Tool:
+    def __init__(self, tool_id: str) -> None:
+        self.tool_id = tool_id
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities(supports_embedded=True)
+
+    def create_main_widget(self, parent: object) -> object:  # pragma: no cover
+        return object()
+
+    def cleanup(self) -> None:  # pragma: no cover
+        pass
+
+    def is_dirty(self) -> bool:  # pragma: no cover
+        return False
+
+
+def test_missing_tools_are_reported_sorted() -> None:
+    manifest = _Manifest(
+        tiles=(
+            _Tile(id="zz_missing", is_tool=True),
+            _Tile(id="aa_missing", is_tool=True),
+            _Tile(id="some_engine", is_tool=False),
+        )
+    )
+    missing = missing_embeddable_manifest_tools(manifest)
+    assert missing == ["aa_missing", "zz_missing"]
+
+
+def test_registered_tool_is_not_reported() -> None:
+    tool_id = "coverage_check_tool"
+    register_embeddable_tool(_Tool(tool_id))
+    try:
+        manifest = _Manifest(tiles=(_Tile(id=tool_id, is_tool=True),))
+        assert missing_embeddable_manifest_tools(manifest) == []
+    finally:
+        EMBEDDABLE_TOOL_REGISTRY.pop(tool_id, None)
+
+
+def test_engine_tiles_are_ignored() -> None:
+    manifest = _Manifest(tiles=(_Tile(id="mujoco_unified", is_tool=False),))
+    assert missing_embeddable_manifest_tools(manifest) == []

--- a/tests/unit/launcher/test_sidekick_host_port.py
+++ b/tests/unit/launcher/test_sidekick_host_port.py
@@ -1,0 +1,230 @@
+"""Headless tests for :mod:`src.launchers.sidekick_host_port`.
+
+The port is exercised against a fake :class:`TabHost`, proving the
+launcher-side Sidekick bridge needs no Qt to be validated. End-to-end
+adapter behaviour (descriptors, undo metadata) is covered by the vendor
+suite ``tests/unit/sidekick/agent/test_subtab_adapter.py``; here we pin
+the host-port semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from sidekick.agent.subtab_adapter import (
+    CalculatorRun,
+    SubtabActionPort,
+    SubtabAdapter,
+)
+
+from src.launchers.sidekick_host_port import (
+    LauncherSubtabPort,
+    create_launcher_subtab_adapter,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class _FakeHost:
+    """In-memory TabHost double mirroring EmbeddedHostWidget semantics."""
+
+    def __init__(self) -> None:
+        self.known = {"alpha", "beta", "gamma"}
+        self.open: list[str] = []
+        self.backgrounded: set[str] = set()
+        self.popped: set[str] = set()
+        self.active: str | None = None
+
+    def open_tool_ids(self) -> list[str]:
+        return list(self.open)
+
+    def active_tool_id(self) -> str | None:
+        return self.active
+
+    def focus_tab(self, tool_id: str) -> None:
+        if tool_id not in set(self.open) | self.backgrounded | self.popped:
+            raise KeyError(tool_id)
+        self.open_tab(tool_id)
+
+    def open_tab(self, tool_id: str) -> int:
+        if tool_id not in self.known:
+            raise ValueError(f"tool_id {tool_id!r} is not registered")
+        self.backgrounded.discard(tool_id)
+        self.popped.discard(tool_id)
+        if tool_id not in self.open:
+            self.open.append(tool_id)
+        self.active = tool_id
+        return self.open.index(tool_id)
+
+    def close_tab(self, target: int | str, *, destroy: bool = True) -> bool:
+        if not isinstance(target, str) or target not in self.open:
+            return False
+        self.open.remove(target)
+        if not destroy:
+            self.backgrounded.add(target)
+        return True
+
+    def backgrounded_tools(self) -> set[str]:
+        return set(self.backgrounded)
+
+    def popped_out_tools(self) -> set[str]:
+        return set(self.popped)
+
+
+@pytest.fixture
+def fake_host() -> _FakeHost:
+    return _FakeHost()
+
+
+@pytest.fixture
+def port(fake_host: _FakeHost) -> LauncherSubtabPort:
+    return LauncherSubtabPort(fake_host)
+
+
+class TestConstruction:
+    def test_satisfies_subtab_action_port(self, port: LauncherSubtabPort) -> None:
+        assert isinstance(port, SubtabActionPort)
+
+    def test_rejects_non_host(self) -> None:
+        with pytest.raises(TypeError, match="TabHost"):
+            LauncherSubtabPort("not-a-host")  # type: ignore[arg-type]
+
+    def test_factory_builds_registered_adapter(self, fake_host: _FakeHost) -> None:
+        adapter = create_launcher_subtab_adapter(fake_host)
+        assert isinstance(adapter, SubtabAdapter)
+        result = adapter.invoke("subtab.list", {})
+        assert result.ok
+
+
+class TestTabs:
+    def test_list_tabs_open_then_hidden(
+        self, fake_host: _FakeHost, port: LauncherSubtabPort
+    ) -> None:
+        fake_host.open = ["beta", "alpha"]
+        fake_host.backgrounded = {"gamma"}
+        assert list(port.list_tabs()) == ["beta", "alpha", "gamma"]
+
+    def test_active_tab(self, fake_host: _FakeHost, port: LauncherSubtabPort) -> None:
+        assert port.active_tab() is None
+        fake_host.open_tab("alpha")
+        assert port.active_tab() == "alpha"
+
+    def test_focus_unknown_raises(self, port: LauncherSubtabPort) -> None:
+        with pytest.raises(KeyError):
+            port.focus("missing")
+
+    def test_set_visible_true_opens_registered_tool(
+        self, fake_host: _FakeHost, port: LauncherSubtabPort
+    ) -> None:
+        port.set_visible("alpha", True)
+        assert fake_host.open == ["alpha"]
+
+    def test_set_visible_true_unknown_raises_keyerror(
+        self, port: LauncherSubtabPort
+    ) -> None:
+        # The host raises ValueError for unregistered ids; the Protocol
+        # promises KeyError — the port must translate.
+        with pytest.raises(KeyError):
+            port.set_visible("missing", True)
+
+    def test_set_visible_false_backgrounds_open_tab(
+        self, fake_host: _FakeHost, port: LauncherSubtabPort
+    ) -> None:
+        fake_host.open_tab("alpha")
+        port.set_visible("alpha", False)
+        assert fake_host.open == []
+        assert "alpha" in fake_host.backgrounded
+
+    def test_set_visible_false_hidden_is_idempotent(
+        self, fake_host: _FakeHost, port: LauncherSubtabPort
+    ) -> None:
+        fake_host.backgrounded = {"alpha"}
+        port.set_visible("alpha", False)  # no raise
+        assert "alpha" in fake_host.backgrounded
+
+    def test_set_visible_false_unknown_raises(self, port: LauncherSubtabPort) -> None:
+        with pytest.raises(KeyError):
+            port.set_visible("missing", False)
+
+
+class TestWorkspace:
+    def test_snapshot_roundtrip(self, port: LauncherSubtabPort) -> None:
+        assert port.workspace_set_variable("x", 1) is None
+        assert port.workspace_set_variable("x", 2) == 1
+        snap = port.workspace_snapshot()
+        assert dict(snap.values) == {"x": 2}
+
+    def test_injected_registry_is_used(self, fake_host: _FakeHost) -> None:
+        class _Reg:
+            def __init__(self) -> None:
+                self.data: dict[str, Any] = {"seed": 42}
+
+            def list(self) -> list[str]:
+                return sorted(self.data)
+
+            def get(self, name: str, default: Any = None) -> Any:
+                return self.data.get(name, default)
+
+            def set(self, name: str, value: Any) -> None:
+                self.data[name] = value
+
+        reg = _Reg()
+        port = LauncherSubtabPort(fake_host, workspace=reg)
+        assert dict(port.workspace_snapshot().values) == {"seed": 42}
+        port.workspace_set_variable("y", "z")
+        assert reg.data["y"] == "z"
+
+
+class TestCalculators:
+    @staticmethod
+    def _double(inputs: Mapping[str, Any]) -> CalculatorRun:
+        return CalculatorRun(values={"out": float(inputs["x"]) * 2})
+
+    def test_unknown_calculator_raises_keyerror(self, port: LauncherSubtabPort) -> None:
+        with pytest.raises(KeyError):
+            port.calculator_run("nope", {})
+
+    def test_registered_calculator_runs(self, fake_host: _FakeHost) -> None:
+        port = LauncherSubtabPort(fake_host, calculators={"double": self._double})
+        run = port.calculator_run("double", {"x": 3})
+        assert run.values == {"out": 6.0}
+
+    def test_register_calculator_validates(self, port: LauncherSubtabPort) -> None:
+        port.register_calculator("double", self._double)
+        with pytest.raises(ValueError, match="already registered"):
+            port.register_calculator("double", self._double)
+        with pytest.raises(ValueError, match="non-empty"):
+            port.register_calculator("  ", self._double)
+
+
+class TestStateProfiles:
+    def test_in_memory_save_load_delete(self, port: LauncherSubtabPort) -> None:
+        port.state_profile_save("p1", {"a": 1})
+        profile = port.state_profile_load("p1")
+        assert profile.payload == {"a": 1}
+        port.state_profile_delete("p1")
+        with pytest.raises(KeyError):
+            port.state_profile_load("p1")
+        port.state_profile_delete("p1")  # idempotent
+
+    def test_persistence_roundtrip(self, fake_host: _FakeHost, tmp_path) -> None:
+        path = tmp_path / "profiles.json"
+        port = LauncherSubtabPort(fake_host, profile_path=path)
+        port.state_profile_save("p1", {"a": 1})
+        assert json.loads(path.read_text(encoding="utf-8")) == {"p1": {"a": 1}}
+
+        reloaded = LauncherSubtabPort(fake_host, profile_path=path)
+        assert reloaded.state_profile_load("p1").payload == {"a": 1}
+
+    def test_corrupt_profile_store_is_ignored(
+        self, fake_host: _FakeHost, tmp_path
+    ) -> None:
+        path = tmp_path / "profiles.json"
+        path.write_text("not json", encoding="utf-8")
+        port = LauncherSubtabPort(fake_host, profile_path=path)
+        with pytest.raises(KeyError):
+            port.state_profile_load("anything")


### PR DESCRIPTION
## Summary

Operational hardening of the launcher tab architecture plus the first host-side wiring for the Sidekick agent layer.

- **Sidekick ↔ tabs bridge (epic #5967 follow-up)**: new `src/launchers/sidekick_host_port.py` implements the `sidekick.agent.subtab_adapter.SubtabActionPort` Protocol over `EmbeddedHostWidget`. Until now the SubtabAdapter had no production port, so chat agents could not see or control launcher tabs. `create_launcher_subtab_adapter(host)` returns a ready-to-register `SidekickActionHandler`. The port is headless-safe (no PyQt6 imports; duck-typed `TabHost` protocol) and supports an injected workspace registry, named calculators, and JSON-persisted state profiles.
- **Pop-out robustness**: `pop_out_tab` / `dock_back` now bracket widget re-parenting with the existing pause/resume hooks so tools holding GL contexts, timers, or IPC can quiesce across top-level-window migration. New public introspection API: `open_tool_ids()`, `active_tool_id()`, `focus_tab()`, `popped_out_tools()`.
- **Bootstrap truthfulness**: `bootstrap_embeddable_tools()` now records tool ids by diffing the registry around each adapter import instead of guessing ids from module names (which mis-recorded multi-tool adapters and `pose_studio.gui`). After bootstrap, `missing_embeddable_manifest_tools()` warns about manifest tool tiles that have no registered embeddable adapter (silent dead tiles become loud).
- Removed a stale "module may not be merged yet / check branch" error message in the swing-flight pipeline GUI.

## Tests

- `tests/launchers/launcher_embed/test_popout_hooks.py` — pop-out/dock-back hook bracketing + introspection API (offscreen Qt).
- `tests/unit/launcher/test_sidekick_host_port.py` — headless port semantics incl. Protocol conformance, KeyError translation, workspace/calculator/profile behaviour, persistence roundtrip.
- `tests/unit/launcher/test_bootstrap_manifest_coverage.py` — manifest gap detection.
- Updated `test_embedded_tool_bootstrap.py` to pin the new diff-based recording contract.

All of the above plus `test_embedded_host_edges.py`, `test_sidekick_tab_dispatch.py`, and `test_simulation_guis.py` pass locally on Python 3.13 with real PyQt6.

Follow-up (separate issue): register the adapter into the `SidekickActionService` used by the chat panel so agent mode can invoke `subtab.*` actions end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)