### PR TITLE
feat(ui): self-explaining disabled buttons, shortcut hints, Frankenstein undo (#7443)

### DIFF
--- a/ui/src/components/simulation/SimulationControls.tsx
+++ b/ui/src/components/simulation/SimulationControls.tsx
@@ -219,7 +219,9 @@ export function SimulationControls({
           <button
             onClick={onStart}
             disabled={disabled}
-            aria-label="Start simulation"
+            aria-label="Start simulation (Space)"
+            aria-keyshortcuts="Space"
+            title="Start simulation (Space)"
             className={`${buttonStyles.base} ${disabled ? buttonStyles.disabled : buttonStyles.primary}`}
           >
             <Play size={20} aria-hidden="true" />
@@ -230,7 +232,9 @@ export function SimulationControls({
             {isPaused ? (
               <button
                 onClick={onResume}
-                aria-label="Resume simulation"
+                aria-label="Resume simulation (Space)"
+                aria-keyshortcuts="Space"
+                title="Resume simulation (Space)"
                 className={`${buttonStyles.base} ${buttonStyles.primary}`}
               >
                 <Play size={20} aria-hidden="true" />
@@ -239,7 +243,9 @@ export function SimulationControls({
             ) : (
               <button
                 onClick={onPause}
-                aria-label="Pause simulation"
+                aria-label="Pause simulation (Space)"
+                aria-keyshortcuts="Space"
+                title="Pause simulation (Space)"
                 className={`${buttonStyles.base} ${buttonStyles.warning}`}
               >
                 <Pause size={20} aria-hidden="true" />
@@ -251,7 +257,8 @@ export function SimulationControls({
               <button
                 onClick={onStep}
                 disabled={!isPaused}
-                aria-label="Single step"
+                aria-label="Single step (.)"
+                aria-keyshortcuts="Period"
                 title="Single step (. key)"
                 className={`${buttonStyles.base} ${buttonStyles.small} ${
                   isPaused ? buttonStyles.secondary : buttonStyles.disabled
@@ -263,7 +270,9 @@ export function SimulationControls({
 
             <button
               onClick={onStop}
-              aria-label="Stop simulation"
+              aria-label="Stop simulation (Esc)"
+              aria-keyshortcuts="Escape"
+              title="Stop simulation (Esc)"
               className={`${buttonStyles.base} ${buttonStyles.danger}`}
             >
               <Square size={20} aria-hidden="true" />

--- a/ui/src/components/ui/Button.test.tsx
+++ b/ui/src/components/ui/Button.test.tsx
@@ -37,6 +37,28 @@ describe('Button (#7420)', () => {
     render(<Button className="w-full">Wide</Button>);
     expect(screen.getByRole('button', { name: 'Wide' }).className).toContain('w-full');
   });
+
+  it('wires disabledReason to title + aria-describedby when disabled (#7443)', () => {
+    render(
+      <Button disabled disabledReason="Load both models to compare">
+        Compare
+      </Button>,
+    );
+    const btn = screen.getByRole('button', { name: /compare/i });
+    expect(btn).toHaveAttribute('title', 'Load both models to compare');
+    const describedBy = btn.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const reason = document.getElementById(describedBy as string);
+    expect(reason?.textContent).toBe('Load both models to compare');
+    expect(reason?.className).toContain('sr-only');
+  });
+
+  it('does not surface disabledReason while enabled (#7443)', () => {
+    render(<Button disabledReason="nope">Active</Button>);
+    const btn = screen.getByRole('button', { name: 'Active' });
+    expect(btn).not.toHaveAttribute('aria-describedby');
+    expect(btn).not.toHaveAttribute('title');
+  });
 });
 
 describe('Input/Select (#7420)', () => {

--- a/ui/src/components/ui/Button.tsx
+++ b/ui/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success' | 'ghost';
@@ -7,6 +7,13 @@ export type ButtonSize = 'sm' | 'md' | 'lg';
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
+  /**
+   * #7443: when a button is disabled for a knowable reason, pass it here. The
+   * reason is wired to both `title` (pointer tooltip) and a visually-hidden
+   * `aria-describedby` node so assistive tech announces *why* the control is
+   * dead instead of leaving the user guessing. Ignored when not disabled.
+   */
+  disabledReason?: string;
 }
 
 const BASE =
@@ -35,9 +42,42 @@ const SIZES: Record<ButtonSize, string> = {
  * states stay consistent app-wide.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = 'primary', size = 'md', className = '', type = 'button', ...rest },
+  {
+    variant = 'primary',
+    size = 'md',
+    className = '',
+    type = 'button',
+    disabledReason,
+    disabled,
+    title,
+    'aria-describedby': ariaDescribedBy,
+    ...rest
+  },
   ref
 ) {
   const classes = `${BASE} ${VARIANTS[variant]} ${SIZES[size]} ${className}`.trim();
-  return <button ref={ref} type={type} className={classes} {...rest} />;
+  const reasonId = useId();
+  // Only surface the reason while actually disabled (#7443).
+  const showReason = Boolean(disabled && disabledReason);
+  const describedBy =
+    [ariaDescribedBy, showReason ? reasonId : null].filter(Boolean).join(' ') ||
+    undefined;
+  return (
+    <>
+      <button
+        ref={ref}
+        type={type}
+        className={classes}
+        disabled={disabled}
+        title={showReason ? disabledReason : title}
+        aria-describedby={describedBy}
+        {...rest}
+      />
+      {showReason && (
+        <span id={reasonId} className="sr-only">
+          {disabledReason}
+        </span>
+      )}
+    </>
+  );
 });

--- a/ui/src/components/ui/HelpPanel.tsx
+++ b/ui/src/components/ui/HelpPanel.tsx
@@ -17,6 +17,7 @@ import {
   HELP_TOPICS,
   FEATURE_HELP,
   CATEGORY_LABELS,
+  KEYBOARD_SHORTCUTS,
   searchHelp,
   getTopicsByCategory,
   getRelatedTopics,
@@ -375,6 +376,29 @@ export function HelpPanel({ initialTopicId, isOpen: controlledOpen, onClose }: H
                       </div>
                     </button>
                   ))}
+                </div>
+
+                {/* #7443: surface the otherwise-undiscoverable shortcuts. */}
+                <div className="mt-6">
+                  <h4 className="text-sm font-semibold text-gray-200 mb-2">
+                    Keyboard shortcuts
+                  </h4>
+                  <ul className="divide-y divide-gray-800 rounded-lg border border-gray-700 bg-gray-800/50">
+                    {KEYBOARD_SHORTCUTS.map((sc) => (
+                      <li
+                        key={`${sc.scope}-${sc.keys}`}
+                        className="flex items-center justify-between gap-3 px-3 py-2 text-xs"
+                      >
+                        <span className="text-gray-300">{sc.description}</span>
+                        <span className="flex items-center gap-2 flex-shrink-0">
+                          <kbd className="rounded bg-gray-700 px-1.5 py-0.5 font-mono text-gray-100">
+                            {sc.keys}
+                          </kbd>
+                          <span className="text-gray-400">{sc.scope}</span>
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             )}

--- a/ui/src/components/ui/helpData.ts
+++ b/ui/src/components/ui/helpData.ts
@@ -364,6 +364,38 @@ export const QUICK_TIPS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Keyboard shortcuts (#7443) — single source of truth so HelpPanel can list
+// every global/page binding instead of leaving them undiscoverable.
+// ---------------------------------------------------------------------------
+
+export interface KeyboardShortcut {
+  keys: string;
+  description: string;
+  /** Where the binding applies (global, or a specific page/area). */
+  scope: string;
+}
+
+export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
+  { keys: 'F1', description: 'Open / close this help panel', scope: 'Global' },
+  {
+    keys: 'Space',
+    description: 'Start, pause, resume, or single-step the simulation',
+    scope: 'Simulation',
+  },
+  { keys: 'Esc', description: 'Stop the running simulation', scope: 'Simulation' },
+  {
+    keys: '.',
+    description: 'Single-step while paused',
+    scope: 'Simulation',
+  },
+  {
+    keys: 'Ctrl+Z',
+    description: 'Undo the last Frankenstein tree edit',
+    scope: 'Model Explorer',
+  },
+];
+
+// ---------------------------------------------------------------------------
 // Category Labels
 // ---------------------------------------------------------------------------
 

--- a/ui/src/pages/ModelExplorer.test.tsx
+++ b/ui/src/pages/ModelExplorer.test.tsx
@@ -236,6 +236,48 @@ describe('ModelExplorer Page UI & Frankenstein Mode', () => {
     // Check that TreeDiffModal is rendered and lists added components in comparison
     expect(screen.getByText(/Model Comparison/i)).toBeInTheDocument();
   });
+
+  it('undoes a copy via Ctrl+Z (#7443)', async () => {
+    render(<ModelExplorerPage />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/Frankenstein Mode/i));
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/Select Source/i), {
+        target: { value: 'source_robot' },
+      });
+      fireEvent.change(screen.getByLabelText(/Select Target/i), {
+        target: { value: 'target_robot' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('src_joint_1'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('tgt_root'));
+    });
+
+    // Undo is disabled before any edit.
+    expect(
+      screen.getByLabelText(/Undo last Frankenstein edit/i),
+    ).toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/Copy Component/i));
+    });
+    expect(screen.getAllByText(/src_joint_1_copy/i)).toHaveLength(1);
+    // After the edit, Undo is enabled.
+    expect(
+      screen.getByLabelText(/Undo last Frankenstein edit/i),
+    ).not.toBeDisabled();
+
+    // Ctrl+Z reverts the copy.
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    });
+    expect(screen.queryByText(/src_joint_1_copy/i)).not.toBeInTheDocument();
+  });
 });
 
 describe('JointManipulator component', () => {

--- a/ui/src/pages/ModelExplorer.tsx
+++ b/ui/src/pages/ModelExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useURDFModel } from '@/api/useURDFModel';
 import { apiFetch } from '@/api/fetch';
 import { ModelPreviewViewport } from '@/components/model-explorer/ModelPreviewViewport';
@@ -41,6 +41,32 @@ export function ModelExplorerPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isDiffOpen, setIsDiffOpen] = useState(false);
+
+  // #7443: bounded undo history for Frankenstein tree edits. Each mutating
+  // op snapshots the pre-edit (source, target) trees; Undo / Ctrl+Z restores
+  // the most recent snapshot. Capped so a long editing session can't grow it
+  // without bound.
+  const FRANKENSTEIN_UNDO_LIMIT = 20;
+  const undoStackRef = useRef<
+    { source: URDFTreeNode[]; target: URDFTreeNode[] }[]
+  >([]);
+  const [canUndo, setCanUndo] = useState(false);
+
+  const snapshotForUndo = useCallback(() => {
+    undoStackRef.current.push({ source: sourceTree, target: targetTree });
+    if (undoStackRef.current.length > FRANKENSTEIN_UNDO_LIMIT) {
+      undoStackRef.current.shift();
+    }
+    setCanUndo(true);
+  }, [sourceTree, targetTree]);
+
+  const handleUndo = useCallback(() => {
+    const prev = undoStackRef.current.pop();
+    if (!prev) return;
+    setSourceTree(prev.source);
+    setTargetTree(prev.target);
+    setCanUndo(undoStackRef.current.length > 0);
+  }, []);
 
   // Fetch model for 3D preview (renders target model in Frankenstein mode if loaded)
   const activePreviewModel = frankensteinMode
@@ -101,19 +127,22 @@ export function ModelExplorerPage() {
     loadModelData(name, 'target');
   }, [loadModelData]);
 
-  // Tree action handlers
+  // Tree action handlers. Each snapshots state first so the op is undoable (#7443).
   const handleCopyComponent = useCallback((nodeId: string) => {
+    snapshotForUndo();
     const updated = copyComponent(sourceTree, targetTree, nodeId, selectedTargetNodeId);
     setTargetTree(updated);
-  }, [sourceTree, targetTree, selectedTargetNodeId]);
+  }, [sourceTree, targetTree, selectedTargetNodeId, snapshotForUndo]);
 
   const handleCopyChain = useCallback((nodeId: string) => {
+    snapshotForUndo();
     const updated = copyLinkChain(sourceTree, targetTree, nodeId, selectedTargetNodeId);
     setTargetTree(updated);
-  }, [sourceTree, targetTree, selectedTargetNodeId]);
+  }, [sourceTree, targetTree, selectedTargetNodeId, snapshotForUndo]);
 
   const handleSwapSubtrees = useCallback(() => {
     if (!selectedSourceNodeId || !selectedTargetNodeId) return;
+    snapshotForUndo();
     const { sourceTree: newSrc, targetTree: newTgt } = swapSubtrees(
       sourceTree,
       targetTree,
@@ -122,12 +151,34 @@ export function ModelExplorerPage() {
     );
     setSourceTree(newSrc);
     setTargetTree(newTgt);
-  }, [sourceTree, targetTree, selectedSourceNodeId, selectedTargetNodeId]);
+  }, [sourceTree, targetTree, selectedSourceNodeId, selectedTargetNodeId, snapshotForUndo]);
 
   const handleMergeAll = useCallback(() => {
+    snapshotForUndo();
     const updated = mergeTrees(sourceTree, targetTree, selectedTargetNodeId);
     setTargetTree(updated);
-  }, [sourceTree, targetTree, selectedTargetNodeId]);
+  }, [sourceTree, targetTree, selectedTargetNodeId, snapshotForUndo]);
+
+  // #7443: Ctrl+Z undoes the last Frankenstein edit. Scoped to the page and
+  // ignored while typing in a field.
+  useEffect(() => {
+    if (!frankensteinMode) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        e.target instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        handleUndo();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [frankensteinMode, handleUndo]);
 
   // Compute diff
   const treeDiff = useMemo(() => {
@@ -209,12 +260,49 @@ export function ModelExplorerPage() {
 
           {frankensteinMode && (
             <div className="flex gap-2">
+              {(() => {
+                const compareDisabled =
+                  sourceTree.length === 0 || targetTree.length === 0;
+                // #7443: explain WHY Compare is dead instead of a silent
+                // no-op button.
+                const compareReason = compareDisabled
+                  ? 'Load both a source and a target model to compare'
+                  : undefined;
+                return (
+                  <>
+                    <button
+                      onClick={() => setIsDiffOpen(true)}
+                      disabled={compareDisabled}
+                      title={compareReason}
+                      aria-describedby={
+                        compareReason ? 'compare-disabled-reason' : undefined
+                      }
+                      className="flex-1 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-400 text-white rounded text-xs font-medium transition-colors shadow-lg"
+                    >
+                      Compare
+                    </button>
+                    {compareReason && (
+                      <span id="compare-disabled-reason" className="sr-only">
+                        {compareReason}
+                      </span>
+                    )}
+                  </>
+                );
+              })()}
+              {/* #7443: undo the last Frankenstein tree edit (also Ctrl+Z). */}
               <button
-                onClick={() => setIsDiffOpen(true)}
-                disabled={sourceTree.length === 0 || targetTree.length === 0}
-                className="flex-1 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-800 disabled:text-gray-400 text-white rounded text-xs font-medium transition-colors shadow-lg"
+                onClick={handleUndo}
+                disabled={!canUndo}
+                title={
+                  canUndo
+                    ? 'Undo last edit (Ctrl+Z)'
+                    : 'Nothing to undo'
+                }
+                aria-label="Undo last Frankenstein edit"
+                aria-keyshortcuts="Control+Z"
+                className="py-1.5 px-3 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-400 text-gray-100 rounded text-xs font-medium transition-colors"
               >
-                Compare
+                Undo
               </button>
               {selectedSourceNodeId && selectedTargetNodeId && (
                 <button


### PR DESCRIPTION
## Issue

**Closes #7443** — affordance gaps that made the app feel opaque.

1. **Disabled-with-reason.** The shared `Button` primitive gains a `disabledReason` prop that, while disabled, wires the reason to both `title` and a visually-hidden `aria-describedby` node. Applied to ModelExplorer''s Compare button ("Load both a source and a target model to compare").
2. **Discoverable shortcuts.** SimulationControls'' Start/Pause/Resume/Stop/Step buttons carry the key in `aria-label` + `title` + `aria-keyshortcuts`. Added a single-source `KEYBOARD_SHORTCUTS` table to `helpData.ts` and a "Keyboard shortcuts" section to the HelpPanel overview (F1 / Space / Esc / `.` / Ctrl+Z + scope).
3. **Frankenstein undo.** ModelExplorer keeps a bounded (20-deep) history of `(source, target)` tree snapshots; every copy/chain/swap/merge pushes a snapshot, and an **Undo** button + page-scoped **Ctrl+Z** restore the previous state.

## Tests

- Button `disabledReason` wiring (surfaced only while disabled).
- Ctrl+Z reverts a copy; Undo button enable/disable states.
- Touched suites green (52 tests).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)