### PR TITLE
fix(ui): make the simulation store the single source of truth for parameters (#7424)

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -122,11 +122,12 @@ export function useSimulation(engineType: string) {
       // is only reached on an explicit start(), never on a silent reconnect.
       setFrames([]);
 
+      // duration/timestep come from the caller's config (the store is the
+      // single source of truth, #7424) — no hardcoded simulation defaults here.
+      // Only live_analysis carries a safe fallback when the caller omits it.
       ws.send(JSON.stringify({
         action: 'start',
         config: {
-          duration: 3.0,
-          timestep: 0.002,
           live_analysis: true,
           ...config,
         },

--- a/ui/src/components/simulation/ParameterPanel.test.tsx
+++ b/ui/src/components/simulation/ParameterPanel.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * ParameterPanel tests (issue #7424).
+ *
+ * The panel is a controlled view over the simulation store; it must not own
+ * or reset parameter values on its own.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ParameterPanel } from './ParameterPanel';
+import {
+  DEFAULT_PARAMETERS,
+  type SimulationParameters,
+} from '@/stores/useSimulationStore';
+
+function make(overrides: Partial<SimulationParameters> = {}): SimulationParameters {
+  return { ...DEFAULT_PARAMETERS, ...overrides };
+}
+
+describe('ParameterPanel', () => {
+  it('renders the controlled value from props, not a hardcoded default', () => {
+    render(
+      <ParameterPanel engine="mujoco" value={make({ duration: 10 })} onChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/Duration/)).toHaveValue(10);
+  });
+
+  it('does not push any value to the store on mount (#7424)', () => {
+    const onChange = vi.fn();
+    render(
+      <ParameterPanel engine="mujoco" value={make({ duration: 10 })} onChange={onChange} />,
+    );
+    // The old panel fired onChange on mount, clobbering user values. It must not.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('remounting with the same store value keeps it (no reset)', () => {
+    const onChange = vi.fn();
+    const value = make({ duration: 10 });
+    const { unmount } = render(
+      <ParameterPanel engine="mujoco" value={value} onChange={onChange} />,
+    );
+    unmount();
+    render(<ParameterPanel engine="drake" value={value} onChange={onChange} />);
+    // Even though the engine differs, the panel shows the store value untouched.
+    expect(screen.getByLabelText(/Duration/)).toHaveValue(10);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('clearing the duration field then typing yields the typed value, not a default', () => {
+    const onChange = vi.fn();
+    render(
+      <ParameterPanel engine="mujoco" value={make({ duration: 10 })} onChange={onChange} />,
+    );
+    const input = screen.getByLabelText(/Duration/);
+
+    // Clear mid-edit: must NOT commit 3.0 (the old "|| 3.0" bug).
+    fireEvent.change(input, { target: { value: '' } });
+    const committedAfterClear = onChange.mock.calls.map((c) => c[0]);
+    expect(committedAfterClear).not.toContainEqual({ duration: 3.0 });
+
+    // Type a new value.
+    fireEvent.change(input, { target: { value: '12' } });
+    expect(onChange).toHaveBeenLastCalledWith({ duration: 12 });
+  });
+
+  it('forwards a reset-to-defaults click', () => {
+    const onResetDefaults = vi.fn();
+    render(
+      <ParameterPanel
+        engine="drake"
+        value={make()}
+        onChange={vi.fn()}
+        onResetDefaults={onResetDefaults}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /reset to engine defaults/i }));
+    expect(onResetDefaults).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/simulation/ParameterPanel.tsx
+++ b/ui/src/components/simulation/ParameterPanel.tsx
@@ -1,89 +1,62 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState } from 'react';
 import { Input, Select } from '@/components/ui';
-
-export interface SimulationParameters {
-  duration: number;
-  timestep: number;
-  liveAnalysis: boolean;
-  gpuAcceleration: boolean;
-  model?: string;
-}
+import type { SimulationParameters } from '@/stores/useSimulationStore';
 
 interface Props {
   engine: string;
   disabled?: boolean;
-  onChange: (params: SimulationParameters) => void;
+  /** Controlled parameter values (owned by useSimulationStore, #7424). */
+  value: SimulationParameters;
+  /** Apply a partial change to the store. */
+  onChange: (params: Partial<SimulationParameters>) => void;
+  /** Reset duration/timestep to the current engine's defaults. */
+  onResetDefaults?: () => void;
 }
 
-// Engine-specific default configurations
-const ENGINE_DEFAULTS: Record<string, Partial<SimulationParameters>> = {
-  mujoco: {
-    duration: 3.0,
-    timestep: 0.002,
-  },
-  drake: {
-    duration: 5.0,
-    timestep: 0.001,
-  },
-  pinocchio: {
-    duration: 3.0,
-    timestep: 0.001,
-  },
-  opensim: {
-    duration: 2.0,
-    timestep: 0.005,
-  },
-  myosim: {
-    duration: 3.0,
-    timestep: 0.002,
-  },
-  myosuite: {
-    duration: 3.0,
-    timestep: 0.002,
-  },
-};
+/**
+ * ParameterPanel is a controlled view over the simulation store (#7424).
+ *
+ * It holds NO mirror copy of duration/timestep/toggles — the store is the
+ * single source of truth, so remounting (navigate away and back) or switching
+ * engines can no longer clobber user-set values. The numeric inputs keep only a
+ * transient raw-string buffer while editing so clearing the field does not snap
+ * the committed value to a default mid-edit; the parsed value is committed on
+ * change when valid and on blur otherwise.
+ */
+export function ParameterPanel({
+  engine,
+  disabled,
+  value,
+  onChange,
+  onResetDefaults,
+}: Props) {
+  // Transient edit buffer for the duration field; null = mirror the store.
+  const [durationDraft, setDurationDraft] = useState<string | null>(null);
 
-function getEngineDefaults(engine: string): { duration: number; timestep: number } {
-  const defaults = ENGINE_DEFAULTS[engine.toLowerCase()] || {};
-  return {
-    duration: defaults.duration ?? 3.0,
-    timestep: defaults.timestep ?? 0.002,
+  const commitDuration = (raw: string) => {
+    const parsed = Number(raw);
+    if (raw.trim() !== '' && !Number.isNaN(parsed)) {
+      onChange({ duration: parsed });
+    }
   };
-}
-
-export function ParameterPanel({ engine, disabled, onChange }: Props) {
-  const engineDefaults = useMemo(() => getEngineDefaults(engine), [engine]);
-
-  const [duration, setDuration] = useState(engineDefaults.duration);
-  const [timestep, setTimestep] = useState(engineDefaults.timestep);
-  const [liveAnalysis, setLiveAnalysis] = useState(true);
-  const [gpuAcceleration, setGpuAcceleration] = useState(false);
-
-  // Reset values when engine changes
-  useEffect(() => {
-    setDuration(engineDefaults.duration);
-    setTimestep(engineDefaults.timestep);
-  }, [engineDefaults]);
-
-  // Notify parent of parameter changes
-  const notifyChange = useCallback(() => {
-    onChange({
-      duration,
-      timestep,
-      liveAnalysis,
-      gpuAcceleration,
-    });
-  }, [duration, timestep, liveAnalysis, gpuAcceleration, onChange]);
-
-  useEffect(() => {
-    notifyChange();
-  }, [notifyChange]);
 
   return (
     <div className="space-y-4">
-      <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
-        Simulation Parameters
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+          Simulation Parameters
+        </h3>
+        {onResetDefaults && (
+          <button
+            type="button"
+            onClick={onResetDefaults}
+            disabled={disabled}
+            className="text-xs text-blue-400 hover:text-blue-300 disabled:text-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-400 rounded px-1"
+          >
+            Reset to engine defaults
+          </button>
+        )}
+      </div>
 
       {/* Duration */}
       <div>
@@ -99,8 +72,17 @@ export function ParameterPanel({ engine, disabled, onChange }: Props) {
           min="0.1"
           max="60"
           step="0.1"
-          value={duration}
-          onChange={(e) => setDuration(parseFloat(e.target.value) || 3.0)}
+          value={durationDraft ?? value.duration}
+          onChange={(e) => {
+            // Keep the raw string while editing so an empty field does not snap
+            // to a default; commit the parsed value when it is valid.
+            setDurationDraft(e.target.value);
+            commitDuration(e.target.value);
+          }}
+          onBlur={(e) => {
+            commitDuration(e.target.value);
+            setDurationDraft(null);
+          }}
           disabled={disabled}
           className="w-full"
           aria-describedby="duration-help"
@@ -120,8 +102,8 @@ export function ParameterPanel({ engine, disabled, onChange }: Props) {
         </label>
         <Select
           id="timestep-input"
-          value={timestep}
-          onChange={(e) => setTimestep(parseFloat(e.target.value))}
+          value={value.timestep}
+          onChange={(e) => onChange({ timestep: parseFloat(e.target.value) })}
           disabled={disabled}
           className="w-full"
           aria-describedby="timestep-help"
@@ -150,17 +132,17 @@ export function ParameterPanel({ engine, disabled, onChange }: Props) {
         <button
           id="live-analysis-toggle"
           role="switch"
-          aria-checked={liveAnalysis}
-          onClick={() => setLiveAnalysis(!liveAnalysis)}
+          aria-checked={value.liveAnalysis}
+          onClick={() => onChange({ liveAnalysis: !value.liveAnalysis })}
           disabled={disabled}
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors
                      focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-800
                      disabled:opacity-50 disabled:cursor-not-allowed
-                     ${liveAnalysis ? 'bg-blue-600' : 'bg-gray-600'}`}
+                     ${value.liveAnalysis ? 'bg-blue-600' : 'bg-gray-600'}`}
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform
-                       ${liveAnalysis ? 'translate-x-6' : 'translate-x-1'}`}
+                       ${value.liveAnalysis ? 'translate-x-6' : 'translate-x-1'}`}
           />
         </button>
       </div>
@@ -179,17 +161,17 @@ export function ParameterPanel({ engine, disabled, onChange }: Props) {
         <button
           id="gpu-toggle"
           role="switch"
-          aria-checked={gpuAcceleration}
-          onClick={() => setGpuAcceleration(!gpuAcceleration)}
+          aria-checked={value.gpuAcceleration}
+          onClick={() => onChange({ gpuAcceleration: !value.gpuAcceleration })}
           disabled={disabled}
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors
                      focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-800
                      disabled:opacity-50 disabled:cursor-not-allowed
-                     ${gpuAcceleration ? 'bg-green-600' : 'bg-gray-600'}`}
+                     ${value.gpuAcceleration ? 'bg-green-600' : 'bg-gray-600'}`}
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform
-                       ${gpuAcceleration ? 'translate-x-6' : 'translate-x-1'}`}
+                       ${value.gpuAcceleration ? 'translate-x-6' : 'translate-x-1'}`}
           />
         </button>
       </div>

--- a/ui/src/pages/Simulation.tsx
+++ b/ui/src/pages/Simulation.tsx
@@ -5,7 +5,8 @@ import { useEngineStore, selectEffectiveEngine } from '@/stores/useEngineStore';
 import { useSimulationStore } from '@/stores/useSimulationStore';
 import { EngineSelector } from '@/components/simulation/EngineSelector';
 import { SimulationControls } from '@/components/simulation/SimulationControls';
-import { ParameterPanel, type SimulationParameters } from '@/components/simulation/ParameterPanel';
+import { ParameterPanel } from '@/components/simulation/ParameterPanel';
+import type { SimulationParameters } from '@/stores/useSimulationStore';
 import { ActuatorPanel } from '@/components/simulation/ActuatorPanel';
 import { RecordingsPanel } from '@/components/simulation/RecordingsPanel';
 import { EngineComparisonPanel } from '@/components/simulation/EngineComparisonPanel';
@@ -49,7 +50,8 @@ export function SimulationPage() {
   );
 
   const parameters = useSimulationStore((s) => s.parameters);
-  const replaceParameters = useSimulationStore((s) => s.replaceParameters);
+  const setParameters = useSimulationStore((s) => s.setParameters);
+  const resetToEngineDefaults = useSimulationStore((s) => s.resetToEngineDefaults);
   const markRun = useSimulationStore((s) => s.markRun);
   const recording = useSimulationStore((s) => s.recording);
   const markRecordingStarted = useSimulationStore((s) => s.startRecording);
@@ -209,11 +211,15 @@ export function SimulationPage() {
   );
 
   const handleParameterChange = useCallback(
-    (params: SimulationParameters) => {
-      replaceParameters(params);
+    (params: Partial<SimulationParameters>) => {
+      setParameters(params);
     },
-    [replaceParameters]
+    [setParameters]
   );
+
+  const handleResetDefaults = useCallback(() => {
+    resetToEngineDefaults(effectiveEngine || 'mujoco');
+  }, [resetToEngineDefaults, effectiveEngine]);
 
   const handleStart = useCallback(() => {
     if (!effectiveEngine) {
@@ -359,7 +365,9 @@ export function SimulationPage() {
           <ParameterPanel
             engine={effectiveEngine || 'mujoco'}
             disabled={isRunning || !effectiveEngine}
+            value={parameters}
             onChange={handleParameterChange}
+            onResetDefaults={handleResetDefaults}
           />
         </div>
 

--- a/ui/src/stores/useSimulationStore.test.ts
+++ b/ui/src/stores/useSimulationStore.test.ts
@@ -3,6 +3,7 @@ import { act } from '@testing-library/react';
 import {
   useSimulationStore,
   DEFAULT_PARAMETERS,
+  getEngineDefaults,
 } from './useSimulationStore';
 
 describe('useSimulationStore', () => {
@@ -100,6 +101,38 @@ describe('useSimulationStore', () => {
       const state = useSimulationStore.getState();
       expect(state.parameters).toEqual(DEFAULT_PARAMETERS);
       expect(state.hasRun).toBe(false);
+    });
+  });
+
+  describe('getEngineDefaults (#7424)', () => {
+    it('returns per-engine defaults (case-insensitive)', () => {
+      expect(getEngineDefaults('drake')).toEqual({ duration: 5.0, timestep: 0.001 });
+      expect(getEngineDefaults('DRAKE')).toEqual({ duration: 5.0, timestep: 0.001 });
+    });
+
+    it('falls back to global defaults for unknown engines', () => {
+      expect(getEngineDefaults('nonexistent')).toEqual({
+        duration: DEFAULT_PARAMETERS.duration,
+        timestep: DEFAULT_PARAMETERS.timestep,
+      });
+    });
+  });
+
+  describe('resetToEngineDefaults (#7424)', () => {
+    it('applies the engine defaults and preserves unrelated fields', () => {
+      act(() => {
+        useSimulationStore
+          .getState()
+          .setParameters({ duration: 42, liveAnalysis: false });
+      });
+      act(() => {
+        useSimulationStore.getState().resetToEngineDefaults('drake');
+      });
+      const { parameters } = useSimulationStore.getState();
+      expect(parameters.duration).toBe(5.0);
+      expect(parameters.timestep).toBe(0.001);
+      // Toggles are not part of engine defaults — left as the user set them.
+      expect(parameters.liveAnalysis).toBe(false);
     });
   });
 

--- a/ui/src/stores/useSimulationStore.ts
+++ b/ui/src/stores/useSimulationStore.ts
@@ -54,6 +54,12 @@ export interface SimulationStoreActions {
    * ran), this is a no-op (#7424 parameter-reset bug guard).
    */
   hydrateDefaults: (defaults: Partial<Pick<SimulationParameters, 'duration' | 'timestep'>>) => void;
+  /**
+   * Apply the given engine's default duration/timestep, replacing the current
+   * values. Explicit user action only ("Reset to engine defaults", #7424) —
+   * never called automatically on mount or engine change.
+   */
+  resetToEngineDefaults: (engine: string) => void;
   /** Mark that a simulation has been started */
   markRun: () => void;
   /** Mark server-side recording as active (issue #7452) */
@@ -76,6 +82,35 @@ export const DEFAULT_PARAMETERS: SimulationParameters = {
   liveAnalysis: true,
   gpuAcceleration: false,
 };
+
+/**
+ * Per-engine default duration/timestep (single source of truth, #7424).
+ *
+ * Previously duplicated in ParameterPanel; engines absent here fall back to
+ * `DEFAULT_PARAMETERS`.
+ */
+export const ENGINE_DEFAULTS: Record<
+  string,
+  Pick<SimulationParameters, 'duration' | 'timestep'>
+> = {
+  mujoco: { duration: 3.0, timestep: 0.002 },
+  drake: { duration: 5.0, timestep: 0.001 },
+  pinocchio: { duration: 3.0, timestep: 0.001 },
+  opensim: { duration: 2.0, timestep: 0.005 },
+  myosim: { duration: 3.0, timestep: 0.002 },
+  myosuite: { duration: 3.0, timestep: 0.002 },
+};
+
+/** Resolve an engine's default duration/timestep, falling back to global defaults. */
+export function getEngineDefaults(
+  engine: string,
+): Pick<SimulationParameters, 'duration' | 'timestep'> {
+  const defaults = ENGINE_DEFAULTS[engine.toLowerCase()];
+  return {
+    duration: defaults?.duration ?? DEFAULT_PARAMETERS.duration,
+    timestep: defaults?.timestep ?? DEFAULT_PARAMETERS.timestep,
+  };
+}
 
 export const DEFAULT_RECORDING: RecordingState = {
   status: 'idle',
@@ -111,6 +146,12 @@ export const useSimulationStore = create<SimulationStore>((set) => ({
         defaultsHydrated: true,
       };
     }),
+
+  resetToEngineDefaults: (engine) =>
+    set((state) => ({
+      parameters: { ...state.parameters, ...getEngineDefaults(engine) },
+      parametersTouched: true,
+    })),
 
   markRun: () => set({ hasRun: true }),
 


### PR DESCRIPTION
## Summary

`ParameterPanel` kept a local `useState` mirror seeded from a hardcoded `ENGINE_DEFAULTS` table and fired `onChange` on mount, so every remount (navigate away from /simulation and back) or engine change pushed those defaults up through `replaceParameters` and **silently overwrote the user''s values** in `useSimulationStore`. Clearing the duration field mid-edit also snapped the value to `3.0` via `parseFloat(...) || 3.0`.

## Fix

- `ParameterPanel` is now a **controlled** view: it reads `value` from props and writes partial changes via `onChange` (store `setParameters`). The local mirror state and the mount-time `notifyChange` effect are gone, so remounts and engine switches can no longer clobber user values.
- The numeric duration input keeps a transient raw-string buffer while editing and only commits a parsed, non-empty, non-NaN value — no mid-edit snap to a default.
- A **"Reset to engine defaults"** button (explicit user action only) calls the new store action `resetToEngineDefaults(engine)`.

### DRY consolidation
- `ENGINE_DEFAULTS` + `getEngineDefaults` moved into `useSimulationStore` and exported (removed the ParameterPanel duplicate).
- `SimulationParameters` is now defined/exported only by the store.
- Removed the hardcoded `duration: 3.0` / `timestep: 0.002` literals from the WebSocket start payload in `client.ts` — the caller always supplies the real config; only `live_analysis` keeps a fallback.

## Tests
- new `ParameterPanel.test.tsx`: controlled value, no mount push, remount keeps value, clear-then-type yields the typed value (not 3.0), reset click;
- store tests for `getEngineDefaults` and `resetToEngineDefaults`.

All 22 pass; `tsc` + `eslint` clean; `grep "3.0" client.ts` shows no hardcoded sim defaults.

Closes #7424

🤖 Generated with [Claude Code](https://claude.com/claude-code)