### PR TITLE
fix(web): clear analysis tools mounted guard on unmount

### DIFF
--- a/ui/src/api/useAnalysisTools.test.ts
+++ b/ui/src/api/useAnalysisTools.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('useAnalysisTools lifecycle guard', () => {
+  it('clears the mounted ref on unmount before async completions can set state', () => {
+    const source = readFileSync(join(__dirname, 'useAnalysisTools.ts'), 'utf-8');
+
+    expect(source).toMatch(/import\s+\{[^}]*useEffect[^}]*\}\s+from 'react';/);
+    expect(source).toMatch(
+      /useEffect\(\(\) => \{\s*isMountedRef\.current = true;\s*return \(\) => \{\s*isMountedRef\.current = false;\s*\};\s*\}, \[\]\);/,
+    );
+  });
+});

--- a/ui/src/api/useAnalysisTools.ts
+++ b/ui/src/api/useAnalysisTools.ts
@@ -11,7 +11,7 @@
  *  - POST /api/analysis/export     -> streamed CSV/JSON file download
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiFetch } from './fetch';
 import { getApiBase } from './backend';
 
@@ -63,6 +63,13 @@ export function useAnalysisTools() {
   const [loadState, setLoadState] = useState<AnalysisLoadState>('idle');
   const [error, setError] = useState<string | null>(null);
   const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const fetchMetrics = useCallback(async () => {
     setLoadState('loading');


### PR DESCRIPTION
## Summary
- add the missing mount/unmount cleanup effect to `useAnalysisTools`
- add a focused lifecycle guard regression test for the mounted-ref contract

Closes #8151

## Validation
- Red first: `npm run test:run -- useAnalysisTools` failed before the hook cleanup on the missing `useEffect`/cleanup assertion
- `npm run test:run -- useAnalysisTools`
- `npm run type-check`
- `npx eslint src\api\useAnalysisTools.ts src\api\useAnalysisTools.test.ts --quiet`
- `git diff --check`
- Pre-push hook passed