### PR TITLE
fix(physics): ball-flight launch-angle/spin unit bug (tour driver carried 0 m)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.289                                            |
+| **Spec Version**        | 1.0.291                                            |
 | **Last Spec Update**    | 2026-06-10                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,17 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-10** - Corrected the ball-flight launch-condition unit contract
+  for #7246. `LaunchConditions` remains radians for launch/azimuth angles and
+  RPM for spin rate, while `LaunchConditions.from_user_units(...)` is now the
+  canonical degree-to-radian conversion boundary for GUI and swing-pipeline
+  callers so user-facing degrees and impact rad/s spin do not collapse carry
+  distance to zero.
+- **2026-06-10** - Extended the Rust C3D parser for #7212. The
+  `upstream-mocap-io` C3D path now decodes int16 and float analog channel data,
+  surfaces additive PyO3 `analog` and `force_platforms` keys, parses
+  `FORCE_PLATFORM:{TYPE,CHANNEL,CORNERS,ORIGIN}`, and preserves existing
+  marker/event dictionary keys and marker-only fixture behavior.
 - **2026-06-10** - Completed the #7205 Frankenstein composition validation
   surface. `CompositionValidator` now emits warning-level findings for heavy
   attached subtrees and direct attachment geometry AABB overlaps, while the
@@ -883,6 +894,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10 | 1.0.291 | Corrected the ball-flight launch-condition unit contract for #7246. `LaunchConditions` continues to store launch/azimuth angles in radians and spin rate in RPM, and `LaunchConditions.from_user_units(...)` is now the canonical user-facing conversion boundary used by the ball-flight GUI and swing-to-flight pipeline. The pipeline converts impact rad/s spin back to RPM before simulation, and regression tests pin the tour-driver carry sanity gate so degree/rad-s misuse cannot silently collapse carry to zero again. |
 | 2026-06-10 | 1.0.290 | Rust C3D analog and force-platform metadata slice for #7212. `upstream-mocap-io` now decodes C3D analog channels in int16 mode with SCALE/OFFSET/GEN_SCALE and in float mode without int scaling, advances marker frame stride across analog-bearing records, parses FORCE_PLATFORM TYPE/CHANNEL/CORNERS/ORIGIN metadata, and exposes additive PyO3 `analog` / `force_platforms` keys while preserving existing marker/event keys and marker-only fixture behavior. |
 | 2026-06-10 | 1.0.289 | Completed the Frankenstein composition validation surface for #7205. `CompositionValidator` now emits warning-level `subtree_mass_ratio` findings when attached subtree mass exceeds roughly 2x the parent chain mass and `geometry_overlap` findings when directly attached link AABBs overlap. The active Frankenstein model panel now renders current validation findings in a dedicated list so warnings and blocking errors are visible before save/export. |
 | 2026-06-10 | 1.0.288 | React/Tauri launcher parity decision (#7221). Added ADR-0028 choosing the manifest-driven multi-window Tauri model while keeping PyQt canonical for embedded tabs/docks. The React dashboard now persists a manifest-keyed launcher window registry, reconciles it with `useLauncherManifest.ts`, and exposes a window list/focus menu that reuses the local launcher API. |

--- a/src/shared/python/physics/ball_launch_conditions.py
+++ b/src/shared/python/physics/ball_launch_conditions.py
@@ -7,6 +7,7 @@ sprint decomposition (issue #2486).
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -17,13 +18,81 @@ from src.shared.python.physics.atmosphere import air_density as _isa_air_density
 
 @dataclass(frozen=True)
 class LaunchConditions:
-    """Initial launch conditions."""
+    """Initial launch conditions for the ball-flight simulator.
+
+    Units (the contract every consumer relies on — see
+    ``BallFlightSimulator`` and ``flight_models``):
+
+    * ``velocity`` — ball speed in metres per second.
+    * ``launch_angle`` — vertical launch angle in **radians** above the
+      horizontal. Consumers feed it straight into ``cos``/``sin``.
+    * ``azimuth_angle`` — horizontal bearing in **radians** (0 = +x).
+    * ``spin_rate`` — backspin magnitude in **RPM** (revolutions per
+      minute). Consumers convert with ``* 2*pi/60`` to rad/s.
+    * ``spin_axis`` — unit vector of the spin axis.
+
+    Golf inputs are conventionally given in degrees and RPM; build from
+    those with :meth:`from_user_units` rather than constructing this
+    dataclass directly, so the degree→radian conversion happens in one
+    place (DRY) and cannot be forgotten.
+    """
 
     velocity: float
     launch_angle: float
     azimuth_angle: float = 0.0
     spin_rate: float = 0.0
     spin_axis: np.ndarray = field(default_factory=lambda: np.array([0.0, -1.0, 0.0]))
+
+    @classmethod
+    def from_user_units(
+        cls,
+        velocity: float,
+        launch_angle_deg: float,
+        azimuth_deg: float = 0.0,
+        spin_rate_rpm: float = 0.0,
+        spin_axis: np.ndarray | None = None,
+    ) -> LaunchConditions:
+        """Build ``LaunchConditions`` from golf-facing units.
+
+        Converts ``launch_angle_deg`` and ``azimuth_deg`` (degrees) into
+        the radians this dataclass stores; ``spin_rate_rpm`` is already
+        the stored unit (RPM) and is passed through. This is the single
+        conversion seam — callers that hand-built the dataclass with
+        degrees (and rad/s) silently produced garbage trajectories.
+
+        Args:
+            velocity: Ball speed [m/s], must be finite and >= 0.
+            launch_angle_deg: Vertical launch angle [degrees].
+            azimuth_deg: Horizontal bearing [degrees], 0 = +x.
+            spin_rate_rpm: Backspin magnitude [RPM], must be >= 0.
+            spin_axis: Optional spin-axis unit vector; defaults to the
+                pure-backspin axis.
+
+        Returns:
+            A ``LaunchConditions`` with angles in radians and spin in RPM.
+
+        Raises:
+            ValueError: If ``velocity`` or ``spin_rate_rpm`` is negative
+                or non-finite.
+        """
+        if not math.isfinite(velocity) or velocity < 0.0:
+            raise ValueError(f"velocity must be finite and >= 0, got {velocity!r}")
+        if not math.isfinite(spin_rate_rpm) or spin_rate_rpm < 0.0:
+            raise ValueError(
+                f"spin_rate_rpm must be finite and >= 0, got {spin_rate_rpm!r}"
+            )
+        axis = (
+            np.asarray(spin_axis, dtype=float)
+            if spin_axis is not None
+            else np.array([0.0, -1.0, 0.0])
+        )
+        return cls(
+            velocity=float(velocity),
+            launch_angle=math.radians(launch_angle_deg),
+            azimuth_angle=math.radians(azimuth_deg),
+            spin_rate=float(spin_rate_rpm),
+            spin_axis=axis,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/shared/python/physics/swing_ball_flight_pipeline.py
+++ b/src/shared/python/physics/swing_ball_flight_pipeline.py
@@ -81,6 +81,7 @@ class FlightSimulatorProtocol(Protocol):
 # ---------------------------------------------------------------------------
 
 _MAX_LAUNCH_ANGLE_DEG: float = 90.0
+_MAX_LAUNCH_ANGLE_RAD: float = math.pi / 2.0  # launch_angle is stored in radians
 _MIN_LAUNCH_SPEED_MS: float = 0.0  # exclusive lower bound
 
 # ---------------------------------------------------------------------------
@@ -191,20 +192,24 @@ class _LaunchConditionsDeriver:
             azimuth_deg = float(np.degrees(np.arctan2(ball_vel[1], ball_vel[0])))
 
         spin_w = post.ball_angular_velocity
-        spin_rate = float(
+        # Impact solver reports angular velocity in rad/s; LaunchConditions
+        # stores RPM (the unit BallFlightSimulator expects). Converting via
+        # from_user_units keeps the rad/s → RPM step in one place.
+        spin_rate_rad_s = float(
             math.hypot(spin_w[0], spin_w[1], spin_w[2])
         )  # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm
+        spin_rate_rpm = spin_rate_rad_s * 60.0 / (2.0 * math.pi)
         spin_axis = (
-            post.ball_angular_velocity / spin_rate
-            if spin_rate > 1e-12
+            post.ball_angular_velocity / spin_rate_rad_s
+            if spin_rate_rad_s > 1e-12
             else np.array([0.0, -1.0, 0.0])
         )
 
-        return LaunchConditions(
+        return LaunchConditions.from_user_units(
             velocity=speed,
-            launch_angle=launch_angle_deg,
-            azimuth_angle=azimuth_deg,
-            spin_rate=spin_rate,
+            launch_angle_deg=launch_angle_deg,
+            azimuth_deg=azimuth_deg,
+            spin_rate_rpm=spin_rate_rpm,
             spin_axis=np.asarray(spin_axis, dtype=float),
         )
 
@@ -489,7 +494,8 @@ class SwingBallFlightPipeline:
             launch.velocity,
         )
         require(
-            0.0 <= launch.launch_angle <= _MAX_LAUNCH_ANGLE_DEG,
-            f"launch_angle must be in [0°, {_MAX_LAUNCH_ANGLE_DEG}°]",
+            0.0 <= launch.launch_angle <= _MAX_LAUNCH_ANGLE_RAD,
+            f"launch_angle must be in [0, {_MAX_LAUNCH_ANGLE_RAD:.4f}] rad "
+            f"([0°, {_MAX_LAUNCH_ANGLE_DEG}°])",
             launch.launch_angle,
         )

--- a/src/tools/ball_flight_gui/gui.py
+++ b/src/tools/ball_flight_gui/gui.py
@@ -211,13 +211,15 @@ class BallFlightWidget(QWidget):
             )
 
             speed_ms = self._speed_spin.value() * 0.44704  # mph to m/s
-            angle = self._angle_spin.value()
-            spin_rps = self._spin_spin.value() / 60.0 * 2 * np.pi  # rpm to rad/s
 
-            launch = LaunchConditions(
+            # LaunchConditions stores radians + RPM; from_user_units does the
+            # degree→radian conversion and keeps RPM. Passing degrees as the
+            # raw launch_angle (and rad/s as spin_rate) previously drove the
+            # ball straight into the ground (carry = 0).
+            launch = LaunchConditions.from_user_units(
                 velocity=speed_ms,
-                launch_angle=angle,
-                spin_rate=spin_rps,
+                launch_angle_deg=self._angle_spin.value(),
+                spin_rate_rpm=self._spin_spin.value(),
             )
 
             sim = BallFlightSimulator()
@@ -232,7 +234,8 @@ class BallFlightWidget(QWidget):
                     f"Ball Flight Results\n"
                     f"{'=' * 40}\n"
                     f"Launch: {self._speed_spin.value():.0f} mph, "
-                    f"{angle:.1f}°, {self._spin_spin.value():.0f} rpm\n\n"
+                    f"{self._angle_spin.value():.1f}°, "
+                    f"{self._spin_spin.value():.0f} rpm\n\n"
                     f"Carry:       {carry:.1f} m ({carry * 1.09361:.1f} yd)\n"
                     f"Max Height:  {max_h:.1f} m ({max_h * 3.28084:.1f} ft)\n"
                     f"Flight Time: {last.time:.2f} s\n"

--- a/src/tools/ball_flight_gui/gui.py
+++ b/src/tools/ball_flight_gui/gui.py
@@ -43,19 +43,39 @@ class BallFlightWidget(QWidget):
     def _build_ui(self) -> None:
         layout = QHBoxLayout(self)
         splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.addWidget(self._build_controls_panel())
+        splitter.addWidget(self._build_results_panel())
+        splitter.setSizes([350, 650])
+        layout.addWidget(splitter)
 
-        # Left: controls
+    def _build_controls_panel(self) -> QWidget:
         left = QWidget()
         left_layout = QVBoxLayout(left)
+        self._add_title(left_layout)
+        left_layout.addWidget(self._build_launch_group())
+        left_layout.addWidget(self._build_environment_group())
+        left_layout.addWidget(self._build_aero_group())
+        left_layout.addWidget(self._build_preset_group())
 
+        self._run_btn = QPushButton("Simulate Flight")
+        self._run_btn.setStyleSheet(
+            "background-color: #1565C0; color: white; font-weight: bold; padding: 12px;"
+        )
+        self._run_btn.clicked.connect(self._run_simulation)
+        left_layout.addWidget(self._run_btn)
+        left_layout.addStretch()
+        return left
+
+    @staticmethod
+    def _add_title(layout: QVBoxLayout) -> None:
         title = QLabel("Aerodynamic Ball Flight Simulator")
         title_font = title.font()
         title_font.setPointSize(14)
         title_font.setBold(True)
         title.setFont(title_font)
-        left_layout.addWidget(title)
+        layout.addWidget(title)
 
-        # Launch conditions
+    def _build_launch_group(self) -> QGroupBox:
         launch_group = QGroupBox("Launch Conditions")
         launch_form = QFormLayout(launch_group)
 
@@ -82,10 +102,9 @@ class BallFlightWidget(QWidget):
         self._sidespin_spin.setValue(0.0)
         self._sidespin_spin.setSuffix(" rpm")
         launch_form.addRow("Sidespin:", self._sidespin_spin)
+        return launch_group
 
-        left_layout.addWidget(launch_group)
-
-        # Environment
+    def _build_environment_group(self) -> QGroupBox:
         env_group = QGroupBox("Environment")
         env_form = QFormLayout(env_group)
 
@@ -106,10 +125,9 @@ class BallFlightWidget(QWidget):
         self._altitude.setValue(0.0)
         self._altitude.setSuffix(" ft")
         env_form.addRow("Altitude:", self._altitude)
+        return env_group
 
-        left_layout.addWidget(env_group)
-
-        # Aerodynamic options
+    def _build_aero_group(self) -> QGroupBox:
         aero_group = QGroupBox("Aerodynamic Model")
         aero_layout = QVBoxLayout(aero_group)
         self._chk_dimples = QCheckBox("Dimple geometry effects")
@@ -120,9 +138,9 @@ class BallFlightWidget(QWidget):
         aero_layout.addWidget(self._chk_magnus)
         self._chk_seam = QCheckBox("Seam orientation effects")
         aero_layout.addWidget(self._chk_seam)
-        left_layout.addWidget(aero_group)
+        return aero_group
 
-        # Presets
+    def _build_preset_group(self) -> QGroupBox:
         preset_group = QGroupBox("Club Presets")
         preset_layout = QHBoxLayout(preset_group)
         for name, speed, angle, spin in [
@@ -135,20 +153,9 @@ class BallFlightWidget(QWidget):
                 lambda checked, s=speed, a=angle, sp=spin: self._apply_preset(s, a, sp)
             )
             preset_layout.addWidget(btn)
-        left_layout.addWidget(preset_group)
+        return preset_group
 
-        # Run
-        self._run_btn = QPushButton("Simulate Flight")
-        self._run_btn.setStyleSheet(
-            "background-color: #1565C0; color: white; font-weight: bold; padding: 12px;"
-        )
-        self._run_btn.clicked.connect(self._run_simulation)
-        left_layout.addWidget(self._run_btn)
-
-        left_layout.addStretch()
-        splitter.addWidget(left)
-
-        # Right: results
+    def _build_results_panel(self) -> QWidget:
         right = QWidget()
         right_layout = QVBoxLayout(right)
         results_group = QGroupBox("Flight Results")
@@ -192,10 +199,7 @@ class BallFlightWidget(QWidget):
         )
         results_layout.addWidget(self._results_text)
         right_layout.addWidget(results_group)
-        splitter.addWidget(right)
-
-        splitter.setSizes([350, 650])
-        layout.addWidget(splitter)
+        return right
 
     def _apply_preset(self, speed: float, angle: float, spin: float) -> None:
         self._speed_spin.setValue(speed)

--- a/tests/unit/physics/test_launch_conditions_units_7223.py
+++ b/tests/unit/physics/test_launch_conditions_units_7223.py
@@ -1,0 +1,95 @@
+"""Unit-convention regression tests for LaunchConditions (#7223).
+
+BallFlightSimulator, ball_enhanced_simulator, and flight_models all read
+``launch_angle`` as radians and ``spin_rate`` as RPM. The swing→flight
+pipeline and the ball-flight GUI used to construct LaunchConditions with
+degrees and rad/s, which drove the ball straight into the ground
+(carry = 0). These tests pin the contract and the conversion seam.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.physics.ball_launch_conditions import LaunchConditions
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestFromUserUnits:
+    def test_converts_degrees_to_radians(self) -> None:
+        lc = LaunchConditions.from_user_units(
+            velocity=70.0, launch_angle_deg=12.0, azimuth_deg=3.0
+        )
+        assert lc.launch_angle == pytest.approx(math.radians(12.0))
+        assert lc.azimuth_angle == pytest.approx(math.radians(3.0))
+
+    def test_spin_rpm_passes_through(self) -> None:
+        lc = LaunchConditions.from_user_units(
+            velocity=70.0, launch_angle_deg=12.0, spin_rate_rpm=2700.0
+        )
+        assert lc.spin_rate == pytest.approx(2700.0)
+
+    def test_default_spin_axis_is_backspin(self) -> None:
+        lc = LaunchConditions.from_user_units(velocity=70.0, launch_angle_deg=12.0)
+        assert np.allclose(lc.spin_axis, [0.0, -1.0, 0.0])
+
+    def test_custom_spin_axis_preserved(self) -> None:
+        lc = LaunchConditions.from_user_units(
+            velocity=70.0,
+            launch_angle_deg=12.0,
+            spin_axis=np.array([1.0, 0.0, 0.0]),
+        )
+        assert np.allclose(lc.spin_axis, [1.0, 0.0, 0.0])
+
+    @pytest.mark.parametrize("bad", [-1.0, float("nan"), float("inf")])
+    def test_rejects_bad_velocity(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="velocity"):
+            LaunchConditions.from_user_units(velocity=bad, launch_angle_deg=12.0)
+
+    @pytest.mark.parametrize("bad", [-1.0, float("nan"), float("inf")])
+    def test_rejects_bad_spin(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="spin_rate_rpm"):
+            LaunchConditions.from_user_units(
+                velocity=70.0, launch_angle_deg=12.0, spin_rate_rpm=bad
+            )
+
+
+def _rust_available() -> bool:
+    from src.shared.python.physics.rust_kernel import is_rust_available
+
+    return bool(is_rust_available())
+
+
+@pytest.mark.skipif(not _rust_available(), reason="upstream_physics kernel not built")
+class TestTourDriverCarryIsPhysical:
+    """A tour-driver launch must carry a sane distance, not 0.
+
+    This is the exact failure mode the unit bug produced: with degrees
+    fed where radians were expected, sin(launch_angle) went negative and
+    carry collapsed to 0.
+    """
+
+    def test_correct_units_give_sane_carry(self) -> None:
+        from src.shared.python.physics.ball_simulator import BallFlightSimulator
+
+        lc = LaunchConditions.from_user_units(
+            velocity=75.0, launch_angle_deg=11.0, spin_rate_rpm=2700.0
+        )
+        traj = BallFlightSimulator().simulate_trajectory(lc, max_time=12.0, dt=0.005)
+        carry = float(np.hypot(traj[-1].position[0], traj[-1].position[1]))
+        max_h = max(p.position[2] for p in traj)
+        assert 180.0 < carry < 320.0, f"unphysical carry {carry:.1f} m"
+        assert 20.0 < max_h < 120.0, f"unphysical apex {max_h:.1f} m"
+
+    def test_raw_degrees_would_collapse_carry(self) -> None:
+        # Documents the bug: passing degrees as raw radians collapses carry.
+        from src.shared.python.physics.ball_simulator import BallFlightSimulator
+
+        broken = LaunchConditions(velocity=75.0, launch_angle=11.0, spin_rate=283.0)
+        traj = BallFlightSimulator().simulate_trajectory(broken, max_time=12.0, dt=0.01)
+        carry = float(np.hypot(traj[-1].position[0], traj[-1].position[1]))
+        assert carry < 10.0  # the old (wrong) behaviour

--- a/tests/unit/physics/test_swing_ball_flight_pipeline_5337.py
+++ b/tests/unit/physics/test_swing_ball_flight_pipeline_5337.py
@@ -306,23 +306,28 @@ class TestLaunchConditionsDeriver:
         assert lc.velocity == pytest.approx(65.0, rel=1e-4)
 
     def test_launch_angle_matches_geometry(self):
+        # LaunchConditions stores launch_angle in RADIANS (#7223), so the
+        # derived angle must equal the geometric angle converted to radians.
         angle_deg = 15.0
         post = _make_post_impact(speed=60.0, angle_deg=angle_deg)
         lc = self.deriver.derive(post)
-        assert lc.launch_angle == pytest.approx(angle_deg, abs=0.1)
+        assert lc.launch_angle == pytest.approx(math.radians(angle_deg), abs=1e-3)
 
     def test_zero_horizontal_speed_gives_90_degree_angle(self):
         post = _make_post_impact(speed=10.0, angle_deg=0.0)
         # Override to pure vertical
         post.ball_velocity[:] = np.array([0.0, 0.0, 10.0])
         lc = self.deriver.derive(post)
-        assert lc.launch_angle == pytest.approx(90.0, abs=0.1)
+        assert lc.launch_angle == pytest.approx(math.radians(90.0), abs=1e-3)
 
-    def test_spin_rate_matches_angular_velocity_magnitude(self):
+    def test_spin_rate_is_rpm_from_angular_velocity_magnitude(self):
+        # ball_angular_velocity is rad/s; LaunchConditions.spin_rate is RPM
+        # (the unit BallFlightSimulator expects) — #7223.
         post = _make_post_impact()
         post.ball_angular_velocity[:] = np.array([0.0, -200.0, 0.0])
         lc = self.deriver.derive(post)
-        assert lc.spin_rate == pytest.approx(200.0, rel=1e-4)
+        expected_rpm = 200.0 * 60.0 / (2.0 * math.pi)
+        assert lc.spin_rate == pytest.approx(expected_rpm, rel=1e-4)
 
 
 # ===========================================================================


### PR DESCRIPTION
## The bug

`LaunchConditions.launch_angle` is consumed as **radians** and `spin_rate` as **RPM** — the contract that `BallFlightSimulator`, `ball_enhanced_simulator`, `flight_models` (whose factory does `launch_angle=math.radians(deg)`, `spin_rate=rpm`), and the ball-flight REST route (`math.radians(...)`, RPM) all share.

Two callers fed **degrees + rad/s** instead:
- `swing_ball_flight_pipeline._LaunchConditionsDeriver` passed `launch_angle_deg` and a rad/s spin magnitude.
- `ball_flight_gui` passed the degree spinbox value and converted RPM→rad/s (variable literally named `spin_rps`).

Because `sin(11 rad)` is negative, the initial vertical velocity pointed **down** and the ball drove into the ground. Verified empirically against the Rust kernel:

```
Interp A (radians+RPM):    carry=254.0 m  maxH=71.0 m   ← correct
Interp B (degrees+rad/s):  carry=  0.0 m  maxH= 0.0 m   ← what both callers passed
```

So the ball-flight GUI produced **carry = 0 on every shot**, and every swing→flight pipeline trajectory was corrupted.

## The fix (DRY single conversion seam)

- `ball_launch_conditions.py`: documented the unit contract on every field and added `LaunchConditions.from_user_units(velocity, launch_angle_deg, azimuth_deg, spin_rate_rpm, spin_axis)` — the one place deg→rad happens and RPM passes through, with finite/non-negative DbC validation. Callers should never hand-build the dataclass with raw user units again.
- `swing_ball_flight_pipeline.py`: derive via `from_user_units`, converting the impact solver's rad/s spin to RPM; the launch-angle precondition now validates radians `[0, π/2]` (it had been validating the value as if it were degrees `[0, 90]`).
- `ball_flight_gui/gui.py`: build via `from_user_units`.

## Tests

- New `tests/unit/physics/test_launch_conditions_units_7223.py`: conversion unit tests + a **tour-driver carry sanity gate** (radians+RPM → 180–320 m, and a documentation test that the raw-degrees path collapses carry to ~0). The carry tests skip when the `upstream_physics` kernel isn't built.
- Updated `test_swing_ball_flight_pipeline_5337.py`: three deriver tests had encoded the buggy degrees/rad-s convention; they now assert radians + RPM.

All physics + ball-flight GUI + flight-model suites pass locally (Rust kernel built via `maturin develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)