### PR TITLE
fix(ui): debounce slider commands with out-of-order + failure handling (#7425)

### DIFF
--- a/ui/src/components/simulation/ActuatorPanel.tsx
+++ b/ui/src/components/simulation/ActuatorPanel.tsx
@@ -131,9 +131,9 @@ export function ActuatorPanel({
   }, [fetchActuators, isRunning, refreshInterval]);
 
   const handleValueChange = useCallback(async (index: number, value: number) => {
-    // #6898: surface failures (bad index, engine not loaded) via setError
-    // instead of silently swallowing them, which left the slider moved while
-    // the engine was unchanged.
+    // #6898: surface failures (bad index, engine not loaded) instead of
+    // silently swallowing them. Reports failure in-band so the slider can
+    // revert to the confirmed value (#7425).
     try {
       await apiFetch('/api/simulation/actuators', {
         method: 'POST',
@@ -144,10 +144,12 @@ export function ActuatorPanel({
         }),
       });
       setError(null);
+      return { success: true };
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to update actuator value',
-      );
+      const message =
+        err instanceof Error ? err.message : 'Failed to update actuator value';
+      setError(message);
+      return { success: false, error: message };
     }
   }, []);
 
@@ -294,6 +296,7 @@ export function ActuatorPanel({
                         actuator={act}
                         onValueChange={handleValueChange}
                         onControlTypeChange={handleControlTypeChange}
+                        onError={setError}
                         availableTypes={panelState.available_control_types}
                       />
                     ));
@@ -325,6 +328,7 @@ export function ActuatorPanel({
                               actuator={act}
                               onValueChange={handleValueChange}
                               onControlTypeChange={handleControlTypeChange}
+                              onError={setError}
                               availableTypes={panelState.available_control_types}
                             />
                           ))}

--- a/ui/src/components/simulation/ActuatorSlider.test.tsx
+++ b/ui/src/components/simulation/ActuatorSlider.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * ActuatorSlider tests (issue #7425) — debounced send + failure revert.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ActuatorSlider } from './ActuatorSlider';
+import type { ActuatorInfo } from './ActuatorPanel';
+
+const ACT: ActuatorInfo = {
+  index: 2,
+  name: 'hip',
+  control_type: 'constant',
+  value: 0,
+  min_value: -10,
+  max_value: 10,
+  units: 'Nm',
+  joint_type: 'hinge',
+};
+
+describe('ActuatorSlider', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('debounces drag ticks into a single send with the final value', async () => {
+    const onValueChange = vi.fn().mockResolvedValue({ success: true });
+    render(
+      <ActuatorSlider
+        actuator={ACT}
+        onValueChange={onValueChange}
+        onControlTypeChange={vi.fn()}
+        availableTypes={['constant']}
+      />,
+    );
+    const slider = screen.getByLabelText(/hip control value/i);
+
+    act(() => {
+      fireEvent.change(slider, { target: { value: '1' } });
+      fireEvent.change(slider, { target: { value: '2' } });
+      fireEvent.change(slider, { target: { value: '3' } });
+    });
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith(2, 3);
+  });
+
+  it('reverts to the actuator value and reports when a send fails', async () => {
+    const onValueChange = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: 'engine not loaded' });
+    const onError = vi.fn();
+    render(
+      <ActuatorSlider
+        actuator={ACT}
+        onValueChange={onValueChange}
+        onControlTypeChange={vi.fn()}
+        onError={onError}
+        availableTypes={['constant']}
+      />,
+    );
+    const slider = screen.getByLabelText(/hip control value/i) as HTMLInputElement;
+
+    act(() => {
+      fireEvent.change(slider, { target: { value: '7' } });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onError).toHaveBeenCalledWith('engine not loaded');
+    // Reverted to the confirmed actuator value (0).
+    expect(Number(slider.value)).toBe(0);
+  });
+});

