### PR TITLE
fix(web): preserve engine state on unload failure

### DIFF
--- a/ui/src/stores/useEngineStore.test.ts
+++ b/ui/src/stores/useEngineStore.test.ts
@@ -8,12 +8,32 @@ import {
   selectEngineSupportsCapability,
 } from './useEngineStore';
 
+function setEngineLoaded(engineName: string): void {
+  useEngineStore.setState((state) => ({
+    engines: state.engines.map((e) =>
+      e.name === engineName ? { ...e, loadState: 'loaded' as const } : e
+    ),
+  }));
+}
+
+function okJson(body: unknown = {}): Response {
+  return new Response(JSON.stringify(body));
+}
+
+function errorJson(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: 'Error',
+  });
+}
+
 describe('useEngineStore', () => {
   beforeEach(() => {
     // Reset the store to initial state before each test
     act(() => {
       useEngineStore.getState().resetEngines();
     });
+    global.fetch = vi.fn(() => Promise.resolve(okJson())) as typeof fetch;
   });
 
   describe('initial state', () => {
@@ -75,12 +95,7 @@ describe('useEngineStore', () => {
 
   describe('unloadEngine', () => {
     it('sets engine to idle', async () => {
-      // Manually set an engine to loaded
-      useEngineStore.setState((state) => ({
-        engines: state.engines.map((e) =>
-          e.name === 'mujoco' ? { ...e, loadState: 'loaded' as const } : e
-        ),
-      }));
+      setEngineLoaded('mujoco');
 
       await act(async () => {
         await useEngineStore.getState().unloadEngine('mujoco');
@@ -93,11 +108,9 @@ describe('useEngineStore', () => {
     });
 
     it('clears selection if unloading the selected engine', async () => {
+      setEngineLoaded('mujoco');
       useEngineStore.setState({
         selectedEngine: 'mujoco',
-        engines: useEngineStore.getState().engines.map((e) =>
-          e.name === 'mujoco' ? { ...e, loadState: 'loaded' as const } : e
-        ),
       });
 
       await act(async () => {
@@ -108,12 +121,51 @@ describe('useEngineStore', () => {
     });
 
     it('does not clear selection if unloading a different engine', async () => {
+      setEngineLoaded('drake');
       useEngineStore.setState({ selectedEngine: 'mujoco' });
 
       await act(async () => {
         await useEngineStore.getState().unloadEngine('drake');
       });
 
+      expect(useEngineStore.getState().selectedEngine).toBe('mujoco');
+    });
+
+    it('keeps selection and surfaces error when backend unload is rejected', async () => {
+      setEngineLoaded('mujoco');
+      useEngineStore.setState({ selectedEngine: 'mujoco' });
+      global.fetch = vi.fn(() =>
+        Promise.resolve(errorJson({ detail: 'engine still busy' }, 409))
+      ) as typeof fetch;
+
+      await act(async () => {
+        await useEngineStore.getState().unloadEngine('mujoco');
+      });
+
+      const mujoco = useEngineStore
+        .getState()
+        .engines.find((e) => e.name === 'mujoco');
+      expect(mujoco?.loadState).toBe('error');
+      expect(mujoco?.error).toContain('engine still busy');
+      expect(useEngineStore.getState().selectedEngine).toBe('mujoco');
+    });
+
+    it('keeps selection and surfaces error when backend unload has a network failure', async () => {
+      setEngineLoaded('mujoco');
+      useEngineStore.setState({ selectedEngine: 'mujoco' });
+      global.fetch = vi.fn(() =>
+        Promise.reject(new Error('Network error'))
+      ) as typeof fetch;
+
+      await act(async () => {
+        await useEngineStore.getState().unloadEngine('mujoco');
+      });
+
+      const mujoco = useEngineStore
+        .getState()
+        .engines.find((e) => e.name === 'mujoco');
+      expect(mujoco?.loadState).toBe('error');
+      expect(mujoco?.error).toContain('Network error');
       expect(useEngineStore.getState().selectedEngine).toBe('mujoco');
     });
 

--- a/ui/src/stores/useEngineStore.ts
+++ b/ui/src/stores/useEngineStore.ts
@@ -135,6 +135,10 @@ async function loadEngineApi(engineName: string): Promise<EngineLoadResponse> {
   }
 }
 
+function getErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
 // ── Initial state ─────────────────────────────────────────────────────────
 
 function createInitialEngines(): ManagedEngine[] {
@@ -246,8 +250,7 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
         set({ selectedEngine: engineName });
       }
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Unknown error loading engine';
+      const message = getErrorMessage(err, 'Unknown error loading engine');
       set((state) => ({
         engines: state.engines.map((e) =>
           e.name === engineName
@@ -259,7 +262,6 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
   },
 
   unloadEngine: async (engineName) => {
-    const { selectedEngine } = get();
     // Idempotence guard (#7427): ignore an unload for an engine that is not
     // loaded or already has an operation in flight.
     const current = get().engines.find((e) => e.name === engineName);
@@ -270,14 +272,29 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
     set((state) => ({
       engines: state.engines.map((e) =>
         e.name === engineName
-          ? { ...e, loadState: 'unloading' as EngineLoadState }
+          ? { ...e, loadState: 'unloading' as EngineLoadState, error: undefined }
           : e
       ),
     }));
     try {
       await apiFetch<unknown>(`/api/engines/${engineName}/unload`, { method: 'POST' });
-    } catch {
-      // Best-effort: still update client state even if backend call fails
+    } catch (err) {
+      const detail = getErrorMessage(
+        err,
+        `Unknown error unloading engine: ${engineName}`
+      );
+      set((state) => ({
+        engines: state.engines.map((e) =>
+          e.name === engineName
+            ? {
+                ...e,
+                loadState: 'error' as EngineLoadState,
+                error: `Failed to unload engine: ${engineName}: ${detail}`,
+              }
+            : e
+        ),
+      }));
+      return;
     }
     set((state) => ({
       engines: state.engines.map((e) =>
@@ -286,7 +303,7 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
           : e
       ),
       selectedEngine:
-        selectedEngine === engineName ? null : selectedEngine,
+        state.selectedEngine === engineName ? null : state.selectedEngine,
     }));
   },
 


### PR DESCRIPTION
## Summary
- stop treating failed engine unload requests as successful client-side unloads
- keep the selected engine intact on backend/HTTP/network unload failure
- surface the normalized unload error on the affected `ManagedEngine`
- add Vitest coverage for unload success, idle no-op, HTTP failure, and network failure

## Root Cause
`unloadEngine()` swallowed every `apiFetch('/api/engines/{engine}/unload')` error and always marked the engine idle afterward. That let frontend state drift from backend state whenever unload failed or the backend was unreachable.

## Validation
- `npm run test:run -- useEngineStore.test.ts`
- `npx eslint src/stores/useEngineStore.ts src/stores/useEngineStore.test.ts`
- `npm run type-check`
- `git diff --check`
- pre-push hook completed; Python-only checks were skipped for this web-only change

Closes #8165.