### PR TITLE
Design C3D viewer renderer backend contract

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.298                                            |
+| **Spec Version**        | 1.0.299                                            |
 | **Last Spec Update**    | 2026-06-11                                         |
 
 ## 2. Purpose & Mission
@@ -75,7 +75,9 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
   GPU playback backend while retaining matplotlib fallback, and
   `viewer_3d_backend.py` pins the 60 fps target plus parity checklist for
   scrubbing, speed control, loop playback, marker groups, view presets, and
-  skeleton overlay.
+  skeleton overlay. The BunkerShot calibration optimizer now imports
+  `scipy.optimize` lazily so cross-engine equivalence imports can use
+  `WrenchTrace` without optional calibration optimizer dependencies.
 - **2026-06-10** - Added the #7207 model explorer composition-flow controller.
   `src/tools/model_explorer/composition_flow.py` now attaches a complete
   source URDF model to a working Frankenstein model through a declared
@@ -938,6 +940,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10 | 1.0.299 | Cross-engine equivalence import-boundary fix for #7214. `CalibrationOptimizer.optimize()` now imports `scipy.optimize.differential_evolution` lazily so importing `src.bunkershot3d.postproc.wrench_trace` through shared simulation backends does not require optional calibration optimizer dependencies in the equivalence CI environment. |
 | 2026-06-10 | 1.0.298 | C3D viewer renderer backend decision for #7214. Added ADR-0030 choosing PyQtGL as the first desktop GPU playback path while keeping matplotlib fallback, plus a focused `viewer_3d_backend.py` decision contract that carries the 60 fps target and parity checklist for scrubbing, speed control, loop playback, marker groups, view presets, and skeleton overlay before replacement. |
 | 2026-06-10 | 1.0.297 | Model explorer composition-flow controller for #7207. Added `CompositionFlowController` to attach a complete source URDF model to a working Frankenstein model via selected or declared attachment points, copy links/joints/materials with deterministic name mapping, validate the composed result immediately, and export validation-gated URDF or MJCF preview content. `FrankensteinEditor` now exposes an Attach Source Model action plus public export helper, and `URDFModel.from_file()` carries attachment sidecar metadata into the editor. Focused headless tests cover human-plus-arm composition, MJCF export, validation refusal, and the offscreen editor attach/export path. |
 | 2026-06-10 | 1.0.296 | Model explorer attachment manifests for #7206. Added a first-party `attachment_manifest` parser for versioned `<model>.attachments.json` sidecars, checked in the JSON Schema and docs, exposed declared attachment points plus non-fatal warnings through `ModelLibrary` model info, and updated the attachment dialog to list declared mount points first, prefill their interface-frame origin, and report payload-limit warnings. Focused tests cover valid/missing/malformed manifests, imported-model exposure, dialog defaults, and payload warning contracts. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.297                                            |
+| **Spec Version**        | 1.0.298                                            |
 | **Last Spec Update**    | 2026-06-11                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,12 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-10** - Added the #7214 C3D viewer renderer decision and backend
+  contract. ADR-0030 chooses `pyqtgraph.opengl`/PyQtGL as the first desktop
+  GPU playback backend while retaining matplotlib fallback, and
+  `viewer_3d_backend.py` pins the 60 fps target plus parity checklist for
+  scrubbing, speed control, loop playback, marker groups, view presets, and
+  skeleton overlay.
 - **2026-06-10** - Added the #7207 model explorer composition-flow controller.
   `src/tools/model_explorer/composition_flow.py` now attaches a complete
   source URDF model to a working Frankenstein model through a declared
@@ -932,6 +938,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10 | 1.0.298 | C3D viewer renderer backend decision for #7214. Added ADR-0030 choosing PyQtGL as the first desktop GPU playback path while keeping matplotlib fallback, plus a focused `viewer_3d_backend.py` decision contract that carries the 60 fps target and parity checklist for scrubbing, speed control, loop playback, marker groups, view presets, and skeleton overlay before replacement. |
 | 2026-06-10 | 1.0.297 | Model explorer composition-flow controller for #7207. Added `CompositionFlowController` to attach a complete source URDF model to a working Frankenstein model via selected or declared attachment points, copy links/joints/materials with deterministic name mapping, validate the composed result immediately, and export validation-gated URDF or MJCF preview content. `FrankensteinEditor` now exposes an Attach Source Model action plus public export helper, and `URDFModel.from_file()` carries attachment sidecar metadata into the editor. Focused headless tests cover human-plus-arm composition, MJCF export, validation refusal, and the offscreen editor attach/export path. |
 | 2026-06-10 | 1.0.296 | Model explorer attachment manifests for #7206. Added a first-party `attachment_manifest` parser for versioned `<model>.attachments.json` sidecars, checked in the JSON Schema and docs, exposed declared attachment points plus non-fatal warnings through `ModelLibrary` model info, and updated the attachment dialog to list declared mount points first, prefill their interface-frame origin, and report payload-limit warnings. Focused tests cover valid/missing/malformed manifests, imported-model exposure, dialog defaults, and payload warning contracts. |
 | 2026-06-10 | 1.0.295 | Split the launcher entrypoint below the file-size budget for #7217. Sidekick sidebar installation, process cleanup polling, launcher domain orchestration, and GUI startup bootstrap moved from `src/launchers/upstream_drift_launcher.py` into focused modules, preserving compatibility imports and the canonical frameless-window helper under `src/launchers/launcher_ui/frameless_window.py`. The launcher entrypoint is now below 1200 lines, so its file-size budget exception was removed. |