--- a/ui/src/components/simulation/ActuatorSlider.tsx
+++ b/ui/src/components/simulation/ActuatorSlider.tsx
@@ -1,5 +1,9 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { ActuatorInfo } from './ActuatorPanel';
+import {
+  useDebouncedCommand,
+  type CommandResult,
+} from '@/utils/useDebouncedCommand';
 
 const CONTROL_TYPE_LABELS: Record<string, string> = {
   constant: 'Constant',
@@ -12,42 +16,25 @@ export function ActuatorSlider({
   actuator,
   onValueChange,
   onControlTypeChange,
+  onError,
   availableTypes,
 }: {
   actuator: ActuatorInfo;
-  onValueChange: (index: number, value: number) => void;
+  onValueChange: (index: number, value: number) => Promise<CommandResult>;
   onControlTypeChange: (index: number, type: string) => void;
+  onError?: (message: string) => void;
   availableTypes: string[];
 }) {
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragValue, setDragValue] = useState(actuator.value);
-  const localValue = isDragging ? dragValue : actuator.value;
-
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
-
-  const handleChange = useCallback(
-    (newValue: number) => {
-      setIsDragging(true);
-      setDragValue(newValue);
-
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => {
-        onValueChange(actuator.index, newValue);
-        setIsDragging(false);
-      }, 50);
-    },
-    [actuator.index, onValueChange],
+  // Debounce drag ticks into a single send; revert + report on failure (#7425).
+  const send = useCallback(
+    (value: number) => onValueChange(actuator.index, value),
+    [onValueChange, actuator.index],
   );
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, []);
+  const { value: localValue, setValue: handleChange } = useDebouncedCommand(
+    actuator.value,
+    send,
+    onError ?? (() => {}),
+  );
 
   const range = actuator.max_value - actuator.min_value;
   const percentage =

--- a/ui/src/pages/Simulation.test.tsx
+++ b/ui/src/pages/Simulation.test.tsx
@@ -443,11 +443,26 @@ describe('SimulationPage', () => {
       expect(screen.getByLabelText(/speed factor/i)).toBeInTheDocument();
     });
 
