### PR TITLE
fix(motion): gate placeholder matching backends

### DIFF
--- a/docs/motion_pipeline/README.md
+++ b/docs/motion_pipeline/README.md
@@ -31,17 +31,22 @@ If selected without a real dynamics model, the API returns a 400-class
 configuration error instead of reporting placeholder zero torques as a
 successful solve.
 
+The production motion-matching factory currently exposes only implemented
+solver surfaces. OpenSim CMC, OpenSim RRA, and Drake trajectory optimization
+remain experimental backend-development classes until they produce real solves;
+they are not available through the default factory path.
+
 ---
 
 ## When to Choose Each Engine
 
-| Use Case                                                 | Recommended Engine | Why                                           |
-| -------------------------------------------------------- | ------------------ | --------------------------------------------- |
-| **Contact-rich dynamics** (ground reaction, ball impact) | MuJoCo             | Best contact handling, day-to-day development |
-| **Trajectory optimization** (finding optimal swing)      | Drake              | Built-in trajopt solvers, system analysis     |
-| **Fast IK solutions** (real-time retargeting)            | Pinocchio          | Optimized rigid-body algorithms               |
-| **Biomechanics validation**                              | OpenSim            | Gold-standard musculoskeletal models          |
-| **Muscle dynamics**                                      | MyoSuite           | Detailed muscle activation modeling           |
+| Use Case                                                 | Recommended Engine | Why                                                                      |
+| -------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------ |
+| **Contact-rich dynamics** (ground reaction, ball impact) | MuJoCo             | Best contact handling, day-to-day development                            |
+| **Trajectory optimization** (finding optimal swing)      | Drake              | Engine capability; motion-matching trajopt is not production-exposed yet |
+| **Fast IK solutions** (real-time retargeting)            | Pinocchio          | Optimized rigid-body algorithms                                          |
+| **Biomechanics validation**                              | OpenSim            | Gold-standard musculoskeletal models                                     |
+| **Muscle dynamics**                                      | MyoSuite           | Detailed muscle activation modeling                                      |
 
 ---
 

