### PR TITLE
Harden API auth/security (Part of #7740)

### DIFF
--- a/src/api/auth/security.py
+++ b/src/api/auth/security.py
@@ -2,18 +2,12 @@
 
 import os
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from typing import Any, cast
 
-# Python 3.10 compatibility: timezone.utc was added in 3.11
 from src.api.utils.datetime_compat import UTC
 from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
-
-try:
-    from datetime import timezone
-except ImportError:
-    timezone.utc = timezone.utc  # noqa: UP017
-from typing import Any, cast
 
 import bcrypt
 import jwt
@@ -47,13 +41,48 @@ if not _secret_key_env:
         # code to forge valid JWT tokens. A randomly generated key is unguessable
         # and scoped to this process lifetime, so forged tokens cannot be externally
         # crafted. Tokens will be invalidated on process restart.
+        #
+        # CAVEAT: This key is generated independently per process. In a
+        # multi-worker deployment (e.g. several Gunicorn/Uvicorn workers, or
+        # WEB_CONCURRENCY>1) each worker signs JWTs with a different key, so a
+        # token issued by one worker is rejected by another, producing
+        # intermittent 401s. Set GOLF_API_SECRET_KEY to a shared value to keep
+        # tokens valid across all workers.
         SECRET_KEY = secrets.token_urlsafe(32)
-        logger.warning(
-            "SECURITY WARNING: No GOLF_API_SECRET_KEY or SECRET_KEY env var set. "
-            "A random per-process key has been generated; all JWT tokens will be "
-            "invalidated on restart. Set GOLF_API_SECRET_KEY for production."
-        )
+        try:
+            _web_concurrency = int(os.getenv("WEB_CONCURRENCY", "1"))
+        except ValueError:
+            _web_concurrency = 1
+        if _web_concurrency > 1:
+            logger.error(
+                "SECURITY ERROR: No GOLF_API_SECRET_KEY or SECRET_KEY env var "
+                "set while WEB_CONCURRENCY=%s. Each worker generated a distinct "
+                "per-process key, so JWTs issued by one worker will be rejected "
+                "by the others, causing intermittent 401s. Set "
+                "GOLF_API_SECRET_KEY to a shared, random value.",
+                _web_concurrency,
+            )
+        else:
+            logger.warning(
+                "SECURITY WARNING: No GOLF_API_SECRET_KEY or SECRET_KEY env var "
+                "set. A random per-process key has been generated; all JWT "
+                "tokens will be invalidated on restart and will NOT be valid "
+                "across multiple workers (WEB_CONCURRENCY>1). Set "
+                "GOLF_API_SECRET_KEY for production."
+            )
 elif len(_secret_key_env) < 32:
+    if _environment == "production":
+        logger.error(
+            "SECURITY ERROR: SECRET_KEY is less than 32 characters. A short "
+            "signing key materially weakens HS256 JWT security and is not "
+            "permitted in production. Set GOLF_API_SECRET_KEY or SECRET_KEY to "
+            "a key of at least 32 characters."
+        )
+        raise RuntimeError(
+            "SECRET_KEY must be at least 32 characters in production. Set "
+            "GOLF_API_SECRET_KEY or SECRET_KEY to a longer, randomly generated "
+            "value."
+        )
     logger.warning(
         "SECURITY WARNING: SECRET_KEY is less than 32 characters. "
         "Use a longer, randomly generated key for production."
@@ -80,6 +109,16 @@ _USAGE_QUOTA_FIELDS = {
     "api_calls": "api_calls_per_month",
     "video_analyses": "video_analyses_per_month",
     "simulations": "simulations_per_month",
+}
+
+# Maps a resource type to the User instance attribute holding the current
+# month's usage count. Used for attribute access (getattr/setattr) on User
+# instances, as opposed to ``_USAGE_COUNTER_COLUMNS`` which holds the
+# class-level SQLAlchemy columns used to build UPDATE statements.
+_USAGE_COUNTER_FIELDS = {
+    "api_calls": "api_calls_this_month",
+    "video_analyses": "video_analyses_this_month",
+    "simulations": "simulations_this_month",
 }
 
 
@@ -418,21 +457,11 @@ class UsageTracker:
         if user is None:
             raise ValueError("user must be provided")
 
-        if resource_type == "api_calls":
-            return bool(
-                int(user.api_calls_this_month) < self.quota_limit(user, resource_type)
-            )
-        if resource_type == "video_analyses":
-            return bool(
-                int(user.video_analyses_this_month)
-                < self.quota_limit(user, resource_type)
-            )
-        if resource_type == "simulations":
-            return bool(
-                int(user.simulations_this_month) < self.quota_limit(user, resource_type)
-            )
-
-        return False
+        counter_field = _USAGE_COUNTER_FIELDS.get(resource_type)
+        if counter_field is None:
+            return False
+        current = int(getattr(user, counter_field))
+        return bool(current < self.quota_limit(user, resource_type))
 
     @precondition(
         lambda self, user, resource_type: (
@@ -528,12 +557,10 @@ class UsageTracker:
             user: User to increment usage for
             resource_type: Type of resource used
         """
-        if resource_type == "api_calls":
-            user.api_calls_this_month = int(user.api_calls_this_month) + 1  # type: ignore[assignment]
-        elif resource_type == "video_analyses":
-            user.video_analyses_this_month = int(user.video_analyses_this_month) + 1  # type: ignore[assignment]
-        elif resource_type == "simulations":
-            user.simulations_this_month = int(user.simulations_this_month) + 1  # type: ignore[assignment]
+        counter_field = _USAGE_COUNTER_FIELDS.get(resource_type)
+        if counter_field is None:
+            return
+        setattr(user, counter_field, int(getattr(user, counter_field)) + 1)
 
     def get_usage_summary(self, user: User) -> dict[str, Any]:
         """Get usage summary for a user.

--- a/tests/unit/api/test_security.py
+++ b/tests/unit/api/test_security.py
@@ -19,6 +19,75 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
+class _FakeClock:
+    """Deterministic stand-in for the ``time`` module used by AuthCache.
+
+    Exposes a ``time()`` method so it can be assigned to ``AuthCache._time``,
+    letting tests control TTL expiry without real sleeps.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+class TestSecretKeyValidation:
+    """Module-import-time validation of the JWT signing secret."""
+
+    @staticmethod
+    def _reload_security() -> object:
+        import importlib
+
+        import src.api.auth.security as security_module
+
+        return importlib.reload(security_module)
+
+    def test_short_key_rejected_in_production(self) -> None:
+        """A <32-char SECRET_KEY must raise in production, not just warn."""
+        with patch.dict(
+            os.environ,
+            {"GOLF_API_SECRET_KEY": "short", "ENVIRONMENT": "production"},
+            clear=False,
+        ):
+            os.environ.pop("SECRET_KEY", None)
+            with pytest.raises(RuntimeError, match="at least 32 characters"):
+                self._reload_security()
+        # Restore a clean module state for subsequent tests.
+        self._reload_security()
+
+    def test_short_key_warns_in_development(self) -> None:
+        """A <32-char SECRET_KEY is accepted (warn-only) outside production."""
+        with patch.dict(
+            os.environ,
+            {"GOLF_API_SECRET_KEY": "short", "ENVIRONMENT": "development"},
+            clear=False,
+        ):
+            os.environ.pop("SECRET_KEY", None)
+            module = self._reload_security()
+            secret_key = module.SECRET_KEY  # type: ignore[attr-defined]
+            assert secret_key == "short"
+        self._reload_security()
+
+    def test_long_key_accepted_in_production(self) -> None:
+        """A >=32-char SECRET_KEY is accepted in production."""
+        long_key = "x" * 40
+        with patch.dict(
+            os.environ,
+            {"GOLF_API_SECRET_KEY": long_key, "ENVIRONMENT": "production"},
+            clear=False,
+        ):
+            os.environ.pop("SECRET_KEY", None)
+            module = self._reload_security()
+            secret_key = module.SECRET_KEY  # type: ignore[attr-defined]
+            assert secret_key == long_key
+        self._reload_security()
+
+
 class TestSecurityManagerContract:
     """Design by Contract tests for SecurityManager class."""
 
@@ -640,6 +709,82 @@ class TestAuthCache:
 
             assert cache.get("key1") == "value1"
             assert cache.get("key2") == "value2"
+
+    def test_get_expires_entry_after_ttl(self) -> None:
+        """Expired entries are evicted on read and return None."""
+        with patch.dict(
+            os.environ, {"GOLF_API_SECRET_KEY": "test-secret-key-32chars-long!!"}
+        ):
+            from src.api.auth.security import AuthCache
+
+            clock = _FakeClock(start=1000.0)
+            cache = AuthCache(ttl_seconds=10)
+            cache._time = clock
+
+            cache.set("k", "v")
+            # Within TTL: still cached.
+            clock.advance(9.0)
+            assert cache.get("k") == "v"
+            # Past TTL: expired, returns None and the entry is deleted.
+            clock.advance(2.0)  # now 11s since set, ttl is 10
+            assert cache.get("k") is None
+            # Lookup token is internal; assert the backing store was pruned.
+            assert cache._cache == {}
+
+    def test_ttl_monkeypatch_overrides_instance_value(self) -> None:
+        """Monkeypatching the class TTL_SECONDS wins over the instance TTL."""
+        with patch.dict(
+            os.environ, {"GOLF_API_SECRET_KEY": "test-secret-key-32chars-long!!"}
+        ):
+            from src.api.auth.security import AuthCache
+
+            clock = _FakeClock(start=0.0)
+            cache = AuthCache(ttl_seconds=10)
+            cache._time = clock
+            cache.set("k", "v")
+
+            # Shrink the effective TTL via the class attribute. _effective_ttl
+            # detects the monkeypatch and prefers it over the instance's 10s.
+            with patch.object(AuthCache, "TTL_SECONDS", 1):
+                clock.advance(2.0)  # 2s > patched 1s TTL
+                assert cache.get("k") is None
+
+    def test_evict_overflow_is_bounded_fifo(self) -> None:
+        """The cache stays bounded and evicts the oldest entry first (FIFO)."""
+        with patch.dict(
+            os.environ, {"GOLF_API_SECRET_KEY": "test-secret-key-32chars-long!!"}
+        ):
+            from src.api.auth.security import AuthCache
+
+            cache = AuthCache(ttl_seconds=300, max_entries=2)
+
+            cache.set("first", "1")
+            cache.set("second", "2")
+            assert len(cache._cache) == 2
+
+            # Inserting a third entry must evict the oldest ("first") to stay
+            # within max_entries, leaving the two most-recent entries.
+            cache.set("third", "3")
+            assert len(cache._cache) == 2
+            assert cache.get("first") is None
+            assert cache.get("second") == "2"
+            assert cache.get("third") == "3"
+
+    def test_max_entries_monkeypatch_overrides_instance_value(self) -> None:
+        """Monkeypatching MAX_ENTRIES wins over the instance bound."""
+        with patch.dict(
+            os.environ, {"GOLF_API_SECRET_KEY": "test-secret-key-32chars-long!!"}
+        ):
+            from src.api.auth.security import AuthCache
+
+            cache = AuthCache(ttl_seconds=300, max_entries=100)
+            with patch.object(AuthCache, "MAX_ENTRIES", 1):
+                cache.set("a", "1")
+                cache.set("b", "2")
+                # Bound is the patched value of 1, so only the newest remains.
+                assert len(cache._cache) == 1
+                assert cache.get("a") is None
+                assert cache.get("b") == "2"
 
 
 class TestComputePrefixHash:


### PR DESCRIPTION
Part of #7740 — deferred P2 findings in `src/api/auth/security.py`.

Addresses:
- [G] Remove dead/broken timezone shim (security.py:12-15) — no-op self-assign, false "added in 3.11" comment
- [G] Reject SECRET_KEY <32 chars in production (raise RuntimeError; warn-only in dev)
- [G] Document per-worker dev-key divergence warning
- [I] Collapse triple resource-type branching in check_quota/increment_usage via the existing `_USAGE_*` maps (getattr)
- [B] Add TTL-expiry / monkeypatch / FIFO-eviction tests for AuthCache with an injected fake clock

Production auth behavior unchanged except the new short-key rejection (production only). Dev/test behavior preserved.
