### PR TITLE
ci: build the 4 remaining PyO3 crates as wheels + probe them (#7602)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -2185,7 +2185,7 @@ jobs:
           source "$RUNNER_TEMP/rust-venv/bin/activate"
           python -m ensurepip --upgrade || true
           python -m pip install --upgrade pip maturin
-          for crate in rust_core/upstream-physics rust_core/upstream-mocap-preproc rust_core/upstream-mocap-io rust_core/upstream-muscle rust_core/upstream-motion-matching rust_core/ai_backend; do
+          for crate in rust_core/upstream-physics rust_core/upstream-mocap-preproc rust_core/upstream-mocap-io rust_core/upstream-muscle rust_core/upstream-motion-matching rust_core/ai_backend rust_core/upstream-urdf rust_core/upstream-realtime rust_core/upstream-mesh rust_core/upstream-pinocchio-id; do
             (cd "$crate" && python -m maturin build --interpreter python --features python --release)
           done
           echo "Wheels built successfully"
@@ -2205,7 +2205,11 @@ jobs:
             upstream_mocap_io \
             upstream_muscle \
             upstream_motion_matching \
-            ai_backend
+            ai_backend \
+            upstream_urdf \
+            upstream_realtime \
+            upstream_mesh \
+            upstream_pinocchio_id
           CI_RUST_WHEELS_EXPECTED=1 python -m pytest \
             tests/unit/test_ball_flight_physics.py \
             tests/unit/shared_python/test_ball_flight_physics.py \
@@ -2482,7 +2486,7 @@ jobs:
           source "$RUNNER_TEMP/rust-venv/bin/activate"
           python -m ensurepip --upgrade || true
           python -m pip install --upgrade pip maturin
-          for crate in rust_core/upstream-physics rust_core/upstream-mocap-preproc rust_core/upstream-mocap-io rust_core/upstream-muscle rust_core/upstream-motion-matching rust_core/ai_backend; do
+          for crate in rust_core/upstream-physics rust_core/upstream-mocap-preproc rust_core/upstream-mocap-io rust_core/upstream-muscle rust_core/upstream-motion-matching rust_core/ai_backend rust_core/upstream-urdf rust_core/upstream-realtime rust_core/upstream-mesh rust_core/upstream-pinocchio-id; do
             (cd "$crate" && python -m maturin build --interpreter python --features python --release)
           done
           echo "Wheels built successfully"
@@ -2502,7 +2506,11 @@ jobs:
             upstream_mocap_io \
             upstream_muscle \
             upstream_motion_matching \
-            ai_backend
+            ai_backend \
+            upstream_urdf \
+            upstream_realtime \
+            upstream_mesh \
+            upstream_pinocchio_id
 
       - name: Run parity suite (wheels mandatory)
         # CI_RUST_WHEELS_EXPECTED=1 (job env) makes a skipped Rust-parity test

--- a/scripts/ci/import_built_rust_wheels.py
+++ b/scripts/ci/import_built_rust_wheels.py
@@ -26,6 +26,10 @@ EXPECTED_BINDINGS: dict[str, tuple[str, ...]] = {
     "upstream_muscle": ("f_l", "f_v", "HillMuscleModel"),
     "upstream_motion_matching": ("finite_diff_q_to_qdot_qddot",),
     "ai_backend": ("AIConfig", "AIEngine", "RagPipeline"),
+    "upstream_urdf": ("parse_urdf", "write_urdf", "parse_mjcf", "write_mjcf"),
+    "upstream_realtime": ("Server", "Subscriber", "validate_channel"),
+    "upstream_mesh": ("compute_convex_hull", "fit_aabb", "fit_obb"),
+    "upstream_pinocchio_id": ("compute_qdot", "compute_qddot", "inverse_dynamics"),
 }
 
 
@@ -74,6 +78,51 @@ def smoke_module(module_name: str, module: ModuleType) -> None:
         cfg = module.AIConfig("k", "https://api.example/v1", "m", ":memory:")
         if cfg.chat_url() != "https://api.example/v1/chat/completions":
             raise RuntimeError("ai_backend AIConfig smoke returned wrong chat URL")
+    elif module_name == "upstream_urdf":
+        minimal_urdf = '<robot name="r"><link name="base"/></robot>'
+        robot_json = module.parse_urdf(minimal_urdf)
+        if '"base"' not in robot_json:
+            raise RuntimeError("upstream_urdf parse_urdf smoke dropped the base link")
+        round_tripped = module.write_urdf(robot_json)
+        if "base" not in round_tripped:
+            raise RuntimeError("upstream_urdf write_urdf smoke dropped the base link")
+    elif module_name == "upstream_realtime":
+        # Channels must match the scope/topic pattern (see channels.rs).
+        module.validate_channel("swing/telemetry")
+        try:
+            module.validate_channel("not-a-valid-channel")
+        except Exception as exc:  # noqa: BLE001 - controlled backend error smoke.
+            _ = exc
+        else:
+            raise RuntimeError(
+                "upstream_realtime validate_channel accepted an invalid channel"
+            )
+    elif module_name == "upstream_mesh":
+        import numpy as np
+
+        # Primitive fitting requires at least 4 points (a tetrahedron here).
+        vertices = np.array(
+            [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]],
+            dtype=np.float32,
+        )
+        center, extents, _volume_ratio = module.fit_aabb(vertices)
+        # AABB of these points: center = (min+max)/2, extents = (max-min).
+        if tuple(round(c, 3) for c in center) != (1.0, 1.0, 1.0):
+            raise RuntimeError(f"upstream_mesh fit_aabb smoke returned center {center}")
+        if tuple(round(e, 3) for e in extents) != (2.0, 2.0, 2.0):
+            raise RuntimeError(
+                f"upstream_mesh fit_aabb smoke returned extents {extents}"
+            )
+    elif module_name == "upstream_pinocchio_id":
+        import numpy as np
+
+        q = np.array([[0.0], [1.0], [4.0]], dtype=np.float64)
+        times = np.array([0.0, 1.0, 2.0], dtype=np.float64)
+        qdot = np.asarray(module.compute_qdot(q, times))
+        if qdot.shape != (3, 1):
+            raise RuntimeError(
+                f"upstream_pinocchio_id compute_qdot smoke returned shape {qdot.shape}"
+            )
 
 
 def verify_module(module_name: str) -> None:


