### PR TITLE
fix: harden docker scan and logging hygiene

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -47,7 +47,8 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
-          # Don't fail the build initially - triage first
+          # SARIF upload remains nonblocking; the table scan below is the
+          # blocking HIGH/CRITICAL gate.
           exit-code: "0"
           timeout: "30m0s"
 
@@ -62,9 +63,8 @@ jobs:
         with:
           image-ref: "upstreamdrift:ci"
           format: "table"
-          severity: "CRITICAL,HIGH,MEDIUM"
-          # Exit with error only on CRITICAL vulnerabilities
+          severity: "CRITICAL,HIGH"
+          # Fail the build on HIGH or CRITICAL vulnerabilities.
           exit-code: "1"
-          ignore-unfixed: true
           vuln-type: "os,library"
           timeout: "30m0s"

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.301                                            |
+| **Spec Version**        | 1.0.302                                            |
 | **Last Spec Update**    | 2026-06-11                                         |
 
 ## 2. Purpose & Mission
@@ -70,6 +70,12 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-10** - Closed the #7279/#7282 audit hygiene wave. The Docker
+  security scan still uploads HIGH/CRITICAL SARIF findings, but the table scan
+  is now the blocking HIGH/CRITICAL gate without `ignore-unfixed`. The audited
+  API and launcher production modules now route module loggers through
+  `logging_pkg.logging_config.get_logger(__name__)`, with a repo-hygiene test
+  preventing the remediated files from returning to direct `logging.getLogger`.
 - **2026-06-10** - Hardened the audit regressions tracked by #7269, #7270,
   and #7271. Model Explorer inspect/compare path resolution now rejects
   absolute paths and parent traversal before resolving candidates only under
@@ -957,6 +963,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-10 | 1.0.302 | Audit hygiene fixes for #7279 and #7282. `.github/workflows/docker-security-scan.yml` now blocks HIGH and CRITICAL Trivy container vulnerabilities in the table scan while retaining SARIF upload, and audited API/launcher production modules now use the canonical logging infrastructure instead of direct module-level `logging.getLogger` calls. Added security CI acceptance coverage for the Docker HIGH/CRITICAL gate and a repo-hygiene test for the remediated logger modules. |
 | 2026-06-10 | 1.0.301 | Audit regression fixes for #7269, #7270, and #7271. Model Explorer API path resolution now validates caller paths before filesystem reads and resolves only within approved model directories, closing the direct existing-path containment bypass. Motion-pipeline keypoint gap filling now guards both before/after neighbor keypoint indexes and pins mismatched-neighbor behavior in the main and pure-Python implementations. `SwingBallFlightPipeline` now emits `LaunchConditions` in the units consumed by `BallFlightSimulator`: launch and azimuth angles in radians, spin rate in RPM, with updated DbC validation and unit tests. |
 | 2026-06-10 | 1.0.300 | Completed the #7207 model explorer composition UX flow. Added `CompositionUxController` for library drag payloads, non-mutating drop/ghost previews, highlighted target/source links, validation summaries, committed drops, and a validation-aware export chooser that enables URDF/MJCF while explicitly marking SDF/OSIM unavailable until writers exist. `FrankensteinEditor` now exposes preview, commit, and export-choice hooks, with offscreen tests covering simple humanoid plus arm preview, commit, validation pass, and MJCF export. |
 | 2026-06-10 | 1.0.299 | Cross-engine equivalence import-boundary fix for #7214. `CalibrationOptimizer.optimize()` now imports `scipy.optimize.differential_evolution` lazily so importing `src.bunkershot3d.postproc.wrench_trace` through shared simulation backends does not require optional calibration optimizer dependencies in the equivalence CI environment. |

--- a/scripts/config/architecture_budget.json
+++ b/scripts/config/architecture_budget.json
@@ -17,6 +17,22 @@
       "owner": "@dieterolson @D-sorganization/core-maintainers",
       "reason": "Issue #7217 legacy launcher decomposition: main remains over the function-lines budget until startup and window orchestration move into focused launcher modules.",
       "expires_on": "2026-09-30"
+    },
+    {
+      "path": "src/launchers/cross_engine_dashboard.py",
+      "symbol": "_create_dashboard_window_class",
+      "rule": "function-lines",
+      "owner": "@dieterolson @D-sorganization/core-maintainers",
+      "reason": "Issue #7288: pre-existing dashboard window factory exceeds the changed-file architecture budget; split UI construction, orchestration, and rendering after the #7282 logging hygiene fix lands.",
+      "expires_on": "2026-08-31"
+    },
+    {
+      "path": "src/launchers/cross_engine_dashboard.py",
+      "symbol": "_create_dashboard_window_class._Window._update_charts",
+      "rule": "function-lines",
+      "owner": "@dieterolson @D-sorganization/core-maintainers",
+      "reason": "Issue #7288: pre-existing chart update method exceeds the changed-file architecture budget; extract a chart renderer after the #7282 logging hygiene fix lands.",
+      "expires_on": "2026-08-31"
     }
   ]
 }

