### PR TITLE
fix(mocap-io): Rust C3D parser ignored 1-D POINT:UNITS — golf captures loaded 1000x too small

### DIFF
--- a/rust_core/upstream-mocap-io/src/c3d.rs
+++ b/rust_core/upstream-mocap-io/src/c3d.rs
@@ -360,7 +360,14 @@ fn parse_point_params(
                             }
                         }
                     "UNITS"
-                        if element_size == -1 && dims.len() == 2 => {
+                        // POINT:UNITS is most commonly a 1-D char array
+                        // (dims = [string_len]) holding a single unit
+                        // string such as "mm" or "m"; some writers emit a
+                        // 2-D char array (dims = [string_len, n_strings]).
+                        // Accept both — ignoring the 1-D form silently
+                        // defaulted meter-based files to mm and shrank
+                        // their coordinates 1000x.
+                        if element_size == -1 && (dims.len() == 1 || dims.len() == 2) => {
                             let slen = dims[0];
                             // First string is the unit.
                             if slen <= data.len() {

--- a/rust_core/upstream-mocap-io/tests/golden_smoke.rs
+++ b/rust_core/upstream-mocap-io/tests/golden_smoke.rs
@@ -28,6 +28,59 @@ fn parse_c3d_smoke() {
     assert_eq!(data.positions.len(), data.n_frames * data.n_markers * 3);
 }
 
+fn repo_data(name: &str) -> PathBuf {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest).join("../..").join("data").join(name)
+}
+
+/// The Tour-Average golf captures declare POINT:UNITS = "m" via a 1-D
+/// char parameter. A parser that misses that (and falls back to the mm
+/// default) shrinks the swing to a ~2 mm bounding box — regression
+/// guard for the dims.len()==1 UNITS fix.
+#[test]
+fn parse_c3d_meter_units_ta_golf() {
+    let path = repo_data("C3D_TA_Driver.c3d");
+    if !path.exists() {
+        eprintln!("skipping: repo data file missing at {path:?}");
+        return;
+    }
+    let data = c3d::parse_c3d_file(&path).expect("parse C3D_TA_Driver.c3d");
+    assert_eq!(data.units, "m", "TA golf files declare meters");
+    assert_eq!(data.n_markers, 38);
+    let max_abs = data
+        .positions
+        .iter()
+        .filter(|v| v.is_finite())
+        .fold(0.0_f32, |acc, v| acc.max(v.abs()));
+    assert!(
+        max_abs > 0.5 && max_abs < 10.0,
+        "expected a human-scale capture in meters, got max |coord| = {max_abs}"
+    );
+}
+
+/// The CMU academic captures declare POINT:UNITS = "mm"; positions must
+/// come back mm→m scaled to human magnitudes.
+#[test]
+fn parse_c3d_mm_units_cmu() {
+    let path = repo_data("cmu_mocap/subject_64/64_01.c3d");
+    if !path.exists() {
+        eprintln!("skipping: repo data file missing at {path:?}");
+        return;
+    }
+    let data = c3d::parse_c3d_file(&path).expect("parse 64_01.c3d");
+    assert_eq!(data.units, "mm", "CMU files declare millimeters");
+    assert_eq!(data.n_markers, 45);
+    let max_abs = data
+        .positions
+        .iter()
+        .filter(|v| v.is_finite())
+        .fold(0.0_f32, |acc, v| acc.max(v.abs()));
+    assert!(
+        max_abs > 0.5 && max_abs < 10.0,
+        "expected a human-scale capture after mm→m scaling, got max |coord| = {max_abs}"
+    );
+}
+
 #[test]
 fn parse_trc_smoke() {
     let path = golden("sample.trc");

--- a/tests/integration/test_c3d_data_folder_coverage.py
+++ b/tests/integration/test_c3d_data_folder_coverage.py
@@ -1,0 +1,107 @@
+"""Every C3D file shipped in ``data/`` must load through the C3D adapter.
+
+The repo carries two distinct capture types:
+
+* Tour-Average golf swings (``data/C3D_TA_*.c3d``) — 38 markers,
+  float-mode coordinates declared in **meters** via a 1-D
+  ``POINT:UNITS`` char parameter.
+* CMU academic mocap (``data/cmu_mocap/subject_64/*.c3d``) — 45
+  markers, coordinates declared in **millimeters**.
+
+A units-parsing regression in the Rust parser scaled the meter-based
+golf files down 1000x (a 2 mm golf swing) while leaving the mm-based
+CMU files coincidentally correct, so this suite pins human-scale
+magnitudes for every file rather than just successful parsing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.motion_pipeline.sources.c3d_adapter import (
+    _HAS_C3D_BACKEND,
+    C3DAdapter,
+)
+
+pytestmark = [pytest.mark.integration]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "data"
+
+ALL_C3D_FILES = sorted(DATA_DIR.rglob("*.c3d"))
+
+# Marker counts per capture type; anything new in data/ falls back to
+# the generic >0 assertion.
+EXPECTED_MARKERS = {"C3D_TA_": 38, "64_": 45}
+
+# A human capture (golf swing or locomotion) expressed in meters must
+# span more than half a meter and stay well under 10 m from origin.
+HUMAN_SCALE_MIN_M = 0.5
+HUMAN_SCALE_MAX_M = 10.0
+
+
+def _expected_marker_count(path: Path) -> int | None:
+    for prefix, count in EXPECTED_MARKERS.items():
+        if path.name.startswith(prefix):
+            return count
+    return None
+
+
+def test_data_folder_contains_both_capture_types() -> None:
+    """Guard: the two known capture families are present in data/."""
+    names = {p.name for p in ALL_C3D_FILES}
+    assert "C3D_TA_Driver.c3d" in names
+    assert "C3D_TA_Iron.c3d" in names
+    assert any(n.startswith("64_") for n in names), "CMU subject_64 files missing"
+
+
+@pytest.mark.skipif(not _HAS_C3D_BACKEND, reason="no C3D backend installed")
+@pytest.mark.parametrize("c3d_path", ALL_C3D_FILES, ids=[p.name for p in ALL_C3D_FILES])
+def test_every_data_c3d_loads_at_human_scale(c3d_path: Path) -> None:
+    adapter = C3DAdapter()
+    assert adapter.supports(c3d_path)
+
+    meta = adapter.metadata(c3d_path)
+    assert meta.fps > 0
+    assert meta.frame_count > 0
+
+    trajectory = adapter.load(c3d_path)
+    assert len(trajectory.frames) == meta.frame_count
+
+    expected_markers = _expected_marker_count(c3d_path)
+    # Occlusion drops markers per frame — and some CMU takes have a
+    # marker occluded for the whole capture — so compare the best frame
+    # against a small tolerance below the declared marker count.
+    max_markers = max(len(f.markers) for f in trajectory.frames)
+    if expected_markers is not None:
+        assert expected_markers - 3 <= max_markers <= expected_markers, (
+            f"{c3d_path.name}: expected ~{expected_markers} markers, got {max_markers}"
+        )
+    else:
+        assert max_markers > 0
+
+    coords = [
+        abs(c)
+        for frame in trajectory.frames
+        for marker in frame.markers.values()
+        for c in (marker.x, marker.y, marker.z)
+    ]
+    assert coords, f"{c3d_path.name}: no finite marker coordinates"
+    max_abs = max(coords)
+    assert HUMAN_SCALE_MIN_M < max_abs < HUMAN_SCALE_MAX_M, (
+        f"{c3d_path.name}: max |coord| = {max_abs:.4f} m is not human-scale; "
+        "units were likely mis-parsed (meters-vs-millimeters regression)"
+    )
+
+
+@pytest.mark.skipif(not _HAS_C3D_BACKEND, reason="no C3D backend installed")
+def test_units_metadata_distinguishes_both_types() -> None:
+    """The golf files report meters; the CMU files report millimeters."""
+    adapter = C3DAdapter()
+    golf = adapter.load(DATA_DIR / "C3D_TA_Driver.c3d")
+    cmu = adapter.load(DATA_DIR / "cmu_mocap" / "subject_64" / "64_01.c3d")
+    assert golf.metadata["units"].startswith("m")
+    assert not golf.metadata["units"].startswith("mm")
+    assert cmu.metadata["units"].startswith("mm")


### PR DESCRIPTION
## Summary

**Bug**: `rust_core/upstream-mocap-io/src/c3d.rs` only matched `POINT:UNITS` when encoded as a 2-D char array. The far more common 1-D form (a single unit string) was silently ignored, so `units` came back empty and the parser fell back to the mm default.

**Impact**: the Tour-Average golf captures (`data/C3D_TA_Driver.c3d`, `C3D_TA_Iron.c3d`) declare `UNITS = "m"` via the 1-D form. The parser applied a mm→m scale to data already in meters, producing a golf swing with a ~2 mm bounding box (max |coord| 0.0023 m). The CMU files (`data/cmu_mocap/subject_64/*.c3d`, `UNITS = "mm"`) were only correct because the wrong default coincided with their actual units. Verified against ezc3d ground truth before/after.

## Changes

- `c3d.rs`: accept `dims.len() == 1 || dims.len() == 2` for the UNITS parameter.
- `golden_smoke.rs`: two new Rust regression tests pinning parsed units and human-scale coordinate magnitudes for both capture families.
- New `tests/integration/test_c3d_data_folder_coverage.py`: parametrized over **every** `.c3d` under `data/` (17 files, both types), asserting fps/frame counts, expected marker counts (with occlusion tolerance), human-scale magnitudes (the exact failure mode this bug produced), and that the two capture types report their distinct units through `C3DAdapter`.

## Tests

- `cargo test` in `upstream-mocap-io`: 5/5 pass.
- `maturin develop --release --features python`, then the new integration suite + `tests/unit/motion_pipeline/sources` (c3d/rust selection): 27/27 pass, including `test_c3d_rust_matches_ezc3d` parity.

Note: rebuilding the wheel from current main source surfaced two pre-existing failures in `test_trc_adapter.py::test_trc_load_invalid_lines` and `test_opencap_adapter.py::test_opencap_session_imports_to_canonical_observations` that are unrelated to this change (TRC/OpenCap paths; no diff there). Filing a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)