### PR TITLE
chore(ci): pin ruff to 0.15.17 across CI + pre-commit

### DIFF
--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -278,7 +278,7 @@ jobs:
         run: |
           # Pin versions to match CI Standard quality gate
           python -m ensurepip --upgrade || true
-          pip install ruff==0.14.10 black==26.1.0 mypy==1.13.0 autoflake
+          pip install ruff==0.15.17 black==26.1.0 mypy==1.13.0 autoflake
           # Install project deps so mypy can resolve imports
           python -m ensurepip --upgrade || true
           if ! pip install -e ".[dev]"; then

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -70,7 +70,7 @@ jobs:
       - run: |
           npm install -g @google/jules
           python -m ensurepip --upgrade || true
-          pip install ruff==0.14.10
+          pip install ruff==0.15.17
 
       - name: Identify Target File
         id: target

--- a/.github/workflows/Jules-Tech-Debt-Assessor.yml
+++ b/.github/workflows/Jules-Tech-Debt-Assessor.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m ensurepip --upgrade || true
-          pip install ruff==0.14.10 mypy bandit radon pip-audit vulture
+          pip install ruff==0.15.17 mypy bandit radon pip-audit vulture
           python -m ensurepip --upgrade || true
           if ! pip install -e ".[dev]"; then
             python -m ensurepip --upgrade || true

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -192,7 +192,7 @@ jobs:
           # RECORD metadata. Ignore ambient installs so pip lays down clean
           # copies instead of trying to uninstall corrupted cache entries.
           python -m ensurepip --upgrade || true
-          python -m pip install --no-cache-dir --ignore-installed ruff==0.14.10 "mypy==1.20.1" bandit==1.7.7 pydocstyle==6.3.0 semgrep
+          python -m pip install --no-cache-dir --ignore-installed ruff==0.15.17 "mypy==1.20.1" bandit==1.7.7 pydocstyle==6.3.0 semgrep
 
       - name: Lint
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
 
   # Ruff - Fast Python linter with auto-fix
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.17
     hooks:
       - id: ruff
         name: "ruff (lint + fix)"


### PR DESCRIPTION
## Problem

Ruff version pins were skewed across the repo:

- `.github/workflows/ci-standard.yml`, `Jules-PR-AutoFix.yml`, `Jules-Tech-Custodian.yml`, `Jules-Tech-Debt-Assessor.yml` pinned `ruff==0.14.10`
- `.pre-commit-config.yaml` pinned `astral-sh/ruff-pre-commit` rev `v0.14.10`
- `pyproject.toml` requires `ruff>=0.15.10`; the dev `.venv` ships `0.15.17`

Ruff 0.15 changed lambda-parameter formatting, so files formatted with the local 0.15.x toolchain could fail `ruff format --check` under CI's 0.14.10 (this bit `src/launchers/settings_dialog.py`, worked around in #7488 via `functools.partial`).

## Change

Bump every CI workflow pin and the pre-commit rev to a single **`0.15.17`**, matching `pyproject` (`>=0.15.10`) and the local venv.

## Verification

Ran the local `0.15.17` ruff over the full tree in a fresh worktree off `origin/main`:

- `ruff format .` → **5613 files left unchanged** (zero diffs)
- `ruff check .` → **All checks passed!**

The codebase is already 0.15-clean — this PR only removes the version skew, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