--- a/docs/adr/0030-c3d-viewer-renderer-backend.md
+++ b/docs/adr/0030-c3d-viewer-renderer-backend.md
@@ -1,0 +1,57 @@
+# ADR 0030: C3D Viewer Renderer Backend
+
+## Status
+
+Accepted
+
+## Context
+
+The C3D 3D viewer currently renders marker playback through matplotlib in
+`viewer_3d_tab.py`. That path already supports scrubbing, speed control, looped
+playback, marker groups, view presets, and skeleton overlays, but it is
+CPU-bound during interactive playback. Issue #7214 requires a top-of-the-line
+interactive path targeting 60 fps on CMU C3D clips around 45 markers and 1000
+frames while preserving the existing matplotlib fallback until feature parity is
+verified.
+
+Two candidate families were considered:
+
+- `pyqtgraph.opengl` in-process with Qt. This matches the existing desktop
+  launcher model, reuses the optional PyQtGL marker renderer in
+  `src/shared/python/plot_style/renderers/pyqtgl.py`, and avoids introducing a
+  realtime transport boundary for the first production slice.
+- WebGL/Three.js in the Tauri/React UI. This remains attractive for long-term
+  web parity, but it requires a marker-frame streaming protocol and a second UI
+  implementation before it can replace the desktop tab.
+
+## Decision
+
+Use `pyqtgraph.opengl` as the first GPU backend for the desktop C3D viewer and
+keep matplotlib as the fallback backend. Backend selection is explicit and
+contract-tested in `viewer_3d_backend.py`: prefer PyQtGL when requested and
+available, otherwise use matplotlib. The PyQtGL path must satisfy the parity
+checklist before it can become the default replacement for the existing tab:
+scrubbing, speed control, loop playback, marker groups, view presets, and
+skeleton overlay.
+
+The first implementation slice intentionally adds only the backend decision
+contract. The follow-up slice should wire a PyQtGL scene adapter into
+`Viewer3DTab` without growing that file further; new renderer orchestration
+belongs in sibling modules.
+
+## Consequences
+
+- The desktop launcher can get a GPU-rate path without waiting for Tauri/WebGL
+  transport work.
+- Matplotlib remains available for headless tests, environments without
+  `pyqtgraph.opengl`, and parity fallback.
+- The backend contract gives future benchmark tests a stable place to assert the
+  60 fps target and CMU acceptance dimensions.
+- A later WebGL ADR or extension can reuse the same parity checklist and should
+  define the marker-frame streaming boundary before adding React rendering code.
+
+## Validation
+
+- `tests/unit/apps/test_viewer_3d_backend.py` covers PyQtGL selection,
+  matplotlib fallback, explicit fallback preference, dataset-shape DbC, and the
+  required parity checklist.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 | [0026](0026-canonical-dynamic-state-v2.md)         | Canonical Dynamic State v2                                      | Accepted | 2026-05-31 |
 | [0027](0027-canonical-viewport-backend.md)         | Canonical 3D Viewport Backend                                   | Accepted | 2026-05-31 |
 | [0028](0028-react-tauri-launcher-parity.md)        | React/Tauri launcher parity model                               | Accepted | 2026-06-10 |
+| [0030](0030-c3d-viewer-renderer-backend.md)        | C3D Viewer Renderer Backend                                     | Accepted | 2026-06-10 |
 
 Note: ADR 0013 was amended on 2026-05-31 to document the CC-32
 canonical-core app-shell registry reuse of the embeddable-tool contract.

