### PR TITLE
fix(api): clean motion pipeline upload temps

### DIFF
--- a/src/shared/python/motion_pipeline/api.py
+++ b/src/shared/python/motion_pipeline/api.py
@@ -172,6 +172,21 @@ def _validate_source_format(source_format: str) -> None:
         )
 
 
+def _cleanup_temp_upload(tmp_path: Path | None, request_id: str) -> None:
+    """Best-effort removal for persisted upload files."""
+    if tmp_path is None:
+        return
+    try:
+        tmp_path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning(
+            "Request %s: failed to remove temporary upload %s",
+            request_id,
+            tmp_path,
+            exc_info=True,
+        )
+
+
 def create_app() -> FastAPI:
     """
     Create FastAPI application with motion pipeline endpoints.
@@ -247,8 +262,9 @@ Returns MotionMatchingResult with matched trajectory and error metrics.
         # auto-detected (issue #6930).
         _validate_source_format(source_format)
 
-        # Save uploaded file temporarily
+        tmp_path: Path | None = None
         try:
+            # Save uploaded file temporarily
             with tempfile.NamedTemporaryFile(
                 delete=False, suffix=Path(file.filename).suffix
             ) as tmp:
@@ -282,9 +298,6 @@ Returns MotionMatchingResult with matched trajectory and error metrics.
             result = pipeline.run(tmp_path)
             audit_log = pipeline.get_audit_log()
 
-            # Clean up temp file
-            tmp_path.unlink(missing_ok=True)
-
             logger.info(
                 f"Request {request_id}: Pipeline completed success={result.success}"
             )
@@ -303,6 +316,8 @@ Returns MotionMatchingResult with matched trajectory and error metrics.
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
             ) from e
+        finally:
+            _cleanup_temp_upload(tmp_path, request_id)
 
     @app.post(
         "/api/v1/motion-pipeline/run-config",
@@ -344,6 +359,7 @@ Accepts JSON config body plus file upload.
         # Reject an unknown source_format up front (issue #6930).
         _validate_source_format(parsed_config.source_format)
 
+        tmp_path: Path | None = None
         try:
             # Save uploaded file temporarily
             with tempfile.NamedTemporaryFile(
@@ -361,8 +377,6 @@ Accepts JSON config body plus file upload.
             result = pipeline.run(tmp_path)
             audit_log = pipeline.get_audit_log()
 
-            tmp_path.unlink(missing_ok=True)
-
             return PipelineResponse.from_result(result, audit_log)
 
         except ValueError as e:
@@ -375,6 +389,8 @@ Accepts JSON config body plus file upload.
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
             ) from e
+        finally:
+            _cleanup_temp_upload(tmp_path, request_id)
 
     return app
 

--- a/tests/unit/motion_pipeline/orchestrator/test_api.py
+++ b/tests/unit/motion_pipeline/orchestrator/test_api.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 fastapi_testclient = pytest.importorskip("fastapi.testclient")
 from fastapi.testclient import TestClient  # noqa: E402
 
+from src.shared.python.motion_pipeline import api as api_module  # noqa: E402
 from src.shared.python.motion_pipeline.api import (  # noqa: E402
     PipelineRequest,
     PipelineResponse,
@@ -17,6 +21,20 @@ from src.shared.python.motion_pipeline.api import (  # noqa: E402
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(create_app())
+
+
+@pytest.fixture
+def force_api_temp_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    real_named_temporary_file = api_module.tempfile.NamedTemporaryFile
+
+    def named_temporary_file_in_tmp_path(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("dir", tmp_path)
+        return real_named_temporary_file(*args, **kwargs)
+
+    monkeypatch.setattr(
+        api_module.tempfile, "NamedTemporaryFile", named_temporary_file_in_tmp_path
+    )
+    return tmp_path
 
 
 def test_health_endpoint(client: TestClient) -> None:
@@ -145,3 +163,53 @@ def test_run_config_malformed_json_returns_422(client: TestClient) -> None:
         data={"config": "{not valid json"},
     )
     assert r.status_code == 422
+
+
+def test_run_pipeline_cleans_upload_temp_file_on_invalid_input(
+    client: TestClient,
+    force_api_temp_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_paths: list[Path] = []
+
+    def fail_run(_pipeline: object, source_path: Path) -> None:
+        captured_paths.append(source_path)
+        raise ValueError("boom")
+
+    monkeypatch.setattr(api_module.MotionPipeline, "run", fail_run)
+
+    r = client.post(
+        "/api/v1/motion-pipeline/run",
+        files={"file": ("x.c3d", b"\x00" * 8, "application/octet-stream")},
+        data={"source_format": "c3d"},
+    )
+
+    assert r.status_code == 400
+    assert captured_paths
+    assert not captured_paths[0].exists()
+    assert list(force_api_temp_dir.iterdir()) == []
+
+
+def test_run_config_cleans_upload_temp_file_on_pipeline_runtime_error(
+    client: TestClient,
+    force_api_temp_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_paths: list[Path] = []
+
+    def fail_run(_pipeline: object, source_path: Path) -> None:
+        captured_paths.append(source_path)
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_module.MotionPipeline, "run", fail_run)
+
+    r = client.post(
+        "/api/v1/motion-pipeline/run-config",
+        files={"file": ("x.c3d", b"\x00" * 8, "application/octet-stream")},
+        data={"config": '{"source_format": "c3d"}'},
+    )
+
+    assert r.status_code == 500
+    assert captured_paths
+    assert not captured_paths[0].exists()
+    assert list(force_api_temp_dir.iterdir()) == []


### PR DESCRIPTION
## Summary
- clean persisted motion-pipeline upload temp files from both `/run` and `/run-config` in `finally` blocks
- share best-effort temp upload cleanup with warning logs on OS unlink failures
- add regressions proving temp files are removed when pipeline execution raises invalid-input and runtime errors

## Root Cause
Both endpoints wrote uploads with `NamedTemporaryFile(delete=False)` and unlinked only after `pipeline.run(...)` returned successfully. Any `ValueError` or `RuntimeError` skipped the unlink and left the upload on disk.

## Validation
- `py -3.13 -m pytest -q tests\unit\motion_pipeline\orchestrator\test_api.py -k "cleans_upload_temp_file"`
- `py -3.13 -m pytest -q tests\unit\motion_pipeline\orchestrator\test_api.py`
- `py -3.13 -m ruff check src\shared\python\motion_pipeline\api.py tests\unit\motion_pipeline\orchestrator\test_api.py`
- `py -3.13 -m ruff format --check src\shared\python\motion_pipeline\api.py tests\unit\motion_pipeline\orchestrator\test_api.py`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, wildcard/debug/print guards, mypy, bandit, pytest

Closes #8162.