### PR DESCRIPTION
## Problem (#7602 / U3)

`upstream-urdf`, `upstream-realtime`, `upstream-mesh`, and
`upstream-pinocchio-id` each expose a `#[pymodule]` (`src/bindings.rs`), but
none of them were in the maturin build loop. Their wheels were never built or
import-tested in CI, so a regression in their PyO3 bindings could land
undetected.

## Change

- Add all four crates to the maturin build loop in **both** the
  `rust-quality-gate` and `rust-wheel-parity` jobs.
- Add them to the fail-closed import tripwire
  (`scripts/ci/import_built_rust_wheels.py`): `EXPECTED_BINDINGS` entries plus a
  minimal smoke call per module:
  - `upstream_urdf`: `parse_urdf` → `write_urdf` round-trip
  - `upstream_realtime`: `validate_channel` accept/reject (scope/topic pattern)
  - `upstream_mesh`: `fit_aabb` on a tetrahedron
  - `upstream_pinocchio_id`: `compute_qdot` finite-difference shape check
- Extend both `import_built_rust_wheels.py` invocations in `ci-standard.yml`.

No facade changes. No empty `[workspace]` needed — all four already build under
the existing workspace.

## Verification

Local (maturin 1.13.3, cargo 1.94, CPython 3.12): all four wheels build with
`maturin build --release --features python` and pass the extended probe
(`import_built_rust_wheels.py upstream_urdf upstream_realtime upstream_mesh upstream_pinocchio_id`).
The `rust-wheel-parity` job (no path gate) exercises this end-to-end in CI.

Refs #7602
Part of #7599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
