### PR TITLE
fix(ui): harden engine load/unload against double-clicks, stale auto-select, accidental unload (#7427)

### DIFF
--- a/ui/src/components/simulation/EngineSelector.test.tsx
+++ b/ui/src/components/simulation/EngineSelector.test.tsx
@@ -143,7 +143,7 @@ describe('EngineSelector', () => {
       expect(screen.getByRole('button', { name: /unload mujoco/i })).toBeInTheDocument();
     });
 
-    it('calls onUnload when Unload button clicked', () => {
+    it('calls onUnload only after the inline confirm (#7427)', () => {
       const onUnload = vi.fn();
       const engines = [
         createEngine({ name: 'mujoco', displayName: 'MuJoCo', loadState: 'loaded' }),
@@ -157,8 +157,38 @@ describe('EngineSelector', () => {
         />
       );
 
-      fireEvent.click(screen.getByRole('button', { name: /unload mujoco/i }));
+      // First click only opens the confirm step — no unload yet.
+      fireEvent.click(screen.getByRole('button', { name: /^unload mujoco/i }));
+      expect(onUnload).not.toHaveBeenCalled();
+
+      // Confirming triggers the unload.
+      fireEvent.click(
+        screen.getByRole('button', { name: /confirm unload mujoco/i }),
+      );
       expect(onUnload).toHaveBeenCalledWith('mujoco');
+    });
+
+    it('cancels the unload confirm without calling onUnload (#7427)', () => {
+      const onUnload = vi.fn();
+      const engines = [
+        createEngine({ name: 'mujoco', displayName: 'MuJoCo', loadState: 'loaded' }),
+      ];
+      render(
+        <EngineSelector
+          {...defaultProps}
+          engines={engines}
+          selectedEngine={null}
+          onUnload={onUnload}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /^unload mujoco/i }));
+      fireEvent.click(screen.getByRole('button', { name: /cancel unload/i }));
+      expect(onUnload).not.toHaveBeenCalled();
+      // The original Unload button is back.
+      expect(
+        screen.getByRole('button', { name: /^unload mujoco/i }),
+      ).toBeInTheDocument();
     });
 
     it('disables Unload button on selected engine', () => {

--- a/ui/src/components/simulation/EngineSelector.tsx
+++ b/ui/src/components/simulation/EngineSelector.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { Loader2, Check, AlertCircle, Power, PowerOff } from 'lucide-react';
 import type { ManagedEngine, EngineLoadState } from '@/stores/useEngineStore';
 
@@ -13,6 +14,7 @@ interface Props {
 function LoadStateIcon({ state }: { state: EngineLoadState }) {
   switch (state) {
     case 'loading':
+    case 'unloading':
       return <Loader2 className="w-4 h-4 animate-spin text-blue-400" aria-hidden="true" />;
     case 'loaded':
       return <Check className="w-4 h-4 text-emerald-400" aria-hidden="true" />;
@@ -27,6 +29,8 @@ function LoadStateLabel({ engine }: { engine: ManagedEngine }) {
   switch (engine.loadState) {
     case 'loading':
       return <span className="text-blue-400">Loading...</span>;
+    case 'unloading':
+      return <span className="text-blue-400">Unloading...</span>;
     case 'loaded':
       return (
         <span className="text-emerald-400">
@@ -48,6 +52,36 @@ export function EngineSelector({
   onUnload,
   disabled,
 }: Props) {
+  // Inline two-step unload confirm (#7427): name of the engine awaiting
+  // confirmation, auto-cancelled after 3s. Avoids a disruptive modal while
+  // still guarding against an accidental single-click unload.
+  const [confirmUnload, setConfirmUnload] = useState<string | null>(null);
+  const confirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearConfirm = () => {
+    if (confirmTimer.current) {
+      clearTimeout(confirmTimer.current);
+      confirmTimer.current = null;
+    }
+    setConfirmUnload(null);
+  };
+
+  const requestUnloadConfirm = (engineName: string) => {
+    if (confirmTimer.current) {
+      clearTimeout(confirmTimer.current);
+    }
+    setConfirmUnload(engineName);
+    confirmTimer.current = setTimeout(() => setConfirmUnload(null), 3000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimer.current) {
+        clearTimeout(confirmTimer.current);
+      }
+    };
+  }, []);
+
   return (
     <div className="mb-6">
       <label
@@ -68,7 +102,9 @@ export function EngineSelector({
           const isSelected = selectedEngine === engine.name;
           const isLoaded = engine.loadState === 'loaded';
           const isLoading = engine.loadState === 'loading';
+          const isUnloading = engine.loadState === 'unloading';
           const isError = engine.loadState === 'error';
+          const isConfirming = confirmUnload === engine.name;
           // #6900: an engine whose package is not installed must not be loadable.
           const isUnavailable = engine.available === false;
 
@@ -130,26 +166,59 @@ export function EngineSelector({
 
               {/* Load/Unload button — absolute positioned on right */}
               <div className="absolute right-2 top-1/2 -translate-y-1/2">
-                {isLoaded ? (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onUnload(engine.name);
-                    }}
-                    disabled={disabled || isSelected}
-                    aria-label={`Unload ${engine.displayName}`}
-                    title={isSelected ? 'Cannot unload active engine' : `Unload ${engine.displayName}`}
-                    className={`
-                      p-2 rounded-md text-xs transition-colors
-                      ${isSelected
-                        ? 'text-gray-600 cursor-not-allowed'
-                        : 'text-gray-400 hover:text-red-400 hover:bg-red-500/10'
-                      }
-                      focus:outline-none focus:ring-2 focus:ring-red-400
-                    `}
-                  >
-                    <PowerOff className="w-4 h-4" />
-                  </button>
+                {isLoaded || isUnloading ? (
+                  isConfirming ? (
+                    <div className="flex items-center gap-1" role="group" aria-label="Confirm unload">
+                      <span className="text-[10px] text-gray-300 mr-1">Unload?</span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          clearConfirm();
+                          onUnload(engine.name);
+                        }}
+                        aria-label={`Confirm unload ${engine.displayName}`}
+                        title="Confirm unload"
+                        className="p-1.5 rounded-md text-emerald-400 hover:bg-emerald-500/10 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                      >
+                        <Check className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          clearConfirm();
+                        }}
+                        aria-label="Cancel unload"
+                        title="Cancel"
+                        className="p-1.5 rounded-md text-gray-400 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        requestUnloadConfirm(engine.name);
+                      }}
+                      disabled={disabled || isSelected || isUnloading}
+                      aria-label={`Unload ${engine.displayName}`}
+                      title={isSelected ? 'Cannot unload active engine' : `Unload ${engine.displayName}`}
+                      className={`
+                        p-2 rounded-md text-xs transition-colors
+                        ${isSelected || isUnloading
+                          ? 'text-gray-600 cursor-not-allowed'
+                          : 'text-gray-400 hover:text-red-400 hover:bg-red-500/10'
+                        }
+                        focus:outline-none focus:ring-2 focus:ring-red-400
+                      `}
+                    >
+                      {isUnloading ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <PowerOff className="w-4 h-4" />
+                      )}
+                    </button>
+                  )
                 ) : (
                   <button
                     onClick={(e) => {

--- a/ui/src/stores/useEngineStore.test.ts
+++ b/ui/src/stores/useEngineStore.test.ts
@@ -116,6 +116,18 @@ describe('useEngineStore', () => {
 
       expect(useEngineStore.getState().selectedEngine).toBe('mujoco');
     });
+
+    it('is a no-op (no backend call) when the engine is not loaded (#7427)', async () => {
+      // 'drake' starts idle — unload must not POST to the backend.
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
+
+      await act(async () => {
+        await useEngineStore.getState().unloadEngine('drake');
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('requestLoad', () => {
@@ -200,6 +212,47 @@ describe('useEngineStore', () => {
       await useEngineStore.getState().requestLoad('drake');
 
       expect(useEngineStore.getState().selectedEngine).toBe('drake');
+    });
+
+    it('ignores a second concurrent load request (idempotence, #7427)', async () => {
+      // First call hangs in 'loading'; a rapid second call must be a no-op so
+      // the UI never fires duplicate load POSTs.
+      const fetchSpy = vi.fn(
+        () =>
+          new Promise<Response>(() => {
+            /* never resolves */
+          })
+      );
+      global.fetch = fetchSpy as typeof fetch;
+
+      const first = useEngineStore.getState().requestLoad('mujoco');
+      const loadingCalls = fetchSpy.mock.calls.length;
+      // Second click while still loading.
+      await useEngineStore.getState().requestLoad('mujoco');
+
+      // No additional fetch was issued by the second request.
+      expect(fetchSpy.mock.calls.length).toBe(loadingCalls);
+      const mujoco = useEngineStore
+        .getState()
+        .engines.find((e) => e.name === 'mujoco');
+      expect(mujoco?.loadState).toBe('loading');
+      void first;
+    });
+
+    it('does not auto-select an engine that failed to load (#7427)', async () => {
+      // A failed load must never leave a selected engine the backend lacks.
+      global.fetch = vi.fn(() =>
+        Promise.reject(new Error('Network error'))
+      ) as typeof fetch;
+
+      expect(useEngineStore.getState().selectedEngine).toBeNull();
+      await useEngineStore.getState().requestLoad('drake');
+
+      const drake = useEngineStore
+        .getState()
+        .engines.find((e) => e.name === 'drake');
+      expect(drake?.loadState).toBe('error');
+      expect(useEngineStore.getState().selectedEngine).toBeNull();
     });
 
     it('marks engine unavailable if probe returns not available', async () => {

--- a/ui/src/stores/useEngineStore.ts
+++ b/ui/src/stores/useEngineStore.ts
@@ -13,7 +13,12 @@ import type { EngineLoadResponse, EngineProbeResponse } from '@/api/generated/ty
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
-export type EngineLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+export type EngineLoadState =
+  | 'idle'
+  | 'loading'
+  | 'loaded'
+  | 'unloading'
+  | 'error';
 
 export interface ManagedEngine {
   name: string;
@@ -181,6 +186,12 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
   },
 
   requestLoad: async (engineName) => {
+    // Idempotence guard (#7427): ignore a second request while one is already
+    // in flight, even if a rapid double-click slipped past the disabled button.
+    const current = get().engines.find((e) => e.name === engineName);
+    if (current?.loadState === 'loading' || current?.loadState === 'unloading') {
+      return;
+    }
     // Set to loading
     set((state) => ({
       engines: state.engines.map((e) =>
@@ -225,8 +236,13 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
         ),
       }));
 
-      // Auto-select if nothing is selected
-      if (!get().selectedEngine) {
+      // Auto-select if nothing is selected — but only if the engine is still
+      // loaded by the time the load resolves (#7427). A concurrent unload (this
+      // tab, another window, or a backend-side eviction) could have flipped it
+      // back, and selecting an engine the backend no longer has makes Start
+      // fail confusingly.
+      const justLoaded = get().engines.find((e) => e.name === engineName);
+      if (!get().selectedEngine && justLoaded?.loadState === 'loaded') {
         set({ selectedEngine: engineName });
       }
     } catch (err) {
@@ -244,6 +260,20 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
 
   unloadEngine: async (engineName) => {
     const { selectedEngine } = get();
+    // Idempotence guard (#7427): ignore an unload for an engine that is not
+    // loaded or already has an operation in flight.
+    const current = get().engines.find((e) => e.name === engineName);
+    if (current?.loadState !== 'loaded') {
+      return;
+    }
+    // Mark in flight so the UI can disable the button / show a spinner.
+    set((state) => ({
+      engines: state.engines.map((e) =>
+        e.name === engineName
+          ? { ...e, loadState: 'unloading' as EngineLoadState }
+          : e
+      ),
+    }));
     try {
       await apiFetch<unknown>(`/api/engines/${engineName}/unload`, { method: 'POST' });
     } catch {


### PR DESCRIPTION
## Summary

Three robustness/UX gaps in the engine load/unload flow (epic #7444).

1. **Double-click duplicate requests.** `requestLoad`/`unloadEngine` now early-return if an operation for that engine is already in flight (`loadState` `loading` or the new `unloading`), so a rapid double-click cannot fire duplicate POSTs even if it slips past the disabled button.
2. **Stale auto-select.** After `loadEngineApi` resolves, `requestLoad` re-reads the just-updated engine and only auto-selects when its `loadState` is still `loaded` — a concurrent unload (another window or backend eviction) no longer leaves the UI pointing at an engine the backend doesn't have, which made Start fail confusingly.
3. **No unload confirmation.** `unloadEngine` briefly marks the engine `unloading` (new state → spinner + disabled button), and `EngineSelector` now requires a lightweight inline two-step confirm (Unload → "Unload? ✓ / ✕", auto-cancel after 3s) instead of a single destructive click. No modal.

## Tests

- store: double-load idempotence (no duplicate fetch), no-auto-select-on-failure, no-op unload when not loaded;
- `EngineSelector`: confirm-required and confirm-cancel cases (the existing single-click unload test updated to the two-step flow).

All store (27) + selector (19) tests pass; `tsc` + `eslint` clean.

Closes #7427

🤖 Generated with [Claude Code](https://claude.com/claude-code)