### PR TITLE
⚡ Bolt: [performance improvement] Added learning for avoiding false np.einsum optimizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2026-06-18 - Replacing np.linalg.norm with math.hypot in Camera Controllers
 **Learning:** `np.linalg.norm` creates significant overhead for small arrays. For calculating distances in a camera controller (often 3D or 2D offsets), `math.hypot` is significantly faster, avoiding intermediate array allocation and function dispatch overhead.
 **Action:** Replace `np.linalg.norm(offset)` with `math.hypot(offset[0], offset[1], offset[2])` for 3D vectors and `math.hypot(velocity[0], velocity[1])` for 2D vectors in camera and UI updates to prevent unnecessary overhead. Ensure the lengths are fixed and known.
+
+## 2026-06-21 - Avoiding False np.einsum Optimizations
+**Learning:** Replacing simple `np.sum(arr, axis=1)` calls with `np.einsum('ij->i', arr)` does not improve performance and is based on a false premise. Simple `np.sum` calls do not allocate temporary arrays (unlike chained operations like `x * y + z`) and are backed by highly optimized C code. `np.einsum` incurs parsing overhead for its subscript string, making it slower and less readable for basic reductions.
+**Action:** Do not replace `np.sum(arr, axis=1)` on plain arrays with `np.einsum`. Only use `np.einsum` to fuse operations where actual temporary arrays would otherwise be allocated (e.g., replacing `np.sum(x * y, axis=1)` with `np.einsum('ij,ij->i', x, y)`).


### PR DESCRIPTION
💡 What: Documented that replacing simple `np.sum` calls with `np.einsum` does not actually improve performance.
🎯 Why: Simple `np.sum` calls do not allocate temporary arrays (unlike chained operations like `x * y + z`) and are backed by highly optimized C code, while `np.einsum` incurs parsing overhead for its subscript string, making it slower and less readable for basic reductions.
📊 Impact: Helps prevent applying false optimizations in future work.
🔬 Measurement: Verify via code review.

---
*PR created automatically by Jules for task [12745657485533537716](https://jules.google.com/task/12745657485533537716) started by @dieterolson*