--- a/src/shared/python/motion_pipeline/matching/__init__.py
+++ b/src/shared/python/motion_pipeline/matching/__init__.py
@@ -11,7 +11,9 @@ from .base import (
     MotionMatchingRequest,
     MotionMatchingResult,
     MotionMatchingSolver,
+    is_production_matching_backend,
     make_matching_solver,
+    production_matching_backends,
 )
 from .contact import (
     ContactModel,
@@ -35,6 +37,8 @@ __all__ = [
     "CostWeights",
     "make_matching_solver",
     "MatchingBackendType",
+    "is_production_matching_backend",
+    "production_matching_backends",
     # costs
     "joint_tracking_cost",
     "marker_tracking_cost",

--- a/src/shared/python/motion_pipeline/matching/base.py
+++ b/src/shared/python/motion_pipeline/matching/base.py
@@ -224,6 +224,32 @@ class MatchingBackendType(str, Enum):
     INVERSE_DYN_PINOCCHIO = "pinocchio_inverse_dyn"  # Pinocchio RNEA
 
 
+_EXPERIMENTAL_BACKEND_REASONS: dict[MatchingBackendType, str] = {
+    MatchingBackendType.CMC: "OpenSim CMC muscle redundancy solve is not implemented",
+    MatchingBackendType.RRA: "OpenSim RRA setup, execution, and residual parsing are not implemented",
+    MatchingBackendType.TRAJOPT_DRAKE: (
+        "Drake direct-collocation/contact-implicit trajectory optimization "
+        "is not implemented"
+    ),
+}
+
+
+def production_matching_backends() -> frozenset[MatchingBackendType]:
+    """Return backends the factory may expose for production solver creation."""
+    return frozenset(
+        backend
+        for backend in MatchingBackendType
+        if backend not in _EXPERIMENTAL_BACKEND_REASONS
+    )
+
+
+def is_production_matching_backend(backend: MatchingBackendType | str) -> bool:
+    """Return whether ``backend`` is production-exposed by default."""
+    if isinstance(backend, str):
+        backend = MatchingBackendType(backend.lower())
+    return backend in production_matching_backends()
+
+
 @dataclass
 class CostWeights:
     """
@@ -558,6 +584,7 @@ def make_matching_solver(
     cost_weights: CostWeights | None = None,
     *,
     urdf_path: str | None = None,
+    allow_experimental: bool = False,
 ) -> MotionMatchingSolver:
     """
     Factory function to create a motion matching solver for the specified backend.
@@ -566,6 +593,8 @@ def make_matching_solver(
         backend: Backend type (cmc, rra, drake_trajopt, mujoco_torque, pinocchio_inverse_dyn)
         cost_weights: Optional cost weights
         urdf_path: Optional production URDF path for Pinocchio inverse dynamics
+        allow_experimental: Opt in to unavailable placeholder backends for
+            solver-development tests only.
 
     Returns:
         MotionMatchingSolver instance
@@ -576,6 +605,14 @@ def make_matching_solver(
     """
     if isinstance(backend, str):
         backend = MatchingBackendType(backend.lower())
+
+    experimental_reason = _EXPERIMENTAL_BACKEND_REASONS.get(backend)
+    if experimental_reason is not None and not allow_experimental:
+        raise ValueError(
+            f"Motion matching backend '{backend.value}' is not production-ready: "
+            f"{experimental_reason}. Pass allow_experimental=True only for "
+            "backend-development tests."
+        )
 
     if backend == MatchingBackendType.CMC:
         from .cmc import CMCMatchingSolver

--- a/tests/unit/motion_pipeline/matching/test_base.py
+++ b/tests/unit/motion_pipeline/matching/test_base.py
@@ -19,7 +19,9 @@ from src.shared.python.motion_pipeline.matching.base import (
     MatchingBackendType,
     MotionMatchingRequest,
     MotionMatchingResult,
+    is_production_matching_backend,
     make_matching_solver,
+    production_matching_backends,
 )
 from src.shared.python.motion_pipeline.matching.inverse_dyn_pinocchio import (
     PinocchioInverseDynMatchingSolver,
@@ -113,14 +115,54 @@ def test_make_matching_solver_unknown_backend_raises() -> None:
 @pytest.mark.parametrize(
     "backend",
     [
+        MatchingBackendType.TORQUE_MUJOCO,
+        MatchingBackendType.INVERSE_DYN_PINOCCHIO,
+    ],
+)
+def test_make_matching_solver_returns_protocol_for_production_backends(
+    backend: MatchingBackendType,
+) -> None:
+    solver = make_matching_solver(backend)
+    assert hasattr(solver, "match")
+
+
+def test_production_matching_backends_exclude_unimplemented_placeholders() -> None:
+    assert production_matching_backends() == {
+        MatchingBackendType.TORQUE_MUJOCO,
+        MatchingBackendType.INVERSE_DYN_PINOCCHIO,
+    }
+    assert is_production_matching_backend(MatchingBackendType.CMC) is False
+    assert is_production_matching_backend("rra") is False
+    assert is_production_matching_backend(MatchingBackendType.TRAJOPT_DRAKE) is False
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
         MatchingBackendType.CMC,
         MatchingBackendType.RRA,
         MatchingBackendType.TRAJOPT_DRAKE,
-        MatchingBackendType.TORQUE_MUJOCO,
     ],
 )
-def test_make_matching_solver_returns_protocol(backend: MatchingBackendType) -> None:
-    solver = make_matching_solver(backend)
+def test_make_matching_solver_rejects_unimplemented_backends_by_default(
+    backend: MatchingBackendType,
+) -> None:
+    with pytest.raises(ValueError, match="not production-ready"):
+        make_matching_solver(backend)
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        MatchingBackendType.CMC,
+        MatchingBackendType.RRA,
+        MatchingBackendType.TRAJOPT_DRAKE,
+    ],
+)
+def test_make_matching_solver_requires_explicit_experimental_opt_in(
+    backend: MatchingBackendType,
+) -> None:
+    solver = make_matching_solver(backend, allow_experimental=True)
     assert hasattr(solver, "match")
 
 

--- a/tests/unit/motion_pipeline/matching/test_cmc.py
+++ b/tests/unit/motion_pipeline/matching/test_cmc.py
@@ -15,20 +15,10 @@ def test_cmc_solver_constructs_without_opensim() -> None:
     assert s is not None
 
 
-def test_cmc_solver_match_returns_placeholder_failure() -> None:
-    """Placeholder CMC reports success=False with a clear message."""
-    s = CMCMatchingSolver()
-    ref = make_pendulum_reference_trajectory(num_frames=5)
-    rig = make_simple_rig(num_joints=1)
-    result = s.match(ref, rig)
-    assert isinstance(result, MotionMatchingResult)
-    assert result.success is False
-    assert "CMC" in (result.message or "")
-    assert result.metadata.get("backend") == "cmc"
-    assert result.metadata.get("status") == "not_implemented"
-    assert result.metadata.get("production_ready") is False
-
-
+@pytest.mark.xfail(
+    reason="CMC muscle redundancy solve is not implemented yet; see #8131",
+    strict=True,
+)
 def test_cmc_solver_with_opensim() -> None:
     pytest.importorskip("opensim")
     s = CMCMatchingSolver()
@@ -36,3 +26,9 @@ def test_cmc_solver_with_opensim() -> None:
     rig = make_simple_rig(num_joints=1)
     result = s.match(ref, rig)
     assert isinstance(result, MotionMatchingResult)
+    assert result.success is True
+    assert (
+        result.activation_trajectory is not None or result.torque_trajectory is not None
+    )
+    assert result.fit_metrics
+    assert result.metadata.get("production_ready") is True

--- a/tests/unit/motion_pipeline/matching/test_rra.py
+++ b/tests/unit/motion_pipeline/matching/test_rra.py
@@ -14,19 +14,10 @@ def test_rra_solver_constructs() -> None:
     assert RRAMatchingSolver() is not None
 
 
-def test_rra_solver_match_returns_placeholder_failure() -> None:
-    s = RRAMatchingSolver()
-    ref = make_pendulum_reference_trajectory(num_frames=5)
-    rig = make_simple_rig(num_joints=1)
-    result = s.match(ref, rig)
-    assert isinstance(result, MotionMatchingResult)
-    assert result.success is False
-    assert "RRA" in (result.message or "")
-    assert result.metadata.get("backend") == "rra"
-    assert result.metadata.get("status") == "not_implemented"
-    assert result.metadata.get("production_ready") is False
-
-
+@pytest.mark.xfail(
+    reason="OpenSim RRA setup/execution/parsing is not implemented yet; see #8131",
+    strict=True,
+)
 def test_rra_solver_with_opensim() -> None:
     pytest.importorskip("opensim")
     s = RRAMatchingSolver()
@@ -34,3 +25,7 @@ def test_rra_solver_with_opensim() -> None:
     rig = make_simple_rig(num_joints=1)
     result = s.match(ref, rig)
     assert isinstance(result, MotionMatchingResult)
+    assert result.success is True
+    assert result.tracked_trajectory is not None
+    assert result.residual_report
+    assert result.metadata.get("production_ready") is True

--- a/tests/unit/motion_pipeline/matching/test_trajopt_drake.py
+++ b/tests/unit/motion_pipeline/matching/test_trajopt_drake.py
@@ -16,18 +16,10 @@ def test_drake_trajopt_solver_constructs() -> None:
     assert DrakeTrajoptMatchingSolver() is not None
 
 
-def test_drake_trajopt_match_returns_placeholder_failure() -> None:
-    s = DrakeTrajoptMatchingSolver()
-    ref = make_pendulum_reference_trajectory(num_frames=5)
-    rig = make_simple_rig(num_joints=1)
-    result = s.match(ref, rig)
-    assert isinstance(result, MotionMatchingResult)
-    assert result.success is False
-    assert result.metadata.get("backend") == "drake_trajopt"
-    assert result.metadata.get("status") == "not_implemented"
-    assert result.metadata.get("production_ready") is False
-
-
+@pytest.mark.xfail(
+    reason="Drake trajectory optimization matching is not implemented yet; see #8131",
+    strict=True,
+)
 def test_drake_trajopt_with_pydrake() -> None:
     pytest.importorskip("pydrake")
     s = DrakeTrajoptMatchingSolver()
@@ -35,3 +27,7 @@ def test_drake_trajopt_with_pydrake() -> None:
     rig = make_simple_rig(num_joints=1)
     result = s.match(ref, rig)
     assert isinstance(result, MotionMatchingResult)
+    assert result.success is True
+    assert result.tracked_trajectory is not None
+    assert result.fit_metrics
+    assert result.metadata.get("production_ready") is True


### PR DESCRIPTION
## Summary
- Gates unimplemented CMC, RRA, and Drake trajectory-optimization matching backends out of the default production factory path.
- Adds explicit production-backend capability helpers and requires `allow_experimental=True` for placeholder solver-development construction.
- Replaces placeholder-acceptance tests with factory contract tests and strict dependency-present xfails tied to #8131.
- Updates the motion-pipeline guide so Drake/OpenSim matching is not documented as production-exposed.

Closes #8126

Follow-up implementation tracker: #8131

## Validation
- `py -3.13 -m ruff check src\shared\python\motion_pipeline\matching\base.py src\shared\python\motion_pipeline\matching\__init__.py tests\unit\motion_pipeline\matching\test_base.py tests\unit\motion_pipeline\matching\test_cmc.py tests\unit\motion_pipeline\matching\test_rra.py tests\unit\motion_pipeline\matching\test_trajopt_drake.py`
- `py -3.13 -m ruff format --check src\shared\python\motion_pipeline\matching\base.py src\shared\python\motion_pipeline\matching\__init__.py tests\unit\motion_pipeline\matching\test_base.py tests\unit\motion_pipeline\matching\test_cmc.py tests\unit\motion_pipeline\matching\test_rra.py tests\unit\motion_pipeline\matching\test_trajopt_drake.py`
- `$env:QT_QPA_PLATFORM='offscreen'; py -3.13 -m pytest -q tests\unit\motion_pipeline\matching\test_base.py tests\unit\motion_pipeline\matching\test_cmc.py tests\unit\motion_pipeline\matching\test_rra.py tests\unit\motion_pipeline\matching\test_trajopt_drake.py tests\unit\motion_pipeline\orchestrator\test_orchestrator_e2e.py::test_placeholder_matching_backend_failure_is_invalid_input tests\integration\motion_pipeline\test_compat_matrix.py::test_placeholder_matching_backends_are_never_reported_supported`
- `npx prettier --check docs\motion_pipeline\README.md`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, prettier, mypy, bandit, unit tests