### PR TITLE
⚡ Bolt: Use np.vdot for squared distance in KD-tree query

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2294,4 +2294,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - **Performance:** Replaced `np.sum(forces, axis=0)` with `sum((s.force for s in self._sources.values()), np.zeros(3))` in `ForceAccumulator` methods (`get_total_force`, `get_total_torque`, and `get_total_generalized_force`) in `src/engines/common/state.py` to avoid intermediate list and array allocations, yielding ~30% faster execution time for accumulating forces and torques.
 
 ### Performance Improvements
+- Replaced `np.sum(diff ** 2)` with `np.vdot(diff, diff)` in `_tree_index.py` for faster KD-tree nearest neighbor queries.
 - Replaced `np.sum(..., axis=1)` with `np.einsum('ij->i', ...)` for array reductions in critical pathways in data input and plotting.

--- a/src/robotics/planning/motion/_tree_index.py
+++ b/src/robotics/planning/motion/_tree_index.py
@@ -143,7 +143,8 @@ class TreeConfigIndex:
 
         _, tree_idx = self._kd_tree.query(query, k=1)
         best_idx = int(tree_idx)
-        best_squared = float(np.sum((self._view()[best_idx] - query) ** 2))
+        diff = self._view()[best_idx] - query
+        best_squared = float(np.vdot(diff, diff))
         if self._kd_tree_size < self._count:
             tail_idx, tail_squared = self._nearest_in_view(
                 query,


### PR DESCRIPTION
💡 What: Replaced `np.sum(diff ** 2)` with `np.vdot(diff, diff)` when computing squared distances in `_nearest_with_kd_tree` in `src/robotics/planning/motion/_tree_index.py`.

🎯 Why: Calling `diff ** 2` in numpy creates an intermediate array allocation. For small, fixed computations in a hot loop (like a KD-tree nearest neighbor query), avoiding this allocation using the dot product natively yields a significant performance improvement.

📊 Impact: Expected to reduce calculation time for the squared norm computation significantly (around a ~50% reduction for typical 1D arrays in Python/NumPy tests), speeding up KD-tree queries overall in the RRT planner.

🔬 Measurement: Verified the performance via a local `timeit` test where `np.vdot` outperformed `np.sum(diff ** 2)` significantly. Also verified that `tests/unit/robotics/test_planning_motion.py` still passes locally to ensure correctness.

---
*PR created automatically by Jules for task [14565019443927450129](https://jules.google.com/task/14565019443927450129) started by @dieterolson*