### PR TITLE
Enforce Signal shape invariants with always-on raises (#7704)

### DIFF
--- a/src/shared/python/signal_toolkit/core.py
+++ b/src/shared/python/signal_toolkit/core.py
@@ -63,29 +63,29 @@ class Signal:
         self.time = np.asarray(self.time, dtype=np.float64)
         self.values = np.asarray(self.values, dtype=np.float64)
 
-        require(
-            self.time.ndim == 1,
-            f"Time must be 1D array, got shape {self.time.shape}",
-            self.time.shape,
-        )
+        # Structural invariants are enforced with always-on raises rather than
+        # require() because require() early-returns when the contract level is
+        # OFF (and is a no-op under ``python -O``). Constructing a Signal with
+        # mismatched shapes is a data-model corruption that must never be
+        # silently accepted, regardless of the runtime contract level.
+        if self.time.ndim != 1:
+            raise ValueError(f"Time must be 1D array, got shape {self.time.shape}")
 
         if self.values.ndim == 1:
-            require(
-                len(self.time) == len(self.values),
-                f"Time and values must have same length: "
-                f"{len(self.time)} vs {len(self.values)}",
-            )
+            if len(self.time) != len(self.values):
+                raise ValueError(
+                    f"Time and values must have same length: "
+                    f"{len(self.time)} vs {len(self.values)}"
+                )
         elif self.values.ndim == 2:
-            require(
-                self.values.shape[0] == len(self.time),
-                f"First dimension of values must match time length: "
-                f"{self.values.shape[0]} vs {len(self.time)}",
-            )
+            if self.values.shape[0] != len(self.time):
+                raise ValueError(
+                    f"First dimension of values must match time length: "
+                    f"{self.values.shape[0]} vs {len(self.time)}"
+                )
         else:
-            require(
-                False,
-                f"Values must be 1D or 2D array, got shape {self.values.shape}",
-                self.values.shape,
+            raise ValueError(
+                f"Values must be 1D or 2D array, got shape {self.values.shape}"
             )
 
     @property

--- a/tests/unit/shared_python/test_signal_toolkit_core.py
+++ b/tests/unit/shared_python/test_signal_toolkit_core.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 from src.shared.python.signal_toolkit.core import Signal, SignalGenerator
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def t100() -> np.ndarray:
@@ -36,6 +38,54 @@ class TestSignal:
     def test_invalid_length_mismatch(self, t100: np.ndarray) -> None:
         with pytest.raises((ValueError, AssertionError)):
             Signal(time=t100, values=np.zeros(50))
+
+    def test_invalid_values_3d_raises(self, t100: np.ndarray) -> None:
+        with pytest.raises(ValueError):
+            Signal(time=t100, values=np.zeros((100, 2, 2)))
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            # mismatched 1D length
+            "Signal(time=np.zeros(3), values=np.zeros(4))",
+            # 2D time array (ndim != 1)
+            "Signal(time=np.zeros((2, 2)), values=np.zeros(4))",
+            # 3D values array
+            "Signal(time=np.zeros(3), values=np.zeros((3, 2, 2)))",
+        ],
+    )
+    def test_structural_invariants_enforced_under_O(self, snippet: str) -> None:
+        """Issue #7704: shape invariants must raise even under ``python -O``.
+
+        ``require()`` is a no-op when the contract level is OFF (which is the
+        default under ``-O``), so the structural checks must use always-on
+        ``raise`` statements. Run a child interpreter with ``-O`` to confirm
+        the malformed Signal is rejected rather than silently constructed.
+        """
+        import subprocess
+        import sys
+
+        program = (
+            "import numpy as np\n"
+            "from src.shared.python.signal_toolkit.core import Signal\n"
+            "try:\n"
+            f"    {snippet}\n"
+            "except ValueError:\n"
+            "    print('REJECTED')\n"
+            "else:\n"
+            "    print('ACCEPTED')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-O", "-c", program],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert "REJECTED" in result.stdout, (
+            f"invalid Signal accepted under -O: stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        )
 
     def test_fs_property(self, basic_signal: Signal) -> None:
         assert np.isclose(basic_signal.fs, 99.0, rtol=0.02)


### PR DESCRIPTION
## Summary

`Signal.__post_init__` validated all structural invariants (time.ndim==1, time/values length match, 1D/2D values constraint) solely through `require()`. The active `require()` early-returns when the contract level is OFF — the default under `python -O` — so a `Signal` with mismatched shapes was silently constructed and later failed deep inside numpy or yielded wrong results.

Replaced the structural checks in `src/shared/python/signal_toolkit/core.py` with always-on `raise ValueError`, independent of contract level. `require()` is retained for the optional `resample` precondition.

## Test

`tests/unit/shared_python/test_signal_toolkit_core.py`:
- new 3D-values rejection test
- subprocess test constructing malformed Signals under `python -O` and asserting they are rejected

Refs #7704

Issue closure note: #7704 will be closed after merge because the anti-phantom guard can reject closing keywords on branches without a reliable issue-body path match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)