### PR TITLE
fix(ui): surface out-of-range/empty field input instead of silently accepting it (#7429, #7442)

### DIFF
--- a/ui/src/components/simulation/PolynomialGeneratorPanel.test.tsx
+++ b/ui/src/components/simulation/PolynomialGeneratorPanel.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * PolynomialGeneratorPanel tests (issue #7429).
+ *
+ * Guards that an empty or NaN-containing coefficient list can never be
+ * submitted from the UI.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PolynomialGeneratorPanel } from './PolynomialGeneratorPanel';
+import type { ActuatorInfo } from './ActuatorPanel';
+
+const ACTUATORS: ActuatorInfo[] = [
+  {
+    index: 0,
+    name: 'hip',
+    control_type: 'torque',
+    value: 0,
+    min_value: -1,
+    max_value: 1,
+    units: 'Nm',
+    joint_type: 'hinge',
+  },
+];
+
+function renderExpanded(onApply = vi.fn().mockResolvedValue(undefined)) {
+  render(
+    <PolynomialGeneratorPanel actuators={ACTUATORS} onApplyPolynomial={onApply} />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Polynomial Generator/ }));
+  return onApply;
+}
+
+describe('PolynomialGeneratorPanel', () => {
+  it('renders nothing when there are no actuators', () => {
+    const { container } = render(
+      <PolynomialGeneratorPanel actuators={[]} onApplyPolynomial={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('disables Remove when only one coefficient remains', () => {
+    renderExpanded();
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    // Default starts with two coefficients -> both removable.
+    expect(removeButtons[0]).toBeEnabled();
+
+    fireEvent.click(removeButtons[0]);
+
+    const remaining = screen.getAllByRole('button', { name: 'Remove' });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toBeDisabled();
+  });
+
+  it('cannot remove the last coefficient (no empty list)', () => {
+    const onApply = renderExpanded();
+    // Remove the second coefficient ('0'), leaving the first ('1').
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[1]);
+    const lastRemove = screen.getByRole('button', { name: 'Remove' });
+    fireEvent.click(lastRemove); // disabled, should be a no-op
+    expect(screen.getAllByLabelText(/Coefficient \d/)).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply Polynomial/ }));
+    expect(onApply).toHaveBeenCalledWith(0, [1]);
+  });
+
+  it('disables Apply and flags the field when a coefficient is empty/NaN', () => {
+    const onApply = renderExpanded();
+    const firstInput = screen.getAllByLabelText(/Coefficient \d/)[0];
+    fireEvent.change(firstInput, { target: { value: '' } });
+
+    const apply = screen.getByRole('button', { name: /Apply Polynomial/ });
+    expect(apply).toBeDisabled();
+    expect(firstInput).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(apply);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it('submits the parsed numeric coefficients when all are valid', () => {
+    const onApply = renderExpanded();
+    const inputs = screen.getAllByLabelText(/Coefficient \d/);
+    fireEvent.change(inputs[0], { target: { value: '2.5' } });
+    fireEvent.change(inputs[1], { target: { value: '-1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply Polynomial/ }));
+    expect(onApply).toHaveBeenCalledWith(0, [2.5, -1]);
+  });
+});

--- a/ui/src/components/simulation/PolynomialGeneratorPanel.tsx
+++ b/ui/src/components/simulation/PolynomialGeneratorPanel.tsx
@@ -14,11 +14,28 @@ export function PolynomialGeneratorPanel({
   const [selectedActuatorIndex, setSelectedActuatorIndex] = useState(
     actuators.length > 0 ? actuators[0].index : 0
   );
-  const [coefficients, setCoefficients] = useState<number[]>([1.0, 0.0]);
+  // Stored as raw strings so empty/NaN input is detectable (not silently
+  // coerced to 0) — see issue #7429.
+  const [coefficients, setCoefficients] = useState<string[]>(['1', '0']);
 
   if (actuators.length === 0) {
     return null;
   }
+
+  const parsed = coefficients.map((c) => Number(c));
+  const hasInvalid = coefficients.some(
+    (c) => c.trim() === '' || Number.isNaN(Number(c))
+  );
+  // A polynomial needs at least one term and every term must be valid.
+  const canApply = coefficients.length > 0 && !hasInvalid;
+  const canRemove = coefficients.length > 1;
+
+  const handleApply = () => {
+    if (!canApply) {
+      return;
+    }
+    void onApplyPolynomial(selectedActuatorIndex, parsed);
+  };
 
   return (
     <div className="bg-gray-800/40 border border-white/5 rounded-md p-3">
@@ -56,57 +73,81 @@ export function PolynomialGeneratorPanel({
           {/* Coefficients List */}
           <div className="space-y-2">
             <span className="text-xs text-gray-400 block font-medium">Coefficients</span>
-            {coefficients.map((coeff, index) => (
-              <div key={index} className="flex items-center gap-2">
-                <label htmlFor={`coeff-${index}`} className="text-xs text-gray-500 w-24">
-                  Coefficient {index}
-                </label>
-                <input
-                  id={`coeff-${index}`}
-                  type="number"
-                  step="0.1"
-                  value={coeff}
-                  onChange={(e) => {
-                    const val = parseFloat(e.target.value);
-                    const next = [...coefficients];
-                    next[index] = isNaN(val) ? 0 : val;
-                    setCoefficients(next);
-                  }}
-                  className="w-20 text-xs bg-gray-700 text-gray-200 rounded px-1.5 py-1 border-none focus:ring-1 focus:ring-blue-400 font-mono"
-                  aria-label={`Coefficient ${index}`}
-                />
-                <button
-                  type="button"
-                  onClick={() => {
-                    const next = coefficients.filter((_, i) => i !== index);
-                    setCoefficients(next);
-                  }}
-                  className="text-xs text-red-400 hover:text-red-300 font-medium px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
-                  aria-label="Remove"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
+            {coefficients.map((coeff, index) => {
+              const invalid = coeff.trim() === '' || Number.isNaN(Number(coeff));
+              return (
+                <div key={index} className="flex items-center gap-2">
+                  <label
+                    htmlFor={`coeff-${index}`}
+                    className="text-xs text-gray-500 w-24"
+                  >
+                    Coefficient {index}
+                  </label>
+                  <input
+                    id={`coeff-${index}`}
+                    type="number"
+                    step="0.1"
+                    value={coeff}
+                    onChange={(e) => {
+                      const next = [...coefficients];
+                      next[index] = e.target.value;
+                      setCoefficients(next);
+                    }}
+                    aria-invalid={invalid}
+                    className={`w-20 text-xs bg-gray-700 text-gray-200 rounded px-1.5 py-1 focus:ring-1 focus:ring-blue-400 font-mono ${
+                      invalid ? 'border border-red-500' : 'border-none'
+                    }`}
+                    aria-label={`Coefficient ${index}`}
+                  />
+                  <button
+                    type="button"
+                    disabled={!canRemove}
+                    title={
+                      canRemove
+                        ? undefined
+                        : 'A polynomial needs at least one coefficient'
+                    }
+                    onClick={() => {
+                      if (!canRemove) {
+                        return;
+                      }
+                      const next = coefficients.filter((_, i) => i !== index);
+                      setCoefficients(next);
+                    }}
+                    className="text-xs text-red-400 hover:text-red-300 disabled:text-gray-600 disabled:hover:text-gray-600 disabled:cursor-not-allowed font-medium px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                    aria-label="Remove"
+                  >
+                    Remove
+                  </button>
+                </div>
+              );
+            })}
           </div>
 
           {/* Actions */}
           <div className="flex gap-2 pt-2 border-t border-white/5">
             <button
               type="button"
-              onClick={() => setCoefficients([...coefficients, 0.0])}
+              onClick={() => setCoefficients([...coefficients, '0'])}
               className="text-xs bg-gray-700 hover:bg-gray-600 text-gray-200 px-2.5 py-1 rounded transition-colors"
             >
               Add Coefficient
             </button>
             <button
               type="button"
-              onClick={() => onApplyPolynomial(selectedActuatorIndex, coefficients)}
-              className="text-xs bg-blue-600 hover:bg-blue-500 text-white font-medium px-3 py-1 rounded transition-colors ml-auto"
+              disabled={!canApply}
+              title={canApply ? undefined : 'Fix invalid coefficient'}
+              onClick={handleApply}
+              className="text-xs bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 disabled:cursor-not-allowed text-white font-medium px-3 py-1 rounded transition-colors ml-auto"
             >
               Apply Polynomial
             </button>
           </div>
+          {hasInvalid && (
+            <p role="alert" className="text-xs text-red-400">
+              Fix invalid coefficient before applying.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/components/ux/HelpfulField.test.tsx
+++ b/ui/src/components/ux/HelpfulField.test.tsx
@@ -72,4 +72,58 @@ describe('HelpfulField', () => {
     expect(isInRange(meta, 3)).toBe(true);
     expect(isInRange(meta, 1000)).toBe(false);
   });
+
+  it('shows a visible, programmatic error for an out-of-range value', () => {
+    render(
+      <HelpfulField
+        fieldId="simulation.duration"
+        value={3}
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByLabelText(/Duration/);
+    fireEvent.change(input, { target: { value: '1000' } });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    // The error element is referenced by aria-describedby.
+    expect(input.getAttribute('aria-describedby')).toContain(alert.id);
+  });
+
+  it('flags empty/NaN numeric input as invalid rather than accepting it', () => {
+    const onViolation = vi.fn();
+    render(
+      <HelpfulField
+        fieldId="simulation.duration"
+        value={3}
+        onChange={() => {}}
+        onViolation={onViolation}
+      />,
+    );
+    const input = screen.getByLabelText(/Duration/);
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    // NaN must not be forwarded to onViolation.
+    expect(onViolation).not.toHaveBeenCalled();
+  });
+
+  it('clears the error when the value returns to range', () => {
+    render(
+      <HelpfulField
+        fieldId="simulation.duration"
+        value={3}
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByLabelText(/Duration/);
+    fireEvent.change(input, { target: { value: '1000' } });
+    expect(screen.queryByRole('alert')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+  });
 });

--- a/ui/src/components/ux/HelpfulField.tsx
+++ b/ui/src/components/ux/HelpfulField.tsx
@@ -12,7 +12,7 @@
  * is intentionally NOT implemented here (deferred).
  */
 
-import { useId } from 'react';
+import { useId, useState } from 'react';
 import { getFieldMetadata } from '../../ux/fieldMetadata';
 import { isInRange, isNumericRange } from '../../ux/fieldHelpers';
 
@@ -39,6 +39,8 @@ export function HelpfulField({
   const meta = getFieldMetadata(fieldId);
   const helpId = useId();
   const inputId = useId();
+  const errorId = useId();
+  const [violation, setViolation] = useState<string | null>(null);
   const numeric = isNumericRange(meta.validRange);
   const enumValues =
     Array.isArray(meta.validRange) && !numeric
@@ -47,14 +49,29 @@ export function HelpfulField({
 
   const handleChange = (raw: string) => {
     onChange(raw);
-    if (numeric && onViolation) {
-      const parsed = Number(raw);
-      if (!Number.isNaN(parsed) && !isInRange(meta, parsed)) {
+    if (!numeric) {
+      return;
+    }
+    // Number('') === 0, so an empty/blank input must be detected on the raw
+    // string, not via Number(). Treat empty/NaN input as invalid so it is
+    // surfaced rather than silently accepted (WCAG 3.3.1).
+    const blank = raw.trim() === '';
+    const parsed = Number(raw);
+    const isNumber = !blank && !Number.isNaN(parsed);
+    const range = meta.validRange as [number, number];
+    if (!isNumber || !isInRange(meta, parsed)) {
+      const unit = meta.units ? ` ${meta.units}` : '';
+      setViolation(`Value must be between ${range[0]} and ${range[1]}${unit}`);
+      // Only forward a real numeric breach to parents; never NaN/blank.
+      if (onViolation && isNumber) {
         onViolation(fieldId, parsed);
       }
+    } else {
+      setViolation(null);
     }
   };
 
+  const describedBy = violation ? `${helpId} ${errorId}` : helpId;
   const unitSuffix = meta.units ? ` (${meta.units})` : '';
 
   return (
@@ -89,14 +106,22 @@ export function HelpfulField({
           disabled={disabled}
           min={numeric ? meta.validRange![0] : undefined}
           max={numeric ? meta.validRange![1] : undefined}
-          aria-describedby={helpId}
+          aria-describedby={describedBy}
+          aria-invalid={!!violation}
           onChange={(e) => handleChange(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+          className={`w-full px-3 py-2 bg-gray-700 border rounded-md text-white ${
+            violation ? 'border-red-500' : 'border-gray-600'
+          }`}
         />
       )}
       <p id={helpId} className="text-xs text-gray-500" title={meta.defaultSource}>
         {meta.shortHelp}
       </p>
+      {violation && (
+        <p id={errorId} role="alert" className="text-xs text-red-400">
+          {violation}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two related field-validation honesty bugs from the UI/UX overhaul epic (#7444): the UI accepted invalid input without telling the user.

### HelpfulField (#7442)
An out-of-range numeric value fired the `onViolation` callback but rendered **no visible/programmatic error** — most callers surfaced nothing (WCAG 3.3.1 Error Identification). Now:
- tracks violation state and renders a `role="alert"` message;
- sets `aria-invalid` + extends `aria-describedby` to the error;
- shows a red border while invalid;
- treats empty/blank input as invalid too (`Number('')` is `0`, so the blank case is detected on the raw string and is **not** forwarded to `onViolation` as a spurious `0`);
- clears the error when the value returns to range.

### PolynomialGeneratorPanel (#7429)
The user could remove every coefficient row and still click **Apply Polynomial**, sending `coefficients: []` to the backend; an empty number input was also silently coerced to `0`. Now:
- coefficients are held as raw strings so empty/NaN is detectable;
- **Remove** is disabled at one remaining coefficient (with a tooltip);
- **Apply** is disabled (tooltip "Fix invalid coefficient" + inline alert) whenever any coefficient is empty/NaN, and the click handlers guard against both;
- invalid inputs get `aria-invalid` + a red border.

## Tests
- `HelpfulField.test.tsx`: out-of-range shows alert + `aria-invalid`; empty input is flagged without forwarding NaN; error clears back in range.
- new `PolynomialGeneratorPanel.test.tsx`: disabled Remove/Apply, no-empty-list, and valid parsed submission.

All 13 tests pass; `eslint` + `tsc --noEmit` clean.

Closes #7429
Closes #7442

🤖 Generated with [Claude Code](https://claude.com/claude-code)