### PR TITLE
Guard refresh_models/index_codebase chat WS actions against crashes (#7687)

### DIFF
--- a/src/api/routes/chat_ws.py
+++ b/src/api/routes/chat_ws.py
@@ -254,14 +254,24 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                 # Tools issue #2547 / PR #2566: poll the configured provider
                 # for available models and ship the result over the chat
                 # socket so the dock widget can repopulate its dropdown.
-                payload = await asyncio.to_thread(chat_service.refresh_models)
-                await websocket.send_json(
-                    {
-                        "type": "model_list",
-                        "models": payload["models"],
-                        "refreshed_at": payload["refreshed_at"],
-                    }
-                )
+                # Issue #7687: a provider/network failure here used to escape
+                # chat_stream and tear the socket down with no error frame.
+                try:
+                    payload = await asyncio.to_thread(chat_service.refresh_models)
+                    await websocket.send_json(
+                        {
+                            "type": "model_list",
+                            "models": payload["models"],
+                            "refreshed_at": payload["refreshed_at"],
+                        }
+                    )
+                except WebSocketDisconnect:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.exception("Error refreshing models")
+                    await websocket.send_json(
+                        {"type": "error", "detail": _INTERNAL_ERROR_DETAIL}
+                    )
 
             elif action == "index_codebase":
                 # Tools issue #2549 / PR #2567. Run the existing
@@ -270,6 +280,8 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                 # ``complete`` (or ``error``) event when the rebuild
                 # finishes. We deliberately don't reimplement the
                 # indexer here — see ``src/shared/python/codemap``.
+                # Issue #7687: a rebuild failure must surface as an error frame
+                # instead of crashing the whole chat socket.
                 await websocket.send_json(
                     {
                         "type": "index_status",
@@ -278,8 +290,20 @@ async def chat_stream(websocket: WebSocket, session_id: str = "new") -> None:  #
                         "symbols_inserted": 0,
                     }
                 )
-                payload = await chat_service.run_codemap_rebuild()
-                await websocket.send_json({"type": "index_status", **payload})
+                try:
+                    payload = await chat_service.run_codemap_rebuild()
+                    await websocket.send_json({"type": "index_status", **payload})
+                except WebSocketDisconnect:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.exception("Error indexing codebase")
+                    await websocket.send_json(
+                        {
+                            "type": "index_status",
+                            "state": "error",
+                            "detail": _INTERNAL_ERROR_DETAIL,
+                        }
+                    )
 
             else:
                 await websocket.send_json(

--- a/tests/unit/api/test_routes_chat_ws.py
+++ b/tests/unit/api/test_routes_chat_ws.py
@@ -19,6 +19,21 @@ class MockChatService:
     def __init__(self):
         self.add_message_error = False
         self.stream_chunks = [{"type": "chunk", "content": "mock "}, "response"]
+        # Issue #7687: toggles that make the model-refresh / codemap-rebuild
+        # actions raise, to verify failures surface as error frames instead of
+        # tearing down the socket.
+        self.refresh_models_error = False
+        self.codemap_rebuild_error = False
+
+    def refresh_models(self):
+        if self.refresh_models_error:
+            raise RuntimeError("provider unreachable")
+        return {"models": ["m1", "m2"], "refreshed_at": "now"}
+
+    async def run_codemap_rebuild(self):
+        if self.codemap_rebuild_error:
+            raise RuntimeError("indexer crashed")
+        return {"state": "complete", "files_parsed": 3, "symbols_inserted": 9}
 
     def get_or_create_session(self, session_id):
         return MockSession(session_id or "new_id")
@@ -165,6 +180,63 @@ def test_chat_websocket_unknown_action(client: TestClient) -> None:
         data = websocket.receive_json()
         assert data["type"] == "error"
         assert "Unknown action: unknown_action" in data["detail"]
+
+
+def test_refresh_models_success(client: TestClient) -> None:
+    with client.websocket_connect("/ws/chat/session_1") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "refresh_models"})
+        data = websocket.receive_json()
+        assert data["type"] == "model_list"
+        assert data["models"] == ["m1", "m2"]
+
+
+def test_refresh_models_failure_sends_error_frame(
+    client: TestClient, app: FastAPI
+) -> None:
+    """Issue #7687: a refresh failure must yield an error frame, and the
+    socket must stay alive for subsequent actions."""
+    app.state.chat_service.refresh_models_error = True
+    with client.websocket_connect("/ws/chat/session_1") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "refresh_models"})
+        data = websocket.receive_json()
+        assert data["type"] == "error"
+        # Socket survived — a follow-up action still works.
+        websocket.send_json({"action": "history"})
+        follow = websocket.receive_json()
+        assert follow["type"] == "history"
+
+
+def test_index_codebase_success(client: TestClient) -> None:
+    with client.websocket_connect("/ws/chat/session_1") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "index_codebase"})
+        running = websocket.receive_json()
+        assert running["type"] == "index_status"
+        assert running["state"] == "running"
+        final = websocket.receive_json()
+        assert final["type"] == "index_status"
+        assert final["state"] == "complete"
+
+
+def test_index_codebase_failure_sends_error_status(
+    client: TestClient, app: FastAPI
+) -> None:
+    """Issue #7687: a rebuild crash must produce an ``error`` index_status
+    frame rather than killing the socket."""
+    app.state.chat_service.codemap_rebuild_error = True
+    with client.websocket_connect("/ws/chat/session_1") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "index_codebase"})
+        running = websocket.receive_json()
+        assert running["state"] == "running"
+        err = websocket.receive_json()
+        assert err["type"] == "index_status"
+        assert err["state"] == "error"
+        # Socket survived.
+        websocket.send_json({"action": "history"})
+        assert websocket.receive_json()["type"] == "history"
 
 
 def test_chat_websocket_disconnect(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

In `src/api/routes/chat_ws.py` the `refresh_models` and `index_codebase` WS actions called `chat_service.refresh_models()` / `run_codemap_rebuild()` with no local error handling. Any exception (provider unreachable, indexer crash) propagated out of `chat_stream` and tore down the chat WebSocket without an error frame, leaving the client hung.

Both actions now use the same pattern already applied to the streaming `send` path: re-raise `WebSocketDisconnect`, `logger.exception(...)` everything else, and emit an error frame:
- `refresh_models` → `{"type": "error", ...}`
- `index_codebase` → `{"type": "index_status", "state": "error", ...}`

The socket stays alive for subsequent actions.

## Tests

Added to `tests/unit/api/test_routes_chat_ws.py` (MockChatService gained `refresh_models`/`run_codemap_rebuild` with failure toggles):
- `test_refresh_models_success` / `test_refresh_models_failure_sends_error_frame`
- `test_index_codebase_success` / `test_index_codebase_failure_sends_error_status`

Failure tests also assert the socket survives by issuing a follow-up `history` action.

Closes #7687

🤖 Generated with [Claude Code](https://claude.com/claude-code)