### PR TITLE
fix(ci): remove unavailable Windows Tauri runner leg

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -154,23 +154,20 @@ jobs:
             os: linux
             runner: d-sorg-fleet-docker
             target: x86_64-unknown-linux-gnu
-          - artifact_name: windows-x64
-            os: windows
-            runner: [self-hosted, Windows]
-            target: x86_64-pc-windows-msvc
+          # Windows leg removed: org has no compatible `[self-hosted, Windows]`
+          # runner for this Tauri packaging job, so the matrix entry queued
+          # indefinitely before step-level gates could run. Re-add only after
+          # Windows runner capacity exists and Cargo build scripts are allowed.
           # macOS leg removed: org has no `[self-hosted, macOS]` runners. Jobs
           # with this label queued indefinitely. Re-add when macOS runner
           # capacity is provisioned and macOS becomes an active deliverable.
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
-    env:
-      WINDOWS_TAURI_RELEASE_ENABLED: ${{ vars.TAURI_WINDOWS_RELEASE_ENABLED == 'true' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Node.js
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
@@ -183,41 +180,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Setup Rust (Windows)
-        if: matrix.os == 'windows' && env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
-        shell: pwsh
-        env:
-          RUST_TARGET: ${{ matrix.target }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
-          if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
-            Invoke-WebRequest -Uri "https://win.rustup.rs" -OutFile "rustup-init.exe"
-            .\rustup-init.exe -y --default-toolchain stable --profile minimal
-            $env:PATH = "$cargoBin;$env:PATH"
-            $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          }
-          rustup toolchain install stable --profile minimal --target $env:RUST_TARGET
-          rustup default stable
-          rustup target add $env:RUST_TARGET
-          rustup --version
-          rustc --version
-          cargo --version
-
-      # Per-target Rust cache for release builds. Each platform gets its own
-      # cache so the Linux/Windows matrix legs don't trash each other.
+      # Per-target Rust cache for release builds.
       - name: Cache Rust target (build)
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: ui/src-tauri -> target
           key: ud-tauri-build-${{ runner.name }}-${{ matrix.target }}
-
-      - name: Report Windows Tauri release disabled
-        if: matrix.os == 'windows' && env.WINDOWS_TAURI_RELEASE_ENABLED != 'true'
-        shell: pwsh
-        run: |
-          Write-Host "::notice::Windows Tauri release packaging is skipped because this self-hosted Windows runner blocks Cargo build-script executables with Application Control (os error 4551). Set repository variable TAURI_WINDOWS_RELEASE_ENABLED=true only after the selected Windows runner policy allows Cargo build scripts."
 
       - name: Install Linux dependencies
         if: matrix.os == 'linux'
@@ -237,17 +205,14 @@ jobs:
           apt_retry install -y libwebkit2gtk-4.1-dev libappindicator3-dev libdbus-1-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         working-directory: ui
         run: npm ci
 
       - name: Build frontend
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         working-directory: ui
         run: npm run build
 
       - name: Build Tauri app
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
         env:
           GITHUB_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
@@ -255,7 +220,6 @@ jobs:
           projectPath: ui
 
       - name: Upload artifacts
-        if: matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: golf-modeling-suite-${{ matrix.artifact_name }}

--- a/tests/ci/test_ci_infrastructure.py
+++ b/tests/ci/test_ci_infrastructure.py
@@ -572,14 +572,11 @@ class TestCIEnvironmentCompatibility:
         assert build_job["name"] == "Build (${{ matrix.artifact_name }})"
         assert build_job["runs-on"] == "${{ matrix.runner }}"
         assert "matrix.platform" not in workflow_text
-        assert {entry["artifact_name"] for entry in matrix_entries} == {
-            "linux-x64",
-            "windows-x64",
-        }
+        assert {entry["artifact_name"] for entry in matrix_entries} == {"linux-x64"}
         for entry in matrix_entries:
             assert "platform" not in entry
             assert isinstance(entry["artifact_name"], str)
-            assert entry["os"] in {"linux", "windows"}
+            assert entry["os"] == "linux"
 
         upload = next(
             step
@@ -590,8 +587,8 @@ class TestCIEnvironmentCompatibility:
             "golf-modeling-suite-${{ matrix.artifact_name }}"
         )
 
-    def test_tauri_windows_build_avoids_bash_rust_toolchain_action(self) -> None:
-        """Windows self-hosted build setup must avoid the bash-based Rust action."""
+    def test_tauri_build_matrix_omits_unavailable_windows_runner(self) -> None:
+        """Windows Tauri packaging must not queue on unavailable runner labels."""
         try:
             import yaml
         except ImportError:
@@ -603,86 +600,44 @@ class TestCIEnvironmentCompatibility:
             ),
         )
         build_job = workflow["jobs"]["build"]
-        steps = build_job["steps"]
-        unix_setup = next(
-            step for step in steps if step.get("name") == "Setup Rust (Unix)"
-        )
-        windows_setup = next(
-            step for step in steps if step.get("name") == "Setup Rust (Windows)"
-        )
+        matrix_entries = build_job["strategy"]["matrix"]["include"]
 
