### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for 3D vector magnitude in motion optimization objective calculation

### DIFF
--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_motion_opt_simulation.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_motion_opt_simulation.py
@@ -203,11 +203,10 @@ def evaluate_objective(
         objective += objectives.weight_torque * total_torque
 
     if objectives.target_ball_position is not None:
+        pos_diff = metrics["final_club_position"] - objectives.target_ball_position
         distance_error = float(
-            np.linalg.norm(
-                metrics["final_club_position"] - objectives.target_ball_position,
-            ),
-        )
+            math.hypot(pos_diff[0], pos_diff[1], pos_diff[2])
+        )  # ⚡ Bolt: math.hypot is significantly faster than np.linalg.norm for small 3D arrays  # noqa: E501
         objective += objectives.weight_accuracy * distance_error
 
     return objective


### PR DESCRIPTION
💡 What: Replaced `np.linalg.norm(metrics["final_club_position"] - objectives.target_ball_position)` with `math.hypot(pos_diff[0], pos_diff[1], pos_diff[2])` in `evaluate_objective` function of `src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_motion_opt_simulation.py`.
🎯 Why: `np.linalg.norm` has significant overhead due to temporary array allocation and function dispatching for small arrays. Using `math.hypot` with explicit extraction avoids this overhead.
📊 Impact: Improves execution speed for evaluating distance error in trajectory optimization objective function, which is critical since this function is evaluated frequently in tight simulation loops.
🔬 Measurement: Using `math.hypot` on 3D array element extraction is measurably faster than `np.linalg.norm` for 3D arrays.

---
*PR created automatically by Jules for task [4297356397355366052](https://jules.google.com/task/4297356397355366052) started by @dieterolson*