### PR TITLE
chore(ui): dedup zustand to a single v5 via tunnel-rat override (#7437)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6109,34 +6109,6 @@
         "zustand": "^4.3.2"
       }
     },
-    "node_modules/tunnel-rat/node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,6 +67,9 @@
     "flatted": "^3.4.2",
     "rollup": "^4.59.0",
     "esbuild": "^0.25.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "tunnel-rat": {
+      "zustand": "$zustand"
+    }
   }
 }


### PR DESCRIPTION
## Issue

**Closes #7437** — two zustand majors were bundled: the app''s direct `zustand@5.0.13` and a transitive `zustand@4.5.7` pulled by `tunnel-rat@0.1.2` (via `@react-three/drei`).

`tunnel-rat@0.1.2` is the latest version and depends on `zustand@^4.3.2`, but it only uses the **named** `create` export — which exists in v5 — so forcing v5 is safe. Added:

```json
"overrides": { "tunnel-rat": { "zustand": "$zustand" } }
```

`npm ls zustand` now reports a single deduped `5.0.13`; the stale nested lock entry was removed.

## Verification

- `npm ls zustand` → single v5, no `invalid`/duplicate.
- UI test suite green (Simulation + Scene3D smoke pass).
- `vite build` succeeds — drei''s `Html`/tunnel features resolve the single zustand copy.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)