-        assert unix_setup["if"] == "matrix.os != 'windows'"
-        assert "dtolnay/rust-toolchain" in unix_setup["uses"]
-        assert windows_setup["if"] == (
-            "matrix.os == 'windows' && env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'"
-        )
-        assert windows_setup["shell"] == "pwsh"
-        assert "dtolnay/rust-toolchain" not in windows_setup.get("uses", "")
-        windows_script = windows_setup["run"]
-        assert (
-            "rustup toolchain install stable --profile minimal --target $env:RUST_TARGET"
-            in windows_script
-        )
-        assert "rustup default stable" in windows_script
-        assert "rustup target add $env:RUST_TARGET" in windows_script
-        assert "cargo --version" in windows_script
+        for entry in matrix_entries:
+            assert entry["os"] != "windows"
+            assert entry["runner"] != ["self-hosted", "Windows"]
+            assert entry["artifact_name"] != "windows-x64"
 
         cache_step = next(
-            step for step in steps if step.get("name") == "Cache Rust target (build)"
+            step
+            for step in build_job["steps"]
+            if step.get("name") == "Cache Rust target (build)"
         )
         cache_key = cache_step["with"]["key"]
         assert "${{ runner.name }}" in cache_key
         assert "${{ matrix.target }}" in cache_key
 
-    def test_tauri_windows_release_packaging_requires_policy_opt_in(self) -> None:
-        """Windows packaging needs an App-Control-compatible runner policy."""
+    def test_tauri_build_has_no_step_level_windows_runner_gate(self) -> None:
+        """Unavailable Windows packaging must be removed before runner assignment."""
         try:
             import yaml
         except ImportError:
             pytest.skip("PyYAML is required for workflow structure checks")
 
+        workflow_text = (
+            REPO_ROOT / ".github" / "workflows" / "tauri-build.yml"
+        ).read_text(encoding="utf-8")
         workflow = yaml.safe_load(
-            (REPO_ROOT / ".github" / "workflows" / "tauri-build.yml").read_text(
-                encoding="utf-8",
-            ),
+            workflow_text,
         )
         build_job = workflow["jobs"]["build"]
         steps = build_job["steps"]
-        build_enabled = (
-            "matrix.os != 'windows' || env.WINDOWS_TAURI_RELEASE_ENABLED == 'true'"
-        )
 
-        assert (
-            build_job["env"]["WINDOWS_TAURI_RELEASE_ENABLED"]
-            == "${{ vars.TAURI_WINDOWS_RELEASE_ENABLED == 'true' && 'true' || 'false' }}"
-        )
-
-        notice_step = next(
-            step
-            for step in steps
-            if step.get("name") == "Report Windows Tauri release disabled"
-        )
-        assert notice_step["if"] == (
-            "matrix.os == 'windows' && env.WINDOWS_TAURI_RELEASE_ENABLED != 'true'"
-        )
-        assert "Application Control" in notice_step["run"]
-        assert "os error 4551" in notice_step["run"]
-        assert "TAURI_WINDOWS_RELEASE_ENABLED=true" in notice_step["run"]
-
-        gated_step_names = {
-            "Setup Node.js",
-            "Cache Rust target (build)",
-            "Install frontend dependencies",
-            "Build frontend",
-            "Build Tauri app",
-            "Upload artifacts",
-        }
-        gated_steps = {
-            step["name"]: step for step in steps if step.get("name") in gated_step_names
-        }
-        assert set(gated_steps) == gated_step_names
-        for step in gated_steps.values():
-            assert step["if"] == build_enabled
+        assert "WINDOWS_TAURI_RELEASE_ENABLED" not in build_job.get("env", {})
+        assert "TAURI_WINDOWS_RELEASE_ENABLED" not in workflow_text
+        assert not re.search(r"runner:\s*\[self-hosted,\s*Windows\]", workflow_text)
+        assert "windows-x64" not in workflow_text
+        for step in steps:
+            assert "WINDOWS_TAURI_RELEASE_ENABLED" not in str(step.get("if", ""))
 
     def test_bot_ci_trigger_validates_token_before_authenticated_trigger(
         self,


### PR DESCRIPTION
## Summary
- removes the Windows Tauri release matrix leg that requested `[self-hosted, Windows]` before any step-level opt-out could run
- removes the dead `TAURI_WINDOWS_RELEASE_ENABLED` step gates from the build job
- updates CI infrastructure tests so unavailable Windows Tauri packaging cannot be reintroduced as a queued matrix leg

## Root Cause
The Tauri release `build` job included a `windows-x64` matrix entry with `runner: [self-hosted, Windows]`. The workflow tried to skip Windows packaging inside individual steps, but GitHub has to assign the job to that unavailable runner before any step-level `if` can execute. That leaves the job queued indefinitely and contributes to runner saturation.

## Validation
- Red first: `py -3.13 -m pytest -q tests\\ci\\test_ci_infrastructure.py -k "tauri_build_matrix_uses_named_runner_metadata or tauri_build_matrix_omits_unavailable_windows_runner or tauri_build_has_no_step_level_windows_runner_gate"`
- `py -3.13 -m pytest -q tests\\ci\\test_ci_infrastructure.py`
- `py -3.13 -m ruff format --check tests\\ci\\test_ci_infrastructure.py`
- `py -3.13 -m ruff check tests\\ci\\test_ci_infrastructure.py`
- `py -3.13 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/tauri-build.yml').read_text(encoding='utf-8')); print('tauri-build.yml parses')"`
- `actionlint .github\\workflows\\tauri-build.yml`
- `git diff --check`
- pre-push hook: ruff, ruff format, prettier, bandit, unit pytest slice all passed

## Coordination
The Repository_Management lease helper was attempted for #8124 and failed open while adding the label/comment; this PR is linked with `Closes #8124` for durable issue closure.

Closes #8124
