### PR TITLE
Harden simulation_ws + data_explorer API routes (Part of #7740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the simulation WebSocket and data-explorer API routes (deferred P2
+  findings from #7740): the WS start guard now rejects a non-positive
+  `speed_factor` instead of silently clamping it to 1.0, and its duration /
+  timestep bounds reuse the Pydantic `SimulationRequest` constants
+  (`MAX_SIMULATION_DURATION` / `MAX_TIMESTEP` / `MIN_TIMESTEP`) so a value
+  between the old looser WS caps and the model caps no longer passes the WS
+  layer only to fail validation with a generic error. The repeated
+  `app.state.simulation_service.stats` reach-through chain was collapsed into a
+  single `_resolve_sim_stats` accessor, and the previously-untested
+  `_run_simulation_loop` success paths (frame emission/throttle, pause/resume,
+  real-time pacing, live-analysis) now have direct async coverage. In the data
+  explorer, `_find_dataset_path` rejects glob metacharacters and matches by
+  exact filename (closing a wildcard existence oracle), `GET /datasets` bounds
+  its recursive scan with `os.scandir` + offset/limit and a hard cap instead of
+  sorting the whole tree synchronously, and the dead contract-violating
+  `_store_cached_dataset` helper was removed. Added filter operator/edge-case
+  and ambiguous-name 409 tests.
 - Rendered the catch-all 404 route synchronously so unknown deep links show the
   recoverable branded "Page not found" screen immediately instead of racing the
   route-level lazy-loading fallback (#7430).

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,8 +38,8 @@
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.465                                            |
-| **Last Spec Update**    | 2026-06-20                                         |
+| **Spec Version**        | 1.0.466                                            |
+| **Last Spec Update**    | 2026-06-21                                         |
 
 ## 2. Purpose & Mission
 
@@ -70,6 +70,15 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-06-21** - Hardened the simulation WebSocket and Data Explorer API
+  routes for deferred #7740 findings: WebSocket start validation now rejects
+  non-positive speed factors and shares duration/timestep bounds with
+  `SimulationRequest`, simulation stats access is centralized behind one
+  helper, Data Explorer dataset lookup rejects glob metacharacters, recursive
+  dataset listing is paginated and bounded, and the dead cache helper was
+  removed. Focused unit-marked tests cover the new WebSocket success/error
+  branches, filter operators, ambiguous dataset names, glob rejection, and
+  bounded listing behavior.
 - **2026-06-20** - Deduplicated the chat WebSocket protocol loop for issue
   #7720: `src/api/routes/chat_ws.py` and the portable chat router factory now
   share one handshake/send/history/new-session/transport-error loop, with
@@ -1851,6 +1860,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-21 | 1.0.466 | Hardened the simulation WebSocket and Data Explorer API routes for deferred #7740 findings. WebSocket start validation now rejects non-positive speed factors and reuses `SimulationRequest` duration/timestep bounds, simulation stats access is centralized behind one helper, Data Explorer dataset lookup rejects glob metacharacters, recursive dataset listing is paginated and bounded, and the dead cache helper was removed. Focused unit-marked tests cover the new WebSocket success/error branches, filter operators, ambiguous dataset names, glob rejection, and bounded listing behavior. |
 | 2026-06-20 | 1.0.465 | Added isolated transition hazard-rule coverage for issue #7715. The MDP transition tests now pin hazard penalties and DbC guard behavior directly so policy updates cannot bypass invalid-state validation. |
 | 2026-06-20 | 1.0.465 | Hoisted OpenSim Manager/Integrator construction out of the perturbation per-step loop for issue #7713, preserving analyzer behavior while avoiding repeated runtime setup on every simulated step. |
 | 2026-06-20 | 1.0.465 | Added chat WebSocket failure-path coverage for issue #7721. `tests/unit/api/test_chat_ws.py` now exercises `refresh_models` provider exceptions and `index_codebase` codemap rebuild exceptions, asserting sanitized client-facing error frames, server-side traceback logging, and continued socket usability after a model refresh failure. |

--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi import APIRouter, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
 
 from src.api.middleware.error_handler import handle_api_errors
@@ -58,11 +58,20 @@ class DatasetInfo(BaseModel):
 
 
 class DatasetListResponse(BaseModel):
-    """Response listing available datasets."""
+    """Response listing available datasets.
+
+    ``total`` reports the number of entries returned in this (paginated) page,
+    preserving the historical field semantics. ``offset``/``limit`` echo the
+    pagination window and ``truncated`` flags when the on-disk scan hit the
+    hard cap and more files may exist beyond the returned page (#7740 H).
+    """
 
     datasets: list[DatasetInfo]
     total: int
     search_dir: str
+    offset: int = 0
+    limit: int = 0
+    truncated: bool = False
 
 
 class DatasetPreviewResponse(BaseModel):
@@ -129,6 +138,14 @@ MAX_DATASET_SIZE_BYTES = 50 * 1024 * 1024  # 50MB max file size
 MAX_DATASET_ROWS = 100000  # 100K rows max
 MAX_DATASET_COLUMNS = 500  # 500 columns max
 MAX_CACHE_AGE_SECONDS = 3600  # 1 hour cache TTL
+
+# Pagination bounds for GET /datasets (finding #7740 H). The handler previously
+# did ``sorted(output_dir.rglob("*"))`` — materializing and sorting the whole
+# tree, then a stat()+header-open per entry, synchronously in an async handler.
+# We now cap the scan: iterate lazily, collect at most this many candidate
+# files, and only header-open the requested page.
+DEFAULT_DATASET_PAGE_LIMIT = 100  # default page size when caller omits ``limit``
+MAX_DATASET_LIST_SCAN = 1000  # hard ceiling on files examined per request
 
 # On-disk JSON has no line-oriented streaming guarantee, so reading a preview /
 # stats / filter source must ``json.loads`` the whole document. To keep that
@@ -562,28 +579,29 @@ async def _get_cached_dataset(
     return columns, rows, dataset_format
 
 
-async def _store_cached_dataset(
-    name: str, columns: list[str], rows: list[dict[str, Any]], dataset_format: str
-) -> None:
-    """Store an imported dataset with duplicate rejection and LRU eviction."""
-    async with _cache_lock:
-        if name in _loaded_datasets:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Dataset '{name}' is already imported",
-            )
-        _loaded_datasets[name] = {
-            "columns": columns,
-            "rows": rows,
-            "format": dataset_format,
-        }
-        _enforce_loaded_dataset_limit_locked()
+# Glob metacharacters that would let a client-supplied dataset name be
+# interpreted as an ``rglob`` *pattern* rather than a literal filename
+# (finding #7740 F): e.g. ``*.csv`` or ``swing*`` would match unintended files
+# and turn the 409-vs-404 distinction into an existence oracle.
+_GLOB_METACHARACTERS = frozenset("*?[]")
 
 
 def _find_dataset_path(name: str) -> Path:
-    """Resolve a dataset filename from output, rejecting ambiguous matches."""
+    """Resolve a dataset filename from output, rejecting ambiguous matches.
+
+    ``name`` is matched as a *literal* filename, never as a glob pattern. Names
+    containing glob metacharacters (``* ? [ ]``) are rejected outright so a
+    client cannot enumerate the output tree via wildcard expansion (#7740 F).
+    """
+    if any(ch in _GLOB_METACHARACTERS for ch in name):
+        raise HTTPException(
+            status_code=400,
+            detail="Dataset name must not contain glob metacharacters (* ? [ ])",
+        )
     output_dir = _get_output_dir()
-    matches = sorted(path for path in output_dir.rglob(name) if path.is_file())
+    matches = sorted(
+        path for path in output_dir.rglob("*") if path.name == name and path.is_file()
+    )
     if not matches:
         raise HTTPException(status_code=404, detail=f"Dataset '{name}' not found")
     if len(matches) > 1:
@@ -734,58 +752,132 @@ def _row_matches_filter(row: dict[str, Any], request: DatasetFilterRequest) -> b
     return num_val <= num_filter
 
 
+_SUPPORTED_DATASET_SUFFIXES = {".csv", ".json", ".hdf5", ".h5", ".c3d"}
+
+
+def _scan_dataset_files(output_dir: Path, scan_cap: int) -> tuple[list[Path], bool]:
+    """Walk ``output_dir`` for dataset files, bounded by ``scan_cap``.
+
+    Uses ``os.scandir`` (not ``Path.rglob("*")``) so directories are skipped
+    before any sorting/stat work, and stops collecting once ``scan_cap`` files
+    have been gathered. Returns the sorted candidate paths plus a ``truncated``
+    flag set when the cap was reached and more files may exist (#7740 H).
+
+    Precondition: ``scan_cap`` must be positive.
+    Postcondition: at most ``scan_cap`` paths are returned.
+    """
+    collected: list[Path] = []
+    truncated = False
+    stack: list[Path] = [output_dir]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                            continue
+                        if not entry.is_file(follow_symlinks=False):
+                            continue
+                    except OSError as exc:
+                        logger.debug("Could not stat %s: %s", entry.path, exc)
+                        continue
+                    suffix = os.path.splitext(entry.name)[1].lower()
+                    if suffix not in _SUPPORTED_DATASET_SUFFIXES:
+                        continue
+                    collected.append(Path(entry.path))
+                    if len(collected) >= scan_cap:
+                        truncated = True
+                        break
+        except OSError as exc:
+            logger.debug("Could not scan %s: %s", current, exc)
+        if truncated:
+            break
+    # Sort only the (bounded) candidate set for a stable, paginated order.
+    collected.sort()
+    return collected, truncated
+
+
+def _dataset_info_for_path(filepath: Path, output_dir: Path) -> DatasetInfo:
+    """Build a ``DatasetInfo`` for a single on-disk dataset file."""
+    columns: list[str] = []
+    suffix = filepath.suffix.lower()
+    try:
+        if suffix == ".csv":
+            with open(filepath, encoding="utf-8", newline="") as f:
+                columns = next(csv.reader(f), [])
+        elif suffix == ".json":
+            # Stream only the header/first object instead of json.load()-ing a
+            # possibly-huge file (issue #6990).
+            columns = _stream_json_columns(filepath)
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        logger.debug("Could not read columns from %s: %s", filepath.name, exc)
+
+    # SECURITY (issue #6636 F6): never return absolute server paths. Expose
+    # only the path relative to the output dir so the filesystem layout is not
+    # leaked to clients.
+    try:
+        rel_path = str(filepath.relative_to(output_dir))
+    except ValueError:
+        rel_path = filepath.name
+
+    try:
+        size_bytes = filepath.stat().st_size
+    except OSError:
+        size_bytes = 0
+
+    return DatasetInfo(
+        name=filepath.name,
+        path=rel_path,
+        format=filepath.suffix.lstrip("."),
+        size_bytes=size_bytes,
+        columns=columns,
+    )
+
+
 # ── Endpoints ──
 
 
 @router.get("/datasets", response_model=DatasetListResponse)
-async def list_datasets() -> DatasetListResponse:
+async def list_datasets(
+    offset: int = Query(0, ge=0, description="Number of on-disk files to skip"),
+    limit: int = Query(
+        DEFAULT_DATASET_PAGE_LIMIT,
+        ge=1,
+        le=MAX_DATASET_LIST_SCAN,
+        description="Maximum number of on-disk datasets to return",
+    ),
+) -> DatasetListResponse:
     """List available datasets in the output directory.
+
+    The on-disk scan is bounded (#7740 H): the directory tree is walked lazily
+    with ``os.scandir`` up to ``MAX_DATASET_LIST_SCAN`` files, and only the
+    requested ``offset``/``limit`` window is header-opened. Imported (in-memory)
+    datasets are always appended.
 
     See issue #1206
     """
     output_dir = _get_output_dir()
     datasets: list[DatasetInfo] = []
+    truncated = False
+    on_disk_names: set[str] = set()
 
     if output_dir.exists():
-        supported = {".csv", ".json", ".hdf5", ".h5", ".c3d"}
-        for filepath in sorted(output_dir.rglob("*")):
-            if filepath.suffix.lower() in supported and filepath.is_file():
-                columns: list[str] = []
-                try:
-                    if filepath.suffix.lower() == ".csv":
-                        with open(filepath, encoding="utf-8", newline="") as f:
-                            columns = next(csv.reader(f), [])
-                    elif filepath.suffix.lower() == ".json":
-                        # Stream only the header/first object instead of
-                        # json.load()-ing a possibly-huge file (issue #6990).
-                        columns = _stream_json_columns(filepath)
-                except (FileNotFoundError, PermissionError, OSError) as exc:
-                    logger.debug(
-                        "Could not read columns from %s: %s", filepath.name, exc
-                    )
+        # Cap the scan at offset+limit (bounded by the hard ceiling) so a deep
+        # tree never materializes fully; only the requested page is opened.
+        scan_cap = min(MAX_DATASET_LIST_SCAN, offset + limit)
+        candidates, truncated = _scan_dataset_files(output_dir, scan_cap)
+        page = candidates[offset : offset + limit]
+        for filepath in page:
+            info = _dataset_info_for_path(filepath, output_dir)
+            on_disk_names.add(info.name)
+            datasets.append(info)
 
-                # SECURITY (issue #6636 F6): never return absolute server
-                # paths. Expose only the path relative to the output dir so
-                # the filesystem layout is not leaked to clients.
-                try:
-                    rel_path = str(filepath.relative_to(output_dir))
-                except ValueError:
-                    rel_path = filepath.name
-
-                datasets.append(
-                    DatasetInfo(
-                        name=filepath.name,
-                        path=rel_path,
-                        format=filepath.suffix.lstrip("."),
-                        size_bytes=filepath.stat().st_size,
-                        columns=columns,
-                    )
-                )
-
-    # Also include any loaded (imported) datasets
+    # Also include any loaded (imported) datasets not already listed on disk.
     async with _cache_lock:
         for name, ds in _loaded_datasets.items():
-            if not any(d.name == name for d in datasets):
+            if name not in on_disk_names:
                 datasets.append(
                     DatasetInfo(
                         dataset_id=ds.get("dataset_id"),
@@ -802,6 +894,9 @@ async def list_datasets() -> DatasetListResponse:
         datasets=datasets,
         total=len(datasets),
         search_dir=output_dir.name,
+        offset=offset,
+        limit=limit,
+        truncated=truncated,
     )
 
 

--- a/src/api/routes/simulation_ws.py
+++ b/src/api/routes/simulation_ws.py
@@ -14,7 +14,13 @@ from pydantic import BaseModel, ValidationError
 
 from src.api.auth.ws_auth import resolve_ws_user
 from src.api.dependencies import get_ws_engine_manager
-from src.api.models.requests import MAX_STATE_VECTOR_LEN, SimulationRequest
+from src.api.models.requests import (
+    MAX_SIMULATION_DURATION,
+    MAX_STATE_VECTOR_LEN,
+    MAX_TIMESTEP,
+    MIN_TIMESTEP,
+    SimulationRequest,
+)
 from src.shared.python.core.contracts import require
 from src.shared.python.engine_core.engine_registry import EngineType
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -46,9 +52,17 @@ def _clamp_speed_factor(raw: object) -> float:
     return value
 
 
-_MAX_WS_DURATION = 3600.0  # 1 hour hard cap for WebSocket sessions
-_MAX_WS_TIMESTEP = 1.0  # 1 second upper bound
-_MIN_WS_TIMESTEP = 1e-6  # 1 microsecond lower bound
+# The WebSocket numeric-field guard must agree with the Pydantic request model
+# (``SimulationRequest``), which is the single source of truth for duration /
+# timestep bounds. Previously the WS layer used looser caps (3600s / 1.0s), so
+# values between the WS cap and the Pydantic cap passed the WS guard only to be
+# rejected with a generic "Invalid simulation config" by ``model_validate``.
+# Reusing the model's constants keeps the two layers consistent and yields a
+# specific error frame (DRY; finding #7740). ``MAX_*`` are inclusive upper
+# bounds in the model (``le=``), so the WS guard rejects strictly above them.
+_MAX_WS_DURATION = MAX_SIMULATION_DURATION  # 300s, matches Pydantic ``le``
+_MAX_WS_TIMESTEP = MAX_TIMESTEP  # 0.1s, matches Pydantic ``le``
+_MIN_WS_TIMESTEP = MIN_TIMESTEP  # 1e-6s, matches Pydantic floor
 
 
 def _validate_ws_numeric_fields(config_input: dict[str, Any]) -> str | None:
@@ -72,9 +86,14 @@ def _validate_ws_numeric_fields(config_input: dict[str, Any]) -> str | None:
         try:
             sf_value = float(raw_sf)
         except (TypeError, ValueError):
-            return "speed_factor must be a finite number"
+            return "speed_factor must be a positive finite number"
         if not math.isfinite(sf_value):
-            return "speed_factor must be a finite number"
+            return "speed_factor must be a positive finite number"
+        # Reject non-positive speed_factor instead of silently clamping it to
+        # 1.0 in ``_clamp_speed_factor`` — the WS guard's contract is to reject,
+        # not clamp, bad start-config values (finding #7740).
+        if sf_value <= 0:
+            return "speed_factor must be a positive finite number"
 
     if "duration" in config_input:
         raw_dur = config_input["duration"]
@@ -84,8 +103,10 @@ def _validate_ws_numeric_fields(config_input: dict[str, Any]) -> str | None:
             return "duration must be a positive finite number"
         if not math.isfinite(dur_value) or dur_value <= 0:
             return "duration must be a positive finite number"
-        if dur_value >= _MAX_WS_DURATION:
-            return f"duration must be less than {_MAX_WS_DURATION}s"
+        # ``_MAX_WS_DURATION`` mirrors the Pydantic ``le`` bound, so the cap
+        # value itself is valid and only strictly-larger values are rejected.
+        if dur_value > _MAX_WS_DURATION:
+            return f"duration must not exceed {_MAX_WS_DURATION}s"
 
     if "timestep" in config_input:
         raw_ts = config_input["timestep"]
@@ -95,8 +116,8 @@ def _validate_ws_numeric_fields(config_input: dict[str, Any]) -> str | None:
             return "timestep must be a positive finite number"
         if not math.isfinite(ts_value) or ts_value <= 0:
             return "timestep must be a positive finite number"
-        if ts_value >= _MAX_WS_TIMESTEP:
-            return f"timestep must be less than {_MAX_WS_TIMESTEP}s"
+        if ts_value > _MAX_WS_TIMESTEP:
+            return f"timestep must not exceed {_MAX_WS_TIMESTEP}s"
         if ts_value < _MIN_WS_TIMESTEP:
             return f"timestep must be at least {_MIN_WS_TIMESTEP}s"
 
@@ -297,14 +318,29 @@ def _engine_analysis_to_dict(engine: object) -> dict[str, Any]:
     return payload
 
 
+def _resolve_sim_stats(websocket: WebSocket) -> Any:
+    """Return the shared simulation-service ``stats`` object, or ``None``.
+
+    Collapses the ``websocket.app.state.simulation_service.stats`` reach-through
+    chain into a single Law-of-Demeter-respecting accessor so the five call
+    sites cannot drift apart (DRY; finding #7740). Every ``getattr`` defaults to
+    ``None`` so a partially-initialised app state (or a test double missing any
+    link) yields ``None`` rather than raising.
+
+    Postcondition: returns the ``stats`` object when fully resolvable, else
+    ``None``.
+    """
+    app_state = getattr(getattr(websocket, "app", None), "state", None)
+    simulation_service = getattr(app_state, "simulation_service", None)
+    return getattr(simulation_service, "stats", None)
+
+
 def _get_simulation_speed_factor(
     websocket: WebSocket,
     config: dict[str, Any],
 ) -> float:
     """Return the current simulation speed factor from shared app state."""
-    app_state = getattr(getattr(websocket, "app", None), "state", None)
-    simulation_service = getattr(app_state, "simulation_service", None)
-    stats = getattr(simulation_service, "stats", None)
+    stats = _resolve_sim_stats(websocket)
     speed_factor = getattr(stats, "speed_factor", config.get("speed_factor"))
     if not isinstance(speed_factor, (int, float)) or speed_factor <= 0:
         return _DEFAULT_SPEED_FACTOR
@@ -323,9 +359,7 @@ def _compute_real_time_sleep_delay(
 
 def _reset_simulation_stats(websocket: WebSocket, config: dict[str, Any]) -> None:
     """Reset shared simulation stats for a new WebSocket simulation run."""
-    app_state = getattr(getattr(websocket, "app", None), "state", None)
-    simulation_service = getattr(app_state, "simulation_service", None)
-    stats = getattr(simulation_service, "stats", None)
+    stats = _resolve_sim_stats(websocket)
     if stats is None:
         return
     stats.start_time = time.time()
@@ -431,9 +465,7 @@ def _apply_set_speed(
     """
     speed_factor = _clamp_speed_factor(msg.get("speed_factor", _DEFAULT_SPEED_FACTOR))
     config["speed_factor"] = speed_factor
-    app_state = getattr(getattr(websocket, "app", None), "state", None)
-    simulation_service = getattr(app_state, "simulation_service", None)
-    stats = getattr(simulation_service, "stats", None)
+    stats = _resolve_sim_stats(websocket)
     if stats is not None:
         stats.speed_factor = speed_factor
 
@@ -532,9 +564,7 @@ async def _run_simulation_loop(
     steps_per_second = 1.0 / timestep
     frame_skip = max(1, int(steps_per_second / target_fps))
     loop = asyncio.get_running_loop()
-    app_state = getattr(getattr(websocket, "app", None), "state", None)
-    simulation_service = getattr(app_state, "simulation_service", None)
-    stats = getattr(simulation_service, "stats", None)
+    stats = _resolve_sim_stats(websocket)
 
     while time_elapsed < duration:
         step_started_at = loop.time()

--- a/tests/api/test_phase3_api.py
+++ b/tests/api/test_phase3_api.py
@@ -30,6 +30,8 @@ from src.api.models.responses import (
     URDFModelResponse,
 )
 
+pytestmark = pytest.mark.unit
+
 # ──────────────────────────────────────────────────────────────
 #  Contract Tests: URDF Model Responses (#1201)
 # ──────────────────────────────────────────────────────────────

--- a/tests/unit/api/test_chat_ws.py
+++ b/tests/unit/api/test_chat_ws.py
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 from src.api.routes import chat_ws
 
-pytestmark = pytest.mark.anyio
+pytestmark = [pytest.mark.unit, pytest.mark.anyio]
 
 _LAUNCHER_TOKEN = "test-launcher-token"
 _WS_HEADERS = {"origin": "http://localhost"}

--- a/tests/unit/api/test_routes_data_explorer.py
+++ b/tests/unit/api/test_routes_data_explorer.py
@@ -12,6 +12,20 @@ from src.api.routes.data_explorer import router
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _clear_loaded_dataset_cache():
+    """Reset the module-global in-memory dataset cache between tests.
+
+    ``_loaded_datasets`` is process-global, so without this an imported file
+    name leaks across tests (e.g. duplicate-import 409s, ghost list entries).
+    """
+    import src.api.routes.data_explorer as de
+
+    de._loaded_datasets.clear()
+    yield
+    de._loaded_datasets.clear()
+
+
 @pytest.fixture
 def temp_dataset_dir():
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
@@ -337,3 +351,277 @@ def test_preview_streams_only_limit_rows_for_large_json(
     assert data["columns"] == ["x", "y"]
     assert len(data["rows"]) == 5
     assert data["total_rows"] == total
+
+
+# ---------------------------------------------------------------------------
+# Filter operator correctness + edge cases (finding #7740 C)
+# ---------------------------------------------------------------------------
+
+
+def _filter(client: TestClient, name: str, **body: object) -> dict:
+    resp = client.post(f"/tools/data-explorer/datasets/{name}/filter", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _import_csv(client: TestClient, name: str, content: bytes) -> None:
+    files = {"file": (name, content, "text/csv")}
+    assert client.post("/tools/data-explorer/import", files=files).status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("operator", "value", "expected"),
+    [
+        ("eq", "2", [{"a": "2", "b": "y"}]),
+        ("ne", "2", [{"a": "1", "b": "x"}, {"a": "3", "b": "z"}]),
+        ("gt", "2", [{"a": "3", "b": "z"}]),
+        ("lt", "2", [{"a": "1", "b": "x"}]),
+        ("gte", "2", [{"a": "2", "b": "y"}, {"a": "3", "b": "z"}]),
+        ("lte", "2", [{"a": "1", "b": "x"}, {"a": "2", "b": "y"}]),
+    ],
+)
+def test_filter_numeric_operators(
+    client: TestClient,
+    temp_dataset_dir,
+    operator: str,
+    value: str,
+    expected: list,
+) -> None:
+    """ne/gt/lt/gte/lte each select the correct rows on column 'a'."""
+    _import_csv(client, "ops.csv", b"a,b\n1,x\n2,y\n3,z\n")
+    data = _filter(client, "ops.csv", column="a", operator=operator, value=value)
+    assert data["rows"] == expected
+
+
+def test_filter_contains_is_case_insensitive(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """The 'contains' operator matches case-insensitively on substrings."""
+    _import_csv(client, "names.csv", b"name\nSwingAlpha\nbeta\nGAMMA\n")
+    data = _filter(client, "names.csv", column="name", operator="contains", value="a")
+    # All three contain an 'a'/'A' somewhere.
+    assert {r["name"] for r in data["rows"]} == {"SwingAlpha", "beta", "GAMMA"}
+
+    data2 = _filter(
+        client, "names.csv", column="name", operator="contains", value="swing"
+    )
+    assert [r["name"] for r in data2["rows"]] == ["SwingAlpha"]
+
+
+def test_filter_non_numeric_cells_excluded_from_numeric_ops(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """gt/lt on a column with non-numeric cells silently skips those rows."""
+    _import_csv(client, "mixed.csv", b"a\n1\nfoo\n5\n\n")
+    data = _filter(client, "mixed.csv", column="a", operator="gt", value="0")
+    # Only the numeric rows 1 and 5 qualify; 'foo' and the empty cell are out.
+    assert [r["a"] for r in data["rows"]] == ["1", "5"]
+
+
+def test_filter_empty_string_eq_matches_blank_cells(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """An eq filter with an empty value matches genuinely-empty cells."""
+    _import_csv(client, "blank.csv", b"a,b\n1,\n2,present\n")
+    data = _filter(client, "blank.csv", column="b", operator="eq", value="")
+    assert [r["a"] for r in data["rows"]] == ["1"]
+
+
+def test_filter_unicode_values(client: TestClient, temp_dataset_dir) -> None:
+    """Filtering matches unicode cell content exactly and via contains."""
+    _import_csv(
+        client,
+        "uni.csv",
+        "city\nMünchen\nZürich\nLondon\n".encode(),
+    )
+    eq_data = _filter(client, "uni.csv", column="city", operator="eq", value="München")
+    assert [r["city"] for r in eq_data["rows"]] == ["München"]
+
+    contains_data = _filter(
+        client, "uni.csv", column="city", operator="contains", value="ü"
+    )
+    assert {r["city"] for r in contains_data["rows"]} == {"München", "Zürich"}
+
+
+def test_filter_unknown_column_returns_400(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """Filtering on a missing column is a structured 400, not a silent empty."""
+    _import_csv(client, "cols.csv", b"a\n1\n")
+    resp = client.post(
+        "/tools/data-explorer/datasets/cols.csv/filter",
+        json={"column": "nope", "operator": "eq", "value": "1"},
+    )
+    assert resp.status_code == 400
+
+
+def test_row_matches_filter_operator_matrix() -> None:
+    """Direct _row_matches_filter coverage for every operator branch."""
+    from src.api.routes.data_explorer import (
+        DatasetFilterRequest,
+        _row_matches_filter,
+    )
+
+    row = {"a": "5", "s": "Hello"}
+
+    def req(op: str, value: str, col: str = "a") -> DatasetFilterRequest:
+        return DatasetFilterRequest(column=col, operator=op, value=value)
+
+    assert _row_matches_filter(row, req("eq", "5")) is True
+    assert _row_matches_filter(row, req("eq", "6")) is False
+    assert _row_matches_filter(row, req("ne", "6")) is True
+    assert _row_matches_filter(row, req("ne", "5")) is False
+    assert _row_matches_filter(row, req("gt", "4")) is True
+    assert _row_matches_filter(row, req("gt", "5")) is False
+    assert _row_matches_filter(row, req("lt", "6")) is True
+    assert _row_matches_filter(row, req("gte", "5")) is True
+    assert _row_matches_filter(row, req("lte", "5")) is True
+    assert _row_matches_filter(row, req("contains", "ell", col="s")) is True
+    assert _row_matches_filter(row, req("contains", "xyz", col="s")) is False
+    # Missing column -> empty string, so eq "" matches.
+    assert _row_matches_filter(row, req("eq", "", col="missing")) is True
+
+
+# ---------------------------------------------------------------------------
+# _find_dataset_path: glob rejection + ambiguous-name 409 (finding #7740 F)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_rejects_glob_metacharacters(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """A name with glob metacharacters must be rejected, not expanded (#7740 F)."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "swing.csv").write_text("a\n1\n", encoding="utf-8")
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resp = client.post(
+            "/tools/data-explorer/datasets/*.csv/filter",
+            json={"column": "a", "operator": "eq", "value": "1"},
+        )
+    # The wildcard must not silently match swing.csv; it is rejected outright.
+    assert resp.status_code == 400
+
+
+def test_find_dataset_path_rejects_glob_pattern() -> None:
+    """_find_dataset_path raises 400 for names containing * ? [ ]."""
+    from fastapi import HTTPException
+
+    from src.api.routes.data_explorer import _find_dataset_path
+
+    for bad in ("*.csv", "swing*", "data?.csv", "set[1].csv"):
+        with pytest.raises(HTTPException) as exc:
+            _find_dataset_path(bad)
+        assert exc.value.status_code == 400
+
+
+def test_find_dataset_path_matches_exact_filename_only(
+    temp_dataset_dir,
+) -> None:
+    """A literal name must match by exact filename, not as a glob."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "swing.csv").write_text("a\n1\n", encoding="utf-8")
+
+    from src.api.routes.data_explorer import _find_dataset_path
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resolved = _find_dataset_path("swing.csv")
+    assert resolved.name == "swing.csv"
+
+
+def test_find_dataset_path_ambiguous_name_409(temp_dataset_dir) -> None:
+    """Two files with the same name in different subdirs yield a 409."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from fastapi import HTTPException
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "a").mkdir()
+    (output_dir / "b").mkdir()
+    (output_dir / "a" / "dup.csv").write_text("x\n1\n", encoding="utf-8")
+    (output_dir / "b" / "dup.csv").write_text("x\n2\n", encoding="utf-8")
+
+    from src.api.routes.data_explorer import _find_dataset_path
+
+    with (
+        patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir),
+        pytest.raises(HTTPException) as exc,
+    ):
+        _find_dataset_path("dup.csv")
+    assert exc.value.status_code == 409
+
+
+def test_stats_ambiguous_name_returns_409(client: TestClient, temp_dataset_dir) -> None:
+    """The ambiguous-name 409 surfaces through an endpoint, not just the helper."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "x").mkdir()
+    (output_dir / "y").mkdir()
+    (output_dir / "x" / "dup.csv").write_text("v\n1\n", encoding="utf-8")
+    (output_dir / "y" / "dup.csv").write_text("v\n2\n", encoding="utf-8")
+
+    no_raise = TestClient(client.app, raise_server_exceptions=False)
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resp = no_raise.get("/tools/data-explorer/datasets/dup.csv/stats")
+    assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# list_datasets pagination + bounded scan (finding #7740 H)
+# ---------------------------------------------------------------------------
+
+
+def test_list_datasets_pagination_offset_limit(
+    client: TestClient, temp_dataset_dir
+) -> None:
+    """offset/limit return a stable, non-overlapping window of on-disk files."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    for i in range(10):
+        (output_dir / f"set_{i:02d}.csv").write_text("a\n1\n", encoding="utf-8")
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        page1 = client.get("/tools/data-explorer/datasets?offset=0&limit=4").json()
+        page2 = client.get("/tools/data-explorer/datasets?offset=4&limit=4").json()
+
+    names1 = [d["name"] for d in page1["datasets"]]
+    names2 = [d["name"] for d in page2["datasets"]]
+    assert len(names1) == 4
+    assert len(names2) == 4
+    # Stable sorted order, no overlap between pages.
+    assert set(names1).isdisjoint(names2)
+    assert names1 == sorted(names1)
+
+
+def test_list_datasets_truncates_at_scan_cap(
+    client: TestClient, temp_dataset_dir, monkeypatch
+) -> None:
+    """When the tree exceeds the hard scan cap, truncated=True is reported."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import src.api.routes.data_explorer as de
+
+    output_dir = Path(temp_dataset_dir)
+    for i in range(6):
+        (output_dir / f"f_{i}.csv").write_text("a\n1\n", encoding="utf-8")
+
+    # Force a tiny cap so the scan is provably bounded.
+    monkeypatch.setattr(de, "MAX_DATASET_LIST_SCAN", 3)
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resp = client.get("/tools/data-explorer/datasets?limit=3")
+    body = resp.json()
+    assert body["truncated"] is True
+    assert len(body["datasets"]) <= 3

--- a/tests/unit/api/test_routes_models.py
+++ b/tests/unit/api/test_routes_models.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 from src.api.routes.models import router
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def app() -> FastAPI:

--- a/tests/unit/api/test_simulation_ws.py
+++ b/tests/unit/api/test_simulation_ws.py
@@ -864,6 +864,14 @@ class TestValidateWsNumericFields:
     def test_valid_speed_factor_accepted(self) -> None:
         assert self._call({"speed_factor": 2.0}) is None
 
+    def test_zero_speed_factor_rejected(self) -> None:
+        """A zero speed_factor must be rejected, not silently clamped to 1.0."""
+        assert self._call({"speed_factor": 0.0}) is not None
+
+    def test_negative_speed_factor_rejected(self) -> None:
+        """A negative speed_factor must be rejected, not silently clamped."""
+        assert self._call({"speed_factor": -2.0}) is not None
+
     # duration checks
     def test_nan_duration_rejected(self) -> None:
         assert self._call({"duration": float("nan")}) is not None
@@ -877,12 +885,13 @@ class TestValidateWsNumericFields:
     def test_negative_duration_rejected(self) -> None:
         assert self._call({"duration": -1.0}) is not None
 
-    def test_duration_at_cap_rejected(self) -> None:
-        """duration >= 3600s must be rejected."""
-        assert self._call({"duration": 3600.0}) is not None
+    def test_duration_over_cap_rejected(self) -> None:
+        """duration above the Pydantic cap (300s) must be rejected."""
+        assert self._call({"duration": 300.1}) is not None
 
-    def test_duration_just_below_cap_accepted(self) -> None:
-        assert self._call({"duration": 3599.9}) is None
+    def test_duration_at_cap_accepted(self) -> None:
+        """The cap value itself is valid (Pydantic uses an inclusive ``le``)."""
+        assert self._call({"duration": 300.0}) is None
 
     def test_valid_duration_accepted(self) -> None:
         assert self._call({"duration": 10.0}) is None
@@ -900,9 +909,13 @@ class TestValidateWsNumericFields:
     def test_negative_timestep_rejected(self) -> None:
         assert self._call({"timestep": -0.001}) is not None
 
-    def test_timestep_at_max_rejected(self) -> None:
-        """timestep >= 1.0s must be rejected."""
-        assert self._call({"timestep": 1.0}) is not None
+    def test_timestep_over_max_rejected(self) -> None:
+        """timestep above the Pydantic cap (0.1s) must be rejected."""
+        assert self._call({"timestep": 0.2}) is not None
+
+    def test_timestep_at_max_accepted(self) -> None:
+        """The cap value itself is valid (Pydantic uses an inclusive ``le``)."""
+        assert self._call({"timestep": 0.1}) is None
 
     def test_timestep_too_small_rejected(self) -> None:
         """timestep < 1e-6 must be rejected."""
@@ -1039,3 +1052,226 @@ async def test_simulation_stream_rejects_timestep_too_small(
     assert len(websocket.sent) == 1
     assert "error" in websocket.sent[0]
     load_engine.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_simulation_stream_rejects_non_positive_speed_factor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero/negative speed_factor must be rejected before the engine loads.
+
+    Regression for finding #7740: a non-positive speed_factor was silently
+    clamped to 1.0 by ``_clamp_speed_factor`` instead of being rejected.
+    """
+    websocket: Any = _RouteWebSocket(
+        [{"action": "start", "config": {"speed_factor": -1.0}}]
+    )
+    load_engine = AsyncMock()
+
+    monkeypatch.setattr(
+        simulation_ws_module, "resolve_ws_user", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(simulation_ws_module, "_load_simulation_engine", load_engine)
+
+    await simulation_ws_module.simulation_stream(websocket, "mujoco")
+
+    assert websocket.accepted is True
+    assert websocket.closed is True
+    assert len(websocket.sent) == 1
+    assert "error" in websocket.sent[0]
+    load_engine.assert_not_called()
+
+
+def test_ws_bounds_match_pydantic_single_source_of_truth() -> None:
+    """The WS numeric guard reuses the Pydantic request-model bounds (#7740).
+
+    Previously the WS layer used looser caps (3600s / 1.0s) than the Pydantic
+    model (300s / 0.1s), so gap values passed the WS guard then failed
+    ``model_validate`` with a generic error. They must now be identical.
+    """
+    from src.api.models.requests import (
+        MAX_SIMULATION_DURATION,
+        MAX_TIMESTEP,
+        MIN_TIMESTEP,
+    )
+
+    assert simulation_ws_module._MAX_WS_DURATION == MAX_SIMULATION_DURATION
+    assert simulation_ws_module._MAX_WS_TIMESTEP == MAX_TIMESTEP
+    assert simulation_ws_module._MIN_WS_TIMESTEP == MIN_TIMESTEP
+
+
+# ---------------------------------------------------------------------------
+# _resolve_sim_stats — single reach-through accessor (finding #7740)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSimStats:
+    """_resolve_sim_stats collapses the app.state.simulation_service.stats chain."""
+
+    def test_returns_stats_when_fully_resolvable(self) -> None:
+        websocket: Any = _WebSocket(speed_factor=2.0)
+        stats = simulation_ws_module._resolve_sim_stats(websocket)
+        assert stats is not None
+        assert stats.speed_factor == pytest.approx(2.0)
+
+    def test_returns_none_when_service_missing(self) -> None:
+        websocket: Any = _WebSocket()  # no simulation_service on app state
+        assert simulation_ws_module._resolve_sim_stats(websocket) is None
+
+    def test_returns_none_when_app_missing(self) -> None:
+        websocket: Any = object()  # no .app attribute at all
+        assert simulation_ws_module._resolve_sim_stats(websocket) is None
+
+
+# ---------------------------------------------------------------------------
+# _run_simulation_loop — direct async coverage of the CC-13 success branches
+# (finding #7740: e2e monkeypatches the loop away, leaving it untested).
+# ---------------------------------------------------------------------------
+
+
+class _FakeStepEngine:
+    """Minimal engine exposing step/get_state for loop tests."""
+
+    def __init__(self) -> None:
+        self.steps = 0
+        self._q = np.array([0.0, 0.0])
+        self._v = np.array([0.0, 0.0])
+
+    def step(self, timestep: float) -> None:
+        self.steps += 1
+        self._q = self._q + timestep
+        self._v = self._v + timestep
+
+    def get_state(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._q, self._v
+
+
+class _LoopWebSocket:
+    """WebSocket double driving _run_simulation_loop with scripted commands."""
+
+    def __init__(
+        self,
+        command_messages: list[dict[str, Any]] | None = None,
+        *,
+        speed_factor: float = 1.0,
+    ) -> None:
+        self._messages = list(command_messages or [])
+        self.sent: list[dict[str, Any]] = []
+        self.app = _App(speed_factor=speed_factor)
+
+    async def receive_json(self) -> dict[str, Any]:
+        if self._messages:
+            return self._messages.pop(0)
+        # No queued command -> behave like an idle client so the loop proceeds.
+        raise TimeoutError
+
+    async def send_json(self, data: dict[str, Any]) -> None:
+        self.sent.append(data)
+
+
+class TestRunSimulationLoop:
+    """Cover the loop's frame-emission, pause/resume, analysis, and pacing paths."""
+
+    @pytest.mark.anyio
+    async def test_emits_frames_and_steps_engine(self) -> None:
+        """The loop steps the engine and streams throttled frame payloads."""
+        engine = _FakeStepEngine()
+        websocket: Any = _LoopWebSocket(speed_factor=1000.0)
+        config = {"duration": 0.01, "timestep": 0.01}
+
+        frame, elapsed = await simulation_ws_module._run_simulation_loop(
+            websocket, engine, config
+        )
+
+        assert engine.steps >= 1
+        assert frame >= 1
+        assert elapsed == pytest.approx(0.01)
+        # First frame is the "running" status, then at least one data frame.
+        assert websocket.sent[0] == {"status": "running", "duration": 0.01}
+        data_frames = [m for m in websocket.sent if "frame" in m]
+        assert data_frames
+        assert "state" in data_frames[0]
+        assert "q" in data_frames[0]["state"]
+
+    @pytest.mark.anyio
+    async def test_includes_analysis_when_requested(self) -> None:
+        """live_analysis adds an analysis payload derived from get_state."""
+        engine = _FakeStepEngine()
+        websocket: Any = _LoopWebSocket(speed_factor=1000.0)
+        config = {"duration": 0.01, "timestep": 0.01, "live_analysis": True}
+
+        await simulation_ws_module._run_simulation_loop(websocket, engine, config)
+
+        data_frames = [m for m in websocket.sent if "frame" in m]
+        assert data_frames
+        assert "analysis" in data_frames[0]
+        assert data_frames[0]["analysis"]["joint_angles"] is not None
+
+    @pytest.mark.anyio
+    async def test_stop_command_breaks_loop_early(self) -> None:
+        """A stop command ends the loop before the duration elapses."""
+        engine = _FakeStepEngine()
+        websocket: Any = _LoopWebSocket([{"action": "stop"}], speed_factor=1000.0)
+        # Long duration so only the stop command ends the loop.
+        config = {"duration": 10.0, "timestep": 0.01}
+
+        frame, _elapsed = await simulation_ws_module._run_simulation_loop(
+            websocket, engine, config
+        )
+
+        assert frame == 0
+        assert engine.steps == 0
+
+    @pytest.mark.anyio
+    async def test_pause_then_resume_continues(self) -> None:
+        """A pause command parks the loop until a resume arrives, then runs."""
+        engine = _FakeStepEngine()
+        websocket: Any = _LoopWebSocket(
+            [{"action": "pause"}, {"action": "resume"}],
+            speed_factor=1000.0,
+        )
+        config = {"duration": 0.01, "timestep": 0.01}
+
+        await simulation_ws_module._run_simulation_loop(websocket, engine, config)
+
+        assert {"status": "paused"} in websocket.sent
+        assert engine.steps >= 1
+
+    @pytest.mark.anyio
+    async def test_pause_then_stop_breaks(self) -> None:
+        """A stop while paused ends the loop without further stepping."""
+        engine = _FakeStepEngine()
+        websocket: Any = _LoopWebSocket(
+            [{"action": "pause"}, {"action": "stop"}],
+            speed_factor=1000.0,
+        )
+        config = {"duration": 10.0, "timestep": 0.01}
+
+        frame, _elapsed = await simulation_ws_module._run_simulation_loop(
+            websocket, engine, config
+        )
+
+        assert {"status": "paused"} in websocket.sent
+        assert frame == 0
+
+    @pytest.mark.anyio
+    async def test_real_time_pacing_sleeps_between_steps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At slow speed the loop awaits a real-time pacing delay each step."""
+        engine = _FakeStepEngine()
+        # speed_factor=1 with a non-trivial timestep -> a positive sleep delay.
+        websocket: Any = _LoopWebSocket(speed_factor=1.0)
+        config = {"duration": 0.02, "timestep": 0.01}
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        monkeypatch.setattr(simulation_ws_module.asyncio, "sleep", fake_sleep)
+
+        await simulation_ws_module._run_simulation_loop(websocket, engine, config)
+
+        # At least one positive pacing delay was awaited.
+        assert any(d > 0 for d in sleeps)


### PR DESCRIPTION
Part of #7740 — deferred P2 findings in `src/api/routes/simulation_ws.py` and `src/api/routes/data_explorer.py`.

simulation_ws.py:
- [C] Reject non-positive speed_factor (was silently clamped to 1.0)
- [C] Reconcile WS vs Pydantic timestep/duration bounds (single source of truth)
- [C] Collapse the 5× app_state→simulation_service→stats reach-through into `_resolve_sim_stats`
- [L] Async unit tests for `_run_simulation_loop` (frame emission/throttle, pause/resume, pacing, analysis)

data_explorer.py:
- [E] Remove dead, contract-violating `_store_cached_dataset`
- [F] Reject glob metacharacters in `_find_dataset_path` (exact filename match; closes the existence oracle)
- [H] Bound the unpaginated recursive `list_datasets` walk (limit/offset + hard cap, scandir, skip dirs)
- [C] Operator/edge-case tests (ne/gt/lt/gte/lte/contains, None/empty/non-numeric/unicode, ambiguous-name 409)

Real bugs fixed: glob-injection in dataset lookup, unbounded sync directory walk in an async handler, and the speed_factor clamp violating the reject-not-clamp contract.
