### PR TITLE
Finalize desktop-only web-parity exemptions in the registry (ADR-0031)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,10 @@ every user-facing feature (`parity`, `gap` + open issue number, or `exempt` +
 reason). **PRs adding user-facing PyQt6 features must add or update a registry
 entry.** CI enforces this via `tests/config/feature_parity/` (gap entries need
 an issue, referenced paths must exist, every launcher tile must be covered)
-and a freshness gate on the generated matrix doc. After editing the JSON,
-regenerate the human-readable matrix:
+and a freshness gate on the generated matrix doc. Desktop-only exemptions are
+decided in [ADR-0031](docs/adr/0031-web-parity-exemptions.md) — **changing an
+exempt entry requires updating that ADR in the same PR.** After editing the
+JSON, regenerate the human-readable matrix:
 
 ```bash
 python3 -m scripts.generate_feature_parity_matrix

--- a/docs/adr/0031-web-parity-exemptions.md
+++ b/docs/adr/0031-web-parity-exemptions.md
@@ -1,0 +1,100 @@
+# ADR-0031: Web feature-parity exemptions (desktop-only features)
+
+- Status: Accepted
+- Date: 2026-06-12
+- Decision Makers: UpstreamDrift maintainers
+- Related Issues/PRs: #7460, #7445, epic #7462
+
+## Context
+
+The PyQt6 desktop app is the canonical model and the Tauri/React web app must
+match it (epic #7462). Several large desktop features have no web counterpart,
+and until now that was implicit: every parity review re-litigated them, and
+contributors could not tell deliberate scope from accidental drift. ADR-0028
+set the precedent for one such decision (embedded tabs/docks vs. the web
+multi-window model); the remaining features needed the same treatment.
+
+The web shell runs against a **local server trust model**: the FastAPI backend
+is a localhost process serving a browser UI. Anything reachable from the
+browser is reachable from any page the browser visits (CSRF/DNS-rebinding
+class risks) and from any user on a shared machine. The browser surface must
+therefore never expose arbitrary code execution or host-administration
+capabilities.
+
+## Decision
+
+The feature-parity registry (`src/config/feature_parity.json`, #7445) is the
+**enforcement mechanism**: every exempt feature carries a one-sentence reason
+citing this ADR, and CI (`tests/config/feature_parity/`) gates the registry
+plus the generated matrix doc. Parity audits diff against the registry instead
+of rediscovering these decisions.
+
+Decisions made in #7460, in three groups:
+
+### 1. Trust-model exemptions (never web features under the local-server model)
+
+- `sidekick.terminal_repl_jupyter_skills` — an OS terminal, Python REPL,
+  Jupyter kernel, or skills runner exposed over HTTP is a remote-shell
+  endpoint. That is a non-starter: any browser page could pivot through it to
+  full code execution on the host. Web chat instead gets structured context
+  via #7453.
+- `launcher.docker_management` — Docker daemon control is root-equivalent on
+  most hosts; exposing start/stop/build over HTTP would hand container escape
+  primitives to the browser surface. Candidate for Tauri mode only, where the
+  shell is a trusted native process.
+- `launcher.mcp_config` — writes local MCP configuration files for desktop AI
+  integrations; file-system configuration of the user's machine is a
+  local-machine concern outside the web trust boundary.
+
+### 2. Capability exemptions (depend on local resources the browser cannot have)
+
+- `tools.matlab_suite` — requires a licensed local MATLAB installation;
+  browser-exempt, possible later in Tauri mode.
+- `engines.dashboards` and `biomech.exercise_injury_dashboards` — experimental
+  desktop dashboards whose equivalent web surface is the Simulation page;
+  exercise routing is not a web feature.
+- `launcher.embedded_tabs_docks` — already decided in ADR-0028 (web uses the
+  multi-window model).
+
+### 3. Roadmap exemptions (plausible web features, deliberately deferred)
+
+Marked `exempt` with reason "roadmap — revisit after epic #7462 core lands"
+rather than opened as issues now, so the gap list stays an actionable backlog:
+
+- `tools.pose_editing` (Pose Studio) — heavy native-viewer coupling; a web
+  pose editor is a major project.
+- `docs.document_library` — indexes local files via SQLite; a thin web reader
+  is plausible later.
+- `simulation.golf_suite_batch` — parameter sweeps/batch runs could become
+  API-backed web jobs.
+- `optimization.swing_optimizer` — long-running trajectory optimization suits
+  an API-backed job model.
+
+## Alternatives Considered
+
+1. Open roadmap issues now for group 3. Rejected: issues without a committed
+   horizon go stale and dilute the gap backlog; the registry reason preserves
+   the intent and the revisit trigger (epic #7462 core landing).
+2. Expose terminal/Docker behind authentication on the web surface. Rejected:
+   localhost auth does not remove the CSRF/rebinding attack surface, and a
+   compromised browser session would still gain host code execution.
+3. Leave exemptions implicit (status quo). Rejected: every parity audit
+   re-litigated the same features.
+
+## Consequences
+
+- Positive: parity audits diff against the registry; scope decisions are
+  explicit, cited, and CI-enforced; the security boundary of the local server
+  is written down.
+- Negative: roadmap items have no tracking issue until they are picked up;
+  the revisit trigger is procedural (post-epic review), not automated.
+- **Changing any exemption requires updating this ADR** (and the registry
+  entry's reason) in the same PR — the registry description and CLAUDE.md
+  state this rule.
+
+## Validation
+
+`tests/config/feature_parity/test_registry.py` (exempt entries require a
+reason; no `pending_decision` entries remain) and
+`tests/config/feature_parity/test_matrix_freshness.py` (generated matrix
+matches the registry byte-for-byte).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 | [0027](0027-canonical-viewport-backend.md)         | Canonical 3D Viewport Backend                                   | Accepted | 2026-05-31 |
 | [0028](0028-react-tauri-launcher-parity.md)        | React/Tauri launcher parity model                               | Accepted | 2026-06-10 |
 | [0030](0030-c3d-viewer-renderer-backend.md)        | C3D Viewer Renderer Backend                                     | Accepted | 2026-06-10 |
+| [0031](0031-web-parity-exemptions.md)              | Web feature-parity exemptions (desktop-only features)           | Accepted | 2026-06-12 |
 
 Note: ADR 0013 was amended on 2026-05-31 to document the CC-32
 canonical-core app-shell registry reuse of the embeddable-tool contract.

--- a/docs/development/feature_parity_matrix.md
+++ b/docs/development/feature_parity_matrix.md
@@ -7,7 +7,7 @@ Generated from [`src/config/feature_parity.json`](../../src/config/feature_parit
 The PyQt6 desktop app is the canonical model; the web app must match
 (epic #7462, registry mechanism #7445).
 
-**Summary:** 9 parity · 16 gap · 11 exempt (10 pending decision in #7460).
+**Summary:** 9 parity · 16 gap · 11 exempt (0 pending decision in #7460).
 
 | Feature | Status | PyQt6 | API | Web | Tracking |
 | --- | --- | --- | --- | --- | --- |
@@ -15,36 +15,36 @@ The PyQt6 desktop app is the canonical model; the web app must match
 | `analysis.counterfactuals`<br>ZTCF/ZVCF + induced-acceleration counterfactuals | 🔴 gap | `src/shared/python/biomechanics/ztcf.py` | — | — | #7450 |
 | `analysis.cross_engine_robustness`<br>Cross-engine robustness dashboard (perturbation/CV) | 🔴 gap | `src/launchers/cross_engine_dashboard.py` | — | — | #7455 |
 | `analysis.static_plots`<br>Static analysis plots (20+ plot types) | 🔴 gap | `src/shared/python/plot_engine/pyqt6_widget.py` | — | — | #7449 |
-| `biomech.exercise_injury_dashboards`<br>Exercise + injury-risk biomechanics dashboards | ⚪ exempt | `src/launchers/exercise_dashboard.py` | — | — | Desktop biomechanics dashboards; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `biomech.exercise_injury_dashboards`<br>Exercise + injury-risk biomechanics dashboards | ⚪ exempt | `src/launchers/exercise_dashboard.py` | — | — | Desktop biomechanics dashboards; the web Simulation page is the equivalent web surface — exercise routing is not a web feature (ADR-0031). |
 | `canonical_core.workspaces`<br>Canonical-core estimation/comparison workspaces | ✅ parity | `src/tools/canonical_core/estimation.py` | — | `ui/src/pages/CanonicalCoreShell.tsx` | — |
 | `chat.live_context`<br>Live app/engine context in chat | 🔴 gap | `src/launchers/launcher_sidekick_sidebar.py` | — | `ui/src/pages/Chat.tsx` | #7453 |
 | `chat.transport`<br>AI chat transport (message send/stream) | ✅ parity | `src/launchers/launcher_sidekick_sidebar.py` | `src/api/routes/chat_ws.py` | `ui/src/pages/Chat.tsx` | — |
 | `diagnostics.integrations_health`<br>Diagnostics + integrations-health panel | 🔴 gap | `src/launchers/integrations_health_panel.py` | — | — | #7458 |
-| `docs.document_library`<br>Document library / project map viewer | ⚪ exempt | `src/launchers/library_widget.py` | — | — | Desktop documentation browser; desktop-only candidate pending #7460. — **pending decision (#7460)** |
-| `engines.dashboards`<br>Per-engine interactive dashboards (Drake/MuJoCo/Pinocchio) | ⚪ exempt | `src/launchers/drake_dashboard.py` | — | — | Experimental desktop dashboards; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `docs.document_library`<br>Document library / project map viewer | ⚪ exempt | `src/launchers/library_widget.py` | — | — | Roadmap — indexes local files via SQLite; a thin web reader is plausible but not near-term; revisit after epic #7462 core lands (ADR-0031). |
+| `engines.dashboards`<br>Per-engine interactive dashboards (Drake/MuJoCo/Pinocchio) | ⚪ exempt | `src/launchers/drake_dashboard.py` | — | — | Experimental desktop dashboards; the web Simulation page is the equivalent web surface (ADR-0031). |
 | `engines.load_and_simulate`<br>Engine load/probe + basic simulation loop | ✅ parity | `src/launchers/launcher_simulation.py` | `src/api/routes/engines.py` | `ui/src/pages/Simulation.tsx` | — |
 | `export.recordings_downloads`<br>Export/recording parity (HDF5/MAT/C3D/CSV/video, persisted recordings) | 🔴 gap | `src/shared/python/data_io/export.py` | `src/api/routes/export.py` | — | #7451 |
-| `launcher.docker_management`<br>Docker engine management dialog | ⚪ exempt | `src/launchers/docker_manager.py` | — | — | Manages the local Docker daemon from the desktop; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `launcher.docker_management`<br>Docker engine management dialog | ⚪ exempt | `src/launchers/docker_manager.py` | — | — | Exposing local Docker daemon control over HTTP is a security risk under the local-server trust model (ADR-0031); Tauri-mode-only candidate. |
 | `launcher.embedded_tabs_docks`<br>Embedded tool host (tabs + docks) | ⚪ exempt | `src/launchers/embedded_host.py` | — | — | Desktop windowing composition is explicitly desktop-only per ADR-0028 (React shell uses routes, not embedded Qt docks). |
-| `launcher.mcp_config`<br>MCP server configuration writer/preferences | ⚪ exempt | `src/launchers/mcp_config_writer.py` | — | — | Writes local MCP configuration files for desktop AI integrations; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `launcher.mcp_config`<br>MCP server configuration writer/preferences | ⚪ exempt | `src/launchers/mcp_config_writer.py` | — | — | Writes local MCP configuration files for desktop AI integrations — a local-machine concern outside the web trust boundary (ADR-0031). |
 | `launcher.tile_grid`<br>Launcher tile grid from shared manifest | ✅ parity | `src/launchers/unified_launcher.py` | `src/api/routes/launcher.py` | `ui/src/pages/Dashboard.tsx` | — |
 | `launcher.tile_web_reachability`<br>Manifest tile web-reachability contract (route / native-window / unavailable) | 🔴 gap | `src/launchers/unified_launcher.py` | — | `ui/src/pages/Dashboard.tsx` | #7461 |
 | `mocap.breadth`<br>Motion-capture breadth (C3D upload/playback, OpenPose source) | 🔴 gap | `src/tools/freemocap_sidecar/run_freemocap.py` | `src/api/routes/motion_capture.py` | `ui/src/pages/MotionCapture.tsx` | #7454 |
 | `onboarding.about_version`<br>About/version info + onboarding | 🔴 gap | `src/launchers/about_dialog.py` | — | — | #7459 |
-| `optimization.swing_optimizer`<br>Swing Optimizer (trajectory optimization GUI) | ⚪ exempt | `src/shared/python/optimization/swing_optimizer.py` | — | — | Desktop optimization GUI; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `optimization.swing_optimizer`<br>Swing Optimizer (trajectory optimization GUI) | ⚪ exempt | `src/shared/python/optimization/swing_optimizer.py` | — | — | Roadmap — long-running trajectory optimization suits an API-backed web job, but is not near-term; revisit after epic #7462 core lands (ADR-0031). |
 | `platform.aip_protocol`<br>AI Protocol (AIP) structured method dispatch | ✅ parity | — | `src/api/routes/aip.py` | — | — |
 | `settings.preferences`<br>Settings/preferences surface + persistence | 🔴 gap | `src/launchers/settings_dialog.py` | — | — | #7457 |
-| `sidekick.terminal_repl_jupyter_skills`<br>Sidekick OS terminal / REPL / Jupyter / skills | ⚪ exempt | `src/launchers/launcher_sidekick_sidebar.py` | — | — | Desktop-native OS integration (terminal/REPL/Jupyter/skills) per ADR-0028; final disposition pending #7460. — **pending decision (#7460)** |
+| `sidekick.terminal_repl_jupyter_skills`<br>Sidekick OS terminal / REPL / Jupyter / skills | ⚪ exempt | `src/launchers/launcher_sidekick_sidebar.py` | — | — | Remote shell/REPL/Jupyter execution over HTTP is a non-starter under the local-server trust model (ADR-0031); web chat gets context via #7453 instead. |
 | `simulation.controls_wiring`<br>Web SimulationControls wiring (camera presets, recording toggle, trajectory export, force overlays, actuator controls) | 🔴 gap | `src/launchers/launcher_simulation.py` | — | `ui/src/components/simulation/SimulationControls.tsx` | #7452 |
-| `simulation.golf_suite_batch`<br>Golf Simulation Suite (parameter sweeps, batch runs) | ⚪ exempt | `src/tools/golf_simulation_suite/__main__.py` | — | — | Desktop batch-simulation GUI; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `simulation.golf_suite_batch`<br>Golf Simulation Suite (parameter sweeps, batch runs) | ⚪ exempt | `src/tools/golf_simulation_suite/__main__.py` | — | — | Roadmap — parameter sweeps/batch runs could become API-backed web jobs, but the desktop GUI stays canonical; revisit after epic #7462 core lands (ADR-0031). |
 | `simulation.realtime_ws_stream`<br>Live simulation data over WebSocket pub-sub | ✅ parity | `src/launchers/launcher_simulation.py` | `src/api/routes/simulation_ws.py` | `ui/src/pages/Simulation.tsx` | — |
 | `simulation.shot_tracer`<br>Shot Tracer / ball-flight visualization | 🔴 gap | `src/launchers/_shot_tracer_gui.py` | `src/api/routes/ball_flight.py` | — | #7456 |
 | `tools.character_builder`<br>Character Builder (humanoid URDF generation) | 🔴 gap | `src/shared/python/model_generation/cli/main.py` | `src/api/routes/character_builder.py` | `ui/src/pages/CharacterBuilder.tsx` | #7448 |
 | `tools.data_explorer`<br>Data Explorer (import/filter/visualize datasets) | 🔴 gap | — | `src/api/routes/data_explorer.py` | `ui/src/pages/DataExplorer.tsx` | #7448 |
 | `tools.dataset_generator`<br>Swing dataset generation and import | ✅ parity | — | `src/api/routes/dataset.py` | `ui/src/pages/DatasetGenerator.tsx` | — |
-| `tools.matlab_suite`<br>MATLAB/Simscape model suite | ⚪ exempt | `src/launchers/matlab_suite_dialog.py` | — | — | Requires a local MATLAB installation; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `tools.matlab_suite`<br>MATLAB/Simscape model suite | ⚪ exempt | `src/launchers/matlab_suite_dialog.py` | — | — | Requires a local MATLAB installation on the user's machine; browser-exempt, possible later in Tauri mode (ADR-0031). |
 | `tools.model_explorer`<br>Model Explorer (browse/select/build URDF-MJCF) | 🔴 gap | `src/tools/model_explorer/launch_model_explorer.py` | `src/api/routes/model_explorer.py` | `ui/src/pages/ModelExplorer.tsx` | #7448 |
-| `tools.pose_editing`<br>Pose Studio interactive pose editing | ⚪ exempt | `src/tools/pose_studio/__main__.py` | — | — | Interactive 3D pose editing; desktop-only candidate pending #7460. — **pending decision (#7460)** |
+| `tools.pose_editing`<br>Pose Studio interactive pose editing | ⚪ exempt | `src/tools/pose_studio/__main__.py` | — | — | Roadmap — heavy native-viewer coupling makes a web pose editor a major project; revisit after epic #7462 core lands (ADR-0031). |
 | `tools.putting_green`<br>Putting green simulation | ✅ parity | `src/engines/physics_engines/putting_green/python/simulator.py` | `src/api/routes/putting_green.py` | `ui/src/pages/PuttingGreen.tsx` | — |
 | `tools.terrain_engine`<br>Terrain and topography configuration | ✅ parity | — | `src/api/routes/terrain.py` | `ui/src/pages/Terrain.tsx` | — |
 

--- a/src/config/feature_parity.json
+++ b/src/config/feature_parity.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "description": "Machine-readable feature-parity registry (PyQt6 = canonical model; Tauri/React web app must match). Statuses: parity | gap (requires open issue) | exempt (requires reason). Entries with pending_decision=true await the desktop-only exemption decision in issue #7460 (G12). See docs/development/feature_parity_matrix.md (generated) and epic #7462.",
+  "description": "Machine-readable feature-parity registry (PyQt6 = canonical model; Tauri/React web app must match). Statuses: parity | gap (requires open issue) | exempt (requires reason). Desktop-only exemptions were decided in issue #7460 and are documented in docs/adr/0031-web-parity-exemptions.md; changing an exemption requires updating that ADR. See docs/development/feature_parity_matrix.md (generated) and epic #7462.",
   "features": {
     "launcher.tile_grid": {
       "title": "Launcher tile grid from shared manifest",
@@ -254,8 +254,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Desktop-native OS integration (terminal/REPL/Jupyter/skills) per ADR-0028; final disposition pending #7460.",
-      "pending_decision": true,
+      "reason": "Remote shell/REPL/Jupyter execution over HTTP is a non-starter under the local-server trust model (ADR-0031); web chat gets context via #7453 instead.",
       "tiles": []
     },
     "launcher.embedded_tabs_docks": {
@@ -273,8 +272,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Manages the local Docker daemon from the desktop; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Exposing local Docker daemon control over HTTP is a security risk under the local-server trust model (ADR-0031); Tauri-mode-only candidate.",
       "tiles": []
     },
     "launcher.mcp_config": {
@@ -283,8 +281,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Writes local MCP configuration files for desktop AI integrations; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Writes local MCP configuration files for desktop AI integrations — a local-machine concern outside the web trust boundary (ADR-0031).",
       "tiles": []
     },
     "tools.matlab_suite": {
@@ -293,8 +290,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Requires a local MATLAB installation; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Requires a local MATLAB installation on the user's machine; browser-exempt, possible later in Tauri mode (ADR-0031).",
       "tiles": ["matlab_unified"]
     },
     "tools.pose_editing": {
@@ -303,8 +299,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Interactive 3D pose editing; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Roadmap — heavy native-viewer coupling makes a web pose editor a major project; revisit after epic #7462 core lands (ADR-0031).",
       "tiles": ["pose_studio"]
     },
     "docs.document_library": {
@@ -313,8 +308,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Desktop documentation browser; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Roadmap — indexes local files via SQLite; a thin web reader is plausible but not near-term; revisit after epic #7462 core lands (ADR-0031).",
       "tiles": ["project_map"]
     },
     "engines.dashboards": {
@@ -323,8 +317,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Experimental desktop dashboards; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Experimental desktop dashboards; the web Simulation page is the equivalent web surface (ADR-0031).",
       "tiles": ["drake_dashboard", "mujoco_dashboard", "pinocchio_dashboard"]
     },
     "biomech.exercise_injury_dashboards": {
@@ -333,8 +326,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Desktop biomechanics dashboards; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Desktop biomechanics dashboards; the web Simulation page is the equivalent web surface — exercise routing is not a web feature (ADR-0031).",
       "tiles": ["biomech_exercise", "injury_analysis"]
     },
     "simulation.golf_suite_batch": {
@@ -343,8 +335,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Desktop batch-simulation GUI; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Roadmap — parameter sweeps/batch runs could become API-backed web jobs, but the desktop GUI stays canonical; revisit after epic #7462 core lands (ADR-0031).",
       "tiles": ["golf_simulation_suite"]
     },
     "optimization.swing_optimizer": {
@@ -353,8 +344,7 @@
       "api": null,
       "web": null,
       "status": "exempt",
-      "reason": "Desktop optimization GUI; desktop-only candidate pending #7460.",
-      "pending_decision": true,
+      "reason": "Roadmap — long-running trajectory optimization suits an API-backed web job, but is not near-term; revisit after epic #7462 core lands (ADR-0031).",
       "tiles": ["swing_optimizer"]
     }
   }


### PR DESCRIPTION
## Summary

Finalizes all 10 `pending_decision` exemptions in the feature-parity registry (G12, epic #7462) and documents the rationale in a new ADR. Docs+config only — no runtime code changes.

Fixes #7460

## Decisions

**Trust-model exemptions** (never browser features under the local-server model):

- `sidekick.terminal_repl_jupyter_skills` — remote shell/REPL/Jupyter over HTTP is a non-starter; web chat gets context via #7453 instead
- `launcher.docker_management` — Docker daemon control over HTTP is root-equivalent; Tauri-mode-only candidate
- `launcher.mcp_config` — local-machine file configuration, outside the web trust boundary

**Capability exemptions:**

- `tools.matlab_suite` — requires local MATLAB; possible later in Tauri mode
- `engines.dashboards` + `biomech.exercise_injury_dashboards` — web Simulation page is the equivalent web surface; exercise routing is not a web feature

**Roadmap exemptions** (no new issues, per the epic's stance — reason records "revisit after epic #7462 core lands"):

- `tools.pose_editing` (Pose Studio) — heavy native-viewer coupling
- `docs.document_library` — local SQLite/file indexing; thin web reader plausible later
- `simulation.golf_suite_batch` — sweeps/batch runs could become API-backed web jobs
- `optimization.swing_optimizer` — long-running optimization suits an API-backed job model

## Changes

- `src/config/feature_parity.json` — all `pending_decision` flags removed; each exemption now has a final one-sentence reason citing ADR-0031
- `docs/adr/0031-web-parity-exemptions.md` — new ADR with the security rationale, referencing ADR-0028 and the registry as the enforcement mechanism; indexed in `docs/adr/README.md`
- `docs/development/feature_parity_matrix.md` — regenerated via `scripts/generate_feature_parity_matrix.py`
- `CLAUDE.md` — registry section now states that changing an exempt entry requires updating ADR-0031 in the same PR

## Acceptance criteria

- [x] Each row from the issue table has a registry entry: `exempt` + one-sentence reason (+ ADR reference)
- [x] Short ADR capturing the security rationale for the trust-model exemptions (ADR-0031)
- [x] Future parity audits can diff against the registry (CI gate `tests/config/feature_parity/` — all 24 tests pass locally; matrix freshness gate green)

## What remains

Nothing for this issue. Roadmap items carry their revisit trigger in the registry reason rather than tracking issues, per the epic's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
