### PR TITLE
fix(motion_pipeline): correct pure-Python Kalman steady-state init via DRY delegation (#7410)

### DIFF
--- a/src/shared/python/motion_pipeline/preprocessing/_filter_pure_python.py
+++ b/src/shared/python/motion_pipeline/preprocessing/_filter_pure_python.py
@@ -281,13 +281,12 @@ def _kalman_filter(
 ) -> np.ndarray:
     """Apply a 1D random-walk Kalman smoother (RTS) to each marker/keypoint coord.
 
-    Uses a forward-pass Kalman filter followed by a backward-pass RTS smoother.
-    This eliminates the forward-pass transient and gives optimal smoothing for
-    offline (batch) mocap data where all frames are available.
-
-    The steady-state P initialization avoids the long high-gain transient that
-    would otherwise reduce smoothing quality for the first 20–30 frames when
-    starting with P=1.0.
+    Delegates to the single canonical implementation in :mod:`.filter`
+    (``_kalman_filter_python``) so the two modules can never drift apart again
+    (issue #7409 / #7410 — this copy previously used a wrong-sign steady-state
+    ``P`` initialization derived from an incorrect DARE). The import is deferred
+    to function call time to avoid a module-level import cycle with
+    :mod:`.filter`, which lazily imports helpers from this module.
 
     Args:
         data: Array of shape (n_frames, n_points, n_dims).
@@ -297,57 +296,9 @@ def _kalman_filter(
     Returns:
         Smoothed array of identical shape.
     """
-    if data.size == 0:
-        return data
+    from .filter import _kalman_filter_python
 
-    q = float(process_noise)
-    r = float(measurement_noise)
-
-    # Steady-state P for a random-walk model solves the DARE:
-    #   P_ss = P_ss * r / (P_ss + r) + q
-    # Positive root: P_ss = 0.5 * (q + sqrt(q^2 + 4*q*r))
-    p_steady = 0.5 * (q + np.sqrt(q**2 + 4.0 * q * r))
-
-    filtered = np.zeros_like(data)
-    n_frames = data.shape[0]
-
-    for i in range(data.shape[1]):
-        for j in range(data.shape[2]):
-            series = data[:, i, j]
-
-            # --- Forward pass ---
-            x_fwd = np.empty(n_frames)
-            p_fwd = np.empty(n_frames)
-
-            p = p_steady
-            x = float(series[0])
-
-            for t in range(n_frames):
-                # Predict (random-walk: x_k = x_{k-1}, P_k = P_{k-1} + Q)
-                p_pred = p + q
-                # Update (Kalman gain and correction)
-                k_gain = p_pred / (p_pred + r)
-                x = x + k_gain * (series[t] - x)
-                p = (1.0 - k_gain) * p_pred
-                x_fwd[t] = x
-                p_fwd[t] = p
-
-            # --- Backward RTS smoother pass ---
-            smoothed = np.empty(n_frames)
-            smoothed[-1] = x_fwd[-1]
-            p_s = p_fwd[-1]
-
-            for t in range(n_frames - 2, -1, -1):
-                # Predicted covariance at t+1 (using forward filter's P at t)
-                p_pred = p_fwd[t] + q
-                # RTS smoother gain
-                g_s = p_fwd[t] / p_pred
-                smoothed[t] = x_fwd[t] + g_s * (smoothed[t + 1] - x_fwd[t])
-                p_s = p_fwd[t] + g_s**2 * (p_s - p_pred)
-
-            filtered[:, i, j] = smoothed
-
-    return filtered
+    return _kalman_filter_python(data, process_noise, measurement_noise)
 
 
 def _ewma(data: np.ndarray, alpha: float = 0.5) -> np.ndarray:

--- a/tests/unit/motion_pipeline/preprocessing/test_filter.py
+++ b/tests/unit/motion_pipeline/preprocessing/test_filter.py
@@ -249,3 +249,52 @@ def test_pure_python_filter_fallbacks() -> None:
 
         res_gaussian = _gaussian_filter(data, sigma=1.0)
         assert res_gaussian.shape == data.shape
+
+
+def _kalman_steady_state_fixed_point(q: float, r: float, iters: int = 100_000) -> float:
+    """Iterate the random-walk DARE ``P = (P + q) * r / (P + q + r)`` to convergence."""
+    p = 1.0
+    for _ in range(iters):
+        p = (p + q) * r / (p + q + r)
+    return p
+
+
+def test_kalman_steady_state_matches_dare_fixed_point() -> None:
+    """The closed-form steady-state P must equal the DARE fixed point (#7410)."""
+    q, r = 0.01, 0.1
+    closed_form = 0.5 * (-q + np.sqrt(q**2 + 4.0 * q * r))
+    assert closed_form == pytest.approx(
+        _kalman_steady_state_fixed_point(q, r), abs=1e-12
+    )
+
+
+def test_kalman_pure_python_matches_canonical_implementation() -> None:
+    """Regression for #7410: the pure-Python copy must match ``filter.py`` exactly.
+
+    Before the fix the pure-Python module used a wrong-sign steady-state P
+    initialization, biasing the first smoothed frame by ~5e-3.
+    """
+    from src.shared.python.motion_pipeline.preprocessing import (
+        _filter_pure_python as pure,
+    )
+    from src.shared.python.motion_pipeline.preprocessing.filter import (
+        _kalman_filter_python,
+    )
+
+    rng = np.random.default_rng(0)
+    data = np.cumsum(rng.standard_normal((40, 2, 3)), axis=0)
+
+    canonical = _kalman_filter_python(data, process_noise=0.01, measurement_noise=0.1)
+    pure_result = pure._kalman_filter(data, process_noise=0.01, measurement_noise=0.1)
+    assert np.allclose(pure_result, canonical, atol=1e-9)
+
+
+def test_kalman_smoother_constant_signal_has_no_init_transient() -> None:
+    """A constant noise-free signal must smooth to that constant everywhere (#7410)."""
+    from src.shared.python.motion_pipeline.preprocessing.filter import (
+        _kalman_filter_python,
+    )
+
+    data = np.full((30, 1, 1), 5.0)
+    smoothed = _kalman_filter_python(data, process_noise=0.01, measurement_noise=0.1)
+    assert np.allclose(smoothed, 5.0, atol=1e-9)


### PR DESCRIPTION
## Summary

The pure-Python RTS smoother (`_filter_pure_python._kalman_filter`) initialized the forward-pass covariance with a **wrong-sign** steady-state `P` (`+q` instead of `-q`), derived from an incorrect DARE where `Q` is added *after* the measurement update instead of in the prediction step. The model actually used (predict `p += q`; update) has steady state solving `P = (P+q)·r/(P+q+r)`, i.e. `P_ss = 0.5·(-q + sqrt(q² + 4qr))`.

The wrong init biased the **first smoothed frame by ~5e-3** (mm of marker error) and diverged from the correct sibling copy in `filter.py`. This pure-Python path is the *only* Kalman path when the optional Rust wheel `upstream_mocap_preproc` is absent — the default in CI and fresh checkouts.

## Fix (DRY)

As recommended in the issue, the duplicated Kalman implementation is **deleted** and `_kalman_filter` now delegates to the single canonical `_kalman_filter_python` in `filter.py`, so the two modules can never drift again. The import is deferred to call time to avoid a module-level cycle (`filter.py` lazily imports helpers from this module).

## Tests (TDD)

Added to `tests/unit/motion_pipeline/preprocessing/test_filter.py`:
- closed-form steady-state `P` equals the DARE fixed point (iterated 10⁵×), `atol=1e-12`;
- pure-Python output now matches canonical `filter.py` output, `atol=1e-9` (formerly off by ~5e-3 on frame 0);
- constant noise-free signal smooths to the constant with no init transient, `atol=1e-9`.

All 18 tests in the file pass; `ruff check`/`ruff format` clean.

Closes #7410

🤖 Generated with [Claude Code](https://claude.com/claude-code)