### PR TITLE
docs: refresh project map and SPEC module map with operational gap inventory

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -70,6 +70,16 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-10** - Refreshed the Module Map against the actual source tree
+  (the previous tree listed entry points and API files that no longer
+  exist) and linked the operational project map. The full gap inventory
+  from the 2026-06-10 operational deep dive lives in
+  `docs/architecture/PROJECT_MAP.md` §16, tracked by issues #7202–#7221
+  (model-composition epic, sidekick agent wiring, C3D/Rust analog support,
+  startup + config consolidation, and related work). Landed alongside:
+  sidekick subtab host port + pop-out lifecycle hooks (#7199), the Rust C3D
+  1-D `POINT:UNITS` fix with full `data/` coverage (#7200), and sibling
+  model-repository discovery in the model explorer (#7201).
 - **2026-06-10** - Resolved Python-version provenance drift for #7160:
   `pyproject.toml`, `install.sh`, `CLAUDE.md`, user-facing installation docs,
   `SPEC.md`, the standard CI test matrix, Docker base images, and
@@ -231,78 +241,67 @@ UpstreamDrift sits at the center of a biomechanical simulation ecosystem. It dep
 
 ### Module Map
 
-| 2026-06-03 | 1.0.224 | Bolt: Optimized `np.linalg.norm(v[:2])` to `math.hypot(v[0], v[1])` in `ball_trajectory_analysis.py` to avoid temporary array allocation and speed up calculation. |
+The operational companion to this map (startup phases, tab/sidekick wiring,
+and the tracked implementation-gap inventory) lives in
+[`docs/architecture/PROJECT_MAP.md`](docs/architecture/PROJECT_MAP.md) §16.
 
 ````
 UpstreamDrift/
+├── launch_upstream_drift.py        # Canonical entry point (web/classic/api-only/engine)
+├── launch_golf_suite.py            # Legacy alias entry point (console script target; #7215)
 ├── src/
 │   ├── engines/
-│   │   ├── physics_engines/        # Engine adapters and integrations (package directories)
-│   │   │   ├── mujoco/             # MuJoCo backend (supported)
+│   │   ├── physics_engines/        # Engine adapters (package directories)
+│   │   │   ├── mujoco/             # MuJoCo backend (core)
 │   │   │   ├── drake/              # Drake backend (extended)
 │   │   │   ├── pinocchio/          # Pinocchio backend (extended)
+│   │   │   ├── jaxsim/             # JaxSim backend (beta)
 │   │   │   ├── opensim/            # OpenSim backend (experimental)
 │   │   │   ├── myosuite/           # MyoSuite backend (experimental)
 │   │   │   ├── pendulum/           # Simplified educational models
 │   │   │   └── putting_green/      # Putting green simulation
-│   │   └── pendulum_models/        # Simplified educational models
-│   │       ├── twodof_pendulum.py
-│   │       └── biomechanical_pendulum.py
-│   ├── launchers/                  # GUI/CLI entry points
-│   │   ├── upstream_drift_launcher.py        # PyQt6 professional GUI (main entrypoint)
-│   │   ├── golf_suite_launcher.py  # Multi-engine suite launcher
-│   │   ├── unified_launcher.py     # Unified launcher interface
-│   │   └── cli_launcher.py         # Command-line interface
-│   ├── api/                        # FastAPI REST backend
-│   │   ├── main.py                 # API entry point
-│   │   ├── endpoints/              # REST endpoint definitions
-│   │   └── models.py               # Pydantic request/response models
-│   ├── config/                     # Configuration management
-│   │   └── launcher_manifest_loader.py # Config loading and validation
-│   ├── shared/                     # Cross-engine utilities
-│   │   ├── validators.py           # Shared validation logic
-│   │   ├── utilities.py            # Helper functions
-│   │   └── exceptions.py           # Exception definitions
-
-│   └── tools/                      # Development and analysis tools
-│       ├── analysis_tools.py       # Biomechanical analysis utilities
-│       └── validation_tools.py     # Cross-engine validation
-├── rust_core/
-│   └── upstream-physics/           # Rust physics kernels
-│       ├── src/
-│       │   ├── lib.rs
-│       │   └── physics.rs
-│       └── Cargo.toml
-├── ui/
-│   ├── src/
-│   │   ├── main.ts                 # Tauri app entry point
-│   │   └── components/             # React/Vue components
-│   ├── tauri.conf.json
-│   └── package.json
-├── shared/
-│   └── models/                     # URDF/model definitions
-│       ├── golf_swing_models/
-│       ├── human_body_models/
-│       └── pendulum_models/
-├── tests/
-│   ├── unit/                       # Unit tests per module
-│   ├── integration/                # Cross-engine integration tests
-│   ├── acceptance/                 # End-to-end scenario tests
-│   ├── cross_engine/               # Cross-validation tests
-│   ├── physics_validation/         # Physics accuracy tests
-│   ├── benchmarks/                 # Performance benchmarks
-│   └── conftest.py                 # Pytest fixtures and configuration
-├── .github/
-│   └── workflows/
-
-│       ├── ci-standard.yml         # Standard CI checks
-│       ├── heavy-tests-opt-in.yml  # Heavy tests (custom runner)
-│       ├── nightly-cross-validation.yml
-│       ├── tauri-build.yml
-│       ├── vendor-freshness.yml
-│       └── docker-size-gates.yml
-├── pyproject.toml
-├── poetry.lock
+│   │   ├── pendulum_models/        # Educational pendulum models
+│   │   └── Simscape_Multibody_Models/  # MATLAB models + C3D viewer app
+│   ├── launchers/                  # PyQt6 launcher (50+ modules)
+│   │   ├── upstream_drift_launcher.py  # Main window (size split tracked: #7217)
+│   │   ├── embedded_host.py        # Tab/dock host: pop-out, backgrounding
+│   │   ├── embedded_tool_bootstrap.py  # Embeddable-adapter registration
+│   │   ├── sidekick_host_port.py   # Sidekick agent ↔ tabs bridge (subtab port)
+│   │   └── {mujoco,drake,pinocchio,jaxsim}_dashboard.py, dialogs, theme, …
+│   ├── api/                        # FastAPI backend
+│   │   ├── local_server.py         # Server entry (web UI host)
+│   │   ├── routes/                 # 30+ endpoint modules
+│   │   ├── services/               # Simulation/chat/analysis services
+│   │   └── auth/, middleware/, models/, utils/
+│   ├── config/                     # Launcher manifest + models.yaml loaders
+│   ├── tools/                      # Embeddable tool tabs (model_explorer,
+│   │                               # ball_flight_gui, putting_green_gui,
+│   │                               # swing_flight_pipeline, pose_studio,
+│   │                               # video_analyzer, sidekick, …)
+│   └── shared/python/              # Cross-cutting libraries; highlights:
+│       ├── engine_core/            # EngineManager/Registry/probes/capabilities
+│       ├── launcher_embed/         # EmbeddableTool contract + registry (ADR-0013)
+│       ├── physics/                # Ball flight models, impact, swing→flight pipeline
+│       ├── motion_pipeline/        # Mocap ingestion (C3D/TRC/BVH), IK backends
+│       ├── model_generation/       # URDF/MJCF parsing, Frankenstein editor (VENDORED)
+│       ├── sidekick/               # Shared tools library + agent layer (VENDORED)
+│       ├── humanoid_character_builder/  # Parametric humanoid URDF generation
+│       └── pose_interchange/, realtime/, simulation_backends/, config/, …
+├── rust_core/                      # Maturin crates
+│   ├── upstream-physics/           # Ball flight, aero, contact, RK4 kernels
+│   ├── upstream-mocap-io/          # C3D/TRC/BVH parsers (PyO3)
+│   ├── upstream-mocap-preproc/, upstream-urdf/, upstream-mesh/,
+│   ├── upstream-muscle/, upstream-motion-matching/, upstream-pinocchio-id/,
+│   └── upstream-realtime/, upstream-codemap/, ai_backend/
+├── ui/                             # React + Tauri launcher (manifest-driven)
+├── vendor/ud-tools/                # Vendored Tools repo (canonical for sidekick
+│                                   # and model_generation packages)
+├── data/                           # Sample data incl. C3D captures (golf TA + CMU)
+├── tests/                          # unit/, integration/, launchers/, api/, tools/,
+│                                   # heavy_integration/, benchmarks/, …
+├── scripts/                        # CI gates + config baselines (scripts/config/)
+├── docs/                           # ADRs, architecture (PROJECT_MAP.md), guides
+├── pyproject.toml                  # Canonical dependency + console-script source
 ├── SPEC.md                         # This file
 └── README.md
 

--- a/docs/architecture/PROJECT_MAP.md
+++ b/docs/architecture/PROJECT_MAP.md
@@ -1,11 +1,13 @@
 # UpstreamDrift - Complete Project Map
 
-> **Version 2.1** | Last updated: February 2026
+> **Version 2.1.1** | Last updated: 2026-06-10
 >
 > This document is the single comprehensive reference for every feature,
 > module, and tool in the UpstreamDrift Golf Modeling Suite. It is designed
 > to give users (and developers) full visibility into what the platform can
 > do, including features that are not yet exposed as launcher tiles.
+> Section 16 is the operational gap inventory — the started-but-unfinished
+> seams, each tracked by a GitHub issue.
 
 ---
 
@@ -26,6 +28,7 @@
 13. [Examples & Tutorials](#13-examples--tutorials)
 14. [Hidden / Unexposed Features](#14-hidden--unexposed-features-summary)
 15. [Deprecated / Archived Code](#15-deprecated--archived-code)
+16. [Operational Status & Gap Inventory](#16-operational-status--gap-inventory-2026-06-10)
 
 ---
 
@@ -654,3 +657,75 @@ python3 launch_golf_suite.py --engine pendulum
 # Custom port
 python3 launch_golf_suite.py --port 9000
 ```
+
+---
+
+## 16. Operational Status & Gap Inventory (2026-06-10)
+
+Findings from the 2026-06-10 operational deep dive across simulation
+processes, the launcher tab architecture, model composition, the C3D
+pipeline, and startup wiring. Working subsystems are noted for context;
+every gap is tracked by a dedicated issue with detailed instructions.
+
+### Verified working
+
+- **Putting simulation** — full pipeline (roll physics, green surface,
+  stroke params) with GUI tile and REST endpoints; integration tests pass.
+- **Ball flight** — seven literature flight models behind one registry,
+  Rust kernel preferred, GUI tile wired.
+- **Full swing forward dynamics** — engine (MuJoCo/Drake/Pinocchio) →
+  `SwingState` → impact solver → ball flight via
+  `swing_ball_flight_pipeline.py`; GUI tile wired.
+- **Engine loading** — all engines load through `LOADER_MAP` factories +
+  runtime probes in `engine_core`; missing wheels degrade to UNAVAILABLE
+  instead of crashing discovery.
+- **Tabs/pop-out** — `EmbeddedHostWidget` supports keep-running
+  backgrounding and pop-out windows that re-dock on close (state is never
+  destroyed by a pop-out close); pop-out transitions call the tools''
+  pause/resume hooks (PR #7199).
+- **C3D reading** — both capture families in `data/` (Tour-Average golf,
+  meters; CMU academic, millimeters) load correctly through the Rust
+  parser after the 1-D `POINT:UNITS` fix (PR #7200), with every file
+  covered by `tests/integration/test_c3d_data_folder_coverage.py`.
+- **Sibling model repos** — the model explorer discovers URDF/MJCF models
+  in `Drake_Models` / `MuJoCo_Models` / `Pinocchio_Models` /
+  `OpenSim_Models` next to the checkout (PR #7201;
+  `UD_SIBLING_MODEL_REPOS` overrides the roots).
+
+### Tracked gaps
+
+| Area                     | Gap                                                                                    | Issue |
+| ------------------------ | -------------------------------------------------------------------------------------- | ----- |
+| Model composition (epic) | Mix-and-match robots + biomechanics flagship                                           | #7202 |
+| Model composition        | OpenSim `.osim` loader missing                                                         | #7203 |
+| Model composition        | Drake `.sdf` loader missing                                                            | #7204 |
+| Model composition        | No validation of composed models (loops/mass/geometry)                                 | #7205 |
+| Model composition        | No attachment-point semantics                                                          | #7206 |
+| Model composition        | Drag-drop composition UX + 3D preview                                                  | #7207 |
+| Model conversion         | MJCF round-trip drops FIXED joints                                                     | #7208 |
+| Sidekick                 | Agent mode not registered in the chat panel (port exists, service unwired)             | #7209 |
+| Launcher                 | No shared event bus / context between tools                                            | #7210 |
+| Launcher                 | Hard-coded embeddable-adapter bootstrap list                                           | #7211 |
+| Mocap                    | Rust C3D parser lacks analog channels / force plates / events                          | #7212 |
+| Mocap                    | TRC + OpenCap tests fail against a fresh-built wheel                                   | #7213 |
+| Mocap                    | 3D viewer is matplotlib-bound; no GPU playback path                                    | #7214 |
+| Startup                  | Duplicate entry scripts; eager engine imports; no headless Qt fallback                 | #7215 |
+| Config                   | Three config dirs (`config/`, `configs/`, `src/shared/python/config/`) with no arbiter | #7216 |
+| Tech debt                | `upstream_drift_launcher.py` exceeds the 1200-line budget (2700+)                      | #7217 |
+| Simulation               | Ball flight has no REST endpoint (putting green does)                                  | #7218 |
+| Simulation               | Two divergent MATLAB engine launch paths                                               | #7219 |
+| Simulation               | No inverse swing optimization (target flight → swing)                                  | #7220 |
+| React UI                 | Tabs/pop-out/backgrounding parity vs multi-window undecided                            | #7221 |
+
+### Vendoring rule (recurring trap)
+
+`src/shared/python/model_generation/**` and `src/shared/python/sidekick/**`
+are vendored child copies of the Tools repository (header: "WARNING: DO NOT
+EDIT"). Canonical changes land in Tools and sync here; first-party additions
+belong under `src/tools/` or `src/launchers/` and must not shadow a Tools
+module (`tests/unit/repo_hygiene/` enforces this).
+
+### Maintenance
+
+Update §16 when a tracked gap closes (strike the row, link the PR) or a new
+gap is found — the same cadence as SPEC.md §4.


### PR DESCRIPTION
## Summary

Documentation companion to the 2026-06-10 operational deep dive (PRs #7199, #7200, #7201; issues #7202–#7221).

- **`docs/architecture/PROJECT_MAP.md`**: bumped to 2.1.1 / 2026-06-10 and added **§16 Operational Status & Gap Inventory** — what was verified working (putting / ball-flight / swing→flight pipelines, probe-based engine loading, tab pop-out + backgrounding, C3D loading for both capture families, sibling model-repo discovery) and a table mapping every identified implementation gap to its tracking issue, plus the recurring vendored-package editing trap (`model_generation`/`sidekick` are Tools child copies).
- **`SPEC.md`**: the §4 Module Map listed entry points and API files that do not exist (`golf_suite_launcher.py` as "multi-engine suite launcher", `unified_launcher.py`, `cli_launcher.py`, `src/api/main.py`, `endpoints/`) and contained a stray changelog table row inside the section. Replaced with an accurate tree (verified against the source tree), linked the operational map, and added a dated Recent Spec Updates entry.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)