-    it('calls setSpeed when slider value changes', () => {
+    it('calls setSpeed (debounced) when slider value changes (#7425)', async () => {
       render(<SimulationPage />, { wrapper: createWrapper() });
       const slider = screen.getByLabelText(/speed factor/i);
+      // Debounced: the value updates immediately but the send is deferred.
       fireEvent.change(slider, { target: { value: '2.5' } });
-      expect(mockSimulation.setSpeed).toHaveBeenCalledWith(2.5);
+      await waitFor(() =>
+        expect(mockSimulation.setSpeed).toHaveBeenCalledWith(2.5),
+      );
+    });
+
+    it('coalesces a rapid speed drag into a single setSpeed call (#7425)', async () => {
+      render(<SimulationPage />, { wrapper: createWrapper() });
+      const slider = screen.getByLabelText(/speed factor/i);
+      fireEvent.change(slider, { target: { value: '1.5' } });
+      fireEvent.change(slider, { target: { value: '2.0' } });
+      fireEvent.change(slider, { target: { value: '2.5' } });
+      await waitFor(() =>
+        expect(mockSimulation.setSpeed).toHaveBeenCalledWith(2.5),
+      );
+      expect(mockSimulation.setSpeed).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ui/src/pages/Simulation.tsx
+++ b/ui/src/pages/Simulation.tsx
@@ -6,6 +6,7 @@ import { useSimulationStore } from '@/stores/useSimulationStore';
 import { EngineSelector } from '@/components/simulation/EngineSelector';
 import { SimulationControls } from '@/components/simulation/SimulationControls';
 import { ParameterPanel, type SimulationParameters } from '@/components/simulation/ParameterPanel';
+import { useDebouncedCommand } from '@/utils/useDebouncedCommand';
 import { ActuatorPanel } from '@/components/simulation/ActuatorPanel';
 import { RecordingsPanel } from '@/components/simulation/RecordingsPanel';
 import { EngineComparisonPanel } from '@/components/simulation/EngineComparisonPanel';
@@ -86,14 +87,23 @@ export function SimulationPage() {
     setSpeed,
   } = useSimulation(activeEngine);
 
-  const handleSpeedChange = useCallback(async (value: number) => {
-    setSpeedFactor(value);
-    // setSpeed reports failure in-band (issue #7166) — no rejection to catch.
-    const result = await setSpeed(value);
-    if (!result.success) {
-      showError(result.error ?? 'Failed to update speed');
-    }
-  }, [setSpeed, showError]);
+  // Speed slider: debounce drag ticks into a single in-order send and revert on
+  // failure (#7425). setSpeed reports failure in-band (#7166). `speedFactor` is
+  // the last confirmed value; on success we advance it so the display sticks.
+  const sendSpeed = useCallback(
+    async (value: number) => {
+      const result = await setSpeed(value);
+      if (result.success) {
+        setSpeedFactor(value);
+      }
+      return result;
+    },
+    [setSpeed],
+  );
+  const {
+    value: speedDisplay,
+    setValue: handleSpeedChange,
+  } = useDebouncedCommand(speedFactor, sendSpeed, showError);
 
   // Hide controls the active engine cannot serve (#7452): recording captures
   // forward-simulation frames, so without forward_sim it would be a no-op.
@@ -381,7 +391,7 @@ export function SimulationPage() {
         {isRunning && (
           <div className="mb-4 border-t border-gray-700 pt-4">
             <label htmlFor="speed-factor" className="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
-              Speed Factor ({speedFactor.toFixed(1)}x)
+              Speed Factor ({speedDisplay.toFixed(1)}x)
             </label>
             <input
               id="speed-factor"
@@ -389,7 +399,7 @@ export function SimulationPage() {
               min="0.1"
               max="5.0"
               step="0.1"
-              value={speedFactor}
+              value={speedDisplay}
               onChange={(e) => handleSpeedChange(parseFloat(e.target.value))}
               className="w-full h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
             />

--- a/ui/src/utils/useDebouncedCommand.test.ts
+++ b/ui/src/utils/useDebouncedCommand.test.ts
@@ -1,0 +1,83 @@
+/**
+ * useDebouncedCommand tests (issue #7425).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDebouncedCommand } from './useDebouncedCommand';
+
+describe('useDebouncedCommand', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('coalesces rapid changes into a single send with the final value', async () => {
+    const send = vi.fn().mockResolvedValue({ success: true });
+    const { result } = renderHook(() =>
+      useDebouncedCommand(1, send, vi.fn(), 200),
+    );
+
+    act(() => {
+      result.current.setValue(2);
+      result.current.setValue(3);
+      result.current.setValue(4);
+    });
+    // Display updates immediately; no send yet.
+    expect(result.current.value).toBe(4);
+    expect(send).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(4);
+  });
+
+  it('reverts the displayed value and reports on send failure', async () => {
+    const onError = vi.fn();
+    const send = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: 'boom' });
+    const { result } = renderHook(() =>
+      useDebouncedCommand(1, send, onError, 200),
+    );
+
+    act(() => {
+      result.current.setValue(9);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onError).toHaveBeenCalledWith('boom');
+    // Reverted to the last confirmed backend value.
+    expect(result.current.value).toBe(1);
+  });
+
+  it('does not send when unmounted during the debounce window', async () => {
+    const send = vi.fn().mockResolvedValue({ success: true });
+    const { result, unmount } = renderHook(() =>
+      useDebouncedCommand(1, send, vi.fn(), 200),
+    );
+
+    act(() => {
+      result.current.setValue(5);
+    });
+    unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('follows the confirmed value when nothing is pending', () => {
+    const send = vi.fn().mockResolvedValue({ success: true });
+    const { result, rerender } = renderHook(
+      ({ confirmed }) => useDebouncedCommand(confirmed, send, vi.fn(), 200),
+      { initialProps: { confirmed: 1 } },
+    );
+    expect(result.current.value).toBe(1);
+
+    rerender({ confirmed: 7 });
+    expect(result.current.value).toBe(7);
+  });
+});

--- a/ui/src/utils/useDebouncedCommand.ts
+++ b/ui/src/utils/useDebouncedCommand.ts
@@ -1,0 +1,99 @@
+/**
+ * useDebouncedCommand — debounce a slider/range value into a single network
+ * command, with out-of-order protection and failure reverting (issue #7425).
+ *
+ * UI state should update immediately for responsiveness; the network call is
+ * debounced so a drag does not fire one request per tick. A monotonically
+ * increasing request id guards against out-of-order responses applying a stale
+ * value, and a failed send reverts the displayed value to the last confirmed
+ * backend value.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface CommandResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface DebouncedCommand {
+  /** Current displayed value (optimistic while a send is pending). */
+  value: number;
+  /** Update the displayed value and schedule a debounced send. */
+  setValue: (next: number) => void;
+  /** True while a debounce/send is in flight. */
+  pending: boolean;
+}
+
+/**
+ * @param confirmedValue The last value confirmed by the backend (source of
+ *   truth); the displayed value follows it whenever no edit is pending.
+ * @param send Performs the network command; must report failure in-band.
+ * @param onError Called with a message when a send fails.
+ * @param delayMs Debounce window (default 200ms).
+ */
+export function useDebouncedCommand(
+  confirmedValue: number,
+  send: (value: number) => Promise<CommandResult>,
+  onError: (message: string) => void,
+  delayMs = 200,
+): DebouncedCommand {
+  // Optimistic in-flight value; null means "follow the confirmed value". Using
+  // a derived display value (editValue ?? confirmedValue) avoids a setState in
+  // an effect to track external refreshes.
+  const [editValue, setEditValue] = useState<number | null>(null);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestIdRef = useRef(0);
+  const latestAppliedRef = useRef(0);
+  // Keep stable refs so the debounced closure never goes stale. Updated in an
+  // effect (not during render) to satisfy react-hooks/refs.
+  const sendRef = useRef(send);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    sendRef.current = send;
+    onErrorRef.current = onError;
+  }, [send, onError]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const setValue = useCallback(
+    (next: number) => {
+      setEditValue(next);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => {
+        const id = ++requestIdRef.current;
+        void sendRef.current(next).then((result) => {
+          // Ignore stale responses: only the most recent request may apply.
+          if (id < latestAppliedRef.current) {
+            return;
+          }
+          latestAppliedRef.current = id;
+          if (!result.success) {
+            onErrorRef.current(result.error ?? 'Command failed');
+          }
+          // On success the confirmed value advances and the optimistic value is
+          // dropped; on failure we also drop it, reverting to confirmed.
+          if (id === requestIdRef.current) {
+            setEditValue(null);
+          }
+        });
+      }, delayMs);
+    },
+    [delayMs],
+  );
+
+  return {
+    value: editValue ?? confirmedValue,
+    setValue,
+    pending: editValue !== null,
+  };
+}


### PR DESCRIPTION
## Summary

Two slider→API paths misbehaved under rapid input:
- the **speed slider** awaited `setSpeed` directly from the range `onChange`, firing one POST per drag tick (dozens per drag) with no ordering guard — responses could land out of order and settle on a stale speed;
- **ActuatorSlider** debounced but fired `onValueChange` fire-and-forget and always cleared the dragging state, so a failed send left the slider showing the user''s value while the backend held the old one (silent divergence).

## Fix

New shared hook `ui/src/utils/useDebouncedCommand.ts`:
- updates the displayed value immediately (derived as `editValue ?? confirmed`, so external refreshes are followed without a setState-in-effect);
- debounces the network call (200ms) and clears the pending timeout on unmount;
- tracks a monotonically increasing request id so out-of-order responses can''t apply a stale value;
- on failure invokes `onError` **and reverts** the displayed value to the last confirmed backend value.

Wired into `Simulation.tsx` speed slider (success advances the confirmed `speedFactor`; failure toasts via `showError`) and `ActuatorSlider` (`ActuatorPanel.handleValueChange` now returns `{success,error}` and passes `setError` as `onError`; a failed send reverts the slider to `actuator.value`).

## Tests
- `useDebouncedCommand`: single send with the final value, failure revert+report, unmount cancels, follows confirmed value;
- `ActuatorSlider`: debounced single send, failure revert;
- `Simulation` speed slider: debounced flow + rapid-drag-coalesces-to-one-call.

`tsc` + `eslint` clean.

Closes #7425

🤖 Generated with [Claude Code](https://claude.com/claude-code)