### PR TITLE
fix(api): report loaded engines as available

### DIFF
--- a/src/api/routes/engines.py
+++ b/src/api/routes/engines.py
@@ -13,7 +13,10 @@ from pydantic import BaseModel
 
 from src.api.middleware.error_handler import handle_api_errors
 from src.shared.python.core.contracts import precondition
-from src.shared.python.engine_core.engine_registry import EngineType
+from src.shared.python.engine_core.engine_registry import (
+    EngineType,
+    is_usable_engine_status,
+)
 from src.shared.python.engine_core.workflow_adapter import EngineWorkflowAdapter
 
 from ..auth.middleware import OptionalAuth, is_local_mode
@@ -64,7 +67,6 @@ _NON_LEVEL_METADATA_KEYS: frozenset[str] = frozenset(
     }
 )
 
-
 router = APIRouter()
 
 
@@ -106,8 +108,10 @@ async def get_engines(
 
     for engine_type in EngineType:
         status = engine_manager.get_engine_status(engine_type)
-        is_available = engine_type in available_engines
         is_loaded = current_engine == engine_type
+        is_available = engine_type in available_engines or is_usable_engine_status(
+            status
+        )
 
         engines.append(
             EngineStatusResponse(

--- a/src/shared/python/engine_core/engine_manager.py
+++ b/src/shared/python/engine_core/engine_manager.py
@@ -27,6 +27,7 @@ from .engine_registry import (
     EngineStatus,
     EngineType,
     get_registry,
+    is_usable_engine_status,
 )
 from .interfaces import PhysicsEngine
 
@@ -209,11 +210,15 @@ class EngineManager(ContractChecker):
         return self.active_physics_engine
 
     def get_available_engines(self) -> list[EngineType]:
-        """Get list of available engines."""
+        """Get list of engines that are usable by callers.
+
+        ``LOADED`` remains available-for-use: the engine passed discovery,
+        loaded successfully, and is the live backend for subsequent requests.
+        """
         return [
             engine
             for engine, status in self.engine_status.items()
-            if status == EngineStatus.AVAILABLE
+            if is_usable_engine_status(status)
         ]
 
     @precondition(

--- a/src/shared/python/engine_core/engine_registry.py
+++ b/src/shared/python/engine_core/engine_registry.py
@@ -37,6 +37,16 @@ class EngineStatus(Enum):
     ERROR = "error"
 
 
+USABLE_ENGINE_STATUSES: frozenset[EngineStatus] = frozenset(
+    {EngineStatus.AVAILABLE, EngineStatus.LOADED}
+)
+
+
+def is_usable_engine_status(status: EngineStatus) -> bool:
+    """Return whether an engine status means callers can use the engine."""
+    return status in USABLE_ENGINE_STATUSES
+
+
 EngineFactory: TypeAlias = Callable[[], PhysicsEngine]
 
 

--- a/tests/unit/api/test_routes_engines.py
+++ b/tests/unit/api/test_routes_engines.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from src.api.routes.engines import router
 from src.api.dependencies import get_engine_manager
-from src.shared.python.engine_core.engine_registry import EngineType
+from src.shared.python.engine_core.engine_registry import EngineStatus, EngineType
 
 
 class MockEngineCapabilities:
@@ -39,22 +39,20 @@ class MockEngineManager:
         return EngineType.MUJOCO
 
     def get_engine_status(self, engine_type):
-        from enum import Enum
-
-        class Status(Enum):
-            LOADED = "loaded"
-            AVAILABLE = "available"
-            UNAVAILABLE = "unavailable"
-
         if engine_type == EngineType.MUJOCO:
-            return Status.LOADED
-        return Status.AVAILABLE
+            return EngineStatus.LOADED
+        return EngineStatus.AVAILABLE
 
     def switch_engine(self, engine_type):
         return True
 
     def get_active_physics_engine(self):
         return MockEngine()
+
+
+class LoadedOnlyEngineManager(MockEngineManager):
+    def get_available_engines(self):
+        return []
 
 
 @pytest.fixture
@@ -101,6 +99,25 @@ def test_routes_engines_surfaces_jaxsim_capabilities(client: TestClient) -> None
         "gradients",
         "parameter_sensitivity",
     ]
+
+
+def test_loaded_current_engine_is_reported_available() -> None:
+    """A loaded current engine is usable even if availability discovery is stale."""
+    test_app = FastAPI()
+    test_app.include_router(router)
+    test_app.dependency_overrides[get_engine_manager] = LoadedOnlyEngineManager
+    client = TestClient(test_app)
+
+    response = client.get("/engines")
+    assert response.status_code == 200
+
+    mujoco = next(
+        engine for engine in response.json()["engines"] if engine["name"] == "mujoco"
+    )
+    assert mujoco["status"] == "loaded"
+    assert mujoco["loaded"] is True
+    assert mujoco["available"] is True
+    assert mujoco["is_available"] is True
 
 
 def test_load_engine(client: TestClient) -> None:

--- a/tests/unit/test_engine_manager.py
+++ b/tests/unit/test_engine_manager.py
@@ -11,6 +11,7 @@ from src.shared.python.engine_core.engine_manager import (
     EngineStatus,
     EngineType,
 )
+from src.shared.python.engine_core.engine_registry import is_usable_engine_status
 from src.shared.python.core.contracts import PreconditionError
 
 
@@ -161,6 +162,21 @@ class TestEngineManager:
         manager.engine_status.clear()
         status = manager.get_engine_status(EngineType.MUJOCO)
         assert status == EngineStatus.UNAVAILABLE
+
+    def test_loaded_engines_are_available_for_use(self) -> None:
+        """Loaded engines are usable and must remain in available-engine lists."""
+        manager = object.__new__(EngineManager)
+        manager.engine_status = {
+            EngineType.MUJOCO: EngineStatus.LOADED,
+            EngineType.DRAKE: EngineStatus.AVAILABLE,
+            EngineType.PINOCCHIO: EngineStatus.UNAVAILABLE,
+            EngineType.OPENSIM: EngineStatus.ERROR,
+        }
+
+        assert manager.get_available_engines() == [
+            EngineType.MUJOCO,
+            EngineType.DRAKE,
+        ]
 
     def test_engine_manager_get_engine_info(self) -> None:
         """Test getting engine information."""
@@ -333,6 +349,14 @@ class TestEngineStatus:
 
         for status, expected_value in expected_values.items():
             assert status.value == expected_value
+
+    def test_usable_status_contract(self) -> None:
+        """Available and loaded statuses are usable; transient/error states are not."""
+        assert is_usable_engine_status(EngineStatus.AVAILABLE) is True
+        assert is_usable_engine_status(EngineStatus.LOADED) is True
+        assert is_usable_engine_status(EngineStatus.UNAVAILABLE) is False
+        assert is_usable_engine_status(EngineStatus.LOADING) is False
+        assert is_usable_engine_status(EngineStatus.ERROR) is False
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- centralize the engine usable-status contract in `engine_registry`
- treat `LOADED` as usable in `EngineManager.get_available_engines()`
- make `GET /engines` defensively report loaded engines as available
- add focused API and manager regression tests for loaded-current-engine semantics

Closes #8155

## Validation
- py -3.13 -m pytest -q tests\unit\api\test_routes_engines.py tests\unit\test_engine_manager.py tests\unit\test_engine_manager_availability_guard.py
- py -3.13 -m ruff format --check src\api\routes\engines.py src\shared\python\engine_core\engine_manager.py src\shared\python\engine_core\engine_registry.py tests\unit\api\test_routes_engines.py tests\unit\test_engine_manager.py
- py -3.13 -m ruff check src\api\routes\engines.py src\shared\python\engine_core\engine_manager.py src\shared\python\engine_core\engine_registry.py tests\unit\api\test_routes_engines.py tests\unit\test_engine_manager.py
- git diff --check
- pre-push hook