### PR TITLE
fix(ui): route-level error boundary + production-gated logging (#7434)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { SimulationPage } from './pages/Simulation';
 import { DashboardPage } from './pages/Dashboard';
 import { ModelExplorerPage } from './pages/ModelExplorer';
@@ -18,25 +18,22 @@ import { RouteTitle } from './utils/RouteTitle';
 import { BallFlightPage } from './pages/BallFlight';
 import { SettingsPage } from './pages/Settings';
 import { ToastProvider } from './components/ui/Toast';
+import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import { useWebSettingsBootstrap } from './api/useWebSettings';
 import { DiagnosticsPanel } from './components/ui/DiagnosticsPanel';
 import { HelpPanel } from './components/ui/HelpPanel';
 import { useUIStore } from './stores';
 
-function App() {
-  const helpOpen = useUIStore((s) => s.helpOpen);
-  const setHelpOpen = useUIStore((s) => s.setHelpOpen);
-
-  // Load persisted web settings (font scale, simulation defaults) at app
-  // start; server file is the source of truth, localStorage is a cache (#7457).
-  useWebSettingsBootstrap();
-
+/**
+ * Route-level error boundary: a crash on one page is contained and reset when
+ * the route changes, so sidebar/browser navigation still recovers the app
+ * instead of bricking the whole tree (#7434).
+ */
+function RoutedContent() {
+  const location = useLocation();
   return (
-    <BrowserRouter>
-      <ScrollToTop />
-      <RouteTitle />
-      <ToastProvider>
-        <Routes>
+    <ErrorBoundary resetKeys={[location.pathname]} label={location.pathname}>
+      <Routes>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/simulation" element={<SimulationPage />} />
           <Route path="/tools/model-explorer" element={<ModelExplorerPage />} />
@@ -65,7 +62,25 @@ function App() {
           <Route path="/settings" element={<SettingsPage />} />
           {/* Catch-all 404 (#7430) — must stay last. */}
           <Route path="*" element={<NotFoundPage />} />
-        </Routes>
+      </Routes>
+    </ErrorBoundary>
+  );
+}
+
+function App() {
+  const helpOpen = useUIStore((s) => s.helpOpen);
+  const setHelpOpen = useUIStore((s) => s.setHelpOpen);
+
+  // Load persisted web settings (font scale, simulation defaults) at app
+  // start; server file is the source of truth, localStorage is a cache (#7457).
+  useWebSettingsBootstrap();
+
+  return (
+    <BrowserRouter>
+      <ScrollToTop />
+      <RouteTitle />
+      <ToastProvider>
+        <RoutedContent />
         <DiagnosticsPanel />
         <HelpPanel isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
       </ToastProvider>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { getApiBase } from './backend';
 import { apiFetch } from './fetch';
 import { withLauncherWebSocketToken } from './websocketToken';
+import { logger } from '../utils/logger';
 import type { EngineListResponse, EngineStatusResponse } from './generated/types';
 
 /**
@@ -159,12 +160,12 @@ export function useSimulation(engineType: string) {
           });
         }
       } catch (err) {
-        console.error("WS Parse Error", err);
+        logger.error('WS Parse Error', err);
       }
     };
 
     ws.onerror = () => {
-      console.error('WebSocket error occurred');
+      logger.error('WebSocket error occurred');
       if (isMountedRef.current) {
         setWsError('WebSocket connection error — check server status');
       }
@@ -194,7 +195,7 @@ export function useSimulation(engineType: string) {
       // last frame's time, mark the connection 'lost', and require an explicit
       // user restart (calling start()) to begin a new run. This guarantees we
       // never reset frames/time without user action.
-      console.warn(
+      logger.warn(
         'WebSocket closed unexpectedly. Connection lost — an explicit restart ' +
           'is required (the simulation cannot resume from where it stopped).',
       );

--- a/ui/src/components/ui/ErrorBoundary.test.tsx
+++ b/ui/src/components/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * ErrorBoundary tests (issue #7434) — route-level reset + recovery.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function Boom({ explode }: { explode: boolean }): React.ReactElement {
+  if (explode) {
+    throw new Error('kaboom');
+  }
+  return <div>healthy page</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs caught errors to console.error; silence it for clean output.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the fallback (with a home link) when a child throws', () => {
+    render(
+      <ErrorBoundary label="/simulation">
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('error-boundary-fallback')).toBeInTheDocument();
+    expect(screen.getByText(/simulation/)).toBeInTheDocument();
+    const home = screen.getByText('Back to Dashboard');
+    expect(home).toHaveAttribute('href', '/');
+  });
+
+  it('clears the error when a resetKey changes (navigation recovery)', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['/simulation']}>
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('error-boundary-fallback')).toBeInTheDocument();
+
+    // Navigate to another route with a healthy page.
+    rerender(
+      <ErrorBoundary resetKeys={['/dashboard']}>
+        <Boom explode={false} />
+      </ErrorBoundary>,
+    );
+    expect(
+      screen.queryByTestId('error-boundary-fallback'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('healthy page')).toBeInTheDocument();
+  });
+
+  it('keeps showing the fallback while the same resetKey persists', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['/simulation']}>
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    rerender(
+      <ErrorBoundary resetKeys={['/simulation']}>
+        <Boom explode={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('error-boundary-fallback')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/ErrorBoundary.tsx
+++ b/ui/src/components/ui/ErrorBoundary.tsx
@@ -9,6 +9,7 @@
  */
 
 import { Component, type ReactNode } from 'react';
+import { logger } from '../../utils/logger';
 
 interface Props {
   /** Content to render when no error has occurred. */
@@ -17,11 +18,26 @@ interface Props {
   fallback?: ReactNode;
   /** Optional callback when an error is caught. */
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  /**
+   * When any value in this array changes between renders, a latched error is
+   * cleared automatically. Pass the current route (e.g. `[location.pathname]`)
+   * so navigating away from a crashed page recovers it (#7434).
+   */
+  resetKeys?: ReadonlyArray<unknown>;
+  /** Human-readable label (e.g. the route path) shown in the fallback. */
+  label?: string;
 }
 
 interface State {
   hasError: boolean;
   error: Error | null;
+}
+
+function keysChanged(
+  a: ReadonlyArray<unknown> = [],
+  b: ReadonlyArray<unknown> = [],
+): boolean {
+  return a.length !== b.length || a.some((v, i) => !Object.is(v, b[i]));
 }
 
 export class ErrorBoundary extends Component<Props, State> {
@@ -34,9 +50,19 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
+  componentDidUpdate(prevProps: Props) {
+    // Clear a latched error once a reset key (typically the route) changes, so
+    // navigation recovers the boundary without a full reload.
+    if (
+      this.state.hasError &&
+      keysChanged(prevProps.resetKeys, this.props.resetKeys)
+    ) {
+      this.setState({ hasError: false, error: null });
+    }
+  }
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    // eslint-disable-next-line no-console
-    console.error('ErrorBoundary caught:', error, errorInfo);
+    logger.error('ErrorBoundary caught:', error, errorInfo);
     this.props.onError?.(error, errorInfo);
   }
 
@@ -81,7 +107,11 @@ export class ErrorBoundary extends Component<Props, State> {
               </div>
               <div>
                 <h2 className="text-lg font-semibold text-gray-100">Something went wrong</h2>
-                <p className="text-sm text-gray-400">The application encountered an unexpected error.</p>
+                <p className="text-sm text-gray-400">
+                  {this.props.label
+                    ? `The page "${this.props.label}" encountered an unexpected error.`
+                    : 'The application encountered an unexpected error.'}
+                </p>
               </div>
             </div>
 
@@ -109,6 +139,14 @@ export class ErrorBoundary extends Component<Props, State> {
                 Try Again
               </button>
             </div>
+
+            {/* Plain anchor: works even when the router context is itself dead. */}
+            <a
+              href="/"
+              className="mt-3 block text-center text-sm text-blue-400 hover:text-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400 rounded"
+            >
+              Back to Dashboard
+            </a>
           </div>
         </div>
       );

--- a/ui/src/utils/logger.ts
+++ b/ui/src/utils/logger.ts
@@ -1,0 +1,30 @@
+/**
+ * Lightweight client logger (issue #7434).
+ *
+ * Wraps the console so diagnostic noise is suppressed in production builds
+ * while remaining available during development and tests. Use this instead of
+ * calling `console.*` directly in `ui/src` runtime code.
+ *
+ * Vite exposes the build mode via `import.meta.env.PROD` (a static boolean
+ * replaced at build time), so the calls tree-shake away in production.
+ */
+
+const isProd = import.meta.env.PROD;
+
+export const logger = {
+  error(...args: unknown[]): void {
+    if (!isProd) {
+      console.error(...args);
+    }
+  },
+  warn(...args: unknown[]): void {
+    if (!isProd) {
+      console.warn(...args);
+    }
+  },
+  info(...args: unknown[]): void {
+    if (!isProd) {
+      console.info(...args);
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Two resilience issues from the UI/UX overhaul epic (#7444).

### 1. One crash bricks navigation
`main.tsx` wrapped the whole app in a single `ErrorBoundary`, so a render error on any page replaced the entire tree — and because the router lived inside the dead subtree, the user could not navigate to a working page.

- `App.tsx` now wraps `<Routes>` in a **route-level** `ErrorBoundary` keyed on `location.pathname`.
- `ErrorBoundary` gains a `resetKeys` prop that clears a latched error when a key changes (via `componentDidUpdate`), so navigating away recovers the page without a reload.
- The fallback names the failing route and offers a plain `<a href="/">` **Back to Dashboard** link that works even when the router context itself is dead.

### 2. Console noise in production
`client.ts` and `ErrorBoundary.tsx` called `console.error/warn` unconditionally.

- Added `ui/src/utils/logger.ts` (`error/warn/info`, gated on `import.meta.env.PROD`) and routed those call sites through it. No unconditional `console.*` remain in `ui/src` runtime paths.

## Tests (new `ErrorBoundary.test.tsx`)
- a throwing child shows the fallback with the home link;
- changing `resetKeys` clears it and renders the healthy page;
- an unchanged `resetKey` keeps the fallback latched.

All pass; `eslint` + `tsc --noEmit` clean.

Closes #7434

🤖 Generated with [Claude Code](https://claude.com/claude-code)