### PR TITLE
fix(ci): disable unavailable Windows Tauri leg

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -154,10 +154,10 @@ jobs:
             os: linux
             runner: d-sorg-fleet-docker
             target: x86_64-unknown-linux-gnu
-          - artifact_name: windows-x64
-            os: windows
-            runner: [self-hosted, Windows]
-            target: x86_64-pc-windows-msvc
+          # Windows leg removed: org currently has no online
+          # `[self-hosted, Windows]` runner capacity, so this matrix entry
+          # queued indefinitely before step-level gates could skip packaging.
+          # Re-add only after a documented Windows runner is available.
           # macOS leg removed: org has no `[self-hosted, macOS]` runners. Jobs
           # with this label queued indefinitely. Re-add when macOS runner
           # capacity is provisioned and macOS becomes an active deliverable.

--- a/docs/operations/production-readiness.md
+++ b/docs/operations/production-readiness.md
@@ -45,7 +45,7 @@ repository is a development or test convenience.
 | ------------------ | --------------------------------------------- | --------- | ----------------- | --------------------- |
 | Python wheel       | Linux x86_64, macOS arm64, Windows 10+ x86_64 | 3.11-3.13 | core; +extras     | CPU                   |
 | Docker image (API) | Linux x86_64                                  | 3.11      | core+extended     | CPU; optional CUDA 12 |
-| Tauri desktop      | Linux x86_64, macOS arm64, Windows 10+ x86_64 | bundled   | core+extended     | CPU                   |
+| Tauri desktop      | Linux x86_64                                  | bundled   | core+extended     | CPU                   |
 | Rust crate         | Linux, macOS, Windows                         | n/a       | n/a               | CPU                   |
 
 Supported means a release has a green smoke test in `tests/smoke/` for the
@@ -86,8 +86,9 @@ publish steps when those release jobs are enabled.
 - Python: 3.11 and 3.12 for the published package — `requires-python = ">=3.11"`
   in `pyproject.toml` is canonical and the standard CI matrix tests 3.11 and
   3.12. Wheel smoke tests also cover 3.13 where release artifacts are built.
-- Operating systems: Linux for CI and service deployments; Windows 10+ and
-  macOS arm64/x64 for desktop artifacts when produced by the Tauri workflow.
+- Operating systems: Linux for CI, service deployments, and automatically built
+  Tauri desktop artifacts. Windows and macOS desktop artifacts are disabled in
+  the Tauri workflow until matching self-hosted runner capacity is provisioned.
 - Native engines: MuJoCo is part of the default package dependency set. Drake,
   Pinocchio, OpenSim, and MyoSuite are optional and only supported when their
   extras and platform prerequisites are installed.

--- a/tests/ci/test_ci_infrastructure.py
+++ b/tests/ci/test_ci_infrastructure.py
@@ -559,14 +559,17 @@ class TestCIEnvironmentCompatibility:
         assert build_job["name"] == "Build (${{ matrix.artifact_name }})"
         assert build_job["runs-on"] == "${{ matrix.runner }}"
         assert "matrix.platform" not in workflow_text
-        assert {entry["artifact_name"] for entry in matrix_entries} == {
-            "linux-x64",
-            "windows-x64",
-        }
+        assert {entry["artifact_name"] for entry in matrix_entries} == {"linux-x64"}
         for entry in matrix_entries:
             assert "platform" not in entry
             assert isinstance(entry["artifact_name"], str)
-            assert entry["os"] in {"linux", "windows"}
+            assert entry["os"] == "linux"
+            assert entry["runner"] == "d-sorg-fleet-docker"
+        assert "runner: [self-hosted, Windows]" not in workflow_text
+        assert (
+            "Re-add only after a documented Windows runner is available."
+            in workflow_text
+        )
 
         upload = next(
             step


### PR DESCRIPTION
## Summary
- Removes the unavailable `[self-hosted, Windows]` Tauri build matrix leg so release/main runs no longer queue forever before step-level gates can run.
- Documents Linux as the currently automated Tauri desktop artifact and records Windows/macOS as disabled until matching self-hosted runner capacity exists.
- Updates the CI infrastructure test to assert the workflow schedules only available runner capacity.

Closes #8124

## Validation
- `py -3.13 -m pytest -q tests\ci\test_ci_infrastructure.py -k tauri`
- `py -3.13 scripts\check_local_only_workflows.py --workflow-dir .github\workflows`
- `py -3.13 -m ruff check tests\ci\test_ci_infrastructure.py`
- `py -3.13 -m ruff format --check tests\ci\test_ci_infrastructure.py`
- `npx prettier --check .github\workflows\tauri-build.yml docs\operations\production-readiness.md`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, prettier, unit tests