--- a/src/bunkershot3d/calibration/optimizer.py
+++ b/src/bunkershot3d/calibration/optimizer.py
@@ -3,7 +3,6 @@ Optimization loop for calibrating backend parameters to bulk properties.
 """
 
 import numpy as np
-from scipy.optimize import differential_evolution
 from typing import Any
 
 
@@ -44,6 +43,8 @@ class CalibrationOptimizer:
         raise ValueError("Experiment does not define known target properties.")
 
     def optimize(self) -> dict[str, float]:
+        from scipy.optimize import differential_evolution
+
         bounds = [(0.01, 1.0), (0.01, 1.0)]
 
         # differential_evolution is a stochastic population-based method suitable for noisy granular simulations

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_backend.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/ui/tabs/viewer_3d_backend.py
@@ -1,0 +1,95 @@
+"""Renderer backend policy for the C3D 3D viewer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+FPS_TARGET = 60
+CMU_ACCEPTANCE_MARKERS = 45
+CMU_ACCEPTANCE_FRAMES = 1000
+
+PARITY_FEATURES: tuple[str, ...] = (
+    "scrubbing",
+    "speed_control",
+    "loop",
+    "marker_groups",
+    "view_presets",
+    "skeleton_overlay",
+)
+
+
+class RendererBackend(StrEnum):
+    """Supported C3D 3D-viewer renderer backends."""
+
+    PYQTGL = "pyqtgl"
+    MATPLOTLIB = "matplotlib"
+
+
+@dataclass(frozen=True, slots=True)
+class Viewer3DBackendDecision:
+    """Backend decision and acceptance contract for one C3D dataset."""
+
+    backend: RendererBackend
+    reason: str
+    target_fps: int
+    marker_count: int
+    frame_count: int
+    parity_features: tuple[str, ...] = PARITY_FEATURES
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend, RendererBackend):
+            raise TypeError("backend must be a RendererBackend")
+        if not self.reason:
+            raise ValueError("reason must be non-empty")
+        _validate_positive_int("target_fps", self.target_fps)
+        _validate_positive_int("marker_count", self.marker_count)
+        _validate_positive_int("frame_count", self.frame_count)
+        if not self.parity_features:
+            raise ValueError("parity_features must be non-empty")
+
+
+def select_viewer_3d_backend(
+    *,
+    prefer_gpu: bool,
+    pyqtgl_available: bool,
+    marker_count: int,
+    frame_count: int,
+) -> Viewer3DBackendDecision:
+    """Choose the renderer backend for a C3D 3D-viewer dataset.
+
+    Postcondition: the returned decision always carries the 60 fps target
+    and the feature-parity checklist required before replacing the
+    matplotlib path.
+    """
+    _validate_positive_int("marker_count", marker_count)
+    _validate_positive_int("frame_count", frame_count)
+    if not isinstance(prefer_gpu, bool):
+        raise TypeError("prefer_gpu must be bool")
+    if not isinstance(pyqtgl_available, bool):
+        raise TypeError("pyqtgl_available must be bool")
+
+    if not prefer_gpu:
+        backend = RendererBackend.MATPLOTLIB
+        reason = "matplotlib fallback explicitly requested"
+    elif pyqtgl_available:
+        backend = RendererBackend.PYQTGL
+        reason = "pyqtgraph.opengl available"
+    else:
+        backend = RendererBackend.MATPLOTLIB
+        reason = "pyqtgraph.opengl unavailable; using matplotlib fallback"
+
+    return Viewer3DBackendDecision(
+        backend=backend,
+        reason=reason,
+        target_fps=FPS_TARGET,
+        marker_count=marker_count,
+        frame_count=frame_count,
+    )
+
+
+def _validate_positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be int")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")

--- a/tests/bunkershot3d/test_optimizer.py
+++ b/tests/bunkershot3d/test_optimizer.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 from bunkershot3d.calibration.optimizer import CalibrationOptimizer
 from bunkershot3d.calibration.angle_of_repose import AngleOfReposeExperiment
@@ -27,3 +29,20 @@ def test_drained_shear_cell_optimization() -> None:
     best_params = optimizer.optimize()
 
     assert np.isclose(best_params["friction_coefficient"], 0.5, atol=0.05)
