### PR TITLE
⚡ Bolt: Cache intermediate NumPy array to avoid redundant allocations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2306,6 +2306,8 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - Replaced `math.sqrt(x**2 + y**2)` with `math.hypot(x, y)` for explicit vector components to reduce overhead and improve execution speed by ~1.5-2x.
 - Optimized boolean mask reduction in `trendline.py` by replacing `np.sum(mask)` with `mask.sum()`, achieving ~1.8x speedup by avoiding array conversion checks.
 - Replaced `np.sum(..., axis=1)` with `np.einsum('ij->i', ...)` for array reductions in critical pathways in data input and plotting.
+- Cached `np.abs(torques)` in the biomechanics metrics route so peak and total
+  torque calculations reuse one temporary array.
 
 ### 2026-06-23
 

--- a/src/api/routes/physics.py
+++ b/src/api/routes/physics.py
@@ -418,8 +418,9 @@ async def get_metrics(
             import numpy as np
 
             torques = ctrl.current_torques
-            peak_torque = float(np.max(np.abs(torques)))
-            total_torque_magnitude = float(np.sum(np.abs(torques)))
+            abs_torques = np.abs(torques)
+            peak_torque = float(np.max(abs_torques))
+            total_torque_magnitude = float(np.sum(abs_torques))
 
         return BiomechanicsMetricsResponse(
             sim_time=sim_time,


### PR DESCRIPTION
⚡ Bolt: Cache intermediate NumPy array to avoid redundant allocations

💡 What: Cached the result of `np.abs(torques)` into a variable `abs_torques` instead of computing it twice for peak and total torque calculations in `src/api/routes/physics.py`.
🎯 Why: `np.abs(torques)` allocates a temporary array. Calling it twice redundantly allocates memory and consumes CPU cycles.
📊 Impact: Eliminates one unnecessary NumPy array allocation and absolute value calculation per API request, marginally reducing memory overhead and execution time.
🔬 Measurement: Verify by executing the API performance tests; no regressions expected.

---
*PR created automatically by Jules for task [4541508799695540864](https://jules.google.com/task/4541508799695540864) started by @dieterolson*