### PR TITLE
fix(ui): responsive WorkspaceShell + min-0 canvas + square-viewport caps (#7415, #7416, #7417)

### DIFF
--- a/ui/src/components/layout/WorkspaceShell.test.tsx
+++ b/ui/src/components/layout/WorkspaceShell.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Responsive WorkspaceShell tests (UI/UX #7415).
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { WorkspaceShell } from './WorkspaceShell';
+
+describe('WorkspaceShell', () => {
+  it('renders left, right, main, and bottom content', () => {
+    render(
+      <WorkspaceShell
+        leftPanel={<div>LEFT</div>}
+        rightPanel={<div>RIGHT</div>}
+        bottomPanel={<div>BOTTOM</div>}
+      >
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    // Docked panels render their content (duplicated into the hidden drawer too).
+    expect(screen.getAllByText('LEFT').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('RIGHT').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('MAIN')).toBeInTheDocument();
+    expect(screen.getByText('BOTTOM')).toBeInTheDocument();
+  });
+
+  it('keeps the main element shrinkable for canvas children (min-w-0/min-h-0)', () => {
+    render(
+      <WorkspaceShell leftPanel={<div>L</div>}>
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    const main = screen.getByRole('main');
+    expect(main.className).toContain('min-w-0');
+    expect(main.className).toContain('min-h-0');
+  });
+
+  it('opens the left drawer when its toggle is clicked', () => {
+    render(
+      <WorkspaceShell leftPanel={<div>LEFTPANEL</div>} leftPanelLabel="Controls">
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    // No dialog before opening.
+    expect(screen.queryByRole('dialog')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Controls' }));
+    const dialog = screen.getByRole('dialog', { name: 'Controls' });
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it('closes the drawer via the close button', () => {
+    render(
+      <WorkspaceShell rightPanel={<div>RP</div>} rightPanelLabel="Details">
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+    expect(screen.getByRole('dialog', { name: 'Details' })).toBeInTheDocument();
+    // There are two "Close Details" affordances (backdrop + button); clicking
+    // either dismisses the drawer.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close Details' })[0]);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('omits a side entirely when its panel prop is not provided', () => {
+    render(
+      <WorkspaceShell leftPanel={<div>ONLYLEFT</div>}>
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    // Only the left toggle exists; no right toggle.
+    expect(
+      screen.getByRole('button', { name: 'Controls' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Details' })).toBeNull();
+  });
+});

--- a/ui/src/components/layout/WorkspaceShell.tsx
+++ b/ui/src/components/layout/WorkspaceShell.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+export interface WorkspaceShellProps {
+  /** Left sidebar content (controls). Omit for a two-column layout. */
+  leftPanel?: ReactNode;
+  /** Right sidebar content (live data / inspectors). Omit to hide. */
+  rightPanel?: ReactNode;
+  /** Optional full-width strip below the main area (e.g. a plot strip). */
+  bottomPanel?: ReactNode;
+  /** Main content (3D viewport, canvas, etc.). */
+  children: ReactNode;
+  /** Accessible labels for the drawer toggle buttons. */
+  leftPanelLabel?: string;
+  rightPanelLabel?: string;
+  /** Extra classes for the outer container (rarely needed). */
+  className?: string;
+}
+
+const ASIDE_BASE =
+  'flex flex-col flex-shrink-0 bg-gray-800 overflow-y-auto min-h-0';
+
+/**
+ * Canonical responsive workspace frame (UI/UX #7415).
+ *
+ * Replaces the bespoke `w-80`/`w-72` fixed-width aside markup that every
+ * multi-panel page hand-rolled. Above the `lg` breakpoint it renders the
+ * classic three-column layout; below it the side panels collapse into
+ * toggleable overlay drawers so every control stays reachable on narrow
+ * windows and Tauri popouts.
+ *
+ * The `min-w-0`/`min-h-0` on the `<main>` element is load-bearing: without it
+ * a flex child containing a WebGL canvas refuses to shrink below its content
+ * size and overflows (see #7416).
+ */
+export function WorkspaceShell({
+  leftPanel,
+  rightPanel,
+  bottomPanel,
+  children,
+  leftPanelLabel = 'Controls',
+  rightPanelLabel = 'Details',
+  className = '',
+}: WorkspaceShellProps) {
+  const [leftOpen, setLeftOpen] = useState(false);
+  const [rightOpen, setRightOpen] = useState(false);
+
+  const hasLeft = leftPanel != null;
+  const hasRight = rightPanel != null;
+
+  return (
+    <div
+      className={`flex flex-col h-screen bg-gray-900 overflow-hidden ${className}`.trim()}
+    >
+      {/* Mobile/tablet top bar with drawer toggles (hidden at lg+). */}
+      {(hasLeft || hasRight) && (
+        <div className="flex lg:hidden items-center justify-between gap-2 bg-gray-800 border-b border-gray-700 px-3 py-2 flex-shrink-0">
+          {hasLeft ? (
+            <DrawerToggle
+              label={leftPanelLabel}
+              expanded={leftOpen}
+              onClick={() => setLeftOpen(true)}
+            />
+          ) : (
+            <span />
+          )}
+          {hasRight ? (
+            <DrawerToggle
+              label={rightPanelLabel}
+              expanded={rightOpen}
+              onClick={() => setRightOpen(true)}
+            />
+          ) : (
+            <span />
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        {/* Left: docked column at lg+; overlay drawer below. */}
+        {hasLeft && (
+          <>
+            <aside
+              className={`${ASIDE_BASE} border-r border-gray-700 hidden lg:flex lg:w-72 xl:w-80`}
+            >
+              {leftPanel}
+            </aside>
+            <DrawerOverlay
+              open={leftOpen}
+              side="left"
+              label={leftPanelLabel}
+              onClose={() => setLeftOpen(false)}
+            >
+              {leftPanel}
+            </DrawerOverlay>
+          </>
+        )}
+
+        {/* Main: must be allowed to shrink (#7416). */}
+        <main className="flex-1 flex flex-col min-w-0 min-h-0 relative">
+          <div className="flex-1 flex flex-col min-w-0 min-h-0">{children}</div>
+          {bottomPanel != null && (
+            <div className="flex-shrink-0">{bottomPanel}</div>
+          )}
+        </main>
+
+        {/* Right: docked column at xl+; overlay drawer below. */}
+        {hasRight && (
+          <>
+            <aside
+              className={`${ASIDE_BASE} border-l border-gray-700 hidden xl:flex xl:w-72`}
+            >
+              {rightPanel}
+            </aside>
+            <DrawerOverlay
+              open={rightOpen}
+              side="right"
+              label={rightPanelLabel}
+              onClose={() => setRightOpen(false)}
+            >
+              {rightPanel}
+            </DrawerOverlay>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface DrawerToggleProps {
+  label: string;
+  expanded: boolean;
+  onClick: () => void;
+}
+
+function DrawerToggle({ label, expanded, onClick }: DrawerToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-expanded={expanded}
+      className="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md bg-gray-700 hover:bg-gray-600 text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+    >
+      <span aria-hidden="true">☰</span>
+      {label}
+    </button>
+  );
+}
+
+interface DrawerOverlayProps {
+  open: boolean;
+  side: 'left' | 'right';
+  label: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+function DrawerOverlay({
+  open,
+  side,
+  label,
+  onClose,
+  children,
+}: DrawerOverlayProps) {
+  if (!open) return null;
+  const sideClasses =
+    side === 'left'
+      ? 'left-0 border-r border-gray-700'
+      : 'right-0 border-l border-gray-700';
+  return (
+    <div className="lg:hidden fixed inset-0 z-50 flex" role="dialog" aria-modal="true" aria-label={label}>
+      {/* Backdrop */}
+      <button
+        type="button"
+        aria-label={`Close ${label}`}
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60"
+      />
+      <aside
+        className={`${ASIDE_BASE} absolute inset-y-0 w-72 max-w-[85vw] ${sideClasses} shadow-xl`}
+      >
+        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700 flex-shrink-0">
+          <span className="text-sm font-semibold text-gray-200">{label}</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={`Close ${label}`}
+            className="px-2 py-0.5 text-gray-400 hover:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 rounded"
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </div>
+        {children}
+      </aside>
+    </div>
+  );
+}

--- a/ui/src/pages/AnalysisTools.tsx
+++ b/ui/src/pages/AnalysisTools.tsx
@@ -13,6 +13,7 @@ import { useAnalysisTools, EXPORT_FORMATS } from '@/api/useAnalysisTools';
 import type { ExportFormat } from '@/api/useAnalysisTools';
 import { CounterfactualPanel } from '@/components/analysis/CounterfactualPanel';
 import { PlotsSection } from '@/components/analysis/PlotsSection';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 export type {
   AnalysisLoadState,
   ExportFormat,
@@ -55,11 +56,10 @@ export function AnalysisToolsPage() {
 
   const metricEntries = metrics ? Object.entries(metrics.metrics) : [];
 
-  return (
-    <div className="flex h-screen bg-gray-900 text-gray-100">
-      {/* Left Sidebar - Current Metrics Snapshot */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
-        <div className="p-4 border-b border-gray-700">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0 text-gray-100">
+      {/* Current Metrics Snapshot */}
+      <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Current Metrics</h2>
           <p className="text-xs text-gray-500 mt-1">
             {metricEntries.length} metric{metricEntries.length !== 1 ? 's' : ''} from live engine
@@ -94,10 +94,12 @@ export function AnalysisToolsPage() {
             Refresh Metrics
           </button>
         </div>
-      </aside>
+    </div>
+  );
 
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col min-w-0">
+  return (
+    <WorkspaceShell leftPanel={leftPanel} leftPanelLabel="Current Metrics">
+      <div className="flex-1 flex flex-col min-w-0 min-h-0 text-gray-100">
         {/* Header */}
         <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
           <h1 className="text-lg font-semibold text-gray-100">Analysis Tools</h1>
@@ -224,7 +226,7 @@ export function AnalysisToolsPage() {
             </div>
           </div>
         </div>
-      </main>
-    </div>
+      </div>
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/BallFlight.tsx
+++ b/ui/src/pages/BallFlight.tsx
@@ -26,6 +26,7 @@ import { HelpfulField } from '@/components/ux/HelpfulField';
 import { getFieldMetadata } from '@/ux/fieldMetadata';
 import { isInRange } from '@/ux/fieldHelpers';
 import { BallFlightScene3D } from '@/components/visualization/BallFlightScene3D';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 
 /** Flight-model metadata from GET /tools/ball-flight/models. See issue #7456 */
 export interface FlightModelInfo {
@@ -285,10 +286,8 @@ export function BallFlightPage() {
   const canSimulate =
     !loading && selected.length > 0 && invalidFields.length === 0;
 
-  return (
-    <div className="flex h-screen bg-gray-900 overflow-hidden">
-      {/* Left panel: launch conditions + model selection */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Shot Tracer</h2>
           <p className="text-xs text-gray-500">
@@ -374,11 +373,12 @@ export function BallFlightPage() {
             </div>
           )}
         </div>
-      </aside>
+    </div>
+  );
 
-      {/* Center: 3D overlay + 2D profiles */}
-      <main className="flex-1 flex flex-col bg-gray-950 min-w-0 overflow-y-auto">
-        <div className="h-80 flex-shrink-0">
+  const mainContent = (
+    <div className="flex-1 flex flex-col bg-gray-950 min-w-0 min-h-0 overflow-y-auto">
+        <div className="h-64 sm:h-80 flex-shrink-0">
           <BallFlightScene3D trajectories={trajectories3d} />
         </div>
         {results && results.length > 0 ? (
@@ -414,10 +414,11 @@ export function BallFlightPage() {
             Simulate to compare trajectories.
           </div>
         )}
-      </main>
+    </div>
+  );
 
-      {/* Right panel: per-model metrics table */}
-      <aside className="w-80 bg-gray-800 border-l border-gray-700 flex-shrink-0 overflow-y-auto">
+  const rightPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4">
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
             Metrics by Model
@@ -470,7 +471,17 @@ export function BallFlightPage() {
             </p>
           )}
         </div>
-      </aside>
     </div>
+  );
+
+  return (
+    <WorkspaceShell
+      leftPanel={leftPanel}
+      rightPanel={rightPanel}
+      leftPanelLabel="Launch Conditions"
+      rightPanelLabel="Metrics by Model"
+    >
+      {mainContent}
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/DataExplorer.tsx
+++ b/ui/src/pages/DataExplorer.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useCallback, useEffect, useMemo, memo } from 'react';
 import { apiFetch, apiFetchForm } from '@/api/fetch';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 
 /** Dataset info from the API. See issue #1206 */
 export interface DatasetInfo {
@@ -377,10 +378,8 @@ export function DataExplorerPage() {
       : [];
   }, [preview?.rows, sortColumn, sortAscending]);
 
-  return (
-    <div className="flex h-screen bg-gray-900 overflow-hidden">
-      {/* Left Panel: Dataset List + Controls */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Data Explorer</h2>
           <p className="text-xs text-gray-500">
@@ -521,10 +520,12 @@ export function DataExplorerPage() {
             {error}
           </div>
         )}
-      </aside>
+    </div>
+  );
 
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col min-w-0">
+  return (
+    <WorkspaceShell leftPanel={leftPanel} leftPanelLabel="Data Explorer">
+      <div className="flex-1 flex flex-col min-w-0 min-h-0">
         {/* Toolbar */}
         <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 flex items-center gap-4">
           <div className="flex gap-1">
@@ -619,7 +620,7 @@ export function DataExplorerPage() {
             </div>
           )}
         </div>
-      </main>
-    </div>
+      </div>
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/DatasetGenerator.tsx
+++ b/ui/src/pages/DatasetGenerator.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useCallback } from 'react';
 import { useDatasetGenerator } from '@/api/useDatasetGenerator';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 import type { FeatureInfo, PlotType, ExportFormat, DatasetControl } from '@/api/useDatasetGenerator';
 export type {
   DatasetControl,
@@ -78,10 +79,8 @@ export function DatasetGeneratorPage() {
     exportDataset(generateResult.dataset_id, exportFormat);
   }, [generateResult, exportFormat, exportDataset]);
 
-  return (
-    <div className="flex h-screen bg-gray-900 text-gray-100">
-      {/* Left Sidebar */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0 text-gray-100">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Dataset Generator</h2>
           <p className="text-xs text-gray-500 mt-1">Generate and import datasets</p>
@@ -174,10 +173,12 @@ export function DatasetGeneratorPage() {
             </div>
           )}
         </div>
-      </aside>
+    </div>
+  );
 
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col min-w-0">
+  return (
+    <WorkspaceShell leftPanel={leftPanel} leftPanelLabel="Dataset Generator">
+      <div className="flex-1 flex flex-col min-w-0 min-h-0 text-gray-100">
         {/* Header */}
         <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
           <h1 className="text-lg font-semibold text-gray-100">Dataset Generator</h1>
@@ -340,7 +341,7 @@ export function DatasetGeneratorPage() {
             )}
           </div>
         </div>
-      </main>
-    </div>
+      </div>
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/MotionCapture.tsx
+++ b/ui/src/pages/MotionCapture.tsx
@@ -10,6 +10,7 @@
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { apiFetch, apiFetchForm } from '@/api/fetch';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 
 /** Capture source from the API. See issues #1206, #7454 */
 export interface CaptureSource {
@@ -401,10 +402,8 @@ export function MotionCapturePage() {
 
   const selectedSourceInfo = sources.find((s) => s.type === selectedSource);
 
-  return (
-    <div className="flex h-screen bg-gray-900 overflow-hidden">
-      {/* Left Panel: Source Selection + Controls */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Motion Capture</h2>
           <p className="text-xs text-gray-500">
@@ -655,11 +654,14 @@ export function MotionCapturePage() {
             {error}
           </div>
         )}
-      </aside>
+    </div>
+  );
 
-      {/* Center: Skeleton Visualization */}
-      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
-        <div className="w-full max-w-2xl aspect-square p-4">
+  const mainContent = (
+    <div className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0 min-h-0 p-2 sm:p-4">
+        {/* #7417: constrain the square by width AND height so it never
+            overflows narrow or short windows. */}
+        <div className="w-full aspect-square max-w-[min(42rem,90vw,calc(100vh-8rem))]">
           <SkeletonRenderer joints={joints} width={500} height={500} />
         </div>
 
@@ -684,10 +686,11 @@ export function MotionCapturePage() {
             </div>
           </div>
         )}
-      </main>
+    </div>
+  );
 
-      {/* Right Panel: Joint Data */}
-      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const rightPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
             Joint Data
@@ -765,7 +768,17 @@ export function MotionCapturePage() {
               ))}
           </div>
         )}
-      </aside>
     </div>
+  );
+
+  return (
+    <WorkspaceShell
+      leftPanel={leftPanel}
+      rightPanel={rightPanel}
+      leftPanelLabel="Capture Controls"
+      rightPanelLabel="Joint Data"
+    >
+      {mainContent}
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/PuttingGreen.tsx
+++ b/ui/src/pages/PuttingGreen.tsx
@@ -10,6 +10,7 @@
 
 import { useState, useCallback } from 'react';
 import { apiFetch } from '@/api/fetch';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 
 /** Putt simulation result from the API. See issue #1206 */
 export interface PuttResult {
@@ -344,10 +345,8 @@ export function PuttingGreenPage() {
   const aimPoint = reading?.aim_point ?? null;
   const scatterPoints = scatterResult?.final_positions ?? null;
 
-  return (
-    <div className="flex h-screen bg-gray-900 overflow-hidden">
-      {/* Left Panel: Controls */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Putting Green Simulator</h2>
           <p className="text-xs text-gray-500">Physics-based putting simulation</p>
@@ -546,11 +545,14 @@ export function PuttingGreenPage() {
             {error}
           </div>
         )}
-      </aside>
+    </div>
+  );
 
-      {/* Center: Green Visualization */}
-      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
-        <div className="w-full max-w-[600px] aspect-square p-4">
+  const mainContent = (
+    <div className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0 min-h-0 p-2 sm:p-4">
+        {/* #7417: constrain the square by width AND height so it never
+            overflows narrow or short windows. */}
+        <div className="w-full aspect-square max-w-[min(600px,90vw,calc(100vh-8rem))]">
           <GreenCanvas
             width={greenWidth}
             height={greenHeight}
@@ -597,10 +599,11 @@ export function PuttingGreenPage() {
             </div>
           </div>
         )}
-      </main>
+    </div>
+  );
 
-      {/* Right Panel: Green Reading */}
-      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const rightPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
             Green Reading
@@ -685,7 +688,17 @@ export function PuttingGreenPage() {
             </div>
           )}
         </div>
-      </aside>
     </div>
+  );
+
+  return (
+    <WorkspaceShell
+      leftPanel={leftPanel}
+      rightPanel={rightPanel}
+      leftPanelLabel="Controls"
+      rightPanelLabel="Green Reading"
+    >
+      {mainContent}
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/Terrain.tsx
+++ b/ui/src/pages/Terrain.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { useTerrain } from '@/api/useTerrain';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 import type { TerrainPreset, TerrainMaterial, TerrainTypeInfo } from '@/api/useTerrain';
 export type {
   ActiveTerrain,
@@ -49,10 +50,8 @@ export function TerrainPage() {
 
   const isLoading = loadState === 'loading';
 
-  return (
-    <div className="flex h-screen bg-gray-900 text-gray-100">
-      {/* Left Sidebar */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0 text-gray-100">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Terrain Engine</h2>
           <p className="text-xs text-gray-500 mt-1">Load and configure terrain</p>
@@ -153,10 +152,12 @@ export function TerrainPage() {
             {isLoading ? 'Loading...' : 'Load Terrain'}
           </button>
         </div>
-      </aside>
+    </div>
+  );
 
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col min-w-0">
+  return (
+    <WorkspaceShell leftPanel={leftPanel} leftPanelLabel="Terrain Engine">
+      <div className="flex-1 flex flex-col min-w-0 min-h-0 text-gray-100">
         {/* Header */}
         <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
           <h1 className="text-lg font-semibold text-gray-100">Terrain Engine</h1>
@@ -291,7 +292,7 @@ export function TerrainPage() {
             </div>
           )}
         </div>
-      </main>
-    </div>
+      </div>
+    </WorkspaceShell>
   );
 }

--- a/ui/src/pages/VideoAnalyzer.tsx
+++ b/ui/src/pages/VideoAnalyzer.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useCallback, useRef } from 'react';
 import { apiFetchForm } from '@/api/fetch';
+import { WorkspaceShell } from '@/components/layout/WorkspaceShell';
 
 /** Video analysis result from the API. See issue #1206 */
 export interface VideoAnalysisResult {
@@ -198,10 +199,8 @@ export function VideoAnalyzerPage() {
     setCurrentFrameIdx((prev) => Math.min(totalFrames - 1, prev + 1));
   }, [totalFrames]);
 
-  return (
-    <div className="flex h-screen bg-gray-900 overflow-hidden">
-      {/* Left Panel: Controls */}
-      <aside className="w-80 bg-gray-800 border-r border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const leftPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Video Analyzer</h2>
           <p className="text-xs text-gray-500">
@@ -344,10 +343,11 @@ export function VideoAnalyzerPage() {
             {error}
           </div>
         )}
-      </aside>
+    </div>
+  );
 
-      {/* Center: Video Player */}
-      <main className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0">
+  const mainContent = (
+    <div className="flex-1 flex items-center justify-center bg-gray-950 relative min-w-0 min-h-0 p-2 sm:p-4">
         {videoUrl ? (
           <div className="relative w-full max-w-3xl aspect-video">
             <video
@@ -392,10 +392,11 @@ export function VideoAnalyzerPage() {
             </p>
           </div>
         )}
-      </main>
+    </div>
+  );
 
-      {/* Right Panel: Analysis Results */}
-      <aside className="w-72 bg-gray-800 border-l border-gray-700 flex flex-col flex-shrink-0 overflow-y-auto">
+  const rightPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
         {/* Summary */}
         <div className="p-4 border-b border-gray-700">
           <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
@@ -475,7 +476,17 @@ export function VideoAnalyzerPage() {
             </div>
           )}
         </div>
-      </aside>
     </div>
+  );
+
+  return (
+    <WorkspaceShell
+      leftPanel={leftPanel}
+      rightPanel={rightPanel}
+      leftPanelLabel="Controls"
+      rightPanelLabel="Analysis Results"
+    >
+      {mainContent}
+    </WorkspaceShell>
   );
 }


### PR DESCRIPTION
## What

Introduces a shared responsive workspace frame (`components/layout/WorkspaceShell.tsx`) and migrates the multi-panel pages off the bespoke fixed-width `w-80`/`w-72` sidebar markup they each hand-rolled.

## Issues

- **Closes #7415** — One canonical `WorkspaceShell` (left/right/bottom/main props). Three-column at `lg+`/`xl+`; below `lg` the side panels become toggleable overlay drawers (backdrop + close button, `aria-modal` dialog) so every control stays reachable on narrow windows / Tauri popouts. Migrated: AnalysisTools, BallFlight, DataExplorer, DatasetGenerator, MotionCapture, PuttingGreen, Terrain, VideoAnalyzer.
- **Closes #7416** — the shell `<main>` carries `min-w-0 min-h-0` so a flex child holding a WebGL canvas shrinks instead of overflowing; same applied to the BallFlight 3D scene wrapper.
- **Closes #7417** — PuttingGreen / MotionCapture square viewports now cap by width AND height: `max-w-[min(600px,90vw,calc(100vh-8rem))]`, padding `p-2 sm:p-4`.

## Out of scope (follow-up)

`Simulation.tsx` (was gated behind #7425/#7506, now landed) and `ModelExplorer`/`CharacterBuilder` (ModelExplorer needs the #7418 dynamic-width drawer treatment) migrate in a follow-up PR.

## Tests

New `WorkspaceShell.test.tsx` covers render, drawer open/close, `min-0` on main, and side-omission. All migrated page tests stay green (92 passing locally).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)