### PR TITLE
fix(ui): structural a11y + accessible names (#7440, #7441)

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -54,6 +54,15 @@ describe('App', () => {
     expect(typeof App).toBe('function');
   });
 
+  it('renders a skip-to-main-content link as the first focusable (#7441)', () => {
+    render(<App />, { wrapper: createWrapper() });
+    const skip = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skip).toHaveAttribute('href', '#main-content');
+    // sr-only until focused.
+    expect(skip.className).toContain('sr-only');
+    expect(skip.className).toContain('focus:not-sr-only');
+  });
+
   it('renders the branded 404 page for unknown routes (#7430)', async () => {
     window.history.pushState({}, '', '/tools/does-not-exist');
     render(<App />, { wrapper: createWrapper() });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -144,6 +144,14 @@ function App() {
 
   return (
     <BrowserRouter>
+      {/* #7441: first focusable element — lets keyboard users jump past the
+          per-page sidebars straight to the main content. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-blue-600 focus:text-white focus:px-3 focus:py-2 focus:rounded"
+      >
+        Skip to main content
+      </a>
       <ScrollToTop />
       <RouteTitle />
       <ToastProvider>

--- a/ui/src/components/layout/WorkspaceShell.test.tsx
+++ b/ui/src/components/layout/WorkspaceShell.test.tsx
@@ -35,6 +35,17 @@ describe('WorkspaceShell', () => {
     expect(main.className).toContain('min-h-0');
   });
 
+  it('exposes the skip-link target on main (#7441)', () => {
+    render(
+      <WorkspaceShell leftPanel={<div>L</div>}>
+        <div>MAIN</div>
+      </WorkspaceShell>,
+    );
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+
   it('opens the left drawer when its toggle is clicked', () => {
     render(
       <WorkspaceShell leftPanel={<div>LEFTPANEL</div>} leftPanelLabel="Controls">

--- a/ui/src/components/layout/WorkspaceShell.tsx
+++ b/ui/src/components/layout/WorkspaceShell.tsx
@@ -96,8 +96,13 @@ export function WorkspaceShell({
           </>
         )}
 
-        {/* Main: must be allowed to shrink (#7416). */}
-        <main className="flex-1 flex flex-col min-w-0 min-h-0 relative">
+        {/* Main: must be allowed to shrink (#7416). The id is the skip-link
+            target (#7441) so keyboard users can jump past the sidebars. */}
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex-1 flex flex-col min-w-0 min-h-0 relative"
+        >
           <div className="flex-1 flex flex-col min-w-0 min-h-0">{children}</div>
           {bottomPanel != null && (
             <div className="flex-shrink-0">{bottomPanel}</div>

--- a/ui/src/components/model-explorer/ModelTree.test.tsx
+++ b/ui/src/components/model-explorer/ModelTree.test.tsx
@@ -44,6 +44,27 @@ describe('ModelTree Component', () => {
     expect(handleSelect).toHaveBeenCalledWith(mockNodes[0]);
   });
 
+  it('gives each tree item an accessible name with node type (#7440)', () => {
+    render(
+      <ModelTree
+        modelName="Test Model"
+        treeNodes={mockNodes}
+        selectedNodeId={null}
+        onNodeSelect={() => {}}
+        side="single"
+      />,
+    );
+    const items = screen.getAllByRole('treeitem');
+    const labels = items.map((el) => el.getAttribute('aria-label'));
+    expect(labels).toContain('root_link, root');
+    expect(labels).toContain('arm_joint, joint');
+    // The expandable root exposes its expanded state to AT.
+    const root = items.find(
+      (el) => el.getAttribute('aria-label') === 'root_link, root',
+    );
+    expect(root).toHaveAttribute('aria-expanded');
+  });
+
   it('shows action buttons in Frankenstein mode for source side', () => {
     const handleCopyComponent = vi.fn();
     const handleCopyChain = vi.fn();

--- a/ui/src/components/model-explorer/ModelTree.tsx
+++ b/ui/src/components/model-explorer/ModelTree.tsx
@@ -73,6 +73,7 @@ function TreeNodeComponent({
         role="treeitem"
         aria-selected={isSelected}
         aria-expanded={childNodes.length > 0 ? expanded : undefined}
+        aria-label={`${node.name}, ${node.node_type}`}
       >
         {/* Expand/collapse toggle */}
         {childNodes.length > 0 ? (
@@ -90,8 +91,11 @@ function TreeNodeComponent({
           <span className="w-3 flex-shrink-0" />
         )}
 
-        {/* Node icon */}
-        <span className={`text-[10px] font-bold ${iconColor} w-4 h-4 rounded bg-gray-900/50 flex items-center justify-center flex-shrink-0`}>
+        {/* Node icon (decorative — the type is in the treeitem's aria-label) */}
+        <span
+          aria-hidden="true"
+          className={`text-[10px] font-bold ${iconColor} w-4 h-4 rounded bg-gray-900/50 flex items-center justify-center flex-shrink-0`}
+        >
           {icon}
         </span>
 

--- a/ui/src/components/model-explorer/TreeDiffModal.tsx
+++ b/ui/src/components/model-explorer/TreeDiffModal.tsx
@@ -31,7 +31,7 @@ export function TreeDiffModal({
         {/* Header */}
         <div className="px-6 py-4 bg-gray-950 border-b border-gray-800 flex items-center justify-between">
           <h2 className="text-lg font-bold text-white flex items-center gap-2">
-            <span className="text-blue-500 font-mono">📊</span> Model Comparison
+            <span className="text-blue-500 font-mono" aria-hidden="true">📊</span> Model Comparison
           </h2>
           <button
             onClick={onClose}

--- a/ui/src/components/simulation/EngineSelector.tsx
+++ b/ui/src/components/simulation/EngineSelector.tsx
@@ -213,9 +213,9 @@ export function EngineSelector({
                       `}
                     >
                       {isUnloading ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
                       ) : (
-                        <PowerOff className="w-4 h-4" />
+                        <PowerOff className="w-4 h-4" aria-hidden="true" />
                       )}
                     </button>
                   )
@@ -253,7 +253,7 @@ export function EngineSelector({
                     {isUnavailable ? (
                       'Unavailable'
                     ) : isLoading ? (
-                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
                     ) : isError ? (
                       'Retry'
                     ) : (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Reduced-motion safety net (#7441): users who request reduced motion get
+ * near-instant animations/transitions app-wide. Tailwind `motion-reduce:`
+ * variants can still refine individual cases; this is the global guard so
+ * ungated `animate-*`/`transition-*` utilities (toasts, modals, pulses) never
+ * animate against the OS preference. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Shared focus ring for one-off focusable elements that don't use the
  * Button/Input/Select primitives (UI/UX #7420). Plain CSS (not @apply) for
  * Tailwind v4 compatibility, matching the .sidekick-focus-ring convention. */

--- a/ui/src/pages/Simulation.tsx
+++ b/ui/src/pages/Simulation.tsx
@@ -345,6 +345,10 @@ export function SimulationPage() {
 
   return (
     <div className="flex h-screen bg-gray-900 overflow-hidden">
+      {/* #7441: every page needs exactly one top-level heading; the visible
+          sidebar/section headings start at h2, so this sr-only h1 anchors the
+          hierarchy without changing the visual design. */}
+      <h1 className="sr-only">Simulation</h1>
       {/* Left Sidebar - Controls */}
       <aside className="w-80 bg-gray-800 border-r border-gray-700 p-4 overflow-y-auto flex-shrink-0 z-10">
         <h2 className="text-xl font-bold text-white mb-2">Golf Suite</h2>


### PR DESCRIPTION
## Issues

**Closes #7441** — structural accessibility:
- **Skip link**: a `sr-only` "Skip to main content" anchor is the first focusable element in the app shell; `WorkspaceShell`'s `<main>` carries `id="main-content"` + `tabIndex={-1}` as the target.
- **Reduced motion**: a global `@media (prefers-reduced-motion: reduce)` rule in `index.css` near-instantly resolves animations/transitions so ungated `animate-*`/`transition-*` utilities (toasts, modals, pulses) honor the OS setting.
- **Headings**: Simulation gains a `sr-only` `h1` so its `h2` sidebar headings no longer start the page without a top-level heading.

**Closes #7440** — accessible names / announcements:
- ModelTree treeitems get `aria-label="name, type"`; the decorative type glyph is `aria-hidden` (`aria-expanded`/`aria-selected` already present).
- EngineSelector inline `Loader2` spinners are `aria-hidden` (buttons carry their own `aria-label`; visible "Loading…" labels announce state).
- TreeDiffModal decorative emoji is `aria-hidden`.
- ConnectionStatus already exposes `role=status` + `aria-live` (#7440.5).

## Note

The #7439 contrast sweep (`text-gray-500` → `text-gray-400`, ~159 sites) is intentionally left for its own focused PR — it is a large mechanical change and doesn't belong bundled with these structural fixes.

## Tests

Skip-link presence/href, `main-content` target id/tabindex, ModelTree `aria-label`/`aria-expanded`. Existing suites green (71 passing across touched files).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)