### PR TITLE
fix(diagnostics): isolate timed out API probes

### DIFF
--- a/src/api/routes/diagnostics.py
+++ b/src/api/routes/diagnostics.py
@@ -117,7 +117,7 @@ async def get_full_diagnostics() -> dict[str, Any]:
         build_report,
     )
 
-    diag = LauncherDiagnostics()
+    diag = LauncherDiagnostics(capture_results=False, publish_results=False)
     outcomes = await safe_gather(
         *(_run_probe(diag, name, DiagnosticResult) for name in DIAGNOSTIC_CHECKS)
     )
@@ -135,6 +135,7 @@ async def get_full_diagnostics() -> dict[str, Any]:
         else:
             results.append(outcome)
 
+    diag.finalize_results(results, publish=True)
     return build_report(results, expected_tiles=len(diag.EXPECTED_TILE_IDS))
 
 

--- a/src/launchers/launcher_diagnostics.py
+++ b/src/launchers/launcher_diagnostics.py
@@ -188,10 +188,17 @@ class LauncherDiagnostics:
         "project_map": "Project Map",
     }
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        capture_results: bool = True,
+        publish_results: bool = True,
+    ) -> None:
         """Initialize diagnostics."""
         self.results: list[DiagnosticResult] = []
         self._start_time = time.time()
+        self._capture_results = capture_results
+        self._publish_results = publish_results
 
     @staticmethod
     def _push_to_ring_buffer(results: list[DiagnosticResult]) -> None:
@@ -218,13 +225,13 @@ class LauncherDiagnostics:
         except Exception:  # noqa: BLE001
             pass
 
-    def _record_result(self, result: DiagnosticResult) -> None:
-        """Append *result* to ``self.results`` and push it to the ring buffer.
+    @staticmethod
+    def _publish_result(result: DiagnosticResult) -> None:
+        """Push one diagnostic result to shared diagnostic channels.
 
         Best-effort ring-buffer write: any failure from `record_event` is
         silently swallowed so a buffer outage never breaks the diagnostic run.
         """
-        self.results.append(result)
         try:
             from src.shared.python.app_state import get_state_logger
 
@@ -253,6 +260,26 @@ class LauncherDiagnostics:
             )
         except Exception:  # noqa: BLE001
             pass
+
+    def _record_result(self, result: DiagnosticResult) -> None:
+        """Append and publish *result* according to this instance's policy."""
+        if self._capture_results:
+            self.results.append(result)
+        if self._publish_results:
+            self._publish_result(result)
+
+    def finalize_results(
+        self,
+        results: list[DiagnosticResult],
+        *,
+        publish: bool | None = None,
+    ) -> None:
+        """Replace captured results and optionally publish that final result set."""
+        self.results = list(results)
+        should_publish = self._publish_results if publish is None else publish
+        if should_publish:
+            for result in results:
+                self._publish_result(result)
 
     def run_all_checks(self) -> dict[str, Any]:
         """Run all diagnostic checks and return comprehensive report.

--- a/tests/unit/api/test_diagnostics_routes.py
+++ b/tests/unit/api/test_diagnostics_routes.py
@@ -85,6 +85,45 @@ class TestFullDiagnosticsEndpoint:
         assert by_name[slow_name]["status"] == "warning"
         assert "timed out" in by_name[slow_name]["message"]
 
+    def test_timed_out_probe_cannot_publish_late_success(
+        self, stubbed_checks: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slow_name = DIAGNOSTIC_CHECKS[0]
+        instances: list[LauncherDiagnostics] = []
+        published: list[tuple[str, str]] = []
+        original_init = LauncherDiagnostics.__init__
+
+        def tracking_init(self: LauncherDiagnostics, *args: Any, **kwargs: Any) -> None:
+            original_init(self, *args, **kwargs)
+            instances.append(self)
+
+        def slow_check(self: LauncherDiagnostics) -> DiagnosticResult:
+            time.sleep(0.15)
+            result = DiagnosticResult(name=slow_name, status="pass", message="late")
+            self._record_result(result)
+            return result
+
+        monkeypatch.setattr(LauncherDiagnostics, "__init__", tracking_init)
+        monkeypatch.setattr(LauncherDiagnostics, f"check_{slow_name}", slow_check)
+        monkeypatch.setattr(
+            LauncherDiagnostics,
+            "_publish_result",
+            staticmethod(lambda result: published.append((result.name, result.status))),
+        )
+        monkeypatch.setattr(diagnostics_routes, "PROBE_TIMEOUT_SECONDS", 0.05)
+
+        body = _client().get("/api/v1/diagnostics/full").json()
+        time.sleep(0.25)
+
+        by_name = {check["name"]: check for check in body["checks"]}
+        assert by_name[slow_name]["status"] == "warning"
+        assert instances
+        recorded = [(result.name, result.status) for result in instances[0].results]
+        assert (slow_name, "warning") in recorded
+        assert (slow_name, "pass") not in recorded
+        assert (slow_name, "warning") in published
+        assert (slow_name, "pass") not in published
+
     def test_hidden_in_production(
         self, stubbed_checks: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- add capture/publish policy controls to `LauncherDiagnostics`
- run `/api/v1/diagnostics/full` probes with worker side effects suppressed
- finalize and publish the API's single authoritative outcome list after all probe wrappers complete
- add a timeout regression proving a late probe success cannot overwrite/publish after the API returned a timeout warning

Closes #8141

## Validation
- `py -3.13 -m pytest -q tests\unit\api\test_diagnostics_routes.py`
- `py -3.13 -m ruff format src\api\routes\diagnostics.py src\launchers\launcher_diagnostics.py tests\unit\api\test_diagnostics_routes.py`
- `py -3.13 -m ruff check src\api\routes\diagnostics.py src\launchers\launcher_diagnostics.py tests\unit\api\test_diagnostics_routes.py`
- `git diff --check`

## Notes
- Push hooks also passed: ruff, format, formatter guidance, wildcard/debug/print guards, mypy, bandit, and unit tests.
- A broader launcher diagnostics slice still shows the pre-existing stale expected-tile failures covered by PR #8139, so this PR keeps validation scoped to the API timeout contract it changes.