### PR TITLE
Tighten feature-parity loader + reconcile stale issue refs (#7740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tightened the feature-parity registry loader and reconciled stale issue refs
+  (deferred P2 findings from #7740): `FeatureParityEntry.from_dict` now rejects a
+  non-string `notes` field and rejects a truthy `pending_decision` on any
+  non-`exempt` entry (it is exemption-scoped). The duplicated positive-integer
+  issue-number predicate is extracted into a shared `_is_valid_issue` helper used
+  by both the gap and non-gap branches. The two parity rows that still carried
+  open-issue links — `analysis.static_plots` (#7449) and
+  `simulation.shot_tracer` (#7456), both since closed completed — drop the `issue`
+  field (provenance preserved in `notes`); the generated parity matrix doc is
+  regenerated to match.
 - Hardened the simulation WebSocket and data-explorer API routes (deferred P2
   findings from #7740): the WS start guard now rejects a non-positive
   `speed_factor` instead of silently clamping it to 1.0, and its duration /

--- a/docs/development/feature_parity_matrix.md
+++ b/docs/development/feature_parity_matrix.md
@@ -14,7 +14,7 @@ The PyQt6 desktop app is the canonical model; the web app must match
 | `analysis.analysis_tools_api`<br>Analysis Tools REST endpoints (swing metrics, biomechanics) | 🔴 gap | — | `src/api/routes/analysis_tools.py` | `ui/src/pages/AnalysisTools.tsx` | #7448 |
 | `analysis.counterfactuals`<br>ZTCF/ZVCF + induced-acceleration counterfactuals | 🔴 gap | `src/shared/python/biomechanics/ztcf.py` | — | — | #7450 |
 | `analysis.cross_engine_robustness`<br>Cross-engine robustness dashboard (perturbation/CV) | ✅ parity | `src/launchers/cross_engine_dashboard.py` | `src/api/routes/cross_engine.py` | `ui/src/pages/CrossEngineDashboard.tsx` | — |
-| `analysis.static_plots`<br>Static analysis plots (20+ plot types) | ✅ parity | `src/shared/python/plot_engine/pyqt6_widget.py` | `src/api/routes/analysis_plots.py` | `ui/src/components/analysis/PlotsSection.tsx` | #7449 |
+| `analysis.static_plots`<br>Static analysis plots (20+ plot types) | ✅ parity | `src/shared/python/plot_engine/pyqt6_widget.py` | `src/api/routes/analysis_plots.py` | `ui/src/components/analysis/PlotsSection.tsx` | — |
 | `biomech.exercise_injury_dashboards`<br>Exercise + injury-risk biomechanics dashboards | ⚪ exempt | `src/launchers/exercise_dashboard.py` | — | — | Desktop biomechanics dashboards; desktop-only candidate pending #7460. — **pending decision (#7460)** |
 | `canonical_core.workspaces`<br>Canonical-core estimation/comparison workspaces | ✅ parity | `src/tools/canonical_core/estimation.py` | — | `ui/src/pages/CanonicalCoreShell.tsx` | — |
 | `chat.live_context`<br>Live app/engine context in chat | ✅ parity | `src/launchers/launcher_sidekick_sidebar.py` | `src/api/services/chat_app_context.py` | `ui/src/components/ui/ChatContextChip.tsx` | — |
@@ -39,7 +39,7 @@ The PyQt6 desktop app is the canonical model; the web app must match
 | `simulation.controls_wiring`<br>Web SimulationControls wiring (camera presets, recording toggle, trajectory export, force overlays, actuator controls) | 🔴 gap | `src/launchers/launcher_simulation.py` | — | `ui/src/components/simulation/SimulationControls.tsx` | #7452 |
 | `simulation.golf_suite_batch`<br>Golf Simulation Suite (parameter sweeps, batch runs) | ⚪ exempt | `src/tools/golf_simulation_suite/__main__.py` | — | — | Desktop batch-simulation GUI; desktop-only candidate pending #7460. — **pending decision (#7460)** |
 | `simulation.realtime_ws_stream`<br>Live simulation data over WebSocket pub-sub | ✅ parity | `src/launchers/launcher_simulation.py` | `src/api/routes/simulation_ws.py` | `ui/src/pages/Simulation.tsx` | — |
-| `simulation.shot_tracer`<br>Shot Tracer / ball-flight visualization | ✅ parity | `src/launchers/_shot_tracer_gui.py` | `src/api/routes/ball_flight.py` | `ui/src/pages/BallFlight.tsx` | #7456 |
+| `simulation.shot_tracer`<br>Shot Tracer / ball-flight visualization | ✅ parity | `src/launchers/_shot_tracer_gui.py` | `src/api/routes/ball_flight.py` | `ui/src/pages/BallFlight.tsx` | — |
 | `tools.character_builder`<br>Character Builder (humanoid URDF generation) | 🔴 gap | `src/shared/python/model_generation/cli/main.py` | `src/api/routes/character_builder.py` | `ui/src/pages/CharacterBuilder.tsx` | #7448 |
 | `tools.data_explorer`<br>Data Explorer (import/filter/visualize datasets) | 🔴 gap | — | `src/api/routes/data_explorer.py` | `ui/src/pages/DataExplorer.tsx` | #7448 |
 | `tools.dataset_generator`<br>Swing dataset generation and import | ✅ parity | — | `src/api/routes/dataset.py` | `ui/src/pages/DatasetGenerator.tsx` | — |

--- a/src/config/feature_parity.json
+++ b/src/config/feature_parity.json
@@ -92,9 +92,8 @@
       "api": "src/api/routes/analysis_plots.py",
       "web": "ui/src/components/analysis/PlotsSection.tsx",
       "status": "parity",
-      "issue": 7449,
       "tiles": [],
-      "notes": "GET /analysis/plot-types enumerates AnalysisOrchestrator.PLOT_TYPES; GET /analysis/plot-data/{plot_type} returns PlotData JSON rendered by the web PlotsSection."
+      "notes": "Reached parity via #7449 (closed completed 2026-06-12). GET /analysis/plot-types enumerates AnalysisOrchestrator.PLOT_TYPES; GET /analysis/plot-data/{plot_type} returns PlotData JSON rendered by the web PlotsSection."
     },
     "analysis.counterfactuals": {
       "title": "ZTCF/ZVCF + induced-acceleration counterfactuals",
@@ -159,8 +158,8 @@
       "api": "src/api/routes/ball_flight.py",
       "web": "ui/src/pages/BallFlight.tsx",
       "status": "parity",
-      "issue": 7456,
-      "tiles": ["shot_tracer"]
+      "tiles": ["shot_tracer"],
+      "notes": "Reached parity via #7456 (closed completed 2026-06-12); web BallFlight page consumes the existing /ball_flight API."
     },
     "settings.preferences": {
       "title": "Settings/preferences surface + persistence",

--- a/src/config/feature_parity_loader.py
+++ b/src/config/feature_parity_loader.py
@@ -35,6 +35,16 @@ REGISTRY_PATH = CONFIG_DIR / "feature_parity.json"
 VALID_STATUSES = frozenset({"parity", "gap", "exempt"})
 
 
+def _is_valid_issue(value: Any) -> bool:
+    """True when ``value`` is a positive-integer GitHub issue number.
+
+    ``bool`` is a subclass of ``int`` in Python, so ``True``/``False`` would
+    otherwise sneak through an ``isinstance(value, int)`` check; reject them
+    explicitly.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 @dataclass(frozen=True)
 class FeatureParityEntry:
     """A single feature-parity registry entry.
@@ -99,14 +109,12 @@ class FeatureParityEntry:
 
         issue = data.get("issue")
         if status == "gap":
-            if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
+            if not _is_valid_issue(issue):
                 raise ValueError(
                     f"Gap entry '{feature_id}' requires a positive integer "
                     f"'issue' number, got {issue!r}"
                 )
-        elif issue is not None and (
-            not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0
-        ):
+        elif issue is not None and not _is_valid_issue(issue):
             raise ValueError(f"Entry '{feature_id}' has invalid issue number {issue!r}")
 
         reason = data.get("reason")
@@ -132,6 +140,22 @@ class FeatureParityEntry:
                 f"non-empty strings"
             )
 
+        # pending_decision is exemption-scoped: it flags an exempt entry whose
+        # exemption awaits the #7460 decision. A truthy value on any other
+        # status is a registry authoring error.
+        pending_decision = data.get("pending_decision", False)
+        if pending_decision and status != "exempt":
+            raise ValueError(
+                f"Entry '{feature_id}' sets 'pending_decision' but status is "
+                f"{status!r}; pending_decision is only valid for 'exempt' entries"
+            )
+
+        notes = data.get("notes", "")
+        if not isinstance(notes, str):
+            raise ValueError(
+                f"Entry '{feature_id}' field 'notes' must be a string, got {notes!r}"
+            )
+
         return cls(
             feature_id=feature_id,
             title=title.strip(),
@@ -141,9 +165,9 @@ class FeatureParityEntry:
             web=data.get("web"),
             issue=issue,
             reason=reason.strip() if isinstance(reason, str) else None,
-            pending_decision=bool(data.get("pending_decision", False)),
+            pending_decision=bool(pending_decision),
             tiles=tuple(tiles_raw),
-            notes=data.get("notes", ""),
+            notes=notes,
         )
 
     @property

--- a/tests/config/feature_parity/test_registry.py
+++ b/tests/config/feature_parity/test_registry.py
@@ -231,6 +231,65 @@ class TestLoaderContracts:
                 "x.y", {"title": "X", "status": "parity", "tiles": [""]}
             )
 
+    @pytest.mark.unit
+    def test_pending_decision_on_non_exempt_rejected(self) -> None:
+        with pytest.raises(ValueError, match="pending_decision is only valid"):
+            FeatureParityEntry.from_dict(
+                "x.y",
+                {"title": "X", "status": "parity", "pending_decision": True},
+            )
+
+    @pytest.mark.unit
+    def test_pending_decision_on_gap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="pending_decision is only valid"):
+            FeatureParityEntry.from_dict(
+                "x.y",
+                {
+                    "title": "X",
+                    "status": "gap",
+                    "issue": 7449,
+                    "pending_decision": True,
+                },
+            )
+
+    @pytest.mark.unit
+    def test_pending_decision_on_exempt_allowed(self) -> None:
+        entry = FeatureParityEntry.from_dict(
+            "x.y",
+            {
+                "title": "X",
+                "status": "exempt",
+                "reason": "Desktop-only; pending #7460",
+                "pending_decision": True,
+            },
+        )
+        assert entry.pending_decision is True
+
+    @pytest.mark.unit
+    def test_falsy_pending_decision_on_non_exempt_allowed(self) -> None:
+        # An explicit falsy pending_decision must not trip the exempt-scope check.
+        entry = FeatureParityEntry.from_dict(
+            "x.y",
+            {"title": "X", "status": "parity", "pending_decision": False},
+        )
+        assert entry.pending_decision is False
+
+    @pytest.mark.unit
+    def test_non_string_notes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="'notes' must be a string"):
+            FeatureParityEntry.from_dict(
+                "x.y", {"title": "X", "status": "parity", "notes": 123}
+            )
+
+    @pytest.mark.unit
+    def test_string_notes_accepted(self) -> None:
+        entry = FeatureParityEntry.from_dict(
+            "x.y",
+            {"title": "X", "status": "parity", "notes": "clarifying note"},
+        )
+        assert entry.notes == "clarifying note"
+
+    @pytest.mark.unit
     def test_valid_gap_entry_loads(self) -> None:
         entry = FeatureParityEntry.from_dict(
             "a.b",


### PR DESCRIPTION
Part of #7740.

Clears four deferred P2 findings against the feature-parity config loader and data.

## Findings addressed

- [x] **[E] Validate `notes` type** (`feature_parity_loader.py`) — `notes` was taken raw via `data.get("notes", "")` while every other field is type-validated. `from_dict` now raises `ValueError` when `notes` is present and not a `str`.
- [x] **[E] Reject `pending_decision` on non-exempt entries** (`feature_parity_loader.py`) — `pending_decision` is exemption-scoped but was coerced for any status. `from_dict` now raises `ValueError` when `pending_decision` is truthy and `status != "exempt"`. An explicit falsy value on a non-exempt entry still loads.
- [x] **[F] Deduplicate the issue-number predicate** (`feature_parity_loader.py`) — the 3-clause positive-integer-issue predicate (incl. the `isinstance(bool)` subtlety) was verbatim in both the gap and non-gap branches. Extracted a `_is_valid_issue(value)` helper used by both.
- [x] **[E] Reconcile parity rows carrying gap issue numbers** (`feature_parity.json`) — see below.

## JSON reconciliation decision

Two `parity` rows still carried open-tracking-issue links in the CI-gated matrix:

- `analysis.static_plots` → **#7449** (`[Parity G1] Static analysis plots … plot-data API + web Analysis parity`)
- `simulation.shot_tracer` → **#7456** (`[Parity G8] Shot Tracer / ball-flight visualization missing from web app`)

I inspected both issues: **both are CLOSED with `stateReason = COMPLETED`** (2026-06-12). The rows are therefore genuinely at parity (their `api`/`web` paths exist and are wired), so the open-issue link was stale. Per the finding's guidance ("if genuinely at parity, drop the issue (or move to notes)"), I **dropped the `issue` field** from both entries and preserved the provenance in `notes` (`Reached parity via #74xx (closed completed 2026-06-12)`). Neither was downgraded to `gap` because neither has an outstanding gap.

The generated matrix doc `docs/development/feature_parity_matrix.md` was regenerated (`python -m scripts.generate_feature_parity_matrix`) so the freshness gate passes; both rows now show `—` in the tracking column.

## Tests

Added unit tests (`@pytest.mark.unit`) in `tests/config/feature_parity/test_registry.py` for the new `ValueError` paths (pending_decision on parity/gap rejected, on exempt allowed, falsy allowed; non-string notes rejected, string notes accepted). Full `tests/config/feature_parity/` suite passes (39 tests), including the CI parity gate and the matrix-freshness gate. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
