### PR TITLE
fix(ui): bound, dedup, and assertively announce toasts (#7428)

### DIFF
--- a/ui/src/components/ui/Toast.test.tsx
+++ b/ui/src/components/ui/Toast.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Toast stacking/dedup/a11y tests (issue #7428).
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ToastProvider, useToast, type ToastType } from './Toast';
+
+// readCachedSettings is consulted for notification prefs; default to "all".
+vi.mock('@/api/settingsClient', () => ({
+  readCachedSettings: () => null,
+}));
+
+function Emitter({
+  onReady,
+}: {
+  onReady: (api: ReturnType<typeof useToast>) => void;
+}) {
+  const api = useToast();
+  onReady(api);
+  return null;
+}
+
+function setup() {
+  let api: ReturnType<typeof useToast> | null = null;
+  render(
+    <ToastProvider>
+      <Emitter onReady={(a) => (api = a)} />
+    </ToastProvider>,
+  );
+  return () => api!;
+}
+
+function emit(getApi: () => ReturnType<typeof useToast>, msg: string, type: ToastType) {
+  act(() => {
+    getApi().showToast(msg, type);
+  });
+}
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('caps the visible stack at 5, dropping the oldest', () => {
+    const getApi = setup();
+    for (let i = 0; i < 10; i++) {
+      emit(getApi, `error ${i}`, 'error');
+    }
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts.length).toBe(5);
+    // Oldest (error 0..4) dropped; newest retained.
+    expect(screen.queryByText('error 0')).not.toBeInTheDocument();
+    expect(screen.getByText('error 9')).toBeInTheDocument();
+  });
+
+  it('coalesces duplicate (message, type) toasts with a count badge', () => {
+    const getApi = setup();
+    emit(getApi, 'backend down', 'error');
+    emit(getApi, 'backend down', 'error');
+    emit(getApi, 'backend down', 'error');
+
+    // One toast, not three.
+    expect(screen.getAllByText('backend down')).toHaveLength(1);
+    expect(screen.getByText('×3')).toBeInTheDocument();
+  });
+
+  it('announces error toasts assertively and others politely', () => {
+    const getApi = setup();
+    emit(getApi, 'boom', 'error');
+    emit(getApi, 'fyi', 'info');
+
+    const errorToast = screen.getByText('boom').closest('[aria-live]');
+    expect(errorToast).toHaveAttribute('role', 'alert');
+    expect(errorToast).toHaveAttribute('aria-live', 'assertive');
+
+    const infoToast = screen.getByText('fyi').closest('[aria-live]');
+    expect(infoToast).toHaveAttribute('role', 'status');
+    expect(infoToast).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/ui/src/components/ui/Toast.tsx
+++ b/ui/src/components/ui/Toast.tsx
@@ -9,7 +9,12 @@ interface Toast {
   message: string;
   type: ToastType;
   duration?: number;
+  /** Number of coalesced occurrences of an identical (message, type) toast. */
+  count: number;
 }
+
+/** Maximum simultaneously-visible toasts; oldest are dropped beyond this. */
+const MAX_TOASTS = 5;
 
 interface ToastContextType {
   showToast: (message: string, type?: ToastType, duration?: number) => void;
@@ -44,24 +49,35 @@ const ICON_STYLES = {
 
 function ToastItem({ toast, onClose }: { toast: Toast; onClose: () => void }) {
   const Icon = ICONS[toast.type];
+  const assertive = toast.type === 'error';
 
   useEffect(() => {
     if (toast.duration) {
       const timer = setTimeout(onClose, toast.duration);
       return () => clearTimeout(timer);
     }
-  }, [toast.duration, onClose]);
+    // `toast.count` is a dep so a coalesced duplicate restarts the dismiss timer.
+  }, [toast.duration, toast.count, onClose]);
 
   return (
     <div
-      role="alert"
-      aria-live="polite"
+      role={assertive ? 'alert' : 'status'}
+      aria-live={assertive ? 'assertive' : 'polite'}
+      aria-atomic="true"
       className={`flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg
                   backdrop-blur-sm animate-in slide-in-from-right-5 duration-200
                   ${STYLES[toast.type]}`}
     >
       <Icon className={`w-5 h-5 flex-shrink-0 ${ICON_STYLES[toast.type]}`} aria-hidden="true" />
       <p className="text-sm font-medium flex-1">{toast.message}</p>
+      {toast.count > 1 && (
+        <span
+          className="text-xs font-semibold px-1.5 py-0.5 rounded-full bg-white/15"
+          aria-label={`${toast.count} occurrences`}
+        >
+          ×{toast.count}
+        </span>
+      )}
       <button
         onClick={onClose}
         className="p-1 rounded hover:bg-white/10 transition-colors focus:outline-none focus:ring-2 focus:ring-white/20"
@@ -89,7 +105,23 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     if (verbosity === 'errors' && type !== 'error' && type !== 'warning') return;
     const resolvedDuration = duration ?? prefs?.toast_duration_ms ?? 4000;
     const id = `toast-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-    setToasts((prev) => [...prev, { id, message, type, duration: resolvedDuration }]);
+    setToasts((prev) => {
+      // Deduplicate: an identical (message, type) toast already on screen is
+      // coalesced — bump its count and restart its timer instead of stacking.
+      const existing = prev.find((t) => t.message === message && t.type === type);
+      if (existing) {
+        return prev.map((t) =>
+          t === existing
+            ? { ...t, count: t.count + 1, duration: resolvedDuration }
+            : t,
+        );
+      }
+      // Cap the stack: drop the oldest beyond MAX_TOASTS.
+      return [
+        ...prev,
+        { id, message, type, duration: resolvedDuration, count: 1 },
+      ].slice(-MAX_TOASTS);
+    });
   }, []);
 
   const showSuccess = useCallback((message: string) => showToast(message, 'success'), [showToast]);


### PR DESCRIPTION
## Summary

`Toast.tsx` appended every `showToast` to an unbounded list with uniform politeness, so repeated failures (backend down + retries) could fill the screen, and screen-reader users got errors announced lazily.

## Fix

- **Cap** the visible stack at `MAX_TOASTS = 5`; drop the oldest beyond it (`.slice(-MAX_TOASTS)`).
- **Deduplicate**: an identical `(message, type)` toast already on screen is coalesced — bump a `×N` count badge and restart its dismiss timer instead of stacking a duplicate.
- **Accessibility**: error toasts render `role="alert"` `aria-live="assertive"`; others `role="status"` `aria-live="polite"`; both `aria-atomic="true"`.
- The dismiss-timer effect now depends on `toast.count` so a coalesced duplicate refreshes the countdown.

## Tests (new `Toast.test.tsx`)

- 10 rapid errors → ≤5 toasts (oldest dropped);
- 3 identical errors → one toast with a `×3` badge;
- error announced assertively, info politely.

All pass; `eslint` + `tsc --noEmit` clean.

Closes #7428

🤖 Generated with [Claude Code](https://claude.com/claude-code)