### PR TITLE
fix(api): bound motion capture state retention

### DIFF
--- a/src/api/routes/motion_capture.py
+++ b/src/api/routes/motion_capture.py
@@ -15,6 +15,7 @@ import importlib.util
 import logging
 import math
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -175,6 +176,87 @@ _sessions: dict[str, dict[str, Any]] = {}
 _recordings: dict[str, dict[str, Any]] = {}
 _session_state: dict[str, int] = {"counter": 0}
 
+MAX_CAPTURE_SESSIONS = 32
+MAX_CAPTURE_RECORDINGS = 16
+CAPTURE_STATE_TTL_SECONDS = 60 * 60
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _entry_timestamp(entry: dict[str, Any], primary_key: str) -> float | None:
+    timestamp = entry.get(primary_key, entry.get("created_at"))
+    return float(timestamp) if timestamp is not None else None
+
+
+def _is_expired(entry: dict[str, Any], primary_key: str, now: float) -> bool:
+    timestamp = _entry_timestamp(entry, primary_key)
+    return timestamp is not None and now - timestamp > CAPTURE_STATE_TTL_SECONDS
+
+
+def _stopped_sessions_oldest_first() -> list[tuple[str, dict[str, Any]]]:
+    return sorted(
+        (
+            (session_id, session)
+            for session_id, session in _sessions.items()
+            if session.get("status") != "recording"
+        ),
+        key=lambda item: _entry_timestamp(item[1], "updated_at") or 0.0,
+    )
+
+
+def _prune_stopped_sessions() -> None:
+    stopped = _stopped_sessions_oldest_first()
+    while len(_sessions) > MAX_CAPTURE_SESSIONS and stopped:
+        session_id, _session = stopped.pop(0)
+        _sessions.pop(session_id, None)
+
+
+def _drop_oldest_stopped_session() -> bool:
+    stopped = _stopped_sessions_oldest_first()
+    if not stopped:
+        return False
+    session_id, _session = stopped[0]
+    _sessions.pop(session_id, None)
+    return True
+
+
+def _prune_recordings() -> None:
+    while len(_recordings) > MAX_CAPTURE_RECORDINGS:
+        oldest_name = min(
+            _recordings,
+            key=lambda name: (
+                _entry_timestamp(_recordings[name], "last_accessed_at") or 0.0
+            ),
+        )
+        _recordings.pop(oldest_name, None)
+
+
+def _cleanup_ephemeral_state(now: float | None = None) -> None:
+    """Bound process-local motion capture state by TTL and item count."""
+    current_time = _now() if now is None else now
+
+    expired_sessions = [
+        session_id
+        for session_id, session in _sessions.items()
+        if session.get("status") != "recording"
+        and _is_expired(session, "updated_at", current_time)
+    ]
+    for session_id in expired_sessions:
+        _sessions.pop(session_id, None)
+
+    expired_recordings = [
+        name
+        for name, recording in _recordings.items()
+        if _is_expired(recording, "last_accessed_at", current_time)
+    ]
+    for name in expired_recordings:
+        _recordings.pop(name, None)
+
+    _prune_stopped_sessions()
+    _prune_recordings()
+
 
 # ── Endpoints ──
 
@@ -264,6 +346,7 @@ async def start_capture_session(
 
     See issue #1206
     """
+    _cleanup_ephemeral_state()
     valid_sources = {"mediapipe", "openpose", "c3d"}
     if request.source_type not in valid_sources:
         raise HTTPException(
@@ -279,14 +362,28 @@ async def start_capture_session(
             detail=f"Capture source '{request.source_type}' is unavailable: {reason}",
         )
 
+    if len(_sessions) >= MAX_CAPTURE_SESSIONS:
+        _drop_oldest_stopped_session()
+    if len(_sessions) >= MAX_CAPTURE_SESSIONS:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                "Too many active motion-capture sessions; stop an existing session "
+                "before starting another"
+            ),
+        )
+
     _session_state["counter"] += 1
     session_id = f"session_{_session_state['counter']}"
+    now = _now()
 
     _sessions[session_id] = {
         "source_type": request.source_type,
         "frame_rate": request.frame_rate,
         "status": "recording",
         "frames": [],
+        "created_at": now,
+        "updated_at": now,
     }
 
     return CaptureSessionResponse(
@@ -307,11 +404,14 @@ async def stop_capture_session(session_id: str) -> CaptureSessionResponse:
 
     See issue #1206
     """
+    _cleanup_ephemeral_state()
     if session_id not in _sessions:
         raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
 
     session = _sessions[session_id]
     session["status"] = "stopped"
+    now = _now()
+    session["updated_at"] = now
 
     # Save as a recording
     recording_name = f"recording_{session_id}"
@@ -319,7 +419,10 @@ async def stop_capture_session(session_id: str) -> CaptureSessionResponse:
         "source_type": session["source_type"],
         "frame_rate": session["frame_rate"],
         "frames": session["frames"],
+        "created_at": now,
+        "last_accessed_at": now,
     }
