### PR TITLE
fix: address upstream audit regressions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.300                                            |
+| **Spec Version**        | 1.0.301                                            |
 | **Last Spec Update**    | 2026-06-11                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,14 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-10** - Hardened the audit regressions tracked by #7269, #7270,
+  and #7271. Model Explorer inspect/compare path resolution now rejects
+  absolute paths and parent traversal before resolving candidates only under
+  approved model roots; motion-pipeline linear keypoint gap filling leaves
+  unmatched low-confidence keypoints unchanged when neighboring frames have
+  mismatched keypoint counts, including the pure-Python fallback; and
+  `SwingBallFlightPipeline` now derives `LaunchConditions` using the simulator
+  contract of radians for launch/azimuth angles and RPM for spin rate.
 - **2026-06-10** - Completed the #7207 model explorer composition UX flow.
   `src/tools/model_explorer/composition_ux.py` now provides a headless
   drag/drop orchestration layer with library payloads, non-mutating ghost
@@ -949,6 +957,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10 | 1.0.301 | Audit regression fixes for #7269, #7270, and #7271. Model Explorer API path resolution now validates caller paths before filesystem reads and resolves only within approved model directories, closing the direct existing-path containment bypass. Motion-pipeline keypoint gap filling now guards both before/after neighbor keypoint indexes and pins mismatched-neighbor behavior in the main and pure-Python implementations. `SwingBallFlightPipeline` now emits `LaunchConditions` in the units consumed by `BallFlightSimulator`: launch and azimuth angles in radians, spin rate in RPM, with updated DbC validation and unit tests. |
 | 2026-06-10 | 1.0.300 | Completed the #7207 model explorer composition UX flow. Added `CompositionUxController` for library drag payloads, non-mutating drop/ghost previews, highlighted target/source links, validation summaries, committed drops, and a validation-aware export chooser that enables URDF/MJCF while explicitly marking SDF/OSIM unavailable until writers exist. `FrankensteinEditor` now exposes preview, commit, and export-choice hooks, with offscreen tests covering simple humanoid plus arm preview, commit, validation pass, and MJCF export. |
 | 2026-06-10 | 1.0.299 | Cross-engine equivalence import-boundary fix for #7214. `CalibrationOptimizer.optimize()` now imports `scipy.optimize.differential_evolution` lazily so importing `src.bunkershot3d.postproc.wrench_trace` through shared simulation backends does not require optional calibration optimizer dependencies in the equivalence CI environment. |
 | 2026-06-10 | 1.0.298 | C3D viewer renderer backend decision for #7214. Added ADR-0030 choosing PyQtGL as the first desktop GPU playback path while keeping matplotlib fallback, plus a focused `viewer_3d_backend.py` decision contract that carries the 60 fps target and parity checklist for scrubbing, speed control, loop playback, marker groups, view presets, and skeleton overlay before replacement. |

--- a/scripts/config/architecture_budget.json
+++ b/scripts/config/architecture_budget.json
@@ -17,6 +17,22 @@
       "owner": "@dieterolson @D-sorganization/core-maintainers",
       "reason": "Issue #7217 legacy launcher decomposition: main remains over the function-lines budget until startup and window orchestration move into focused launcher modules.",
       "expires_on": "2026-09-30"
+    },
+    {
+      "path": "src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py",
+      "symbol": "_pca_reconstruct_markers",
+      "rule": "function-lines",
+      "owner": "@dieterolson @D-sorganization/core-maintainers",
+      "reason": "Issue #7285: pre-existing PCA reconstruction helper exceeds the changed-file architecture budget; split into focused helpers after the #7270 crash fix lands.",
+      "expires_on": "2026-08-31"
+    },
+    {
+      "path": "src/shared/python/motion_pipeline/preprocessing/gap_fill.py",
+      "symbol": "_pca_reconstruct_markers_python",
+      "rule": "function-lines",
+      "owner": "@dieterolson @D-sorganization/core-maintainers",
+      "reason": "Issue #7285: pre-existing PCA reconstruction helper exceeds the changed-file architecture budget; split into focused helpers after the #7270 crash fix lands.",
+      "expires_on": "2026-08-31"
     }
   ]
 }

--- a/scripts/config/architecture_budget.json
+++ b/scripts/config/architecture_budget.json
@@ -17,22 +17,6 @@
       "owner": "@dieterolson @D-sorganization/core-maintainers",
       "reason": "Issue #7217 legacy launcher decomposition: main remains over the function-lines budget until startup and window orchestration move into focused launcher modules.",
       "expires_on": "2026-09-30"
-    },
-    {
-      "path": "src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py",
-      "symbol": "_pca_reconstruct_markers",
-      "rule": "function-lines",
-      "owner": "@dieterolson @D-sorganization/core-maintainers",
-      "reason": "Issue #7285: pre-existing PCA reconstruction helper exceeds the changed-file architecture budget; split into focused helpers after the #7270 crash fix lands.",
-      "expires_on": "2026-08-31"
-    },
-    {
-      "path": "src/shared/python/motion_pipeline/preprocessing/gap_fill.py",
-      "symbol": "_pca_reconstruct_markers_python",
-      "rule": "function-lines",
-      "owner": "@dieterolson @D-sorganization/core-maintainers",
-      "reason": "Issue #7285: pre-existing PCA reconstruction helper exceeds the changed-file architecture budget; split into focused helpers after the #7270 crash fix lands.",
-      "expires_on": "2026-08-31"
     }
   ]
 }

