### PR TITLE
fix(diagnostics): validate launcher report contracts

### DIFF
--- a/src/launchers/launcher_diagnostics.py
+++ b/src/launchers/launcher_diagnostics.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -132,7 +133,7 @@ class DiagnosticResult:
     """Result of a diagnostic check."""
 
     name: str
-    status: str  # "pass", "fail", "warning"
+    status: str  # "pass", "fail", "warning", "info"
     message: str
     details: dict[str, Any] = field(default_factory=dict)
     duration_ms: float = 0.0
@@ -325,8 +326,51 @@ class LauncherDiagnostics:
     ) -> DiagnosticResult:
         if models is None:
             raise ValueError("models must be provided")
+        if not isinstance(models, list):
+            details["models_type"] = type(models).__name__
+            return DiagnosticResult(
+                name="models_yaml",
+                status="fail",
+                message=f"models must be a list, got {type(models).__name__}",
+                details=details,
+                duration_ms=0,
+            )
+
         details["model_count"] = len(models)
-        details["model_ids"] = [m.get("id", "unknown") for m in models]
+        model_ids: list[str] = []
+        for index, model in enumerate(models):
+            if not isinstance(model, Mapping):
+                details["malformed_model"] = {
+                    "index": index,
+                    "actual_type": type(model).__name__,
+                }
+                return DiagnosticResult(
+                    name="models_yaml",
+                    status="fail",
+                    message=(
+                        f"models[{index}] must be a mapping, got {type(model).__name__}"
+                    ),
+                    details=details,
+                    duration_ms=0,
+                )
+
+            model_id = model.get("id")
+            if not isinstance(model_id, str) or not model_id:
+                details["malformed_model"] = {
+                    "index": index,
+                    "field": "id",
+                    "actual_type": type(model_id).__name__,
+                }
+                return DiagnosticResult(
+                    name="models_yaml",
+                    status="fail",
+                    message=f"models[{index}].id must be a string",
+                    details=details,
+                    duration_ms=0,
+                )
+            model_ids.append(model_id)
+
+        details["model_ids"] = model_ids
 
         found_ids = set(details["model_ids"])
         expected_ids = set(self.PARENT_MANIFEST_TILE_IDS)
@@ -560,10 +604,13 @@ class LauncherDiagnostics:
         }
 
         if not LAYOUT_CONFIG_FILE.exists():
+            expected_tiles = len(self.EXPECTED_TILE_IDS)
             result = DiagnosticResult(
                 name="layout_config",
                 status="pass",
-                message="No saved layout (will use defaults with 17 tiles)",
+                message=(
+                    f"No saved layout (will use defaults with {expected_tiles} tiles)"
+                ),
                 details=details,
                 duration_ms=(time.time() - start) * 1000,
             )
