### PR TITLE
fix(analysis): wrap CRP to [-180,180] so coordination phase stays bounded (#7409)

### DIFF
--- a/src/shared/python/analysis/coordination_metrics.py
+++ b/src/shared/python/analysis/coordination_metrics.py
@@ -221,16 +221,23 @@ class CoordinationMetricsMixin:
     ) -> np.ndarray:
         """Compute Continuous Relative Phase (CRP) between two joints.
 
-        CRP = Phase1 - Phase2.
-        Used to analyze coordination dynamics. Near 0 implies in-phase,
-        near 180 implies anti-phase.
+        CRP is the wrapped phase difference ``Phase1 - Phase2`` reported on
+        ``[-180, 180]`` degrees (Hamill et al. convention). Near 0 implies
+        in-phase, near +-180 implies anti-phase.
+
+        The per-joint phase angles are unwrapped (monotonic across cycles), so
+        subtracting them directly would accumulate any per-cycle mismatch and
+        drift outside ``[-180, 180]`` whenever the joints desynchronize by one
+        or more phase wraps. The difference is therefore re-wrapped per frame so
+        the result is always the bounded instantaneous phase offset (issue
+        #7409).
 
         Args:
             joint_idx_1: Proximal joint index
             joint_idx_2: Distal joint index
 
         Returns:
-            Array of CRP values in degrees
+            Array of CRP values in degrees on ``[-180, 180]``.
         """
         if joint_idx_1 is None:
             raise ValueError("joint_idx_1 must be provided")
@@ -240,7 +247,9 @@ class CoordinationMetricsMixin:
         if len(phi1) == 0 or len(phi2) == 0:
             return np.array([])
 
-        crp = phi1 - phi2
+        # Wrap the difference to (-180, 180] so CRP stays bounded even when the
+        # two unwrapped phase series accumulate a different number of cycles.
+        crp = (phi1 - phi2 + 180.0) % 360.0 - 180.0
         return np.asarray(crp)
 
     def compute_correlations(

--- a/tests/unit/analysis/test_coordination_metrics.py
+++ b/tests/unit/analysis/test_coordination_metrics.py
@@ -112,6 +112,50 @@ class TestComputeContinuousRelativePhase:
         result = obj.compute_continuous_relative_phase(0, 5)
         assert len(result) == 0
 
+    @staticmethod
+    def _make_two_joint_instance(
+        cycles_1: float, cycles_2: float, phase_offset_deg: float = 0.0, n: int = 400
+    ) -> CoordinationMetricsMixin:
+        """Build a mixin instance with two joints at given cycle counts/offset."""
+
+        class _Concrete(CoordinationMetricsMixin):
+            pass
+
+        obj = _Concrete()
+        obj.times = np.linspace(0.0, 1.0, n)
+        obj.dt = obj.times[1] - obj.times[0]
+        u = np.linspace(0.0, 1.0, n)
+        offset = np.deg2rad(phase_offset_deg)
+        t1 = 2 * np.pi * cycles_1 * u
+        t2 = 2 * np.pi * cycles_2 * u + offset
+        obj.joint_positions = np.column_stack([np.sin(t1), np.sin(t2)])
+        obj.joint_velocities = np.column_stack([np.cos(t1), np.cos(t2)])
+        obj.joint_torques = np.zeros((n, 2))
+        return obj
+
+    def test_crp_constant_offset_equal_frequency_is_bounded(self) -> None:
+        # Two sinusoids 90 deg apart, same frequency -> CRP ~ constant +-90 deg.
+        obj = self._make_two_joint_instance(4, 4, phase_offset_deg=90.0)
+        crp = obj.compute_continuous_relative_phase(0, 1)
+        assert np.all(np.abs(crp) <= 180.0 + 1e-6)
+        # Constant offset -> low spread (ignore unwrap transients at the ends).
+        interior = crp[5:-5]
+        assert np.ptp(interior) < 20.0
+
+    def test_crp_different_frequency_stays_in_range(self) -> None:
+        # Regression for #7409: 4 vs 5 cycles formerly drifted to 360 deg.
+        obj = self._make_two_joint_instance(4, 5)
+        crp = obj.compute_continuous_relative_phase(0, 1)
+        assert np.all(crp >= -180.0 - 1e-6)
+        assert np.all(crp <= 180.0 + 1e-6)
+
+    def test_crp_anti_phase(self) -> None:
+        # Two sinusoids 180 deg apart -> |CRP| ~ 180 deg.
+        obj = self._make_two_joint_instance(4, 4, phase_offset_deg=180.0)
+        crp = obj.compute_continuous_relative_phase(0, 1)
+        interior = crp[5:-5]
+        assert np.allclose(np.abs(interior), 180.0, atol=5.0)
+
 
 class TestComputeCorrelations:
     def test_coordination_metrics_returns_tuple(self) -> None:


### PR DESCRIPTION
## Summary

`ContinuousMetricsMixin.compute_continuous_relative_phase` returned the difference of two **independently unwrapped** phase series, so the Continuous Relative Phase (CRP) drifted to arbitrarily large values (e.g. `360°`) whenever the two joints accumulated a different number of phase wraps — the normal case when proximal and distal segments oscillate at different rates. This invalidated the method's documented interpretation ("near 0 implies in-phase, near 180 implies anti-phase").

## Fix

Wrap the phase difference per frame:

```python
crp = (phi1 - phi2 + 180.0) % 360.0 - 180.0
```

CRP is now reported on `[-180, 180]°` (Hamill et al. convention). Docstring updated to document the wrapping and the bounded range.

## Tests (TDD)

Added ground-truth regression tests in `tests/unit/analysis/test_coordination_metrics.py`:
- constant-offset equal-frequency → bounded, ~constant `±90°`;
- **4-vs-5-cycle different frequency** (regression for this bug; formerly reached `360°`) → stays within `[-180, 180]`;
- anti-phase (180° offset) → `|CRP| ≈ 180°`.

All 26 tests in the file pass; `ruff check`/`ruff format` clean.

Closes #7409

🤖 Generated with [Claude Code](https://claude.com/claude-code)