--- a/src/api/routes/model_explorer.py
+++ b/src/api/routes/model_explorer.py
@@ -19,6 +19,7 @@ import defusedxml.ElementTree as ElementTree
 from fastapi import APIRouter, Depends, HTTPException
 
 from src.api.middleware.error_handler import handle_api_errors
+from src.api.utils.path_validation import resolve_contained_path
 from src.shared.python.core.contracts import postcondition, precondition
 
 from ..dependencies import get_logger
@@ -249,32 +250,49 @@ def _parse_urdf_tree(urdf_content: str, file_path: str) -> ModelExplorerResponse
     "Model path must be a non-empty string",
 )
 def _resolve_model_path(model_path: str) -> Path:
-    """Resolve a model path relative to the project root.
+    """Resolve a model path under one of the approved model directories.
 
     Args:
-        model_path: Relative or absolute model path.
+        model_path: Relative model path or model filename.
 
     Returns:
         Resolved absolute path.
 
     Raises:
-        HTTPException: If file not found.
+        HTTPException: If the path is unsafe or not found.
     """
     root = _find_project_root()
-    resolved = root / model_path
-    if resolved.exists():
-        return resolved
+    user_path = Path(model_path)
+    if (
+        user_path.is_absolute()
+        or (len(model_path) >= 2 and model_path[1] == ":")
+        or model_path.startswith(("/", "\\"))
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid path: absolute paths are not allowed",
+        )
+    if ".." in user_path.parts or ".." in model_path:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid path: parent directory references not allowed",
+        )
 
-    # Try direct path
-    direct = Path(model_path)
-    if direct.exists():
-        return direct
+    allowed_dirs = [(root / model_dir).resolve() for model_dir in _MODEL_DIRS]
+    candidate = root / user_path
+    try:
+        return resolve_contained_path(candidate, allowed_dirs)
+    except HTTPException as exc:
+        if exc.status_code != 404:
+            raise
 
-    # Search in model directories
     for model_dir in _MODEL_DIRS:
-        candidate = root / model_dir / Path(model_path).name
-        if candidate.exists():
-            return candidate
+        candidate = root / model_dir / user_path.name
+        try:
+            return resolve_contained_path(candidate, [root / model_dir])
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
 
     raise HTTPException(
         status_code=404,

--- a/src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py
+++ b/src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py
@@ -426,122 +426,26 @@ def _pca_reconstruct_markers(
         return list(frames)
 
     marker_names = list(frames[0].markers.keys())
-    n_markers = len(marker_names)
-    n_dims = n_markers * 3
-
-    # Stack into (n_frames, n_markers*3)
-    M = np.zeros((n_frames, n_dims), dtype=float)
-    occ_mask = np.zeros((n_frames, n_dims), dtype=bool)  # True = occluded
-    for i, frame in enumerate(frames):
-        for j, name in enumerate(marker_names):
-            m = frame.markers.get(name)
-            if m is None:
-                occ_mask[i, 3 * j : 3 * j + 3] = True
-                continue
-            M[i, 3 * j] = m.x
-            M[i, 3 * j + 1] = m.y
-            M[i, 3 * j + 2] = m.z
-            if m.occluded:
-                occ_mask[i, 3 * j : 3 * j + 3] = True
-
-    # Identify rows with no occlusions -> basis rows
-    fully_visible_rows = ~occ_mask.any(axis=1)
-    n_visible = int(fully_visible_rows.sum())
-
-    # Need at least a couple visible rows to build a basis. Otherwise fall
-    # back entirely to linear interpolation.
-    if n_visible < 2:
+    matrix, occ_mask = _stack_marker_matrix(frames, marker_names)
+    basis = _build_marker_pca_basis(matrix, occ_mask, rank)
+    if basis is None:
         return _fill_gaps_markers(
             list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
         )
 
-    M_visible = M[fully_visible_rows]
+    mean, basis_vectors, basis_rank = basis
+    skip_frames = _large_gap_frames(gap_indices, max_gap)
+    filled_frames, pca_failed_frames = _apply_marker_pca_projection(
+        frames=frames,
+        marker_names=marker_names,
+        matrix=matrix,
+        occ_mask=occ_mask,
+        mean=mean,
+        basis_vectors=basis_vectors,
+        basis_rank=basis_rank,
+        skip_frames=skip_frames,
+    )
 
-    # Center on the visible-row mean (column-wise) for stable PCA
-    mean = M_visible.mean(axis=0)
-    Mc = M_visible - mean
-
-    # SVD: Mc = U S Vt; columns of V (rows of Vt) are the basis directions
-    try:
-        _, S, Vt = np.linalg.svd(Mc, full_matrices=False)
-    except np.linalg.LinAlgError:
-        return _fill_gaps_markers(
-            list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
-        )
-
-    # Truncate to rank k. Default is min(6, effective rank).
-    eps = max(S.shape[0], 1) * np.finfo(float).eps * (S.max() if S.size else 1.0)
-    effective_rank = int((eps < S).sum())
-    if effective_rank == 0:
-        return _fill_gaps_markers(
-            list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
-        )
-    k = min(6, effective_rank) if rank is None else min(rank, effective_rank)
-    V_k = Vt[:k].T  # (n_dims, k)
-
-    # Determine which gaps exceed max_gap and should be skipped (left for
-    # linear fallback later).
-    skip_frames: set[int] = set()
-    for start, end in gap_indices:
-        gap_size = end - start + 1
-        if gap_size > max_gap:
-            for i in range(start, end + 1):
-                skip_frames.add(i)
-
-    # Build new frames; for each occluded row, solve least-squares for
-    # basis coefficients using only visible coords.
-    filled_frames = list(frames)
-    pca_failed_frames: set[int] = set()
-
-    for i in range(n_frames):
-        if not occ_mask[i].any():
-            continue  # nothing occluded
-        if i in skip_frames:
-            pca_failed_frames.add(i)
-            continue
-
-        visible_idx = np.where(~occ_mask[i])[0]
-        if visible_idx.size < k:
-            # Under-determined: not enough visible coords to fit k coeffs
-            pca_failed_frames.add(i)
-            continue
-
-        # Solve V_k[visible] @ c = (M[i, visible] - mean[visible])
-        A = V_k[visible_idx]
-        b = M[i, visible_idx] - mean[visible_idx]
-        try:
-            coeffs, *_ = np.linalg.lstsq(A, b, rcond=None)
-        except np.linalg.LinAlgError:
-            pca_failed_frames.add(i)
-            continue
-
-        reconstructed = mean + V_k @ coeffs
-        if not np.all(np.isfinite(reconstructed)):
-            pca_failed_frames.add(i)
-            continue
-
-        # Back-fill occluded entries
-        frame = filled_frames[i]
-        new_markers = dict(frame.markers)
-        for j, name in enumerate(marker_names):
-            base = 3 * j
-            if occ_mask[i, base]:  # j-th marker is occluded
-                new_markers[name] = Marker(
-                    name=name,
-                    x=float(reconstructed[base]),
-                    y=float(reconstructed[base + 1]),
-                    z=float(reconstructed[base + 2]),
-                    residual=None,
-                    occluded=False,
-                )
-        filled_frames[i] = MarkerFrame(
-            timestamp=frame.timestamp,
-            markers=new_markers,
-            frame_index=frame.frame_index,
-        )
-
-    # Linear-interpolation fallback for frames PCA couldn't handle. Compute
-    # remaining gap intervals from the still-occluded frames.
     if pca_failed_frames:
         remaining_gaps = _find_gaps_markers(filled_frames)
         if remaining_gaps:
@@ -550,3 +454,139 @@ def _pca_reconstruct_markers(
             )
 
     return filled_frames
+
+
+def _stack_marker_matrix(
+    frames: list[MarkerFrame],
+    marker_names: list[str],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return marker coordinate matrix and matching occlusion mask."""
+    n_dims = len(marker_names) * 3
+    matrix = np.zeros((len(frames), n_dims), dtype=float)
+    occ_mask = np.zeros((len(frames), n_dims), dtype=bool)
+    for i, frame in enumerate(frames):
+        for j, name in enumerate(marker_names):
+            marker = frame.markers.get(name)
+            base = 3 * j
+            if marker is None:
+                occ_mask[i, base : base + 3] = True
+                continue
+            matrix[i, base] = marker.x
+            matrix[i, base + 1] = marker.y
+            matrix[i, base + 2] = marker.z
+            if marker.occluded:
+                occ_mask[i, base : base + 3] = True
+    return matrix, occ_mask
+
+
+def _build_marker_pca_basis(
+    matrix: np.ndarray,
+    occ_mask: np.ndarray,
+    rank: int | None,
+) -> tuple[np.ndarray, np.ndarray, int] | None:
+    """Build a PCA basis from fully visible marker rows."""
+    fully_visible_rows = ~occ_mask.any(axis=1)
+    n_visible = int(fully_visible_rows.sum())
+    if n_visible < 2:
+        return None
+
+    visible_matrix = matrix[fully_visible_rows]
+    mean = visible_matrix.mean(axis=0)
+    centered = visible_matrix - mean
+    try:
+        _, singular_values, basis_rows = np.linalg.svd(centered, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return None
+
+    eps = max(singular_values.shape[0], 1) * np.finfo(float).eps
+    eps *= singular_values.max() if singular_values.size else 1.0
+    effective_rank = int((eps < singular_values).sum())
+    if effective_rank == 0:
+        return None
+    basis_rank = min(6, effective_rank) if rank is None else min(rank, effective_rank)
+    return mean, basis_rows[:basis_rank].T, basis_rank
+
+
+def _large_gap_frames(gap_indices: list[tuple[int, int]], max_gap: int) -> set[int]:
+    """Return frame indices whose gaps exceed the PCA fill limit."""
+    frames_to_skip: set[int] = set()
+    for start, end in gap_indices:
+        gap_size = end - start + 1
+        if gap_size > max_gap:
+            frames_to_skip.update(range(start, end + 1))
+    return frames_to_skip
+
+
+def _apply_marker_pca_projection(
+    *,
+    frames: list[MarkerFrame],
+    marker_names: list[str],
+    matrix: np.ndarray,
+    occ_mask: np.ndarray,
+    mean: np.ndarray,
+    basis_vectors: np.ndarray,
+    basis_rank: int,
+    skip_frames: set[int],
+) -> tuple[list[MarkerFrame], set[int]]:
+    """Project occluded marker rows onto the PCA basis."""
+    filled_frames = list(frames)
+    pca_failed_frames: set[int] = set()
+
+    for i in range(len(frames)):
+        if not occ_mask[i].any():
+            continue  # nothing occluded
+        if i in skip_frames:
+            pca_failed_frames.add(i)
+            continue
+
+        visible_idx = np.where(~occ_mask[i])[0]
+        if visible_idx.size < basis_rank:
+            # Under-determined: not enough visible coords to fit k coeffs
+            pca_failed_frames.add(i)
+            continue
+
+        # Solve V_k[visible] @ c = (M[i, visible] - mean[visible])
+        system_matrix = basis_vectors[visible_idx]
+        target = matrix[i, visible_idx] - mean[visible_idx]
+        try:
+            coeffs, *_ = np.linalg.lstsq(system_matrix, target, rcond=None)
+        except np.linalg.LinAlgError:
+            pca_failed_frames.add(i)
+            continue
+
+        reconstructed = mean + basis_vectors @ coeffs
+        if not np.all(np.isfinite(reconstructed)):
+            pca_failed_frames.add(i)
+            continue
+
+        filled_frames[i] = _replace_occluded_markers(
+            filled_frames[i], marker_names, occ_mask[i], reconstructed
+        )
+
+    return filled_frames, pca_failed_frames
+
+
+def _replace_occluded_markers(
+    frame: MarkerFrame,
+    marker_names: list[str],
+    row_mask: np.ndarray,
+    reconstructed: np.ndarray,
+) -> MarkerFrame:
+    """Return a frame with reconstructed coordinates for occluded markers."""
+    new_markers = dict(frame.markers)
+    for j, name in enumerate(marker_names):
+        base = 3 * j
+        if row_mask[base]:
+            new_markers[name] = Marker(
+                name=name,
+                x=float(reconstructed[base]),
+                y=float(reconstructed[base + 1]),
+                z=float(reconstructed[base + 2]),
+                residual=None,
+                occluded=False,
+            )
+    return MarkerFrame(
+        timestamp=frame.timestamp,
+        markers=new_markers,
+        frame_index=frame.frame_index,
+    )

--- a/src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py
+++ b/src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py
@@ -220,7 +220,7 @@ def _linear_interp_keypoints(
         for j, kp in enumerate(frame.keypoints):
             if kp.confidence < 0.5:
                 # Interpolate from before/after
-                if after and j < len(after.keypoints):
+                if after and j < len(before.keypoints) and j < len(after.keypoints):
                     t = (i - start + 1) / (end - start + 2)
                     kp_before = before.keypoints[j]
                     kp_after = after.keypoints[j]

--- a/src/shared/python/motion_pipeline/preprocessing/gap_fill.py
+++ b/src/shared/python/motion_pipeline/preprocessing/gap_fill.py
@@ -234,7 +234,7 @@ def _linear_interp_keypoints(
         for j, kp in enumerate(frame.keypoints):
             if kp.confidence < 0.5:
                 # Interpolate from before/after
-                if after and j < len(after.keypoints):
+                if after and j < len(before.keypoints) and j < len(after.keypoints):
                     t = (i - start + 1) / (end - start + 2)
                     kp_before = before.keypoints[j]
                     kp_after = after.keypoints[j]

--- a/src/shared/python/motion_pipeline/preprocessing/gap_fill.py
+++ b/src/shared/python/motion_pipeline/preprocessing/gap_fill.py
@@ -519,130 +519,26 @@ def _pca_reconstruct_markers_python(
         return list(frames)
 
     marker_names = list(frames[0].markers.keys())
-    n_markers = len(marker_names)
-    n_dims = n_markers * 3
-
-    # Stack into (n_frames, n_markers*3)
-    M = np.zeros((n_frames, n_dims), dtype=float)
-    occ_mask = np.zeros((n_frames, n_dims), dtype=bool)  # True = occluded
-    for i, frame in enumerate(frames):
-        for j, name in enumerate(marker_names):
-            m = frame.markers.get(name)
-            if m is None:
-                occ_mask[i, 3 * j : 3 * j + 3] = True
-                continue
-            M[i, 3 * j] = m.x
-            M[i, 3 * j + 1] = m.y
-            M[i, 3 * j + 2] = m.z
-            if m.occluded:
-                occ_mask[i, 3 * j : 3 * j + 3] = True
-
-    # Identify rows with no occlusions -> basis rows
-    fully_visible_rows = ~occ_mask.any(axis=1)
-    n_visible = int(fully_visible_rows.sum())
-
-    # Need at least a couple visible rows to build a basis. Otherwise fall
-    # back entirely to linear interpolation.
-    if n_visible < 2:
+    matrix, occ_mask = _stack_marker_matrix(frames, marker_names)
+    basis = _build_marker_pca_basis(matrix, occ_mask, rank)
+    if basis is None:
         return _fill_gaps_markers(
             list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
         )
 
-    M_visible = M[fully_visible_rows]
+    mean, basis_vectors, basis_rank = basis
+    skip_frames = _large_gap_frames(gap_indices, max_gap)
+    filled_frames, pca_failed_frames = _apply_marker_pca_projection(
+        frames=frames,
+        marker_names=marker_names,
+        matrix=matrix,
+        occ_mask=occ_mask,
+        mean=mean,
+        basis_vectors=basis_vectors,
+        basis_rank=basis_rank,
+        skip_frames=skip_frames,
+    )
 
-    # Center on the visible-row mean (column-wise) for stable PCA
-    mean = M_visible.mean(axis=0)
-    Mc = M_visible - mean
-
-    # SVD: Mc = U S Vt; columns of V (rows of Vt) are the basis directions
-    try:
-        _, S, Vt = np.linalg.svd(Mc, full_matrices=False)
-    except np.linalg.LinAlgError:
-        return _fill_gaps_markers(
-            list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
-        )
-
-    # Truncate to rank k using a relative threshold (1 % of the largest singular
-    # value). A pure machine-epsilon cut-off includes near-zero noise components
-    # in k, which causes the lstsq minimum-norm solution to produce zero for the
-    # occluded marker instead of the correct PCA-projected value.
-    if S.size == 0 or S.max() == 0.0:
-        return _fill_gaps_markers(
-            list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
-        )
-    relative_threshold = 0.01 * float(S.max())
-    effective_rank = int((relative_threshold < S).sum())
-
-    if effective_rank == 0:
-        return _fill_gaps_markers(
-            list(frames), gap_indices, GapFillStrategy.LINEAR, max_gap
-        )
-    k = min(6, effective_rank) if rank is None else min(rank, effective_rank)
-    V_k = Vt[:k].T  # (n_dims, k)
-
-    # Determine which gaps exceed max_gap and should be skipped (left for
-    # linear fallback later).
-    skip_frames: set[int] = set()
-    for start, end in gap_indices:
-        gap_size = end - start + 1
-        if gap_size > max_gap:
-            for i in range(start, end + 1):
-                skip_frames.add(i)
-
-    # Build new frames; for each occluded row, solve least-squares for
-    # basis coefficients using only visible coords.
-    filled_frames = list(frames)
-    pca_failed_frames: set[int] = set()
-
-    for i in range(n_frames):
-        if not occ_mask[i].any():
-            continue  # nothing occluded
-        if i in skip_frames:
-            pca_failed_frames.add(i)
-            continue
-
-        visible_idx = np.where(~occ_mask[i])[0]
-        if visible_idx.size < k:
-            # Under-determined: not enough visible coords to fit k coeffs
-            pca_failed_frames.add(i)
-            continue
-
-        # Solve V_k[visible] @ c = (M[i, visible] - mean[visible])
-        A = V_k[visible_idx]
-        b = M[i, visible_idx] - mean[visible_idx]
-        try:
-            coeffs, *_ = np.linalg.lstsq(A, b, rcond=None)
-        except np.linalg.LinAlgError:
-            pca_failed_frames.add(i)
-            continue
-
-        reconstructed = mean + V_k @ coeffs
-        if not np.all(np.isfinite(reconstructed)):
-            pca_failed_frames.add(i)
-            continue
-
-        # Back-fill occluded entries
-        frame = filled_frames[i]
-        new_markers = dict(frame.markers)
-        for j, name in enumerate(marker_names):
-            base = 3 * j
-            if occ_mask[i, base]:  # j-th marker is occluded
-                new_markers[name] = Marker(
-                    name=name,
-                    x=float(reconstructed[base]),
-                    y=float(reconstructed[base + 1]),
-                    z=float(reconstructed[base + 2]),
-                    residual=None,
-                    occluded=False,
-                )
-        filled_frames[i] = MarkerFrame(
-            timestamp=frame.timestamp,
-            markers=new_markers,
-            frame_index=frame.frame_index,
-        )
-
-    # Linear-interpolation fallback for frames PCA couldn't handle. Compute
-    # remaining gap intervals from the still-occluded frames.
     if pca_failed_frames:
         remaining_gaps = _find_gaps_markers(filled_frames)
         if remaining_gaps:
@@ -651,3 +547,145 @@ def _pca_reconstruct_markers_python(
             )
 
     return filled_frames
+
+
+def _stack_marker_matrix(
+    frames: list[MarkerFrame],
+    marker_names: list[str],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return marker coordinate matrix and matching occlusion mask."""
+    n_dims = len(marker_names) * 3
+    matrix = np.zeros((len(frames), n_dims), dtype=float)
+    occ_mask = np.zeros((len(frames), n_dims), dtype=bool)
+    for i, frame in enumerate(frames):
+        for j, name in enumerate(marker_names):
+            marker = frame.markers.get(name)
+            base = 3 * j
+            if marker is None:
+                occ_mask[i, base : base + 3] = True
+                continue
+            matrix[i, base] = marker.x
+            matrix[i, base + 1] = marker.y
+            matrix[i, base + 2] = marker.z
+            if marker.occluded:
+                occ_mask[i, base : base + 3] = True
+    return matrix, occ_mask
+
+
+def _build_marker_pca_basis(
+    matrix: np.ndarray,
+    occ_mask: np.ndarray,
+    rank: int | None,
+) -> tuple[np.ndarray, np.ndarray, int] | None:
+    """Build a PCA basis from fully visible marker rows."""
+    fully_visible_rows = ~occ_mask.any(axis=1)
+    n_visible = int(fully_visible_rows.sum())
+    if n_visible < 2:
+        return None
+
+    visible_matrix = matrix[fully_visible_rows]
+    mean = visible_matrix.mean(axis=0)
+    centered = visible_matrix - mean
+    try:
+        _, singular_values, basis_rows = np.linalg.svd(centered, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return None
+
+    effective_rank = _effective_marker_pca_rank(singular_values)
+    if effective_rank == 0:
+        return None
+    basis_rank = min(6, effective_rank) if rank is None else min(rank, effective_rank)
+    return mean, basis_rows[:basis_rank].T, basis_rank
+
+
+def _effective_marker_pca_rank(singular_values: np.ndarray) -> int:
+    """Return rank after filtering near-zero PCA noise components."""
+    if singular_values.size == 0 or singular_values.max() == 0.0:
+        return 0
+    relative_threshold = 0.01 * float(singular_values.max())
+    return int((relative_threshold < singular_values).sum())
+
+
+def _large_gap_frames(gap_indices: list[tuple[int, int]], max_gap: int) -> set[int]:
+    """Return frame indices whose gaps exceed the PCA fill limit."""
+    frames_to_skip: set[int] = set()
+    for start, end in gap_indices:
+        gap_size = end - start + 1
+        if gap_size > max_gap:
+            frames_to_skip.update(range(start, end + 1))
+    return frames_to_skip
+
+
+def _apply_marker_pca_projection(
+    *,
+    frames: list[MarkerFrame],
+    marker_names: list[str],
+    matrix: np.ndarray,
+    occ_mask: np.ndarray,
+    mean: np.ndarray,
+    basis_vectors: np.ndarray,
+    basis_rank: int,
+    skip_frames: set[int],
+) -> tuple[list[MarkerFrame], set[int]]:
+    """Project occluded marker rows onto the PCA basis."""
+    filled_frames = list(frames)
+    pca_failed_frames: set[int] = set()
+
+    for i in range(len(frames)):
+        if not occ_mask[i].any():
+            continue  # nothing occluded
+        if i in skip_frames:
+            pca_failed_frames.add(i)
+            continue
+
+        visible_idx = np.where(~occ_mask[i])[0]
+        if visible_idx.size < basis_rank:
+            # Under-determined: not enough visible coords to fit k coeffs
+            pca_failed_frames.add(i)
+            continue
+
+        # Solve V_k[visible] @ c = (M[i, visible] - mean[visible])
+        system_matrix = basis_vectors[visible_idx]
+        target = matrix[i, visible_idx] - mean[visible_idx]
+        try:
+            coeffs, *_ = np.linalg.lstsq(system_matrix, target, rcond=None)
+        except np.linalg.LinAlgError:
+            pca_failed_frames.add(i)
+            continue
+
+        reconstructed = mean + basis_vectors @ coeffs
+        if not np.all(np.isfinite(reconstructed)):
+            pca_failed_frames.add(i)
+            continue
+
+        filled_frames[i] = _replace_occluded_markers(
+            filled_frames[i], marker_names, occ_mask[i], reconstructed
+        )
+
+    return filled_frames, pca_failed_frames
+
+
+def _replace_occluded_markers(
+    frame: MarkerFrame,
+    marker_names: list[str],
+    row_mask: np.ndarray,
+    reconstructed: np.ndarray,
+) -> MarkerFrame:
+    """Return a frame with reconstructed coordinates for occluded markers."""
+    new_markers = dict(frame.markers)
+    for j, name in enumerate(marker_names):
+        base = 3 * j
+        if row_mask[base]:
+            new_markers[name] = Marker(
+                name=name,
+                x=float(reconstructed[base]),
+                y=float(reconstructed[base + 1]),
+                z=float(reconstructed[base + 2]),
+                residual=None,
+                occluded=False,
+            )
+    return MarkerFrame(
+        timestamp=frame.timestamp,
+        markers=new_markers,
+        frame_index=frame.frame_index,
+    )

--- a/src/shared/python/physics/swing_ball_flight_pipeline.py
+++ b/src/shared/python/physics/swing_ball_flight_pipeline.py
@@ -10,7 +10,7 @@ Implements the foundational pipeline tile from Issue #5337:
 Design-by-Contract invariants
 ------------------------------
 - ``launch_speed`` of the derived ``LaunchConditions`` must be > 0.
-- ``launch_angle_deg`` must be in [0°, 90°].
+- ``launch_angle`` must be in [0, pi/2] radians.
 - ``PipelineResult`` is always fully populated (no None trajectory).
 
 Law of Demeter
@@ -80,7 +80,7 @@ class FlightSimulatorProtocol(Protocol):
 # Constants
 # ---------------------------------------------------------------------------
 
-_MAX_LAUNCH_ANGLE_DEG: float = 90.0
+_MAX_LAUNCH_ANGLE_RAD: float = math.pi / 2.0
 _MIN_LAUNCH_SPEED_MS: float = 0.0  # exclusive lower bound
 
 # ---------------------------------------------------------------------------
@@ -176,35 +176,36 @@ class _LaunchConditionsDeriver:
             math.hypot(ball_vel[0], ball_vel[1], ball_vel[2])
         )  # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm
 
-        # Launch angle from horizontal plane
+        # Launch angle from horizontal plane. LaunchConditions uses radians.
         horiz_speed = float(
             math.hypot(ball_vel[0], ball_vel[1])
         )  # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm
         if horiz_speed < 1e-12:
-            launch_angle_deg = 90.0
+            launch_angle_rad = math.pi / 2.0
         else:
-            launch_angle_deg = float(np.degrees(np.arctan2(ball_vel[2], horiz_speed)))
+            launch_angle_rad = float(math.atan2(ball_vel[2], horiz_speed))
 
-        # Azimuth angle (compass bearing, 0 = forward = +x)
-        azimuth_deg = 0.0
+        # Azimuth angle (compass bearing, 0 = forward = +x), in radians.
+        azimuth_rad = 0.0
         if horiz_speed > 1e-12:
-            azimuth_deg = float(np.degrees(np.arctan2(ball_vel[1], ball_vel[0])))
+            azimuth_rad = float(math.atan2(ball_vel[1], ball_vel[0]))
 
         spin_w = post.ball_angular_velocity
-        spin_rate = float(
+        spin_rate_rad_s = float(
             math.hypot(spin_w[0], spin_w[1], spin_w[2])
         )  # ⚡ Bolt: math.hypot is ~5x faster than np.linalg.norm
+        spin_rate_rpm = spin_rate_rad_s * 60.0 / (2.0 * math.pi)
         spin_axis = (
-            post.ball_angular_velocity / spin_rate
-            if spin_rate > 1e-12
+            post.ball_angular_velocity / spin_rate_rad_s
+            if spin_rate_rad_s > 1e-12
             else np.array([0.0, -1.0, 0.0])
         )
 
         return LaunchConditions(
             velocity=speed,
-            launch_angle=launch_angle_deg,
-            azimuth_angle=azimuth_deg,
-            spin_rate=spin_rate,
+            launch_angle=launch_angle_rad,
+            azimuth_angle=azimuth_rad,
+            spin_rate=spin_rate_rpm,
             spin_axis=np.asarray(spin_axis, dtype=float),
         )
 
@@ -489,7 +490,7 @@ class SwingBallFlightPipeline:
             launch.velocity,
         )
         require(
-            0.0 <= launch.launch_angle <= _MAX_LAUNCH_ANGLE_DEG,
-            f"launch_angle must be in [0°, {_MAX_LAUNCH_ANGLE_DEG}°]",
+            0.0 <= launch.launch_angle <= _MAX_LAUNCH_ANGLE_RAD,
+            f"launch_angle must be in [0, {_MAX_LAUNCH_ANGLE_RAD}] radians",
             launch.launch_angle,
         )

--- a/tests/unit/api/test_routes_model_explorer.py
+++ b/tests/unit/api/test_routes_model_explorer.py
@@ -1,10 +1,15 @@
 """Unit tests for the model explorer API route."""
 
+from pathlib import Path
+
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from src.api.routes import model_explorer
 from src.api.routes.model_explorer import router
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
@@ -43,6 +48,45 @@ def test_inspect_model_not_found(client: TestClient) -> None:
     data = response.json()
     assert "detail" in data
     assert "not found" in data["detail"].lower()
+
+
+def test_resolve_model_path_rejects_existing_absolute_path_outside_allowed_dirs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing files outside model roots must not bypass containment."""
+    repo_root = tmp_path / "repo"
+    allowed = repo_root / "src" / "shared" / "urdf"
+    allowed.mkdir(parents=True)
+    outside = tmp_path / "outside.urdf"
+    outside.write_text("<robot name='outside'><link name='base'/></robot>")
+
+    monkeypatch.setattr(model_explorer, "_find_project_root", lambda: repo_root)
+    monkeypatch.setattr(model_explorer, "_MODEL_DIRS", [Path("src/shared/urdf")])
+
+    with pytest.raises(HTTPException) as excinfo:
+        model_explorer._resolve_model_path(str(outside))
+
+    assert excinfo.value.status_code == 400
+
+
+def test_resolve_model_path_rejects_traversal_to_existing_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent traversal must be rejected before filesystem existence checks."""
+    repo_root = tmp_path / "repo"
+    allowed = repo_root / "src" / "shared" / "urdf"
+    allowed.mkdir(parents=True)
+    (tmp_path / "outside.urdf").write_text(
+        "<robot name='outside'><link name='base'/></robot>"
+    )
+
+    monkeypatch.setattr(model_explorer, "_find_project_root", lambda: repo_root)
+    monkeypatch.setattr(model_explorer, "_MODEL_DIRS", [Path("src/shared/urdf")])
+
+    with pytest.raises(HTTPException) as excinfo:
+        model_explorer._resolve_model_path("../outside.urdf")
+
+    assert excinfo.value.status_code == 400
 
 
 def test_compare_models_success(client: TestClient) -> None:

--- a/tests/unit/motion_pipeline/preprocessing/test_gap_fill.py
+++ b/tests/unit/motion_pipeline/preprocessing/test_gap_fill.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from src.shared.python.motion_pipeline.contracts import (
+    Keypoint,
+    KeypointFrame,
     KeypointSequence,
     MarkerTrajectory,
 )
@@ -13,6 +15,8 @@ from src.shared.python.motion_pipeline.preprocessing.gap_fill import (
     GapFillStrategy,
     gap_fill,
 )
+
+pytestmark = pytest.mark.unit
 
 from ._local_fixtures import (
     make_keypoint_sequence,
@@ -63,6 +67,54 @@ def test_gap_fill_keypoints_linear_fills_low_confidence_window() -> None:
     assert xs[-1] > xs[0]
     assert out.metadata.get("gap_filled") is True
     assert out.metadata.get("strategy") == "linear"
+
+
+def test_gap_fill_keypoints_mismatched_neighbour_counts_does_not_crash() -> None:
+    """Linear interpolation leaves unmatched low-confidence keypoints unchanged."""
+    frames = [
+        KeypointFrame(
+            timestamp=0.0,
+            keypoints=[Keypoint(x=0.0, y=0.0, z=0.0, confidence=1.0, name="hip")],
+            schema_name="custom",
+            frame_index=0,
+        ),
+        KeypointFrame(
+            timestamp=1.0,
+            keypoints=[
+                Keypoint(x=1.0, y=0.0, z=0.0, confidence=0.1, name="hip"),
+                Keypoint(x=1.0, y=1.0, z=0.0, confidence=0.1, name="extra"),
+            ],
+            schema_name="custom",
+            frame_index=1,
+        ),
+        KeypointFrame(
+            timestamp=2.0,
+            keypoints=[
+                Keypoint(x=2.0, y=0.0, z=0.0, confidence=1.0, name="hip"),
+                Keypoint(x=2.0, y=1.0, z=0.0, confidence=1.0, name="extra"),
+            ],
+            schema_name="custom",
+            frame_index=2,
+        ),
+    ]
+    seq = KeypointSequence(id="mismatched", frames=frames)
+
+    out = gap_fill(seq, strategy=GapFillStrategy.LINEAR, max_gap=1)
+
+    assert isinstance(out, KeypointSequence)
+    assert out.frames[1].keypoints[0].confidence == pytest.approx(0.5)
+    assert out.frames[1].keypoints[1].confidence == pytest.approx(0.1)
+
+    from src.shared.python.motion_pipeline.preprocessing._gap_fill_pure_python import (
+        GapFillStrategy as PureGapFillStrategy,
+        gap_fill as pure_gap_fill,
+    )
+
+    pure_out = pure_gap_fill(seq, strategy=PureGapFillStrategy.LINEAR, max_gap=1)
+
+    assert isinstance(pure_out, KeypointSequence)
+    assert pure_out.frames[1].keypoints[0].confidence == pytest.approx(0.5)
+    assert pure_out.frames[1].keypoints[1].confidence == pytest.approx(0.1)
 
 
 def test_gap_fill_keypoints_nearest_uses_previous() -> None:

--- a/tests/unit/physics/test_swing_ball_flight_pipeline_5337.py
+++ b/tests/unit/physics/test_swing_ball_flight_pipeline_5337.py
@@ -38,6 +38,8 @@ from src.shared.python.physics.swing_ball_flight_pipeline import (
     _TrajectoryMetricsExtractor,
 )
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -309,20 +311,26 @@ class TestLaunchConditionsDeriver:
         angle_deg = 15.0
         post = _make_post_impact(speed=60.0, angle_deg=angle_deg)
         lc = self.deriver.derive(post)
-        assert lc.launch_angle == pytest.approx(angle_deg, abs=0.1)
+        assert lc.launch_angle == pytest.approx(math.radians(angle_deg), abs=1e-6)
 
     def test_zero_horizontal_speed_gives_90_degree_angle(self):
         post = _make_post_impact(speed=10.0, angle_deg=0.0)
         # Override to pure vertical
         post.ball_velocity[:] = np.array([0.0, 0.0, 10.0])
         lc = self.deriver.derive(post)
-        assert lc.launch_angle == pytest.approx(90.0, abs=0.1)
+        assert lc.launch_angle == pytest.approx(math.pi / 2.0, abs=1e-6)
 
-    def test_spin_rate_matches_angular_velocity_magnitude(self):
+    def test_spin_rate_converts_angular_velocity_to_rpm(self):
         post = _make_post_impact()
         post.ball_angular_velocity[:] = np.array([0.0, -200.0, 0.0])
         lc = self.deriver.derive(post)
-        assert lc.spin_rate == pytest.approx(200.0, rel=1e-4)
+        assert lc.spin_rate == pytest.approx(200.0 * 60.0 / (2.0 * math.pi))
+
+    def test_azimuth_angle_matches_geometry_in_radians(self):
+        post = _make_post_impact()
+        post.ball_velocity[:] = np.array([30.0, 30.0, 10.0])
+        lc = self.deriver.derive(post)
+        assert lc.azimuth_angle == pytest.approx(math.pi / 4.0, abs=1e-6)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Harden model-explorer API path resolution so inspect/compare only read files under approved model roots.
- Fix linear keypoint gap filling for mismatched neighbor keypoint counts in both main and pure-Python implementations.
- Refactor marker PCA gap-fill helpers below the changed-file architecture budget.
- Correct swing-ball-flight launch condition units to match the ball-flight simulator contract: radians for angles and RPM for spin rate.
- Add unit suite markers and regression tests for the affected paths.

Fixes #7269
Fixes #7270
Fixes #7271
Fixes #7285

## Validation
- `python3 -m ruff check src/api/routes/model_explorer.py src/shared/python/motion_pipeline/preprocessing/gap_fill.py src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py src/shared/python/physics/swing_ball_flight_pipeline.py tests/unit/api/test_routes_model_explorer.py tests/unit/motion_pipeline/preprocessing/test_gap_fill.py tests/unit/physics/test_swing_ball_flight_pipeline_5337.py`
- `python3 -m ruff format --check src/api/routes/model_explorer.py src/shared/python/motion_pipeline/preprocessing/gap_fill.py src/shared/python/motion_pipeline/preprocessing/_gap_fill_pure_python.py src/shared/python/physics/swing_ball_flight_pipeline.py tests/unit/api/test_routes_model_explorer.py tests/unit/motion_pipeline/preprocessing/test_gap_fill.py tests/unit/physics/test_swing_ball_flight_pipeline_5337.py`
- `python3 -m pytest -q tests/unit/api/test_routes_model_explorer.py tests/unit/motion_pipeline/preprocessing/test_gap_fill.py tests/unit/physics/test_swing_ball_flight_pipeline_5337.py`
- `UD_ENFORCE_SUITE_MARKERS=1 python3 -m pytest --collect-only -q tests/unit/api/test_routes_model_explorer.py tests/unit/motion_pipeline/preprocessing/test_gap_fill.py tests/unit/physics/test_swing_ball_flight_pipeline_5337.py`
- `python3 scripts/ci/check_file_size_budget.py`
- `python3 scripts/ci/check_architecture_budget.py`
- `python3 scripts/check_spec_paths.py`
- `python3 scripts/check_docs_governance.py`

Local push hooks also passed ruff, ruff format, formatter guidance, wildcard/debug/print checks, prettier, mypy, bandit, and unit tests. After the PCA helper refactor commit, I reran `python3 scripts/ci/check_architecture_budget.py`, `python3 -m pytest -q tests/unit/motion_pipeline/preprocessing/test_gap_fill.py`, and focused ruff for both gap-fill modules.