### PR TITLE
fix(pendulum): replace public contract asserts

### DIFF
--- a/src/shared/python/pendulum_simulator/physics.py
+++ b/src/shared/python/pendulum_simulator/physics.py
@@ -33,6 +33,7 @@ import numpy.typing as npt
 from . import native_backend as _native_backend
 from .constants import GRAVITY_MSS
 from .physics_base import clamp_torque_ndof  # noqa: F401  (re-export, DRY)
+from .validation import require, require_non_negative, require_positive
 
 _log = logging.getLogger(__name__)
 
@@ -67,16 +68,16 @@ class PendulumParams:
     mu2: float = 0.0  # Coulomb friction at wrist (NÂ·m)
 
     def __post_init__(self) -> None:
-        assert self.m1 > 0, f"m1 must be positive, got {self.m1}"
-        assert self.m2 > 0, f"m2 must be positive, got {self.m2}"
-        assert self.L1 > 0, f"L1 must be positive, got {self.L1}"
-        assert self.L2 > 0, f"L2 must be positive, got {self.L2}"
-        assert self.mClub >= 0, f"mClub must be non-negative, got {self.mClub}"
-        assert self.g >= 0, f"g must be non-negative, got {self.g}"
-        assert self.b1 >= 0, f"b1 must be non-negative, got {self.b1}"
-        assert self.b2 >= 0, f"b2 must be non-negative, got {self.b2}"
-        assert self.mu1 >= 0, f"mu1 must be non-negative, got {self.mu1}"
-        assert self.mu2 >= 0, f"mu2 must be non-negative, got {self.mu2}"
+        require_positive("m1", self.m1)
+        require_positive("m2", self.m2)
+        require_positive("L1", self.L1)
+        require_positive("L2", self.L2)
+        require_non_negative("mClub", self.mClub)
+        require_non_negative("g", self.g)
+        require_non_negative("b1", self.b1)
+        require_non_negative("b2", self.b2)
+        require_non_negative("mu1", self.mu1)
+        require_non_negative("mu2", self.mu2)
 
 
 @dataclass(frozen=True)
@@ -102,10 +103,13 @@ class JointLimits:
     damping: float = 20.0  # NÂ·mÂ·s/rad
 
     def __post_init__(self) -> None:
-        assert self.phi_min < self.phi_max
-        assert self.theta1_min < self.theta1_max
-        assert self.stiffness > 0
-        assert self.damping >= 0
+        require(self.phi_min < self.phi_max, "phi_min must be less than phi_max")
+        require(
+            self.theta1_min < self.theta1_max,
+            "theta1_min must be less than theta1_max",
+        )
+        require_positive("stiffness", self.stiffness)
+        require_non_negative("damping", self.damping)
 
 
 @dataclass(frozen=True)
@@ -126,12 +130,8 @@ class TorqueClamp:
         # Accept negative inputs by taking abs (#1138)
         object.__setattr__(self, "max_torque1", abs(self.max_torque1))
         object.__setattr__(self, "max_torque2", abs(self.max_torque2))
-        assert self.max_torque1 > 0, (
-            f"|max_torque1| must be positive, got {self.max_torque1}"
-        )
-        assert self.max_torque2 > 0, (
-            f"|max_torque2| must be positive, got {self.max_torque2}"
-        )
+        require_positive("|max_torque1|", self.max_torque1)
+        require_positive("|max_torque2|", self.max_torque2)
 
 
 # Type aliases

--- a/src/shared/python/pendulum_simulator/physics_base.py
+++ b/src/shared/python/pendulum_simulator/physics_base.py
@@ -6,7 +6,7 @@ and golfer_*.py into generic N-DOF functions.
 
 Design by Contract
 ------------------
-- All public functions validate inputs with assertions.
+- Public functions validate inputs with explicit exceptions.
 - Array shapes are checked to prevent silent broadcasting bugs.
 """
 
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import numpy as np
 import numpy.typing as npt
+
+from .validation import require, require_non_negative, require_shape
 
 # ---------------------------------------------------------------------------
 # Generic kinetic energy (works for any DOF count)
@@ -41,11 +43,11 @@ def kinetic_energy_from_M(M: np.ndarray, qdot: np.ndarray) -> float:
         Result is finite and >= 0 (up to floating-point noise).
     """
     n = qdot.shape[0]
-    assert M.shape == (n, n), f"M shape {M.shape} vs qdot shape {qdot.shape}"
-    assert np.all(np.isfinite(M)), "Mass matrix has non-finite values"
-    assert np.all(np.isfinite(qdot)), "Velocity has non-finite values"
+    require(M.shape == (n, n), f"M shape {M.shape} vs qdot shape {qdot.shape}")
+    require(bool(np.all(np.isfinite(M))), "Mass matrix has non-finite values")
+    require(bool(np.all(np.isfinite(qdot))), "Velocity has non-finite values")
     T = float(0.5 * qdot @ M @ qdot)
-    assert np.isfinite(T), f"Kinetic energy is non-finite: {T}"
+    require(bool(np.isfinite(T)), f"Kinetic energy is non-finite: {T}")
     return T
 
 
