### PR TITLE
fix(a11y): raise low-contrast helper text to AA + slider track (#7439)

### DIFF
--- a/ui/src/api/diagnostics.ts
+++ b/ui/src/api/diagnostics.ts
@@ -87,7 +87,7 @@ export function statusColorClass(status: string): string {
     case 'warning':
       return 'text-yellow-400';
     case 'unconfigured':
-      return 'text-gray-500';
+      return 'text-gray-400';
     case 'info':
       return 'text-blue-400';
     default:

--- a/ui/src/components/analysis/AnalysisPanel.tsx
+++ b/ui/src/components/analysis/AnalysisPanel.tsx
@@ -237,7 +237,7 @@ export function AnalysisPanel({
         {activeTab === 'metrics' && (
           <div>
             {!statistics ? (
-              <p className="text-gray-500 text-sm italic">
+              <p className="text-gray-400 text-sm italic">
                 {isRunning
                   ? 'Collecting metrics...'
                   : 'Start a simulation to see metrics.'}
@@ -271,7 +271,7 @@ export function AnalysisPanel({
                       <div className="text-lg font-mono text-white">
                         {metric.current.toFixed(3)}
                       </div>
-                      <div className="text-xs text-gray-500 flex justify-between">
+                      <div className="text-xs text-gray-400 flex justify-between">
                         <span>min: {metric.minimum.toFixed(2)}</span>
                         <span>max: {metric.maximum.toFixed(2)}</span>
                       </div>
@@ -321,7 +321,7 @@ export function AnalysisPanel({
         {activeTab === 'plots' && (
           <div>
             {timeSeriesData.length < 2 ? (
-              <p className="text-gray-500 text-sm italic">
+              <p className="text-gray-400 text-sm italic">
                 {isRunning
                   ? 'Collecting data for plots...'
                   : 'Start a simulation to see time-series plots.'}
@@ -444,7 +444,7 @@ export function AnalysisPanel({
                 className={`flex items-center gap-2 px-4 py-2 rounded font-medium text-sm transition-colors ${
                   statistics && statistics.sample_count > 0
                     ? 'bg-blue-600 hover:bg-blue-700 text-white'
-                    : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                    : 'bg-gray-700 text-gray-400 cursor-not-allowed'
                 }`}
                 aria-label="Export as CSV"
               >
@@ -457,7 +457,7 @@ export function AnalysisPanel({
                 className={`flex items-center gap-2 px-4 py-2 rounded font-medium text-sm transition-colors ${
                   statistics && statistics.sample_count > 0
                     ? 'bg-green-600 hover:bg-green-700 text-white'
-                    : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                    : 'bg-gray-700 text-gray-400 cursor-not-allowed'
                 }`}
                 aria-label="Export as JSON"
               >
@@ -467,7 +467,7 @@ export function AnalysisPanel({
             </div>
 
             {statistics && (
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-gray-400">
                 {statistics.sample_count} samples available ({statistics.metrics.length}{' '}
                 metrics tracked)
               </div>

--- a/ui/src/components/analysis/CounterfactualPanel.tsx
+++ b/ui/src/components/analysis/CounterfactualPanel.tsx
@@ -149,7 +149,7 @@ export function CounterfactualPanel() {
           Counterfactual Analysis (ZTCF / ZVCF / Induced)
         </h3>
         {support?.engine && (
-          <span className="text-xs text-gray-500">engine: {support.engine}</span>
+          <span className="text-xs text-gray-400">engine: {support.engine}</span>
         )}
       </div>
 
@@ -208,21 +208,21 @@ export function CounterfactualPanel() {
           {summary && (
             <div className="grid grid-cols-4 gap-2 text-xs bg-gray-700/50 p-3 rounded">
               <div>
-                <span className="text-gray-500">kind</span>
+                <span className="text-gray-400">kind</span>
                 <div className="text-gray-200 font-mono">{result.kind}</div>
               </div>
               <div>
-                <span className="text-gray-500">frames × DoFs</span>
+                <span className="text-gray-400">frames × DoFs</span>
                 <div className="text-gray-200 font-mono">
                   {summary.frames} × {summary.dofs}
                 </div>
               </div>
               <div>
-                <span className="text-gray-500">peak |accel| ({result.units})</span>
+                <span className="text-gray-400">peak |accel| ({result.units})</span>
                 <div className="text-gray-200 font-mono">{summary.peakAbs.toFixed(4)}</div>
               </div>
               <div>
-                <span className="text-gray-500">peak time (s)</span>
+                <span className="text-gray-400">peak time (s)</span>
                 <div className="text-gray-200 font-mono">{summary.peakTime.toFixed(3)}</div>
               </div>
             </div>

--- a/ui/src/components/analysis/LivePlot.tsx
+++ b/ui/src/components/analysis/LivePlot.tsx
@@ -71,7 +71,7 @@ export function LivePlot({ frames, maxPoints = 100 }: Props) {
 
   if (frames.length < 2) {
     return (
-      <div className="flex items-center justify-center h-full text-gray-500">
+      <div className="flex items-center justify-center h-full text-gray-400">
         <p className="text-sm italic">Waiting for simulation data...</p>
       </div>
     );
@@ -79,7 +79,7 @@ export function LivePlot({ frames, maxPoints = 100 }: Props) {
 
   if (!hasJointAngles && !hasVelocities) {
     return (
-      <div className="flex items-center justify-center h-full text-gray-500">
+      <div className="flex items-center justify-center h-full text-gray-400">
         <p className="text-sm italic">No analysis data available. Enable Live Analysis in parameters.</p>
       </div>
     );

--- a/ui/src/components/analysis/PlotDataChart.tsx
+++ b/ui/src/components/analysis/PlotDataChart.tsx
@@ -145,7 +145,7 @@ export function PlotDataChart({ data }: Props) {
         : 'No data recorded';
     return (
       <div
-        className="flex items-center justify-center h-full text-gray-500"
+        className="flex items-center justify-center h-full text-gray-400"
         data-testid="plot-empty-state"
       >
         <p className="text-sm italic">{message}</p>

--- a/ui/src/components/analysis/PlotsSection.tsx
+++ b/ui/src/components/analysis/PlotsSection.tsx
@@ -68,7 +68,7 @@ export function PlotsSection() {
       <div className="h-80">
         {isLoading ? (
           <div
-            className="flex items-center justify-center h-full text-gray-500"
+            className="flex items-center justify-center h-full text-gray-400"
             data-testid="plots-loading"
           >
             <p className="text-sm italic">Loading plot data…</p>
@@ -77,7 +77,7 @@ export function PlotsSection() {
           <PlotDataChart data={plotData} />
         ) : (
           !error && (
-            <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="flex items-center justify-center h-full text-gray-400">
               <p className="text-sm italic">
                 Run a simulation, then pick a plot type to view post-run analysis.
               </p>

--- a/ui/src/components/model-explorer/InspectorPanel.tsx
+++ b/ui/src/components/model-explorer/InspectorPanel.tsx
@@ -7,7 +7,7 @@ interface PropertyInspectorProps {
 export function PropertyInspector({ node }: PropertyInspectorProps) {
   if (!node) {
     return (
-      <div className="text-xs text-gray-500 italic text-center py-4">
+      <div className="text-xs text-gray-400 italic text-center py-4">
         Select a node to inspect properties
       </div>
     );
@@ -34,12 +34,12 @@ export function PropertyInspector({ node }: PropertyInspectorProps) {
       </div>
 
       {node.parent_id && (
-        <div className="text-[11px] text-gray-500 border-t border-gray-700/50 pt-2 font-mono">
+        <div className="text-[11px] text-gray-400 border-t border-gray-700/50 pt-2 font-mono">
           Parent: {node.parent_id}
         </div>
       )}
       {node.children.length > 0 && (
-        <div className="text-[11px] text-gray-500 font-mono truncate" title={node.children.join(', ')}>
+        <div className="text-[11px] text-gray-400 font-mono truncate" title={node.children.join(', ')}>
           Children: {node.children.join(', ')}
         </div>
       )}

--- a/ui/src/components/model-explorer/JointManipulator.tsx
+++ b/ui/src/components/model-explorer/JointManipulator.tsx
@@ -24,7 +24,7 @@ export function JointManipulator({
 }: JointManipulatorProps) {
   if (joints.length === 0) {
     return (
-      <div className="text-xs text-gray-500 italic text-center py-2">
+      <div className="text-xs text-gray-400 italic text-center py-2">
         No movable joints
       </div>
     );

--- a/ui/src/components/model-explorer/ModelTree.tsx
+++ b/ui/src/components/model-explorer/ModelTree.tsx
@@ -82,7 +82,7 @@ function TreeNodeComponent({
               e.stopPropagation();
               setExpanded(!expanded);
             }}
-            className="text-xs text-gray-500 hover:text-gray-300 w-3 flex-shrink-0"
+            className="text-xs text-gray-400 hover:text-gray-300 w-3 flex-shrink-0"
             aria-label={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? '▼' : '▶'}
@@ -104,7 +104,7 @@ function TreeNodeComponent({
 
         {/* Joint type badge */}
         {node.node_type === 'joint' && node.properties.joint_type != null && (
-          <span className="text-[10px] text-gray-500 ml-1">
+          <span className="text-[10px] text-gray-400 ml-1">
             ({String(node.properties.joint_type)})
           </span>
         )}
@@ -230,7 +230,7 @@ export function ModelTree({
     <div className="flex flex-col h-full bg-gray-800/40 backdrop-blur-md border border-gray-700/50 rounded-xl overflow-hidden shadow-2xl">
       <div className="px-4 py-3 bg-gray-800 border-b border-gray-700/80 flex items-center justify-between">
         <div className="flex flex-col">
-          <span className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">
+          <span className="text-[10px] uppercase font-bold text-gray-400 tracking-wider">
             {side === 'source' ? 'Source Model' : side === 'target' ? 'Target Model' : 'Model Structure'}
           </span>
           <span className="text-xs font-semibold text-gray-200 font-mono truncate max-w-[200px]" title={modelName}>
@@ -244,7 +244,7 @@ export function ModelTree({
 
       <div className="flex-1 overflow-y-auto p-3 space-y-1" role="tree">
         {rootNodes.length === 0 ? (
-          <div className="text-xs text-gray-500 italic text-center py-8">
+          <div className="text-xs text-gray-400 italic text-center py-8">
             No nodes found
           </div>
         ) : (

--- a/ui/src/components/model-explorer/TreeDiffModal.tsx
+++ b/ui/src/components/model-explorer/TreeDiffModal.tsx
@@ -58,7 +58,7 @@ export function TreeDiffModal({
             <div className="text-center py-12 space-y-2">
               <div className="text-4xl">🎉</div>
               <p className="text-sm text-gray-300 font-medium">Models are completely identical!</p>
-              <p className="text-xs text-gray-500">No differences detected in structure or properties.</p>
+              <p className="text-xs text-gray-400">No differences detected in structure or properties.</p>
             </div>
           ) : (
             <div className="space-y-6">
@@ -137,7 +137,7 @@ export function TreeDiffModal({
 
         {/* Footer */}
         <div className="px-6 py-4 bg-gray-950 border-t border-gray-800 flex items-center justify-between">
-          <div className="text-xs text-gray-500">
+          <div className="text-xs text-gray-400">
             {!noDiff && 'Review the tree differences before finalizing your URDF composition.'}
           </div>
           <div className="flex gap-2">

--- a/ui/src/components/simulation/ActuatorPanel.tsx
+++ b/ui/src/components/simulation/ActuatorPanel.tsx
@@ -236,7 +236,7 @@ export function ActuatorPanel({
         <h4 className="text-xs font-semibold text-gray-300 uppercase">
           Actuator Controls
         </h4>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-gray-400">
           {collapsed ? '+' : '-'}
           {panelState ? ` (${panelState.n_actuators})` : ''}
         </span>
@@ -252,7 +252,7 @@ export function ActuatorPanel({
 
           {panelState && panelState.actuators.length > 0 ? (
             <>
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-gray-400">
                 Engine: {panelState.engine_name}
               </div>
 
@@ -317,7 +317,7 @@ export function ActuatorPanel({
                         <span className="text-gray-300">
                           {regionName} ({acts.length})
                         </span>
-                        <span className="text-gray-500">{isCollapsed ? '+' : '-'}</span>
+                        <span className="text-gray-400">{isCollapsed ? '+' : '-'}</span>
                       </button>
 
                       {!isCollapsed && (
@@ -340,7 +340,7 @@ export function ActuatorPanel({
               </div>
             </>
           ) : (
-            <div className="text-xs text-gray-500 italic text-center py-2">
+            <div className="text-xs text-gray-400 italic text-center py-2">
               {panelState ? 'No actuators available' : 'Loading actuators...'}
             </div>
           )}

--- a/ui/src/components/simulation/ActuatorSlider.tsx
+++ b/ui/src/components/simulation/ActuatorSlider.tsx
@@ -64,7 +64,7 @@ export function ActuatorSlider({
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-xs text-gray-500 w-12 text-right font-mono">
+        <span className="text-xs text-gray-400 w-12 text-right font-mono">
           {actuator.min_value.toFixed(1)}
         </span>
         <div className="flex-1 relative">
@@ -75,7 +75,7 @@ export function ActuatorSlider({
             step={(range / 200) || 0.1}
             value={localValue}
             onChange={(e) => handleChange(parseFloat(e.target.value))}
-            className="w-full h-1.5 bg-gray-600 rounded-lg appearance-none cursor-pointer"
+            className="w-full h-1.5 bg-gray-500 rounded-lg appearance-none cursor-pointer accent-blue-500"
             aria-label={`${actuator.name} control value`}
           />
           <div
@@ -83,7 +83,7 @@ export function ActuatorSlider({
             style={{ width: `${Math.max(0, Math.min(100, percentage))}%` }}
           />
         </div>
-        <span className="text-xs text-gray-500 w-12 font-mono">
+        <span className="text-xs text-gray-400 w-12 font-mono">
           {actuator.max_value.toFixed(1)}
         </span>
       </div>

--- a/ui/src/components/simulation/EngineComparisonPanel.tsx
+++ b/ui/src/components/simulation/EngineComparisonPanel.tsx
@@ -37,7 +37,7 @@ export function EngineComparisonPanel({ viewModel, onToggleEngine, disabled }: P
         </h3>
       </div>
 
-      <div className="mb-3 text-xs text-gray-500">{viewModel.datasetLabel}</div>
+      <div className="mb-3 text-xs text-gray-400">{viewModel.datasetLabel}</div>
 
       <div className="mb-4 grid grid-cols-1 gap-2" aria-label="Comparison engines">
         {viewModel.options.map((option) => {
@@ -62,7 +62,7 @@ export function EngineComparisonPanel({ viewModel, onToggleEngine, disabled }: P
               />
               <span className="min-w-0">
                 <span className="block font-medium">{option.displayName}</span>
-                <span className="block truncate text-xs text-gray-500">
+                <span className="block truncate text-xs text-gray-400">
                   {option.disabledReason ?? option.capabilities.join(', ')}
                 </span>
               </span>
@@ -99,19 +99,19 @@ export function EngineComparisonPanel({ viewModel, onToggleEngine, disabled }: P
                 </span>
               </div>
               <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
-                <dt className="text-gray-500">Version</dt>
+                <dt className="text-gray-400">Version</dt>
                 <dd className="truncate text-gray-300">{column.provenance.version}</dd>
-                <dt className="text-gray-500">Frame</dt>
+                <dt className="text-gray-400">Frame</dt>
                 <dd className="text-gray-300">
                   {column.provenance.frame ?? 'not run'}
                 </dd>
-                <dt className="text-gray-500">Time</dt>
+                <dt className="text-gray-400">Time</dt>
                 <dd className="text-gray-300">
                   {column.provenance.time === null
                     ? 'not run'
                     : `${column.provenance.time.toFixed(3)}s`}
                 </dd>
-                <dt className="text-gray-500">Metrics</dt>
+                <dt className="text-gray-400">Metrics</dt>
                 <dd className="text-gray-300">{Object.keys(column.metrics).length}</dd>
               </dl>
             </article>

--- a/ui/src/components/simulation/EngineSelector.tsx
+++ b/ui/src/components/simulation/EngineSelector.tsx
@@ -21,7 +21,7 @@ function LoadStateIcon({ state }: { state: EngineLoadState }) {
     case 'error':
       return <AlertCircle className="w-4 h-4 text-red-400" aria-hidden="true" />;
     default:
-      return <Power className="w-4 h-4 text-gray-500" aria-hidden="true" />;
+      return <Power className="w-4 h-4 text-gray-400" aria-hidden="true" />;
   }
 }
 
@@ -40,7 +40,7 @@ function LoadStateLabel({ engine }: { engine: ManagedEngine }) {
     case 'error':
       return <span className="text-red-400">{engine.error || 'Failed to load'}</span>;
     default:
-      return <span className="text-gray-500">Not loaded</span>;
+      return <span className="text-gray-400">Not loaded</span>;
   }
 }
 
@@ -90,7 +90,7 @@ export function EngineSelector({
       >
         Physics Engines
       </label>
-      <p className="text-xs text-gray-500 mb-3">
+      <p className="text-xs text-gray-400 mb-3">
         Click <strong>Load</strong> to activate an engine. Select a loaded engine to simulate.
       </p>
       <div
@@ -239,7 +239,7 @@ export function EngineSelector({
                     className={`
                       px-3 py-1.5 rounded-md text-xs font-medium transition-all
                       ${isUnavailable
-                        ? 'bg-gray-600/30 text-gray-500 border border-gray-600/50'
+                        ? 'bg-gray-600/30 text-gray-400 border border-gray-600/50'
                         : isLoading
                         ? 'bg-blue-500/20 text-blue-400 cursor-wait'
                         : isError

--- a/ui/src/components/simulation/LauncherDashboard.tsx
+++ b/ui/src/components/simulation/LauncherDashboard.tsx
@@ -224,7 +224,7 @@ function TileCard({
                     </span>
                 ))}
                 {tile.capabilities.length > 3 && (
-                    <span className="px-1.5 py-0.5 text-gray-500 text-[9px]">
+                    <span className="px-1.5 py-0.5 text-gray-400 text-[9px]">
                         +{tile.capabilities.length - 3}
                     </span>
                 )}
@@ -340,7 +340,7 @@ export function LauncherDashboard({
             <header className="flex items-center justify-between px-6 py-4 bg-gray-800/80 border-b border-gray-700 flex-shrink-0">
                 <div>
                     <h1 className="text-xl font-bold text-white">Golf Modeling Suite</h1>
-                    <p className="text-xs text-gray-500 mt-0.5">
+                    <p className="text-xs text-gray-400 mt-0.5">
                         {tiles.length} tiles · {engines.length} engines · {toolsAndExternal.length} tools
                     </p>
                 </div>
@@ -365,7 +365,7 @@ export function LauncherDashboard({
                             aria-label="Launched windows"
                         >
                             {launchedWindows.length === 0 ? (
-                                <p className="px-3 py-2 text-sm text-gray-500">No launched windows</p>
+                                <p className="px-3 py-2 text-sm text-gray-400">No launched windows</p>
                             ) : (
                                 launchedWindows.map((record) => (
                                     <div
@@ -374,7 +374,7 @@ export function LauncherDashboard({
                                     >
                                         <div className="min-w-0">
                                             <p className="truncate text-sm font-medium text-white">{record.name}</p>
-                                            <p className="text-xs text-gray-500">
+                                            <p className="text-xs text-gray-400">
                                                 {record.launchCount} launch{record.launchCount === 1 ? '' : 'es'}
                                             </p>
                                         </div>
@@ -450,21 +450,21 @@ export function LauncherDashboard({
                     {selectedTile ? (
                         <span>
                             Selected: <strong className="text-white">{selectedTile.name}</strong>
-                            <span className="ml-2 text-xs text-gray-500">
+                            <span className="ml-2 text-xs text-gray-400">
                                 {selectedTileAction?.kind === 'blocked'
                                     ? selectedTileAction.reason
                                     : selectedTile.description}
                             </span>
                         </span>
                     ) : (
-                        <span className="text-gray-500">Select a tile to launch</span>
+                        <span className="text-gray-400">Select a tile to launch</span>
                     )}
                     {onShowAbout && (
                         <button
                             id="about-link"
                             onClick={onShowAbout}
                             aria-label="About UpstreamDrift"
-                            className="text-xs text-gray-500 underline-offset-2 hover:text-gray-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-400 rounded"
+                            className="text-xs text-gray-400 underline-offset-2 hover:text-gray-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-400 rounded"
                         >
                             About
                         </button>
@@ -485,7 +485,7 @@ export function LauncherDashboard({
             focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900
             ${selectedTile && selectedLaunchable
                             ? 'bg-green-600 hover:bg-green-500 text-white shadow-lg shadow-green-600/30 hover:shadow-green-500/40'
-                            : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                            : 'bg-gray-700 text-gray-400 cursor-not-allowed'
                         }
           `}
                 >

--- a/ui/src/components/simulation/ParameterPanel.tsx
+++ b/ui/src/components/simulation/ParameterPanel.tsx
@@ -87,7 +87,7 @@ export function ParameterPanel({
           className="w-full"
           aria-describedby="duration-help"
         />
-        <p id="duration-help" className="mt-1 text-xs text-gray-500">
+        <p id="duration-help" className="mt-1 text-xs text-gray-400">
           Simulation run time (0.1 - 60s)
         </p>
       </div>
@@ -113,7 +113,7 @@ export function ParameterPanel({
           <option value="0.005">0.005s (Fast)</option>
           <option value="0.01">0.01s (Very fast)</option>
         </Select>
-        <p id="timestep-help" className="mt-1 text-xs text-gray-500">
+        <p id="timestep-help" className="mt-1 text-xs text-gray-400">
           Physics integration step size
         </p>
       </div>
@@ -127,7 +127,7 @@ export function ParameterPanel({
           >
             Live Analysis
           </label>
-          <p className="text-xs text-gray-500">Stream joint angles & velocities</p>
+          <p className="text-xs text-gray-400">Stream joint angles & velocities</p>
         </div>
         <button
           id="live-analysis-toggle"
@@ -156,7 +156,7 @@ export function ParameterPanel({
           >
             GPU Acceleration
           </label>
-          <p className="text-xs text-gray-500">Use GPU for physics (if available)</p>
+          <p className="text-xs text-gray-400">Use GPU for physics (if available)</p>
         </div>
         <button
           id="gpu-toggle"
@@ -181,7 +181,7 @@ export function ParameterPanel({
         <p className="text-xs text-gray-400">
           <span className="font-semibold text-gray-300">Engine:</span> {engine}
         </p>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="text-xs text-gray-400 mt-1">
           {engine.toLowerCase() === 'mujoco' && 'Full contact physics, muscle simulation'}
           {engine.toLowerCase() === 'drake' && 'Optimization & control focused'}
           {engine.toLowerCase() === 'pinocchio' && 'Fast rigid body dynamics'}

--- a/ui/src/components/simulation/PolynomialGeneratorPanel.tsx
+++ b/ui/src/components/simulation/PolynomialGeneratorPanel.tsx
@@ -46,7 +46,7 @@ export function PolynomialGeneratorPanel({
         className="flex items-center justify-between w-full text-left font-semibold text-xs text-gray-300 uppercase tracking-wider"
       >
         <span>Polynomial Generator</span>
-        <span className="text-gray-500">{collapsed ? '+' : '-'}</span>
+        <span className="text-gray-400">{collapsed ? '+' : '-'}</span>
       </button>
 
       {!collapsed && (
@@ -79,7 +79,7 @@ export function PolynomialGeneratorPanel({
                 <div key={index} className="flex items-center gap-2">
                   <label
                     htmlFor={`coeff-${index}`}
-                    className="text-xs text-gray-500 w-24"
+                    className="text-xs text-gray-400 w-24"
                   >
                     Coefficient {index}
                   </label>
@@ -138,7 +138,7 @@ export function PolynomialGeneratorPanel({
               disabled={!canApply}
               title={canApply ? undefined : 'Fix invalid coefficient'}
               onClick={handleApply}
-              className="text-xs bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 disabled:cursor-not-allowed text-white font-medium px-3 py-1 rounded transition-colors ml-auto"
+              className="text-xs bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-400 disabled:cursor-not-allowed text-white font-medium px-3 py-1 rounded transition-colors ml-auto"
             >
               Apply Polynomial
             </button>

--- a/ui/src/components/simulation/RecordingsPanel.tsx
+++ b/ui/src/components/simulation/RecordingsPanel.tsx
@@ -123,11 +123,11 @@ export function RecordingsPanel({ isRunning = false }: RecordingsPanelProps) {
           )}
 
           {busy && !error && (
-            <p className="text-xs text-gray-500 italic">Loading…</p>
+            <p className="text-xs text-gray-400 italic">Loading…</p>
           )}
 
           {loaded && recordings.length === 0 && !busy && (
-            <p className="text-xs text-gray-500 italic">
+            <p className="text-xs text-gray-400 italic">
               No recordings yet. Run a simulation, then save it.
             </p>
           )}

--- a/ui/src/components/simulation/SimulationToolbar.tsx
+++ b/ui/src/components/simulation/SimulationToolbar.tsx
@@ -256,7 +256,7 @@ export function SimulationToolbar({
                 <span className="text-white font-mono">
                   {joint.angle_deg.toFixed(1)}&deg;
                 </span>
-                <span className="text-gray-500 font-mono">
+                <span className="text-gray-400 font-mono">
                   {joint.velocity.toFixed(2)} rad/s
                 </span>
               </div>

--- a/ui/src/components/ui/AboutModal.tsx
+++ b/ui/src/components/ui/AboutModal.tsx
@@ -68,7 +68,7 @@ export function AboutModal({ isOpen, onClose }: Props) {
         <div className="mb-4 flex items-start justify-between">
           <div>
             <h2 className="text-lg font-bold text-white">UpstreamDrift</h2>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-400">
               Biomechanical motion analysis platform
             </p>
           </div>

--- a/ui/src/components/ui/DiagnosticsPanel.tsx
+++ b/ui/src/components/ui/DiagnosticsPanel.tsx
@@ -200,7 +200,7 @@ export function DiagnosticsPanel() {
                       <span>Process</span>
                       <span
                         className={
-                          diagnostics.backend.running ? 'text-green-400' : 'text-gray-500'
+                          diagnostics.backend.running ? 'text-green-400' : 'text-gray-400'
                         }
                       >
                         {diagnostics.backend.running

--- a/ui/src/components/ui/HelpPanel.tsx
+++ b/ui/src/components/ui/HelpPanel.tsx
@@ -168,7 +168,7 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
         <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-700 bg-gray-800/80">
           <HelpCircle className="w-5 h-5 text-blue-400 flex-shrink-0" aria-hidden="true" />
           <h2 className="text-lg font-semibold text-gray-100 flex-1">Help</h2>
-          <span className="text-xs text-gray-500 hidden sm:inline">Press F1 to toggle</span>
+          <span className="text-xs text-gray-400 hidden sm:inline">Press F1 to toggle</span>
           <button
             onClick={handleClose}
             className="p-1.5 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
@@ -182,7 +182,7 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
         <div className="px-4 py-2 border-b border-gray-700">
           <div className="relative">
             <Search
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500"
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
               aria-hidden="true"
             />
             <input
@@ -206,11 +206,11 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
             {searchQuery.trim() ? (
               // Search results
               <div>
-                <div className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <div className="px-2 py-1 text-xs font-medium text-gray-400 uppercase tracking-wider">
                   Search Results ({searchResults.length})
                 </div>
                 {searchResults.length === 0 ? (
-                  <div className="px-2 py-4 text-sm text-gray-500 text-center">
+                  <div className="px-2 py-4 text-sm text-gray-400 text-center">
                     No results found
                   </div>
                 ) : (
@@ -236,7 +236,7 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
                 if (topics.length === 0) return null;
                 return (
                   <div key={category} className="mb-3">
-                    <div className="px-2 py-1 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <div className="px-2 py-1 text-xs font-medium text-gray-400 uppercase tracking-wider">
                       {CATEGORY_LABELS[category as HelpCategory]}
                     </div>
                     {topics.map((topic) => (
@@ -282,7 +282,7 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
                     if (line.startsWith('- ')) {
                       return (
                         <div key={i} className="flex gap-2 ml-2 text-gray-300 text-sm">
-                          <span className="text-gray-500 flex-shrink-0">-</span>
+                          <span className="text-gray-400 flex-shrink-0">-</span>
                           <span>{line.substring(2)}</span>
                         </div>
                       );
@@ -370,7 +370,7 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
                       <div className="text-sm font-medium text-gray-200">
                         {topic.title}
                       </div>
-                      <div className="text-xs text-gray-500 mt-1">
+                      <div className="text-xs text-gray-400 mt-1">
                         {topic.shortDescription}
                       </div>
                     </button>

--- a/ui/src/components/ux/HelpfulField.tsx
+++ b/ui/src/components/ux/HelpfulField.tsx
@@ -114,7 +114,7 @@ export function HelpfulField({
           }`}
         />
       )}
-      <p id={helpId} className="text-xs text-gray-500" title={meta.defaultSource}>
+      <p id={helpId} className="text-xs text-gray-400" title={meta.defaultSource}>
         {meta.shortHelp}
       </p>
       {violation && (

--- a/ui/src/components/visualization/Scene3D.tsx
+++ b/ui/src/components/visualization/Scene3D.tsx
@@ -303,7 +303,7 @@ export function Scene3D({
       <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex items-center gap-2 bg-black/75 backdrop-blur-md px-4 py-2 rounded-full border border-white/10 shadow-xl z-20">
         {/* Camera Views */}
         <div className="flex items-center gap-1 border-r border-white/10 pr-2">
-          <span className="text-[10px] text-gray-500 uppercase font-bold tracking-wider mr-1">View</span>
+          <span className="text-[10px] text-gray-400 uppercase font-bold tracking-wider mr-1">View</span>
           <button
             onClick={() => handleCameraPreset('front')}
             className="px-2 py-1 text-xs text-gray-300 hover:text-white rounded hover:bg-white/10 transition-colors"
@@ -334,7 +334,7 @@ export function Scene3D({
 
         {/* Transform Gizmo Controls */}
         <div className="flex items-center gap-1">
-          <span className="text-[10px] text-gray-500 uppercase font-bold tracking-wider mr-1">Gizmo</span>
+          <span className="text-[10px] text-gray-400 uppercase font-bold tracking-wider mr-1">Gizmo</span>
           <button
             onClick={() => setTransformMode('translate')}
             className={`px-2 py-1 text-xs rounded transition-colors ${

--- a/ui/src/pages/AnalysisTools.tsx
+++ b/ui/src/pages/AnalysisTools.tsx
@@ -61,14 +61,14 @@ export function AnalysisToolsPage() {
       {/* Current Metrics Snapshot */}
       <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Current Metrics</h2>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-gray-400 mt-1">
             {metricEntries.length} metric{metricEntries.length !== 1 ? 's' : ''} from live engine
           </p>
         </div>
 
         <div className="flex-1 overflow-y-auto p-4">
           {metricEntries.length === 0 && !isLoading && (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               No metrics loaded. Load an engine and click Refresh to fetch a live snapshot.
             </div>
           )}
@@ -139,7 +139,7 @@ export function AnalysisToolsPage() {
                     samples (sim time {statistics.sim_time.toFixed(3)}s)
                   </div>
                   {statistics.sample_count === 0 && (
-                    <div className="text-xs text-gray-500 italic text-center py-2">
+                    <div className="text-xs text-gray-400 italic text-center py-2">
                       No metric history yet — run a simulation to collect samples.
                     </div>
                   )}
@@ -149,23 +149,23 @@ export function AnalysisToolsPage() {
                         <div className="text-xs font-medium text-gray-300 mb-1">{stat.metric_name}</div>
                         <div className="grid grid-cols-5 gap-2 text-xs">
                           <div>
-                            <span className="text-gray-500">current</span>
+                            <span className="text-gray-400">current</span>
                             <div className="text-gray-200 font-mono">{stat.current.toFixed(3)}</div>
                           </div>
                           <div>
-                            <span className="text-gray-500">min</span>
+                            <span className="text-gray-400">min</span>
                             <div className="text-gray-200 font-mono">{stat.minimum.toFixed(3)}</div>
                           </div>
                           <div>
-                            <span className="text-gray-500">max</span>
+                            <span className="text-gray-400">max</span>
                             <div className="text-gray-200 font-mono">{stat.maximum.toFixed(3)}</div>
                           </div>
                           <div>
-                            <span className="text-gray-500">mean</span>
+                            <span className="text-gray-400">mean</span>
                             <div className="text-gray-200 font-mono">{stat.mean.toFixed(3)}</div>
                           </div>
                           <div>
-                            <span className="text-gray-500">std</span>
+                            <span className="text-gray-400">std</span>
                             <div className="text-gray-200 font-mono">{stat.std_dev.toFixed(3)}</div>
                           </div>
                         </div>
@@ -174,7 +174,7 @@ export function AnalysisToolsPage() {
                   </div>
                 </div>
               ) : (
-                <div className="text-xs text-gray-500 italic text-center py-4">
+                <div className="text-xs text-gray-400 italic text-center py-4">
                   Click "Load Statistics" to view summary data
                 </div>
               )}
@@ -217,9 +217,9 @@ export function AnalysisToolsPage() {
                 <div className="mt-3 bg-gray-700/50 p-3 rounded text-xs" data-testid="export-result">
                   <div className="text-green-400 font-medium mb-1">Export Complete</div>
                   <div className="grid grid-cols-2 gap-2">
-                    <div><span className="text-gray-500">Format:</span> <span className="text-gray-200 font-mono">{exportResult.format}</span></div>
-                    <div><span className="text-gray-500">File:</span> <span className="text-gray-200 font-mono">{exportResult.filename}</span></div>
-                    <div><span className="text-gray-500">Size:</span> <span className="text-gray-200 font-mono">{(exportResult.size_bytes / 1024).toFixed(1)} KB</span></div>
+                    <div><span className="text-gray-400">Format:</span> <span className="text-gray-200 font-mono">{exportResult.format}</span></div>
+                    <div><span className="text-gray-400">File:</span> <span className="text-gray-200 font-mono">{exportResult.filename}</span></div>
+                    <div><span className="text-gray-400">Size:</span> <span className="text-gray-200 font-mono">{(exportResult.size_bytes / 1024).toFixed(1)} KB</span></div>
                   </div>
                 </div>
               )}

--- a/ui/src/pages/BallFlight.tsx
+++ b/ui/src/pages/BallFlight.tsx
@@ -290,7 +290,7 @@ export function BallFlightPage() {
     <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Shot Tracer</h2>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-400">
             Multi-model ball-flight comparison
           </p>
         </div>
@@ -329,7 +329,7 @@ export function BallFlightPage() {
             Flight Models
           </h3>
           {models.length === 0 && !error && (
-            <p className="text-xs text-gray-500 italic">Loading models…</p>
+            <p className="text-xs text-gray-400 italic">Loading models…</p>
           )}
           {models.map((model) => (
             <label
@@ -409,7 +409,7 @@ export function BallFlightPage() {
             </div>
           </div>
         ) : (
-          <div className="p-8 text-sm text-gray-500 italic text-center">
+          <div className="p-8 text-sm text-gray-400 italic text-center">
             Set launch conditions, pick at least one flight model, and click
             Simulate to compare trajectories.
           </div>
@@ -465,7 +465,7 @@ export function BallFlightPage() {
               </tbody>
             </table>
           ) : (
-            <p className="text-xs text-gray-500 italic text-center py-4">
+            <p className="text-xs text-gray-400 italic text-center py-4">
               Run a simulation to compare carry, apex, flight time, and
               offline distance across models.
             </p>

--- a/ui/src/pages/CharacterBuilder.tsx
+++ b/ui/src/pages/CharacterBuilder.tsx
@@ -259,7 +259,7 @@ export function CharacterBuilderPage() {
             <div className="bg-gray-900/50 rounded-lg p-3 border border-gray-700/50">
               <table className="w-full text-left border-collapse text-xs">
                 <thead>
-                  <tr className="border-b border-gray-800 text-gray-500 font-semibold">
+                  <tr className="border-b border-gray-800 text-gray-400 font-semibold">
                     <th className="pb-1.5">Segment</th>
                     <th className="pb-1.5">Length</th>
                     <th className="pb-1.5">Mass</th>

--- a/ui/src/pages/DataExplorer.tsx
+++ b/ui/src/pages/DataExplorer.tsx
@@ -63,7 +63,7 @@ const DataTable = memo(function DataTable({
 }) {
   if (columns.length === 0) {
     return (
-      <div className="text-sm text-gray-500 italic text-center py-8">
+      <div className="text-sm text-gray-400 italic text-center py-8">
         No data to display
       </div>
     );
@@ -136,7 +136,7 @@ const DataTable = memo(function DataTable({
 function StatsPanel({ stats }: { stats: DatasetStats | null }) {
   if (!stats) {
     return (
-      <div className="text-xs text-gray-500 italic text-center py-4">
+      <div className="text-xs text-gray-400 italic text-center py-4">
         Load a dataset to view statistics
       </div>
     );
@@ -156,26 +156,26 @@ function StatsPanel({ stats }: { stats: DatasetStats | null }) {
           {colStats.mean != null ? (
             <div className="grid grid-cols-3 gap-1 text-xs">
               <div>
-                <span className="text-gray-500">min</span>
+                <span className="text-gray-400">min</span>
                 <span className="text-gray-300 font-mono ml-1">
                   {colStats.min?.toFixed(2)}
                 </span>
               </div>
               <div>
-                <span className="text-gray-500">avg</span>
+                <span className="text-gray-400">avg</span>
                 <span className="text-gray-300 font-mono ml-1">
                   {colStats.mean?.toFixed(2)}
                 </span>
               </div>
               <div>
-                <span className="text-gray-500">max</span>
+                <span className="text-gray-400">max</span>
                 <span className="text-gray-300 font-mono ml-1">
                   {colStats.max?.toFixed(2)}
                 </span>
               </div>
             </div>
           ) : (
-            <div className="text-xs text-gray-500">Non-numeric</div>
+            <div className="text-xs text-gray-400">Non-numeric</div>
           )}
         </div>
       ))}
@@ -382,7 +382,7 @@ export function DataExplorerPage() {
     <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Data Explorer</h2>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-400">
             Browse and analyze simulation datasets
           </p>
         </div>
@@ -408,7 +408,7 @@ export function DataExplorerPage() {
           </h3>
 
           {datasets.length === 0 && (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               No datasets found. Import a CSV or JSON file.
             </div>
           )}
@@ -424,7 +424,7 @@ export function DataExplorerPage() {
               }`}
             >
               <div className="text-xs text-gray-200 truncate">{ds.name}</div>
-              <div className="text-xs text-gray-500 flex gap-2">
+              <div className="text-xs text-gray-400 flex gap-2">
                 <span>{ds.format}</span>
                 {ds.size_bytes > 0 && (
                   <span>{(ds.size_bytes / 1024).toFixed(1)} KB</span>
@@ -596,7 +596,7 @@ export function DataExplorerPage() {
                 <h3 className="text-lg font-semibold text-gray-400 mb-2">
                   Select a Dataset
                 </h3>
-                <p className="text-sm text-gray-500 max-w-xs">
+                <p className="text-sm text-gray-400 max-w-xs">
                   Choose a dataset from the sidebar or import a CSV/JSON file
                   to browse and analyze data.
                 </p>

--- a/ui/src/pages/DatasetGenerator.tsx
+++ b/ui/src/pages/DatasetGenerator.tsx
@@ -83,7 +83,7 @@ export function DatasetGeneratorPage() {
     <div className="flex flex-col flex-1 min-h-0 text-gray-100">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Dataset Generator</h2>
-          <p className="text-xs text-gray-500 mt-1">Generate and import datasets</p>
+          <p className="text-xs text-gray-400 mt-1">Generate and import datasets</p>
         </div>
 
         {/* Sidebar Tabs */}
@@ -110,7 +110,7 @@ export function DatasetGeneratorPage() {
               {catalogLoading ? (
                 <CatalogSkeleton />
               ) : features.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No features available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No features available</div>
               ) : (
                 features.map((f: FeatureInfo) => (
                   <div key={f.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
@@ -131,7 +131,7 @@ export function DatasetGeneratorPage() {
               {catalogLoading ? (
                 <CatalogSkeleton />
               ) : plotTypes.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No plot types available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No plot types available</div>
               ) : (
                 plotTypes.map((pt: PlotType) => (
                   <div key={pt.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
@@ -156,7 +156,7 @@ export function DatasetGeneratorPage() {
               {catalogLoading ? (
                 <CatalogSkeleton />
               ) : exportFormats.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No export formats available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No export formats available</div>
               ) : (
                 exportFormats.map((ef: ExportFormat) => (
                   <div key={ef.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
@@ -240,7 +240,7 @@ export function DatasetGeneratorPage() {
                   ))}
                 </div>
               ) : (
-                <div className="text-xs text-gray-500 italic">No controls available</div>
+                <div className="text-xs text-gray-400 italic">No controls available</div>
               )}
 
               <div className="mt-4 flex gap-2">
@@ -317,23 +317,23 @@ export function DatasetGeneratorPage() {
                 <h3 className="text-sm font-semibold text-blue-300 mb-2">Generated Dataset</h3>
                 <div className="grid grid-cols-2 gap-3 text-xs">
                   <div>
-                    <span className="text-gray-500">ID</span>
+                    <span className="text-gray-400">ID</span>
                     <div className="text-gray-200 font-mono">{generateResult.dataset_id}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Name</span>
+                    <span className="text-gray-400">Name</span>
                     <div className="text-gray-200 font-mono">{generateResult.name}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Rows</span>
+                    <span className="text-gray-400">Rows</span>
                     <div className="text-gray-200 font-mono">{generateResult.rows}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Columns</span>
+                    <span className="text-gray-400">Columns</span>
                     <div className="text-gray-200 font-mono">{generateResult.columns.length}</div>
                   </div>
                   <div className="col-span-2">
-                    <span className="text-gray-500">Created</span>
+                    <span className="text-gray-400">Created</span>
                     <div className="text-gray-200 font-mono">{generateResult.created_at}</div>
                   </div>
                 </div>

--- a/ui/src/pages/ModelExplorer.tsx
+++ b/ui/src/pages/ModelExplorer.tsx
@@ -212,7 +212,7 @@ export function ModelExplorerPage() {
               <button
                 onClick={() => setIsDiffOpen(true)}
                 disabled={sourceTree.length === 0 || targetTree.length === 0}
-                className="flex-1 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded text-xs font-medium transition-colors shadow-lg"
+                className="flex-1 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-400 text-white rounded text-xs font-medium transition-colors shadow-lg"
               >
                 Compare
               </button>
@@ -240,7 +240,7 @@ export function ModelExplorerPage() {
           {!error && !frankensteinMode && (
             <div className="flex-1 flex flex-col gap-3 min-w-0">
               <div className="space-y-1">
-                <label htmlFor="single-select" className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">
+                <label htmlFor="single-select" className="text-[10px] uppercase font-bold text-gray-400 tracking-wider">
                   Select Model
                 </label>
                 <select
@@ -263,7 +263,7 @@ export function ModelExplorerPage() {
               {/* #7419: scroll the tree instead of clipping a tall model. */}
               <div className="flex-1 min-h-0 min-w-0 overflow-y-auto">
                 {loading ? (
-                  <div className="text-xs text-gray-500 italic text-center py-12">Loading model structure...</div>
+                  <div className="text-xs text-gray-400 italic text-center py-12">Loading model structure...</div>
                 ) : (
                   <ModelTree
                     modelName={selectedModelName || ''}
@@ -282,7 +282,7 @@ export function ModelExplorerPage() {
               {/* Source Tree Area */}
               <div className="flex-1 flex flex-col gap-3 min-w-0 h-full">
                 <div className="space-y-1">
-                  <label htmlFor="source-select" className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">
+                  <label htmlFor="source-select" className="text-[10px] uppercase font-bold text-gray-400 tracking-wider">
                     Select Source
                   </label>
                   <select
@@ -319,7 +319,7 @@ export function ModelExplorerPage() {
               {/* Target Tree Area */}
               <div className="flex-1 flex flex-col gap-3 min-w-0 h-full">
                 <div className="space-y-1">
-                  <label htmlFor="target-select" className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">
+                  <label htmlFor="target-select" className="text-[10px] uppercase font-bold text-gray-400 tracking-wider">
                     Select Target
                   </label>
                   <select
@@ -372,13 +372,13 @@ export function ModelExplorerPage() {
         } w-72 bg-gray-950 border-l border-gray-800 flex-col flex-shrink-0`}
       >
         <div className="p-4 border-b border-gray-850">
-          <h3 className="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-3">
+          <h3 className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-3">
             Properties
           </h3>
           <PropertyInspector node={selectedNode} />
         </div>
         <div className="flex-1 overflow-y-auto p-4">
-          <h3 className="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-3">
+          <h3 className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-3">
             Joint Manipulator
           </h3>
           <JointManipulator

--- a/ui/src/pages/MotionCapture.tsx
+++ b/ui/src/pages/MotionCapture.tsx
@@ -406,7 +406,7 @@ export function MotionCapturePage() {
     <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Motion Capture</h2>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-400">
             C3D, OpenPose, and MediaPipe analysis
           </p>
         </div>
@@ -441,7 +441,7 @@ export function MotionCapturePage() {
                   {source.name}
                 </span>
               </div>
-              <div className="text-xs text-gray-500 mt-0.5 ml-4">
+              <div className="text-xs text-gray-400 mt-0.5 ml-4">
                 {source.description}
               </div>
               {!source.available && (
@@ -456,7 +456,7 @@ export function MotionCapturePage() {
           ))}
 
           {sources.length === 0 && (
-            <div className="text-xs text-gray-500 italic text-center py-2">
+            <div className="text-xs text-gray-400 italic text-center py-2">
               Loading sources...
             </div>
           )}
@@ -481,7 +481,7 @@ export function MotionCapturePage() {
               className="block w-full text-xs text-gray-400 file:mr-2 file:py-1.5 file:px-3 file:rounded file:border-0 file:bg-blue-600 file:text-white file:text-xs hover:file:bg-blue-500 file:cursor-pointer"
             />
             {uploading && (
-              <div className="text-xs text-gray-500 italic">Uploading…</div>
+              <div className="text-xs text-gray-400 italic">Uploading…</div>
             )}
             {uploadResult && (
               <div
@@ -534,7 +534,7 @@ export function MotionCapturePage() {
               <div className="flex items-center gap-2 text-xs">
                 <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
                 <span className="text-red-400">Recording...</span>
-                <span className="text-gray-500 ml-auto">
+                <span className="text-gray-400 ml-auto">
                   {activeSession.session_id}
                 </span>
               </div>
@@ -566,7 +566,7 @@ export function MotionCapturePage() {
           </h3>
 
           {recordings.length === 0 && (
-            <div className="text-xs text-gray-500 italic text-center py-2">
+            <div className="text-xs text-gray-400 italic text-center py-2">
               No recordings yet
             </div>
           )}
@@ -586,7 +586,7 @@ export function MotionCapturePage() {
               }`}
             >
               <div className="text-xs text-gray-200 truncate">{rec.name}</div>
-              <div className="text-xs text-gray-500 flex gap-2">
+              <div className="text-xs text-gray-400 flex gap-2">
                 <span>{rec.source_type}</span>
                 <span>{rec.total_frames} frames</span>
                 <span>{rec.duration_seconds.toFixed(1)}s</span>
@@ -679,7 +679,7 @@ export function MotionCapturePage() {
               <h3 className="text-lg font-semibold text-gray-400 mb-2">
                 No Skeleton Data
               </h3>
-              <p className="text-sm text-gray-500 max-w-xs">
+              <p className="text-sm text-gray-400 max-w-xs">
                 Select a capture source and start recording, or load a
                 recording to visualize skeleton data.
               </p>
@@ -719,14 +719,14 @@ export function MotionCapturePage() {
               <span className="text-xs text-gray-300 truncate flex-1">
                 {joint.name}
               </span>
-              <span className="text-xs text-gray-500 font-mono">
+              <span className="text-xs text-gray-400 font-mono">
                 {(joint.confidence * 100).toFixed(0)}%
               </span>
             </div>
           ))}
 
           {joints.length === 0 && (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               No joints loaded
             </div>
           )}

--- a/ui/src/pages/PuttingGreen.tsx
+++ b/ui/src/pages/PuttingGreen.tsx
@@ -349,7 +349,7 @@ export function PuttingGreenPage() {
     <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Putting Green Simulator</h2>
-          <p className="text-xs text-gray-500">Physics-based putting simulation</p>
+          <p className="text-xs text-gray-400">Physics-based putting simulation</p>
         </div>
 
         {/* Stroke Controls */}
@@ -637,7 +637,7 @@ export function PuttingGreenPage() {
               </div>
             </div>
           ) : (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               Click &quot;Read Green&quot; to analyze the putt line
             </div>
           )}
@@ -683,7 +683,7 @@ export function PuttingGreenPage() {
               </div>
             </div>
           ) : (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               Simulate a putt to see results
             </div>
           )}

--- a/ui/src/pages/Simulation.tsx
+++ b/ui/src/pages/Simulation.tsx
@@ -352,7 +352,7 @@ export function SimulationPage() {
       {/* Left Sidebar - Controls */}
       <aside className="w-80 bg-gray-800 border-r border-gray-700 p-4 overflow-y-auto flex-shrink-0 z-10">
         <h2 className="text-xl font-bold text-white mb-2">Golf Suite</h2>
-        <p className="text-xs text-gray-500 mb-6">
+        <p className="text-xs text-gray-400 mb-6">
           {loadedEngines.length} engine{loadedEngines.length !== 1 ? 's' : ''} loaded
         </p>
 
@@ -416,7 +416,7 @@ export function SimulationPage() {
               onChange={(e) => handleSpeedChange(parseFloat(e.target.value))}
               className="w-full h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
             />
-            <div className="flex justify-between text-[10px] text-gray-500 mt-1">
+            <div className="flex justify-between text-[10px] text-gray-400 mt-1">
               <span>0.1x</span>
               <span>1.0x (Real-time)</span>
               <span>5.0x</span>
@@ -475,7 +475,7 @@ export function SimulationPage() {
               <div className="text-center">
                 <div className="text-4xl mb-4 text-gray-600">⚡</div>
                 <h3 className="text-lg font-semibold text-gray-400 mb-2">Load a Physics Engine</h3>
-                <p className="text-sm text-gray-500 max-w-xs">
+                <p className="text-sm text-gray-400 max-w-xs">
                   Select and load an engine from the sidebar to begin simulation.
                   Only loaded engines consume system resources.
                 </p>
@@ -521,7 +521,7 @@ export function SimulationPage() {
             </div>
           </div>
         ) : (
-          <div className="text-sm text-gray-500 italic text-center mt-10">
+          <div className="text-sm text-gray-400 italic text-center mt-10">
             {effectiveEngine
               ? 'Start simulation to view live data'
               : 'Load an engine to get started'}

--- a/ui/src/pages/Terrain.tsx
+++ b/ui/src/pages/Terrain.tsx
@@ -54,7 +54,7 @@ export function TerrainPage() {
     <div className="flex flex-col flex-1 min-h-0 text-gray-100">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-sm font-semibold text-gray-200">Terrain Engine</h2>
-          <p className="text-xs text-gray-500 mt-1">Load and configure terrain</p>
+          <p className="text-xs text-gray-400 mt-1">Load and configure terrain</p>
         </div>
 
         {/* Sidebar Tabs */}
@@ -79,7 +79,7 @@ export function TerrainPage() {
           {sidebarTab === 'presets' && (
             <div className="space-y-2">
               {presets.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No presets available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No presets available</div>
               ) : (
                 presets.map((preset: TerrainPreset) => (
                   <button
@@ -93,7 +93,7 @@ export function TerrainPage() {
                   >
                     <div className="text-sm font-medium text-gray-200">{preset.name}</div>
                     <div className="text-xs text-gray-400 mt-0.5">{preset.description}</div>
-                    <div className="text-xs text-gray-500 mt-1">Type: {preset.terrain_type}</div>
+                    <div className="text-xs text-gray-400 mt-1">Type: {preset.terrain_type}</div>
                   </button>
                 ))
               )}
@@ -104,7 +104,7 @@ export function TerrainPage() {
           {sidebarTab === 'materials' && (
             <div className="space-y-2">
               {materials.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No materials available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No materials available</div>
               ) : (
                 materials.map((mat: TerrainMaterial) => (
                   <div key={mat.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
@@ -129,7 +129,7 @@ export function TerrainPage() {
           {sidebarTab === 'types' && (
             <div className="space-y-2">
               {terrainTypes.length === 0 ? (
-                <div className="text-xs text-gray-500 italic text-center py-4">No terrain types available</div>
+                <div className="text-xs text-gray-400 italic text-center py-4">No terrain types available</div>
               ) : (
                 terrainTypes.map((tt: TerrainTypeInfo) => (
                   <div key={tt.id} className="p-3 bg-gray-700/30 rounded-md border border-gray-600">
@@ -186,7 +186,7 @@ export function TerrainPage() {
                   </svg>
                 </div>
                 <h3 className="text-lg font-semibold text-gray-400 mb-2">Load a Terrain</h3>
-                <p className="text-sm text-gray-500 max-w-xs">
+                <p className="text-sm text-gray-400 max-w-xs">
                   Select a terrain preset from the sidebar and click Load to begin.
                 </p>
               </div>
@@ -206,19 +206,19 @@ export function TerrainPage() {
                 <h3 className="text-sm font-semibold text-gray-300 mb-3">Active Terrain</h3>
                 <div className="grid grid-cols-2 gap-3 text-xs">
                   <div>
-                    <span className="text-gray-500">Name</span>
+                    <span className="text-gray-400">Name</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.name}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Type</span>
+                    <span className="text-gray-400">Type</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.terrain_type}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Material</span>
+                    <span className="text-gray-400">Material</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.material}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Loaded</span>
+                    <span className="text-gray-400">Loaded</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.loaded_at}</div>
                   </div>
                 </div>
@@ -229,25 +229,25 @@ export function TerrainPage() {
                 <h3 className="text-sm font-semibold text-gray-300 mb-3">Terrain Properties</h3>
                 <div className="grid grid-cols-2 gap-3 text-xs">
                   <div>
-                    <span className="text-gray-500">Dimensions</span>
+                    <span className="text-gray-400">Dimensions</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.properties.dimensions.join(' x ')}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Resolution</span>
+                    <span className="text-gray-400">Resolution</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.properties.resolution}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Elevation Range</span>
+                    <span className="text-gray-400">Elevation Range</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.properties.elevation_range.join(' - ')}</div>
                   </div>
                   <div>
-                    <span className="text-gray-500">Slope Range</span>
+                    <span className="text-gray-400">Slope Range</span>
                     <div className="text-gray-200 font-mono">{activeTerrain.properties.slope_range.join(' - ')}°</div>
                   </div>
                 </div>
                 {activeTerrain.properties.features.length > 0 && (
                   <div className="mt-3">
-                    <span className="text-gray-500 text-xs">Features: </span>
+                    <span className="text-gray-400 text-xs">Features: </span>
                     <div className="flex flex-wrap gap-1 mt-1">
                       {activeTerrain.properties.features.map((f: string) => (
                         <span key={f} className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded">{f}</span>
@@ -282,9 +282,9 @@ export function TerrainPage() {
                   <div className="mt-3 bg-gray-700/50 p-3 rounded text-xs">
                     <div className="text-gray-400 mb-1">Query Result:</div>
                     <div className="grid grid-cols-2 gap-2">
-                      <div><span className="text-gray-500">Dimensions:</span> <span className="text-gray-200 font-mono">{queryResult.dimensions?.join(' x ') ?? 'N/A'}</span></div>
-                      <div><span className="text-gray-500">Resolution:</span> <span className="text-gray-200 font-mono">{queryResult.resolution ?? 'N/A'}</span></div>
-                      <div><span className="text-gray-500">Material:</span> <span className="text-gray-200 font-mono">{queryResult.material ?? 'N/A'}</span></div>
+                      <div><span className="text-gray-400">Dimensions:</span> <span className="text-gray-200 font-mono">{queryResult.dimensions?.join(' x ') ?? 'N/A'}</span></div>
+                      <div><span className="text-gray-400">Resolution:</span> <span className="text-gray-200 font-mono">{queryResult.resolution ?? 'N/A'}</span></div>
+                      <div><span className="text-gray-400">Material:</span> <span className="text-gray-200 font-mono">{queryResult.material ?? 'N/A'}</span></div>
                     </div>
                   </div>
                 )}

--- a/ui/src/pages/VideoAnalyzer.tsx
+++ b/ui/src/pages/VideoAnalyzer.tsx
@@ -90,7 +90,7 @@ function JointAngleChart({
   const entries = Object.entries(angles);
   if (entries.length === 0) {
     return (
-      <div className="text-xs text-gray-500 italic text-center py-2">
+      <div className="text-xs text-gray-400 italic text-center py-2">
         No joint angle data
       </div>
     );
@@ -203,7 +203,7 @@ export function VideoAnalyzerPage() {
     <div className="flex flex-col flex-1 min-h-0">
         <div className="p-4 border-b border-gray-700">
           <h2 className="text-lg font-bold text-white mb-1">Video Analyzer</h2>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-400">
             Upload and analyze golf swing videos
           </p>
         </div>
@@ -386,7 +386,7 @@ export function VideoAnalyzerPage() {
             <h3 className="text-lg font-semibold text-gray-400 mb-2">
               Upload a Video
             </h3>
-            <p className="text-sm text-gray-500 max-w-xs">
+            <p className="text-sm text-gray-400 max-w-xs">
               Select a golf swing video to analyze pose estimation,
               joint angles, and swing metrics.
             </p>
@@ -431,7 +431,7 @@ export function VideoAnalyzerPage() {
               </div>
             </div>
           ) : (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               No analysis yet
             </div>
           )}
@@ -464,14 +464,14 @@ export function VideoAnalyzerPage() {
 
           {currentFrame ? (
             <>
-              <div className="text-xs text-gray-500 mb-2">
+              <div className="text-xs text-gray-400 mb-2">
                 t={currentFrame.timestamp.toFixed(3)}s | conf={' '}
                 {(currentFrame.confidence * 100).toFixed(1)}%
               </div>
               <JointAngleChart angles={currentFrame.joint_angles} />
             </>
           ) : (
-            <div className="text-xs text-gray-500 italic text-center py-4">
+            <div className="text-xs text-gray-400 italic text-center py-4">
               Analyze a video to view joint data
             </div>
           )}

--- a/ui/src/utils/colorGuard.test.ts
+++ b/ui/src/utils/colorGuard.test.ts
@@ -40,3 +40,27 @@ describe('color-system guard (#7421)', () => {
     expect(offenders, `Use gray-* (neutrals) / blue-* (primary). Offending files: ${offenders.join(', ')}`).toEqual([]);
   });
 });
+
+/**
+ * Contrast guard (UI/UX #7439): `text-gray-500` (#6B7280) is ~2.8:1 on the
+ * app's gray-900/950 surfaces — below the WCAG AA 4.5:1 minimum for body text.
+ * Foreground text must use `text-gray-400` or lighter. This locks the sweep so
+ * a regression can't silently reintroduce the failing class.
+ */
+describe('contrast guard (#7439)', () => {
+  it('uses no text-gray-500 foreground class in tsx/ts sources', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC_ROOT)) {
+      if (!/\.tsx?$/.test(file)) continue;
+      const rel = relative(SRC_ROOT, file).replace(/\\/g, '/');
+      if (rel.startsWith('utils/colorGuard')) continue;
+      if (/text-gray-500/.test(readFileSync(file, 'utf8'))) {
+        offenders.push(rel);
+      }
+    }
+    expect(
+      offenders,
+      `text-gray-500 fails AA on dark surfaces — use text-gray-400+. Offending: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Issue

**Closes #7439** — multiple foreground colors failed WCAG AA contrast on the dark surfaces.

- `text-gray-500` (#6B7280) is ~2.8:1 on gray-900/950 — below the 4.5:1 text minimum. Swept every foreground `text-gray-500` to `text-gray-400` across `ui/src` (35 files incl. the `api/diagnostics.ts` status-color map).
- Disabled-button contrast is already standardized in the shared `Button` primitive (`disabled:bg-gray-700 disabled:text-gray-400`).
- `ActuatorSlider` track raised from `bg-gray-600` (~2.5:1) to `bg-gray-500` + `accent-blue-500` so the filled portion/thumb are clearly visible.

## Regression lock

Added a **contrast guard** test next to the existing color-system guard that fails if `text-gray-500` reappears in `ui/src`.

## Verification

Contrast + color guards green; 494 page/component tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)