### PR TITLE
fix(api): remove shadowed engine load route

### DIFF
--- a/src/api/routes/engines.py
+++ b/src/api/routes/engines.py
@@ -33,23 +33,6 @@ if TYPE_CHECKING:
     from src.shared.python.engine_core.engine_manager import EngineManager
 
 
-def _sanitize_for_json(obj: Any) -> Any:
-    """Recursively convert numpy arrays and other non-JSON types to native Python."""
-    import numpy as np
-
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, np.integer):
-        return int(obj)
-    if isinstance(obj, np.floating):
-        return float(obj)
-    if isinstance(obj, dict):
-        return {k: _sanitize_for_json(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_sanitize_for_json(v) for v in obj]
-    return obj
-
-
 # Capability levels that may appear in a CapabilityLevelResponse.
 # See src/shared/python/engine_core/capabilities.py::CapabilityLevel.
 _VALID_CAPABILITY_LEVELS: frozenset[str] = frozenset({"full", "partial", "none"})
@@ -155,85 +138,41 @@ async def probe_engine(
     response_model=EngineLoadResponse,
     response_model_exclude_none=True,
 )
+@precondition(
+    lambda engine_name, model_path=None, engine_manager=None: (
+        engine_name is not None and len(engine_name.strip()) > 0
+    ),
+    "Engine type must be a non-empty string",
+)
 @handle_api_errors
-async def load_engine_lazy(
+async def load_engine(
     engine_name: str,
     model_path: str | None = None,
     engine_manager: EngineManager = Depends(get_engine_manager),
 ) -> dict[str, Any]:
-    """Load an engine (for lazy loading UI)."""
+    """Load a physics engine, optionally loading a validated model afterward."""
     try:
-        if model_path:
-            validate_model_path(model_path)
         workflow = EngineWorkflowAdapter(engine_manager)
         result = workflow.load(engine_name)
         if not result.ok:
             raise HTTPException(
                 status_code=result.status_code, detail=result.payload["detail"]
             )
+
+        # Invalidate control-metadata caches so subsequent requests reflect the new engine.
+        clear_physics_caches()
+
+        if model_path:
+            validated_path = validate_model_path(model_path)
+            engine = engine_manager.get_active_physics_engine()
+            if engine and hasattr(engine, "load_from_path"):
+                engine.load_from_path(validated_path)
+
         return result.payload
     except HTTPException:
         raise
-    except (RuntimeError, TypeError, AttributeError) as e:
+    except (ImportError, RuntimeError, TypeError, AttributeError) as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
-
-
-@router.post("/engines/{engine_type}/load")
-@precondition(
-    lambda engine_type, model_path=None, engine_manager=None, _user=None: (
-        engine_type is not None and len(engine_type.strip()) > 0
-    ),
-    "Engine type must be a non-empty string",
-)
-async def load_engine(
-    engine_type: str,
-    model_path: str | None = None,
-    engine_manager: EngineManager = Depends(get_engine_manager),
-    _user: Any = Depends(OptionalAuth()),
-) -> dict[str, Any]:
-    """Load a specific physics engine with optional model."""
-    workflow = EngineWorkflowAdapter(engine_manager)
-    engine_enum = workflow.parse_engine_identifier(engine_type)
-    if engine_enum is None:
-        raise HTTPException(
-            status_code=400, detail=f"Unknown engine type: {engine_type}"
-        )
-
-    try:
-        # Use switch_engine which is the public API for loading engines
-        success = engine_manager.switch_engine(engine_enum)
-        if not success:
-            raise HTTPException(
-                status_code=400, detail=f"Failed to load engine: {engine_type}"
-            )
-
-        # Invalidate control-metadata caches so subsequent requests reflect the new engine
-        clear_physics_caches()
-
-        engine = engine_manager.get_active_physics_engine()
-
-        if model_path and engine:
-            validated_path = validate_model_path(model_path)
-            if hasattr(engine, "load_from_path"):
-                engine.load_from_path(validated_path)
-
-        state = None
-        if engine and hasattr(engine, "get_state"):
-            raw_state = engine.get_state()
-            # Convert numpy arrays to lists for JSON serialization
-            state = _sanitize_for_json(raw_state) if raw_state else None
-
-        return {
-            "status": "loaded",
-            "engine": engine_type,
-            "model": model_path,
-            "state": state,
-        }
-
-    except ImportError as exc:
-        raise HTTPException(
-            status_code=500, detail=f"Error loading engine: {str(exc)}"
-        ) from exc
 
 
 @router.post("/engines/{engine_type}/unload")

--- a/src/shared/python/engine_core/workflow_adapter.py
+++ b/src/shared/python/engine_core/workflow_adapter.py
@@ -85,7 +85,7 @@ class EngineWorkflowAdapter:
         """Load a named engine through EngineManager."""
         if engine_name is None:
             raise ValueError("engine_name must be provided")
-        engine_type = self.resolve_engine(engine_name)
+        engine_type = self.parse_engine_identifier(engine_name)
         if engine_type is None:
             return EngineWorkflowResult(
                 ok=False,

--- a/tests/unit/api/test_route_uniqueness.py
+++ b/tests/unit/api/test_route_uniqueness.py
@@ -20,6 +20,7 @@ the failure mode cannot recur silently.
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 
 import pytest
@@ -27,6 +28,14 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
 from src.api.route_registry import discover_routes, register_routes
+
+
+_ROUTE_PARAMETER_RE = re.compile(r"\{[^}/]+\}")
+
+
+def _normalize_route_path(path: str) -> str:
+    """Treat routes that differ only by parameter names as the same path shape."""
+    return _ROUTE_PARAMETER_RE.sub("{}", path)
 
 
 def _route_table(app: FastAPI) -> dict[tuple[str, str], list[str]]:
@@ -40,7 +49,9 @@ def _route_table(app: FastAPI) -> dict[tuple[str, str], list[str]]:
                 continue
             endpoint = route.endpoint
             qualname = getattr(endpoint, "__qualname__", str(endpoint))
-            table[(method, route.path)].append(f"{endpoint.__module__}.{qualname}")
+            table[(method, _normalize_route_path(route.path))].append(
+                f"{endpoint.__module__}.{qualname}"
+            )
     return table
 
 
@@ -51,7 +62,9 @@ def _reachable_endpoints(app: FastAPI) -> set[int]:
         if not isinstance(route, APIRoute):
             continue
         for method in route.methods or ():
-            seen.setdefault((method, route.path), id(route.endpoint))
+            seen.setdefault(
+                (method, _normalize_route_path(route.path)), id(route.endpoint)
+            )
     return set(seen.values())
 
 
@@ -78,6 +91,13 @@ def test_no_duplicate_method_path_pairs(registered_app: FastAPI) -> None:
             for (method, path), handlers in sorted(duplicates.items())
         )
     )
+
+
+def test_route_path_normalization_ignores_parameter_names() -> None:
+    """Same-shape parameterized routes must be treated as duplicate paths."""
+    assert _normalize_route_path(
+        "/engines/{engine_name}/load"
+    ) == _normalize_route_path("/engines/{engine_type}/load")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/api/test_routes_engines.py
+++ b/tests/unit/api/test_routes_engines.py
@@ -1,5 +1,7 @@
 """Unit tests for the engines API route."""
 
+from pathlib import Path
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -21,17 +23,23 @@ class MockEngineCapabilities:
 
 
 class MockEngine:
-    def get_capabilities(self):
+    def __init__(self) -> None:
+        self.loaded_paths: list[str] = []
+
+    def get_capabilities(self) -> MockEngineCapabilities:
         return MockEngineCapabilities()
 
-    def load_from_path(self, path):
-        pass
+    def load_from_path(self, path: str) -> None:
+        self.loaded_paths.append(path)
 
-    def get_state(self):
+    def get_state(self) -> dict[str, float]:
         return {"time": 0.0}
 
 
 class MockEngineManager:
+    def __init__(self) -> None:
+        self.active_engine = MockEngine()
+
     def get_available_engines(self):
         return [EngineType.MUJOCO, EngineType.DRAKE, EngineType.JAXSIM]
 
@@ -54,7 +62,7 @@ class MockEngineManager:
         return True
 
     def get_active_physics_engine(self):
-        return MockEngine()
+        return self.active_engine
 
 
 @pytest.fixture
@@ -110,6 +118,27 @@ def test_load_engine(client: TestClient) -> None:
     data = response.json()
     assert data["status"] == "loaded"
     assert data["engine"] == "mujoco"
+
+
+def test_load_engine_with_model_path_loads_active_engine(
+    client: TestClient,
+    mock_engine_manager: MockEngineManager,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loading with model_path validates then passes the path to the active engine."""
+    from src.api.utils import path_validation
+
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model_path = model_dir / "model.xml"
+    model_path.write_text("<mujoco />", encoding="utf-8")
+    monkeypatch.setattr(path_validation, "ALLOWED_MODEL_DIRS", [model_dir.resolve()])
+
+    response = client.post("/engines/mujoco/load", params={"model_path": "model.xml"})
+
+    assert response.status_code == 200
+    assert mock_engine_manager.active_engine.loaded_paths == [str(model_path.resolve())]
 
 
 def test_load_unknown_engine(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- collapse the duplicate `POST /engines/{...}/load` handlers into one workflow-backed route
- preserve validated `model_path` loading into the active engine after a successful switch
- normalize route parameter names in the uniqueness guard so same-shape paths cannot shadow each other again

## Root Cause
FastAPI resolves routes with first-match-wins semantics, but the route uniqueness test keyed by literal template strings. `/engines/{engine_name}/load` and `/engines/{engine_type}/load` therefore looked distinct to the test while one handler permanently shadowed the other at runtime.

## Validation
- `py -3.13 -m pytest -q tests\unit\api\test_route_uniqueness.py tests\unit\api\test_routes_engines.py`
- `py -3.13 -m ruff check src\api\routes\engines.py src\shared\python\engine_core\workflow_adapter.py tests\unit\api\test_route_uniqueness.py tests\unit\api\test_routes_engines.py`
- `py -3.13 -m ruff format --check src\api\routes\engines.py src\shared\python\engine_core\workflow_adapter.py tests\unit\api\test_route_uniqueness.py tests\unit\api\test_routes_engines.py`
- `git diff --check`
- route metadata probe confirms only one `POST /engines/{...}/load` route remains
- pre-push hook: ruff, ruff format, formatter guidance, wildcard/debug/print guards, mypy, bandit, pytest

Closes #8164.