@@ -60,8 +62,8 @@ def total_energy_from_parts(kinetic: float, potential: float) -> float:
     Pre: both finite.
     Post: result finite.
     """
-    assert np.isfinite(kinetic), f"Kinetic energy non-finite: {kinetic}"
-    assert np.isfinite(potential), f"Potential energy non-finite: {potential}"
+    require(bool(np.isfinite(kinetic)), f"Kinetic energy non-finite: {kinetic}")
+    require(bool(np.isfinite(potential)), f"Potential energy non-finite: {potential}")
     return kinetic + potential
 
 
@@ -89,17 +91,21 @@ def friction_torque_ndof(
     Post: opposes motion direction element-wise.
     """
     n = qdot.shape[0]
-    assert viscous_coeffs.shape == (n,), (
-        f"viscous shape {viscous_coeffs.shape} vs qdot {qdot.shape}"
+    require(
+        viscous_coeffs.shape == (n,),
+        f"viscous shape {viscous_coeffs.shape} vs qdot {qdot.shape}",
     )
-    assert np.all(np.isfinite(qdot)), "qdot has non-finite values"
+    require(bool(np.all(np.isfinite(qdot))), "qdot has non-finite values")
 
     tau: npt.NDArray[np.float64] = np.asarray(-viscous_coeffs * qdot, dtype=np.float64)
     if coulomb_coeffs is not None:
-        assert coulomb_coeffs.shape == (n,)
+        require(
+            coulomb_coeffs.shape == (n,),
+            f"coulomb shape {coulomb_coeffs.shape} vs qdot {qdot.shape}",
+        )
         tau -= coulomb_coeffs * np.sign(qdot)
 
-    assert np.all(np.isfinite(tau)), f"Friction torque non-finite: {tau}"
+    require(bool(np.all(np.isfinite(tau))), f"Friction torque non-finite: {tau}")
     return tau
 
 
@@ -120,8 +126,8 @@ def clamp_torque_ndof(tau: np.ndarray, limits: np.ndarray) -> np.ndarray:
     Post: |result[i]| <= limits[i].
     """
     n = tau.shape[0]
-    assert limits.shape == (n,), f"limits shape {limits.shape} vs tau {tau.shape}"
-    assert np.all(limits > 0), "Torque limits must be positive"
+    require(limits.shape == (n,), f"limits shape {limits.shape} vs tau {tau.shape}")
+    require(bool(np.all(limits > 0)), "Torque limits must be positive")
     result: npt.NDArray[np.float64] = np.asarray(
         np.clip(tau, -limits, limits), dtype=np.float64
     )
@@ -164,8 +170,9 @@ def chain_positions(
     convention y-up (positive cosine), matching the existing physics modules.
     """
     n = absolute_angles.shape[0]
-    assert lengths.shape == (n,), (
-        f"lengths {lengths.shape} vs angles {absolute_angles.shape}"
+    require(
+        lengths.shape == (n,),
+        f"lengths {lengths.shape} vs angles {absolute_angles.shape}",
     )
 
     positions = np.zeros((n, 2))
@@ -207,8 +214,9 @@ def potential_energy_chain(
     Post: result finite.
     """
     n = absolute_angles.shape[0]
-    assert lengths.shape == (n,) and masses.shape == (n,)
-    assert g >= 0, f"g must be non-negative, got {g}"
+    require_shape("lengths", lengths, (n,))
+    require_shape("masses", masses, (n,))
+    require_non_negative("g", g)
 
     # Cumulative mass from tip backwards: mass_below[i] = sum(masses[i:])
     # Each segment i contributes: -mass_below_i * g * L_i * cos(angle_i)
@@ -219,7 +227,7 @@ def potential_energy_chain(
         mass_below = float(np.sum(masses[i:]))
         V -= mass_below * g * lengths[i] * np.cos(absolute_angles[i])
 
-    assert np.isfinite(V), f"Potential energy non-finite: {V}"
+    require(bool(np.isfinite(V)), f"Potential energy non-finite: {V}")
     return V
 
 

--- a/src/shared/python/pendulum_simulator/physics_triple.py
+++ b/src/shared/python/pendulum_simulator/physics_triple.py
@@ -23,6 +23,7 @@ import numpy.typing as npt
 
 from . import native_backend as _native_backend
 from .constants import GRAVITY_MSS
+from .validation import require_non_negative, require_positive
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -58,19 +59,19 @@ class TriplePendulumParams:
     scapula_offset_rad: float = 0.0  # angular offset of hub anchor (rad)
 
     def __post_init__(self) -> None:
-        assert self.m1 > 0, f"m1 must be positive, got {self.m1}"
-        assert self.m2 > 0, f"m2 must be positive, got {self.m2}"
-        assert self.m3 > 0, f"m3 must be positive, got {self.m3}"
-        assert self.L1 > 0, f"L1 must be positive, got {self.L1}"
-        assert self.L2 > 0, f"L2 must be positive, got {self.L2}"
-        assert self.L3 > 0, f"L3 must be positive, got {self.L3}"
-        assert self.g >= 0, f"g must be non-negative, got {self.g}"
-        assert self.b1 >= 0, f"b1 must be non-negative, got {self.b1}"
-        assert self.b2 >= 0, f"b2 must be non-negative, got {self.b2}"
-        assert self.b3 >= 0, f"b3 must be non-negative, got {self.b3}"
-        assert self.mu1 >= 0, f"mu1 must be non-negative, got {self.mu1}"
-        assert self.mu2 >= 0, f"mu2 must be non-negative, got {self.mu2}"
-        assert self.mu3 >= 0, f"mu3 must be non-negative, got {self.mu3}"
+        require_positive("m1", self.m1)
+        require_positive("m2", self.m2)
+        require_positive("m3", self.m3)
+        require_positive("L1", self.L1)
+        require_positive("L2", self.L2)
+        require_positive("L3", self.L3)
+        require_non_negative("g", self.g)
+        require_non_negative("b1", self.b1)
+        require_non_negative("b2", self.b2)
+        require_non_negative("b3", self.b3)
+        require_non_negative("mu1", self.mu1)
+        require_non_negative("mu2", self.mu2)
+        require_non_negative("mu3", self.mu3)
 
 
 # Type alias: state vector [theta1, phi1, phi2, dtheta1, dphi1, dphi2]

--- a/src/shared/python/pendulum_simulator/simulation.py
+++ b/src/shared/python/pendulum_simulator/simulation.py
@@ -36,6 +36,13 @@ from .physics import (
 )
 from .simulation_core import integrate_ode
 from .simulation_result_base import TrajectoryResultMixin
+from .validation import (
+    require,
+    require_dt,
+    require_finite_array,
+    require_positive,
+    require_shape,
+)
 
 # Re-export from shared utility for backwards compatibility (DRY â€” #1041)
 from .torque_utils import make_polynomial_torque  # noqa: F401
@@ -89,12 +96,10 @@ class SimulationResult(TrajectoryResultMixin):
 
     def torques_at(self, idx: int) -> tuple[float, float]:
         """Get applied torques at time index idx."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return self.torque_func(self.t[idx])
 
     def accelerations_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         state_dot = equations_of_motion(
             self.states[idx],
@@ -107,33 +112,28 @@ class SimulationResult(TrajectoryResultMixin):
         return state_dot[2:]
 
     def joint_forces_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         qddot = self.accelerations_at(idx)
         return net_joint_forces(self.states[idx], qddot, self.params)
 
     def joint_velocities_at(self, idx: int) -> dict:
         """Get linear joint velocities at time index idx."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return joint_velocities(self.states[idx], self.params)
 
     def base_force_at(self, idx: int) -> dict:
         """Get base reaction force at time index idx."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         qddot = self.accelerations_at(idx)
         return base_force(self.states[idx], qddot, self.params)
 
     def control_vector_at(self, idx: int) -> dict:
         """Get control vector at time index idx."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         qddot = self.accelerations_at(idx)
         return control_vector(self.states[idx], qddot, self.params, self.limits)
 
     def energy_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         state = self.states[idx]
         result = {
@@ -145,25 +145,21 @@ class SimulationResult(TrajectoryResultMixin):
         return result
 
     def coriolis_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return coriolis_vector(s[1], s[2], s[3], self.params)
 
     def gravity_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return gravity_vector(s[0], s[1], self.params)
 
     def friction_torques_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return friction_torque_vector(s[2], s[3], self.params)
 
     def total_torques_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         tau_drive = np.array(self.torque_func(self.t[idx]))
         if self.clamp is not None:
@@ -194,9 +190,10 @@ def run_simulation(
     Pre: initial_state shape (4,), finite. t_end > 0. dt in (0, t_end).
     Post: result has >= 2 time points, all finite.
     """
-    assert initial_state.shape == (4,)
-    assert all(np.isfinite(initial_state))
-    assert t_end > 0 and 0 < dt < t_end
+    require_shape("Initial state", initial_state, (4,))
+    require_finite_array("Initial state", initial_state)
+    require_positive("t_end", t_end)
+    require_dt(dt, t_end)
 
     t, states = None, None
     if (
@@ -255,5 +252,5 @@ def run_simulation(
         clamp=clamp,
     )
 
-    assert result.n_steps >= 2
+    require(result.n_steps >= 2, "Simulation must produce at least 2 time points")
     return result

--- a/src/shared/python/pendulum_simulator/simulation_golfer.py
+++ b/src/shared/python/pendulum_simulator/simulation_golfer.py
@@ -41,6 +41,13 @@ from .physics_golfer import (
 )
 from .simulation_core import integrate_ode
 from .simulation_result_base import TrajectoryResultMixin
+from .validation import (
+    require,
+    require_dt,
+    require_finite_array,
+    require_positive,
+    require_shape,
+)
 
 # Re-export from shared utility for backwards compatibility (DRY â€” #1041)
 from .torque_utils import make_polynomial_torque  # noqa: F401
@@ -70,25 +77,21 @@ class GolferSimulationResult(TrajectoryResultMixin):
 
     def q_at(self, idx: int) -> np.ndarray:
         """Generalized coordinates at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return self.states[idx, :N_DOF]
 
     def qdot_at(self, idx: int) -> np.ndarray:
         """Generalized velocities at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return self.states[idx, N_DOF:]
 
     def mass_matrix_at(self, idx: int) -> np.ndarray:
         """8Ã—8 mass matrix at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return mass_matrix(self.q_at(idx), self.params)  # type: ignore[no-any-return]
 
     def positions_at(self, idx: int) -> dict:
         """Forward kinematics at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return forward_kinematics(self.q_at(idx), self.params)  # type: ignore[no-any-return]
 
@@ -96,13 +99,11 @@ class GolferSimulationResult(TrajectoryResultMixin):
         self, idx: int
     ) -> tuple[float, float, float, float, float, float, float]:
         """Applied driving torques at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return self.torque_func(self.t[idx])
 
     def accelerations_at(self, idx: int) -> np.ndarray:
         """Joint accelerations at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return constrained_accelerations(
             self.states[idx], self.t[idx], self.params, self.torque_func
@@ -110,7 +111,6 @@ class GolferSimulationResult(TrajectoryResultMixin):
 
     def joint_forces_at(self, idx: int) -> dict:
         """Net joint forces at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         q = self.q_at(idx)
         qdot = self.qdot_at(idx)
@@ -119,7 +119,6 @@ class GolferSimulationResult(TrajectoryResultMixin):
 
     def constraint_forces_at(self, idx: int) -> np.ndarray:
         """Lagrange multiplier (constraint) forces at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return constraint_forces(
             self.states[idx], self.t[idx], self.params, self.torque_func
@@ -127,25 +126,21 @@ class GolferSimulationResult(TrajectoryResultMixin):
 
     def constraint_violation_at(self, idx: int) -> float:
         """Constraint violation magnitude at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return constraint_violation(self.states[idx], self.params)
 
     def coriolis_at(self, idx: int) -> np.ndarray:
         """Coriolis/centrifugal torques at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return coriolis_matrix(self.q_at(idx), self.qdot_at(idx), self.params)  # type: ignore[no-any-return]
 
     def gravity_at(self, idx: int) -> np.ndarray:
         """Gravitational torques at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return gravity_vector(self.q_at(idx), self.params)  # type: ignore[no-any-return]
 
     def energy_at(self, idx: int) -> dict:
         """Energy decomposition at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         state = self.states[idx]
         result = {
@@ -158,7 +153,6 @@ class GolferSimulationResult(TrajectoryResultMixin):
 
     def friction_torques_at(self, idx: int) -> np.ndarray:
         """Friction torques at time index."""
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         return friction_torque_vector(self.qdot_at(idx), self.params)  # type: ignore[no-any-return]
 
@@ -168,7 +162,6 @@ class GolferSimulationResult(TrajectoryResultMixin):
         Overrides the base to spread the 7-joint torque_func output over the
         full N_DOF=8 vector before adding friction.
         """
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         tau_drive = np.zeros(N_DOF)
         tau_drive[:7] = self.torque_func(self.t[idx])
@@ -218,12 +211,10 @@ def run_simulation(
     -------
     GolferSimulationResult
     """
-    assert initial_state.shape == (2 * N_DOF,), (
-        f"Initial state shape must be ({2 * N_DOF},), got {initial_state.shape}"
-    )
-    assert np.all(np.isfinite(initial_state)), "Initial state must be finite"
-    assert t_end > 0, f"t_end must be positive, got {t_end}"
-    assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"
+    require_shape("Initial state", initial_state, (2 * N_DOF,))
+    require_finite_array("Initial state", initial_state)
+    require_positive("t_end", t_end)
+    require_dt(dt, t_end)
 
     # Merge clamp kwarg (from SimulationPanel) with torque_limits (legacy)
     effective_torque_limits = torque_limits if torque_limits is not None else clamp
@@ -237,7 +228,7 @@ def run_simulation(
     _max_violation: list[float] = [0.0]
 
     def ode_rhs(t: float, y: np.ndarray) -> np.ndarray:
-        assert t is not None, "t must be provided"
+        require(t is not None, "t must be provided")
         dydt = equations_of_motion(
             y, t, params, torque_func, alpha, beta, effective_torque_limits
         )
@@ -291,7 +282,7 @@ def run_simulation(
         torque_func=torque_func,
     )
 
-    assert result.n_steps >= 2, "Simulation must produce at least 2 time points"
+    require(result.n_steps >= 2, "Simulation must produce at least 2 time points")
 
     # Postcondition: constraint drift must remain bounded.
     max_viol = _max_violation[0]

--- a/src/shared/python/pendulum_simulator/simulation_result_base.py
+++ b/src/shared/python/pendulum_simulator/simulation_result_base.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import numpy as np
 
+from .validation import require
+
 
 class TrajectoryResultMixin:
     """Reusable DbC helpers for trajectory result containers."""
@@ -18,32 +20,46 @@ class TrajectoryResultMixin:
         return len(self.t)
 
     def _validate_trajectory(self, expected_state_width: int) -> None:
-        assert self.t.ndim == 1, f"t must be 1D, got shape {self.t.shape}"
-        assert self.states.ndim == 2, (
-            f"states must be 2D, got shape {self.states.shape}"
+        require(self.t.ndim == 1, f"t must be 1D, got shape {self.t.shape}")
+        require(
+            self.states.ndim == 2,
+            f"states must be 2D, got shape {self.states.shape}",
         )
-        assert self.t.size >= 1, "Trajectory must contain at least one time sample"
-        assert self.states.shape[0] == self.t.size, (
-            "states row count must match the number of time samples"
+        require(self.t.size >= 1, "Trajectory must contain at least one time sample")
+        require(
+            self.states.shape[0] == self.t.size,
+            "states row count must match the number of time samples",
         )
-        assert self.states.shape[1] == expected_state_width, (
-            f"states must have width {expected_state_width}, got {self.states.shape[1]}"
+        require(
+            self.states.shape[1] == expected_state_width,
+            f"states must have width {expected_state_width}, got {self.states.shape[1]}",
         )
-        assert np.all(np.isfinite(self.t)), "Time vector must be finite"
-        assert np.all(np.isfinite(self.states)), "State trajectory must be finite"
+        require(bool(np.all(np.isfinite(self.t))), "Time vector must be finite")
+        require(
+            bool(np.all(np.isfinite(self.states))), "State trajectory must be finite"
+        )
         if self.t.size > 1:
-            assert np.all(np.diff(self.t) > 0), (
-                "Time vector must be strictly increasing"
+            require(
+                bool(np.all(np.diff(self.t) > 0)),
+                "Time vector must be strictly increasing",
             )
 
     def _check_idx(self, idx: int) -> None:
-        assert 0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
+        require(idx is not None, "idx must be provided")
+        require(
+            isinstance(idx, int | np.integer),
+            f"idx must be an integer, got {type(idx).__name__}",
+        )
+        require(
+            0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
+        )
 
     @staticmethod
     def _assert_energy_finite(result: dict, idx: int) -> None:
         """Shared postcondition: all energy components must be finite."""
-        assert all(np.isfinite(v) for v in result.values()), (
-            f"Non-finite energy at idx={idx}: {result}"
+        require(
+            all(np.isfinite(v) for v in result.values()),
+            f"Non-finite energy at idx={idx}: {result}",
         )
 
     def total_torques_at(self, idx: int) -> np.ndarray:
@@ -53,7 +69,6 @@ class TrajectoryResultMixin:
         apply torque clamping (e.g. double-pendulum with TorqueClamp) must
         override this method.
         """
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         torque_func = self.torque_func  # type: ignore[attr-defined]
         tau_drive = np.array(torque_func(self.t[idx]))

--- a/src/shared/python/pendulum_simulator/simulation_triple.py
+++ b/src/shared/python/pendulum_simulator/simulation_triple.py
@@ -33,6 +33,13 @@ from .physics_triple import (
 )
 from .simulation_core import integrate_ode
 from .simulation_result_base import TrajectoryResultMixin
+from .validation import (
+    require,
+    require_dt,
+    require_finite_array,
+    require_positive,
+    require_shape,
+)
 
 # Re-export from shared utility for backwards compatibility (DRY â€” #1041)
 from .torque_utils import make_polynomial_torque  # noqa: F401
@@ -55,13 +62,11 @@ class TripleSimulationResult(TrajectoryResultMixin):
         self._validate_trajectory(expected_state_width=6)
 
     def mass_matrix_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return mass_matrix_components(s[1], s[2], self.params)
 
     def positions_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return forward_kinematics(s[0], s[1], s[2], self.params)
@@ -71,7 +76,6 @@ class TripleSimulationResult(TrajectoryResultMixin):
         return self.torque_func(self.t[idx])
 
     def accelerations_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         state_dot = equations_of_motion(
             self.states[idx], self.t[idx], self.params, self.torque_func
@@ -79,25 +83,21 @@ class TripleSimulationResult(TrajectoryResultMixin):
         return state_dot[3:]
 
     def joint_forces_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         qddot = self.accelerations_at(idx)
         return net_joint_forces(self.states[idx], qddot, self.params)
 
     def coriolis_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return coriolis_vector(s[1], s[2], s[3], s[4], s[5], self.params)
 
     def gravity_at(self, idx: int) -> np.ndarray:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return gravity_vector(s[0], s[1], s[2], self.params)
 
     def energy_at(self, idx: int) -> dict:
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         state = self.states[idx]
         result = {
@@ -115,7 +115,6 @@ class TripleSimulationResult(TrajectoryResultMixin):
         -------
         np.ndarray, shape (3,)  [NÂ·m]
         """
-        assert idx is not None, "idx must be provided"
         self._check_idx(idx)
         s = self.states[idx]
         return friction_torque_vector(s[3], s[4], s[5], self.params)
@@ -161,18 +160,16 @@ def run_simulation(
       visualisation-quality results.  Use tighter values only when
       quantitative energy conservation is required.
     """
-    assert initial_state.shape == (6,), (
-        f"Initial state shape must be (6,), got {initial_state.shape}"
-    )
-    assert all(np.isfinite(initial_state)), "Initial state must be finite"
-    assert t_end > 0, f"t_end must be positive, got {t_end}"
-    assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"
+    require_shape("Initial state", initial_state, (6,))
+    require_finite_array("Initial state", initial_state)
+    require_positive("t_end", t_end)
+    require_dt(dt, t_end)
 
     # Merge clamp kwarg (from SimulationPanel) with torque_limits (legacy)
     effective_torque_limits = torque_limits if torque_limits is not None else clamp
 
     def ode_rhs(t: float, y: np.ndarray) -> np.ndarray:
-        assert t is not None, "t must be provided"
+        require(t is not None, "t must be provided")
         dydt = equations_of_motion(y, t, params, torque_func, effective_torque_limits)
         # Apply joint limit penalty torques if enabled (#1151)
         if limits is not None:
@@ -211,5 +208,5 @@ def run_simulation(
         torque_func=torque_func,
     )
 
-    assert result.n_steps >= 2, "Simulation must produce at least 2 time points"
+    require(result.n_steps >= 2, "Simulation must produce at least 2 time points")
     return result

--- a/src/shared/python/pendulum_simulator/validation.py
+++ b/src/shared/python/pendulum_simulator/validation.py
@@ -1,0 +1,39 @@
+"""Explicit validation helpers for pendulum simulator public contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def require(condition: bool, message: str) -> None:
+    """Raise ``ValueError`` when a public contract condition is false."""
+    if not condition:
+        raise ValueError(message)
+
+
+def require_shape(name: str, value: Any, expected: tuple[int, ...]) -> None:
+    """Validate an array-like object's exact shape."""
+    actual = getattr(value, "shape", None)
+    require(actual == expected, f"{name} shape must be {expected}, got {actual}")
+
+
+def require_finite_array(name: str, value: np.ndarray) -> None:
+    """Validate that an array has only finite values."""
+    require(bool(np.all(np.isfinite(value))), f"{name} must be finite")
+
+
+def require_positive(name: str, value: float) -> None:
+    """Validate that a scalar is strictly positive."""
+    require(value > 0, f"{name} must be positive, got {value}")
+
+
+def require_non_negative(name: str, value: float) -> None:
+    """Validate that a scalar is non-negative."""
+    require(value >= 0, f"{name} must be non-negative, got {value}")
+
+
+def require_dt(dt: float, t_end: float) -> None:
+    """Validate a simulation output time step against the integration horizon."""
+    require(0 < dt < t_end, f"dt must be in (0, t_end), got {dt}")

--- a/tests/unit/pendulum_simulator/test_physics.py
+++ b/tests/unit/pendulum_simulator/test_physics.py
@@ -62,11 +62,11 @@ class TestPendulumParams:
         assert p.mClub == pytest.approx(0.1)
 
     def test_physics_negative_mass_raises(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             PendulumParams(m1=-1.0, m2=0.3, L1=0.65, L2=1.10)
 
     def test_zero_length_raises(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             PendulumParams(m1=1.0, m2=0.3, L1=0.0, L2=1.10)
 
 
@@ -80,7 +80,7 @@ class TestJointLimits:
         assert jl.phi_min < jl.phi_max
 
     def test_inverted_phi_raises(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             JointLimits(phi_min=1.0, phi_max=-1.0)
 
 

--- a/tests/unit/pendulum_simulator/test_simulation_result_base.py
+++ b/tests/unit/pendulum_simulator/test_simulation_result_base.py
@@ -52,13 +52,13 @@ class TestTrajectoryResultMixin:
 
     def test_validate_wrong_state_width_raises(self) -> None:
         result = _ConcreteResult(n=10, state_width=4)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             result._validate_trajectory(6)
 
     def test_validate_non_finite_states_raises(self) -> None:
         result = _ConcreteResult(n=5, state_width=4)
         result.states[2, 1] = np.nan
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             result._validate_trajectory(4)
 
     def test_validate_strictly_increasing_time(self) -> None:
@@ -69,7 +69,7 @@ class TestTrajectoryResultMixin:
     def test_validate_non_monotone_time_raises(self) -> None:
         result = _ConcreteResult(n=5, state_width=4)
         result.t = np.array([0.0, 0.5, 0.3, 0.8, 1.0])  # not increasing
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             result._validate_trajectory(4)
 
     def test_check_idx_valid(self) -> None:
@@ -79,12 +79,12 @@ class TestTrajectoryResultMixin:
 
     def test_check_idx_negative_raises(self) -> None:
         result = _ConcreteResult(n=5)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             result._check_idx(-1)
 
     def test_check_idx_out_of_range_raises(self) -> None:
         result = _ConcreteResult(n=5)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             result._check_idx(5)
 
     def test_all_positions_length(self) -> None:
@@ -126,7 +126,7 @@ class TestTrajectoryResultMixin:
         )  # should not raise
 
     def test_assert_energy_finite_nan_raises(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             TrajectoryResultMixin._assert_energy_finite(
                 {"kinetic": float("nan"), "potential": 2.0}, idx=0
             )

--- a/tests/unit/test_pendulum_public_contracts.py
+++ b/tests/unit/test_pendulum_public_contracts.py
@@ -1,0 +1,144 @@
+"""Public pendulum simulator contracts must survive optimized Python."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.shared.python.pendulum_simulator.physics import PendulumParams
+from src.shared.python.pendulum_simulator.physics_base import (
+    clamp_torque_ndof,
+    kinetic_energy_from_M,
+)
+from src.shared.python.pendulum_simulator.physics_golfer import GolferParams, N_DOF
+from src.shared.python.pendulum_simulator.physics_triple import TriplePendulumParams
+from src.shared.python.pendulum_simulator.simulation import (
+    SimulationResult,
+    run_simulation as run_double_simulation,
+)
+from src.shared.python.pendulum_simulator.simulation_golfer import (
+    run_simulation as run_golfer_simulation,
+)
+from src.shared.python.pendulum_simulator.simulation_triple import (
+    run_simulation as run_triple_simulation,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _double_params() -> PendulumParams:
+    return PendulumParams(m1=5.0, m2=0.3, L1=0.65, L2=1.1)
+
+
+def _triple_params() -> TriplePendulumParams:
+    return TriplePendulumParams(m1=5.0, m2=0.3, m3=0.05, L1=0.65, L2=1.1, L3=0.1)
+
+
+def _golfer_params() -> GolferParams:
+    return GolferParams(
+        m_hub=0.1,
+        m_r_upper=2.0,
+        m_r_fore=1.5,
+        m_l_upper=2.0,
+        m_l_fore=1.5,
+        m_club=0.4,
+        L_hub=0.2,
+        L_r_upper=0.3,
+        L_r_fore=0.25,
+        L_l_upper=0.3,
+        L_l_fore=0.25,
+        L_club=1.0,
+        d_rs=0.2,
+        d_ls=0.2,
+        grip_right=0.2,
+        grip_left=0.3,
+    )
+
+
+def _zero_double_torque(_t: float) -> tuple[float, float]:
+    return 0.0, 0.0
+
+
+def _zero_triple_torque(_t: float) -> tuple[float, float, float]:
+    return 0.0, 0.0, 0.0
+
+
+def _zero_golfer_torque(_t: float) -> np.ndarray:
+    return np.zeros(7)
+
+
+def test_double_runner_rejects_invalid_public_inputs_with_value_error() -> None:
+    with pytest.raises(ValueError, match=r"Initial state shape must be \(4,\)"):
+        run_double_simulation(_double_params(), np.zeros(3), 0.2, _zero_double_torque)
+
+    with pytest.raises(ValueError, match="Initial state must be finite"):
+        run_double_simulation(
+            _double_params(),
+            np.array([0.0, 0.0, np.inf, 0.0]),
+            0.2,
+            _zero_double_torque,
+        )
+
+    with pytest.raises(ValueError, match="t_end must be positive"):
+        run_double_simulation(_double_params(), np.zeros(4), -1.0, _zero_double_torque)
+
+    with pytest.raises(ValueError, match=r"dt must be in \(0, t_end\)"):
+        run_double_simulation(
+            _double_params(), np.zeros(4), 0.2, _zero_double_torque, dt=0.3
+        )
+
+
+def test_triple_runner_rejects_invalid_public_inputs_with_value_error() -> None:
+    with pytest.raises(ValueError, match=r"Initial state shape must be \(6,\)"):
+        run_triple_simulation(_triple_params(), np.zeros(4), 0.2, _zero_triple_torque)
+
+    with pytest.raises(ValueError, match="Initial state must be finite"):
+        state = np.zeros(6)
+        state[1] = np.nan
+        run_triple_simulation(_triple_params(), state, 0.2, _zero_triple_torque)
+
+
+def test_golfer_runner_rejects_invalid_public_inputs_with_value_error() -> None:
+    with pytest.raises(
+        ValueError, match=f"Initial state shape must be \\({2 * N_DOF},\\)"
+    ):
+        run_golfer_simulation(_golfer_params(), np.zeros(4), 0.2, _zero_golfer_torque)
+
+    with pytest.raises(ValueError, match="Initial state must be finite"):
+        state = np.zeros(2 * N_DOF)
+        state[-1] = np.inf
+        run_golfer_simulation(_golfer_params(), state, 0.2, _zero_golfer_torque)
+
+
+def test_physics_base_rejects_invalid_public_inputs_with_value_error() -> None:
+    with pytest.raises(ValueError, match="M shape"):
+        kinetic_energy_from_M(np.eye(2), np.zeros(3))
+
+    with pytest.raises(ValueError, match="Mass matrix has non-finite values"):
+        kinetic_energy_from_M(np.array([[np.inf]]), np.zeros(1))
+
+    with pytest.raises(ValueError, match="Torque limits must be positive"):
+        clamp_torque_ndof(np.array([1.0]), np.array([0.0]))
+
+
+def test_result_container_rejects_invalid_public_inputs_with_value_error() -> None:
+    params = _double_params()
+
+    with pytest.raises(ValueError, match="states must have width 4"):
+        SimulationResult(
+            t=np.array([0.0]),
+            states=np.zeros((1, 3)),
+            params=params,
+            torque_func=_zero_double_torque,
+        )
+
+    result = SimulationResult(
+        t=np.array([0.0, 0.1]),
+        states=np.zeros((2, 4)),
+        params=params,
+        torque_func=_zero_double_torque,
+    )
+    with pytest.raises(ValueError, match="idx must be provided"):
+        result.energy_at(None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"Index 2 out of range"):
+        result.energy_at(2)

--- a/tests/unit/test_simulation_core.py
+++ b/tests/unit/test_simulation_core.py
@@ -51,15 +51,15 @@ class TestIntegrateOde:
         np.testing.assert_allclose(states[:, 0], np.cos(t), atol=0.02)
 
     def test_simulation_core_invalid_t_end_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             integrate_ode(_linear_decay, np.array([1.0]), -1.0, dt=0.01)
 
     def test_non_finite_initial_state_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             integrate_ode(_linear_decay, np.array([np.inf]), 1.0, dt=0.01)
 
     def test_dt_larger_than_t_end_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             integrate_ode(_linear_decay, np.array([1.0]), 0.5, dt=1.0)
 
     def test_all_states_finite(self) -> None:

--- a/tests/unit/test_simulation_golfer.py
+++ b/tests/unit/test_simulation_golfer.py
@@ -71,5 +71,5 @@ class TestRunSimulationGolfer:
     def test_simulation_golfer_invalid_t_end_raises(self) -> None:
         params = _make_params()
         y0 = np.zeros(2 * N_DOF)
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             run_simulation(params, y0, -1.0, _zero_torque, dt=0.02)

--- a/tests/unit/test_simulation_triple.py
+++ b/tests/unit/test_simulation_triple.py
@@ -27,7 +27,7 @@ class TestTriplePendulumParams:
         assert p.m1 == pytest.approx(5.0)
 
     def test_simulation_triple_negative_mass_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             _make_params(m1=-1.0)
 
 
@@ -53,11 +53,11 @@ class TestRunSimulationTriple:
     def test_simulation_triple_invalid_t_end_raises(self) -> None:
         params = _make_params()
         y0 = np.zeros(6)
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             run_simulation(params, y0, -1.0, _zero_torque, dt=0.01)
 
     def test_wrong_initial_state_raises(self) -> None:
         params = _make_params()
         y0 = np.zeros(4)  # Wrong shape — should be (6,)
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError):
             run_simulation(params, y0, 0.2, _zero_torque, dt=0.01)


### PR DESCRIPTION
## Summary
- Replaces raw assert-based public contracts in pendulum simulator entry points, result validation, and shared physics helpers with explicit ValueError validation.
- Adds focused regression coverage for double, triple, golfer, physics-base, and result-container contract failures.
- Verifies the new contract path under optimized Python (`python -O`) so validation is retained when asserts are stripped.

Closes #8128

## Validation
- `py -3.13 -m ruff check src\shared\python\pendulum_simulator\validation.py src\shared\python\pendulum_simulator\simulation_result_base.py src\shared\python\pendulum_simulator\simulation.py src\shared\python\pendulum_simulator\simulation_triple.py src\shared\python\pendulum_simulator\simulation_golfer.py src\shared\python\pendulum_simulator\physics_base.py src\shared\python\pendulum_simulator\physics.py src\shared\python\pendulum_simulator\physics_triple.py tests\unit\test_pendulum_public_contracts.py tests\unit\test_simulation_core.py tests\unit\test_simulation_triple.py tests\unit\test_simulation_golfer.py tests\unit\pendulum_simulator\test_simulation_result_base.py tests\unit\pendulum_simulator\test_physics.py`
- `py -3.13 -m ruff format --check src\shared\python\pendulum_simulator\validation.py src\shared\python\pendulum_simulator\simulation_result_base.py src\shared\python\pendulum_simulator\simulation.py src\shared\python\pendulum_simulator\simulation_triple.py src\shared\python\pendulum_simulator\simulation_golfer.py src\shared\python\pendulum_simulator\physics_base.py src\shared\python\pendulum_simulator\physics.py src\shared\python\pendulum_simulator\physics_triple.py tests\unit\test_pendulum_public_contracts.py tests\unit\test_simulation_core.py tests\unit\test_simulation_triple.py tests\unit\test_simulation_golfer.py tests\unit\pendulum_simulator\test_simulation_result_base.py tests\unit\pendulum_simulator\test_physics.py`
- `$env:QT_QPA_PLATFORM='offscreen'; py -3.13 -m pytest -q tests\unit\test_pendulum_public_contracts.py tests\unit\test_simulation_core.py tests\unit\test_simulation_triple.py tests\unit\test_simulation_golfer.py tests\unit\pendulum_simulator\test_simulation_result_base.py tests\unit\pendulum_simulator\test_physics_base.py tests\unit\pendulum_simulator\test_physics.py tests\unit\pendulum_simulator\test_physics_triple.py`
- `$env:QT_QPA_PLATFORM='offscreen'; py -3.13 -O -m pytest -q tests\unit\test_pendulum_public_contracts.py tests\unit\pendulum_simulator\test_simulation_result_base.py`
- pre-push hook: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, bandit, unit tests