--- a/src/api/routes/analysis_tools.py
+++ b/src/api/routes/analysis_tools.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import logging
 import math
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +23,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from src.shared.python.core.contracts import precondition
+from src.shared.python.logging_pkg.logging_config import get_logger as get_module_logger
 
 from ..dependencies import get_engine_manager, get_logger
 from ..models.requests import (
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 router = APIRouter()
 
-logger = logging.getLogger(__name__)
+logger = get_module_logger(__name__)
 
 
 def _check_position_support(engine: Any) -> None:

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -3,7 +3,6 @@
 import asyncio
 import contextlib
 import json
-import logging
 import math
 import time
 from typing import Any
@@ -18,7 +17,6 @@ from src.shared.python.core.contracts import require
 from src.shared.python.engine_core.engine_registry import EngineType
 from src.shared.python.logging_pkg.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
 router = APIRouter()
 _DEFAULT_SPEED_FACTOR = 1.0
 logger = get_logger(__name__)

--- a/src/launchers/base.py
+++ b/src/launchers/base.py
@@ -9,7 +9,6 @@ multiple launcher implementations.
 
 from __future__ import annotations
 
-import logging
 import os
 import subprocess
 import sys
@@ -36,8 +35,9 @@ if TYPE_CHECKING:
 
 from src.shared.python.theme.style_constants import Styles
 from src.shared.python.theme.typography import Weights, get_display_font, get_qfont
+from src.shared.python.logging_pkg.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Repository root - single source of truth
 REPO_ROOT = Path(__file__).parent.parent.parent.resolve()

--- a/src/launchers/cross_engine_dashboard.py
+++ b/src/launchers/cross_engine_dashboard.py
@@ -54,12 +54,12 @@ from src.shared.python.plot_style import (
     PlotStyleSpec,
     PresetLibrary,
 )
+from src.shared.python.logging_pkg.logging_config import get_logger
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
-logger = logging.getLogger(__name__)
-
+logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Engine stub (graceful degradation when physics package is not installed)
 # ---------------------------------------------------------------------------

--- a/tests/unit/repo_hygiene/test_logging_contract.py
+++ b/tests/unit/repo_hygiene/test_logging_contract.py
@@ -1,0 +1,26 @@
+"""Repository logging hygiene checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.unit
+
+
+def test_audited_production_modules_use_canonical_logger() -> None:
+    """Issue #7282: audited production modules must not bypass log config."""
+    audited_paths = [
+        "src/api/routes/analysis_tools.py",
+        "src/api/routes/simulation_ws.py",
+        "src/launchers/base.py",
+        "src/launchers/cross_engine_dashboard.py",
+    ]
+
+    for relative_path in audited_paths:
+        content = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert "logging.getLogger(" not in content
+        assert "logging_pkg.logging_config import get_logger" in content

--- a/tests/unit/test_security_ci_acceptance.py
+++ b/tests/unit/test_security_ci_acceptance.py
@@ -6,7 +6,11 @@ import json
 import re
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.unit
 
 
 def _read(path: str) -> str:
@@ -35,6 +39,15 @@ def test_standard_ci_runs_blocking_semgrep_and_trivy() -> None:
     assert ('exit-code: "1"' in workflow) or ("exit-code: '1'" in workflow)
     assert "trivy" in trivy_test
     assert '"fs"' in trivy_test
+
+
+def test_docker_security_scan_blocks_high_and_critical() -> None:
+    workflow = _read(".github/workflows/docker-security-scan.yml")
+
+    assert 'severity: "CRITICAL,HIGH"' in workflow
+    assert 'exit-code: "1"' in workflow
+    assert "Fail the build on HIGH or CRITICAL vulnerabilities." in workflow
+    assert "ignore-unfixed: true" not in workflow
 
 
 def test_codeowners_has_two_owners_for_critical_paths() -> None:


### PR DESCRIPTION
## Summary
- Make Docker image Trivy table scan fail on HIGH and CRITICAL vulnerabilities while preserving SARIF upload.
- Route audited API/launcher production module loggers through canonical `logging_pkg.logging_config.get_logger`.
- Add regression/hygiene coverage for Docker scan severity and remediated logger modules.
- Add short-lived architecture-budget exceptions for pre-existing `cross_engine_dashboard.py` decomposition debt exposed by the logger touch; tracked by #7288.
- Update SPEC.md for the audit hygiene wave.

Fixes #7279
Fixes #7282
Refs #7288

## Validation
- `python3 -m ruff check src/launchers/base.py src/launchers/cross_engine_dashboard.py src/api/routes/analysis_tools.py src/api/routes/simulation_ws.py tests/unit/test_security_ci_acceptance.py tests/unit/repo_hygiene/test_logging_contract.py`
- `python3 -m ruff format --check src/launchers/base.py src/launchers/cross_engine_dashboard.py src/api/routes/analysis_tools.py src/api/routes/simulation_ws.py tests/unit/test_security_ci_acceptance.py tests/unit/repo_hygiene/test_logging_contract.py`
- `python3 -m pytest -q tests/unit/test_security_ci_acceptance.py tests/unit/repo_hygiene/test_logging_contract.py`
- `python3 scripts/ci/check_file_size_budget.py`
- `python3 scripts/ci/check_architecture_budget.py`
- `python3 scripts/check_spec_paths.py`
- `python3 scripts/check_docs_governance.py`

Local push hooks also passed ruff, ruff format, formatter guidance, wildcard/debug/print checks, prettier, mypy, bandit, and unit tests.