### PR TITLE
fix(tauri): kill the Python backend on window close / app exit (#7436)

### DIFF
--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -147,17 +147,27 @@ fn start_backend(state: State<'_, BackendProcess>) -> Result<BackendStatus, Stri
     })
 }
 
+/// Kill the managed backend child if one is running. Shared by the
+/// `stop_backend` command and the window-close / app-exit shutdown hooks
+/// (issue #7436) so the Python process never outlives the app.
+fn kill_backend(process: &BackendProcess) {
+    // Lock defensively: a poisoned mutex must not prevent shutdown.
+    let mut guard = match process.0.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(mut child) = guard.take() {
+        let pid = child.id();
+        let _ = child.kill();
+        let _ = child.wait();
+        log::info!("Backend server stopped (pid {})", pid);
+    }
+}
+
 /// Stop the Python backend server.
 #[tauri::command]
 fn stop_backend(state: State<'_, BackendProcess>) -> Result<BackendStatus, String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-
-    if let Some(ref mut child) = *guard {
-        let _ = child.kill();
-        let _ = child.wait();
-        log::info!("Backend server stopped");
-    }
-    *guard = None;
+    kill_backend(&state);
 
     Ok(BackendStatus {
         running: false,
@@ -265,12 +275,31 @@ pub fn run() {
             }
             Ok(())
         })
+        // #7436: when a window is destroyed, kill the spawned Python backend so
+        // it does not outlive the app and block the port on relaunch.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                if let Some(process) = window.app_handle().try_state::<BackendProcess>() {
+                    kill_backend(&process);
+                }
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             start_backend,
             stop_backend,
             backend_status,
             get_diagnostics,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running Golf Modeling Suite");
+        .build(tauri::generate_context!())
+        .expect("error while running Golf Modeling Suite")
+        // #7436: belt-and-suspenders for multi-window / non-window exits —
+        // ensure the backend is killed on any app exit, not just a window
+        // Destroyed event.
+        .run(|app_handle, event| {
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                if let Some(process) = app_handle.try_state::<BackendProcess>() {
+                    kill_backend(&process);
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Issue

**Closes #7436** — the spawned backend `Child` outlived the app: closing the window left the Python process running, so on relaunch `BACKEND_PORT` was occupied and startup failed (or orphaned processes accumulated).

## Fix

- Extracted `kill_backend(&BackendProcess)` (locks defensively through a poisoned mutex so shutdown can never be blocked); `stop_backend` routes through it.
- `on_window_event`: on `WindowEvent::Destroyed`, kill the managed backend child.
- Switched `.run()` to `.build()` + `.run(|app, event|)` and also kill the backend on `RunEvent::ExitRequested` for multi-window / non-window-close exits.

## Verification

`cargo check` + `cargo clippy` clean.

## Deferred

Graceful `POST /api/shutdown`-first (item 2) and port-reuse / free-port detection on launch (item 3) are follow-up enhancements; this PR resolves the core orphaned-process / failed-relaunch acceptance criterion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)