+    _cleanup_ephemeral_state(now)
 
     return CaptureSessionResponse(
         session_id=session_id,
@@ -335,8 +438,11 @@ async def list_recordings() -> list[RecordingInfo]:
 
     See issue #1206
     """
+    _cleanup_ephemeral_state()
     result = []
+    now = _now()
     for name, rec in _recordings.items():
+        rec["last_accessed_at"] = now
         frames = rec.get("frames", [])
         frame_rate = rec.get("frame_rate", 30.0)
         total_frames = len(frames)
@@ -364,6 +470,7 @@ async def control_playback(request: PlaybackRequest) -> PlaybackResponse:
 
     See issue #1206
     """
+    _cleanup_ephemeral_state()
     if request.recording_name not in _recordings:
         raise HTTPException(
             status_code=404,
@@ -371,6 +478,7 @@ async def control_playback(request: PlaybackRequest) -> PlaybackResponse:
         )
 
     recording = _recordings[request.recording_name]
+    recording["last_accessed_at"] = _now()
     total_frames = len(recording.get("frames", []))
 
     valid_actions = {"play", "pause", "stop", "seek"}
@@ -413,6 +521,7 @@ async def get_frame(recording_name: str, frame_index: int) -> SkeletonFrame:
 
     See issue #1206
     """
+    _cleanup_ephemeral_state()
     if recording_name not in _recordings:
         raise HTTPException(
             status_code=404,
@@ -420,6 +529,7 @@ async def get_frame(recording_name: str, frame_index: int) -> SkeletonFrame:
         )
 
     recording = _recordings[recording_name]
+    recording["last_accessed_at"] = _now()
     frames = recording.get("frames", [])
 
     if frame_index < 0 or frame_index >= len(frames):
@@ -454,6 +564,7 @@ async def upload_c3d(file: UploadFile = File(...)) -> C3DUploadResponse:
 
     See issue #7454
     """
+    _cleanup_ephemeral_state()
     filename = file.filename or "upload.c3d"
     if not filename.lower().endswith(".c3d"):
         raise HTTPException(
@@ -490,12 +601,16 @@ async def upload_c3d(file: UploadFile = File(...)) -> C3DUploadResponse:
 
     _session_state["counter"] += 1
     recording_name = f"c3d_{Path(filename).stem}_{_session_state['counter']}"
+    now = _now()
     _recordings[recording_name] = {
         "source_type": "c3d",
         "frame_rate": frame_rate,
         "frames": frames,
         "joint_names": marker_names,
+        "created_at": now,
+        "last_accessed_at": now,
     }
+    _cleanup_ephemeral_state(now)
 
     duration = len(frames) / frame_rate if frame_rate > 0 else 0.0
     return C3DUploadResponse(

--- a/tests/unit/api/test_routes_motion_capture.py
+++ b/tests/unit/api/test_routes_motion_capture.py
@@ -26,6 +26,7 @@ def app() -> FastAPI:
     # Clear state before each test
     _sessions.clear()
     _recordings.clear()
+    mc._session_state["counter"] = 0
     return test_app
 
 
@@ -83,6 +84,58 @@ def test_capture_session_flow(
     frame_resp = client.get(f"/tools/motion-capture/frame/{rec_name}/0")
     assert frame_resp.status_code == 200
     assert frame_resp.json()["frame_index"] == 0
+
+
+def test_stopped_sessions_are_pruned_when_session_bound_is_reached(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stopped sessions cannot accumulate without bound in process memory."""
+    monkeypatch.setattr(mc, "_source_availability", lambda _sid: (True, None))
+    monkeypatch.setattr(mc, "MAX_CAPTURE_SESSIONS", 1)
+
+    first = client.post(
+        "/tools/motion-capture/session/start",
+        json={"source_type": "mediapipe", "frame_rate": 30.0},
+    ).json()["session_id"]
+    stop_resp = client.post(f"/tools/motion-capture/session/{first}/stop")
+    assert stop_resp.status_code == 200
+
+    second_resp = client.post(
+        "/tools/motion-capture/session/start",
+        json={"source_type": "mediapipe", "frame_rate": 30.0},
+    )
+
+    assert second_resp.status_code == 200
+    second = second_resp.json()["session_id"]
+    assert first not in _sessions
+    assert second in _sessions
+
+
+def test_recordings_are_pruned_to_configured_bound(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Old recordings are pruned before listing so memory has a hard ceiling."""
+    now = mc._now()
+    _recordings["old"] = {
+        "source_type": "mediapipe",
+        "frame_rate": 30.0,
+        "frames": [],
+        "created_at": now,
+        "last_accessed_at": now,
+    }
+    _recordings["new"] = {
+        "source_type": "mediapipe",
+        "frame_rate": 30.0,
+        "frames": [],
+        "created_at": now + 1.0,
+        "last_accessed_at": now + 1.0,
+    }
+    monkeypatch.setattr(mc, "MAX_CAPTURE_RECORDINGS", 1)
+    response = client.get("/tools/motion-capture/recordings")
+
+    assert response.status_code == 200
+    assert [recording["name"] for recording in response.json()] == ["new"]
+    assert set(_recordings) == {"new"}
 
 
 def test_sources_report_honest_availability(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add explicit ephemeral retention bounds for motion-capture sessions and recordings
- prune stopped sessions by TTL/count and reject new sessions only when active sessions still fill the cap
- prune recordings by TTL/count and refresh access timestamps on list/playback/frame reads
- add tests for stopped-session pruning and recording cap pruning

## Root Cause
The motion-capture route stored sessions and full recording frame payloads in module-level dictionaries with no TTL, count bound, or cleanup path. Long-lived processes could grow memory monotonically across repeated sessions/uploads.

## Validation
- `py -3.13 -m pytest -q tests\unit\api\test_routes_motion_capture.py -k "pruned"` initially failed against the unbounded state
- `py -3.13 -m pytest -q tests\unit\api\test_routes_motion_capture.py`
- `py -3.13 -m ruff check src\api\routes\motion_capture.py tests\unit\api\test_routes_motion_capture.py`
- `py -3.13 -m ruff format --check src\api\routes\motion_capture.py tests\unit\api\test_routes_motion_capture.py`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, wildcard/debug/print guards, mypy, bandit, pytest

Closes #8163.