### PR TITLE
Harden URDF parsing in models route (Part of #7740)

### DIFF
--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -17,8 +17,6 @@ from typing import Any
 import defusedxml.ElementTree as ElementTree
 from fastapi import APIRouter, Depends, HTTPException
 
-from src.shared.python.core.contracts import postcondition, precondition
-
 from ..dependencies import get_logger
 from ..models.responses import (
     ModelListResponse,
@@ -44,6 +42,98 @@ _MODEL_DIRS = [
 def _find_project_root() -> Path:
     """Find the project root directory by looking for known markers."""
     return find_project_root()
+
+
+# Default attribute values for URDF vector/color attributes.
+_DEFAULT_XYZ = "0 0 0"
+_DEFAULT_RPY = "0 0 0"
+_DEFAULT_AXIS = "0 0 1"
+_DEFAULT_RGBA = "0.5 0.5 0.5 1.0"
+
+
+def _parse_floats(text: str, element: str) -> list[float]:
+    """Parse a whitespace-separated list of floats from a URDF attribute.
+
+    Args:
+        text: Raw attribute text (e.g. ``"0 0 0.2"``).
+        element: Human-readable name of the offending attribute/element,
+            used in the error message.
+
+    Returns:
+        List of parsed floats.
+
+    Raises:
+        ValueError: If any token is not a valid float.
+    """
+    try:
+        return [float(token) for token in text.split()]
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid numeric value in URDF {element} attribute: {text!r}"
+        ) from exc
+
+
+def _parse_scalar(text: str, element: str) -> float:
+    """Parse a single float from a URDF attribute.
+
+    Args:
+        text: Raw attribute text.
+        element: Name of the offending attribute/element for errors.
+
+    Returns:
+        The parsed float.
+
+    Raises:
+        ValueError: If the value is not a valid float.
+    """
+    try:
+        return float(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid numeric value in URDF {element} attribute: {text!r}"
+        ) from exc
+
+
+def _parse_vec3(text: str, element: str) -> list[float]:
+    """Parse and validate a 3-component vector from a URDF attribute.
+
+    Args:
+        text: Raw attribute text.
+        element: Name of the offending attribute/element for errors.
+
+    Returns:
+        A list of exactly three floats.
+
+    Raises:
+        ValueError: If the value is non-numeric or not exactly 3 components.
+    """
+    values = _parse_floats(text, element)
+    if len(values) != 3:
+        raise ValueError(
+            f"URDF {element} must have 3 components, got {len(values)}: {text!r}"
+        )
+    return values
+
+
+def _parse_color(text: str, element: str = "color rgba") -> list[float]:
+    """Parse and validate an RGBA color from a URDF attribute.
+
+    Args:
+        text: Raw ``rgba`` attribute text.
+        element: Name of the offending attribute/element for errors.
+
+    Returns:
+        A list of exactly four floats.
+
+    Raises:
+        ValueError: If the value is non-numeric or not exactly 4 components.
+    """
+    values = _parse_floats(text, element)
+    if len(values) != 4:
+        raise ValueError(
+            f"URDF {element} must have 4 components, got {len(values)}: {text!r}"
+        )
+    return values
 
 
 def discover_models() -> list[dict[str, str]]:
@@ -113,9 +203,9 @@ def _parse_urdf_geometry(  # noqa: C901
     Returns:
         Dictionary with geometry_type, dimensions, origin, rotation, and color.
     """
-    if not (materials is not None):
+    if materials is None:
         raise ValueError("materials must be provided")
-    if not (visual_elem is not None):
+    if visual_elem is None:
         raise ValueError("visual_elem must be provided")
     result: dict[str, Any] = {
         "geometry_type": "box",
@@ -129,10 +219,12 @@ def _parse_urdf_geometry(  # noqa: C901
     # Parse origin
     origin_elem = visual_elem.find("origin")
     if origin_elem is not None:
-        xyz = origin_elem.get("xyz", "0 0 0")
-        rpy = origin_elem.get("rpy", "0 0 0")
-        result["origin"] = [float(x) for x in xyz.split()]
-        result["rotation"] = [float(x) for x in rpy.split()]
+        result["origin"] = _parse_vec3(
+            origin_elem.get("xyz", _DEFAULT_XYZ), "visual origin xyz"
+        )
+        result["rotation"] = _parse_vec3(
+            origin_elem.get("rpy", _DEFAULT_RPY), "visual origin rpy"
+        )
 
     # Parse geometry
     geom_elem = visual_elem.find("geometry")
@@ -144,8 +236,7 @@ def _parse_urdf_geometry(  # noqa: C901
 
         if box is not None:
             result["geometry_type"] = "box"
-            size = box.get("size", "0.1 0.1 0.1")
-            dims = [float(x) for x in size.split()]
+            dims = _parse_floats(box.get("size", "0.1 0.1 0.1"), "box size")
             result["dimensions"] = {
                 "width": dims[0] if len(dims) > 0 else 0.1,
                 "height": dims[1] if len(dims) > 1 else 0.1,
@@ -154,19 +245,22 @@ def _parse_urdf_geometry(  # noqa: C901
         elif cylinder is not None:
             result["geometry_type"] = "cylinder"
             result["dimensions"] = {
-                "radius": float(cylinder.get("radius", "0.05")),
-                "length": float(cylinder.get("length", "0.3")),
+                "radius": _parse_scalar(
+                    cylinder.get("radius", "0.05"), "cylinder radius"
+                ),
+                "length": _parse_scalar(
+                    cylinder.get("length", "0.3"), "cylinder length"
+                ),
             }
         elif sphere is not None:
             result["geometry_type"] = "sphere"
             result["dimensions"] = {
-                "radius": float(sphere.get("radius", "0.1")),
+                "radius": _parse_scalar(sphere.get("radius", "0.1"), "sphere radius"),
             }
         elif mesh is not None:
             result["geometry_type"] = "mesh"
             result["mesh_path"] = mesh.get("filename", "")
-            scale = mesh.get("scale", "1 1 1")
-            scale_vals = [float(x) for x in scale.split()]
+            scale_vals = _parse_floats(mesh.get("scale", "1 1 1"), "mesh scale")
             result["dimensions"] = {
                 "scale_x": scale_vals[0] if len(scale_vals) > 0 else 1.0,
                 "scale_y": scale_vals[1] if len(scale_vals) > 1 else 1.0,
@@ -179,8 +273,7 @@ def _parse_urdf_geometry(  # noqa: C901
         mat_name = mat_elem.get("name", "")
         color_elem = mat_elem.find("color")
         if color_elem is not None:
-            rgba = color_elem.get("rgba", "0.5 0.5 0.5 1.0")
-            result["color"] = [float(x) for x in rgba.split()]
+            result["color"] = _parse_color(color_elem.get("rgba", _DEFAULT_RGBA))
         elif mat_name in materials:
             result["color"] = materials[mat_name]
 
@@ -201,8 +294,7 @@ def _parse_urdf_materials(root: Any) -> dict[str, list[float]]:
         mat_name = mat_elem.get("name", "")
         color_elem = mat_elem.find("color")
         if color_elem is not None:
-            rgba = color_elem.get("rgba", "0.5 0.5 0.5 1.0")
-            materials[mat_name] = [float(x) for x in rgba.split()]
+            materials[mat_name] = _parse_color(color_elem.get("rgba", _DEFAULT_RGBA))
     return materials
 
 
@@ -218,9 +310,9 @@ def _parse_urdf_links(
     Returns:
         List of URDFLinkGeometry descriptors for each link with visual data.
     """
-    if not (materials is not None):
+    if materials is None:
         raise ValueError("materials must be provided")
-    if not (root is not None):
+    if root is None:
         raise ValueError("root must be provided")
     links: list[URDFLinkGeometry] = []
     for link_elem in root.findall("link"):
@@ -259,23 +351,20 @@ def _parse_urdf_joint_element(joint_elem: Any) -> URDFJointDescriptor:
     rotation = [0.0, 0.0, 0.0]
     origin_elem = joint_elem.find("origin")
     if origin_elem is not None:
-        xyz = origin_elem.get("xyz", "0 0 0")
-        rpy = origin_elem.get("rpy", "0 0 0")
-        origin = [float(x) for x in xyz.split()]
-        rotation = [float(x) for x in rpy.split()]
+        origin = _parse_vec3(origin_elem.get("xyz", _DEFAULT_XYZ), "joint origin xyz")
+        rotation = _parse_vec3(origin_elem.get("rpy", _DEFAULT_RPY), "joint origin rpy")
 
     axis = [0.0, 0.0, 1.0]
     axis_elem = joint_elem.find("axis")
     if axis_elem is not None:
-        axis_str = axis_elem.get("xyz", "0 0 1")
-        axis = [float(x) for x in axis_str.split()]
+        axis = _parse_vec3(axis_elem.get("xyz", _DEFAULT_AXIS), "joint axis xyz")
 
     lower_limit = None
     upper_limit = None
     limit_elem = joint_elem.find("limit")
     if limit_elem is not None:
-        lower_limit = float(limit_elem.get("lower", "0"))
-        upper_limit = float(limit_elem.get("upper", "0"))
+        lower_limit = _parse_scalar(limit_elem.get("lower", "0"), "joint limit lower")
+        upper_limit = _parse_scalar(limit_elem.get("upper", "0"), "joint limit upper")
 
     return URDFJointDescriptor(
         name=joint_name,
@@ -318,7 +407,7 @@ def _find_root_link(links: list[URDFLinkGeometry], child_links: set[str]) -> str
     Returns:
         Name of the root link, or "base" if none can be determined.
     """
-    if not (links is not None):
+    if links is None:
         raise ValueError("links must be provided")
     all_link_names = {link.link_name for link in links}
     root_candidates = all_link_names - child_links
@@ -329,14 +418,6 @@ def _find_root_link(links: list[URDFLinkGeometry], child_links: set[str]) -> str
     )
 
 
-@precondition(
-    lambda urdf_content: urdf_content is not None and len(urdf_content) > 0,
-    "URDF content must be a non-empty string",
-)
-@postcondition(
-    lambda result: result is not None and result.model_name is not None,
-    "Parsed URDF model must have a valid model name",
-)
 def _parse_urdf(urdf_content: str) -> URDFModelResponse:
     """Parse a URDF XML string into a URDFModelResponse.
 
@@ -344,11 +425,14 @@ def _parse_urdf(urdf_content: str) -> URDFModelResponse:
         urdf_content: Raw URDF XML string.
 
     Returns:
-        Parsed model data.
+        Parsed model data. ``model_name`` is always populated (defaults to
+        ``"unknown"`` when the ``<robot>`` element has no ``name`` attribute).
 
     Raises:
-        ValueError: If the URDF cannot be parsed.
+        ValueError: If ``urdf_content`` is empty or the URDF cannot be parsed.
     """
+    if not urdf_content:
+        raise ValueError("URDF content must be a non-empty string")
     try:
         root = ElementTree.fromstring(urdf_content)
     except ElementTree.ParseError as e:
@@ -381,7 +465,13 @@ async def list_models(
     try:
         models = discover_models()
         return ModelListResponse(models=models)
-    except (RuntimeError, TypeError, AttributeError) as exc:
+    except (
+        RuntimeError,
+        TypeError,
+        AttributeError,
+        OSError,
+        ValueError,
+    ) as exc:
         if logger:
             logger.exception("Error listing models")
         raise HTTPException(
@@ -421,11 +511,20 @@ async def get_model_urdf(  # noqa: C901
             break
 
     if model_entry is None:
-        # Try partial match
-        for m in models:
-            if model_name in m["name"] or m["name"].endswith(model_name):
-                model_entry = m
-                break
+        # Fall back to an exact basename match (names may be disambiguated
+        # with a "parent_dir/name" prefix in discover_models()). Require an
+        # unambiguous single match so resolution is deterministic.
+        basename_matches = [
+            m for m in models if m["name"].rsplit("/", 1)[-1] == model_name
+        ]
+        if len(basename_matches) == 1:
+            model_entry = basename_matches[0]
+        elif len(basename_matches) > 1:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Model '{model_name}' is ambiguous. "
+                f"Candidates: {[m['name'] for m in basename_matches]}",
+            )
 
     if model_entry is None:
         raise HTTPException(

--- a/tests/api/test_phase3_api.py
+++ b/tests/api/test_phase3_api.py
@@ -640,6 +640,87 @@ class TestURDFParser:
         assert result.joints[0].parent_link == "a"
         assert result.joints[1].parent_link == "b"
 
+    def test_parse_empty_content_raises(self) -> None:
+        """Empty URDF content raises a descriptive ValueError."""
+        from src.api.routes.models import _parse_urdf
+
+        with pytest.raises(ValueError, match="non-empty"):
+            _parse_urdf("")
+
+    def test_parse_non_numeric_box_size_raises(self) -> None:
+        """A non-numeric float attribute raises ValueError naming the element."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="bad_box">
+          <link name="l">
+            <visual>
+              <geometry><box size="0.1 abc 0.1"/></geometry>
+            </visual>
+          </link>
+        </robot>"""
+        with pytest.raises(ValueError, match="box size"):
+            _parse_urdf(urdf)
+
+    def test_parse_non_numeric_origin_raises(self) -> None:
+        """A non-numeric origin xyz attribute raises ValueError."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="bad_origin">
+          <link name="l">
+            <visual>
+              <geometry><sphere radius="0.1"/></geometry>
+              <origin xyz="0 0 nan_x" rpy="0 0 0"/>
+            </visual>
+          </link>
+        </robot>"""
+        with pytest.raises(ValueError, match="visual origin xyz"):
+            _parse_urdf(urdf)
+
+    def test_parse_short_origin_vector_raises(self) -> None:
+        """An origin xyz with fewer than 3 components raises ValueError."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="short_origin">
+          <link name="l">
+            <visual>
+              <geometry><sphere radius="0.1"/></geometry>
+              <origin xyz="0 0" rpy="0 0 0"/>
+            </visual>
+          </link>
+        </robot>"""
+        with pytest.raises(ValueError, match="3 components"):
+            _parse_urdf(urdf)
+
+    def test_parse_empty_axis_vector_raises(self) -> None:
+        """An empty joint axis attribute raises ValueError (not a silent [])."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="empty_axis">
+          <link name="a"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <link name="b"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <joint name="j" type="revolute">
+            <parent link="a"/><child link="b"/>
+            <axis xyz=""/>
+          </joint>
+        </robot>"""
+        with pytest.raises(ValueError, match="joint axis xyz"):
+            _parse_urdf(urdf)
+
+    def test_parse_short_rgba_color_raises(self) -> None:
+        """An rgba color with fewer than 4 components raises ValueError."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="short_rgba">
+          <link name="l">
+            <visual>
+              <geometry><sphere radius="0.1"/></geometry>
+              <material name="m"><color rgba="1 0 0"/></material>
+            </visual>
+          </link>
+        </robot>"""
+        with pytest.raises(ValueError, match="4 components"):
+            _parse_urdf(urdf)
+
 
 # ──────────────────────────────────────────────────────────────
 #  Model Discovery Tests (#1201)

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -50,3 +50,64 @@ def test_get_model_urdf_not_found(client: TestClient) -> None:
     """Test getting parsed URDF data for non-existent model."""
     response = client.get("/models/unknown_model/urdf")
     assert response.status_code == 404
+
+
+def test_get_model_urdf_basename_fallback(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A disambiguated 'dir/name' entry resolves by exact basename."""
+    import src.api.routes.models as models_mod
+
+    monkeypatch.setattr(
+        models_mod,
+        "discover_models",
+        lambda: [
+            {"name": "sub/widget", "format": "urdf", "path": "missing/widget.urdf"},
+        ],
+    )
+    # Exact basename "widget" matches the single "sub/widget" entry. The file
+    # does not exist, so resolution gets past the name lookup and 404s on the
+    # missing file (deterministic basename match, not a substring guess).
+    response = client.get("/models/widget/urdf")
+    assert response.status_code == 404
+    assert "file not found" in response.json()["detail"].lower()
+
+
+def test_get_model_urdf_ambiguous_basename(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two entries sharing a basename yield a 404 listing the candidates."""
+    import src.api.routes.models as models_mod
+
+    monkeypatch.setattr(
+        models_mod,
+        "discover_models",
+        lambda: [
+            {"name": "a/widget", "format": "urdf", "path": "a/widget.urdf"},
+            {"name": "b/widget", "format": "urdf", "path": "b/widget.urdf"},
+        ],
+    )
+    response = client.get("/models/widget/urdf")
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "ambiguous" in detail.lower()
+    assert "a/widget" in detail and "b/widget" in detail
+
+
+def test_get_model_urdf_no_substring_match(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A substring of a model name no longer resolves (deterministic match)."""
+    import src.api.routes.models as models_mod
+
+    monkeypatch.setattr(
+        models_mod,
+        "discover_models",
+        lambda: [
+            {"name": "simple_pendulum", "format": "urdf", "path": "x/sp.urdf"},
+        ],
+    )
+    # "pendulum" used to match via the old substring fallback; now it 404s.
+    response = client.get("/models/pendulum/urdf")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()


### PR DESCRIPTION
Part of #7740.

Consolidated cluster of deferred P2 findings in `src/api/routes/models.py` (URDF parsing) and its tests. Surgical, behavior-preserving except where a finding fixes a real correctness bug (malformed-input handling and non-deterministic partial match).

## Findings addressed

- [x] **[E] Extract duplicated rgba color parsing + magic defaults** (was models.py:182/204) — added `_parse_color`/`_parse_vec3`/`_parse_floats`/`_parse_scalar` helpers + module-constant defaults (`_DEFAULT_XYZ/RPY/AXIS/RGBA`); re-pointed all duplicate parse sites (geometry, materials, joints).
- [x] **[F] Guard `float()` of URDF attributes** (was models.py:134) — all attribute parsing now goes through `_parse_floats`/`_parse_scalar`, which catch `ValueError` and re-raise naming the offending element (e.g. `"box size"`, `"visual origin xyz"`).
- [x] **[F] Validate vector length after parsing** — `_parse_vec3` enforces exactly 3 components (xyz/rpy/axis); `_parse_color` enforces 4 (rgba). Empty/short attrs now raise instead of yielding `[]`/2-element lists.
- [x] **[F] Broaden `list_models` exception guard** (was models.py:384) — added `OSError` and `ValueError` so `logger.exception` runs for `rglob` (OSError/PermissionError) and `relative_to` (ValueError) failures.
- [x] **[F] Tighten partial-match in `get_model_urdf`** (was models.py:426) — replaced unanchored substring/suffix match with exact basename equality; returns 404 listing candidates on ambiguity. Resolution is now deterministic.
- [x] **[F] Replace `-O`-strippable contract decorators on `_parse_urdf`** (was models.py:332) — dropped `@precondition`/`@postcondition`; non-empty input is now enforced by an explicit body `raise ValueError`. The structurally-guaranteed postcondition (model_name always set) is dropped and documented in the docstring instead.
- [x] **[F] Simplify double-negative precondition checks** — `if not (x is not None)` → `if x is None` at all three sites (`_parse_urdf_geometry`, `_parse_urdf_links`, `_find_root_link`).
- [x] **[G] Add validation + partial-match tests** — `TestURDFParser` gains non-numeric box size, non-numeric/short origin, empty axis, short rgba, and empty-content cases; `tests/unit/api/test_routes_models.py` gains basename-fallback, ambiguous-basename, and no-substring-match cases for `get_model_urdf`.

## Validation

- `tests/api/test_phase3_api.py` + `tests/unit/api/test_routes_models.py`: **56 passed** (repo venv).
- `ruff check` + `ruff format --check`: clean.
- File size 568 lines (under 1200 budget).

Real bugs fixed: malformed/short/empty URDF numeric attributes previously produced raw `ValueError`/`IndexError` or silently-wrong short vectors; `get_model_urdf` previously resolved by non-deterministic substring match.
