### PR TITLE
fix(api): make durable task idempotency atomic

### DIFF
--- a/src/api/task_manager_durable.py
+++ b/src/api/task_manager_durable.py
@@ -104,6 +104,10 @@ class StorageBackend(Protocol):
         """Create a new task record."""
         ...
 
+    def create_or_get_task(self, record: TaskRecord) -> TaskRecord:
+        """Atomically create a task or return the existing task for its run_id."""
+        ...
+
     def get_task(self, task_id: str) -> TaskRecord | None:
         """Retrieve a task by ID."""
         ...
@@ -182,21 +186,29 @@ class SQLiteBackend:
 
         self.db_path = Path(db_path)
         self._local = threading.local()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._connections: set[sqlite3.Connection] = set()
         self._init_db()
 
     def _get_conn(self) -> sqlite3.Connection:
         """Get thread-local database connection."""
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = sqlite3.connect(
+        conn = getattr(self._local, "conn", None)
+        if conn is None or conn not in self._connections:
+            conn = sqlite3.connect(
                 str(self.db_path),
                 timeout=30.0,
                 isolation_level=None,  # Autocommit mode
+                # Backend methods serialize access with _lock; cross-thread close
+                # is required to release worker-created connections on shutdown.
+                check_same_thread=False,
             )
-            self._local.conn.row_factory = sqlite3.Row
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-            self._local.conn.execute("PRAGMA busy_timeout=30000")
-        return cast(sqlite3.Connection, getattr(self._local, "conn", None))
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=30000")
+            self._local.conn = conn
+            with self._lock:
+                self._connections.add(conn)
+        return cast(sqlite3.Connection, conn)
 
     @contextmanager
     def _transaction(self) -> Generator[sqlite3.Connection, None, None]:
@@ -332,6 +344,41 @@ class SQLiteBackend:
             """,
                 self._record_to_values(record),
             )
+
+    def create_or_get_task(self, record: TaskRecord) -> TaskRecord:
+        """Atomically create a task or return the existing task for ``run_id``.
+
+        Only run_id conflicts are treated as idempotent success. A task_id
+        collision without a matching run_id remains an integrity failure.
+        """
+        if record.run_id is None:
+            self.create_task(record)
+            return record
+
+        with self._lock, self._transaction() as conn:
+            cursor = conn.execute(
+                """
+                INSERT OR IGNORE INTO tasks (
+                    task_id, run_id, status, task_type, input_data,
+                    config_hash, code_version, progress, result, error,
+                    created_at, updated_at, heartbeat_at, started_at, completed_at,
+                    worker_id, retry_count, max_retries, ttl_seconds,
+                    retention_seconds, priority
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                self._record_to_values(record),
+            )
+            if cursor.rowcount == 1:
+                return record
+
+            existing = conn.execute(
+                "SELECT * FROM tasks WHERE run_id = ?", (record.run_id,)
+            ).fetchone()
+            if existing is None:
+                raise sqlite3.IntegrityError(
+                    f"Task id collision while creating task {record.task_id!r}"
+                )
+            return self._row_to_record(existing)
 
     def get_task(self, task_id: str) -> TaskRecord | None:
         """Retrieve a task by ID."""
@@ -515,12 +562,13 @@ class SQLiteBackend:
         return count
 
     def close(self) -> None:
-        """Close the thread-local SQLite connection for the current thread."""
+        """Close all SQLite connections opened by this backend."""
         with self._lock:
-            conn = getattr(self._local, "conn", None)
-            if conn is None:
-                return
-            conn.close()
+            connections = tuple(self._connections)
+            self._connections.clear()
+            for conn in connections:
+                with suppress(sqlite3.Error):
+                    conn.close()
             self._local.conn = None
 
 
@@ -643,15 +691,6 @@ class DurableTaskManager:
             If run_id is provided and a task with that run_id exists,
             returns the existing task_id instead of creating a new one.
         """
-        # Check idempotency
-        if run_id:
-            existing = self.backend.find_by_run_id(run_id)
-            if existing:
-                logger.debug(
-                    "Found existing task for run_id %s: %s", run_id, existing.task_id
-                )
-                return existing.task_id
-
         # Generate task ID and config hash
         task_id = str(uuid.uuid4())
         config_hash = hashlib.sha256(
@@ -675,7 +714,13 @@ class DurableTaskManager:
             max_retries=max_retries,
         )
 
-        self.backend.create_task(record)
+        created = self.backend.create_or_get_task(record)
+        if created.task_id != task_id:
+            logger.debug(
+                "Found existing task for run_id %s: %s", run_id, created.task_id
+            )
+            return created.task_id
+
         logger.info(
             "Created task %s (type=%s, priority=%d)", task_id, task_type, priority
         )

--- a/tests/api/test_task_manager_durable.py
+++ b/tests/api/test_task_manager_durable.py
@@ -1,7 +1,10 @@
 """Tests for the durable task manager."""
 
 import asyncio
+import sqlite3
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -210,6 +213,26 @@ class TestSQLiteBackend:
         assert "ttl-expired" in expired_ids
         assert "retention-expired" in expired_ids
 
+    def test_close_closes_worker_thread_connections(self, tmp_path: Path) -> None:
+        """Owner-thread close must release connections opened by worker threads."""
+        db_path = tmp_path / "tasks.db"
+        backend = SQLiteBackend(db_path=db_path)
+
+        def worker() -> sqlite3.Connection:
+            backend.create_task(TaskRecord(task_id="worker-task"))
+            return backend._get_conn()
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            worker_conn = pool.submit(worker).result(timeout=5)
+
+            backend.close()
+
+            with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+                pool.submit(lambda: worker_conn.execute("SELECT 1")).result(timeout=5)
+
+        assert backend._connections == set()
+        backend.close()
+
 
 class TestDurableTaskManager:
     """Test the durable task manager orchestrator."""
@@ -241,6 +264,45 @@ class TestDurableTaskManager:
         )
 
         assert task_id1 == task_id2
+
+    def test_create_task_run_id_is_atomic_under_race(self, tmp_path: Path) -> None:
+        """Concurrent same-run_id creates return one task id without IntegrityError."""
+
+        class RacingBackend(SQLiteBackend):
+            def __init__(self, db_path: Path) -> None:
+                super().__init__(db_path=db_path)
+                self._race_barrier = threading.Barrier(2)
+
+            def find_by_run_id(self, run_id: str) -> TaskRecord | None:
+                found = super().find_by_run_id(run_id)
+                if found is None:
+                    self._race_barrier.wait(timeout=5)
+                return found
+
+        backend = RacingBackend(tmp_path / "tasks.db")
+        manager = DurableTaskManager(backend=backend, auto_cleanup=False)
+        try:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(
+                        manager.create_task,
+                        task_type="simulation",
+                        input_data={"index": index},
+                        run_id="same-run",
+                    )
+                    for index in range(2)
+                ]
+                task_ids = [future.result(timeout=5) for future in futures]
+
+            assert task_ids[0] == task_ids[1]
+            task = manager.get_task(task_ids[0])
+            assert task is not None
+            assert task.run_id == "same-run"
+            existing = backend.find_by_run_id("same-run")
+            assert existing is not None
+            assert existing.task_id == task_ids[0]
+        finally:
+            asyncio.run(manager.shutdown())
 
     def test_acquire_and_release_task(self, task_manager: DurableTaskManager):
         """Test acquiring a task for a worker and releasing it."""


### PR DESCRIPTION
## Summary
- move DurableTaskManager run_id idempotency into an atomic storage-backend create-or-get operation
- track all SQLite task DB connections and make shutdown close worker-thread connections as well as the caller thread connection
- add regressions for same-run_id concurrent creation and owner-thread shutdown after worker-thread SQLite use

## Root Cause
`create_task(run_id=...)` performed a check-then-insert outside the storage boundary, so concurrent callers could both observe no existing task and one would escape a SQLite unique constraint failure. Separately, SQLite connections were stored only in `threading.local()`, so `close()` only released the caller thread's connection and left worker-created DB handles alive.

## Validation
- `py -3.13 -m pytest -q tests\api\test_task_manager_durable.py -k "worker_thread_connections or run_id_is_atomic"`
- `py -3.13 -m pytest -q tests\api\test_task_manager_durable.py`
- `py -3.13 -m ruff check src\api\task_manager_durable.py tests\api\test_task_manager_durable.py`
- `py -3.13 -m ruff format --check src\api\task_manager_durable.py tests\api\test_task_manager_durable.py`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, wildcard/debug/print guards, mypy, bandit, pytest

Closes #8156.
Closes #8157.