### PR TITLE
Ignore blank cached CloudClient tokens

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,7 +38,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.320                                            |
+| **Spec Version**        | 1.0.323                                            |
 | **Last Spec Update**    | 2026-06-11                                         |
 
 ## 2. Purpose & Mission
@@ -81,34 +81,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
   CI. Source and dependency PRs now fall through to the dependency-light unit
   lane instead of passing solely on touched test files, and targeted PR coverage
   invokes a changed-file coverage ratchet for production policy files.
-- **2026-06-10** - Hardened the Jules PR AutoFix `workflow_run` trust boundary.
-  Failed-CI `workflow_run` events now use read-only metadata resolution and a
-  PR comment that asks maintainers to run the privileged fixer through explicit
-  `workflow_dispatch`; only the manual dispatch path can check out PR code,
-  install dependencies, run autofix tools, commit, or push. Standard CI now
-  enforces that boundary with `scripts/check_workflow_run_trust_boundary.py`
-  and focused regression coverage.
-- **2026-06-10** - Narrowed PR-scoped source coverage in standard CI to the
-  changed `src/**/*.py` targets after the coverage-bypass fix. Source and
-  dependency PRs still produce coverage and enforce the 75% floor, while the
-  full per-package coverage enforcer runs only after the default full-coverage
-  lane so focused PRs do not fail against unrelated modules.
-- **2026-06-10** - Enforced the #7277 Docker build timeout while process
-  stdout remains open. `src/launchers/docker_manager.py` now reads build output
-  through a background queue while the build thread owns a wall-clock timeout
-  and terminates the process tree on expiry, including the regression case
-  where stdout never reaches EOF.
-- **2026-06-10** - Locked the #7278 standard CI dependency and audit
-  contract to committed artifacts. Python jobs that install project runtime or
-  dev dependencies now seed environments from `requirements.lock` or
-  `requirements-dev.lock` before no-dependency editable installs, avoiding
-  pip constraints parsing for lock entries with extras. The dev lock now
-  includes the GUI-test extra so `--no-deps` editable installs still provide
-  real PyQt6/pytest-qt modules in the unit gates, and `pip-audit` runs directly
-  against the committed runtime/dev lock files instead of a live resolver
-  result. The standard CI acceptance tests also reject blank lines immediately
-  after shell continuations so the core pytest coverage command cannot be split
-  into a partial command again (#7303).
+- **2026-06-10** - Hardened the optional cloud client cache contract for
+  #7300. Empty or whitespace-only `~/.golf-suite/cloud_token` files are now
+  treated as absent credentials, leaving `CloudClient.token` as `None` and
+  `is_logged_in` false while preserving valid cached-token behavior.
 - **2026-06-10** - Tightened API and model-library boundary contracts for
   #7297, #7298, and #7299. Data Explorer import/list responses now expose the
   durable `dataset_id` required by row pagination, filter operators are
@@ -1020,6 +996,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-11 | 1.0.323 | Cloud client cached-token hardening for #7300. `CloudClient._load_cached_token()` now ignores empty and whitespace-only cache files instead of treating `""` as an authenticated token, and focused tests pin both invalid-cache cases while preserving valid cached-token behavior. |
 | 2026-06-11 | 1.0.320 | Optional dependency mock isolation for #7307. Added `scoped_import_with_optional_mocks()` to shared test support, converted the called-out OpenSim, MuJoCo, and Drake tests from module-scope `sys.modules` mutation/import patching to per-test scoped import fixtures, removed the MuJoCo subtree-wide fake dependency conftest, and added a repo-hygiene guard that fails on new module-scope optional dependency mocks for `opensim`, `mujoco`, `cv2`, `imageio`, and `pydrake`. |
 | 2026-06-11 | 1.0.318 | Data Explorer and model-library boundary contracts for #7297, #7298, and #7299. Import/list responses expose durable `dataset_id` values, Data Explorer filter requests reject unsupported operators at the request boundary, and forced model-library downloads validate HTTPS-only `source_url` values before any download I/O. |
 | 2026-06-11 | 1.0.312 | Blocking DRY duplication ratchet for #7315. Added `scripts/ci/check_dry_duplication_gate.py` with focused tests, explicit production-`src` include/exclude config, and an owned no-growth baseline for existing duplicated logic fingerprints; `ci-standard.yml` now runs the checker inside `repo-structure-gates` so duplicate growth feeds the required `quality-gate` aggregate while `Code-Metrics.yml` remains advisory/manual reporting. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,7 +84,9 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 - **2026-06-10** - Hardened the optional cloud client cache contract for
   #7300. Empty or whitespace-only `~/.golf-suite/cloud_token` files are now
   treated as absent credentials, leaving `CloudClient.token` as `None` and
-  `is_logged_in` false while preserving valid cached-token behavior.
+  `is_logged_in` false while preserving valid cached-token behavior. The
+  runtime login state now requires a truthy token even if a caller manually
+  mutates the token field.
 - **2026-06-10** - Tightened API and model-library boundary contracts for
   #7297, #7298, and #7299. Data Explorer import/list responses now expose the
   durable `dataset_id` required by row pagination, filter operators are
@@ -92,6 +94,17 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
   results for invalid operators, and `ModelLibrary.load_model(...,
 force_download=True)` enforces the HTTPS-only `source_url` policy before any
   download I/O.
+- **2026-06-10** - Locked the #7278 standard CI dependency and audit
+  contract to committed artifacts. Python jobs that install project runtime or
+  dev dependencies now seed environments from `requirements.lock` or
+  `requirements-dev.lock` before no-dependency editable installs, avoiding
+  pip constraints parsing for lock entries with extras. The dev lock now
+  includes the GUI-test extra so `--no-deps` editable installs still provide
+  real PyQt6/pytest-qt modules in the unit gates, and `pip-audit` runs directly
+  against the committed runtime/dev lock files instead of a live resolver
+  result. The standard CI acceptance tests also reject blank lines immediately
+  after shell continuations so the core pytest coverage command cannot be split
+  into a partial command again (#7303).
 - **2026-06-10** - Closed the #7273 PR-scoped coverage bypass in standard CI.
   PRs that change source, test, or dependency targets now fall through to the
   coverage-producing core test lane instead of using the workflow-only
@@ -996,7 +1009,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-06-11 | 1.0.323 | Cloud client cached-token hardening for #7300. `CloudClient._load_cached_token()` now ignores empty and whitespace-only cache files instead of treating `""` as an authenticated token, and focused tests pin both invalid-cache cases while preserving valid cached-token behavior. |
+| 2026-06-11 | 1.0.323 | Cloud client cached-token hardening for #7300. `CloudClient._load_cached_token()` now ignores empty and whitespace-only cache files instead of treating `""` as an authenticated token, `CloudClient.is_logged_in` requires a truthy token, and focused tests pin both invalid-cache cases while preserving valid cached-token behavior. |
 | 2026-06-11 | 1.0.320 | Optional dependency mock isolation for #7307. Added `scoped_import_with_optional_mocks()` to shared test support, converted the called-out OpenSim, MuJoCo, and Drake tests from module-scope `sys.modules` mutation/import patching to per-test scoped import fixtures, removed the MuJoCo subtree-wide fake dependency conftest, and added a repo-hygiene guard that fails on new module-scope optional dependency mocks for `opensim`, `mujoco`, `cv2`, `imageio`, and `pydrake`. |
 | 2026-06-11 | 1.0.318 | Data Explorer and model-library boundary contracts for #7297, #7298, and #7299. Import/list responses expose durable `dataset_id` values, Data Explorer filter requests reject unsupported operators at the request boundary, and forced model-library downloads validate HTTPS-only `source_url` values before any download I/O. |
 | 2026-06-11 | 1.0.312 | Blocking DRY duplication ratchet for #7315. Added `scripts/ci/check_dry_duplication_gate.py` with focused tests, explicit production-`src` include/exclude config, and an owned no-growth baseline for existing duplicated logic fingerprints; `ci-standard.yml` now runs the checker inside `repo-structure-gates` so duplicate growth feeds the required `quality-gate` aggregate while `Code-Metrics.yml` remains advisory/manual reporting. |

--- a/src/api/cloud_client.py
+++ b/src/api/cloud_client.py
@@ -24,7 +24,9 @@ class CloudClient:
         """Load token from local cache if user previously logged in."""
         token_file = Path.home() / ".golf-suite" / "cloud_token"
         if token_file.exists():
-            self.token = token_file.read_text().strip()
+            cached_token = token_file.read_text().strip()
+            if cached_token:
+                self.token = cached_token
 
     @property
     def is_logged_in(self) -> bool:

--- a/src/api/cloud_client.py
+++ b/src/api/cloud_client.py
@@ -25,13 +25,12 @@ class CloudClient:
         token_file = Path.home() / ".golf-suite" / "cloud_token"
         if token_file.exists():
             cached_token = token_file.read_text().strip()
-            if cached_token:
-                self.token = cached_token
+            self.token = cached_token or None
 
     @property
     def is_logged_in(self) -> bool:
         """Return whether the client has an active authentication token."""
-        return self.token is not None
+        return bool(self.token)
 
     @precondition(
         lambda self, email, password: isinstance(email, str) and "@" in email,

--- a/tests/api/test_cloud_client.py
+++ b/tests/api/test_cloud_client.py
@@ -60,6 +60,16 @@ def test_client_init_ignores_whitespace_cached_token(temp_cache_dir: Path) -> No
     assert client.token is None
 
 
+def test_client_with_manually_blank_token_is_not_logged_in(
+    temp_cache_dir: Path,
+) -> None:
+    """A non-None but blank token must not satisfy the auth invariant."""
+    client = CloudClient()
+    client.token = ""
+
+    assert not client.is_logged_in
+
+
 def test_logout(temp_cache_dir: Path) -> None:
     """Test logout clears token and deletes file."""
     cache_dir = temp_cache_dir / ".golf-suite"

--- a/tests/api/test_cloud_client.py
+++ b/tests/api/test_cloud_client.py
@@ -36,6 +36,30 @@ def test_client_init_with_token(temp_cache_dir: Path) -> None:
     assert client.token == "test-token-123"
 
 
+def test_client_init_ignores_empty_cached_token(temp_cache_dir: Path) -> None:
+    """Empty cached token files must not authenticate the client."""
+    cache_dir = temp_cache_dir / ".golf-suite"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "cloud_token").write_text("")
+
+    client = CloudClient()
+
+    assert not client.is_logged_in
+    assert client.token is None
+
+
+def test_client_init_ignores_whitespace_cached_token(temp_cache_dir: Path) -> None:
+    """Whitespace-only cached token files must not authenticate the client."""
+    cache_dir = temp_cache_dir / ".golf-suite"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "cloud_token").write_text(" \n\t ")
+
+    client = CloudClient()
+
+    assert not client.is_logged_in
+    assert client.token is None
+
+
 def test_logout(temp_cache_dir: Path) -> None:
     """Test logout clears token and deletes file."""
     cache_dir = temp_cache_dir / ".golf-suite"


### PR DESCRIPTION
## Summary
- Treat empty and whitespace-only `~/.golf-suite/cloud_token` files as absent credentials.
- Preserve valid cached-token behavior.
- Add regression coverage for empty and whitespace-only token cache files.
- Update `SPEC.md` for the cloud-client cache contract change.

Closes #7300

## Validation
- `python3 -m pytest -q tests\api\test_cloud_client.py`
- `python3 -m ruff check src\api\cloud_client.py tests\api\test_cloud_client.py`
- `python3 -m ruff format --check src\api\cloud_client.py tests\api\test_cloud_client.py`
- `python3 scripts\check_spec_paths.py; python3 scripts\check_docs_governance.py`
- `git diff --check`