@@ -1134,6 +1181,7 @@ def build_report(
     passed = sum(1 for r in results if r.status == "pass")
     failed = sum(1 for r in results if r.status == "fail")
     warnings = sum(1 for r in results if r.status == "warning")
+    infos = sum(1 for r in results if r.status == "info")
 
     return {
         "summary": {
@@ -1141,6 +1189,7 @@ def build_report(
             "passed": passed,
             "failed": failed,
             "warnings": warnings,
+            "infos": infos,
             "status": "healthy" if failed == 0 else "degraded",
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "expected_tiles": expected_tiles,
@@ -1161,7 +1210,8 @@ def generate_recommendations(  # noqa: C901
         if result.status == "fail":
             if result.name == "models_yaml":
                 recommendations.append(
-                    "CRITICAL: Ensure src/config/models.yaml exists and contains all 17 model definitions"
+                    "CRITICAL: Ensure src/config/models.yaml exists "
+                    "and contains the canonical local model definitions"
                 )
             elif result.name == "model_registry":
                 recommendations.append(
@@ -1183,7 +1233,9 @@ def generate_recommendations(  # noqa: C901
                 details = result.details
                 if details.get("missing_from_saved"):
                     recommendations.append(
-                        f"LIKELY CAUSE: Saved layout is missing tiles. Delete {LAYOUT_CONFIG_FILE} to reset to defaults with all 17 tiles"
+                        "LIKELY CAUSE: Saved layout is missing tiles. "
+                        f"Delete {LAYOUT_CONFIG_FILE} to reset to defaults "
+                        "with all expected tiles"
                     )
             elif result.name == "asset_files":
                 recommendations.append("Some tile icons may not display correctly")
@@ -1209,6 +1261,10 @@ def generate_recommendations(  # noqa: C901
                     recommendations.append(
                         "A newer version of ud-tools is available. Run 'Sync Shared Tools' in Settings to update"
                     )
+        elif result.status == "info":
+            recommendations.append(
+                f"Informational diagnostic: {result.name} - {result.message}"
+            )
 
     if not recommendations:
         recommendations.append("All systems operational - no issues detected")
@@ -1227,7 +1283,10 @@ def reset_layout_config() -> bool:
         if backup_path is not None:
             logger.info("Backed up existing config to %s", backup_path)
 
-        logger.info("Layout config reset - launcher will use defaults (17 tiles)")
+        logger.info(
+            "Layout config reset - launcher will use defaults (%s tiles)",
+            len(LauncherDiagnostics.EXPECTED_TILE_IDS),
+        )
         return True
     except (RuntimeError, ValueError, OSError):
         logger.exception("Failed to reset layout config")

--- a/src/launchers/settings_dialog.py
+++ b/src/launchers/settings_dialog.py
@@ -1266,7 +1266,8 @@ class SettingsWidget(QWidget):
         passed = summary.get("passed", 0)
         failed = summary.get("failed", 0)
         warnings = summary.get("warnings", 0)
-        total = summary.get("total_checks", passed + failed + warnings)
+        infos = summary.get("infos", 0)
+        total = summary.get("total_checks", passed + failed + warnings + infos)
 
         status_color = "#2da44e" if status == "HEALTHY" else "#d29922"
         return f"""
@@ -1275,7 +1276,8 @@ class SettingsWidget(QWidget):
             <p><b>{total} checks:</b>
                 <span style="color:#2da44e;">{passed} passed</span>,
                 <span style="color:#f85149;">{failed} failed</span>,
-                <span style="color:#d29922;">{warnings} warnings</span>
+                <span style="color:#d29922;">{warnings} warnings</span>,
+                <span style="color:#58a6ff;">{infos} info</span>
             </p>
         </div>
         """

--- a/tests/launchers/test_launcher_diagnostics.py
+++ b/tests/launchers/test_launcher_diagnostics.py
@@ -9,6 +9,7 @@ import yaml  # noqa: E402
 from src.launchers.launcher_diagnostics import (  # noqa: E402
     DiagnosticResult,
     LauncherDiagnostics,
+    build_report,
     reset_layout_config,
     run_cli_diagnostics,
 )
@@ -129,6 +130,59 @@ def test_check_models_yaml_missing_models_key(mock_exists) -> None:
     assert "missing 'models'" in res.message
 
 
+@pytest.mark.parametrize(
+    ("models", "message_fragment", "details"),
+    [
+        ("bad-models", "models must be a list", {"models_type": "str"}),
+        (
+            ["bad-entry"],
+            "models[0] must be a mapping",
+            {"malformed_model": {"index": 0, "actual_type": "str"}},
+        ),
+        (
+            [{}],
+            "models[0].id must be a string",
+            {
+                "malformed_model": {
+                    "index": 0,
+                    "field": "id",
+                    "actual_type": "NoneType",
+                }
+            },
+        ),
+        (
+            [{"id": 123}],
+            "models[0].id must be a string",
+            {
+                "malformed_model": {
+                    "index": 0,
+                    "field": "id",
+                    "actual_type": "int",
+                }
+            },
+        ),
+    ],
+)
+@patch("pathlib.Path.exists", return_value=True)
+def test_check_models_yaml_rejects_malformed_model_entries(
+    mock_exists,
+    models,
+    message_fragment,
+    details,
+) -> None:
+    diag = LauncherDiagnostics()
+    data = {"models": models}
+
+    with patch("builtins.open", mock_open(read_data=yaml.dump(data))):
+        res = diag.check_models_yaml()
+
+    assert res.name == "models_yaml"
+    assert res.status == "fail"
+    assert message_fragment in res.message
+    for key, expected_value in details.items():
+        assert res.details[key] == expected_value
+
+
 @patch("pathlib.Path.exists", return_value=True)
 def test_check_models_yaml_incomplete(mock_exists) -> None:
     diag = LauncherDiagnostics()
@@ -141,6 +195,28 @@ def test_check_models_yaml_incomplete(mock_exists) -> None:
     assert res.name == "models_yaml"
     assert res.status == "fail"
     assert "Missing" in res.message
+
+
+def test_build_report_counts_info_statuses() -> None:
+    report = build_report(
+        [
+            DiagnosticResult("python_environment", "pass", "ok"),
+            DiagnosticResult("tools_sidebar", "info", "optional unavailable"),
+        ],
+        expected_tiles=0,
+    )
+
+    summary = report["summary"]
+    assert summary["total_checks"] == 2
+    assert summary["passed"] == 1
+    assert summary["failed"] == 0
+    assert summary["warnings"] == 0
+    assert summary["infos"] == 1
+    assert (
+        summary["passed"] + summary["failed"] + summary["warnings"] + summary["infos"]
+        == summary["total_checks"]
+    )
+    assert any("informational" in rec.lower() for rec in report["recommendations"])
 
 
 @patch("src.shared.python.config.model_registry.ModelRegistry")

--- a/tests/unit/test_launcher_diagnostics.py
+++ b/tests/unit/test_launcher_diagnostics.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 # Try to import the launcher diagnostics module
 try:
@@ -33,6 +34,15 @@ except ImportError as e:
     pytest.skip(
         f"Cannot import launcher_diagnostics module: {e}", allow_module_level=True
     )
+
+
+def _local_model_ids() -> set[str]:
+    models_yaml = Path("src/config/models.yaml")
+    data = yaml.safe_load(models_yaml.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    models = data["models"]
+    assert isinstance(models, list)
+    return {model["id"] for model in models}
 
 
 @pytest.fixture(autouse=True)
@@ -113,8 +123,14 @@ class TestLauncherDiagnostics:
         """Test that expected tile IDs are defined."""
         diag = LauncherDiagnostics()
         expected_ids = diag.EXPECTED_TILE_IDS
+        local_ids = _local_model_ids()
 
-        assert len(expected_ids) == 17, "Assertion failed: len(expected_ids) == 17"
+        assert set(diag.PARENT_MANIFEST_TILE_IDS) == local_ids, (
+            "Assertion failed: parent manifest IDs match local models.yaml"
+        )
+        assert set(expected_ids) >= local_ids, (
+            "Assertion failed: runtime expected IDs cover local models.yaml IDs"
+        )
         assert "mujoco_unified" in expected_ids, (
             "Assertion failed: mujoco_unified in expected_ids"
         )
@@ -170,18 +186,22 @@ class TestLauncherDiagnostics:
         assert "passed" in summary, "Assertion failed: passed in summary"
         assert "failed" in summary, "Assertion failed: failed in summary"
         assert "warnings" in summary, "Assertion failed: warnings in summary"
+        assert "infos" in summary, "Assertion failed: infos in summary"
         assert "status" in summary, "Assertion failed: status in summary"
         assert "timestamp" in summary, "Assertion failed: timestamp in summary"
         assert "expected_tiles" in summary, (
             "Assertion failed: expected_tiles in summary"
         )
-        assert summary["expected_tiles"] == 17, (
-            "Assertion failed: summary[expected_tiles] == 17"
-        )
+        assert summary["expected_tiles"] == len(
+            LauncherDiagnostics.EXPECTED_TILE_IDS
+        ), "Assertion failed: summary[expected_tiles] matches expected IDs"
 
         # Verify counts add up
         assert (
-            summary["passed"] + summary["failed"] + summary["warnings"]
+            summary["passed"]
+            + summary["failed"]
+            + summary["warnings"]
+            + summary["infos"]
             == summary["total_checks"]
         )
 
@@ -498,8 +518,8 @@ class TestCLIDiagnostics:
             run_cli_diagnostics()
 
         log_text = caplog.text
-        assert "Golf Modeling Suite" in log_text, (
-            "Assertion failed: Golf Modeling Suite in log_text"
+        assert "UpstreamDrift - Launcher Diagnostics" in log_text, (
+            "Assertion failed: UpstreamDrift - Launcher Diagnostics in log_text"
         )
         assert "Status:" in log_text, "Assertion failed: Status: in log_text"
         assert "Recommendations:" in log_text, (


### PR DESCRIPTION
## Summary
- reject malformed `models.yaml` structures with structured diagnostic failures instead of crashing
- count `info` diagnostics in launcher reports and render them in the settings dialog summary
- preserve current `main` provider-expansion semantics: parent-manifest validation uses `PARENT_MANIFEST_TILE_IDS`, while runtime registry diagnostics keep provider-expanded `EXPECTED_TILE_IDS`

Closes #8137
Closes #8138

## Validation
- `py -3.13 -m pytest -q tests\launchers\test_launcher_diagnostics.py tests\launchers\test_settings_dialog.py tests\unit\test_launcher_diagnostics.py tests\unit\launchers\test_launcher_diagnostics_fixes.py tests\unit\api\test_diagnostics_routes.py tests\unit\test_api_diagnostics.py`
- `py -3.13 -m ruff format --check src\launchers\launcher_diagnostics.py src\launchers\settings_dialog.py tests\launchers\test_launcher_diagnostics.py tests\unit\test_launcher_diagnostics.py`
- `py -3.13 -m ruff check src\launchers\launcher_diagnostics.py src\launchers\settings_dialog.py tests\launchers\test_launcher_diagnostics.py tests\unit\test_launcher_diagnostics.py`
- `git diff --check`
- Pre-push hook passed: ruff, ruff format, formatter guidance, import/debug/print guards, bandit, unit pytest

## Notes
- Replaces closed dirty PR #8139 with a clean branch from current `origin/main`.