+
+
+def test_wrench_trace_import_does_not_require_scipy_optimize(monkeypatch) -> None:
+    """Cross-engine imports should not need calibration optimizer extras."""
+
+    real_import = __import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "scipy.optimize":
+            raise ModuleNotFoundError("No module named 'scipy.optimize'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+
+    module = importlib.import_module("src.bunkershot3d.postproc.wrench_trace")
+
+    assert hasattr(module, "WrenchTrace")

--- a/tests/unit/apps/test_viewer_3d_backend.py
+++ b/tests/unit/apps/test_viewer_3d_backend.py
@@ -1,0 +1,111 @@
+"""Tests for C3D 3D-viewer renderer backend selection."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = (
+    _REPO_ROOT
+    / "src"
+    / "engines"
+    / "Simscape_Multibody_Models"
+    / "3D_Golf_Model"
+    / "python"
+    / "src"
+    / "apps"
+    / "ui"
+    / "tabs"
+    / "viewer_3d_backend.py"
+)
+
+_SPEC = importlib.util.spec_from_file_location("viewer_3d_backend", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+FPS_TARGET = _MODULE.FPS_TARGET
+PARITY_FEATURES = _MODULE.PARITY_FEATURES
+RendererBackend = _MODULE.RendererBackend
+Viewer3DBackendDecision = _MODULE.Viewer3DBackendDecision
+select_viewer_3d_backend = _MODULE.select_viewer_3d_backend
+
+
+def test_selects_pyqtgl_when_gpu_preferred_and_available() -> None:
+    decision = select_viewer_3d_backend(
+        prefer_gpu=True,
+        pyqtgl_available=True,
+        marker_count=45,
+        frame_count=1000,
+    )
+
+    assert decision.backend is RendererBackend.PYQTGL
+    assert decision.target_fps == FPS_TARGET
+    assert decision.reason == "pyqtgraph.opengl available"
+
+
+def test_falls_back_to_matplotlib_when_optional_dependency_missing() -> None:
+    decision = select_viewer_3d_backend(
+        prefer_gpu=True,
+        pyqtgl_available=False,
+        marker_count=45,
+        frame_count=1000,
+    )
+
+    assert decision.backend is RendererBackend.MATPLOTLIB
+    assert "pyqtgraph.opengl unavailable" in decision.reason
+
+
+def test_respects_explicit_matplotlib_preference() -> None:
+    decision = select_viewer_3d_backend(
+        prefer_gpu=False,
+        pyqtgl_available=True,
+        marker_count=45,
+        frame_count=1000,
+    )
+
+    assert decision.backend is RendererBackend.MATPLOTLIB
+    assert decision.reason == "matplotlib fallback explicitly requested"
+
+
+def test_decision_rejects_invalid_dataset_shape() -> None:
+    with pytest.raises(ValueError, match="marker_count"):
+        select_viewer_3d_backend(
+            prefer_gpu=True,
+            pyqtgl_available=True,
+            marker_count=0,
+            frame_count=1000,
+        )
+
+    with pytest.raises(ValueError, match="frame_count"):
+        select_viewer_3d_backend(
+            prefer_gpu=True,
+            pyqtgl_available=True,
+            marker_count=45,
+            frame_count=0,
+        )
+
+
+def test_backend_decision_contract_is_complete() -> None:
+    decision = Viewer3DBackendDecision(
+        backend=RendererBackend.PYQTGL,
+        reason="available",
+        target_fps=60,
+        marker_count=45,
+        frame_count=1000,
+        parity_features=PARITY_FEATURES,
+    )
+
+    assert set(decision.parity_features) == {
+        "scrubbing",
+        "speed_control",
+        "loop",
+        "marker_groups",
+        "view_presets",
+        "skeleton_overlay",
+    }


### PR DESCRIPTION
## Summary
- Adds ADR-0030 selecting `pyqtgraph.opengl`/PyQtGL as the first desktop GPU playback backend for the high-performance C3D viewer, with matplotlib retained as fallback.
- Adds a small backend-selection contract for the viewer with DbC validation, a 60 fps target, CMU-scale acceptance constants, and the parity checklist that must be preserved before replacing the current renderer.
- Adds focused unit coverage for GPU selection, fallback behavior, invalid preconditions, and the parity checklist.

Refs #7214

## Validation
- `python3 -m ruff format --check src\engines\Simscape_Multibody_Models\3D_Golf_Model\python\src\apps\ui\tabs\viewer_3d_backend.py tests\unit\apps\test_viewer_3d_backend.py`
- `python3 -m ruff check src\engines\Simscape_Multibody_Models\3D_Golf_Model\python\src\apps\ui\tabs\viewer_3d_backend.py tests\unit\apps\test_viewer_3d_backend.py`
- `python3 -m pytest tests\unit\apps\test_viewer_3d_backend.py -q`
- `python3 scripts\check_spec_paths.py`
- `python3 scripts\ci\check_version_consistency.py`
- `python3 scripts\ci\check_file_size_budget.py`
- `python3 scripts\ci\check_architecture_budget.py`
- `git diff --check`
- pre-push hooks: ruff, ruff format, formatter guidance, wildcard/debug/print guards, prettier, bandit, pytest

## Follow-up for #7214
This PR intentionally does not close #7214. The remaining implementation work is to wire the PyQtGL renderer into the C3D viewer playback path, benchmark the CMU-scale fixture at the 60 fps target, and retire matplotlib from the hot playback path only after parity is proven.